### PR TITLE
Fix notifications in Firefox by calling the constructor with 'new'

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -324,7 +324,7 @@ function process_notification(notification) {
     } else if (notification.webkit_notify === false && typeof Notification !== "undefined" && $.browser.mozilla === true) {
         Notification.requestPermission(function (perm) {
             if (perm === 'granted') {
-                Notification(title, {
+                new Notification(title, {
                     body: content,
                     iconUrl: ui.small_avatar_url(message)
                 });

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -324,7 +324,7 @@ function process_notification(notification) {
     } else if (notification.webkit_notify === false && typeof Notification !== "undefined" && $.browser.mozilla === true) {
         Notification.requestPermission(function (perm) {
             if (perm === 'granted') {
-                new Notification(title, {
+                notification_object = new Notification(title, {
                     body: content,
                     iconUrl: ui.small_avatar_url(message)
                 });


### PR DESCRIPTION
Calling the browser notification constructor without the new keyword throws an error that prevents the notification from being displayed.

cc @bgilbert who found this bug and helped fix/test