### PR TITLE
Fix a puppet config to be used SSO

### DIFF
--- a/README.prod.md
+++ b/README.prod.md
@@ -355,7 +355,7 @@ configuration change.
 
 (1) Edit /etc/zulip/zulip.conf and change the puppet_classes line to read:
 
-puppet_classes = zulip::enterprise, zulip::apache_sso
+puppet_classes = zulip::voyager, zulip::apache_sso
 
 (2) As root, run
 


### PR DESCRIPTION
It appears from the puppet::enterprise, as has been changed to puppet::voyager.