### PR TITLE
Add emoji map to the compose box.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -282,6 +282,13 @@ $(function () {
     });
 
     function handle_compose_click(e) {
+        // Emoji clicks should be handled by their own click handler in popover.js
+        if ($(e.target).is("#emoji_map") ||
+            $(e.target).is(".emoji_popover") ||
+            $(e.target).is(".emoji_popover.inner") ||
+            $(e.target).is("img.emoji")) {
+            return;
+        }
         // Don't let clicks in the compose area count as
         // "unfocusing" our compose -- in other words, e.g.
         // clicking "Press enter to send" should not
@@ -391,7 +398,8 @@ $(function () {
         // of modals or selecting text (for copy+paste) trigger cancelling.
         if (compose.composing() && !$(e.target).is("a") &&
             ($(e.target).closest(".modal").length === 0) &&
-            window.getSelection().toString() === "") {
+            window.getSelection().toString() === "" &&
+            ($(e.target).closest('#emoji_map').length === 0)) {
             compose.cancel();
         }
     });

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -183,6 +183,11 @@ function process_hotkey(e) {
     // Process hotkeys specially when in an input, select, textarea, or send button
     if ($('input:focus,select:focus,textarea:focus,#compose-send-button:focus').length > 0) {
         if (event_name === 'escape') {
+            // emoji window should trap escape before it is able to close the compose box
+            if ($('.emoji_popover').css('display') === 'inline-block') {
+                popovers.hide_emoji_map_popover();
+                return;
+            }
             // If one of our typeaheads is open, do nothing so that the Esc
             // will go to close it
             if ($("#subject").data().typeahead.shown ||
@@ -252,7 +257,10 @@ function process_hotkey(e) {
                 narrow.by('is', 'private', opts);
             });
         case 'escape': // Esc: close actions popup, cancel compose, clear a find, or un-narrow
-            if (popovers.any_active()) {
+            if ($('.emoji_popover').css('display') === 'inline-block') {
+                popovers.hide_emoji_map_popover();
+            }
+            else if (popovers.any_active()) {
                 popovers.hide_all();
             } else if (compose.composing()) {
                 compose.cancel();

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -4,6 +4,7 @@ var exports = {};
 
 var current_actions_popover_elem;
 var current_message_info_popover_elem;
+var emoji_map_is_open = false;
 
 var userlist_placement = "right";
 
@@ -185,6 +186,14 @@ function topic_sidebar_popped() {
     return current_topic_sidebar_elem !== undefined;
 }
 
+exports.hide_emoji_map_popover = function () {
+    if (emoji_map_is_open) {
+        $('.emoji_popover').css('display', 'none');
+        $('.drag').css('display', 'none');
+        emoji_map_is_open = false;
+    }
+};
+
 exports.hide_stream_sidebar_popover = function () {
     if (stream_sidebar_popped()) {
         $(current_stream_sidebar_elem).popover("destroy");
@@ -213,6 +222,22 @@ exports.hide_user_sidebar_popover = function () {
     }
 };
 
+function render_emoji_popover() {
+    var content = templates.render('emoji_popover_content', {
+        emoji_list: emoji.emojis_by_name
+    });
+
+    $('.emoji_popover').append(content);
+
+    $('.drag').show();
+    $('.emoji_popover').css('display', 'inline-block');
+
+    $("#new_message_content").focus();
+
+    emoji_map_is_open = true;
+
+}
+
 exports.register_click_handlers = function () {
     $("#main_div").on("click", ".actions_hover", function (e) {
         var row = $(this).closest(".message_row");
@@ -224,6 +249,80 @@ exports.register_click_handlers = function () {
         var row = $(this).closest(".message_row");
         e.stopPropagation();
         show_message_info_popover(this, rows.id(row));
+    });
+
+    var isDragging=false;
+    var top_border = $('#floating_recipient_bar').position().top + $('#floating_recipient_bar').height();
+    var total_height;
+    var emoji_popover_height;
+    var emoji_popover_elem;
+    var previous_mouse_position;
+    var compose_box_padding;
+    var emoji_height = 25;
+    $("body").on("mouseover", ".emoji_popover", function (e) {
+        total_height = $('body > .app').outerHeight() - top_border - 70;
+        if (total_height <= 300) {
+            // don't allow dragging if the viewport is small enough that it
+            // would obscure everything to drag the emojis
+            $('.drag').hide();
+        } else {
+            $('.drag').show();
+        }
+    });
+
+    $("body").on("mousedown", ".drag", function (e) {
+        // leave a little extra padding for the message box so that it doesn't get too big
+        total_height = $('body > .app').outerHeight() - top_border - 70;
+        isDragging = true;
+        previous_mouse_position = e.pageY;
+        emoji_popover_elem = $(".emoji_popover");
+        emoji_popover_height =  emoji_popover_elem.height();
+        compose_box_padding = $('#compose').height() - emoji_popover_height;
+    });
+
+    $("body").on("mousemove", function (e) {
+        e.preventDefault();
+        if(isDragging) {
+            var new_height = emoji_popover_height + (previous_mouse_position - e.pageY);
+            if (new_height + compose_box_padding > total_height) {
+                emoji_popover_elem.height(total_height - compose_box_padding);
+            } else if (new_height < emoji_height) {
+                emoji_popover_elem.height(emoji_height);
+            } else {
+                emoji_popover_elem.height(new_height);
+            }
+        }
+    });
+
+    $("body").on("mouseup", function (e) {
+        isDragging = false;
+        emoji_popover_height = null;
+    });
+
+
+    $("body").on("click", ".emoji_popover", function (e) {
+        e.stopPropagation();
+    });
+
+    $(".emoji_popover").on("click", ".emoji", function (e) {
+        var emoji_choice = $(e.target).attr("title");
+        var textarea = $("#new_message_content");
+        textarea.val(textarea.val() + " " + emoji_choice);
+        textarea.focus();
+        e.stopPropagation();
+    });
+
+    $("#compose").on("click", "#emoji_map", function (e) {
+        if (emoji_map_is_open) {
+            // If the popover is already shown, clicking again should toggle it.
+            popovers.hide_emoji_map_popover();
+            e.stopPropagation();
+            return;
+        }
+        popovers.hide_all();
+
+        render_emoji_popover();
+        e.stopPropagation();
     });
 
     $('body').on('click', '.user_popover .narrow_to_private_messages', function (e) {
@@ -570,7 +669,7 @@ exports.register_click_handlers = function () {
 
 exports.any_active = function () {
     // True if any popover (that this module manages) is currently shown.
-    return popovers.actions_popped() || user_sidebar_popped() || stream_sidebar_popped() || topic_sidebar_popped() || message_info_popped();
+    return popovers.actions_popped() || user_sidebar_popped() || stream_sidebar_popped() || topic_sidebar_popped() || message_info_popped() || emoji_map_is_open;
 };
 
 exports.hide_all = function () {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -352,6 +352,11 @@ $(function () {
         }
     });
 
+    // Override the #compose mousewheel prevention below just for the emoji box
+    $('.emoji_popover').mousewheel(function (e) {
+        e.stopPropagation();
+    });
+
     // Ignore wheel events in the compose area which weren't already handled above.
     $('#compose').mousewheel(function (e) {
         e.stopPropagation();

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -3005,6 +3005,44 @@ li.expanded_subject {
     color: #000;
 }
 
+.drag {
+    display: none;
+    height: 18px;
+    width: 100%;
+    top: 23px;
+    position: relative;
+    cursor: ns-resize;
+}
+
+.emoji_popover {
+    display: none;
+    position: relative;
+    margin-top: 10px;
+    bottom: 0px;
+    z-index: 1010;
+    width: 100%;
+    height: 60px;
+    padding: 1px;
+    text-align: center;
+    background-color: #ffffff;
+    border: 1px solid #ccc;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    overflow: hidden;
+    overflow-y: scroll;
+}
+
+.emoji_popover .emoji {
+    margin: 2px;
+    box-sizing: border-box;
+    cursor: pointer;
+    display: inline-block;
+}
+
+.emoji_popover .emoji:active {
+    border-radius: 5px;
+    border: 2px white solid;
+}
+
 #enter_sends {
     margin-top: 0px;
     margin-right: 5px;

--- a/static/templates/emoji_popover_content.handlebars
+++ b/static/templates/emoji_popover_content.handlebars
@@ -1,0 +1,5 @@
+{{! Contents of the "emoji map" popup }}
+{{#each emoji_list}}
+    <div class="emoji emoji-{{@key}}" title= ":{{@key}}:" />
+{{/each}}
+

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -69,19 +69,24 @@
             <tr>
               <td class="messagebox" colspan="2">
                   <textarea class="new_message_textarea" name="content" id="new_message_content"
-                            value="" placeholder="Compose your message here..." tabindex="140" maxlength="10000"></textarea>
+                            value="" placeholder="{{ _('Compose your message here') }}..." tabindex="140" maxlength="10000"></textarea>
+              <div class="drag"></div>
+              <div class="emoji_popover"></div>
+
               <div id="below-compose-content">
                   <input type="file" id="file_input" class="notvisible pull-left" multiple />
+                  <a class="message-control-button icon-vector-smile"
+                        id="emoji_map" href="#"></a>
                   <a class="message-control-button icon-vector-dropbox notdisplayed"
-                     id="attach_dropbox_files" href="#" title="Attach files from Dropbox"></a>
+                     id="attach_dropbox_files" href="#" title="{{ _('Attach files from Dropbox') }}"></a>
                   <a class="message-control-button icon-vector-paper-clip notdisplayed"
-                     id="attach_files" href="#" title="Attach files"></a>
+                     id="attach_files" href="#" title="{{ _('Attach files') }}"></a>
                   <a class="message-control-button icon-vector-font"
                      href="#markdown-help" title="Formatting" data-toggle="modal"></a>
-                  <a id="restore-draft" onclick="compose.restore_message();">Restore draft</a>
-                  <span id="sending-indicator">Sending...</span>
+                  <a id="restore-draft" onclick="compose.restore_message();">{{ _('Restore draft') }}</a>
+                   <span id="sending-indicator">{{ _('Sending') }}...</span>
                   <div id="send_controls">
-                  <label id="enter-sends-label" class="compose_checkbox_label" for="enter_sends">Press Enter to send&nbsp;</label>
+                  <label id="enter-sends-label" class="compose_checkbox_label" for="enter_sends">{{ _('Press Enter to send') }}&nbsp;</label>
                     <input type="checkbox" id="enter_sends" name="enter_sends" value="enter_sends" />
                     <input type="submit" value="Send" id="compose-send-button" class="btn btn-primary send_message" tabindex="150"/>
                   </div>

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -17,6 +17,9 @@ var page_params = {{ page_params }};
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<link href="/static/images/logo/apple-touch-icon-precomposed.png" rel="apple-touch-icon-precomposed" />
+<link rel="stylesheet" type="text/css" href="/static/third/gemoji/sprite.css" />
 <style type="text/css">
 
 #css-loading {

--- a/zerver/tests/frontend/node/templates.js
+++ b/zerver/tests/frontend/node/templates.js
@@ -1,6 +1,7 @@
 add_dependencies({
     Handlebars: 'handlebars',
-    templates: 'js/templates'
+    templates: 'js/templates',
+    emoji: 'js/emoji'
 });
 
 global.$ = require('jquery');
@@ -58,6 +59,20 @@ function render(template_name, args) {
     var link = $(html).find("a.respond_button");
     assert.equal(link.text().trim(), 'Reply');
     global.write_test_output("actions_popover_content.handlebars", html);
+}());
+
+(function emoji_popover_content() {
+    var args = {
+        emoji_list: global.emoji.emojis_by_name
+    };
+
+    var html = '<div style="height: 250px">';
+    html += render('emoji_popover_content', args);
+    html += "</div>";
+    // test to make sure the first emoji is present in the popover
+    var emoji_key = $(html).find(".emoji-100").attr('title');
+    assert.equal(emoji_key, ':100:');
+    global.write_test_output("emoji_popover_content.handlebars", html);
 }());
 
 (function admin_tab() {


### PR DESCRIPTION
- Expand a box full of emojis into the
compose window for users to graphically select emojis.

- Append an emoji to the end of the message when a user
clicks the emoji in the emoji box.

- Trap the escape key to always close the emoji box
before closing anything else if the box is open.

- Fixes: #147.