### PR TITLE
Python 3 mode in provision.py

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -35,7 +35,7 @@ def setup_virtualenv(target_venv_path, requirements_file, virtualenv_args=None):
 
     # Check if a cached version already exists
     path = os.path.join(ZULIP_PATH, 'scripts', 'lib', 'hash_reqs.py')
-    output = subprocess.check_output([path, requirements_file])
+    output = subprocess.check_output([path, requirements_file], universal_newlines=True)
     sha1sum = output.split()[0]
     if target_venv_path is None:
         cached_venv_path = os.path.join(VENV_CACHE_PATH, sha1sum, 'venv')

--- a/tools/provision.py
+++ b/tools/provision.py
@@ -43,8 +43,8 @@ else:
 # Ideally we wouldn't need to install a dependency here, before we
 # know the codename.
 subprocess.check_call(["sudo", "apt-get", "install", "-y", "lsb-release"])
-vendor = subprocess.check_output(["lsb_release", "-is"]).strip()
-codename = subprocess.check_output(["lsb_release", "-cs"]).strip()
+vendor = subprocess.check_output(["lsb_release", "-is"], universal_newlines=True).strip()
+codename = subprocess.check_output(["lsb_release", "-cs"], universal_newlines=True).strip()
 if not (vendor in SUPPORTED_PLATFORMS and codename in SUPPORTED_PLATFORMS[vendor]):
     logging.critical("Unsupported platform: {} {}".format(vendor, codename))
     sys.exit(1)
@@ -104,7 +104,7 @@ LOUD = dict(_out=sys.stdout, _err=sys.stderr)
 
 def setup_node_modules():
     # type: () -> None
-    output = subprocess.check_output(['sha1sum', 'package.json'])
+    output = subprocess.check_output(['sha1sum', 'package.json'], universal_newlines=True)
     sha1sum = output.split()[0]
     success_stamp = os.path.join('node_modules', '.npm-success-stamp', sha1sum)
     if not os.path.exists(success_stamp):
@@ -119,7 +119,7 @@ def setup_node_modules():
 def install_npm():
     # type: () -> None
     if "--travis" not in sys.argv:
-        if subprocess.check_output(['npm', '--version']).strip() != NPM_VERSION:
+        if subprocess.check_output(['npm', '--version'], universal_newlines=True).strip() != NPM_VERSION:
             run(["sudo", "npm", "install", "-g", "npm@{}".format(NPM_VERSION)])
 
         return
@@ -127,11 +127,11 @@ def install_npm():
     run(['mkdir', '-p', TRAVIS_NODE_PATH])
 
     npm_exe = os.path.join(TRAVIS_NODE_PATH, 'bin', 'npm')
-    travis_npm = subprocess.check_output(['which', 'npm']).strip()
+    travis_npm = subprocess.check_output(['which', 'npm'], universal_newlines=True).strip()
     if os.path.exists(npm_exe):
         run(['sudo', 'ln', '-sf', npm_exe, travis_npm])
 
-    version = subprocess.check_output(['npm', '--version']).strip()
+    version = subprocess.check_output(['npm', '--version'], universal_newlines=True).strip()
     if os.path.exists(npm_exe) and version == NPM_VERSION:
         print("Using cached npm")
         return
@@ -146,7 +146,7 @@ def main():
     run(["sudo", "apt-get", "-y", "install", "--no-install-recommends"] + APT_DEPENDENCIES[codename])
 
     if subprocess.call(['dpkg', '-s', TSEARCH_PACKAGE_NAME]):
-        temp_deb_path = subprocess.check_output(["mktemp", "package_XXXXXX.deb", "--tmpdir"])
+        temp_deb_path = subprocess.check_output(["mktemp", "package_XXXXXX.deb", "--tmpdir"], universal_newlines=True)
         run(["wget", "-O", temp_deb_path, TSEARCH_URL])
         run(["sudo", "dpkg", "--install", temp_deb_path])
 


### PR DESCRIPTION
Make provision.py runnable on python 3.

Install a python 3 venv using 'requirements/py3_dev.txt' when provision.py is run from python 3. Retain original behaviour of making a python 2 venv using 'requirments/py2_dev.txt' and a python 3 venv using 'requirements/mypy.txt' when provision.py is run from python 2.

Even though provision.py itself is runnable on python 3, the subprocess calls it makes after installing a venv will not succeed in python 3 because of missing dependencies.