### PR TITLE
Make a lister module and refactor lint-all to use it.

### DIFF
--- a/tools/lint-all
+++ b/tools/lint-all
@@ -13,6 +13,8 @@ from collections import defaultdict
 from six.moves import filter
 from six.moves import map
 
+import lister
+
 parser = optparse.OptionParser()
 parser.add_option('--full',
     action='store_true',
@@ -27,60 +29,23 @@ os.chdir(path.join(path.dirname(__file__), '..'))
 
 # Exclude some directories and files from lint checking
 
-exclude_trees = """
+exclude = """
 static/third
 confirmation
 frontend_tests/casperjs
 zerver/migrations
 node_modules
-""".split()
-
-exclude_files = """
 docs/html_unescape.py
 zproject/test_settings.py
 zproject/settings.py
 tools/jslint/jslint.js
 api/setup.py
 api/integrations/perforce/git_p4.py
+puppet/apt/.forge-release
 """.split()
 
-if options.modified:
-    # If the user specifies, use `git ls-files -m` to only check modified, non-staged
-    # files in the current checkout.  This makes things fun faster.
-    files = list(map(str.strip, subprocess.check_output(['git', 'ls-files', '-m']).split('\n')))
-else:
-    files = []
-
-files += args
-
-if not files and not options.modified:
-    # If no files are specified on the command line, use the entire git checkout
-    files = list(map(str.strip, subprocess.check_output(['git', 'ls-files']).split('\n')))
-
-files = list(filter(bool, files)) # remove empty file caused by trailing \n
-
-if not files:
-    raise Exception('There are no files to check!')
-
-# Categorize by language all files we want to check
-by_lang   = defaultdict(list)
-
-for filepath in files:
-    if (not filepath or not path.isfile(filepath)
-        or (filepath in exclude_files)
-        or any(filepath.startswith(d+'/') for d in exclude_trees)):
-        continue
-
-    _, exn = path.splitext(filepath)
-    if not exn:
-        # No extension; look at the first line
-        with open(filepath) as f:
-            if re.match(r'^#!.*\bpython', f.readline()):
-                exn = '.py'
-
-    by_lang[exn].append(filepath)
-
-by_lang['.sh'] = [_f for _f in map(str.strip, subprocess.check_output("grep --files-with-matches '#!.*\(ba\)\?sh' $(git ls-tree --name-only -r HEAD scripts/ tools/ bin/ | grep -v [.])", shell=True).split('\n')) if _f]
+by_lang = lister.list_files(args, modified_only=options.modified, use_shebang=True,
+    ftypes=['.py', '.sh', '.js', '.pp'], group_by_ftype=True, exclude=exclude)
 
 # Invoke the appropriate lint checker for each language,
 # and also check files for extra whitespace.

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -45,7 +45,7 @@ puppet/apt/.forge-release
 """.split()
 
 by_lang = lister.list_files(args, modified_only=options.modified, use_shebang=True,
-    ftypes=['.py', '.sh', '.js', '.pp'], group_by_ftype=True, exclude=exclude)
+    ftypes=['py', 'sh', 'js', 'pp'], group_by_ftype=True, exclude=exclude)
 
 # Invoke the appropriate lint checker for each language,
 # and also check files for extra whitespace.
@@ -57,10 +57,10 @@ logger = logging.getLogger()
 logger.setLevel(logging.WARNING)
 
 def check_pyflakes():
-    if not by_lang['.py']:
+    if not by_lang['py']:
         return False
     failed = False
