### PR TITLE
Initialize new_message_count to 0 by default.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -135,7 +135,7 @@ if (window.bridge !== undefined) {
     window.bridge.updateCount(0);
 }
 
-var new_message_count;
+var new_message_count = 0;
 
 exports.update_title_count = function (count) {
     new_message_count = count;


### PR DESCRIPTION
860cf6871611bf0d4d4818f32d1f4835236d5c4d introduced calls to
notifications.redraw_title() on narrow activation.  This introduced a
bug when the Zulip desktop app reloads while narrowed --
new_message_count would still be set to undefined when
narrow.activate() is called as the page (re)loads, and thus we'd call
window.bridge.updateCount(undefined), resulting in a traceback.

We fix this by just initializing it to 0, rather than using the old
default value of undefined.