### PR TITLE
Provision.py: Create directory zulip/var/log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ npm-debug.log
 uploads/
 test_uploads/
 *.mo
+var/*

--- a/tools/build-release-tarball
+++ b/tools/build-release-tarball
@@ -44,6 +44,9 @@ fi
 git checkout-index -f -a --prefix "$TMP_CHECKOUT"
 cd "$TMP_CHECKOUT"
 
+# create var/log directory
+mkdir -p "var/log"
+
 # Use default settings so there is no chance of leaking secrets
 cp zproject/local_settings_template.py zproject/local_settings.py
 

--- a/tools/provision.py
+++ b/tools/provision.py
@@ -27,6 +27,9 @@ NPM_VERSION = '3.9.3'
 PY2_VENV_PATH = "/srv/zulip-venv"
 PY3_VENV_PATH = "/srv/zulip-py3-venv"
 TRAVIS_NODE_PATH = os.path.join(os.environ['HOME'], 'node')
+VAR_DIR_PATH = os.path.join(ZULIP_PATH, 'var')
+LOG_DIR_PATH = os.path.join(VAR_DIR_PATH, 'log')
+
 
 if PY2:
     VENV_PATH = PY2_VENV_PATH
@@ -178,6 +181,9 @@ def main():
     # npm install and management commands expect to be run from the root of the
     # project.
     os.chdir(ZULIP_PATH)
+
+    # create log directory `zulip/var/log`
+    run(["mkdir", "-p", LOG_DIR_PATH])
 
     if "--travis" in sys.argv:
         run(["tools/setup/install-phantomjs", "--travis"])

--- a/tools/provision.py
+++ b/tools/provision.py
@@ -29,6 +29,7 @@ PY3_VENV_PATH = "/srv/zulip-py3-venv"
 TRAVIS_NODE_PATH = os.path.join(os.environ['HOME'], 'node')
 VAR_DIR_PATH = os.path.join(ZULIP_PATH, 'var')
 LOG_DIR_PATH = os.path.join(VAR_DIR_PATH, 'log')
+TEST_UPLOAD_DIR_PATH = os.path.join(VAR_DIR_PATH, 'test_uploads')
 
 
 if PY2:
@@ -184,6 +185,8 @@ def main():
 
     # create log directory `zulip/var/log`
     run(["mkdir", "-p", LOG_DIR_PATH])
+    # create test upload directory `var/test_upload`
+    run(["mkdir", "-p", TEST_UPLOAD_DIR_PATH])
 
     if "--travis" in sys.argv:
         run(["tools/setup/install-phantomjs", "--travis"])

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -217,7 +217,8 @@ USE_TZ = True
 
 DEPLOY_ROOT = os.path.join(os.path.realpath(os.path.dirname(__file__)), '..')
 LOCALE_PATHS = (os.path.join(DEPLOY_ROOT, 'locale'),)
-
+# this directory will be used to store logs for development environment
+DEVELOPMENT_LOG_DIRECTORY = os.path.join(DEPLOY_ROOT, 'var', 'log')
 # Make redirects work properly behind a reverse proxy
 USE_X_FORWARDED_HOST = True
 
@@ -796,7 +797,7 @@ else:
 for (var, path) in ZULIP_PATHS:
     if DEVELOPMENT:
         # if DEVELOPMENT, store these files in the Zulip checkout
-        path = os.path.basename(path)
+        path = os.path.join(DEVELOPMENT_LOG_DIRECTORY, os.path.basename(path))
     vars()[var] = path
 
 ZULIP_WORKER_TEST_FILE = '/tmp/zulip-worker-test-file'

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -65,7 +65,7 @@ CACHES['database'] = {
 LOGGING['loggers']['zulip.requests']['level'] = 'CRITICAL'
 LOGGING['loggers']['zulip.management']['level'] = 'CRITICAL'
 
-LOCAL_UPLOADS_DIR = 'test_uploads'
+LOCAL_UPLOADS_DIR = 'var/test_uploads'
 
 S3_KEY = 'test-key'
 S3_SECRET_KEY = 'test-secret-key'


### PR DESCRIPTION
Thir PR addresses the point 1 of Issue #1132 . It creates a log directly `var/log` in zulip root directory.

@timabbott : please review