### PR TITLE
Update Zulip support email to zulip-devel@googlegroups.com.

### DIFF
--- a/api/integrations/basecamp/zulip_basecamp_mirror
+++ b/api/integrations/basecamp/zulip_basecamp_mirror
@@ -49,7 +49,7 @@ client = zulip.Client(
     site=config.ZULIP_SITE,
     api_key=config.ZULIP_API_KEY,
     client="ZulipBasecamp/" + VERSION)
-user_agent = "Basecamp To Zulip Mirroring script (support@zulip.com)"
+user_agent = "Basecamp To Zulip Mirroring script (zulip-devel@googlegroups.com)"
 htmlParser = HTMLParser()
 
 # find some form of JSON loader/dumper, with a preference order for speed.

--- a/api/integrations/codebase/zulip_codebase_mirror
+++ b/api/integrations/codebase/zulip_codebase_mirror
@@ -58,7 +58,7 @@ client = zulip.Client(
     site=config.ZULIP_SITE,
     api_key=config.ZULIP_API_KEY,
     client="ZulipCodebase/" + VERSION)
-user_agent = "Codebase To Zulip Mirroring script (support@zulip.com)"
+user_agent = "Codebase To Zulip Mirroring script (zulip-devel@googlegroups.com)"
 
 # find some form of JSON loader/dumper, with a preference order for speed.
 json_implementations = ['ujson', 'cjson', 'simplejson', 'json']

--- a/api/setup.py
+++ b/api/setup.py
@@ -26,7 +26,7 @@ package_info = dict(
     version=version(),
     description='Bindings for the Zulip message API',
     author='Zulip, Inc.',
-    author_email='support@zulip.com',
+    author_email='zulip-devel@googlegroups.com',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',

--- a/bots/jabber_mirror.py
+++ b/bots/jabber_mirror.py
@@ -54,6 +54,6 @@ while backoff.keep_going():
 print ""
 print ""
 print "ERROR: The Jabber mirroring bot is unable to continue mirroring Jabber."
-print "Please contact support@zulip.com if you need assistance."
+print "Please contact zulip-devel@googlegroups.com if you need assistance."
 print ""
 sys.exit(1)

--- a/puppet/zulip_internal/files/mediawiki/LocalSettings.php
+++ b/puppet/zulip_internal/files/mediawiki/LocalSettings.php
@@ -49,8 +49,8 @@ $wgLogo             = "$wgStylePath/common/images/wiki.png";
 $wgEnableEmail      = true;
 $wgEnableUserEmail  = true; # UPO
 
-$wgEmergencyContact = "support@zulip.com";
-$wgPasswordSender   = "support@zulip.com";
+$wgEmergencyContact = "zulip-devel@googlegroups.com";
+$wgPasswordSender   = "zulip-devel@googlegroups.com";
 
 $wgEnotifUserTalk      = true; # UPO
 $wgEnotifWatchlist     = true; # UPO

--- a/static/html/404.html
+++ b/static/html/404.html
@@ -33,7 +33,7 @@
 
         <p>We know this is stressful, but we still love you.</p>
 
-        <p>If you'd like, you can <a href="mailto:support@zulip.com?Subject=404%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20404%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
+        <p>If you'd like, you can <a href="mailto:zulip-devel@googlegroups.com?Subject=404%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20404%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
     </div>
 </div>
 

--- a/static/html/5xx.html
+++ b/static/html/5xx.html
@@ -39,7 +39,7 @@
             data-screen-name="ZulipStatus"
             >@ZulipStatus on Twitter</a>.</p>
 
-        <p>If you'd like, you can <a href="mailto:support@zulip.com?Subject=500%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20500%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
+        <p>If you'd like, you can <a href="mailto:zulip-devel@googlegroups.com?Subject=500%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20500%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
     </div>
 </div>
 

--- a/templates/zerver/deactivated.html
+++ b/templates/zerver/deactivated.html
@@ -8,7 +8,7 @@
 
 <p>The organization you are trying to join, {{ deactivated_domain_name }}, has
 been deactivated. Please
-contact <a href="mailto:support@zulip.com">support@zulip.com</a> to reactivate
+contact <a href="mailto:zulip-devel@googlegroups.com">zulip-devel@googlegroups.com</a> to reactivate
 this group.</p>
 
 {% endblock %}

--- a/templates/zerver/integrations.html
+++ b/templates/zerver/integrations.html
@@ -24,7 +24,7 @@
 
     <p class="portico-large-text">With Zulip integrations, your team can stay up-to-date on
     code changes, issue tickets, build system results, and much more. If you don't see the system you would like to integrate with it, or run into any
-    trouble, don't hesitate to <a href="mailto:support@zulip.com?subject=Integration%20question">email us</a>.</p>
+    trouble, don't hesitate to <a href="mailto:zulip-devel@googlegroups.com?subject=Integration%20question">email us</a>.</p>
 
     <p>Many of these integrations require creating a Zulip bot. You can do so on your <a href="/#settings">Zulip settings page</a>. Be sure to note its username and API key.</p>
 
@@ -270,7 +270,7 @@
         example, auto-restarting through <code>supervisord</code>).</p>
 
         <p>Please
