### PR TITLE
Custom realm filters

### DIFF
--- a/frontend_tests/casper_tests/11-admin.js
+++ b/frontend_tests/casper_tests/11-admin.js
@@ -91,6 +91,41 @@ casper.waitWhileSelector('.emoji_row', function () {
     casper.test.assertDoesntExist('.emoji_row');
 });
 
+// Test custom realm filters
+casper.waitForSelector('.admin-filter-form', function () {
+    casper.fill('form.admin-filter-form', {
+        'pattern': '#(?P<id>[0-9]+)',
+        'url_format_string': 'https://trac.zulip.net/ticket/%(id)s'
+    });
+    casper.click('form.admin-filter-form input.btn');
+});
+
+casper.waitUntilVisible('div#admin-filter-status', function () {
+    casper.test.assertSelectorHasText('div#admin-filter-status', 'Custom filter added!');
+});
+
+casper.waitForSelector('.filter_row', function () {
+    casper.test.assertSelectorHasText('.filter_row span.filter_pattern', '#(?P<id>[0-9]+)');
+    casper.test.assertSelectorHasText('.filter_row span.filter_url_format_string', 'https://trac.zulip.net/ticket/%(id)s');
+    casper.click('.filter_row button');
+});
+
+casper.waitWhileSelector('.filter_row', function () {
+    casper.test.assertDoesntExist('.filter_row');
+});
+
+casper.waitForSelector('.admin-filter-form', function () {
+    casper.fill('form.admin-filter-form', {
+        'pattern': 'a',
+        'url_format_string': 'https://trac.zulip.net/ticket/%(id)s'
+    });
+    casper.click('form.admin-filter-form input.btn');
+});
+
+casper.waitUntilVisible('div#admin-filter-pattern-status', function () {
+    casper.test.assertSelectorHasText('div#admin-filter-pattern-status', 'Failed: Filter pattern cannot start with `a`, use one of the valid prefixes: #');
+});
+
 // TODO: Test stream deletion
 
 common.then_log_out();

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -752,6 +752,29 @@ function render(template_name, args) {
     assert.equal(emoji_url.attr('src'), 'http://emojipedia-us.s3.amazonaws.com/cache/46/7f/467fe69069c408e07517621f263ea9b5.png');
 }());
 
+(function admin_filter_list() {
+    global.use_template('admin_filter_list');
+    var args = {
+        filter: {
+            "pattern": "#(?P<id>[0-9]+)",
+            "url_format_string": "https://trac.humbughq.com/ticket/%(id)s"
+        }
+    };
+
+    var html = '';
+    html += '<tbody id="admin_filters_table">';
+    html += render('admin_filter_list', args);
+    html += '</tbody>';
+
+    global.write_test_output('admin_filter_list.handlebars', html);
+
+    var filter_pattern = $(html).find('tr.filter_row:first span.filter_pattern');
+    var filter_format = $(html).find('tr.filter_row:first span.filter_url_format_string');
+
+    assert.equal(filter_pattern.text(), '#(?P<id>[0-9]+)');
+    assert.equal(filter_format.text(), 'https://trac.humbughq.com/ticket/%(id)s');
+}());
+
 // By the end of this test, we should have compiled all our templates.  Ideally,
 // we will also have exercised them to some degree, but that's a little trickier
 // to enforce.

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -84,6 +84,25 @@ exports.populate_emoji = function (emoji_data) {
     loading.destroy_indicator($('#admin_page_emoji_loading_indicator'));
 };
 
