### PR TITLE
Merge mypy and py3k test suites in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,13 @@ env:
     - TEST_SUITE=frontend
     - TEST_SUITE=backend
     - TEST_SUITE=production
-    - TEST_SUITE=py3k
 language: python
 python:
   - "2.7"
 matrix:
   include:
     - python: "3.4"
-      env: TEST_SUITE=mypy
+      env: TEST_SUITE=static-analysis
     - python: "3.4"
       env: TEST_SUITE=lint-all
       sudo: required

--- a/docs/mypy.md
+++ b/docs/mypy.md
@@ -28,7 +28,7 @@ You can learn more about it at:
 * [Using mypy with Python 2 code](http://mypy.readthedocs.io/en/latest/python2.html)
 
 The mypy type checker is run automatically as part of Zulip's Travis
-CI testing process.
+CI testing process in the 'static-analysis' build.
 
 ## Zulip goals
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -336,8 +336,9 @@ compatibility as we continue to develop new features in zulip, we have a
 special tool, tools/check-py3, which checks all code for Python 3
 syntactic compatibility by running a subset of the automated migration
 tools and checking if they trigger any changes. tools/check-py3 is run
-automatically in Zulip's Travis CI tests to avoid any regressions, but
-is not included in test-all since it is quite slow.
+automatically in Zulip's Travis CI tests (in the 'static-analysis'
+build) to avoid any regressions, but is not included in test-all since
+it is quite slow.
 
 To run tooks/check-py3, you need to install the modernize and future
 python packages (which are included in requirements/py3k.txt, which

--- a/tools/travis/py3k
+++ b/tools/travis/py3k
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-tools/check-py3

--- a/tools/travis/setup-mypy
+++ b/tools/travis/setup-mypy
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-set -x
-pip install --no-deps -r requirements/mypy.txt

--- a/tools/travis/setup-static-analysis
+++ b/tools/travis/setup-static-analysis
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
 set -x
+pip install --no-deps -r requirements/mypy.txt
 pip install --no-deps -r requirements/py3k.txt

--- a/tools/travis/static-analysis
+++ b/tools/travis/static-analysis
@@ -16,3 +16,5 @@ else
     echo "on mypy, how Zulip is using mypy, and how to debug common issues."
     exit "$retcode"
 fi
+
+tools/check-py3


### PR DESCRIPTION
mypy and py3k test suites have low running times compared to backend, production and frontend test suites, so clubbing them together will not increase total time for all tests.