### PR TITLE
Apply a bunch of python 3 compatibility filters

### DIFF
--- a/analytics/management/commands/active_user_stats.py
+++ b/analytics/management/commands/active_user_stats.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 

--- a/analytics/management/commands/active_user_stats_by_day.py
+++ b/analytics/management/commands/active_user_stats_by_day.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 import datetime
 import pytz
@@ -19,6 +20,6 @@ class Command(BaseCommand):
             date = datetime.datetime.now() - datetime.timedelta(days=1)
         else:
             date = datetime.datetime.strptime(options["date"], "%Y-%m-%d")
-        print "Activity data for", date
-        print activity_averages_during_day(date)
-        print "Please note that the total registered user count is a total for today"
+        print("Activity data for", date)
+        print(activity_averages_during_day(date))
+        print("Please note that the total registered user count is a total for today")

--- a/analytics/management/commands/analyze_mit.py
+++ b/analytics/management/commands/analyze_mit.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from optparse import make_option
 from django.core.management.base import BaseCommand
@@ -63,7 +64,7 @@ def compute_stats(log_level):
         logging.info("Top %6s | %s%%" % (size, round(top_percents[size], 1)))
 
     grand_total = sum(total_counts.values())
-    print grand_total
+    print(grand_total)
     logging.info("%15s | %s" % ("Client", "Percentage"))
     for client in total_counts.keys():
         logging.info("%15s | %s%%" % (client, round(100. * total_counts[client] / grand_total, 1)))

--- a/analytics/management/commands/analyze_user_activity.py
+++ b/analytics/management/commands/analyze_user_activity.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from zerver.lib.statistics import seconds_usage_between
 
@@ -16,7 +17,7 @@ def analyze_activity(options):
     if options["realm"]:
         user_profile_query = user_profile_query.filter(realm__domain=options["realm"])
 
-    print "Per-user online duration:\n"
+    print("Per-user online duration:\n")
     total_duration = datetime.timedelta(0)
     for user_profile in user_profile_query:
         duration = seconds_usage_between(user_profile, day_start, day_end)
@@ -25,11 +26,11 @@ def analyze_activity(options):
             continue
 
         total_duration += duration
-        print "%-*s%s" % (37, user_profile.email, duration, )
+        print("%-*s%s" % (37, user_profile.email, duration, ))
 
-    print "\nTotal Duration:                      %s" % (total_duration,)
-    print "\nTotal Duration in minutes:           %s" % (total_duration.total_seconds() / 60.,)
-    print "Total Duration amortized to a month: %s" % (total_duration.total_seconds() * 30. / 60.,)
+    print("\nTotal Duration:                      %s" % (total_duration,))
+    print("\nTotal Duration in minutes:           %s" % (total_duration.total_seconds() / 60.,))
+    print("Total Duration amortized to a month: %s" % (total_duration.total_seconds() * 30. / 60.,))
 
 class Command(BaseCommand):
     help = """Report analytics of user activity on a per-user and realm basis.

--- a/analytics/management/commands/client_activity.py
+++ b/analytics/management/commands/client_activity.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 from django.db.models import Count
@@ -48,8 +49,8 @@ python2.7 manage.py client_activity jesstess@zulip.com"""
         counts.sort()
 
         for count in counts:
-            print "%25s %15d" % (count[1], count[0])
-        print "Total:", total
+            print("%25s %15d" % (count[1], count[0]))
+        print("Total:", total)
 
 
     def handle(self, *args, **options):
@@ -70,5 +71,5 @@ python2.7 manage.py client_activity jesstess@zulip.com"""
                     self.compute_activity(UserActivity.objects.filter(
                             user_profile__realm=realm))
                 except Realm.DoesNotExist:
-                    print "Unknown user or domain %s" % (arg,)
+                    print("Unknown user or domain %s" % (arg,))
                     exit(1)

--- a/analytics/management/commands/realm_stats.py
+++ b/analytics/management/commands/realm_stats.py
@@ -71,7 +71,7 @@ class Command(BaseCommand):
         if options['realms']:
             try:
                 realms = [get_realm(domain) for domain in options['realms']]
-            except Realm.DoesNotExist, e:
+            except Realm.DoesNotExist as e:
                 print e
                 exit(1)
         else:

--- a/analytics/management/commands/realm_stats.py
+++ b/analytics/management/commands/realm_stats.py
@@ -106,12 +106,11 @@ class Command(BaseCommand):
                 print("%d messages sent via the API" % (self.api_messages(realm, days_ago),))
                 print("%d group private messages" % (self.group_private_messages(realm, days_ago),))
 
-            num_notifications_enabled = len(filter(lambda x: x.enable_desktop_notifications == True,
-                                                   active_users))
+            num_notifications_enabled = len([x for x in active_users if x.enable_desktop_notifications == True])
             self.report_percentage(num_notifications_enabled, num_active,
                                    "active users have desktop notifications enabled")
 
-            num_enter_sends = len(filter(lambda x: x.enter_sends, active_users))
+            num_enter_sends = len([x for x in active_users if x.enter_sends])
             self.report_percentage(num_enter_sends, num_active,
                                    "active users have enter-sends")
 

--- a/analytics/management/commands/realm_stats.py
+++ b/analytics/management/commands/realm_stats.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 import datetime
 import pytz
@@ -65,45 +66,45 @@ class Command(BaseCommand):
             fraction = 0.0
         else:
             fraction = numerator / float(denominator)
-        print "%.2f%% of" % (fraction * 100,), text
+        print("%.2f%% of" % (fraction * 100,), text)
 
     def handle(self, *args, **options):
         if options['realms']:
             try:
                 realms = [get_realm(domain) for domain in options['realms']]
             except Realm.DoesNotExist as e:
-                print e
+                print(e)
                 exit(1)
         else:
             realms = Realm.objects.all()
 
         for realm in realms:
-            print realm.domain
+            print(realm.domain)
 
             user_profiles = UserProfile.objects.filter(realm=realm, is_active=True)
             active_users = self.active_users(realm)
             num_active = len(active_users)
 
-            print "%d active users (%d total)" % (num_active, len(user_profiles))
+            print("%d active users (%d total)" % (num_active, len(user_profiles)))
             streams = Stream.objects.filter(realm=realm).extra(
                 tables=['zerver_subscription', 'zerver_recipient'],
                 where=['zerver_subscription.recipient_id = zerver_recipient.id',
                        'zerver_recipient.type = 2',
                        'zerver_recipient.type_id = zerver_stream.id',
                        'zerver_subscription.active = true']).annotate(count=Count("name"))
-            print "%d streams" % (streams.count(),)
+            print("%d streams" % (streams.count(),))
 
             for days_ago in (1, 7, 30):
-                print "In last %d days, users sent:" % (days_ago,)
+                print("In last %d days, users sent:" % (days_ago,))
                 sender_quantities = [self.messages_sent_by(user, days_ago) for user in user_profiles]
                 for quantity in sorted(sender_quantities, reverse=True):
-                    print quantity,
-                print ""
+                    print(quantity, end=' ')
+                print("")
 
-                print "%d stream messages" % (self.stream_messages(realm, days_ago),)
-                print "%d one-on-one private messages" % (self.private_messages(realm, days_ago),)
-                print "%d messages sent via the API" % (self.api_messages(realm, days_ago),)
-                print "%d group private messages" % (self.group_private_messages(realm, days_ago),)
+                print("%d stream messages" % (self.stream_messages(realm, days_ago),))
+                print("%d one-on-one private messages" % (self.private_messages(realm, days_ago),))
+                print("%d messages sent via the API" % (self.api_messages(realm, days_ago),))
+                print("%d group private messages" % (self.group_private_messages(realm, days_ago),))
 
             num_notifications_enabled = len(filter(lambda x: x.enable_desktop_notifications == True,
                                                    active_users))
@@ -124,8 +125,8 @@ class Command(BaseCommand):
             starrers = UserMessage.objects.filter(user_profile__in=user_profiles,
                                                   flags=UserMessage.flags.starred).values(
                 "user_profile").annotate(count=Count("user_profile"))
-            print "%d users have starred %d messages" % (
-                len(starrers), sum([elt["count"] for elt in starrers]))
+            print("%d users have starred %d messages" % (
+                len(starrers), sum([elt["count"] for elt in starrers])))
 
             active_user_subs = Subscription.objects.filter(
                 user_profile__in=user_profiles, active=True)
@@ -133,20 +134,20 @@ class Command(BaseCommand):
             # Streams not in home view
             non_home_view = active_user_subs.filter(in_home_view=False).values(
                 "user_profile").annotate(count=Count("user_profile"))
-            print "%d users have %d streams not in home view" % (
-                len(non_home_view), sum([elt["count"] for elt in non_home_view]))
+            print("%d users have %d streams not in home view" % (
+                len(non_home_view), sum([elt["count"] for elt in non_home_view])))
 
             # Code block markup
             markup_messages = human_messages.filter(
                 sender__realm=realm, content__contains="~~~").values(
                 "sender").annotate(count=Count("sender"))
-            print "%d users have used code block markup on %s messages" % (
-                len(markup_messages), sum([elt["count"] for elt in markup_messages]))
+            print("%d users have used code block markup on %s messages" % (
+                len(markup_messages), sum([elt["count"] for elt in markup_messages])))
 
             # Notifications for stream messages
             notifications = active_user_subs.filter(notifications=True).values(
                 "user_profile").annotate(count=Count("user_profile"))
-            print "%d users receive desktop notifications for %d streams" % (
-                len(notifications), sum([elt["count"] for elt in notifications]))
+            print("%d users receive desktop notifications for %d streams" % (
+                len(notifications), sum([elt["count"] for elt in notifications])))
 
-            print ""
+            print("")

--- a/analytics/management/commands/stream_stats.py
+++ b/analytics/management/commands/stream_stats.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 from django.db.models import Q
@@ -16,25 +17,25 @@ class Command(BaseCommand):
             try:
                 realms = [get_realm(domain) for domain in options['realms']]
             except Realm.DoesNotExist as e:
-                print e
+                print(e)
                 exit(1)
         else:
             realms = Realm.objects.all()
 
         for realm in realms:
-            print realm.domain
-            print "------------"
-            print "%25s %15s %10s" % ("stream", "subscribers", "messages")
+            print(realm.domain)
+            print("------------")
+            print("%25s %15s %10s" % ("stream", "subscribers", "messages"))
             streams = Stream.objects.filter(realm=realm).exclude(Q(name__istartswith="tutorial-"))
             invite_only_count = 0
             for stream in streams:
                 if stream.invite_only:
                     invite_only_count += 1
                     continue
-                print "%25s" % (stream.name,),
+                print("%25s" % (stream.name,), end=' ')
                 recipient = Recipient.objects.filter(type=Recipient.STREAM, type_id=stream.id)
-                print "%10d" % (len(Subscription.objects.filter(recipient=recipient, active=True)),),
+                print("%10d" % (len(Subscription.objects.filter(recipient=recipient, active=True)),), end=' ')
                 num_messages = len(Message.objects.filter(recipient=recipient))
-                print "%12d" % (num_messages,)
-            print "%d invite-only streams" % (invite_only_count,)
-            print ""
+                print("%12d" % (num_messages,))
+            print("%d invite-only streams" % (invite_only_count,))
+            print("")

--- a/analytics/management/commands/stream_stats.py
+++ b/analytics/management/commands/stream_stats.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         if options['realms']:
             try:
                 realms = [get_realm(domain) for domain in options['realms']]
-            except Realm.DoesNotExist, e:
+            except Realm.DoesNotExist as e:
                 print e
                 exit(1)
         else:

--- a/analytics/management/commands/user_stats.py
+++ b/analytics/management/commands/user_stats.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 import datetime
 import pytz
@@ -23,19 +24,19 @@ class Command(BaseCommand):
             try:
                 realms = [get_realm(domain) for domain in options['realms']]
             except Realm.DoesNotExist as e:
-                print e
+                print(e)
                 exit(1)
         else:
             realms = Realm.objects.all()
 
         for realm in realms:
-            print realm.domain
+            print(realm.domain)
             user_profiles = UserProfile.objects.filter(realm=realm, is_active=True)
-            print "%d users" % (len(user_profiles),)
-            print "%d streams" % (len(Stream.objects.filter(realm=realm)),)
+            print("%d users" % (len(user_profiles),))
+            print("%d streams" % (len(Stream.objects.filter(realm=realm)),))
 
             for user_profile in user_profiles:
-                print "%35s" % (user_profile.email,),
+                print("%35s" % (user_profile.email,), end=' ')
                 for week in range(10):
-                    print "%5d" % (self.messages_sent_by(user_profile, week)),
-                print ""
+                    print("%5d" % (self.messages_sent_by(user_profile, week)), end=' ')
+                print("")

--- a/analytics/management/commands/user_stats.py
+++ b/analytics/management/commands/user_stats.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         if options['realms']:
             try:
                 realms = [get_realm(domain) for domain in options['realms']]
-            except Realm.DoesNotExist, e:
+            except Realm.DoesNotExist as e:
                 print e
                 exit(1)
         else:

--- a/analytics/management/commands/user_stats.py
+++ b/analytics/management/commands/user_stats.py
@@ -6,6 +6,7 @@ import pytz
 
 from django.core.management.base import BaseCommand
 from zerver.models import UserProfile, Realm, Stream, Message, get_realm
+from six.moves import range
 
 class Command(BaseCommand):
     help = "Generate statistics on user activity."

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -18,6 +18,7 @@ import re
 import pytz
 from six.moves import filter
 from six.moves import map
+from six.moves import range
 eastern_tz = pytz.timezone('US/Eastern')
 
 def make_table(title, cols, rows, has_row_class=False):

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django.db import connection
 from django.template import RequestContext, loader
 from django.utils.html import mark_safe
@@ -15,6 +16,7 @@ import itertools
 import time
 import re
 import pytz
+from six.moves import filter
 eastern_tz = pytz.timezone('US/Eastern')
 
 def make_table(title, cols, rows, has_row_class=False):
@@ -226,7 +228,7 @@ def realm_summary_table(realm_minutes):
     def meets_goal(row):
         return row['active_user_count'] >= 5
 
-    num_active_sites = len(filter(meets_goal, rows))
+    num_active_sites = len(list(filter(meets_goal, rows)))
 
     # create totals
     total_active_user_count = 0

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -17,6 +17,7 @@ import time
 import re
 import pytz
 from six.moves import filter
+from six.moves import map
 eastern_tz = pytz.timezone('US/Eastern')
 
 def make_table(title, cols, rows, has_row_class=False):
@@ -24,7 +25,7 @@ def make_table(title, cols, rows, has_row_class=False):
     if not has_row_class:
         def fix_row(row):
             return dict(cells=row, row_class=None)
-        rows = map(fix_row, rows)
+        rows = list(map(fix_row, rows))
 
     data = dict(title=title, cols=cols, rows=rows)
 
@@ -377,7 +378,7 @@ def ad_hoc_queries():
         cursor = connection.cursor()
         cursor.execute(query)
         rows = cursor.fetchall()
-        rows = map(list, rows)
+        rows = list(map(list, rows))
         cursor.close()
 
         def fix_rows(i, fixup_func):
@@ -611,7 +612,7 @@ def raw_user_activity_table(records):
                 format_date_for_activity_reports(record.last_visit)
         ]
 
-    rows = map(row, records)
+    rows = list(map(row, records))
     title = 'Raw Data'
     return make_table(title, cols, rows)
 

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -19,6 +19,7 @@ import pytz
 from six.moves import filter
 from six.moves import map
 from six.moves import range
+from six.moves import zip
 eastern_tz = pytz.timezone('US/Eastern')
 
 def make_table(title, cols, rows, has_row_class=False):
@@ -41,7 +42,7 @@ def dictfetchall(cursor):
     "Returns all rows from a cursor as a dict"
     desc = cursor.description
     return [
-        dict(zip([col[0] for col in desc], row))
+        dict(list(zip([col[0] for col in desc], row)))
         for row in cursor.fetchall()
     ]
 

--- a/api/integrations/hg/zulip-changegroup.py
+++ b/api/integrations/hg/zulip-changegroup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Zulip hook for Mercurial changeset pushes.
-# Copyright © 2012-2014 Zulip, Inc.
+# Copyright Â© 2012-2014 Zulip, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,10 @@
 #
 # This hook is called when changesets are pushed to the master repository (ie
 # `hg push`). See https://zulip.com/integrations for installation instructions.
+from __future__ import absolute_import
 
 import zulip
+from six.moves import range
 
 VERSION = "0.9"
 

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -575,7 +575,7 @@ def gitBranchExists(branch):
 _gitConfig = {}
 
 def gitConfig(key):
-    if not _gitConfig.has_key(key):
+    if key not in _gitConfig:
         cmd = [ "git", "config", key ]
         s = read_pipe(cmd, ignore_error=True)
         _gitConfig[key] = s.strip()
@@ -586,7 +586,7 @@ def gitConfigBool(key):
        variable is set to true, and False if set to false or not present
        in the config."""
 
-    if not _gitConfig.has_key(key):
+    if key not in _gitConfig:
         cmd = [ "git", "config", "--bool", key ]
         s = read_pipe(cmd, ignore_error=True)
         v = s.strip()
@@ -594,7 +594,7 @@ def gitConfigBool(key):
     return _gitConfig[key]
 
 def gitConfigList(key):
-    if not _gitConfig.has_key(key):
+    if key not in _gitConfig:
         s = read_pipe(["git", "config", "--get-all", key], ignore_error=True)
         _gitConfig[key] = s.strip().split(os.linesep)
     return _gitConfig[key]
@@ -650,7 +650,7 @@ def findUpstreamBranchPoint(head = "HEAD"):
         tip = branches[branch]
         log = extractLogMessageFromGitCommit(tip)
         settings = extractSettingsGitLog(log)
-        if settings.has_key("depot-paths"):
+        if "depot-paths" in settings:
             paths = ",".join(settings["depot-paths"])
             branchByDepotPath[paths] = "remotes/p4/" + branch
 
@@ -660,9 +660,9 @@ def findUpstreamBranchPoint(head = "HEAD"):
         commit = head + "~%s" % parent
         log = extractLogMessageFromGitCommit(commit)
         settings = extractSettingsGitLog(log)
-        if settings.has_key("depot-paths"):
+        if "depot-paths" in settings:
             paths = ",".join(settings["depot-paths"])
-            if branchByDepotPath.has_key(paths):
+            if paths in branchByDepotPath:
                 return [branchByDepotPath[paths], settings]
 
         parent = parent + 1
