### PR TITLE
Corrected alphabetical order of integrated applications.

### DIFF
--- a/templates/zerver/integrations.html
+++ b/templates/zerver/integrations.html
@@ -212,6 +212,12 @@
             <span class="integration-label">Trac</span>
          </a>
        </div>
+       <div class="integration-lozenge integration-travis">
+         <a class="integration-link integration-travis" href="#travis">
+            <img class="integration-logo" src="/static/images/integrations/logos/travis.png" alt="Travis CI logo" />
+            <span class="integration-label">Travis CI</span>
+         </a>
+       </div>
        <div class="integration-lozenge integration-trello">
          <a class="integration-link integration-trello" href="#trello">
             <img class="integration-logo" src="/static/images/integrations/logos/trello.png" alt="Trello logo" />
@@ -234,12 +240,6 @@
          <a class="integration-link integration-zendesk" href="#zendesk">
             <img class="integration-logo" src="/static/images/integrations/logos/zendesk.png" alt="Zendesk logo" />
             <span class="integration-label">Zendesk</span>
-         </a>
-       </div>
-       <div class="integration-lozenge integration-travis">
-         <a class="integration-link integration-travis" href="#travis">
-            <img class="integration-logo" src="/static/images/integrations/logos/travis.png" alt="Travis CI logo" />
-            <span class="integration-label">Travis CI</span>
          </a>
        </div>
     </div>


### PR DESCRIPTION
Moved Travis CI to the right alphabetical position on /integrations page.