### PR TITLE
Get test coverage on /avatar.

### DIFF
--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -88,11 +88,13 @@ def avatar(request, email):
     except UserProfile.DoesNotExist:
         avatar_source = 'G'
     url = get_avatar_url(avatar_source, email)
-    if '?' in url:
-        sep = '&'
-    else:
-        sep = '?'
-    url += sep + request.META['QUERY_STRING']
+
+    # We can rely on the url already having query parameters. Because
+    # our templates depend on being able to use the ampersand to
+    # add query parameters to our url, get_avatar_url does '?x=x'
+    # hacks to prevent us from having to jump through decode/encode hoops.
+    assert '?' in url
+    url += '&' + request.META['QUERY_STRING']
     return redirect(url)
 
 def get_stream_name(stream):


### PR DESCRIPTION
The second commit here is necessary to get 100% code coverage, which I think is a worthwhile goal, just so we don't keep having to re-visit this super-fiddly function whenever we look at code coverage.  Unfortunately, there's not a good way to get true 100% coverage without removing the dead code path or without introducing trickier logic that might have risks of its own.  AFAIK Python doesn't have a simple way to concatenate query parameters to a URL without breaking apart the URL first, which seems like overkill when we're dealing with a URL that comes from our codebase.

Having said all that, I'm happy to punt on the second commit and just be satisfied with getting more test coverage from the first commit for now.

I also don't know the current state of the world in terms of whether we still use gravatar.com, still want to generate avatars for non-users, etc.  @timabbott, are you aware of anybody else touching the avatar system these days?