### PR TITLE
travis: Add Python 3 compatibility test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - TEST_SUITE=frontend
   - TEST_SUITE=backend
   - TEST_SUITE=production
+  - TEST_SUITE=py3k
 language: python
 python:
   - "2.7"

--- a/tools/travis/py3k
+++ b/tools/travis/py3k
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+fixers="
+lib2to3.fixes.fix_apply
+lib2to3.fixes.fix_except
+lib2to3.fixes.fix_exitfunc
+lib2to3.fixes.fix_funcattrs
+lib2to3.fixes.fix_has_key
+lib2to3.fixes.fix_idioms
+lib2to3.fixes.fix_intern
+lib2to3.fixes.fix_isinstance
+lib2to3.fixes.fix_methodattrs
+lib2to3.fixes.fix_ne
+lib2to3.fixes.fix_numliterals
+lib2to3.fixes.fix_paren
+lib2to3.fixes.fix_reduce
+lib2to3.fixes.fix_renames
+lib2to3.fixes.fix_repr
+lib2to3.fixes.fix_standarderror
+lib2to3.fixes.fix_sys_exc
+lib2to3.fixes.fix_throw
+lib2to3.fixes.fix_tuple_params
+lib2to3.fixes.fix_types
+lib2to3.fixes.fix_ws_comma
+lib2to3.fixes.fix_xreadlines
+libfuturize.fixes.fix_absolute_import
+libfuturize.fixes.fix_next_call
+libfuturize.fixes.fix_print_with_import
+libfuturize.fixes.fix_raise
+libmodernize.fixes.fix_basestring
+libmodernize.fixes.fix_filter
+libmodernize.fixes.fix_imports_six
+libmodernize.fixes.fix_input_six
+libmodernize.fixes.fix_int_long_tuple
+libmodernize.fixes.fix_map
+libmodernize.fixes.fix_raise_six
+libmodernize.fixes.fix_xrange_six
+libmodernize.fixes.fix_zip
+libmodernize.fixes.fix_unicode_type
+"
+
+echo; echo "Testing for additions of Python 2 patterns we've removed as part of moving towards Python 3 compatibility."; echo
+
+for fixer in $fixers; do
+    echo "Running Python 3 compatibility test $fixer"
+    futurize -f $fixer -j4 -n -w . >/dev/null 2>/dev/null
+    git diff --exit-code || (echo; echo "Python 3 compatibility error(s) detected!  See diff above for what you need to change." && exit 1)
+done
+
+echo "No issues detected!"

--- a/tools/travis/setup-py3k
+++ b/tools/travis/setup-py3k
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+set -x
+sudo pip install future
+sudo pip install modernize


### PR DESCRIPTION
This tests whether a new patch introduces any regressions related to
any of the Python 3 compatibility fixers we've run in the past, so
that we can make continuous forward progress on our path towards
Python 3 compatibility.

This produces error output that looks like this:
"""
Testing for additions of Python 2 patterns we've removed as part of moving towards Python 3 compatibility.

Running Python 3 compatibility test lib2to3.fixes.fix_apply
Running Python 3 compatibility test lib2to3.fixes.fix_except
diff --git a/zerver/views/__init__.py b/zerver/views/__init__.py
index b5c0102..2defd46 100644
--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -296,7 +296,7 @@ def accounts_register(request):
                 do_activate_user(user_profile)
                 do_change_password(user_profile, password)
                 do_change_full_name(user_profile, full_name)
-            except UserProfile.DoesNotExist, e:
+            except UserProfile.DoesNotExist as e:
                 user_profile = do_create_user(email, password, realm, full_name, short_name,
                                               prereg_user=prereg_user,
                                               newsletter_data={"IP": request.META['REMOTE_ADDR']})

Python 3 compatability error(s) detected!  See diff above for what you need to change.
"""