### PR TITLE
nginx: Enable gzip compression on main content types.

### DIFF
--- a/puppet/zulip/files/nginx/nginx.conf
+++ b/puppet/zulip/files/nginx/nginx.conf
@@ -30,6 +30,17 @@ http {
 
     gzip on;
     gzip_disable "msie6";
+    gzip_proxied any;
+    gzip_types
+      audio/ogg
+      application/json
+      application/octet-stream
+      application/xml
+      application/x-javascript
+      image/png
+      text/css
+      text/plain;
+    gzip_vary on;
 
     # Select a Connection header for sockjs reverse-proxying
     map $http_upgrade $connection_upgrade {


### PR DESCRIPTION
Apparently, previously nginx was only compressing text/html content.
This should result in a substantial savings in network traffic -- some
quick testing I did found it cut the total data transferred for
loading a logged-in zulip.com instance from 3MB to 1.2MB.