@@ -686,8 +686,8 @@ def createOrUpdateBranchesFromOrigin(localRefPrefix = "refs/remotes/p4/", silent
         originHead = line
 
         original = extractSettingsGitLog(extractLogMessageFromGitCommit(originHead))
-        if (not original.has_key('depot-paths')
-            or not original.has_key('change')):
+        if ('depot-paths' not in original
+            or 'change' not in original):
             continue
 
         update = False
@@ -697,7 +697,7 @@ def createOrUpdateBranchesFromOrigin(localRefPrefix = "refs/remotes/p4/", silent
             update = True
         else:
             settings = extractSettingsGitLog(extractLogMessageFromGitCommit(remoteHead))
-            if settings.has_key('change') > 0:
+            if ('change' in settings) > 0:
                 if settings['depot-paths'] == original['depot-paths']:
                     originP4Change = int(original['change'])
                     p4Change = int(settings['change'])
@@ -836,7 +836,7 @@ class P4UserMap:
 
         results = p4CmdList("user -o")
         for r in results:
-            if r.has_key('User'):
+            if 'User' in r:
                 self.myP4UserId = r['User']
                 return r['User']
         die("Could not find your p4 user id")
@@ -860,7 +860,7 @@ class P4UserMap:
         self.emails = {}
 
         for output in p4CmdList("users"):
-            if not output.has_key("User"):
+            if "User" not in output:
                 continue
             self.users[output["User"]] = output["FullName"] + " <" + output["Email"] + ">"
             self.emails[output["Email"]] = output["User"]
@@ -1081,7 +1081,7 @@ class P4Submit(Command, P4UserMap):
         gitEmail = read_pipe(["git", "log", "--max-count=1",
                               "--format=%ae", id])
         gitEmail = gitEmail.strip()
-        if not self.emails.has_key(gitEmail):
+        if gitEmail not in self.emails:
             return (None,gitEmail)
         else:
             return (self.emails[gitEmail],gitEmail)
@@ -1105,14 +1105,14 @@ class P4Submit(Command, P4UserMap):
         results = p4CmdList("client -o")        # find the current client
         client = None
         for r in results:
-            if r.has_key('Client'):
+            if 'Client' in r:
                 client = r['Client']
                 break
         if not client:
             die("could not get client spec")
         results = p4CmdList(["changes", "-c", client, "-m", "1"])
         for r in results:
-            if r.has_key('change'):
+            if 'change' in r:
                 return r['change']
         die("Could not get changelist number for last submit - cannot patch up user details")
 
@@ -1130,10 +1130,10 @@ class P4Submit(Command, P4UserMap):
 
         result = p4CmdList("change -f -i", stdin=input)
         for r in result:
-            if r.has_key('code'):
+            if 'code' in r:
                 if r['code'] == 'error':
                     die("Could not modify user field of changelist %s to %s:%s" % (changelist, newUser, r['data']))
-            if r.has_key('data'):
+            if 'data' in r:
                 print("Updated user field for changelist %s to %s" % (changelist, newUser))
                 return
         die("Could not modify user field of changelist %s to %s" % (changelist, newUser))
@@ -1143,7 +1143,7 @@ class P4Submit(Command, P4UserMap):
         # which are required to modify changelists.
         results = p4CmdList(["protects", self.depotPath])
         for r in results:
-            if r.has_key('perm'):
+            if 'perm' in r:
                 if r['perm'] == 'admin':
                     return 1
                 if r['perm'] == 'super':
@@ -1195,7 +1195,7 @@ class P4Submit(Command, P4UserMap):
         mtime = os.stat(template_file).st_mtime
 
         # invoke the editor
-        if os.environ.has_key("P4EDITOR") and (os.environ.get("P4EDITOR") != ""):
+        if "P4EDITOR" in os.environ and (os.environ.get("P4EDITOR") != ""):
             editor = os.environ.get("P4EDITOR")
         else:
             editor = read_pipe("git var GIT_EDITOR").strip()
@@ -1379,7 +1379,7 @@ class P4Submit(Command, P4UserMap):
         separatorLine = "######## everything below this line is just the diff #######\n"
 
         # diff
-        if os.environ.has_key("P4DIFF"):
+        if "P4DIFF" in os.environ:
             del(os.environ["P4DIFF"])
         diff = ""
         for editedFile in editedFiles:
@@ -1503,7 +1503,7 @@ class P4Submit(Command, P4UserMap):
             logMessage = extractLogMessageFromGitCommit(name)
             values = extractSettingsGitLog(logMessage)
 
-            if not values.has_key('change'):
+            if 'change' not in values:
                 # a tag pointing to something not sent to p4; ignore
                 if verbose:
                     print "git tag %s does not give a p4 commit" % name
@@ -1939,7 +1939,7 @@ class P4Sync(Command, P4UserMap):
                              for path in self.cloneExclude]
         files = []
         fnum = 0
-        while commit.has_key("depotFile%s" % fnum):
+        while "depotFile%s" % fnum in commit:
             path =  commit["depotFile%s" % fnum]
 
             if [p for p in self.cloneExclude
@@ -2003,7 +2003,7 @@ class P4Sync(Command, P4UserMap):
 
         branches = {}
         fnum = 0
-        while commit.has_key("depotFile%s" % fnum):
+        while "depotFile%s" % fnum in commit:
             path =  commit["depotFile%s" % fnum]
             found = [p for p in self.depotPaths
                      if p4PathStartsWith(path, p)]
@@ -2141,7 +2141,7 @@ class P4Sync(Command, P4UserMap):
             else:
                 die("Error from p4 print: %s" % err)
 
-        if marshalled.has_key('depotFile') and self.stream_have_file_info:
+        if 'depotFile' in marshalled and self.stream_have_file_info:
             # start of a new file - output the old one first
             self.streamOneP4File(self.stream_file, self.stream_contents)
             self.stream_file = {}
@@ -2197,7 +2197,7 @@ class P4Sync(Command, P4UserMap):
                       cb=streamP4FilesCbSelf)
 
             # do the last chunk
-            if self.stream_file.has_key('depotFile'):
+            if 'depotFile' in self.stream_file:
                 self.streamOneP4File(self.stream_file, self.stream_contents)
 
     def make_email(self, userid):
@@ -2213,7 +2213,7 @@ class P4Sync(Command, P4UserMap):
         gitStream.write("tag %s\n" % labelName)
         gitStream.write("from %s\n" % commit)
 
-        if labelDetails.has_key('Owner'):
+        if 'Owner' in labelDetails:
             owner = labelDetails["Owner"]
         else:
             owner = None
@@ -2229,7 +2229,7 @@ class P4Sync(Command, P4UserMap):
         gitStream.write("tagger %s\n" % tagger)
 
         print "labelDetails=",labelDetails
-        if labelDetails.has_key('Description'):
+        if 'Description' in labelDetails:
             description = labelDetails['Description']
         else:
             description = 'Label from git p4'
@@ -2285,7 +2285,7 @@ class P4Sync(Command, P4UserMap):
 
         change = int(details["change"])
 
-        if self.labels.has_key(change):
+        if change in self.labels:
             label = self.labels[change]
             labelDetails = label[0]
             labelRevisions = label[1]
@@ -2374,7 +2374,7 @@ class P4Sync(Command, P4UserMap):
             change = p4Cmd(["changes", "-m", "1"] + ["%s...@%s" % (p, name)
                                 for p in self.depotPaths])
 
-            if change.has_key('change'):
+            if 'change' in change:
                 # find the corresponding git commit; take the oldest commit
                 changelist = int(change['change'])
                 gitCommit = read_pipe(["git", "rev-list", "--max-count=1",
@@ -2427,7 +2427,7 @@ class P4Sync(Command, P4UserMap):
         for info in p4CmdList(command):
             details = p4Cmd(["branch", "-o", info["branch"]])
             viewIdx = 0
-            while details.has_key("View%s" % viewIdx):
+            while "View%s" % viewIdx in details:
                 paths = details["View%s" % viewIdx].split(" ")
                 viewIdx = viewIdx + 1
                 # require standard //depot/foo/... //depot/bar/... mapping
@@ -2493,7 +2493,7 @@ class P4Sync(Command, P4UserMap):
         d["options"] = ' '.join(sorted(option_keys.keys()))
 
     def readOptions(self, d):
-        self.keepRepoPath = (d.has_key('options')
+        self.keepRepoPath = ('options' in d
                              and ('keepRepoPath' in d['options']))
 
     def gitRefForBranch(self, branch):
@@ -2794,8 +2794,8 @@ class P4Sync(Command, P4UserMap):
                 settings = extractSettingsGitLog(logMsg)
 
                 self.readOptions(settings)
-                if (settings.has_key('depot-paths')
-                    and settings.has_key ('change')):
+                if ('depot-paths' in settings
+                    and 'change' in settings):
                     change = int(settings['change']) + 1
                     p4Change = max(p4Change, change)
 

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -13,6 +13,7 @@ import sys
 import six
 from six.moves import input
 from six.moves import range
+from six.moves import zip
 if sys.hexversion < 0x02040000:
     # The limiter is the subprocess module
     sys.stderr.write("git-p4: requires Python 2.4 or later.\n")

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -2807,7 +2807,7 @@ class P4Sync(Command, P4UserMap):
                             prev_list = prev.split("/")
                             cur_list = cur.split("/")
                             for i in range(0, min(len(cur_list), len(prev_list))):
-                                if cur_list[i] <> prev_list[i]:
+                                if cur_list[i] != prev_list[i]:
                                     i = i - 1
                                     break
 

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -52,7 +52,7 @@ def p4_build_cmd(cmd):
     """
     real_cmd = ["p4"]
 
-    if isinstance(cmd,basestring):
+    if isinstance(cmd, basestring):
         real_cmd = ' '.join(real_cmd) + ' ' + cmd
     else:
         real_cmd += cmd
@@ -91,7 +91,7 @@ def write_pipe(c, stdin):
     if verbose:
         sys.stderr.write('Writing pipe: %s\n' % str(c))
 
-    expand = isinstance(c,basestring)
+    expand = isinstance(c, basestring)
     p = subprocess.Popen(c, stdin=subprocess.PIPE, shell=expand)
     pipe = p.stdin
     val = pipe.write(stdin)
@@ -109,7 +109,7 @@ def read_pipe(c, ignore_error=False):
     if verbose:
         sys.stderr.write('Reading pipe: %s\n' % str(c))
 
-    expand = isinstance(c,basestring)
+    expand = isinstance(c, basestring)
     p = subprocess.Popen(c, stdout=subprocess.PIPE, shell=expand)
     pipe = p.stdout
     val = pipe.read()
@@ -169,7 +169,7 @@ def p4_has_move_command():
     return True
 
 def system(cmd):
-    expand = isinstance(cmd,basestring)
+    expand = isinstance(cmd, basestring)
     if verbose:
         sys.stderr.write("executing %s\n" % str(cmd))
     retcode = subprocess.call(cmd, shell=expand)
@@ -356,7 +356,7 @@ def getP4OpenedType(file):
 # Return the set of all p4 labels
 def getP4Labels(depotPaths):
     labels = set()
-    if isinstance(depotPaths,basestring):
+    if isinstance(depotPaths, basestring):
         depotPaths = [depotPaths]
 
     for l in p4CmdList(["labels"] + ["%s..." % p for p in depotPaths]):
@@ -423,7 +423,7 @@ def isModeExecChanged(src_mode, dst_mode):
 
 def p4CmdList(cmd, stdin=None, stdin_mode='w+b', cb=None):
 
-    if isinstance(cmd,basestring):
+    if isinstance(cmd, basestring):
         cmd = "-G " + cmd
         expand = True
     else:
@@ -440,7 +440,7 @@ def p4CmdList(cmd, stdin=None, stdin_mode='w+b', cb=None):
     stdin_file = None
     if stdin is not None:
         stdin_file = tempfile.TemporaryFile(prefix='p4-stdin', mode=stdin_mode)
-        if isinstance(stdin,basestring):
+        if isinstance(stdin, basestring):
             stdin_file.write(stdin)
         else:
             for i in stdin:
@@ -1074,21 +1074,21 @@ class P4Submit(Command, P4UserMap):
 
         print "Patched up RCS keywords in %s" % file
 
-    def p4UserForCommit(self,id):
+    def p4UserForCommit(self, id):
         # Return the tuple (perforce user,git email) for a given git commit id
         self.getUserMapFromPerforceServer()
         gitEmail = read_pipe(["git", "log", "--max-count=1",
                               "--format=%ae", id])
         gitEmail = gitEmail.strip()
         if gitEmail not in self.emails:
-            return (None,gitEmail)
+            return (None, gitEmail)
         else:
-            return (self.emails[gitEmail],gitEmail)
+            return (self.emails[gitEmail], gitEmail)
 
-    def checkValidP4Users(self,commits):
+    def checkValidP4Users(self, commits):
         # check if any git authors cannot be mapped to p4 users
         for id in commits:
-            (user,email) = self.p4UserForCommit(id)
+            (user, email) = self.p4UserForCommit(id)
             if not user:
                 msg = "Cannot find p4 user for email %s in commit %s." % (email, id)
                 if gitConfigBool("git-p4.allowMissingP4Users"):
@@ -1322,7 +1322,7 @@ class P4Submit(Command, P4UserMap):
 
                 for file in kwfiles:
                     if verbose:
-                        print "zapping %s with %s" % (line,pattern)
+                        print "zapping %s with %s" % (line, pattern)
                     # File is being deleted, so not open in p4.  Must
                     # disable the read-only bit on windows.
                     if self.isWindows and file not in editedFiles:
@@ -2227,7 +2227,7 @@ class P4Sync(Command, P4UserMap):
 
         gitStream.write("tagger %s\n" % tagger)
 
-        print "labelDetails=",labelDetails
+        print "labelDetails=", labelDetails
         if 'Description' in labelDetails:
             description = labelDetails['Description']
         else:
@@ -2361,7 +2361,7 @@ class P4Sync(Command, P4UserMap):
 
             if not m.match(name):
                 if verbose:
-                    print "label %s does not match regexp %s" % (name,validLabelRegexp)
+                    print "label %s does not match regexp %s" % (name, validLabelRegexp)
                 continue
 
             if name in ignoredP4Labels:
@@ -2673,7 +2673,7 @@ class P4Sync(Command, P4UserMap):
         newestRevision = 0
 
         fileCnt = 0
-        fileArgs = ["%s...%s" % (p,revision) for p in self.depotPaths]
+        fileArgs = ["%s...%s" % (p, revision) for p in self.depotPaths]
 
         for info in p4CmdList(["files"] + fileArgs):
 

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -731,8 +731,7 @@ def p4ChangesForPaths(depotPaths, changeRange):
         changeNum = int(line.split(" ")[1])
         changes[changeNum] = True
 
-    changelist = changes.keys()
-    changelist.sort()
+    changelist = sorted(changes.keys())
     return changelist
 
 def p4PathStartsWith(path, prefix):

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 import sys
 import six
 from six.moves import input
+from six.moves import range
 if sys.hexversion < 0x02040000:
     # The limiter is the subprocess module
     sys.stderr.write("git-p4: requires Python 2.4 or later.\n")

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -7,6 +7,7 @@
 #            2007 Trolltech ASA
 # License: MIT <http://www.opensource.org/licenses/mit-license.php>
 #
+from __future__ import print_function
 import sys
 if sys.hexversion < 0x02040000:
     # The limiter is the subprocess module
@@ -693,7 +694,7 @@ def createOrUpdateBranchesFromOrigin(localRefPrefix = "refs/remotes/p4/", silent
         update = False
         if not gitBranchExists(remoteHead):
             if verbose:
-                print "creating %s" % remoteHead
+                print("creating %s" % remoteHead)
             update = True
         else:
             settings = extractSettingsGitLog(extractLogMessageFromGitCommit(remoteHead))
@@ -895,9 +896,9 @@ class P4Debug(Command):
     def run(self, args):
         j = 0
         for output in p4CmdList(args):
-            print 'Element: %d' % j
+            print('Element: %d' % j)
             j += 1
-            print output
+            print(output)
         return True
 
 class P4RollBack(Command):
@@ -938,14 +939,14 @@ class P4RollBack(Command):
 
                 if len(p4Cmd("changes -m 1 "  + ' '.join (['%s...@%s' % (p, maxChange)
                                                            for p in depotPaths]))) == 0:
-                    print "Branch %s did not exist at change %s, deleting." % (ref, maxChange)
+                    print("Branch %s did not exist at change %s, deleting." % (ref, maxChange))
                     system("git update-ref -d %s `git rev-parse %s`" % (ref, ref))
                     continue
 
                 while change and int(change) > maxChange:
                     changed = True
                     if self.verbose:
-                        print "%s is at %s ; rewinding towards %s" % (ref, change, maxChange)
+                        print("%s is at %s ; rewinding towards %s" % (ref, change, maxChange))
                     system("git update-ref %s \"%s^\"" % (ref, ref))
                     log = extractLogMessageFromGitCommit(ref)
                     settings =  extractSettingsGitLog(log)
@@ -955,7 +956,7 @@ class P4RollBack(Command):
                     change = settings['change']
 
                 if changed:
-                    print "%s rewound to %s" % (ref, change)
+                    print("%s rewound to %s" % (ref, change))
 
         return True
 
@@ -1069,10 +1070,10 @@ class P4Submit(Command, P4UserMap):
         except:
             # cleanup our temporary file
             os.unlink(outFileName)
-            print "Failed to strip RCS keywords in %s" % file
+            print("Failed to strip RCS keywords in %s" % file)
             raise
 
-        print "Patched up RCS keywords in %s" % file
+        print("Patched up RCS keywords in %s" % file)
 
     def p4UserForCommit(self, id):
         # Return the tuple (perforce user,git email) for a given git commit id
@@ -1092,7 +1093,7 @@ class P4Submit(Command, P4UserMap):
             if not user:
                 msg = "Cannot find p4 user for email %s in commit %s." % (email, id)
                 if gitConfigBool("git-p4.allowMissingP4Users"):
-                    print "%s" % msg
+                    print("%s" % msg)
                 else:
                     die("Error: %s\nSet git-p4.allowMissingP4Users to true to allow this." % msg)
 
@@ -1219,8 +1220,8 @@ class P4Submit(Command, P4UserMap):
     def applyCommit(self, id):
         """Apply one commit, return True if it succeeded."""
 
-        print "Applying", read_pipe(["git", "show", "-s",
-                                     "--format=format:%h %s", id])
+        print("Applying", read_pipe(["git", "show", "-s",
+                                     "--format=format:%h %s", id]))
 
         (p4User, gitEmail) = self.p4UserForCommit(id)
 
@@ -1298,7 +1299,7 @@ class P4Submit(Command, P4UserMap):
         if os.system(tryPatchCmd) != 0:
             fixed_rcs_keywords = False
             patch_succeeded = False
-            print "Unfortunately applying the change failed!"
+            print("Unfortunately applying the change failed!")
 
             # Patch failed, maybe it's just RCS keyword woes. Look through
             # the patch to see if that's possible.
@@ -1316,13 +1317,13 @@ class P4Submit(Command, P4UserMap):
                         for line in read_pipe_lines(["git", "diff", "%s^..%s" % (id, id), file]):
                             if regexp.search(line):
                                 if verbose:
-                                    print "got keyword match on %s in %s in %s" % (pattern, line, file)
+                                    print("got keyword match on %s in %s in %s" % (pattern, line, file))
                                 kwfiles[file] = pattern
                                 break
 
                 for file in kwfiles:
                     if verbose:
-                        print "zapping %s with %s" % (line, pattern)
+                        print("zapping %s with %s" % (line, pattern))
                     # File is being deleted, so not open in p4.  Must
                     # disable the read-only bit on windows.
                     if self.isWindows and file not in editedFiles:
@@ -1331,7 +1332,7 @@ class P4Submit(Command, P4UserMap):
                     fixed_rcs_keywords = True
 
             if fixed_rcs_keywords:
-                print "Retrying the patch with RCS keywords cleaned up"
+                print("Retrying the patch with RCS keywords cleaned up")
                 if os.system(tryPatchCmd) == 0:
                     patch_succeeded = True
 
@@ -1411,34 +1412,34 @@ class P4Submit(Command, P4UserMap):
             # Leave the p4 tree prepared, and the submit template around
             # and let the user decide what to do next
             #
-            print
-            print "P4 workspace prepared for submission."
-            print "To submit or revert, go to client workspace"
-            print "  " + self.clientPath
-            print
-            print "To submit, use \"p4 submit\" to write a new description,"
-            print "or \"p4 submit -i %s\" to use the one prepared by" \
-                  " \"git p4\"." % fileName
-            print "You can delete the file \"%s\" when finished." % fileName
+            print()
+            print("P4 workspace prepared for submission.")
+            print("To submit or revert, go to client workspace")
+            print("  " + self.clientPath)
+            print()
+            print("To submit, use \"p4 submit\" to write a new description,")
+            print("or \"p4 submit -i %s\" to use the one prepared by" \
+                  " \"git p4\"." % fileName)
+            print("You can delete the file \"%s\" when finished." % fileName)
 
             if self.preserveUser and p4User and not self.p4UserIsMe(p4User):
-                print "To preserve change ownership by user %s, you must\n" \
+                print("To preserve change ownership by user %s, you must\n" \
                       "do \"p4 change -f <change>\" after submitting and\n" \
-                      "edit the User field."
+                      "edit the User field.")
             if pureRenameCopy:
-                print "After submitting, renamed files must be re-synced."
-                print "Invoke \"p4 sync -f\" on each of these files:"
+                print("After submitting, renamed files must be re-synced.")
+                print("Invoke \"p4 sync -f\" on each of these files:")
                 for f in pureRenameCopy:
-                    print "  " + f
+                    print("  " + f)
 
-            print
-            print "To revert the changes, use \"p4 revert ...\", and delete"
-            print "the submit template file \"%s\"" % fileName
+            print()
+            print("To revert the changes, use \"p4 revert ...\", and delete")
+            print("the submit template file \"%s\"" % fileName)
             if filesToAdd:
-                print "Since the commit adds new files, they must be deleted:"
+                print("Since the commit adds new files, they must be deleted:")
                 for f in filesToAdd:
-                    print "  " + f
-            print
+                    print("  " + f)
+            print()
             return True
 
         #
@@ -1471,7 +1472,7 @@ class P4Submit(Command, P4UserMap):
         else:
             # skip this patch
             ret = False
-            print "Submission cancelled, undoing p4 changes."
+            print("Submission cancelled, undoing p4 changes.")
             for f in editedFiles:
                 p4_revert(f)
             for f in filesToAdd:
@@ -1495,7 +1496,7 @@ class P4Submit(Command, P4UserMap):
 
             if not m.match(name):
                 if verbose:
-                    print "tag %s does not match regexp %s" % (name, validLabelRegexp)
+                    print("tag %s does not match regexp %s" % (name, validLabelRegexp))
                 continue
 
             # Get the p4 commit this corresponds to
@@ -1505,7 +1506,7 @@ class P4Submit(Command, P4UserMap):
             if 'change' not in values:
                 # a tag pointing to something not sent to p4; ignore
                 if verbose:
-                    print "git tag %s does not give a p4 commit" % name
+                    print("git tag %s does not give a p4 commit" % name)
                 continue
             else:
                 changelist = values['change']
@@ -1540,10 +1541,10 @@ class P4Submit(Command, P4UserMap):
                 labelTemplate += "\t%s\n" % depot_side
 
             if self.dry_run:
-                print "Would create p4 label %s for tag" % name
+                print("Would create p4 label %s for tag" % name)
             elif self.prepare_p4_only:
-                print "Not creating p4 label %s for tag due to option" \
-                      " --prepare-p4-only" % name
+                print("Not creating p4 label %s for tag due to option" \
+                      " --prepare-p4-only" % name)
             else:
                 p4_write_pipe(["label", "-i"], labelTemplate)
 
@@ -1552,7 +1553,7 @@ class P4Submit(Command, P4UserMap):
                           ["%s@%s" % (depot_side, changelist) for depot_side in clientSpec.mappings])
 
                 if verbose:
-                    print "created p4 label for tag %s" % name
+                    print("created p4 label for tag %s" % name)
 
     def run(self, args):
         if len(args) == 0:
@@ -1590,10 +1591,10 @@ class P4Submit(Command, P4UserMap):
             self.conflict_behavior = val
 
         if self.verbose:
-            print "Origin branch is " + self.origin
+            print("Origin branch is " + self.origin)
 
         if len(self.depotPath) == 0:
-            print "Internal error: cannot locate perforce depot path from existing branches"
+            print("Internal error: cannot locate perforce depot path from existing branches")
             sys.exit(128)
 
         self.useClientSpec = False
@@ -1611,7 +1612,7 @@ class P4Submit(Command, P4UserMap):
         if self.clientPath == "":
             die("Error: Cannot locate perforce checkout of %s in client view" % self.depotPath)
 
-        print "Perforce checkout for depot path %s located at %s" % (self.depotPath, self.clientPath)
+        print("Perforce checkout for depot path %s located at %s" % (self.depotPath, self.clientPath))
         self.oldWorkingDirectory = os.getcwd()
 
         # ensure the clientPath exists
@@ -1622,9 +1623,9 @@ class P4Submit(Command, P4UserMap):
 
         chdir(self.clientPath, is_client_path=True)
         if self.dry_run:
-            print "Would synchronize p4 checkout in %s" % self.clientPath
+            print("Would synchronize p4 checkout in %s" % self.clientPath)
         else:
-            print "Synchronizing p4 checkout..."
+            print("Synchronizing p4 checkout...")
             if new_client_dir:
                 # old one was destroyed, and maybe nobody told p4
                 p4_sync("...", "-f")
@@ -1681,13 +1682,13 @@ class P4Submit(Command, P4UserMap):
         # continue to try the rest of the patches, or quit.
         #
         if self.dry_run:
-            print "Would apply"
+            print("Would apply")
         applied = []
         last = len(commits) - 1
         for i, commit in enumerate(commits):
             if self.dry_run:
-                print " ", read_pipe(["git", "show", "-s",
-                                      "--format=format:%h %s", commit])
+                print(" ", read_pipe(["git", "show", "-s",
+                                      "--format=format:%h %s", commit]))
                 ok = True
             else:
                 ok = self.applyCommit(commit)
@@ -1695,15 +1696,15 @@ class P4Submit(Command, P4UserMap):
                 applied.append(commit)
             else:
                 if self.prepare_p4_only and i < last:
-                    print "Processing only the first commit due to option" \
-                          " --prepare-p4-only"
+                    print("Processing only the first commit due to option" \
+                          " --prepare-p4-only")
                     break
                 if i < last:
                     quit = False
                     while True:
                         # prompt for what to do, or use the option/variable
                         if self.conflict_behavior == "ask":
-                            print "What do you want to do?"
+                            print("What do you want to do?")
                             response = raw_input("[s]kip this commit but apply"
                                                  " the rest, or [q]uit? ")
                             if not response:
@@ -1717,10 +1718,10 @@ class P4Submit(Command, P4UserMap):
                                 self.conflict_behavior)
 
                         if response[0] == "s":
-                            print "Skipping this commit, but applying the rest"
+                            print("Skipping this commit, but applying the rest")
                             break
                         if response[0] == "q":
-                            print "Quitting"
+                            print("Quitting")
                             quit = True
                             break
                     if quit:
@@ -1733,7 +1734,7 @@ class P4Submit(Command, P4UserMap):
         elif self.prepare_p4_only:
             pass
         elif len(commits) == len(applied):
-            print "All commits applied!"
+            print("All commits applied!")
 
             sync = P4Sync()
             if self.branch:
@@ -1745,17 +1746,17 @@ class P4Submit(Command, P4UserMap):
 
         else:
             if len(applied) == 0:
-                print "No commits applied."
+                print("No commits applied.")
             else:
-                print "Applied only the commits marked with '*':"
+                print("Applied only the commits marked with '*':")
                 for c in commits:
                     if c in applied:
                         star = "*"
                     else:
                         star = " "
-                    print star, read_pipe(["git", "show", "-s",
-                                           "--format=format:%h %s",  c])
-                print "You will have to do 'git p4 sync' and rebase."
+                    print(star, read_pipe(["git", "show", "-s",
+                                           "--format=format:%h %s",  c]))
+                print("You will have to do 'git p4 sync' and rebase.")
 
         if gitConfigBool("git-p4.exportLabels"):
             self.exportLabels = True
@@ -1931,7 +1932,7 @@ class P4Sync(Command, P4UserMap):
         self.gitStream.write("progress checkpoint\n\n")
         out = self.gitOutput.readline()
         if self.verbose:
-            print "checkpoint finished: " + out
+            print("checkpoint finished: " + out)
 
     def extractFilesFromCommit(self, commit):
         self.cloneExclude = [re.sub(r"\.\.\.$", "", path)
@@ -2084,7 +2085,7 @@ class P4Sync(Command, P4UserMap):
             # Ideally, someday, this script can learn how to generate
             # appledouble files directly and import those to git, but
             # non-mac machines can never find a use for apple filetype.
-            print "\nIgnoring apple filetype file %s" % file['depotFile']
+            print("\nIgnoring apple filetype file %s" % file['depotFile'])
             return
 
         # Note that we do not try to de-mangle keywords on utf16 files,
@@ -2208,7 +2209,7 @@ class P4Sync(Command, P4UserMap):
     # Stream a p4 tag
     def streamTag(self, gitStream, labelName, labelDetails, commit, epoch):
         if verbose:
-            print "writing tag %s for commit %s" % (labelName, commit)
+            print("writing tag %s for commit %s" % (labelName, commit))
         gitStream.write("tag %s\n" % labelName)
         gitStream.write("from %s\n" % commit)
 
@@ -2227,7 +2228,7 @@ class P4Sync(Command, P4UserMap):
 
         gitStream.write("tagger %s\n" % tagger)
 
-        print "labelDetails=", labelDetails
+        print("labelDetails=", labelDetails)
         if 'Description' in labelDetails:
             description = labelDetails['Description']
         else:
@@ -2242,7 +2243,7 @@ class P4Sync(Command, P4UserMap):
         author = details["user"]
 
         if self.verbose:
-            print "commit into %s" % branch
+            print("commit into %s" % branch)
 
         # start with reading files; if that fails, we should not
         # create a commit.
@@ -2276,7 +2277,7 @@ class P4Sync(Command, P4UserMap):
 
         if len(parent) > 0:
             if self.verbose:
-                print "parent %s" % parent
+                print("parent %s" % parent)
             self.gitStream.write("from %s\n" % parent)
 
         self.streamP4Files(new_files)
@@ -2289,7 +2290,7 @@ class P4Sync(Command, P4UserMap):
             labelDetails = label[0]
             labelRevisions = label[1]
             if self.verbose:
-                print "Change %s is labelled %s" % (change, labelDetails)
+                print("Change %s is labelled %s" % (change, labelDetails))
 
             files = p4CmdList(["files"] + ["%s...@%s" % (p, change)
                                                 for p in self.branchPrefixes])
@@ -2321,14 +2322,14 @@ class P4Sync(Command, P4UserMap):
 
         l = p4CmdList(["labels"] + ["%s..." % p for p in self.depotPaths])
         if len(l) > 0 and not self.silent:
-            print "Finding files belonging to labels in %s" % repr(self.depotPaths)
+            print("Finding files belonging to labels in %s" % repr(self.depotPaths))
 
         for output in l:
             label = output["label"]
             revisions = {}
             newestChange = 0
             if self.verbose:
-                print "Querying files for label %s" % label
+                print("Querying files for label %s" % label)
             for file in p4CmdList(["files"] +
                                       ["%s...@%s" % (p, label)
                                           for p in self.depotPaths]):
@@ -2340,7 +2341,7 @@ class P4Sync(Command, P4UserMap):
             self.labels[newestChange] = [output, revisions]
 
         if self.verbose:
-            print "Label changes: %s" % self.labels.keys()
+            print("Label changes: %s" % self.labels.keys())
 
     # Import p4 labels as git tags. A direct mapping does not
     # exist, so assume that if all the files are at the same revision
@@ -2348,7 +2349,7 @@ class P4Sync(Command, P4UserMap):
     # just ignore.
     def importP4Labels(self, stream, p4Labels):
         if verbose:
-            print "import p4 labels: " + ' '.join(p4Labels)
+            print("import p4 labels: " + ' '.join(p4Labels))
 
         ignoredP4Labels = gitConfigList("git-p4.ignoredP4Labels")
         validLabelRegexp = gitConfig("git-p4.labelImportRegexp")
@@ -2361,7 +2362,7 @@ class P4Sync(Command, P4UserMap):
 
             if not m.match(name):
                 if verbose:
-                    print "label %s does not match regexp %s" % (name, validLabelRegexp)
+                    print("label %s does not match regexp %s" % (name, validLabelRegexp))
                 continue
 
             if name in ignoredP4Labels:
@@ -2379,7 +2380,7 @@ class P4Sync(Command, P4UserMap):
                 gitCommit = read_pipe(["git", "rev-list", "--max-count=1",
                      "--reverse", ":/\[git-p4:.*change = %d\]" % changelist])
                 if len(gitCommit) == 0:
-                    print "could not find git commit for changelist %d" % changelist
+                    print("could not find git commit for changelist %d" % changelist)
                 else:
                     gitCommit = gitCommit.strip()
                     commitFound = True
@@ -2387,16 +2388,16 @@ class P4Sync(Command, P4UserMap):
                     try:
                         tmwhen = time.strptime(labelDetails['Update'], "%Y/%m/%d %H:%M:%S")
                     except ValueError:
-                        print "Could not convert label time %s" % labelDetails['Update']
+                        print("Could not convert label time %s" % labelDetails['Update'])
                         tmwhen = 1
 
                     when = int(time.mktime(tmwhen))
                     self.streamTag(stream, name, labelDetails, gitCommit, when)
                     if verbose:
-                        print "p4 label %s mapped to git commit %s" % (name, gitCommit)
+                        print("p4 label %s mapped to git commit %s" % (name, gitCommit))
             else:
                 if verbose:
-                    print "Label %s has no changelists - possibly deleted?" % name
+                    print("Label %s has no changelists - possibly deleted?" % name)
 
             if not commitFound:
                 # We can't import this label; don't try again as it will get very
@@ -2441,8 +2442,8 @@ class P4Sync(Command, P4UserMap):
 
                     if destination in self.knownBranches:
                         if not self.silent:
-                            print "p4 branch %s defines a mapping from %s to %s" % (info["branch"], source, destination)
-                            print "but there exists another mapping from %s to %s already!" % (self.knownBranches[destination], destination)
+                            print("p4 branch %s defines a mapping from %s to %s" % (info["branch"], source, destination))
+                            print("but there exists another mapping from %s to %s already!" % (self.knownBranches[destination], destination))
                         continue
 
                     self.knownBranches[destination] = source
@@ -2506,28 +2507,28 @@ class P4Sync(Command, P4UserMap):
 
     def gitCommitByP4Change(self, ref, change):
         if self.verbose:
-            print "looking in ref " + ref + " for change %s using bisect..." % change
+            print("looking in ref " + ref + " for change %s using bisect..." % change)
 
         earliestCommit = ""
         latestCommit = parseRevision(ref)
 
         while True:
             if self.verbose:
-                print "trying: earliest %s latest %s" % (earliestCommit, latestCommit)
+                print("trying: earliest %s latest %s" % (earliestCommit, latestCommit))
             next = read_pipe("git rev-list --bisect %s %s" % (latestCommit, earliestCommit)).strip()
             if len(next) == 0:
                 if self.verbose:
-                    print "argh"
+                    print("argh")
                 return ""
             log = extractLogMessageFromGitCommit(next)
             settings = extractSettingsGitLog(log)
             currentChange = int(settings['change'])
             if self.verbose:
-                print "current change %s" % currentChange
+                print("current change %s" % currentChange)
 
             if currentChange == change:
                 if self.verbose:
-                    print "found %s" % next
+                    print("found %s" % next)
                 return next
 
             if currentChange < change:
@@ -2573,7 +2574,7 @@ class P4Sync(Command, P4UserMap):
             if len(read_pipe(["git", "diff-tree", blob, target])) == 0:
                 parentFound = True
                 if self.verbose:
-                    print "Found parent of %s in commit %s" % (branch, blob)
+                    print("Found parent of %s in commit %s" % (branch, blob))
                 break
         if parentFound:
             return blob
@@ -2604,7 +2605,7 @@ class P4Sync(Command, P4UserMap):
                         filesForCommit = branches[branch]
 
                         if self.verbose:
-                            print "branch is %s" % branch
+                            print("branch is %s" % branch)
 
                         self.updatedBranches.add(branch)
 
@@ -2625,13 +2626,13 @@ class P4Sync(Command, P4UserMap):
                                         print("\n    Resuming with change %s" % change);
 
                                 if self.verbose:
-                                    print "parent determined through known branches: %s" % parent
+                                    print("parent determined through known branches: %s" % parent)
 
                         branch = self.gitRefForBranch(branch)
                         parent = self.gitRefForBranch(parent)
 
                         if self.verbose:
-                            print "looking for initial parent for %s; current parent is %s" % (branch, parent)
+                            print("looking for initial parent for %s; current parent is %s" % (branch, parent))
 
                         if len(parent) == 0 and branch in self.initialParents:
                             parent = self.initialParents[branch]
@@ -2641,7 +2642,7 @@ class P4Sync(Command, P4UserMap):
                         if len(parent) > 0:
                             tempBranch = "%s/%d" % (self.tempBranchLocation, change)
                             if self.verbose:
-                                print "Creating temporary branch: " + tempBranch
+                                print("Creating temporary branch: " + tempBranch)
                             self.commit(description, filesForCommit, tempBranch)
                             self.tempBranches.append(tempBranch)
                             self.checkpoint()
@@ -2650,7 +2651,7 @@ class P4Sync(Command, P4UserMap):
                             self.commit(description, filesForCommit, branch, blob)
                         else:
                             if self.verbose:
-                                print "Parent of %s not found. Committing into head of %s" % (branch, parent)
+                                print("Parent of %s not found. Committing into head of %s" % (branch, parent))
                             self.commit(description, filesForCommit, branch, parent)
                 else:
                     files = self.extractFilesFromCommit(description)
@@ -2659,11 +2660,11 @@ class P4Sync(Command, P4UserMap):
                     # only needed once, to connect to the previous commit
                     self.initialParent = ""
             except IOError:
-                print self.gitError.read()
+                print(self.gitError.read())
                 sys.exit(1)
 
     def importHeadRevision(self, revision):
-        print "Doing initial import of %s from revision %s into %s" % (' '.join(self.depotPaths), revision, self.branch)
+        print("Doing initial import of %s from revision %s into %s" % (' '.join(self.depotPaths), revision, self.branch))
 
         details = {}
         details["user"] = "git perforce import user"
@@ -2715,8 +2716,8 @@ class P4Sync(Command, P4UserMap):
         try:
             self.commit(details, self.extractFilesFromCommit(details), self.branch)
         except IOError:
-            print "IO error with git fast-import. Is your git version recent enough?"
-            print self.gitError.read()
+            print("IO error with git fast-import. Is your git version recent enough?")
+            print(self.gitError.read())
 
 
     def run(self, args):
@@ -2738,7 +2739,7 @@ class P4Sync(Command, P4UserMap):
             self.hasOrigin = originP4BranchesExist()
             if self.hasOrigin:
                 if not self.silent:
-                    print 'Syncing with origin first, using "git fetch origin"'
+                    print('Syncing with origin first, using "git fetch origin"')
                 system("git fetch origin")
 
         branch_arg_given = bool(self.branch)
@@ -2777,14 +2778,14 @@ class P4Sync(Command, P4UserMap):
 
             if len(self.p4BranchesInGit) > 1:
                 if not self.silent:
-                    print "Importing from/into multiple branches"
+                    print("Importing from/into multiple branches")
                 self.detectBranches = True
                 for branch in branches.keys():
                     self.initialParents[self.refPrefix + branch] = \
                         branches[branch]
 
             if self.verbose:
-                print "branches: %s" % self.p4BranchesInGit
+                print("branches: %s" % self.p4BranchesInGit)
 
             p4Change = 0
             for branch in self.p4BranchesInGit:
@@ -2819,7 +2820,7 @@ class P4Sync(Command, P4UserMap):
                 self.depotPaths = sorted(self.previousDepotPaths)
                 self.changeRange = "@%s,#head" % p4Change
                 if not self.silent and not self.detectBranches:
-                    print "Performing incremental import into %s git branch" % self.branch
+                    print("Performing incremental import into %s git branch" % self.branch)
 
         # accept multiple ref name abbreviations:
         #    refs/foo/bar/branch -> use it exactly
@@ -2836,7 +2837,7 @@ class P4Sync(Command, P4UserMap):
 
         if len(args) == 0 and self.depotPaths:
             if not self.silent:
-                print "Depot paths: %s" % ' '.join(self.depotPaths)
+                print("Depot paths: %s" % ' '.join(self.depotPaths))
         else:
             if self.depotPaths and self.depotPaths != args:
                 print ("previous import used depot path %s and now %s was specified. "
@@ -2906,8 +2907,8 @@ class P4Sync(Command, P4UserMap):
             else:
                 self.getBranchMapping()
             if self.verbose:
-                print "p4-git branches: %s" % self.p4BranchesInGit
-                print "initial parents: %s" % self.initialParents
+                print("p4-git branches: %s" % self.p4BranchesInGit)
+                print("initial parents: %s" % self.initialParents)
             for b in self.p4BranchesInGit:
                 if b != "master":
 
@@ -2959,8 +2960,8 @@ class P4Sync(Command, P4UserMap):
                                     self.branch)
 
                 if self.verbose:
-                    print "Getting p4 changes for %s...%s" % (', '.join(self.depotPaths),
-                                                              self.changeRange)
+                    print("Getting p4 changes for %s...%s" % (', '.join(self.depotPaths),
+                                                              self.changeRange))
                 changes = p4ChangesForPaths(self.depotPaths, self.changeRange)
 
                 if len(self.maxChanges) > 0:
@@ -2968,10 +2969,10 @@ class P4Sync(Command, P4UserMap):
 
             if len(changes) == 0:
                 if not self.silent:
-                    print "No changes to import!"
+                    print("No changes to import!")
             else:
                 if not self.silent and not self.detectBranches:
-                    print "Import destination: %s" % self.branch
+                    print("Import destination: %s" % self.branch)
 
                 self.updatedBranches = set()
 
@@ -2986,7 +2987,7 @@ class P4Sync(Command, P4UserMap):
                 self.importChanges(changes)
 
                 if not self.silent:
-                    print ""
+                    print("")
                     if len(self.updatedBranches) > 0:
                         sys.stdout.write("Updated branches: ")
                         for b in self.updatedBranches:
@@ -3054,7 +3055,7 @@ class P4Rebase(Command):
         # the branchpoint may be p4/foo~3, so strip off the parent
         upstream = re.sub("~[0-9]+$", "", upstream)
 
-        print "Rebasing the current branch onto %s" % upstream
+        print("Rebasing the current branch onto %s" % upstream)
         oldHead = read_pipe("git rev-parse HEAD").strip()
         system("git rebase %s" % upstream)
         system("git diff-tree --stat --summary -M %s HEAD" % oldHead)
@@ -3117,7 +3118,7 @@ class P4Clone(P4Sync):
         if not self.cloneDestination:
             self.cloneDestination = self.defaultDestination(args)
 
-        print "Importing from %s into %s" % (', '.join(depotPaths), self.cloneDestination)
+        print("Importing from %s into %s" % (', '.join(depotPaths), self.cloneDestination))
 
         if not os.path.exists(self.cloneDestination):
             os.makedirs(self.cloneDestination)
@@ -3139,8 +3140,8 @@ class P4Clone(P4Sync):
             if not self.cloneBare:
                 system([ "git", "checkout", "-f" ])
         else:
-            print 'Not checking out any branch, use ' \
-                  '"git checkout -q -b master <branch>"'
+            print('Not checking out any branch, use ' \
+                  '"git checkout -q -b master <branch>"')
 
         # auto-set this variable if invoked with --use-client-spec
         if self.useClientSpec_from_options:
@@ -3173,7 +3174,7 @@ class P4Branches(Command):
             log = extractLogMessageFromGitCommit("refs/remotes/%s" % branch)
             settings = extractSettingsGitLog(log)
 
-            print "%s <= %s (%s)" % (branch, ",".join(settings["depot-paths"]), settings["change"])
+            print("%s <= %s (%s)" % (branch, ",".join(settings["depot-paths"]), settings["change"]))
         return True
 
 class HelpFormatter(optparse.IndentedHelpFormatter):
@@ -3187,12 +3188,12 @@ class HelpFormatter(optparse.IndentedHelpFormatter):
             return ""
 
 def printUsage(commands):
-    print "usage: %s <command> [options]" % sys.argv[0]
-    print ""
-    print "valid commands: %s" % ", ".join(commands)
-    print ""
-    print "Try %s <command> --help for command specific help." % sys.argv[0]
-    print ""
+    print("usage: %s <command> [options]" % sys.argv[0])
+    print("")
+    print("valid commands: %s" % ", ".join(commands))
+    print("")
+    print("Try %s <command> --help for command specific help." % sys.argv[0])
+    print("")
 
 commands = {
     "debug" : P4Debug,
@@ -3216,8 +3217,8 @@ def main():
         klass = commands[cmdName]
         cmd = klass()
     except KeyError:
-        print "unknown command %s" % cmdName
-        print ""
+        print("unknown command %s" % cmdName)
+        print("")
         printUsage(commands.keys())
         sys.exit(2)
 

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -8,7 +8,9 @@
 # License: MIT <http://www.opensource.org/licenses/mit-license.php>
 #
 from __future__ import print_function
+from __future__ import absolute_import
 import sys
+import six
 if sys.hexversion < 0x02040000:
     # The limiter is the subprocess module
     sys.stderr.write("git-p4: requires Python 2.4 or later.\n")
@@ -53,7 +55,7 @@ def p4_build_cmd(cmd):
     """
     real_cmd = ["p4"]
 
-    if isinstance(cmd, basestring):
+    if isinstance(cmd, six.string_types):
         real_cmd = ' '.join(real_cmd) + ' ' + cmd
     else:
         real_cmd += cmd
@@ -92,7 +94,7 @@ def write_pipe(c, stdin):
     if verbose:
         sys.stderr.write('Writing pipe: %s\n' % str(c))
 
-    expand = isinstance(c, basestring)
+    expand = isinstance(c, six.string_types)
     p = subprocess.Popen(c, stdin=subprocess.PIPE, shell=expand)
     pipe = p.stdin
     val = pipe.write(stdin)
@@ -110,7 +112,7 @@ def read_pipe(c, ignore_error=False):
     if verbose:
         sys.stderr.write('Reading pipe: %s\n' % str(c))
 
-    expand = isinstance(c, basestring)
+    expand = isinstance(c, six.string_types)
     p = subprocess.Popen(c, stdout=subprocess.PIPE, shell=expand)
     pipe = p.stdout
     val = pipe.read()
@@ -127,7 +129,7 @@ def read_pipe_lines(c):
     if verbose:
         sys.stderr.write('Reading pipe: %s\n' % str(c))
 
-    expand = isinstance(c, basestring)
+    expand = isinstance(c, six.string_types)
     p = subprocess.Popen(c, stdout=subprocess.PIPE, shell=expand)
     pipe = p.stdout
     val = pipe.readlines()
@@ -170,7 +172,7 @@ def p4_has_move_command():
     return True
 
 def system(cmd):
-    expand = isinstance(cmd, basestring)
+    expand = isinstance(cmd, six.string_types)
     if verbose:
         sys.stderr.write("executing %s\n" % str(cmd))
     retcode = subprocess.call(cmd, shell=expand)
@@ -180,7 +182,7 @@ def system(cmd):
 def p4_system(cmd):
     """Specifically invoke p4 as the system command. """
     real_cmd = p4_build_cmd(cmd)
-    expand = isinstance(real_cmd, basestring)
+    expand = isinstance(real_cmd, six.string_types)
     retcode = subprocess.call(real_cmd, shell=expand)
     if retcode:
         raise CalledProcessError(retcode, real_cmd)
@@ -357,7 +359,7 @@ def getP4OpenedType(file):
 # Return the set of all p4 labels
 def getP4Labels(depotPaths):
     labels = set()
-    if isinstance(depotPaths, basestring):
+    if isinstance(depotPaths, six.string_types):
         depotPaths = [depotPaths]
 
     for l in p4CmdList(["labels"] + ["%s..." % p for p in depotPaths]):
@@ -424,7 +426,7 @@ def isModeExecChanged(src_mode, dst_mode):
 
 def p4CmdList(cmd, stdin=None, stdin_mode='w+b', cb=None):
 
-    if isinstance(cmd, basestring):
+    if isinstance(cmd, six.string_types):
         cmd = "-G " + cmd
         expand = True
     else:
@@ -441,7 +443,7 @@ def p4CmdList(cmd, stdin=None, stdin_mode='w+b', cb=None):
     stdin_file = None
     if stdin is not None:
         stdin_file = tempfile.TemporaryFile(prefix='p4-stdin', mode=stdin_mode)
-        if isinstance(stdin, basestring):
+        if isinstance(stdin, six.string_types):
             stdin_file.write(stdin)
         else:
             for i in stdin:

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import sys
 import six
+from six.moves import input
 if sys.hexversion < 0x02040000:
     # The limiter is the subprocess module
     sys.stderr.write("git-p4: requires Python 2.4 or later.\n")
@@ -1213,7 +1214,7 @@ class P4Submit(Command, P4UserMap):
             return True
 
         while True:
-            response = raw_input("Submit template unchanged. Submit anyway? [y]es, [n]o (skip this patch) ")
+            response = input("Submit template unchanged. Submit anyway? [y]es, [n]o (skip this patch) ")
             if response == 'y':
                 return True
             if response == 'n':
@@ -1707,7 +1708,7 @@ class P4Submit(Command, P4UserMap):
                         # prompt for what to do, or use the option/variable
                         if self.conflict_behavior == "ask":
                             print("What do you want to do?")
-                            response = raw_input("[s]kip this commit but apply"
+                            response = input("[s]kip this commit but apply"
                                                  " the rest, or [q]uit? ")
                             if not response:
                                 continue

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -2321,7 +2321,7 @@ class P4Sync(Command, P4UserMap):
 
         l = p4CmdList(["labels"] + ["%s..." % p for p in self.depotPaths])
         if len(l) > 0 and not self.silent:
-            print "Finding files belonging to labels in %s" % `self.depotPaths`
+            print "Finding files belonging to labels in %s" % repr(self.depotPaths)
 
         for output in l:
             label = output["label"]

--- a/api/integrations/perforce/zulip_change-commit.py
+++ b/api/integrations/perforce/zulip_change-commit.py
@@ -33,6 +33,7 @@ For example:
   1234 //depot/security/src/
 
 '''
+from __future__ import print_function
 
 import os
 import sys
@@ -59,12 +60,12 @@ try:
     changelist = int(sys.argv[1])
     changeroot = sys.argv[2]
 except IndexError:
-    print >> sys.stderr, "Wrong number of arguments.\n\n",
-    print >> sys.stderr,  __doc__
+    print("Wrong number of arguments.\n\n", end=' ', file=sys.stderr)
+    print(__doc__, file=sys.stderr)
     sys.exit(-1)
 except ValueError:
-    print >> sys.stderr, "First argument must be an integer.\n\n",
-    print >> sys.stderr, __doc__
+    print("First argument must be an integer.\n\n", end=' ', file=sys.stderr)
+    print(__doc__, file=sys.stderr)
     sys.exit(-1)
 
 metadata = git_p4.p4_describe(changelist)

--- a/api/setup.py
+++ b/api/setup.py
@@ -9,8 +9,8 @@ import itertools
 def version():
     version_py = os.path.join(os.path.dirname(__file__), "zulip", "__init__.py")
     with open(version_py) as in_handle:
-        version_line = itertools.dropwhile(lambda x: not x.startswith("__version__"),
-                                           in_handle).next()
+        version_line = next(itertools.dropwhile(lambda x: not x.startswith("__version__"),
+                                           in_handle))
     version = version_line.split('=')[-1].strip().replace('"', '')
     return version
 

--- a/api/setup.py
+++ b/api/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import os
 import sys
 
@@ -60,13 +61,13 @@ except ImportError:
     try:
         import simplejson
     except ImportError:
-        print >>sys.stderr, "simplejson is not installed"
+        print("simplejson is not installed", file=sys.stderr)
         sys.exit(1)
     try:
         import requests
         assert(LooseVersion(requests.__version__) >= LooseVersion('0.12.1'))
     except (ImportError, AssertionError):
-        print >>sys.stderr, "requests >=0.12.1 is not installed"
+        print("requests >=0.12.1 is not installed", file=sys.stderr)
         sys.exit(1)
 
 

--- a/api/zulip/__init__.py
+++ b/api/zulip/__init__.py
@@ -351,7 +351,7 @@ class Client(object):
             else:
                 req_url = url
             return self.do_api_query(request, API_VERSTRING + req_url, method=method, **query_kwargs)
-        call.func_name = name
+        call.__name__ = name
         setattr(cls, name, call)
 
     def call_on_each_event(self, callback, event_types=None, narrow=[]):

--- a/api/zulip/__init__.py
+++ b/api/zulip/__init__.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import print_function
 import simplejson
 import requests
 import time
@@ -87,7 +88,7 @@ class RandomExponentialBackoff(CountingBackoff):
         try:
             logger.warning(message)
         except NameError:
-            print message
+            print(message)
         time.sleep(delay)
 
 def _default_client():
@@ -273,9 +274,9 @@ class Client(object):
         def end_error_retry(succeeded):
             if query_state["had_error_retry"] and self.verbose:
                 if succeeded:
-                    print "Success!"
+                    print("Success!")
                 else:
-                    print "Failed!"
+                    print("Failed!")
 
         while True:
             try:
@@ -364,7 +365,7 @@ class Client(object):
 
                 if 'error' in res.get('result'):
                     if self.verbose:
-                        print "Server returned error:\n%s" % res['msg']
+                        print("Server returned error:\n%s" % res['msg'])
                     time.sleep(1)
                 else:
                     return (res['queue_id'], res['last_event_id'])
@@ -378,13 +379,13 @@ class Client(object):
             if 'error' in res.get('result'):
                 if res["result"] == "http-error":
                     if self.verbose:
-                        print "HTTP error fetching events -- probably a server restart"
+                        print("HTTP error fetching events -- probably a server restart")
                 elif res["result"] == "connection-error":
                     if self.verbose:
-                        print "Connection error fetching events -- probably server is temporarily down?"
+                        print("Connection error fetching events -- probably server is temporarily down?")
                 else:
                     if self.verbose:
-                        print "Server returned error:\n%s" % res["msg"]
+                        print("Server returned error:\n%s" % res["msg"])
                     if res["msg"].startswith("Bad event queue id:"):
                         # Our event queue went away, probably because
                         # we were asleep or the server restarted

--- a/api/zulip/__init__.py
+++ b/api/zulip/__init__.py
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 from __future__ import print_function
+from __future__ import absolute_import
 import simplejson
 import requests
 import time
@@ -36,6 +37,7 @@ from distutils.version import LooseVersion
 
 from six.moves.configparser import SafeConfigParser
 import logging
+import six
 
 
 __version__ = "0.2.4"
@@ -244,7 +246,7 @@ class Client(object):
         request = {}
 
         for (key, val) in orig_request.iteritems():
-            if not (isinstance(val, str) or isinstance(val, unicode)):
+            if not (isinstance(val, str) or isinstance(val, six.text_type)):
                 request[key] = simplejson.dumps(val)
             else:
                 request[key] = val

--- a/api/zulip/__init__.py
+++ b/api/zulip/__init__.py
@@ -34,7 +34,7 @@ import urllib
 import random
 from distutils.version import LooseVersion
 
-from ConfigParser import SafeConfigParser
+from six.moves.configparser import SafeConfigParser
 import logging
 
 

--- a/bots/irc-mirror.py
+++ b/bots/irc-mirror.py
@@ -6,6 +6,7 @@
 # Setup: First, you need to install python-irc version 8.5.3
 # (https://bitbucket.org/jaraco/irc)
 
+from __future__ import print_function
 import irc.bot
 import irc.strings
 from irc.client import ip_numstr_to_quad, ip_quad_to_numstr
@@ -53,12 +54,12 @@ class IRCBot(irc.bot.SingleServerIRCBot):
             return
 
         # Forward the PM to Zulip
-        print zulip_client.send_message({
+        print(zulip_client.send_message({
                 "sender": sender,
                 "type": "private",
                 "to": "username@example.com",
                 "content": content,
-                })
+                }))
 
     def on_pubmsg(self, c, e):
         content = e.arguments[0]
@@ -68,14 +69,14 @@ class IRCBot(irc.bot.SingleServerIRCBot):
             return
 
         # Forward the stream message to Zulip
-        print zulip_client.send_message({
+        print(zulip_client.send_message({
                 "forged": "yes",
                 "sender": sender,
                 "type": "stream",
                 "to": stream,
                 "subject": "IRC",
                 "content": content,
-                })
+                }))
 
     def on_dccmsg(self, c, e):
         c.privmsg("You said: " + e.arguments[0])

--- a/bots/jabber_mirror.py
+++ b/bots/jabber_mirror.py
@@ -21,6 +21,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import print_function
 import sys
 import subprocess
 import os
@@ -39,7 +40,7 @@ args.extend(sys.argv[1:])
 
 backoff = RandomExponentialBackoff(timeout_success_equivalent=300)
 while backoff.keep_going():
-    print "Starting Jabber mirroring bot"
+    print("Starting Jabber mirroring bot")
     try:
         ret = subprocess.call(args)
     except:
@@ -51,9 +52,9 @@ while backoff.keep_going():
 
     backoff.fail()
 
-print ""
-print ""
-print "ERROR: The Jabber mirroring bot is unable to continue mirroring Jabber."
-print "Please contact zulip-devel@googlegroups.com if you need assistance."
-print ""
+print("")
+print("")
+print("ERROR: The Jabber mirroring bot is unable to continue mirroring Jabber.")
+print("Please contact zulip-devel@googlegroups.com if you need assistance.")
+print("")
 sys.exit(1)

--- a/bots/jabber_mirror_backend.py
+++ b/bots/jabber_mirror_backend.py
@@ -44,7 +44,7 @@ import optparse
 
 from sleekxmpp import ClientXMPP, InvalidJID, JID
 from sleekxmpp.exceptions import IqError, IqTimeout
-from ConfigParser import SafeConfigParser
+from six.moves.configparser import SafeConfigParser
 import os, sys, zulip, getpass
 import re
 

--- a/bots/summarize_stream.py
+++ b/bots/summarize_stream.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This is hacky code to analyze data on our support stream.  The main
 # reusable bits are get_recent_messages and get_words.
 
@@ -31,7 +32,7 @@ def analyze_messages(msgs, word_count, email_count):
         if False:
             if ' ack' in msg['content']:
                 name = msg['sender_full_name'].split()[0]
-                print 'ACK', name
+                print('ACK', name)
         m = re.search('ticket (Z....).*email: (\S+).*~~~(.*)', msg['content'], re.M | re.S)
         if m:
             ticket, email, req = m.groups()
@@ -40,9 +41,9 @@ def analyze_messages(msgs, word_count, email_count):
                 word_count[word] += 1
             email_count[email] += 1
         if False:
-            print
+            print()
             for k, v in msg.items():
-                print '%-20s: %s' % (k, v)
+                print('%-20s: %s' % (k, v))
 
 def generate_support_stats():
     client = zulip.Client()
@@ -68,12 +69,12 @@ def generate_support_stats():
         words = filter(lambda w: len(w) >= 5, words)
         words = sorted(words, key=lambda w: word_count[w], reverse=True)
         for word in words:
-            print word, word_count[word]
+            print(word, word_count[word])
 
     if False:
         emails = email_count.keys()
         emails = sorted(emails, key=lambda w: email_count[w], reverse=True)
         for email in emails:
-            print email, email_count[email]
+            print(email, email_count[email])
 
 generate_support_stats()

--- a/bots/summarize_stream.py
+++ b/bots/summarize_stream.py
@@ -65,8 +65,8 @@ def generate_support_stats():
 
     if True:
         words = word_count.keys()
-        words = filter(lambda w: word_count[w] >= 10, words)
-        words = filter(lambda w: len(w) >= 5, words)
+        words = [w for w in words if word_count[w] >= 10]
+        words = [w for w in words if len(w) >= 5]
         words = sorted(words, key=lambda w: word_count[w], reverse=True)
         for word in words:
             print(word, word_count[word])

--- a/bots/zephyr_mirror.py
+++ b/bots/zephyr_mirror.py
@@ -21,13 +21,14 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import absolute_import
 import sys
 import subprocess
 import os
 import traceback
 import signal
 
-from zephyr_mirror_backend import parse_args
+from .zephyr_mirror_backend import parse_args
 
 def die(signal, frame):
     # We actually want to exit, so run os._exit (so as not to be caught and restarted)

--- a/bots/zephyr_mirror.py
+++ b/bots/zephyr_mirror.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 
 from __future__ import absolute_import
+from __future__ import print_function
 import sys
 import subprocess
 import os
@@ -53,30 +54,30 @@ if options.forward_class_messages and not options.noshard:
     if options.on_startup_command is not None:
         subprocess.call([options.on_startup_command])
     from zerver.lib.parallel import run_parallel
-    print "Starting parallel zephyr class mirroring bot"
+    print("Starting parallel zephyr class mirroring bot")
     jobs = list("0123456789abcdef")
     def run_job(shard):
         subprocess.call(args + ["--shard=%s" % (shard,)])
         return 0
     for (status, job) in run_parallel(run_job, jobs, threads=16):
-        print "A mirroring shard died!"
+        print("A mirroring shard died!")
         pass
     sys.exit(0)
 
 backoff = RandomExponentialBackoff(timeout_success_equivalent=300)
 while backoff.keep_going():
-    print "Starting zephyr mirroring bot"
+    print("Starting zephyr mirroring bot")
     try:
         subprocess.call(args)
     except:
         traceback.print_exc()
     backoff.fail()
 
-print ""
-print ""
-print "ERROR: The Zephyr mirroring bot is unable to continue mirroring Zephyrs."
-print "This is often caused by failing to maintain unexpired Kerberos tickets"
-print "or AFS tokens.  See https://zulip.com/zephyr for documentation on how to"
-print "maintain unexpired Kerberos tickets and AFS tokens."
-print ""
+print("")
+print("")
+print("ERROR: The Zephyr mirroring bot is unable to continue mirroring Zephyrs.")
+print("This is often caused by failing to maintain unexpired Kerberos tickets")
+print("or AFS tokens.  See https://zulip.com/zephyr for documentation on how to")
+print("maintain unexpired Kerberos tickets and AFS tokens.")
+print("")
 sys.exit(1)

--- a/bots/zephyr_mirror_backend.py
+++ b/bots/zephyr_mirror_backend.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 
 import sys
 from six.moves import map
+from six.moves import range
 try:
     import simplejson
 except ImportError:
@@ -44,7 +45,7 @@ import select
 DEFAULT_SITE = "https://api.zulip.com"
 
 class States:
-    Startup, ZulipToZephyr, ZephyrToZulip, ChildSending = range(4)
+    Startup, ZulipToZephyr, ZephyrToZulip, ChildSending = list(range(4))
 CURRENT_STATE = States.Startup
 
 def to_zulip_username(zephyr_username):

--- a/bots/zephyr_mirror_backend.py
+++ b/bots/zephyr_mirror_backend.py
@@ -20,8 +20,10 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import absolute_import
 
 import sys
+from six.moves import map
 try:
     import simplejson
 except ImportError:

--- a/provision.py
+++ b/provision.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import logging
@@ -53,9 +54,9 @@ VENV_PATH="/srv/zulip-venv"
 ZULIP_PATH="/srv/zulip"
 
 if not os.path.exists(os.path.join(os.path.dirname(__file__), ".git")):
-    print "Error: No Zulip git repository present at /srv/zulip!"
-    print "To setup the Zulip development environment, you should clone the code"
-    print "from GitHub, rather than using a Zulip production release tarball."
+    print("Error: No Zulip git repository present at /srv/zulip!")
+    print("To setup the Zulip development environment, you should clone the code")
+    print("from GitHub, rather than using a Zulip production release tarball.")
     sys.exit(1)
 
 # TODO: Parse arguments properly

--- a/puppet/zulip_internal/files/postgresql/pg_backup_and_purge.py
+++ b/puppet/zulip_internal/files/postgresql/pg_backup_and_purge.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2.7
 
+from __future__ import print_function
 import subprocess
 import sys
 import logging
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def run(args, dry_run=False):
     if dry_run:
-        print "Would have run: " + " ".join(args)
+        print("Would have run: " + " ".join(args))
         return ""
 
     p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,

--- a/scripts/setup/generate_secrets.py
+++ b/scripts/setup/generate_secrets.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2.7
 # This tools generates local_settings_generated.py using the template
 
+from __future__ import print_function
 import sys, os, os.path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -23,7 +24,7 @@ CAMO_KEY=%s
 """ % (camo_key,)
     with open(CAMO_CONFIG_FILENAME, 'w') as camo_file:
         camo_file.write(camo_config)
-    print "Generated Camo config file %s" % (CAMO_CONFIG_FILENAME,)
+    print("Generated Camo config file %s" % (CAMO_CONFIG_FILENAME,))
 
 def generate_django_secretkey():
     # Secret key generation taken from Django's startproject.py
@@ -55,7 +56,7 @@ def generate_secrets(development=False):
     out.write("".join(lines))
     out.close()
 
-    print "Generated %s with auto-generated secrets!" % (OUTPUT_SETTINGS_FILENAME,)
+    print("Generated %s with auto-generated secrets!" % (OUTPUT_SETTINGS_FILENAME,))
 
 if __name__ == '__main__':
 

--- a/tools/deprecated/finbot/money.py
+++ b/tools/deprecated/finbot/money.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
 import datetime
 import monthdelta
 
@@ -26,7 +27,7 @@ class Company(object):
             delta = flow.cashflow(start_date, end_date, (end_date - start_date).days)
             cash += delta
             if self.verbose:
-                print flow.name, round(delta, 2)
+                print(flow.name, round(delta, 2))
         return round(cash, 2)
 
     def cash_at_date(self, start, end):
@@ -39,10 +40,10 @@ class Company(object):
         cur_date = parse_date(start)
         end_date = parse_date(end)
         while cur_date <= end_date:
-            print cur_date, self.cash_at_date_internal(start_date, cur_date)
+            print(cur_date, self.cash_at_date_internal(start_date, cur_date))
             cur_date += monthdelta.MonthDelta(1)
             if self.verbose:
-                print
+                print()
 
 # CashFlow objects fundamentally just provide a function that says how
 # much cash has been spent by that source at each time
@@ -208,5 +209,5 @@ if __name__ == "__main__":
     assert(c.cash_at_date("2012-01-01", "2012-02-15") == 499207.33)
     c.add_flow(SemiMonthlyWages("Payroll", -4000, "2012-01-01"))
 
-    print c
+    print(c)
     c.cash_monthly_summary("2012-01-01", "2012-07-01")

--- a/tools/deprecated/finbot/monthdelta.py
+++ b/tools/deprecated/finbot/monthdelta.py
@@ -85,7 +85,7 @@ class MonthDelta:
                     day = 29
                 elif day > 28:
                     day = 28
-            elif month in (4,6,9,11) and day > 30:
+            elif month in (4, 6, 9, 11) and day > 30:
                 day = 30
             try:
                 return other.replace(year, month, day)

--- a/tools/deprecated/generate-activity-metrics.py
+++ b/tools/deprecated/generate-activity-metrics.py
@@ -58,7 +58,7 @@ def points_during_day(data, noon):
     before =datetime_to_timestamp(noon - timedelta(hours=12))
     after = datetime_to_timestamp(noon + timedelta(hours=12))
 
-    between = filter(lambda pt: pt[1] > before and pt[1] < after, data)
+    between = [pt for pt in data if pt[1] > before and pt[1] < after]
     return between
 
 def best_during_day(data, day):

--- a/tools/deprecated/generate-activity-metrics.py
+++ b/tools/deprecated/generate-activity-metrics.py
@@ -3,7 +3,9 @@
 # Generates % delta activity metrics from graphite/statsd data
 #
 from __future__ import print_function
+from __future__ import absolute_import
 import os, sys
+from six.moves import range
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
@@ -111,11 +113,11 @@ def parse_data(data, today):
         best_today = best_during_day(metric['datapoints'], today)
         print("Date\t\t\t\tUsers\t\tChange from then to today")
         print("Today, 0 days ago:\t\t%.01f" % (best_today,))
-        print_results(xrange(1, 1000), [0, 1, 2, 3, 4, 7])
+        print_results(range(1, 1000), [0, 1, 2, 3, 4, 7])
 
         print("\n\nWeekly Wednesday results")
         print("Date\t\t\t\tUsers\t\tDelta from previous week")
-        print_results(reversed(xrange(1, 1000)), [2], True)
+        print_results(reversed(range(1, 1000)), [2], True)
 
 
 

--- a/tools/deprecated/generate-activity-metrics.py
+++ b/tools/deprecated/generate-activity-metrics.py
@@ -2,6 +2,7 @@
 #
 # Generates % delta activity metrics from graphite/statsd data
 #
+from __future__ import print_function
 import os, sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -43,7 +44,7 @@ def get_data(url, username, pw):
     res = requests.get(url, auth=HTTPDigestAuth(username, pw), verify=False)
 
     if res.status_code != 200:
-        print "Failed to fetch data url: %s" % (res.error,)
+        print("Failed to fetch data url: %s" % (res.error,))
         return []
 
     return extract_json_response(res)
@@ -98,8 +99,8 @@ def parse_data(data, today):
                         percent = percent_diff(best_last_time, best)
 
                 if best is not None:
-                    print "Last %s, %s %s ago:\t%.01f\t\t%s" \
-                        % (day.strftime("%A"), i, "days", best, percent)
+                    print("Last %s, %s %s ago:\t%.01f\t\t%s" \
+                        % (day.strftime("%A"), i, "days", best, percent))
                 best_last_time = best
 
     for metric in data:
@@ -108,12 +109,12 @@ def parse_data(data, today):
         metric['datapoints'].sort(key=lambda p: p[1])
 
         best_today = best_during_day(metric['datapoints'], today)
-        print "Date\t\t\t\tUsers\t\tChange from then to today"
-        print "Today, 0 days ago:\t\t%.01f" % (best_today,)
+        print("Date\t\t\t\tUsers\t\tChange from then to today")
+        print("Today, 0 days ago:\t\t%.01f" % (best_today,))
         print_results(xrange(1, 1000), [0, 1, 2, 3, 4, 7])
 
-        print "\n\nWeekly Wednesday results"
-        print "Date\t\t\t\tUsers\t\tDelta from previous week"
+        print("\n\nWeekly Wednesday results")
+        print("Date\t\t\t\tUsers\t\tDelta from previous week")
         print_results(reversed(xrange(1, 1000)), [2], True)
 
 
@@ -151,7 +152,7 @@ if __name__ == '__main__':
     startfrom = noon_of(day=datetime.now())
     if options.start_from != 'today':
         startfrom = noon_of(day=datetime.fromtimestamp(int(options.start_from)))
-        print "Using baseline of today as %s" % (startfrom,)
+        print("Using baseline of today as %s" % (startfrom,))
 
     realm_key = statsd_key(options.realm, True)
     buckets = [options.bucket]

--- a/tools/emoji_dump/emoji_dump.py
+++ b/tools/emoji_dump/emoji_dump.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
 import os
 import shutil
 import subprocess
@@ -66,13 +67,13 @@ for name, code_point in emoji_map.items():
         try:
             bw_font(name, code_point)
         except Exception as e:
-            print e
-            print 'Missing {}, {}'.format(name, code_point)
+            print(e)
+            print('Missing {}, {}'.format(name, code_point))
             failed = True
             continue
 
     os.symlink('unicode/{}.png'.format(code_point), 'out/{}.png'.format(name))
 
 if failed:
-    print "Errors dumping emoji!"
+    print("Errors dumping emoji!")
     sys.exit(1)

--- a/tools/show-profile-results.py
+++ b/tools/show-profile-results.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
 import sys
 import pstats
 
@@ -12,10 +13,10 @@ can find more advanced tools for showing profiler results.
 try:
     fn = sys.argv[1]
 except:
-    print '''
+    print('''
     Please supply a filename.  (If you use the profiled decorator,
     the file will have a suffix of ".profile".)
-    '''
+    ''')
     sys.exit(1)
 
 p = pstats.Stats(fn)

--- a/tools/test_user_agent_parsing.py
+++ b/tools/test_user_agent_parsing.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
 import re
 from collections import defaultdict
 import os
@@ -15,19 +16,19 @@ for line in file(user_agents_path).readlines():
     line = line.strip()
     match = re.match('^(?P<count>[0-9]+) "(?P<user_agent>.*)"$', line)
     if match is None:
-        print line
+        print(line)
         continue
     groupdict = match.groupdict()
     count = groupdict["count"]
     user_agent = groupdict["user_agent"]
     ret = parse_user_agent(user_agent)
     if ret is None:
-        print "parse error", line
+        print("parse error", line)
         parse_errors += 1
         continue
     user_agents_parsed[ret["name"]] += int(count)
 
 for key in user_agents_parsed:
-    print "    ", key, user_agents_parsed[key]
+    print("    ", key, user_agents_parsed[key])
 
-print "%s parse errors!" % (parse_errors,)
+print("%s parse errors!" % (parse_errors,))

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -409,13 +409,13 @@ class REQ(object):
 # expected to call json_error or json_success, as it uses json_error
 # internally when it encounters an error
 def has_request_variables(view_func):
-    num_params = view_func.func_code.co_argcount
-    if view_func.func_defaults is None:
+    num_params = view_func.__code__.co_argcount
+    if view_func.__defaults__ is None:
         num_default_params = 0
     else:
-        num_default_params = len(view_func.func_defaults)
-    default_param_names = view_func.func_code.co_varnames[num_params - num_default_params:]
-    default_param_values = view_func.func_defaults
+        num_default_params = len(view_func.__defaults__)
+    default_param_names = view_func.__code__.co_varnames[num_params - num_default_params:]
+    default_param_values = view_func.__defaults__
     if default_param_values is None:
         default_param_values = []
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -242,7 +242,7 @@ def authenticated_rest_api_view(view_func):
         try:
             # Could be a UserProfile or a Deployment
             profile = validate_api_key(role, api_key)
-        except JsonableError, e:
+        except JsonableError as e:
             return json_unauthorized(e.error)
         request.user = profile
         process_client(request, profile)

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -326,7 +326,7 @@ def internal_notify_view(view_func):
             # We got called through the non-Tornado server somehow.
             # This is not a security check; it's an internal assertion
             # to help us find bugs.
-            raise RuntimeError, 'notify view called with no Tornado handler'
+            raise RuntimeError('notify view called with no Tornado handler')
         request._email = "internal"
         return view_func(request, *args, **kwargs)
     return _wrapped_view_func

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -23,6 +23,7 @@ import base64
 import logging
 import cProfile
 from zerver.lib.mandrill_client import get_mandrill_client
+from six.moves import zip
 
 if settings.ZULIP_COM:
     from zilencer.models import get_deployment_by_domain, Deployment

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -63,7 +63,7 @@ class HomepageForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         self.domain = kwargs.get("domain")
-        if kwargs.has_key("domain"):
+        if "domain" in kwargs:
             del kwargs["domain"]
         super(HomepageForm, self).__init__(*args, **kwargs)
 

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -34,7 +34,7 @@ def not_mit_mailing_list(value):
         try:
             DNS.dnslookup("%s.pobox.ns.athena.mit.edu" % username, DNS.Type.TXT)
             return True
-        except DNS.Base.ServerError, e:
+        except DNS.Base.ServerError as e:
             if e.rcode == DNS.Status.NXDOMAIN:
                 raise ValidationError(mark_safe(u'That user does not exist at MIT or is a <a href="https://ist.mit.edu/email-lists">mailing list</a>. If you want to sign up an alias for Zulip, <a href="mailto:support@zulip.com">contact us</a>.'))
             else:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.conf import settings
 from django.core import validators

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -29,6 +29,7 @@ from django.core.mail import EmailMessage
 from django.utils.timezone import now
 
 from confirmation.models import Confirmation
+import six
 
 session_engine = import_module(settings.SESSION_ENGINE)
 
@@ -764,7 +765,7 @@ def extract_recipients(s):
     except ValueError:
         data = s
 
-    if isinstance(data, basestring):
+    if isinstance(data, six.string_types):
         data = data.split(',')
 
     if not isinstance(data, list):
@@ -892,7 +893,7 @@ def check_message(sender, client, message_type_name, message_to,
             recipient = recipient_for_emails(message_to, not_forged_mirror_message,
                                              forwarder_user_profile, sender)
         except ValidationError as e:
-            assert isinstance(e.messages[0], basestring)
+            assert isinstance(e.messages[0], six.string_types)
             raise JsonableError(e.messages[0])
     else:
         raise JsonableError("Invalid message type")

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -31,6 +31,7 @@ from django.utils.timezone import now
 from confirmation.models import Confirmation
 import six
 from six.moves import filter
+from six.moves import map
 
 session_engine = import_module(settings.SESSION_ENGINE)
 
@@ -2272,7 +2273,7 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
             'id': um.user_profile_id,
             'flags': um.flags_list()
         }
-    send_event(event, map(user_info, ums))
+    send_event(event, list(map(user_info, ums)))
 
 def encode_email_address(stream):
     return encode_email_address_helper(stream.name, stream.email_token)
@@ -2409,7 +2410,7 @@ def get_status_dict(requesting_user_profile):
 def get_realm_user_dicts(user_profile):
     # Due to our permission model, it is advantageous to find the admin users in bulk.
     admins = user_profile.realm.get_admin_users()
-    admin_emails = set(map(lambda up: up.email, admins))
+    admin_emails = set([up.email for up in admins])
     return [{'email'     : userdict['email'],
              'is_admin'  : userdict['email'] in admin_emails,
              'is_bot'    : userdict['is_bot'],
@@ -2573,7 +2574,7 @@ def apply_events(state, events, user_profile):
                 return sub['name'].lower()
 
             if event['op'] == "add":
-                added_names = map(name, event["subscriptions"])
+                added_names = list(map(name, event["subscriptions"]))
                 was_added = lambda s: name(s) in added_names
 
                 # add the new subscriptions
@@ -2583,7 +2584,7 @@ def apply_events(state, events, user_profile):
                 state['unsubscribed'] = list(itertools.ifilterfalse(was_added, state['unsubscribed']))
 
             elif event['op'] == "remove":
-                removed_names = map(name, event["subscriptions"])
+                removed_names = list(map(name, event["subscriptions"]))
                 was_removed = lambda s: name(s) in removed_names
 
                 # Find the subs we are affecting.

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -890,7 +890,7 @@ def check_message(sender, client, message_type_name, message_to,
         try:
             recipient = recipient_for_emails(message_to, not_forged_mirror_message,
                                              forwarder_user_profile, sender)
-        except ValidationError, e:
+        except ValidationError as e:
             assert isinstance(e.messages[0], basestring)
             raise JsonableError(e.messages[0])
     else:
@@ -940,7 +940,7 @@ def internal_prep_message(sender_email, recipient_type_name, recipients,
     try:
         return check_message(sender, get_client("Internal"), recipient_type_name,
                              parsed_recipients, subject, content, realm)
-    except JsonableError, e:
+    except JsonableError as e:
         logging.error("Error queueing internal message by %s: %s" % (sender_email, str(e)))
 
     return None

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2416,9 +2416,9 @@ def get_realm_user_dicts(user_profile):
             for userdict in get_active_user_dicts_in_realm(user_profile.realm)]
 
 def get_realm_bot_dicts(user_profile):
-    return [{'email'     : botdict['email'],
-             'full_name' : botdict['full_name'],
-             'api_key'   : botdict['api_key'],
+    return [{'email': botdict['email'],
+             'full_name': botdict['full_name'],
+             'api_key': botdict['api_key'],
              'default_sending_stream': botdict['default_sending_stream__name'],
              'default_events_register_stream': botdict['default_events_register_stream__name'],
              'default_all_public_streams': botdict['default_all_public_streams'],

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -32,6 +32,7 @@ from confirmation.models import Confirmation
 import six
 from six.moves import filter
 from six.moves import map
+from six.moves import range
 
 session_engine = import_module(settings.SESSION_ENGINE)
 

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -34,6 +34,7 @@ from zerver.lib.cache import cache_with_key, cache_get_many, cache_set_many
 import zerver.lib.alert_words as alert_words
 import zerver.lib.mention as mention
 import six
+from six.moves import range
 
 
 # Format version of the bugdown rendering; stored along with rendered
@@ -727,7 +728,7 @@ class BugdownUListPreprocessor(markdown.preprocessors.Preprocessor):
         inserts = 0
         fence = None
         copy = lines[:]
-        for i in xrange(len(lines) - 1):
+        for i in range(len(lines) - 1):
             # Ignore anything that is inside a fenced code block
             m = FENCE_RE.match(lines[i])
             if not fence and m:

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -10,7 +10,7 @@ import glob
 import twitter
 import platform
 import time
-import HTMLParser
+import six.moves.html_parser
 import httplib2
 import itertools
 import urllib
@@ -433,7 +433,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
 
             ## TODO: unescape is an internal function, so we should
             ## use something else if we can find it
-            text = HTMLParser.HTMLParser().unescape(res['text'])
+            text = six.moves.html_parser.HTMLParser().unescape(res['text'])
             urls = res.get('urls', {})
             user_mentions = res.get('user_mentions', [])
             media = res.get('media', [])

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -33,6 +33,7 @@ from zerver.lib.timeout import timeout, TimeoutExpired
 from zerver.lib.cache import cache_with_key, cache_get_many, cache_set_many
 import zerver.lib.alert_words as alert_words
 import zerver.lib.mention as mention
+import six
 
 
 # Format version of the bugdown rendering; stored along with rendered
@@ -849,7 +850,7 @@ class AtomicLinkPattern(LinkPattern):
         ret = LinkPattern.handleMatch(self, m)
         if ret is None:
             return None
-        if not isinstance(ret, basestring):
+        if not isinstance(ret, six.string_types):
             ret.text = markdown.util.AtomicString(ret.text)
         return ret
 

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -215,7 +215,7 @@ def cache(func):
     def keyfunc(*args, **kwargs):
         # Django complains about spaces because memcached rejects them
         key = func_uniqifier + repr((args, kwargs))
-        return key.replace('-','--').replace(' ','-s')
+        return key.replace('-', '--').replace(' ', '-s')
 
     return cache_with_key(keyfunc)(func)
 

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -209,7 +209,7 @@ def cache(func):
        Uses a key based on the function's name, filename, and
        the repr() of its arguments."""
 
-    func_uniqifier = '%s-%s' % (func.func_code.co_filename, func.func_name)
+    func_uniqifier = '%s-%s' % (func.__code__.co_filename, func.__name__)
 
     @wraps(func)
     def keyfunc(*args, **kwargs):

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -45,7 +45,7 @@ def get_or_create_key_prefix():
 
     filename = os.path.join(settings.DEPLOY_ROOT, "memcached_prefix")
     try:
-        fd = os.open(filename, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0444)
+        fd = os.open(filename, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o444)
         prefix = base64.b16encode(hashlib.sha256(str(random.getrandbits(256))).digest())[:32].lower() + ':'
         # This does close the underlying file
         with os.fdopen(fd, 'w') as f:

--- a/zerver/lib/ccache.py
+++ b/zerver/lib/ccache.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #!/usr/bin/env python2.7
 # This file is adapted from samples/shellinabox/ssh-krb-wrapper in
 # https://github.com/davidben/webathena, which has the following
@@ -27,6 +28,7 @@
 
 import base64
 import struct
+import six
 
 # Some DER encoding stuff. Bleh. This is because the ccache contains a
 # DER-encoded krb5 Ticket structure, whereas Webathena deserializes
@@ -48,7 +50,7 @@ def der_encode_tlv(tag, value):
     return chr(tag) + der_encode_length(len(value)) + value
 
 def der_encode_integer_value(val):
-    if not isinstance(val, (int, long)):
+    if not isinstance(val, six.integer_types):
         raise TypeError("int")
     # base 256, MSB first, two's complement, minimum number of octets
     # necessary. This has a number of annoying edge cases:

--- a/zerver/lib/ccache.py
+++ b/zerver/lib/ccache.py
@@ -83,7 +83,7 @@ def der_encode_uint32(val):
     return der_encode_integer(val)
 
 def der_encode_string(val):
-    if not isinstance(val, unicode):
+    if not isinstance(val, six.text_type):
         raise TypeError("unicode")
     return der_encode_tlv(0x1b, val.encode("utf-8"))
 

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -7,6 +7,7 @@ import base64
 import ujson
 import os
 import string
+from six.moves import range
 
 def random_api_key():
     choices = string.ascii_letters + string.digits

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -278,6 +278,6 @@ def process_message(message, rcpt_to=None, pre_checked=False):
             process_missed_message(to, message, pre_checked)
         else:
             process_stream_message(to, subject, message, debug_info)
-    except ZulipEmailForwardError, e:
+    except ZulipEmailForwardError as e:
         # TODO: notify sender of error, retry if appropriate.
         log_and_report(message, e.message, debug_info)

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -15,6 +15,7 @@ from zerver.lib.upload import upload_message_image
 from zerver.lib.utils import generate_random_token
 from zerver.models import Stream, Recipient, get_user_profile_by_email, \
     get_user_profile_by_id, get_display_recipient, get_recipient
+import six
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +125,7 @@ def send_to_missed_message_address(address, message):
 
     # Testing with basestring so we don't depend on the list return type from
     # get_display_recipient
-    if not isinstance(display_recipient, basestring):
+    if not isinstance(display_recipient, six.string_types):
         display_recipient = ','.join([user['email'] for user in display_recipient])
 
     body = filter_footer(extract_body(message))

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -189,8 +189,7 @@ def extract_body(message):
 
 def filter_footer(text):
     # Try to filter out obvious footers.
-    possible_footers = filter(lambda line: line.strip().startswith("--"),
-                              text.split("\n"))
+    possible_footers = [line for line in text.split("\n") if line.strip().startswith("--")]
     if len(possible_footers) != 1:
         # Be conservative and don't try to scrub content if there
         # isn't a trivial footer structure.

--- a/zerver/lib/event_queue.py
+++ b/zerver/lib/event_queue.py
@@ -10,7 +10,7 @@ import socket
 import logging
 import ujson
 import requests
-import cPickle as pickle
+import six.moves.cPickle as pickle
 import atexit
 import sys
 import signal

--- a/zerver/lib/event_queue.py
+++ b/zerver/lib/event_queue.py
@@ -322,8 +322,7 @@ def do_gc_event_queues(to_remove, affected_users, affected_realms):
         if key not in client_dict:
             return
 
-        new_client_list = filter(lambda c: c.event_queue.id not in to_remove,
-                                client_dict[key])
+        new_client_list = [c for c in client_dict[key] if c.event_queue.id not in to_remove]
         if len(new_client_list) == 0:
             del client_dict[key]
         else:

--- a/zerver/lib/migrate.py
+++ b/zerver/lib/migrate.py
@@ -1,14 +1,15 @@
+from __future__ import print_function
 import re
 import time
 
 def timed_ddl(db, stmt):
-    print
-    print time.asctime()
-    print stmt
+    print()
+    print(time.asctime())
+    print(stmt)
     t = time.time()
     db.execute(stmt)
     delay = time.time() - t
-    print 'Took %.2fs' % (delay,)
+    print('Took %.2fs' % (delay,))
 
 def validate(sql_thingy):
     # Do basic validation that table/col name is safe.
@@ -24,16 +25,16 @@ def do_batch_update(db, table, cols, vals, batch_size=10000, sleep=0.1):
         SET (%s) = (%s)
         WHERE id >= %%s AND id < %%s
     ''' % (table, ', '.join(cols), ', '.join(['%s'] * len(cols)))
-    print stmt
+    print(stmt)
     (min_id, max_id) = db.execute("SELECT MIN(id), MAX(id) FROM %s" % (table,))[0]
     if min_id is None:
         return
 
-    print "%s rows need updating" % (max_id - min_id,)
+    print("%s rows need updating" % (max_id - min_id,))
     while min_id <= max_id:
         lower = min_id
         upper = min_id + batch_size
-        print '%s about to update range [%s,%s)' % (time.asctime(), lower, upper)
+        print('%s about to update range [%s,%s)' % (time.asctime(), lower, upper))
         db.start_transaction()
         params = list(vals) + [lower, upper]
         db.execute(stmt, params=params)
@@ -73,7 +74,7 @@ def create_index_if_nonexistant(db, table, col, index):
     test = """SELECT relname FROM pg_class
               WHERE relname = %s"""
     if len(db.execute(test, params=[index])) != 0:
-        print "Not creating index '%s' because it already exists" % (index,)
+        print("Not creating index '%s' because it already exists" % (index,))
     else:
         stmt = "CREATE INDEX %s ON %s (%s)" % (index, table, col)
         timed_ddl(db, stmt)
@@ -88,13 +89,13 @@ def act_on_message_ranges(db, orm, tasks, batch_size=5000, sleep=0.5):
     try:
         min_id = all_objects.all().order_by('id')[0].id
     except IndexError:
-        print 'There is no work to do'
+        print('There is no work to do')
         return
 
     max_id = all_objects.all().order_by('-id')[0].id
-    print "max_id = %d" % (max_id,)
+    print("max_id = %d" % (max_id,))
     overhead = int((max_id + 1 - min_id)/ batch_size * sleep / 60)
-    print "Expect this to take at least %d minutes, just due to sleeps alone." % (overhead,)
+    print("Expect this to take at least %d minutes, just due to sleeps alone." % (overhead,))
 
     while min_id <= max_id:
         lower = min_id
@@ -102,7 +103,7 @@ def act_on_message_ranges(db, orm, tasks, batch_size=5000, sleep=0.5):
         if upper > max_id:
             upper = max_id
 
-        print '%s about to update range %s to %s' % (time.asctime(), lower, upper)
+        print('%s about to update range %s to %s' % (time.asctime(), lower, upper))
 
         db.start_transaction()
         for filterer, action in tasks:

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -220,7 +220,7 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile, missed_messages, m
         'url': 'https://%s' % (settings.EXTERNAL_HOST,),
         'reply_warning': False,
         'external_host': settings.EXTERNAL_HOST,
-        'mention':missed_messages[0].recipient.type == Recipient.STREAM,
+        'mention': missed_messages[0].recipient.type == Recipient.STREAM,
         'reply_to_zulip': True,
     }
 

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from confirmation.models import Confirmation
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
@@ -381,7 +382,7 @@ def clear_followup_emails_queue(email, mail_client=None):
     for email in mail_client.messages.list_scheduled(to=email):
         result = mail_client.messages.cancel_scheduled(id=email["_id"])
         if result.get("status") == "error":
-            print result.get("name"), result.get("error")
+            print(result.get("name"), result.get("error"))
     return
 
 def log_digest_event(msg):

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -445,7 +445,7 @@ def send_future_email(recipients, email_html, email_text, subject,
                'tags': tags,
                }
     # ignore any delays smaller than 1-minute because it's cheaper just to sent them immediately
-    if type(delay) is not datetime.timedelta:
+    if not isinstance(delay, datetime.timedelta):
         raise TypeError("specified delay is of the wrong type: %s" % (type(delay),))
     if delay < datetime.timedelta(minutes=1):
         results = mail_client.messages.send(message=message, async=False, ip_pool="Main Pool")

--- a/zerver/lib/parallel.py
+++ b/zerver/lib/parallel.py
@@ -22,7 +22,7 @@ def run_parallel(job, data, threads=6):
             sys.stdin.close()
             try:
                 os.close(pty.STDIN_FILENO)
-            except OSError, e:
+            except OSError as e:
                 if e.errno != errno.EBADF:
                     raise
             sys.stdin = open("/dev/null", "r")
@@ -43,7 +43,7 @@ def run_parallel(job, data, threads=6):
         try:
             (status, item) = wait_for_one()
             yield (status, item)
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.ECHILD:
                 break
             else:

--- a/zerver/lib/parallel.py
+++ b/zerver/lib/parallel.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 import os
 import pty
@@ -62,10 +63,10 @@ if __name__ == "__main__":
     for (status, job) in run_parallel(wait_and_print, jobs):
         output.append(job)
     if output == expected_output:
-        print "Successfully passed test!"
+        print("Successfully passed test!")
     else:
-        print "Failed test!"
-        print jobs
-        print expected_output
-        print output
+        print("Failed test!")
+        print(jobs)
+        print(expected_output)
+        print(output)
 

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -99,7 +99,7 @@ class SimpleQueueClient(object):
             try:
                 consumer(ch, method, properties, body)
                 ch.basic_ack(delivery_tag=method.delivery_tag)
-            except Exception, e:
+            except Exception as e:
                 ch.basic_nack(delivery_tag=method.delivery_tag)
                 raise e
 

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -40,7 +40,7 @@ def add_ratelimit_rule(range_seconds, num_requests):
 
 def remove_ratelimit_rule(range_seconds, num_requests):
     global rules
-    rules = filter(lambda x: x[0] != range_seconds and x[1] != num_requests, rules)
+    rules = [x for x in rules if x[0] != range_seconds and x[1] != num_requests]
 
 def block_user(user, seconds, domain='all'):
     "Manually blocks a user id for the desired number of seconds"

--- a/zerver/lib/statistics.py
+++ b/zerver/lib/statistics.py
@@ -7,6 +7,7 @@ from django.utils.timezone import utc
 
 from datetime import timedelta
 from itertools import chain
+from six.moves import range
 
 def median(data):
     data = sorted(data)

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -319,7 +319,7 @@ class AuthedTestCase(TestCase):
 
     def fixture_data(self, type, action, file_type='json'):
         return open(os.path.join(os.path.dirname(__file__),
-                                 "../fixtures/%s/%s_%s.%s" % (type, type, action,file_type))).read()
+                                 "../fixtures/%s/%s_%s.%s" % (type, type, action, file_type))).read()
 
     # Subscribe to a stream directly
     def subscribe_to_stream(self, email, stream_name, realm=None):

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django.test import TestCase
 
 from zerver.lib.initial_password import initial_password
@@ -32,6 +33,7 @@ import ujson
 import urllib
 
 from contextlib import contextmanager
+import six
 
 API_KEYS = {}
 
@@ -256,7 +258,7 @@ class AuthedTestCase(TestCase):
             message_type_name = "private"
         else:
             message_type_name = "stream"
-        if isinstance(recipient_list, basestring):
+        if isinstance(recipient_list, six.string_types):
             recipient_list = [recipient_list]
         (sending_client, _) = Client.objects.get_or_create(name="test suite")
 

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from django.test.runner import DiscoverRunner
 
 from zerver.lib.cache import bounce_key_prefix_for_testing
@@ -46,7 +47,7 @@ def enforce_timely_test_completion(test_method, test_name, delay):
     max_delay = max_delay * 3
 
     if delay > max_delay:
-        print 'Test is TOO slow: %s (%.3f s)' % (test_name, delay)
+        print('Test is TOO slow: %s (%.3f s)' % (test_name, delay))
 
 def fast_tests_only():
     return os.environ.get('FAST_TESTS_ONLY', False)
@@ -61,10 +62,10 @@ def run_test(test):
 
     bounce_key_prefix_for_testing(test_name)
 
-    print 'Running', test_name
+    print('Running', test_name)
     if not hasattr(test, "_pre_setup"):
-        print "somehow the test doesn't have _pre_setup; it may be an import fail."
-        print "Here's a debugger. Good luck!"
+        print("somehow the test doesn't have _pre_setup; it may be an import fail.")
+        print("Here's a debugger. Good luck!")
         import pdb; pdb.set_trace()
     test._pre_setup()
 
@@ -99,5 +100,5 @@ class Runner(DiscoverRunner):
         get_sqlalchemy_connection()
         self.run_suite(suite)
         self.teardown_test_environment()
-        print 'DONE!'
-        print
+        print('DONE!')
+        print()

--- a/zerver/lib/timeout.py
+++ b/zerver/lib/timeout.py
@@ -5,6 +5,7 @@ import time
 import ctypes
 import threading
 import six
+from six.moves import range
 
 # Based on http://code.activestate.com/recipes/483752/
 
@@ -70,7 +71,7 @@ def timeout(timeout, func, *args, **kwargs):
         #
         # We need to retry, because an async exception received while the
         # thread is in a system call is simply ignored.
-        for i in xrange(10):
+        for i in range(10):
             thread.raise_async_timeout()
             time.sleep(0.1)
             if not thread.isAlive():

--- a/zerver/lib/timeout.py
+++ b/zerver/lib/timeout.py
@@ -4,6 +4,7 @@ import sys
 import time
 import ctypes
 import threading
+import six
 
 # Based on http://code.activestate.com/recipes/483752/
 
@@ -79,5 +80,5 @@ def timeout(timeout, func, *args, **kwargs):
     if thread.exc_info:
         # Raise the original stack trace so our error messages are more useful.
         # from http://stackoverflow.com/a/4785766/90777
-        raise thread.exc_info[0], thread.exc_info[1], thread.exc_info[2]
+        six.reraise(thread.exc_info[0], thread.exc_info[1], thread.exc_info[2])
     return thread.result

--- a/zerver/lib/tornado_ioloop_logging.py
+++ b/zerver/lib/tornado_ioloop_logging.py
@@ -66,7 +66,7 @@ class InstrumentedPoll(object):
         # outside poll
         if self._times and t1 - self._last_print >= 5:
             total = t1 - self._times[0][0]
-            in_poll = sum(b-a for a,b in self._times)
+            in_poll = sum(b-a for a, b in self._times)
             if total > 0:
                 percent_busy = 100 * (1 - in_poll/total)
                 if settings.PRODUCTION or percent_busy > 20:

--- a/zerver/lib/unminify.py
+++ b/zerver/lib/unminify.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import re
 import os.path
 import sourcemap
+from six.moves import map
 
 
 class SourceMap(object):
@@ -31,7 +32,7 @@ class SourceMap(object):
                 minified_src = match.groups()[0] + '.js'
                 index = self._index_for(minified_src)
 
-                gen_line, gen_col = map(int, match.groups()[2:4])
+                gen_line, gen_col = list(map(int, match.groups()[2:4]))
                 # The sourcemap lib is 0-based, so subtract 1 from line and col.
                 try:
                     result = index.lookup(line=gen_line-1, column=gen_col-1)

--- a/zerver/lib/utils.py
+++ b/zerver/lib/utils.py
@@ -7,6 +7,7 @@ import os
 from time import sleep
 
 from django.conf import settings
+from six.moves import range
 
 def statsd_key(val, clean_periods=False):
     if not isinstance(val, str):
@@ -59,7 +60,7 @@ def run_in_batches(all_list, batch_size, callback, sleep_time = 0, logger = None
         return
 
     limit = (len(all_list) / batch_size) + 1;
-    for i in xrange(limit):
+    for i in range(limit):
         start = i*batch_size
         end = (i+1) * batch_size
         if end >= len(all_list):

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -25,9 +25,11 @@ A simple example of composition is this:
 To extend this concept, it's simply a matter of writing your own validator
 for any particular type of object.
 '''
+from __future__ import absolute_import
+import six
 
 def check_string(var_name, val):
-    if not isinstance(val, basestring):
+    if not isinstance(val, six.string_types):
         return '%s is not a string' % (var_name,)
     return None
 

--- a/zerver/management/commands/add_users_to_streams.py
+++ b/zerver/management/commands/add_users_to_streams.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from optparse import make_option
 
@@ -51,6 +52,6 @@ class Command(BaseCommand):
             for user_profile in user_profiles:
                 stream, _ = create_stream_if_needed(user_profile.realm, stream_name)
                 did_subscribe = do_add_subscription(user_profile, stream)
-                print "%s %s to %s" % (
+                print("%s %s to %s" % (
                     "Subscribed" if did_subscribe else "Already subscribed",
-                    user_profile.email, stream_name)
+                    user_profile.email, stream_name))

--- a/zerver/management/commands/bankrupt_users.py
+++ b/zerver/management/commands/bankrupt_users.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 
@@ -17,7 +18,7 @@ class Command(BaseCommand):
             try:
                 user_profile = get_user_profile_by_email(email)
             except UserProfile.DoesNotExist:
-                print "e-mail %s doesn't exist in the system, skipping" % (email,)
+                print("e-mail %s doesn't exist in the system, skipping" % (email,))
                 continue
 
             do_update_message_flags(user_profile, "add", "read", None, True)
@@ -29,6 +30,6 @@ class Command(BaseCommand):
                 new_pointer = messages[0].id
                 user_profile.pointer = new_pointer
                 user_profile.save(update_fields=["pointer"])
-                print "%s: %d => %d" % (email, old_pointer, new_pointer)
+                print("%s: %d => %d" % (email, old_pointer, new_pointer))
             else:
-                print "%s has no messages, can't bankrupt!" % (email,)
+                print("%s has no messages, can't bankrupt!" % (email,))

--- a/zerver/management/commands/bulk_change_user_name.py
+++ b/zerver/management/commands/bulk_change_user_name.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 
@@ -21,7 +22,7 @@ class Command(BaseCommand):
                 try:
                     user_profile = get_user_profile_by_email(email)
                     old_name = user_profile.full_name
-                    print "%s: %s -> %s" % (email, old_name, new_name)
+                    print("%s: %s -> %s" % (email, old_name, new_name))
                     do_change_full_name(user_profile, new_name)
                 except UserProfile.DoesNotExist:
-                    print "* E-mail %s doesn't exist in the system, skipping." % (email,)
+                    print("* E-mail %s doesn't exist in the system, skipping." % (email,))

--- a/zerver/management/commands/change_user_email.py
+++ b/zerver/management/commands/change_user_email.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 
@@ -20,7 +21,7 @@ class Command(BaseCommand):
         try:
             user_profile = get_user_profile_by_email(old_email)
         except UserProfile.DoesNotExist:
-            print "Old e-mail doesn't exist in the system."
+            print("Old e-mail doesn't exist in the system.")
             exit(1)
 
         do_change_user_email(user_profile, new_email)

--- a/zerver/management/commands/check_redis.py
+++ b/zerver/management/commands/check_redis.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from zerver.models import get_user_profile_by_id
 from zerver.lib.rate_limiter import client, max_api_calls, max_api_window
@@ -44,7 +45,7 @@ than max_api_calls! (trying to trim) %s %s" % (key, count))
 
     def handle(self, *args, **options):
         if not settings.RATE_LIMITING:
-            print "This machine is not using redis or rate limiting, aborting"
+            print("This machine is not using redis or rate limiting, aborting")
             exit(1)
 
         # Find all keys, and make sure they're all within size constraints

--- a/zerver/management/commands/checkconfig.py
+++ b/zerver/management/commands/checkconfig.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from optparse import make_option
 
@@ -18,5 +19,5 @@ class Command(BaseCommand):
             except AttributeError:
                 pass
 
-            print "Error: You must set %s in /etc/zulip/settings.py." % (setting_name,)
+            print("Error: You must set %s in /etc/zulip/settings.py." % (setting_name,))
             sys.exit(1)

--- a/zerver/management/commands/create_realm.py
+++ b/zerver/management/commands/create_realm.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 from optparse import make_option
 
 from django.conf import settings
@@ -55,16 +56,16 @@ Usage: python2.7 manage.py create_realm --domain=foo.com --name='Foo, Inc.'"""
 
     def handle(self, *args, **options):
         if options["domain"] is None or options["name"] is None:
-            print >>sys.stderr, "\033[1;31mPlease provide both a domain and name.\033[0m\n"
+            print("\033[1;31mPlease provide both a domain and name.\033[0m\n", file=sys.stderr)
             self.print_help("python2.7 manage.py", "create_realm")
             exit(1)
 
         if options["open_realm"] and options["deployment_id"] is not None:
-            print >>sys.stderr, "\033[1;31mExternal deployments cannot be open realms.\033[0m\n"
+            print("\033[1;31mExternal deployments cannot be open realms.\033[0m\n", file=sys.stderr)
             self.print_help("python2.7 manage.py", "create_realm")
             exit(1)
         if options["deployment_id"] is not None and settings.VOYAGER:
-            print >>sys.stderr, "\033[1;31mExternal deployments are not supported on voyager deployments.\033[0m\n"
+            print("\033[1;31mExternal deployments are not supported on voyager deployments.\033[0m\n", file=sys.stderr)
             exit(1)
 
         domain = options["domain"]
@@ -75,12 +76,12 @@ Usage: python2.7 manage.py create_realm --domain=foo.com --name='Foo, Inc.'"""
         realm, created = do_create_realm(
             domain, name, restricted_to_domain=not options["open_realm"])
         if created:
-            print domain, "created."
+            print(domain, "created.")
             if options["deployment_id"] is not None:
                 deployment = Deployment.objects.get(id=options["deployment_id"])
                 deployment.realms.add(realm)
                 deployment.save()
-                print "Added to deployment", str(deployment.id)
+                print("Added to deployment", str(deployment.id))
             elif settings.ZULIP_COM:
                 deployment = Deployment.objects.get(base_site_url="https://zulip.com/")
                 deployment.realms.add(realm)
@@ -89,6 +90,6 @@ Usage: python2.7 manage.py create_realm --domain=foo.com --name='Foo, Inc.'"""
 
             set_default_streams(realm, ["social", "engineering"])
 
-            print "\033[1;36mDefault streams set to social,engineering,zulip!\033[0m"
+            print("\033[1;36mDefault streams set to social,engineering,zulip!\033[0m")
         else:
-            print domain, "already exists."
+            print(domain, "already exists.")

--- a/zerver/management/commands/create_stream.py
+++ b/zerver/management/commands/create_stream.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 
@@ -27,7 +28,7 @@ the command."""
         try:
             realm = get_realm(domain)
         except Realm.DoesNotExist:
-            print "Unknown domain %s" % (domain,)
+            print("Unknown domain %s" % (domain,))
             exit(1)
 
         do_create_stream(realm, stream_name.decode(encoding))

--- a/zerver/management/commands/create_user.py
+++ b/zerver/management/commands/create_user.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 import sys
 import argparse
@@ -68,7 +69,7 @@ parameters, or specify no parameters for interactive user creation.""")
                         validators.validate_email(email)
                         break
                     except ValidationError:
-                        print >> sys.stderr, "Invalid email address."
+                        print("Invalid email address.", file=sys.stderr)
                 full_name = raw_input("Full name: ")
 
         try:

--- a/zerver/management/commands/create_user.py
+++ b/zerver/management/commands/create_user.py
@@ -13,6 +13,7 @@ from zerver.models import Realm, get_realm, email_to_username
 from zerver.lib.actions import do_create_user
 from zerver.views import notify_new_user
 from zerver.lib.initial_password import initial_password
+from six.moves import input
 
 class Command(BaseCommand):
     help = """Create the specified user with a default initial password.
@@ -64,13 +65,13 @@ Terms of Service by passing --this-user-has-accepted-the-tos.""")
 parameters, or specify no parameters for interactive user creation.""")
             else:
                 while True:
-                    email = raw_input("Email: ")
+                    email = input("Email: ")
                     try:
                         validators.validate_email(email)
                         break
                     except ValidationError:
                         print("Invalid email address.", file=sys.stderr)
-                full_name = raw_input("Full name: ")
+                full_name = input("Full name: ")
 
         try:
             notify_new_user(do_create_user(email, initial_password(email),

--- a/zerver/management/commands/deactivate_realm.py
+++ b/zerver/management/commands/deactivate_realm.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 
@@ -13,6 +14,6 @@ class Command(BaseCommand):
                             help='domain of realm to deactivate')
 
     def handle(self, *args, **options):
-        print "Deactivating", options["domain"]
+        print("Deactivating", options["domain"])
         do_deactivate_realm(get_realm(options["domain"]))
-        print "Done!"
+        print("Done!")

--- a/zerver/management/commands/deactivate_user.py
+++ b/zerver/management/commands/deactivate_user.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from optparse import make_option
 
@@ -22,23 +23,23 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         user_profile = get_user_profile_by_email(options['email'])
 
-        print "Deactivating %s (%s) - %s" % (user_profile.full_name,
+        print("Deactivating %s (%s) - %s" % (user_profile.full_name,
                                              user_profile.email,
-                                             user_profile.realm.domain)
-        print "%s has the following active sessions:" % (user_profile.email,)
+                                             user_profile.realm.domain))
+        print("%s has the following active sessions:" % (user_profile.email,))
         for session in user_sessions(user_profile):
-            print session.expire_date, session.get_decoded()
-        print ""
-        print "%s has %s active bots that will also be deactivated." % (
+            print(session.expire_date, session.get_decoded())
+        print("")
+        print("%s has %s active bots that will also be deactivated." % (
                 user_profile.email,
                 UserProfile.objects.filter(
                     is_bot=True, is_active=True, bot_owner=user_profile
                 ).count()
-            )
+            ))
 
         if not options["for_real"]:
-            print "This was a dry run. Pass -f to actually deactivate."
+            print("This was a dry run. Pass -f to actually deactivate.")
             exit(1)
 
         do_deactivate_user(user_profile)
-        print "Sessions deleted, user deactivated."
+        print("Sessions deleted, user deactivated.")

--- a/zerver/management/commands/dump_messages.py
+++ b/zerver/management/commands/dump_messages.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from optparse import make_option
 from django.core.management.base import BaseCommand
@@ -31,4 +32,4 @@ class Command(BaseCommand):
         messages = Message.objects.filter(pub_date__gt=cutoff, recipient__in=recipients)
 
         for message in messages:
-            print message.to_dict(False)
+            print(message.to_dict(False))

--- a/zerver/management/commands/email-mirror.py
+++ b/zerver/management/commands/email-mirror.py
@@ -110,7 +110,7 @@ def select_mailbox(result, proto):
 
 def list_mailboxes(res, proto):
     # List all of the mailboxes for this account.
-    return proto.list("","*").addCallback(select_mailbox, proto)
+    return proto.list("", "*").addCallback(select_mailbox, proto)
 
 def connected(proto):
     d = proto.login(settings.EMAIL_GATEWAY_LOGIN, settings.EMAIL_GATEWAY_PASSWORD)

--- a/zerver/management/commands/email-mirror.py
+++ b/zerver/management/commands/email-mirror.py
@@ -87,9 +87,8 @@ def fetch(result, proto, mailboxes):
     if not result:
         return proto.logout()
 
-    message_uids = result.keys()
     # Make sure we forward the messages in time-order.
-    message_uids.sort()
+    message_uids = sorted(result.keys())
     for uid in message_uids:
         message = email.message_from_string(result[uid]["RFC822"])
         process_message(message)

--- a/zerver/management/commands/email-mirror.py
+++ b/zerver/management/commands/email-mirror.py
@@ -34,6 +34,7 @@ This script can be used via two mechanisms:
 
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 import email
 import os
@@ -144,13 +145,13 @@ class Command(BaseCommand):
                 try:
                     mark_missed_message_address_as_used(rcpt_to)
                 except ZulipEmailForwardError:
-                    print "5.1.1 Bad destination mailbox address: Bad or expired missed message address."
+                    print("5.1.1 Bad destination mailbox address: Bad or expired missed message address.")
                     exit(posix.EX_NOUSER)
             else:
                 try:
                     extract_and_validate(rcpt_to)
                 except ZulipEmailForwardError:
-                    print "5.1.1 Bad destination mailbox address: Please use the address specified in your Streams page."
+                    print("5.1.1 Bad destination mailbox address: Please use the address specified in your Streams page.")
                     exit(posix.EX_NOUSER)
 
             # Read in the message, at most 25MiB. This is the limit enforced by
@@ -159,7 +160,7 @@ class Command(BaseCommand):
 
             if len(sys.stdin.read(1)) != 0:
                 # We're not at EOF, reject large mail.
-                print "5.3.4 Message too big for system: Max size is 25MiB"
+                print("5.3.4 Message too big for system: Max size is 25MiB")
                 exit(posix.EX_DATAERR)
 
             queue_json_publish(
@@ -175,7 +176,7 @@ class Command(BaseCommand):
             if (not settings.EMAIL_GATEWAY_BOT or not settings.EMAIL_GATEWAY_LOGIN or
                 not settings.EMAIL_GATEWAY_PASSWORD or not settings.EMAIL_GATEWAY_IMAP_SERVER or
                 not settings.EMAIL_GATEWAY_IMAP_PORT or not settings.EMAIL_GATEWAY_IMAP_FOLDER):
-                print "Please configure the Email Mirror Gateway in your local_settings.py, or specify $ORIGINAL_RECIPIENT if piping a single mail."
+                print("Please configure the Email Mirror Gateway in your local_settings.py, or specify $ORIGINAL_RECIPIENT if piping a single mail.")
                 exit(1)
             reactor.callLater(0, main)
             reactor.run()

--- a/zerver/management/commands/enqueue_digest_emails.py
+++ b/zerver/management/commands/enqueue_digest_emails.py
@@ -92,7 +92,7 @@ in a while.
             return
 
         deployment_domains = domains_for_this_deployment()
-        for realm in Realm.objects.filter(deactivated=False,show_digest_email=True):
+        for realm in Realm.objects.filter(deactivated=False, show_digest_email=True):
             domain = realm.domain
             if not should_process_digest(domain, deployment_domains):
                 continue

--- a/zerver/management/commands/enqueue_file.py
+++ b/zerver/management/commands/enqueue_file.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 from zerver.lib.queue import queue_json_publish
@@ -47,7 +48,7 @@ You can use "-" to represent stdin.
             except IndexError:
                 payload = line
 
-            print 'Queueing to queue %s: %s' % (queue_name, payload)
+            print('Queueing to queue %s: %s' % (queue_name, payload))
 
             # Verify that payload is valid json.
             data = ujson.loads(payload)

--- a/zerver/management/commands/expunge_logs.py
+++ b/zerver/management/commands/expunge_logs.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 import os
 import sys
@@ -60,7 +61,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if len(options['log_files']) == 0:
-            print >>sys.stderr, 'WARNING: No log files specified; doing nothing.'
+            print('WARNING: No log files specified; doing nothing.', file=sys.stderr)
 
         for infile in options['log_files']:
             try:
@@ -68,5 +69,5 @@ class Command(BaseCommand):
             except KeyboardInterrupt:
                 raise
             except:
-                print >>sys.stderr, 'WARNING: Could not expunge from', infile
+                print('WARNING: Could not expunge from', infile, file=sys.stderr)
                 traceback.print_exc()

--- a/zerver/management/commands/generate_invite_links.py
+++ b/zerver/management/commands/generate_invite_links.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 from confirmation.models import Confirmation
@@ -26,7 +27,7 @@ class Command(BaseCommand):
         for email in options['emails']:
             try:
                 get_user_profile_by_email(email)
-                print email + ": There is already a user registered with that address."
+                print(email + ": There is already a user registered with that address.")
                 duplicates = True
                 continue
             except UserProfile.DoesNotExist:
@@ -40,8 +41,8 @@ class Command(BaseCommand):
         if domain:
             realm = get_realm(domain)
         if not realm:
-            print "The realm %s doesn't exist yet, please create it first." % (domain,)
-            print "Don't forget default streams!"
+            print("The realm %s doesn't exist yet, please create it first." % (domain,))
+            print("Don't forget default streams!")
             exit(1)
 
         for email in options['emails']:
@@ -49,14 +50,14 @@ class Command(BaseCommand):
                 if realm.restricted_to_domain and \
                         domain.lower() != email.split("@", 1)[-1].lower() and \
                         not options["force"]:
-                    print "You've asked to add an external user (%s) to a closed realm (%s)." % (
-                        email, domain)
-                    print "Are you sure? To do this, pass --force."
+                    print("You've asked to add an external user (%s) to a closed realm (%s)." % (
+                        email, domain))
+                    print("Are you sure? To do this, pass --force.")
                     exit(1)
                 else:
                     prereg_user = PreregistrationUser(email=email, realm=realm)
             else:
                 prereg_user = PreregistrationUser(email=email)
             prereg_user.save()
-            print email + ": " + Confirmation.objects.get_link_for_object(prereg_user)
+            print(email + ": " + Confirmation.objects.get_link_for_object(prereg_user))
 

--- a/zerver/management/commands/import_dump.py
+++ b/zerver/management/commands/import_dump.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from optparse import make_option
 
@@ -41,9 +42,9 @@ Usage: python2.7 manage.py import_dump [--destroy-rebuild-database] [--chunk-siz
     def new_instance_check(self, model):
         count = model.objects.count()
         if count:
-            print "Zulip instance is not empty, found %d rows in %s table. " \
-                % (count, model._meta.db_table)
-            print "You may use --destroy-rebuild-database to destroy and rebuild the database prior to import."
+            print("Zulip instance is not empty, found %d rows in %s table. " \
+                % (count, model._meta.db_table))
+            print("You may use --destroy-rebuild-database to destroy and rebuild the database prior to import.")
             exit(1)
 
 
@@ -110,7 +111,7 @@ Usage: python2.7 manage.py import_dump [--destroy-rebuild-database] [--chunk-siz
         encoding = sys.getfilesystemencoding()
 
         if len(args) == 0:
-            print "Please provide at least one database dump file name."
+            print("Please provide at least one database dump file name.")
             exit(1)
 
         if not options["destroy_rebuild_database"]:
@@ -133,10 +134,10 @@ Usage: python2.7 manage.py import_dump [--destroy-rebuild-database] [--chunk-siz
             try:
                 fp = open(file_name, 'r')
             except IOError:
-                print "File not found: '%s'" % (file_name,)
+                print("File not found: '%s'" % (file_name,))
                 exit(1)
 
-            print "Processing file: %s ..." % (file_name,)
+            print("Processing file: %s ..." % (file_name,))
 
             # parse the database dump and load in memory
             # TODO: change this to a streaming parser to support loads > RAM size
@@ -146,19 +147,19 @@ Usage: python2.7 manage.py import_dump [--destroy-rebuild-database] [--chunk-siz
                 self.increment_row_counter(row_counter, database_dump, model)
                 self.import_table(database_dump, realm_notification_map, model)
 
-            print ""
+            print("")
 
         # set notifications_stream_id on realm objects to correct value now
         # that foreign keys are in streams table
         if len(realm_notification_map):
-            print "Setting realm notification stream..."
+            print("Setting realm notification stream...")
             for id, notifications_stream_id in realm_notification_map.items():
                 Realm.objects \
                     .filter(id=id) \
                     .update(notifications_stream = notifications_stream_id)
 
-        print ""
-        print "Testing data import: "
+        print("")
+        print("Testing data import: ")
 
         # test that everything from all json dumps made it into the database
         for model in models_to_import:

--- a/zerver/management/commands/knight.py
+++ b/zerver/management/commands/knight.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand, CommandError
 from django.core.exceptions import ValidationError
@@ -45,16 +46,16 @@ ONLY perform this on customer request from an authorized person.
             else:
                 if options['ack']:
                     do_change_is_admin(profile, True, permission=options['permission'])
-                    print "Done!"
+                    print("Done!")
                 else:
-                    print "Would have granted %s %s rights for %s" % (email, options['permission'], profile.realm.domain)
+                    print("Would have granted %s %s rights for %s" % (email, options['permission'], profile.realm.domain))
         else:
             if profile.has_perm(options['permission'], profile.realm):
                 if options['ack']:
                     do_change_is_admin(profile, False, permission=options['permission'])
-                    print "Done!"
+                    print("Done!")
                 else:
-                    print "Would have removed %s's %s rights on %s" % (email, options['permission'],
-                            profile.realm.domain)
+                    print("Would have removed %s's %s rights on %s" % (email, options['permission'],
+                            profile.realm.domain))
             else:
                 raise CommandError("User did not have permission for this realm!")

--- a/zerver/management/commands/print_email_delivery_backlog.py
+++ b/zerver/management/commands/print_email_delivery_backlog.py
@@ -5,6 +5,7 @@ Shows backlog count of ScheduledJobs of type Email
 """
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -24,7 +25,7 @@ Usage: python2.7 manage.py print_email_delivery_backlog
 """
 
     def handle(self, *args, **options):
-        print len(ScheduledJob.objects.filter(type=ScheduledJob.EMAIL,
-                                                  scheduled_timestamp__lte=datetime.utcnow()-timedelta(minutes=1)))
+        print(len(ScheduledJob.objects.filter(type=ScheduledJob.EMAIL,
+                                                  scheduled_timestamp__lte=datetime.utcnow()-timedelta(minutes=1))))
         return
 

--- a/zerver/management/commands/purge_queue.py
+++ b/zerver/management/commands/purge_queue.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 from django.core.management import CommandError
@@ -15,4 +16,4 @@ class Command(BaseCommand):
         queue = SimpleQueueClient()
         queue.ensure_queue(queue_name, lambda: None)
         queue.channel.queue_purge(queue_name)
-        print "Done"
+        print("Done")

--- a/zerver/management/commands/query_ldap.py
+++ b/zerver/management/commands/query_ldap.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 import sys
 
@@ -16,10 +17,10 @@ def query_ldap(**options):
         if isinstance(backend, LDAPBackend):
             ldap_attrs = _LDAPUser(backend, backend.django_to_ldap_username(email)).attrs
             if ldap_attrs is None:
-                print "No such user found"
+                print("No such user found")
             else:
                 for django_field, ldap_field in settings.AUTH_LDAP_USER_ATTR_MAP.items():
-                    print "%s: %s" % (django_field, ldap_attrs[ldap_field])
+                    print("%s: %s" % (django_field, ldap_attrs[ldap_field]))
 
 class Command(BaseCommand):
     def add_arguments(self, parser):

--- a/zerver/management/commands/rate_limit.py
+++ b/zerver/management/commands/rate_limit.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from zerver.models import UserProfile, get_user_profile_by_email
 from zerver.lib.rate_limiter import block_user, unblock_user
@@ -36,7 +37,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if (not options['api_key'] and not options['email']) or \
            (options['api_key'] and options['email']):
-            print "Please enter either an email or API key to manage"
+            print("Please enter either an email or API key to manage")
             exit(1)
 
         if options['email']:
@@ -45,7 +46,7 @@ class Command(BaseCommand):
             try:
                 user_profile = UserProfile.objects.get(api_key=options['api_key'])
             except:
-                print "Unable to get user profile for api key %s" % (options['api_key'], )
+                print("Unable to get user profile for api key %s" % (options['api_key'], ))
                 exit(1)
 
         users = [user_profile]
@@ -55,7 +56,7 @@ class Command(BaseCommand):
 
         operation = options['operation']
         for user in users:
-            print "Applying operation to User ID: %s: %s" % (user.id, operation)
+            print("Applying operation to User ID: %s: %s" % (user.id, operation))
 
             if operation == 'block':
                 block_user(user, options['seconds'], options['domain'])

--- a/zerver/management/commands/realm_alias.py
+++ b/zerver/management/commands/realm_alias.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 from zerver.models import Realm, RealmAlias, get_realm
@@ -25,15 +26,15 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         realm = get_realm(options["domain"])
         if options["op"] == "show":
-            print "Aliases for %s:" % (realm.domain,)
+            print("Aliases for %s:" % (realm.domain,))
             for alias in realm_aliases(realm):
-                print alias
+                print(alias)
             sys.exit(0)
 
         alias = options['alias']
         if options["op"] == "add":
             if get_realm(alias) is not None:
-                print "A Realm already exists for this domain, cannot add it as an alias for another realm!"
+                print("A Realm already exists for this domain, cannot add it as an alias for another realm!")
                 sys.exit(1)
             RealmAlias.objects.create(realm=realm, domain=alias)
             sys.exit(0)

--- a/zerver/management/commands/realm_emoji.py
+++ b/zerver/management/commands/realm_emoji.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 from zerver.models import Realm, get_realm
@@ -33,7 +34,7 @@ Example: python2.7 manage.py realm_emoji --realm=zulip.com --op=show
         realm = get_realm(options["domain"])
         if options["op"] == "show":
             for name, url in realm.get_emoji().iteritems():
-                print name, url
+                print(name, url)
             sys.exit(0)
 
         name = options['name']

--- a/zerver/management/commands/realm_filters.py
+++ b/zerver/management/commands/realm_filters.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
@@ -39,7 +40,7 @@ Example: python2.7 manage.py realm_filters --realm=zulip.com --op=show
     def handle(self, *args, **options):
         realm = get_realm(options["domain"])
         if options["op"] == "show":
-            print "%s: %s" % (realm.domain, all_realm_filters().get(realm.domain, ""))
+            print("%s: %s" % (realm.domain, all_realm_filters().get(realm.domain, "")))
             sys.exit(0)
 
         pattern = options['pattern']

--- a/zerver/management/commands/remove_users_from_stream.py
+++ b/zerver/management/commands/remove_users_from_stream.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from optparse import make_option
 
@@ -51,6 +52,6 @@ class Command(BaseCommand):
 
         for user_profile in user_profiles:
             did_remove = do_remove_subscription(user_profile, stream)
-            print "%s %s from %s" % (
+            print("%s %s from %s" % (
                 "Removed" if did_remove else "Couldn't remove",
-                user_profile.email, stream_name)
+                user_profile.email, stream_name))

--- a/zerver/management/commands/rename_stream.py
+++ b/zerver/management/commands/rename_stream.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 
@@ -27,7 +28,7 @@ class Command(BaseCommand):
         try:
             realm = get_realm(domain)
         except Realm.DoesNotExist:
-            print "Unknown domain %s" % (domain,)
+            print("Unknown domain %s" % (domain,))
             exit(1)
 
         do_rename_stream(realm, old_name.decode(encoding),

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -238,7 +238,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
                         if response is RespondAsynchronously:
                             async_request_stop(request)
                             return
-                    except Exception, e:
+                    except Exception as e:
                         # If the view raised an exception, run it through exception
                         # middleware, and if the exception middleware returns a
                         # response, use that. Otherwise, reraise the exception.
@@ -265,7 +265,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
                     response = response.render()
 
 
-            except http.Http404, e:
+            except http.Http404 as e:
                 if settings.DEBUG:
                     from django.views import debug
                     response = debug.technical_404_response(request, e)
@@ -298,7 +298,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
             except SystemExit:
                 # See https://code.djangoproject.com/ticket/4701
                 raise
-            except Exception, e:
+            except Exception as e:
                 exc_info = sys.exc_info()
                 signals.got_request_exception.send(sender=self.__class__, request=request)
                 return self.handle_uncaught_exception(request, resolver, exc_info)

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -251,7 +251,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
 
                 if response is None:
                     try:
-                        view_name = callback.func_name
+                        view_name = callback.__name__
                     except AttributeError:
                         view_name = callback.__class__.__name__ + '.__call__'
                     raise ValueError("The view %s.%s returned None." %

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.conf import settings
 settings.RUNNING_INSIDE_TORNADO = True
@@ -73,11 +74,11 @@ class Command(BaseCommand):
             from django.utils import translation
             translation.activate(settings.LANGUAGE_CODE)
 
-            print "Validating Django models.py..."
+            print("Validating Django models.py...")
             self.validate(display_num_errors=True)
-            print "\nDjango version %s" % (django.get_version())
-            print "Tornado server is running at http://%s:%s/" % (addr, port)
-            print "Quit the server with %s." % (quit_command,)
+            print("\nDjango version %s" % (django.get_version()))
+            print("Tornado server is running at http://%s:%s/" % (addr, port))
+            print("Quit the server with %s." % (quit_command,))
 
             if settings.USING_RABBITMQ:
                 queue_client = get_queue_client()

--- a/zerver/management/commands/set_default_streams.py
+++ b/zerver/management/commands/set_default_streams.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 
@@ -36,8 +37,8 @@ python2.7 manage.py set_default_streams --domain=foo.com --streams=
 
     def handle(self, **options):
         if options["domain"] is None or options["streams"] is None:
-            print >>sys.stderr, "Please provide both a domain name and a default \
-set of streams (which can be empty, with `--streams=`)."
+            print("Please provide both a domain name and a default \
+set of streams (which can be empty, with `--streams=`).", file=sys.stderr)
             exit(1)
 
         stream_names = [stream.strip() for stream in options["streams"].split(",")]

--- a/zerver/management/commands/set_message_flags.py
+++ b/zerver/management/commands/set_message_flags.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from optparse import make_option
 import logging
@@ -41,7 +42,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if not options["flag"] or not options["op"] or not options["email"]:
-            print "Please specify an operation, a flag and an email"
+            print("Please specify an operation, a flag and an email")
             exit(1)
 
         op = options['op']

--- a/zerver/management/commands/show_admins.py
+++ b/zerver/management/commands/show_admins.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 from zerver.models import get_realm, Realm
@@ -17,16 +18,16 @@ class Command(BaseCommand):
         try:
             realm = get_realm(realm)
         except Realm.DoesNotExist:
-            print 'There is no realm called %s.' % (realm,)
+            print('There is no realm called %s.' % (realm,))
             sys.exit(1)
 
         users = realm.get_admin_users()
 
         if users:
-            print 'Admins:\n'
+            print('Admins:\n')
             for user in users:
-                print '  %s (%s)' % (user.email, user.full_name)
+                print('  %s (%s)' % (user.email, user.full_name))
         else:
-            print 'There are no admins for this realm!'
+            print('There are no admins for this realm!')
 
-        print '\nYou can use the "knight" management command to knight admins.'
+        print('\nYou can use the "knight" management command to knight admins.')

--- a/zerver/management/commands/turn_off_digests.py
+++ b/zerver/management/commands/turn_off_digests.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from optparse import make_option
 
@@ -35,12 +36,12 @@ class Command(BaseCommand):
             for email in emails:
                 user_profiles.append(get_user_profile_by_email(email))
 
-        print "Turned off digest emails for:"
+        print("Turned off digest emails for:")
         for user_profile in user_profiles:
             already_disabled_prefix = ""
             if user_profile.enable_digest_emails:
                 do_change_enable_digest_emails(user_profile, False)
             else:
                 already_disabled_prefix = "(already off) "
-            print "%s%s <%s>" % (already_disabled_prefix, user_profile.full_name,
-                                 user_profile.email)
+            print("%s%s <%s>" % (already_disabled_prefix, user_profile.full_name,
+                                 user_profile.email))

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -290,7 +290,7 @@ class RateLimitMiddleware(object):
         return response
 
     def process_exception(self, request, exception):
-        if type(exception) == RateLimited:
+        if isinstance(exception, RateLimited):
             resp = json_error("API usage exceeded rate limit, try again in %s secs" % (request._ratelimit_secs_to_freedom,), status=429)
             resp['Retry-After'] = request._ratelimit_secs_to_freedom
             return resp

--- a/zerver/test_bugdown.py
+++ b/zerver/test_bugdown.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 from django.conf import settings
 from django.test import TestCase
 
@@ -149,7 +150,7 @@ class BugdownTest(TestCase):
         for name, test in format_tests.iteritems():
             converted = bugdown_convert(test['input'])
 
-            print "Running Bugdown test %s" % (name,)
+            print("Running Bugdown test %s" % (name,))
             self.assertEqual(converted, test['expected_output'])
 
         def replaced(payload, url, phrase=''):
@@ -164,7 +165,7 @@ class BugdownTest(TestCase):
             return payload % ("<a href=\"%s\"%s title=\"%s\">%s</a>" % (href, target, href, url),)
 
 
-        print "Running Bugdown Linkify tests"
+        print("Running Bugdown Linkify tests")
         self.maxDiff = None
         for inline_url, reference, url in linkify_tests:
             try:

--- a/zerver/test_decorators.py
+++ b/zerver/test_decorators.py
@@ -39,12 +39,12 @@ class DecoratorTestCase(TestCase):
             get_total(request)
         self.assertEqual(str(cm.exception), "Bad value for 'numbers': bad_value")
 
-        request.REQUEST['numbers'] = ujson.dumps([2,3,5,8,13,21])
+        request.REQUEST['numbers'] = ujson.dumps([2, 3, 5, 8, 13, 21])
         with self.assertRaises(JsonableError) as cm:
             get_total(request)
         self.assertEqual(str(cm.exception), "13 is an unlucky number!")
 
-        request.REQUEST['numbers'] = ujson.dumps([1,2,3,4,5,6])
+        request.REQUEST['numbers'] = ujson.dumps([1, 2, 3, 4, 5, 6])
         result = get_total(request)
         self.assertEqual(result, 21)
 
@@ -68,12 +68,12 @@ class DecoratorTestCase(TestCase):
             get_total(request)
         self.assertEqual(str(cm.exception), 'argument "numbers" is not valid json.')
 
-        request.REQUEST['numbers'] = ujson.dumps([1,2,"what?",4,5,6])
+        request.REQUEST['numbers'] = ujson.dumps([1, 2, "what?", 4, 5, 6])
         with self.assertRaises(JsonableError) as cm:
             get_total(request)
         self.assertEqual(str(cm.exception), 'numbers[2] is not an integer')
 
-        request.REQUEST['numbers'] = ujson.dumps([1,2,3,4,5,6])
+        request.REQUEST['numbers'] = ujson.dumps([1, 2, 3, 4, 5, 6])
         result = get_total(request)
         self.assertEqual(result, 21)
 

--- a/zerver/test_email_mirror.py
+++ b/zerver/test_email_mirror.py
@@ -94,7 +94,7 @@ class TestStreamEmailMessagesEmptyBody(AuthedTestCase):
                 incoming_valid_message['Subject'],
                 incoming_valid_message,
                 debug_info)
-        except ZulipEmailForwardError, e:
+        except ZulipEmailForwardError as e:
             # empty body throws exception
             exception_message = e.message
         self.assertEqual(exception_message, "Unable to find plaintext or HTML message body")

--- a/zerver/test_events.py
+++ b/zerver/test_events.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 from django.test import TestCase
 
 from zerver.models import (
@@ -52,6 +53,7 @@ from zerver.tornadoviews import get_events_backend
 
 from collections import OrderedDict
 import ujson
+from six.moves import range
 
 
 class GetEventsTest(AuthedTestCase):
@@ -691,7 +693,7 @@ class EventQueueTest(TestCase):
 
     def test_event_collapsing(self):
         queue = EventQueue("1")
-        for pointer_val in xrange(1, 10):
+        for pointer_val in range(1, 10):
             queue.push({"type": "pointer",
                         "pointer": pointer_val,
                         "timestamp": str(pointer_val)})
@@ -702,13 +704,13 @@ class EventQueueTest(TestCase):
                            "timestamp": "9"}])
 
         queue = EventQueue("2")
-        for pointer_val in xrange(1, 10):
+        for pointer_val in range(1, 10):
             queue.push({"type": "pointer",
                         "pointer": pointer_val,
                         "timestamp": str(pointer_val)})
         queue.push({"type": "unknown"})
         queue.push({"type": "restart", "server_generation": "1"})
-        for pointer_val in xrange(11, 20):
+        for pointer_val in range(11, 20):
             queue.push({"type": "pointer",
                         "pointer": pointer_val,
                         "timestamp": str(pointer_val)})
@@ -723,7 +725,7 @@ class EventQueueTest(TestCase):
                           {"id": 20,
                            "type": "restart",
                            "server_generation": "2"}])
-        for pointer_val in xrange(21, 23):
+        for pointer_val in range(21, 23):
             queue.push({"type": "pointer",
                         "pointer": pointer_val,
                         "timestamp": str(pointer_val)})

--- a/zerver/test_events.py
+++ b/zerver/test_events.py
@@ -763,7 +763,7 @@ class EventQueueTest(TestCase):
                            "all": False,
                            "flag": "read",
                            "operation": "add",
-                           "messages": [1,2,3,4,5,6],
+                           "messages": [1, 2, 3, 4, 5, 6],
                            "timestamp": "1"}])
 
     def test_flag_remove_collapsing(self):
@@ -786,7 +786,7 @@ class EventQueueTest(TestCase):
                            "all": False,
                            "flag": "collapsed",
                            "operation": "remove",
-                           "messages": [1,2,3,4,5,6],
+                           "messages": [1, 2, 3, 4, 5, 6],
                            "timestamp": "1"}])
 
     def test_collapse_event(self):

--- a/zerver/test_external.py
+++ b/zerver/test_external.py
@@ -26,6 +26,7 @@ import urllib2
 from boto.s3.connection import S3Connection
 from boto.s3.key import Key
 from StringIO import StringIO
+from six.moves import range
 
 class MITNameTest(TestCase):
     def test_valid_hesiod(self):

--- a/zerver/test_hooks.py
+++ b/zerver/test_hooks.py
@@ -427,7 +427,7 @@ class PivotalV3HookTests(AuthedTestCase):
     def send_pivotal_message(self, name):
         email = "hamlet@zulip.com"
         api_key = self.get_api_key(email)
-        return self.send_json_payload(email, "/api/v1/external/pivotal?api_key=%s&stream=%s" % (api_key,"pivotal"),
+        return self.send_json_payload(email, "/api/v1/external/pivotal?api_key=%s&stream=%s" % (api_key, "pivotal"),
                                       self.fixture_data('pivotal', name, file_type='xml'),
                                       stream_name="pivotal",
                                       content_type="application/xml")
@@ -498,7 +498,7 @@ class PivotalV5HookTests(AuthedTestCase):
     def send_pivotal_message(self, name):
         email = "hamlet@zulip.com"
         api_key = self.get_api_key(email)
-        return self.send_json_payload(email, "/api/v1/external/pivotal?api_key=%s&stream=%s" % (api_key,"pivotal"),
+        return self.send_json_payload(email, "/api/v1/external/pivotal?api_key=%s&stream=%s" % (api_key, "pivotal"),
                                       self.fixture_data('pivotal', "v5_" + name, file_type='json'),
                                       stream_name="pivotal",
                                       content_type="application/xml")
@@ -583,7 +583,7 @@ class NewRelicHookTests(AuthedTestCase):
     def send_new_relic_message(self, name):
         email = "hamlet@zulip.com"
         api_key = self.get_api_key(email)
-        return self.send_json_payload(email, "/api/v1/external/newrelic?api_key=%s&stream=%s" % (api_key,"newrelic"),
+        return self.send_json_payload(email, "/api/v1/external/newrelic?api_key=%s&stream=%s" % (api_key, "newrelic"),
                                       self.fixture_data('newrelic', name, file_type='txt'),
                                       stream_name="newrelic",
                                       content_type="application/x-www-form-urlencoded")

--- a/zerver/test_messages.py
+++ b/zerver/test_messages.py
@@ -1070,7 +1070,7 @@ class GetOldMessagesTest(AuthedTestCase):
         error is returned.
         """
         self.login("hamlet@zulip.com")
-        bad_stream_content = (0, [], ["x","y"])
+        bad_stream_content = (0, [], ["x", "y"])
         self.exercise_bad_narrow_operand("pm-with", bad_stream_content,
             "Bad value for 'narrow'")
 

--- a/zerver/test_messages.py
+++ b/zerver/test_messages.py
@@ -40,6 +40,7 @@ import datetime
 import time
 import re
 import ujson
+from six.moves import range
 
 
 def get_sqlalchemy_query_params(query):

--- a/zerver/test_messages.py
+++ b/zerver/test_messages.py
@@ -844,8 +844,7 @@ class GetOldMessagesTest(AuthedTestCase):
                             stream, no_log=True)
         self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM)
         messages = get_user_messages(get_user_profile_by_email("hamlet@zulip.com"))
-        stream_messages = filter(lambda msg: msg.recipient.type == Recipient.STREAM,
-                                 messages)
+        stream_messages = [msg for msg in messages if msg.recipient.type == Recipient.STREAM]
         stream_name = get_display_recipient(stream_messages[0].recipient)
         stream_id = stream_messages[0].recipient.id
 
@@ -883,8 +882,7 @@ class GetOldMessagesTest(AuthedTestCase):
         self.check_well_formed_messages_response(result)
 
         messages = get_user_messages(get_user_profile_by_email("starnine@mit.edu"))
-        stream_messages = filter(lambda msg: msg.recipient.type == Recipient.STREAM,
-                                 messages)
+        stream_messages = [msg for msg in messages if msg.recipient.type == Recipient.STREAM]
 
         self.assertEqual(len(result["messages"]), 2)
         for i, message in enumerate(result["messages"]):
@@ -916,8 +914,7 @@ class GetOldMessagesTest(AuthedTestCase):
         self.check_well_formed_messages_response(result)
 
         messages = get_user_messages(get_user_profile_by_email("starnine@mit.edu"))
-        stream_messages = filter(lambda msg: msg.recipient.type == Recipient.STREAM,
-                                 messages)
+        stream_messages = [msg for msg in messages if msg.recipient.type == Recipient.STREAM]
         self.assertEqual(len(result["messages"]), 2)
         for i, message in enumerate(result["messages"]):
             self.assertEqual(message["type"], "stream")
@@ -1125,7 +1122,7 @@ class GetOldMessagesTest(AuthedTestCase):
         with queries_captured() as queries:
             get_old_messages_backend(request, user_profile)
 
-        queries = filter(lambda q: q['sql'].startswith("SELECT message_id, flags"), queries)
+        queries = [q for q in queries if q['sql'].startswith("SELECT message_id, flags")]
 
         ids = {}
         for stream_name in ['Scotland']:

--- a/zerver/test_signup.py
+++ b/zerver/test_signup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 from django.conf import settings
 from django.test import TestCase
 
@@ -25,6 +26,7 @@ import re
 import ujson
 
 from urlparse import urlparse
+from six.moves import range
 
 
 class PublicURLTest(TestCase):
@@ -122,7 +124,7 @@ class LoginTest(AuthedTestCase):
 
     def test_register(self):
         realm = get_realm("zulip.com")
-        streams = ["stream_%s" % i for i in xrange(40)]
+        streams = ["stream_%s" % i for i in range(40)]
         for stream in streams:
             create_stream_if_needed(realm, stream)
 
@@ -170,7 +172,7 @@ class LoginTest(AuthedTestCase):
         You can log in even if your password contain non-ASCII characters.
         """
         email = "test@zulip.com"
-        password = u"hümbüǵ"
+        password = u"hÃ¼mbÃ¼Çµ"
 
         # Registering succeeds.
         self.register("test", password)
@@ -445,7 +447,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         self.login("hamlet@zulip.com")
         invitee = "alice-test@zulip.com"
 
-        stream_name = u"hümbüǵ"
+        stream_name = u"hÃ¼mbÃ¼Çµ"
         realm = get_realm("zulip.com")
         stream, _ = create_stream_if_needed(realm, stream_name)
 

--- a/zerver/test_subs.py
+++ b/zerver/test_subs.py
@@ -896,7 +896,7 @@ class SubscriptionAPITest(AuthedTestCase):
         self.assert_length(queries, 43)
 
         self.assert_length(events, 6, exact=True)
-        for ev in filter(lambda x: x['event']['type'] not in ('message', 'stream'), events):
+        for ev in [x for x in events if x['event']['type'] not in ('message', 'stream')]:
             self.assertEqual(ev['event']['op'], 'add')
             self.assertEqual(
                     set(ev['event']['subscriptions'][0]['subscribers']),

--- a/zerver/test_subs.py
+++ b/zerver/test_subs.py
@@ -30,6 +30,7 @@ from zerver.lib.actions import (
 import random
 import ujson
 import urllib
+import six
 
 
 class StreamAdminTest(AuthedTestCase):
@@ -656,8 +657,8 @@ class SubscriptionAPITest(AuthedTestCase):
         json = ujson.loads(result.content)
         self.assertIn("subscriptions", json)
         for stream in json['subscriptions']:
-            self.assertIsInstance(stream['name'], basestring)
-            self.assertIsInstance(stream['color'], basestring)
+            self.assertIsInstance(stream['name'], six.string_types)
+            self.assertIsInstance(stream['color'], six.string_types)
             self.assertIsInstance(stream['invite_only'], bool)
             # check that the stream name corresponds to an actual stream
             try:

--- a/zerver/test_subs.py
+++ b/zerver/test_subs.py
@@ -31,6 +31,7 @@ import random
 import ujson
 import urllib
 import six
+from six.moves import range
 
 
 class StreamAdminTest(AuthedTestCase):
@@ -962,7 +963,7 @@ class SubscriptionAPITest(AuthedTestCase):
 
     def test_bulk_subscribe_MIT(self):
         realm = get_realm("mit.edu")
-        streams = ["stream_%s" % i for i in xrange(40)]
+        streams = ["stream_%s" % i for i in range(40)]
         for stream in streams:
             create_stream_if_needed(realm, stream)
 
@@ -981,7 +982,7 @@ class SubscriptionAPITest(AuthedTestCase):
     def test_bulk_subscribe_many(self):
         # Create a whole bunch of streams
         realm = get_realm("zulip.com")
-        streams = ["stream_%s" % i for i in xrange(20)]
+        streams = ["stream_%s" % i for i in range(20)]
         for stream in streams:
             create_stream_if_needed(realm, stream)
 
@@ -1402,7 +1403,7 @@ class GetSubscribersTest(AuthedTestCase):
         gather_subscriptions returns correct results with only 3 queries
         """
         realm = get_realm("zulip.com")
-        streams = ["stream_%s" % i for i in xrange(10)]
+        streams = ["stream_%s" % i for i in range(10)]
         for stream in streams:
             create_stream_if_needed(realm, stream)
         users_to_subscribe = [self.email, "othello@zulip.com", "cordelia@zulip.com"]

--- a/zerver/tests.py
+++ b/zerver/tests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.test import TestCase
 
@@ -40,7 +41,7 @@ import time
 import ujson
 
 def bail(msg):
-    print '\nERROR: %s\n' % (msg,)
+    print('\nERROR: %s\n' % (msg,))
     sys.exit(1)
 
 try:

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -623,7 +623,7 @@ def finish_google_oauth2(request):
     return login_or_register_remote_user(request, email_address, user_profile, full_name)
 
 def login_page(request, **kwargs):
-    extra_context = kwargs.pop('extra_context',{})
+    extra_context = kwargs.pop('extra_context', {})
     if dev_auth_enabled():
         users = UserProfile.objects.filter(is_bot=False, is_active=True)
         extra_context['direct_admins'] = sorted([u.email for u in users if u.is_admin()])
@@ -1039,7 +1039,7 @@ def export(request, user_profile):
     userprofile_ids = set(userprofile["id"] for userprofile in response['zerver_userprofile'])
 
     response['zerver_stream'] = [model_to_dict(x, exclude=["email_token"])
-                                 for x in Stream.objects.select_related().filter(realm=user_profile.realm,invite_only=False)]
+                                 for x in Stream.objects.select_related().filter(realm=user_profile.realm, invite_only=False)]
 
     stream_ids = set(x["id"] for x in response['zerver_stream'])
 
@@ -1161,8 +1161,8 @@ def get_public_streams_backend(request, user_profile):
 @has_request_variables
 def update_realm(request, user_profile, name=REQ(validator=check_string, default=None),
                  restricted_to_domain=REQ(validator=check_bool, default=None),
-                 invite_required=REQ(validator=check_bool,default=None),
-                 invite_by_admins_only=REQ(validator=check_bool,default=None)):
+                 invite_required=REQ(validator=check_bool, default=None),
+                 invite_by_admins_only=REQ(validator=check_bool, default=None)):
     realm = user_profile.realm
     data = {}
     if name is not None and realm.name != name:
@@ -1536,7 +1536,7 @@ def json_change_settings(request, user_profile,
 
 @authenticated_json_post_view
 @has_request_variables
-def json_time_setting(request, user_profile, twenty_four_hour_time=REQ(validator=check_bool,default=None)):
+def json_time_setting(request, user_profile, twenty_four_hour_time=REQ(validator=check_bool, default=None)):
     result = {}
     if twenty_four_hour_time is not None and \
         user_profile.twenty_four_hour_time != twenty_four_hour_time:
@@ -1548,7 +1548,7 @@ def json_time_setting(request, user_profile, twenty_four_hour_time=REQ(validator
 
 @authenticated_json_post_view
 @has_request_variables
-def json_left_side_userlist(request, user_profile, left_side_userlist=REQ(validator=check_bool,default=None)):
+def json_left_side_userlist(request, user_profile, left_side_userlist=REQ(validator=check_bool, default=None)):
     result = {}
     if left_side_userlist is not None and \
         user_profile.left_side_userlist != left_side_userlist:

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -95,6 +95,7 @@ import hmac
 from collections import defaultdict
 
 from zerver.lib.rest import rest_dispatch as _rest_dispatch
+from six.moves import map
 rest_dispatch = csrf_exempt((lambda request, *args, **kwargs: _rest_dispatch(request, globals(), *args, **kwargs)))
 
 def list_to_streams(streams_raw, user_profile, autocreate=False, invite_only=False):
@@ -2198,7 +2199,7 @@ def get_bots_backend(request, user_profile):
             default_all_public_streams=bot_profile.default_all_public_streams,
         )
 
-    return json_success({'bots': map(bot_info, bot_profiles)})
+    return json_success({'bots': list(map(bot_info, bot_profiles))})
 
 @authenticated_json_post_view
 @has_request_variables

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -39,6 +39,7 @@ import ujson
 
 from zerver.lib.rest import rest_dispatch as _rest_dispatch
 from six.moves import map
+import six
 rest_dispatch = csrf_exempt((lambda request, *args, **kwargs: _rest_dispatch(request, globals(), *args, **kwargs)))
 
 # This is a Pool that doesn't close connections.  Therefore it can be used with
@@ -292,7 +293,7 @@ class NarrowBuilder(object):
         return query.where(maybe_negate(cond))
 
 def highlight_string(string, locs):
-    if isinstance(string, unicode):
+    if isinstance(string, six.text_type):
         string = string.encode('utf-8')
 
     highlight_start = '<span class="highlight">'
@@ -326,7 +327,7 @@ def narrow_parameter(json):
         # We have to support a legacy tuple format.
         if isinstance(elem, list):
             if (len(elem) != 2
-                or any(not isinstance(x, str) and not isinstance(x, unicode)
+                or any(not isinstance(x, str) and not isinstance(x, six.text_type)
                        for x in elem)):
                 raise ValueError("element is not a string pair")
             return dict(operator=elem[0], operand=elem[1])

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -38,6 +38,7 @@ import re
 import ujson
 
 from zerver.lib.rest import rest_dispatch as _rest_dispatch
+from six.moves import map
 rest_dispatch = csrf_exempt((lambda request, *args, **kwargs: _rest_dispatch(request, globals(), *args, **kwargs)))
 
 # This is a Pool that doesn't close connections.  Therefore it can be used with
@@ -349,7 +350,7 @@ def narrow_parameter(json):
 
         raise ValueError("element is not a dictionary")
 
-    return map(convert_term, data)
+    return list(map(convert_term, data))
 
 def is_public_stream(stream, realm):
     if not valid_stream_name(stream):
@@ -403,7 +404,7 @@ def exclude_muting_conditions(user_profile, narrow):
             in_home_view=False,
             recipient__type=Recipient.STREAM
         ).values('recipient_id')
-        muted_recipient_ids = map(lambda row: row['recipient_id'], rows)
+        muted_recipient_ids = [row['recipient_id'] for row in rows]
         condition = not_(column("recipient_id").in_(muted_recipient_ids))
         conditions.append(condition)
 
@@ -429,7 +430,7 @@ def exclude_muting_conditions(user_profile, narrow):
                 topic_cond = func.upper(column("subject")) == func.upper(muted[1])
                 return and_(stream_cond, topic_cond)
 
-            condition = not_(or_(*map(mute_cond, muted_topics)))
+            condition = not_(or_(*list(map(mute_cond, muted_topics))))
             return conditions + [condition]
 
     return conditions

--- a/zerver/views/webhooks.py
+++ b/zerver/views/webhooks.py
@@ -719,7 +719,7 @@ def api_stash_webhook(request, user_profile, stream=REQ(default='')):
                     entry["toCommit"]["message"].split("\n")[0]) for \
                        entry in commit_entries]
         head_ref = commit_entries[-1]["toCommit"]["displayId"]
-    except KeyError, e:
+    except KeyError as e:
         return json_error("Missing key %s in JSON" % (e.message,))
 
     try:

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -104,7 +104,7 @@ class SignupWorker(QueueProcessingWorker):
                         merge_vars=merge_vars,
                         double_optin=False,
                         send_welcome=False)
-            except MailChimpException, e:
+            except MailChimpException as e:
                 if e.code == 214:
                     logging.warning("Attempted to sign up already existing email to list: %s" % (data['EMAIL'],))
                 else:

--- a/zilencer/management/commands/create_deployment.py
+++ b/zilencer/management/commands/create_deployment.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 from optparse import make_option
 import sys
 
@@ -31,17 +32,17 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if None in (options["api"], options["web"], options["domain"]):
-            print >>sys.stderr, "\033[1;31mYou must provide a domain, an API URL, and a web URL.\033[0m\n"
+            print("\033[1;31mYou must provide a domain, an API URL, and a web URL.\033[0m\n", file=sys.stderr)
             self.print_help("python2.7 manage.py", "create_realm")
             exit(1)
 
         if not options["no_realm"]:
             CreateRealm().handle(*args, **options)
-            print # Newline
+            print() # Newline
 
         realm = get_realm(options["domain"])
         if realm is None:
-            print >>sys.stderr, "\033[1;31mRealm does not exist!\033[0m\n"
+            print("\033[1;31mRealm does not exist!\033[0m\n", file=sys.stderr)
             exit(2)
 
         dep = Deployment()
@@ -55,6 +56,6 @@ class Command(BaseCommand):
         dep.base_api_url = options["api"]
         dep.base_site_url = options["web"]
         dep.save()
-        print "Deployment %s created." % (dep.id,)
-        print "DEPLOYMENT_ROLE_NAME = %s" % (dep.name,)
-        print "DEPLOYMENT_ROLE_KEY = %s" % (dep.api_key,)
+        print("Deployment %s created." % (dep.id,))
+        print("DEPLOYMENT_ROLE_NAME = %s" % (dep.name,))
+        print("DEPLOYMENT_ROLE_KEY = %s" % (dep.api_key,))

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -28,6 +28,7 @@ import random
 import glob
 import os
 from optparse import make_option
+from six.moves import range
 
 settings.TORNADO_SERVER = None
 
@@ -126,7 +127,7 @@ class Command(BaseCommand):
             names = [("Othello, the Moor of Venice", "othello@zulip.com"), ("Iago", "iago@zulip.com"),
                      ("Prospero from The Tempest", "prospero@zulip.com"),
                      ("Cordelia Lear", "cordelia@zulip.com"), ("King Hamlet", "hamlet@zulip.com")]
-            for i in xrange(options["extra_users"]):
+            for i in range(options["extra_users"]):
                 names.append(('Extra User %d' % (i,), 'extrauser%d@zulip.com' % (i,)))
             create_users(realms, names)
             iago = UserProfile.objects.get(email="iago@zulip.com")
@@ -156,16 +157,16 @@ class Command(BaseCommand):
         user_profiles = [user_profile.id for user_profile in UserProfile.objects.all()]
 
         # Create several initial huddles
-        for i in xrange(options["num_huddles"]):
+        for i in range(options["num_huddles"]):
             get_huddle(random.sample(user_profiles, random.randint(3, 4)))
 
         # Create several initial pairs for personals
         personals_pairs = [random.sample(user_profiles, 2)
-                           for i in xrange(options["num_personals"])]
+                           for i in range(options["num_personals"])]
 
         threads = options["threads"]
         jobs = []
-        for i in xrange(threads):
+        for i in range(threads):
             count = options["num_messages"] / threads
             if i < options["num_messages"] % threads:
                 count += 1
@@ -313,7 +314,7 @@ def restore_saved_messages():
         if message_type == 'personal':
             old_message["recipient"][0]["email"] = fix_email(old_message["recipient"][0]["email"])
         elif message_type == "huddle":
-            for i in xrange(len(old_message["recipient"])):
+            for i in range(len(old_message["recipient"])):
                 old_message["recipient"][i]["email"] = fix_email(old_message["recipient"][i]["email"])
 
         old_messages.append(old_message)

--- a/zilencer/management/commands/print_initial_password.py
+++ b/zilencer/management/commands/print_initial_password.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 from zerver.lib.initial_password import initial_password
@@ -14,9 +15,9 @@ class Command(BaseCommand):
                             help="email of user to show password and API key for")
 
     def handle(self, *args, **options):
-        print self.fmt % ('email', 'password', 'API key')
+        print(self.fmt % ('email', 'password', 'API key'))
         for email in options['emails']:
             if '@' not in email:
-                print 'ERROR: %s does not look like an email address' % (email,)
+                print('ERROR: %s does not look like an email address' % (email,))
                 continue
-            print self.fmt % (email, initial_password(email), get_user_profile_by_email(email).api_key)
+            print(self.fmt % (email, initial_password(email), get_user_profile_by_email(email).api_key))

--- a/zilencer/management/commands/render_old_messages.py
+++ b/zilencer/management/commands/render_old_messages.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 
@@ -20,6 +21,6 @@ Usage: python2.7 manage.py render_old_messages"""
             for message in messages:
                 message.maybe_render_content(None, save=True)
             total_rendered += len(messages)
-            print datetime.datetime.now(), total_rendered
+            print(datetime.datetime.now(), total_rendered)
             # Put in some sleep so this can run safely on low resource machines
             time.sleep(0.25)

--- a/zilencer/management/commands/sync_api_key.py
+++ b/zilencer/management/commands/sync_api_key.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from django.core.management.base import BaseCommand
 from zerver.models import get_user_profile_by_email, UserProfile
 import os
-from ConfigParser import SafeConfigParser
+from six.moves.configparser import SafeConfigParser
 
 class Command(BaseCommand):
     help = """Sync your API key from ~/.zuliprc into your development instance"""

--- a/zilencer/management/commands/sync_api_key.py
+++ b/zilencer/management/commands/sync_api_key.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 from django.core.management.base import BaseCommand
 from zerver.models import get_user_profile_by_email, UserProfile
@@ -23,4 +24,4 @@ class Command(BaseCommand):
             user_profile.api_key = api_key
             user_profile.save(update_fields=["api_key"])
         except UserProfile.DoesNotExist:
-            print "User %s does not exist; not syncing API key" % (email,)
+            print("User %s does not exist; not syncing API key" % (email,))

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.views import login as django_login_page
@@ -11,7 +12,7 @@ from zerver.lib.rest import rest_dispatch as _rest_dispatch
 from zerver.lib.validator import check_dict
 from zerver.models import get_realm, get_user_profile_by_email, resolve_email_to_domain, \
         UserProfile
-from error_notify import notify_server_error, notify_browser_error
+from .error_notify import notify_server_error, notify_browser_error
 from django.conf import settings
 import time
 

--- a/zproject/local_settings.py
+++ b/zproject/local_settings.py
@@ -7,10 +7,10 @@
 # On a normal Zulip production server, zproject/local_settings.py is a
 # symlink to /etc/zulip/settings.py (based off local_settings_template.py).
 import platform
-import ConfigParser
+import six.moves.configparser
 from base64 import b64decode
 
-config_file = ConfigParser.RawConfigParser()
+config_file = six.moves.configparser.RawConfigParser()
 config_file.read("/etc/zulip/zulip.conf")
 
 # Whether we're running in a production environment. Note that PRODUCTION does

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Django settings for zulip project.
 ########################################################################
 # Here's how settings for the Zulip project work:
@@ -76,11 +77,11 @@ TUTORIAL_ENABLED = True
 # Import variables like secrets from the local_settings file
 # Import local_settings after determining the deployment/machine type
 if PRODUCTION:
-    from local_settings import *
+    from .local_settings import *
 else:
     # For the Dev VM environment, we use the same settings as the
     # sample local_settings.py file, with a few exceptions.
-    from local_settings_template import *
+    from .local_settings_template import *
     EXTERNAL_HOST = 'localhost:9991'
     ALLOWED_HOSTS = ['localhost']
     AUTHENTICATION_BACKENDS = ('zproject.backends.DevAuthBackend',)

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -12,7 +12,7 @@ import os
 import platform
 import time
 import sys
-import ConfigParser
+import six.moves.configparser
 
 from zerver.lib.db import TimeTrackingConnection
 
@@ -20,14 +20,14 @@ from zerver.lib.db import TimeTrackingConnection
 # INITIAL SETTINGS
 ########################################################################
 
-config_file = ConfigParser.RawConfigParser()
+config_file = six.moves.configparser.RawConfigParser()
 config_file.read("/etc/zulip/zulip.conf")
 
 # Whether this instance of Zulip is running in a production environment.
 PRODUCTION = config_file.has_option('machine', 'deploy_type')
 DEVELOPMENT = not PRODUCTION
 
-secrets_file = ConfigParser.RawConfigParser()
+secrets_file = six.moves.configparser.RawConfigParser()
 if PRODUCTION:
     secrets_file.read("/etc/zulip/zulip-secrets.conf")
 else:
@@ -374,7 +374,7 @@ try:
     domain = config_file.get('django', 'cookie_domain')
     SESSION_COOKIE_DOMAIN = '.' + domain
     CSRF_COOKIE_DOMAIN    = '.' + domain
-except ConfigParser.Error:
+except six.moves.configparser.Error:
     # Failing here is OK
     pass
 

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 import os
 
 DATABASES["default"] = {"NAME": "zulip_test",

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -32,7 +32,7 @@ urlpatterns = patterns('',
     url(r'^accounts/webathena_kerberos_login/', 'zerver.views.webathena_kerberos_login'),
 
     url(r'^accounts/password/reset/$', 'django.contrib.auth.views.password_reset',
-        {'post_reset_redirect' : '/accounts/password/reset/done/',
+        {'post_reset_redirect': '/accounts/password/reset/done/',
             'template_name': 'zerver/reset.html',
             'email_template_name': 'registration/password_reset_email.txt',
             }),
@@ -157,7 +157,7 @@ urlpatterns += patterns('zerver.views',
     url(r'^api/v1/fetch_google_client_id$', 'api_fetch_google_client_id'),
 
     # These are integration-specific web hook callbacks
-    url(r'^api/v1/external/beanstalk$' ,    'webhooks.api_beanstalk_webhook'),
+    url(r'^api/v1/external/beanstalk$',     'webhooks.api_beanstalk_webhook'),
     url(r'^api/v1/external/github$',        'webhooks.api_github_landing'),
     url(r'^api/v1/external/jira$',          'webhooks.api_jira_webhook'),
     url(r'^api/v1/external/pivotal$',       'webhooks.api_pivotal_webhook'),

--- a/zulip_tools.py
+++ b/zulip_tools.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
 import os
 import sys
 import datetime
@@ -27,4 +28,4 @@ def make_deploy_path():
 if __name__ == '__main__':
     cmd = sys.argv[1]
     if cmd == 'make_deploy_path':
-        print make_deploy_path()
+        print(make_deploy_path())


### PR DESCRIPTION
This branch is partial progress towards making Zulip support Python 3.  

The approach I've been taking is applying safe filters from the 2to3, futurize, and modernize libraries to make the Zulip code closer to Python 3 support without breaking anything in Python 2.  

This partial progress should pass tests and be basically mergable; the only one in this pull request that I feel does something problematic to the code is libmodernize.fixes.fix_dict_six, which changes a bunch of cases that are in iterator context and don't need to be; I think my plan would be to skip merging that commit for now.

This branch passes tests on Python 2 and with a bit of hackery (removing dependencies, fixing some encoding things, etc.) I got it passing like 90% of our tests on Python 3.  We'll need to fix those issues properly so I'm leaving them out of the PR and just including the stuff that seems sane.

