### PR TITLE
Move 5 legacy global variables to pointer.js.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -365,7 +365,7 @@ $(function () {
     });
 
     $('#yes-bankrupt').click(function (e) {
-        fast_forward_pointer();
+        pointer.fast_forward_pointer();
         $("#yes-bankrupt").hide();
         $("#no-bankrupt").hide();
         $(this).after($("<div>").addClass("alert alert-info settings_committed")

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -618,8 +618,8 @@ util.execute_early(function () {
 
     $(document).on('message_id_changed', function (event) {
         var old_id = event.old_id, new_id = event.new_id;
-        if (furthest_read === old_id) {
-            furthest_read = new_id;
+        if (pointer.furthest_read === old_id) {
+            pointer.furthest_read = new_id;
         }
         if (stored_messages[old_id]) {
             stored_messages[new_id] = stored_messages[old_id];

--- a/static/js/pointer.js
+++ b/static/js/pointer.js
@@ -1,0 +1,81 @@
+var pointer = (function () {
+
+var exports = {};
+
+exports.recenter_pointer_on_display = false;
+
+// Toggles re-centering the pointer in the window
+// when Home is next clicked by the user
+exports.suppress_scroll_pointer_update = false;
+exports.furthest_read = -1;
+exports.server_furthest_read = -1;
+
+var pointer_update_in_flight = false;
+
+function update_pointer() {
+    if (!pointer_update_in_flight) {
+        pointer_update_in_flight = true;
+        return channel.put({
+            url:      '/json/users/me/pointer',
+            idempotent: true,
+            data:     {pointer: pointer.furthest_read},
+            success: function () {
+                pointer.server_furthest_read = pointer.furthest_read;
+                pointer_update_in_flight = false;
+            },
+            error: function () {
+                pointer_update_in_flight = false;
+            }
+        });
+    } else {
+        // Return an empty, resolved Deferred.
+        return $.when();
+    }
+}
+
+
+exports.send_pointer_update = function () {
+    // Only bother if you've read new messages.
+    if (pointer.furthest_read > pointer.server_furthest_read) {
+        update_pointer();
+    }
+};
+
+function unconditionally_send_pointer_update() {
+    if (pointer_update_in_flight) {
+        // Keep trying.
+        var deferred = $.Deferred();
+
+        setTimeout(function () {
+            deferred.resolve(unconditionally_send_pointer_update());
+        }, 100);
+        return deferred;
+    } else {
+        return update_pointer();
+    }
+}
+
+exports.fast_forward_pointer = function () {
+    channel.get({
+        url: '/users/me',
+        idempotent: true,
+        data: {email: page_params.email},
+        success: function (data) {
+            unread.mark_all_as_read(function () {
+                pointer.furthest_read = data.max_message_id;
+                unconditionally_send_pointer_update().then(function () {
+                    ui.change_tab_to('#home');
+                    reload.initiate({immediate: true,
+                                     save_pointer: false,
+                                     save_narrow: false,
+                                     save_compose: true});
+                });
+            });
+        }
+    });
+};
+return exports;
+}());
+if (typeof module !== 'undefined') {
+    module.exports = pointer;
+}

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -226,10 +226,10 @@ function get_events_success(events) {
     }
 
     if (new_pointer !== undefined
-        && new_pointer > furthest_read)
+        && new_pointer > pointer.furthest_read)
     {
-        furthest_read = new_pointer;
-        server_furthest_read = new_pointer;
+        pointer.furthest_read = new_pointer;
+        pointer.server_furthest_read = new_pointer;
         home_msg_list.select_id(new_pointer, {then_scroll: true, use_closest: true});
     }
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -125,8 +125,8 @@ function update_in_home_view(sub, value) {
         // In case we added messages to what's visible in the home view, we need to re-scroll to make
         // sure the pointer is still visible. We don't want the auto-scroll handler to move our pointer
         // to the old scroll location before we have a chance to update it.
-        recenter_pointer_on_display = true;
-        suppress_scroll_pointer_update = true;
+        pointer.recenter_pointer_on_display = true;
+        pointer.suppress_scroll_pointer_update = true;
 
         if (! home_msg_list.empty()) {
             process_loaded_for_unread(home_msg_list.all());

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -508,10 +508,10 @@ function scroll_finished() {
     actively_scrolling = false;
 
     if ($('#home').hasClass('active')) {
-        if (!suppress_scroll_pointer_update) {
+        if (!pointer.suppress_scroll_pointer_update) {
             keep_pointer_in_view();
         } else {
-            suppress_scroll_pointer_update = false;
+            pointer.suppress_scroll_pointer_update = false;
         }
         floating_recipient_bar.update();
         if (viewport.scrollTop() === 0 &&

--- a/static/js/viewport.js
+++ b/static/js/viewport.js
@@ -95,7 +95,7 @@ exports.set_message_position = function (message_top, message_height, viewport_i
         message_top
         - message_offset;
 
-    suppress_scroll_pointer_update = true; // Gets set to false in the scroll handler.
+    pointer.suppress_scroll_pointer_update = true; // Gets set to false in the scroll handler.
     exports.scrollTop(new_scroll_top);
 };
 
@@ -258,7 +258,7 @@ exports.is_narrow = function () {
 };
 
 exports.system_initiated_animate_scroll = function (scroll_amount) {
-    suppress_scroll_pointer_update = true; // Gets set to false in the scroll handler.
+    pointer.suppress_scroll_pointer_update = true; // Gets set to false in the scroll handler.
     var viewport_offset = exports.scrollTop();
     in_stoppable_autoscroll = true;
     exports.message_pane.animate({
@@ -270,7 +270,7 @@ exports.system_initiated_animate_scroll = function (scroll_amount) {
 };
 
 exports.user_initiated_animate_scroll = function (scroll_amount) {
-    suppress_scroll_pointer_update = true; // Gets set to false in the scroll handler.
+    pointer.suppress_scroll_pointer_update = true; // Gets set to false in the scroll handler.
     in_stoppable_autoscroll = false; // defensive
 
     var viewport_offset = exports.scrollTop();

--- a/static/js/zulip.js
+++ b/static/js/zulip.js
@@ -14,17 +14,11 @@ var queued_mark_as_read = [];
 var queued_flag_timer;
 
 
-// Toggles re-centering the pointer in the window
-// when Home is next clicked by the user
-var recenter_pointer_on_display = false;
-var suppress_scroll_pointer_update = false;
+
 // Includes both scroll and arrow events. Negative means scroll up,
 // positive means scroll down.
 var last_viewport_movement_direction = 1;
 
-var furthest_read = -1;
-var server_furthest_read = -1;
-var pointer_update_in_flight = false;
 
 function keep_pointer_in_view() {
     // See recenter_view() for related logic to keep the pointer onscreen.
@@ -148,9 +142,9 @@ function scroll_to_selected() {
 function maybe_scroll_to_selected() {
     // If we have been previously instructed to re-center to the
     // selected message, then do so
-    if (recenter_pointer_on_display) {
+    if (pointer.recenter_pointer_on_display) {
         scroll_to_selected();
-        recenter_pointer_on_display = false;
+        pointer.recenter_pointer_on_display = false;
     }
 }
 
@@ -219,67 +213,9 @@ function respond_to_message(opts) {
 
 }
 
-function update_pointer() {
-    if (!pointer_update_in_flight) {
-        pointer_update_in_flight = true;
-        return channel.put({
-            url:      '/json/users/me/pointer',
-            idempotent: true,
-            data:     {pointer: furthest_read},
-            success: function () {
-                server_furthest_read = furthest_read;
-                pointer_update_in_flight = false;
-            },
-            error: function () {
-                pointer_update_in_flight = false;
-            }
-        });
-    } else {
-        // Return an empty, resolved Deferred.
-        return $.when();
-    }
-}
 
-function send_pointer_update() {
-    // Only bother if you've read new messages.
-    if (furthest_read > server_furthest_read) {
-        update_pointer();
-    }
-}
 
-function unconditionally_send_pointer_update() {
-    if (pointer_update_in_flight) {
-        // Keep trying.
-        var deferred = $.Deferred();
 
-        setTimeout(function () {
-            deferred.resolve(unconditionally_send_pointer_update());
-        }, 100);
-        return deferred;
-    } else {
-        return update_pointer();
-    }
-}
-
-function fast_forward_pointer() {
-    channel.get({
-        url: '/users/me',
-        idempotent: true,
-        data: {email: page_params.email},
-        success: function (data) {
-            unread.mark_all_as_read(function () {
-                furthest_read = data.max_message_id;
-                unconditionally_send_pointer_update().then(function () {
-                    ui.change_tab_to('#home');
-                    reload.initiate({immediate: true,
-                                     save_pointer: false,
-                                     save_narrow: false,
-                                     save_compose: true});
-                });
-            });
-        }
-    });
-}
 
 function consider_bankruptcy() {
     // Until we've handled possibly declaring bankruptcy, don't show
@@ -319,12 +255,12 @@ function main() {
     activity.set_user_statuses(page_params.initial_presences,
                                page_params.initial_servertime);
 
-    server_furthest_read = page_params.initial_pointer;
+    pointer.server_furthest_read = page_params.initial_pointer;
     if (page_params.orig_initial_pointer !== undefined &&
-        page_params.orig_initial_pointer > server_furthest_read) {
-        server_furthest_read = page_params.orig_initial_pointer;
+        page_params.orig_initial_pointer > pointer.server_furthest_read) {
+        pointer.server_furthest_read = page_params.orig_initial_pointer;
     }
-    furthest_read = server_furthest_read;
+    pointer.furthest_read = pointer.server_furthest_read;
 
     // Before trying to load messages: is this user way behind?
     consider_bankruptcy();
@@ -332,7 +268,7 @@ function main() {
     // We only send pointer updates when the user has been idle for a
     // short while to avoid hammering the server
     $(document).idle({idle: 1000,
-                      onIdle: send_pointer_update,
+                      onIdle: pointer.send_pointer_update,
                       keepTracking: true});
 
     $(document).on('message_selected.zulip', function (event) {
@@ -343,9 +279,9 @@ function main() {
         // Additionally, don't advance the pointer server-side
         // if the selected message is local-only
         if (event.msg_list === home_msg_list && page_params.narrow_stream === undefined) {
-            if (event.id > furthest_read &&
+            if (event.id > pointer.furthest_read &&
                 home_msg_list.get(event.id).local_id === undefined) {
-                furthest_read = event.id;
+                pointer.furthest_read = event.id;
             }
         }
 

--- a/tools/jslint/check-all.js
+++ b/tools/jslint/check-all.js
@@ -22,7 +22,7 @@ var globals =
     + ' csrf_token'
 
     // Modules, defined in their respective files.
-    + ' compose compose_fade rows hotkeys narrow reload search subs'
+    + ' compose compose_fade rows hotkeys narrow reload search subs pointer'
     + ' composebox_typeahead server_events typeahead_helper notifications hashchange'
     + ' invite ui util activity timerender MessageList MessageListView blueslip unread stream_list'
     + ' message_edit tab_bar emoji popovers navigate people settings alert_words_ui message_store'
@@ -58,9 +58,8 @@ var globals =
     + ' respond_to_message recenter_view last_viewport_movement_direction'
     + ' scroll_to_selected get_private_message_recipient'
     + ' viewport process_loaded_for_unread'
-    + ' maybe_scroll_to_selected recenter_pointer_on_display suppress_scroll_pointer_update'
-    + ' fast_forward_pointer recent_subjects unread_subjects'
-    + ' furthest_read server_furthest_read'
+    + ' maybe_scroll_to_selected'
+    + ' recent_subjects unread_subjects'
     ;
 
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -680,6 +680,7 @@ JS_SPECS = {
             'js/resize.js',
             'js/floating_recipient_bar.js',
             'js/ui.js',
+            'js/pointer.js',
             'js/click_handlers.js',
             'js/scroll_bar.js',
             'js/gear_menu.js',
@@ -715,7 +716,7 @@ JS_SPECS = {
             'js/emoji.js',
             'js/referral.js',
             'js/custom_markdown.js',
-            'js/bot_data.js',
+            'js/bot_data.js'
             # JS bundled by webpack is also included here if PIPELINE setting is true
         ],
         'output_filename': 'min/app.js'


### PR DESCRIPTION
Move recenter_pointer_on_display, suppress_scroll_pointer_update, fast_forward_pointer, furthest_read, and server_furthest_read to pointer.js.

Issue: https://github.com/zulip/zulip/issues/610