### PR TITLE
Exit 1 for failed install

### DIFF
--- a/scripts/setup/install
+++ b/scripts/setup/install
@@ -6,4 +6,4 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 mkdir -p /var/log/zulip
-"$(dirname "$(dirname "$0")")/lib/install" "$@" 2>&1 | tee -a /var/log/zulip/install.log || echo "Installation error" && exit 1
+"$(dirname "$(dirname "$0")")/lib/install" "$@" 2>&1 | tee -a /var/log/zulip/install.log

--- a/scripts/setup/install
+++ b/scripts/setup/install
@@ -1,7 +1,9 @@
 #!/bin/bash
+set -e
+set -o pipefail
 if [ "$EUID" -ne 0 ]; then
     echo "Error: The installation script must be run as root" >&2
     exit 1
 fi
 mkdir -p /var/log/zulip
-"$(dirname "$(dirname "$0")")/lib/install" "$@" 2>&1 | tee -a /var/log/zulip/install.log || echo "Installation error" && exit 1
+"$(dirname "$(dirname "$0")")/lib/install" "$@" 2>&1 | tee -a /var/log/zulip/install.log

--- a/scripts/setup/install
+++ b/scripts/setup/install
@@ -6,4 +6,4 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 mkdir -p /var/log/zulip
-"$(dirname "$(dirname "$0")")/lib/install" "$@" 2>&1 | tee -a /var/log/zulip/install.log
+"$(dirname "$(dirname "$0")")/lib/install" "$@" 2>&1 | tee -a /var/log/zulip/install.log || echo "Installation error" && exit 1

--- a/scripts/setup/install
+++ b/scripts/setup/install
@@ -4,4 +4,4 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 mkdir -p /var/log/zulip
-"$(dirname "$(dirname "$0")")/lib/install" "$@" 2>&1 | tee -a /var/log/zulip/install.log
+"$(dirname "$(dirname "$0")")/lib/install" "$@" 2>&1 | tee -a /var/log/zulip/install.log || echo "Installation error" && exit 1


### PR DESCRIPTION
Proposed fix for issue #82, This will still print the full error message from line 7 if it fails. Line 6 shouldn't fail since it has checked root privelages at that point, but still could if there are disk write errors for other reasons.