### PR TITLE
Fix 'manage.py makemessages' error.

### DIFF
--- a/provision.py
+++ b/provision.py
@@ -37,6 +37,7 @@ APT_DEPENDENCIES = {
         "node-jquery",
         "yui-compressor",
         "puppet",               # Used by lint-all
+        "gettext",              # Used by makemessages i18n
     ]
 }
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -218,6 +218,7 @@ USE_TZ = True
 
 DEPLOY_ROOT = os.path.join(os.path.realpath(os.path.dirname(__file__)), '..')
 TEMPLATE_DIRS = ( os.path.join(DEPLOY_ROOT, 'templates'), )
+LOCALE_PATHS = ( os.path.join(DEPLOY_ROOT, 'locale'), )
 
 # Make redirects work properly behind a reverse proxy
 USE_X_FORWARDED_HOST = True


### PR DESCRIPTION
Running 'manage.py makemessages' produces two errors as referenced in #265. This commit adds LOCALE_PATH in settings.py and adds gettext to APT_DEPENDECIES in provision.py 

Closes #265