### PR TITLE
zerver/lib: Fix annotations in cache.py and cache_helpers.py

### DIFF
--- a/docs/mypy.md
+++ b/docs/mypy.md
@@ -158,3 +158,8 @@ to annotate strings in Zulip's code.  We follow the style of doing
 of doing `import six` and using `six.text_type` for annotation, because
 `text_type` is used so extensively for type annotations that we don't
 need to be that verbose.
+
+Sometimes you'll find that you have to convert strings from one type to
+another.  `zerver/lib/str_utils.py` has utility functions to help with that.
+It also has documentation (in docstrings) which explains the right way
+to use them.

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -67,6 +67,7 @@ from zerver.lib.narrow import check_supported_events_narrow_filter
 from zerver.lib.request import JsonableError
 from zerver.lib.session_user import get_session_user
 from zerver.lib.upload import claim_attachment, delete_message_image
+from zerver.lib.str_utils import NonBinaryStr
 
 import DNS
 import ujson
@@ -80,7 +81,6 @@ import logging
 import itertools
 from collections import defaultdict
 
-NON_BINARY_STR = TypeVar('NON_BINARY_STR', str, text_type)
 # This will be used to type annotate parameters in a function if the function
 # works on both str and unicode in python 2 but in python 3 it only works on str.
 SizedTextIterable = Union[Sequence[text_type], AbstractSet[text_type]]
@@ -521,15 +521,15 @@ def do_change_user_email(user_profile, new_email):
                'new_email': new_email})
 
 def compute_irc_user_fullname(email):
-    # type: (NON_BINARY_STR) -> NON_BINARY_STR
+    # type: (NonBinaryStr) -> NonBinaryStr
     return email.split("@")[0] + " (IRC)"
 
 def compute_jabber_user_fullname(email):
-    # type: (NON_BINARY_STR) -> NON_BINARY_STR
+    # type: (NonBinaryStr) -> NonBinaryStr
     return email.split("@")[0] + " (XMPP)"
 
 def compute_mit_user_fullname(email):
-    # type: (NON_BINARY_STR) -> NON_BINARY_STR
+    # type: (NonBinaryStr) -> NonBinaryStr
     try:
         # Input is either e.g. username@mit.edu or user|CROSSREALM.INVALID@mit.edu
         match_user = re.match(r'^([a-zA-Z0-9_.-]+)(\|.+)?@mit\.edu$', email.lower())

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -7,6 +7,7 @@ from django.core.cache import cache as djcache
 from django.core.cache import get_cache
 from django.conf import settings
 from django.db.models import Q
+from django.core.cache.backends.base import BaseCache
 
 from typing import Any, Callable, Iterable, Optional, Union, TypeVar
 
@@ -92,7 +93,7 @@ def bounce_key_prefix_for_testing(test_name):
     KEY_PREFIX = test_name + u':' + text_type(os.getpid()) + u':'
 
 def get_cache_backend(cache_name):
-    # type: (Optional[str]) -> get_cache
+    # type: (Optional[str]) -> BaseCache
     if cache_name is None:
         return djcache
     return get_cache(cache_name)

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -294,7 +294,7 @@ def get_stream_cache_key(stream_name, realm):
         realm_id, make_safe_digest(stream_name.strip().lower()))
 
 def update_user_profile_caches(user_profiles):
-    # type: (Iterable[Any]) -> Any
+    # type: (Iterable[Any]) -> None
     items_for_remote_cache = {}
     for user_profile in user_profiles:
         items_for_remote_cache[user_profile_by_email_cache_key(user_profile.email)] = (user_profile,)

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -244,23 +244,23 @@ def cache(func):
     return cache_with_key(keyfunc)(func)
 
 def message_cache_key(message_id):
-    # type: (int) -> str
-    return "message:%d" % (message_id,)
+    # type: (int) -> text_type
+    return u"message:%d" % (message_id,)
 
 def display_recipient_cache_key(recipient_id):
-    # type: (int) -> str
-    return "display_recipient_dict:%d" % (recipient_id,)
+    # type: (int) -> text_type
+    return u"display_recipient_dict:%d" % (recipient_id,)
 
 def user_profile_by_email_cache_key(email):
-    # type: (str) -> str
+    # type: (text_type) -> text_type
     # See the comment in zerver/lib/avatar.py:gravatar_hash for why we
     # are proactively encoding email addresses even though they will
     # with high likelihood be ASCII-only for the foreseeable future.
-    return 'user_profile_by_email:%s' % (make_safe_digest(email.strip()),)
+    return u'user_profile_by_email:%s' % (make_safe_digest(email.strip()),)
 
 def user_profile_by_id_cache_key(user_profile_id):
