### PR TITLE
Change occurrences of 'python2.7' to 'python'

### DIFF
--- a/analytics/management/commands/analyze_user_activity.py
+++ b/analytics/management/commands/analyze_user_activity.py
@@ -44,7 +44,7 @@ It will correctly not count server-initiated reloads in the activity statistics.
 
 The duration flag can be used to control how many days to show usage duration for
 
-Usage: python2.7 manage.py analyze_user_activity [--realm=zulip.com] [--date=2013-09-10] [--duration=1]
+Usage: python manage.py analyze_user_activity [--realm=zulip.com] [--date=2013-09-10] [--duration=1]
 
 By default, if no date is selected 2013-09-10 is used. If no realm is provided, information
 is shown for all realms"""

--- a/analytics/management/commands/client_activity.py
+++ b/analytics/management/commands/client_activity.py
@@ -14,9 +14,9 @@ class Command(BaseCommand):
 
 Usage examples:
 
-python2.7 manage.py client_activity
-python2.7 manage.py client_activity zulip.com
-python2.7 manage.py client_activity jesstess@zulip.com"""
+python manage.py client_activity
+python manage.py client_activity zulip.com
+python manage.py client_activity jesstess@zulip.com"""
 
     def add_arguments(self, parser):
         parser.add_argument('arg', metavar='<arg>', type=str, nargs='?', default=None,

--- a/api/bin/zulip-send
+++ b/api/bin/zulip-send
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # zulip-send -- Sends a message to the specified recipients.
 

--- a/api/examples/create-user
+++ b/api/examples/create-user
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012-2014 Zulip, Inc.

--- a/api/examples/edit-message
+++ b/api/examples/edit-message
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012 Zulip, Inc.

--- a/api/examples/get-public-streams
+++ b/api/examples/get-public-streams
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012 Zulip, Inc.

--- a/api/examples/list-members
+++ b/api/examples/list-members
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2014 Zulip, Inc.

--- a/api/examples/list-subscriptions
+++ b/api/examples/list-subscriptions
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012 Zulip, Inc.

--- a/api/examples/print-events
+++ b/api/examples/print-events
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012 Zulip, Inc.

--- a/api/examples/print-messages
+++ b/api/examples/print-messages
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012 Zulip, Inc.

--- a/api/examples/print-next-message
+++ b/api/examples/print-next-message
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012 Zulip, Inc.

--- a/api/examples/recent-messages
+++ b/api/examples/recent-messages
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012 Zulip, Inc.

--- a/api/examples/send-message
+++ b/api/examples/send-message
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012 Zulip, Inc.

--- a/api/examples/subscribe
+++ b/api/examples/subscribe
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012 Zulip, Inc.

--- a/api/examples/unsubscribe
+++ b/api/examples/unsubscribe
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2012 Zulip, Inc.

--- a/api/integrations/asana/zulip_asana_config.py
+++ b/api/integrations/asana/zulip_asana_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2014 Zulip, Inc.

--- a/api/integrations/asana/zulip_asana_mirror
+++ b/api/integrations/asana/zulip_asana_mirror
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Asana integration for Zulip

--- a/api/integrations/basecamp/zulip_basecamp_config.py
+++ b/api/integrations/basecamp/zulip_basecamp_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2014 Zulip, Inc.

--- a/api/integrations/basecamp/zulip_basecamp_mirror
+++ b/api/integrations/basecamp/zulip_basecamp_mirror
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Zulip mirror of Basecamp activity

--- a/api/integrations/codebase/zulip_codebase_config.py
+++ b/api/integrations/codebase/zulip_codebase_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2014 Zulip, Inc.

--- a/api/integrations/codebase/zulip_codebase_mirror
+++ b/api/integrations/codebase/zulip_codebase_mirror
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Zulip mirror of Codebase HQ activity

--- a/api/integrations/git/post-receive
+++ b/api/integrations/git/post-receive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Zulip notification post-receive hook.

--- a/api/integrations/git/zulip_git_config.py
+++ b/api/integrations/git/zulip_git_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2014 Zulip, Inc.

--- a/api/integrations/hg/zulip-changegroup.py
+++ b/api/integrations/hg/zulip-changegroup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Zulip hook for Mercurial changeset pushes.

--- a/api/integrations/nagios/nagios-notify-zulip
+++ b/api/integrations/nagios/nagios-notify-zulip
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import optparse
 import zulip
 

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -33,7 +33,7 @@ import stat
 try:
     from subprocess import CalledProcessError
 except ImportError:
-    # from python2.7:subprocess.py
+    # from python:subprocess.py
     # Exception classes used by this module.
     class CalledProcessError(Exception):
         """This exception is raised when a process run by check_call() returns

