### PR TITLE
wrong link to the translations doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ PostgreSQL extension][tsearch], as separate repos.
 
 * **Translations**.  Zulip is in the process of being translated into
 10+ languages, and we love contributions to our translations.  See our
-[translating documentation](transifex) if you're interested in
+[translating documentation][transifex] if you're interested in
 contributing!
 
 [cla]: https://opensource.dropbox.com/cla/

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ contributing!
 [redmine]: https://github.com/zulip/zulip-redmine-plugin
 [trello]: https://github.com/zulip/trello-to-zulip
 [tsearch]: https://github.com/zulip/tsearch_extras
-[transifex]: https://www.transifex.com/zulip/zulip/
+[transifex]: https://zulip.readthedocs.io/en/latest/translating.html#testing-translations
 [z-org]: https://github.com/zulip/zulip.github.io
 
 ## How to get involved with contributing to Zulip


### PR DESCRIPTION
@timabbott I guess in the Readme doc, the Translations link should lead to the documentation and not to the activity page. 

![o_t](https://cloud.githubusercontent.com/assets/10063868/16519543/7339e8fa-3fa7-11e6-9f6d-4156ea9ed06c.png)

Moreover earlier one would see a 404 error on clicking the same link.
