### PR TITLE
[WIP] Use a virtualenv in production

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -4,17 +4,21 @@ import sys
 import logging
 import subprocess
 
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(BASE_DIR)
+import scripts.lib.setup_path_on_import
+
 if __name__ == "__main__":
     if 'posix' in os.name and os.geteuid() == 0:
         from django.core.management.base import CommandError
         raise CommandError("manage.py should not be run as root.")
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "zproject.settings")
-    os.environ.setdefault("PYTHONSTARTUP", os.path.join(os.path.dirname(__file__), "scripts/lib/pythonrc.py"))
+    os.environ.setdefault("PYTHONSTARTUP", os.path.join(BASE_DIR, "scripts/lib/pythonrc.py"))
 
     from django.conf import settings
 
     logger = logging.getLogger("zulip.management")
-    subprocess.check_call([os.path.join(os.path.dirname(__file__), "scripts", "lib", "log-management-command"),
+    subprocess.check_call([os.path.join(BASE_DIR, "scripts", "lib", "log-management-command"),
                            " ".join(sys.argv)])
 
     if "--no-traceback" not in sys.argv and len(sys.argv) > 1:

--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_queue_worker_errors
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_queue_worker_errors
@@ -7,6 +7,8 @@ from __future__ import print_function
 
 import sys
 sys.path.append('/home/zulip/deployments/current')
+import scripts.lib.setup_path_on_import
+
 from zproject import settings
 
 import glob

--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_send_receive_time
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_send_receive_time
@@ -18,6 +18,9 @@ import random
 import traceback
 import os
 
+sys.path.append('/home/zulip/deployments/current')
+import scripts.lib.setup_path_on_import
+
 import django
 
 def total_seconds(timedelta):

--- a/puppet/zulip/files/nagios_plugins/zulip_postgres_appdb/check_fts_update_log
+++ b/puppet/zulip/files/nagios_plugins/zulip_postgres_appdb/check_fts_update_log
@@ -5,6 +5,10 @@ Nagios plugin to check the length of the FTS update log.
 """
 from __future__ import print_function
 
+import sys
+sys.path.append('/home/zulip/deployments/current')
+import scripts.lib.setup_path_on_import
+
 import psycopg2
 
 states = {

--- a/puppet/zulip/files/nagios_plugins/zulip_postgres_common/check_postgres_backup
+++ b/puppet/zulip/files/nagios_plugins/zulip_postgres_common/check_postgres_backup
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import dateutil.parser
-import pytz
 import subprocess
 from datetime import datetime, timedelta
+
+import sys
+sys.path.append('/home/zulip/deployments/current')
+import scripts.lib.setup_path_on_import
+
+import dateutil.parser
+import pytz
 
 states = {
     "OK": 0,

--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -8,6 +8,20 @@
 # search column search_tsvector in the main zerver_message.
 from __future__ import print_function
 
+import sys
+
+# We want to use a virtualenv in production, which will be in /home/zulip/deployments/current.
+# So we should add that path to sys.path and then import scripts.lib.setup_path_on_import.
+# But this file is also used in development, where the above path will not exist.
+# So `import scripts.lib.setup_path_on_import` will raise an ImportError.
+# In development, we just want to skip this step since we know that virtualenv will already be in use.
+# So catch the ImportError and do nothing.
+sys.path.append('/home/zulip/deployments/current')
+try:
+    import scripts.lib.setup_path_on_import
+except ImportError:
+    pass
+
 import psycopg2
 import psycopg2.extensions
 import select

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -4,65 +4,9 @@ class zulip::app_frontend_base {
   include zulip::nginx
   include zulip::supervisor
 
-  $web_packages = [ # Needed for memcached usage
-                    "python-pylibmc",
-                    # Fast JSON parser
-                    "python-ujson",
-                    # Django dependencies
-                    "python-django",
-                    "python-django-guardian",
-                    "python-django-pipeline",
-                    "python-django-bitfield",
-                    "python-jinja2",
-                    # Needed for mock objects in decorators
-                    "python-mock",
-                    # Tornado dependencies
-                    "python-tornado",
-                    "python-sockjs-tornado",
-                    # Needed for our fastcgi setup
-                    "python-flup",
-                    # Needed for markdown processing
-                    "python-markdown",
-                    "python-pygments",
-                    # Used for Hesiod lookups, etc.
-                    "python-dns",
+  $web_packages = [
                     # Needed to access our database
                     "postgresql-client-${zulip::base::postgres_version}",
-                    "python-psycopg2",
-                    # Needed for building complex DB queries
-                    "python-sqlalchemy",
-                    # Needed for integrations
-                    "python-twitter",
-                    "python-defusedxml",
-                    # Needed for the email mirror
-                    "python-twisted",
-                    "python-html2text",
-                    # Needed to access rabbitmq
-                    "python-pika",
-                    # Needed for timezone work
-                    "python-tz",
-                    # Needed to parse source maps for error reporting
-                    "python-sourcemap",
-                    # Needed for redis
-                    "python-redis",
-                    # Needed for S3 file uploads
-                    "python-boto",
-                    # Needed to send email
-                    "python-mandrill",
-                    # Needed to generate diffs for edits
-                    "python-diff-match-patch",
-                    # Needed for iOS
-                    "python-apns-client",
-                    # Needed for Android push
-                    "python-gcm-client",
-                    # Needed for avatar image resizing
-                    "python-imaging",
-                    # Needed for LDAP support
-                    "python-django-auth-ldap",
-                    # Needed for Google Apps mobile auth
-                    "python-googleapi",
-                    # Needed for JWT-based auth
-                    "python-pyjwt",
                     ]
   define safepackage ( $ensure = present ) {
     if !defined(Package[$title]) {

--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -2,12 +2,6 @@ class zulip::base {
   include apt
   $base_packages = [ # Accurate time is essential
                      "ntp",
-                     # Dependencies of our API
-                     "python-requests",
-                     "python-simplejson",
-                     "python-typing",
-                     # For development/debugging convenience
-                     "ipython",
                      # Used in scripts
                      "netcat",
                      # Nagios plugins; needed to ensure /var/lib/nagios_plugins exists

--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -4,7 +4,7 @@ class zulip::postgres_appdb_base {
   include zulip::supervisor
 
   $appdb_packages = [# Needed to run process_fts_updates
-                     "python-psycopg2",
+                     "python-psycopg2", # TODO: use a virtualenv instead
                      # Needed for our full text search system
                      "postgresql-${zulip::base::postgres_version}-tsearch-extras",
                      ]

--- a/puppet/zulip/manifests/postgres_common.pp
+++ b/puppet/zulip/manifests/postgres_common.pp
@@ -7,8 +7,8 @@ class zulip::postgres_common {
                         "ptop",
                         # Python modules used in our monitoring/worker threads
                         "python-gevent",
-                        "python-tz",
-                        "python-dateutil",
+                        "python-tz", # TODO: use a virtualenv instead
+                        "python-dateutil", # TODO: use a virtualenv instead
                         # our dictionary
                         "hunspell-en-us",
                         ]

--- a/puppet/zulip_internal/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness
+++ b/puppet/zulip_internal/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness
@@ -13,6 +13,10 @@ import datetime
 import os
 import sys
 
+import sys
+sys.path.append('/home/zulip/deployments/current')
+import scripts.lib.setup_path_on_import
+
 import django
 
 os.environ['DJANGO_SETTINGS_MODULE'] = "zproject.settings"

--- a/puppet/zulip_internal/files/postgresql/pg_backup_and_purge.py
+++ b/puppet/zulip_internal/files/postgresql/pg_backup_and_purge.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+
+import sys
+sys.path.append('/home/zulip/deployments/current')
+import scripts.lib.setup_path_on_import
+
 import subprocess
 import sys
 import logging

--- a/puppet/zulip_internal/files/zulip-ec2-configure-interfaces
+++ b/puppet/zulip_internal/files/zulip-ec2-configure-interfaces
@@ -49,6 +49,10 @@ import logging.handlers
 import subprocess
 import re
 
+import sys
+sys.path.append('/home/zulip/deployments/current')
+import scripts.lib.setup_path_on_import
+
 import boto.utils
 import netifaces
 from six.moves import range

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,1 +1,4 @@
 -r common.txt
+netifaces==0.10.4
+flup==1.0.2
+python-dateutil==2.5.3

--- a/scripts/get-django-setting
+++ b/scripts/get-django-setting
@@ -3,9 +3,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
+from os.path import dirname, abspath
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+BASE_DIR = dirname(dirname(abspath(__file__)))
+sys.path.append(BASE_DIR)
+import scripts.lib.setup_path_on_import
+
 os.environ['DJANGO_SETTINGS_MODULE'] = 'zproject.settings'
 from django.conf import settings
 

--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+
+import os
+import argparse
+from os.path import dirname, abspath
+import sys
+
+ZULIP_PATH = dirname(dirname(dirname(abspath(__file__))))
+if ZULIP_PATH not in sys.path:
+    sys.path.append(ZULIP_PATH)
+
+from zulip_tools import run
+from scripts.lib.setup_venv import setup_virtualenv, VENV_DEPENDENCIES
+
+parser = argparse.ArgumentParser(description="Create a production virtualenv with caching")
+parser.add_argument("target")
+args = parser.parse_args()
+
+# install dependencies for setting up the virtualenv
+run(["apt-get", "-y", "install"] + VENV_DEPENDENCIES)
+
+cached_venv_path = setup_virtualenv(args.target, os.path.join(ZULIP_PATH, "requirements", "prod.txt"))
+# Now the virtualenv has been activated

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -25,6 +25,10 @@ apt-get update
 apt-get -y dist-upgrade $APT_OPTIONS
 apt-get install -y puppet git python python-six $ADDITIONAL_PACKAGES
 
+# Create and activate a virtualenv
+/root/zulip/scripts/lib/create-production-venv /root/zulip/zulip-venv
+
+# puppet apply
 mkdir -p /etc/zulip
 echo -e "[machine]\npuppet_classes = $PUPPET_CLASSES\ndeploy_type = $DEPLOYMENT_TYPE" > /etc/zulip/zulip.conf
 /root/zulip/scripts/zulip-puppet-apply -f

--- a/scripts/lib/log-management-command
+++ b/scripts/lib/log-management-command
@@ -2,7 +2,12 @@
 import sys
 import logging
 import os
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+from os.path import dirname, abspath
+
+BASE_DIR = dirname(dirname(dirname(abspath(__file__))))
+sys.path.append(BASE_DIR)
+import scripts.lib.setup_path_on_import
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "zproject.settings")
 from django.conf import settings
 

--- a/scripts/lib/setup_path_on_import.py
+++ b/scripts/lib/setup_path_on_import.py
@@ -1,0 +1,15 @@
+"""
+Use libraries from a virtualenv (by modifying sys.path) in production.
+Also add Zulip's root directory to sys.path
+"""
+
+import os
+from os.path import dirname, abspath
+import sys
+
+BASE_DIR = dirname(dirname(dirname(abspath(__file__))))
+activate_this = os.path.join(BASE_DIR, "zulip-venv", "bin", "activate_this.py")
+if os.path.exists(activate_this):
+    # this file will exist in production
+    exec(open(activate_this).read(), {}, dict(__file__=activate_this)) # type: ignore # https://github.com/python/mypy/issues/1577
+sys.path.append(BASE_DIR)

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -30,7 +30,10 @@ deploy_path = sys.argv[1]
 
 logging.info("Upgrading system packages...")
 subprocess.check_call(["apt-get", "update"])
-subprocess.check_call(["apt-get", "upgrade"])
+subprocess.check_call(["apt-get", "-y", "upgrade"])
+
+subprocess.check_call([os.path.join(deploy_path, "scripts", "lib", "create-production-venv"),
+                       os.path.join(deploy_path, "zulip-venv")])
 
 if os.path.exists("/etc/supervisor/conf.d/zulip_db.conf"):
    subprocess.check_call(["supervisorctl", "stop", "process-fts-updates"], preexec_fn=su_to_zulip)

--- a/scripts/setup/generate_secrets.py
+++ b/scripts/setup/generate_secrets.py
@@ -3,8 +3,12 @@
 
 from __future__ import print_function
 import sys, os, os.path
+from os.path import dirname, abspath
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+BASE_DIR = dirname(dirname(dirname(abspath(__file__))))
+sys.path.append(BASE_DIR)
+import scripts.lib.setup_path_on_import
+
 os.environ['DJANGO_SETTINGS_MODULE'] = 'zproject.settings'
 
 from django.utils.crypto import get_random_string

--- a/zproject/wsgi.py
+++ b/zproject/wsgi.py
@@ -14,6 +14,12 @@ framework.
 
 """
 import os
+from os.path import dirname, abspath
+import sys
+
+BASE_DIR = dirname(dirname(abspath(__file__)))
+sys.path.append(BASE_DIR)
+import scripts.lib.setup_path_on_import
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "zproject.settings")
 


### PR DESCRIPTION
The first 2 commits are good and can probably be merged. Please review them.

The 3rd commit is the one where I actually use a virtualenv in production. However my attempt failed. Here's what I did:

I created a production tarball using `tools/build-release-tarball`.

I set up a production server according to the steps given in [README.prod.md](https://github.com/zulip/zulip/blob/master/README.prod.md), except a few changes:
* I used my own tarball instead of the one [from zulip.com](https://www.zulip.com/dist/releases/zulip-server-latest.tar.gz).
* I used my own certificates instead of using letsencrypt or openssl.
* Instead of doing `su zulip -c /home/zulip/deployments/current/scripts/setup/initialize-database`, I switched to user zulip (`su zulip`), switched to the venv (`source zulip-venv/bin/activate`) and then ran the script (`/home/zulip/deployments/current/scripts/setup/initialize-database`).

Everything ran as expected. I opened my browser and registered and logged in to zulip. No errors till now.

Now I wanted to see whether supervisor is actually using my virtualenv. So I logged out from the user `zulip`, which brought me back to the root user's prompt. I then did `apt-get purge python-django`. I again interacted with zulip in my browser and it showed no errors.

I had almost started celebrating, but it struck me that I should try to `supervisorctl stop all`. That worked. I then did `supervisorctl start all`. That failed with this output (only first 6 lines shown because rest are similar):
```
zulip-django: ERROR (abnormal termination)
zulip-tornado: ERROR (abnormal termination)
process-fts-updates: started
zulip-events-user-presence: ERROR (abnormal termination)
zulip-events-user-activity-interval: ERROR (abnormal termination)
zulip-events-user-activity: ERROR (abnormal termination)
```

Apart from `process-fts-updates`, all services had a `ERROR (abnormal termination)`. My browser also displayed 500. This means my venv is not being used.

I again installed `python-django` and other packages which got removed when I purged `python-django` using apt. Then I did `supervisorctl start all`. That worked. Zulip then ran well on my browser too.