### PR TITLE
Refactor puppet modules to be more modular

### DIFF
--- a/puppet/zulip/manifests/app_frontend.pp
+++ b/puppet/zulip/manifests/app_frontend.pp
@@ -132,6 +132,11 @@ class zulip::app_frontend {
     owner  => 'zulip',
     group  => 'zulip',
   }
+  file { '/home/zulip/prod-static':
+    ensure => 'directory',
+    owner  => 'zulip',
+    group  => 'zulip',
+  }
   file { '/home/zulip/deployments':
     ensure => 'directory',
     owner  => 'zulip',

--- a/puppet/zulip/manifests/app_frontend.pp
+++ b/puppet/zulip/manifests/app_frontend.pp
@@ -1,0 +1,29 @@
+# Default configuration for a Zulip app frontend
+class zulip::app_frontend {
+  include zulip::app_frontend_base
+
+  file { "/etc/nginx/sites-available/zulip-enterprise":
+    require => Package["nginx-full"],
+    ensure => file,
+    owner  => "root",
+    group  => "root",
+    mode => 644,
+    source => "puppet:///modules/zulip/nginx/sites-available/zulip-enterprise",
+    notify => Service["nginx"],
+  }
+  file { '/etc/nginx/sites-enabled/zulip-enterprise':
+    require => Package["nginx-full"],
+    ensure => 'link',
+    target => '/etc/nginx/sites-available/zulip-enterprise',
+    notify => Service["nginx"],
+  }
+
+  # Restart the server regularly to avoid potential memory leak problems.
+  file { "/etc/cron.d/restart-zulip":
+    ensure => file,
+    owner  => "root",
+    group  => "root",
+    mode => 644,
+    source => "puppet:///modules/zulip/cron.d/restart-zulip",
+  }
+}

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -1,6 +1,4 @@
 class zulip::app_frontend_base {
-  include zulip::rabbit
-  include zulip::memcached
   include zulip::nginx
   include zulip::supervisor
 

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -1,3 +1,5 @@
+# Minimal configuration to run a Zulip application server.
+# Default nginx configuration is included in extension app_frontend.pp.
 class zulip::app_frontend_base {
   include zulip::nginx
   include zulip::supervisor

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -1,10 +1,10 @@
 class zulip::app_frontend_base {
   include zulip::rabbit
+  include zulip::memcached
   include zulip::nginx
   include zulip::supervisor
 
   $web_packages = [ # Needed for memcached usage
-                    "memcached",
                     "python-pylibmc",
                     # Fast JSON parser
                     "python-ujson",
@@ -100,14 +100,6 @@ class zulip::app_frontend_base {
     group => "root",
     mode => 755,
   }
-  file { "/etc/memcached.conf":
-    require => Package[memcached],
-    ensure => file,
-    owner  => "root",
-    group  => "root",
-    mode => 644,
-    source => "puppet:///modules/zulip/memcached.conf",
-  }
   file { "/etc/supervisor/conf.d/zulip.conf":
     require => Package[supervisor],
     ensure => file,
@@ -122,10 +114,6 @@ class zulip::app_frontend_base {
     owner => "zulip",
     group => "zulip",
     mode => 755,
-  }
-  service { 'memcached':
-    ensure     => running,
-    subscribe  => File['/etc/memcached.conf'],
   }
   file { '/home/zulip/logs':
     ensure => 'directory',

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -26,7 +26,7 @@ class zulip::app_frontend_base {
                     # Used for Hesiod lookups, etc.
                     "python-dns",
                     # Needed to access our database
-                    "postgresql-client-9.3",
+                    "postgresql-client-${zulip::base::postgres_version}",
                     "python-psycopg2",
                     # Needed for building complex DB queries
                     "python-sqlalchemy",

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -1,4 +1,4 @@
-class zulip::app_frontend {
+class zulip::app_frontend_base {
   include zulip::rabbit
   include zulip::nginx
   include zulip::supervisor

--- a/puppet/zulip/manifests/apt_repository.pp
+++ b/puppet/zulip/manifests/apt_repository.pp
@@ -1,0 +1,12 @@
+# This only works if zulip::base is included
+class zulip::apt_repository {
+  apt::source {'zulip':
+    location    => 'http://ppa.launchpad.net/tabbott/zulip/ubuntu',
+    release     => 'trusty',
+    repos       => 'main',
+    key         => '84C2BE60E50E336456E4749CE84240474E26AE47',
+    key_source  => 'https://zulip.com/dist/keys/zulip.asc',
+    pin         => '995',
+    include_src => true,
+  }
+}

--- a/puppet/zulip/manifests/apt_repository.pp
+++ b/puppet/zulip/manifests/apt_repository.pp
@@ -1,8 +1,8 @@
-# This only works if zulip::base is included
+# This depends on zulip::base having already been evaluated
 class zulip::apt_repository {
   apt::source {'zulip':
     location    => 'http://ppa.launchpad.net/tabbott/zulip/ubuntu',
-    release     => 'trusty',
+    release     => $zulip::base::release_name,
     repos       => 'main',
     key         => '84C2BE60E50E336456E4749CE84240474E26AE47',
     key_source  => 'https://zulip.com/dist/keys/zulip.asc',

--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -1,22 +1,12 @@
 class zulip::base {
   include apt
-  $base_packages = [ # Basic requirements for effective operation of a server
+  $base_packages = [ # Accurate time is essential
                      "ntp",
-                     # This is just good practice
-                     "molly-guard",
                      # Dependencies of our API
                      "python-requests",
                      "python-simplejson",
                      # For development/debugging convenience
                      "ipython",
-                     "screen",
-                     "strace",
-                     "vim",
-                     "moreutils",
-                     "emacs23-nox",
-                     "git",
-                     "puppet-el",
-                     "host",
                      ]
   package { $base_packages: ensure => "installed" }
 

--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -10,6 +10,17 @@ class zulip::base {
                      ]
   package { $base_packages: ensure => "installed" }
 
+  $release_name = $operatingsystemrelease ? {
+    # Debian releases
+    /7.[0-9]*/ => 'wheezy',
+    /8.[0-9]*/ => 'jessie',
+    # Ubuntu releases
+    '12.04' => 'precise',
+    '14.04' => 'trusty',
+    '15.04' => 'vivid',
+    '15.10' => 'wily',
+  }
+
   group { 'zulip':
     ensure     => present,
   }

--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -21,6 +21,15 @@ class zulip::base {
     '15.10' => 'wily',
   }
 
+  $postgres_version = $release_name ? {
+    'wheezy'  => '9.1',
+    'jessie'  => '9.4',
+    'precise' => '9.1',
+    'trusty'  => '9.3',
+    'vivid'   => '9.4',
+    'wily'    => '9.4',
+  }
+
   group { 'zulip':
     ensure     => present,
   }

--- a/puppet/zulip/manifests/memcached.pp
+++ b/puppet/zulip/manifests/memcached.pp
@@ -1,0 +1,17 @@
+class zulip::memcached {
+  $memcached_packages = ["memcached"]
+  package { $memcached_packages: ensure => "installed" }
+
+  file { "/etc/memcached.conf":
+    require => Package[memcached],
+    ensure => file,
+    owner  => "root",
+    group  => "root",
+    mode => 644,
+    source => "puppet:///modules/zulip/memcached.conf",
+  }
+  service { 'memcached':
+    ensure     => running,
+    subscribe  => File['/etc/memcached.conf'],
+  }
+}

--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -1,3 +1,4 @@
+# Minimal shared configuration needed to run a Zulip postgres database.
 class zulip::postgres_appdb_base {
   include zulip::postgres_common
   include zulip::supervisor

--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -6,7 +6,7 @@ class zulip::postgres_appdb_base {
   $appdb_packages = [# Needed to run process_fts_updates
                      "python-psycopg2",
                      # Needed for our full text search system
-                     "postgresql-9.3-tsearch-extras",
+                     "postgresql-${zulip::base::postgres_version}-tsearch-extras",
                      ]
   define safepackage ( $ensure = present ) {
     if !defined(Package[$title]) {
@@ -38,16 +38,16 @@ class zulip::postgres_appdb_base {
     notify => Service[supervisor],
   }
 
-  file { '/usr/share/postgresql/9.3/tsearch_data/en_us.dict':
+  file { "/usr/share/postgresql/${zulip::base::postgres_version}/tsearch_data/en_us.dict":
     ensure => 'link',
     target => '/var/cache/postgresql/dicts/en_us.dict',
   }
-  file { '/usr/share/postgresql/9.3/tsearch_data/en_us.affix':
+  file { "/usr/share/postgresql/${zulip::base::postgres_version}/tsearch_data/en_us.affix":
     ensure => 'link',
     target => '/var/cache/postgresql/dicts/en_us.affix',
   }
-  file { "/usr/share/postgresql/9.3/tsearch_data/zulip_english.stop":
-    require => Package["postgresql-9.3"],
+  file { "/usr/share/postgresql/${zulip::base::postgres_version}/tsearch_data/zulip_english.stop":
+    require => Package["postgresql-${zulip::base::postgres_version}"],
     ensure => file,
     owner => "root",
     group => "root",

--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -39,10 +39,12 @@ class zulip::postgres_appdb_base {
   }
 
   file { "/usr/share/postgresql/${zulip::base::postgres_version}/tsearch_data/en_us.dict":
+    require => Package["postgresql-${zulip::base::postgres_version}"],
     ensure => 'link',
     target => '/var/cache/postgresql/dicts/en_us.dict',
   }
   file { "/usr/share/postgresql/${zulip::base::postgres_version}/tsearch_data/en_us.affix":
+    require => Package["postgresql-${zulip::base::postgres_version}"],
     ensure => 'link',
     target => '/var/cache/postgresql/dicts/en_us.affix',
   }

--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -1,4 +1,4 @@
-class zulip::postgres_appdb {
+class zulip::postgres_appdb_base {
   include zulip::postgres_common
   include zulip::supervisor
 

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -1,10 +1,10 @@
-# postgres_appdb extends postgres_appdb_base by automatically
+# postgres_appdb_tuned extends postgres_appdb_base by automatically
 # generating tuned database configuration.
-class zulip::postgres_appdb {
+class zulip::postgres_appdb_tuned {
   include zulip::postgres_appdb_base
 
-  file { '/etc/postgresql/9.3/main/postgresql.conf.template':
-    require => Package["postgresql-9.3"],
+  file { "/etc/postgresql/${zulip::base::postgres_version}/main/postgresql.conf.template":
+    require => Package["postgresql-${zulip::base::postgres_version}"],
     ensure => file,
     owner  => "postgres",
     group  => "postgres",
@@ -41,12 +41,12 @@ vm.dirty_background_ratio = 5
   exec { 'pgtune':
     require => Package["pgtune"],
     # Let Postgres use half the memory on the machine
-    command => "pgtune -T Web -M $half_memory -i /etc/postgresql/9.3/main/postgresql.conf.template -o /etc/postgresql/9.3/main/postgresql.conf",
+    command => "pgtune -T Web -M $half_memory -i /etc/postgresql/${zulip::base::postgres_version}/main/postgresql.conf.template -o /etc/postgresql/${zulip::base::postgres_version}/main/postgresql.conf",
     refreshonly => true,
-    subscribe => File['/etc/postgresql/9.3/main/postgresql.conf.template']
+    subscribe => File["/etc/postgresql/${zulip::base::postgres_version}/main/postgresql.conf.template"]
   }
 
-  exec { 'pg_ctlcluster 9.3 main restart':
+  exec { "pg_ctlcluster ${zulip::base::postgres_version} main restart":
     require => Exec["sysctl_p"],
     refreshonly => true,
     subscribe => [ Exec['pgtune'], File['/etc/sysctl.d/40-postgresql.conf'] ]

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -1,0 +1,55 @@
+# postgres_appdb extends postgres_appdb_base by automatically
+# generating tuned database configuration.
+class zulip::postgres_appdb {
+  include zulip::postgres_appdb_base
+
+  file { '/etc/postgresql/9.3/main/postgresql.conf.template':
+    require => Package["postgresql-9.3"],
+    ensure => file,
+    owner  => "postgres",
+    group  => "postgres",
+    mode   => 644,
+    source => "puppet:///modules/zulip/postgresql/postgresql.conf.template"
+  }
+
+  # We can't use the built-in $memorysize fact because it's a string with human-readable units
+  $total_memory = regsubst(file('/proc/meminfo'), '^.*MemTotal:\s*(\d+) kB.*$', '\1', 'M') * 1024
+  $half_memory = $total_memory / 2
+  $half_memory_pages = $half_memory / 4096
+
+  file {'/etc/sysctl.d/40-postgresql.conf':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => 644,
+    content =>
+"kernel.shmall = $half_memory_pages
+kernel.shmmax = $half_memory
+
+# These are the defaults on newer kernels
+vm.dirty_ratio = 10
+vm.dirty_background_ratio = 5
+"
+    }
+
+  exec { "sysctl_p":
+    command   => "/sbin/sysctl -p /etc/sysctl.d/40-postgresql.conf",
+    subscribe => File['/etc/sysctl.d/40-postgresql.conf'],
+    refreshonly => true,
+  }
+
+  exec { 'pgtune':
+    require => Package["pgtune"],
+    # Let Postgres use half the memory on the machine
+    command => "pgtune -T Web -M $half_memory -i /etc/postgresql/9.3/main/postgresql.conf.template -o /etc/postgresql/9.3/main/postgresql.conf",
+    refreshonly => true,
+    subscribe => File['/etc/postgresql/9.3/main/postgresql.conf.template']
+  }
+
+  exec { 'pg_ctlcluster 9.3 main restart':
+    require => Exec["sysctl_p"],
+    refreshonly => true,
+    subscribe => [ Exec['pgtune'], File['/etc/sysctl.d/40-postgresql.conf'] ]
+  }
+
+}

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -9,7 +9,7 @@ class zulip::postgres_appdb_tuned {
     owner  => "postgres",
     group  => "postgres",
     mode   => 644,
-    source => "puppet:///modules/zulip/postgresql/postgresql.conf.template"
+    content => template("zulip/postgresql/postgresql.conf.template.erb"),
   }
 
   # We can't use the built-in $memorysize fact because it's a string with human-readable units

--- a/puppet/zulip/manifests/postgres_common.pp
+++ b/puppet/zulip/manifests/postgres_common.pp
@@ -1,6 +1,6 @@
 class zulip::postgres_common {
   $postgres_packages = [# The database itself
-                        "postgresql-9.3",
+                        "postgresql-${zulip::base::postgres_version}",
                         # tools for database setup
                         "pgtune",
                         # tools for database monitoring

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -1,7 +1,7 @@
 class zulip::voyager {
   include zulip::base
   include zulip::app_frontend
-  include zulip::postgres_appdb
+  include zulip::postgres_appdb_base
   include zulip::redis
 
   apt::source {'zulip':

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -1,18 +1,9 @@
 class zulip::voyager {
+  include zulip::apt_repository
   include zulip::base
   include zulip::app_frontend
   include zulip::postgres_appdb_tuned
   include zulip::redis
-
-  apt::source {'zulip':
-    location    => 'http://ppa.launchpad.net/tabbott/zulip/ubuntu',
-    release     => 'trusty',
-    repos       => 'main',
-    key         => '84C2BE60E50E336456E4749CE84240474E26AE47',
-    key_source  => 'https://zulip.com/dist/keys/zulip.asc',
-    pin         => '995',
-    include_src => true,
-  }
 
   file { "/etc/nginx/sites-available/zulip-enterprise":
     require => Package["nginx-full"],

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -1,7 +1,7 @@
 class zulip::voyager {
   include zulip::apt_repository
   include zulip::base
-  include zulip::app_frontend
+  include zulip::app_frontend_base
   include zulip::postgres_appdb_tuned
   include zulip::redis
 

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -1,3 +1,13 @@
+# This class includes all the modules you need to run an entire Zulip
+# installation on a single server.  If desired, you can split up the
+# different components of a Zulip installation on different servers by
+# using the modules below on different machines (the module list is
+# stored in `puppet_classes` in /etc/zulip/zulip.conf).  In general,
+# every machine should have `zulip::base` and `zulip::apt_repository`
+# included, but the various service modules can be arranged on
+# different machines or the same machine as desired (corresponding
+# configuration in /etc/zulip/settings.py for how to find the various
+# services is also required to make this work).
 class zulip::voyager {
   include zulip::apt_repository
   include zulip::base

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -30,12 +30,6 @@ class zulip::voyager {
     notify => Service["nginx"],
   }
 
-  file { '/home/zulip/prod-static':
-    ensure => 'directory',
-    owner  => 'zulip',
-    group  => 'zulip',
-  }
-
   file { "/etc/cron.d/restart-zulip":
     ensure => file,
     owner  => "root",

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -9,8 +9,9 @@
 # configuration in /etc/zulip/settings.py for how to find the various
 # services is also required to make this work).
 class zulip::voyager {
-  include zulip::apt_repository
   include zulip::base
+  # zulip::apt_repository must come after zulip::base
+  include zulip::apt_repository
   include zulip::app_frontend
   include zulip::postgres_appdb_tuned
   include zulip::memcached

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -1,7 +1,7 @@
 class zulip::voyager {
   include zulip::base
   include zulip::app_frontend
-  include zulip::postgres_appdb_base
+  include zulip::postgres_appdb_tuned
   include zulip::redis
 
   apt::source {'zulip':
@@ -42,54 +42,5 @@ class zulip::voyager {
     group  => "root",
     mode => 644,
     source => "puppet:///modules/zulip/cron.d/restart-zulip",
-  }
-
-  file { '/etc/postgresql/9.3/main/postgresql.conf.template':
-    require => Package["postgresql-9.3"],
-    ensure => file,
-    owner  => "postgres",
-    group  => "postgres",
-    mode   => 644,
-    source => "puppet:///modules/zulip/postgresql/postgresql.conf.template"
-  }
-
-  # We can't use the built-in $memorysize fact because it's a string with human-readable units
-  $total_memory = regsubst(file('/proc/meminfo'), '^.*MemTotal:\s*(\d+) kB.*$', '\1', 'M') * 1024
-  $half_memory = $total_memory / 2
-  $half_memory_pages = $half_memory / 4096
-
-  file {'/etc/sysctl.d/40-postgresql.conf':
-    ensure => file,
-    owner  => 'root',
-    group  => 'root',
-    mode   => 644,
-    content =>
-"kernel.shmall = $half_memory_pages
-kernel.shmmax = $half_memory
-
-# These are the defaults on newer kernels
-vm.dirty_ratio = 10
-vm.dirty_background_ratio = 5
-"
-    }
-
-  exec { "sysctl_p":
-    command   => "/sbin/sysctl -p /etc/sysctl.d/40-postgresql.conf",
-    subscribe => File['/etc/sysctl.d/40-postgresql.conf'],
-    refreshonly => true,
-  }
-
-  exec { 'pgtune':
-    require => Package["pgtune"],
-    # Let Postgres use half the memory on the machine
-    command => "pgtune -T Web -M $half_memory -i /etc/postgresql/9.3/main/postgresql.conf.template -o /etc/postgresql/9.3/main/postgresql.conf",
-    refreshonly => true,
-    subscribe => File['/etc/postgresql/9.3/main/postgresql.conf.template']
-  }
-
-  exec { 'pg_ctlcluster 9.3 main restart':
-    require => Exec["sysctl_p"],
-    refreshonly => true,
-    subscribe => [ Exec['pgtune'], File['/etc/sysctl.d/40-postgresql.conf'] ]
   }
 }

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -1,33 +1,9 @@
 class zulip::voyager {
   include zulip::apt_repository
   include zulip::base
-  include zulip::app_frontend_base
+  include zulip::app_frontend
   include zulip::postgres_appdb_tuned
   include zulip::memcached
   include zulip::rabbit
   include zulip::redis
-
-  file { "/etc/nginx/sites-available/zulip-enterprise":
-    require => Package["nginx-full"],
-    ensure => file,
-    owner  => "root",
-    group  => "root",
-    mode => 644,
-    source => "puppet:///modules/zulip/nginx/sites-available/zulip-enterprise",
-    notify => Service["nginx"],
-  }
-  file { '/etc/nginx/sites-enabled/zulip-enterprise':
-    require => Package["nginx-full"],
-    ensure => 'link',
-    target => '/etc/nginx/sites-available/zulip-enterprise',
-    notify => Service["nginx"],
-  }
-
-  file { "/etc/cron.d/restart-zulip":
-    ensure => file,
-    owner  => "root",
-    group  => "root",
-    mode => 644,
-    source => "puppet:///modules/zulip/cron.d/restart-zulip",
-  }
 }

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -3,6 +3,8 @@ class zulip::voyager {
   include zulip::base
   include zulip::app_frontend_base
   include zulip::postgres_appdb_tuned
+  include zulip::memcached
+  include zulip::rabbit
   include zulip::redis
 
   file { "/etc/nginx/sites-available/zulip-enterprise":

--- a/puppet/zulip/templates/postgresql/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/postgresql.conf.template.erb
@@ -38,15 +38,15 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/9.3/main'		# use data in another directory
+data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/9.3/main/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/9.3/main/pg_ident.conf'	# ident configuration file
+ident_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/9.3-main.pid'		# write an extra PID file
+external_pid_file = '/var/run/postgresql/<%= scope["zulip::base::postgres_version"] %>-main.pid'		# write an extra PID file
 					# (change requires restart)
 
 

--- a/puppet/zulip_internal/manifests/app_frontend.pp
+++ b/puppet/zulip_internal/manifests/app_frontend.pp
@@ -1,5 +1,7 @@
 class zulip_internal::app_frontend {
   include zulip::app_frontend_base
+  include zulip::memcached
+  include zulip::rabbit
   include zulip::postfix_localmail
   $app_packages = [# Needed for minify-js
                    "yui-compressor",

--- a/puppet/zulip_internal/manifests/app_frontend.pp
+++ b/puppet/zulip_internal/manifests/app_frontend.pp
@@ -1,5 +1,5 @@
 class zulip_internal::app_frontend {
-  include zulip::app_frontend
+  include zulip::app_frontend_base
   include zulip::postfix_localmail
   $app_packages = [# Needed for minify-js
                    "yui-compressor",

--- a/puppet/zulip_internal/manifests/base.pp
+++ b/puppet/zulip_internal/manifests/base.pp
@@ -14,6 +14,18 @@ class zulip_internal::base {
                         "debian-goodies",
                         # For our EC2 network setup script
                         "python-netifaces",
+                        # Popular editors
+                        "vim",
+                        "emacs23-nox",
+                        "puppet-el",
+                        # Prevent accidental reboots
+                        "molly-guard",
+                        # Useful tools in a production environment
+                        "screen",
+                        "strace",
+                        "moreutils",
+                        "host",
+                        "git",
                          ]
   package { $org_base_packages: ensure => "installed" }
 

--- a/puppet/zulip_internal/manifests/postgres_appdb.pp
+++ b/puppet/zulip_internal/manifests/postgres_appdb.pp
@@ -1,6 +1,6 @@
 class zulip_internal::postgres_appdb {
   include zulip_internal::postgres_common
-  include zulip::postgres_appdb
+  include zulip::postgres_appdb_base
 
   file { "/etc/postgresql/9.1/main/pg_hba.conf":
     require => Package["postgresql-9.1"],


### PR DESCRIPTION
This branch implements 2 major things:
* The puppet piece of making it easy to install different submodules of Zulip on different servers.
* Adding variables for the postgres and Linux versions to make the puppet configuration support non-Trusty platforms without hackery.  This should help a lot as it's a key step required for #79, #42, #43, and #41.  

I've tested that it runs happily on an Ubuntu Vivid test machine (except for the fact that there's no `pgtune`) and our CI will hopefully confirm that it also still works on Ubuntu trusty.  

Before merging I'll also want to confirm that this branch has no effect on a happily configured Ubuntu trusty machine.