### PR TITLE
Generic cache references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ zerver/fixtures/migration-status
 zerver/fixtures/test_data1.json
 .kdev4
 zulip.kdev4
-memcached_prefix
+remote_cache_prefix
 coverage/
 /queue_error
 .test-js-with-node.html

--- a/docs/code-style.rst
+++ b/docs/code-style.rst
@@ -79,13 +79,13 @@ In our Django code, never do direct
 use ``get_user_profile_by_{email,id}``. There are 3 reasons for this:
 
 #. It's guaranteed to correctly do a case-inexact lookup
-#. It fetches the user object from memcached, which is faster
+#. It fetches the user object from remote cache, which is faster
 #. It always fetches a UserProfile object which has been queried using
    .selected\_related(), and thus will perform well when one later
    accesses related models like the Realm.
 
 Similarly we have ``get_client`` and ``get_stream`` functions to fetch
-those commonly accessed objects via memcached.
+those commonly accessed objects via remote cache.
 
 Using Django model objects as keys in sets/dicts
 ------------------------------------------------

--- a/puppet/zulip_internal/files/graphite/aggregation-rules.conf
+++ b/puppet/zulip_internal/files/graphite/aggregation-rules.conf
@@ -33,11 +33,11 @@
 #       every 5 seconds (see local.js), so aggregating over a longer period of time
 #       will inflate the output value
 
-# Aggregate all per-bucket memcached stats into a generic hit/miss stat
+# Aggregate all per-bucket remote cache stats into a generic hit/miss stat
 stats.<app>.cache.all.hit (5) = sum stats.<app>.cache.*.hit
 stats.<app>.cache.all.miss (5) = sum stats.<app>.cache.*.miss
 
-# Aggregate all per-bucket memcached stats counts into a generic hit/miss stat
+# Aggregate all per-bucket remote cache stats counts into a generic hit/miss stat
 stats_counts.<app>.cache.all.hit (5) = sum stats_counts.<app>.cache.*.hit
 stats_counts.<app>.cache.all.miss (5) = sum stats_counts.<app>.cache.*.miss
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2266,16 +2266,16 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
     # Update the message as stored in the (deprecated) message
     # cache (for shunting the message over to Tornado in the old
     # get_messages API) and also the to_dict caches.
-    items_for_memcached = {}
+    items_for_remote_cache = {}
     event['message_ids'] = []
     for changed_message in changed_messages:
         event['message_ids'].append(changed_message.id)
-        items_for_memcached[message_cache_key(changed_message.id)] = (changed_message,)
-        items_for_memcached[to_dict_cache_key(changed_message, True)] = \
+        items_for_remote_cache[message_cache_key(changed_message.id)] = (changed_message,)
+        items_for_remote_cache[to_dict_cache_key(changed_message, True)] = \
             (stringify_message_dict(changed_message.to_dict_uncached(apply_markdown=True)),)
-        items_for_memcached[to_dict_cache_key(changed_message, False)] = \
+        items_for_remote_cache[to_dict_cache_key(changed_message, False)] = \
             (stringify_message_dict(changed_message.to_dict_uncached(apply_markdown=False)),)
