### PR TITLE
Mark strings for translation in templates/zerver

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -31,11 +31,24 @@ file is as follows:
     key=<api key from the web interface>
     email=<your email address>
     site=<your Zulip server's URI>
+    insecure=<true or false, true means do not verify the server certificate>
+    cert_bundle=<path to a file containing CA or server certificates to trust>
+
+If omitted, these settings have the following defaults:
+
+    site=https://api.zulip.com
+    insecure=false
+    cert_bundle=<the default CA bundle trusted by Python>
 
 Alternatively, you may explicitly use "--user" and "--api-key" in our
 examples, which is especially useful if you are running several bots
-which share a home directory.  There is also a "--site" option for
-setting the Zulip server on the command line.
+which share a home directory.
+
+The command line equivalents for other configuration options are:
+
+    --site=<your Zulip server's URI>
+    --insecure
+    --cert-bundle=<file>
 
 You can obtain your Zulip API key, create bots, and manage bots all
 from your Zulip [settings page](https://zulip.com/#settings).
@@ -101,3 +114,46 @@ Alternatively, if you don't want to use your ~/.zuliprc file:
         --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5 \
         hamlet@example.com cordelia@example.com -m \
         "Conscience doth make cowards of us all."
+
+#### Working with an untrusted server certificate
+
+If your server has either a self-signed certificate, or a certificate signed
+by a CA that you don't wish to globally trust then by default the API will
+fail with an SSL verification error.
+
+You can add `insecure=true` to your .zuliprc file.
+
+    [api]
+    site=https://zulip.example.com
+    insecure=true
+
+This disables verification of the server certificate, so connections are
+encrypted but unauthenticated. This is not secure, but may be good enough
+for a development environment.
+
+
+You can explicitly trust the server certificate using `cert_bundle=<filename>`
+in your .zuliprc file.
+
+    [api]
+    site=https://zulip.example.com
+    cert_bundle=/home/bots/certs/zulip.example.com.crt
+
+You can also explicitly trust a different set of Certificate Authorities from
+the default bundle that is trusted by Python. For example to trust a company
+internal CA.
+
+    [api]
+    site=https://zulip.example.com
+    cert_bundle=/home/bots/certs/example.com.ca-bundle
+
+Save the server certificate (or the CA certificate) in its own file,
+converting to PEM format first if necessary.
+Verify that the certificate you have saved is the same as the one on the
+server.
+
+The `cert_bundle` option trusts the server / CA certificate only for
+interaction with the zulip site, and is relatively secure.
+
+Note that a certificate bundle is merely one or more certificates combined
+into a single file.

--- a/api/zulip/__init__.py
+++ b/api/zulip/__init__.py
@@ -117,6 +117,19 @@ def generate_option_group(parser, prefix=''):
                      default=None,
                      dest="zulip_client",
                      help=optparse.SUPPRESS_HELP)
+    group.add_option('--insecure',
+                     action='store_true',
+                     dest='insecure',
+                     help='''Do not verify the server certificate.
+                          The https connection will not be secure.''')
+    group.add_option('--cert-bundle',
+                     action='store',
+                     dest='cert_bundle',
+                     help='''Specify a file containing either the
+                          server certificate, or a set of trusted
+                          CA certificates. This will be used to
+                          verify the server's identity. All
+                          certificates should be PEM encoded.''')
     return group
 
 def init_from_options(options, client=None):
@@ -126,7 +139,8 @@ def init_from_options(options, client=None):
         client = _default_client()
     return Client(email=options.zulip_email, api_key=options.zulip_api_key,
                   config_file=options.zulip_config_file, verbose=options.verbose,
-                  site=options.zulip_site, client=client)
+                  site=options.zulip_site, client=client,
+                  cert_bundle=options.cert_bundle, insecure=options.insecure)
 
 def get_default_config_filename():
     config_file = os.path.join(os.environ["HOME"], ".zuliprc")
@@ -138,15 +152,14 @@ def get_default_config_filename():
 class Client(object):
     def __init__(self, email=None, api_key=None, config_file=None,
                  verbose=False, retry_on_errors=True,
-                 site=None, client=None):
+                 site=None, client=None,
+                 cert_bundle=None, insecure=None):
         if client is None:
             client = _default_client()
-        if None in (api_key, email):
-            if config_file is None:
-                config_file = get_default_config_filename()
-            if not os.path.exists(config_file):
-                raise RuntimeError("api_key or email not specified and %s does not exist"
-                                   % (config_file,))
+
+        if config_file is None:
+            config_file = get_default_config_filename()
+        if os.path.exists(config_file):
             config = SafeConfigParser()
             with file(config_file, 'r') as f:
                 config.readfp(f, config_file)
@@ -156,6 +169,22 @@ class Client(object):
                 email = config.get("api", "email")
             if site is None and config.has_option("api", "site"):
                 site = config.get("api", "site")
+            if cert_bundle is None and config.has_option("api", "cert_bundle"):
+                cert_bundle = config.get("api", "cert_bundle")
+            if insecure is None and config.has_option("api", "insecure"):
+                # Be quite strict about what is accepted so that users don't
+                # disable security unintentionally.
+                insecure_setting = config.get("api", "insecure").lower()
+                if insecure_setting == "true":
+                    insecure = True
+                elif insecure_setting == "false":
+                    insecure = False
+                else:
+                    raise RuntimeError("insecure is set to '%s', it must be 'true' or 'false' if it is used in %s"
+                                       % (insecure_setting, config_file))
+        elif None in (api_key, email):
+            raise RuntimeError("api_key or email not specified and %s does not exist"
+                               % (config_file,))
 
         self.api_key = api_key
         self.email = email
@@ -174,6 +203,17 @@ class Client(object):
         self.base_url += "/"
         self.retry_on_errors = retry_on_errors
         self.client_name = client
+
+        if insecure:
+            self.tls_verification=False
+        elif cert_bundle is not None:
+            if not os.path.isfile(cert_bundle):
+                raise RuntimeError("tls bundle '%s' does not exist"
+                                   %(cert_bundle,))
+            self.tls_verification=cert_bundle
+        else:
+            # Default behavior: verify against system CA certificates
+            self.tls_verification=True
 
     def get_user_agent(self):
         vendor = ''
@@ -249,7 +289,7 @@ class Client(object):
                         urlparse.urljoin(self.base_url, url),
                         auth=requests.auth.HTTPBasicAuth(self.email,
                                                          self.api_key),
-                        verify=True, timeout=90,
+                        verify=self.tls_verification, timeout=90,
                         headers={"User-agent": self.get_user_agent()},
                         **kwargs)
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 [Unreleased]
+- Added options to the Python api for working with untrusted server certificates.
 
 [1.3.7] - 2015-10-19
 - Turn off desktop and audible notifications for streams by default.

--- a/templates/zerver/accounts_accept_terms.html
+++ b/templates/zerver/accounts_accept_terms.html
@@ -1,5 +1,5 @@
 {% extends "zerver/portico_signup.html" %}
-
+{% load i18n %}
 {% comment %}
 Allow the user to accept the terms, creating an email record of that fact.
 {% endcomment %}
@@ -7,24 +7,25 @@ Allow the user to accept the terms, creating an email record of that fact.
 {% block for_you %}for {% if company_name %} {{company_name}} {% else %} __________ {% endif %} {% endblock %}
 {% block portico_content %}
 
