### PR TITLE
Use assert_in_response by fixing line-wrapping in templates.

### DIFF
--- a/templates/zerver/deactivated.html
+++ b/templates/zerver/deactivated.html
@@ -5,9 +5,8 @@
 
 <p>{{ _('Hi there! Thank you for your interest in Zulip') }}.</p>
 
-<p>{% trans %} The organization you are trying to join, {{ deactivated_domain_name }}, has
-been deactivated. Please
-contact <a href="mailto:{{ zulip_administrator }}">{{ zulip_administrator }}</a> to reactivate
+<p>{% trans %} The organization you are trying to join, {{ deactivated_domain_name }}, has been deactivated.
+Please contact <a href="mailto:{{ zulip_administrator }}">{{ zulip_administrator }}</a> to reactivate
 this group{% endtrans %}.</p>
 
 {% endblock %}

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -462,7 +462,7 @@ class DeactivatedRealmTest(AuthedTestCase):
         """
         do_deactivate_realm(get_realm("zulip.com"))
         result = self.login_with_return("hamlet@zulip.com")
-        self.assertIn("has been deactivated", result.content.decode('utf-8').replace("\n", " "))
+        self.assert_in_response("has been deactivated", result)
 
     def test_webhook_deactivated_realm(self):
         """
@@ -590,7 +590,7 @@ class InactiveUserTest(AuthedTestCase):
         do_deactivate_user(user_profile)
 
         result = self.login_with_return("hamlet@zulip.com")
-        self.assertIn("Please enter a correct email and password", result.content.decode('utf-8').replace("\n", " "))
+        self.assert_in_response("Please enter a correct email and password", result)
 
     def test_webhook_deactivated_user(self):
         """

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -157,7 +157,7 @@ class LoginTest(AuthedTestCase):
         realm.save(update_fields=["deactivated"])
 
         result = self.register("test", "test")
-        self.assertIn("has been deactivated", result.content.decode('utf-8').replace("\n", " "))
+        self.assert_in_response("has been deactivated", result)
 
         with self.assertRaises(UserProfile.DoesNotExist):
             get_user_profile_by_email('test@zulip.com')
@@ -172,7 +172,7 @@ class LoginTest(AuthedTestCase):
         realm.save(update_fields=["deactivated"])
 
         result = self.login_with_return("hamlet@zulip.com")
-        self.assertIn("has been deactivated", result.content.decode('utf-8').replace("\n", " "))
+        self.assert_in_response("has been deactivated", result)
 
     def test_logout(self):
         # type: () -> None


### PR DESCRIPTION
Discussed here - https://github.com/zulip/zulip/pull/1225#discussion_r70507085
> It might be worth fixing the line-wrapping in templates/zerver/deactivated.html and then using `assert_in_response` here instead.