### PR TITLE
Decode response.content

### DIFF
--- a/zerver/lib/response.py
+++ b/zerver/lib/response.py
@@ -5,6 +5,7 @@ import ujson
 
 from typing import Optional, Any, Dict, List
 from six import text_type
+from zerver.lib.str_utils import force_bytes
 
 
 class HttpResponseUnauthorized(HttpResponse):
@@ -23,16 +24,16 @@ class HttpResponseUnauthorized(HttpResponse):
 def json_unauthorized(message, www_authenticate=None):
     # type: (text_type, Optional[text_type]) -> HttpResponse
     resp = HttpResponseUnauthorized("zulip", www_authenticate=www_authenticate)
-    resp.content = ujson.dumps({"result": "error",
-                                "msg": message}) + "\n"
+    resp.content = force_bytes(ujson.dumps({"result": "error",
+                                            "msg": message}) + "\n")
     return resp
 
 def json_method_not_allowed(methods):
     # type: (List[text_type]) -> text_type
     resp = HttpResponseNotAllowed(methods)
-    resp.content = ujson.dumps({"result": "error",
+    resp.content = force_bytes(ujson.dumps({"result": "error",
         "msg": "Method Not Allowed",
-        "allowed_methods": methods})
+        "allowed_methods": methods}))
     return resp
 
 def json_response(res_type="success", msg="", data=None, status=200):

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -391,6 +391,14 @@ class AuthedTestCase(TestCase):
         # type: (HttpResponse, text_type, int) -> None
         self.assertIn(msg_substring, self.get_json_error(result, status_code=status_code))
 
