### PR TITLE
Upgrade mypy

### DIFF
--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -1,3 +1,3 @@
 six==1.10.0
-git+https://github.com/rwbarton/mypy.git@3f4497689636cc9eea44239ba3ab73f1f5c7aaa6
-typed-ast==0.5.2
+git+https://github.com/sharmaeklavya2/mypy.git@4d2db8601def7813142e3bdd91b14f331ea0427c
+typed-ast==0.5.5


### PR DESCRIPTION
I had to type annotate some variables to pass the newer mypy's checks. All commits pass the older mypy's checks.

The last commit (`zilencer's populate_db.py: Type annotate all variables.`) was not required to make newer mypy pass, but I did that annotation work anyways, because it improved readability. I later found out a wrong annotation because of that extra work (`zilencer's populate_db.py: Improve an annotation.`), so maybe we'll gain more than readability by doing such variable annotation in the future.