### PR TITLE
Make twitter settings validation test more explicit

### DIFF
--- a/zerver/test_bugdown.py
+++ b/zerver/test_bugdown.py
@@ -295,7 +295,7 @@ class BugdownTest(TestCase):
                                                        make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315459', media_tweet_html, """<div class="twitter-image"><a href="http://t.co/xo7pAhK6n3" target="_blank" title="http://t.co/xo7pAhK6n3"><img src="https://pbs.twimg.com/media/BdoEjD4IEAIq86Z.jpg:small"></a></div>""")))
 
     def test_fetch_tweet_data_settings_validation(self):
-        with self.settings(TEST_SUITE=False):
+        with self.settings(TEST_SUITE=False, TWITTER_CONSUMER_KEY=None):
             self.assertIs(None, bugdown.fetch_tweet_data('287977969287315459'))
 
     def test_realm_emoji(self):


### PR DESCRIPTION
This allows you to have settings lying around in your development environment while allowing the test to run.