### PR TITLE
Add minimal PEP-484 annotations to make mypy pass on most of codebase

### DIFF
--- a/analytics/management/commands/active_user_stats.py
+++ b/analytics/management/commands/active_user_stats.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
 
         # Calculate 10min, 2hrs, 12hrs, 1day, 2 business days (TODO business days), 1 week bucket of stats
         hour_buckets = [0.16, 2, 12, 24, 48, 168]
-        user_info = defaultdict(dict)
+        user_info = defaultdict(dict) # type: Dict[str, Dict[float, List[str]]]
 
         for last_presence in users:
             if last_presence.status == UserPresence.IDLE:

--- a/analytics/management/commands/analyze_mit.py
+++ b/analytics/management/commands/analyze_mit.py
@@ -27,15 +27,15 @@ def compute_stats(log_level):
                            "bitcoin@mit.edu", "lp@mit.edu", "clocks@mit.edu",
                            "root@mit.edu", "nagios@mit.edu",
                            "www-data|local-realm@mit.edu"])
-    user_counts = {}
+    user_counts = {} # type: Dict[str, Dict[str, int]]
     for m in mit_query.select_related("sending_client", "sender"):
         email = m.sender.email
         user_counts.setdefault(email, {})
         user_counts[email].setdefault(m.sending_client.name, 0)
         user_counts[email][m.sending_client.name] += 1
 
-    total_counts = {}
-    total_user_counts = {}
+    total_counts = {} # type: Dict[str, int]
+    total_user_counts = {} # type: Dict[str, int]
     for email, counts in user_counts.items():
         total_user_counts.setdefault(email, 0)
         for client_name, count in counts.items():
@@ -44,7 +44,7 @@ def compute_stats(log_level):
             total_user_counts[email] += count
 
     logging.debug("%40s | %10s | %s" % ("User", "Messages", "Percentage Zulip"))
-    top_percents = {}
+    top_percents = {} # type: Dict[int, float]
     for size in [10, 25, 50, 100, 200, len(total_user_counts.keys())]:
         top_percents[size] = 0.0
     for i, email in enumerate(sorted(total_user_counts.keys(),

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
+from typing import *
+
 from django.db import connection
 from django.template import RequestContext, loader
 from django.utils.html import mark_safe
@@ -76,7 +78,7 @@ def get_realm_day_counts():
     rows = dictfetchall(cursor)
     cursor.close()
 
-    counts = defaultdict(dict)
+    counts = defaultdict(dict) # type: Dict[str, Dict[int, int]]
     for row in rows:
         counts[row['domain']][row['age']] = row['cnt']
 
@@ -620,7 +622,8 @@ def raw_user_activity_table(records):
     return make_table(title, cols, rows)
 
 def get_user_activity_summary(records):
-    summary = {}
+    # type: (Any) -> Any
+    summary = {} # type: Dict[str, Dict[str, Any]]
     def update(action, record):
         if action not in summary:
             summary[action] = dict(
@@ -817,8 +820,9 @@ def realm_user_summary_table(all_records, admin_emails):
 
 @zulip_internal
 def get_realm_activity(request, realm):
-    data = []
-    all_user_records = {}
+    # type: (Any, Any) -> Any
+    data = [] # type: List[Tuple[str, str]]
+    all_user_records = {} # type: Dict[str, Any]
 
     try:
         admins = get_realm(realm).get_admin_users()
@@ -860,7 +864,7 @@ def get_realm_activity(request, realm):
 def get_user_activity(request, email):
     records = get_user_activity_records_for_email(email)
 
-    data = []
+    data = [] # type: List[Tuple[str, str]]
     user_summary = get_user_activity_summary(records)
     content = user_activity_summary_table(user_summary)
 

--- a/api/setup.py
+++ b/api/setup.py
@@ -70,7 +70,7 @@ except ImportError:
         sys.exit(1)
     try:
         import requests
-        assert(LooseVersion(requests.__version__) >= LooseVersion('0.12.1'))
+        assert(LooseVersion(requests.__version__) >= LooseVersion('0.12.1')) # type: ignore # https://github.com/JukkaL/mypy/issues/1165
     except (ImportError, AssertionError):
         print("requests >=0.12.1 is not installed", file=sys.stderr)
         sys.exit(1)

--- a/api/setup.py
+++ b/api/setup.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
+from typing import *
+
 import os
 import sys
 
@@ -16,6 +18,7 @@ def version():
     return version
 
 def recur_expand(target_root, dir):
+    # type: (Any, Any) -> Generator[Tuple[str, List[str]], None, None]
     for root, _, files in os.walk(dir):
         paths = [os.path.join(root, f) for f in files]
         if len(paths):

--- a/bots/jabber_mirror_backend.py
+++ b/bots/jabber_mirror_backend.py
@@ -37,6 +37,7 @@
 #               | other sender|  x  |    |        |
 # public mode   +-------------+-----+----+--------+----
 #               | self sender |     |    |        |
+from typing import *
 
 import logging
 import threading
@@ -78,11 +79,11 @@ class JabberToZulipBot(ClientXMPP):
             self.nick = jid.username
             jid.resource = "zulip"
         ClientXMPP.__init__(self, jid, password)
-        self.rooms = set()
+        self.rooms = set() # type: Set[str]
         self.rooms_to_join = rooms
         self.add_event_handler("session_start", self.session_start)
         self.add_event_handler("message", self.message)
-        self.zulip = None
+        self.zulip = None # type: zulip.Client
         self.use_ipv6 = False
 
         self.register_plugin('xep_0045') # Jabber chatrooms
@@ -195,7 +196,7 @@ class JabberToZulipBot(ClientXMPP):
 class ZulipToJabberBot(object):
     def __init__(self, zulip_client):
         self.client = zulip_client
-        self.jabber = None
+        self.jabber = None # type: JabberToZulipBot
 
     def set_jabber_client(self, client):
         self.jabber = client

--- a/bots/summarize_stream.py
+++ b/bots/summarize_stream.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from typing import *
 # This is hacky code to analyze data on our support stream.  The main
 # reusable bits are get_recent_messages and get_words.
 
@@ -50,13 +51,13 @@ def generate_support_stats():
     narrow = 'stream:support'
     count = 2000
     msgs = get_recent_messages(client, narrow, count)
-    msgs_by_topic = collections.defaultdict(list)
+    msgs_by_topic = collections.defaultdict(list) # type: Dict[str, List[Dict[str, Any]]]
     for msg in msgs:
         topic = msg['subject']
         msgs_by_topic[topic].append(msg)
 
-    word_count = collections.defaultdict(int)
-    email_count = collections.defaultdict(int)
+    word_count = collections.defaultdict(int) # type: Dict[str, int]
+    email_count = collections.defaultdict(int) # type: Dict[str, int]
 
     if False:
         for topic in msgs_by_topic:

--- a/bots/zephyr_mirror_backend.py
+++ b/bots/zephyr_mirror_backend.py
@@ -21,6 +21,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from __future__ import absolute_import
+from typing import *
 
 import sys
 from six.moves import map
@@ -28,7 +29,7 @@ from six.moves import range
 try:
     import simplejson
 except ImportError:
-    import json as simplejson
+    import json as simplejson # type: ignore
 import re
 import time
 import subprocess
@@ -47,6 +48,8 @@ DEFAULT_SITE = "https://api.zulip.com"
 class States(object):
     Startup, ZulipToZephyr, ZephyrToZulip, ChildSending = list(range(4))
 CURRENT_STATE = States.Startup
+
+logger = None # type: logging.Logger
 
 def to_zulip_username(zephyr_username):
     if "@" in zephyr_username:
@@ -878,6 +881,7 @@ def parse_zephyr_subs(verbose=False):
     return zephyr_subscriptions
 
 def open_logger():
+    # type: () -> logging.Logger
     if options.log_path is not None:
         log_file = options.log_path
     elif options.forward_class_messages:
@@ -1025,7 +1029,7 @@ if __name__ == "__main__":
 
     signal.signal(signal.SIGINT, die_gracefully)
 
-    (options, args) = parse_args()
+    (options, args) = parse_args() # type: Any, List[str]
 
     logger = open_logger()
     configure_logger(logger, "parent")
@@ -1113,7 +1117,7 @@ or specify the --api-key-file option.""" % (options.api_key_file,))))
         options.session_path = "/var/tmp/%s" % (options.user,)
 
     if options.forward_from_zulip:
-        child_pid = os.fork()
+        child_pid = os.fork() # type: int
         if child_pid == 0:
             CURRENT_STATE = States.ZulipToZephyr
             # Run the zulip => zephyr mirror in the child

--- a/confirmation/settings.py
+++ b/confirmation/settings.py
@@ -2,9 +2,10 @@
 
 # Copyright: (c) 2008, Jarek Zgoda <jarek.zgoda@gmail.com>
 
+from typing import *
+
 __revision__ = '$Id: settings.py 12 2008-11-23 19:38:52Z jarek.zgoda $'
 
 STATUS_ACTIVE = 1
 
-STATUS_FIELDS = {
-}
+STATUS_FIELDS = {} # type: Dict[Any, Any]

--- a/scripts/lib/pythonrc.py
+++ b/scripts/lib/pythonrc.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 try:
     from django.conf import settings
     from zerver.models import *
-    from zerver.lib.actions import *
+    from zerver.lib.actions import * # type: ignore # Otherwise have duplicate imports with previous line
 except Exception:
     import traceback
     print("\nException importing Zulip core modules on startup!")

--- a/tools/test_user_agent_parsing.py
+++ b/tools/test_user_agent_parsing.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from zerver.lib.user_agent import parse_user_agent
 
-user_agents_parsed = defaultdict(int)
+user_agents_parsed = defaultdict(int) # type: Dict[str, int]
 user_agents_path = os.path.join(os.path.dirname(__file__), "user_agents_unique")
 parse_errors = 0
 for line in open(user_agents_path).readlines():

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -30,7 +30,7 @@ if settings.ZULIP_COM:
 else:
     from mock import Mock
     get_deployment_by_domain = Mock()
-    Deployment = Mock()
+    Deployment = Mock() # type: ignore # https://github.com/JukkaL/mypy/issues/1188
 
 def get_deployment_or_userprofile(role):
     return get_user_profile_by_email(role) if "@" in role else get_deployment_by_domain(role)

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -49,7 +49,7 @@ def asynchronous(method):
     def wrapper(request, *args, **kwargs):
         return method(request, handler=request._tornado_handler, *args, **kwargs)
     if getattr(method, 'csrf_exempt', False):
-        wrapper.csrf_exempt = True
+        wrapper.csrf_exempt = True # type: ignore # https://github.com/JukkaL/mypy/issues/1170
     return wrapper
 
 def update_user_activity(request, user_profile):

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -385,7 +385,7 @@ class REQ(object):
         """
 
         self.post_var_name = whence
-        self.func_var_name = None
+        self.func_var_name = None # type: str
         self.converter = converter
         self.validator = validator
         self.default = default

--- a/zerver/finders.py
+++ b/zerver/finders.py
@@ -19,7 +19,7 @@ class ExcludeUnminifiedMixin(object):
         # However, we work around that by moving it later,
         # in update-prod-static.
 
-        super_class = super(ExcludeUnminifiedMixin, self)
+        super_class = super(ExcludeUnminifiedMixin, self) # type: ignore # https://github.com/JukkaL/mypy/issues/857
         for path, storage in super_class.list(ignore_patterns):
             if not re.search(excluded, path):
                 yield path, storage

--- a/zerver/finders.py
+++ b/zerver/finders.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 import re
 from django.contrib.staticfiles.finders import FileSystemFinder
@@ -9,6 +10,7 @@ class ExcludeUnminifiedMixin(object):
     in production. """
 
     def list(self, ignore_patterns):
+        # type: (Any) -> Generator[Tuple[str, str], None, None]
         # We can't use ignore_patterns because the patterns are
         # applied to just the file part, not the entire path
         excluded = '^(js|styles|templates)/'

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from typing import *
 
 from django.conf import settings
 from django.core import validators
@@ -575,7 +576,7 @@ def do_send_messages(messages):
         message['message'].update_calculated_fields()
 
     # Save the message receipts in the database
-    user_message_flags = defaultdict(dict)
+    user_message_flags = defaultdict(dict) # type: Dict[int, Dict[int, List[str]]]
     with transaction.atomic():
         Message.objects.bulk_create([message['message'] for message in messages])
         ums = []
@@ -1042,7 +1043,7 @@ def bulk_get_subscriber_user_ids(stream_dicts, user_profile, sub_dict):
         user_profile__is_active=True,
         active=True).values("user_profile_id", "recipient__type_id")
 
-    result = dict((stream["id"], []) for stream in stream_dicts)
+    result = dict((stream["id"], []) for stream in stream_dicts) # type: Dict[int, List[int]]
     for sub in subscriptions:
         result[sub["recipient__type_id"]].append(sub["user_profile_id"])
 
@@ -1114,7 +1115,7 @@ def get_subscribers_to_streams(streams):
     arrays of all the streams within 'streams' to which that user is
     subscribed.
     """
-    subscribes_to = {}
+    subscribes_to = {} # type: Dict[str, List[Stream]]
     for stream in streams:
         try:
             subscribers = get_subscribers(stream)
@@ -1160,7 +1161,7 @@ def bulk_add_subscriptions(streams, users):
     for stream in streams:
         stream_map[recipients_map[stream.id].id] = stream
 
-    subs_by_user = defaultdict(list)
+    subs_by_user = defaultdict(list) # type: Dict[int, List[Subscription]]
     all_subs_query = Subscription.objects.select_related("user_profile")
     for sub in all_subs_query.filter(user_profile__in=users,
                                      recipient__type=Recipient.STREAM):
@@ -1222,8 +1223,8 @@ def bulk_add_subscriptions(streams, users):
                                            user_profile__is_active=True,
                                            active=True).select_related('recipient', 'user_profile')
 
-    all_subs_by_stream = defaultdict(list)
-    emails_by_stream = defaultdict(list)
+    all_subs_by_stream = defaultdict(list) # type: Dict[int, List[UserProfile]]
+    emails_by_stream = defaultdict(list) # type: Dict[int, List[str]]
     for sub in all_subs:
         all_subs_by_stream[sub.recipient.type_id].append(sub.user_profile)
         emails_by_stream[sub.recipient.type_id].append(sub.user_profile.email)
@@ -1233,7 +1234,7 @@ def bulk_add_subscriptions(streams, users):
             return []
         return emails_by_stream[stream.id]
 
-    sub_tuples_by_user = defaultdict(list)
+    sub_tuples_by_user = defaultdict(list) # type: Dict[int, List[Tuple[Subscription, Stream]]]
     new_streams = set()
     for (sub, stream) in subs_to_add + subs_to_activate:
         sub_tuples_by_user[sub.user_profile.id].append((sub, stream))
@@ -1336,7 +1337,7 @@ def bulk_remove_subscriptions(users, streams):
     for stream in streams:
         stream_map[recipients_map[stream.id].id] = stream
 
-    subs_by_user = dict((user_profile.id, []) for user_profile in users)
+    subs_by_user = dict((user_profile.id, []) for user_profile in users) # type: Dict[int, List[Subscription]]
     for sub in Subscription.objects.select_related("user_profile").filter(user_profile__in=users,
                                                                           recipient__in=list(recipients_map.values()),
                                                                           active=True):
@@ -1369,7 +1370,7 @@ def bulk_remove_subscriptions(users, streams):
                               for stream in new_vacant_streams])
         send_event(event, active_user_ids(user_profile.realm))
 
