### PR TITLE
Remove readme-symlink.md.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,6 @@ Contents:
 .. toctree::
    :maxdepth: 3
 
-   readme-symlink
    integration-guide
    new-feature-tutorial
    code-contribution-checklist

--- a/docs/readme-symlink.md
+++ b/docs/readme-symlink.md
@@ -1,1 +1,0 @@
-../README.md


### PR DESCRIPTION
This was causing lots of warnings during the sphinx build. Adding a title didn't have the desired effect, either.

```
zulip\docs\index.rst:26: WARNING: toctree contains
reference to document 'readme-symlink' that doesn't have a title: no link will be ge
nerated
```

https://zulip.readthedocs.io/en/latest/ shows the same behaviour.