### PR TITLE
Annotate zerver/views/webhooks/deskdotcom.py

### DIFF
--- a/zerver/views/webhooks/deskdotcom.py
+++ b/zerver/views/webhooks/deskdotcom.py
@@ -1,10 +1,12 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from zerver.models import get_client
+from django.http import HttpRequest, HttpResponse
+from zerver.models import get_client, UserProfile
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
 from zerver.decorator import REQ, has_request_variables, authenticated_rest_api_view
 
+from six import text_type
 
 # Desk.com's integrations all make the user supply a template, where it fills
 # in stuff like {{customer.name}} and posts the result as a "data" parameter.
@@ -16,6 +18,7 @@ from zerver.decorator import REQ, has_request_variables, authenticated_rest_api_
 def api_deskdotcom_webhook(request, user_profile, data=REQ(),
                            topic=REQ(default="Desk.com notification"),
                            stream=REQ(default="desk.com")):
+    # type: (HttpRequest, UserProfile, text_type, text_type, text_type) -> HttpResponse
     check_send_message(user_profile, get_client("ZulipDeskWebhook"), "stream",
                        [stream], topic, data)
     return json_success()


### PR DESCRIPTION
Annotate zerver.views.webhooks.deskdotcom

Noticed that `zerver.lib.action.check_send_message(*args, **kwargs)` has a too generic annotation that is not very helpful for catching type error:

    # type: (*Any, **Any) -> int # TODO: Impose same argspec as check_message.

Need help to fix the above annotation.