### PR TITLE
Port to django-pipeline 1.6.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ diff-match-patch==20121119
 django-auth-ldap==1.2.6
 django-bitfield==1.8.0
 git+https://github.com/rwbarton/django-guardian.git@caf9f0c8c035feb3dff5542fb042dd13126cdd69
-django-pipeline==1.2.2
+django-pipeline==1.6.7
 docopt==0.4.0
 enum34==1.0.4
 fonttools==3.0

--- a/templates/analytics/activity.html
+++ b/templates/analytics/activity.html
@@ -1,6 +1,6 @@
 {% extends "zerver/base.html" %}
 
-{% load compressed %}
+{% load pipeline %}
 {% load minified_js %}
 
 {# User Activity. #}
@@ -13,7 +13,7 @@
 {% block customhead %}
 {{ block.super }}
 {% minified_js 'activity' %}
-{% compressed_css 'activity' %}
+{% stylesheet 'activity' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -2,7 +2,7 @@
 <html>
 
 {# Base template for the whole site. #}
-{% load compressed %}
+{% load pipeline %}
 {% load minified_js %}
 
 <head>
@@ -25,7 +25,7 @@
     {% endif %}
 
     {# We need to import jQuery before Bootstrap #}
-    {% compressed_css 'common' %}
+    {% stylesheet 'common' %}
     {% block page_params %}
     {# blueslip needs page_params.debug_mode.  Set it to false by default. #}
     <script type="text/javascript">

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -3,7 +3,7 @@
 {# The app itself. #}
 {# Includes some other templates as tabs. #}
 
-{% load compressed %}
+{% load pipeline %}
 {% load minified_js %}
 
 {% block page_params %}
@@ -35,9 +35,9 @@ var page_params = {{ page_params }};
 
 {% if nofontface %}
 {# We can't use @font-face on qtwebkit, so use differently minified CSS #}
-{% compressed_css 'app-fontcompat' %}
+{% stylesheet 'app-fontcompat' %}
 {% else %}
-{% compressed_css 'app' %}
+{% stylesheet 'app' %}
 {% endif %}
 {% minified_js 'app' %}
 

--- a/templates/zerver/portico.html
+++ b/templates/zerver/portico.html
@@ -1,6 +1,6 @@
 {% extends "zerver/base.html" %}
 {% load i18n %}
-{% load compressed %}
+{% load pipeline %}
 
 {% comment %}
 A base template for stuff like login, register, etc.
@@ -10,7 +10,7 @@ hence the name.
 {% endcomment %}
 
     {% block customhead %}
-    {% compressed_css 'portico' %}
+    {% stylesheet 'portico' %}
     {% endblock %}
 
 {% block content %}

--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -55,4 +55,8 @@ subprocess.check_call(['mv', os.path.join(settings.STATIC_ROOT, 'source-map'),
                              'prod-static/source-map'],
                       stdout=fp, stderr=fp)
 
+# Remove unminified CSS
+subprocess.check_call(['rm', '-rf', 'prod-static/serve/styles'],
+                      stdout=fp, stderr=fp)
+
 fp.close()

--- a/zerver/finders.py
+++ b/zerver/finders.py
@@ -11,7 +11,7 @@ class ExcludeUnminifiedMixin(object):
     def list(self, ignore_patterns):
         # We can't use ignore_patterns because the patterns are
         # applied to just the file part, not the entire path
-        excluded = '^(js|styles|templates)/'
+        excluded = '^(js|templates)/'
 
         # source-map/ should also not be included.
         # However, we work around that by moving it later,

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -871,7 +871,7 @@ def home(request):
                                    'avatar_url': avatar_url(user_profile),
                                    'show_debug':
                                        settings.DEBUG and ('show_debug' in request.GET),
-                                   'pipeline': settings.PIPELINE,
+                                   'pipeline': settings.PIPELINE.get('PIPELINE_ENABLED'),
                                    'show_invites': show_invites,
                                    'is_admin': user_profile.is_admin(),
                                    'show_webathena': user_profile.realm.domain == "mit.edu",

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -511,14 +511,15 @@ STATIC_URL = '/static/'
 
 # This is the default behavior from Pipeline, but we set it
 # here so that urls.py can read it.
-PIPELINE = not DEBUG
+PIPELINE_ENABLED = not DEBUG
 
 if DEBUG:
     STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
     STATICFILES_FINDERS = (
         'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+        'pipeline.finders.PipelineFinder',
     )
-    if PIPELINE:
+    if PIPELINE_ENABLED:
         STATIC_ROOT = 'prod-static/serve'
     else:
         STATIC_ROOT = 'static/'
@@ -714,7 +715,7 @@ JS_SPECS = {
             'js/referral.js',
             'js/custom_markdown.js',
             'js/bot_data.js',
-            # JS bundled by webpack is also included here if PIPELINE setting is true
+            # JS bundled by webpack is also included here if PIPELINE_ENABLED setting is true
         ],
         'output_filename': 'min/app.js'
     },
@@ -731,16 +732,17 @@ JS_SPECS = {
     },
 }
 
-if PIPELINE:
+if PIPELINE_ENABLED:
     JS_SPECS['app']['source_filenames'].append('js/bundle.js')
 
 app_srcs = JS_SPECS['app']['source_filenames']
 
-PIPELINE_JS = {}  # Now handled in tools/minify-js
-PIPELINE_JS_COMPRESSOR  = None
-
-PIPELINE_CSS_COMPRESSOR = 'pipeline.compressors.yui.YUICompressor'
-PIPELINE_YUI_BINARY     = '/usr/bin/env yui-compressor'
+PIPELINE = {
+    'PIPELINE_ENABLED': PIPELINE_ENABLED,
+    'STYLESHEETS': PIPELINE_CSS,
+    'CSS_COMPRESSOR': 'pipeline.compressors.yui.YUICompressor',
+    'YUI_BINARY': '/usr/bin/env yui-compressor',
+}
 
 ########################################################################
 # LOGGING SETTINGS

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -298,7 +298,10 @@ urlpatterns += patterns('',
 
 
 if settings.DEVELOPMENT:
-    use_prod_static = getattr(settings, 'PIPELINE', False)
+    try:
+        use_prod_static = settings.PIPELINE['PIPELINE_ENABLED']
+    except (AttributeError, KeyError):
+        use_prod_static = False
     static_root = os.path.join(settings.DEPLOY_ROOT,
         'prod-static/serve' if use_prod_static else 'static')
 


### PR DESCRIPTION
Now Zulip is compatible with django-pipeline 1.6.7. It is no more compatible with the older version of django-pipeline (1.2.2). This will also help in adding Python 3 support.