-    pyflakes = subprocess.Popen(['pyflakes'] + by_lang['.py'],
+    pyflakes = subprocess.Popen(['pyflakes'] + by_lang['py'],
         stdout = subprocess.PIPE,
         stderr = subprocess.PIPE)
 
@@ -156,15 +156,15 @@ bash_rules = [
 def check_custom_checks():
     failed = False
 
-    for fn in by_lang['.py']:
+    for fn in by_lang['py']:
         if custom_check_file(fn, python_rules, skip_rules=python_line_skip_rules):
             failed = True
 
-    for fn in by_lang['.js']:
+    for fn in by_lang['js']:
         if custom_check_file(fn, js_rules):
             failed = True
 
-    for fn in by_lang['.sh']:
+    for fn in by_lang['sh']:
         if custom_check_file(fn, bash_rules):
             failed = True
 
@@ -207,14 +207,14 @@ try:
     @lint
     def jslint():
         result = subprocess.call(['tools/node', 'tools/jslint/check-all.js']
-                                 + by_lang['.js'])
+                                 + by_lang['js'])
         return result
 
     @lint
     def puppet():
-        if not by_lang['.pp']:
+        if not by_lang['pp']:
             return 0
-        result = subprocess.call(['puppet', 'parser', 'validate'] + by_lang['.pp'])
+        result = subprocess.call(['puppet', 'parser', 'validate'] + by_lang['pp'])
         return result
 
     @lint

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -6,6 +6,7 @@ import sys
 import subprocess
 import re
 from collections import defaultdict
+import argparse
 
 def get_ftype(fpath, use_shebang):
     ext = os.path.splitext(fpath)[1]
@@ -85,3 +86,22 @@ def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
             result.append(fpath)
 
     return result
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(description="List files tracked by git and optionally filter by type")
+    parser.add_argument('targets', nargs='*',
+                        help='''files and directories to include in the result.
+                        If this is not specified, the current directory is used''')
+    parser.add_argument('-m', '--modified', action='store_true', default=False, help='list only modified files')
+    parser.add_argument('-f', '--ftypes', nargs='+',
+                        help="list of file types to filter on. All files are included if this option is absent")
+    parser.add_argument('--ext-only', dest='extonly', action='store_true', default=False, help='only use extension to determine file type')
+    parser.add_argument('--exclude', nargs='+', help='list of files and directories to exclude from listing')
+    args = parser.parse_args()
+    args.targets = args.targets or []
+    args.ftypes = args.ftypes or []
+    args.exclude = args.exclude or []
+    listing = list_files(targets=args.targets, ftypes=args.ftypes, use_shebang=not args.extonly,
+                         modified_only=args.modified, exclude=args.exclude)
+    for l in listing:
+        print(l)

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -3,17 +3,32 @@ from __future__ import print_function
 
 import os
 import subprocess
+from collections import defaultdict
 
-def list_files(targets=[], modified_only=False, exclude=[]):
+def get_ftype(fpath):
+    ext = os.path.splitext(fpath)[1]
+    if ext:
+        return ext[1:]
+    else:
+        return ''
+
+def list_files(targets=[], ftypes=[], modified_only=False, exclude=[], group_by_ftype=False):
     """
     List files tracked by git.
     Returns a list of files which are either in targets or in directories in targets.
     If targets is [], list of all tracked files in current directory is returned.
 
     Other arguments:
+    ftypes - List of file types on which to filter the search.
+        If ftypes is [], all files are included.
     modified_only - Only include files which have been modified.
     exclude - List of paths to be excluded.
+    group_by_ftype - If True, returns a dict of lists keyed by file type.
+        If False, returns a flat list of files.
     """
+    ftypes = [x.strip('.') for x in ftypes]
+    ftypes_set = set(ftypes)
+
     cmdline = ['git', 'ls-files'] + targets
     if modified_only:
         cmdline.append('-m')
@@ -22,7 +37,7 @@ def list_files(targets=[], modified_only=False, exclude=[]):
     # throw away empty lines and non-files (like symlinks)
     files = list(filter(os.path.isfile, files_gen))
 
-    result = []
+    result = defaultdict(list) if group_by_ftype else []
 
     for fpath in files:
         # this will take a long time if exclude is very large
@@ -34,6 +49,14 @@ def list_files(targets=[], modified_only=False, exclude=[]):
         if in_exclude:
             continue
 
-        result.append(fpath)
+        if ftypes or group_by_ftype:
+            filetype = get_ftype(fpath)
+            if ftypes and filetype not in ftypes_set:
+                continue
+
+        if group_by_ftype:
+            result['.' + filetype].append(fpath)
+        else:
+            result.append(fpath)
 
     return result

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -4,13 +4,18 @@ from __future__ import print_function
 import os
 import subprocess
 
-def list_files(targets=[]):
+def list_files(targets=[], modified_only=False):
     """
     List files tracked by git.
     Returns a list of files which are either in targets or in directories in targets.
     If targets is [], list of all tracked files in current directory is returned.
+
+    Other arguments:
+    modified_only - Only include files which have been modified.
     """
     cmdline = ['git', 'ls-files'] + targets
+    if modified_only:
+        cmdline.append('-m')
 
     files_gen = (x.strip() for x in subprocess.check_output(cmdline, universal_newlines=True).split('\n'))
     # throw away empty lines and non-files (like symlinks)

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import os
+import subprocess
+
+def list_files(targets=[]):
+    """
+    List files tracked by git.
+    Returns a list of files which are either in targets or in directories in targets.
+    If targets is [], list of all tracked files in current directory is returned.
+    """
+    cmdline = ['git', 'ls-files'] + targets
+
+    files_gen = (x.strip() for x in subprocess.check_output(cmdline, universal_newlines=True).split('\n'))
+    # throw away empty lines and non-files (like symlinks)
+    files = list(filter(os.path.isfile, files_gen))
+
+    return files

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import os
 import subprocess
 
-def list_files(targets=[], modified_only=False):
+def list_files(targets=[], modified_only=False, exclude=[]):
     """
     List files tracked by git.
     Returns a list of files which are either in targets or in directories in targets.
@@ -12,6 +12,7 @@ def list_files(targets=[], modified_only=False):
 
     Other arguments:
     modified_only - Only include files which have been modified.
+    exclude - List of paths to be excluded.
     """
     cmdline = ['git', 'ls-files'] + targets
     if modified_only:
@@ -21,4 +22,18 @@ def list_files(targets=[], modified_only=False):
     # throw away empty lines and non-files (like symlinks)
     files = list(filter(os.path.isfile, files_gen))
 
-    return files
+    result = []
+
+    for fpath in files:
+        # this will take a long time if exclude is very large
+        in_exclude = False
+        for expath in exclude:
+            expath = expath.rstrip('/')
+            if fpath == expath or fpath.startswith(expath + '/'):
+                in_exclude = True
+        if in_exclude:
+            continue
+
+        result.append(fpath)
+
+    return result

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -80,7 +80,7 @@ def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
                 continue
 
         if group_by_ftype:
-            result['.' + filetype].append(fpath)
+            result[filetype].append(fpath)
         else:
             result.append(fpath)
 


### PR DESCRIPTION
* Make module tools/lister.py which lists all files in a directory. It can categorize files by their types (type is either found from file extension or from shebang). It uses `git ls-files` to get a file list.

* Remove file-listing code from lint-all. Call functions in lister.py instead.

This refactoring was done because lister.py will be used in other places in the future.