### PR TITLE
Clear user filter after pressing enter. Fixes #360

### DIFF
--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -471,6 +471,8 @@ function maybe_select_person (e) {
             compose.start('private',
                     {trigger: 'sidebar enter key', "private_message_recipient": topPerson});
         }
+        // Clear the user filter
+        $('.user-list-filter').val();
     }
 }
 


### PR DESCRIPTION
As discussed in #360 , the input box is cleared after pressing enter.