-    streams_by_user = defaultdict(list)
+    streams_by_user = defaultdict(list) # type: Dict[int, List[Stream]]
     for (sub, stream) in subs_to_deactivate:
         streams_by_user[sub.user_profile_id].append(stream)
 
@@ -2786,7 +2787,7 @@ def do_invite_users(user_profile, invitee_emails, streams):
     skipped = []
 
     ret_error = None
-    ret_error_data = {}
+    ret_error_data = {} # type: Dict[str, List[Tuple[str, str]]]
 
     for email in invitee_emails:
         if email == '':

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 import codecs
 import markdown
@@ -559,7 +560,7 @@ class Emoji(markdown.inlinepatterns.Pattern):
         orig_syntax = match.group("syntax")
         name = orig_syntax[1:-1]
 
-        realm_emoji = {}
+        realm_emoji = {} # type: Dict[str, str]
         if db_data is not None:
             realm_emoji = db_data['emoji']
 
@@ -990,7 +991,7 @@ def make_md_engine(key, opts):
 
 def subject_links(domain, subject):
     from zerver.models import get_realm, RealmFilter, realm_filters_for_domain
-    matches = []
+    matches = [] # type: List[str]
 
     try:
         realm_filters = realm_filters_for_domain(domain)
@@ -1046,12 +1047,12 @@ def _sanitize_for_log(md):
 
 # Filters such as UserMentionPattern need a message, but python-markdown
 # provides no way to pass extra params through to a pattern. Thus, a global.
-current_message = None
+current_message = None # type: Any # Should be Message but bugdown doesn't import models.py.
 
 # We avoid doing DB queries in our markdown thread to avoid the overhead of
 # opening a new DB connection. These connections tend to live longer than the
 # threads themselves, as well.
-db_data = None
+db_data = None # type: Dict[str, Any]
 
 def do_convert(md, realm_domain=None, message=None):
     """Convert Markdown to HTML, with Zulip-specific settings and hacks."""

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 # This file needs to be different from cache.py because cache.py
 # cannot import anything from zerver.models or we'd have an import
@@ -75,7 +76,7 @@ cache_fillers = {
 def fill_remote_cache(cache):
     remote_cache_time_start = get_remote_cache_time()
     remote_cache_requests_start = get_remote_cache_requests()
-    items_for_remote_cache = {}
+    items_for_remote_cache = {} # type: Dict[str, Any]
     (objects, items_filler, timeout, batch_size) = cache_fillers[cache]
     count = 0
     for obj in objects():

--- a/zerver/lib/context_managers.py
+++ b/zerver/lib/context_managers.py
@@ -7,9 +7,11 @@ from __future__ import absolute_import
 import fcntl
 import os
 from contextlib import contextmanager
+from typing import Generator, Any
 
 @contextmanager
 def flock(lockfile, shared=False):
+    # type: (int, bool) -> Generator[None, None, None]
     """Lock a file object using flock(2) for the duration of a 'with' statement.
 
        If shared is True, use a LOCK_SH lock, otherwise LOCK_EX."""
@@ -22,6 +24,7 @@ def flock(lockfile, shared=False):
 
 @contextmanager
 def lockfile(filename, shared=False):
+    # type: (str, bool) -> Generator[None, None, None]
     """Lock a file using flock(2) for the duration of a 'with' statement.
 
        If shared is True, use a LOCK_SH lock, otherwise LOCK_EX.

--- a/zerver/lib/db.py
+++ b/zerver/lib/db.py
@@ -29,7 +29,7 @@ class TimeTrackingConnection(connection):
     """A psycopg2 connection class that uses TimeTrackingCursors."""
 
     def __init__(self, *args, **kwargs):
-        self.queries = []
+        self.queries = [] # type: List[Dict[str, str]]
         super(TimeTrackingConnection, self).__init__(*args, **kwargs)
 
     def cursor(self, name=None):

--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 from collections import defaultdict
 import datetime
@@ -40,8 +41,8 @@ def gather_hot_conversations(user_profile, stream_messages):
     # Returns a list of dictionaries containing the templating
     # information for each hot conversation.
 
-    conversation_length = defaultdict(int)
-    conversation_diversity = defaultdict(set)
+    conversation_length = defaultdict(int) # type: Dict[Tuple[int, str], int]
+    conversation_diversity = defaultdict(set) # type: Dict[Tuple[int, str], Set[str]]
     for user_message in stream_messages:
         if not user_message.message.sent_by_human():
             # Don't include automated messages in the count.
@@ -99,7 +100,7 @@ def gather_new_users(user_profile, threshold):
     # Gather information on users in the realm who have recently
     # joined.
     if user_profile.realm.domain == "mit.edu":
-        new_users = []
+        new_users = [] # type: List[UserProfile]
     else:
         new_users = list(UserProfile.objects.filter(
                 realm=user_profile.realm, date_joined__gt=threshold,
@@ -110,7 +111,7 @@ def gather_new_users(user_profile, threshold):
 
 def gather_new_streams(user_profile, threshold):
     if user_profile.realm.domain == "mit.edu":
-        new_streams = []
+        new_streams = [] # type: List[Stream]
     else:
         new_streams = list(get_active_streams(user_profile.realm).filter(
                 invite_only=False, date_created__gt=threshold))

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -235,7 +235,7 @@ def find_emailgateway_recipient(message):
     # it is more accurate, so try to find the most-accurate
     # recipient list in descending priority order
     recipient_headers = ["X-Gm-Original-To", "Delivered-To", "To"]
-    recipients = []
+    recipients = [] # type: List[str]
     for recipient_header in recipient_headers:
         r = message.get_all(recipient_header, None)
         if r:

--- a/zerver/lib/event_queue.py
+++ b/zerver/lib/event_queue.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 from django.conf import settings
 from django.utils.timezone import now
@@ -58,8 +59,8 @@ class ClientDescriptor(object):
         self.user_profile_id = user_profile_id
         self.user_profile_email = user_profile_email
         self.realm_id = realm_id
-        self.current_handler_id = None
-        self.current_client_name = None
+        self.current_handler_id = None # type: int
+        self.current_client_name = None # type: str
         self.event_queue = event_queue
         self.queue_timeout = lifespan_secs
         self.event_types = event_types
@@ -192,7 +193,7 @@ class ClientDescriptor(object):
         do_gc_event_queues([self.event_queue.id], [self.user_profile_id],
                            [self.realm_id])
 
-descriptors_by_handler_id = {}
+descriptors_by_handler_id = {} # type: Dict[int, ClientDescriptor]
 
 def get_descriptor_by_handler_id(handler_id):
     return descriptors_by_handler_id.get(handler_id)
@@ -213,10 +214,11 @@ def compute_full_event_type(event):
 
 class EventQueue(object):
     def __init__(self, id):
-        self.queue = deque()
+        # type: (Any) -> None
+        self.queue = deque() # type: deque[Dict[str, str]]
         self.next_event_id = 0
         self.id = id
-        self.virtual_events = {}
+        self.virtual_events = {} # type: Dict[str, Dict[str, str]]
 
     def to_dict(self):
         # If you add a new key to this dict, make sure you add appropriate
@@ -296,7 +298,7 @@ class EventQueue(object):
         return contents
 
 # maps queue ids to client descriptors
-clients = {} # type: Dict[int, ClientDescriptor]
+clients = {} # type: Dict[str, ClientDescriptor]
 # maps user id to list of client descriptors
 user_clients = {} # type: Dict[int, List[ClientDescriptor]]
 # maps realm id to list of client descriptors with all_public_streams=True
@@ -432,7 +434,7 @@ def setup_event_queue():
     atexit.register(dump_event_queues)
     # Make sure we dump event queues even if we exit via signal
     signal.signal(signal.SIGTERM, lambda signum, stack: sys.exit(1))
-    tornado.autoreload.add_reload_hook(dump_event_queues)
+    tornado.autoreload.add_reload_hook(dump_event_queues) # type: ignore # TODO: Fix missing tornado.autoreload stub
 
     try:
         os.rename(settings.JSON_PERSISTENT_QUEUE_FILENAME, "/var/tmp/event_queues.json.last")

--- a/zerver/lib/event_queue.py
+++ b/zerver/lib/event_queue.py
@@ -68,7 +68,7 @@ class ClientDescriptor(object):
         self.apply_markdown = apply_markdown
         self.all_public_streams = all_public_streams
         self.client_type_name = client_type_name
-        self._timeout_handle = None
+        self._timeout_handle = None # type: Any # TODO: should be return type of ioloop.add_timeout
         self.narrow = narrow
         self.narrow_filter = build_narrow_filter(narrow)
 

--- a/zerver/lib/event_queue.py
+++ b/zerver/lib/event_queue.py
@@ -296,11 +296,11 @@ class EventQueue(object):
         return contents
 
 # maps queue ids to client descriptors
-clients = {}
+clients = {} # type: Dict[int, ClientDescriptor]
 # maps user id to list of client descriptors
-user_clients = {}
+user_clients = {} # type: Dict[int, List[ClientDescriptor]]
 # maps realm id to list of client descriptors with all_public_streams=True
-realm_clients_all_streams = {}
+realm_clients_all_streams = {} # type: Dict[int, List[ClientDescriptor]]
 
 # list of registered gc hooks.
 # each one will be called with a user profile id, queue, and bool

--- a/zerver/lib/handlers.py
+++ b/zerver/lib/handlers.py
@@ -1,8 +1,9 @@
 import logging
 from zerver.middleware import async_request_restart
+from typing import *
 
 current_handler_id = 0
-handlers = {}
+handlers = {} # type: Dict[int, Any] # TODO: Should be AsyncDjangoHandler but we don't important runtornado.py.
 
 def get_handler_by_id(handler_id):
     return handlers[handler_id]

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+from typing import *
+
 from confirmation.models import Confirmation
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
@@ -7,7 +9,7 @@ from zerver.decorator import statsd_increment, uses_mandrill
 from zerver.models import Recipient, ScheduledJob, UserMessage, \
     Stream, get_display_recipient, get_user_profile_by_email, \
     get_user_profile_by_id, receives_offline_notifications, \
-    get_context_for_message
+    get_context_for_message, Message
 
 import datetime
 import re
@@ -58,7 +60,7 @@ def build_message_list(user_profile, messages):
     The messages are collapsed into per-recipient and per-sender blocks, like
     our web interface
     """
-    messages_to_render = []
+    messages_to_render = [] # type: List[Dict[str, Any]]
 
     def sender_string(message):
         sender = ''
@@ -324,7 +326,7 @@ def handle_missedmessage_emails(user_profile_id, missed_email_events):
     if not messages:
         return
 
-    messages_by_recipient_subject = defaultdict(list)
+    messages_by_recipient_subject = defaultdict(list) # type: Dict[Tuple[int, str], List[Message]]
     for msg in messages:
         messages_by_recipient_subject[(msg.recipient_id, msg.subject)].append(msg)
 

--- a/zerver/lib/parallel.py
+++ b/zerver/lib/parallel.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from typing import *
 
 import os
 import pty
@@ -7,7 +8,8 @@ import sys
 import errno
 
 def run_parallel(job, data, threads=6):
-    pids = {}
+    # type: (Any, Iterable[Any], int) -> Generator[Tuple[int, Any], None, None]
+    pids = {} # type: Dict[int, Any]
 
     def wait_for_one():
         while True:

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -11,6 +11,7 @@ import atexit
 from collections import defaultdict
 
 from zerver.lib.utils import statsd
+from typing import *
 
 # This simple queuing library doesn't expose much of the power of
 # rabbitmq/pika's queuing system; its purpose is to just provide an
@@ -19,9 +20,9 @@ from zerver.lib.utils import statsd
 class SimpleQueueClient(object):
     def __init__(self):
         self.log = logging.getLogger('zulip.queue')
-        self.queues = set()
-        self.channel = None
-        self.consumers = defaultdict(set)
+        self.queues = set() # type: Set[str]
+        self.channel = None # type: Any
+        self.consumers = defaultdict(set) # type: Dict[str, Set[Any]]
         self._connect()
 
     def _connect(self):
@@ -156,7 +157,7 @@ class TornadoQueueClient(SimpleQueueClient):
     # https://pika.readthedocs.org/en/0.9.8/examples/asynchronous_consumer_example.html
     def __init__(self):
         super(TornadoQueueClient, self).__init__()
-        self._on_open_cbs = []
+        self._on_open_cbs = [] # type: List[Callable[[], None]]
 
     def _connect(self, on_open_cb = None):
         self.log.info("Beginning TornadoQueueClient connection")
@@ -230,7 +231,7 @@ class TornadoQueueClient(SimpleQueueClient):
             lambda: self.channel.basic_consume(wrapped_consumer, queue=queue_name,
                 consumer_tag=self._generate_ctag(queue_name)))
 
