### PR TITLE
Run provision.py outside of the virtualenv

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ set -x
 set -e
 sudo apt-get update
 sudo apt-get install -y python-pbs
-python /srv/zulip/provision.py
+/usr/bin/python /srv/zulip/provision.py
 SCRIPT
 
   config.vm.provision "shell",


### PR DESCRIPTION
By default we are placed inside a virtualenv by the .bash_profile using
/usr/bin/python forces the provisioning script to run outside of this
virtualenv.

This is an alternative to #330 which will allow `vagrant provision` to run on existing installs.