### PR TITLE
Fix flaky casper test for messsage edits

### DIFF
--- a/frontend_tests/casper_tests/09-edit.js
+++ b/frontend_tests/casper_tests/09-edit.js
@@ -43,7 +43,7 @@ casper.then(function () {
     });
 });
 
-casper.waitForSelector(".message_edit_notice", function () {
+casper.waitForSelector(".selected_message .message_edit_notice", function () {
     casper.test.assertSelectorHasText(".last_message .message_content", "test edited");
 });
 
@@ -67,7 +67,7 @@ casper.then(function () {
     });
 });
 
-casper.waitForSelector(".message_edit_notice", function () {
+casper.waitForSelector(".selected_message .message_edit_notice", function () {
     casper.test.assertSelectorHasText(".last_message .sender-status", "test edited one line with me");
 });
 


### PR DESCRIPTION
.message_edit_notice is too broad of a selector to
test if your most recent edit has posted. Also
check if the currently selected message is the one
that's been edited.