### PR TITLE
Add emoji map button to the compose box.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1,6 +1,7 @@
 add_dependencies({
     Handlebars: 'handlebars',
     templates: 'js/templates',
+    emoji: 'js/emoji',
     i18n: 'i18next'
 });
 
@@ -70,6 +71,20 @@ function render(template_name, args) {
     var link = $(html).find("a.respond_button");
     assert.equal(link.text().trim(), 'Reply');
     global.write_test_output("actions_popover_content.handlebars", html);
+}());
+
+(function emoji_popover_content() {
+    var args = {
+        emoji_list: global.emoji.emojis_by_name
+    };
+
+    var html = '<div style="height: 250px">';
+    html += render('emoji_popover_content', args);
+    html += "</div>";
+    // test to make sure the first emoji is present in the popover
+    var emoji_key = $(html).find(".emoji-100").attr('title');
+    assert.equal(emoji_key, ':100:');
+    global.write_test_output("emoji_popover_content.handlebars", html);
 }());
 
 (function admin_tab() {

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ fonttools==3.0
 future==0.15.2
 gcm-client==0.1.4
 gitdb==0.6.4
+glue==0.11.1
 google-api-python-client==1.4.0
 html2text==2015.6.6
 httplib2==0.9.1

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -278,6 +278,13 @@ $(function () {
     });
 
     function handle_compose_click(e) {
+        // Emoji clicks should be handled by their own click handler in popover.js
+        if ($(e.target).is("#emoji_map") ||
+            $(e.target).is(".emoji_popover") ||
+            $(e.target).is(".emoji_popover.inner") ||
+            $(e.target).is("img.emoji")) {
+            return;
+        }
         // Don't let clicks in the compose area count as
         // "unfocusing" our compose -- in other words, e.g.
         // clicking "Press enter to send" should not
@@ -387,7 +394,8 @@ $(function () {
         // of modals or selecting text (for copy+paste) trigger cancelling.
         if (compose.composing() && !$(e.target).is("a") &&
             ($(e.target).closest(".modal").length === 0) &&
-            window.getSelection().toString() === "") {
+            window.getSelection().toString() === "" &&
+            ($(e.target).closest('#emoji_map').length === 0)) {
             compose.cancel();
         }
     });

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -235,8 +235,7 @@ function process_hotkey(e) {
         case 'escape': // Esc: close actions popup, cancel compose, clear a find, or un-narrow
             if ($('.emoji_popover').css('display') === 'inline-block') {
                 popovers.hide_emoji_map_popover();
-            }
-            else if (popovers.any_active()) {
+            } else if (popovers.any_active()) {
                 popovers.hide_all();
             } else if (compose.composing()) {
                 compose.cancel();

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -159,6 +159,11 @@ function process_hotkey(e) {
     // Process hotkeys specially when in an input, select, textarea, or send button
     if ($('input:focus,select:focus,textarea:focus,#compose-send-button:focus').length > 0) {
         if (event_name === 'escape') {
+            // emoji window should trap escape before it is able to close the compose box
+            if ($('.emoji_popover').css('display') === 'inline-block') {
+                popovers.hide_emoji_map_popover();
+                return;
+            }
             // If one of our typeaheads is open, do nothing so that the Esc
             // will go to close it
             if ($("#subject").data().typeahead.shown ||
@@ -228,7 +233,10 @@ function process_hotkey(e) {
                 narrow.by('is', 'private', opts);
             });
         case 'escape': // Esc: close actions popup, cancel compose, clear a find, or un-narrow
-            if (popovers.any_active()) {
+            if ($('.emoji_popover').css('display') === 'inline-block') {
+                popovers.hide_emoji_map_popover();
+            }
+            else if (popovers.any_active()) {
                 popovers.hide_all();
             } else if (compose.composing()) {
                 compose.cancel();

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -289,7 +289,7 @@ exports.register_click_handlers = function () {
 
     $("body").on("mousemove", function (e) {
         e.preventDefault();
-        if(isDragging) {
+        if (isDragging) {
             var new_height = emoji_popover_height + (previous_mouse_position - e.pageY);
             if (new_height + compose_box_padding > total_height) {
                 emoji_popover_elem.height(total_height - compose_box_padding);

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -371,6 +371,11 @@ $(function () {
         }
     });
 
+    // Override the #compose mousewheel prevention below just for the emoji box
+    $('.emoji_popover').mousewheel(function (e) {
+        e.stopPropagation();
+    });
+
     // Ignore wheel events in the compose area which weren't already handled above.
     $('#compose').mousewheel(function (e) {
         e.stopPropagation();

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -3095,6 +3095,44 @@ li.expanded_private_message {
     color: #000;
 }
 
+.drag {
+    display: none;
+    height: 18px;
+    width: 100%;
+    top: 23px;
+    position: relative;
+    cursor: ns-resize;
+}
+
+.emoji_popover {
+    display: none;
+    position: relative;
+    margin-top: 10px;
+    bottom: 0px;
+    z-index: 1010;
+    width: 100%;
+    height: 60px;
+    padding: 1px;
+    text-align: center;
+    background-color: #ffffff;
+    border: 1px solid #ccc;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    overflow: hidden;
+    overflow-y: scroll;
+}
+
+.emoji_popover .emoji {
+    margin: 2px;
+    box-sizing: border-box;
+    cursor: pointer;
+    display: inline-block;
+}
+
+.emoji_popover .emoji:active {
+    border-radius: 5px;
+    border: 2px white solid;
+}
+
 #enter_sends {
     margin-top: 0px;
     margin-right: 5px;

--- a/static/templates/emoji_popover_content.handlebars
+++ b/static/templates/emoji_popover_content.handlebars
@@ -1,0 +1,5 @@
+{{! Contents of the "emoji map" popup }}
+{{#each emoji_list}}
+    <div class="emoji emoji-{{@key}}" title= ":{{@key}}:" />
+{{/each}}
+

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -70,8 +70,13 @@
               <td class="messagebox" colspan="2">
                   <textarea class="new_message_textarea" name="content" id="new_message_content"
                             value="" placeholder="{{ _('Compose your message here') }}..." tabindex="140" maxlength="10000"></textarea>
+              <div class="drag"></div>
+              <div class="emoji_popover"></div>
+
               <div id="below-compose-content">
                   <input type="file" id="file_input" class="notvisible pull-left" multiple />
+                  <a class="message-control-button icon-vector-smile"
+                        id="emoji_map" href="#"></a>
                   <a class="message-control-button icon-vector-dropbox notdisplayed"
                      id="attach_dropbox_files" href="#" title="{{ _('Attach files from Dropbox') }}"></a>
                   <a class="message-control-button icon-vector-paper-clip notdisplayed"

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -15,6 +15,7 @@ var page_params = {{ page_params }};
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <link href="/static/images/logo/apple-touch-icon-precomposed.png" rel="apple-touch-icon-precomposed">
+<link rel="stylesheet" type="text/css" href="/static/third/gemoji/sprite.css" />
 <style type="text/css">
 
 #css-loading {

--- a/tools/setup/emoji_dump/build_emoji
+++ b/tools/setup/emoji_dump/build_emoji
@@ -6,4 +6,5 @@ rm -rf static/third/gemoji/images
 (cd tools/setup/emoji_dump && python ./emoji_dump.py)
 mkdir -p static/third/gemoji/images
 mv tools/setup/emoji_dump/out static/third/gemoji/images/emoji
+mv tools/setup/emoji_dump/sprite* static/third/gemoji/
 cp -RPp assets/zulip-emoji/* static/third/gemoji/images/emoji/


### PR DESCRIPTION
- Move the message-control-buttons to the right of the
compose box in mobile view so that the emoji popover will
not get cut off on the right side of a mobile screen.

- Append an emoji to the end of the message when a user
clicks the emoji in the emoji popover.