### PR TITLE
Fix py3k and apply fixers

### DIFF
--- a/api/integrations/git/post-receive
+++ b/api/integrations/git/post-receive
@@ -29,13 +29,14 @@
 # For example:
 #  aa453216d1b3e49e7f6f98441fa56946ddcd6a20 68f7abf4e6f922807889f52bc043ecd31b79f814 refs/heads/master
 
+from __future__ import absolute_import
 import os
 import sys
 import subprocess
 import os.path
 
 sys.path.insert(0, os.path.dirname(__file__))
-import zulip_git_config as config
+from . import zulip_git_config as config
 VERSION = "0.9"
 
 if config.ZULIP_API_PATH is not None:

--- a/tools/get-handlebar-vars
+++ b/tools/get-handlebar-vars
@@ -90,7 +90,7 @@ def parse_file(fn):
         if isinstance(obj, list):
             return [clean_this(item) for item in obj]
         if isinstance(obj, dict):
-            if len(obj.keys()) == 1 and 'this' in obj:
+            if len(obj) == 1 and 'this' in obj:
                 return clean_this(obj['this'])
             return {k: clean_this(v) for k, v in obj.items()}
         return obj

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+from __future__ import absolute_import
 import os
 import sys
 import subprocess
 import re
 from collections import defaultdict
 import argparse
+from six.moves import filter
 
 def get_ftype(fpath, use_shebang):
     ext = os.path.splitext(fpath)[1]

--- a/tools/print-all/print-all
+++ b/tools/print-all/print-all
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
 import sh
 import os
 import re
@@ -115,7 +116,7 @@ for fil in sh.git('ls-files', _iter=True):
     if filetype == 'html' and fil.startswith('templates/'):
         filetype = 'html+django'
 