-queue_client = None
+queue_client = None # type: SimpleQueueClient
 def get_queue_client():
     global queue_client
     if queue_client is None:

--- a/zerver/lib/socket.py
+++ b/zerver/lib/socket.py
@@ -40,7 +40,7 @@ def get_user_profile(session_id):
     except (UserProfile.DoesNotExist, KeyError):
         return None
 
-connections = dict()
+connections = dict() # type: Dict[int, SocketConnection]
 
 def get_connection(id):
     return connections.get(id)

--- a/zerver/lib/socket.py
+++ b/zerver/lib/socket.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 from django.conf import settings
 from django.utils.importlib import import_module
@@ -79,7 +80,7 @@ class SocketConnection(sockjs.tornado.SockJSConnection):
 
         self.authenticated = False
         self.session.user_profile = None
-        self.close_info = None
+        self.close_info = None # type: CloseErrorInfo
         self.did_close = False
 
         try:
@@ -226,7 +227,7 @@ class SocketConnection(sockjs.tornado.SockJSConnection):
         self.did_close = True
 
 def fake_message_sender(event):
-    log_data = dict()
+    log_data = dict() # type: Dict[str, Any]
     record_request_start_data(log_data)
 
     req = event['request']

--- a/zerver/lib/statistics.py
+++ b/zerver/lib/statistics.py
@@ -119,5 +119,5 @@ def activity_averages_between(begin, end, by_day=True):
         return dict((day, calculate_stats(values, all_users=users_to_measure))
                     for day, values in six.iteritems(seconds_active))
     else:
