### PR TITLE
Make the nginx log directory owned by zulip

### DIFF
--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -39,6 +39,13 @@ class zulip::nginx {
     ensure => absent,
   }
 
+  file { '/var/log/nginx':
+    ensure     => "directory",
+    owner      => "zulip",
+    group      => "adm",
+    mode       => 650
+  }
+
   service { 'nginx':
     ensure     => running,
   }


### PR DESCRIPTION
This is required to make log2zulip not error out when reading the nginx
error.log.