### PR TITLE
Defer loading zxcvbn

### DIFF
--- a/frontend_tests/casper_tests/05-settings.js
+++ b/frontend_tests/casper_tests/05-settings.js
@@ -17,6 +17,7 @@ casper.then(function () {
 });
 
 casper.waitUntilVisible("#old_password", function () {
+  casper.waitForResource("zxcvbn.js", function () {
     casper.test.assertVisible("#old_password");
     casper.test.assertVisible("#new_password");
     casper.test.assertVisible("#confirm_password");
@@ -30,6 +31,7 @@ casper.waitUntilVisible("#old_password", function () {
         "confirm_password": "qwertyuiop"
     });
     casper.click('input[name="change_settings"]');
+  });
 });
 
 casper.waitUntilVisible('#settings-status', function () {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -184,7 +184,8 @@ exports.setup_page = function () {
         $('#pw_change_link').hide();
         $('#pw_change_controls').show();
         if (page_params.password_auth_enabled !== false) {
-            // zxcvbn.js is pretty big, and is only needed on password change, so load it asynchronously.
+            // zxcvbn.js is pretty big, and is only needed on password
+            // change, so load it asynchronously.
             $.getScript('/static/third/zxcvbn/zxcvbn.js', function() {
                 $('#pw_strength .bar').removeClass("fade");
             });

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -186,7 +186,7 @@ exports.setup_page = function () {
         if (page_params.password_auth_enabled !== false) {
             // zxcvbn.js is pretty big, and is only needed on password
             // change, so load it asynchronously.
-            $.getScript('/static/third/zxcvbn/zxcvbn.js', function() {
+            $.getScript('/static/third/zxcvbn/zxcvbn.js', function () {
                 $('#pw_strength .bar').removeClass("fade");
             });
         }

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -183,6 +183,12 @@ exports.setup_page = function () {
         e.preventDefault();
         $('#pw_change_link').hide();
         $('#pw_change_controls').show();
+        if (page_params.password_auth_enabled !== false) {
+            // zxcvbn.js is pretty big, and is only needed on password change, so load it asynchronously.
+            $.getScript('/static/third/zxcvbn/zxcvbn.js', function() {
+                $('#pw_strength .bar').removeClass("fade");
+            });
+        }
     });
 
     $('#new_password').on('change keyup', function () {

--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -32,11 +32,6 @@ $(function () {
         }
     });
 
-    if (page_params.password_auth_enabled !== false) {
-        // zxcvbn.js is pretty big, and is only needed on password change, so load it asynchronously.
-        $.getScript('/static/third/zxcvbn/zxcvbn.js');
-    }
-
     if (typeof $ !== 'undefined') {
         $.fn.expectOne = function () {
             if (blueslip && this.length !== 1) {

--- a/static/templates/settings_tab.handlebars
+++ b/static/templates/settings_tab.handlebars
@@ -47,7 +47,7 @@
             <label class="control-label">{{t "Password strength" }}</label>
             <div class="controls">
               <div class="progress" id="pw_strength">
-                <div class="bar bar-danger" style="width: 10%;"></div>
+                <div class="bar bar-danger fade" style="width: 10%;"></div>
               </div>
             </div>
           </div>
@@ -392,4 +392,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
Defer loading zxcvbn.js until we actually need it. Greys out the password strength bar until the zxcvbn is loaded.

Fixes https://github.com/zulip/zulip/issues/263.