### PR TITLE
Fix clear user filter after pressing enter in search box

### DIFF
--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -471,6 +471,8 @@ function maybe_select_person (e) {
             compose.start('private',
                     {trigger: 'sidebar enter key', "private_message_recipient": topPerson});
         }
+        // clear current search box text
+        $('.user-list-filter').val('');
     }
 }
 


### PR DESCRIPTION
This targets the Bug #360 .
Worked on this regarding GSOC`16 for writing an electron based desktop app