### PR TITLE
Fix typo and formatting in docs.

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -437,7 +437,7 @@ server homepage just shows a list of the users that exist on the
 server and you can login as any of them by just clicking on a user.
 This setup saves time for the common case where you want to test
 something other than the login process; to test the login process
-you'll want to change AUTHENTICATION_BACKENDS in the not-PRODUCTION
+you'll want to change `AUTHENTICATION_BACKENDS` in the not-PRODUCTION
 case of `zproject/settings.py` from zproject.backends.DevAuthBackend
 to use the auth method(s) you'd like to test.
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -15,7 +15,7 @@ Schema and initial data changes
 -------------------------------
 
 If you change the database schema or change the initial test data, you
-have have to regenerate the pristine test database by running
+have to regenerate the pristine test database by running
 ``tools/do-destroy-rebuild-test-database``.
 
 Wiping the test databases


### PR DESCRIPTION
I changed AUTHENTICATION_BACKENDS to `AUTHENTICATION_BACKENDS` in README.dev.md because `_` is interpreted as emphasis or italics in some markdown programs.

I removed a duplicate word in docs/testing.rst.