### PR TITLE
Add an api endpoint to fetch GOOGLE_CLIENT_ID

### DIFF
--- a/zerver/test_signup.py
+++ b/zerver/test_signup.py
@@ -83,6 +83,25 @@ class PublicURLTest(TestCase):
         for status_code, url_set in post_urls.iteritems():
             self.fetch("post", url_set, status_code)
 
+    def test_get_gcid_when_not_configured(self):
+        with self.settings(GOOGLE_CLIENT_ID=None):
+            resp = self.client.get("/api/v1/fetch_gcid")
+            self.assertEquals(400, resp.status_code,
+                msg="Expected 400, received %d for GET /api/v1/fetch_gcid" % resp.status_code,
+            )
+            data = ujson.loads(resp.content)
+            self.assertEqual('error', data['result'])
+
+    def test_get_gcid_when_configured(self):
+        with self.settings(GOOGLE_CLIENT_ID="ABCD"):
+            resp = self.client.get("/api/v1/fetch_gcid")
+            self.assertEquals(200, resp.status_code,
+                msg="Expected 200, received %d for GET /api/v1/fetch_gcid" % resp.status_code,
+            )
+            data = ujson.loads(resp.content)
+            self.assertEqual('success', data['result'])
+            self.assertEqual('ABCD', data['gcid'])
+
 class LoginTest(AuthedTestCase):
     """
     Logging in, registration, and logging out.

--- a/zerver/test_signup.py
+++ b/zerver/test_signup.py
@@ -85,22 +85,22 @@ class PublicURLTest(TestCase):
 
     def test_get_gcid_when_not_configured(self):
         with self.settings(GOOGLE_CLIENT_ID=None):
-            resp = self.client.get("/api/v1/fetch_gcid")
+            resp = self.client.get("/api/v1/fetch_google_client_id")
             self.assertEquals(400, resp.status_code,
-                msg="Expected 400, received %d for GET /api/v1/fetch_gcid" % resp.status_code,
+                msg="Expected 400, received %d for GET /api/v1/fetch_google_client_id" % resp.status_code,
             )
             data = ujson.loads(resp.content)
             self.assertEqual('error', data['result'])
 
     def test_get_gcid_when_configured(self):
         with self.settings(GOOGLE_CLIENT_ID="ABCD"):
-            resp = self.client.get("/api/v1/fetch_gcid")
+            resp = self.client.get("/api/v1/fetch_google_client_id")
             self.assertEquals(200, resp.status_code,
-                msg="Expected 200, received %d for GET /api/v1/fetch_gcid" % resp.status_code,
+                msg="Expected 200, received %d for GET /api/v1/fetch_google_client_id" % resp.status_code,
             )
             data = ujson.loads(resp.content)
             self.assertEqual('success', data['result'])
-            self.assertEqual('ABCD', data['gcid'])
+            self.assertEqual('ABCD', data['google_client_id'])
 
 class LoginTest(AuthedTestCase):
     """

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -1881,6 +1881,12 @@ def json_fetch_api_key(request, user_profile, password=REQ(default='')):
         return json_error("Your username or password is incorrect.")
     return json_success({"api_key": user_profile.api_key})
 
+@csrf_exempt
+def api_fetch_gcid(request):
+    if not settings.GOOGLE_CLIENT_ID:
+        return json_error("GCID is not configured", status=400)
+    return json_success({"gcid": settings.GOOGLE_CLIENT_ID})
+
 def get_status_list(requesting_user_profile):
     return {'presences': get_status_dict(requesting_user_profile),
             'server_timestamp': time.time()}

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -1882,10 +1882,10 @@ def json_fetch_api_key(request, user_profile, password=REQ(default='')):
     return json_success({"api_key": user_profile.api_key})
 
 @csrf_exempt
-def api_fetch_gcid(request):
+def api_fetch_google_client_id(request):
     if not settings.GOOGLE_CLIENT_ID:
-        return json_error("GCID is not configured", status=400)
-    return json_success({"gcid": settings.GOOGLE_CLIENT_ID})
+        return json_error("GOOGLE_CLIENT_ID is not configured", status=400)
+    return json_success({"google_client_id": settings.GOOGLE_CLIENT_ID})
 
 def get_status_list(requesting_user_profile):
     return {'presences': get_status_dict(requesting_user_profile),

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -154,7 +154,7 @@ urlpatterns += patterns('zerver.views',
     url(r'^api/v1/fetch_api_key$',          'api_fetch_api_key'),
 
     # Used to present the GOOGLE_CLIENT_ID to mobile apps
-    url(r'^api/v1/fetch_gcid$',             'api_fetch_gcid'),
+    url(r'^api/v1/fetch_google_client_id$',             'api_fetch_google_client_id'),
 
     # These are integration-specific web hook callbacks
     url(r'^api/v1/external/beanstalk$' ,    'webhooks.api_beanstalk_webhook'),

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -153,6 +153,9 @@ urlpatterns += patterns('zerver.views',
     # password/pair and returns an API key.
     url(r'^api/v1/fetch_api_key$',          'api_fetch_api_key'),
 
+    # Used to present the GOOGLE_CLIENT_ID to mobile apps
+    url(r'^api/v1/fetch_gcid$',             'api_fetch_gcid'),
+
     # These are integration-specific web hook callbacks
     url(r'^api/v1/external/beanstalk$' ,    'webhooks.api_beanstalk_webhook'),
     url(r'^api/v1/external/github$',        'webhooks.api_github_landing'),


### PR DESCRIPTION
Further to #102, this provides an endpoint suitable for mobile apps to consume the GOOGLE_CLIENT_ID if configured.