### PR TITLE
Fix 'python-django-guardian' download

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -17,8 +17,8 @@ cp -a /root/zulip/puppet/zulip/files/puppet.conf /etc/puppet/
 
 # Hack to get required python-django-guardian while the PPA build of django-guardian isn't working :(
 apt-get -y install python-django
-wget https://zulip.com/dist/packages/python-django-guardian_1.3-1~zulip4_all.deb
-dpkg -i /root/python-django-guardian_1.3-1~zulip4_all.deb
+wget -O /tmp/python-django-guardian_1.3-1~zulip4_all.deb https://zulip.com/dist/packages/python-django-guardian_1.3-1~zulip4_all.deb
+dpkg -i /tmp/python-django-guardian_1.3-1~zulip4_all.deb
 
 mkdir -p /etc/zulip
 echo -e "[machine]\npuppet_classes = zulip::voyager\ndeploy_type = voyager" > /etc/zulip/zulip.conf

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -17,8 +17,8 @@ cp -a /root/zulip/puppet/zulip/files/puppet.conf /etc/puppet/
 
 # Hack to get required python-django-guardian while the PPA build of django-guardian isn't working :(
 apt-get -y install python-django
-wget -O /tmp/python-django-guardian_1.3-1~zulip4_all.deb https://zulip.com/dist/packages/python-django-guardian_1.3-1~zulip4_all.deb
-dpkg -i /tmp/python-django-guardian_1.3-1~zulip4_all.deb
+wget https://zulip.com/dist/packages/python-django-guardian_1.3-1~zulip4_all.deb
+dpkg -i ./python-django-guardian_1.3-1~zulip4_all.deb
 
 mkdir -p /etc/zulip
 echo -e "[machine]\npuppet_classes = zulip::voyager\ndeploy_type = voyager" > /etc/zulip/zulip.conf


### PR DESCRIPTION
While the docu on https://www.zulip.org/server.html says:
```
cd /root/zulip
./scripts/setup/install
```
This script downloads the `python-django-guardian_1.3-1~zulip4_all.deb` file to current working dir (`/root/zulip` if you follow the docu), but tries to install it from /root/.
This fails obviously. So i changed the download location to /tmp/.