--- a/api/integrations/perforce/git_p4.py
+++ b/api/integrations/perforce/git_p4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 #
 # git-p4.py -- A tool for bidirectional operation between a Perforce depot and git.
 #

--- a/api/integrations/perforce/zulip_change-commit.py
+++ b/api/integrations/perforce/zulip_change-commit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2012-2014 Zulip, Inc.

--- a/api/integrations/perforce/zulip_perforce_config.py
+++ b/api/integrations/perforce/zulip_perforce_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2014 Zulip, Inc.

--- a/api/integrations/rss/rss-bot
+++ b/api/integrations/rss/rss-bot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # RSS integration for Zulip

--- a/api/integrations/svn/post-commit
+++ b/api/integrations/svn/post-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Zulip notification post-commit hook.

--- a/api/integrations/svn/zulip_svn_config.py
+++ b/api/integrations/svn/zulip_svn_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2014 Zulip, Inc.

--- a/api/integrations/twitter/twitter-bot
+++ b/api/integrations/twitter/twitter-bot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Twitter integration for Zulip

--- a/api/integrations/twitter/twitter-search-bot
+++ b/api/integrations/twitter/twitter-search-bot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Twitter search integration for Zulip

--- a/api/setup.py
+++ b/api/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/assets/favicon/generate
+++ b/assets/favicon/generate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import absolute_import
 import xml.etree.ElementTree as ET
 import subprocess

--- a/bots/check-mirroring
+++ b/bots/check-mirroring
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 from __future__ import absolute_import
 import sys

--- a/bots/gcal-bot
+++ b/bots/gcal-bot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import sys
 import time

--- a/bots/irc-mirror.py
+++ b/bots/irc-mirror.py
@@ -93,11 +93,11 @@ class IRCBot(irc.bot.SingleServerIRCBot):
                 return
             self.dcc_connect(address, port)
 
-usage = """python2.7 irc-mirror.py --server=IRC_SERVER --channel=<CHANNEL> --nick-prefix=<NICK> [optional args]
+usage = """python irc-mirror.py --server=IRC_SERVER --channel=<CHANNEL> --nick-prefix=<NICK> [optional args]
 
 Example:
 
-python2.7 irc-mirror.py --irc-server=127.0.0.1 --channel='#test' --nick-prefix=username
+python irc-mirror.py --irc-server=127.0.0.1 --channel='#test' --nick-prefix=username
   --site=https://zulip.example.com --user=irc-bot@example.com
   --api-key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 

--- a/bots/irc-mirror.py
+++ b/bots/irc-mirror.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.7
+#!/usr/bin/env python
 #
 # EXPERIMENTAL
 # IRC <=> Zulip mirroring bot

--- a/bots/jabber_mirror.py
+++ b/bots/jabber_mirror.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # Copyright (C) 2014 Zulip, Inc.
 #
 # Permission is hereby granted, free of charge, to any person

--- a/bots/jabber_mirror_backend.py
+++ b/bots/jabber_mirror_backend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 #
 # Copyright (C) 2013 Permabit, Inc.
 # Copyright (C) 2013--2014 Zulip, Inc.

--- a/bots/log2zulip
+++ b/bots/log2zulip
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import subprocess
 import os

--- a/bots/process_ccache
+++ b/bots/process_ccache
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import sys
 import subprocess
 import base64

--- a/bots/sync-public-streams
+++ b/bots/sync-public-streams
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import sys
 import os
 import logging

--- a/bots/tddium-notify-humbug
+++ b/bots/tddium-notify-humbug
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # Copyright (C) 2012 Zulip, Inc.
 #
 # Permission is hereby granted, free of charge, to any person

--- a/bots/zephyr_mirror.py
+++ b/bots/zephyr_mirror.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # Copyright (C) 2012 Zulip, Inc.
 #
 # Permission is hereby granted, free of charge, to any person

--- a/bots/zephyr_mirror_backend.py
+++ b/bots/zephyr_mirror_backend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # Copyright (C) 2012 Zulip, Inc.
 #
 # Permission is hereby granted, free of charge, to any person

--- a/docs/code-style.rst
+++ b/docs/code-style.rst
@@ -352,9 +352,9 @@ styles (separate lines for each selector)::
 Python
 ------
 
