### PR TITLE
Sorting stream list based on stream activity.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -645,7 +645,7 @@ exports.setup_page = function () {
 
     $("#ui-settings").on("click", "input[name='change_settings']", function (e) {
         var labs_updates = {};
-        _.each(["autoscroll_forever", "default_desktop_notifications"],
+        _.each(["autoscroll_forever", "default_desktop_notifications", "sort_streams_on_activity"],
             function (setting) {
                 labs_updates[setting] = $("#" + setting).is(":checked");
         });

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -29,10 +29,20 @@ exports.build_stream_list = function () {
 
     streams.sort(function (a, b) {
         if (sort_recent) {
-            if (recent_subjects.has(b) && ! recent_subjects.has(a)) {
-                return 1;
-            } else if (! recent_subjects.has(b) && recent_subjects.has(a)) {
-                return -1;
+            if (!page_params.sort_streams_on_activity) {
+                if (recent_subjects.has(b) && ! recent_subjects.has(a)) {
+                    return 1;
+                } else if (! recent_subjects.has(b) && recent_subjects.has(a)) {
+                    return -1;
+                }
+            } else {
+                if (recent_subjects.has(b) && ! recent_subjects.has(a)) {
+                    return 1;
+                } else if (! recent_subjects.has(b) && recent_subjects.has(a)) {
+                    return -1;
+                } else if (recent_subjects.has(b) && recent_subjects.has(a)) {
+                    return recent_subjects.get(b)[0].timestamp - recent_subjects.get(a)[0].timestamp;
+                }
             }
         }
         return util.strcmp(a, b);

--- a/static/templates/settings_tab.handlebars
+++ b/static/templates/settings_tab.handlebars
@@ -378,7 +378,18 @@
           Enable desktop notifications for new streams
         </label>
 
+        <div class="controls">
+          <input type="checkbox" name="sort_streams_on_activity" id="sort_streams_on_activity"
+                 {{#if page_params.sort_streams_on_activity}}
+                 checked="yes"
+              {{/if}} />
+        </div>
+        <label for="sort_streams_on_activity" class="control-label">
+          Keep active streams always on top of list
+        </label>
+
       </div>
+
       <div class="control-group">
         <div class="controls ui-submission">
           <input type="submit" name="change_settings" value="Save changes" class="btn btn-big btn-primary" />

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1832,9 +1832,16 @@ def do_change_default_desktop_notifications(user_profile, default_desktop_notifi
     user_profile.default_desktop_notifications = default_desktop_notifications
     user_profile.save(update_fields=["default_desktop_notifications"])
 
-def do_change_stream_listing(user_profile, sort_streams_on_activity):
+def do_change_stream_listing(user_profile, sort_streams_on_activity, log=True):
     user_profile.sort_streams_on_activity = sort_streams_on_activity
     user_profile.save(update_fields=["sort_streams_on_activity"])
+    event = {'type': 'update_display_settings',
+             'user': user_profile.email,
+             'setting_name': 'sort_streams_on_activity',
+             'setting': sort_streams_on_activity}
+    if log:
+        log_event(event)
+    send_event(event, [user_profile.id])
 
 def do_change_twenty_four_hour_time(user_profile, setting_value, log=True):
     user_profile.twenty_four_hour_time = setting_value

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1832,6 +1832,10 @@ def do_change_default_desktop_notifications(user_profile, default_desktop_notifi
     user_profile.default_desktop_notifications = default_desktop_notifications
     user_profile.save(update_fields=["default_desktop_notifications"])
 
+def do_change_stream_listing(user_profile, sort_streams_on_activity):
+    user_profile.sort_streams_on_activity = sort_streams_on_activity
+    user_profile.save(update_fields=["sort_streams_on_activity"])
+
 def do_change_twenty_four_hour_time(user_profile, setting_value, log=True):
     user_profile.twenty_four_hour_time = setting_value
     user_profile.save(update_fields=["twenty_four_hour_time"])

--- a/zerver/migrations/0009_stream_list_ordering.py
+++ b/zerver/migrations/0009_stream_list_ordering.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0008_preregistrationuser_upper_email_idx'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='sort_streams_on_activity',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AlterField(
+            model_name='userprofile',
+            name='enable_stream_desktop_notifications',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AlterField(
+            model_name='userprofile',
+            name='enable_stream_sounds',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -328,6 +328,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     enter_sends = models.NullBooleanField(default=True)
     autoscroll_forever = models.BooleanField(default=False)
     left_side_userlist = models.BooleanField(default=False)
+    sort_streams_on_activity = models.BooleanField(default=False)
 
     # display settings
     twenty_four_hour_time = models.BooleanField(default=False)

--- a/zerver/test_events.py
+++ b/zerver/test_events.py
@@ -36,6 +36,7 @@ from zerver.lib.actions import (
     do_update_message,
     do_update_pointer,
     do_change_twenty_four_hour_time,
+    do_change_stream_listing,
     do_change_left_side_userlist,
     fetch_initial_state_data,
 )
@@ -448,6 +449,19 @@ class EventsRegisterTest(AuthedTestCase):
         # The first False is probably a noop, then we get transitions in both directions.
         for setting_value in [False, True, False]:
             events = self.do_test(lambda: do_change_twenty_four_hour_time(self.user_profile, setting_value))
+            error = schema_checker('events[0]', events[0])
+            self.assert_on_error(error)
+
+    def test_change_stream_listing_preference(self):
+        schema_checker = check_dict([
+            ('type', equals('update_display_settings')),
+            ('setting_name', equals('sort_streams_on_activity')),
+            ('user', check_string),
+            ('setting', check_bool),
+            ])
+        # The first False is probably a noop, then we get transitions in both directions.
+        for setting_value in [False, True, False]:
+            events = self.do_test(lambda: do_change_stream_listing(self.user_profile, setting_value))
             error = schema_checker('events[0]', events[0])
             self.assert_on_error(error)
 

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -827,6 +827,7 @@ def home(request):
         name_changes_disabled = name_changes_disabled(user_profile.realm),
         has_mobile_devices    = num_push_devices_for_user(user_profile) > 0,
         autoscroll_forever = user_profile.autoscroll_forever,
+        sort_streams_on_activity = user_profile.sort_streams_on_activity,
         default_desktop_notifications = user_profile.default_desktop_notifications,
         avatar_url            = avatar_url(user_profile),
         mandatory_topics      = user_profile.realm.mandatory_topics,

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -10,7 +10,7 @@ from zerver.lib.actions import do_change_password, \
     do_change_enter_sends, do_change_enable_sounds, \
     do_change_enable_offline_email_notifications, do_change_enable_digest_emails, \
     do_change_enable_offline_push_notifications, do_change_autoscroll_forever, \
-    do_change_default_desktop_notifications, \
+    do_change_default_desktop_notifications, do_change_stream_listing, \
     do_change_enable_stream_desktop_notifications, do_change_enable_stream_sounds, \
     do_regenerate_api_key, do_change_avatar_source, do_change_twenty_four_hour_time, do_change_left_side_userlist
 from zerver.lib.avatar import avatar_url
@@ -31,7 +31,9 @@ def json_change_ui_settings(request, user_profile,
                             autoscroll_forever=REQ(validator=check_bool,
                                                    default=None),
                             default_desktop_notifications=REQ(validator=check_bool,
-                                                              default=None)):
+                                                              default=None),
+                            sort_streams_on_activity=REQ(validator=check_bool,
+                                                         default=None),):
 
     result = {}
 
@@ -44,6 +46,11 @@ def json_change_ui_settings(request, user_profile,
             user_profile.default_desktop_notifications != default_desktop_notifications:
         do_change_default_desktop_notifications(user_profile, default_desktop_notifications)
         result['default_desktop_notifications'] = default_desktop_notifications
+
+    if sort_streams_on_activity is not None and \
+            user_profile.sort_streams_on_activity != sort_streams_on_activity:
+        do_change_stream_listing(user_profile, sort_streams_on_activity)
+        result['sort_streams_on_activity'] = sort_streams_on_activity
 
     return json_success(result)
 


### PR DESCRIPTION
In case when both streams are present in recent_subjects, instead of sorting them in alphabetical order(util.strcmp), this change/patch lists them based on their recent activity. It keeps recently active streams placed on the top of the stream list. I did manual testing on local setup to confirm the expected behavior. 
Shantanu
