### PR TITLE
Filter streams on subscriptions page (resolves #565)

### DIFF
--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -14,7 +14,7 @@ casper.waitForSelector('.sub_unsub_button.subscribed-button', function () {
     casper.test.assertTextExists('Subscribed', 'Initial subscriptions loaded');
     casper.click('form#add_new_subscription input.btn');
 });
-casper.waitForText('Create stream', function () {
+casper.waitForSelector('#create_stream_button', function () {
     casper.test.assertTextExists('Create stream', 'Modal for specifying new stream users');
     casper.fill('form#stream_creation_form', {stream_name: 'Waseemio'});
     casper.click('form#stream_creation_form button.btn.btn-primary');
@@ -32,20 +32,34 @@ casper.then(function () {
 });
 casper.waitForText('Create stream', function () {
     casper.test.assertTextExists('Create stream', 'Modal for specifying new stream users');
-    casper.fill('form#stream_creation_form', {stream_name: 'WASeemio'});
-    casper.click('form#stream_creation_form button.btn.btn-primary');
-});
-casper.waitForText('Already subscribed', function () {
-    casper.test.assertTextExists('Already subscribed', "Can't subscribe twice to a stream");
-    casper.click('form#add_new_subscription input.btn');
-});
-casper.waitForText('Create stream', function () {
-    casper.test.assertTextExists('Create stream', 'Modal for specifying new stream users');
     casper.fill('form#stream_creation_form', {stream_name: '  '});
     casper.click('form#stream_creation_form button.btn.btn-primary');
 });
-casper.waitForText('Error adding subscription', function () {
-    casper.test.assertTextExists('Error adding subscription', "Can't subscribe to an empty stream name");
+casper.waitForText('Error creating stream', function () {
+    casper.test.assertTextExists('Invalid stream name', "Can't create a stream without a name");
+});
+
+casper.then(function () {
+    casper.test.info('Streams should be filtered when typing in the create box');
+});
+
+casper.then(function () {
+    casper.test.assertSelectorHasText('.subscription_row .subscription_name', 'Verona', 'Verona stream exists before filtering');
+    casper.test.assertSelectorDoesntHaveText('.subscription_row.notdisplayed .subscription_name', 'Verona', 'Verona stream shown before filtering');
+});
+
+casper.then(function () {
+    casper.fill('form#add_new_subscription', {stream_name: 'was'});
+    casper.evaluate(function () {
+        $('#add_new_subscription input[type="text"]').expectOne()
+            .trigger($.Event('input'));
+    });
+});
+
+casper.then(function () {
+    casper.test.assertSelectorHasText('.subscription_row.notdisplayed .subscription_name', 'Verona', 'Verona stream not shown after filtering');
+    casper.test.assertSelectorHasText('.subscription_row .subscription_name', 'Waseemio', 'Waseemio stream exists after filtering');
+    casper.test.assertSelectorDoesntHaveText('.subscription_row.notdisplayed .subscription_name', 'Waseemio', 'Waseemio stream shown after filtering');
 });
 
 common.then_log_out();

--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -12,13 +12,14 @@ casper.then(function () {
 });
 casper.waitForSelector('.sub_unsub_button.subscribed-button', function () {
     casper.test.assertTextExists('Subscribed', 'Initial subscriptions loaded');
-    casper.fill('form#add_new_subscription', {stream_name: 'Waseemio'});
     casper.click('form#add_new_subscription input.btn');
 });
-casper.waitForText('Waseemio', function () {
-    casper.test.assertTextExists('Create stream Waseemio', 'Modal for specifying new stream users');
+casper.waitForText('Create stream', function () {
+    casper.test.assertTextExists('Create stream', 'Modal for specifying new stream users');
+    casper.fill('form#stream_creation_form', {stream_name: 'Waseemio'});
     casper.click('form#stream_creation_form button.btn.btn-primary');
 });
+
 casper.waitFor(function () {
     return casper.evaluate(function () {
         return $('.subscription_name').is(':contains("Waseemio")');
@@ -27,13 +28,21 @@ casper.waitFor(function () {
 
 casper.then(function () {
     casper.test.assertSelectorHasText('.subscription_name', 'Waseemio', 'Subscribing to a stream');
-    casper.fill('form#add_new_subscription', {stream_name: 'WASeemio'});
     casper.click('form#add_new_subscription input.btn');
+});
+casper.waitForText('Create stream', function () {
+    casper.test.assertTextExists('Create stream', 'Modal for specifying new stream users');
+    casper.fill('form#stream_creation_form', {stream_name: 'WASeemio'});
+    casper.click('form#stream_creation_form button.btn.btn-primary');
 });
 casper.waitForText('Already subscribed', function () {
     casper.test.assertTextExists('Already subscribed', "Can't subscribe twice to a stream");
-    casper.fill('form#add_new_subscription', {stream_name: '  '});
     casper.click('form#add_new_subscription input.btn');
+});
+casper.waitForText('Create stream', function () {
+    casper.test.assertTextExists('Create stream', 'Modal for specifying new stream users');
+    casper.fill('form#stream_creation_form', {stream_name: '  '});
+    casper.click('form#stream_creation_form button.btn.btn-primary');
 });
 casper.waitForText('Error adding subscription', function () {
     casper.test.assertTextExists('Error adding subscription', "Can't subscribe to an empty stream name");

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -52,7 +52,7 @@ exports.initialize = function () {
     // link (in the gear menu), then focus the new stream textbox.
     subs_link.on('click', function (e) {
         $(document).one('subs_page_loaded.zulip', function (e) {
-            $('#create_stream_name').focus().select();
+            $('#create_or_filter_stream_row input[type="text"]').focus().select();
         });
     });
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -281,7 +281,7 @@ function add_email_hint(row) {
 function add_sub_to_table(sub) {
     sub = add_admin_options(sub);
     var html = templates.render('subscription', sub);
-    $('#create_stream_row').after(html);
+    $('#create_or_filter_stream_row').after(html);
     settings_for_sub(sub).collapse('show');
     add_email_hint(sub);
 }
@@ -425,6 +425,54 @@ function populate_subscriptions(subs, subscribed) {
     return sub_rows;
 }
 
+exports.filter_table = function (query) {
+    var sub_name_elements = $('#subscriptions_table .subscription_name');
+
+    if (query === '') {
+        _.each(sub_name_elements, function (sub_name_elem) {
+            $(sub_name_elem).parents('.subscription_row').removeClass("notdisplayed");
+        });
+        return;
+    }
+
+    var search_terms = query.toLowerCase().split(",");
+    search_terms = _.map(search_terms, function (s) {
+        return s.trim();
+    });
+
+    _.each(sub_name_elements, function (sub_name_elem) {
+        var sub_name = $(sub_name_elem).text();
+        var matches = _.any(search_terms, function (search_term) {
+            var lower_sub_name = sub_name.toLowerCase();
+            var idx = lower_sub_name.indexOf(search_term);
+            if (idx === 0) {
+                // matched at beginning of the string
+                return true;
+            }
+            // we know now that idx === -1 or idx > 0
+            if (idx !== -1 && lower_sub_name.charAt(idx - 1) === ' ') {
+                // matched with a space immediately preceding
+                return true;
+            }
+            return false;
+        });
+
+        if (matches) {
+            $(sub_name_elem).parents('.subscription_row').removeClass("notdisplayed");
+        } else {
+            $(sub_name_elem).parents('.subscription_row').addClass("notdisplayed");
+        }
+    });
+};
+
+function actually_filter_streams() {
+    var search_box = $("#create_or_filter_stream_row input[type='text']");
+    var query = search_box.expectOne().val().trim();
+    exports.filter_table(query);
+}
+
+var filter_streams = _.throttle(actually_filter_streams, 50);
+
 exports.setup_page = function () {
     loading.make_indicator($('#subs_page_loading_indicator'));
 
@@ -485,6 +533,7 @@ exports.setup_page = function () {
         });
 
         loading.destroy_indicator($('#subs_page_loading_indicator'));
+        $("#create_or_filter_stream_row input[type='text']").on("input", filter_streams);
         $(document).trigger($.Event('subs_page_loaded.zulip'));
     }
 
@@ -561,6 +610,7 @@ function ajaxSubscribe(stream) {
         data: {"subscriptions": JSON.stringify([{"name": stream}]) },
         success: function (resp, statusText, xhr, form) {
             $("#create_stream_name").val("");
+            exports.filter_table("");
 
             var res = $.parseJSON(xhr.responseText);
             if (!$.isEmptyObject(res.already_subscribed)) {
@@ -605,6 +655,7 @@ function ajaxSubscribeForCreation(stream, principals, invite_only, announce) {
         },
         success: function (data) {
             $("#create_stream_name").val("");
+            exports.filter_table("");
             $("#subscriptions-status").hide();
             $('#stream-creation').modal("hide");
             // The rest of the work is done via the subscribe event we will get
@@ -707,11 +758,21 @@ $(function () {
     $("#subscriptions_table").on("submit", "#add_new_subscription", function (e) {
         e.preventDefault();
 
-        if (!should_list_all_streams()) {
+        if (!should_list_all_streams() && $("#create_stream_name").val()) {
             ajaxSubscribe($("#create_stream_name").val());
             return;
         } else {
-            show_new_stream_modal();
+            if ($("#search_stream_name").val().length > 0 && $(".subscription_row:not(.notdisplayed)").length > 0) {
+                var sub_id = $(".subscription_row:not(.notdisplayed):first").data("subscriptionId");
+                var settings = $("#subscription_settings_" + sub_id);
+                if (settings.hasClass('in')) {
+                    settings.collapse('hide');
+                } else {
+                    settings.collapse('show');
+                }
+            } else {
+                show_new_stream_modal();
+            }
         }
     });
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -471,9 +471,11 @@ exports.setup_page = function () {
         });
 
         $('#subscriptions_table').empty();
+
         var template_data = {
             can_create_streams: page_params.can_create_streams,
-            subscriptions: sub_rows
+            subscriptions: sub_rows,
+            hide_all_streams: !should_list_all_streams()
         };
         var rendered = templates.render('subscription_table_body', template_data);
         $('#subscriptions_table').append(rendered);
@@ -648,6 +650,10 @@ function show_new_stream_modal() {
     $('#stream-creation').modal("show");
 }
 
+function hide_new_stream_modal() {
+    $('#stream-creation').modal("hide");
+}
+
 exports.invite_user_to_stream = function (user_email, stream_name, success, failure) {
     return channel.post({
         url: "/json/users/me/subscriptions",
@@ -704,15 +710,8 @@ $(function () {
         if (!should_list_all_streams()) {
             ajaxSubscribe($("#create_stream_name").val());
             return;
-        }
-
-        var stream = $.trim($("#create_stream_name").val());
-        var stream_status = compose.check_stream_existence(stream);
-        if (stream_status === "does-not-exist") {
-            $("#stream_name").text(stream);
-            show_new_stream_modal();
         } else {
-            ajaxSubscribe(stream);
+            show_new_stream_modal();
         }
     });
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2707,13 +2707,13 @@ button.topic_edit_cancel {
 
 #create_stream_name {
     width: 220px;
-    margin-top: 10px;
+    margin: 5px 0 20px 0;
 }
 
 #create_stream_button {
     min-width: 140px;
     margin-left: 15px;
-    margin-top: 10px;
+    margin-top: -15px;
 }
 
 .sub_settings_title {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2480,7 +2480,11 @@ div.floating_recipient {
 }
 
 #add_new_subscription {
-    text-align: center;
+    text-align: left;
+}
+
+#create_or_filter_stream_row > .subscription_table_elem {
+    text-align: left;
 }
 
 #subscriptions-status {
@@ -2699,21 +2703,28 @@ button.topic_edit_cancel {
     padding: 0 15px 0 0;
 }
 
-#create_stream_row td {
+#create_or_filter_stream_row td {
     background-color: #f3f3f3;
     border-color: #BBB;
     border-bottom: 1px solid #BBB;
 }
 
-#create_stream_name {
+#create_or_filter_stream_row input[type="text"] {
     width: 220px;
-    margin: 5px 0 20px 0;
+    margin: 5px 0 20px 38px;
+}
+
+form#add_new_subscription {
+    display: inline;
 }
 
 #create_stream_button {
     min-width: 140px;
-    margin-left: 15px;
-    margin-top: -15px;
+    float: right;
+    margin-top: 9px;
+    /* margin-right: 38px will align with .sub_unsub_button
+       10px will align with the right edge of #subscriptions_table */
+    margin-right: 38px;
 }
 
 .sub_settings_title {

--- a/static/templates/subscription_table_body.handlebars
+++ b/static/templates/subscription_table_body.handlebars
@@ -1,17 +1,15 @@
-{{#if can_create_streams}}
-  <div id="create_stream_row">
+  <div id="create_or_filter_stream_row">
       <div class="subscription_table_elem">
         <form id="add_new_subscription" class="form-inline" action="">
-            {{#if hide_all_streams}}
-                <input type="text" name="stream_name" id="create_stream_name"
-                       class="something" placeholder="{{t 'Stream name' }}" value="" />
+            <input type="text" name="stream_name" id="search_stream_name"
+              placeholder="Filter by stream name" value="" />
+            {{#if can_create_streams}}
+                <input type="submit" class="btn btn-primary"
+                  id="create_stream_button" value="{{t 'Create new stream' }}" />
             {{/if}}
-            <input type="submit" class="btn btn-primary"
-                   id="create_stream_button" value="{{t 'Create new stream' }}" />
         </form>
       </div>
   </div>
-{{/if}}
 
 {{#each subscriptions}}
 {{partial "subscription"}}

--- a/static/templates/subscription_table_body.handlebars
+++ b/static/templates/subscription_table_body.handlebars
@@ -2,10 +2,12 @@
   <div id="create_stream_row">
       <div class="subscription_table_elem">
         <form id="add_new_subscription" class="form-inline" action="">
-          <input type="text" name="stream_name" id="create_stream_name"
-                 placeholder="{{t 'Stream name' }}" value="" />
-          <input type="submit" class="btn btn-primary"
-                 id="create_stream_button" value="{{t 'Create new stream' }}" />
+            {{#if hide_all_streams}}
+                <input type="text" name="stream_name" id="create_stream_name"
+                       class="something" placeholder="{{t 'Stream name' }}" value="" />
+            {{/if}}
+            <input type="submit" class="btn btn-primary"
+                   id="create_stream_button" value="{{t 'Create new stream' }}" />
         </form>
       </div>
   </div>

--- a/templates/zerver/stream_creation_prompt.html
+++ b/templates/zerver/stream_creation_prompt.html
@@ -2,10 +2,15 @@
      aria-labelledby="stream-creation-label" aria-hidden="true">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-    <h3 id="stream-creation-label">{% trans %}Create stream{% endtrans %} <span id="stream_name"></span></h3>
+    <h3 id="stream-creation-label">{% trans %}Create stream{% endtrans %}</h3>
   </div>
   <form id="stream_creation_form" class="form-inline">
       <div class="modal-body">
+          <div>
+            <b>{% trans %}Stream name{% endtrans %}</b><br />
+            <input type="text" name="stream_name" id="create_stream_name"
+                 placeholder="{{ _('Stream name') }}" value="" />
+          </div>
           <div id="make-invite-only">
             <b>{% trans %}Stream accessibility{% endtrans %}</b><br />
             <label class="radio">


### PR DESCRIPTION
This is additional to PR #684. It provides filtering on the subscriptions page.

Where the user has `can_create_streams` permission (i.e. always at the moment), filtering is applied when the user types into the create stream box. I think this is the key use case (and avoids creating similar but not precisely-duplicate streams).

If the user lacks that permission, a specific filtering box is rendered instead.