### PR TITLE
Setting for rabbitmq server address

### DIFF
--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -37,7 +37,7 @@ class SimpleQueueClient(object):
         self._connect()
 
     def _get_parameters(self):
-        return pika.ConnectionParameters('localhost',
+        return pika.ConnectionParameters(settings.RABBITMQ_HOST,
             credentials = pika.PlainCredentials(
                 settings.RABBITMQ_USERNAME, settings.RABBITMQ_PASSWORD))
 
@@ -259,4 +259,3 @@ def queue_json_publish(queue_name, event, processor):
             get_queue_client().json_publish(queue_name, event)
         else:
             processor(event)
-

--- a/zproject/local_settings_template.py
+++ b/zproject/local_settings_template.py
@@ -298,3 +298,8 @@ AUTH_LDAP_USER_ATTR_MAP = {
 }
 
 CAMO_URI = ''
+
+# By default, Zulip connects to rabbitmq running locally on the machine,
+# but Zulip also supports connecting to RabbitMQ over the network;
+# to use a remote RabbitMQ instance, set RABBITMQ_HOST here.
+# RABBITMQ_HOST = "localhost"

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -126,6 +126,7 @@ DEFAULT_SETTINGS = {'TWITTER_CONSUMER_KEY': '',
                     'JWT_AUTH_KEYS': {},
                     'NAME_CHANGES_DISABLED': False,
                     'DEPLOYMENT_ROLE_NAME': "",
+                    'RABBITMQ_HOST': 'localhost',
                     # The following bots only exist in non-VOYAGER installs
                     'ERROR_BOT': None,
                     'NEW_USER_BOT': None,
@@ -327,6 +328,7 @@ elif REMOTE_POSTGRES_HOST != '':
 ########################################################################
 
 USING_RABBITMQ = True
+# RABBITMQ_HOST default is 'localhost'
 RABBITMQ_USERNAME = 'zulip'
 RABBITMQ_PASSWORD = get_secret("rabbitmq_password")
 


### PR DESCRIPTION
Added setting for rabbitmq server address.
The "default" is `localhost`.
The variable name is `RABBITMQ_HOST`.