### PR TITLE
Clean up development server logging output

### DIFF
--- a/tools/clean-repo
+++ b/tools/clean-repo
@@ -8,4 +8,4 @@
 #     chmod +x .git/hooks/post-checkout
 
 cd "$(dirname "$0")/.."
-find . -name '*.pyc' -print -delete | sed 's|^|[clean-repo] Deleting |'
+find . -name '*.pyc' -delete

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -77,7 +77,7 @@ os.setpgrp()
 # zulip/urls.py.
 cmds = [['./tools/compile-handlebars-templates', 'forever'],
         ['./tools/webpack', 'watch'],
-        ['python', 'manage.py', 'runserver', '--nostatic'] +
+        ['python', 'manage.py', 'rundjango'] +
           manage_args + ['localhost:%d' % (django_port,)],
         ['python', 'manage.py', 'runtornado'] +
           manage_args + ['localhost:%d' % (tornado_port,)],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     },
     devServer: {
         port: 9994,
+        stats: "errors-only",
         watchOptions: {
             aggregateTimeout: 300,
             poll: 1000

--- a/zerver/management/commands/rundjango.py
+++ b/zerver/management/commands/rundjango.py
@@ -1,0 +1,13 @@
+# Wrapper around Django's runserver to allow filtering logs.
+
+from django.core.servers.basehttp import WSGIRequestHandler
+orig_log_message = WSGIRequestHandler.log_message
+def log_message_monkey(self, format, *args):
+    # Filter output for 200 or 304 responses.
+    if args[1] == '200' or args[1] == '304':
+        return
+    return orig_log_message(self, format, *args)
+
+WSGIRequestHandler.log_message = log_message_monkey
+
+from django.core.management.commands.runserver import Command

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -183,7 +183,10 @@ def write_log_line(log_data, path, method, remote_ip, email, client_name,
     logger_line = '%-15s %-7s %3d %s%s %s' % \
                     (remote_ip, method, status_code,
                      logger_timing, extra_request_data, logger_client)
-    logger.info(logger_line)
+    if (status_code in [200, 304] and method == "GET" and path.startswith("/static")):
+        logger.debug(logger_line)
+    else:
+        logger.info(logger_line)
 
     if (is_slow_query(time_delta, path)):
         queue_json_publish("slow_queries", "%s (%s)" % (logger_timing, email), lambda e: None)

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -857,6 +857,11 @@ LOGGING = {
             'level':    'INFO',
             'propagate': False,
         },
+        'requests': {
+            'handlers': ['console', 'file', 'errors_file'],
+            'level':    'WARNING',
+            'propagate': False,
+        },
         ## Uncomment the following to get all database queries logged to the console
         # 'django.db': {
         #     'handlers': ['console'],

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -847,6 +847,11 @@ LOGGING = {
             'level':    'INFO',
             'propagate': False,
         },
+        'zulip.queue': {
+            'handlers': ['console', 'file', 'errors_file'],
+            'level':    'WARNING',
+            'propagate': False,
+        },
         'zulip.management': {
             'handlers': ['file', 'errors_file'],
             'level':    'INFO',


### PR DESCRIPTION
This series of commits substantially cleans up the console output from `run-dev.py`.  While it's still not perfect, the new output for starting a web server looks like the below:

```
tabbott@monastery:~/zulip$ ./tools/run-dev.py 
2015-12-13 22:10:11,898 INFO: process_fts_updates starting
Recompiling templates
2015-12-13 22:10:11,931 INFO: Not in recovery; listening for FTS updates
done
Validating Django models.py...
System check identified no issues (0 silenced).

Django version 1.8.3
Tornado server is running at http://localhost:9993/
Quit the server with CTRL-C.
2015-12-14 01:10:14,110 INFO     Tornado loaded 1 event queues in 0.009s
2015-12-14 01:10:14,122 INFO     Tornado  92.9% busy over the past  0.0 seconds
http://localhost:9994/webpack-dev-server/
webpack result is served from http://localhost:9991/webpack/
content is served from /home/tabbott/zulip
2015-12-14 01:10:15,434 INFO     127.0.0.1       POST    200  37ms (+start: 369ms) /json/get_events [1450073359:0/1] (tabbott@zulip.com via website)
2015-12-14 01:10:18,239 INFO     127.0.0.1       SOCKET  200   0ms /socket/open [transport=xhr_streaming] (unknown via ?)
2015-12-14 01:10:18,252 INFO     127.0.0.1       POST    200   2ms (lp: 2.2s) /json/get_events [1450073359:0/1] (tabbott@zulip.com via website)
2015-12-14 01:10:18,255 INFO     Disconnected handler for queue 1450073359:0 (tabbott@zulip.com/website)
2015-12-14 01:10:18,292 INFO     127.0.0.1       SOCKET  200  10ms (db: 4ms/2q) /socket/auth [transport=xhr_streaming] (tabbott@zulip.com via ?)
Performing system checks...

System check identified no issues (0 silenced).
2015-12-14 01:10:20,714 INFO     Worker 0 connecting to queue test
2015-12-14 01:10:20,747 INFO     Worker 0 connecting to queue feedback_messages
2015-12-14 01:10:20,766 INFO     Worker 0 connecting to queue missedmessage_mobile_notifications
2015-12-14 01:10:20,852 INFO     Worker 0 connecting to queue user_activity_interval
2015-12-14 01:10:20,854 INFO     Worker 0 connecting to queue slow_queries
2015-12-14 01:10:20,920 INFO     Worker 0 connecting to queue missedmessage_emails
2015-12-14 01:10:20,963 INFO     Worker 0 connecting to queue email_mirror
2015-12-14 01:10:20,993 INFO     Worker 0 connecting to queue message_sender
2015-12-14 01:10:21,057 INFO     Worker 0 connecting to queue digest_emails
December 14, 2015 - 01:10:21
Django version 1.8.3, using settings 'zproject.settings'
Starting development server at http://localhost:9992/
Quit the server with CONTROL-C.
2015-12-14 01:10:21,171 INFO     Worker 0 connecting to queue invites
2015-12-14 01:10:21,180 INFO     Worker 0 connecting to queue signups
2015-12-14 01:10:21,254 INFO     Worker 0 connecting to queue user_activity
2015-12-14 01:10:21,327 INFO     Worker 0 connecting to queue user_presence
2015-12-14 01:10:21,377 INFO     Worker 0 connecting to queue error_reports

webpack: bundle is now VALID.
2015-12-14 01:10:22,387 INFO     127.0.0.1       DELETE  200 522ms /json/events [1450073359:0] (tabbott@zulip.com via website)
2015-12-14 01:10:25,512 INFO     127.0.0.1       DELETE  400   2ms /json/events (tabbott@zulip.com via website)
2015-12-14 01:10:25,512 INFO     status=400, data={"msg":"Bad event queue id: 1450073359:0","result":"error"}
, uid=tabbott@zulip.com
2015-12-14 01:10:25,525 INFO     127.0.0.1       GET     200   7ms /api/v1/events [1450073412:0/0] (tabbott@zulip.com via internal)
2015-12-14 01:10:25,544 INFO     127.0.0.1       GET     200   5ms /api/v1/events [1450073412:1/0] (tabbott@zulip.com via internal)
2015-12-14 01:10:25,951 INFO     127.0.0.1       GET     200   2ms /api/v1/events [1450073412:1/0] (tabbott@zulip.com via internal)
2015-12-14 01:10:25,957 INFO     127.0.0.1       GET     200   2ms /api/v1/events [1450073412:0/0] (tabbott@zulip.com via internal)
2015-12-14 01:10:26,250 INFO     127.0.0.1       GET     200  1.6s (mem: 139ms/13) (db: 277ms/22q) (+start: 463ms) / [1450073412:0] (tabbott@zulip.com via website)
2015-12-14 01:10:26,252 INFO     127.0.0.1       GET     200 733ms (mem: 138ms/11) (db: 119ms/23q) / [1450073412:1] (tabbott@zulip.com via website)
2015-12-14 01:10:35,574 INFO     Received event: {u'status': 2, u'user_profile_id': 17, u'client': u'website', u'time': 1450073435}
2015-12-14 01:10:35,661 INFO     127.0.0.1       POST    200 139ms (db: 8ms/3q) /json/update_active_status (tabbott@zulip.com via website)
2015-12-14 01:10:35,759 INFO     127.0.0.1       POST    200 133ms (mem: 8ms/2) (db: 8ms/7q) (+start: 85ms) /json/get_old_messages (tabbott@zulip.com via website)
2015-12-14 01:10:35,823 INFO     127.0.0.1       SOCKET  200   0ms /socket/open [transport=xhr_streaming] (unknown via ?)
2015-12-14 01:10:35,974 WARNING  Not Found: /user_uploads/unk/byqgM1qjol1mzje_KzeNRT5F/guinea.jpg
2015-12-14 01:10:35,981 INFO     127.0.0.1       GET     404   8ms /user_uploads/unk/byqgM1qjol1mzje_KzeNRT5F/guinea.jpg (unauth via ?)
[14/Dec/2015 01:10:35]"GET /user_uploads/unk/byqgM1qjol1mzje_KzeNRT5F/guinea.jpg HTTP/1.0" 404 1867
2015-12-14 01:10:36,077 INFO     127.0.0.1       SOCKET  200   9ms (db: 3ms/2q) /socket/auth [transport=xhr_streaming] (tabbott@zulip.com via ?)
```