### PR TITLE
Replace args/kwargs with explicit arg names

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -860,9 +860,14 @@ def extract_recipients(s):
 
 # check_send_message:
 # Returns the id of the sent message.  Has same argspec as check_message.
-def check_send_message(*args, **kwargs):
-    # type: (*Any, **Any) -> int # TODO: Impose same argspec as check_message.
-    message = check_message(*args, **kwargs)
+def check_send_message(sender, client, message_type_name, message_to,
+                       subject_name, message_content, realm=None, forged=False,
+                       forged_timestamp=None, forwarder_user_profile=None, local_id=None,
+                       sender_queue_id=None):
+    # type: (UserProfile, Client, str, Optional[List[text_type]], text_type, text_type, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[int], Optional[text_type]) -> int
+    message = check_message(sender, client, message_type_name, message_to,
+            subject_name, message_content, realm, forged, forged_timestamp,
+            forwarder_user_profile, local_id, sender_queue_id)
     return do_send_messages([message])[0]
 
 def check_stream_name(stream_name):


### PR DESCRIPTION
This is done to enhance static type checking

@timabbott however, I ran into the below error while run_mypy. Could you help to debug this? Thanks!

    zerver/lib/test_helpers.py: note: In member "send_message" of class "AuthedTestCase":
    zerver/lib/test_helpers.py:309: error: Argument 4 to "check_send_message" has incompatible type Iterable[str]; expected List[unicode]