### PR TITLE
Show 5 most recent "Private messages" when clicked

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -13,6 +13,9 @@ add_dependencies({
 
 set_global('recent_subjects', new global.Dict());
 set_global('unread', {});
+set_global('message_store', {
+    recent_private_messages: new global.Array()
+});
 
 var stream_list = require('js/stream_list.js');
 
@@ -23,6 +26,7 @@ $.fn.expectOne = function () {
 };
 
 global.use_template('sidebar_subject_list');
+global.use_template('sidebar_private_message_list');
 global.use_template('stream_sidebar_row');
 global.use_template('stream_privacy');
 
@@ -45,6 +49,29 @@ global.use_template('stream_privacy');
     var topic = $(topic_html).find('a').text().trim();
     assert.equal(topic, 'coding');
 }());
+
+(function test_build_private_messages_list() {
+    var reply_tos = "alice@zulip.com,bob@zulip.com";
+    var active_conversation = "Alice, Bob";
+    var max_conversations = 5;
+
+
+    var conversations = {reply_to: reply_tos,
+                      display_reply_to: active_conversation,
+                      timestamp: 0 };
+    global.message_store.recent_private_messages.push(conversations);
+
+    global.unread.num_unread_for_person = function () {
+        return 1;
+    };
+
+    var convos_html = stream_list._build_private_messages_list(active_conversation, max_conversations);
+    global.write_test_output("test_build_private_messages_list", convos_html);
+
+    var conversation = $(convos_html).find('a').text().trim();
+    assert.equal(conversation, active_conversation);
+}());
+
 
 (function test_add_stream_to_sidebar() {
     // Make a couple calls to add_stream_to_sidebar() and make sure they

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -10,6 +10,7 @@ var load_more_enabled = true;
 
 // used for our URL rewriting in insert_new_messages
 var humbug_images_re = new RegExp("https://humbug-user-uploads.s3.amazonaws.com/([^\"]+)", 'g');
+exports.recent_private_messages = [];
 
 exports.get = function get(message_id) {
     return stored_messages[message_id];
@@ -56,6 +57,25 @@ exports.process_message_for_recent_subjects = function process_message_for_recen
     });
 
     recent_subjects.set(stream, recents);
+};
+
+exports.process_message_for_recent_private_messages = function process_message_for_recent_private_messages(message, remove_message) {
+    var current_timestamp = 0;
+
+    // If this conversation is already tracked, we'll replace with new timestamp,
+    // so remove it from the current list.
+    exports.recent_private_messages = _.filter(exports.recent_private_messages, function (recent_pm) {
+        return recent_pm.reply_to !== message.reply_to;
+    });
+
+    var new_conversation = {reply_to: message.reply_to,
+                            display_reply_to: message.display_reply_to,
+                            timestamp: Math.max(message.timestamp, current_timestamp)};
+
+    exports.recent_private_messages.push(new_conversation);
+    exports.recent_private_messages.sort(function (a, b) {
+        return b.timestamp - a.timestamp;
+    });
 };
 
 function set_topic_edit_properties(message) {
@@ -120,6 +140,7 @@ function add_message_metadata(message) {
                 get_private_message_recipient(message, 'email'));
         message.display_reply_to = get_private_message_recipient(message, 'full_name', 'email');
 
+        exports.process_message_for_recent_private_messages(message);
         involved_people = message.display_recipient;
         break;
     }
@@ -333,6 +354,7 @@ exports.update_messages = function update_messages(events) {
     }
     unread.update_unread_counts();
     stream_list.update_streams_sidebar();