-    cache_set_many(items_for_memcached)
+    cache_set_many(items_for_remote_cache)
 
     def user_info(um):
         return {

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -436,7 +436,7 @@ def do_deactivate_stream(stream, log=True):
     stream.name = new_name[:Stream.MAX_NAME_LENGTH]
     stream.save()
 
-    # Remove the old stream information from memcached.
+    # Remove the old stream information from remote cache.
     old_cache_key = get_stream_cache_key(old_name, stream.realm)
     cache_delete(old_cache_key)
 
@@ -609,7 +609,7 @@ def do_send_messages(messages):
     for message in messages:
         cache_save_message(message['message'])
         # Render Markdown etc. here and store (automatically) in
-        # memcached, so that the single-threaded Tornado server
+        # remote cache, so that the single-threaded Tornado server
         # doesn't have to.
         user_flags = user_message_flags.get(message['message'].id, {})
         sender = message['message'].sender
@@ -2244,7 +2244,7 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
 
             for m in messages_list:
                 # The cached ORM object is not changed by messages.update()
-                # and the memcached update requires the new value
+                # and the remote cache update requires the new value
                 m.subject = subject
 
             changed_messages += messages_list

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -18,25 +18,25 @@ import os.path
 import hashlib
 
 remote_cache_time_start = 0.0
-memcached_total_time = 0.0
-memcached_total_requests = 0
+remote_cache_total_time = 0.0
+remote_cache_total_requests = 0
 
 def get_remote_cache_time():
-    return memcached_total_time
+    return remote_cache_total_time
 
 def get_remote_cache_requests():
-    return memcached_total_requests
+    return remote_cache_total_requests
 
 def remote_cache_stats_start():
     global remote_cache_time_start
     remote_cache_time_start = time.time()
 
 def remote_cache_stats_finish():
-    global memcached_total_time
-    global memcached_total_requests
+    global remote_cache_total_time
+    global remote_cache_total_requests
     global remote_cache_time_start
-    memcached_total_requests += 1
-    memcached_total_time += (time.time() - remote_cache_time_start)
+    remote_cache_total_requests += 1
+    remote_cache_total_time += (time.time() - remote_cache_time_start)
 
 def get_or_create_key_prefix():
     if settings.TEST_SUITE:

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -17,26 +17,26 @@ import os
 import os.path
 import hashlib
 
-memcached_time_start = 0.0
+remote_cache_time_start = 0.0
 memcached_total_time = 0.0
 memcached_total_requests = 0
 
-def get_memcached_time():
+def get_remote_cache_time():
     return memcached_total_time
 
 def get_memcached_requests():
     return memcached_total_requests
 
 def memcached_stats_start():
-    global memcached_time_start
-    memcached_time_start = time.time()
+    global remote_cache_time_start
+    remote_cache_time_start = time.time()
 
 def memcached_stats_finish():
     global memcached_total_time
     global memcached_total_requests
-    global memcached_time_start
+    global remote_cache_time_start
     memcached_total_requests += 1
-    memcached_total_time += (time.time() - memcached_time_start)
+    memcached_total_time += (time.time() - remote_cache_time_start)
 
 def get_or_create_key_prefix():
     if settings.TEST_SUITE:

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -24,7 +24,7 @@ memcached_total_requests = 0
 def get_remote_cache_time():
     return memcached_total_time
 
-def get_memcached_requests():
+def get_remote_cache_requests():
     return memcached_total_requests
 
 def memcached_stats_start():

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -44,7 +44,7 @@ def get_or_create_key_prefix():
         # The Python tests overwrite KEY_PREFIX on each test.
         return 'test_suite:' + str(os.getpid()) + ':'
 
-    filename = os.path.join(settings.DEPLOY_ROOT, "memcached_prefix")
+    filename = os.path.join(settings.DEPLOY_ROOT, "remote_cache_prefix")
     try:
         fd = os.open(filename, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o444)
         prefix = base64.b16encode(hashlib.sha256(str(random.getrandbits(256))).digest())[:32].lower() + ':'
@@ -64,7 +64,7 @@ def get_or_create_key_prefix():
             time.sleep(0.5)
 
     if not prefix:
-        print("Could not read memcache key prefix file")
+        print("Could not read remote cache key prefix file")
         sys.exit(1)
 
     return prefix

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -27,11 +27,11 @@ def get_remote_cache_time():
 def get_remote_cache_requests():
     return memcached_total_requests
 
-def memcached_stats_start():
+def remote_cache_stats_start():
     global remote_cache_time_start
     remote_cache_time_start = time.time()
 
-def memcached_stats_finish():
+def remote_cache_stats_finish():
     global memcached_total_time
     global memcached_total_requests
     global remote_cache_time_start
@@ -123,24 +123,24 @@ def cache_with_key(keyfunc, cache_name=None, timeout=None, with_statsd_key=None)
     return decorator
 
 def cache_set(key, val, cache_name=None, timeout=None):
-    memcached_stats_start()
+    remote_cache_stats_start()
     cache_backend = get_cache_backend(cache_name)
     ret = cache_backend.set(KEY_PREFIX + key, (val,), timeout=timeout)
-    memcached_stats_finish()
+    remote_cache_stats_finish()
     return ret
 
 def cache_get(key, cache_name=None):
-    memcached_stats_start()
+    remote_cache_stats_start()
     cache_backend = get_cache_backend(cache_name)
     ret = cache_backend.get(KEY_PREFIX + key)
-    memcached_stats_finish()
+    remote_cache_stats_finish()
     return ret
 
 def cache_get_many(keys, cache_name=None):
     keys = [KEY_PREFIX + key for key in keys]
-    memcached_stats_start()
+    remote_cache_stats_start()
     ret = get_cache_backend(cache_name).get_many(keys)
-    memcached_stats_finish()
+    remote_cache_stats_finish()
     return dict([(key[len(KEY_PREFIX):], value) for key, value in ret.items()])
 
 def cache_set_many(items, cache_name=None, timeout=None):
@@ -148,21 +148,21 @@ def cache_set_many(items, cache_name=None, timeout=None):
     for key in items:
         new_items[KEY_PREFIX + key] = items[key]
     items = new_items
-    memcached_stats_start()
+    remote_cache_stats_start()
     ret = get_cache_backend(cache_name).set_many(items, timeout=timeout)
-    memcached_stats_finish()
+    remote_cache_stats_finish()
     return ret
 
 def cache_delete(key, cache_name=None):
-    memcached_stats_start()
+    remote_cache_stats_start()
     get_cache_backend(cache_name).delete(KEY_PREFIX + key)
-    memcached_stats_finish()
+    remote_cache_stats_finish()
 
 def cache_delete_many(items, cache_name=None):
-    memcached_stats_start()
+    remote_cache_stats_start()
     get_cache_backend(cache_name).delete_many(
         KEY_PREFIX + item for item in items)
-    memcached_stats_finish()
+    remote_cache_stats_finish()
 
 # Required Arguments are as follows:
 # * object_ids: The list of object ids to look up

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -72,7 +72,7 @@ cache_fillers = {
     'session': (lambda: Session.objects.all(), session_cache_items, 3600*24*7, 10000),
     }
 
-def fill_memcached_cache(cache):
+def fill_remote_cache(cache):
     remote_cache_time_start = get_remote_cache_time()
     remote_cache_requests_start = get_remote_cache_requests()
     items_for_remote_cache = {}
@@ -85,6 +85,6 @@ def fill_memcached_cache(cache):
             cache_set_many(items_for_remote_cache, timeout=3600*24)
             items_for_remote_cache = {}
     cache_set_many(items_for_remote_cache, timeout=3600*24*7)
-    logging.info("Succesfully populated %s cache!  Consumed %s memcached queries (%s time)" % \
+    logging.info("Succesfully populated %s cache!  Consumed %s remote cache queries (%s time)" % \
                      (cache, get_remote_cache_requests() - remote_cache_requests_start,
                       round(get_remote_cache_time() - remote_cache_time_start, 2)))

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -9,7 +9,7 @@ from zerver.models import Message, UserProfile, Stream, get_stream_cache_key, \
     Huddle, huddle_hash_cache_key
 from zerver.lib.cache import cache_with_key, cache_set, message_cache_key, \
     user_profile_by_email_cache_key, user_profile_by_id_cache_key, \
-    get_remote_cache_time, get_memcached_requests, cache_set_many
+    get_remote_cache_time, get_remote_cache_requests, cache_set_many
 from django.utils.importlib import import_module
 from django.contrib.sessions.models import Session
 import logging
@@ -74,7 +74,7 @@ cache_fillers = {
 
 def fill_memcached_cache(cache):
     remote_cache_time_start = get_remote_cache_time()
-    memcached_requests_start = get_memcached_requests()
+    remote_cache_requests_start = get_remote_cache_requests()
     items_for_remote_cache = {}
     (objects, items_filler, timeout, batch_size) = cache_fillers[cache]
     count = 0
@@ -86,5 +86,5 @@ def fill_memcached_cache(cache):
             items_for_remote_cache = {}
     cache_set_many(items_for_remote_cache, timeout=3600*24*7)
     logging.info("Succesfully populated %s cache!  Consumed %s memcached queries (%s time)" % \
-                     (cache, get_memcached_requests() - memcached_requests_start,
+                     (cache, get_remote_cache_requests() - remote_cache_requests_start,
                       round(get_remote_cache_time() - remote_cache_time_start, 2)))

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -9,7 +9,7 @@ from zerver.models import Message, UserProfile, Stream, get_stream_cache_key, \
     Huddle, huddle_hash_cache_key
 from zerver.lib.cache import cache_with_key, cache_set, message_cache_key, \
     user_profile_by_email_cache_key, user_profile_by_id_cache_key, \
-    get_memcached_time, get_memcached_requests, cache_set_many
+    get_remote_cache_time, get_memcached_requests, cache_set_many
 from django.utils.importlib import import_module
 from django.contrib.sessions.models import Session
 import logging
@@ -73,7 +73,7 @@ cache_fillers = {
     }
 
 def fill_memcached_cache(cache):
-    memcached_time_start = get_memcached_time()
+    remote_cache_time_start = get_remote_cache_time()
     memcached_requests_start = get_memcached_requests()
     items_for_remote_cache = {}
     (objects, items_filler, timeout, batch_size) = cache_fillers[cache]
@@ -87,4 +87,4 @@ def fill_memcached_cache(cache):
     cache_set_many(items_for_remote_cache, timeout=3600*24*7)
     logging.info("Succesfully populated %s cache!  Consumed %s memcached queries (%s time)" % \
                      (cache, get_memcached_requests() - memcached_requests_start,
-                      round(get_memcached_time() - memcached_time_start, 2)))
+                      round(get_remote_cache_time() - remote_cache_time_start, 2)))

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -32,29 +32,29 @@ def message_fetch_objects():
     return Message.objects.select_related().filter(~Q(sender__email='tabbott/extra@mit.edu'),
                                                     id__gt=max_id - MESSAGE_CACHE_SIZE)
 
-def message_cache_items(items_for_memcached, message):
-    items_for_memcached[message_cache_key(message.id)] = (message,)
+def message_cache_items(items_for_remote_cache, message):
+    items_for_remote_cache[message_cache_key(message.id)] = (message,)
 
-def user_cache_items(items_for_memcached, user_profile):
-    items_for_memcached[user_profile_by_email_cache_key(user_profile.email)] = (user_profile,)
-    items_for_memcached[user_profile_by_id_cache_key(user_profile.id)] = (user_profile,)
+def user_cache_items(items_for_remote_cache, user_profile):
+    items_for_remote_cache[user_profile_by_email_cache_key(user_profile.email)] = (user_profile,)
+    items_for_remote_cache[user_profile_by_id_cache_key(user_profile.id)] = (user_profile,)
 
-def stream_cache_items(items_for_memcached, stream):
-    items_for_memcached[get_stream_cache_key(stream.name, stream.realm_id)] = (stream,)
+def stream_cache_items(items_for_remote_cache, stream):
+    items_for_remote_cache[get_stream_cache_key(stream.name, stream.realm_id)] = (stream,)
 
-def client_cache_items(items_for_memcached, client):
-    items_for_memcached[get_client_cache_key(client.name)] = (client,)
+def client_cache_items(items_for_remote_cache, client):
+    items_for_remote_cache[get_client_cache_key(client.name)] = (client,)
 
-def huddle_cache_items(items_for_memcached, huddle):
-    items_for_memcached[huddle_hash_cache_key(huddle.huddle_hash)] = (huddle,)
+def huddle_cache_items(items_for_remote_cache, huddle):
+    items_for_remote_cache[huddle_hash_cache_key(huddle.huddle_hash)] = (huddle,)
 
-def recipient_cache_items(items_for_memcached, recipient):
-    items_for_memcached[get_recipient_cache_key(recipient.type, recipient.type_id)] = (recipient,)
+def recipient_cache_items(items_for_remote_cache, recipient):
+    items_for_remote_cache[get_recipient_cache_key(recipient.type, recipient.type_id)] = (recipient,)
 
 session_engine = import_module(settings.SESSION_ENGINE)
-def session_cache_items(items_for_memcached, session):
+def session_cache_items(items_for_remote_cache, session):
     store = session_engine.SessionStore(session_key=session.session_key)
-    items_for_memcached[store.cache_key] = store.decode(session.session_data)
+    items_for_remote_cache[store.cache_key] = store.decode(session.session_data)
 
 # Format is (objects query, items filler function, timeout, batch size)
 #
@@ -75,16 +75,16 @@ cache_fillers = {
 def fill_memcached_cache(cache):
     memcached_time_start = get_memcached_time()
     memcached_requests_start = get_memcached_requests()
-    items_for_memcached = {}
+    items_for_remote_cache = {}
     (objects, items_filler, timeout, batch_size) = cache_fillers[cache]
     count = 0
     for obj in objects():
-        items_filler(items_for_memcached, obj)
+        items_filler(items_for_remote_cache, obj)
         count += 1
         if (count % batch_size == 0):
-            cache_set_many(items_for_memcached, timeout=3600*24)
-            items_for_memcached = {}
-    cache_set_many(items_for_memcached, timeout=3600*24*7)
+            cache_set_many(items_for_remote_cache, timeout=3600*24)
+            items_for_remote_cache = {}
+    cache_set_many(items_for_remote_cache, timeout=3600*24*7)
     logging.info("Succesfully populated %s cache!  Consumed %s memcached queries (%s time)" % \
                      (cache, get_memcached_requests() - memcached_requests_start,
                       round(get_memcached_time() - memcached_time_start, 2)))

--- a/zerver/management/commands/create_realm.py
+++ b/zerver/management/commands/create_realm.py
@@ -41,7 +41,8 @@ Usage: python2.7 manage.py create_realm --domain=foo.com --name='Foo, Inc.'"""
 
     def validate_domain(self, domain):
         # Domains can't contain whitespace if they are to be used in memcached
-        # keys.
+        # keys. Seems safer to leave that as the default case regardless of
+        # which backing store we use.
         if re.search("\s", domain):
             raise ValueError("Domains can't contain whitespace")
 

--- a/zerver/management/commands/fill_memcached_caches.py
+++ b/zerver/management/commands/fill_memcached_caches.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from optparse import make_option
 from django.core.management.base import BaseCommand
-from zerver.lib.cache_helpers import fill_memcached_cache, cache_fillers
+from zerver.lib.cache_helpers import fill_remote_cache, cache_fillers
 
 class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
@@ -11,8 +11,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if options["cache"] is not None:
-            return fill_memcached_cache(options["cache"])
+            return fill_remote_cache(options["cache"])
 
         for cache in cache_fillers.keys():
-            fill_memcached_cache(cache)
+            fill_remote_cache(cache)
 

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -118,21 +118,21 @@ def write_log_line(log_data, path, method, remote_ip, email, client_name,
     memcached_output = ""
     if 'remote_cache_time_start' in log_data:
         remote_cache_time_delta = get_remote_cache_time() - log_data['remote_cache_time_start']
-        memcached_count_delta = get_remote_cache_requests() - log_data['remote_cache_requests_start']
+        remote_cache_count_delta = get_remote_cache_requests() - log_data['remote_cache_requests_start']
         if 'remote_cache_requests_stopped' in log_data:
             # (now - restarted) + (stopped - start) = (now - start) + (stopped - restarted)
             remote_cache_time_delta += (log_data['remote_cache_time_stopped'] -
                                      log_data['remote_cache_time_restarted'])
-            memcached_count_delta += (log_data['remote_cache_requests_stopped'] -
+            remote_cache_count_delta += (log_data['remote_cache_requests_stopped'] -
                                       log_data['remote_cache_requests_restarted'])
 
         if (remote_cache_time_delta > 0.005):
             memcached_output = " (mem: %s/%s)" % (format_timedelta(remote_cache_time_delta),
-                                                  memcached_count_delta)
+                                                  remote_cache_count_delta)
 
         if not suppress_statsd:
             statsd.timing("%s.memcached.time" % (statsd_path,), timedelta_ms(remote_cache_time_delta))
-            statsd.incr("%s.memcached.querycount" % (statsd_path,), memcached_count_delta)
+            statsd.incr("%s.memcached.querycount" % (statsd_path,), remote_cache_count_delta)
 
     startup_output = ""
     if 'startup_time_delta' in log_data and log_data["startup_time_delta"] > 0.005:

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -131,8 +131,8 @@ def write_log_line(log_data, path, method, remote_ip, email, client_name,
                                                      remote_cache_count_delta)
 
         if not suppress_statsd:
-            statsd.timing("%s.memcached.time" % (statsd_path,), timedelta_ms(remote_cache_time_delta))
-            statsd.incr("%s.memcached.querycount" % (statsd_path,), remote_cache_count_delta)
+            statsd.timing("%s.remote_cache.time" % (statsd_path,), timedelta_ms(remote_cache_time_delta))
+            statsd.incr("%s.remote_cache.querycount" % (statsd_path,), remote_cache_count_delta)
 
     startup_output = ""
     if 'startup_time_delta' in log_data and log_data["startup_time_delta"] > 0.005:

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -115,7 +115,7 @@ def write_log_line(log_data, path, method, remote_ip, email, client_name,
         time_delta = ((log_data['time_stopped'] - log_data['time_started']) +
                       (time.time() - log_data['time_restarted']))
         optional_orig_delta = " (lp: %s)" % (format_timedelta(orig_time_delta),)
-    memcached_output = ""
+    remote_cache_output = ""
     if 'remote_cache_time_start' in log_data:
         remote_cache_time_delta = get_remote_cache_time() - log_data['remote_cache_time_start']
         remote_cache_count_delta = get_remote_cache_requests() - log_data['remote_cache_requests_start']
@@ -127,8 +127,8 @@ def write_log_line(log_data, path, method, remote_ip, email, client_name,
                                       log_data['remote_cache_requests_restarted'])
 
         if (remote_cache_time_delta > 0.005):
-            memcached_output = " (mem: %s/%s)" % (format_timedelta(remote_cache_time_delta),
-                                                  remote_cache_count_delta)
+            remote_cache_output = " (mem: %s/%s)" % (format_timedelta(remote_cache_time_delta),
+                                                     remote_cache_count_delta)
 
         if not suppress_statsd:
             statsd.timing("%s.memcached.time" % (statsd_path,), timedelta_ms(remote_cache_time_delta))
@@ -178,7 +178,7 @@ def write_log_line(log_data, path, method, remote_ip, email, client_name,
     logger_client = "(%s via %s)" % (email, client_name)
     logger_timing = '%5s%s%s%s%s%s %s' % \
                      (format_timedelta(time_delta), optional_orig_delta,
-                      memcached_output, bugdown_output,
+                      remote_cache_output, bugdown_output,
                       db_time_output, startup_output, path)
     logger_line = '%-15s %-7s %3d %s%s %s' % \
                     (remote_ip, method, status_code,

--- a/zerver/test_messages.py
+++ b/zerver/test_messages.py
@@ -1087,7 +1087,7 @@ class GetOldMessagesTest(AuthedTestCase):
         m = Message.objects.all().order_by('-id')[0]
         m.rendered_content = m.rendered_content_version = None
         m.content = 'test content'
-        # Use to_dict_uncached directly to avoid having to deal with memcached
+        # Use to_dict_uncached directly to avoid having to deal with remote cache
         d = m.to_dict_uncached(True)
         self.assertEqual(d['content'], '<p>test content</p>')
 

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -548,7 +548,7 @@ def get_old_messages_backend(request, user_profile,
     # 'user_messages' dictionary maps each message to the user's
     # UserMessage object for that message, which we will attach to the
     # rendered message dict before returning it.  We attempt to
-    # bulk-fetch rendered message dicts from memcached using the
+    # bulk-fetch rendered message dicts from remote cache using the
     # 'messages' list.
     search_fields = dict()
     message_ids = []


### PR DESCRIPTION
Related to #378, switch all non-specific cache references to generic `remote_cache` instead of `memcached`.

Would have just switched `\w*memcached\w*` to `\w*cache\w*`, but there are a few functions / variables where they would overlap and might cause problems.

There are still a ton of references to memcached throughout the code, but **hopefully** those are all actual memcached references, and some will stay even if the backing store is changed (e.g. [zerver/lib/cache.py `cache`](https://github.com/zulip/zulip/blob/master/zerver/lib/cache.py#L218)).