-        contact <a href="mailto:support@zulip.com?subject=Asana%20integration%20question">support@zulip.com</a>
+        contact <a href="mailto:zulip-devel@googlegroups.com?subject=Asana%20integration%20question">zulip-devel@googlegroups.com</a>
         if you'd like assistance with maintaining this integration.
         </p>
       </li>
@@ -924,7 +924,7 @@
           <li>Did you set up a post-build action for your project?</li>
           <li>Does the stream you picked (e.g. <code>jenkins</code>) already exist? If not, add yourself to it and try again.</li>
           <li>Are your access key and email address correct? Test them using <a href="/api">our curl API</a>.</li>
-          <li>Still stuck? Email <a href="mailto:support@zulip.com?subject=Jenkins">support@zulip.com</a>.</li>
+          <li>Still stuck? Email <a href="mailto:zulip-devel@googlegroups.com?subject=Jenkins">zulip-devel@googlegroups.com</a>.</li>
         </ul>
       </p>
     </div>

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -93,7 +93,7 @@ class OurAuthenticationForm(AuthenticationForm):
         if user_profile.realm.deactivated:
             error_msg = u"""Sorry for the trouble, but %s has been deactivated.
 
-Please contact support@zulip.com to reactivate this group.""" % (
+Please contact zulip-devel@googlegroups.com to reactivate this group.""" % (
                 user_profile.realm.name,)
             raise ValidationError(mark_safe(error_msg))
 

--- a/zproject/local_settings.py
+++ b/zproject/local_settings.py
@@ -109,7 +109,7 @@ NAGIOS_STAGING_SEND_BOT = 'iago@zulip.com'
 NAGIOS_STAGING_RECEIVE_BOT = 'cordelia@zulip.com'
 
 # Also used for support email in emails templates
-ZULIP_ADMINISTRATOR = 'support@zulip.com'
+ZULIP_ADMINISTRATOR = 'zulip-devel@googlegroups.com'
 
 ADMINS = (
     ('Zulip Error Reports', 'errors@zulip.com'),

--- a/zproject/local_settings_template.py
+++ b/zproject/local_settings_template.py
@@ -96,7 +96,7 @@ INLINE_IMAGE_PREVIEW = True
 # By default, files uploaded by users and user avatars are stored
 # directly on the Zulip server.  If file storage in Amazon S3 (or
 # elsewhere, e.g. your corporate fileshare) is desired, please contact
-# Zulip Support (support@zulip.com) for further instructions on
+# Zulip Support (zulip-devel@googlegroups.com) for further instructions on
 # setting up the appropriate integration.
 LOCAL_UPLOADS_DIR = "/home/zulip/uploads"
 


### PR DESCRIPTION
Ideally some of these templates should really point to the
local installation's support email address, but this is a
good start.

Exceptions:
* Where to report security incidents
* MIT Zephyr-related pages
* zulip.com terms and conditions