-<p>(Welcome! We think you'll like it here.)</p>
+<p>({% trans "Welcome! We think you'll like it here" %}.)</p>
+
 
 <div class="pitch">
     <hr/>
-    <p>You're almost there. We just need you to do one last thing.</p>
-    <h3>Accept the Zulip terms of service</h3>
+    <p>{% trans "You're almost there. We just need you to do one last thing" %}.</p>
+    <h3>{% trans "Accept the Zulip terms of service" %}</h3>
 </div>
 
 <form method="post" class="form-horizontal" id="registration" action="{% url 'zerver.views.accounts_accept_terms' %}">
 {% csrf_token %}
     <div class="control-group">
-        <label for="id_email" class="control-label">Email</label>
+        <label for="id_email" class="control-label">{% trans "Email" %}</label>
         <div class="controls fakecontrol">
             <p>{{ email }}</p>
         </div>
     </div>
     <div class="control-group">
-        <label for="id_full_name" class="control-label">Your name</label>
+        <label for="id_full_name" class="control-label">{% trans "Your name" %}</label>
         <div class="controls">
             <input id="id_full_name" class="required" type="text" name="full_name"
                    value="{% if form.full_name.value %}{{ form.full_name.value }}{% endif %}"
@@ -50,7 +51,7 @@ Allow the user to accept the terms, creating an email record of that fact.
                 {% endcomment %}
                 <input id="id_terms" class="required" type="checkbox" name="terms"
                        {% if form.terms.value %}checked="checked"{% endif %} />
-                I agree to the <a href="/terms">Terms of Service</a>.
+                {% trans "I agree to the" %} <a href="/terms">{% trans "Terms of Service" %}</a>.
             </label>
             {% if form.terms.errors %}
                 {% for error in form.terms.errors %}

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -1,5 +1,5 @@
 {% extends "zerver/portico_signup.html" %}
-
+{% load i18n %}
 {# Home page for not logged-in users. #}
 
 {# This is where we pitch the app and solicit signups. #}
@@ -16,14 +16,14 @@ $(function () {
 
         <div class="register-form">
             <p class="lead">
-              <div class="register-page-header">Let's get started…</div>
+              <div class="register-page-header">{% trans "Let's get started" %}…</div>
             </p>
             <form class="form-inline" id="send_confirm" name="email_form"
                   action="{{ current_url }}" method="post">
                 {% csrf_token %}
-                <input type="text" class="email required" placeholder="Enter your work email address"
+                <input type="text" class="email required" placeholder="{% trans "Enter your work email address" %}"
                        id="email" name="email"/>
-                <input type="submit" class="btn btn-primary btn-large register-button" value="Sign up"/>
+                <input type="submit" class="btn btn-primary btn-large register-button" value="{% trans "Sign up" %}"/>
             </form>
             <div id="errors"></div>
             {% if form.email.errors %}
@@ -32,11 +32,11 @@ $(function () {
                 {% endfor %}
             {% endif %}
 
-            <div class="alert alert-pitch" id="company-email">Please use your
+            <div class="alert alert-pitch" id="company-email">{% blocktrans %}Please use your
             company email address to sign up. Otherwise, we won’t be able to
-            connect you with your coworkers.</div>
+            connect you with your coworkers{% endblocktrans %}.</div>
             <div class="register-google">
-                <a href="{% url 'zerver.views.start_google_oauth2' %}" class="zocial google register-google-button">Sign up with Google</a>
+                <a href="{% url 'zerver.views.start_google_oauth2' %}" class="zocial google register-google-button">{% trans "Sign up with Google" %}</a>
             </div>
         </div>
 

--- a/templates/zerver/accounts_send_confirm.html
+++ b/templates/zerver/accounts_send_confirm.html
@@ -1,15 +1,15 @@
 {% extends "zerver/portico_signup.html" %}
-
+{% load i18n %}
 {# Displayed after a user attempts to sign up. #}
 
 {% block portico_content %}
 <div class="app portico-page">
   <div class="app-main portico-page-container">
-            <h2>Thanks for signing up!</h2>
-            <p class="lead">Check your email so we can get started.</p>
+            <h2>{% trans "Thanks for signing up!" %}</h2>
+            <p class="lead">{% trans "Check your email so we can get started" %}.</p>
 
-            <p>Still no email? We can <a href="#" id="resend_email_link">resend it</a>.<br/>
-            <small>(Just in case, take a look at your Spam folder.)</small></p>
+            <p>{% blocktrans %}Still no email? We can <a href="#" id="resend_email_link">resend it</a>{% endblocktrans %}.<br/>
+            <small>({% trans "Just in case, take a look at your Spam folder" %}.)</small></p>
             <form id="resend_confirm" action="/accounts/home/" method="post" style="position: absolute;">
                 {% csrf_token %}
                 <input type="hidden" class="email" id="email" value="{{ email }}" name="email"/>&nbsp;

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -1,12 +1,12 @@
 {% extends "zerver/portico.html" %}
-
+{% load i18n %}
 {# API information page #}
 
 {% block portico_content %}
-    <div class="apps-page-header">Do&nbsp;we&nbsp;have&nbsp;apps? App&#8209;solutely.</div>
-    <div class="apps-muted">Ok, I take it back, I'm sorry, please don't go.</div>
+    <div class="apps-page-header">{% blocktrans %}Do we have apps? Appsolutely.{% endblocktrans %}</div>
+    <div class="apps-muted">{% blocktrans %}Ok, I take it back, I'm sorry, please don't go.{% endblocktrans %}</div>
 
-    <h3 class="apps-instructions-header">Installation instructions</h3>
+    <h3 class="apps-instructions-header">{% blocktrans %}Installation instructions{% endblocktrans %}</h3>
     <ul class="nav nav-tabs" id="apps-tabs">
     {% if not_voyager %}
       <li class="active"><a href="#android" data-toggle="tab">Android</a></li>
@@ -23,10 +23,10 @@
       <div class="tab-pane active" id="android">
         <img class="screenshot android-screenshot pull-left" src="/static/images/app-screenshots/zulip-android.png" alt="screenshot of the Zulip app on Android" />
 
-        <p>Zulip has a free, <strong>100% native app</strong> for Android,
+        <p>{% blocktrans %}Zulip has a free, <strong>100% native app</strong> for Android,
           and you can easily grab it from
           the <a href="https://play.google.com/store/apps/details?id=com.zulip.android">Google
-          Play Store</a>.</p>
+          Play Store</a>{% endblocktrans %}.</p>
 
         <a href="https://play.google.com/store/apps/details?id=com.zulip.android">
           <img alt="Get it on Google Play"
@@ -37,9 +37,9 @@
       <div class="tab-pane" id="iphone">
         <img class="screenshot iphone-screenshot pull-left" src="/static/images/app-screenshots/zulip-iphone.png" alt="screenshot of the Zulip app on iOS" />
 
-        <p>Zulip has a free, <strong>100% native app</strong> for iPhone and
+        <p>{% blocktrans %}Zulip has a free, <strong>100% native app</strong> for iPhone and
         iPad. Please grab it from
-        the <a href="http://itunes.com/apps/zulip">App Store</a>!</p>
+        the <a href="http://itunes.com/apps/zulip">App Store</a>{% endblocktrans %}!</p>
 
         <a href="http://itunes.com/apps/zulip">
           <img alt="Get it in the App Store" src="/static/images/app-screenshots/ios_badge.png" alt="Apple App Store icon for Zulip" />
@@ -48,16 +48,16 @@
       </div>
       {% endif %}
       <div class="tab-pane" id="mac">
-        <p>You love your Mac. And you love Zulip. So what could be
+        <p>{% blocktrans %}You love your Mac. And you love Zulip. So what could be
         better than a Zulip app for Mac? Enjoy notifications for
         messages and PMs in your dock whether you're in Sublime,
-        emacs, or Photoshop.</p>
+        emacs, or Photoshop.{% endblocktrans %}</p>
 
         <p style="text-align: center">
         {% if not_voyager %}
-          <a href="https://zulip.com/dist/apps/mac/Zulip-latest.dmg" class="btn btn-large btn-primary btn-app-download"><i class="icon-vector-download"></i> Download Zulip for Mac</a>
+          <a href="https://zulip.com/dist/apps/mac/Zulip-latest.dmg" class="btn btn-large btn-primary btn-app-download"><i class="icon-vector-download"></i> {% blocktrans %}Download Zulip for Mac{% endblocktrans %}</a>
         {% else %}
-          <a href="https://zulip.com/dist/apps/sso/mac/Zulip-latest.dmg" class="btn btn-large btn-primary btn-app-download"><i class="icon-vector-download"></i> Download Zulip for Mac</a>
+          <a href="https://zulip.com/dist/apps/sso/mac/Zulip-latest.dmg" class="btn btn-large btn-primary btn-app-download"><i class="icon-vector-download"></i> {% blocktrans %}Download Zulip for Mac{% endblocktrans %}</a>
         {% endif %}
         </p>
 
@@ -65,12 +65,12 @@
       </div>
 
       <div class="tab-pane" id="linux">
-        <p>Zulip provides a native Linux app that runs standalone
+        <p>{% blocktrans %}Zulip provides a native Linux app that runs standalone
         outside of your browser. How you install it depends on what
-        you're running:</p>
+        you're running:{% endblocktrans %}</p>
 
-        <h3>Debian and Ubuntu</h3>
-        We have an APT repository for Zulip, so adding and installing the app is easy:
+        <h3>{% blocktrans %}Debian and Ubuntu{% endblocktrans %}</h3>
+        {% blocktrans %}We have an APT repository for Zulip, so adding and installing the app is easy:{% endblocktrans %}
         <div class="codehilite"><pre>wget https://zulip.com/dist/keys/user-apt.asc
 cat user-apt.asc | sudo apt-key add -
 sudo apt-add-repository http://apt.zulip.com/user/
@@ -83,29 +83,29 @@ sudo apt-get install zulip-desktop-sso
 
 
 
-        <h3>Other</h3>
+        <h3>{% trans "Other" %}</h3>
         {% if not_voyager %}
-          <p>We provide a <a href="https://zulip.com/dist/apps/linux/zulip-desktop_latest.bin.tar.gz">binary tarball</a> of the Zulip application, built for 64-bit systems.
+          <p>{% blocktrans %}We provide a <a href="https://zulip.com/dist/apps/linux/zulip-desktop_latest.bin.tar.gz">binary tarball</a> of the Zulip application, built for 64-bit systems.{% endblocktrans %}
           </p>
         {% else %}
-          <p>We provide a <a href="https://zulip.com/dist/apps/sso/linux/zulip-desktop_latest.bin.tar.gz">binary tarball</a> of the Zulip application, built for 64-bit systems.
+          <p>{% blocktrans %}We provide a <a href="https://zulip.com/dist/apps/sso/linux/zulip-desktop_latest.bin.tar.gz">binary tarball</a> of the Zulip application, built for 64-bit systems.{% endblocktrans %}
           </p>
         {% endif %}
       </div>
 
       <div class="tab-pane" id="windows">
-        <p>Windows. It's the best OS for your needs: gaming,
+        <p>{% blocktrans %}Windows. It's the best OS for your needs: gaming,
         coding, expense reports. But you always felt that something
-        was missing... until now.</p>
+        was missing... until now.{% endblocktrans %}</p>
 
-        <p>We proudly present <b>Zulip for Windows</b>: the second-best app for Windows on the market today (after
-        Solitaire, obviously.)</p>
+        <p>{% blocktrans %}We proudly present <b>Zulip for Windows</b>: the second-best app for Windows on the market today (after
+        Solitaire, obviously.){% endblocktrans %}</p>
 
         <p style="text-align: center">
           {% if not_voyager %}
-            <a href="https://zulip.com/dist/apps/win/zulip-latest.exe" class="btn btn-large btn-primary btn-app-download"><i class="icon-vector-download"></i> Download Zulip for Windows</a>
+            <a href="https://zulip.com/dist/apps/win/zulip-latest.exe" class="btn btn-large btn-primary btn-app-download"><i class="icon-vector-download"></i> {% blocktrans %}Download Zulip for Windows{% endblocktrans %}</a>
           {% else %}
-            <a href="https://zulip.com/dist/apps/sso/win/zulip-latest.exe" class="btn btn-large btn-primary btn-app-download"><i class="icon-vector-download"></i> Download Zulip for Windows</a>
+            <a href="https://zulip.com/dist/apps/sso/win/zulip-latest.exe" class="btn btn-large btn-primary btn-app-download"><i class="icon-vector-download"></i> {% blocktrans %}Download Zulip for Windows{% endblocktrans %}</a>
           {% endif %}
         </p>
 
@@ -113,10 +113,10 @@ sudo apt-get install zulip-desktop-sso
       </div>
 
       <div class="tab-pane" id="plan9">
-        <p>First, connect to our hosted 9P filesystem
+        <p>{% blocktrans %}First, connect to our hosted 9P filesystem
         at <code>plan9.zulip.com</code> and then... no, we're
         totally kidding. There definitely isn't a version of Zulip
-        for Plan 9.</p>
+        for Plan 9.{% endblocktrans %}</p>
       </div>
 
 

--- a/templates/zerver/bankruptcy.html
+++ b/templates/zerver/bankruptcy.html
@@ -1,17 +1,18 @@
+{% load i18n %}
 <div class="modal hide" id="bankruptcy" tabindex="-1" role="dialog"
      aria-labelledby="bankruptcy-label" aria-hidden="true">
 
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-        <h3 id="bankruptcy-label">Welcome back</h3>
+        <h3 id="bankruptcy-label">{% trans 'Welcome back' %}</h3>
     </div>
 
     <div id="bankruptcy-unread-count"></div>
 
     <div class="modal-footer">
         <button id="yes-bankrupt" class="bankruptcy_button btn btn-primary"
-                aria-hidden="true">Yes, please!</button>
+                aria-hidden="true">{% trans 'Yes, please!' %}</button>
         <button id="no-bankrupt" class="bankruptcy_button btn btn-default"
-                data-dismiss="modal" aria-hidden="true">No, I'll catch up.</button>
+                data-dismiss="modal" aria-hidden="true">{% trans "No, I'll catch up" %}.</button>
     </div>
 </div>

--- a/templates/zerver/closed_realm.html
+++ b/templates/zerver/closed_realm.html
@@ -1,11 +1,11 @@
 {% extends "zerver/portico.html" %}
-
+{% load i18n %}
 {% block portico_content %}
 
-<h3>Closed realm</h3>
+<h3>{% trans 'Closed realm' %}</h3>
 
-<p>Hi there! Thank you for your interest in Zulip.</p>
+<p>{% trans 'Hi there! Thank you for your interest in Zulip' %}.</p>
 
-<p>The organization you are trying to join, {{ closed_domain_name }}, only allows users with e-mail addresses within the organization. Please ask for a new invite to an appropriate e-mail address.</p>
+<p>{% blocktrans %}The organization you are trying to join, {{ closed_domain_name }}, only allows users with e-mail addresses within the organization. Please ask for a new invite to an appropriate e-mail address{% endblocktrans %}.</p>
 
 {% endblock %}

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <div id="compose">
   <div id="compose-notifications" class="notifications above-composebox">
   </div>
@@ -7,14 +8,14 @@
             <span class="new_message_button">
               <button type="button" class="btn btn-default btn-large compose_stream_button"
                       id="left_bar_compose_stream_button_big" title="New stream message (c)">
-                <i class="icon-vector-bullhorn"></i><span class="compose_stream_button_label">&nbsp;&nbsp;New stream message</span>
+                <i class="icon-vector-bullhorn"></i><span class="compose_stream_button_label">&nbsp;&nbsp;{% trans 'New stream message' %}</span>
               </button>
             </span>
             {% if not embedded %}
             <span class="new_message_button">
               <button type="button" class="btn btn-default btn-large compose_private_button"
                       id="left_bar_compose_private_button_big" title="New private message (C)">
-                <i class="icon-vector-user"></i><span class="compose_private_button_label">&nbsp;&nbsp;New private message</span>
+                <i class="icon-vector-user"></i><span class="compose_private_button_label">&nbsp;&nbsp;{% trans 'New private message' %}</span>
               </button>
             </span>
             {% endif %}
@@ -43,15 +44,15 @@
               </td>
               <td class="right_part">
                   <span id="compose-lock-icon">
-                    <i class="icon-vector-lock" title="This is an invite-only stream"></i>
+                    <i class="icon-vector-lock" title="{% trans 'This is an invite-only stream' %}"></i>
                   </span>
                   <input type="text" class="recipient_box" name="stream" id="stream"
                          maxlength="30"
-                         value="" placeholder="Stream" autocomplete="off" tabindex="120"/>
+                         value="" placeholder="{% trans 'Stream' %}" autocomplete="off" tabindex="120"/>
                   <i class="icon-vector-narrow icon-vector-small"></i>
                   <input type="text" class="recipient_box" name="subject" id="subject"
                          maxlength="60"
-                         value="" placeholder="Topic" autocomplete="off" tabindex="130"/>
+                         value="" placeholder="{% trans 'Topic' %}" autocomplete="off" tabindex="130"/>
               </td>
             </tr>
             <tr id="private-message">
@@ -60,28 +61,28 @@
               </td>
               <td class="right_part">
                 <div class="pm_recipient">
-                <span class="you_text">You and</span>
+                <span class="you_text">{% trans 'You and' %}</span>
                 <input type="text" class="recipient_box" name="recipient" id="private_message_recipient"
-                               value="" placeholder="one or more people..." autocomplete="off" tabindex="130"/>
+                               value="" placeholder="{% trans 'one or more people' %}..." autocomplete="off" tabindex="130"/>
                 </div>
               </td>
             </tr>
             <tr>
               <td class="messagebox" colspan="2">
                   <textarea class="new_message_textarea" name="content" id="new_message_content"
-                            value="" placeholder="Compose your message here..." tabindex="140" maxlength="10000"></textarea>
+                            value="" placeholder="{% trans 'Compose your message here' %}..." tabindex="140" maxlength="10000"></textarea>
               <div id="below-compose-content">
                   <input type="file" id="file_input" class="notvisible pull-left" multiple />
                   <a class="message-control-button icon-vector-dropbox notdisplayed"
-                     id="attach_dropbox_files" href="#" title="Attach files from Dropbox"></a>
+                     id="attach_dropbox_files" href="#" title="{% trans 'Attach files from Dropbox' %}"></a>
                   <a class="message-control-button icon-vector-paper-clip notdisplayed"
-                     id="attach_files" href="#" title="Attach files"></a>
+                     id="attach_files" href="#" title="{% trans 'Attach files' %}"></a>
                   <a class="message-control-button icon-vector-font"
                      href="#markdown-help" title="Formatting" data-toggle="modal"></a>
-                  <a id="restore-draft" onclick="compose.restore_message();">Restore draft</a>
-                  <span id="sending-indicator">Sending...</span>
+                  <a id="restore-draft" onclick="compose.restore_message();">{% trans 'Restore draft' %}</a>
+                  <span id="sending-indicator">{% trans 'Sending' %}...</span>
                   <div id="send_controls">
-                  <label id="enter-sends-label" class="compose_checkbox_label" for="enter_sends">Press Enter to send&nbsp;</label>
+                  <label id="enter-sends-label" class="compose_checkbox_label" for="enter_sends">{% trans 'Press Enter to send' %}&nbsp;</label>
                     <input type="checkbox" id="enter_sends" name="enter_sends" value="enter_sends" />
                     <input type="submit" value="Send" id="compose-send-button" class="btn btn-primary send_message" tabindex="150"/>
                   </div>

--- a/templates/zerver/deactivated.html
+++ b/templates/zerver/deactivated.html
@@ -1,14 +1,14 @@
 {% extends "zerver/portico.html" %}
-
+{% load i18n %}
 {% block portico_content %}
 
-<h3>Deactivated organization</h3>
+<h3>{% trans 'Deactivated organization' %}</h3>
 
-<p>Hi there! Thank you for your interest in Zulip.</p>
+<p>{% trans 'Hi there! Thank you for your interest in Zulip' %}.</p>
 
-<p>The organization you are trying to join, {{ deactivated_domain_name }}, has
+<p>{% blocktrans %} The organization you are trying to join, {{ deactivated_domain_name }}, has
 been deactivated. Please
 contact <a href="mailto:{{ zulip_administrator }}">{{ zulip_administrator }}</a> to reactivate
-this group.</p>
+this group{% endblocktrans %}.</p>
 
 {% endblock %}

--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -1,150 +1,151 @@
 {% extends "zerver/portico.html" %}
+{% load i18n %}
 
 {% block portico_content %}
-    <div class="feature-page-header">Zulip Features</div>
+    <div class="feature-page-header">{% blocktrans %}Zulip Features{% endblocktrans %}</div>
       <div class="feature-block left">
         <i class="icon-vector-random icon-vector-3x feature-icon"></i>
-        <h4>Threaded group conversations</h4>
-        <p>Talk about multiple topics at once without getting lost or
-        overwhelmed.</p>
+        <h4>{% blocktrans %}Threaded group conversations{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Talk about multiple topics at once without getting lost or
+        overwhelmed.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-comments icon-vector-3x feature-icon"></i>
-        <h4>One-on-one and group private conversations</h4>
-        <p>Have private conversations with one or as many people as you need.</p>
+        <h4>{% blocktrans %}One-on-one and group private conversations{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Have private conversations with one or as many people as you need.{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-home icon-vector-3x feature-icon"></i>
-        <h4>Persistence</h4>
-        <p>We're always receiving messages for you, even when you're
-        logged out.</p>
+        <h4>{% trans "Persistence" %}</h4>
+        <p>{% blocktrans %}We're always receiving messages for you, even when you're
+        logged out.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-road icon-vector-3x feature-icon"></i>
-        <h4>History</h4>
-        <p>Join a stream and see its history, so even new team
-        members are never out of the loop.</p>
+        <h4>{% trans "History" %}</h4>
+        <p>{% blocktrans %}Join a stream and see its history, so even new team
+        members are never out of the loop.{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-search icon-vector-3x feature-icon"></i>
-        <h4>Full-history search</h4>
-        <p>Search is both snappy and smart, helping you look for text,
+        <h4>{% blocktrans %}Full-history search{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Search is both snappy and smart, helping you look for text,
         people, and threads of conversation, with advanced search
-        operators for fine-grained control.</p>
+        operators for fine-grained control.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-group icon-vector-3x feature-icon"></i>
-        <h4>Team presence and buddy list</h4>
-        <p>See who is online at a glance.</p>
+        <h4>{% blocktrans %}Team presence and buddy list{% endblocktrans %}</h4>
+        <p>{% blocktrans %}See who is online at a glance.{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-picture icon-vector-3x feature-icon"></i>
-        <h4>Inline image, video, and tweet previews</h4>
-        <p>Send a link and we'll automatically generate an inline
-        preview.</p>
+        <h4>{% blocktrans %}Inline image, video, and tweet previews{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Send a link and we'll automatically generate an inline
+        preview.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-paper-clip icon-vector-3x feature-icon"></i>
-        <h4>Drag-and-drop file uploads</h4>
-        <p>Drag a file into the compose box and we'll upload and
+        <h4>{% blocktrans %}Drag-and-drop file uploads{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Drag a file into the compose box and we'll upload and
         preview it for you. Sharing and discussing work with team
-        mates has never been easier.</p>
+        mates has never been easier.{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-user icon-vector-3x feature-icon"></i>
-        <h4>@-notifications</h4>
-        <p>Want someone's attention in a conversation? @-notify them
-        and they'll be right over.</p>
+        <h4>{% trans "@-notifications" %}</h4>
+        <p>{% blocktrans %}Want someone's attention in a conversation? @-notify them
+        and they'll be right over.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-bullhorn icon-vector-3x feature-icon"></i>
-        <h4>Stream-wide announcements</h4>
-        <p>Use <code>@all</code> or <code>@everyone</code> to get the
-        attention of everyone in a stream.</p>
+        <h4>{% blocktrans %}Stream-wide announcements{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Use <code>@all</code> or <code>@everyone</code> to get the
+        attention of everyone in a stream.{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-envelope icon-vector-3x feature-icon"></i>
-        <h4>Emails for important missed messages</h4>
-        <p>If you're missing important conversations when you're away from
+        <h4>{% blocktrans %}Emails for important missed messages{% endblocktrans %}</h4>
+        <p>{% blocktrans %}If you're missing important conversations when you're away from
         Zulip, we'll send you an email summary so you're always in the
-        loop.</p>
+        loop.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-info-sign icon-vector-3x feature-icon"></i>
-        <h4>Desktop notifications</h4>
-        <p>Configurable for private and stream messages.</p>
+        <h4>{% blocktrans %}Desktop notifications{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Configurable for private and stream messages.{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-bell icon-vector-3x feature-icon"></i>
-        <h4>Audible notifications</h4>
-        <p>So you don't miss important messages even when your eyes
-        are elsewhere.</p>
+        <h4>{% blocktrans %}Audible notifications{% endblocktrans %}</h4>
+        <p>{% blocktrans %}So you don't miss important messages even when your eyes
+        are elsewhere.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-font icon-vector-3x feature-icon"></i>
-        <h4>Hotkeys</h4>
-        <p>Communicate as efficiently as you use your favorite text editor.</p>
+        <h4>{% trans "Hotkeys" %}</h4>
+        <p>{% blocktrans %}Communicate as efficiently as you use your favorite text editor.{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-thumbs-up icon-vector-3x feature-icon"></i>
-        <h4>Emoji</h4>
-        <p>Sometimes it's the simple things in life, like being able
-        to give a <tt>:thumbsup:</tt> while chatting.</p>
+        <h4>{% trans "Emoji" %}</h4>
+        <p>{% blocktrans %}Sometimes it's the simple things in life, like being able
+        to give a <tt>:thumbsup:</tt> while chatting.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-edit icon-vector-3x feature-icon"></i>
-        <h4>Code</h4>
-        <p>Discuss code, even multi-line code, with ease, including
-        syntax-highlighting.</p>
+        <h4>{% trans "Code" %}</h4>
+        <p>{% blocktrans %}Discuss code, even multi-line code, with ease, including
+        syntax-highlighting.{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-quote-left icon-vector-3x feature-icon"></i>
-        <h4>Lightweight markup</h4>
-        <p>Get bulleted lists, clickable links, and nicely-formatted
-        e-mail pastes automatically.</p>
+        <h4>{% blocktrans %}Lightweight markup{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Get bulleted lists, clickable links, and nicely-formatted
+        e-mail pastes automatically.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-eraser icon-vector-3x feature-icon"></i>
-        <h4>Message editing</h4>
-        <p>Don't worry, you can always fix that typo.</p>
+        <h4>{% blocktrans %}Message editing{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Don't worry, you can always fix that typo.{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-lock icon-vector-3x feature-icon"></i>
-        <h4>Invite-only streams</h4>
-        <p>Enjoy the benefits of threaded conversations while
-        controlling your audience and privacy.</p>
+        <h4>{% blocktrans %}Invite-only streams{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Enjoy the benefits of threaded conversations while
+        controlling your audience and privacy.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-star-empty icon-vector-3x feature-icon"></i>
-        <h4>Starred messages</h4>
-        <p>Keep a todo list or keep track of interesting
-        conversations.</p>
+        <h4>{% blocktrans %}Starred messages{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Keep a todo list or keep track of interesting
+        conversations.{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-github icon-vector-3x feature-icon"></i>
-        <h4>Integrations</h4>
-        <p>Get alerts and updates from your favorite services with
+        <h4>{% trans "Integrations" %}</h4>
+        <p>{% blocktrans %}Get alerts and updates from your favorite services with
         off-the-shelf <a href="/integrations">integrations</a> for
-        Trac, Nagios, Github, Jenkins, and more.</p>
+        Trac, Nagios, Github, Jenkins, and more.{% endblocktrans %}</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-sitemap icon-vector-3x feature-icon"></i>
-        <h4>API</h4>
-        <p>Want to roll your own notifications? We've got a
+        <h4>{% trans "API" %}</h4>
+        <p>{% blocktrans %}Want to roll your own notifications? We've got a
         dead-simple RESTful <a href="/api">API and Python bindings</a>
         that will make integrations&mdash;both sending and
-        receiving&mdash;a snap!</p>
+        receiving&mdash;a snap!{% endblocktrans %}</p>
       </div>
       <div class="feature-block left">
         <i class="icon-vector-mobile-phone icon-vector-3x feature-icon"></i>
-        <h4>Mobile apps</h4>
-        <p>Check Zulip on the go with native <a href="/apps">iOS and
-        Android apps</a>.</p>
+        <h4>{% blocktrans %}Mobile apps{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Check Zulip on the go with native <a href="/apps">iOS and
+        Android apps</a>{% endblocktrans %}.</p>
       </div>
       <div class="feature-block">
         <i class="icon-vector-desktop icon-vector-3x feature-icon"></i>
-        <h4>Desktop apps</h4>
-        <p>Prefer Zulip in its own window and rich, OS-level notifications?
-          Enjoy <a href="/apps">Zulip on your desktop</a>.</p>
+        <h4>{% blocktrans %}Desktop apps{% endblocktrans %}</h4>
+        <p>{% blocktrans %}Prefer Zulip in its own window and rich, OS-level notifications?
+          Enjoy <a href="/apps">Zulip on your desktop</a>{% endblocktrans %}.</p>
       </div>
 {% endblock %}

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% load i18n %}
 {% block hello_page_container %} hello-main{% endblock %}
 {% block hello_page_footer %} hello-footer{% endblock %}
 {% block os_announcement %}
@@ -7,10 +8,10 @@
     <img src="/static/images/logo/zballoon.png" class="os-illustration" alt="Zulip balloon" />
     <div class="main-headline-text">
       <span class="tagline os-tagline">
-         Zulip has been released as open source software!
+         {% trans 'Zulip has been released as open source software!' %}
       </span>
       <span class="footnote os-footnote">
-         Read the <a href="https://blogs.dropbox.com/tech/2015/09/open-sourcing-zulip-a-dropbox-hack-week-project" target="_blank">announcement</a> or go to <a href="https://www.zulip.org" target="_blank">the Zulip open source project website</a>.
+         {% blocktrans %}Read the <a href="https://blogs.dropbox.com/tech/2015/09/open-sourcing-zulip-a-dropbox-hack-week-project" target="_blank">announcement</a> or go to <a href="https://www.zulip.org" target="_blank">the Zulip open source project website</a>.{% endblocktrans %}
       </span>
     </div>
   </div>
@@ -23,14 +24,14 @@
     <img src="/static/images/logo/textlogo@2x.png" class="main-headline-logo" alt="Zulip logo" />
     <div class="main-headline-text">
       <span class="tagline">
-        Finally, workplace chat that actually improves your productivity.*
+        {% trans 'Finally, workplace chat that actually improves your productivity.*' %}
       </span>
-      <span class="footnote">* It's also great for sharing cat pictures.</span>
+      <span class="footnote">{% trans "* It's also great for sharing cat pictures" %}.</span>
         {% if not_voyager %}
         {% elif only_sso %}
-          <a href="{% url 'login-sso' %}" class="main-signup-button btn btn-large btn-primary">Log in now!</a>
+          <a href="{% url 'login-sso' %}" class="main-signup-button btn btn-large btn-primary">{% trans 'Log in now!' %}</a>
         {% else %}
-          <a href="{% url 'register' %}" class="main-signup-button btn btn-large btn-primary">Register now!</a>
+          <a href="{% url 'register' %}" class="main-signup-button btn btn-large btn-primary">{% trans 'Register now!' %}</a>
         {% endif %}
     </div>
     <img src="/static/images/landing-page/laptop-screenshot.png" class="main-image" alt="Screenshot of Zulip" />
@@ -41,15 +42,15 @@
   <div class="app-main feature-line-container">
    <div class="feature-text">
     <span class="tagline">
-      Conversations, not&nbsp;messages.
+      {% trans 'Conversations, not messages' %}.
     </span>
     <span class="description">
-      <p>Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s
+      <p>{% blocktrans %}Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s
       easy to keep conversations straight. Are your coworkers discussing
       a software bug and the content of your website at the same time?
-      No problem.
+      No problem.{% endblocktrans %}
     </p>
-    <p>You wouldn’t tolerate email without subject lines or threading, so why do you for chat?</p>
+    <p>{% trans "You wouldn’t tolerate email without subject lines or threading, so why do you for chat?" %}</p>
     </span>
   </div>
   <div class="feature-illustration">
@@ -62,15 +63,15 @@
   <div class="app-main feature-line-container">
    <div class="feature-text">
     <span class="tagline">
-      Easily&nbsp;read&nbsp;just the&nbsp;important&nbsp;things.
+      {% trans 'Easily read just the important things' %}.
     </span>
     <span class="description">
-      <p>Sometimes, important things get discussed when you&rsquo;re not
-      around. Unfortunately, so do a lot of unimportant things.</p>
+      <p>{% blocktrans %}Sometimes, important things get discussed when you&rsquo;re not
+      around. Unfortunately, so do a lot of unimportant things.{% endblocktrans %}</p>
 
-      <p><em>Narrowing</em> by stream or topic lets you focus on that important
+      <p>{% blocktrans %}<em>Narrowing</em> by stream or topic lets you focus on that important
       customer project without having to read about how Jim&rsquo;s guitar lessons
-      are going.</p>
+      are going.{% endblocktrans %}</p>
     </span>
   </div>
   <div class="feature-illustration">
@@ -83,12 +84,12 @@
   <div class="app-main feature-line-container">
    <div class="feature-text">
     <span class="tagline">
-      Search&nbsp;that&rsquo;s&nbsp;better than&nbsp;Gmail&rsquo;s.
+      {% trans "Search that's better than Gmail's" %}.
     </span>
     <span class="description">
-      An impressive amount of knowledge lives in your chat system.  Zulip&rsquo;s
+      {%  blocktrans %}An impressive amount of knowledge lives in your chat system.  Zulip&rsquo;s
       powerful and fast search will delight you with how quickly you can find
-      exactly what you&rsquo;re looking for.
+      exactly what you&rsquo;re looking for.{% endblocktrans %}
     </span>
   </div>
   <div class="feature-illustration">
@@ -101,14 +102,14 @@
   <div class="app-main feature-line-container">
    <div class="feature-text">
     <span class="tagline">
-      Integrations&nbsp;that don&rsquo;t&nbsp;intrude.
+      {% trans "Integrations that don't intrude" %}.
     </span>
     <span class="description">
-      <p>Zulip has <a href="/integrations">many integrations</a> and
+      <p>{% blocktrans %}Zulip has <a href="/integrations">many integrations</a> and
       a powerful <a href="/api">API</a> to match. But here&rsquo;s
       where it gets interesting: thanks to how Zulip categorizes messages,
       automated messages never overwhelm you. As with any topic in Zulip,
-      they&rsquo;re easy to focus on, skim, defer to later, or ignore&mdash;as appropriate.</p>
+      they&rsquo;re easy to focus on, skim, defer to later, or ignore&mdash;as appropriate.{% endblocktrans %}</p>
     </span>
   </div>
   <div class="feature-illustration">
@@ -121,12 +122,12 @@
   <div class="app-main feature-line-container">
    <div class="feature-text">
     <span class="tagline">
-      As&nbsp;technical&nbsp;as you&nbsp;want&nbsp;to&nbsp;be.
+      {% trans 'As technical as you want to be' %}.
     </span>
     <span class="description">
-      <p>Keyboard shortcuts? Check.<br />
-        Syntax highlighting? Check.<br />
-        Discuss code and technical topics with ease.</p>
+      <p>{% trans 'Keyboard shortcuts? Check.' %}<br />
+        {% trans 'Syntax highlighting? Check.' %}<br />
+        {% trans 'Discuss code and technical topics with ease.' %}</p>
     </span>
   </div>
   <div class="feature-illustration">
@@ -139,12 +140,12 @@
   <div class="app-main feature-line-container">
    <div class="feature-text">
     <span class="tagline">
-      &hellip;and&nbsp;all&nbsp;the obvious&nbsp;stuff,&nbsp;too.
+      &hellip; {% trans 'and all the obvious stuff, too.' %}
     </span>
     <span class="description">
-      <p>Drag-and-drop file uploads, image pasting, group private messages,
+      <p>{% blocktrans %}Drag-and-drop file uploads, image pasting, group private messages,
          audible notifications, missed-message emails, desktop apps, and
-        <a href="/features">everything else you might want</a>. Including emoji, naturally.</p>
+        <a href="/features">everything else you might want</a>. Including emoji, naturally.{% endblocktrans %}</p>
     </span>
   </div>
   <div class="feature-illustration">
@@ -157,7 +158,7 @@
   <div class="app-main feature-line-container">
    <div class="platform-text">
     <span class="tagline">
-      On&nbsp;the&nbsp;platform of&nbsp;your&nbsp;choice.
+      {% trans 'On the platform of your choice.' %}
     </span>
    </div>
    <div class="platform-icons">
@@ -193,9 +194,9 @@
   <div class="app-main feature-line-container centered-content">
     {% if not_voyager %}
     {% elif only_sso %}
-      <a href="{% url 'login-sso' %}" class="bottom-signup-button btn btn-large btn-primary">Log in now</a>
+      <a href="{% url 'login-sso' %}" class="bottom-signup-button btn btn-large btn-primary">{% trans 'Log in now' %}</a>
     {% else %}
-      <a href="{% url 'register' %}" class="bottom-signup-button btn btn-large btn-primary">Register now</a>
+      <a href="{% url 'register' %}" class="bottom-signup-button btn btn-large btn-primary">{% trans 'Register now' %}</a>
     {% endif %}
   </div>
 </div>

--- a/templates/zerver/home.html
+++ b/templates/zerver/home.html
@@ -1,54 +1,55 @@
+{% load i18n %}
 {# Home tab of the app, containing messages. #}
     <div class="message_area_padder message_list" id="main_div">
       <div id="loading_more_messages_indicator"></div>
       <div id="page_loading_indicator"></div>
       <div id="first_run_message" class="empty_feed_notice">
-        <h4>Welcome to {{product_name}}</h4>
-        <p>See, the thing about it is... there aren't any messages
+        <h4>{% trans 'Welcome to' %} {{product_name}}</h4>
+        <p>{% blocktrans %}See, the thing about it is... there aren't any messages
         here for you right now. I'm sure someone will eventually send
-        you one.</p>
+        you one.{% endblocktrans %}</p>
 
-        <p>Or, <strong>take matters into your own hands</strong>,
-        and <a href="#" class="empty_feed_compose_stream">
-        compose a new stream message</a>.</p>
+        <p>{% trans 'Or' %}, <strong>{% trans 'take matters into your own hands' %}</strong>,
+        {% trans 'and' %} <a href="#" class="empty_feed_compose_stream">
+        {% trans 'compose a new stream message' %}</a>.</p>
       </div>
       <div id="empty_narrow_message" class="empty_feed_notice">
-        <h4>Nothing's been sent here yet!</h4>
+        <h4>{% trans "Nothing's been sent here yet!" %}</h4>
 
-        <p>Why not <a href="#" class="empty_feed_compose_stream">
-            start the conversation</a>?</p>
+        <p>{% trans 'Why not' %} <a href="#" class="empty_feed_compose_stream">
+            {% trans 'start the conversation' %}</a>?</p>
       </div>
       <div id="empty_narrow_all_private_message" class="empty_feed_notice">
-        <h4>You have no private messages yet!</h4>
+        <h4>{% trans 'You have no private messages yet!' %}</h4>
 
-        <p>Why not <a href="#" class="empty_feed_compose_private">
-            start the conversation</a>?</p>
+        <p>{% trans 'Why not' %} <a href="#" class="empty_feed_compose_private">
+            {% trans 'start the conversation' %}</a>?</p>
       </div>
       <div id="empty_narrow_private_message" class="empty_feed_notice">
-        <h4>You have no private messages with this person yet!</h4>
+        <h4>{% trans 'You have no private messages with this person yet!' %}</h4>
 
-        <p>Why not <a href="#" class="empty_feed_compose_private">
-            start the conversation</a>?</p>
+        <p>{% trans 'Why not' %} <a href="#" class="empty_feed_compose_private">
+            {% trans 'start the conversation' %}</a>?</p>
       </div>
       <div id="empty_narrow_multi_private_message" class="empty_feed_notice">
-        <h4>You have no private messages with these people yet!</h4>
+        <h4>{% trans 'You have no private messages with these people yet!' %}</h4>
 
-        <p>Why not <a href="#" class="empty_feed_compose_private">
-            start the conversation</a>?</p>
+        <p>{% trans 'Why not' %} <a href="#" class="empty_feed_compose_private">
+            {% trans 'start the conversation' %}</a>?</p>
       </div>
       <div id="nonsubbed_stream_narrow_message" class="empty_feed_notice">
-        <h4>You aren't subscribed to this stream!</h4>
+        <h4>{% trans "You aren't subscribed to this stream!" %}</h4>
 
-        <p>Want to <a href="#" class="empty_feed_join">join it</a>?</p>
+        <p>{% trans 'Want to' %} <a href="#" class="empty_feed_join">{% trans 'join it' %}</a>?</p>
       </div>
       <div id="empty_star_narrow_message" class="empty_feed_notice">
-        <h4>You haven't starred anything yet!</h4>
+        <h4>{% trans "You haven't starred anything yet!" %}</h4>
       </div>
       <div id="empty_narrow_all_mentioned" class="empty_feed_notice">
-        <h4>You haven't been mentioned yet.</h4>
+        <h4>{% trans "You haven't been mentioned yet" %}.</h4>
       </div>
       <div id="empty_search_narrow_message" class="empty_feed_notice">
-        <h4>Nobody has talked about that yet!</h4>
+        <h4>{% trans 'Nobody has talked about that yet!' %}</h4>
       </div>
       <div class="message_table focused_table" id="zhome">
       </div>

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -1,5 +1,5 @@
 {% extends "zerver/base.html" %}
-
+{% load i18n %}
 {# The app itself. #}
 {# Includes some other templates as tabs. #}
 
@@ -46,8 +46,8 @@ var page_params = {{ page_params }};
 {% endblock %}
 {% block content %}
 <div id="css-loading">
-    <h3>Loading...</h3>
-    <p>If this message does not go away, please wait a couple seconds and <a href="javascript:location.reload(true)">reload</a> the page.</p>
+    <h3>{% trans 'Loading' %}...</h3>
+    <p>{% trans 'If this message does not go away, please wait a couple seconds and' %} <a href="javascript:location.reload(true)">{% trans 'reload' %}</a> {% trans 'the page' %}.</p>
 </div>
 
 <div id="top-screen" class="screen"></div>

--- a/templates/zerver/initial_invite_page.html
+++ b/templates/zerver/initial_invite_page.html
@@ -1,5 +1,5 @@
 {% extends "zerver/portico.html" %}
-
+{% load i18n %}
 {% load minified_js %}
 
 {# A landing page for the first user in a realm, prompting her to invite her colleages. #}
@@ -18,18 +18,18 @@
 
 {% block portico_content %}
 
-<h1 style="margin-top:30px;">You're the first one here!</h1>
+<h1 style="margin-top:30px;">{% trans "You're the first one here!" %}</h1>
 <p>
-  Let's invite some folks for you to chat with:
+  {% trans "Let's invite some folks for you to chat with" %}:
 </p>
 <div id="invite_rows">
     <form id="invite_form">
     {% csrf_token %}
     <div class="invite_row"><input name="email_1" class="invite_email" type={% if not invite_suffix %}"email"{% else %}"text"{% endif %} /> {% if invite_suffix %}@{{invite_suffix}}{% endif %}</div>
-	<p id="invite_blurb">(We'll email invitations to them)</p>
+	<p id="invite_blurb">({% trans "We'll email invitations to them" %})</p>
     <div class="alert" id="invite_error" style="display: none;">
     </div>
-    <button id="submit_invitation" class="btn btn-primary" data-loading-text="Next">Next »</button>
+    <button id="submit_invitation" class="btn btn-primary" data-loading-text="Next">{% trans 'Next' %} »</button>
     </form>
 </div>
 {% endblock %}

--- a/templates/zerver/invite_user.html
+++ b/templates/zerver/invite_user.html
@@ -1,15 +1,16 @@
+{% load i18n %}
 <div class="modal hide" id="invite-user" tabindex="-1" role="dialog"
      aria-labelledby="invite-user-label" aria-hidden="true">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-    <h3 id="invite-user-label">Invite coworkers to {{product_name}}</h3>
+    <h3 id="invite-user-label">{% trans 'Invite coworkers to' %} {{product_name}}</h3>
   </div>
   <form id="invite_user_form" class="form-horizontal"
         action="/json/invite_users" method="POST">{% csrf_token %}
     <div class="modal-body">
       <div class="control-group">
         <div id="invite-result"></div>
-        <label class="control-label" for="invitee_emails">Emails (one on each line or comma-separated)</label>
+        <label class="control-label" for="invitee_emails">{% trans 'Emails (one on each line or comma-separated)' %}</label>
         <div class="controls">
           <textarea rows="2" id="invitee_emails"
                     name="invitee_emails"
@@ -18,13 +19,13 @@
       </div>
         <div class="alert" id="invite_status"></div>
       <div class="control-group">
-        <label class="control-label" for="streams_to_add">Streams they should join</label>
+        <label class="control-label" for="streams_to_add">{% trans 'Streams they should join' %}</label>
         <div class="controls" id="streams_to_add"></div>
       </div>
     </div>
     <div class="modal-footer">
-      <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
-      <button id="submit-invitation" class="btn btn-primary" data-loading-text="Inviting..." type="submit">Invite</button>
+      <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">{% trans 'Cancel' %}</button>
+      <button id="submit-invitation" class="btn btn-primary" data-loading-text="Inviting..." type="submit">{% trans 'Invite' %}</button>
     </div>
   </form>
 </div>

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -1,76 +1,77 @@
+{% load i18n %}
 <div class="modal hide" id="keyboard-shortcuts" tabindex="-1" role="dialog"
      aria-labelledby="keyboard-shortcuts-label" aria-hidden="true">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-    <h3 id="keyboard-shortcuts-label">Keyboard shortcuts</h3>
+    <h3 id="keyboard-shortcuts-label">{% blocktrans %}Keyboard shortcuts{% endblocktrans %}</h3>
   </div>
   <div class="modal-body">
     <div>
       <table class="hotkeys_table table table-striped table-bordered table-condensed">
         <thead>
           <tr>
-            <th colspan="2">Navigation</th>
+            <th colspan="2">{% trans "Navigation" %}</th>
           </tr>
         </thead>
         <tr>
           <td class="hotkey">/</td>
-          <td class="definition">Initiate a search</td>
+          <td class="definition">{% blocktrans %}Initiate a search{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">q</td>
-          <td class="definition">Search people</td>
+          <td class="definition">{% blocktrans %}Search people{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">Up or k</td>
-          <td class="definition">Previous message</td>
+          <td class="definition">{% blocktrans %}Previous message{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">Down or j</td>
-          <td class="definition">Next message</td>
+          <td class="definition">{% blocktrans %}Next message{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">PgUp, K</td>
-          <td class="definition">Scroll up</td>
+          <td class="definition">{% blocktrans %}Scroll up{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">PgDn, J, Spacebar</td>
-          <td class="definition">Scroll down</td>
+          <td class="definition">{% blocktrans %}Scroll down{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">End</td>
-          <td class="definition">Last message</td>
+          <td class="definition">{% blocktrans %}Last message{% endblocktrans %}</td>
         </tr>
       </table>
 
       <table class="hotkeys_table table table-striped table-bordered table-condensed">
         <thead>
           <tr>
-            <th colspan="2">Composing messages</th>
+            <th colspan="2">{% blocktrans %}Composing messages{% endblocktrans %}</th>
           </tr>
         </thead>
         <tr>
           <td class="hotkey">Enter or r</td>
-          <td class="definition">Reply to message</td>
+          <td class="definition">{% blocktrans %}Reply to message{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">R</td>
-          <td class="definition">Reply to author</td>
+          <td class="definition">{% blocktrans %}Reply to author{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">c</td>
-          <td class="definition">New stream message</td>
+          <td class="definition">{% blocktrans %}New stream message{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">C</td>
-          <td class="definition">New private message</td>
+          <td class="definition">{% blocktrans %}New private message{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">Tab then Enter</td>
-          <td class="definition">Send message</td>
+          <td class="definition">{% blocktrans %}Send message{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">Esc</td>
-          <td class="definition">Cancel compose</td>
+          <td class="definition">{% blocktrans %}Cancel compose{% endblocktrans %}</td>
         </tr>
       </table>
     </div>
@@ -79,53 +80,53 @@
       <table class="hotkeys_table table table-striped table-bordered table-condensed">
         <thead>
           <tr>
-            <th colspan="2">Narrowing</th>
+            <th colspan="2">{% trans "Narrowing" %}</th>
           </tr>
         </thead>
         <tr>
           <td class="hotkey">s</td>
-          <td class="definition">Narrow by stream</td>
+          <td class="definition">{% blocktrans %}Narrow by stream{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">S</td>
-          <td class="definition">Narrow by topic</td>
+          <td class="definition">{% blocktrans %}Narrow by topic{% endblocktrans %}</td>
           </tr>
         <tr>
           <td class="hotkey">v</td>
-          <td class="definition">Narrow to all private messages</td>
+          <td class="definition">{% blocktrans %}Narrow to all private messages{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">A or D</td>
-          <td class="definition">Cycle between stream narrows</td>
+          <td class="definition">{% blocktrans %}Cycle between stream narrows{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">Esc</td>
-          <td class="definition">Return to home view</td>
+          <td class="definition">{% blocktrans %}Return to home view{% endblocktrans %}</td>
         </tr>
       </table>
 
       <table class="hotkeys_table table table-striped table-bordered table-condensed">
         <thead>
           <tr>
-            <th colspan="2">Menus</th>
+            <th colspan="2">{% trans "Menus" %}</th>
           </tr>
         </thead>
         <tr>
           <td class="hotkey">i</td>
-          <td class="definition">Open message actions menu</td>
+          <td class="definition">{% blocktrans %}Open message actions menu{% endblocktrans %}</td>
         </tr>
         <tr id="edit-message-hotkey-help">
           <td class="hotkey">i then Enter</td>
-          <td class="definition">Edit a message you sent</td>
+          <td class="definition">{% blocktrans %}Edit a message you sent{% endblocktrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">?</td>
-          <td class="definition">Show these keyboard shortcuts</td>
+          <td class="definition">{% blocktrans %}Show these keyboard shortcuts{% endblocktrans %}</td>
         </tr>
       </table>
     </div>
   </div>
   <div class="modal-footer">
-    <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">Close</button>
+    <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">{% trans "Close" %}</button>
   </div>
 </div>

--- a/templates/zerver/left-sidebar.html
+++ b/templates/zerver/left-sidebar.html
@@ -1,22 +1,23 @@
+{% load i18n %}
           <div class="left-sidebar" id="left-sidebar">
               <div class="bottom_sidebar">
                       <ul id="global_filters" class="filters">
                           {# Special-case this link so we don't actually go to page top. #}
                           <li data-name="home"
-                          class="global-filter active-filter"><span class="filter-icon"><i class="icon-vector-home"></i></span><a href="#">Home <span class="count"><span class="value"></span></span></a></li>
-                          <li data-name="private" class="global-filter"><span class="filter-icon"><i class="icon-vector-user"></i></span><a href="#narrow/is/private">Private messages <span class="count"><span class="value"></span></span></a></li>
-                          <li data-name="starred" class="global-filter"><span class="filter-icon"><i class="icon-vector-star"></i></span><a href="#narrow/is/starred">Starred messages</a></li>
-                          <li data-name="mentioned" class="global-filter"><span class="filter-icon"><i class="icon-vector-tag"></i></span><a href="#narrow/is/mentioned">@-mentions<span class="count"><span class="value"></span></span></a></li>
+                          class="global-filter active-filter"><span class="filter-icon"><i class="icon-vector-home"></i></span><a href="#">{% trans 'Home' %} <span class="count"><span class="value"></span></span></a></li>
+                          <li data-name="private" class="global-filter"><span class="filter-icon"><i class="icon-vector-user"></i></span><a href="#narrow/is/private">{% trans 'Private messages' %} <span class="count"><span class="value"></span></span></a></li>
+                          <li data-name="starred" class="global-filter"><span class="filter-icon"><i class="icon-vector-star"></i></span><a href="#narrow/is/starred">{% trans 'Starred messages' %}</a></li>
+                          <li data-name="mentioned" class="global-filter"><span class="filter-icon"><i class="icon-vector-tag"></i></span><a href="#narrow/is/mentioned">{% trans '@-mentions' %}<span class="count"><span class="value"></span></span></a></li>
                       </ul>
                       <div id="streams_list" class="zoom-out">
-                        <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title">STREAMS</h4>
+                        <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title">{% trans 'STREAMS' %}</h4>
                           <a href=""><i id="streams_inline_cog" class='icon-vector-cog' data-toggle="tooltip" title="Subscribe, add, or configure streams"></i></a>
                         </div>
                         <div id="topics_header">
                           <div class="all-streams-padding">
                             <ul class="filters">
                               <li data-name="all-streams">
-                                <i class="icon-vector-chevron-left"></i> <a href="" class="show-all-streams">All streams</a>
+                                <i class="icon-vector-chevron-left"></i> <a href="" class="show-all-streams">{% trans 'All streams' %}</a>
                               </li>
                             </ul>
                           </div>
@@ -27,24 +28,24 @@
                       </div>
                       <div id="share-the-love">
                         <div id="share-the-love-expand-collapse">
-                          <i class="toggle icon-vector-caret-right"></i><div id="sharethelove-header"><h4 class="share-the-love-title">SHARE THE LOVE<span class="still-have-invites"> (<span class="invite-count">0</span>)</span></h4></div>
+                          <i class="toggle icon-vector-caret-right"></i><div id="sharethelove-header"><h4 class="share-the-love-title">{% trans 'SHARE THE LOVE' %}<span class="still-have-invites"> (<span class="invite-count">0</span>)</span></h4></div>
                         </div>
                         <div id="share-the-love-contents">
                           <div id="tell-a-friend-success" class="alert alert-success">
-                            <strong>Thanks!</strong> A hand-crafted, artisanal invite is on the way.
+                            <strong>{% trans 'Thanks!' %}</strong> {% trans 'A hand-crafted, artisanal invite is on the way' %}.
                           </div>
                           <div class="still-have-invites" id="encouraging-invite-message">
                             <p>
-                              Know someone who would love Zulip for their company or group? Invite 'em!
+                              {% trans "Know someone who would love Zulip for their company or group? Invite 'em!" %}
                             </p>
                           </div>
                           <div class="no-more-invites">
                             <p>
-                              We'll have more invites for you soon, but
+                              {% blocktrans %}We'll have more invites for you soon, but
                               for now, enjoy this <a target="_blank"
                                                      href="http://www.youtube.com/watch?v=PW71En5Pa5s#t=2m01s">song
                                 that expresses how we feel when you're
-                                logged out</a>.
+                                logged out</a>.{% endblocktrans %}
                             </p>
                           </div>
                           <div class="still-have-invites">
@@ -56,7 +57,7 @@
                           </div>
                           <div class="invite-count-area">
                             <span id="invite-hearts"></span>
-                            <small class="pull-right"><span class="invite-count">0</span> invite<span class="invite-count-is-plural">s</span> remaining</small>
+                            <small class="pull-right"><span class="invite-count">0</span> {% trans 'invite' %}<span class="invite-count-is-plural">s</span> {% trans 'remaining' %}</small>
                           </div>
                         </div>
                       </div>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -2,6 +2,7 @@
 
 {# Login page. #}
 
+{% load i18n %}
 {% load minified_js %}
 
 {% block customhead %}
@@ -15,10 +16,10 @@
     <img src="/static/images/logo/zballoon.png" class="os-illustration" alt="Zulip balloon" />
     <div class="main-headline-text">
       <span class="tagline os-tagline">
-         Zulip has been released as open source software!
+         {% trans 'Zulip has been released as open source software!' %}
       </span>
       <span class="footnote os-footnote">
-         Read the <a href="https://blogs.dropbox.com/tech/2015/09/open-sourcing-zulip-a-dropbox-hack-week-project" target="_blank">announcement</a> or go to <a href="https://www.zulip.org" target="_blank">the Zulip open source project website</a>.
+         {% trans 'Read the' %} <a href="https://blogs.dropbox.com/tech/2015/09/open-sourcing-zulip-a-dropbox-hack-week-project" target="_blank">{% trans 'announcement' %}</a> {% trans 'or go to' %} <a href="https://www.zulip.org" target="_blank">{% trans 'the Zulip open source project website' %}</a>.
       </span>
     </div>
   </div>
@@ -44,19 +45,19 @@ autofocus('#id_username');
   <div class="app-main login-page-container">
 
     {% if dev_auth_enabled %}
-    <h3 class="login-page-header">Zulip Dev Login</h3>
+    <h3 class="login-page-header">{% trans 'Zulip Dev Login' %}</h3>
     {% if not password_auth_enabled %}
-    <h4 class="login-page-subheader">Choose a user:</h4>
+    <h4 class="login-page-subheader">{% trans 'Choose a user' %}:</h4>
     {% endif %}
     {% else %}
-    <h3 class="login-page-header">You look familiar.</h3>
+    <h3 class="login-page-header">{% trans 'You look familiar' %}.</h3>
     {% endif %}
 
 {% if only_sso %}
     {% comment %}SSO users don't have a password.{% endcomment %}
 
     <div class="login-sso">
-      <a href="/accounts/login/sso" class="btn btn-large btn-primary">Sign in with SSO</a>
+      <a href="/accounts/login/sso" class="btn btn-large btn-primary">{% trans 'Sign in with SSO' %}</a>
     </div>
 
 {% else %}
@@ -65,7 +66,7 @@ autofocus('#id_username');
 {% if form.errors or desktop_sso_unknown_email %}
 <div class="alert alert-error">
     {% if desktop_sso_unknown_email %}
-        Zulip is not currently available for your domain. <br />
+        {% trans 'Zulip is not currently available for your domain' %}. <br />
     {% else %}
         {% for error in form.errors.values %}
         <div>{{ error | striptags }}</div>
@@ -76,7 +77,7 @@ autofocus('#id_username');
 
     {% if email %}
     <div class="alert">
-        You've already registered with this email address. Please log in below.
+        {% trans "You've already registered with this email address. Please log in below" %}.
     </div>
     {% endif %}
 
@@ -91,7 +92,7 @@ autofocus('#id_username');
         >
             {% csrf_token %}
             <div class="control-group">
-                <label for="id_username" class="control-label">Email</label>
+                <label for="id_username" class="control-label">{% trans 'Email' %}</label>
                 <div class="controls">
                     <input id="id_username" type="email" name="username" class="email required" value="{{ email }}" maxlength="72" />
                 </div>
@@ -99,7 +100,7 @@ autofocus('#id_username');
 
             {% if not desktop_sso_dispatch %}
             <div class="control-group">
-                <label for="id_password" class="control-label">Password</label>
+                <label for="id_password" class="control-label">{% trans 'Password' %}</label>
                 <div class="controls">
                     <input id="id_password" name="password" class="required" type="password" />
                 </div>
@@ -110,7 +111,7 @@ autofocus('#id_username');
                     <input type="submit" class="btn btn-large btn-primary" value="Log in" />
                     {% if not desktop_sso_dispatch %}
                     <span class="login-forgot-password">
-                      <a href="{% url 'django.contrib.auth.views.password_reset' %}">Forgot password?</a>
+                      <a href="{% url 'django.contrib.auth.views.password_reset' %}">{% trans 'Forgot password?' %}</a>
                     </span>
                     {% endif %}
                 </div>
@@ -123,14 +124,14 @@ autofocus('#id_username');
             {% csrf_token %}
 	    <div class="control-group">
 	        {% if password_auth_enabled %}
-	        <label for="direct_email" class="direct-label">or Choose a user:</label>
+	        <label for="direct_email" class="direct-label">{% trans 'or Choose a user' %}:</label>
 		{% endif %}
 	        <div class="controls">
-                    <p>(Administrators)</p>
+                    <p>({% trans 'Administrators' %})</p>
 		    {% for user_email in direct_admins %}
 		    <p><input type="submit" name="direct_email" class="btn-direct btn-admin" value="{{ user_email }}" /></p>
 		    {% endfor %}
-                    <p>(Normal users)</p>
+                    <p>({% trans 'Normal users' %})</p>
 		    {% for user_email in direct_users %}
 		    <p><input type="submit" name="direct_email" class="btn-direct btn-user" value="{{ user_email }}" /></p>
 		    {% endfor %}
@@ -141,7 +142,7 @@ autofocus('#id_username');
 
     {% if google_auth_enabled %}
     <div class="login-google">
-    or <a href="{% url 'zerver.views.start_google_oauth2' %}" class="login-google-button zocial google">Sign in with Google</a>
+    or <a href="{% url 'zerver.views.start_google_oauth2' %}" class="login-google-button zocial google">{% trans 'Sign in with Google' %}</a>
     </div>
     {% endif %}
 

--- a/templates/zerver/markdown_help.html
+++ b/templates/zerver/markdown_help.html
@@ -1,15 +1,16 @@
+{% load i18n %}
 <div class="modal hide" id="markdown-help" tabindex="-1" role="dialog"
      aria-labelledby="markdown-help-label" aria-hidden="true">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-    <h3 id="markdown-help-label">Message formatting</h3>
+    <h3 id="markdown-help-label">{% blocktrans %}Message formatting{% endblocktrans %}</h3>
   </div>
   <div class="modal-body">
     <div id="markdown-instructions">
       <table class="table table-striped table-condensed table-rounded table-bordered" id="fmt_help_table">
         <thead><tr>
-          <th>You type</th>
-          <th>You get</th>
+          <th>{% blocktrans %}You type{% endblocktrans %}</th>
+          <th>{% blocktrans %}You get{% endblocktrans %}</th>
         </tr></thead>
 
         <tbody>
@@ -70,7 +71,7 @@ def zulip():
           </td>
         </tr>
         <tr>
-          <td colspan="2">You can also make a code block by indenting each line with 4 spaces.</td>
+          <td colspan="2">{% blocktrans %}You can also make a code block by indenting each line with 4 spaces.{% endblocktrans %}</td>
         </tr>
         <tr>
           <td>&gt; Quoted</td>
@@ -84,17 +85,17 @@ Quoted block
           <td><blockquote><p>Quoted block</p></blockquote></td>
         </tr>
         <tr>
-          <td colspan="2">You can also make <a target="_blank"
+          <td colspan="2">{% blocktrans %}You can also make <a target="_blank"
           href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#wiki-tables">tables</a>
           with this <a target="_blank"
           href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#wiki-tables">Markdown-ish
-          table syntax</a>.</td>
+          table syntax</a>{% endblocktrans %}.</td>
         </tr>
         </tbody>
       </table>
     </div>
   </div>
   <div class="modal-footer">
-    <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">Close</button>
+    <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">{% trans "Close" %}</button>
   </div>
 </div>

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <div class="header">
 <div class="header-main rightside-userlist" id="top_navbar">
   <div class="column-left">
@@ -16,7 +17,7 @@
             <form id="searchbox_form" class="form-search navbar-search">
               <div id="search_arrows" class="input-append">
                 <i class="icon-vector-search"></i>
-                <input class="search-query input-block-level" id="search_query" type="text" placeholder="Search"
+                <input class="search-query input-block-level" id="search_query" type="text" placeholder="{% trans 'Search' %}"
                        autocomplete="off" />
                 {# Start the button off disabled since there is no active search #}
                 <button class="btn search_button" type="button" id="search_exit" disabled="disabled"><i class="icon-vector-remove"></i></button>
@@ -46,62 +47,62 @@
                   <li style="display:none;"><a href="#home" data-toggle="tab"></a></li>
                   <li title="Manage Streams">
                     <a href="#subscriptions" data-toggle="tab">
-                      <i class="icon-vector-exchange"></i> Manage Streams
+                      <i class="icon-vector-exchange"></i> {% trans 'Manage Streams' %}
                     </a>
                   </li>
                   <li title="Settings">
                     <a href="#settings" data-toggle="tab">
-                      <i class="icon-vector-wrench"></i> Settings
+                      <i class="icon-vector-wrench"></i> {% trans 'Settings' %}
                     </a>
                   </li>
                   <li title="Keyboard shortcuts">
                     <a href="#keyboard-shortcuts" role="button" data-toggle="modal">
-                      <i class="icon-vector-question-sign"></i> Keyboard shortcuts
+                      <i class="icon-vector-question-sign"></i> {% trans 'Keyboard shortcuts' %}
                     </a>
                   </li>
                   <li title="Message formatting">
                     <a href="#markdown-help" role="button" data-toggle="modal">
-                      <i class="icon-vector-pencil"></i> Message formatting
+                      <i class="icon-vector-pencil"></i> {% trans 'Message formatting' %}
                     </a>
                   </li>
                   <li title="Search help">
                     <a href="#search-operators" role="button" data-toggle="modal">
-                      <i class="icon-vector-search"></i> Search help
+                      <i class="icon-vector-search"></i> {% trans 'Search help' %}
                     </a>
                   </li>
                   <li class="divider"></li>
                   <li title="Desktop & mobile apps">
                     <a href="/apps" target="_blank" role="button">
-                      <i class="icon-vector-desktop"></i> Desktop & mobile apps
+                      <i class="icon-vector-desktop"></i> {% trans 'Desktop & mobile apps' %}
                     </a>
                   </li>
                   <li title="Integrations">
                     <a href="/integrations" target="_blank" role="button">
-                      <i class="icon-vector-github"></i> Integrations
+                      <i class="icon-vector-github"></i> {% trans 'Integrations' %}
                     </a>
                   </li>
                   <li title="API documentation">
                     <a href="/api" target="_blank" role="button">
-                      <i class="icon-vector-sitemap"></i> API documentation
+                      <i class="icon-vector-sitemap"></i> {% trans 'API documentation' %}
                     </a>
                   </li>
                   <li class="divider"></li>
                   <li title="Administration" class="admin-menu-item">
                     <a href="#administration" role="button" data-toggle="tab">
-                      <i class="icon-vector-bolt"></i> Administration
+                      <i class="icon-vector-bolt"></i> {% trans 'Administration' %}
                     </a>
                   </li>
                   {% if show_invites %}
                   <li title="Invite coworkers to {{product_name}}">
                     <a href="#invite-user" role="button" data-toggle="modal">
-                      <i class="icon-vector-plus-sign"></i> Invite coworkers
+                      <i class="icon-vector-plus-sign"></i> {% trans 'Invite coworkers' %}
                     </a>
                   </li>
                   {% endif %}
                   {% if enable_feedback %}
                   <li title="Feedback">
                     <a href="#feedback" class="feedback">
-                      <i class="icon-vector-comment"></i> Feedback
+                      <i class="icon-vector-comment"></i> {% trans 'Feedback' %}
                     </a>
                   </li>
                   {% endif %}
@@ -109,19 +110,19 @@
                   {% if show_webathena %}
                   <li title="Grant {{product_name}} the Kerberos tickets needed to run your Zephyr mirror via Webathena" id="webathena_login_menu">
                     <a href="#webathena" class="webathena_login">
-                      <i class="icon-vector-bolt"></i>Link with Webathena
+                      <i class="icon-vector-bolt"></i>{% trans 'Link with Webathena' %}
                     </a>
                   </li>
                   {% endif %}
                   <li title="Log out">
                     <a href="#logout" class="logout_button">
-                      <i class="icon-vector-off"></i> Log out
+                      <i class="icon-vector-off"></i> {% trans 'Log out' %}
                     </a>
                   </li>
                   {% if show_debug %}
                   <li title="Debug">
                     <a href="#debug" data-toggle="tab">
-                      <i class="icon-vector-barcode"></i> Debug
+                      <i class="icon-vector-barcode"></i> {% trans 'Debug' %}
                     </a>
                   </li>
                   {% endif %}

--- a/templates/zerver/portico.html
+++ b/templates/zerver/portico.html
@@ -1,5 +1,5 @@
 {% extends "zerver/base.html" %}
-
+{% load i18n %}
 {% load compressed %}
 
 {% comment %}
@@ -28,13 +28,13 @@ hence the name.
 
   <div class="column-right top-links">
           {% if not only_sso %}
-          <a href="{{login_url}}">Log in</a>
+          <a href="{{login_url}}">{% trans 'Log in' %}</a>
           {% endif %}
 
           {% if only_sso %}
-          <a href="{% url 'login-sso' %}">Log In</a>
+          <a href="{% url 'login-sso' %}">{% trans 'Log In' %}</a>
           {% else %}
-          <a href="{% url 'register' %}">Register</a>
+          <a href="{% url 'register' %}">{% trans 'Register' %}</a>
           {% endif %}
   </div>
 </div>
@@ -55,19 +55,19 @@ hence the name.
 <div class="footer">
   <div class="footer-main">
     <ul class="footer-navigation">
-      <li><a href="/hello">About</a></li>
+      <li><a href="/hello">{% trans 'About' %}</a></li>
       {% if zulip_com %}
       <li><span class="little-bullet">·</span></li>
-      <li><a href="/terms">Legal</a></li>
+      <li><a href="/terms">{% trans 'Legal' %}</a></li>
       {% endif %}
       <li><span class="little-bullet">·</span></li>
-      <li><a href="{{login_url}}">Log in</a></li>
+      <li><a href="{{login_url}}">{% trans 'Log in' %}</a></li>
       {% if not only_sso %}
       <li><span class="little-bullet">·</span></li>
       <li>
           {% if zulip_com %}
           {% else %}
-          <a href="{% url 'register' %}">Register</a>
+          <a href="{% url 'register' %}">{% trans 'Register' %}</a>
           {% endif %}
       </li>
       {% endif %}

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -1,5 +1,5 @@
 {% extends "zerver/portico_signup.html" %}
-
+{% load i18n %}
 {% comment %}
 Gather other user information, after having confirmed
 their email address.
@@ -17,21 +17,21 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
 
 <div class="pitch">
 
-    <p style="margin-top:30px;">You're almost there. We just need you to do one last thing.</p>
-    <h3>Tell us a bit about yourself.</h3>
+    <p style="margin-top:30px;">{% trans "You're almost there. We just need you to do one last thing" %}.</p>
+    <h3>{% trans 'Tell us a bit about yourself' %}.</h3>
 </div>
 
 <form method="post" class="form-horizontal" id="registration" action="{% url 'zerver.views.accounts_register' %}">
 {% csrf_token %}
     <div class="control-group">
-        <label for="id_email" class="control-label">Email</label>
+        <label for="id_email" class="control-label">{% trans 'Email' %}</label>
         <div class="controls fakecontrol">
             <input type='hidden' name='key' value='{{ key }}' />
             <p>{{ email }}</p>
         </div>
     </div>
     <div class="control-group">
-        <label for="id_full_name" class="control-label">Full name</label>
+        <label for="id_full_name" class="control-label">{% trans 'Full name' %}</label>
         <div class="controls">
             {% if lock_name %}
                 <p class="fakecontrol">{{ full_name }}</p>
@@ -49,13 +49,13 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
     </div>
     {% if password_auth_enabled %}
         <div class="control-group">
-            <label for="id_password" class="control-label">Password</label>
+            <label for="id_password" class="control-label">{% trans 'Password' %}</label>
             <div class="controls">
                 <input id="id_password" class="required" type="password" name="password"
                        value="{% if form.password.value %}{{ form.password.value }}{% endif %}"
                        maxlength="100" />
                 {% if full_name %}
-                <span class="help-inline">This is used for mobile applications and other tools that require a password.</span>
+                <span class="help-inline">{% trans 'This is used for mobile applications and other tools that require a password' %}.</span>
                 {% endif %}
                 {% if form.password.errors %}
                     {% for error in form.password.errors %}
@@ -65,7 +65,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
             </div>
         </div>
         <div class="control-group">
-            <label class="control-label">Password strength</label>
+            <label class="control-label">{% trans 'Password strength' %}</label>
             <div class="controls">
                 <div class="progress" id="pw_strength">
                     <div class="bar bar-danger" style="width: 10%;"></div>
@@ -89,7 +89,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                     {% endcomment %}
                     <input id="id_terms" class="required" type="checkbox" name="terms"
                            {% if form.terms.value %}checked="checked"{% endif %} />
-                    I agree to the <a href="/terms" target="_blank">Terms of Service</a>.
+                    {% trans 'I agree to the' %} <a href="/terms" target="_blank">{% trans 'Terms of Service' %}</a>.
                 </label>
                 {% if form.terms.errors %}
                     {% for error in form.terms.errors %}

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -1,15 +1,15 @@
 {% extends "zerver/portico_signup.html" %}
-
+{% load i18n %}
 {% block portico_content %}
 
 <div class="pitch">
-    <h3>Reset your password.</h3>
+    <h3>{% trans 'Reset your password' %}.</h3>
 </div>
 
 <form method="post" class="form-horizontal" action="{% url 'django.contrib.auth.views.password_reset' %}">
 {% csrf_token %}
     <div class="control-group">
-        <label for="id_email" class="control-label">Email</label>
+        <label for="id_email" class="control-label">{% trans 'Email' %}</label>
         <div class="controls">
             <input id="id_email" class="required" type="text" name="email"
                    value="{% if form.email.value %}{{ form.email.value }}{% endif %}"

--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -1,5 +1,5 @@
 {% extends "zerver/portico_signup.html" %}
-
+{% load i18n %}
 {% block customhead %}
 {{ block.super }}
 <script type="text/javascript" src="/static/third/zxcvbn/zxcvbn.js"></script>
@@ -9,14 +9,14 @@
 
 <div class="pitch">
     <hr/>
-    <h3>Reset your password.</h3>
+    <h3>{% trans 'Reset your password' %}.</h3>
 </div>
 
 {% if validlink %}
     <form method="post" id="password_reset" class="form-horizontal">
     {% csrf_token %}
         <div class="control-group">
-            <label for="id_new_password1" class="control-label">Password</label>
+            <label for="id_new_password1" class="control-label">{% trans 'Password' %}</label>
             <div class="controls">
                 <input id="id_new_password1" class="required" type="password" name="new_password1"
                        value="{% if form.new_password1.value %}{{ form.new_password1.value }}{% endif %}"
@@ -29,7 +29,7 @@
             </div>
         </div>
         <div class="control-group">
-            <label class="control-label">Password strength</label>
+            <label class="control-label">{% trans 'Password strength' %}</label>
             <div class="controls">
                 <div class="progress" id="pw_strength">
                     <div class="bar bar-danger" style="width: 10%;"></div>
@@ -37,7 +37,7 @@
             </div>
         </div>
         <div class="control-group">
-            <label for="id_new_password2" class="control-label">Confirm password</label>
+            <label for="id_new_password2" class="control-label">{% trans 'Confirm password' %}</label>
             <div class="controls">
                 <input id="id_new_password2" class="required" type="password" name="new_password2"
                        value="{% if form.new_password2.value %}{{ form.new_password2.value }}{% endif %}"
@@ -61,7 +61,7 @@
     autofocus('#id_new_password1');
 </script>
 {% else %}
-    <p>Sorry, the link you provided is invalid or has already been used.</p>
+    <p>{% trans 'Sorry, the link you provided is invalid or has already been used' %}.</p>
 {% endif %}
 
 {% endblock %}

--- a/templates/zerver/reset_done.html
+++ b/templates/zerver/reset_done.html
@@ -1,7 +1,7 @@
 {% extends "zerver/portico_signup.html" %}
-
+{% load i18n %}
 {% block portico_content %}
-<h1 style="margin-top: 20px">We've reset your password!</h1>
-<p>Please <a href="{% url 'django.contrib.auth.views.login' %}">log in</a>.</p>
+<h1 style="margin-top: 20px">{% trans "We've reset your password!" %}</h1>
+<p>{% trans 'Please' %} <a href="{% url 'django.contrib.auth.views.login' %}">{% trans 'log in' %}</a>.</p>
 
 {% endblock %}

--- a/templates/zerver/reset_emailed.html
+++ b/templates/zerver/reset_emailed.html
@@ -1,7 +1,7 @@
 {% extends "zerver/portico_signup.html" %}
-
+{% load i18n %}
 {% block portico_content %}
-<h1 style="margin-top: 20px">We just sent you a password reset!</h1>
-<h1>Check your email to finish the process.</h1>
-<p>(Or don't, but then why did you fill out this form?)</p>
+<h1 style="margin-top: 20px">{% trans 'We just sent you a password reset!' %}</h1>
+<h1>{% trans 'Check your email to finish the process' %}.</h1>
+<p>({% trans "Or don't, but then why did you fill out this form?" %})</p>
 {% endblock %}

--- a/templates/zerver/right-sidebar.html
+++ b/templates/zerver/right-sidebar.html
@@ -1,46 +1,47 @@
+{% load i18n %}
           <div class="right-sidebar" id="right-sidebar">
               <div class="alert alert_sidebar alert-error home-error-bar" id="connection-error">
-                <strong>Unable to connect to {{product_name}}.</strong>  Updates may be delayed.
-                <br /><br /> Retrying soon... <br /><br /> <a class="restart_get_updates_button">Try now</a>.
+                <strong>{% trans 'Unable to connect to' %} {{product_name}}.</strong>  {% trans 'Updates may be delayed' %}.
+                <br /><br /> {% trans 'Retrying soon' %}... <br /><br /> <a class="restart_get_updates_button">{% trans 'Try now' %}</a>.
               </div>
               <div class="alert alert_sidebar alert-error home-error-bar" id="get_old_messages_error">
-                <strong>Unable to connect to {{product_name}}.</strong>  Could not fetch messages.
-                <br /><br /> Retrying soon... <br /><br />
+                <strong>{% trans 'Unable to connect to' %} {{product_name}}.</strong>  {% trans 'Could not fetch messages' %}.
+                <br /><br /> {% trans 'Retrying soon' %}... <br /><br />
               </div>
               <div class="alert alert_sidebar alert-error home-error-bar" id="zephyr-mirror-error">
-                <strong>Your Zephyr mirror is not working.</strong>
-                  <span id="normal-zephyr-mirror-error-text">We
+                <strong>{% trans 'Your Zephyr mirror is not working' %}.</strong>
+                  <span id="normal-zephyr-mirror-error-text">{% blocktrans %}We
                   recommend that you <a class="webathena_login">give
                   {{product_name}} the ability to mirror the messages for you via
                   WebAthena</a>.  If you'd prefer, you can instead
                   <a href="/zephyr-mirror" target="_blank">run the Zephyr mirror script yourself</a>
-                  in a screen session.</span>
-                  <span id="desktop-zephyr-mirror-error-text" class="notdisplayed">To fix
+                  in a screen session{% endblocktrans %}.</span>
+                  <span id="desktop-zephyr-mirror-error-text" class="notdisplayed">{% blocktrans %}To fix
                   this, you'll need
-                  to use <a href="https://zephyr.zulip.com">the web interface</a></span>
+                  to use <a href="https://zephyr.zulip.com">the web interface</a>{% endblocktrans %}</span>
               </div>
               <div class="alert alert_sidebar alert-error home-error-bar" id="home-error"></div>
               <div class="alert alert_sidebar alert-error home-error-bar" id="reloading-application"></div>
               {% if enable_feedback %}
               <div id="feedback_section">
                 <button type="button" class="btn btn-default btn-large" id="feedback_button">
-                  <i class="icon-vector-comment"></i>&nbsp;&nbsp;Send feedback
+                  <i class="icon-vector-comment"></i>&nbsp;&nbsp;{% trans 'Send feedback' %}
                 </button>
               </div>
               {% endif %}
               <div id="user-list">
                 <div id="userlist-header">
-                  <h4 class='sidebar-title' id='userlist-title'>USERS</h4>
+                  <h4 class='sidebar-title' id='userlist-title'>{% trans 'USERS' %}</h4>
                 </div>
                  <input class="user-list-filter" type="text" placeholder="Search people" />
                  <ul id="user_presences" class="filters scrolling_list"></ul>
               {% if show_invites %}
-                 <a id="invite-user-link" href="#invite-user" data-toggle="modal"><i class="icon-vector-plus-sign"></i>Invite coworkers</a>
+                 <a id="invite-user-link" href="#invite-user" data-toggle="modal"><i class="icon-vector-plus-sign"></i>{% trans 'Invite coworkers' %}</a>
               {% endif %}
               </div>
               <div id="group-pm-list">
                 <div id="group-pm-header">
-                  <h4 class='sidebar-title' id='group-pm-title'>GROUP PMs</h4>
+                  <h4 class='sidebar-title' id='group-pm-title'>{% trans 'GROUP PMs' %}</h4>
                 </div>
                 <ul id="group-pms" class="filters scrolling_list">
                 </ul>

--- a/templates/zerver/search_operators.html
+++ b/templates/zerver/search_operators.html
@@ -1,83 +1,82 @@
+{% load i18n %}
 <div class="modal hide" id="search-operators" tabindex="-1" role="dialog"
      aria-labelledby="search-operators-label" aria-hidden="true">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-    <h3 id="search-operators-label">Search help</h3>
+    <h3 id="search-operators-label">{% trans 'Search help' %}</h3>
   </div>
   <div class="modal-body">
     <table class="table table-striped table-condensed table-rounded table-bordered" id="fmt_help_table">
       <thead>
         <tr>
-          <th>Operator</th>
-          <th>Effect</th>
+          <th>{% trans 'Operator' %}</th>
+          <th>{% trans 'Effect' %}</th>
         </tr>
       </thead>
       <tr>
         <td class="operator">stream:<span class="operator_value">stream</span></td>
-        <td class="definition">Narrow to messages on stream <span class="operator_value">stream</span></td>
+        <td class="definition">{% trans 'Narrow to messages on stream' %} <span class="operator_value">stream</span></td>
       </tr>
       <tr>
         <td class="operator">topic:<span class="operator_value">topic</span></td>
-        <td class="definition">Narrow to messages with topic <span class="operator_value">topic</span></td>
+        <td class="definition">{% trans 'Narrow to messages with topic' %} <span class="operator_value">topic</span></td>
       </tr>
       <tr>
         <td class="operator">pm-with:<span class="operator_value">email</span></td>
-        <td class="definition">Narrow to private messages with <span class="operator_value">email</span></td>
+        <td class="definition">{% trans 'Narrow to private messages with' %} <span class="operator_value">email</span></td>
       </tr>
       <tr>
         <td class="operator">sender:<span class="operator_value">email</span></td>
-        <td class="definition">Narrow to messages sent by <span class="operator_value">email</span></td>
+        <td class="definition">{% trans 'Narrow to messages sent by' %} <span class="operator_value">email</span></td>
       </tr>
       <tr>
         <td class="operator">sender:me</td>
-        <td class="definition">Narrow to messages sent by you.</td>
+        <td class="definition">{% trans 'Narrow to messages sent by you' %}.</td>
       </tr>
       <tr>
         <td class="operator">near:<span class="operator_value">id</span></td>
-        <td class="definition">Center the view around message ID <span class="operator_value">id</span></td>
+        <td class="definition">{% trans 'Center the view around message ID' %} <span class="operator_value">id</span></td>
       </tr>
       <tr>
         <td class="operator">id:<span class="operator_value">id</span></td>
-        <td class="definition">Narrow to just message ID <span class="operator_value">id</span></td>
+        <td class="definition">{% trans 'Narrow to just message ID' %} <span class="operator_value">id</span></td>
       </tr>
       <tr>
       <tr>
         <td class="operator">is:alerted</td>
-        <td class="definition">Narrow to messages with alert words.</td>
+        <td class="definition">{% trans 'Narrow to messages with alert words' %}.</td>
       </tr>
         <td class="operator">is:mentioned</td>
-        <td class="definition">Narrow to messages that mention you.</td>
+        <td class="definition">{% trans 'Narrow to messages that mention you' %}.</td>
       </tr>
       <tr>
         <td class="operator">is:private</td>
-        <td class="definition">Narrow to private messages.</td>
+        <td class="definition">{% trans 'Narrow to private messages' %}.</td>
       </tr>
       <tr>
         <td class="operator">is:starred</td>
-        <td class="definition">Narrow to starred messages.</td>
+        <td class="definition">{% trans 'Narrow to starred messages' %}.</td>
       </tr>
       <tr>
         <td class="operator"><span class="operator_value">keyword</span></td>
-        <td class="definition">Search for <span class="operator_value">keyword</span> in the topic or message content</td>
+        <td class="definition">{% trans 'Search for' %} <span class="operator_value">{% trans 'keyword' %}</span> {% trans 'in the topic or message content' %}</td>
       </tr>
       <tr>
         <td class="operator">-topic:<span class="operator_value">topic</span></td>
-        <td class="definition">Exclude messages with topic <span class="operator_value">topic</span></td>
+        <td class="definition">{% trans 'Exclude messages with topic' %} <span class="operator_value">topic</span></td>
       </tr>
     </table>
-    <p>You can use any combination of these search operators in a
-    single query.  For example:</p>
+    <p>{% trans 'You can use any combination of these search operators in a single query' %}.  {% trans 'For example' %}:</p>
 
     <p>&nbsp; <span class="operator">stream:<span class="operator_value">streamname</span>
           sender:<span class="operator_value">user@example.com</span>
             <span class="operator_value">keyword</span></span></p>
 
-    <p>would search for messages sent
-    by <span class="operator_value">user@example.com</span> to stream
+    <p>{% trans 'would search for messages sent by' %} <span class="operator_value">user@example.com</span> {% trans 'to stream' %}
     <span class="operator_value">streamname</span>
-    containing the keyword <span class="operator_value">keyword</span>.</p>
+    {% trans 'containing the keyword' %} <span class="operator_value">keyword</span>.</p>
   </div>
   <div class="modal-footer">
-    <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">Close</button>
+    <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">{% trans 'Close' %}</button>
   </div>
 </div>

--- a/templates/zerver/stream_creation_prompt.html
+++ b/templates/zerver/stream_creation_prompt.html
@@ -1,41 +1,42 @@
+{% load i18n %}
 <div class="modal hide" id="stream-creation" tabindex="-1" role="dialog"
      aria-labelledby="stream-creation-label" aria-hidden="true">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-    <h3 id="stream-creation-label">Create stream <span id="stream_name"></span></h3>
+    <h3 id="stream-creation-label">{% blocktrans %}Create stream{% endblocktrans %} <span id="stream_name"></span></h3>
   </div>
   <form id="stream_creation_form" class="form-inline">
       <div class="modal-body">
           <div id="make-invite-only">
-            <b>Stream accessibility</b><br />
+            <b>{% blocktrans %}Stream accessibility{% endblocktrans %}</b><br />
             <label class="radio">
               <input type="radio" name="privacy" value="public" checked />
               <span class="icon-vector-globe"></span>
-              Anyone can join
+              {% blocktrans %}Anyone can join{% endblocktrans %}
             </label><br />
             <label class="radio">
               <input type="radio" name="privacy" value="invite-only" />
               <span class="icon-vector-lock"></span>
-              People must be invited
+              {% blocktrans %}People must be invited{% endblocktrans %}
             </label>
           </div>
           <div id="announce-new-stream">
             <br />
             <label class="checkbox">
               <input type="checkbox" name="announce" value="announce" checked />
-              Announce stream
+              {% blocktrans %}Announce stream{% endblocktrans %}
             </label>
             <span class="icon-vector-question-sign" id="announce-stream-docs"></span>
           </div>
           <br />
           <div class="control-group">
-            <label class="control-label" for="people_to_add"><b>People to add</b></label><br />
+            <label class="control-label" for="people_to_add"><b>{% blocktrans %}People to add{% endblocktrans %}</b></label><br />
             <div class="controls" id="people_to_add"></div>
           </div>
       </div>
       <div class="modal-footer">
-          <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
-          <button class="btn btn-primary" type="submit">Create</button>
+          <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">{% trans "Cancel" %}</button>
+          <button class="btn btn-primary" type="submit">{% trans "Create" %}</button>
       </div>
   </form>
 </div>

--- a/templates/zerver/subscriptions.html
+++ b/templates/zerver/subscriptions.html
@@ -1,7 +1,8 @@
+{% load i18n %}
 {# Subscriptions management tab of the app. #}
 
     <div class="subscriptions">
-      <h1><i class="icon-vector-exchange streams-icon"></i>Streams</h1>
+      <h1><i class="icon-vector-exchange streams-icon"></i>{% trans "Streams" %}</h1>
       <div class="alert" id="subscriptions-status"></div>
       <div id="subs_page_loading_indicator"></div>
       <div id="subscriptions_table">

--- a/templates/zerver/tutorial_finale.html
+++ b/templates/zerver/tutorial_finale.html
@@ -1,15 +1,16 @@
+{% load i18n %}
 <div class="modal hide" id="tutorial-finale" tabindex="-1" role="dialog"
      aria-labelledby="tutorial-finale-label" aria-hidden="true">
   <div class="modal-header">
-    <h3 id="tutorial-finale-label">Welcome to {{ product_name }}</h3>
+    <h3 id="tutorial-finale-label">{% blocktrans %}Welcome to {{ product_name }}{% endblocktrans %}</h3>
   </div>
   <div class="modal-body">
-    <p>Streams, topics, and narrowing make {{ product_name }} conversations
-    efficient and productive.</p>
+    <p>{% blocktrans %}Streams, topics, and narrowing make {{ product_name }} conversations
+    efficient and productive.{% endblocktrans %}</p>
 
-    <p>That's all there is to it, so let's get started!</p>
+    <p>{% blocktrans %}That's all there is to it, so let's get started!{% endblocktrans %}</p>
   </div>
   <div class="modal-footer">
-      <button class="btn btn-primary" type="submit" id="tutorial-get-started">Get started</button>
+      <button class="btn btn-primary" type="submit" id="tutorial-get-started">{% blocktrans %}Get started{% endblocktrans %}</button>
   </div>
 </div>

--- a/templates/zerver/unsubscribe_link_error.html
+++ b/templates/zerver/unsubscribe_link_error.html
@@ -1,12 +1,13 @@
 {% extends "zerver/portico.html" %}
+{% load i18n %}
 
 {% block portico_content %}
 
-<h1>Unknown email unsubscribe request</h1>
+<h1>{% blocktrans %}Unknown email unsubscribe request{% endblocktrans %}</h1>
 
-<p>Hi there! It looks like you tried to unsubscribe from something, but we don't
-recognize the URL.</p>
+<p>{% blocktrans %}Hi there! It looks like you tried to unsubscribe from something, but we don't
+recognize the URL.{% endblocktrans %}</p>
 
-<p>Please double-check that you have the full URL and try again, or <a href="mailto:{{ zulip_admin }}?Subject=Unsubscribe%20me%2C%20please!&Body=Hi%20there!%0A%0AI%20clicked%20this%20unsubscribe%20link%20in%20a%20Zulip%20e-mail%2C%20but%20it%20took%20me%20to%20an%20error%20page%3A%0A%0A_____________%0A%0APlease%20unsubscribe%20me.%0A%0AThanks%2C%0A_____________%0A">email us</a> and we'll get this squared away!</p>
+<p>{% blocktrans %}Please double-check that you have the full URL and try again, or <a href="mailto:{{ zulip_admin }}?Subject=Unsubscribe%20me%2C%20please!&Body=Hi%20there!%0A%0AI%20clicked%20this%20unsubscribe%20link%20in%20a%20Zulip%20e-mail%2C%20but%20it%20took%20me%20to%20an%20error%20page%3A%0A%0A_____________%0A%0APlease%20unsubscribe%20me.%0A%0AThanks%2C%0A_____________%0A">email us</a> and we'll get this squared away!{% endblocktrans %}</p>
 
 {% endblock %}

--- a/templates/zerver/unsubscribe_success.html
+++ b/templates/zerver/unsubscribe_success.html
@@ -1,11 +1,12 @@
 {% extends "zerver/portico.html" %}
+{% load i18n %}
 
 {% block portico_content %}
 
-<h1>Email settings updated</h1>
+<h1>{% blocktrans %}Email settings updated{% endblocktrans %}</h1>
 
-<p>We've updated your email subscription settings, and you won't get {{ subscription_type }} emails anymore.</p>
+<p>{% blocktrans %}We've updated your email subscription settings, and you won't get {{ subscription_type }} emails anymore.{% endblocktrans %}</p>
 
-<p>To undo this change or review your other subscription settings, please visit your <a href="https://{{ external_host }}/#settings">Zulip Settings page</a>.</p>
+<p>{% blocktrans %}To undo this change or review your other subscription settings, please visit your <a href="https://{{ external_host }}/#settings">Zulip Settings page</a>{% endblocktrans %}.</p>
 
 {% endblock %}


### PR DESCRIPTION
In order to enable internationalization support in Zulip, and to use Django internationalization tools, all strings in Zulip frontend needs to be marked for translation.