### PR TITLE
Install libfreetype6-dev in the development environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,12 @@ Install the following non-Python dependencies:
  * python-dev
  * redis-server — rate limiting
  * tsearch-extras — better text search
+ * libfreetype6-dev - needed before you pip install Pillow to properly generate emoji PNGs
 
 On Debian or Ubuntu systems:
 
 ```
-sudo apt-get install libffi-dev memcached rabbitmq-server libldap2-dev python-dev redis-server postgresql-server-dev-all libmemcached-dev
+sudo apt-get install libffi-dev memcached rabbitmq-server libldap2-dev python-dev redis-server postgresql-server-dev-all libmemcached-dev libfreetype6-dev
 
 # If on 12.04 or wheezy:
 sudo apt-get install postgresql-9.1
@@ -160,7 +161,7 @@ Now continue with the "All systems" instructions below.
 On Fedora 22 (experimental):
 
 ```
-sudo dnf install libffi-devel memcached rabbitmq-server openldap-devel python-devel redis postgresql-server postgresql-devel postgresql libmemcached-devel
+sudo dnf install libffi-devel memcached rabbitmq-server openldap-devel python-devel redis postgresql-server postgresql-devel postgresql libmemcached-devel freetype-devel
 wget https://launchpad.net/~tabbott/+archive/ubuntu/zulip/+files/tsearch-extras_0.1.3.tar.gz
 tar xvzf tsearch-extras_0.1.3.tar.gz
 cd ts2

--- a/provision.py
+++ b/provision.py
@@ -17,6 +17,7 @@ SUPPORTED_PLATFORMS = {
 APT_DEPENDENCIES = {
     "trusty": [
         "closure-compiler",
+        "libfreetype6-dev",
         "libffi-dev",
         "memcached",
         "rabbitmq-server",


### PR DESCRIPTION
This fixes a problem where the emoji_dump tool was not correctly
generating the black-and-white emoji.  Pillow compiled without
libfreetype cannot extract those emoji (and gives an error of the form
"The _imagingft C module is not installed"), and if libfreetype-dev
isn't installed, pip will happily build and install Pillow without
libfreetype.