### PR TITLE
Improve test coverage on decorators/clean up rate limiting a bit.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -477,13 +477,6 @@ def to_non_negative_int(x):
         raise ValueError("argument is negative")
     return x
 
-def to_non_negative_float(x):
-    # type: (float) -> float
-    x = float(x)
-    if x < 0:
-        raise ValueError("argument is negative")
-    return x
-
 def flexible_boolean(boolean):
     # type: (text_type) -> bool
     """Returns True for any of "1", "true", or "True".  Returns False otherwise."""

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -13,7 +13,7 @@ from zerver.lib.str_utils import force_bytes
 
 from zerver.decorator import authenticated_api_view, authenticated_json_post_view, \
     has_request_variables, REQ, JsonableError, \
-    to_non_negative_int, to_non_negative_float
+    to_non_negative_int
 from django.utils.html import escape as escape_html
 from zerver.lib import bugdown
 from zerver.lib.actions import recipient_for_emails, do_update_message_flags, \


### PR DESCRIPTION
The first commit is pretty trivial.

The second and third commits are symptomatic of what happens when a decorator has lots of conditional logic in it.  It makes it really difficult to put test coverage on it.  Since the code is already in production, I jumped though all the testing hoops to cover the conditional branches first, and then that allowed me to extract some of the logic to a function that's more easily testable in the future.