### PR TITLE
Support "file:///" as hyperlink

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -634,6 +634,7 @@ def sanitize_url(url):
     except ValueError:
         # Bad url - so bad it couldn't be parsed.
         return ''
+
     # If there is no scheme or netloc and there is a '@' in the path,
     # treat it as a mailto: and set the appropriate scheme
     if scheme == '' and netloc == '' and '@' in path:

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -634,7 +634,6 @@ def sanitize_url(url):
     except ValueError:
         # Bad url - so bad it couldn't be parsed.
         return ''
-
     # If there is no scheme or netloc and there is a '@' in the path,
     # treat it as a mailto: and set the appropriate scheme
     if scheme == '' and netloc == '' and '@' in path:
@@ -651,7 +650,7 @@ def sanitize_url(url):
     if not scheme:
         return sanitize_url('http://' + url)
 
-    locless_schemes = ['mailto', 'news']
+    locless_schemes = ['mailto', 'news', 'file']
     if netloc == '' and scheme not in locless_schemes:
         # This fails regardless of anything else.
         # Return immediately to save additional proccessing
@@ -661,7 +660,7 @@ def sanitize_url(url):
     # appears to have a netloc.  Additionally there are plenty of other
     # schemes that do weird things like launch external programs.  To be
     # on the safe side, we whitelist the scheme.
-    if scheme not in ('http', 'https', 'ftp', 'mailto'):
+    if scheme not in ('http', 'https', 'ftp', 'mailto', 'file'):
         return None
 
     # Upstream code scans path, parameters, and query for colon characters
@@ -940,12 +939,13 @@ class Bugdown(markdown.Extension):
                     %s           # zero-to-6 sets of paired parens
                 )?)              # Path is optional
                 | (?:[\w.-]+\@[\w.-]+\.[\w]+) # Email is separate, since it can't have a path
+                %s
             )
             (?=                            # URL must be followed by (not included in group)
                 [!:;\?\),\.\'\"\>]*         # Optional punctuation characters
                 (?:\Z|\s)                  # followed by whitespace or end of string
             )
-            """ % (tlds, nested_paren_chunk)
+            """ % (tlds, nested_paren_chunk, r"| (?:file://(/[^/ ]*)+/?)" if settings.ENABLE_FILE_LINKS else r"")
         md.inlinePatterns.add('autolink', AutoLink(link_regex), '>link')
 
         md.preprocessors.add('hanging_ulists',

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -940,7 +940,7 @@ class Bugdown(markdown.Extension):
                     %s           # zero-to-6 sets of paired parens
                 )?)              # Path is optional
                 | (?:[\w.-]+\@[\w.-]+\.[\w]+) # Email is separate, since it can't have a path
-                %s
+                %s               # File path start with file:///, enable by setting ENABLE_FILE_LINKS=True
             )
             (?=                            # URL must be followed by (not included in group)
                 [!:;\?\),\.\'\"\>]*         # Optional punctuation characters

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -999,7 +999,7 @@ class Message(models.Model):
 
     @staticmethod
     def content_has_link(content):
-        return 'http://' in content or 'https://' in content or '/user_uploads' in content
+        return 'http://' in content or 'https://' in content or '/user_uploads' in content or 'file:///' in content
 
     def update_calculated_fields(self):
         # TODO: rendered_content could also be considered a calculated field

--- a/zerver/test_bugdown.py
+++ b/zerver/test_bugdown.py
@@ -175,6 +175,11 @@ class BugdownTest(TestCase):
             converted = bugdown_convert(inline_url)
             self.assertEqual(match, converted)
 
+    def test_inline_file(self):
+        msg = 'Check out this file file:///Volumes/myserver/Users/Shared/pi.py'
+        converted = bugdown_convert(msg)
+        self.assertEqual(converted, '<p>Check out this file <a href="file:///Volumes/myserver/Users/Shared/pi.py" target="_blank" title="file:///Volumes/myserver/Users/Shared/pi.py">file:///Volumes/myserver/Users/Shared/pi.py</a></p>')
+
     def test_inline_youtube(self):
         msg = 'Check out the debate: http://www.youtube.com/watch?v=hx1mjT73xYE'
         converted = bugdown_convert(msg)

--- a/zproject/local_settings_template.py
+++ b/zproject/local_settings_template.py
@@ -112,6 +112,10 @@ ERROR_REPORTING = True
 # a link to an image is referenced in a message.
 INLINE_IMAGE_PREVIEW = True
 
+# Controls whether or not Zulip will parse links starting with
+# "file:///" as a hyperlink.
+ENABLE_FILE_LINKS = False
+
 # By default, files uploaded by users and user avatars are stored
 # directly on the Zulip server.  If file storage in Amazon S3 is
 # desired, you can configure that as follows:

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -159,6 +159,7 @@ DEFAULT_SETTINGS = {'TWITTER_CONSUMER_KEY': '',
                     'REMOTE_POSTGRES_SSLMODE': '',
                     'GOOGLE_CLIENT_ID': '',
                     'DBX_APNS_CERT_FILE': None,
+                    'ENABLE_FILE_LINKS' : False,
                     }
 
 for setting_name, setting_val in DEFAULT_SETTINGS.iteritems():

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -51,6 +51,9 @@ CACHES['database'] = {
     }
 }
 
+# Enable file:/// hyperlink for test
+ENABLE_FILE_LINKS = True
+
 LOGGING['loggers']['zulip.requests']['level'] = 'CRITICAL'
 LOGGING['loggers']['zulip.management']['level'] = 'CRITICAL'
 


### PR DESCRIPTION
fixed #380

Add the support of `file:///` as hyperlink. It is default to be off.
Enable by setting `ENABLE_FILE_LINKS = True` in `zproject/settings.py` 
Notice that the browser will block the link start with `file:///` and need to install extension to fix it.
