### PR TITLE
subscription button in notification bot fixed #456

### DIFF
--- a/static/js/custom_markdown.js
+++ b/static/js/custom_markdown.js
@@ -11,7 +11,7 @@ var exports = {};
 
     function add_sub(stream_name, $status_message) {
         channel.post({
-            url: '/users/me/subscriptions',
+            url: '/json/users/me/subscriptions',
             data: {
                 subscriptions: JSON.stringify([{'name': stream_name}])
             }


### PR DESCRIPTION
Fixes  [#456](https://github.com/zulip/zulip/issues/456)
On clicking subscribe button in notification bot, button was sending post request to incorrect url.