### PR TITLE
Optimize performance of Travis CI test suite.

### DIFF
--- a/tools/travis/production-helper
+++ b/tools/travis/production-helper
@@ -15,7 +15,7 @@ apt-get update
 apt-mark hold initramfs-tools initramfs-tools-bin oracle-java8-installer udev linux-image-3.19.0-28-generic linux-image-generic-lts-vivid base-files linux-firmware chromium-browser google-chrome-stable g++-4.8 gcc-4.8 cpp-4.8 openjdk-6-jre-headless openjdk-7-jre-headless
 apt-get upgrade -y $APT_OPTIONS
 # Install Zulip
-/root/zulip/scripts/setup/install
+/root/zulip/scripts/setup/install </dev/null
 
 cat >>/etc/zulip/settings.py <<EOF
 # Travis CI override settings above

--- a/tools/travis/production-helper
+++ b/tools/travis/production-helper
@@ -11,6 +11,7 @@ mv zulip-server-travis /root/zulip
 
 # Do an apt upgrade to start with an up-to-date machine
 export APT_OPTIONS="-o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
+apt-get update
 apt-get upgrade -y $APT_OPTIONS
 # Install Zulip
 /root/zulip/scripts/setup/install

--- a/tools/travis/production-helper
+++ b/tools/travis/production-helper
@@ -12,6 +12,7 @@ mv zulip-server-travis /root/zulip
 # Do an apt upgrade to start with an up-to-date machine
 export APT_OPTIONS="-o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
 apt-get update
+apt-mark hold initramfs-tools initramfs-tools-bin oracle-java8-installer udev linux-image-3.19.0-28-generic linux-image-generic-lts-vivid base-files linux-firmware chromium-browser google-chrome-stable g++-4.8 gcc-4.8 cpp-4.8 openjdk-6-jre-headless openjdk-7-jre-headless
 apt-get upgrade -y $APT_OPTIONS
 # Install Zulip
 /root/zulip/scripts/setup/install


### PR DESCRIPTION
(This seems to achieved its goals, in that Travis CI doesn't install the extra upgraded packages, but for some odd reason Travis CI hangs at the end of `scripts/setup/install` in `tools/travis/production-helper`.  Needs debugging.