### PR TITLE
Preserve compose message after auto-refresh

### DIFF
--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -13,45 +13,52 @@ exports.is_in_progress = function () {
     return reload_in_progress;
 };
 
-function preserve_state(send_after_reload) {
+function preserve_state(send_after_reload, save_pointer, save_narrow, save_compose) {
     if (send_after_reload === undefined) {
         send_after_reload = 0;
     }
     var url = "#reload:send_after_reload=" + Number(send_after_reload);
     url += "+csrf_token=" + encodeURIComponent(csrf_token);
 
-    if (compose.composing() === 'stream') {
-        url += "+msg_type=stream";
-        url += "+stream=" + encodeURIComponent(compose.stream_name());
-        url += "+subject=" + encodeURIComponent(compose.subject());
-    } else if (compose.composing() === 'private') {
-        url += "+msg_type=private";
-        url += "+recipient=" + encodeURIComponent(compose.recipient());
-    }
-
-    if (compose.composing()) {
-        url += "+msg=" + encodeURIComponent(compose.message_content());
-    }
-
-    var pointer = home_msg_list.selected_id();
-    if (pointer !== -1) {
-        url += "+pointer=" + pointer;
-    }
-    var row = home_msg_list.selected_row();
-    if (!narrow.active()) {
-        if (row.length > 0) {
-            url += "+offset=" + row.offset().top;
+    if (save_compose) {
+        if (compose.composing() === 'stream') {
+            url += "+msg_type=stream";
+            url += "+stream=" + encodeURIComponent(compose.stream_name());
+            url += "+subject=" + encodeURIComponent(compose.subject());
+        } else if (compose.composing() === 'private') {
+            url += "+msg_type=private";
+            url += "+recipient=" + encodeURIComponent(compose.recipient());
         }
-    } else {
-        url += "+offset=" + home_msg_list.pre_narrow_offset;
 
-        var narrow_pointer = narrowed_msg_list.selected_id();
-        if (narrow_pointer !== -1) {
-            url += "+narrow_pointer=" + narrow_pointer;
+        if (compose.composing()) {
+            url += "+msg=" + encodeURIComponent(compose.message_content());
         }
-        var narrow_row = narrowed_msg_list.selected_row();
-        if (narrow_row.length > 0) {
-            url += "+narrow_offset=" + narrow_row.offset().top;
+    }
+
+    if (save_pointer) {
+        var pointer = home_msg_list.selected_id();
+        if (pointer !== -1) {
+            url += "+pointer=" + pointer;
+        }
+    }
+
+    if (save_narrow) {
+        var row = home_msg_list.selected_row();
+        if (!narrow.active()) {
+            if (row.length > 0) {
+                url += "+offset=" + row.offset().top;
+            }
+        } else {
+            url += "+offset=" + home_msg_list.pre_narrow_offset;
+
+            var narrow_pointer = narrowed_msg_list.selected_id();
+            if (narrow_pointer !== -1) {
+                url += "+narrow_pointer=" + narrow_pointer;
+            }
+            var narrow_row = narrowed_msg_list.selected_row();
+            if (narrow_row.length > 0) {
+                url += "+narrow_offset=" + narrow_row.offset().top;
+            }
         }
     }
 
@@ -159,12 +166,12 @@ function cleanup_before_reload() {
     }
 }
 
-function do_reload_app(send_after_reload, save_state, message) {
+function do_reload_app(send_after_reload, save_pointer, save_narrow, save_compose, message) {
     if (reload_in_progress) { return; }
 
     // TODO: we should completely disable the UI here
-    if (save_state) {
-        preserve_state(send_after_reload);
+    if (save_pointer || save_narrow || save_compose) {
+        preserve_state(send_after_reload, save_pointer, save_narrow, save_compose);
     }
 
     if (message === undefined) {
@@ -186,12 +193,18 @@ function do_reload_app(send_after_reload, save_state, message) {
 exports.initiate = function (options) {
     options = _.defaults({}, options, {
         immediate: false,
-        save_state: true,
+        save_pointer: true,
+        save_narrow: true,
+        save_compose: true,
         send_after_reload: false
     });
 
     if (options.immediate) {
-        do_reload_app(options.send_after_reload, options.save_state, options.message);
+        do_reload_app(options.send_after_reload,
+                      options.save_pointer,
+                      options.save_narrow,
+                      options.save_compose,
+                      options.message);
     }
 
     if (reload_pending) {
@@ -209,7 +222,11 @@ exports.initiate = function (options) {
     var compose_done_handler, compose_started_handler;
 
     function reload_from_idle () {
-        do_reload_app(false, options.save_state, options.message);
+        do_reload_app(false,
+                      options.save_pointer,
+                      options.save_narrow,
+                      options.save_compose,
+                      options.message);
     }
 
     // Make sure we always do a reload eventually

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -287,7 +287,10 @@ function get_events(options) {
                     ($.parseJSON(xhr.responseText).msg.indexOf("too old") !== -1 ||
                      $.parseJSON(xhr.responseText).msg.indexOf("Bad event queue id") !== -1)) {
                     page_params.event_queue_expired = true;
-                    reload.initiate({immediate: true, save_state: false});
+                    reload.initiate({immediate: true,
+                                     save_pointer: false,
+                                     save_narrow: false,
+                                     save_compose: false});
                 }
 
                 if (error_type === 'abort') {

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -289,8 +289,7 @@ function get_events(options) {
                     page_params.event_queue_expired = true;
                     reload.initiate({immediate: true,
                                      save_pointer: false,
-                                     save_narrow: false,
-                                     save_compose: false});
+                                     save_narrow: false});
                 }
 
                 if (error_type === 'abort') {

--- a/static/js/zulip.js
+++ b/static/js/zulip.js
@@ -273,7 +273,10 @@ function fast_forward_pointer() {
                 furthest_read = data.max_message_id;
                 unconditionally_send_pointer_update().then(function () {
                     ui.change_tab_to('#home');
-                    reload.initiate({immediate: true, save_state: false});
+                    reload.initiate({immediate: true,
+                                     save_pointer: false,
+                                     save_narrow: false,
+                                     save_compose: false});
                 });
             });
         }


### PR DESCRIPTION
As stated in #203, if you had started writing a message and put your computer to sleep and came back later, the message would be erased. This PR fixes this by splitting the state into 3 components: pointer, narrow, compose. reload.initiate() now has the options save_pointer, save_narrow, and save_compose which all default to true. When the call to /json/get_events/ 400s, only save_narrow and save_pointer are set to false.

I couldn't figure out a way to write a test for this, since it requires reload to happen. If a test is required, some guidance would be appreciated.