### PR TITLE
[docstrings] Add type annotations to zerver/lib/validator and zerver/lib/rest

### DIFF
--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
 
+from typing import Any, Dict
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 
 from zerver.decorator import authenticated_json_view, authenticated_rest_api_view, \
         process_as_post, JsonableError
 from zerver.lib.response import json_method_not_allowed, json_unauthorized, json_unhandled_exception
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.conf import settings
 
 import logging
@@ -15,6 +16,7 @@ METHODS = ('GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH')
 
 @csrf_exempt
 def rest_dispatch(request, globals_list, **kwargs):
+    # type: (HttpRequest, Dict[str, Any], **Any) -> HttpResponse
     """Dispatch to a REST API endpoint.
 
     This calls the function named in kwargs[request.method], if that request
@@ -33,7 +35,7 @@ def rest_dispatch(request, globals_list, **kwargs):
     make a urls.py pattern put user input into a variable called GET, POST,
     etc.
     """
-    supported_methods = {}
+    supported_methods = {}  # type: Dict[str, Any]
     # duplicate kwargs so we can mutate the original as we go
     for arg in list(kwargs):
         if arg in METHODS:
@@ -47,7 +49,7 @@ def rest_dispatch(request, globals_list, **kwargs):
         return response
 
     # Override requested method if magic method=??? parameter exists
-    method_to_use = request.method
+    method_to_use = request.method  # type: str
     if request.POST and 'method' in request.POST:
         method_to_use = request.POST['method']
     if method_to_use == "SOCKET" and "zulip.emulated_method" in request.META:
@@ -91,5 +93,3 @@ def rest_dispatch(request, globals_list, **kwargs):
         return target_function(request, **kwargs)
 
     return json_method_not_allowed(list(supported_methods.keys()))
-
-

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -28,24 +28,32 @@ for any particular type of object.
 from __future__ import absolute_import
 from django.utils.translation import ugettext as _
 import six
+from typing import Any, Callable, Iterable, Optional, Tuple, TypeVar
+
+Validator = Callable[[str, Any], Optional[str]]
 
 def check_string(var_name, val):
+    # type: (str, Any) -> Optional[str]
     if not isinstance(val, six.string_types):
         return _('%s is not a string') % (var_name,)
     return None
 
 def check_int(var_name, val):
+    # type: (str, Any) -> Optional[str]
     if not isinstance(val, int):
         return _('%s is not an integer') % (var_name,)
     return None
 
 def check_bool(var_name, val):
+    # type: (str, Any) -> Optional[str]
     if not isinstance(val, bool):
         return _('%s is not a boolean') % (var_name,)
     return None
 
 def check_none_or(sub_validator):
+    # type: (Validator) -> Validator
     def f(var_name, val):
+        # type: (str, Any) -> Optional[str]
         if val is None:
             return None
         else:
@@ -53,7 +61,9 @@ def check_none_or(sub_validator):
     return f
 
 def check_list(sub_validator, length=None):
+    # type: (Validator, Optional[int]) -> Validator
     def f(var_name, val):
+        # type: (str, Any) -> Optional[str]
         if not isinstance(val, list):
             return _('%s is not a list') % (var_name,)
 
@@ -72,10 +82,9 @@ def check_list(sub_validator, length=None):
     return f
 
 def check_dict(required_keys):
-    # required_keys is a list of tuples of
-    # key_name/validator
-
+    # type: (Iterable[Tuple[str, Validator]]) -> Validator
     def f(var_name, val):
+        # type: (str, Any) -> Optional[str]
         if not isinstance(val, dict):
             return _('%s is not a dict') % (var_name,)
 
@@ -93,6 +102,7 @@ def check_dict(required_keys):
     return f
 
 def check_variable_type(allowed_type_funcs):
+    # type: (Iterable[Validator]) -> Validator
     """
     Use this validator if an argument is of a variable type (e.g. processing
     properties that might be strings or booleans).
@@ -101,6 +111,7 @@ def check_variable_type(allowed_type_funcs):
     types for this variable.
     """
     def enumerated_type_check(var_name, val):
+
         for func in allowed_type_funcs:
             if not func(var_name, val):
                 return None
@@ -108,7 +119,9 @@ def check_variable_type(allowed_type_funcs):
     return enumerated_type_check
 
 def equals(expected_val):
+    # type: (Any) -> Validator
     def f(var_name, val):
+        # type: (str, Any) -> Optional[str]
         if val != expected_val:
             return (_('%(variable)s != %(expected_value)s (%(value)s is wrong)') %
                     {'variable': var_name,

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -183,7 +183,7 @@ def list_subscriptions_backend(request, user_profile):
 @has_request_variables
 def update_subscriptions_backend(request, user_profile,
                                  delete=REQ(validator=check_list(check_string), default=[]),
-                                 add=REQ(validator=check_list(check_dict([['name', check_string]])), default=[])):
+                                 add=REQ(validator=check_list(check_dict([('name', check_string)])), default=[])):
     # type: (HttpRequest, UserProfile, List[str], List[Dict[str, str]]) -> HttpResponse
     if not add and not delete:
         return json_error(_('Nothing to do. Specify at least one of "add" or "delete".'))
@@ -279,7 +279,7 @@ def stream_button(stream_name):
 @has_request_variables
 def add_subscriptions_backend(request, user_profile,
                               streams_raw = REQ("subscriptions",
-                              validator=check_list(check_dict([['name', check_string]]))),
+                              validator=check_list(check_dict([('name', check_string)]))),
                               invite_only = REQ(validator=check_bool, default=False),
                               announce = REQ(validator=check_bool, default=False),
                               principals = REQ(validator=check_list(check_string), default=None),
@@ -464,10 +464,10 @@ def get_subscription_or_die(stream_name, user_profile):
 @has_request_variables
 def json_subscription_property(request, user_profile, subscription_data=REQ(
         validator=check_list(
-            check_dict([["stream", check_string],
-                        ["property", check_string],
-                        ["value", check_variable_type(
-                            [check_string, check_bool])]])))):
+            check_dict([("stream", check_string),
+                        ("property", check_string),
+                        ("value", check_variable_type(
+                            [check_string, check_bool]))])))):
     # type: (HttpRequest, UserProfile, List[Dict[str, Any]]) -> HttpResponse
     """
     This is the entry point to changing subscription properties. This

--- a/zerver/views/webhooks/travis.py
+++ b/zerver/views/webhooks/travis.py
@@ -13,9 +13,9 @@ def api_travis_webhook(request, user_profile, client,
                        stream=REQ(default='travis'),
                        topic=REQ(default=None),
                        message=REQ('payload', validator=check_dict([
-                           ['author_name', check_string],
-                           ['status_message', check_string],
-                           ['compare_url', check_string],
+                           ('author_name', check_string),
+                           ('status_message', check_string),
+                           ('compare_url', check_string),
                        ]))):
     author = message['author_name']
     message_type = message['status_message']


### PR DESCRIPTION
Adding type annotations for two more files.

There are a few changes that aren't type annotations. For `check_dict`, there was code calling it with lists despite a comment saying to pass in tuples. I made the type annotation match the comment, and changed the code to match the annotation.