### PR TITLE
Change instances of 'coworkers' to 'users'.

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -586,7 +586,7 @@ msgstr "Unterhaltungen, keine Nachrichten"
 #: templates/zerver/hello.html:48
 msgid ""
 "Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s\n"
-"      easy to keep conversations straight. Are your coworkers discussing\n"
+"      easy to keep conversations straight. Are other users discussing\n"
 "      a software bug and the content of your website at the same time?\n"
 "      No problem."
 msgstr "Jede Unterhaltung in Zulip hat ein <em>Thema</em>, so dass es\n      einfach ist, einer Unterhaltung zu folgen. Diskutieren Ihre Kollegen\n      gleichzeitig einen Softwarefehler und den Inhalr Ihrer Website?\n      Kein Problem."
@@ -787,7 +787,7 @@ msgid "Next"
 msgstr "Weiter"
 
 #: templates/zerver/invite_user.html:6
-msgid "Invite coworkers to"
+msgid "Invite more users to"
 msgstr "Mitarbeiter einladen zu"
 
 #: templates/zerver/invite_user.html:13
@@ -1082,7 +1082,7 @@ msgid "Administration"
 msgstr "Administration"
 
 #: templates/zerver/navbar.html:99 templates/zerver/right-sidebar.html:39
-msgid "Invite coworkers"
+msgid "Invite users"
 msgstr "Mitarbeiter einladen"
 
 #: templates/zerver/navbar.html:106

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -582,7 +582,7 @@ msgstr "Conversaciones, no mensajes"
 #: templates/zerver/hello.html:48
 msgid ""
 "Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s\n"
-"      easy to keep conversations straight. Are your coworkers discussing\n"
+"      easy to keep conversations straight. Are other users discussing\n"
 "      a software bug and the content of your website at the same time?\n"
 "      No problem."
 msgstr ""
@@ -783,7 +783,7 @@ msgid "Next"
 msgstr "Siguiente"
 
 #: templates/zerver/invite_user.html:6
-msgid "Invite coworkers to"
+msgid "Invite more users to"
 msgstr ""
 
 #: templates/zerver/invite_user.html:13
@@ -1078,7 +1078,7 @@ msgid "Administration"
 msgstr ""
 
 #: templates/zerver/navbar.html:99 templates/zerver/right-sidebar.html:39
-msgid "Invite coworkers"
+msgid "Invite users"
 msgstr ""
 
 #: templates/zerver/navbar.html:106

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -582,7 +582,7 @@ msgstr ""
 #: templates/zerver/hello.html:48
 msgid ""
 "Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s\n"
-"      easy to keep conversations straight. Are your coworkers discussing\n"
+"      easy to keep conversations straight. Are other users discussing\n"
 "      a software bug and the content of your website at the same time?\n"
 "      No problem."
 msgstr ""
@@ -783,7 +783,7 @@ msgid "Next"
 msgstr ""
 
 #: templates/zerver/invite_user.html:6
-msgid "Invite coworkers to"
+msgid "Invite more users to"
 msgstr ""
 
 #: templates/zerver/invite_user.html:13
@@ -1078,7 +1078,7 @@ msgid "Administration"
 msgstr ""
 
 #: templates/zerver/navbar.html:99 templates/zerver/right-sidebar.html:39
-msgid "Invite coworkers"
+msgid "Invite users"
 msgstr ""
 
 #: templates/zerver/navbar.html:106

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -581,7 +581,7 @@ msgstr ""
 #: templates/zerver/hello.html:48
 msgid ""
 "Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s\n"
-"      easy to keep conversations straight. Are your coworkers discussing\n"
+"      easy to keep conversations straight. Are other users discussing\n"
 "      a software bug and the content of your website at the same time?\n"
 "      No problem."
 msgstr ""
@@ -782,7 +782,7 @@ msgid "Next"
 msgstr ""
 
 #: templates/zerver/invite_user.html:6
-msgid "Invite coworkers to"
+msgid "Invite more users to"
 msgstr ""
 
 #: templates/zerver/invite_user.html:13
@@ -1077,7 +1077,7 @@ msgid "Administration"
 msgstr ""
 
 #: templates/zerver/navbar.html:99 templates/zerver/right-sidebar.html:39
-msgid "Invite coworkers"
+msgid "Invite users"
 msgstr ""
 
 #: templates/zerver/navbar.html:106

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -582,7 +582,7 @@ msgstr ""
 #: templates/zerver/hello.html:48
 msgid ""
 "Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s\n"
-"      easy to keep conversations straight. Are your coworkers discussing\n"
+"      easy to keep conversations straight. Are other users discussing\n"
 "      a software bug and the content of your website at the same time?\n"
 "      No problem."
 msgstr ""
@@ -783,7 +783,7 @@ msgid "Next"
 msgstr ""
 
 #: templates/zerver/invite_user.html:6
