### PR TITLE
Add python-six to early installer dependencies.

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -23,7 +23,7 @@ EOF
 
 apt-get update
 apt-get -y dist-upgrade $APT_OPTIONS
-apt-get install -y puppet git python $ADDITIONAL_PACKAGES
+apt-get install -y puppet git python python-six $ADDITIONAL_PACKAGES
 
 mkdir -p /etc/zulip
 echo -e "[machine]\npuppet_classes = $PUPPET_CLASSES\ndeploy_type = $DEPLOYMENT_TYPE" > /etc/zulip/zulip.conf


### PR DESCRIPTION
Since we're now using python-six in zulip-puppet-apply, we need to
install python-six before calling into zulip-puppet-apply.

@sharmaeklavya2 can you review?