### PR TITLE
Auto-load commonly used modules in manage.py shell.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -9,6 +9,7 @@ if __name__ == "__main__":
         from django.core.management.base import CommandError
         raise CommandError("manage.py should not be run as root.")
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "zproject.settings")
+    os.environ.setdefault("PYTHONSTARTUP", os.path.join(os.path.dirname(__file__), "scripts/lib/pythonrc.py"))
 
     from django.conf import settings
 

--- a/scripts/lib/pythonrc.py
+++ b/scripts/lib/pythonrc.py
@@ -1,0 +1,11 @@
+from __future__ import print_function
+try:
+    from django.conf import settings
+    from zerver.models import *
+    from zerver.lib.actions import *
+except Exception:
+    import traceback
+    print("\nException importing Zulip core modules on startup!")
+    traceback.print_exc()
+else:
+    print("\nSuccessfully imported Zulip settings, models, and actions functions.")

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -107,6 +107,8 @@ def check_pyflakes():
                      'redefinition of unused' in ln or
                      ("zerver/models.py" in ln and
                       " undefined name 'bugdown'" in ln) or
+                     ("scripts/lib/pythonrc.py" in ln and
+                      " import *' used; unable to detect undefined names" in ln) or
                      ("zerver/lib/tornado_ioloop_logging.py" in ln and
                       "redefinition of function 'instrument_tornado_ioloop'" in ln) or
                      ("zephyr_mirror_backend.py:" in ln and


### PR DESCRIPTION
This automatically loads settings, zerver.models.* and
zerver.lib.actions.* when you start `manage.py shell`, which should
save a bit of time basically every time someone uses it.

Fixes #275.

