### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Install the following non-Python dependencies:
 On Debian or Ubuntu systems:
 
 ```
-sudo apt-get install libffi-dev memcached rabbitmq-server libldap2-dev redis-server postgresql-server-dev-all libmemcached-dev
+sudo apt-get install libffi-dev memcached rabbitmq-server libldap2-dev python-dev redis-server postgresql-server-dev-all libmemcached-dev
 
 # If on 12.04 or wheezy:
 sudo apt-get install postgresql-9.1


### PR DESCRIPTION
- Add missing `python-dev` in apt-get install command

Otherwise, the `pip install -r requirements.txt` step fails.