--  Scripts should start with ``#!/usr/bin/env python2.7`` and not
-   ``#!/usr/bin/env python2.7``. See commit ``437d4aee`` for an explanation of
-   why. Don't put such a line on a Python file unless it's meaningful to
+-  Scripts should start with ``#!/usr/bin/env python`` and not
+   ``#/usr/bin/python2.7``. This is needed to add Python 3 compatibility.
+   Don't put such a line on a Python file unless it's meaningful to
    run it as a script. (Some libraries can also be run as scripts, e.g.
    to run a test suite.)
 -  The first import in a file should be

--- a/docs/html_unescape.py
+++ b/docs/html_unescape.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 
 # Remove HTML entity escaping left over from MediaWiki->rST conversion.

--- a/frontend_tests/casperjs/bin/casperjs
+++ b/frontend_tests/casperjs/bin/casperjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 from __future__ import print_function
 import json

--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import subprocess
 import requests

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import os
 import sys
 import logging

--- a/puppet/zulip/files/cron.d/send-digest-emails
+++ b/puppet/zulip/files/cron.d/send-digest-emails
@@ -1,4 +1,4 @@
 MAILTO=root
 
 # Send digest emails once a day. Time is in UTC.
-0 18 * * *   zulip cd /home/zulip/deployments/current && python2.7 manage.py enqueue_digest_emails
+0 18 * * *   zulip cd /home/zulip/deployments/current && python manage.py enqueue_digest_emails

--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_queue_worker_errors
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_queue_worker_errors
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Nagios plugin to check that none of our queue workers have reported errors.

--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_rabbitmq_consumers
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_rabbitmq_consumers
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Nagios plugin to check that the rabbitmq has the correct number of consumers.

--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_rabbitmq_queues
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_rabbitmq_queues
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Nagios plugin to check that the rabbitmq queues are not overflowing as a result

--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_send_receive_time
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_send_receive_time
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Script to provide information about send-receive times.

--- a/puppet/zulip/files/nagios_plugins/zulip_nagios_server/check_postgres_replication_lag
+++ b/puppet/zulip/files/nagios_plugins/zulip_nagios_server/check_postgres_replication_lag
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Nagios plugin to check the difference between the primary and

--- a/puppet/zulip/files/nagios_plugins/zulip_postgres_appdb/check_fts_update_log
+++ b/puppet/zulip/files/nagios_plugins/zulip_postgres_appdb/check_fts_update_log
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Nagios plugin to check the length of the FTS update log.

--- a/puppet/zulip/files/nagios_plugins/zulip_postgres_common/check_postgres_backup
+++ b/puppet/zulip/files/nagios_plugins/zulip_postgres_common/check_postgres_backup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 from __future__ import print_function
 import dateutil.parser

--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # Processes updates to postgres Full Text Search for new/edited messages.
 #
 # Zulip manages its postgres full-text search as follows.  When the

--- a/puppet/zulip/files/supervisor/conf.d/zulip.conf
+++ b/puppet/zulip/files/supervisor/conf.d/zulip.conf
@@ -8,7 +8,7 @@
 ; variables can be expanded using this syntax: "%(ENV_HOME)s".
 
 [fcgi-program:zulip-django]
-command=python2.7 /home/zulip/deployments/current/manage.py runfcgi daemonize=False maxchildren=20 ; the program (relative uses PATH, can take args)
+command=python /home/zulip/deployments/current/manage.py runfcgi daemonize=False maxchildren=20 ; the program (relative uses PATH, can take args)
 ;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
 ;numprocs=1                    ; number of processes copies to start (def 1)
 ;directory=/tmp                ; directory to cwd to before exec (def no cwd)
@@ -43,7 +43,7 @@ socket_owner=zulip:zulip
 socket_mode=0700
 
 [program:zulip-tornado]
-command=python2.7 /home/zulip/deployments/current/manage.py runtornado 127.0.0.1:9993
+command=python /home/zulip/deployments/current/manage.py runtornado 127.0.0.1:9993
 priority=200                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -57,7 +57,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-user-activity]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=user_activity
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=user_activity
 priority=300                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -71,7 +71,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-user-activity-interval]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=user_activity_interval
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=user_activity_interval
 priority=300                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -85,7 +85,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-user-presence]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=user_presence
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=user_presence
 priority=300                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -99,7 +99,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-signups]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=signups
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=signups
 priority=400                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -113,7 +113,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-confirmation-emails]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=invites
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=invites
 priority=500                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -127,7 +127,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-missedmessage_reminders]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=missedmessage_emails
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=missedmessage_emails
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -141,7 +141,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-missedmessage_mobile_notifications]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=missedmessage_mobile_notifications
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=missedmessage_mobile_notifications
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -155,7 +155,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-slowqueries]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=slow_queries
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=slow_queries
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -169,7 +169,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-message_sender]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=message_sender --worker_num=%(process_num)s
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=message_sender --worker_num=%(process_num)s
 process_name=%(program_name)s-%(process_num)s
 priority=350                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
