### PR TITLE
End tools/run-dev.py nicely

### DIFF
--- a/tools/compile-handlebars-templates
+++ b/tools/compile-handlebars-templates
@@ -47,5 +47,9 @@ def run_forever():
 
 if __name__ == '__main__':
     if len(sys.argv) == 2 and sys.argv[1] == 'forever':
-        run_forever()
-    run()
+        try:
+            run_forever()
+        except KeyboardInterrupt:
+            print(sys.argv[0], "exited after receiving KeyboardInterrupt")
+    else:
+        run()


### PR DESCRIPTION
Currently, ending tools/run-dev.py by pressing <kbd>Ctrl</kbd>+<kbd>C</kbd> results in 1 or 2 python Tracebacks. It might seem to some newcomers that this is an error and their zulip installation is faulty.

In this PR, I catch `KeyboardInterrupt`s in 2 files and exit. I also print an exit message so that we can be sure about how the program ended.