+    def assert_equals_response(self, string, response):
+        # type: (text_type, HttpResponse) -> None
+        self.assertEqual(string, response.content.decode('utf-8'))
+
+    def assert_in_response(self, substring, response):
+        # type: (text_type, HttpResponse) -> None
+        self.assertIn(substring, response.content.decode('utf-8'))
+
     def fixture_data(self, type, action, file_type='json'):
         # type: (text_type, text_type, text_type) -> text_type
         return force_text(open(os.path.join(os.path.dirname(__file__),

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -10,7 +10,7 @@ from zerver.lib.actions import do_deactivate_realm, do_deactivate_user, \
     do_reactivate_realm, do_reactivate_user
 from zerver.lib.initial_password import initial_password
 from zerver.lib.test_helpers import (
-    AuthedTestCase, skip_py3
+    AuthedTestCase
 )
 from zerver.models import \
     get_realm, get_user_profile_by_email, email_to_username
@@ -233,7 +233,6 @@ class DevFetchAPIKeyTest(AuthedTestCase):
             self.assert_json_error_contains(result, "Dev environment not enabled.", 400)
 
 class DevGetEmailsTest(AuthedTestCase):
-    @skip_py3
     def test_success(self):
         # type: () -> None
         result = self.client.get("/api/v1/dev_get_emails")

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -238,8 +238,8 @@ class DevGetEmailsTest(AuthedTestCase):
         # type: () -> None
         result = self.client.get("/api/v1/dev_get_emails")
         self.assert_json_success(result)
-        self.assertIn("direct_admins", result.content)
-        self.assertIn("direct_users", result.content)
+        self.assert_in_response("direct_admins", result)
+        self.assert_in_response("direct_users", result)
 
     def test_dev_auth_disabled(self):
         # type: () -> None

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -11,7 +11,7 @@ from zerver.lib.actions import do_deactivate_realm, do_deactivate_user, \
     do_reactivate_user, do_reactivate_realm
 from zerver.lib.initial_password import initial_password
 from zerver.lib.test_helpers import (
-    AuthedTestCase, skip_py3
+    AuthedTestCase
 )
 from zerver.lib.request import \
     REQ, has_request_variables, RequestVariableMissingError, \
@@ -455,7 +455,6 @@ class DeactivatedRealmTest(AuthedTestCase):
         result = self.client.post("/json/fetch_api_key", {"password": test_password})
         self.assert_json_error_contains(result, "has been deactivated", status_code=400)
 
-    @skip_py3
     def test_login_deactivated_realm(self):
         """
         logging in fails in a deactivated realm
@@ -480,7 +479,6 @@ class DeactivatedRealmTest(AuthedTestCase):
         self.assert_json_error_contains(result, "has been deactivated", status_code=400)
 
 class LoginRequiredTest(AuthedTestCase):
-    @skip_py3
     def test_login_required(self):
         """
         Verifies the zulip_login_required decorator blocks deactivated users.
@@ -582,7 +580,6 @@ class InactiveUserTest(AuthedTestCase):
         result = self.client.post("/json/fetch_api_key", {"password": test_password})
         self.assert_json_error_contains(result, "Account not active", status_code=400)
 
-    @skip_py3
     def test_login_deactivated_user(self):
         """
         logging in fails with an inactive user

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -463,7 +463,7 @@ class DeactivatedRealmTest(AuthedTestCase):
         """
         do_deactivate_realm(get_realm("zulip.com"))
         result = self.login_with_return("hamlet@zulip.com")
-        self.assertIn("has been deactivated", result.content.replace("\n", " "))
+        self.assertIn("has been deactivated", result.content.decode('utf-8').replace("\n", " "))
 
     def test_webhook_deactivated_realm(self):
         """
@@ -495,7 +495,7 @@ class LoginRequiredTest(AuthedTestCase):
         # Verify succeeds once logged-in
         self.login(email)
         result = self.client.get('/accounts/accept_terms/')
-        self.assertIn("I agree to the", result.content)
+        self.assert_in_response("I agree to the", result)
 
         # Verify fails if user deactivated (with session still valid)
         user_profile.is_active = False
@@ -507,7 +507,7 @@ class LoginRequiredTest(AuthedTestCase):
         do_reactivate_user(user_profile)
         self.login(email)
         result = self.client.get('/accounts/accept_terms/')
-        self.assertIn("I agree to the", result.content)
+        self.assert_in_response("I agree to the", result)
 
         # Verify fails if realm deactivated
         user_profile.realm.deactivated = True
@@ -593,7 +593,7 @@ class InactiveUserTest(AuthedTestCase):
         do_deactivate_user(user_profile)
 
         result = self.login_with_return("hamlet@zulip.com")
-        self.assertIn("Please enter a correct email and password", result.content.replace("\n", " "))
+        self.assertIn("Please enter a correct email and password", result.content.decode('utf-8').replace("\n", " "))
 
     def test_webhook_deactivated_user(self):
         """

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.http import HttpResponse
 from six.moves.http_cookies import SimpleCookie
 
-from zerver.lib.test_helpers import AuthedTestCase, skip_py3
+from zerver.lib.test_helpers import AuthedTestCase
 
 
 class TranslationTestCase(AuthedTestCase):
@@ -27,7 +27,6 @@ class TranslationTestCase(AuthedTestCase):
                 expected_status, response.status_code, method, url))
         return response
 
-    @skip_py3
     def test_accept_language_header(self):
         # type: () -> None
         languages = [('en', u'Register'),
@@ -41,7 +40,6 @@ class TranslationTestCase(AuthedTestCase):
                                   HTTP_ACCEPT_LANGUAGE=lang)
             self.assert_in_response(word, response)
 
-    @skip_py3
     def test_cookie(self):
         # type: () -> None
         languages = [('en', u'Register'),
@@ -56,7 +54,6 @@ class TranslationTestCase(AuthedTestCase):
             response = self.fetch('get', '/integrations/', 200)
             self.assert_in_response(word, response)
 
-    @skip_py3
     def test_i18n_urls(self):
         # type: () -> None
         languages = [('en', u'Register'),

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -12,7 +12,7 @@ from six.moves.http_cookies import SimpleCookie
 from zerver.lib.test_helpers import AuthedTestCase, skip_py3
 
 
-class TranslationTestCase(TestCase):
+class TranslationTestCase(AuthedTestCase):
     """
     Tranlations strings should change with locale. URLs should be locale
     aware.
@@ -30,44 +30,44 @@ class TranslationTestCase(TestCase):
     @skip_py3
     def test_accept_language_header(self):
         # type: () -> None
-        languages = [('en', 'Register'),
-                     ('de', 'Registrieren'),
-                     ('sr', 'Региструј се'),
-                     ('zh-cn', '注册'),
+        languages = [('en', u'Register'),
+                     ('de', u'Registrieren'),
+                     ('sr', u'Региструј се'),
+                     ('zh-cn', u'注册'),
                      ]
 
         for lang, word in languages:
             response = self.fetch('get', '/integrations/', 200,
                                   HTTP_ACCEPT_LANGUAGE=lang)
-            self.assertTrue(word in response.content)
+            self.assert_in_response(word, response)
 
     @skip_py3
     def test_cookie(self):
         # type: () -> None
-        languages = [('en', 'Register'),
-                     ('de', 'Registrieren'),
-                     ('sr', 'Региструј се'),
-                     ('zh-cn', '注册'),
+        languages = [('en', u'Register'),
+                     ('de', u'Registrieren'),
+                     ('sr', u'Региструј се'),
+                     ('zh-cn', u'注册'),
                      ]
 
         for lang, word in languages:
             self.client.cookies = SimpleCookie({settings.LANGUAGE_COOKIE_NAME: lang}) # type: ignore # SimpleCookie has incomplete stubs in python 3
 
             response = self.fetch('get', '/integrations/', 200)
-            self.assertTrue(word in response.content)
+            self.assert_in_response(word, response)
 
     @skip_py3
     def test_i18n_urls(self):
         # type: () -> None
-        languages = [('en', 'Register'),
-                     ('de', 'Registrieren'),
-                     ('sr', 'Региструј се'),
-                     ('zh-cn', '注册'),
+        languages = [('en', u'Register'),
+                     ('de', u'Registrieren'),
+                     ('sr', u'Региструј се'),
+                     ('zh-cn', u'注册'),
                      ]
 
         for lang, word in languages:
             response = self.fetch('get', '/{}/integrations/'.format(lang), 200)
-            self.assertTrue(word in response.content)
+            self.assert_in_response(word, response)
 
 
 class JsonTranslationTestCase(AuthedTestCase):

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -7,7 +7,7 @@ from django.core.management import call_command
 from zerver.models import get_realm
 from confirmation.models import RealmCreationKey, generate_realm_creation_url
 from datetime import timedelta
-from zerver.lib.test_helpers import AuthedTestCase, skip_py3
+from zerver.lib.test_helpers import AuthedTestCase
 
 class TestSendWebhookFixtureMessage(TestCase):
     COMMAND_NAME = 'send_webhook_fixture_message'
@@ -64,7 +64,6 @@ class TestSendWebhookFixtureMessage(TestCase):
 class TestGenerateRealmCreationLink(AuthedTestCase):
     COMMAND_NAME = "generate_realm_creation_link"
 
-    @skip_py3
     def test_generate_link_and_create_realm(self):
         username = "user1"
         domain = "test.com"
@@ -91,7 +90,6 @@ class TestGenerateRealmCreationLink(AuthedTestCase):
             self.assertEquals(result.status_code, 200)
             self.assert_in_response("The organization creation link has been expired or is not valid.", result)
 
-    @skip_py3
     def test_realm_creation_with_random_link(self):
         with self.settings(OPEN_REALM_CREATION=False):
             # Realm creation attempt with an invalid link should fail
@@ -100,7 +98,6 @@ class TestGenerateRealmCreationLink(AuthedTestCase):
             self.assertEquals(result.status_code, 200)
             self.assert_in_response("The organization creation link has been expired or is not valid.", result)
 
-    @skip_py3
     def test_realm_creation_with_expired_link(self):
         with self.settings(OPEN_REALM_CREATION=False):
             generated_link = generate_realm_creation_url()

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -19,7 +19,7 @@ from zerver.lib.actions import (
 
 from zerver.lib.digest import send_digest_email
 from zerver.lib.notifications import enqueue_welcome_emails, one_click_unsubscribe_link
-from zerver.lib.test_helpers import AuthedTestCase, find_key_by_email, queries_captured, skip_py3
+from zerver.lib.test_helpers import AuthedTestCase, find_key_by_email, queries_captured
 from zerver.lib.test_runner import slow
 from zerver.lib.session_user import get_session_dict_user
 
@@ -126,7 +126,6 @@ class LoginTest(AuthedTestCase):
         self.login("hamlet@zulip.com", password="wrongpassword", fails=True)
         self.assertIsNone(get_session_dict_user(self.client.session))
 
-    @skip_py3
     def test_login_nonexist_user(self):
         # type: () -> None
         result = self.login_with_return("xxx@zulip.com", "xxx")
@@ -147,7 +146,6 @@ class LoginTest(AuthedTestCase):
         user_profile = get_user_profile_by_email('test@zulip.com')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
 
-    @skip_py3
     def test_register_deactivated(self):
         # type: () -> None
         """
@@ -164,7 +162,6 @@ class LoginTest(AuthedTestCase):
         with self.assertRaises(UserProfile.DoesNotExist):
             get_user_profile_by_email('test@zulip.com')
 
-    @skip_py3
     def test_login_deactivated(self):
         # type: () -> None
         """
@@ -203,7 +200,6 @@ class LoginTest(AuthedTestCase):
         self.login(email, password)
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
 
-    @skip_py3
     def test_register_first_user_with_invites(self):
         # type: () -> None
         """
@@ -566,7 +562,6 @@ class EmailUnsubscribeTests(AuthedTestCase):
 
 class RealmCreationTest(AuthedTestCase):
 
-    @skip_py3
     def test_create_realm(self):
         # type: () -> None
         username = "user1"

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -130,7 +130,7 @@ class LoginTest(AuthedTestCase):
     def test_login_nonexist_user(self):
         # type: () -> None
         result = self.login_with_return("xxx@zulip.com", "xxx")
-        self.assertIn("Please enter a correct email and password", result.content)
+        self.assert_in_response("Please enter a correct email and password", result)
 
     def test_register(self):
         # type: () -> None
@@ -159,7 +159,7 @@ class LoginTest(AuthedTestCase):
         realm.save(update_fields=["deactivated"])
 
         result = self.register("test", "test")
-        self.assertIn("has been deactivated", result.content.replace("\n", " "))
+        self.assertIn("has been deactivated", result.content.decode('utf-8').replace("\n", " "))
 
         with self.assertRaises(UserProfile.DoesNotExist):
             get_user_profile_by_email('test@zulip.com')
@@ -175,7 +175,7 @@ class LoginTest(AuthedTestCase):
         realm.save(update_fields=["deactivated"])
 
         result = self.login_with_return("hamlet@zulip.com")
-        self.assertIn("has been deactivated", result.content.replace("\n", " "))
+        self.assertIn("has been deactivated", result.content.decode('utf-8').replace("\n", " "))
 
     def test_logout(self):
         # type: () -> None
@@ -228,7 +228,7 @@ class LoginTest(AuthedTestCase):
         self.assertTrue(result["Location"].endswith(
                 "/accounts/send_confirm/%s@%s" % (username, domain)))
         result = self.client.get(result["Location"])
-        self.assertIn("Check your email so we can get started.", result.content)
+        self.assert_in_response("Check your email so we can get started.", result)
 
         # Visit the confirmation link.
         from django.core.mail import outbox
@@ -251,7 +251,7 @@ class LoginTest(AuthedTestCase):
 
         # Invite other users to join you.
         result = self.client.get(result["Location"])
-        self.assertIn("You're the first one here!", result.content)
+        self.assert_in_response("You're the first one here!", result)
 
         # Reset the outbox for our invites.
         outbox.pop()
@@ -584,7 +584,7 @@ class RealmCreationTest(AuthedTestCase):
             self.assertTrue(result["Location"].endswith(
                     "/accounts/send_confirm/%s@%s" % (username, domain)))
             result = self.client.get(result["Location"])
-            self.assertIn("Check your email so we can get started.", result.content)
+            self.assert_in_response("Check your email so we can get started.", result)
 
             # Visit the confirmation link.
             from django.core.mail import outbox
@@ -613,4 +613,4 @@ class RealmCreationTest(AuthedTestCase):
             self.assertTrue(result["Location"].endswith("/invite/"))
 
             result = self.client.get(result["Location"])
-            self.assertIn("You're the first one here!", result.content)
+            self.assert_in_response("You're the first one here!", result)

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -316,7 +316,7 @@ class MessageSenderWorker(QueueProcessingWorker):
         server_meta['time_request_finished'] = time.time()
         server_meta['worker_log_data'] = request._log_data
 
-        resp_content = resp.content
+        resp_content = resp.content.decode('utf-8')
         result = {'response': ujson.loads(resp_content), 'req_id': event['req_id'],
                   'server_meta': server_meta}
 


### PR DESCRIPTION
`HttpResponse.content` is binary data, but code usually assumes it to be text.

Fix that by using `response.content.decode('utf-8')` instead of `response.content` where appropriate.