### PR TITLE
Correct shell quoting around $DEFAULT_USER in terminate-psql-sessions

### DIFF
--- a/scripts/setup/terminate-psql-sessions
+++ b/scripts/setup/terminate-psql-sessions
@@ -30,7 +30,7 @@ else
 fi
 
 if [ "$EUID" -eq 0 ]; then
-    sudo -u "$DEFAULT_USER" sh -c 'psql postgres "$DEFAULT_USER"' <<EOF
+    sudo -u "$DEFAULT_USER" sh -c "psql postgres '$DEFAULT_USER'" <<EOF
 SELECT pg_terminate_backend($pidname) FROM pg_stat_activity WHERE datname IN ($tables);
 EOF
 else


### PR DESCRIPTION
Previously, we used shell quoting that would result in the shell variable not being substituted. Instead, we use `"`s that will allow for variable substitution.