-msgid "Invite coworkers to"
+msgid "Invite more users to"
 msgstr ""
 
 #: templates/zerver/invite_user.html:13
@@ -1078,7 +1078,7 @@ msgid "Administration"
 msgstr ""
 
 #: templates/zerver/navbar.html:99 templates/zerver/right-sidebar.html:39
-msgid "Invite coworkers"
+msgid "Invite users"
 msgstr ""
 
 #: templates/zerver/navbar.html:106

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -581,7 +581,7 @@ msgstr ""
 #: templates/zerver/hello.html:48
 msgid ""
 "Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s\n"
-"      easy to keep conversations straight. Are your coworkers discussing\n"
+"      easy to keep conversations straight. Are other users discussing\n"
 "      a software bug and the content of your website at the same time?\n"
 "      No problem."
 msgstr ""
@@ -782,7 +782,7 @@ msgid "Next"
 msgstr ""
 
 #: templates/zerver/invite_user.html:6
-msgid "Invite coworkers to"
+msgid "Invite more users to"
 msgstr ""
 
 #: templates/zerver/invite_user.html:13
@@ -1077,7 +1077,7 @@ msgid "Administration"
 msgstr ""
 
 #: templates/zerver/navbar.html:99 templates/zerver/right-sidebar.html:39
-msgid "Invite coworkers"
+msgid "Invite users"
 msgstr ""
 
 #: templates/zerver/navbar.html:106

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -583,7 +583,7 @@ msgstr "Беседы, не сообщения"
 #: templates/zerver/hello.html:48
 msgid ""
 "Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s\n"
-"      easy to keep conversations straight. Are your coworkers discussing\n"
+"      easy to keep conversations straight. Are other users discussing\n"
 "      a software bug and the content of your website at the same time?\n"
 "      No problem."
 msgstr "Каждая беседа в Zulip имеет <em>тему</em>,  поэтому \nлегко поддерживать беседу в нужном ключе. Ваши коллеги обсуждают\nпрограммную ошибку и содержимое сайта в одно и тоже время?\nНикаких проблем."
@@ -784,7 +784,7 @@ msgid "Next"
 msgstr "Далее"
 
 #: templates/zerver/invite_user.html:6
-msgid "Invite coworkers to"
+msgid "Invite more users to"
 msgstr "Пригласить коллег в"
 
 #: templates/zerver/invite_user.html:13
@@ -1079,7 +1079,7 @@ msgid "Administration"
 msgstr "Администрация"
 
 #: templates/zerver/navbar.html:99 templates/zerver/right-sidebar.html:39
-msgid "Invite coworkers"
+msgid "Invite users"
 msgstr "Пригласить коллег"
 
 #: templates/zerver/navbar.html:106

--- a/locale/sr/LC_MESSAGES/django.po
+++ b/locale/sr/LC_MESSAGES/django.po
@@ -582,7 +582,7 @@ msgstr "Разговори, не поруке"
 #: templates/zerver/hello.html:48
 msgid ""
 "Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s\n"
-"      easy to keep conversations straight. Are your coworkers discussing\n"
+"      easy to keep conversations straight. Are other users discussing\n"
 "      a software bug and the content of your website at the same time?\n"
 "      No problem."
 msgstr "Сваки разговор у Зулипу има <em>тему</em> тако да је лако\nразговарати без ометања. Да ли ваше колеге разговарају о\nпрограмској грешци и о садржају вашег сајта у исто време?\nНема проблема."
@@ -783,7 +783,7 @@ msgid "Next"
 msgstr "Следеће"
 
 #: templates/zerver/invite_user.html:6
-msgid "Invite coworkers to"
+msgid "Invite more users to"
 msgstr "Позовите колеге на"
 
 #: templates/zerver/invite_user.html:13
@@ -1078,7 +1078,7 @@ msgid "Administration"
 msgstr "Администрација"
 
 #: templates/zerver/navbar.html:99 templates/zerver/right-sidebar.html:39
-msgid "Invite coworkers"
+msgid "Invite users"
 msgstr "Позовите колеге"
 
 #: templates/zerver/navbar.html:106

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -583,7 +583,7 @@ msgstr "面向会话，而不仅是消息"
 #: templates/zerver/hello.html:48
 msgid ""
 "Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s\n"
-"      easy to keep conversations straight. Are your coworkers discussing\n"
+"      easy to keep conversations straight. Are other users discussing\n"
 "      a software bug and the content of your website at the same time?\n"
 "      No problem."
 msgstr "Zulip里面的每个会话都有一个<em>话题</em>, 这样有利于让对话\\n\"\n保持有条不紊。你的同事们是不是在讨论一个软件Bug的同时，\n又在讨论关于网站的内容？\n用Zulip，没有任何问题。"
