### PR TITLE
Move some javascript global variables to unread.js.

### DIFF
--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -210,7 +210,7 @@ exports.activate = function (raw_operators, opts) {
     var then_select_offset;
 
     if (!was_narrowed_already) {
-        unread_messages_read_in_narrow = false;
+        unread.messages_read_in_narrow = false;
     }
 
     if (!opts.select_first_unread && current_msg_list.get_row(then_select_id).length > 0) {
@@ -467,7 +467,7 @@ exports.deactivate = function () {
         // no longer be there
         // Additionally, we pass empty_ok as the user may have removed **all** streams
         // from her home view
-        if (unread_messages_read_in_narrow) {
+        if (unread.messages_read_in_narrow) {
             // We read some unread messages in a narrow. Instead of going back to
             // where we were before the narrow, go to our first unread message (or
             // the bottom of the feed, if there are no unread messages).

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -6,6 +6,7 @@ var unread_mentioned = new Dict();
 var unread_subjects = new Dict({fold_case: true});
 var unread_privates = new Dict();
 exports.suppress_unread_counts = true;
+exports.messages_read_in_narrow = false;
 
 exports.message_unread = function (message) {
     if (message === undefined) {
@@ -222,7 +223,7 @@ exports.mark_messages_as_read = function mark_messages_as_read (messages, option
             return;
         }
         if (current_msg_list === narrowed_msg_list) {
-            unread_messages_read_in_narrow = true;
+            unread.messages_read_in_narrow = true;
         }
 
         if (options.from !== "server") {

--- a/static/js/zulip.js
+++ b/static/js/zulip.js
@@ -25,7 +25,6 @@ var last_viewport_movement_direction = 1;
 
 var furthest_read = -1;
 var server_furthest_read = -1;
-var unread_messages_read_in_narrow = false;
 var pointer_update_in_flight = false;
 
 function keep_pointer_in_view() {

--- a/tools/jslint/check-all.js
+++ b/tools/jslint/check-all.js
@@ -54,7 +54,7 @@ var globals =
 
     // zulip.js
     + ' all_msg_list home_msg_list narrowed_msg_list current_msg_list'
-    + ' keep_pointer_in_view unread_messages_read_in_narrow'
+    + ' keep_pointer_in_view'
     + ' respond_to_message recenter_view last_viewport_movement_direction'
     + ' scroll_to_selected get_private_message_recipient'
     + ' viewport process_loaded_for_unread'


### PR DESCRIPTION
I decided to work on https://github.com/zulip/zulip/issues/610 while trying to get familiar with zulip.


function process_loaded_for_unread had the description:
> This is annoying to move to unread.js because the natural name	,would be unread.process_loaded_messages, which this calls


I guess it can be renamed to something like process_unread_loaded_messages.
Do you have any suggestions?