### PR TITLE
Add missing wget dependency to provision.py

### DIFF
--- a/provision.py
+++ b/provision.py
@@ -36,6 +36,8 @@ APT_DEPENDENCIES = {
         "git",
         "npm",
         "yui-compressor",
+        "wget",
+        "ca-certificates",      # Explicit dependency in case e.g. wget is already installed
         "puppet",               # Used by lint-all
         "gettext",              # Used by makemessages i18n
     ]


### PR DESCRIPTION
We also explicitly include `ca-certificates`, as it is needed for the install
to complete. Usually this is brought in as a `Recommends` of `wget`, but some
systems may not automatically include such dependencies.

Fixes #470.