### PR TITLE
Fix fading of messages in dialog and users in side-bar.

### DIFF
--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -61,7 +61,7 @@ var _ = global._;
             {type: 'private', reply_to: 'fred@zulip.com,melissa@zulip.com'}
         ));
 
-        assert(!same(
+        assert(same(
             {type: 'private', reply_to: 'fred@zulip.com'},
             {type: 'private', reply_to: 'Fred@zulip.com'}
         ));

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -121,8 +121,8 @@ exports.would_receive_message = function (email) {
     }
 
     // PM, so check if the given email is in the recipients list.
-    var recipients = focused_recipient.reply_to.split(',');
-    return recipients.indexOf(email) !== -1;
+    var recipients = focused_recipient.reply_to.toLowerCase().split(',');
+    return recipients.indexOf(email.toLowerCase()) !== -1;
 };
 
 function _fade_users() {

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -73,7 +73,7 @@ exports.same_major_recipient = function (a, b) {
 
     switch (a.type) {
     case 'private':
-        return a.reply_to === b.reply_to;
+        return a.reply_to.toLowerCase() === b.reply_to.toLowerCase();
     case 'stream':
         return a.stream.toLowerCase() === b.stream.toLowerCase();
     }
@@ -92,7 +92,7 @@ exports.same_recipient = function util_same_recipient(a, b) {
 
     switch (a.type) {
     case 'private':
-        return a.reply_to === b.reply_to;
+        return a.reply_to.toLowerCase() === b.reply_to.toLowerCase();
     case 'stream':
         return exports.same_stream_and_subject(a, b);
     }
@@ -103,7 +103,7 @@ exports.same_recipient = function util_same_recipient(a, b) {
 
 exports.same_sender = function util_same_sender(a, b) {
     return ((a !== undefined) && (b !== undefined) &&
-            (a.sender_email === b.sender_email));
+            (a.sender_email.toLowerCase() === b.sender_email.toLowerCase()));
 };
 
 exports.normalize_recipients = function (recipients) {


### PR DESCRIPTION
Make comparison of emails in compose_fade.js and util.js case-insensitive to fix fading of users and messages respectively.

There is no reason to keep fading of usernames in side-bar and messages in dialog being case-sensitive since it's not allowed to create both "stream" and "Stream" or register both "a@zulip.com" and "A@zulip.com".
