### PR TITLE
Only show "Sign up with google" when enabled

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -37,7 +37,7 @@ $(function () {
             connect you with your coworkers{% endblocktrans %}.</div>
             {% if google_auth_enabled %}
                 <div class="register-google">
-                    <a href="{% url 'zerver.views.start_google_oauth2' %}" class="zocial google register-google-button">Sign up with Google</a>
+                    <a href="{% url 'zerver.views.start_google_oauth2' %}" class="zocial google register-google-button">{% trans "Sign up with Google" %}</a>
                 </div>
             {% endif %}
         </div>

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -35,9 +35,11 @@ $(function () {
             <div class="alert alert-pitch" id="company-email">{% blocktrans %}Please use your
             company email address to sign up. Otherwise, we won’t be able to
             connect you with your coworkers{% endblocktrans %}.</div>
-            <div class="register-google">
-                <a href="{% url 'zerver.views.start_google_oauth2' %}" class="zocial google register-google-button">{% trans "Sign up with Google" %}</a>
-            </div>
+            {% if google_auth_enabled %}
+                <div class="register-google">
+                    <a href="{% url 'zerver.views.start_google_oauth2' %}" class="zocial google register-google-button">Sign up with Google</a>
+                </div>
+            {% endif %}
         </div>
 
 </div>


### PR DESCRIPTION
The default behavior shows a "Sign up with google" button on the signup page, even if google authentication isn't enabled. This PR adds a check.