@@ -185,7 +185,7 @@ directory=/home/zulip/deployments/current/
 numprocs=5
 
 [program:zulip-events-feedback_messages]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=feedback_messages
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=feedback_messages
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -199,7 +199,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-error_reports]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=error_reports
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=error_reports
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -213,7 +213,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-digest_emails]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=digest_emails
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=digest_emails
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -227,7 +227,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-events-email_mirror]
-command=python2.7 /home/zulip/deployments/current/manage.py process_queue --queue_name=email_mirror
+command=python /home/zulip/deployments/current/manage.py process_queue --queue_name=email_mirror
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -241,7 +241,7 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip-deliver-enqueued-emails]
-command=python2.7 /home/zulip/deployments/current/manage.py deliver_email
+command=python /home/zulip/deployments/current/manage.py deliver_email
 priority=600                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)

--- a/puppet/zulip_internal/files/cron.d/active-user-stats
+++ b/puppet/zulip_internal/files/cron.d/active-user-stats
@@ -1,3 +1,3 @@
 MAILTO=root
 
-*/10 * * * *   zulip cd /home/zulip/deployments/current && python2.7 manage.py active_user_stats
+*/10 * * * *   zulip cd /home/zulip/deployments/current && python manage.py active_user_stats

--- a/puppet/zulip_internal/files/cron.d/check-apns-tokens
+++ b/puppet/zulip_internal/files/cron.d/check-apns-tokens
@@ -1,4 +1,4 @@
 MAILTO=root
 
 # Remove any stale apple device tokens from our list
-0 3 * * * zulip cd /home/zulip/deployments/current && python2.7 manage.py check_apns_tokens
+0 3 * * * zulip cd /home/zulip/deployments/current && python manage.py check_apns_tokens

--- a/puppet/zulip_internal/files/cron.d/clearsessions
+++ b/puppet/zulip_internal/files/cron.d/clearsessions
@@ -1,4 +1,4 @@
 MAILTO=root
 
 # Clear all expired Django sessions at 10:22 PM every day.
-22 22 * * *   zulip cd /home/zulip/deployments/current && python2.7 manage.py clearsessions
+22 22 * * *   zulip cd /home/zulip/deployments/current && python manage.py clearsessions

--- a/puppet/zulip_internal/files/nagios_plugins/zulip_zephyr_mirror/check_personal_zephyr_mirrors
+++ b/puppet/zulip_internal/files/nagios_plugins/zulip_zephyr_mirror/check_personal_zephyr_mirrors
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Nagios plugin to check that Zephyr personals mirrors are forwarding.

--- a/puppet/zulip_internal/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness
+++ b/puppet/zulip_internal/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Nagios plugin to check that our MIT users' Zephyr mirrors are running.

--- a/puppet/zulip_internal/files/nagios_plugins/zulip_zephyr_mirror/check_zephyr_mirror
+++ b/puppet/zulip_internal/files/nagios_plugins/zulip_zephyr_mirror/check_zephyr_mirror
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Nagios plugin to check that Zephyr mirror forwarding is running.

--- a/puppet/zulip_internal/files/postgresql/pg_backup_and_purge.py
+++ b/puppet/zulip_internal/files/postgresql/pg_backup_and_purge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 from __future__ import print_function
 import subprocess

--- a/puppet/zulip_internal/files/supervisor/conf.d/stats.conf
+++ b/puppet/zulip_internal/files/supervisor/conf.d/stats.conf
@@ -3,7 +3,7 @@
 
 
 [program:zulip-carbon-cache]
-command=python2.7 /opt/graphite/bin/carbon-cache.py --debug start
+command=python /opt/graphite/bin/carbon-cache.py --debug start
 priority=200                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
@@ -15,7 +15,7 @@ stdout_logfile=/var/log/zulip/carbon-cache.log         ; stdout log path, NONE f
 directory=/home/zulip/
 
 [program:zulip-carbon-aggregator]
-command=python2.7 /opt/graphite/bin/carbon-aggregator.py --debug start
+command=python /opt/graphite/bin/carbon-aggregator.py --debug start
 priority=200                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)

