### PR TITLE
Added help texts for running single backend and casper tests 

### DIFF
--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -27,9 +27,11 @@ except ImportError as e:
 
 os.environ["TORNADO_SERVER"] = "http://localhost:9983"
 
-parser = optparse.OptionParser(r"""
-
-%prog --remote-debug file1 file2 file3""")
+usage = """%prog [Options]
+\ttest-js-with-casper --remote-debug file1 file2 file3
+\ttest-js-with-casper 09-navigation.js
+"""
+parser = optparse.OptionParser(usage)
 
 parser.add_option('--remote-debug',
                   help='Whether or not to enable remote debugging on port 7777',

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -26,7 +26,14 @@ if __name__ == "__main__":
     # "-u" uses unbuffered IO, which is important when wrapping it in subprocess
     os.environ['PYTHONUNBUFFERED'] = 'y'
 
-    parser = optparse.OptionParser()
+    usage = """%prog [options]
+    test-backend # Runs all backend tests
+    test-backend zerver.tests.test_bugdown # run all tests in a test module
+    test-backend zerver.tests.test_bugdown.BugdownTest # run all tests in a test class
+    test-backend zerver.tests.test_bugdown.BugDownTest.test_inline_youtube # run a single test
+    """
+
+    parser = optparse.OptionParser(usage)
     parser.add_option('--nonfatal-errors', action="store_false", default=True,
                       dest="fatal_errors", help="Continue past test failures to run all tests")
     parser.add_option('--coverage', dest='coverage',


### PR DESCRIPTION
`test-backend --help` now displays how to run single backend tests, `test-js-with-casper --help` now displays how to run single casper tests.