### PR TITLE
Improve types in zerver/lib/db.py

### DIFF
--- a/zerver/lib/db.py
+++ b/zerver/lib/db.py
@@ -6,6 +6,7 @@ from psycopg2.extensions import cursor, connection
 from typing import Callable, Optional, Iterable, Any, Dict, Union, TypeVar, \
     Mapping, Sequence
 from six import text_type
+from zerver.lib.str_utils import NonBinaryStr
 
 CursorObj = TypeVar('CursorObj', bound=cursor)
 ParamsT = Union[Iterable[Any], Mapping[text_type, Any]]
@@ -13,7 +14,7 @@ ParamsT = Union[Iterable[Any], Mapping[text_type, Any]]
 # Similar to the tracking done in Django's CursorDebugWrapper, but done at the
 # psycopg2 cursor level so it works with SQLAlchemy.
 def wrapper_execute(self, action, sql, params=()):
-    # type: (CursorObj, Callable[[text_type, Optional[ParamsT]], CursorObj], text_type, ParamsT) -> CursorObj
+    # type: (CursorObj, Callable[[NonBinaryStr, Optional[ParamsT]], CursorObj], NonBinaryStr, ParamsT) -> CursorObj
     start = time.time()
     try:
         return action(sql, params)
@@ -28,11 +29,11 @@ class TimeTrackingCursor(cursor):
     """A psycopg2 cursor class that tracks the time spent executing queries."""
 
     def execute(self, query, vars=None):
-        # type: (text_type, Optional[ParamsT]) -> TimeTrackingCursor
+        # type: (NonBinaryStr, Optional[ParamsT]) -> TimeTrackingCursor
         return wrapper_execute(self, super(TimeTrackingCursor, self).execute, query, vars)
 
     def executemany(self, query, vars):
-        # type: (text_type, Iterable[Any]) -> TimeTrackingCursor
+        # type: (NonBinaryStr, Iterable[Any]) -> TimeTrackingCursor
         return wrapper_execute(self, super(TimeTrackingCursor, self).executemany, query, vars)
 
 class TimeTrackingConnection(connection):

--- a/zerver/lib/db.py
+++ b/zerver/lib/db.py
@@ -8,11 +8,12 @@ from typing import Callable, Optional, Iterable, Any, Dict, Union, TypeVar, \
 from six import text_type
 
 CursorObj = TypeVar('CursorObj', bound=cursor)
+ParamsT = Union[Iterable[Any], Mapping[text_type, Any]]
 
 # Similar to the tracking done in Django's CursorDebugWrapper, but done at the
 # psycopg2 cursor level so it works with SQLAlchemy.
 def wrapper_execute(self, action, sql, params=()):
-    # type: (CursorObj, Callable[[text_type, Optional[Union[Iterable[Any], Dict[text_type, Any]]]], CursorObj], text_type, Union[Iterable[Any], Dict[text_type, Any]]) -> CursorObj
+    # type: (CursorObj, Callable[[text_type, Optional[ParamsT]], CursorObj], text_type, ParamsT) -> CursorObj
     start = time.time()
     try:
         return action(sql, params)
@@ -27,7 +28,7 @@ class TimeTrackingCursor(cursor):
     """A psycopg2 cursor class that tracks the time spent executing queries."""
 
     def execute(self, query, vars=None):
-        # type: (text_type, Optional[Union[Iterable[Any], Dict[text_type, Any]]]) -> TimeTrackingCursor
+        # type: (text_type, Optional[ParamsT]) -> TimeTrackingCursor
         return wrapper_execute(self, super(TimeTrackingCursor, self).execute, query, vars)
 
     def executemany(self, query, vars):


### PR DESCRIPTION
* Use type aliases to shorten annotations
* Fix string annotations

I checked that psycopg2 can take both `str` and `unicode` as query input, hence I used `NonBinaryStr` as type of SQL queries.