### PR TITLE
Correct twitter library in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ smmap==0.9.0
 sockjs-tornado==1.0.1
 sourcemap==0.1.8
 tornado==2.4.1
-twitter==1.17.0
+python-twitter==1.1
 ujson==1.33
 uritemplate==0.6
 wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ jwt==0.3.2
 mandrill==1.0.57
 mock==1.0.1
 oauth2client==1.4.11
-oauthlib==0.1.3
+oauthlib==1.0.3
 pika==0.9.14
 postmonkey==1.0b0
 psycopg2==2.6

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -106,9 +106,8 @@ def fetch_tweet_data(tweet_id):
         if not all(creds.values()):
            return None
 
-        api = twitter.Api(**creds)
-
         try:
+            api = twitter.Api(**creds)
             # Sometimes Twitter hangs on responses.  Timing out here
             # will cause the Tweet to go through as-is with no inline
             # preview, rather than having the message be rejected
@@ -117,6 +116,10 @@ def fetch_tweet_data(tweet_id):
             tweet = timeout(3, api.GetStatus, tweet_id)
             res = tweet.AsDict()
             res['media'] = tweet.media  # AsDict does not include media
+        except AttributeError:
+            logging.error('Unable to load twitter api, you may have the wrong '
+                          'library installed, see https://github.com/zulip/zulip/issues/86')
+            return None
         except TimeoutExpired as e:
             # We'd like to try again later and not cache the bad result,
             # so we need to re-raise the exception (just as though


### PR DESCRIPTION
This only affects development environments and/or hand-built installations relying on the contents of requirements.txt

To fix existing environments, the incorrect api needs to be explicitly removed with `pip uninstall twitter`

Fixes #86 