### PR TITLE
Link to settings page with absolute path, rather than explicitly zulip.com

### DIFF
--- a/templates/zerver/integrations.html
+++ b/templates/zerver/integrations.html
@@ -26,7 +26,7 @@
     code changes, issue tickets, build system results, and much more. If you don't see the system you would like to integrate with it, or run into any
     trouble, don't hesitate to <a href="mailto:support@zulip.com?subject=Integration%20question">email us</a>.</p>
 
-    <p>Many of these integrations require creating a Zulip bot. You can do so on your <a href="https://zulip.com/#settings">Zulip settings page</a>. Be sure to note its username and API key.</p>
+    <p>Many of these integrations require creating a Zulip bot. You can do so on your <a href="/#settings">Zulip settings page</a>. Be sure to note its username and API key.</p>
 
     <div id="integration-instruction-block" class="integration-instruction-block">
        <a href="#" id="integration-list-link"><i class="icon-vector-circle-arrow-left"></i>&nbsp;Back to list</a>
@@ -852,7 +852,7 @@
             <pre><code>npm install --save hubot-zulip</code></pre>
         </li>
 
-        <li><p>On your <a href="https://zulip.com/#settings">Zulip settings page</a>, create a bot account. Note its username, API key and full name; you will use them on the next step.</p></li>
+        <li><p>On your <a href="/#settings">Zulip settings page</a>, create a bot account. Note its username, API key and full name; you will use them on the next step.</p></li>
 
         <li>To run Hubot locally, use:
           <pre><code>HUBOT_ZULIP_BOT=hubot-bot@example.com HUBOT_ZULIP_API_KEY=your_key bin/hubot --adapter zulip --name "myhubot"</code></pre>


### PR DESCRIPTION
Without this, browsing http://localhost:9991/integrations/ and http://localhost:9991/integrations/#hubot has links to settings on zulip.com, rather than localhost:9991