### PR TITLE
Add packages required by Sphinx.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,16 @@ SQLAlchemy==0.7.8
 Werkzeug==0.11.8  # Dependency of moto s3 mock
 South==1.0.2
 Twisted==15.2.1
+alabaster==0.7.8  # Dependency of Sphinx
 apns-client==0.2.1
 argparse==1.2.1
+babel==2.3.4      # Dependency of Sphinx
 boto==2.38.0
 certifi==2015.4.28
 cffi==1.5.2
 chardet==2.3.0
 coverage==4.0.3
+CommonMark==0.5.4 # Dependency of Sphinx
 cryptography==1.2.3
 defusedxml==0.4.1
 diff-match-patch==20121119
@@ -24,6 +27,7 @@ django-auth-ldap==1.2.6
 django-bitfield==1.8.0
 git+https://github.com/rwbarton/django-guardian.git@caf9f0c8c035feb3dff5542fb042dd13126cdd69
 django-pipeline==1.2.2
+docutils==0.12    # Dependency of Sphinx
 docopt==0.4.0
 enum34==1.0.4
 fonttools==3.0
@@ -35,6 +39,7 @@ html2text==2015.6.6
 httplib2==0.9.1
 httpretty==0.8.10 # Dependency of moto s3 mock
 idna==2.0
+imagesize==0.7.1  # Dependency of Sphinx
 ipaddress==1.0.7
 ipython==4.1.2
 ipython-genutils==0.1.0 # Needed for ipython
@@ -72,8 +77,10 @@ simplegeneric==0.8.1 # Needed for ipython
 simplejson==3.7.3
 six==1.9.0
 smmap==0.9.0
+snowballstemmer==1.2.1 # Dependency of Sphinx
 sockjs-tornado==1.0.1
 sourcemap==0.1.8
+sphinx==1.4.1
 sphinx-rtd-theme==0.1.9 # Needed to build docs
 tornado==2.4.1
 traitlets==4.2.1 # Needed for ipython


### PR DESCRIPTION
Since `pip install` is passed `--no-deps`, we need to explicitly list
Sphinx's dependencies in requirements.txt in order for docs generation to
work.