### PR TITLE
casper tests: Increase default viewport size

### DIFF
--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -32,7 +32,7 @@ exports.initialize_casper = function (viewport) {
     // casper.start has been called.
 
     // Set default viewport size to something reasonable
-    casper.page.viewportSize = viewport || {width: 1280, height: 768};
+    casper.page.viewportSize = viewport || {width: 1280, height: 1024};
 
     // Fail if we get a JavaScript error in the page's context.
     // Based on the example at http://phantomjs.org/release-1.5.html


### PR DESCRIPTION
Changed from 1280x768 to 1280x1024 (from 5:3 to 5:4 aspect ratio) to make
failure screenshots more useful.