@@ -784,7 +784,7 @@ msgid "Next"
 msgstr "下一步"
 
 #: templates/zerver/invite_user.html:6
-msgid "Invite coworkers to"
+msgid "Invite more users to"
 msgstr "邀请同事到"
 
 #: templates/zerver/invite_user.html:13
@@ -1079,7 +1079,7 @@ msgid "Administration"
 msgstr "管理Zulip"
 
 #: templates/zerver/navbar.html:99 templates/zerver/right-sidebar.html:39
-msgid "Invite coworkers"
+msgid "Invite users"
 msgstr "邀请同事"
 
 #: templates/zerver/navbar.html:106

--- a/static/js/tutorial.js
+++ b/static/js/tutorial.js
@@ -352,7 +352,7 @@ function finale() {
     var alert_contents;
 
     if (page_params.prompt_for_invites) {
-        alert_contents = "<i class='icon-vector-heart alert-icon'></i>It's lonely in here! <a href='#invite-user' data-toggle='modal'>Invite some coworkers</a>.";
+        alert_contents = "<i class='icon-vector-heart alert-icon'></i>It's lonely in here! <a href='#invite-user' data-toggle='modal'>Invite some users</a>.";
     } else {
         alert_contents = "<i class='icon-vector-desktop alert-icon'></i>What's better than " + page_params.product_name + " in your browser? The <a href='/apps' target='_blank'>"+ page_params.product_name + " desktop app</a>!";
     }

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -45,7 +45,7 @@
     </span>
     <span class="description">
       <p>{% trans %}Every conversation in Zulip has a <em>topic</em>, so it&rsquo;s
-      easy to keep conversations straight. Are your coworkers discussing
+      easy to keep conversations straight. Are other users discussing
       a software bug and the content of your website at the same time?
       No problem.{% endtrans %}
     </p>

--- a/templates/zerver/invite_user.html
+++ b/templates/zerver/invite_user.html
@@ -2,7 +2,7 @@
      aria-labelledby="invite-user-label" aria-hidden="true">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-    <h3 id="invite-user-label">{{ _('Invite coworkers to') }} {{product_name}}</h3>
+    <h3 id="invite-user-label">{{ _('Invite users to') }} {{product_name}}</h3>
   </div>
   <form id="invite_user_form" class="form-horizontal"
         action="/json/invite_users" method="POST">{{ csrf_input }}

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -92,9 +92,9 @@
                     </a>
                   </li>
                   {% if show_invites %}
-                  <li title="Invite coworkers to {{product_name}}">
+                  <li title="Invite more users to {{product_name}}">
                     <a href="#invite-user" role="button" data-toggle="modal">
-                      <i class="icon-vector-plus-sign"></i> {{ _('Invite coworkers') }}
+                      <i class="icon-vector-plus-sign"></i> {{ _('Invite users') }}
                     </a>
                   </li>
                   {% endif %}

--- a/templates/zerver/right-sidebar.html
+++ b/templates/zerver/right-sidebar.html
@@ -35,7 +35,7 @@
                  <input class="user-list-filter" type="text" placeholder="Search people" />
                  <ul id="user_presences" class="filters scrolling_list"></ul>
               {% if show_invites %}
-                 <a id="invite-user-link" href="#invite-user" data-toggle="modal"><i class="icon-vector-plus-sign"></i>{{ _('Invite coworkers') }}</a>
+                 <a id="invite-user-link" href="#invite-user" data-toggle="modal"><i class="icon-vector-plus-sign"></i>{{ _('Invite more users') }}</a>
               {% endif %}
               </div>
               <div id="group-pm-list">

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -190,7 +190,7 @@ class LoginTest(AuthedTestCase):
     def test_register_first_user_with_invites(self):
         """
         The first user in a realm has a special step in their signup workflow
-        for inviting coworkers. Do as realistic an end-to-end test as we can
+        for inviting other users. Do as realistic an end-to-end test as we can
         without Tornado running.
         """
         username = "user1"
@@ -231,7 +231,7 @@ class LoginTest(AuthedTestCase):
         self.assertEquals(result.status_code, 302)
         self.assertTrue(result["Location"].endswith("/invite/"))
 
-        # Invite coworkers to join you.
+        # Invite other users to join you.
         result = self.client.get(result["Location"])
         self.assertIn("You're the first one here!", result.content)
 


### PR DESCRIPTION
    In order to genericize use of Zulip outside companies,
    all instances of coworkers have been changed to users.
    NOTABLE EXCEPTION: When the Zulip instance is domain-
    locked, the reference to coworkers remains.  The reason
    for this is twofold: first, the majority of Zulip instances
    which require a particular domain will be locked to a
    company, and second, the template variable for the domain
    necessary should be added to the alert so it is clear
    to the user what the domain needs to be for access.

Fixes: #861.