### PR TITLE
Cause install to return 1 on failure.

### DIFF
--- a/scripts/setup/install
+++ b/scripts/setup/install
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -o pipefail
 if [ "$EUID" -ne 0 ]; then
     echo "Error: The installation script must be run as root" >&2
     exit 1


### PR DESCRIPTION
This fixes issue #82. Namely, the script in scripts/setup/install was returning 0. Adding `set -e` and `set -o pipeline` causes the install script to exit and return 1 if any part fails, including piping output (`set -o pipeline` does this).