### PR TITLE
Fix emoji urls.

### DIFF
--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -3,8 +3,8 @@ var path = require('path');
 var fs = require('fs');
 
 set_global('page_params', {realm_emoji: {
-  burrito: {display_url: 'static/third/gemoji/images/emoji/burrito.png',
-            source_url: 'static/third/gemoji/images/emoji/burrito.png'}
+  burrito: {display_url: '/static/third/gemoji/images/emoji/burrito.png',
+            source_url: '/static/third/gemoji/images/emoji/burrito.png'}
 }});
 
 add_dependencies({
@@ -120,9 +120,9 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
     {input: 'This is a @**Cordelia Lear** mention',
      expected: '<p>This is a <span class="user-mention" data-user-email="cordelia@zulip.com">@Cordelia Lear</span> mention</p>'},
     {input: 'mmm...:burrito:s',
-     expected: '<p>mmm...<img alt=\":burrito:\" class=\"emoji\" src=\"static/third/gemoji/images/emoji/burrito.png\" title=\":burrito:\">s</p>'},
+     expected: '<p>mmm...<img alt=\":burrito:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/burrito.png\" title=\":burrito:\">s</p>'},
     {input: 'This is an :poop: message',
-     expected: '<p>This is an <img alt=":poop:" class="emoji" src="static/third/gemoji/images/emoji/poop.png" title=":poop:"> message</p>'},
+     expected: '<p>This is an <img alt=":poop:" class="emoji" src="/static/third/gemoji/images/emoji/poop.png" title=":poop:"> message</p>'},
     {input: 'This is a realm filter #1234 with text after it',
      expected: '<p>This is a realm filter <a href="https://trac.zulip.net/ticket/1234" target="_blank" title="https://trac.zulip.net/ticket/1234">#1234</a> with text after it</p>'},
     {input: 'This is a realm filter with ZGROUP_123:45 groups',

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -11,7 +11,7 @@ var default_emojis = [];
 emoji_names.push("zulip");
 
 _.each(emoji_names, function (value) {
-    default_emojis.push({emoji_name: value, emoji_url: "static/third/gemoji/images/emoji/" + value + ".png"});
+    default_emojis.push({emoji_name: value, emoji_url: "/static/third/gemoji/images/emoji/" + value + ".png"});
 });
 
 exports.update_emojis = function update_emojis(realm_emojis) {

--- a/static/js/tutorial.js
+++ b/static/js/tutorial.js
@@ -47,7 +47,7 @@ var fake_messages = [
     },
     {
         id: 3,
-        content: "<p>Looks good to me! <img alt=':+1:' class='emoji' src='static/third/gemoji/images/emoji/+1.png' title=':+1:'></p>",
+        content: "<p>Looks good to me! <img alt=':+1:' class='emoji' src='/static/third/gemoji/images/emoji/+1.png' title=':+1:'></p>",
         is_stream: true,
         sender_full_name: "Jeff Arnold",
         sender_email: "jeff@zulip.com",
@@ -75,7 +75,7 @@ var fake_messages = [
     },
     {
         id: 5,
-        content: "<p>Yay, Twitter integration. <img alt=':heart_eyes:' class='emoji' src='static/third/gemoji/images/emoji/heart_eyes.png' title=':heart_eyes:'></p>",
+        content: "<p>Yay, Twitter integration. <img alt=':heart_eyes:' class='emoji' src='/static/third/gemoji/images/emoji/heart_eyes.png' title=':heart_eyes:'></p>",
         is_stream: true,
         sender_full_name: "Leo Franchi",
         sender_email: "leo@zulip.com",
@@ -117,7 +117,7 @@ var fake_messages = [
     },
     {
         id: 8,
-        content: "<p><img alt=':clock1130:' class='emoji' src='static/third/gemoji/images/emoji/clock1130.png' title=':clock1130:'> Reminder: engineering meeting in 1 hour. <img alt=':clock1130:' class='emoji' src='static/third/gemoji/images/emoji/clock1130.png' title=':clock1130:'></p>",
+        content: "<p><img alt=':clock1130:' class='emoji' src='/static/third/gemoji/images/emoji/clock1130.png' title=':clock1130:'> Reminder: engineering meeting in 1 hour. <img alt=':clock1130:' class='emoji' src='/static/third/gemoji/images/emoji/clock1130.png' title=':clock1130:'></p>",
         is_stream: true,
         sender_full_name: "Reminder Bot",
         sender_email: "reminder-bot@zulip.com",
@@ -173,7 +173,7 @@ var fake_messages = [
     },
     {
         id: 12,
-        content: "<p>No problem, less work for me. <img alt=':smile:' class='emoji' src='static/third/gemoji/images/emoji/smile.png' title=':smile:'></p>",
+        content: "<p>No problem, less work for me. <img alt=':smile:' class='emoji' src='/static/third/gemoji/images/emoji/smile.png' title=':smile:'></p>",
         is_stream: true,
         sender_full_name: "Abbie Patel",
         sender_email: "abbie@zulip.com",

--- a/templates/zerver/markdown_help.html
+++ b/templates/zerver/markdown_help.html
@@ -35,8 +35,8 @@
           </td>
         </tr>
         <tr>
-          <td>:heart: (and <a href="http://www.emoji-cheat-sheet.com/" target="_blank">many others</a>, from the <a href="https://code.google.com/p/noto/" license="static/third/gemoji/images/emoji/NOTICE" target="_blank">Noto Project</a>)</td>
-          <td><img alt=":heart:" class="emoji" src="static/third/gemoji/images/emoji/heart.png" title=":heart:" /></td>
+          <td>:heart: (and <a href="http://www.emoji-cheat-sheet.com/" target="_blank">many others</a>, from the <a href="https://code.google.com/p/noto/" license="/static/third/gemoji/images/emoji/NOTICE" target="_blank">Noto Project</a>)</td>
+          <td><img alt=":heart:" class="emoji" src="/static/third/gemoji/images/emoji/heart.png" title=":heart:" /></td>
         </tr>
         <tr>
           <td>@**Joe Smith**<br/>

--- a/zerver/fixtures/bugdown-data.json
+++ b/zerver/fixtures/bugdown-data.json
@@ -171,19 +171,19 @@
     {
       "name": "many_emoji",
       "input":  "test :smile: again :poop:\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:",
-      "expected_output": "<p>test <img alt=\":smile:\" class=\"emoji\" src=\"static/third/gemoji/images/emoji/smile.png\" title=\":smile:\"> again <img alt=\":poop:\" class=\"emoji\" src=\"static/third/gemoji/images/emoji/poop.png\" title=\":poop:\"><br>\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:</p>",
+      "expected_output": "<p>test <img alt=\":smile:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/smile.png\" title=\":smile:\"> again <img alt=\":poop:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/poop.png\" title=\":poop:\"><br>\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:</p>",
       "bugdown_matches_marked": true
     },
     {
       "name": "random_emoji_1",
       "input": ":hankey:",
-      "expected_output": "<p><img alt=\":hankey:\" class=\"emoji\" src=\"static/third/gemoji/images/emoji/hankey.png\" title=\":hankey:\"></p>",
+      "expected_output": "<p><img alt=\":hankey:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/hankey.png\" title=\":hankey:\"></p>",
       "bugdown_matches_marked": true
     },
     {
       "name": "random_emoji_2",
       "input": ":poop:",
-      "expected_output": "<p><img alt=\":poop:\" class=\"emoji\" src=\"static/third/gemoji/images/emoji/poop.png\" title=\":poop:\"></p>",
+      "expected_output": "<p><img alt=\":poop:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/poop.png\" title=\":poop:\"></p>",
       "bugdown_matches_marked": true
     },
     {
@@ -195,7 +195,7 @@
     {
       "name": "emoji_alongside_punctuation",
       "input": ":smile:, :smile:; :smile:",
-      "expected_output": "<p><img alt=\":smile:\" class=\"emoji\" src=\"static/third/gemoji/images/emoji/smile.png\" title=\":smile:\">, <img alt=\":smile:\" class=\"emoji\" src=\"static/third/gemoji/images/emoji/smile.png\" title=\":smile:\">; <img alt=\":smile:\" class=\"emoji\" src=\"static/third/gemoji/images/emoji/smile.png\" title=\":smile:\"></p>",
+      "expected_output": "<p><img alt=\":smile:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/smile.png\" title=\":smile:\">, <img alt=\":smile:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/smile.png\" title=\":smile:\">; <img alt=\":smile:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/smile.png\" title=\":smile:\"></p>",
       "bugdown_matches_marked": true
     },
     {

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -587,7 +587,7 @@ class Emoji(markdown.inlinepatterns.Pattern):
         if current_message and name in realm_emoji:
             return make_emoji(name, realm_emoji[name]['display_url'], orig_syntax)
         elif name in emoji_list:
-            src = 'static/third/gemoji/images/emoji/%s.png' % (name)
+            src = '/static/third/gemoji/images/emoji/%s.png' % (name)
             return make_emoji(name, src, orig_syntax)
         else:
             return None


### PR DESCRIPTION
When accessing emojis with relative urls we should start the urls with
a slash so that language code doesn't not become part of these urls.

Fixes #1014

@timabbott please review.