### PR TITLE
Add dependencies to setup-py3k.

### DIFF
--- a/tools/travis/setup-py3k
+++ b/tools/travis/setup-py3k
@@ -3,3 +3,5 @@ set -e
 set -x
 pip install --no-deps future==0.15.2
 pip install --no-deps modernize==0.5
+pip install --no-deps six==1.10.0
+pip install --no-deps typing==3.5.0.1


### PR DESCRIPTION
Add 'six' to setup-py3k, because it is being used in tools/lister.py.
Add 'typing' to setup-py3k, so that tools/lister.py can be type annotated in the future.