### PR TITLE
Replace assertItemsEqual by assertEqual.

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -263,7 +263,7 @@ class LoginTest(AuthedTestCase):
         # objects.
         email_recipients = [message.recipients()[0] for message in outbox]
         self.assertEqual(len(outbox), len(invitees))
-        self.assertItemsEqual(email_recipients, invitees)
+        self.assertEqual(sorted(email_recipients), sorted(invitees))
 
         user_profile = get_user_profile_by_email(email)
         self.assertEqual(len(invitees), PreregistrationUser.objects.filter(
@@ -293,7 +293,7 @@ class InviteUserTest(AuthedTestCase):
         from django.core.mail import outbox
         self.assertEqual(len(outbox), len(correct_recipients))
         email_recipients = [email.recipients()[0] for email in outbox]
-        self.assertItemsEqual(email_recipients, correct_recipients)
+        self.assertEqual(sorted(email_recipients), sorted(correct_recipients))
 
     def test_bulk_invite_users(self):
         # type: () -> None

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -769,7 +769,7 @@ class SubscriptionAPITest(AuthedTestCase):
                 self.fail("stream does not exist")
         list_streams = [stream['name'] for stream in json["subscriptions"]]
         # also check that this matches the list of your subscriptions
-        self.assertItemsEqual(list_streams, self.streams)
+        self.assertEqual(sorted(list_streams), sorted(self.streams))
 
     def helper_check_subs_before_and_after_add(self, subscriptions, other_params,
                                                subscribed, already_subscribed,
@@ -793,10 +793,10 @@ class SubscriptionAPITest(AuthedTestCase):
                                                   other_params, invite_only=invite_only)
         self.assert_json_success(result)
         json = ujson.loads(result.content)
-        self.assertItemsEqual(subscribed, json["subscribed"][email])
-        self.assertItemsEqual(already_subscribed, json["already_subscribed"][email])
+        self.assertEqual(sorted(subscribed), sorted(json["subscribed"][email]))
+        self.assertEqual(sorted(already_subscribed), sorted(json["already_subscribed"][email]))
         new_streams = self.get_streams(email)
-        self.assertItemsEqual(new_streams, new_subs)
+        self.assertEqual(sorted(new_streams), sorted(new_subs))
 
     def test_successful_subscriptions_add(self):
         # type: () -> None
@@ -1205,9 +1205,9 @@ class SubscriptionAPITest(AuthedTestCase):
         self.assert_json_success(result)
         json = ujson.loads(result.content)
         for key, val in six.iteritems(json_dict):
-            self.assertItemsEqual(val, json[key])  # we don't care about the order of the items
+            self.assertEqual(sorted(val), sorted(json[key]))  # we don't care about the order of the items
         new_streams = self.get_streams(email)
-        self.assertItemsEqual(new_streams, new_subs)
+        self.assertEqual(sorted(new_streams), sorted(new_subs))
 
     def test_successful_subscriptions_remove(self):
         # type: () -> None
@@ -1530,7 +1530,7 @@ class GetSubscribersTest(AuthedTestCase):
         self.assertIsInstance(result["subscribers"], list)
         true_subscribers = [user_profile.email for user_profile in self.users_subscribed_to_stream(
                 stream_name, domain)]
-        self.assertItemsEqual(result["subscribers"], true_subscribers)
+        self.assertEqual(sorted(result["subscribers"]), sorted(true_subscribers))
 
     def make_subscriber_request(self, stream_name, email=None):
         # type: (text_type, Optional[str]) -> HttpResponse


### PR DESCRIPTION
This is needed because `assertItemsEqual` doesn't exist in python 3.