### PR TITLE
Simplify the new server setup flow.

### DIFF
--- a/README.prod.md
+++ b/README.prod.md
@@ -115,9 +115,13 @@ These instructions should be followed as root.
   ```
   This will report an error if you did not fill in all the mandatory
   settings from `/etc/zulip/settings.py`.  Once this completes
-  successfully, the main installation process will be complete, and if
-  you are planning on using password authentication, you should be able
-  to visit the URL for your server and register for an account.
+  successfully, the main installation process will be complete.
+
+(6) Run
+ ```
+ ./manage.py generate_realm_creation_link
+ ```
+ This command will generate a unique link that can be used for creating your organization and admin account.
 
 (6) Subscribe to [the Zulip announcements Google Group](https://groups.google.com/forum/#!forum/zulip-announce)
   to get announcements about new releases, security issues, etc.

--- a/zerver/management/commands/initialize_voyager_db.py
+++ b/zerver/management/commands/initialize_voyager_db.py
@@ -63,12 +63,8 @@ class Command(BaseCommand):
         email_gateway_bot.is_api_super_user = True
         email_gateway_bot.save()
 
-        (admin_realm, _) = do_create_realm(settings.ADMIN_DOMAIN,
-                                           settings.ADMIN_DOMAIN, True)
-
-        set_default_streams(admin_realm, settings.DEFAULT_NEW_REALM_STREAMS)
-
         self.stdout.write("Successfully populated database with initial data.\n")
+        self.stdout.write("Please run ./manage.py generate_realm_creation_link to generate link for creating organization")
 
     site = Site.objects.get_current()
     site.domain = settings.EXTERNAL_HOST

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -160,7 +160,6 @@ for setting_name, setting_val in six.iteritems(DEFAULT_SETTINGS):
 # of pairs of (setting name, default value that it must be changed from)
 REQUIRED_SETTINGS = [("EXTERNAL_HOST", "zulip.example.com"),
                      ("ZULIP_ADMINISTRATOR", "zulip-admin@example.com"),
-                     ("ADMIN_DOMAIN", "example.com"),
                      # SECRET_KEY doesn't really need to be here, in
                      # that we set it automatically, but just in
                      # case, it seems worth having in this list


### PR DESCRIPTION
Under development. :hourglass_flowing_sand: 
- [x] Get https://github.com/zulip/zulip/pull/1064 merged 
- [x] Add generate_realm_creation_link to new server setup flow.
- [x] Update the documentation in README.prod.md and server.html (https://github.com/zulip/zulip.github.io/pull/6).
- [ ] Get the remainder of initialize_voyager_db.py to run as part of scripts/lib/install.