-    print 'Scanning', fil
+    print('Scanning', fil)
     outname = fil.replace('_', '_u_').replace('.', '_d_').replace('/', '_s_')
     sh.pygmentize(
         '-l', (filetype if filetype else 'text'),
@@ -140,8 +141,8 @@ with open('tools/print-all/tex/epilogue.tex', 'w') as f:
     print_list('Not regular files', notfile)
     print_list('Explicitly excluded', excluded)
 
-print
-print 'Rendering...'
+print()
+print('Rendering...')
 os.chdir('tools/print-all/tex')
 
 if not os.path.exists('utf-8.def'):
@@ -155,13 +156,13 @@ try:
     sh.latex('all_code.tex', _in='')
     sh.dvips('all_code.dvi')
 except sh.ErrorReturnCode as exn:
-    print exn.stdout
+    print(exn.stdout)
     sys.exit(1)
 
-print 'Converting to 2-up...'
+print('Converting to 2-up...')
 sh.psnup('-n', '2', 'all_code.ps', _out='all_code_2up.ps')
 sh.pstopdf('all_code_2up.ps')
 
 os.chdir(orig_cwd)
-print
-print sh.file('tools/print-all/tex/all_code_2up.pdf')
+print()
+print(sh.file('tools/print-all/tex/all_code_2up.pdf'))

--- a/tools/print-all/print-all
+++ b/tools/print-all/print-all
@@ -78,7 +78,7 @@ notfile  = []
 empty    = []
 excluded = []
 
-doc = file('tools/print-all/tex/all_code.tex', 'w')
+doc = open('tools/print-all/tex/all_code.tex', 'w')
 doc.write(r'''
 \input{header}
 \begin{document}

--- a/tools/travis/py3k
+++ b/tools/travis/py3k
@@ -45,6 +45,11 @@ libpasteurize.fixes.fix_newstyle
 
 echo; echo "Testing for additions of Python 2 patterns we've removed as part of moving towards Python 3 compatibility."; echo
 
+if [ -n "$(git status --porcelain)" ]; then
+    echo "The repository is not clean. py3k can only be run if the repository is clean."
+    exit 1
+fi
+
 script_dir=$(dirname "$0")
 lister_path="$script_dir/../lister.py"
 python_files="$($lister_path -f py)"

--- a/tools/travis/py3k
+++ b/tools/travis/py3k
@@ -92,8 +92,9 @@ if git grep -q '\(^\W*import StringIO\|^\W*from StringIO\)'; then
 fi
 
 echo
-if [ -z "$failed" ]; then
+if [ "$failed" == "0" ]; then
     echo "No issues detected!"
 else
     echo "Python 3 compatibility error(s) detected!  See diffs above for what you need to change."
+    exit 1
 fi

--- a/tools/travis/py3k
+++ b/tools/travis/py3k
@@ -67,7 +67,7 @@ done
 fixer="libmodernize.fixes.fix_dict_six"
 echo "Running python 3 compatability test $fixer"
 echo "$python_files" | xargs python-modernize -f $fixer -j4 -n -w >/dev/null 2>/dev/null
-if git diff | grep "^+ " | grep -v '[ ]*for' | grep -v [.]join | grep -v from_iterable; then
+if git --no-pager diff | grep "^+ " | grep -v '[ ]*for' | grep -v [.]join | grep -v from_iterable; then
     echo
     echo "Error: the above are changes suggested by python-modernize "
     echo "to handle the list=>iterator transition in Python 3."
@@ -77,7 +77,7 @@ if git diff | grep "^+ " | grep -v '[ ]*for' | grep -v [.]join | grep -v from_it
     echo "searching through the (unfortunately very spammy) full output below:"
     echo
     # Clear the output
-    git diff
+    git --no-pager diff
     echo
     echo "That was a lot of text!  Read this output from the top for more readable details."
     git reset --hard >/dev/null

--- a/tools/travis/py3k
+++ b/tools/travis/py3k
@@ -45,10 +45,14 @@ libpasteurize.fixes.fix_newstyle
 
 echo; echo "Testing for additions of Python 2 patterns we've removed as part of moving towards Python 3 compatibility."; echo
 
+script_dir=$(dirname "$0")
+lister_path="$script_dir/../lister.py"
+python_files="$($lister_path -f py)"
+
 failed=0
 for fixer in $fixers; do
     echo "Running Python 3 compatibility test $fixer"
-    futurize -f $fixer -j4 -n -w . >/dev/null 2>/dev/null
+    echo "$python_files" | xargs futurize -f $fixer -j4 -n -w >/dev/null 2>/dev/null
     if ! git diff --exit-code; then
         # Clear the output from this one
         git reset --hard >/dev/null
@@ -62,7 +66,7 @@ done
 # with iterators (currently for, join, and from_iterable).
 fixer="libmodernize.fixes.fix_dict_six"
 echo "Running python 3 compatability test $fixer"
-python-modernize -f $fixer -j4 -n -w . >/dev/null 2>/dev/null
+echo "$python_files" | xargs python-modernize -f $fixer -j4 -n -w >/dev/null 2>/dev/null
 if git diff | grep "^+ " | grep -v '[ ]*for' | grep -v [.]join | grep -v from_iterable; then
     echo
     echo "Error: the above are changes suggested by python-modernize "

--- a/tools/travis/py3k
+++ b/tools/travis/py3k
@@ -76,13 +76,13 @@ if git --no-pager diff | grep "^+ " | grep -v '[ ]*for' | grep -v [.]join | grep
     echo "does not display the full context; you can find the diff with context by "
     echo "searching through the (unfortunately very spammy) full output below:"
     echo
-    # Clear the output
     git --no-pager diff
     echo
     echo "That was a lot of text!  Read this output from the top for more readable details."
-    git reset --hard >/dev/null
     failed=1
 fi
+# Clear the output
+git reset --hard >/dev/null
 
 if git grep -q '\(^\W*import StringIO\|^\W*from StringIO\)'; then
     echo "ERROR: StringIO imports not compatible with python 2+3:"


### PR DESCRIPTION
This continues most of the work done in #506. That PR has a lot of unrelated things stuffed together and it got old so I made this new PR.

Here I have fixed `tools/travis/py3k` to use `tools/lister.py`. It now exits with a non-zero exit code so that Travis can pick up errors.

I have also applied the fixers suggested by py3k. (If I would have not applied them, this PR would have failed Travis check).