### PR TITLE
Fix casper tests hanging while development server is running.

### DIFF
--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -38,7 +38,7 @@ var page_params = {{ page_params }};
 {{ minified_js('app')|safe }}
 
 {% if not pipeline %}
-<script type="text/javascript" src="/webpack/bundle.js"></script>
+<script type="text/javascript" src="/static/webpack/bundle.js"></script>
 {% endif %}
 
 {% if debug %}

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -754,6 +754,7 @@ JS_SPECS = {
 }
 
 if PIPELINE:
+    # This is also done in test_settings.py, see comment there..
     JS_SPECS['app']['source_filenames'].append('js/bundle.js')
 
 app_srcs = JS_SPECS['app']['source_filenames']

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -11,6 +11,10 @@ DATABASES["default"] = {"NAME": "zulip_test",
                         "TEST_NAME": "django_zulip_tests",
                         "OPTIONS": {"connection_factory": TimeTrackingConnection },}
 
+# In theory this should just go in zproject/settings.py inside the `if
+# PIPELINE` statement, but because zproject/settings.py is processed
+# first, we have to add it here as a hack.
+JS_SPECS['app']['source_filenames'].append('js/bundle.js')
 
 if "TORNADO_SERVER" in os.environ:
     # This covers the Casper test suite case


### PR DESCRIPTION
This works around a nasty problem with Webpack that you can't run two
copies of the Webpack development server on the same project at the
same time (even if on different ports).  The second copy doesn't fail,
it just hangs waiting for some lock, which is confusing; but even if
that were to be solved, we don't actually need the webpack development
server running to run the Casper tests; we just need bundle.js built.
So the easy solution is to just run webpack manually and be sure to
include bundle.js in the JS_SPECS entry.

As a follow-up to this change, we should clean up how test_settings.py
is implemented to not require duplicating code from settings.py.

Fixes #878.