### PR TITLE
Don't hide the streams gear

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -321,12 +321,6 @@ a:hover code {
     display: inline;
 }
 
-
-#streams_list:hover #streams_inline_cog {
-   visibility: visible;
-   opacity: 0.5;
-}
-
 #streams_list #streams_inline_cog:hover {
    opacity: 1.0;
 }
@@ -335,9 +329,9 @@ a:hover code {
     float: right;
     color: #000;
     text-decoration: none;
-    visibility: hidden;
     font-size: 13px;
     margin-top: 3px;
+    opacity: 0.5;
 }
 
 .tooltip {


### PR DESCRIPTION
Hiding this gear makes it impossible to use on mobile (where there's no hover), and makes it hard to discover on desktop. (That is, you have to basically know it's there before you can discover it.) Users at chat.fhir.org has had trouble with this during onboarding.