### PR TITLE
Puppet ensure rabbitmq running

### DIFF
--- a/puppet/zulip/manifests/rabbit.pp
+++ b/puppet/zulip/manifests/rabbit.pp
@@ -3,7 +3,7 @@ class zulip::rabbit {
                       "rabbitmq-server",
                       ]
   package { $rabbit_packages: ensure => "installed" }
-
+  ->
   file { "/etc/cron.d/rabbitmq-queuesize":
     require => Package[rabbitmq-server],
     ensure => file,
@@ -12,6 +12,7 @@ class zulip::rabbit {
     mode => 644,
     source => "puppet:///modules/zulip/cron.d/rabbitmq-queuesize",
   }
+  ->
   file { "/etc/cron.d/rabbitmq-numconsumers":
     require => Package[rabbitmq-server],
     ensure => file,
@@ -20,7 +21,7 @@ class zulip::rabbit {
     mode => 644,
     source => "puppet:///modules/zulip/cron.d/rabbitmq-numconsumers",
   }
-
+  ->
   file { "/etc/default/rabbitmq-server":
     require => Package[rabbitmq-server],
     ensure => file,
@@ -29,7 +30,7 @@ class zulip::rabbit {
     mode => 644,
     source => "puppet:///modules/zulip/rabbitmq/rabbitmq-server",
   }
-
+  ->
   file { "/etc/rabbitmq/rabbitmq.config":
     require => Package[rabbitmq-server],
     ensure => file,
@@ -38,7 +39,7 @@ class zulip::rabbit {
     mode => 644,
     source => "puppet:///modules/zulip/rabbitmq/rabbitmq.config",
   }
-
+  ->
   service { "rabbitmq-server":
     ensure    => running 
   }

--- a/puppet/zulip/manifests/rabbit.pp
+++ b/puppet/zulip/manifests/rabbit.pp
@@ -26,7 +26,7 @@ class zulip::rabbit {
     require => Package[rabbitmq-server],
     ensure => file,
     owner  => "root",
-    group  => "root",service 
+    group  => "root", 
     mode => 644,
     source => "puppet:///modules/zulip/rabbitmq/rabbitmq-server",
   }

--- a/puppet/zulip/manifests/rabbit.pp
+++ b/puppet/zulip/manifests/rabbit.pp
@@ -1,5 +1,6 @@
 class zulip::rabbit {
   $rabbit_packages = [# Needed to run rabbitmq
+                      "erlang-base",
                       "rabbitmq-server",
                       ]
   package { $rabbit_packages: ensure => "installed" }
@@ -39,8 +40,14 @@ class zulip::rabbit {
     source => "puppet:///modules/zulip/rabbitmq/rabbitmq.config",
   }
 
+  exec { "epmd":
+    command => "epmd -daemon",
+    path    => "/usr/bin/:/bin/",
+  }
+  
   service { "rabbitmq-server":
-    ensure    => running 
+    ensure => running,
+    require => Exec["epmd"],
   }
   
   # TODO: Should also call exactly once "configure-rabbitmq"

--- a/puppet/zulip/manifests/rabbit.pp
+++ b/puppet/zulip/manifests/rabbit.pp
@@ -26,7 +26,7 @@ class zulip::rabbit {
     require => Package[rabbitmq-server],
     ensure => file,
     owner  => "root",
-    group  => "root", 
+    group  => "root",
     mode => 644,
     source => "puppet:///modules/zulip/rabbitmq/rabbitmq-server",
   }

--- a/puppet/zulip/manifests/rabbit.pp
+++ b/puppet/zulip/manifests/rabbit.pp
@@ -39,5 +39,9 @@ class zulip::rabbit {
     source => "puppet:///modules/zulip/rabbitmq/rabbitmq.config",
   }
 
+  service { "rabbitmq-server":
+    ensure    => running 
+  }
+  
   # TODO: Should also call exactly once "configure-rabbitmq"
 }

--- a/puppet/zulip/manifests/rabbit.pp
+++ b/puppet/zulip/manifests/rabbit.pp
@@ -3,7 +3,7 @@ class zulip::rabbit {
                       "rabbitmq-server",
                       ]
   package { $rabbit_packages: ensure => "installed" }
-  ->
+
   file { "/etc/cron.d/rabbitmq-queuesize":
     require => Package[rabbitmq-server],
     ensure => file,
@@ -12,7 +12,6 @@ class zulip::rabbit {
     mode => 644,
     source => "puppet:///modules/zulip/cron.d/rabbitmq-queuesize",
   }
-  ->
   file { "/etc/cron.d/rabbitmq-numconsumers":
     require => Package[rabbitmq-server],
     ensure => file,
@@ -21,7 +20,7 @@ class zulip::rabbit {
     mode => 644,
     source => "puppet:///modules/zulip/cron.d/rabbitmq-numconsumers",
   }
-  ->
+
   file { "/etc/default/rabbitmq-server":
     require => Package[rabbitmq-server],
     ensure => file,
@@ -30,7 +29,7 @@ class zulip::rabbit {
     mode => 644,
     source => "puppet:///modules/zulip/rabbitmq/rabbitmq-server",
   }
-  ->
+
   file { "/etc/rabbitmq/rabbitmq.config":
     require => Package[rabbitmq-server],
     ensure => file,
@@ -39,7 +38,7 @@ class zulip::rabbit {
     mode => 644,
     source => "puppet:///modules/zulip/rabbitmq/rabbitmq.config",
   }
-  ->
+
   service { "rabbitmq-server":
     ensure    => running 
   }

--- a/puppet/zulip/manifests/rabbit.pp
+++ b/puppet/zulip/manifests/rabbit.pp
@@ -26,7 +26,7 @@ class zulip::rabbit {
     require => Package[rabbitmq-server],
     ensure => file,
     owner  => "root",
-    group  => "root",
+    group  => "root",service 
     mode => 644,
     source => "puppet:///modules/zulip/rabbitmq/rabbitmq-server",
   }
@@ -42,6 +42,7 @@ class zulip::rabbit {
 
   exec { "epmd":
     command => "epmd -daemon",
+    require => Package[erlang-base],
     path    => "/usr/bin/:/bin/",
   }
   


### PR DESCRIPTION
This fix the crash of the install script ```./scripts/setup/install``` complaining about a non running rabbit node.

The issue is that moment is that the ```.rabbitmq-server```. is not ensured as ```.running```. by puppet (and is indeed not running). Running it requires the ```.epmd``` daemon to be started first.