--- a/puppet/zulip_internal/files/trac/cgi-bin/trac.cgi
+++ b/puppet/zulip_internal/files/trac/cgi-bin/trac.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2003-2009 Edgewall Software

--- a/puppet/zulip_internal/files/trac/cgi-bin/trac.fcgi
+++ b/puppet/zulip_internal/files/trac/cgi-bin/trac.fcgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2003-2009 Edgewall Software

--- a/puppet/zulip_internal/files/trac/cgi-bin/trac.wsgi
+++ b/puppet/zulip_internal/files/trac/cgi-bin/trac.wsgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C)2008-2009 Edgewall Software

--- a/puppet/zulip_internal/files/zulip-ec2-configure-interfaces
+++ b/puppet/zulip_internal/files/zulip-ec2-configure-interfaces
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2013 Zulip, Inc.

--- a/scripts/get-django-setting
+++ b/scripts/get-django-setting
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import print_function
 

--- a/scripts/lib/log-management-command
+++ b/scripts/lib/log-management-command
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import sys
 import logging
 import os

--- a/scripts/lib/unpack-zulip
+++ b/scripts/lib/unpack-zulip
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import os
 import sys

--- a/scripts/lib/upgrade-zulip
+++ b/scripts/lib/upgrade-zulip
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import os
 import shutil

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 #
 # This script contains the actual logic for upgrading from an old
 # version of Zulip to the new version.  upgrade-zulip-stage-2 is

--- a/scripts/nagios/check-rabbitmq-consumers
+++ b/scripts/nagios/check-rabbitmq-consumers
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 from __future__ import print_function
 import sys

--- a/scripts/nagios/check-rabbitmq-queue
+++ b/scripts/nagios/check-rabbitmq-queue
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 from __future__ import print_function
 import sys

--- a/scripts/nagios/cron_file_helper.py
+++ b/scripts/nagios/cron_file_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import time
 
 def nagios_from_file(results_file):

--- a/scripts/purge-old-deployments
+++ b/scripts/purge-old-deployments
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import sys
 import os
 import logging

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import os
 import sys

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -21,10 +21,10 @@ if pwd.getpwuid(os.getuid())[0] != "zulip":
     sys.exit(1)
 
 # Send a statsd event on restarting the server
-subprocess.check_call(["python2.7", "./manage.py", "send_stats", "incr", "events.server_restart", str(int(time.time()))])
+subprocess.check_call(["python", "./manage.py", "send_stats", "incr", "events.server_restart", str(int(time.time()))])
 
 logging.info("Filling memcached caches")
-subprocess.check_call(["python2.7", "./manage.py", "fill_memcached_caches"])
+subprocess.check_call(["python", "./manage.py", "fill_memcached_caches"])
 
 # Restart the FastCGI and related processes via supervisorctl.
 logging.info("Stopping workers")

--- a/scripts/setup/generate_secrets.py
+++ b/scripts/setup/generate_secrets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # This tools generates local_settings_generated.py using the template
 
 from __future__ import print_function

--- a/scripts/setup/initialize-database
+++ b/scripts/setup/initialize-database
@@ -4,12 +4,12 @@ set -xe
 # Change to root directory of the checkout that we're running from
 cd "$(dirname "$0")/../.."
 
-python2.7 manage.py checkconfig
+python manage.py checkconfig
 
-python2.7 manage.py migrate --noinput
-python2.7 manage.py createcachetable third_party_api_results
+python manage.py migrate --noinput
+python manage.py createcachetable third_party_api_results
 
-if ! python2.7 manage.py initialize_voyager_db; then
+if ! python manage.py initialize_voyager_db; then
     set +x
     echo
     echo -e "\033[32mPopulating default database failed."

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 import sys
 import subprocess

--- a/templates/zerver/api.html
+++ b/templates/zerver/api.html
@@ -65,7 +65,7 @@ to pull out the resulting HTML :)
       </div>
 
       <div class="tab-pane" id="python">
-<div class="codehilite"><pre><span class="c">#!/usr/bin/env python2.7</span>
+<div class="codehilite"><pre><span class="c">#!/usr/bin/env python</span>
 
 <span class="kn">import</span> <span class="nn">zulip</span>
 <span class="kn">import</span> <span class="nn">sys</span>

--- a/tools/clean-venv-cache
+++ b/tools/clean-venv-cache
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import print_function
 import glob

--- a/tools/compile-handlebars-templates
+++ b/tools/compile-handlebars-templates
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import print_function
 

--- a/tools/deprecated/finbot/money.py
+++ b/tools/deprecated/finbot/money.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import division
 from __future__ import print_function
 import datetime

