### PR TITLE
Expand testing done via Travis CI to cover production pipeline.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 install:
-  - pip install pbs
-  - python provision.py --travis
+  - tools/travis/setup-$TEST_SUITE
 cache:
   - apt: false
+env:
+  - TEST_SUITE=frontend
+  - TEST_SUITE=backend
+  - TEST_SUITE=production
 language: python
 python:
   - "2.7"
 # command to run tests
 script:
-  - source /srv/zulip-venv/bin/activate && env PATH=$PATH:/srv/zulip-venv/bin ./tools/test-all
+  - ./tools/travis/$TEST_SUITE
 sudo: required
 services:
 - docker

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -21,6 +21,9 @@ echo -e "[machine]\npuppet_classes = zulip::voyager\ndeploy_type = voyager" > /e
 # These server restarting bits should be moveable into puppet-land, ideally
 apt-get -y upgrade
 if [ -e "/etc/init.d/nginx" ]; then
+    # Check nginx was configured properly now that we've installed it.
+    # Most common failure mode is certs not having been installed.
+    nginx -t
     service nginx restart
 fi
 

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -11,7 +11,7 @@ deb-src http://ppa.launchpad.net/tabbott/zulip/ubuntu trusty main
 EOF
 
 apt-get update
-apt-get -y dist-upgrade
+apt-get -y dist-upgrade $APT_OPTIONS
 apt-get install -y puppet git python
 
 mkdir -p /etc/zulip

--- a/scripts/setup/postgres-init-db
+++ b/scripts/setup/postgres-init-db
@@ -1,7 +1,13 @@
-#!/bin/sh -xe
+#!/bin/bash
+set -e
+set -x
 
 # Make sure the current working directory is readable
 cd /
+
+# Drop any open connections to any old database.  Hackishly call using
+# source because postgres user can't read /root/zulip/scripts/setup.
+source "$(dirname "$0")/terminate-psql-sessions" postgres zulip zulip_base
 
 su postgres -c psql <<EOF
 CREATE USER zulip;
@@ -15,6 +21,7 @@ CREATE SCHEMA zulip AUTHORIZATION zulip;
 CREATE EXTENSION tsearch_extras SCHEMA zulip;
 EOF
 
+# Clear memcached to avoid contamination from previous database state
 sh "$(dirname "$0")/flush-memcached"
 
 echo "Database created"

--- a/scripts/setup/postgres-init-db
+++ b/scripts/setup/postgres-init-db
@@ -5,6 +5,9 @@ set -x
 # Make sure the current working directory is readable
 cd /
 
+# Shut down all services to ensure a quiescent state.
+supervisorctl stop all
+
 # Drop any open connections to any old database.  Hackishly call using
 # source because postgres user can't read /root/zulip/scripts/setup.
 source "$(dirname "$0")/terminate-psql-sessions" postgres zulip zulip_base

--- a/scripts/setup/terminate-psql-sessions
+++ b/scripts/setup/terminate-psql-sessions
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+set -x
+
+cd /
+if [ "$EUID" -eq 0 ]; then
+    version=$(su postgres -c 'psql -A -t -d postgres -c "show server_version"')
+else
+    version=$(psql -A -t -d postgres -c "show server_version")
+fi
+
+major=$(echo $version | cut -d. -f1,2)
+pid_style=$(echo "$major > 9.1" | bc -l)
+username=$1
+shift
+tables=$(echo "'$@'" | sed "s/ /','/g")
+if [ "$pid_style" = "1" ]; then
+    pidname="pid"
+else
+    pidname="procpid"
+fi
+
+if [ "$EUID" -eq 0 ]; then
+    su postgres -c psql postgres postgres <<EOF
+SELECT pg_terminate_backend($pidname) FROM pg_stat_activity WHERE datname IN ($tables);
+EOF
+else
+    psql -h localhost postgres "$username" <<EOF
+SELECT pg_terminate_backend($pidname) FROM pg_stat_activity WHERE datname IN ($tables);
+EOF
+fi

--- a/tools/do-destroy-rebuild-database
+++ b/tools/do-destroy-rebuild-database
@@ -1,5 +1,7 @@
 #!/bin/sh -xe
 
+"$(dirname "$0")/../scripts/setup/terminate-psql-sessions" zulip zulip zulip_base
+
 psql -h localhost postgres zulip <<EOF
 DROP DATABASE IF EXISTS zulip;
 CREATE DATABASE zulip TEMPLATE zulip_base;

--- a/tools/generate-fixtures
+++ b/tools/generate-fixtures
@@ -11,7 +11,8 @@ if [ "$template_grep_error_code" == "0" ]; then
     if [ -e zerver/fixtures/migration-status ] &&
         cmp -s zerver/fixtures/available-migrations zerver/fixtures/migration-status &&
         [ "$1" != "--force" ]; then
