### PR TITLE
Change unbuffering strategy in runtornado.py.

### DIFF
--- a/puppet/zulip/files/supervisor/conf.d/zulip.conf
+++ b/puppet/zulip/files/supervisor/conf.d/zulip.conf
@@ -43,7 +43,7 @@ socket_owner=zulip:zulip
 socket_mode=0700
 
 [program:zulip-tornado]
-command=python /home/zulip/deployments/current/manage.py runtornado 127.0.0.1:9993
+command=python -u /home/zulip/deployments/current/manage.py runtornado 127.0.0.1:9993
 priority=200                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -76,7 +76,7 @@ os.setpgrp()
 cmds = [['./tools/compile-handlebars-templates', 'forever'],
         ['python', 'manage.py', 'rundjango'] +
           manage_args + ['localhost:%d' % (django_port,)],
-        ['python', 'manage.py', 'runtornado'] +
+        ['python', '-u', 'manage.py', 'runtornado'] +
           manage_args + ['localhost:%d' % (tornado_port,)],
         ['./tools/run-dev-queue-processors'] + manage_args,
         ['env', 'PGHOST=localhost', # Force password authentication using .pgpass

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -59,9 +59,6 @@ class Command(BaseCommand):
 
     def handle(self, addrport, **options):
         # type: (str, **bool) -> None
-        # setup unbuffered I/O
-        sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0) # type: ignore # https://github.com/python/typeshed/pull/337
-        sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 0) # type: ignore # https://github.com/python/typeshed/pull/337
         interactive_debug_listen()
 
         import django


### PR DESCRIPTION
Currently runtornado unbuffers its output using
```py
sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
```
This is bad since it throws `ValueError: can't have unbuffered text I/O` in python 3.
So use the `-u` option of python when calling runtornado.py to make output unbuffered.