### PR TITLE
Add linter check for redundant REQ whence argument.

### DIFF
--- a/tools/lint-all
+++ b/tools/lint-all
@@ -241,6 +241,8 @@ python_rules = [
          ('zerver/lib/request.py', 'raise JsonableError(error)'),
      ]),
      'description': 'Argument to JsonableError should be a literal string enclosed by _()'},
+    {'pattern': '([a-zA-Z0-9_]+)=REQ\([\'"]\\1[\'"]',
+     'description': 'REQ\'s first argument already defaults to parameter name'},
     ] + whitespace_rules
 bash_rules = [
     {'pattern': '#!.*sh [-xe]',

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -282,7 +282,7 @@ def authenticated_api_view(view_func):
     @require_post
     @has_request_variables
     @wraps(view_func)
-    def _wrapped_view_func(request, email=REQ(), api_key=REQ('api_key', default=None),
+    def _wrapped_view_func(request, email=REQ(), api_key=REQ(default=None),
                            api_key_legacy=REQ('api-key', default=None),
                            *args, **kwargs):
         if not api_key and not api_key_legacy:

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -609,11 +609,11 @@ def get_old_messages_backend(request, user_profile,
 
 @has_request_variables
 def update_message_flags(request, user_profile,
-                         messages=REQ('messages', validator=check_list(check_int)),
-                         operation=REQ('op'), flag=REQ('flag'),
-                         all=REQ('all', validator=check_bool, default=False),
-                         stream_name=REQ('stream_name', default=None),
-                         topic_name=REQ('topic_name', default=None)):
+                         messages=REQ(validator=check_list(check_int)),
+                         operation=REQ('op'), flag=REQ(),
+                         all=REQ(validator=check_bool, default=False),
+                         stream_name=REQ(default=None),
+                         topic_name=REQ(default=None)):
 
     request._log_data["extra"] = "[%s %s]" % (operation, flag)
     stream = None

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -198,7 +198,7 @@ def regenerate_api_key(request, user_profile):
 
 @has_request_variables
 def change_enter_sends(request, user_profile,
-                       enter_sends=REQ('enter_sends', validator=check_bool)):
+                       enter_sends=REQ(validator=check_bool)):
     # type: (HttpRequest, UserProfile, bool) -> HttpResponse
     do_change_enter_sends(user_profile, enter_sends)
     return json_success()


### PR DESCRIPTION
`REQ` initializations that have the same initial argument (`whence`) as the parameter they're assigned to are redundant -- `REQ` defaults to using the parameter name as the value for `whence`.

This may be too strict/something we don't feel is worth linting for.