### PR TITLE
Reset email password link formatting.

### DIFF
--- a/templates/registration/password_reset_email.txt
+++ b/templates/registration/password_reset_email.txt
@@ -1,7 +1,7 @@
 Psst. Word on the street is that you forgot your password, {{ email}}.
 
 It's all good. Follow the link below and we'll take care of the rest:
-    <{{ protocol}}://{{ domain }}{{ url('django.contrib.auth.views.password_reset_confirm', kwargs=dict(uidb64=uid, token=token)) }}>
+{{ protocol}}://{{ domain }}{{ url('django.contrib.auth.views.password_reset_confirm', kwargs=dict(uidb64=uid, token=token)) }}
 
 Thanks,
 Your friends at Zulip HQ


### PR DESCRIPTION
This is how the text looks -

> It's all good. Follow the link below and we'll take care of the rest:
> &nbsp;&nbsp;&nbsp;&nbsp;<<https://zulip.tabbott.net/accounts/password/reset/NTM/1d1-81m17de619b6d11e9f45/>>

I have removed opening and closing tag. I think we don't need it. Also removed whitespaces. Now it looks like this -

> It's all good. Follow the link below and we'll take care of the rest:
> <https://zulip.tabbott.net/accounts/password/reset/NTM/1d1-81m17de619b6d11e9f45/>