### PR TITLE
Defer permission for Mozilla notifications until after tutorial.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -75,12 +75,6 @@ exports.initialize = function () {
         window_has_focus = false;
     });
 
-    if ($.browser.mozilla === true && typeof Notification !== "undefined") {
-        Notification.requestPermission(function () {
-            asked_permission_already = true;
-        });
-    }
-
     if (window.bridge !== undefined) {
         supports_sound = true;
 
@@ -110,8 +104,18 @@ exports.initialize = function () {
                 return;
             }
             if (notifications_api.checkPermission() !== 0) { // 0 is PERMISSION_ALLOWED
-                notifications_api.requestPermission(function () {});
-                asked_permission_already = true;
+                if(tutorial.is_running()) {
+                    tutorial.defer(function () {
+                        notifications_api.requestPermission(function () {
+                            asked_permission_already = true;
+                        });
+                    });
+                }
+                else {
+                    notifications_api.requestPermission(function () {
+                        asked_permission_already = true;
+                    });
+                }
             }
         });
     }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -474,12 +474,12 @@ $(function () {
     reload.initialize();
     composebox_typeahead.initialize();
     search.initialize();
+    tutorial.initialize();
     notifications.initialize();
     gear_menu.initialize();
     hashchange.initialize();
     invite.initialize();
     activity.initialize();
-    tutorial.initialize();
 });
 
 


### PR DESCRIPTION
This addresses issue #17. It places the notification request into the deferred work that is run once the tutorial finishes.