### PR TITLE
Adding frontend handlebar function nl2br to translate new lines into br tags

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -8,6 +8,7 @@ set_global('$', function () {
 $.fn = {};
 
 add_dependencies({
+    Handlebars: 'handlebars',
     util: 'js/util.js',
     people: 'js/people.js'
 });

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -2,6 +2,12 @@ var util = (function () {
 
 var exports = {};
 
+//Adding for handlebars to check for new lines and to insert a line break if there is
+Handlebars.registerHelper('nl2br', function (text, isXhtml) {
+  var breakTag = (isXhtml || typeof isXhtml === 'undefined') ? '<br />' : '<br>';
+  return (String(text + '')).replace(/(\r\n|\n\r|\r|\n)/g, '$1' + breakTag);
+});
+
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random
 exports.random_int = function random_int(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -5,7 +5,7 @@ var exports = {};
 //Adding for handlebars to check for new lines and to insert a line break if there is
 Handlebars.registerHelper('nl2br', function (text, isXhtml) {
   var breakTag = (isXhtml || typeof isXhtml === 'undefined') ? '<br />' : '<br>';
-  return (String(text + '')).replace(/(\r\n|\n\r|\r|\n)/g, '$1' + breakTag);
+  return (String(text)).replace(/(\r\n|\n\r|\r|\n)/g, '$1' + breakTag);
 });
 
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -30,7 +30,7 @@
             </div>
           </div>
         </div>
-        <div class="message_content">{{#unless status_message}}{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}{{/unless}}</div>
+        <div class="message_content">{{#unless status_message}}{{#if use_match_properties}}{{{nl2br msg/match_content}}}{{else}}{{{nl2br msg/content}}}{{/if}}{{/unless}}</div>
         {{#if last_edit_timestr}}
           {{#unless include_sender}}
           <div class="message_edit_notice" title="Edited ({{last_edit_timestr}})">EDITED</div>


### PR DESCRIPTION
This is due to the often annoying behavior where new lines appear to be truncated when in reality the markdown editor translates multiple newlines into one newline within a message. Unfortunately it does not convert it to a newline. Instead of modifying the markdown editor which would be non-trivial, a stop-gap for the time being is to add a handlebar function which will translate strings with newlines into strings with br tags. Updated the tests to include the handlebars dependencies so they don't crash. Passes all tests.