-    # type: (int) -> str
-    return "user_profile_by_id:%s" % (user_profile_id,)
+    # type: (int) -> text_type
+    return u"user_profile_by_id:%s" % (user_profile_id,)
 
 # TODO: Refactor these cache helpers into another file that can import
 # models.py so that we can replace many of these type: Anys
@@ -271,8 +271,8 @@ def cache_save_user_profile(user_profile):
 
 active_user_dict_fields = ['id', 'full_name', 'short_name', 'email', 'is_realm_admin', 'is_bot'] # type: List[str]
 def active_user_dicts_in_realm_cache_key(realm):
-    # type: (Any) -> str
-    return "active_user_dicts_in_realm:%s" % (realm.id,)
+    # type: (Any) -> text_type
+    return u"active_user_dicts_in_realm:%s" % (realm.id,)
 
 active_bot_dict_fields = ['id', 'full_name', 'short_name',
                           'email', 'default_sending_stream__name',
@@ -280,17 +280,17 @@ active_bot_dict_fields = ['id', 'full_name', 'short_name',
                           'default_all_public_streams', 'api_key',
                           'bot_owner__email', 'avatar_source'] # type: List[str]
 def active_bot_dicts_in_realm_cache_key(realm):
-    # type: (Any) -> str
-    return "active_bot_dicts_in_realm:%s" % (realm.id,)
+    # type: (Any) -> text_type
+    return u"active_bot_dicts_in_realm:%s" % (realm.id,)
 
 def get_stream_cache_key(stream_name, realm):
-    # type: (six.text_type, Any) -> str
+    # type: (text_type, Any) -> text_type
     from zerver.models import Realm
     if isinstance(realm, Realm):
         realm_id = realm.id
     else:
         realm_id = realm
-    return "stream_by_realm_and_name:%s:%s" % (
+    return u"stream_by_realm_and_name:%s:%s" % (
         realm_id, make_safe_digest(stream_name.strip().lower()))
 
 def update_user_profile_caches(user_profiles):
@@ -341,8 +341,8 @@ def flush_realm(sender, **kwargs):
         cache_delete(realm_alert_words_cache_key(realm))
 
 def realm_alert_words_cache_key(realm):
-    # type: (Any) -> str
-    return "realm_alert_words:%s" % (realm.domain,)
+    # type: (Any) -> text_type
+    return u"realm_alert_words:%s" % (realm.domain,)
 
 # Called by models.py to flush the stream cache whenever we save a stream
 # object.

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+
+from six import text_type
 from typing import Any, Dict, Callable, Tuple
 
 # This file needs to be different from cache.py because cache.py
@@ -37,33 +39,33 @@ def message_fetch_objects():
                                                     id__gt=max_id - MESSAGE_CACHE_SIZE)
 
 def message_cache_items(items_for_remote_cache, message):
-    # type: (Dict[str, Tuple[Message]], Message) -> None
+    # type: (Dict[text_type, Tuple[Message]], Message) -> None
     items_for_remote_cache[message_cache_key(message.id)] = (message,)
 
 def user_cache_items(items_for_remote_cache, user_profile):
-    # type: (Dict[str, Tuple[UserProfile]], UserProfile) -> None
+    # type: (Dict[text_type, Tuple[UserProfile]], UserProfile) -> None
     items_for_remote_cache[user_profile_by_email_cache_key(user_profile.email)] = (user_profile,)
     items_for_remote_cache[user_profile_by_id_cache_key(user_profile.id)] = (user_profile,)
 
 def stream_cache_items(items_for_remote_cache, stream):
-    # type: (Dict[str, Tuple[Stream]], Stream) -> None
+    # type: (Dict[text_type, Tuple[Stream]], Stream) -> None
     items_for_remote_cache[get_stream_cache_key(stream.name, stream.realm_id)] = (stream,)
 
 def client_cache_items(items_for_remote_cache, client):
-    # type: (Dict[str, Tuple[Client]], Client) -> None
+    # type: (Dict[text_type, Tuple[Client]], Client) -> None
     items_for_remote_cache[get_client_cache_key(client.name)] = (client,)
 
 def huddle_cache_items(items_for_remote_cache, huddle):
-    # type: (Dict[str, Tuple[Huddle]], Huddle) -> None
+    # type: (Dict[text_type, Tuple[Huddle]], Huddle) -> None
     items_for_remote_cache[huddle_hash_cache_key(huddle.huddle_hash)] = (huddle,)
 
 def recipient_cache_items(items_for_remote_cache, recipient):
-    # type: (Dict[str, Tuple[Recipient]], Recipient) -> None
+    # type: (Dict[text_type, Tuple[Recipient]], Recipient) -> None
     items_for_remote_cache[get_recipient_cache_key(recipient.type, recipient.type_id)] = (recipient,)
 
 session_engine = import_module(settings.SESSION_ENGINE)
 def session_cache_items(items_for_remote_cache, session):
-    # type: (Dict[str, str], Session) -> None
+    # type: (Dict[text_type, text_type], Session) -> None
     store = session_engine.SessionStore(session_key=session.session_key)
     items_for_remote_cache[store.cache_key] = store.decode(session.session_data)
 
@@ -81,13 +83,13 @@ cache_fillers = {
     'message': (message_fetch_objects, message_cache_items, 3600 * 24, 1000),
     'huddle': (lambda: Huddle.objects.select_related().all(), huddle_cache_items, 3600*24*7, 10000),
     'session': (lambda: Session.objects.all(), session_cache_items, 3600*24*7, 10000),
-    } # type: Dict[str, Tuple[Callable[[], List[Any]], Callable[[Dict[str, Any], Any], None], int, int]]
+    } # type: Dict[str, Tuple[Callable[[], List[Any]], Callable[[Dict[text_type, Any], Any], None], int, int]]
 
 def fill_remote_cache(cache):
     # type: (str) -> None
     remote_cache_time_start = get_remote_cache_time()
     remote_cache_requests_start = get_remote_cache_requests()
