### PR TITLE
Run provision.py and lint-all in python 3 mode on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - COVERALLS_PARALLEL=true
     - COVERALLS_SERVICE_NAME=travis-pro
     - COVERALLS_REPO_TOKEN=hnXUEBKsORKHc8xIENGs9JjktlTb2HKlG
+    - BOTO_CONFIG=/tmp/nowhere
   matrix:
     - TEST_SUITE=frontend
     - TEST_SUITE=backend

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 before_install:
    - nvm install 0.10
 install:
@@ -29,6 +30,9 @@ matrix:
   include:
     - python: "3.4"
       env: TEST_SUITE=mypy
+    - python: "3.4"
+      env: TEST_SUITE=lint-all
+      sudo: required
 # command to run tests
 script:
   - ./tools/travis/$TEST_SUITE

--- a/requirements/py3_common.txt
+++ b/requirements/py3_common.txt
@@ -2,3 +2,12 @@
 
 # Used for Hesiod lookups, etc.
 py3dns==3.1.0
+
+# Django extension for static asset pipeline
+django-pipeline==1.6.8
+
+# Needed for LDAP integration
+pyldap==2.4.25.1
+
+# Needed for Twitter card integration
+python-twitter==3.1

--- a/tools/travis/activate-venv
+++ b/tools/travis/activate-venv
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+py_version="$(python -c 'import sys; print(sys.version_info[0])')"
+
+if [ "$py_version" == 2 ]; then
+    source /srv/zulip-venv/bin/activate
+else
+    source /srv/zulip-py3-venv/bin/activate
+fi
+
+echo "Using $VIRTUAL_ENV"

--- a/tools/travis/lint-all
+++ b/tools/travis/lint-all
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source tools/travis/activate-venv
+
+echo "+ ./tools/lint-all"
+./tools/lint-all
+retcode="$?"
+
+echo
+if [ "$retcode" == 0 ]; then
+    echo "tools/lint-all detected no errors on Python 3!"
+else
+    echo "tools/lint-all threw some errors in python 3."
+    echo "This indicates that there is either a bug in your code or your code doesn't"
+    echo "follow our style guidelines (http://zulip.readthedocs.io/en/latest/code-style.html)."
+    echo
+    echo "To run tools/lint-all locally in python 3, you must first install"
+    echo 'the required packages.  To do that, run `python3 provision.py` then'
+    echo '`source /srv/zulip-py3-venv` and then `tools/lint-all`.'
+    echo
+    echo "You can also install tools/lint-all's dependencies manually:"
+    echo "It requires six, typing (check their versions from requirements/common.txt)."
+    echo "and pyflakes (check its version from requirements/dev.txt). It is likely that"
+    echo "you already have a python 3 virtualenv installed in /srv/zulip-py3-venv, but"
+    echo "you might still need to install the dependencies listed above."
+fi

--- a/tools/travis/setup-lint-all
+++ b/tools/travis/setup-lint-all
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+set -x
+python tools/provision.py --travis


### PR DESCRIPTION
Running lint-all in python 3 will prevent getting some python 3 bugs in our code because pyflakes checks differently in python 3.

I could have factored out pyflakes-running code from lint-all so that setup would just include something like `pip install pyflakes`. That would have been easier and lighter on Travis. But I wanted to make our provisioning process python 3 compatible. Running it on Travis is necessary to ensure that python 3 compatibility is not broken in the future.

This pull request is based on #1167 and #1168.