### PR TITLE
Fix issue #853 add warning for @all / @everyone

### DIFF
--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -96,6 +96,37 @@ exports.then_log_out = function () {
     });
 };
 
+// Put the specified string into the field_selector, then
+// select the menu item matching item by typing str.
+exports.select_item_via_typeahead = function (field_selector, str, item) {
+    casper.then(function () {
+        casper.test.info('Looking in ' + field_selector + ' to select ' + str + ', ' + item);
+
+        casper.evaluate(function (field_selector, str, item) {
+            // Set the value and then send a bogus keyup event to trigger
+            // the typeahead.
+            $(field_selector)
+                .focus()
+                .val(str)
+                .trigger($.Event('keyup', { which: 0 }));
+
+            // You might think these steps should be split by casper.then,
+            // but apparently that's enough to make the typeahead close (??),
+            // but not the first time.
+
+            // Trigger the typeahead.
+            // Reaching into the guts of Bootstrap Typeahead like this is not
+            // great, but I found it very hard to do it any other way.
+
+            var tah = $(field_selector).data().typeahead;
+            tah.mouseenter({
+                currentTarget: $('.typeahead:visible li:contains("'+item+'")')[0]
+            });
+            tah.select();
+        }, {field_selector:field_selector, str: str, item: item});
+    });
+};
+
 exports.enable_page_console = function () {
     // Call this (after casper.start) to enable printing page-context
     // console.log (plus some CasperJS-specific messages) to the

--- a/frontend_tests/casper_tests/02-narrow.js
+++ b/frontend_tests/casper_tests/02-narrow.js
@@ -186,38 +186,8 @@ casper.waitUntilVisible('#zfilt', function () {
 
 // Narrow by typing in search strings or operators.
 
-// Put the specified string into the search box, then
-// select the menu item matching 'item'.
-function do_search(str, item) {
-    casper.then(function () {
-        casper.test.info('Searching ' + str + ', ' + item);
-
-        casper.evaluate(function (str, item) {
-            // Set the value and then send a bogus keyup event to trigger
-            // the typeahead.
-            $('#search_query')
-                .focus()
-                .val(str)
-                .trigger($.Event('keyup', { which: 0 }));
-
-            // You might think these steps should be split by casper.then,
-            // but apparently that's enough to make the typeahead close (??),
-            // but not the first time you use do_search.
-
-            // Trigger the typeahead.
-            // Reaching into the guts of Bootstrap Typeahead like this is not
-            // great, but I found it very hard to do it any other way.
-            var tah = $('#search_query').data().typeahead;
-            tah.mouseenter({
-                currentTarget: $('.typeahead:visible li:contains("'+item+'")')[0]
-            });
-            tah.select();
-        }, {str: str, item: item});
-    });
-}
-
 function search_and_check(str, item, check, narrow_title) {
-    do_search(str, item);
+    common.select_item_via_typeahead('#search_query', str, item);
     casper.then(check);
     casper.then(check_narrow_title(narrow_title));
     un_narrow();

--- a/frontend_tests/casper_tests/12-mention.js
+++ b/frontend_tests/casper_tests/12-mention.js
@@ -1,29 +1,5 @@
 var common = require('../casper_lib/common.js').common;
 
-function enter_mention_in_composer(str, item) {
-    casper.then(function () {
-        casper.test.info('Start typing @all');
-        casper.evaluate(function (str, item) {
-            // Set the value and then send a bogus keyup event to trigger
-            // the typeahead.
-            $('#new_message_content')
-                .focus()
-                .val(str)
-                .trigger($.Event('keyup', { which: 0 }));
-
-            // Trigger the typeahead.
-            // Reaching into the guts of Bootstrap Typeahead like this is not
-            // great, but I found it very hard to do it any other way.
-            var tah = $('#new_message_content').data().typeahead;
-            tah.mouseenter({
-                currentTarget: $('.typeahead:visible li:contains("'+item+'")')[0]
-            });
-            tah.select();
-        }, {str: str, item: item});
-    });
-}
-
-/////////////////////////////////////////////////////
 common.start_and_log_in();
 casper.verbonse = true;
 
@@ -38,7 +14,7 @@ casper.then(function () {
         subject: 'Test mention all'
     });
 });
-enter_mention_in_composer('@all', 'all');
+common.select_item_via_typeahead('#new_message_content', '@all', 'all');
 
 casper.waitForText("Are you sure you want to message all", function () {
     casper.test.info('Warning message appears when mentioning @all');

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -190,6 +190,19 @@ function render(template_name, args) {
     assert.equal(button.text(), "Subscribe");
 }());
 
+(function compose_all_everyone() {
+    var args = {
+        count: '101',
+        name: 'all'
+    };
+    var html = render('compose_all_everyone', args);
+    global.write_test_output("compose_all_everyone.handlebars", html);
+    var button = $(html).find("button:first");
+    assert.equal(button.text(), "YES");
+    var error_msg = $(html).find('span.compose-all-everyone-msg').text().trim();
+    assert.equal(error_msg, "Are you sure you want to message all 101 people in this stream?");
+}());
+
 (function compose_notification() {
     var args = {
         "note": "You sent a message to a muted topic.",

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -272,12 +272,7 @@ exports.content_typeahead_selected = function (item) {
     } else if (this.completing === 'mention') {
         beginning = (beginning.substring(0, beginning.length - this.token.length-1)
                 + '@**' + item.full_name + '** ');
-
-        // We insert a special `all` item to the autocompleter above
-        // Don't consider it a user mention
-        if (item.email !== 'all' && item.email !== "everyone") {
-            $(document).trigger('usermention_completed.zulip', {mentioned: item});
-        }
+        $(document).trigger('usermention_completed.zulip', {mentioned: item});
     }
 
     // Keep the cursor after the newly inserted text, as Bootstrap will call textbox.change() to overwrite the text

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1607,6 +1607,7 @@ blockquote p {
     width: 10px;
 }
 
+.compose-all-everyone-controls,
 .compose_invite_user_controls {
     float: right;
 }

--- a/static/templates/compose_all_everyone.handlebars
+++ b/static/templates/compose_all_everyone.handlebars
@@ -1,0 +1,8 @@
+<div class="compose-all-everyone">
+    <span class="compose-all-everyone-msg">
+        {{#tr this}}Are you sure you want to message all <strong>__count__</strong> people in this stream?{{/tr}}
+    </span>
+    <span class="compose-all-everyone-controls">
+        <button type="button" class="compose-all-everyone-confirm">{{t "YES" }}</button>
+    </span>
+</div>

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -25,9 +25,9 @@
         <span class="send-status-close">&times;</span>
         <span id="error-msg"></span>
       </div>
-      <div  id="compose_invite_users" class="alert" style="display: none"></div>
-      <div  id="out-of-view-notification" class="notification-alert">
-     </div>
+      <div  id="compose_invite_users" class="alert home-error-bar"></div>
+      <div  id="compose-all-everyone" class="alert home-error-bar"></div>
+      <div  id="out-of-view-notification" class="notification-alert"></div>
      <div class="composition-area">
       <button type="button" class="close" id='compose_close'>×</button>
       <form id="send_message_form" action="/json/messages" method="post">


### PR DESCRIPTION
The warning contains a count of the number of people in the stream.
An error appears if the warning is ignored and the user tries to send the message anyway.
The message cannot be sent until the warning is acknowledged.
This only applies to stream messages and not private messages.