-    items_for_remote_cache = {} # type: Dict[str, Any]
+    items_for_remote_cache = {} # type: Dict[text_type, Any]
     (objects, items_filler, timeout, batch_size) = cache_fillers[cache]
     count = 0
     for obj in objects():

--- a/zerver/lib/str_utils.py
+++ b/zerver/lib/str_utils.py
@@ -1,3 +1,35 @@
+"""
+String Utilities:
+
+This module helps in converting strings from one type to another.
+
+Currently we have strings of 3 semantic types:
+
+1.  text strings: These strings are used to represent all textual data,
+    like people's names, stream names, content of messages, etc.
+    These strings can contain non-ASCII characters, so its type should be
+    six.text_type (which is `str` in python 3 and `unicode` in python 2).
+
+2.  binary strings: These strings are used to represent binary data.
+    This should be of type six.binary_type (which is `bytes` in python 3
+    and `str` in python 2).
+
+3.  native strings: These strings are for internal use only.  Strings of
+    this type are not meant to be stored in database, displayed to end
+    users, etc.  Things like exception names, parameter names, attribute
+    names, etc should be native strings.  These strings should only
+    contain ASCII characters and they should have type `str`.
+
+There are 3 utility functions provided for converting strings from one type
+to another - force_text, force_bytes, force_str
+
+Interconversion between text strings and binary strings can be done by
+using encode and decode appropriately or by using the utility functions
+force_text and force_bytes.
+
+It is recommended to use the utility functions for other string conversions.
+"""
+
 import six
 from six import text_type, binary_type
 from typing import Any, Mapping, Union, TypeVar
@@ -7,6 +39,7 @@ NonBinaryStr = TypeVar('NonBinaryStr', str, text_type)
 
 def force_text(s):
     # type: (Union[text_type, binary_type]) -> text_type
+    """converts a string to a text string"""
     if isinstance(s, text_type):
         return s
     elif isinstance(s, binary_type):
@@ -16,6 +49,7 @@ def force_text(s):
 
 def force_bytes(s):
     # type: (Union[text_type, binary_type]) -> binary_type
+    """converts a string to binary string"""
     if isinstance(s, binary_type):
         return s
     elif isinstance(s, text_type):
@@ -25,6 +59,7 @@ def force_bytes(s):
 
 def force_str(s):
     # type: (Union[text_type, binary_type]) -> str
+    """converts a string to a native string"""
     if isinstance(s, str):
         return s
     elif isinstance(s, text_type):

--- a/zerver/lib/str_utils.py
+++ b/zerver/lib/str_utils.py
@@ -1,0 +1,40 @@
+import six
+from six import text_type, binary_type
+from typing import Any, Mapping, Union, TypeVar
+
+NonBinaryStr = TypeVar('NonBinaryStr', str, text_type)
+# This is used to represent text or native strings
+
+def force_text(s):
+    # type: (Union[text_type, binary_type]) -> text_type
+    if isinstance(s, text_type):
+        return s
+    elif isinstance(s, binary_type):
+        return s.decode('utf-8')
+    else:
+        raise ValueError("force_text expects a string type")
+
+def force_bytes(s):
+    # type: (Union[text_type, binary_type]) -> binary_type
+    if isinstance(s, binary_type):
+        return s
+    elif isinstance(s, text_type):
+        return s.encode('utf-8')
+    else:
+        raise ValueError("force_bytes expects a string type")
+
+def force_str(s):
+    # type: (Union[text_type, binary_type]) -> str
+    if isinstance(s, str):
+        return s
+    elif isinstance(s, text_type):
+        return s.encode('utf-8')
+    elif isinstance(s, binary_type):
+        return s.decode('utf-8')
+    else:
+        raise ValueError("force_str expects a string type")
+
+def dict_with_str_keys(dct):
+    # type: (Mapping[NonBinaryStr, Any]) -> Dict[str, Any]
+    """applies force_str on the keys of a dict (non-recursively)"""
+    return {force_str(key): value for key, value in six.iteritems(dct)}

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -71,15 +71,15 @@ def tornado_redirected_to_list(lst):
 
 @contextmanager
 def simulated_empty_cache():