--- a/tools/deprecated/generate-activity-metrics.py
+++ b/tools/deprecated/generate-activity-metrics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 #
 # Generates % delta activity metrics from graphite/statsd data
 #

--- a/tools/deprecated/iframe-bot/show-last-messages
+++ b/tools/deprecated/iframe-bot/show-last-messages
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2013 Zulip, Inc.

--- a/tools/deprecated/inject-messages/inject-messages
+++ b/tools/deprecated/inject-messages/inject-messages
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 #
 # This is tool for injecting messages during a usability study.  It's
 # likely useless for other applications.

--- a/tools/deprecated/review
+++ b/tools/deprecated/review
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # encoding: utf-8
 #
 # Copyright (C) 2010 Ksplice, Inc.

--- a/tools/get-handlebar-vars
+++ b/tools/get-handlebar-vars
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import sys
 import re

--- a/tools/minify-js
+++ b/tools/minify-js
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 # Minifies JavaScripts, creating source maps
 

--- a/tools/post-receive
+++ b/tools/post-receive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 #
 # Zulip's post-receive hook.  There is a symlink
 #   from /home/git/repositories/eng/zulip.git/hooks/post-receive

--- a/tools/print-all/print-all
+++ b/tools/print-all/print-all
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import sh
 import os

--- a/tools/run-dev-queue-processors
+++ b/tools/run-dev-queue-processors
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 # This script is only meant to be run from run-dev.py, which sets up the
 # environment correctly and passes the correct arguments for manage.py.  It is a

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import optparse
 import subprocess
 import signal

--- a/tools/send_github_payloads.py
+++ b/tools/send_github_payloads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import sys
 import os
 import simplejson

--- a/tools/setup/emoji_dump/emoji_dump.py
+++ b/tools/setup/emoji_dump/emoji_dump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import os
 import shutil

--- a/tools/setup/install-phantomjs
+++ b/tools/setup/install-phantomjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import os
 import sys

--- a/tools/show-profile-results.py
+++ b/tools/show-profile-results.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import sys
 import pstats

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 from __future__ import print_function
 import optparse

--- a/tools/test_user_agent_parsing.py
+++ b/tools/test_user_agent_parsing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import re
 from collections import defaultdict

--- a/tools/update-deployment
+++ b/tools/update-deployment
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import os
 import sys

--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 # Updates static files for production.
 

--- a/tools/zulip-export/zulip-export
+++ b/tools/zulip-export/zulip-export
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright © 2014 Dropbox, Inc.

--- a/zerver/lib/bugdown/fenced_code.py
+++ b/zerver/lib/bugdown/fenced_code.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Fenced Code Extension for Python Markdown

--- a/zerver/lib/ccache.py
+++ b/zerver/lib/ccache.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # This file is adapted from samples/shellinabox/ssh-krb-wrapper in
 # https://github.com/davidben/webathena, which has the following
 # license:

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -75,7 +75,7 @@ def run_test(test):
             print("Actual test to be run is %s, but import failed." % (actual_test_name,))
             print("Importing test module directly to generate clearer traceback:")
             try:
-                command = ["python2.7", "-c", "import %s" % (actual_test_name,)]
+                command = ["python", "-c", "import %s" % (actual_test_name,)]
                 print("Import test command: `%s`" % (' '.join(command),))
                 subprocess.check_call(command)
             except subprocess.CalledProcessError:

--- a/zerver/management/commands/create_realm.py
+++ b/zerver/management/commands/create_realm.py
@@ -16,7 +16,7 @@ import sys
 class Command(BaseCommand):
     help = """Create a realm for the specified domain.
 
-Usage: python2.7 manage.py create_realm --domain=foo.com --name='Foo, Inc.'"""
+Usage: python manage.py create_realm --domain=foo.com --name='Foo, Inc.'"""
 
     option_list = BaseCommand.option_list + (
         make_option('-o', '--open-realm',
@@ -58,12 +58,12 @@ Usage: python2.7 manage.py create_realm --domain=foo.com --name='Foo, Inc.'"""
     def handle(self, *args, **options):
         if options["domain"] is None or options["name"] is None:
             print("\033[1;31mPlease provide both a domain and name.\033[0m\n", file=sys.stderr)
-            self.print_help("python2.7 manage.py", "create_realm")
+            self.print_help("python manage.py", "create_realm")
             exit(1)
 
         if options["open_realm"] and options["deployment_id"] is not None:
             print("\033[1;31mExternal deployments cannot be open realms.\033[0m\n", file=sys.stderr)
