### PR TITLE
Allow HTML tag brackets inside tag attributes

### DIFF
--- a/tools/check-templates
+++ b/tools/check-templates
@@ -157,8 +157,11 @@ def get_django_tag(text, i):
     return s
 
 def get_html_tag(text, i):
+    quote_count = 0
     end = i + 1
-    while end < len(text) and text[end] != '>':
+    while end < len(text) and (text[end] != '>' or quote_count % 2 != 0):
+        if text[end] == '"':
+            quote_count += 1
         end += 1
     if text[end] != '>':
         raise Exception('Tag missing >')


### PR DESCRIPTION
When we have a tag like this, the HTML linter is getting confused:
`<input type="text" id="filter_pattern" name="pattern" placeholder="#(?P<id>[0-9]+)" />`

This is a small and probably naive fix for the problem at hand: double quotes are counted while scanning the template and if an uneven number of quotes has been recorded before finding a closing bracket ">", then we just continue the search.