-    # type: () -> Generator[List[Tuple[str, Union[str, List[str]], str]], None, None]
-    cache_queries = [] # type: List[Tuple[str, Union[str, List[str]], str]]
+    # type: () -> Generator[List[Tuple[str, Union[text_type, List[text_type]], text_type]], None, None]
+    cache_queries = [] # type: List[Tuple[str, Union[text_type, List[text_type]], text_type]]
     def my_cache_get(key, cache_name=None):
-        # type: (str, Optional[str]) -> Any
+        # type: (text_type, Optional[str]) -> Any
         cache_queries.append(('get', key, cache_name))
         return None
 
     def my_cache_get_many(keys, cache_name=None):
-        # type: (List[str], Optional[str]) -> Dict[str, Any]
+        # type: (List[text_type], Optional[str]) -> Dict[text_type, Any]
         cache_queries.append(('getmany', keys, cache_name))
         return None
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -758,8 +758,8 @@ def stringify_message_dict(message_dict):
     return zlib.compress(force_bytes(ujson.dumps(message_dict)))
 
 def to_dict_cache_key_id(message_id, apply_markdown):
-    # type: (int, bool) -> str
-    return 'message_dict:%d:%d' % (message_id, apply_markdown)
+    # type: (int, bool) -> text_type
+    return u'message_dict:%d:%d' % (message_id, apply_markdown)
 
 def to_dict_cache_key(message, apply_markdown):
     # type: (Message, bool) -> str

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -45,7 +45,7 @@ bugdown = None # type: Any
 MAX_SUBJECT_LENGTH = 60
 MAX_MESSAGE_LENGTH = 10000
 
-STREAM_NAMES = TypeVar('STREAM_NAMES', Sequence[str], AbstractSet[str])
+STREAM_NAMES = TypeVar('STREAM_NAMES', Sequence[text_type], AbstractSet[text_type])
 
 # Doing 1000 remote cache requests to get_display_recipient is quite slow,
 # so add a local cache as well as the remote cache cache.
@@ -701,7 +701,7 @@ def bulk_get_streams(realm, stream_names):
         realm_id = realm
 
     def fetch_streams_by_name(stream_names):
-        # type: (List[str]) -> List[str]
+        # type: (List[text_type]) -> Sequence[Stream]
         #
         # This should be just
         #
@@ -762,7 +762,7 @@ def to_dict_cache_key_id(message_id, apply_markdown):
     return u'message_dict:%d:%d' % (message_id, apply_markdown)
 
 def to_dict_cache_key(message, apply_markdown):
-    # type: (Message, bool) -> str
+    # type: (Message, bool) -> text_type
     return to_dict_cache_key_id(message.id, apply_markdown)
 
 class Message(models.Model):

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -552,7 +552,7 @@ def get_old_messages_backend(request, user_profile,
     # rendered message dict before returning it.  We attempt to
     # bulk-fetch rendered message dicts from remote cache using the
     # 'messages' list.
-    search_fields = dict() # type: Dict[int, Dict[str, str]]
+    search_fields = dict() # type: Dict[int, Dict[str, text_type]]
     message_ids = [] # type: List[int]
     user_message_flags = {} # type: Dict[int, List[str]]
     if include_history:


### PR DESCRIPTION
When I tried to annotate fields in our models, I got a lot of mypy errors. Many annotations in zerver/lib/cache.py, zerver/lib/cache_helpers.py and zerver/models.py were wrong. So I first fixed them. I have made this PR now so that that work can be reviewed.

I have also added a `zerver/lib/text_utils.py`. This is inspired from [django.utils.encoding](https://docs.djangoproject.com/en/1.9/ref/utils/#module-django.utils.encoding).

Some of the intermediate commits don't pass mypy checks, but I couldn't figure out a way to split my commits otherwise. All commits pass tools/test-backend.

zerver/lib/cache.py had a lot of wrong annotations. I fixed as many as I could find. But that produced other mypy errors. When I tried to fix them, I got other mypy errors. This chain continued for some time until I hit a few places where `bytes` were being used (like zlib.compress and decompress in zerver/models.py). Those had bugs which prevented me from annotating some functions correctly, so I had to fix them.