### PR TITLE
Showell bot test fixes

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -4,6 +4,9 @@ from typing import (cast, Any, Callable, Dict, Generator, Iterable, List, Mappin
     Sized, Tuple, Union)
 
 from django.test import TestCase
+from django.test.client import (
+    BOUNDARY, MULTIPART_CONTENT, encode_multipart,
+)
 from django.template import loader
 from django.http import HttpResponse
 from django.utils.translation import ugettext as _
@@ -243,6 +246,23 @@ class AuthedTestCase(TestCase):
         # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
         encoded = urllib.parse.urlencode(info)
         return self.client.patch(url, encoded, **kwargs)
+
+    def client_patch_multipart(self, url, info={}, **kwargs):
+        # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
+        """
+        Use this for patch requests that have file uploads or
+        that need some sort of multi-part content.  In the future
+        Django's test client may become a bit more flexible,
+        so we can hopefully eliminate this.  (When you post
+        with the Django test client, it deals with MULTIPART_CONTENT
+        automatically, but not patch.)
+        """
+        encoded = encode_multipart(BOUNDARY, info)
+        return self.client.patch(
+            url,
+            encoded,
+            content_type=MULTIPART_CONTENT,
+            **kwargs)
 
     def client_put(self, url, info={}, **kwargs):
         # type: (text_type, Dict[str, Any], **Any) -> HttpResponse

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -602,6 +602,22 @@ class BotTest(AuthedTestCase):
         self.assertEqual(profile.avatar_source, UserProfile.AVATAR_FROM_USER)
         # TODO: check img.png was uploaded properly
 
+    def test_add_bot_with_too_many_files(self):
+        # type: () -> None
+        self.login("hamlet@zulip.com")
+        self.assert_num_bots_equal(0)
+        with open(os.path.join(TEST_AVATAR_DIR, 'img.png'), 'rb') as fp1, \
+             open(os.path.join(TEST_AVATAR_DIR, 'img.gif'), 'rb') as fp2:
+            bot_info = dict(
+                full_name='whatever',
+                short_name='whatever',
+                file1=fp1,
+                file2=fp2,
+                )
+            result = self.client.post("/json/bots", bot_info)
+        self.assert_json_error(result, 'You may only upload one file at a time')
+        self.assert_num_bots_equal(0)
+
     def test_add_bot_with_default_sending_stream(self):
         # type: () -> None
         self.login("hamlet@zulip.com")

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -602,6 +602,20 @@ class BotTest(AuthedTestCase):
         bot = bots[0]
         self.assertEqual(bot['bot_owner'], 'hamlet@zulip.com')
 
+    def test_add_bot_with_username_in_use(self):
+        # type: () -> None
+        self.login("hamlet@zulip.com")
+        self.assert_num_bots_equal(0)
+        result = self.create_bot()
+        self.assert_num_bots_equal(1)
+
+        bot_info = dict(
+            full_name='Duplicate',
+            short_name='hambot',
+            )
+        result = self.client.post("/json/bots", bot_info)
+        self.assert_json_error(result, 'Username already in use')
+
     def test_add_bot_with_user_avatar(self):
         # type: () -> None
         self.login("hamlet@zulip.com")

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -556,6 +556,18 @@ class BotTest(AuthedTestCase):
         result = self.client_delete("/json/bots/hambot-bot@zulip.com")
         self.assert_json_success(result)
 
+    def test_add_bot_with_bad_username(self):
+        # type: () -> None
+        self.login("hamlet@zulip.com")
+        self.assert_num_bots_equal(0)
+        bot_info = dict(
+            full_name='',
+            short_name='',
+            )
+        result = self.client.post("/json/bots", bot_info)
+        self.assert_json_error(result, 'Bad name or username')
+        self.assert_num_bots_equal(0)
+
     def test_add_bot(self):
         # type: () -> None
         self.login("hamlet@zulip.com")

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -74,6 +74,9 @@ def find_dict(lst, k, v):
             return dct
     raise Exception('Cannot find element in list where key %s == %s' % (k, v))
 
+# same as in test_uploads.py
+TEST_AVATAR_DIR = os.path.join(os.path.dirname(__file__), 'images')
+
 class SlowQueryTest(TestCase):
     def test_is_slow_query(self):
         # type: () -> None
@@ -586,6 +589,18 @@ class BotTest(AuthedTestCase):
         self.assertEqual(len(bots), 1)
         bot = bots[0]
         self.assertEqual(bot['bot_owner'], 'hamlet@zulip.com')
+
+    def test_add_bot_with_user_avatar(self):
+        # type: () -> None
+        self.login("hamlet@zulip.com")
+        self.assert_num_bots_equal(0)
+        with open(os.path.join(TEST_AVATAR_DIR, 'img.png'), 'rb') as fp:
+            self.create_bot(file=fp)
+        self.assert_num_bots_equal(1)
+
+        profile = get_user_profile_by_email('hambot-bot@zulip.com')
+        self.assertEqual(profile.avatar_source, UserProfile.AVATAR_FROM_USER)
+        # TODO: check img.png was uploaded properly
 
     def test_add_bot_with_default_sending_stream(self):
         # type: () -> None


### PR DESCRIPTION
Getting real close to closing out #1002 

I can't get this test to pass, and I have to head out for the day.  I'll try to debug it later.

```
commit 5fc726ae59dab905fb60388aad825c1cb8909d27
Author: Steve Howell <steve@zulip.com>
Date:   Wed Jul 13 10:22:01 2016 -0700

    BROKEN!!! I can't figure out how to get client_patch to pass files.

diff --git a/zerver/tests/tests.py b/zerver/tests/tests.py
index 0c0d1e4..1a10b87 100644
--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -7,6 +7,7 @@ from mock import patch, MagicMock
 
 from django.http import HttpResponse
 from django.test import TestCase
+from django.test.client import MULTIPART_CONTENT
 
 from zerver.lib.test_helpers import (
     queries_captured, simulated_empty_cache, skip_py3,
@@ -902,6 +903,27 @@ class BotTest(AuthedTestCase):
         bot = self.get_bot()
         self.assertEqual('Fred', bot['full_name'])
 
+    def xxx_test_patch_bot_avatar(self):
+        # type: () -> None
+        self.login("hamlet@zulip.com")
+        bot_info = {
+            'full_name': 'The Bot of Hamlet',
+            'short_name': 'hambot',
+        }
+        result = self.client.post("/json/bots", bot_info)
+        self.assert_json_success(result)
+
+        profile = get_user_profile_by_email('hambot-bot@zulip.com')
+        self.assertEqual(profile.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
+
+        fp = open(os.path.join(TEST_AVATAR_DIR, 'img.png'), 'rb')
+        result = self.client_patch('/json/bots/hambot-bot@zulip.com', dict(file=fp),
+            content_type=MULTIPART_CONTENT)
+        self.assert_json_success(result)
+
+        profile = get_user_profile_by_email('hambot-bot@zulip.com')
+        self.assertEqual(profile.avatar_source, UserProfile.AVATAR_FROM_USER)
+
     def test_patch_bot_to_stream(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
```