### PR TITLE
Tweak GH Notification to display committer e-mails?

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -17,6 +17,11 @@ $(function () {
         <div class="register-form">
             <p class="lead">
               <div class="register-page-header">{% trans "Let's get started" %}…</div>
+                <p>Before joining, please read and make sure you can follow the
+                  <a href="http://wiki.hl7.org/index.php?title=Chat.fhir.org_community_expectations">chat.fhir.org community expectations</a>.
+                </p>
+              </p>
+
             </p>
             <form class="form-inline" id="send_confirm" name="email_form"
                   action="{{ current_url }}" method="post">

--- a/zerver/views/webhooks.py
+++ b/zerver/views/webhooks.py
@@ -1015,6 +1015,8 @@ def api_travis_webhook(request, user_profile, stream=REQ(default='travis'), topi
 
     good_status = ['Passed', 'Fixed']
     bad_status  = ['Failed', 'Broken', 'Still Failing']
+    svn_rev = ''.join(re.findall('@\d+', s))
+
     emoji = ''
     if message_type in good_status:
         emoji = ':thumbsup:'
@@ -1026,11 +1028,12 @@ def api_travis_webhook(request, user_profile, stream=REQ(default='travis'), topi
     build_url = message['build_url']
 
     template = (
+        u'Revision: %s\n'
         u'Author: %s\n'
         u'Build status: %s %s\n'
         u'Details: [changes](%s), [build log](%s)')
 
-    body = template % (author, message_type, emoji, changes, build_url)
+    body = template % (svn_rev, author, message_type, emoji, changes, build_url)
 
     check_send_message(user_profile, get_client('ZulipTravisWebhook'), 'stream', [stream], topic, body)
     return json_success()

--- a/zerver/views/webhooks.py
+++ b/zerver/views/webhooks.py
@@ -229,6 +229,10 @@ def build_commit_list_content(commits, branch, compare_url, pusher):
     for commit in truncated_commits:
         short_id = commit['id'][:7]
         (short_commit_msg, _, _) = commit['message'].partition("\n")
+        svn_rev = re.search('@\d+', commit['message'])
+        svn_rev = svn_rev and svn_rev.group() or ''
+        short_id += svn_rev
+
         content += "* [%s](%s): %s\n" % (short_id, commit['url'],
                                          short_commit_msg)
     if (num_commits > max_commits):

--- a/zerver/views/webhooks.py
+++ b/zerver/views/webhooks.py
@@ -112,7 +112,7 @@ def api_github_v2(user_profile, event, payload, branches, default_stream, commit
                                                      payload['ref'], payload['commits'],
                                                      payload['before'], payload['after'],
                                                      payload['compare'],
-                                                     payload['pusher']['name'],
+                                                     payload['head_commit']['committer']['email'],
                                                      forced=payload['forced'],
                                                      created=payload['created'])
     elif event == 'commit_comment':

--- a/zerver/views/webhooks.py
+++ b/zerver/views/webhooks.py
@@ -1019,7 +1019,7 @@ def api_travis_webhook(request, user_profile, stream=REQ(default='travis'), topi
 
     good_status = ['Passed', 'Fixed']
     bad_status  = ['Failed', 'Broken', 'Still Failing']
-    svn_rev = ''.join(re.findall('@\d+', s))
+    svn_rev = ''.join(re.findall('@\d+', message['message']))
 
     emoji = ''
     if message_type in good_status:


### PR DESCRIPTION
I don't know if this is a common issue or not, but we've got a git repo that's mirrored from SVN. So all commits are _pushed_ by a common "sync-svn-to-git" user, even though they're _committed_ by real community members. It makes more sense for us to display the committer e-mails, rather than pusher names. 

I'd be happy to generalize if we think there's some common notification logic that would be broadly useful. 