-            self.print_help("python2.7 manage.py", "create_realm")
+            self.print_help("python manage.py", "create_realm")
             exit(1)
         if options["deployment_id"] is not None and settings.VOYAGER:
             print("\033[1;31mExternal deployments are not supported on voyager deployments.\033[0m\n", file=sys.stderr)

--- a/zerver/management/commands/deliver_email.py
+++ b/zerver/management/commands/deliver_email.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Deliver email messages that have been queued by various things

--- a/zerver/management/commands/email-mirror.py
+++ b/zerver/management/commands/email-mirror.py
@@ -29,7 +29,7 @@ This script can be used via two mechanisms:
      environment variable.
 
      In Postfix, you can express that via an /etc/aliases entry like this:
-         |/usr/bin/env python2.7 /home/zulip/deployments/current/manage.py email-mirror
+         |/usr/bin/env python /home/zulip/deployments/current/manage.py email-mirror
 """
 
 

--- a/zerver/management/commands/email-mirror.py
+++ b/zerver/management/commands/email-mirror.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Forward messages sent to the configured email gateway to Zulip.

--- a/zerver/management/commands/import_dump.py
+++ b/zerver/management/commands/import_dump.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
 This command should be used only on a newly created, empty Zulip instance to
 import a database dump from one or more JSON files.
 
-Usage: python2.7 manage.py import_dump [--destroy-rebuild-database] [--chunk-size=%s] <json file name> [<json file name>...]""" % (DEFAULT_CHUNK_SIZE,)
+Usage: python manage.py import_dump [--destroy-rebuild-database] [--chunk-size=%s] <json file name> [<json file name>...]""" % (DEFAULT_CHUNK_SIZE,)
 
     option_list = BaseCommand.option_list + (
         make_option('--destroy-rebuild-database',

--- a/zerver/management/commands/print_email_delivery_backlog.py
+++ b/zerver/management/commands/print_email_delivery_backlog.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
 This is run as part of the nagios health check for the deliver_email command.
 Please note that this is only relevant to the SMTP-based email delivery (no Mandrill).
 
-Usage: python2.7 manage.py print_email_delivery_backlog
+Usage: python manage.py print_email_delivery_backlog
 """
 
     def handle(self, *args, **options):

--- a/zerver/management/commands/print_email_delivery_backlog.py
+++ b/zerver/management/commands/print_email_delivery_backlog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 """
 Shows backlog count of ScheduledJobs of type Email

--- a/zerver/management/commands/realm_emoji.py
+++ b/zerver/management/commands/realm_emoji.py
@@ -10,9 +10,9 @@ import six
 class Command(BaseCommand):
     help = """Manage emoji for the specified realm
 
-Example: python2.7 manage.py realm_emoji --realm=zulip.com --op=add robotheart  https://humbug-user-avatars.s3.amazonaws.com/95ffa70fe0e7aea3c052ba91b38a28d8779f5705
-Example: python2.7 manage.py realm_emoji --realm=zulip.com --op=remove robotheart
-Example: python2.7 manage.py realm_emoji --realm=zulip.com --op=show
+Example: python manage.py realm_emoji --realm=zulip.com --op=add robotheart  https://humbug-user-avatars.s3.amazonaws.com/95ffa70fe0e7aea3c052ba91b38a28d8779f5705
+Example: python manage.py realm_emoji --realm=zulip.com --op=remove robotheart
+Example: python manage.py realm_emoji --realm=zulip.com --op=show
 """
 
     def add_arguments(self, parser):
@@ -40,13 +40,13 @@ Example: python2.7 manage.py realm_emoji --realm=zulip.com --op=show
 
         name = options['name']
         if name is None:
-            self.print_help("python2.7 manage.py", "realm_emoji")
+            self.print_help("python manage.py", "realm_emoji")
             sys.exit(1)
 
         if options["op"] == "add":
             img_url = options['img_url']
             if img_url is None:
-                self.print_help("python2.7 manage.py", "realm_emoji")
+                self.print_help("python manage.py", "realm_emoji")
                 sys.exit(1)
             check_add_realm_emoji(realm, name, img_url)
             sys.exit(0)
@@ -54,5 +54,5 @@ Example: python2.7 manage.py realm_emoji --realm=zulip.com --op=show
             do_remove_realm_emoji(realm, name)
             sys.exit(0)
         else:
-            self.print_help("python2.7 manage.py", "realm_emoji")
+            self.print_help("python manage.py", "realm_emoji")
             sys.exit(1)

--- a/zerver/management/commands/realm_filters.py
+++ b/zerver/management/commands/realm_filters.py
@@ -16,9 +16,9 @@ NOTE: Regexes must be simple enough that they can be easily translated to JavaSc
       * Named groups will be converted to numbered groups automatically
       * Inline-regex flags will be stripped, and where possible translated to RegExp-wide flags
 
-Example: python2.7 manage.py realm_filters --realm=zulip.com --op=add '#(?P<id>[0-9]{2,8})' 'https://trac.humbughq.com/ticket/%(id)s'
-Example: python2.7 manage.py realm_filters --realm=zulip.com --op=remove '#(?P<id>[0-9]{2,8})'
-Example: python2.7 manage.py realm_filters --realm=zulip.com --op=show
+Example: python manage.py realm_filters --realm=zulip.com --op=add '#(?P<id>[0-9]{2,8})' 'https://trac.humbughq.com/ticket/%(id)s'
+Example: python manage.py realm_filters --realm=zulip.com --op=remove '#(?P<id>[0-9]{2,8})'
+Example: python manage.py realm_filters --realm=zulip.com --op=show
 """
 
     def add_arguments(self, parser):
