### PR TITLE
Add get_auth_backends endpoint to API

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -245,3 +245,30 @@ class DevGetEmailsTest(AuthedTestCase):
         with mock.patch('zerver.views.dev_auth_enabled', return_value=False):
             result = self.client.get("/api/v1/dev_get_emails")
             self.assert_json_error_contains(result, "Dev environment not enabled.", 400)
+
+class FetchAuthBackends(AuthedTestCase):
+    def test_fetch_auth_backend_format(self):
+        # type: () -> None
+        result = self.client.get("/api/v1/get_auth_backends")
+        self.assert_json_success(result)
+        data = ujson.loads(result.content)
+        self.assertEqual(set(data.keys()),
+                         {'msg', 'password', 'google', 'dev', 'result'})
+        for backend in set(data.keys()) - {'msg', 'result'}:
+            self.assertTrue(isinstance(data[backend], bool))
+
+    def test_fetch_auth_backend(self):
+        # type: () -> None
+        backends = [GoogleMobileOauth2Backend(), DevAuthBackend()]
+        with mock.patch('django.contrib.auth.get_backends', return_value=backends):
+            result = self.client.get("/api/v1/get_auth_backends")
+            self.assert_json_success(result)
+            data = ujson.loads(result.content)
+            self.assertEqual(data, {
+                'msg': '',
+                'password': False,
+                'google': True,
+                'dev': True,
+                'result': 'success',
+            })
+

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -274,6 +274,10 @@ urls += [
 
 # Mobile-specific authentication URLs
 urls += [
+    # This json format view used by the mobile apps lists which authentication
+    # backends the server allows, to display the proper UI and check for server existence
+    url(r'^api/v1/get_auth_backends',       'zerver.views.api_get_auth_backends'),
+
     # This json format view used by the mobile apps accepts a username
     # password/pair and returns an API key.
     url(r'^api/v1/fetch_api_key$',          'zerver.views.api_fetch_api_key'),


### PR DESCRIPTION
We would like to know which kind of authentication backends the server supports

This is information you can get from /login, but not in a way easily parseable
by API apps