### PR TITLE
Turn off desktop notifications by default for new users.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+###
+- Turn off desktop and audible notifications for streams by default.

--- a/templates/zerver/emails/followup/day1.html
+++ b/templates/zerver/emails/followup/day1.html
@@ -24,7 +24,7 @@
 
     <li>Want to <b>share files</b> in Zulip? No problem! Start a new message and click the paperclip, or just drag-and-drop the file into the textbox.</li>
 
-    <li>Trying to <b>get someone's attention</b>? Type in an @-sign followed by their name to "mention" them.</li>
+    <li>Trying to <b>get someone's attention</b>? Type in an @-sign followed by their name to "mention" them. (Want more or fewer notifications? Select Settings under the gear menu to customize how and when Zulip notifies you of new messages.)</li>
 
     <li>Bulleted lists, bold, code blocks, and more are all at your fingertips - just check out <b>"Message formatting"</b> in the gear menu.</li>
 

--- a/templates/zerver/emails/followup/day1.text
+++ b/templates/zerver/emails/followup/day1.text
@@ -9,7 +9,7 @@ https://{{ external_host }}/hello has a nice overview of what we're up to, but h
 
 2. Want to share files in Zulip? No problem! Start a new message and click the paperclip, or just drag-and-drop the file into the textbox.
 
-3. Trying to get someone's attention? Type in an @-sign followed by their name to "mention" them.
+3. Trying to get someone's attention? Type in an @-sign followed by their name to "mention" them. (Want more or fewer notifications? Select Settings under the gear menu to customize how and when Zulip notifies you of new messages.)
 
 4. Bulleted lists, bold, code blocks, and more are all at your fingertips - just check out "Message formatting" in the gear menu.
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -294,8 +294,8 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     ### Notifications settings. ###
 
     # Stream notifications.
-    enable_stream_desktop_notifications = models.BooleanField(default=True)
-    enable_stream_sounds = models.BooleanField(default=True)
+    enable_stream_desktop_notifications = models.BooleanField(default=False)
+    enable_stream_sounds = models.BooleanField(default=False)
 
     # PM + @-mention notifications.
     enable_desktop_notifications = models.BooleanField(default=True)


### PR DESCRIPTION
Previously, it was a really unpleasant to join an active Zulip realm, because the moment you joined, you were bombarded with dozens of desktop notifications for new messages to every stream you were subscribed to by default. This isn't a theoretical concern: We've on-boarded hundreds of Zulip users at the Recurse Center, and since we have an active realm and lots of default streams, we have to have extra instructions to tell every new user to turn these two settings off as soon as they first log in.