### PR TITLE
Update path to language_options.json in production.

### DIFF
--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -56,7 +56,12 @@ subprocess.check_call(['rm', '-rf', 'prod-static/source-map'],
 subprocess.check_call(['mkdir', '-p', 'prod-static'],  # Needed if PRODUCTION
                       stdout=fp, stderr=fp)
 subprocess.check_call(['mv', os.path.join(settings.STATIC_ROOT, 'source-map'),
-                             'prod-static/source-map'],
+                       'prod-static/source-map'],
+                      stdout=fp, stderr=fp)
+
+# Move language_options.json to the production release
+subprocess.check_call(['mv', 'static/locale/language_options.json',
+                       'prod-static/serve/locale/language_options.json'],
                       stdout=fp, stderr=fp)
 
 fp.close()

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -823,8 +823,7 @@ def with_language(string, language):
     return result
 
 def get_language_list():
-    path = os.path.join(settings.DEPLOY_ROOT, 'static',
-                        'locale', 'language_options.json')
+    path = os.path.join(settings.STATIC_ROOT, 'locale', 'language_options.json')
     with open(path, 'r') as reader:
         languages = ujson.load(reader)
         lang_list = []


### PR DESCRIPTION
@umairwaheed I just did a production build off of master, and it failed to run properly in production because it couldn't find language_options.json there (since the `static` directory isn't shipped, effectively this file wasn't being distributed).  I think this should be a mostly correct fix for the problem (still testing).