-        return calculate_stats(list(chain.from_iterable(seconds_active.values())),
+        return calculate_stats(list(chain.from_iterable(seconds_active.values())), # type: ignore # chain.from_iterable needs overload
                                all_users=users_to_measure)

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -55,9 +55,9 @@ def stub(obj, name, f):
 def simulated_queue_client(client):
     # type: (Any) -> Generator[None, None, None]
     real_SimpleQueueClient = queue_processors.SimpleQueueClient
-    queue_processors.SimpleQueueClient = client
+    queue_processors.SimpleQueueClient = client # type: ignore # https://github.com/JukkaL/mypy/issues/1152
     yield
-    queue_processors.SimpleQueueClient = real_SimpleQueueClient
+    queue_processors.SimpleQueueClient = real_SimpleQueueClient # type: ignore # https://github.com/JukkaL/mypy/issues/1152
 
 @contextmanager
 def tornado_redirected_to_list(lst):
@@ -113,17 +113,17 @@ def queries_captured():
     old_executemany = TimeTrackingCursor.executemany
 
     def cursor_execute(self, sql, params=()):
-        return wrapper_execute(self, super(TimeTrackingCursor, self).execute, sql, params)
-    TimeTrackingCursor.execute = cursor_execute
+        return wrapper_execute(self, super(TimeTrackingCursor, self).execute, sql, params)  # type: ignore # https://github.com/JukkaL/mypy/issues/1167
+    TimeTrackingCursor.execute = cursor_execute # type: ignore # https://github.com/JukkaL/mypy/issues/1167
 
     def cursor_executemany(self, sql, params=()):
-        return wrapper_execute(self, super(TimeTrackingCursor, self).executemany, sql, params)
-    TimeTrackingCursor.executemany = cursor_executemany
+        return wrapper_execute(self, super(TimeTrackingCursor, self).executemany, sql, params)  # type: ignore # https://github.com/JukkaL/mypy/issues/1167
+    TimeTrackingCursor.executemany = cursor_executemany # type: ignore # https://github.com/JukkaL/mypy/issues/1167
 
     yield queries
 
-    TimeTrackingCursor.execute = old_execute
-    TimeTrackingCursor.executemany = old_executemany
+    TimeTrackingCursor.execute = old_execute # type: ignore # https://github.com/JukkaL/mypy/issues/1167
+    TimeTrackingCursor.executemany = old_executemany # type: ignore # https://github.com/JukkaL/mypy/issues/1167
 
 
 def find_key_by_email(address):

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -166,7 +166,7 @@ class DummyObject(object):
 class DummyTornadoRequest(object):
     def __init__(self):
         self.connection = DummyObject()
-        self.connection.stream = DummyStream()
+        self.connection.stream = DummyStream() # type: ignore # monkey-patching here
 
 class DummyHandler(object):
     def __init__(self, assert_callback):
@@ -202,7 +202,7 @@ class POSTRequestMock(object):
         self.user = user_profile
         self._tornado_handler = DummyHandler(assert_callback)
         self.session = DummySession()
-        self._log_data = {}
+        self._log_data = {} # type: Dict[str, Any]
         self.META = {'PATH_INFO': 'test'}
 
 class AuthedTestCase(TestCase):

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from typing import *
+
 from django.test import TestCase
 
 from zerver.lib.initial_password import initial_password
@@ -39,10 +41,11 @@ from six.moves import urllib
 from contextlib import contextmanager
 import six
 
-API_KEYS = {}
+API_KEYS = {} # type: Dict[str, str]
 
 @contextmanager
 def stub(obj, name, f):
+    # type: (Any, str, Callable[..., Any]) -> Generator[None, None, None]
     old_f = getattr(obj, name)
     setattr(obj, name, f)
     yield
@@ -50,6 +53,7 @@ def stub(obj, name, f):
 
 @contextmanager
 def simulated_queue_client(client):
+    # type: (Any) -> Generator[None, None, None]
     real_SimpleQueueClient = queue_processors.SimpleQueueClient
     queue_processors.SimpleQueueClient = client
     yield
@@ -57,6 +61,7 @@ def simulated_queue_client(client):
 
 @contextmanager
 def tornado_redirected_to_list(lst):
+    # type: (List) -> Generator[None, None, None]
     real_event_queue_process_notification = event_queue.process_notification
     event_queue.process_notification = lst.append
     yield
@@ -64,6 +69,7 @@ def tornado_redirected_to_list(lst):
 
 @contextmanager
 def simulated_empty_cache():
+    # type: () -> Generator[List[Tuple[str, str, str]], None, None]
     cache_queries = []
     def my_cache_get(key, cache_name=None):
         cache_queries.append(('get', key, cache_name))
@@ -83,6 +89,7 @@ def simulated_empty_cache():
 
 @contextmanager
 def queries_captured():
+    # type: () -> Generator[List[Dict[str, str]], None, None]
     '''
     Allow a user to capture just the queries executed during
     the with statement.

--- a/zerver/lib/timeout.py
+++ b/zerver/lib/timeout.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 import sys
 import time
@@ -33,8 +34,8 @@ def timeout(timeout, func, *args, **kwargs):
     class TimeoutThread(threading.Thread):
         def __init__(self):
             threading.Thread.__init__(self)
-            self.result = None
-            self.exc_info = None
+            self.result = None # type: Any
+            self.exc_info = None # type: Tuple[type, BaseException, Any]
 
             # Don't block the whole program from exiting
             # if this is the only thread left.

--- a/zerver/lib/tornado_ioloop_logging.py
+++ b/zerver/lib/tornado_ioloop_logging.py
@@ -10,9 +10,9 @@ from django.conf import settings
 
 try:
     # Tornado 2.4
-    orig_poll_impl = ioloop._poll
+    orig_poll_impl = ioloop._poll # type: ignore # cross-version type variation is hard for mypy
     def instrument_tornado_ioloop():
-        ioloop._poll = InstrumentedPoll
+        ioloop._poll = InstrumentedPoll # type: ignore # cross-version type variation is hard for mypy
 except:
     # Tornado 3
     from tornado.ioloop import IOLoop, PollIOLoop
@@ -21,7 +21,7 @@ except:
     # be epoll.
     orig_poll_impl = select.epoll
     class InstrumentedPollIOLoop(PollIOLoop):
-        def initialize(self, **kwargs):
+        def initialize(self, **kwargs): # type: ignore # TODO investigate likely buggy monkey patching here
             super(InstrumentedPollIOLoop, self).initialize(impl=InstrumentedPoll(), **kwargs)
 
     def instrument_tornado_ioloop():

--- a/zerver/lib/tornado_ioloop_logging.py
+++ b/zerver/lib/tornado_ioloop_logging.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
+from typing import *
 
 import logging
 import time
@@ -37,7 +38,7 @@ except:
 class InstrumentedPoll(object):
     def __init__(self):
         self._underlying = orig_poll_impl()
-        self._times = []
+        self._times = [] # type: List[Tuple[float, float]]
         self._last_print = 0.0
 
     # Python won't let us subclass e.g. select.epoll, so instead

--- a/zerver/lib/unminify.py
+++ b/zerver/lib/unminify.py
@@ -11,7 +11,7 @@ class SourceMap(object):
 
     def __init__(self, sourcemap_dir):
         self._dir = sourcemap_dir
-        self._indices = {}
+        self._indices = {} # type: Dict[str, sourcemap.SourceMapDecoder]
 
     def _index_for(self, minified_src):
         '''Return the source map index for minified_src, loading it if not

--- a/zerver/management/commands/import_dump.py
+++ b/zerver/management/commands/import_dump.py
@@ -107,7 +107,7 @@ Usage: python2.7 manage.py import_dump [--destroy-rebuild-database] [--chunk-siz
             Client, Message, UserMessage, Huddle, DefaultStream, RealmAlias,
             RealmFilter]
 
-        self.chunk_size = options["chunk_size"]
+        self.chunk_size = options["chunk_size"] # type: int # ignore mypy options bug
         encoding = sys.getfilesystemencoding()
 
         if len(args) == 0:
@@ -124,11 +124,11 @@ Usage: python2.7 manage.py import_dump [--destroy-rebuild-database] [--chunk-siz
         # maps relationship between realm id and notifications_stream_id
         # generally, there should be only one realm per dump, but the code
         # doesn't make that assumption
-        realm_notification_map = dict()
+        realm_notification_map = dict() # type: Dict[int, int]
 
         # maping between table name and a total expected number of rows across
         # all input json files
-        row_counter = dict()
+        row_counter = dict() # type: Dict[str, int]
 
         for file_name in args:
             try:

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from typing import *
 
 from django.conf import settings
 settings.RUNNING_INSIDE_TORNADO = True
@@ -143,7 +144,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
 
         # Set up middleware if needed. We couldn't do this earlier, because
         # settings weren't available.
-        self._request_middleware = None
+        self._request_middleware = None # type: ignore # Should be List[Callable[[WSGIRequest], Any]] https://github.com/JukkaL/mypy/issues/1174
         self.initLock.acquire()
         # Check that middleware is still uninitialised.
         if self._request_middleware is None:
@@ -178,7 +179,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
             self.set_header(h[0], h[1])
 
         if not hasattr(self, "_new_cookies"):
-            self._new_cookies = []
+            self._new_cookies = [] # type: List[http.cookie.SimpleCookie]
         self._new_cookies.append(response.cookies)
 
         self.write(response.content)

--- a/zerver/migrations/0001_initial.py
+++ b/zerver/migrations/0001_initial.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
     ]
 
     if "postgres" not in settings.DATABASES["default"]["ENGINE"]:
-        zulip_postgres_migrations = []
+        zulip_postgres_migrations = [] # type: ignore # https://github.com/JukkaL/mypy/issues/1164
     else:
         zulip_postgres_migrations = [
             # Full-text search

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 from django.db import models
 from django.conf import settings
@@ -29,7 +30,7 @@ import re
 import ujson
 import logging
 
-bugdown = None
+bugdown = None # type: Any
 
 MAX_SUBJECT_LENGTH = 60
 MAX_MESSAGE_LENGTH = 10000
@@ -142,9 +143,10 @@ class Realm(models.Model):
         except IndexError:
             return None
 
-    @deployment.setter
+    @deployment.setter # type: ignore # https://github.com/python/mypy/issues/220
     def set_deployments(self, value):
-        self._deployments = [value]
+        # type: (Any) -> None
+        self._deployments = [value] # type: Any
 
     def get_admin_users(self):
         # This method is kind of expensive, due to our complex permissions model.
@@ -269,7 +271,8 @@ def realm_filters_for_domain_remote_cache(domain):
     return filters
 
 def all_realm_filters():
-    filters = defaultdict(list)
+    # type: () -> Dict[str, List[Tuple[str, str]]]
+    filters = defaultdict(list) # type: Dict[str, List[Tuple[str, str]]]
     for realm_filter in RealmFilter.objects.all():
        filters[realm_filter.realm.domain].append((realm_filter.pattern, realm_filter.url_format_string))
 
@@ -384,7 +387,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     # [["social", "mit"], ["devel", "ios"]]
     muted_topics = models.TextField(default=ujson.dumps([]))
 
-    objects = UserManager()
+    objects = UserManager() # type: UserManager
 
     def can_admin_user(self, target_user):
         """Returns whether this user has permission to modify target_user"""
@@ -712,8 +715,8 @@ class Message(models.Model):
 
         self.mentions_wildcard = False
         self.is_me_message = False
-        self.mentions_user_ids = set()
-        self.user_ids_with_alert_words = set()
+        self.mentions_user_ids = set() # type: Set[int]
+        self.user_ids_with_alert_words = set() # type: Set[int]
 
         if not domain:
             domain = self.sender.realm.domain
@@ -1144,6 +1147,7 @@ def get_realm(domain):
 
 def clear_database():
     pylibmc.Client(['127.0.0.1']).flush_all()
+    model = None # type: Any
     for model in [Message, Stream, UserProfile, Recipient,
                   Realm, Subscription, Huddle, UserMessage, Client,
                   DefaultStream]:
@@ -1186,7 +1190,8 @@ class UserPresence(models.Model):
 
     @staticmethod
     def get_status_dict_by_realm(realm_id):
-        user_statuses = defaultdict(dict)
+        # type: (Any) -> Any
+        user_statuses = defaultdict(dict) # type: Dict[Any, Dict[Any, Any]]
 
         query = UserPresence.objects.filter(
                 user_profile__realm_id=realm_id,

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -36,7 +36,7 @@ MAX_MESSAGE_LENGTH = 10000
 
 # Doing 1000 remote cache requests to get_display_recipient is quite slow,
 # so add a local cache as well as the remote cache cache.
-per_request_display_recipient_cache = {}
+per_request_display_recipient_cache = {} # type: Dict[int, List[Dict[str, Any]]]
 def get_display_recipient_by_id(recipient_id, recipient_type, recipient_type_id):
     if recipient_id not in per_request_display_recipient_cache:
         result = get_display_recipient_remote_cache(recipient_id, recipient_type, recipient_type_id)
@@ -253,7 +253,7 @@ def get_realm_filters_cache_key(domain):
     return 'all_realm_filters:%s' % (domain,)
 
 # We have a per-process cache to avoid doing 1000 remote cache queries during page load
-per_request_realm_filters_cache = {}
+per_request_realm_filters_cache = {} # type: Dict[str, List[RealmFilter]]
 def realm_filters_for_domain(domain):
     domain = domain.lower()
     if domain not in per_request_realm_filters_cache:
@@ -578,7 +578,7 @@ class Recipient(models.Model):
 class Client(models.Model):
     name = models.CharField(max_length=30, db_index=True, unique=True)
 
-get_client_cache = {}
+get_client_cache = {} # type: Dict[str, Client]
 def get_client(name):
     if name not in get_client_cache:
         result = get_client_remote_cache(name)

--- a/zerver/storage.py
+++ b/zerver/storage.py
@@ -35,7 +35,7 @@ class AddHeaderMixin(object):
 
             ret_dict[path] = (path, path, True)
 
-        super_class = super(AddHeaderMixin, self)
+        super_class = super(AddHeaderMixin, self) # type: ignore # https://github.com/JukkaL/mypy/issues/857
         if hasattr(super_class, 'post_process'):
             super_ret = super_class.post_process(paths, dry_run, **kwargs)
         else:

--- a/zerver/test_decorators.py
+++ b/zerver/test_decorators.py
@@ -26,10 +26,9 @@ class DecoratorTestCase(TestCase):
             return sum(numbers)
 
         class Request(object):
-            pass
+            REQUEST = {} # type: Dict[str, str]
 
         request = Request()
-        request.REQUEST = {}
 
         with self.assertRaises(RequestVariableMissingError):
             get_total(request)
@@ -55,10 +54,9 @@ class DecoratorTestCase(TestCase):
             return sum(numbers)
 
         class Request(object):
-            pass
+            REQUEST = {} # type: Dict[str, str]
 
         request = Request()
-        request.REQUEST = {}
 
         with self.assertRaises(RequestVariableMissingError):
             get_total(request)

--- a/zerver/test_external.py
+++ b/zerver/test_external.py
@@ -42,8 +42,10 @@ class MITNameTest(TestCase):
         self.assertTrue(not_mit_mailing_list("sipbexch@mit.edu"))
 
 class S3Test(AuthedTestCase):
-    test_uris = [] # full URIs in public bucket
-    test_keys = [] # keys in authed bucket
+    # full URIs in public bucket
+    test_uris = [] # type: List[str]
+    # keys in authed bucket
+    test_keys = [] # type: List[str]
 
     @slow(2.6, "has to contact external S3 service")
     @skip("Need S3 mock")

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 from django.conf import settings
 from django.contrib.auth import authenticate, login, get_backends
@@ -704,7 +705,7 @@ def home(request):
     request._email = request.user.email
     request.client = get_client("website")
 
-    narrow = []
+    narrow = [] # type: List[List[str]]
     narrow_stream = None
     narrow_topic = request.GET.get("topic")
     if request.GET.get("stream"):
@@ -996,7 +997,7 @@ def export(request, user_profile):
                            ("realmalias", RealmAlias),
                            ("realmfilter", RealmFilter)]:
         response["zerver_"+table] = [model_to_dict(x) for x in
-                                     model.objects.select_related().filter(realm_id=user_profile.realm.id)]
+                                     model.objects.select_related().filter(realm_id=user_profile.realm.id)] # type: ignore
 
     return json_success(response)
 
@@ -1078,7 +1079,8 @@ def get_uploaded_file(request, realm_id, filename,
 @require_post
 @has_request_variables
 def api_fetch_api_key(request, username=REQ, password=REQ):
-    return_data = {}
+    # type: (Any, Any, Any) -> Any
+    return_data = {} # type: Dict[str, bool]
     if username == "google-oauth2-token":
         user_profile = authenticate(google_oauth2_token=password, return_data=return_data)
     else:

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -52,7 +52,7 @@ class NonClosingPool(sqlalchemy.pool.NullPool):
         pass
 
     def recreate(self):
-        return self.__class__(creator=self._creator,
+        return self.__class__(creator=self._creator, # type: ignore # __class__
                               recycle=self._recycle,
                               use_threadlocal=self._use_threadlocal,
                               reset_on_return=self._reset_on_return,
@@ -550,9 +550,9 @@ def get_old_messages_backend(request, user_profile,
     # rendered message dict before returning it.  We attempt to
     # bulk-fetch rendered message dicts from remote cache using the
     # 'messages' list.
-    search_fields = dict()
-    message_ids = []
-    user_message_flags = {}
+    search_fields = dict() # type: Dict[int, Dict[str, str]]
+    message_ids = [] # type: List[int]
+    user_message_flags = {} # type: Dict[int, List[str]]
     if include_history:
         message_ids = [row[0] for row in query_result]
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 from django.conf import settings
 from django.db import transaction
@@ -27,6 +28,7 @@ from six.moves import urllib
 
 from zerver.lib.rest import rest_dispatch as _rest_dispatch
 import six
+
 rest_dispatch = csrf_exempt((lambda request, *args, **kwargs: _rest_dispatch(request, globals(), *args, **kwargs)))
 
 def list_to_streams(streams_raw, user_profile, autocreate=False, invite_only=False):
@@ -162,7 +164,7 @@ def update_subscriptions_backend(request, user_profile,
     if not add and not delete:
         return json_error('Nothing to do. Specify at least one of "add" or "delete".')
 
-    json_dict = {}
+    json_dict = {} # type: Dict[str, Any]
     for method, items in ((add_subscriptions_backend, add), (remove_subscriptions_backend, delete)):
         response = method(request, user_profile, streams_raw=items)
         if response.status_code != 200:
@@ -202,7 +204,7 @@ def remove_subscriptions_backend(request, user_profile,
     else:
         people_to_unsub = set([user_profile])
 
-    result = dict(removed=[], not_subscribed=[])
+    result = dict(removed=[], not_subscribed=[]) # type: Dict[str, List[str]]
     (removed, not_subscribed) = bulk_remove_subscriptions(people_to_unsub, streams)
 
     for (subscriber, stream) in removed:
@@ -284,7 +286,7 @@ def add_subscriptions_backend(request, user_profile,
 
     (subscribed, already_subscribed) = bulk_add_subscriptions(streams, subscribers)
 
-    result = dict(subscribed=defaultdict(list), already_subscribed=defaultdict(list))
+    result = dict(subscribed=defaultdict(list), already_subscribed=defaultdict(list)) # type: Dict[str, Any]
     for (subscriber, stream) in subscribed:
         result["subscribed"][subscriber.email].append(stream.name)
     for (subscriber, stream) in already_subscribed:

--- a/zerver/views/webhooks.py
+++ b/zerver/views/webhooks.py
@@ -1,0 +1,1037 @@
+# Webhooks for external integrations.
+
+from __future__ import absolute_import
+from typing import *
+
+from django.conf import settings
+from zerver.models import UserProfile, get_client, get_user_profile_by_email
+from zerver.lib.actions import check_send_message
+from zerver.lib.notifications import  convert_html_to_markdown
+from zerver.lib.response import json_success, json_error
+from zerver.lib.validator import check_dict
+from zerver.decorator import authenticated_api_view, REQ, \
+    has_request_variables, authenticated_rest_api_view, \
+    api_key_only_webhook_view, to_non_negative_int, flexible_boolean
+from zerver.views.messages import send_message_backend
+from django.db.models import Q
+
+from defusedxml.ElementTree import fromstring as xml_fromstring
+
+import pprint
+import base64
+import logging
+import re
+import ujson
+from functools import wraps
+
+def github_generic_subject(noun, topic_focus, blob):
+    # issue and pull_request objects have the same fields we're interested in
+    return "%s: %s %d: %s" % (topic_focus, noun, blob['number'], blob['title'])
+
+def github_generic_content(noun, payload, blob):
+    action = payload['action']
+    if action == 'synchronize':
+        action = 'synchronized'
+
+    # issue and pull_request objects have the same fields we're interested in
+    content = ("%s %s [%s %s](%s)"
+               % (payload['sender']['login'],
+                  action,
+                  noun,
+                  blob['number'],
+                  blob['html_url']))
+    if payload['action'] in ('opened', 'reopened'):
+        content += "\n\n~~~ quote\n%s\n~~~" % (blob['body'],)
+    return content
+
+
+def api_github_v1(user_profile, event, payload, branches, stream, **kwargs):
+    """
+    processes github payload with version 1 field specification
+    `payload` comes in unmodified from github
+    `stream` is set to 'commits' if otherwise unset
+    """
+    commit_stream = stream
+    issue_stream = 'issues'
+    return api_github_v2(user_profile, event, payload, branches, stream, commit_stream, issue_stream, **kwargs)
+
+
+def api_github_v2(user_profile, event, payload, branches, default_stream, commit_stream, issue_stream, topic_focus = None):
+    """
+    processes github payload with version 2 field specification
+    `payload` comes in unmodified from github
+    `default_stream` is set to what `stream` is in v1 above
+    `commit_stream` and `issue_stream` fall back to `default_stream` if they are empty
+    This and allowing alternative endpoints is what distinguishes v1 from v2 of the github configuration
+    """
+    if not commit_stream:
+        commit_stream = default_stream
+    if not issue_stream:
+        issue_stream = default_stream
+
+    target_stream = commit_stream
+    repository = payload['repository']
+
+    if not topic_focus:
+        topic_focus = repository['name']
+
+    # Event Handlers
+    if event == 'pull_request':
+        pull_req = payload['pull_request']
+        subject = github_generic_subject('pull request', topic_focus, pull_req)
+        content = github_generic_content('pull request', payload, pull_req)
+    elif event == 'issues':
+        # in v1, we assume that this stream exists since it is
+        # deprecated and the few realms that use it already have the
+        # stream
+        target_stream = issue_stream
+        issue = payload['issue']
+        subject = github_generic_subject('issue', topic_focus, issue)
+        content = github_generic_content('issue', payload, issue)
+    elif event == 'issue_comment':
+        # Comments on both issues and pull requests come in as issue_comment events
+        issue = payload['issue']
+        if 'pull_request' not in issue or issue['pull_request']['diff_url'] is None:
+            # It's an issues comment
+            target_stream = issue_stream
+            noun = 'issue'
+        else:
+            # It's a pull request comment
+            noun = 'pull request'
+
+        subject = github_generic_subject(noun, topic_focus, issue)
+        comment = payload['comment']
+        content = ("%s [commented](%s) on [%s %d](%s)\n\n~~~ quote\n%s\n~~~"
+                   % (comment['user']['login'],
+                      comment['html_url'],
+                      noun,
+                      issue['number'],
+                      issue['html_url'],
+                      comment['body']))
+    elif event == 'push':
+        subject, content = build_message_from_gitlog(user_profile, topic_focus,
+                                                     payload['ref'], payload['commits'],
+                                                     payload['before'], payload['after'],
+                                                     payload['compare'],
+                                                     payload['pusher']['name'],
+                                                     forced=payload['forced'],
+                                                     created=payload['created'])
+    elif event == 'commit_comment':
+        comment = payload['comment']
+        subject = "%s: commit %s" % (topic_focus, comment['commit_id'])
+
+        content = ("%s [commented](%s)"
+                   % (comment['user']['login'],
+                      comment['html_url']))
+
+        if comment['line'] is not None:
+            content += " on `%s`, line %d" % (comment['path'], comment['line'])
+
+        content += "\n\n~~~ quote\n%s\n~~~" % (comment['body'],)
+
+    return (target_stream, subject, content)
+
+@authenticated_api_view
+@has_request_variables
+def api_github_landing(request, user_profile, event=REQ,
+                       payload=REQ(validator=check_dict([])),
+                       branches=REQ(default=''),
+                       stream=REQ(default=''),
+                       version=REQ(converter=to_non_negative_int, default=1),
+                       commit_stream=REQ(default=''),
+                       issue_stream=REQ(default=''),
+                       exclude_pull_requests=REQ(converter=flexible_boolean, default=False),
+                       exclude_issues=REQ(converter=flexible_boolean, default=False),
+                       exclude_commits=REQ(converter=flexible_boolean, default=False),
+                       emphasize_branch_in_topic=REQ(converter=flexible_boolean, default=False),
+                       ):
+
+    repository = payload['repository']
+
+    # Special hook for capturing event data. If we see our special test repo, log the payload from github.
+    try:
+        if repository['name'] == 'zulip-test' and repository['id'] == 6893087 and settings.PRODUCTION:
+            with open('/var/log/zulip/github-payloads', 'a') as f:
+                f.write(ujson.dumps({'event': event,
+                                     'payload': payload,
+                                     'branches': branches,
+                                     'stream': stream,
+                                     'version': version,
+                                     'commit_stream': commit_stream,
+                                     'issue_stream': issue_stream,
+                                     'exclude_pull_requests': exclude_pull_requests,
+                                     'exclude_issues': exclude_issues,
+                                     'exclude_commits': exclude_commits,
+                                     'emphasize_branch_in_topic': emphasize_branch_in_topic,
+                                     }))
+                f.write("\n")
+    except Exception:
+        logging.exception("Error while capturing Github event")
+
+    if not stream:
+        stream = 'commits'
+
+    short_ref = re.sub(r'^refs/heads/', '', payload.get('ref', ""))
+    kwargs = dict()
+
+    if emphasize_branch_in_topic and short_ref:
+        kwargs['topic_focus'] = short_ref
+
+    allowed_events = set()
+    if not exclude_pull_requests:
+        allowed_events.add('pull_request')
+
+    if not exclude_issues:
+        allowed_events.add("issues")
+        allowed_events.add("issue_comment")
+
+    if not exclude_commits:
+        allowed_events.add("push")
+        allowed_events.add("commit_comment")
+
+    if event not in allowed_events:
+        return json_success()
+
+    # We filter issue_comment events for issue creation events
+    if event == 'issue_comment' and payload['action'] != 'created':
+        return json_success()
+
+    if event == 'push':
+        # If we are given a whitelist of branches, then we silently ignore
+        # any push notification on a branch that is not in our whitelist.
+        if branches and short_ref not in re.split('[\s,;|]+', branches):
+            return json_success()
+
+    # Map payload to the handler with the right version
+    if version == 2:
+        target_stream, subject, content = api_github_v2(user_profile, event, payload, branches, stream, commit_stream, issue_stream, **kwargs)
+    else:
+        target_stream, subject, content = api_github_v1(user_profile, event, payload, branches, stream, **kwargs)
+
+    request.client = get_client("ZulipGitHubWebhook")
+    return send_message_backend(request, user_profile,
+                                message_type_name="stream",
+                                message_to=[target_stream],
+                                forged=False, subject_name=subject,
+                                message_content=content)
+
+def build_commit_list_content(commits, branch, compare_url, pusher):
+    if compare_url is not None:
+        push_text = "[pushed](%s)" % (compare_url,)
+    else:
+        push_text = "pushed"
+    content = ("%s %s to branch %s\n\n"
+               % (pusher,
+                  push_text,
+                  branch))
+    num_commits = len(commits)
+    max_commits = 10
+    truncated_commits = commits[:max_commits]
+    for commit in truncated_commits:
+        short_id = commit['id'][:7]
+        (short_commit_msg, _, _) = commit['message'].partition("\n")
+        content += "* [%s](%s): %s\n" % (short_id, commit['url'],
+                                         short_commit_msg)
+    if (num_commits > max_commits):
+        content += ("\n[and %d more commits]"
+                    % (num_commits - max_commits,))
+
+    return content
+
+def build_message_from_gitlog(user_profile, name, ref, commits, before, after, url, pusher, forced=None, created=None):
+    short_ref = re.sub(r'^refs/heads/', '', ref)
+    subject = name
+
+    if re.match(r'^0+$', after):
+        content = "%s deleted branch %s" % (pusher,
+                                            short_ref)
+    # 'created' and 'forced' are github flags; the second check is for beanstalk
+    elif (forced and not created) or (forced is None and len(commits) == 0):
+        content = ("%s [force pushed](%s) to branch %s.  Head is now %s"
+                   % (pusher,
+                      url,
+                      short_ref,
+                      after[:7]))
+    else:
+        content = build_commit_list_content(commits, short_ref, url, pusher)
+
+    return (subject, content)
+
+def guess_zulip_user_from_jira(jira_username, realm):
+    try:
+        # Try to find a matching user in Zulip
+        # We search a user's full name, short name,
+        # and beginning of email address
+        user = UserProfile.objects.filter(
+                Q(full_name__iexact=jira_username) |
+                Q(short_name__iexact=jira_username) |
+                Q(email__istartswith=jira_username),
+                is_active=True,
+                realm=realm).order_by("id")[0]
+        return user
+    except IndexError:
+        return None
+
+def convert_jira_markup(content, realm):
+    # Attempt to do some simplistic conversion of JIRA
+    # formatting to Markdown, for consumption in Zulip
+
+    # Jira uses *word* for bold, we use **word**
+    content = re.sub(r'\*([^\*]+)\*', r'**\1**', content)
+
+    # Jira uses {{word}} for monospacing, we use `word`
+    content = re.sub(r'{{([^\*]+?)}}', r'`\1`', content)
+
+    # Starting a line with bq. block quotes that line
+    content = re.sub(r'bq\. (.*)', r'> \1', content)
+
+    # Wrapping a block of code in {quote}stuff{quote} also block-quotes it
+    quote_re = re.compile(r'{quote}(.*?){quote}', re.DOTALL)
+    content = re.sub(quote_re, r'~~~ quote\n\1\n~~~', content)
+
+    # {noformat}stuff{noformat} blocks are just code blocks with no
+    # syntax highlighting
+    noformat_re = re.compile(r'{noformat}(.*?){noformat}', re.DOTALL)
+    content = re.sub(noformat_re, r'~~~\n\1\n~~~', content)
+
+    # Code blocks are delineated by {code[: lang]} {code}
+    code_re = re.compile(r'{code[^\n]*}(.*?){code}', re.DOTALL)
+    content = re.sub(code_re, r'~~~\n\1\n~~~', content)
+
+    # Links are of form: [https://www.google.com] or [Link Title|https://www.google.com]
+    # In order to support both forms, we don't match a | in bare links
+    content = re.sub(r'\[([^\|~]+?)\]', r'[\1](\1)', content)
+
+    # Full links which have a | are converted into a better markdown link
+    full_link_re = re.compile(r'\[(?:(?P<title>[^|~]+)\|)(?P<url>.*)\]')
+    content = re.sub(full_link_re, r'[\g<title>](\g<url>)', content)
+
+    # Try to convert a JIRA user mention of format [~username] into a
+    # Zulip user mention. We don't know the email, just the JIRA username,
+    # so we naively guess at their Zulip account using this
+    if realm:
+        mention_re = re.compile(r'\[~(.*?)\]')
+        for username in mention_re.findall(content):
+            # Try to look up username
+            user_profile = guess_zulip_user_from_jira(username, realm)
+            if user_profile:
+                replacement = "@**%s**" % (user_profile.full_name,)
+            else:
+                replacement = "**%s**" % (username,)
+
+            content = content.replace("[~%s]" % (username,), replacement)
+
+    return content
+
+@api_key_only_webhook_view
+def api_jira_webhook(request, user_profile):
+    try:
+        payload = ujson.loads(request.body)
+    except ValueError:
+        return json_error("Malformed JSON input")
+
+    try:
+        stream = request.GET['stream']
+    except (AttributeError, KeyError):
+        stream = 'jira'
+
+    def get_in(payload, keys, default=''):
+        try:
+            for key in keys:
+                payload = payload[key]
+        except (AttributeError, KeyError, TypeError):
+            return default
+        return payload
+
+    event = payload.get('webhookEvent')
+    author = get_in(payload, ['user', 'displayName'])
+    issueId = get_in(payload, ['issue', 'key'])
+    # Guess the URL as it is not specified in the payload
+    # We assume that there is a /browse/BUG-### page
+    # from the REST url of the issue itself
+    baseUrl = re.match("(.*)\/rest\/api/.*", get_in(payload, ['issue', 'self']))
+    if baseUrl and len(baseUrl.groups()):
+        issue = "[%s](%s/browse/%s)" % (issueId, baseUrl.group(1), issueId)
+    else:
+        issue = issueId
+    title = get_in(payload, ['issue', 'fields', 'summary'])
+    priority = get_in(payload, ['issue', 'fields', 'priority', 'name'])
+    assignee = get_in(payload, ['issue', 'fields', 'assignee', 'displayName'], 'no one')
+    assignee_email = get_in(payload, ['issue', 'fields', 'assignee', 'emailAddress'], '')
+    assignee_mention = ''
+    if assignee_email != '':
+        try:
+            assignee_profile = get_user_profile_by_email(assignee_email)
+            assignee_mention = "@**%s**" % (assignee_profile.full_name,)
+        except UserProfile.DoesNotExist:
+            assignee_mention = "**%s**" % (assignee_email,)
+
+    subject = "%s: %s" % (issueId, title)
+
+    if event == 'jira:issue_created':
+        content = "%s **created** %s priority %s, assigned to **%s**:\n\n> %s" % \
+                  (author, issue, priority, assignee, title)
+    elif event == 'jira:issue_deleted':
+        content = "%s **deleted** %s!" % \
+                  (author, issue)
+    elif event == 'jira:issue_updated':
+        # Reassigned, commented, reopened, and resolved events are all bundled
+        # into this one 'updated' event type, so we try to extract the meaningful
+        # event that happened
+        if assignee_mention != '':
+            assignee_blurb = " (assigned to %s)" % (assignee_mention,)
+        else:
+            assignee_blurb = ''
+        content = "%s **updated** %s%s:\n\n" % (author, issue, assignee_blurb)
+        changelog = get_in(payload, ['changelog',])
+        comment = get_in(payload, ['comment', 'body'])
+
+        if changelog != '':
+            # Use the changelog to display the changes, whitelist types we accept
+            items = changelog.get('items')
+            for item in items:
+                field = item.get('field')
+
+                # Convert a user's target to a @-mention if possible
+                targetFieldString = "**%s**" % (item.get('toString'),)
+                if field == 'assignee' and assignee_mention != '':
+                    targetFieldString = assignee_mention
+
+                fromFieldString = item.get('fromString')
+                if targetFieldString or fromFieldString:
+                    content += "* Changed %s from **%s** to %s\n" % (field, fromFieldString, targetFieldString)
+
+        if comment != '':
+            comment = convert_jira_markup(comment, user_profile.realm)
+            content += "\n%s\n" % (comment,)
+    elif event in ['jira:worklog_updated']:
+        # We ignore these event types
+        return json_success()
+    elif 'transition' in payload:
+        from_status = get_in(payload, ['transition', 'from_status'])
+        to_status = get_in(payload, ['transition', 'to_status'])
+        content = "%s **transitioned** %s from %s to %s" % (author, issue, from_status, to_status)
+    else:
+        # Unknown event type
+        if not settings.TEST_SUITE:
+            if event is None:
+                logging.warning("Got JIRA event with None event type: %s" % (payload,))
+            else:
+                logging.warning("Got JIRA event type we don't understand: %s" % (event,))
+        return json_error("Unknown JIRA event type")
+
+    check_send_message(user_profile, get_client("ZulipJIRAWebhook"), "stream",
+                       [stream], subject, content)
+    return json_success()
+
+def api_pivotal_webhook_v3(request, user_profile, stream):
+    payload = xml_fromstring(request.body)
+
+    def get_text(attrs):
+        start = payload
+        try:
+            for attr in attrs:
+                start = start.find(attr)
+            return start.text
+        except AttributeError:
+            return ""
+
+    event_type = payload.find('event_type').text
+    description = payload.find('description').text
+    project_id = payload.find('project_id').text
+    story_id = get_text(['stories', 'story', 'id'])
+    # Ugh, the URL in the XML data is not a clickable url that works for the user
+    # so we try to build one that the user can actually click on
+    url = "https://www.pivotaltracker.com/s/projects/%s/stories/%s" % (project_id, story_id)
+
+    # Pivotal doesn't tell us the name of the story, but it's usually in the
+    # description in quotes as the first quoted string
+    name_re = re.compile(r'[^"]+"([^"]+)".*')
+    match = name_re.match(description)
+    if match and len(match.groups()):
+        name = match.group(1)
+    else:
+        name = "Story changed" # Failed for an unknown reason, show something
+    more_info = " [(view)](%s)" % (url,)
+
+    if event_type == 'story_update':
+        subject = name
+        content = description + more_info
+    elif event_type == 'note_create':
+        subject = "Comment added"
+        content = description +  more_info
+    elif event_type == 'story_create':
+        issue_desc = get_text(['stories', 'story', 'description'])
+        issue_type = get_text(['stories', 'story', 'story_type'])
+        issue_status = get_text(['stories', 'story', 'current_state'])
+        estimate = get_text(['stories', 'story', 'estimate'])
+        if estimate != '':
+            estimate = " worth %s story points" % (estimate,)
+        subject = name
+        content = "%s (%s %s%s):\n\n~~~ quote\n%s\n~~~\n\n%s" % (description,
+                                                   issue_status,
+                                                   issue_type,
+                                                   estimate,
+                                                   issue_desc,
+                                                   more_info)
+    return subject, content
+
+def api_pivotal_webhook_v5(request, user_profile, stream):
+    payload = ujson.loads(request.body)
+
+    event_type = payload["kind"]
+
+    project_name = payload["project"]["name"]
+    project_id = payload["project"]["id"]
+
+    primary_resources = payload["primary_resources"][0]
+    story_url = primary_resources["url"]
+    story_type = primary_resources["story_type"]
+    story_id = primary_resources["id"]
+    story_name = primary_resources["name"]
+
+    performed_by = payload.get("performed_by", {}).get("name", "")
+
+    story_info = "[%s](https://www.pivotaltracker.com/s/projects/%s): [%s](%s)" % (project_name, project_id, story_name, story_url)
+
+    changes = payload.get("changes", [])
+
+    content = ""
+    subject = "#%s: %s" % (story_id, story_name)
+
+    def extract_comment(change):
+        if change.get("kind") == "comment":
+            return change.get("new_values", {}).get("text", None)
+        return None
+
+    if event_type == "story_update_activity":
+        # Find the changed valued and build a message
+        content += "%s updated %s:\n" % (performed_by, story_info)
+        for change in changes:
+            old_values = change.get("original_values", {})
+            new_values = change["new_values"]
+
+            if "current_state" in old_values and "current_state" in new_values:
+                content += "* state changed from **%s** to **%s**\n" % (old_values["current_state"], new_values["current_state"])
+            if "estimate" in old_values and "estimate" in new_values:
+                old_estimate = old_values.get("estimate", None)
+                if old_estimate is None:
+                    estimate = "is now"
+                else:
+                    estimate = "changed from %s to" % (old_estimate,)
+                new_estimate = new_values["estimate"] if new_values["estimate"] is not None else "0"
+                content += "* estimate %s **%s points**\n" % (estimate, new_estimate)
+            if "story_type" in old_values and "story_type" in new_values:
+                content += "* type changed from **%s** to **%s**\n" % (old_values["story_type"], new_values["story_type"])
+
+            comment = extract_comment(change)
+            if comment is not None:
+                content += "* Comment added:\n~~~quote\n%s\n~~~\n" % (comment,)
+
+    elif event_type == "comment_create_activity":
+        for change in changes:
+            comment = extract_comment(change)
+            if comment is not None:
+                content += "%s added a comment to %s:\n~~~quote\n%s\n~~~" % (performed_by, story_info, comment)
+    elif event_type == "story_create_activity":
+        content += "%s created %s: %s\n" % (performed_by, story_type, story_info)
+        for change in changes:
+            new_values = change.get("new_values", {})
+            if "current_state" in new_values:
+                content += "* State is **%s**\n" % (new_values["current_state"],)
+            if "description" in new_values:
+                content += "* Description is\n\n> %s" % (new_values["description"],)
+    elif event_type == "story_move_activity":
+        content = "%s moved %s" % (performed_by, story_info)
+        for change in changes:
+            old_values = change.get("original_values", {})
+            new_values = change["new_values"]
+            if "current_state" in old_values and "current_state" in new_values:
+                content += " from **%s** to **%s**" % (old_values["current_state"], new_values["current_state"])
+    elif event_type in ["task_create_activity", "comment_delete_activity",
+                        "task_delete_activity", "task_update_activity",
+                        "story_move_from_project_activity", "story_delete_activity",
+                        "story_move_into_project_activity"]:
+        # Known but unsupported Pivotal event types
+        pass
+    else:
+        logging.warning("Unknown Pivotal event type: %s" % (event_type,))
+
+    return subject, content
+
+@api_key_only_webhook_view
+def api_pivotal_webhook(request, user_profile):
+    try:
+        stream = request.GET['stream']
+    except (AttributeError, KeyError):
+        return json_error("Missing stream parameter.")
+
+    subject = content = None
+    try:
+        subject, content = api_pivotal_webhook_v3(request, user_profile, stream)
+    except AttributeError:
+        return json_error("Failed to extract data from Pivotal XML response")
+    except:
+        # Attempt to parse v5 JSON payload
+        try:
+            subject, content = api_pivotal_webhook_v5(request, user_profile, stream)
+        except AttributeError:
+            return json_error("Failed to extract data from Pivotal V5 JSON response")
+
+    if subject is None or content is None:
+        return json_error("Unable to handle Pivotal payload")
+
+    check_send_message(user_profile, get_client("ZulipPivotalWebhook"), "stream",
+                       [stream], subject, content)
+    return json_success()
+
+# Beanstalk's web hook UI rejects url with a @ in the username section of a url
+# So we ask the user to replace them with %40
+# We manually fix the username here before passing it along to @authenticated_rest_api_view
+def beanstalk_decoder(view_func):
+    @wraps(view_func)
+    def _wrapped_view_func(request, *args, **kwargs):
+        try:
+            auth_type, encoded_value = request.META['HTTP_AUTHORIZATION'].split()
+            if auth_type.lower() == "basic":
+                email, api_key = base64.b64decode(encoded_value).split(":")
+                email = email.replace('%40', '@')
+                request.META['HTTP_AUTHORIZATION'] = "Basic %s" % (base64.b64encode("%s:%s" % (email, api_key)))
+        except:
+            pass
+
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped_view_func
+
+@beanstalk_decoder
+@authenticated_rest_api_view
+@has_request_variables
+def api_beanstalk_webhook(request, user_profile,
+                          payload=REQ(validator=check_dict([]))):
+    # Beanstalk supports both SVN and git repositories
+    # We distinguish between the two by checking for a
+    # 'uri' key that is only present for git repos
+    git_repo = 'uri' in payload
+    if git_repo:
+        # To get a linkable url,
+        subject, content = build_message_from_gitlog(user_profile, payload['repository']['name'],
+                                                     payload['ref'], payload['commits'],
+                                                     payload['before'], payload['after'],
+                                                     payload['repository']['url'],
+                                                     payload['pusher_name'])
+    else:
+        author = payload.get('author_full_name')
+        url = payload.get('changeset_url')
+        revision = payload.get('revision')
+        (short_commit_msg, _, _) = payload.get('message').partition("\n")
+
+        subject = "svn r%s" % (revision,)
+        content = "%s pushed [revision %s](%s):\n\n> %s" % (author, revision, url, short_commit_msg)
+
+    check_send_message(user_profile, get_client("ZulipBeanstalkWebhook"), "stream",
+                       ["commits"], subject, content)
+    return json_success()
+
+# Desk.com's integrations all make the user supply a template, where it fills
+# in stuff like {{customer.name}} and posts the result as a "data" parameter.
+# There's no raw JSON for us to work from. Thus, it makes sense to just write
+# a template Zulip message within Desk.com and have the webhook extract that
+# from the "data" param and post it, which this does.
+@authenticated_rest_api_view
+@has_request_variables
+def api_deskdotcom_webhook(request, user_profile, data=REQ(),
+                           topic=REQ(default="Desk.com notification"),
+                           stream=REQ(default="desk.com")):
+    check_send_message(user_profile, get_client("ZulipDeskWebhook"), "stream",
+                       [stream], topic, data)
+    return json_success()
+
+@api_key_only_webhook_view
+@has_request_variables
+def api_newrelic_webhook(request, user_profile, alert=REQ(validator=check_dict([]), default=None),
+                             deployment=REQ(validator=check_dict([]), default=None)):
+    try:
+        stream = request.GET['stream']
+    except (AttributeError, KeyError):
+        return json_error("Missing stream parameter.")
+
+    if alert:
+        # Use the message as the subject because it stays the same for
+        # "opened", "acknowledged", and "closed" messages that should be
+        # grouped.
+        subject = alert['message']
+        content = "%(long_description)s\n[View alert](%(alert_url)s)" % (alert)
+    elif deployment:
+        subject = "%s deploy" % (deployment['application_name'])
+        content = """`%(revision)s` deployed by **%(deployed_by)s**
+%(description)s
+
+%(changelog)s""" % (deployment)
+    else:
+        return json_error("Unknown webhook request")
+
+    check_send_message(user_profile, get_client("ZulipNewRelicWebhook"), "stream",
+                       [stream], subject, content)
+    return json_success()
+
+@authenticated_rest_api_view
+@has_request_variables
+def api_bitbucket_webhook(request, user_profile, payload=REQ(validator=check_dict([])),
+                          stream=REQ(default='commits')):
+    repository = payload['repository']
+    commits = [{'id': commit['raw_node'], 'message': commit['message'],
+                'url': '%s%scommits/%s' % (payload['canon_url'],
+                                           repository['absolute_url'],
+                                           commit['raw_node'])}
+               for commit in payload['commits']]
+
+    subject = repository['name']
+    if len(commits) == 0:
+        # Bitbucket doesn't give us enough information to really give
+        # a useful message :/
+        content = ("%s [force pushed](%s)"
+                   % (payload['user'],
+                      payload['canon_url'] + repository['absolute_url']))
+    else:
+        branch = payload['commits'][-1]['branch']
+        content = build_commit_list_content(commits, branch, None, payload['user'])
+        subject += '/%s' % (branch,)
+
+    check_send_message(user_profile, get_client("ZulipBitBucketWebhook"), "stream",
+                       [stream], subject, content)
+    return json_success()
+
+@authenticated_rest_api_view
+@has_request_variables
+def api_stash_webhook(request, user_profile, stream=REQ(default='')):
+    try:
+        payload = ujson.loads(request.body)
+    except ValueError:
+        return json_error("Malformed JSON input")
+
+    # We don't get who did the push, or we'd try to report that.
+    try:
+        repo_name = payload["repository"]["name"]
+        project_name = payload["repository"]["project"]["name"]
+        branch_name = payload["refChanges"][0]["refId"].split("/")[-1]
+        commit_entries = payload["changesets"]["values"]
+        commits = [(entry["toCommit"]["displayId"],
+                    entry["toCommit"]["message"].split("\n")[0]) for \
+                       entry in commit_entries]
+        head_ref = commit_entries[-1]["toCommit"]["displayId"]
+    except KeyError as e:
+        return json_error("Missing key %s in JSON" % (e.message,))
+
+    try:
+        stream = request.GET['stream']
+    except (AttributeError, KeyError):
+        stream = 'commits'
+
+    subject = "%s/%s: %s" % (project_name, repo_name, branch_name)
+
+    content = "`%s` was pushed to **%s** in **%s/%s** with:\n\n" % (
+        head_ref, branch_name, project_name, repo_name)
+    content += "\n".join("* `%s`: %s" % (
+            commit[0], commit[1]) for commit in commits)
+
+    check_send_message(user_profile, get_client("ZulipStashWebhook"), "stream",
+                       [stream], subject, content)
+    return json_success()
+
+class TicketDict(dict):
+    """
+    A helper class to turn a dictionary with ticket information into
+    an object where each of the keys is an attribute for easy access.
+    """
+    def __getattr__(self, field):
+        if "_" in field:
+            return self.get(field)
+        else:
+            return self.get("ticket_" + field)
+
+def property_name(property, index):
+    # The Freshdesk API is currently pretty broken: statuses are customizable
+    # but the API will only tell you the number associated with the status, not
+    # the name. While we engage the Freshdesk developers about exposing this
+    # information through the API, since only FlightCar uses this integration,
+    # hardcode their statuses.
+    statuses = ["", "", "Open", "Pending", "Resolved", "Closed",
+                "Waiting on Customer", "Job Application", "Monthly"]
+    priorities = ["", "Low", "Medium", "High", "Urgent"]
+
+    if property == "status":
+        return statuses[index] if index < len(statuses) else str(index)
+    elif property == "priority":
+        return priorities[index] if index < len(priorities) else str(index)
+    else:
+        raise ValueError("Unknown property")
+
+def parse_freshdesk_event(event_string):
+    # These are always of the form "{ticket_action:created}" or
+    # "{status:{from:4,to:6}}". Note the lack of string quoting: this isn't
+    # valid JSON so we have to parse it ourselves.
+    data = event_string.replace("{", "").replace("}", "").replace(",", ":").split(":")
+
+    if len(data) == 2:
+        # This is a simple ticket action event, like
+        # {ticket_action:created}.
+        return data
+    else:
+        # This is a property change event, like {status:{from:4,to:6}}. Pull out
+        # the property, from, and to states.
+        property, _, from_state, _, to_state = data
+        return (property, property_name(property, int(from_state)),
+                property_name(property, int(to_state)))
+
+def format_freshdesk_note_message(ticket, event_info):
+    # There are public (visible to customers) and private note types.
+    note_type = event_info[1]
+    content = "%s <%s> added a %s note to [ticket #%s](%s)." % (
+        ticket.requester_name, ticket.requester_email, note_type,
+        ticket.id, ticket.url)
+
+    return content
+
+def format_freshdesk_property_change_message(ticket, event_info):
+    # Freshdesk will only tell us the first event to match our webhook
+    # configuration, so if we change multiple properties, we only get the before
+    # and after data for the first one.
+    content = "%s <%s> updated [ticket #%s](%s):\n\n" % (
+        ticket.requester_name, ticket.requester_email, ticket.id, ticket.url)
+    # Why not `"%s %s %s" % event_info`? Because the linter doesn't like it.
+    content += "%s: **%s** => **%s**" % (
+        event_info[0].capitalize(), event_info[1], event_info[2])
+
+    return content
+
+def format_freshdesk_ticket_creation_message(ticket):
+    # They send us the description as HTML.
+    cleaned_description = convert_html_to_markdown(ticket.description)
+    content = "%s <%s> created [ticket #%s](%s):\n\n" % (
+        ticket.requester_name, ticket.requester_email, ticket.id, ticket.url)
+    content += """~~~ quote
+%s
+~~~\n
+""" % (cleaned_description,)
+    content += "Type: **%s**\nPriority: **%s**\nStatus: **%s**" % (
+        ticket.type, ticket.priority, ticket.status)
+
+    return content
+
+@authenticated_rest_api_view
+@has_request_variables
+def api_freshdesk_webhook(request, user_profile, stream=REQ(default='')):
+    try:
+        payload = ujson.loads(request.body)
+        ticket_data = payload["freshdesk_webhook"]
+    except ValueError:
+        return json_error("Malformed JSON input")
+
+    required_keys = [
+        "triggered_event", "ticket_id", "ticket_url", "ticket_type",
+        "ticket_subject", "ticket_description", "ticket_status",
+        "ticket_priority", "requester_name", "requester_email",
+        ]
+
+    for key in required_keys:
+        if ticket_data.get(key) is None:
+            logging.warning("Freshdesk webhook error. Payload was:")
+            logging.warning(request.body)
+            return json_error("Missing key %s in JSON" % (key,))
+
+    try:
+        stream = request.GET['stream']
+    except (AttributeError, KeyError):
+        stream = 'freshdesk'
+
+    ticket = TicketDict(ticket_data)
+
+    subject = "#%s: %s" % (ticket.id, ticket.subject)
+
+    try:
+        event_info = parse_freshdesk_event(ticket.triggered_event)
+    except ValueError:
+        return json_error("Malformed event %s" % (ticket.triggered_event,))
+
+    if event_info[1] == "created":
+        content = format_freshdesk_ticket_creation_message(ticket)
+    elif event_info[0] == "note_type":
+        content = format_freshdesk_note_message(ticket, event_info)
+    elif event_info[0] in ("status", "priority"):
+        content = format_freshdesk_property_change_message(ticket, event_info)
+    else:
+        # Not an event we know handle; do nothing.
+        return json_success()
+
+    check_send_message(user_profile, get_client("ZulipFreshdeskWebhook"), "stream",
+                       [stream], subject, content)
+    return json_success()
+
+def truncate(string, length):
+    if len(string) > length:
+        string = string[:length-3] + '...'
+    return string
+
+@authenticated_rest_api_view
+def api_zendesk_webhook(request, user_profile):
+    """
+    Zendesk uses trigers with message templates. This webhook uses the
+    ticket_id and ticket_title to create a subject. And passes with zendesk
+    user's configured message to zulip.
+    """
+    try:
+        ticket_title = request.POST['ticket_title']
+        ticket_id = request.POST['ticket_id']
+        message = request.POST['message']
+        stream = request.POST.get('stream', 'zendesk')
+    except KeyError as e:
+        return json_error('Missing post parameter %s' % (e.message,))
+
+    subject = truncate('#%s: %s' % (ticket_id, ticket_title), 60)
+    check_send_message(user_profile, get_client('ZulipZenDeskWebhook'), 'stream',
+                       [stream], subject, message)
+    return json_success()
+
+
+PAGER_DUTY_EVENT_NAMES = {
+    'incident.trigger': 'triggered',
+    'incident.acknowledge': 'acknowledged',
+    'incident.unacknowledge': 'unacknowledged',
+    'incident.resolve': 'resolved',
+    'incident.assign': 'assigned',
+    'incident.escalate': 'escalated',
+    'incident.delegate': 'delineated',
+}
+
+def build_pagerduty_formatdict(message):
+    # Normalize the message dict, after this all keys will exist. I would
+    # rather some strange looking messages than dropping pages.
+
+    format_dict = {} # type: Dict[str, Any]
+    format_dict['action'] = PAGER_DUTY_EVENT_NAMES[message['type']]
+
+    format_dict['incident_id'] = message['data']['incident']['id']
+    format_dict['incident_num'] = message['data']['incident']['incident_number']
+    format_dict['incident_url'] = message['data']['incident']['html_url']
+
+    format_dict['service_name'] = message['data']['incident']['service']['name']
+    format_dict['service_url'] = message['data']['incident']['service']['html_url']
+
+    # This key can be missing on null
+    if message['data']['incident'].get('assigned_to_user', None):
+        format_dict['assigned_to_email'] = message['data']['incident']['assigned_to_user']['email']
+        format_dict['assigned_to_username'] = message['data']['incident']['assigned_to_user']['email'].split('@')[0]
+        format_dict['assigned_to_url'] = message['data']['incident']['assigned_to_user']['html_url']
+    else:
+        format_dict['assigned_to_email'] = 'nobody'
+        format_dict['assigned_to_username'] = 'nobody'
+        format_dict['assigned_to_url'] = ''
+
+    # This key can be missing on null
+    if message['data']['incident'].get('resolved_by_user', None):
+        format_dict['resolved_by_email'] = message['data']['incident']['resolved_by_user']['email']
+        format_dict['resolved_by_username'] = message['data']['incident']['resolved_by_user']['email'].split('@')[0]
+        format_dict['resolved_by_url'] = message['data']['incident']['resolved_by_user']['html_url']
+    else:
+        format_dict['resolved_by_email'] = 'nobody'
+        format_dict['resolved_by_username'] = 'nobody'
+        format_dict['resolved_by_url'] = ''
+
+    trigger_message = []
+    trigger_subject = message['data']['incident']['trigger_summary_data'].get('subject', '')
+    if trigger_subject:
+        trigger_message.append(trigger_subject)
+    trigger_description = message['data']['incident']['trigger_summary_data'].get('description', '')
+    if trigger_description:
+        trigger_message.append(trigger_description)
+    format_dict['trigger_message'] = u'\n'.join(trigger_message)
+    return format_dict
+
+
+def send_raw_pagerduty_json(user_profile, stream, message, topic):
+    subject = topic or 'pagerduty'
+    body = (
+        u'Unknown pagerduty message\n'
+        u'``` py\n'
+        u'%s\n'
+        u'```') % (pprint.pformat(message),)
+    check_send_message(user_profile, get_client('ZulipPagerDutyWebhook'), 'stream',
+                       [stream], subject, body)
+
+
+def send_formated_pagerduty(user_profile, stream, message_type, format_dict, topic):
+    if message_type in ('incident.trigger', 'incident.unacknowledge'):
+        template = (u':imp: Incident '
+        u'[{incident_num}]({incident_url}) {action} by '
+        u'[{service_name}]({service_url}) and assigned to '
+        u'[{assigned_to_username}@]({assigned_to_url})\n\n>{trigger_message}')
+
+    elif message_type == 'incident.resolve' and format_dict['resolved_by_url']:
+        template = (u':grinning: Incident '
+        u'[{incident_num}]({incident_url}) resolved by '
+        u'[{resolved_by_username}@]({resolved_by_url})\n\n>{trigger_message}')
+    elif message_type == 'incident.resolve' and not format_dict['resolved_by_url']:
+        template = (u':grinning: Incident '
+        u'[{incident_num}]({incident_url}) resolved\n\n>{trigger_message}')
+    else:
+        template = (u':no_good: Incident [{incident_num}]({incident_url}) '
+        u'{action} by [{assigned_to_username}@]({assigned_to_url})\n\n>{trigger_message}')
+
+    subject = topic or u'incident {incident_num}'.format(**format_dict)
+    body = template.format(**format_dict)
+
+    check_send_message(user_profile, get_client('ZulipPagerDutyWebhook'), 'stream',
+                       [stream], subject, body)
+
+
+@api_key_only_webhook_view
+@has_request_variables
+def api_pagerduty_webhook(request, user_profile, stream=REQ(default='pagerduty'), topic=REQ(default=None)):
+    payload = ujson.loads(request.body)
+
+    for message in payload['messages']:
+        message_type = message['type']
+
+        if message_type not in PAGER_DUTY_EVENT_NAMES:
+            send_raw_pagerduty_json(user_profile, stream, message, topic)
+
+        try:
+            format_dict = build_pagerduty_formatdict(message)
+        except:
+            send_raw_pagerduty_json(user_profile, stream, message, topic)
+        else:
+            send_formated_pagerduty(user_profile, stream, message_type, format_dict, topic)
+
+    return json_success()
+
+@api_key_only_webhook_view
+@has_request_variables
+def api_travis_webhook(request, user_profile, stream=REQ(default='travis'), topic=REQ(default=None)):
+    message = ujson.loads(request.POST['payload'])
+
+    author = message['author_name']
+    message_type = message['status_message']
+    changes = message['compare_url']
+
+    good_status = ['Passed', 'Fixed']
+    bad_status  = ['Failed', 'Broken', 'Still Failing']
+    emoji = ''
+    if message_type in good_status:
+        emoji = ':thumbsup:'
+    elif message_type in bad_status:
+        emoji = ':thumbsdown:'
+    else:
+        emoji = "(No emoji specified for status '%s'.)" % (message_type,)
+
+    build_url = message['build_url']
+
+    template = (
+        u'Author: %s\n'
+        u'Build status: %s %s\n'
+        u'Details: [changes](%s), [build log](%s)')
+
+    body = template % (author, message_type, emoji, changes, build_url)
+
+    check_send_message(user_profile, get_client('ZulipTravisWebhook'), 'stream', [stream], topic, body)
+    return json_success()

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -59,7 +59,7 @@ class QueueProcessingWorker(object):
     queue_name = None
 
     def __init__(self):
-        self.q = None
+        self.q = None # type: SimpleQueueClient
         if self.queue_name is None:
             raise WorkerDeclarationException("Queue worker declared without queue_name")
 

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest
@@ -56,7 +57,7 @@ def get_active_worker_queues():
     return list(worker_classes.keys())
 
 class QueueProcessingWorker(object):
-    queue_name = None
+    queue_name = None # type: str
 
     def __init__(self):
         self.q = None # type: SimpleQueueClient
@@ -178,7 +179,7 @@ class MissedMessageWorker(QueueProcessingWorker):
     def start(self):
         while True:
             missed_events = self.q.drain_queue("missedmessage_emails", json=True)
-            by_recipient = defaultdict(list)
+            by_recipient = defaultdict(list) # type: Dict[int, List[Dict[str, Any]]]
 
             for event in missed_events:
                 logging.info("Received event: %s" % (event,))

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -245,7 +245,7 @@ class Command(BaseCommand):
         if options["replay_old_messages"]:
             restore_saved_messages()
 
-recipient_hash = {}
+recipient_hash = {} # type: Dict[int, Recipient]
 def get_recipient_by_id(rid):
     if rid in recipient_hash:
         return recipient_hash[rid]

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -30,6 +30,7 @@ import glob
 import os
 from optparse import make_option
 from six.moves import range
+from typing import *
 
 settings.TORNADO_SERVER = None
 
@@ -253,9 +254,9 @@ def get_recipient_by_id(rid):
 
 def restore_saved_messages():
     old_messages = []
-    duplicate_suppression_hash = {}
+    duplicate_suppression_hash = {} # type: Dict[str, bool]
 
-    stream_dict = {}
+    stream_dict = {} # type: Dict[Tuple[str, str], Tuple[str, str]]
     user_set = set()
     email_set = set([u.email for u in UserProfile.objects.all()])
     realm_set = set()
@@ -427,7 +428,7 @@ def restore_saved_messages():
     # change and import those as we go to make subscription changes
     # take effect!
     print(datetime.datetime.now(), "Importing subscriptions...")
-    subscribers = {}
+    subscribers = {} # type: Dict[int, Set[int]]
     for s in Subscription.objects.select_related().all():
         if s.active:
             subscribers.setdefault(s.recipient.id, set()).add(s.user_profile.id)
@@ -662,7 +663,7 @@ def restore_saved_messages():
         current_subs_obj[sub_tuple].active = active
         current_subs_obj[sub_tuple].save(update_fields=["active"])
 
-    subs = {}
+    subs = {} # type: Dict[Tuple[int, int], Subscription]
     for sub in Subscription.objects.all():
         subs[(sub.user_profile_id, sub.recipient_id)] = sub
 
@@ -714,9 +715,9 @@ def send_messages(data):
 
     num_messages = 0
     random_max = 1000000
-    recipients = {}
+    recipients = {} # type: Dict[int, Tuple[int, int, Dict[str, Any]]]
     while num_messages < tot_messages:
-        saved_data = {}
+        saved_data = {} # type: Dict[str, Any]
         message = Message()
         message.sending_client = get_client('populate_db')
         length = random.randint(1, 5)
@@ -768,6 +769,6 @@ def send_messages(data):
         message.pub_date = now()
         do_send_message(message)
 
-        recipients[num_messages] = [message_type, message.recipient.id, saved_data]
+        recipients[num_messages] = (message_type, message.recipient.id, saved_data)
         num_messages += 1
     return tot_messages

--- a/zilencer/management/commands/profile_request.py
+++ b/zilencer/management/commands/profile_request.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from typing import *
 
 from optparse import make_option
 from django.core.management.base import BaseCommand
@@ -23,7 +24,7 @@ class MockRequest(object):
         self.REQUEST = {"anchor": UserMessage.objects.filter(user_profile=self.user).order_by("-message")[200].message_id,
                         "num_before": 1200,
                         "num_after": 200}
-        self.GET = {}
+        self.GET = {} # type: Dict[Any, Any]
         self.session = MockSession()
 
     def get_full_path(self):


### PR DESCRIPTION
Tested that it passes `mypy --silent --py2 --check-untyped-defs zerver/ zproject/ bots/ zilencer/ analytics/ corporate/ confirmation/ tools/ scripts/setup/ scripts/lib/ *.py api/ | grep -v test | grep -v fenced_code | grep -v settings`

This just makes mypy pass without errors so that we can use mypy in our CI -- it doesn't make any effort to annotate most or all functions in any files.  

@sharmaeklavya2 can you review this branch?