### PR TITLE
Improve annotation of zerver/lib/test_helpers.py

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -863,7 +863,7 @@ def check_send_message(sender, client, message_type_name, message_to,
                        subject_name, message_content, realm=None, forged=False,
                        forged_timestamp=None, forwarder_user_profile=None, local_id=None,
                        sender_queue_id=None):
-    # type: (UserProfile, Client, str, List[text_type], text_type, text_type, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[int], Optional[text_type]) -> int
+    # type: (UserProfile, Client, str, Sequence[text_type], text_type, text_type, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[int], Optional[text_type]) -> int
     message = check_message(sender, client, message_type_name, message_to,
                             subject_name, message_content, realm, forged, forged_timestamp,
                             forwarder_user_profile, local_id, sender_queue_id)
@@ -926,7 +926,7 @@ def check_message(sender, client, message_type_name, message_to,
                   subject_name, message_content, realm=None, forged=False,
                   forged_timestamp=None, forwarder_user_profile=None, local_id=None,
                   sender_queue_id=None):
-    # type: (UserProfile, Client, str, List[text_type], text_type, text_type, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[int], Optional[text_type]) -> Dict[str, Any]
+    # type: (UserProfile, Client, str, Sequence[text_type], text_type, text_type, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[int], Optional[text_type]) -> Dict[str, Any]
     stream = None
     if not message_to and message_type_name == 'stream' and sender.default_sending_stream:
         # Use the users default stream

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -236,17 +236,17 @@ class AuthedTestCase(TestCase):
     # Helper because self.client.patch annoying requires you to urlencode
 
     def client_patch(self, url, info={}, **kwargs):
-        # type: (str, Dict[str, Any], **Any) -> HttpResponse
+        # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
         encoded = urllib.parse.urlencode(info)
         return self.client.patch(url, encoded, **kwargs)
 
     def client_put(self, url, info={}, **kwargs):
-        # type: (str, Dict[str, Any], **Any) -> HttpResponse
+        # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
         encoded = urllib.parse.urlencode(info)
         return self.client.put(url, encoded, **kwargs)
 
     def client_delete(self, url, info={}, **kwargs):
-        # type: (str, Dict[str, Any], **Any) -> HttpResponse
+        # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
         encoded = urllib.parse.urlencode(info)
         return self.client.delete(url, encoded, **kwargs)
 
@@ -311,7 +311,7 @@ class AuthedTestCase(TestCase):
 
     def send_message(self, sender_name, raw_recipients, message_type,
                      content=u"test content", subject=u"test", **kwargs):
-        # type: (str, Union[text_type, List[text_type]], int, text_type, text_type, **Any) -> int
+        # type: (text_type, Union[text_type, List[text_type]], int, text_type, text_type, **Any) -> int
         sender = get_user_profile_by_email(sender_name)
         if message_type == Recipient.PERSONAL:
             message_type_name = "private"
@@ -367,7 +367,7 @@ class AuthedTestCase(TestCase):
         return json['msg']
 
     def assert_json_error(self, result, msg, status_code=400):
