### PR TITLE
This allows to override the vars in the install script

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -58,6 +58,15 @@ set +e
 [ -e "/etc/init.d/postgresql" ]; has_postgres=$?
 set -e
 
+# Switch the features depending on the DEPLOYMENT_TYPE 
+if [ "$DEPLOYMENT_TYPE" = "dockervoyager" ]; then
+    has_camo=1
+    has_nginx=1
+    has_appserver=1
+    has_rabbit=1
+    has_postgres=1
+fi
+
 # These server restarting bits should be moveable into puppet-land, ideally
 apt-get -y upgrade
 


### PR DESCRIPTION
See PR #1237, @timabbott.

This is needed for the Docker installation as we for example install nginx and need to set the `has_nginx` to `0` so it won't start.