### PR TITLE
Add feature to allow only administrators to create new streams. 2

### DIFF
--- a/frontend_tests/casper_tests/11-admin.js
+++ b/frontend_tests/casper_tests/11-admin.js
@@ -10,6 +10,45 @@ casper.then(function () {
     casper.test.assertExists('#administration.tab-pane.active', 'Administration page is active');
 });
 
+// Test only admins may create streams Setting
+casper.waitForSelector('input[type="checkbox"][id="id_realm_create_stream_by_admins_only"]', function () {
+    casper.click('input[type="checkbox"][id="id_realm_create_stream_by_admins_only"]');
+    casper.click('form.admin-realm-form input.btn');
+
+    // Test setting was activated
+    casper.waitUntilVisible('#admin-realm-create-stream-by-admins-only-status', function () {
+        casper.test.assertSelectorHasText('#admin-realm-create-stream-by-admins-only-status', 'Only Admins may now create new streams!');
+        casper.test.assertEval(function () {
+            return document.querySelector('input[type="checkbox"][id="id_realm_create_stream_by_admins_only"]').checked;
+        }, 'Only admins may create streams Setting activated');
+    });
+});
+
+casper.then(function () {
+    // Leave the page and return
+    casper.click('#settings-dropdown');
+    casper.click('a[href^="#subscriptions"]');
+    casper.click('#settings-dropdown');
+    casper.click('a[href^="#administration"]');
+
+    casper.waitForSelector('input[type="checkbox"][id="id_realm_create_stream_by_admins_only"]', function () {
+        // Test Setting was saved
+        casper.test.assertEval(function () {
+            return document.querySelector('input[type="checkbox"][id="id_realm_create_stream_by_admins_only"]').checked;
+        }, 'Only admins may create streams Setting saved');
+
+        // Deactivate setting
+        casper.click('input[type="checkbox"][id="id_realm_create_stream_by_admins_only"]');
+        casper.click('form.admin-realm-form input.btn');
+        casper.waitUntilVisible('#admin-realm-create-stream-by-admins-only-status', function () {
+            casper.test.assertSelectorHasText('#admin-realm-create-stream-by-admins-only-status', 'Any user may now create new streams!');
+            casper.test.assertEval(function () {
+                return !(document.querySelector('input[type="checkbox"][id="id_realm_create_stream_by_admins_only"]').checked);
+            }, 'Only admins may create streams Setting deactivated');
+        });
+    });
+});
+
 // Test user deactivation and reactivation
 casper.waitForSelector('.user_row[id="user_cordelia@zulip.com"]', function () {
     casper.test.assertSelectorHasText('.user_row[id="user_cordelia@zulip.com"]', 'Deactivate');

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -90,7 +90,8 @@ exports.setup_page = function () {
         domain:                     page_params.domain,
         realm_restricted_to_domain: page_params.realm_restricted_to_domain,
         realm_invite_required:      page_params.realm_invite_required,
-        realm_invite_by_admins_only: page_params.realm_invite_by_admins_only
+        realm_invite_by_admins_only: page_params.realm_invite_by_admins_only,
+        realm_create_stream_by_admins_only: page_params.realm_create_stream_by_admins_only
     };
     var admin_tab = templates.render('admin_tab', options);
     $("#administration").html(admin_tab);
@@ -99,6 +100,7 @@ exports.setup_page = function () {
     $("#admin-realm-restricted-to-domain-status").expectOne().hide();
     $("#admin-realm-invite-required-status").expectOne().hide();
     $("#admin-realm-invite-by-admins-only-status").expectOne().hide();
+    $("#admin-realm-create-stream-by-admins-only-status").expectOne().hide();
     $("#admin-emoji-status").expectOne().hide();
     $("#admin-emoji-name-status").expectOne().hide();
     $("#admin-emoji-url-status").expectOne().hide();
@@ -244,10 +246,12 @@ exports.setup_page = function () {
         var restricted_to_domain_status = $("#admin-realm-restricted-to-domain-status").expectOne();
         var invite_required_status = $("#admin-realm-invite-required-status").expectOne();
         var invite_by_admins_only_status = $("#admin-realm-invite-by-admins-only-status").expectOne();
+        var create_stream_by_admins_only_status = $("#admin-realm-create-stream-by-admins-only-status").expectOne();
         name_status.hide();
         restricted_to_domain_status.hide();
         invite_required_status.hide();
         invite_by_admins_only_status.hide();
+        create_stream_by_admins_only_status.hide();
 
         e.preventDefault();
         e.stopPropagation();
@@ -256,13 +260,15 @@ exports.setup_page = function () {
         var new_restricted = $("#id_realm_restricted_to_domain").prop("checked");
         var new_invite = $("#id_realm_invite_required").prop("checked");
         var new_invite_by_admins_only = $("#id_realm_invite_by_admins_only").prop("checked");
+        var new_create_stream_by_admins_only = $("#id_realm_create_stream_by_admins_only").prop("checked");
 
         var url = "/json/realm";
         var data = {
             name: JSON.stringify(new_name),
             restricted_to_domain: JSON.stringify(new_restricted),
             invite_required: JSON.stringify(new_invite),
-            invite_by_admins_only: JSON.stringify(new_invite_by_admins_only)
+            invite_by_admins_only: JSON.stringify(new_invite_by_admins_only),
+            create_stream_by_admins_only: JSON.stringify(new_create_stream_by_admins_only)
         };
 
         channel.patch({
@@ -294,6 +300,14 @@ exports.setup_page = function () {
                     }
                     else {
                         ui.report_success("Any user may now invite new users!", invite_by_admins_only_status);
+                    }
+                }
+                if (data.create_stream_by_admins_only !== undefined) {
+                    if (data.create_stream_by_admins_only) {
+                        ui.report_success("Only Admins may now create new streams!", create_stream_by_admins_only_status);
+                    }
+                    else {
+                        ui.report_success("Any user may now create new streams!", create_stream_by_admins_only_status);
                     }
                 }
             },

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -88,6 +88,11 @@ function get_events_success(events) {
                 page_params.realm_invite_required = event.value;
             } else if (event.op === 'update' && event.property === 'invite_by_admins_only') {
                 page_params.realm_invite_by_admins_only = event.value;
+            } else if (event.op === 'update' && event.property === 'create_stream_by_admins_only') {
+                page_params.realm_create_stream_by_admins_only = event.value;
+                if (!page_params.is_admin) {
+                    page_params.can_create_streams = !page_params.realm_create_stream_by_admins_only;
+                }
             } else if (event.op === 'update' && event.property === 'restricted_to_domain') {
                 page_params.realm_restricted_to_domain = event.value;
             }

--- a/static/templates/admin_tab.handlebars
+++ b/static/templates/admin_tab.handlebars
@@ -31,6 +31,7 @@
                 <div class="alert" id="admin-realm-restricted-to-domain-status"></div>
                 <div class="alert" id="admin-realm-invite-required-status"></div>
                 <div class="alert" id="admin-realm-invite-by-admins-only-status"></div>
+                <div class="alert" id="admin-realm-create-stream-by-admins-only-status"></div>
                 <label for="realm_name" class="control-label">Your organization's name</label>
                 <div class="controls">
                   <input type="text" id="id_realm_name" name="realm_name" class="admin-realm-name"
@@ -53,6 +54,12 @@
                 <label for="realm_invite_by_admins_only" id="id_realm_invite_by_admins_only_label" title="If checked, only administrators may invite new users." class="control-label{{#unless realm_invite_required}} control-label-disabled{{/unless}}">Only admins may invite</label>
                 <div class="controls">
                   <input type="checkbox" id="id_realm_invite_by_admins_only" name="realm_invite_by_admins_only" {{#unless realm_invite_required}}disabled="disabled"{{/unless}} {{#if realm_invite_by_admins_only}}checked="checked"{{/if}} />
+                </div>
+              </div>
+              <div class="control-group">
+                <label for="realm_create_stream_by_admins_only" id="id_realm_create_stream_by_admins_only_label" title="If checked, only administrators may create new streams." class="control-label">Only admins may create streams</label>
+                <div class="controls">
+                  <input type="checkbox" id="id_realm_create_stream_by_admins_only" name="realm_create_stream_by_admins_only" {{#if realm_create_stream_by_admins_only}}checked="checked"{{/if}} />
                 </div>
               </div>
               <div class="controls organization-submission">

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -368,6 +368,18 @@ def do_set_realm_invite_by_admins_only(realm, invite_by_admins_only):
     send_event(event, active_user_ids(realm))
     return {}
 
+def do_set_realm_create_stream_by_admins_only(realm, create_stream_by_admins_only):
+    realm.create_stream_by_admins_only = create_stream_by_admins_only
+    realm.save(update_fields=['create_stream_by_admins_only'])
+    event = dict(
+        type="realm",
+        op="update",
+        property='create_stream_by_admins_only',
+        value=create_stream_by_admins_only,
+    )
+    send_event(event, active_user_ids(realm))
+    return {}
+
 def do_deactivate_realm(realm):
     """
     Deactivate this realm. Do NOT deactivate the users -- we need to be able to
@@ -2500,6 +2512,7 @@ def fetch_initial_state_data(user_profile, event_types, queue_id):
         state['realm_restricted_to_domain'] = user_profile.realm.restricted_to_domain
         state['realm_invite_required'] = user_profile.realm.invite_required
         state['realm_invite_by_admins_only'] = user_profile.realm.invite_by_admins_only
+        state['realm_create_stream_by_admins_only'] = user_profile.realm.create_stream_by_admins_only
 
     if want('realm_domain'):
         state['realm_domain'] = user_profile.realm.domain

--- a/zerver/migrations/0016_realm_create_stream_by_admins_only.py
+++ b/zerver/migrations/0016_realm_create_stream_by_admins_only.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0015_attachment'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='realm',
+            name='create_stream_by_admins_only',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -121,6 +121,7 @@ class Realm(models.Model):
     restricted_to_domain = models.BooleanField(default=True)
     invite_required = models.BooleanField(default=False)
     invite_by_admins_only = models.BooleanField(default=False)
+    create_stream_by_admins_only = models.BooleanField(default=False)
     mandatory_topics = models.BooleanField(default=False)
     show_digest_email = models.BooleanField(default=True)
     name_changes_disabled = models.BooleanField(default=False)
@@ -430,7 +431,10 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         # Long term this might be an actual DB attribute.  Short term and long term, we want
         # this to be conceptually a property of the user, although it may actually be administered
         # in a more complicated way, like certain realms may allow only admins to create streams.
-        return True
+        if not self.realm.create_stream_by_admins_only or self.is_realm_admin:
+            return True
+        else:
+            return False
 
 def receives_offline_notifications(user_profile):
     return ((user_profile.enable_offline_email_notifications or

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -29,6 +29,7 @@ from zerver.lib.actions import (
     do_remove_subscription,
     do_rename_stream,
     do_set_muted_topics,
+    do_set_realm_create_stream_by_admins_only,
     do_set_realm_name,
     do_set_realm_restricted_to_domain,
     do_set_realm_invite_required,
@@ -430,6 +431,20 @@ class EventsRegisterTest(AuthedTestCase):
         # The first False is probably a noop, then we get transitions in both directions.
         for invite_by_admins_only in (False, True, False):
             events = self.do_test(lambda: do_set_realm_invite_by_admins_only(self.user_profile.realm, invite_by_admins_only))
+            error = schema_checker('events[0]', events[0])
+            self.assert_on_error(error)
+
+    def test_change_realm_create_stream_by_admins_only(self):
+        schema_checker = check_dict([
+            ('type', equals('realm')),
+            ('op', equals('update')),
+            ('property', equals('create_stream_by_admins_only')),
+            ('value', check_bool),
+        ])
+        # The first False is probably a noop, then we get transitions in both directions.
+        for create_stream_by_admins_only in (False, True, False):
+            events = self.do_test(lambda: do_set_realm_create_stream_by_admins_only(self.user_profile.realm,
+                                                                                create_stream_by_admins_only))
             error = schema_checker('events[0]', events[0])
             self.assert_on_error(error)
 

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -28,7 +28,8 @@ from zerver.lib.actions import do_change_password, do_change_full_name, do_chang
     internal_send_message, update_user_presence, do_events_register, \
     get_status_dict, do_change_enable_offline_email_notifications, \
     do_change_enable_digest_emails, do_set_realm_name, do_set_realm_restricted_to_domain, \
-    do_set_realm_invite_required, do_set_realm_invite_by_admins_only, get_default_subs, \
+    do_set_realm_invite_required, do_set_realm_invite_by_admins_only, \
+    do_set_realm_create_stream_by_admins_only, get_default_subs, \
     user_email_is_unique, do_invite_users, do_refer_friend, compute_mit_user_fullname, \
     do_set_muted_topics, clear_followup_emails_queue, do_update_pointer, realm_user_count
 from zerver.lib.push_notifications import num_push_devices_for_user
@@ -798,6 +799,7 @@ def home(request):
         realm_name            = register_ret['realm_name'],
         realm_invite_required = register_ret['realm_invite_required'],
         realm_invite_by_admins_only = register_ret['realm_invite_by_admins_only'],
+        realm_create_stream_by_admins_only = register_ret['realm_create_stream_by_admins_only'],
         realm_restricted_to_domain = register_ret['realm_restricted_to_domain'],
         enter_sends           = user_profile.enter_sends,
         left_side_userlist    = register_ret['left_side_userlist'],
@@ -1012,7 +1014,8 @@ def get_profile_backend(request, user_profile):
 def update_realm(request, user_profile, name=REQ(validator=check_string, default=None),
                  restricted_to_domain=REQ(validator=check_bool, default=None),
                  invite_required=REQ(validator=check_bool, default=None),
-                 invite_by_admins_only=REQ(validator=check_bool, default=None)):
+                 invite_by_admins_only=REQ(validator=check_bool, default=None),
+                 create_stream_by_admins_only=REQ(validator=check_bool, default=None)):
     realm = user_profile.realm
     data = {}
     if name is not None and realm.name != name:
@@ -1027,6 +1030,9 @@ def update_realm(request, user_profile, name=REQ(validator=check_string, default
     if invite_by_admins_only is not None and realm.invite_by_admins_only != invite_by_admins_only:
         do_set_realm_invite_by_admins_only(realm, invite_by_admins_only)
         data['invite_by_admins_only'] = invite_by_admins_only
+    if create_stream_by_admins_only is not None and realm.create_stream_by_admins_only != create_stream_by_admins_only:
+        do_set_realm_create_stream_by_admins_only(realm, create_stream_by_admins_only)
+        data['create_stream_by_admins_only'] = create_stream_by_admins_only
     return json_success(data)
 
 @authenticated_json_post_view

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -258,7 +258,9 @@ def add_subscriptions_backend(request, user_profile,
                               authorization_errors_fatal = REQ(validator=check_bool, default=True)):
 
     if not user_profile.can_create_streams():
-        return json_error('User cannot create streams.')
+        for stream in streams_raw:
+            if get_stream(stream["name"], user_profile.realm) is None:
+                return json_error('User cannot create streams.')
 
     stream_names = []
     for stream in streams_raw:


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/691

Continues from: https://github.com/zulip/zulip/pull/777
I made a different pull request from @phansen01 for easier updating and reviewing.

Seems complete.

Possible additions:

- Move page_params.can_create_streams update to new server event type,will have to dispatch events with different values to admins and normal users.
- Make the notification bot send messages when setting is changed.

What do you think?