### PR TITLE
setup_venv: Add missing build essential dependencies.

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -18,6 +18,7 @@ if False:
     from typing import List, Optional
 
 VENV_DEPENDENCIES = [
+    "build-essential",
     "libffi-dev",
     "libfreetype6-dev",
     "libldap2-dev",
@@ -25,6 +26,7 @@ VENV_DEPENDENCIES = [
     "postgresql-server-dev-all",
     "python3-dev",          # Needed to install typed-ast dependency of mypy
     "python-dev",
+    "python-pip",
     "python-virtualenv",
 ]
 


### PR DESCRIPTION
Apparently, c74a74dc7427549eba4ececcf91c483ca2876796 introduced a bug
where we are no longer correctly depending on build-essential as part
of the Zulip development environment installation process.

Fixes #1111.