### PR TITLE
Split requirements based on python version

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -1105,7 +1105,7 @@ Once you have created and activated a virtualenv, do the following:
 
 ```
 pip install --upgrade pip # upgrade pip itself because older versions have known issues.
-pip install --no-deps -r requirements/dev.txt # install python packages required for development
+pip install --no-deps -r requirements/py2_dev.txt # install python packages required for development
 ./tools/setup/install-phantomjs
 ./tools/install-mypy
 ./tools/setup/download-zxcvbn

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -51,11 +51,7 @@ django-bitfield==1.8.0
 # migration that removes it.
 git+https://github.com/rwbarton/django-guardian.git@caf9f0c8c035feb3dff5542fb042dd13126cdd69
 
-# Django extension for static asset pipeline
-django-pipeline==1.2.2
-
 docopt==0.4.0
-enum34==1.0.4
 fonttools==3.0
 
 # Needed for Android push notifications
@@ -102,14 +98,8 @@ pyasn1-modules==0.0.5
 pycparser==2.14
 pycrypto==2.6.1
 
-# Used for Hesiod lookups, etc.
-pydns==2.3.6
-
 # Needed for memcached usage
 pylibmc==1.4.3
-
-# Needed for LDAP integration
-python-ldap==2.4.19
 
 # Needed for timezone work
 pytz==2015.4
@@ -141,9 +131,6 @@ tornado==2.4.1
 
 # Needed for Python static typing
 typing==3.5.0.1
-
-# Needed for Twitter card integration
-python-twitter==1.1
 
 # Fast JSON parser
 ujson==1.33

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -127,7 +127,7 @@ rsa==3.1.4
 simplejson==3.7.3
 
 # Needed for Python 2+3 compatibility
-six==1.9.0
+six==1.10.0
 smmap==0.9.0
 
 # Needed for Tornado websockets support

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,3 @@
 -r common.txt
 netifaces==0.10.4
-flup==1.0.2
 python-dateutil==2.5.3

--- a/requirements/py2_common.txt
+++ b/requirements/py2_common.txt
@@ -1,0 +1,1 @@
+-r common.txt

--- a/requirements/py2_common.txt
+++ b/requirements/py2_common.txt
@@ -1,1 +1,15 @@
 -r common.txt
+
+enum34==1.0.4
+
+# Django extension for static asset pipeline
+django-pipeline==1.2.2
+
+# Used for Hesiod lookups, etc.
+pydns==2.3.6
+
+# Needed for LDAP integration
+python-ldap==2.4.19
+
+# Needed for Twitter card integration
+python-twitter==1.1

--- a/requirements/py2_dev.txt
+++ b/requirements/py2_dev.txt
@@ -1,0 +1,2 @@
+-r py2_common.txt
+-r dev.txt

--- a/requirements/py2_prod.txt
+++ b/requirements/py2_prod.txt
@@ -1,2 +1,3 @@
 -r py2_common.txt
 -r prod.txt
+flup==1.0.2

--- a/requirements/py2_prod.txt
+++ b/requirements/py2_prod.txt
@@ -1,0 +1,2 @@
+-r py2_common.txt
+-r prod.txt

--- a/requirements/py3_common.txt
+++ b/requirements/py3_common.txt
@@ -1,0 +1,4 @@
+-r common.txt
+
+# Used for Hesiod lookups, etc.
+py3dns==3.1.0

--- a/requirements/py3_dev.txt
+++ b/requirements/py3_dev.txt
@@ -1,0 +1,3 @@
+-r py3_common.txt
+-r dev.txt
+-r mypy.txt

--- a/requirements/py3k.txt
+++ b/requirements/py3k.txt
@@ -1,4 +1,4 @@
-six==1.9.0
+six==1.10.0
 typing==3.5.0.1
 future==0.15.2
 modernize==0.5

--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -19,5 +19,5 @@ args = parser.parse_args()
 # install dependencies for setting up the virtualenv
 run(["apt-get", "-y", "install"] + VENV_DEPENDENCIES)
 
-cached_venv_path = setup_virtualenv(args.target, os.path.join(ZULIP_PATH, "requirements", "prod.txt"))
+cached_venv_path = setup_virtualenv(args.target, os.path.join(ZULIP_PATH, "requirements", "py2_prod.txt"))
 # Now the virtualenv has been activated

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -66,6 +66,6 @@ def do_setup_virtualenv(venv_path, requirements_file, virtualenv_args):
     activate_this = os.path.join(venv_path, "bin", "activate_this.py")
     exec(open(activate_this).read(), {}, dict(__file__=activate_this)) # type: ignore # https://github.com/python/mypy/issues/1577
 
-    run(["pip", "install", "--upgrade", "pip"])
+    run(["pip", "install", "--upgrade", "pip", "wheel"])
     run(["pip", "install", "--no-deps", "--requirement", requirements_file])
     run(["sudo", "chmod", "-R", "a+rX", venv_path])

--- a/tools/provision.py
+++ b/tools/provision.py
@@ -153,7 +153,7 @@ def main():
     setup_virtualenv(PY3_VENV_PATH,
                      os.path.join(ZULIP_PATH, "requirements", "mypy.txt"),
                      virtualenv_args=['-p', 'python3'])
-    setup_virtualenv(VENV_PATH, os.path.join(ZULIP_PATH, "requirements", "dev.txt"))
+    setup_virtualenv(VENV_PATH, os.path.join(ZULIP_PATH, "requirements", "py2_dev.txt"))
 
     # Put Python2 virtualenv activation in our .bash_profile.
     with open(os.path.expanduser('~/.bash_profile'), 'w+') as bash_profile:


### PR DESCRIPTION
Creating a python 3 virtualenv with requirements/dev.txt fails because some packages are not python 3 compatible. To fix that, I have made files py2_dev.txt and py3_dev.txt.

We will eventually need to do this since some packages are re-written in python 3 with a different name instead of supporting both versions (like pydns and py3dns, python-ldap and pyldap). py3_dev.txt also includes mypy.

py3_dev.txt is missing some packages, like pipeline, but that will get fixed in the future when we upgrade our dependencies.