### PR TITLE
Clean up some relative-path handling in lister using Git magic

### DIFF
--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -34,8 +34,6 @@ if args.all:
     exclude = []
 
 # find all non-excluded files in current directory
-BASE_DIR = dirname(dirname(abspath(__file__)))
-exclude = [os.path.join(BASE_DIR, fpath) for fpath in exclude]
 python_files = lister.list_files(targets=args.targets, ftypes=['py'], use_shebang=False,
                                  modified_only=args.modified, exclude=exclude)
 


### PR DESCRIPTION
This lets us cut out the line which hard-codes how deeply nested in
the tree the `run-mypy` script is, making it simpler to borrow these
scripts in other projects.