### PR TITLE
Add support to vagrant-proxyconf plugin

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -90,6 +90,25 @@ environment][using-dev].
 
 [using-dev]: #using-the-development-environment
 
+## Specifying proxy
+
+If you are using a proxy server for accessing the Internet you need to specify the proxy settings before running `Vagrant up`. Create file `~/.zulip-vagrant-config` (in home directory). Add the following lines to it after changing the values accordingly.
+
+```
+HTTP_PROXY http://proxy_host:port
+HTTPS_PROXY http://proxy_host:port
+NO_PROXY localhost,127.0.0.1,.example.com
+
+```
+
+Install the plugin `vagrant-proxyconf` so that the virtual machine can use the above specified proxy.
+
+```
+vagrant plugin install vagrant-proxyconf.
+```
+
+Now run vagrant up in your terminal to install the development server. If you ran `vagrant up` before and failed, make sure that you run `vagrant destroy` before running the up command again.
+
 
 Using provision.py without Vagrant
 ----------------------------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,34 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/srv/zulip"
+  
+  proxy_config_file = ENV['HOME'] + "/.zulip-vagrant-config"
+  http_proxy = https_proxy = no_proxy = ""
+
+  if File.file?(proxy_config_file)
+    IO.foreach(proxy_config_file) do |line|
+      line.chomp!
+      key, value = line.split(nil, 2)
+      case key
+      when /^([#;]|$)/; # ignore line
+      when "HTTP_PROXY"; http_proxy = value
+      when "HTTPS_PROXY"; https_proxy = value
+      when "NO_PROXY"; no_proxy = value
+      end
+    end
+
+    if Vagrant.has_plugin?("vagrant-proxyconf")
+      if http_proxy != ""
+        config.proxy.http = http_proxy
+      end
+      if https_proxy != ""
+        config.proxy.https = https_proxy
+      end
+      if https_proxy != ""
+        config.proxy.no_proxy = no_proxy
+      end
+    end
+  end
 
   # Specify LXC provider before VirtualBox provider so it's preferred.
   config.vm.provider "lxc" do |lxc|


### PR DESCRIPTION
This PR allows users to configure proxy with the help of a `.zulip-vagrant-config` file so that there is no need to maintain a patched vagrant file.

More details on https://github.com/zulip/zulip/pull/642