### PR TITLE
Add istanbul for running node coverage reports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {},
   "devDependencies": {
     "handlebars": "1.3.0",
+    "istanbul": "0.4.0",
     "jQuery": "1.7.4",
     "jsdom": "0.5.7",
     "xmlhttprequest": "1.5.0",


### PR DESCRIPTION
`tools/test-js-with-node cover` needs istanbul to be installed in
order to work; we might as well install it by default rather than
having it be an extra step users need to deal with.

Of course, since this is only needed in the development environment,
this could suggest we want to fork/conditionalize package.json, but I
think for now it's reasonable to just install everything we use
somewhere -- the npm list is still pretty short and we have that issue
anyway with webpack-dev-server.