### PR TITLE
Added mobile device redirect support using a custom URL scheme

### DIFF
--- a/static/js/mobile_redirect.js
+++ b/static/js/mobile_redirect.js
@@ -1,0 +1,25 @@
+var mobile_redirect = (function(){
+  var exports = {};
+
+  function show_app_alert(contents) {
+    $('#custom-alert-bar-content').html(contents);
+    $('#alert-bar-container').show();
+    $('#alert-bar-container .close-alert-icon').expectOne().click(hide_app_alert);
+  }
+
+  function hide_app_alert() {
+      $('#alert-bar-container').slideUp(100);
+  }
+
+  exports.try_to_display = function(){
+    alert_contents = "<i class='icon-vector-mobile'></i>What's better than " + page_params.product_name + " in your mobile browser? The <a href='/accounts/login/mobile_redirect/' target='_blank'>"+ page_params.product_name + " Mobile app</a>!";
+    show_app_alert(alert_contents);
+  };
+
+  exports.initialize = function() {
+    if (page_params.should_offer_mobile_redirect) {
+      exports.try_to_display();
+    }
+  };
+return exports;
+}());

--- a/static/js/mobile_redirect.js
+++ b/static/js/mobile_redirect.js
@@ -1,5 +1,9 @@
-var mobile_redirect = (function(){
+var mobile_redirect = (function () {
   var exports = {};
+
+  function hide_app_alert() {
+      $('#alert-bar-container').slideUp(100);
+  }
 
   function show_app_alert(contents) {
     $('#custom-alert-bar-content').html(contents);
@@ -7,16 +11,12 @@ var mobile_redirect = (function(){
     $('#alert-bar-container .close-alert-icon').expectOne().click(hide_app_alert);
   }
 
-  function hide_app_alert() {
-      $('#alert-bar-container').slideUp(100);
-  }
-
-  exports.try_to_display = function(){
-    alert_contents = "<i class='icon-vector-mobile'></i>What's better than " + page_params.product_name + " in your mobile browser? The <a href='/accounts/login/mobile_redirect/' target='_blank'>"+ page_params.product_name + " Mobile app</a>!";
+  exports.try_to_display = function () {
+    var alert_contents = "<i class='icon-vector-mobile'></i>What's better than " + page_params.product_name + " in your mobile browser? The <a href='/accounts/login/mobile_redirect/' target='_blank'>"+ page_params.product_name + " Mobile app</a>!";
     show_app_alert(alert_contents);
   };
 
-  exports.initialize = function() {
+  exports.initialize = function () {
     if (page_params.should_offer_mobile_redirect) {
       exports.try_to_display();
     }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -480,6 +480,7 @@ $(function () {
     hashchange.initialize();
     invite.initialize();
     activity.initialize();
+    mobile_redirect.initialize();
 });
 
 

--- a/tools/jslint/check-all.js
+++ b/tools/jslint/check-all.js
@@ -29,7 +29,7 @@ var globals =
     + ' avatar feature_flags search_suggestion referral stream_color Dict'
     + ' Filter summary admin stream_data muting WinChan muting_ui Socket channel gear_menu'
     + ' message_flags bot_data loading favicon resize scroll_bar condense floating_recipient_bar'
-    + ' copy_and_paste click_handlers'
+    + ' copy_and_paste click_handlers mobile_redirect'
 
     // colorspace.js
     + ' colorspace'

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponseForbidden, HttpResponse
 from django.shortcuts import render_to_response, redirect
 from django.template import RequestContext, loader
+from django.utils.http import urlencode
 from django.utils.timezone import now
 from django.utils.cache import patch_cache_control
 from django.core.exceptions import ValidationError
@@ -758,6 +759,12 @@ def home(request):
     else:
         notifications_stream = ""
 
+    user_agent = request.META['HTTP_USER_AGENT']
+    suggestMobileForward = False
+    if "iPhone" in user_agent or "iPad" in user_agent:
+        suggestMobileForward = True
+    # TODO: Add check(s) for andriod devices
+
     # Pass parameters to the client-side JavaScript code.
     # These end up in a global JavaScript Object named 'page_params'.
     page_params = dict(
@@ -827,6 +834,8 @@ def home(request):
         avatar_url            = avatar_url(user_profile),
         mandatory_topics      = user_profile.realm.mandatory_topics,
         show_digest_email     = user_profile.realm.show_digest_email,
+
+        should_offer_mobile_redirect = suggestMobileForward,
     )
     if narrow_stream is not None:
         # In narrow_stream context, initial pointer is just latest message
@@ -1307,3 +1316,15 @@ def email_unsubscribe(request, type, token):
 
     return render_to_response('zerver/unsubscribe_link_error.html', {},
                               context_instance=RequestContext(request))
+
+@login_required(login_url = settings.HOME_NOT_LOGGED_IN)
+def mobile_redirect(request):
+    user_profile = request.user
+    params = {
+        "api_key": user_profile.api_key,
+        "email": user_profile.email,
+        "domain": settings.EXTERNAL_HOST
+    }
+    msg = "%s:///?%s" % ("zulip", urlencode(params))
+    page = "<meta HTTP-EQUIV='REFRESH' content='0; url=%s'>" % msg
+    return HttpResponse(page)

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -1326,5 +1326,5 @@ def mobile_redirect(request):
         "domain": settings.EXTERNAL_HOST
     }
     msg = "%s:///?%s" % ("zulip", urlencode(params))
-    page = "<meta HTTP-EQUIV='REFRESH' content='0; url=%s'>" % msg
+    page = "<meta HTTP-EQUIV='REFRESH' content='0; url=%s'>" % (msg)
     return HttpResponse(page)

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -697,6 +697,7 @@ JS_SPECS = {
             'js/colorspace.js',
             'js/timerender.js',
             'js/tutorial.js',
+            'js/mobile_redirect.js',
             'js/templates.js',
             'js/avatar.js',
             'js/settings.js',

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -19,6 +19,8 @@ urlpatterns = patterns('',
     # want to require a new desktop app build for everyone in that case
     url(r'^desktop_home/$', 'zerver.views.desktop_home'),
 
+    url(r'^accounts/login/mobile_redirect/$', 'zerver.views.mobile_redirect'),
+
     url(r'^accounts/login/sso/$', 'zerver.views.remote_user_sso', name='login-sso'),
     url(r'^accounts/login/jwt/$', 'zerver.views.remote_user_jwt', name='login-jwt'),
     url(r'^accounts/login/google/$', 'zerver.views.start_google_oauth2'),


### PR DESCRIPTION
The user agent is used to identify the OS type (currently iPad and iPhone) and will offer
a notification at the top of the message stream offering to redirect to the Mobile app.
There is currently no support for Android yet.
