### PR TITLE
Remove __pycache__ in tools/clean-repo.

### DIFF
--- a/tools/clean-repo
+++ b/tools/clean-repo
@@ -10,3 +10,4 @@ set -e
 
 cd "$(dirname "$0")/.."
 find . -name "*.pyc" -exec rm -f {} \;
+find . -name "__pycache__" -prune -exec rm -rf {} \;


### PR DESCRIPTION
This is done to support python 3, which stores .pyc files in a directory named `__pycache__`.

Removing `__pycache__` is not needed since we're already removing all .pyc files, but removing `__pycache__` will reduce clutter.