### PR TITLE
Fix running postgres-init-db via a relative path

### DIFF
--- a/scripts/setup/postgres-init-db
+++ b/scripts/setup/postgres-init-db
@@ -2,15 +2,16 @@
 set -e
 set -x
 
-# Make sure the current working directory is readable
-cd /
-
 # Shut down all services to ensure a quiescent state.
 supervisorctl stop all
 
 # Drop any open connections to any old database.  Hackishly call using
 # source because postgres user can't read /root/zulip/scripts/setup.
 source "$(dirname "$0")/terminate-psql-sessions" postgres zulip zulip_base
+
+(
+# Make sure the current working directory is readable by postgres
+cd /
 
 su postgres -c psql <<EOF
 CREATE USER zulip;
@@ -23,6 +24,7 @@ su postgres -c 'psql zulip' <<EOF
 CREATE SCHEMA zulip AUTHORIZATION zulip;
 CREATE EXTENSION tsearch_extras SCHEMA zulip;
 EOF
+)
 
 # Clear memcached to avoid contamination from previous database state
 sh "$(dirname "$0")/flush-memcached"


### PR DESCRIPTION
If the user runs ./scripts/setup/postgres-init-db, then dirname "$0"
would no longer refer to the correct directory after cd /.

NB: Totally untested!