### PR TITLE
puppet: Fix process_queue command lines to use the new argument style.

### DIFF
--- a/puppet/zulip/files/supervisor/conf.d/zulip.conf
+++ b/puppet/zulip/files/supervisor/conf.d/zulip.conf
@@ -57,7 +57,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-user-activity]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue user_activity
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=user_activity
 priority=300                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -71,7 +71,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-user-activity-interval]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue user_activity_interval
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=user_activity_interval
 priority=300                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -85,7 +85,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-user-presence]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue user_presence
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=user_presence
 priority=300                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -99,7 +99,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-signups]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue signups
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=signups
 priority=400                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -113,7 +113,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-confirmation-emails]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue invites
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=invites
 priority=500                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -127,7 +127,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-missedmessage_reminders]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue missedmessage_emails
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=missedmessage_emails
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -141,7 +141,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-missedmessage_mobile_notifications]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue missedmessage_mobile_notifications
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=missedmessage_mobile_notifications
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -155,7 +155,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-slowqueries]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue slow_queries
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=slow_queries
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -169,7 +169,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-message_sender]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue message_sender %(process_num)s
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=message_sender --worker_num=%(process_num)s
 process_name=%(program_name)s-%(process_num)s
 priority=350                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
@@ -185,7 +185,7 @@ directory=/home/zulip/deployments/current/
 numprocs=5
 
 [program:zulip-events-feedback_messages]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue feedback_messages
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=feedback_messages
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -199,7 +199,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-error_reports]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue error_reports
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=error_reports
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -213,7 +213,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-digest_emails]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue digest_emails
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=digest_emails
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -227,7 +227,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-email_mirror]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue email_mirror
+command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=email_mirror
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)

--- a/puppet/zulip_internal/files/nagios3/conf.d/services.cfg
+++ b/puppet/zulip_internal/files/nagios3/conf.d/services.cfg
@@ -412,7 +412,7 @@ define service {
 define service {
         use                             generic-service
         service_description             Check missedmessage_emails queue processor
-        check_command                   check_remote_arg_string!manage.py process_queue missedmessage_emails!1:1!1:1
+        check_command                   check_remote_arg_string!manage.py process_queue --queue_name=missedmessage_emails!1:1!1:1
         max_check_attempts              3
         hostgroup_name                  frontends
         contact_groups                  admins
@@ -421,7 +421,7 @@ define service {
 define service {
         use                             generic-service
         service_description             Check slow_queries queue processor
-        check_command                   check_remote_arg_string!manage.py process_queue slow_queries!1:1!1:1
+        check_command                   check_remote_arg_string!manage.py process_queue --queue_name=slow_queries!1:1!1:1
         max_check_attempts              3
         hostgroup_name                  frontends
         contact_groups                  admins

--- a/zerver/management/commands/process_queue.py
+++ b/zerver/management/commands/process_queue.py
@@ -38,6 +38,7 @@ class Command(BaseCommand):
 
             logger.info("Worker %d connecting to queue %s" % (worker_num, queue_name))
             worker = get_worker(queue_name)
+            worker.setup()
 
             def signal_handler(signal, frame):
                 logger.info("Worker %d disconnecting from queue %s" % (worker_num, queue_name))


### PR DESCRIPTION
cd2348e9aec36d7f26475fa7d966d06588dbeb75 broke installing Zulip in
production since it didn't correctly update the puppet configuration
to call the process_queue script using the new argument format.