### PR TITLE
Add 'blocktrans' to tools/check-templates

### DIFF
--- a/tools/check-templates
+++ b/tools/check-templates
@@ -129,6 +129,7 @@ def is_django_block_tag(tag):
         'if',
         'ifequal',
         'verbatim',
+        'blocktrans',
     ]
 
 def get_handlebars_tag(text, i):


### PR DESCRIPTION
Running check-templates test fails when there are 'blocktrans' tags in django templates. The fix is to add 'blocktrans' to is_django_block_tag function in check-templates.