-        # type: (HttpResponse, str, int) -> None
+        # type: (HttpResponse, text_type, int) -> None
         """
         Invalid POSTs return an error status code and JSON of the form
         {"result": "error", "msg": "reason"}.
@@ -384,7 +384,7 @@ class AuthedTestCase(TestCase):
                                "len(%s) == %s, > %s" % (queries, actual_count, count))
 
     def assert_json_error_contains(self, result, msg_substring, status_code=400):
-        # type: (HttpResponse, str, int) -> None
+        # type: (HttpResponse, text_type, int) -> None
         self.assertIn(msg_substring, self.get_json_error(result, status_code=status_code))
 
     def fixture_data(self, type, action, file_type='json'):
@@ -405,7 +405,7 @@ class AuthedTestCase(TestCase):
 
     # Subscribe to a stream by making an API request
     def common_subscribe_to_streams(self, email, streams, extra_post_data={}, invite_only=False):
-        # type: (str, Iterable[text_type], Dict[str, Any], bool) -> HttpResponse
+        # type: (text_type, Iterable[text_type], Dict[str, Any], bool) -> HttpResponse
         post_data = {'subscriptions': ujson.dumps([{"name": stream} for stream in streams]),
                      'invite_only': ujson.dumps(invite_only)}
         post_data.update(extra_post_data)

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from contextlib import contextmanager
-from typing import cast, Any, Callable, Generator, Iterable, Tuple, Sized, Union, Optional
+from typing import cast, Any, Callable, Dict, Generator, Iterable, List, Optional, Sized, Tuple, Union
 
 from django.test import TestCase
 from django.template import loader
@@ -62,7 +62,7 @@ def stub(obj, name, f):
 
 @contextmanager
 def simulated_queue_client(client):
-    # type: (Any) -> Generator[None, None, None]
+    # type: (type) -> Generator[None, None, None]
     real_SimpleQueueClient = queue_processors.SimpleQueueClient
     queue_processors.SimpleQueueClient = client # type: ignore # https://github.com/JukkaL/mypy/issues/1152
     yield
@@ -70,7 +70,7 @@ def simulated_queue_client(client):
 
 @contextmanager
 def tornado_redirected_to_list(lst):
-    # type: (List) -> Generator[None, None, None]
+    # type: (List[Dict[str, Any]]) -> Generator[None, None, None]
     real_event_queue_process_notification = event_queue.process_notification
     event_queue.process_notification = lst.append
     yield
@@ -191,7 +191,7 @@ class DummyTornadoRequest(object):
 
 class DummyHandler(object):
     def __init__(self, assert_callback):
-        # type: (Any) -> None
+        # type: (Callable) -> None
         self.assert_callback = assert_callback
         self.request = DummyTornadoRequest()
         allocate_handler_id(self)

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -50,7 +50,7 @@ from zerver.lib.str_utils import NonBinaryStr
 from contextlib import contextmanager
 import six
 
-API_KEYS = {} # type: Dict[str, str]
+API_KEYS = {} # type: Dict[text_type, text_type]
 
 @contextmanager
 def stub(obj, name, f):
@@ -285,16 +285,16 @@ class AuthedTestCase(TestCase):
                                  'terms': True})
 
     def get_api_key(self, email):
-        # type: (str) -> str
+        # type: (text_type) -> text_type
         if email not in API_KEYS:
             API_KEYS[email] = get_user_profile_by_email(email).api_key
         return API_KEYS[email]
 
     def api_auth(self, email):
-        # type: (str) -> Dict[str, str]
-        credentials = "%s:%s" % (email, self.get_api_key(email))
+        # type: (text_type) -> Dict[str, text_type]
+        credentials = u"%s:%s" % (email, self.get_api_key(email))
         return {
-            'HTTP_AUTHORIZATION': 'Basic ' + base64.b64encode(credentials)
+            'HTTP_AUTHORIZATION': u'Basic ' + base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
         }
 
     def get_streams(self, email):

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -22,9 +22,10 @@ import DNS
 import mock
 import time
 import ujson
-from six.moves import urllib
 
+from six.moves import urllib
 from six.moves import range
+from six import text_type
 
 class MITNameTest(TestCase):
     def test_valid_hesiod(self):
@@ -66,7 +67,7 @@ class RateLimitTests(AuthedTestCase):
         remove_ratelimit_rule(1, 5)
 
     def send_api_message(self, email, api_key, content):
-        # type: (str, str, str) -> HttpResponse
+        # type: (text_type, text_type, text_type) -> HttpResponse
         return self.client.post("/api/v1/send_message", {"type": "stream",
                                                                    "to": "Verona",
                                                                    "client": "test suite",


### PR DESCRIPTION
The first commit `zerver/lib/actions.py: Use Sequence as parameter type.` is not related to this PR, but I included it here because it's so small.