### PR TITLE
Fix indentation for Trac ticket description changes.

### DIFF
--- a/api/integrations/trac/zulip_trac.py
+++ b/api/integrations/trac/zulip_trac.py
@@ -107,8 +107,8 @@ class ZulipPlugin(Component):
         field_changes = []
         for key in old_values.keys():
             if key == "description":
-                content += '- Changed %s from %s to %s' % (key, markdown_block(old_values.get(key)),
-                                                           markdown_block(ticket.values.get(key)))
+                content += '- Changed %s from %s\n\nto %s' % (key, markdown_block(old_values.get(key)),
+                                                              markdown_block(ticket.values.get(key)))
             elif old_values.get(key) == "":
                 field_changes.append('%s: => **%s**' % (key, ticket.values.get(key)))
             elif ticket.values.get(key) == "":


### PR DESCRIPTION
Before this fix, the "to" was included in the markdown blocks. This way one had to search for the "to" inside the block to find the beginning of the new ticket description.

Before:

<img width="252" alt="before" src="https://cloud.githubusercontent.com/assets/842699/10677160/ee00ea5c-790a-11e5-91f1-ca35020686bd.png">

After:

<img width="227" alt="after" src="https://cloud.githubusercontent.com/assets/842699/10677159/edfa75f0-790a-11e5-9cdf-ed14d8e3e7ba.png">

Still not especially pretty, but at least now the two descriptions are separated.