### PR TITLE
Fix python 3 pyflakes error.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -630,7 +630,7 @@ class ModalLink(markdown.inlinepatterns.Pattern):
 
         return a_tag
 
-upload_re = re.compile(ur"^(?:https://%s.s3.amazonaws.com|/user_uploads/\d+)/[^/]*/([^/]*)$" % (settings.S3_BUCKET,))
+upload_re = re.compile(u"^(?:https://%s.s3.amazonaws.com|/user_uploads/\\d+)/[^/]*/([^/]*)$" % (settings.S3_BUCKET,))
 def url_filename(url):
     # type: (text_type) -> text_type
     """Extract the filename if a URL is an uploaded file, or return the original URL"""


### PR DESCRIPTION
Change raw unicode literal to non-raw.  A raw unicode literal is a syntax error in python 3.  This error was detected by pyflakes in python 3 mode.