### PR TITLE
Document that 'localhost' is necessary in ALLOWED_HOSTS

### DIFF
--- a/zproject/local_settings_template.py
+++ b/zproject/local_settings_template.py
@@ -82,7 +82,7 @@ NOREPLY_EMAIL_ADDRESS = "noreply@example.com"
 # domains/IP addresses for your site. This is a security measure to
 # prevent an attacker from poisoning caches and triggering password
 # reset emails with links to malicious hosts by submitting requests
-# with a fake HTTP Host header.
+# with a fake HTTP Host header. You must include 'localhost' here.
 ALLOWED_HOSTS = ['*']
 
 ### OPTIONAL SETTINGS


### PR DESCRIPTION
It's needed for the tornado server. Otherwise, you get errors like

2015-12-20 09:33:55,124 ERROR    Internal Server Error: /api/v1/events
Traceback (most recent call last):
  File "/home/zulip/deployments/2015-12-20-13-44-47/zerver/management/commands/runtornado.py", line 209, in get_response
    response = middleware_method(request)
  File "/usr/lib/python2.7/dist-packages/django/middleware/common.py", line 62, in process_request
    host = request.get_host()
  File "/usr/lib/python2.7/dist-packages/django/http/request.py", line 101, in get_host
    raise DisallowedHost(msg)
DisallowedHost: Invalid HTTP_HOST header: 'localhost:9993'. You may need to add u'localhost' to ALLOWED_HOSTS.