### PR TITLE
Add python-pbs to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ mandrill==1.0.57
 mock==1.0.1
 oauth2client==1.4.11
 oauthlib==1.0.3
+pbs==0.110
 pika==0.9.14
 postmonkey==1.0b0
 psycopg2==2.6


### PR DESCRIPTION
This is necessary in order to use `vagrant provision` to update the
development VM environment.