### PR TITLE
Fix skipping to latest messages (fast_forward_pointer)

### DIFF
--- a/static/js/pointer.js
+++ b/static/js/pointer.js
@@ -57,7 +57,7 @@ function unconditionally_send_pointer_update() {
 
 exports.fast_forward_pointer = function () {
     channel.get({
-        url: '/users/me',
+        url: '/json/users/me',
         idempotent: true,
         data: {email: page_params.email},
         success: function (data) {


### PR DESCRIPTION
I haven't verified that this works, but I was unable to skip to my latest messages and think this is the fix - it looks like /users/me got moved to /json/users/me at some point.