+    stream_list.update_private_messages();
 };
 
 exports.insert_new_messages = function insert_new_messages(messages) {
@@ -383,6 +405,7 @@ exports.insert_new_messages = function insert_new_messages(messages) {
     unread.process_visible();
     notifications.received_messages(messages);
     stream_list.update_streams_sidebar();
+    stream_list.update_private_messages();
 };
 
 function process_result(messages, opts) {
@@ -410,6 +433,7 @@ function process_result(messages, opts) {
     }
 
     stream_list.update_streams_sidebar();
+    stream_list.update_private_messages();
 
     if (opts.cont !== undefined) {
         opts.cont(messages);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -157,12 +157,21 @@ exports.hide_streamlist_sidebar = function () {
     $(".app-main .column-left").removeClass("expanded");
 };
 
+exports.hide_pm_list_sidebar = function () {
+    $(".app-main .column-left").removeClass("expanded");
+};
+
 exports.show_userlist_sidebar = function () {
     $(".app-main .column-right").addClass("expanded");
     resize.resize_page_components();
 };
 
 exports.show_streamlist_sidebar = function () {
+    $(".app-main .column-left").addClass("expanded");
+    resize.resize_page_components();
+};
+
+exports.show_pm_list_sidebar = function () {
     $(".app-main .column-left").addClass("expanded");
     resize.resize_page_components();
 };

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -175,6 +175,13 @@ exports.resize_bottom_whitespace = function (h) {
     }
 };
 
+exports.resize_stream_filters_container = function (h) {
+    h = narrow_window ? left_userlist_get_new_heights() : get_new_heights();
+    exports.resize_bottom_whitespace(h);
+    $("#stream-filters-container").css('max-height', h.stream_filters_max_height);
+    $('#stream-filters-container').perfectScrollbar('update');
+};
+
 exports.resize_page_components = function () {
     var composebox = $("#compose");
     var floating_recipient_bar = $("#floating_recipient_bar");

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -606,6 +606,21 @@ ul.filters {
     letter-spacing: 0.6px;
 }
 
+.private_message_count {
+    display: block;
+    position: absolute;
+    line-height: 1em;
+    right: 10px;
+    top: 2px;
+    padding: 2px 3px 0px 3px;
+    background: #a6ada4;
+    color: #ffffff;
+    border-radius: 1px;
+    font-size: 12px;
+    font-weight: normal;
+    letter-spacing: 0.6px;
+}
+
 ul.filters i {
     padding-right: 0.25em;
     /* Make filter icons the same width so labels line up. */
@@ -2460,6 +2475,13 @@ div.floating_recipient {
     text-overflow: ellipsis;
 }
 
+.conversation-partners {
+    display: block;
+    line-height: 1.2em;
+    width: 90%;
+    overflow: hidden;
+}
+
 .subscription_header {
     min-height: 47px;
 }
@@ -2831,10 +2853,32 @@ ul.expanded_subjects {
     padding-bottom: 2px;
 }
 
+ul.expanded_private_messages {
+    list-style-type: none;
+    font-weight: 300;
+    font-size: 84%;
+    margin-left: 0px;
+    padding-bottom: 2px;
+}
+
 li.show-more-topics,
 li.expanded_subject {
     position: relative;
     padding-left: 33px;
+}
+
+
+li.show-more-private-messages,
+li.expanded_private_message {
+    position: relative;
+    padding-left: 24px;
+    padding-bottom: 1px;
+    padding-top: 2px;
+}
+
+
+#global_filters li:hover {
+    background-color: #e2e8dd;
 }
 
 .show-all-streams a {
@@ -2846,12 +2890,14 @@ li.expanded_subject {
     margin-bottom: -5px;
 }
 
-.expanded_subject .subject_box {
+.expanded_subject .subject_box,
+#private .expanded_private_message .subject_box {
     display: block;
     margin-right: 38px;
 }
 
-.expanded_subject.zero-subject-unreads .subject_box {
+.expanded_subject.zero-subject-unreads .subject_box, 
+#private .expanded_private_messages.zero-subject-unreads .subject_box {
     display: block;
     margin-right: 15px;
 }
@@ -3979,7 +4025,15 @@ li.show-more-topics a {
     font-size: 75%;
 }
 
+li.show-more-private-messages a {
+    font-size: 90%
+}
+
 .zoom-in .show-more-topics {
+    display: none;
+}
+
+.zoom-in .show-more-private-messages {
     display: none;
 }
 

--- a/static/templates/sidebar_private_message_list.handlebars
+++ b/static/templates/sidebar_private_message_list.handlebars
@@ -1,0 +1,22 @@
+<ul class='expanded_private_messages' data-name='private'>
+    {{#each messages}}
+    <li class='{{#if is_zero}}zero-subject-unreads{{/if}} {{#if zoom_out_hide}}zoom-out-hide{{/if}} expanded_private_message' data-name='{{reply_to}}'>
+      <span class='subject_box'>
+        <a href='{{url}}' class="conversation-partners">
+          {{recipients}}
+        </a>
+        <div class="private_message_count {{#if is_zero}}zero_count{{/if}}">
+            <div class="value">{{unread}}</div>
+        </div>
+      </span>
+      <span class="arrow topic-sidebar-arrow">
+        <i class="icon-vector-chevron-down"></i>
+      </span>
+    </li>
+    {{/each}}
+    {{#if want_show_more_messages_links}}   
+    <li class="show-more-private-messages" data-name='private'>
+      <a href="#">(more conversations)</a>
+    </li>
+    {{/if}}
+</ul>

--- a/tools/jslint/jslint.js
+++ b/tools/jslint/jslint.js
@@ -607,7 +607,10 @@ var JSLINT = (function () {
             use_object: "Use the object literal notation {}.",
             use_or: "Use the || operator.",
             use_param: "Use a named parameter.",
-            used_before_a: "'{a}' was used before it was defined.",
+            used_before_a: "'{a}' was used before it was defined. (If you " +
+                " have added a new module, you need to add it to the whitelist " +
+                "in tools/jslist/check-all.js; if it's a new global you should " +
+                "change it to be an export of the appropriate module)",
             var_a_not: "Variable {a} was not declared correctly.",
             weird_assignment: "Weird assignment.",
             weird_condition: "Weird condition.",


### PR DESCRIPTION
Like the Stream Subject lists, Private messages are now shown
when the user clicks on the "Private message" link. User can drill in
to get more than 5 conversations. Selecting PMs from the user or group
PM lists on the right sidebar also opens the list & highlights the
selected conversation.

Added comments and clearer error message to jslint.js to help devs
understand how to add new global variables without getting the
"used before it was defined" error.