### PR TITLE
Vagrantfile: Don't error on platforms where `lxc-ls` doesn't exist.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,11 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
+def command?(name)
+  `which #{name}`
+  $?.success?
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # For LXC. VirtualBox hosts use a different box, described below.
@@ -15,11 +20,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Specify LXC provider before VirtualBox provider so it's preferred.
   config.vm.provider "lxc" do |lxc|
-    LXC_VERSION = `lxc-ls --version`.strip unless defined? LXC_VERSION
-    if LXC_VERSION >= "1.1.0"
-      # Allow start without AppArmor, otherwise Box will not Start on Ubuntu 14.10
-      # see https://github.com/fgrehm/vagrant-lxc/issues/333
-      lxc.customize 'aa_allow_incomplete', 1
+    if command? "lxc-ls"
+      LXC_VERSION = `lxc-ls --version`.strip unless defined? LXC_VERSION
+      if LXC_VERSION >= "1.1.0"
+        # Allow start without AppArmor, otherwise Box will not Start on Ubuntu 14.10
+        # see https://github.com/fgrehm/vagrant-lxc/issues/333
+        lxc.customize 'aa_allow_incomplete', 1
+      end
     end
   end
 


### PR DESCRIPTION
Apparently vagrant executes the configuration code for all providers,
not just the one that's actually selected.

Fixes #461.