### PR TITLE
Reduce development environment RAM requirements by 750MB.

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -2,9 +2,7 @@
 Installing the Zulip Development environment
 ============================================
 
-You will need a machine with at least 2GB of RAM available (see
-https://github.com/zulip/zulip/issues/32 for a plan for how to
-dramatically reduce this requirement).
+You will need a machine with at least 1.25GB of RAM available.
 
 Start by cloning this repository: `git clone https://github.com/zulip/zulip.git`
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,8 +63,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |vb, override|
     override.vm.box = "ubuntu/trusty64"
-    # 2GiB seemed reasonable here. The VM OOMs with only 1024MiB.
-    vb.memory = 2048
+    # It's possible we can get away with just 1GB; more testing needed
+    vb.memory = 1280
   end
 
 $provision_script = <<SCRIPT


### PR DESCRIPTION
Since we merged cd2348e9aec36d7f26475fa7d966d06588dbeb75 more than a
month ago and haven't seen any noticable regresions as a result, it's
reasonable at this point to do a corresponding decrease in our
documented RAM requirements for the Zulip development environment.