@@ -45,13 +45,13 @@ Example: python2.7 manage.py realm_filters --realm=zulip.com --op=show
 
         pattern = options['pattern']
         if not pattern:
-            self.print_help("python2.7 manage.py", "realm_filters")
+            self.print_help("python manage.py", "realm_filters")
             sys.exit(1)
 
         if options["op"] == "add":
             url_format_string = options['url_format_string']
             if not url_format_string:
-                self.print_help("python2.7 manage.py", "realm_filters")
+                self.print_help("python manage.py", "realm_filters")
                 sys.exit(1)
             do_add_realm_filter(realm, pattern, url_format_string)
             sys.exit(0)
@@ -59,5 +59,5 @@ Example: python2.7 manage.py realm_filters --realm=zulip.com --op=show
             do_remove_realm_filter(realm, pattern)
             sys.exit(0)
         else:
-            self.print_help("python2.7 manage.py", "realm_filters")
+            self.print_help("python manage.py", "realm_filters")
             sys.exit(1)

--- a/zerver/management/commands/remove_users_from_stream.py
+++ b/zerver/management/commands/remove_users_from_stream.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
     def handle(self, **options):
         if options["domain"] is None or options["stream"] is None or \
                 (options["users"] is None and options["all_users"] is None):
-            self.print_help("python2.7 manage.py", "remove_users_from_stream")
+            self.print_help("python manage.py", "remove_users_from_stream")
             exit(1)
 
         realm = get_realm(options["domain"])

--- a/zerver/management/commands/set_default_streams.py
+++ b/zerver/management/commands/set_default_streams.py
@@ -19,9 +19,9 @@ streams.
 
 For example:
 
-python2.7 manage.py set_default_streams --domain=foo.com --streams=foo,bar,baz
-python2.7 manage.py set_default_streams --domain=foo.com --streams="foo,bar,baz with space"
-python2.7 manage.py set_default_streams --domain=foo.com --streams=
+python manage.py set_default_streams --domain=foo.com --streams=foo,bar,baz
+python manage.py set_default_streams --domain=foo.com --streams="foo,bar,baz with space"
+python manage.py set_default_streams --domain=foo.com --streams=
 """
 
     option_list = BaseCommand.option_list + (

--- a/zilencer/management/commands/create_deployment.py
+++ b/zilencer/management/commands/create_deployment.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if None in (options["api"], options["web"], options["domain"]):
             print("\033[1;31mYou must provide a domain, an API URL, and a web URL.\033[0m\n", file=sys.stderr)
-            self.print_help("python2.7 manage.py", "create_realm")
+            self.print_help("python manage.py", "create_realm")
             exit(1)
 
         if not options["no_realm"]:

--- a/zilencer/management/commands/render_old_messages.py
+++ b/zilencer/management/commands/render_old_messages.py
@@ -10,7 +10,7 @@ import time
 class Command(BaseCommand):
     help = """Render all historical messages that haven't been rendered yet.
 
-Usage: python2.7 manage.py render_old_messages"""
+Usage: python manage.py render_old_messages"""
 
     def handle(self, *args, **options):
         total_rendered = 0

--- a/zulip_tools.py
+++ b/zulip_tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 import datetime
 import errno


### PR DESCRIPTION
Occurrences of 'python2.7' in shebangs and shell and subprocess calls have to be changed to 'python' to support python 3.