+exports.populate_filters = function (filters_data) {
+    var filters_table = $("#admin_filters_table").expectOne();
+    filters_table.find("tr.filter_row").remove();
+    _.each(filters_data, function (filter) {
+        filters_table.append(
+            templates.render(
+                "admin_filter_list", {
+                    filter: {
+                        pattern: filter[0],
+                        url_format_string: filter[1],
+                        id: filter[2]
+                    }
+                }
+            )
+        );
+    });
+    loading.destroy_indicator($('#admin_page_filters_loading_indicator'));
+};
+
 exports.setup_page = function () {
     var options = {
         realm_name:                 page_params.realm_name,
@@ -102,6 +121,10 @@ exports.setup_page = function () {
     $("#admin-emoji-status").expectOne().hide();
     $("#admin-emoji-name-status").expectOne().hide();
     $("#admin-emoji-url-status").expectOne().hide();
+    $("#admin-filter-status").expectOne().hide();
+    $("#admin-filter-pattern-status").expectOne().hide();
+    $("#admin-filter-format-status").expectOne().hide();
+
 
     // create loading indicators
     loading.make_indicator($('#admin_page_users_loading_indicator'));
@@ -109,6 +132,7 @@ exports.setup_page = function () {
     loading.make_indicator($('#admin_page_streams_loading_indicator'));
     loading.make_indicator($('#admin_page_deactivated_users_loading_indicator'));
     loading.make_indicator($('#admin_page_emoji_loading_indicator'));
+    loading.make_indicator($('#admin_page_filters_loading_indicator'));
 
     // Populate users and bots tables
     channel.get({
@@ -130,6 +154,9 @@ exports.setup_page = function () {
 
     // Populate emoji table
     exports.populate_emoji(page_params.realm_emoji);
+
+    // Populate filters table
+    exports.populate_filters(page_params.realm_filters);
 
     // Setup click handlers
     $(".admin_user_table").on("click", ".deactivate", function (e) {
@@ -489,6 +516,65 @@ exports.setup_page = function () {
         });
     });
 
+    $('.admin_filters_table').on('click', '.delete', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var btn = $(this);
+
+        channel.del({
+            url: '/json/realm/filters/' + encodeURIComponent(btn.attr('data-filter-id')),
+            error: function (xhr, error_type) {
+                if (xhr.status.toString().charAt(0) === "4") {
+                    btn.closest("td").html(
+                        $("<p>").addClass("text-error").text($.parseJSON(xhr.responseText).msg)
+                    );
+                } else {
+                     btn.text("Failed!");
+                }
+            },
+            success: function () {
+                var row = btn.parents('tr');
+                row.remove();
+            }
+        });
+    });
+
+    $(".administration").on("submit", "form.admin-filter-form", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var filter_status = $('#admin-filter-status');
+        var pattern_status = $('#admin-filter-pattern-status');
+        var format_status = $('#admin-filter-format-status');
+        filter_status.hide();
+        pattern_status.hide();
+        format_status.hide();
+        var filter = {};
+        $(this).serializeArray().map(function (x){filter[x.name] = x.value;});
+
+        channel.put({
+            url: "/json/realm/filters",
+            data: $(this).serialize(),
+            success: function (data) {
+                filter.id = data.id;
+                ui.report_success("Custom filter added!", filter_status);
+            },
+            error: function (xhr, error) {
+                var errors = $.parseJSON(xhr.responseText).msg;
+                if (errors.pattern !== undefined) {
+                    xhr.responseText = JSON.stringify({msg: errors.pattern});
+                    ui.report_error("Failed", xhr, pattern_status);
+                }
+                if (errors.url_format_string !== undefined) {
+                    xhr.responseText = JSON.stringify({msg: errors.url_format_string});
+                    ui.report_error("Failed", xhr, format_status);
+                }
+                if (errors.__all__ !== undefined) {
+                    xhr.responseText = JSON.stringify({msg: errors.__all__});
+                    ui.report_error("Failed", xhr, filter_status);
+                }
+            }
+        });
+    });
 };
 
 return exports;

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -184,6 +184,7 @@ function get_events_success(events) {
         case 'realm_filters':
             page_params.realm_filters = event.realm_filters;
             echo.set_realm_filters(page_params.realm_filters);
+            admin.populate_filters(event.realm_filters);
             break;
         case 'update_global_notifications':
             notifications.handle_global_notification_updates(event.notification_name,

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -3221,7 +3221,8 @@ div.edit_bot {
 
 .edit_bot_form .control-label,
 #create_bot_form .control-label,
-.admin-emoji-form .control-label {
+.admin-emoji-form .control-label,
+.admin-filter-form .control-label {
     width: 10em;
     text-align: right;
     margin-right: 20px;
@@ -3382,12 +3383,14 @@ div.edit_bot {
 #administration .settings-section .admin-realm-form,
 #settings .settings-section .new-bot-form,
 #emoji-settings .new-emoji-form,
+#filter-settings .new-filter-form,
 #settings .settings-section .edit-bot-form-box {
     margin-top: 35px;
 }
 
 #settings .settings-section .new-bot-section-title,
-#emoji-settings .new-emoji-section-title {
+#emoji-settings .new-emoji-section-title,
+#filter-settings .new-filter-section-title {
     top: 20px;
     left: 20px;
 }
@@ -3401,6 +3404,7 @@ div.edit_bot {
 #settings .settings-section .account-settings-form .control-label,
 #settings .settings-section .new-bot-form .control-label,
 #emoji-settings .new-emoji-form .control-label,
+#filter-settings .new-filter-form .control-label,
 #settings .settings-section .edit-bot-form-box .control-label {
     width: 120px;
 }
@@ -3408,6 +3412,7 @@ div.edit_bot {
 #settings .settings-section .account-settings-form .controls,
 #settings .settings-section .new-bot-form .controls,
 #emoji-settings .new-emoji-form .controls,
+#filter-settings .new-filter-form .controls,
 #settings .settings-section .edit-bot-form-box .controls  {
     margin-left: 140px;
 }
@@ -3476,7 +3481,8 @@ div.edit_bot {
 
 #settings .bot-information-box,
 #settings .add-new-bot-box,
-#emoji-settings .add-new-emoji-box {
+#emoji-settings .add-new-emoji-box,
+#filter-settings .add-new-filter-box {
     background: #e3e3e3;
     padding: 10px;
     margin-left: 38px;
@@ -3488,7 +3494,8 @@ div.edit_bot {
 }
 
 #settings .add-new-bot-box,
-#emoji-settings .add-new-emoji-box {
+#emoji-settings .add-new-emoji-box,
+#filter-settings .add-new-filter-box {
     background: #cbe3cb;
 }
 
@@ -3539,6 +3546,7 @@ div.edit_bot {
 
 #settings .settings-section .new-bot-form .control-label,
 #emoji-settings .new-emoji-form .control-label,
+#filter-settings .new-filter-form .control-label,
 #settings .settings-section .edit-bot-form-box .control-label {
     float: left;
     width: 120px;
@@ -3547,7 +3555,8 @@ div.edit_bot {
 }
 
 #settings .settings-section .new-bot-form .controls,
-#emoji-settings .new-emoji-form .controls {
+#emoji-settings .new-emoji-form .controls,
+#filter-settings .new-filter-form .controls {
     margin-left: 110px;
 }
 
@@ -3563,6 +3572,7 @@ div.edit_bot {
 #settings .settings-section .account-settings-form,
 #settings .settings-section .new-bot-form,
 #emoji-settings .new-emoji-form,
+#filter-settings .new-filter-form,
 #settings .settings-section .notification-settings-form,
 #settings .settings-section .display-settings-form,
 #settings .settings-section .edit-bot-form-box {
@@ -3573,6 +3583,7 @@ div.edit_bot {
 #settings .settings-section .account-settings-form .control-label,
 #settings .settings-section .new-bot-form .control-label,
 #emoji-settings .new-emoji-form .control-label,
+#filter-settings .new-filter-form .control-label,
 #settings .settings-section .edit-bot-form-box .control-label {
     display: block;
     width: 120px;
@@ -3587,6 +3598,7 @@ div.edit_bot {
 #settings .settings-section .account-settings-form .controls,
 #settings .settings-section .new-bot-form .controls,
 #emoji-settings .new-emoji-form .controls,
+#filter-settings .new-filter-form .controls,
 #settings .settings-section .edit-bot-form-box .controls {
     margin: auto;
     text-align: center;
@@ -3598,15 +3610,18 @@ div.edit_bot {
 #settings .settings-section .account-settings-form .controls input,
 #settings .settings-section .new-bot-form .controls button,
 #emoji-settings .new-emoji-form .controls button,
+#filter-settings .new-filter-form .controls button,
 #settings .settings-section .edit-bot-form-box .controls button,
 #settings .settings-section .new-bot-form .controls input,
 #emoji-settings .new-emoji-form .controls input,
+#filter-settings .new-filter-form .controls input,
 #settings .settings-section .edit-bot-form-box .controls input {
     margin: auto;
 }
 
 #settings .settings-section .new-bot-form,
-#emoji-settings .new-emoji-form {
+#emoji-settings .new-emoji-form,
+#filter-settings .new-filter-form {
     padding: 0px;
     width: 100%;
     text-align: center;
@@ -4233,7 +4248,8 @@ li.show-more-private-messages a {
 
 }
 
-.admin_emoji_table {
+.admin_emoji_table,
+.admin_filters_table {
     margin: 20px auto;
 }
 
@@ -4254,4 +4270,12 @@ li.show-more-private-messages a {
 
 #emoji-settings .new-emoji-form #emoji_url {
     width: 60%;
+}
+
+.admin_filters_table {
+    margin-top: 20px;
+}
+
+#admin-filter-pattern-status, #admin-filter-format-status {
+    margin: 20px 0 0 0;
 }

--- a/static/templates/admin_filter_list.handlebars
+++ b/static/templates/admin_filter_list.handlebars
@@ -1,0 +1,15 @@
+{{#with filter}}
+<tr class="filter_row">
+  <td>
+      <span class="filter_pattern">{{pattern}}</span>
+  </td>
+  <td>
+      <span class="filter_url_format_string">{{url_format_string}}</span>
+  </td>
+  <td>
+      <button class="btn delete btn-danger" data-filter-id="{{id}}">
+        Delete
+      </button>
+  </td>
+</tr>
+{{/with}}

--- a/static/templates/admin_tab.handlebars
+++ b/static/templates/admin_tab.handlebars
@@ -96,6 +96,41 @@
               </div>
             </form>
           </div>
+          <div id="filter-settings" class="settings-section">
+            <div class="settings-section-title"><i class="icon-vector-filter settings-section-icon"></i>Custom realm filters</div>
+            <div class="admin-table-wrapper">
+              <table class="table table-condensed table-striped admin_filters_table">
+                <tbody id="admin_filters_table">
+                  <th>Pattern</th>
+                  <th>URL format</th>
+                  <th>Actions</th>
+                </tbody>
+              </table>
+            </div>
+            <form class="form-horizontal admin-filter-form">
+              <div class="add-new-filter-box">
+                <div class="new-filter-form">
+                  <div class="settings-section-title new-filter-section-title">Add a New Filter</div>
+                  <div class="alert" id="admin-filter-status"></div>
+                  <div class="control-group">
+                    <label for="filter_pattern" class="control-label">Filter pattern</label>
+                    <input type="text" id="filter_pattern" name="pattern" placeholder="#(?P<id>[0-9]+)" />
+                    <div class="alert" id="admin-filter-pattern-status"></div>
+                  </div>
+                  <div class="control-group">
+                    <label for="filter_format_string" class="control-label">URL format</label>
+                    <input type="text" id="filter_format_string" name="url_format_string" placeholder="https://trac.humbughq.com/ticket/%(id)s" />
+                    <div class="alert" id="admin-filter-format-status"></div>
+                  </div>
+                  <div class="control-group">
+                    <div class="controls">
+                      <input type="submit" class="btn btn-big btn-primary" value="Add filter" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
         </div>
         <div role="tabpanel" class="tab-pane" id="users">
           <div id="admin-user-list" class="settings-section">

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2951,12 +2951,20 @@ def notify_realm_filters(realm):
 #   * Named groups will be converted to numbered groups automatically
 #   * Inline-regex flags will be stripped, and where possible translated to RegExp-wide flags
 def do_add_realm_filter(realm, pattern, url_format_string):
-    RealmFilter(realm=realm, pattern=pattern,
-                url_format_string=url_format_string).save()
+    realm_filter = RealmFilter(
+        realm=realm, pattern=pattern,
+        url_format_string=url_format_string)
+    realm_filter.full_clean()
+    realm_filter.save()
     notify_realm_filters(realm)
 
-def do_remove_realm_filter(realm, pattern):
-    RealmFilter.objects.get(realm=realm, pattern=pattern).delete()
+    return realm_filter.id
+
+def do_remove_realm_filter(realm, pattern=None, id=None):
+    if pattern:
+        RealmFilter.objects.get(realm=realm, pattern=pattern).delete()
+    else:
+        RealmFilter.objects.get(realm=realm, pk=id).delete()
     notify_realm_filters(realm)
 
 def get_emails_from_user_ids(user_ids):

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -894,7 +894,7 @@ class Bugdown(markdown.Extension):
         md.inlinePatterns.add('emoji', Emoji(r'(?<!\w)(?P<syntax>:[^:\s]+:)(?!\w)'), '_end')
         md.inlinePatterns.add('link', AtomicLinkPattern(markdown.inlinepatterns.LINK_RE, md), '>backtick')
 
-        for (pattern, format_string) in self.getConfig("realm_filters"):
+        for (pattern, format_string, id) in self.getConfig("realm_filters"):
             md.inlinePatterns.add('realm_filters/%s' % (pattern,),
                                   RealmFilterPattern(pattern, format_string), '>link')
 

--- a/zerver/management/commands/realm_filters.py
+++ b/zerver/management/commands/realm_filters.py
@@ -56,7 +56,7 @@ Example: python2.7 manage.py realm_filters --realm=zulip.com --op=show
             do_add_realm_filter(realm, pattern, url_format_string)
             sys.exit(0)
         elif options["op"] == "remove":
-            do_remove_realm_filter(realm, pattern)
+            do_remove_realm_filter(realm, pattern=pattern)
             sys.exit(0)
         else:
             self.print_help("python2.7 manage.py", "realm_filters")

--- a/zerver/migrations/0016_realm_filter_validators.py
+++ b/zerver/migrations/0016_realm_filter_validators.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.core.validators
+import zerver.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0015_attachment'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='realmfilter',
+            name='pattern',
+            field=models.TextField(validators=[zerver.models.filter_pattern_validator]),
+        ),
+        migrations.AlterField(
+            model_name='realmfilter',
+            name='url_format_string',
+            field=models.TextField(validators=[django.core.validators.URLValidator, zerver.models.filter_format_validator]),
+        ),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -5,6 +5,8 @@ from django.db import models
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser, UserManager, \
     PermissionsMixin
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
 from django.dispatch import receiver
 from zerver.lib.cache import cache_with_key, flush_user_profile, flush_realm, \
     user_profile_by_id_cache_key, user_profile_by_email_cache_key, \
@@ -247,10 +249,38 @@ def flush_realm_emoji(sender, **kwargs):
 post_save.connect(flush_realm_emoji, sender=RealmEmoji)
 post_delete.connect(flush_realm_emoji, sender=RealmEmoji)
 
+def filter_pattern_validator(value):
+    prefix = value[0]
+    pattern = value[1:]
+    regex = re.compile(r'(\(\?P<\w+>.+\))')
+
+    if not value:
+        raise ValidationError('Filter pattern cannot be empty')
+
+    if prefix not in settings.ALLOWED_FILTER_PREFIXES:
+        raise ValidationError(
+            'Filter pattern cannot start with `%s`, use one of the valid prefixes: %s' %
+            (value[0], ', '.join(settings.ALLOWED_FILTER_PREFIXES)))
+
+    try:
+        re.compile(pattern)
+    except:
+        # Regex is invalid
+        raise ValidationError('Invalid filter pattern')
+
+    if not regex.match(pattern):
+        raise ValidationError('Pattern format string must be in the following format: (?P<\w+>.+)')
+
+def filter_format_validator(value):
+    regex = re.compile(r'.*(%\(\w+\))')
+
+    if not regex.match(value):
+        raise ValidationError('URL format string must be in the following format: `https://example.com/%(\w+)s`')
+
 class RealmFilter(models.Model):
     realm = models.ForeignKey(Realm)
-    pattern = models.TextField()
-    url_format_string = models.TextField()
+    pattern = models.TextField(validators=[filter_pattern_validator])
+    url_format_string = models.TextField(validators=[URLValidator, filter_format_validator])
 
     class Meta(object):
         unique_together = ("realm", "pattern")
@@ -273,7 +303,7 @@ def realm_filters_for_domain(domain):
 def realm_filters_for_domain_remote_cache(domain):
     filters = []
     for realm_filter in RealmFilter.objects.filter(realm=get_realm(domain)):
-       filters.append((realm_filter.pattern, realm_filter.url_format_string))
+        filters.append((realm_filter.pattern, realm_filter.url_format_string, realm_filter.pk))
 
     return filters
 
@@ -281,7 +311,7 @@ def all_realm_filters():
     # type: () -> Dict[str, List[Tuple[str, str]]]
     filters = defaultdict(list) # type: Dict[str, List[Tuple[str, str]]]
     for realm_filter in RealmFilter.objects.all():
-       filters[realm_filter.realm.domain].append((realm_filter.pattern, realm_filter.url_format_string))
+        filters[realm_filter.realm.domain].append((realm_filter.pattern, realm_filter.url_format_string, realm_filter.pk))
 
     return filters
 

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -339,6 +339,15 @@ class BugdownTest(TestCase):
 
         self.assertEqual(converted, '<p>We should fix <a href="https://trac.zulip.net/ticket/224" target="_blank" title="https://trac.zulip.net/ticket/224">#224</a> and <a href="https://trac.zulip.net/ticket/115" target="_blank" title="https://trac.zulip.net/ticket/115">#115</a>, but not issue#124 or #1124z or <a href="https://trac.zulip.net/ticket/16" target="_blank" title="https://trac.zulip.net/ticket/16">trac #15</a> today.</p>')
 
+        RealmFilter(realm=get_realm('zulip.com'), pattern=r'#(?P<id>[a-zA-Z]+-[0-9]+)',
+                    url_format_string=r'https://trac.zulip.net/ticket/%(id)s').save()
+        msg = Message(sender=get_user_profile_by_email('hamlet@zulip.com'))
+
+        content = '#ZUL-123 was fixed and code was deployed to production, also #zul-321 was deployed to staging'
+        converted = bugdown.convert(content, realm_domain='zulip.com', message=msg)
+
+        self.assertEqual(converted, '<p><a href="https://trac.zulip.net/ticket/ZUL-123" target="_blank" title="https://trac.zulip.net/ticket/ZUL-123">#ZUL-123</a> was fixed and code was deployed to production, also <a href="https://trac.zulip.net/ticket/zul-321" target="_blank" title="https://trac.zulip.net/ticket/zul-321">#zul-321</a> was deployed to staging</p>')
+
     def test_stream_subscribe_button_simple(self):
         msg = '!_stream_subscribe_button(simple)'
         converted = bugdown_convert(msg)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -493,12 +493,12 @@ class EventsRegisterTest(AuthedTestCase):
             ('type', equals('realm_filters')),
             ('realm_filters', check_list(None)), # TODO: validate tuples in the list
         ])
-        events = self.do_test(lambda: do_add_realm_filter(get_realm("zulip.com"), "#[123]",
+        events = self.do_test(lambda: do_add_realm_filter(get_realm("zulip.com"), "#(?P<id>[123])",
                                                           "https://realm.com/my_realm_filter/%(id)s"))
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
-        self.do_test(lambda: do_remove_realm_filter(get_realm("zulip.com"), "#[123]"))
+        self.do_test(lambda: do_remove_realm_filter(get_realm("zulip.com"), "#(?P<id>[123])"))
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 

--- a/zerver/views/realm_filters.py
+++ b/zerver/views/realm_filters.py
@@ -1,0 +1,31 @@
+from django.core.exceptions import ValidationError
+from django.views.decorators.csrf import csrf_exempt
+
+from zerver.models import realm_filters_for_domain
+from zerver.lib.actions import do_add_realm_filter, do_remove_realm_filter
+from zerver.lib.response import json_success, json_error
+from zerver.lib.rest import rest_dispatch as _rest_dispatch
+rest_dispatch = csrf_exempt((lambda request, *args, **kwargs: _rest_dispatch(request, globals(), *args, **kwargs)))
+
+
+# Custom realm filters
+def list_filters(request, user_profile):
+    filters = realm_filters_for_domain(user_profile.realm.domain)
+    return json_success({'filters': filters})
+
+def create_filter(request, user_profile):
+    pattern = request.POST.get('pattern', None)
+    url_format_string = request.POST.get('url_format_string', None)
+    try:
+        filter_id = do_add_realm_filter(
+            realm=user_profile.realm,
+            pattern=pattern,
+            url_format_string=url_format_string
+        )
+        return json_success({'id': filter_id})
+    except ValidationError as e:
+        return json_error(e.message_dict)
+
+def delete_filter(request, user_profile, filter_id):
+    do_remove_realm_filter(realm=user_profile.realm, id=filter_id)
+    return json_success({})

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -963,3 +963,6 @@ if PRODUCTION:
 PROFILE_ALL_REQUESTS = False
 
 CROSS_REALM_BOT_EMAILS = set(('feedback@zulip.com', 'notification-bot@zulip.com'))
+
+# Custom realm filters
+ALLOWED_FILTER_PREFIXES = ['#']

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -176,19 +176,24 @@ v1_api_and_json_patterns = patterns('zerver.views',
             {'PATCH': 'update_realm'}),
     url(r'^users/me/presence$', 'rest_dispatch',
             {'POST': 'update_active_status_backend'}),
-    # Endpoint used by iOS devices to register their
-    # unique APNS device token
     url(r'^users/me/apns_device_token$', 'rest_dispatch',
-        {'POST'  : 'add_apns_device_token',
+        {'POST': 'add_apns_device_token',
          'DELETE': 'remove_apns_device_token'}),
     url(r'^users/me/android_gcm_reg_id$', 'rest_dispatch',
         {'POST': 'add_android_reg_id',
          'DELETE': 'remove_android_reg_id'}),
     url(r'^register$', 'rest_dispatch',
-            {'POST': 'api_events_register'}),
-
+        {'POST': 'api_events_register'}),
     # Returns a 204, used by desktop app to verify connectivity status
     url(r'generate_204$', 'generate_204'),
+) + patterns('zerver.views.realm_filters',
+    url(r'^realm/filters$', 'rest_dispatch',
+        {'GET': 'list_filters',
+         'PUT': 'create_filter'}),
+    url(r'^realm/filters/(?P<filter_id>\d+)$', 'rest_dispatch',
+        {'DELETE': 'delete_filter'}),
+    # Endpoint used by iOS devices to register their
+    # unique APNS device token
 ) + patterns('zerver.views.realm_emoji',
     url(r'^realm/emoji$', 'rest_dispatch',
         {'GET': 'list_emoji',


### PR DESCRIPTION
Custom realm filters can now be managed through admin. For example, you can now say that `#([a-z]+)-([0-9]+)` should be expanded to `https://jira.zulip.com/%(pattern)%`, so when you send a message that matches the pattern like `#zul-385`, it gets auto linkified to `https://jira.zulip.com/zul-385`.

I'm still investigating a problem with some patterns that crash the Markdown parser.
