### PR TITLE
Fixed markdown links in README and README.dev

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -308,7 +308,7 @@ Now you're going to install Zulip dependencies in the image:
 
 ```
 docker run -itv $(pwd):/srv/zulip -p 80:9991 user/zulipdev /bin/bash
-$ /usr/bin/python /srv/zulip/provision.py --docker 
+$ /usr/bin/python /srv/zulip/provision.py --docker
 docker ps -af ancestor=user/zulipdev
 docker commit -m "Zulip installed" <container id> user/zulipdev:v2
 ```
@@ -447,4 +447,4 @@ Possible testing issues
   `do-destroy-rebuild*-database` scripts.
 
 - When building the development environment using Vagrant and the LXC provider, if you encounter permissions errors, you may need to `chown -R 1000:$(whoami) /path/to/zulip` on the host before running `vagrant up` in order to ensure that the synced directory has the correct owner during provision. This issue will arise if you run `id username` on the host where `username` is the user running Vagrant and the output is anything but 1000.
-  This seems to be caused by Vagrant behavior; more information can be found here https://github.com/fgrehm/vagrant-lxc/wiki/FAQ#help-my-shared-folders-have-the-wrong-owner
+  This seems to be caused by Vagrant behavior; more information can be found [here](https://github.com/fgrehm/vagrant-lxc/wiki/FAQ#help-my-shared-folders-have-the-wrong-owner).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ guidelines](http://zulip.readthedocs.org/en/latest/code-style.html#commit-messag
 * **Testing**. The Zulip automated tests all run automatically when
 you submit a pull request, but you can also run them all in your
 development environment following the instructions in the [testing
-section](https://github.com/zulip/zulip#running-the-test-suite) below.
+section](https://zulip.readthedocs.org/en/latest/testing.html).
 
 * **Developer Documentation**.  Zulip has a growing collection of
 developer documentation on [Read The Docs](https://zulip.readthedocs.org/).


### PR DESCRIPTION
The testing section was referring to old link in `README.md` itself. I have changed it to *Read the Docs* link. 

I have left the typo in README.dev.md which is fixed by #492. So I may have to rebase once that is merged.