-            psql -h localhost postgres zulip_test << EOF
+        "$(dirname "$0")/../scripts/setup/terminate-psql-sessions" zulip zulip_test zulip_test_base zulip_test_template
+        psql -h localhost postgres zulip_test << EOF
 DROP DATABASE IF EXISTS zulip_test;
 CREATE DATABASE zulip_test TEMPLATE zulip_test_template;
 EOF
@@ -21,6 +22,8 @@ EOF
 fi
 
 mkdir -p zerver/fixtures
+
+"$(dirname "$0")/../scripts/setup/terminate-psql-sessions" zulip zulip_test zulip_test_base zulip_test_template
 
 psql -h localhost postgres zulip_test <<EOF
 DROP DATABASE IF EXISTS zulip_test;

--- a/tools/postgres-init-dev-db
+++ b/tools/postgres-init-dev-db
@@ -49,6 +49,8 @@ else
 fi
 chmod go-rw ~/.pgpass
 
+"$(dirname "$0")/../scripts/setup/terminate-psql-sessions" "$USERNAME" "$DBNAME" "$DBNAME_BASE"
+
 psql -h localhost postgres "$USERNAME" <<EOF
 DROP DATABASE IF EXISTS $DBNAME;
 DROP DATABASE IF EXISTS $DBNAME_BASE;

--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+set -x
+source /srv/zulip-venv/bin/activate
+export PATH=$PATH:/srv/zulip-venv/bin
+./tools/lint-all
+./tools/test-backend

--- a/tools/travis/frontend
+++ b/tools/travis/frontend
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+set -x
+source /srv/zulip-venv/bin/activate
+export PATH=$PATH:/srv/zulip-venv/bin
+./tools/test-js-with-node
+./tools/test-js-with-casper

--- a/tools/travis/production
+++ b/tools/travis/production
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+set -x
+
+sudo ./tools/travis/production-helper

--- a/tools/travis/production-helper
+++ b/tools/travis/production-helper
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+set -x
+
+apt-get install openssl ssl-cert
+ln -s /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/zulip.combined-chain.crt
+ln -s /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/zulip.key
+
+tar -xf zulip-server-travis.tar.gz
+mv zulip-server-travis /root/zulip
+
+export APT_OPTIONS="-o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
+/root/zulip/scripts/setup/install
+
+cat >>/etc/zulip/settings.py <<EOF
+# Travis CI override settings above
+EXTERNAL_HOST = 'zulip.travis.example.com'
+ZULIP_ADMINISTRATOR = 'zulip-travis-admin@travis.example.com'
+ADMIN_DOMAIN = 'travis.example.com'
+AUTHENTICATION_BACKENDS = ( 'zproject.backends.EmailAuthBackend', )
+NOREPLY_EMAIL_ADDRESS = 'noreply@travis.example.com'
+DEFAULT_FROM_EMAIL = "Zulip <zulip@travis.example.com>"
+EOF
+
+su zulip -c /home/zulip/deployments/current/scripts/setup/initialize-database

--- a/tools/travis/setup-backend
+++ b/tools/travis/setup-backend
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+set -x
+pip install pbs
+python provision.py --travis

--- a/tools/travis/setup-frontend
+++ b/tools/travis/setup-frontend
@@ -1,0 +1,1 @@
+setup-backend

--- a/tools/travis/setup-production
+++ b/tools/travis/setup-production
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+set -x
+
+pip install pbs
+python provision.py --travis
+source /srv/zulip-venv/bin/activate
+./tools/build-release-tarball travis
+mv /tmp/tmp.*/zulip-server-travis.tar.gz ./
+
+# Shut down all services so that restarting postgres and rebuilding
+# the postgres database to match the prod installation setup will work.
+sudo supervisorctl stop all
+# Clear memcached to avoid contamination between development and prod
+# environments.
+sudo /etc/init.d/memcached restart
+
+# Drop any open connections to the development postgres installation.
+sudo "$(dirname "$0")/../../scripts/setup/terminate-psql-sessions" postgres zulip zulip_base
+
+# Remove and recreate the postgres database
+sudo pg_ctlcluster 9.3 main stop
+sudo pg_dropcluster 9.3 main
+sudo rm -rf /etc/postgresql/9.3/main /var/lib/postgresql/9.3/main
+sudo pg_createcluster 9.3 main


### PR DESCRIPTION
With this change, we are now testing the production static asset
pipeline and installation process in a new testing job (and also run
the frontend/backend tests separately).

This means that changes that break the Zulip static asset pipeline or
production installation process are more likely to fail tests.  The
testing is imperfect in that it does not have proper isolation -- we
build a complete Zulip development environment and then install a
Zulip production environment on top of it, so e.g. any apt
dependencies installed for Zulip development will still be available
for the Zulip production environment.  But, it's better than nothing!

A good v2 of this would be to have the production setup process just
install the minimum stuff needed to run `build-release-tarball` and
then uninstall it / clean it up so that we can do a more clear
production installation, but that's more work.