### PR TITLE
Autoreload Zulip queue workers.

### DIFF
--- a/tools/test-queue-worker-reload
+++ b/tools/test-queue-worker-reload
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+import os
+import sys
+import time
+import signal
+import subprocess
+import re
+
+from six.moves import range
+
+TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+succesful_worker_launches = [
+                                'launching queue worker thread error_reports',
+                                'launching queue worker thread user_presence',
+                                'launching queue worker thread digest_emails',
+                                'launching queue worker thread slow_queries',
+                                'launching queue worker thread missedmessage_mobile_notifications',
+                                'launching queue worker thread feedback_messages',
+                                'launching queue worker thread signups',
+                                'launching queue worker thread test',
+                                'launching queue worker thread message_sender',
+                                'launching queue worker thread missedmessage_emails',
+                                'launching queue worker thread email_mirror',
+                                'launching queue worker thread user_activity_interval',
+                                'launching queue worker thread invites',
+                                'launching queue worker thread user_activity'
+                            ]
+
+def check_worker_launch(logfile):
+
+    def check(content):
+        flag = True
+        for entry in succesful_worker_launches:
+            flag = flag and entry in content
+        return flag
+
+    failure = True
+    log_output = u''
+    print("Polling logfile", end='')
+    # Attempt to poll the log file for 10 sec. to see if all worker threads are launched.
+    for i in range(10):
+        time.sleep(1)
+        sys.stdout.write('.')
+        sys.stdout.flush()
+        logfile.seek(0)
+        content = logfile.read()
+        log_output = content
+        if check(content):
+            failure = False
+            break
+    sys.stdout.write('\n')
+
+    if not failure:
+        print('Worker threads launched succesfully')
+        return log_output
+    else:
+        print('Error in server startup. Dumping logs')
+        print(log_output)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    print('\nStarting Development Server')
+    logfile = open('/tmp/run-dev-output', 'w+')
+    args = ["{}/run-dev.py".format(TOOLS_DIR)]
+    run_dev = subprocess.Popen(args, stdout=logfile, stderr=logfile)
+
+    check_worker_launch(logfile)
+    logfile.truncate(0)
+
+    print("Attempting to modify a file")
+    subprocess.call(['touch', 'zerver/lib/actions.py'])
+    log_output = check_worker_launch(logfile)
+
+    run_dev.send_signal(signal.SIGINT)
+    run_dev.wait()
+    logfile.close()
+
+    if 'zerver/lib/actions.py modified; restarting server' in log_output:
+        print('Worker threads succesfully autoreloaded')
+        sys.exit(0)
+    else:
+        print("Error autoreloading queue workers. Dumping logs")
+        print(log_output)
+        sys.exit(1)

--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -8,3 +8,4 @@ export PATH=$PATH:/srv/zulip-venv/bin
 ./tools/test-management
 ./tools/test-migrations
 ./tools/test-run-dev
+./tools/test-queue-worker-reload


### PR DESCRIPTION
Possible fix for #1045 and #621. 

@timabbott The autoreload in django requires that django is fully loaded before it executes any function. Because of that I had to add it in process_queue management function.

Using the autoreload module does have its limitations, you cant add a hook function to execute any cleanup and the signal module will not work too.

Here is the terminal output when a file is touched

>(zulip-venv)vagrant@vagrant-base-trusty-amd64:/srv/zulip$ ./tools/run-dev.py --interface=''
Recompiling templates
2016-06-25 06:18:19,413 INFO: process_fts_updates starting
2016-06-25 02:18:19,493 INFO: Not in recovery; listening for FTS updates
done
http://localhost:9994/webpack-dev-server/
webpack result is served from http://localhost:9991/webpack/
content is served from /srv/zulip
Validating Django models.py...
System check identified no issues (0 silenced).
Django version 1.8
Tornado server is running at http://localhost:9993/
Quit the server with CTRL-C.
2016-06-25 02:18:20,639 INFO     Tornado loaded 0 event queues in 0.000s
2016-06-25 02:18:20,643 INFO     Tornado  82.2% busy over the past  0.0 seconds
Performing system checks...
System check identified no issues (0 silenced).
June 25, 2016 - 02:18:21
Django version 1.8, using settings 'zproject.settings'
Starting development server at http://localhost:9992/
Quit the server with CONTROL-C.
webpack: bundle is now VALID.
2016-06-25 02:18:21,880 INFO     launching queue worker thread error_reports
2016-06-25 02:18:21,883 INFO     launching queue worker thread user_presence
2016-06-25 02:18:21,886 INFO     launching queue worker thread digest_emails
2016-06-25 02:18:21,888 INFO     launching queue worker thread slow_queries
2016-06-25 02:18:21,892 INFO     launching queue worker thread missedmessage_mobile_notifications
2016-06-25 02:18:21,896 INFO     launching queue worker thread feedback_messages
2016-06-25 02:18:21,897 INFO     launching queue worker thread signups
2016-06-25 02:18:21,899 INFO     launching queue worker thread test
2016-06-25 02:18:21,903 INFO     launching queue worker thread message_sender
2016-06-25 02:18:21,985 INFO     launching queue worker thread missedmessage_emails
2016-06-25 02:18:21,988 INFO     launching queue worker thread email_mirror
2016-06-25 02:18:21,991 INFO     launching queue worker thread user_activity_interval
2016-06-25 02:18:21,992 INFO     launching queue worker thread invites
2016-06-25 02:18:21,997 INFO     launching queue worker thread user_activity
2016-06-25 02:19:12,147 INFO     /srv/zulip/zerver/lib/actions.py modified; restarting server
2016-06-25 02:19:12,148 INFO     Tornado dumped 0 event queues in 0.000s
Validating Django models.py...
System check identified no issues (0 silenced).
Django version 1.8
Tornado server is running at http://localhost:9993/
Quit the server with CTRL-C.
2016-06-25 02:19:12,751 INFO     Tornado loaded 0 event queues in 0.000s
2016-06-25 02:19:12,753 INFO     Tornado  71.0% busy over the past  0.0 seconds
2016-06-25 02:19:13,274 INFO     launching queue worker thread error_reports
2016-06-25 02:19:13,276 INFO     launching queue worker thread user_presence
2016-06-25 02:19:13,279 INFO     launching queue worker thread digest_emails
2016-06-25 02:19:13,282 INFO     launching queue worker thread slow_queries
2016-06-25 02:19:13,284 INFO     launching queue worker thread missedmessage_mobile_notifications
2016-06-25 02:19:13,286 INFO     launching queue worker thread feedback_messages
2016-06-25 02:19:13,287 INFO     launching queue worker thread signups
2016-06-25 02:19:13,288 INFO     launching queue worker thread test
2016-06-25 02:19:13,289 INFO     launching queue worker thread message_sender
2016-06-25 02:19:13,357 INFO     launching queue worker thread missedmessage_emails
2016-06-25 02:19:13,358 INFO     launching queue worker thread email_mirror
2016-06-25 02:19:13,359 INFO     launching queue worker thread user_activity_interval
2016-06-25 02:19:13,360 INFO     launching queue worker thread invites
2016-06-25 02:19:13,367 INFO     launching queue worker thread user_activity
^C./puppet/zulip/files/postgresql/process_fts_updates exited after receiving KeyboardInterrupt
2016-06-25 02:19:24,881 INFO     Tornado dumped 0 event queues in 0.001s

`
I do have something like a test file too(just didn't push it yet).