### PR TITLE
Fixing regression in saving organization settings on administration page

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -218,7 +218,7 @@ exports.setup_page = function () {
         }
     });
 
-    $(".administration").on("submit", "form.admin-realm", function (e) {
+    $(".administration").on("submit", "form.admin-realm-form", function (e) {
         var name_status = $("#admin-realm-name-status").expectOne();
         var restricted_to_domain_status = $("#admin-realm-restricted-to-domain-status").expectOne();
         var invite_required_status = $("#admin-realm-invite-required-status").expectOne();


### PR DESCRIPTION
Saving the organization settings form in the administration does not work due to a trivial form name mismatch caused by following revisions: 472898cfc632c771a9fcf239f22d7e0437468b17 and 58aba59e36c8fb6e93ec7d95f6a1e54c5328ccab.