### PR TITLE
travis: Cache the phantomjs package downloads between builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 before_install:
-   - nvm install 0.10 
+   - nvm install 0.10
 install:
   - tools/travis/setup-$TEST_SUITE
 cache:
   - apt: false
+  - directories:
+    - /srv/phantomjs
 env:
   - TEST_SUITE=frontend
   - TEST_SUITE=backend

--- a/provision.py
+++ b/provision.py
@@ -113,8 +113,9 @@ def main():
         PHANTOMJS_PATH = "/srv/phantomjs"
         PHANTOMJS_TARBALL = os.path.join(PHANTOMJS_PATH, "phantomjs-1.9.8-linux-x86_64.tar.bz2")
         sh.mkdir("-p", PHANTOMJS_PATH, **LOUD)
-        sh.wget("https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2",
-                output_document=PHANTOMJS_TARBALL, **LOUD)
+        if not os.path.exists(PHANTOMJS_TARBALL):
+            sh.wget("https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2",
+                    output_document=PHANTOMJS_TARBALL, **LOUD)
         sh.tar("xj", directory=PHANTOMJS_PATH, file=PHANTOMJS_TARBALL, **LOUD)
         sh.ln("-sf", os.path.join(PHANTOMJS_PATH, "phantomjs-1.9.8-linux-x86_64", "bin", "phantomjs"),
               "/usr/local/bin/phantomjs", **LOUD)


### PR DESCRIPTION
This should hopefully fix the issue we've been seeing with
bitbucket.org rejecting connections from Travis CI by not needing to
connect to them.