### PR TITLE
Formatting and style fixes to testing & mypy docs

### DIFF
--- a/docs/mypy.md
+++ b/docs/mypy.md
@@ -51,8 +51,8 @@ To run mypy on Zulip's python code, run the command:
 
     tools/run-mypy
 
-It will output errors in the same style of a compiler.  For example,
-if your code has a type error like this:
+It will output errors in the same style as a compiler would.  For
+example, if your code has a type error like this:
 
 ```
 foo = 1
@@ -75,16 +75,16 @@ contribute improvements to error messages upstream.
 Since mypy is a new tool under rapid development and occasionally
 makes breaking changes, Zulip is using a pinned version of mypy from
 its [git repository](https://github.com/python/mypy) rather than
-tracking the (older) latest mypy release on pypi.
+tracking the (older) latest mypy release on PyPI.
 
 ## Excluded files
 
-Since several python files in Zulip's code don't pass mypy's checks
+Since several Python files in Zulip's code don't pass mypy's checks
 (even for unannotated code) right now, a list of files to be excluded
-from the check for CI is present in tools/run-mypy.
+from the check for CI is present in `tools/run-mypy`.
 
-To run mypy on all python files, ignoring the exclude list, you can
-pass the `--all` option to tools/run-mypy.
+To run mypy on all Python files, ignoring the exclude list, you can
+pass the `--all` option to `tools/run-mypy`.
 
     tools/run-mypy --all
 
@@ -95,7 +95,7 @@ errors, please remove them from the exclude list.
 
 For the purposes of Zulip development, you can treat `mypy` like a
 much more powerful linter that can catch a wide range of bugs.  If,
-after running tools/run-mypy on your Zulip branch, you get mypy
+after running `tools/run-mypy` on your Zulip branch, you get mypy
 errors, it's important to get to the bottom of the issue, not just do
 something quick to silence the warnings.  Possible explanations include:
 
@@ -110,35 +110,35 @@ something quick to silence the warnings.  Possible explanations include:
 Each explanation has its own solution, but in every case the result
 should be solving the mypy warning in a way that makes the Zulip
 codebase better.  If you need help understanding an issue, please feel
-free to, mention @sharmaeklavya2 or @timabbott on the relevant pull
+free to mention @sharmaeklavya2 or @timabbott on the relevant pull
 request or issue on GitHub.
 
 If you think you have found a bug in Zulip or mypy, inform the zulip
-developers by opening an issue on [Zulip's github
+developers by opening an issue on [Zulip's GitHub
 repository](https://github.com/zulip/zulip/issues) or posting on
 [zulip-devel](https://groups.google.com/d/forum/zulip-devel).  If it's
 indeed a mypy bug, we can help with reporting it upstream.
 
 ## Annotating strings
 
-In python 3, strings can have non-ASCII characters without any problems.
+In Python 3, strings can have non-ASCII characters without any problems.
 Such characters are required to support languages which use non-latin
 scripts like Japanese and Hindi.  They are also needed to support special
 characters like mathematical symbols, musical symbols, etc.
-In python 2, however, `str` generally doesn't work well with non-ASCII
-characters.  That's why `unicode` was introduced in python 2.
+In Python 2, however, `str` generally doesn't work well with non-ASCII
+characters.  That's why `unicode` was introduced in Python 2.
 
 But there are problems with the `unicode` and `str` system.  Implicit
 conversions between `str` and `unicode` use the `ascii` codec, which
 fails on strings containing non-ASCII characters.  Such errors are hard
 to detect by people who always write in English.  To minimize such
 implicit conversions, we should have a strict separation between `str`
-and `unicode` in python 2.  It might seem that using `unicode` everywhere
+and `unicode` in Python 2.  It might seem that using `unicode` everywhere
 will solve all problems, but unfortunately it doesn't.  This is because
-some parts of the standard library and the python language (like keyword
+some parts of the standard library and the Python language (like keyword
 argument unpacking) insist that parameters passed to them are `str`.
 
-To make our code work correctly on python 2, we have to identify strings
+To make our code work correctly in Python 2, we have to identify strings
 which contain data which could come from non-ASCII sources like stream
 names, people's names, domain names, content of messages, emails, etc.
 These strings should be `unicode`.  We also have to identify strings
@@ -148,11 +148,11 @@ names, etc.
 Mypy can help with this.  We just have to annotate each string as either
 `str` or `unicode` and mypy's static type checking will tell us if we
 are incorrectly mixing the two.  However, `unicode` is not defined in
-python 3.  We want our code to be python 3 compatible in the future.
+Python 3.  We want our code to be Python 3 compatible in the future.
 This can be achieved using 'six', a Python 2 and 3 compatibility library.
 
-`six.text_type` is defined as `str` on python 3 and as `unicode` on
-python 2.  We'll be using `text_type` (instead of `unicode`) and `str`
+`six.text_type` is defined as `str` in Python 3 and as `unicode` in
+Python 2.  We'll be using `text_type` (instead of `unicode`) and `str`
 to annotate strings in Zulip's code.  We follow the style of doing
 `from six import text_type` and using `text_type` for annotation instead
 of doing `import six` and using `six.text_type` for annotation, because

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -158,7 +158,7 @@ asserts, the *actual* value comes first, the *expected* value second.
 >         assert.throws(foobar.somefeature('Invalid Input'));
 >     }());
 
-The test runner (index.js) automatically runs all .js files in the
+The test runner (`index.js`) automatically runs all .js files in the
 frontend\_tests/node directory.
 
 #### Coverage reports
@@ -213,7 +213,7 @@ for writing Casper tests in addition to the debugging notes below:
     <http://docs.casperjs.org/en/latest/modules/tester.html#the-tester-prototype>
 -   Casper uses CSS3 selectors; you can often save time by testing and
     debugging your selectors on the relevant page of the Zulip
-    development app in the Chrome javascript console by using e.g.
+    development app in the Chrome JavaScript console by using e.g.
     `$$("#settings-dropdown")`.
 -   The test suite uses a smaller set of default user accounts and other
     data initialized in the database than the development environment;
@@ -310,10 +310,10 @@ return to a clean state for testing.
 
 ### JavaScript manual testing
 
-debug.js has some tools for profiling Javascript code, including:
+`debug.js` has some tools for profiling JavaScript code, including:
 
 -   \`print\_elapsed\_time\`: Wrap a function with it to print the time
-    that function takes to the javascript console.
+    that function takes to the JavaScript console.
 -   \`IterationProfiler\`: Profile part of looping constructs (like a
     for loop or \$.each). You mark sections of the iteration body and
     the IterationProfiler will sum the costs of those sections over all
@@ -332,19 +332,20 @@ Zulip is working on supporting Python 3, and all new code in Zulip
 should be Python 2+3 compatible. We have converted most of the codebase
 to be compatible with Python 3 using a suite of 2to3 conversion tools
 and some manual work. In order to avoid regressions in that
-compatibility as we continue to develop new features in zulip, we have a
-special tool, tools/check-py3, which checks all code for Python 3
+compatibility as we continue to develop new features in Zulip, we have a
+special tool, `tools/check-py3`, which checks all code for Python 3
 syntactic compatibility by running a subset of the automated migration
-tools and checking if they trigger any changes. tools/check-py3 is run
+tools and checking if they trigger any changes. `tools/check-py3` is run
 automatically in Zulip's Travis CI tests (in the 'static-analysis'
-build) to avoid any regressions, but is not included in test-all since
+build) to avoid any regressions, but is not included in `test-all` since
 it is quite slow.
 
-To run tooks/check-py3, you need to install the modernize and future
-python packages (which are included in requirements/py3k.txt, which
-itself is included in requirements/dev.txt, so you probably already
-have these packages installed).
+To run `tools/check-py3`, you need to install the `modernize` and
+`future` Python packages (which are included in
+`requirements/py3k.txt`, which itself is included in
+`requirements/dev.txt`, so you probably already have these packages
+installed).
 
-To run check-py3 on just the python files in a particular directory, you
-can change the current working directory (e.g. cd zerver/) and run
-check-py3 from there.
+To run `check-py3` on just the Python files in a particular directory, you
+can change the current working directory (e.g. `cd zerver/`) and run
+`check-py3` from there.


### PR DESCRIPTION
Small capitalization, formatting, and grammar fixes to `mypy.md` and `testing.md`.