### PR TITLE
Remove redundant file open.

### DIFF
--- a/zerver/lib/context_managers.py
+++ b/zerver/lib/context_managers.py
@@ -30,12 +30,6 @@ def lockfile(filename, shared=False):
        If shared is True, use a LOCK_SH lock, otherwise LOCK_EX.
 
        The file is given by name and will be created if it does not exist."""
-
-    if not os.path.exists(filename):
-        with open(filename, 'w') as lock:
-            lock.write('0')
-
-    # TODO: Can we just open the file for writing, and skip the above check?
-    with open(filename, 'r') as lock:
+    with open(filename, 'w') as lock:
         with flock(lock, shared=shared):
             yield

--- a/zerver/lib/context_managers.py
+++ b/zerver/lib/context_managers.py
@@ -5,9 +5,8 @@ Context managers, i.e. things you can use with the 'with' statement.
 from __future__ import absolute_import
 
 import fcntl
-import os
 from contextlib import contextmanager
-from typing import Generator, Any
+from typing import Generator
 
 @contextmanager
 def flock(lockfile, shared=False):


### PR DESCRIPTION
Calling open() with mode 'w' or 'a' will create a file if it doesn't exist,
while mode 'r' will cause an exception.  This can be easily tested with:
python -c 'open("test.tmp", "w")'
ls test.tmp