### PR TITLE
Make all backend tests pass on python 3

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -326,4 +326,4 @@ def process_message(message, rcpt_to=None, pre_checked=False):
             process_stream_message(to, subject, message, debug_info)
     except ZulipEmailForwardError as e:
         # TODO: notify sender of error, retry if appropriate.
-        log_and_report(message, e.message, debug_info)
+        log_and_report(message, str(e), debug_info)

--- a/zerver/lib/handlers.py
+++ b/zerver/lib/handlers.py
@@ -41,10 +41,10 @@ def finish_handler(handler_id, event_queue_id, contents, apply_markdown):
                                   queue_id=event_queue_id),
                              request, apply_markdown=apply_markdown)
     except IOError as e:
-        if e.message != 'Stream is closed':
+        if str(e) != 'Stream is closed':
             logging.exception(err_msg)
     except AssertionError as e:
-        if e.message != 'Request closed':
+        if str(e) != 'Request closed':
             logging.exception(err_msg)
     except Exception:
         logging.exception(err_msg)

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -508,11 +508,11 @@ def convert_html_to_markdown(html):
         except OSError:
             continue
 
-    markdown = p.communicate(input=html.encode("utf-8"))[0].strip()
+    markdown = p.communicate(input=html.encode('utf-8'))[0].decode('utf-8').strip()
     # We want images to get linked and inline previewed, but html2text will turn
     # them into links of the form `![](http://foo.com/image.png)`, which is
     # ugly. Run a regex over the resulting description, turning links of the
     # form `![](http://foo.com/image.png?12345)` into
     # `[image.png](http://foo.com/image.png)`.
-    return re.sub(r"!\[\]\((\S*)/(\S*)\?(\S*)\)",
-                  r"[\2](\1/\2)", markdown.decode('utf-8'))
+    return re.sub(u"!\\[\\]\\((\\S*)/(\\S*)\\?(\\S*)\\)",
+                  u"[\\2](\\1/\\2)", markdown)

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -121,7 +121,7 @@ def queries_captured():
             stop = time.time()
             duration = stop - start
             queries.append({
-                'sql': self.mogrify(sql, params),
+                'sql': self.mogrify(sql, params).decode('utf-8'),
                 'time': "%.3f" % duration,
             })
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -7,7 +7,6 @@ from zerver.lib.test_helpers import (
     AuthedTestCase,
     most_recent_message,
     most_recent_usermessage,
-    skip_py3,
 )
 
 from zerver.models import (
@@ -67,7 +66,6 @@ class TestStreamEmailMessagesSuccess(AuthedTestCase):
         self.assertEqual(message.subject, incoming_valid_message['Subject'])
 
 class TestStreamEmailMessagesEmptyBody(AuthedTestCase):
-    @skip_py3
     def test_receive_stream_email_messages_empty_body(self):
 
         # build dummy messages for stream
@@ -101,7 +99,7 @@ class TestStreamEmailMessagesEmptyBody(AuthedTestCase):
                 debug_info)
         except ZulipEmailForwardError as e:
             # empty body throws exception
-            exception_message = e.message
+            exception_message = str(e)
         self.assertEqual(exception_message, "Unable to find plaintext or HTML message body")
 
 class TestMissedPersonalMessageEmailMessages(AuthedTestCase):

--- a/zerver/tests/test_hooks.py
+++ b/zerver/tests/test_hooks.py
@@ -934,13 +934,12 @@ class PagerDutyHookTests(WebhookTestCase):
 
     def test_bad_message(self):
         # type: () -> None
-        expected_message = 'Unknown pagerduty message\n``` py\n{u\'type\': u\'incident.triggered\'}\n```'
+        expected_message = 'Unknown pagerduty message\n```\n{\n  "type":"incident.triggered"\n}\n```'
         self.send_and_test_stream_message('bad_message_type', u"pagerduty", expected_message)
 
-    @skip_py3
     def test_unknown_message_type(self):
         # type: () -> None
-        expected_message = 'Unknown pagerduty message\n``` py\n{u\'type\': u\'foo\'}\n```'
+        expected_message = 'Unknown pagerduty message\n```\n{\n  "type":"foo"\n}\n```'
         self.send_and_test_stream_message('unknown_message_type', u"pagerduty", expected_message)
 
 class TravisHookTests(WebhookTestCase):

--- a/zerver/tests/test_hooks.py
+++ b/zerver/tests/test_hooks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from zerver.lib.test_helpers import AuthedTestCase, skip_py3
+from zerver.lib.test_helpers import AuthedTestCase
 from zerver.lib.test_runner import slow
 from zerver.models import Message, Recipient
 
@@ -1169,13 +1169,11 @@ class TaigaHookTests(WebhookTestCase):
         message = u':notebook: Antek updated description of user story **A newer hope**.\n'
         self.send_and_test_stream_message("userstory_changed_description", u'subject', message)
 
-    @skip_py3
     def test_taiga_userstory_changed_closed(self):
         # type: () -> None
         message = u':chart_with_upwards_trend: Antek changed status of user story **A newer hope** from New to Done.\n:checkered_flag: Antek closed user story **A newer hope**.\n'
         self.send_and_test_stream_message("userstory_changed_closed", u'subject', message)
 
-    @skip_py3
     def test_taiga_userstory_changed_reopened(self):
         # type: () -> None
         message = u':chart_with_upwards_trend: Antek changed status of user story **A newer hope** from Done to New.\n:package: Antek reopened user story **A newer hope**.\n'

--- a/zerver/tests/test_hooks.py
+++ b/zerver/tests/test_hooks.py
@@ -763,7 +763,6 @@ class FreshdeskHookTests(WebhookTestCase):
     STREAM_NAME = 'freshdesk'
     URL_TEMPLATE = u"/api/v1/external/freshdesk?stream={stream}"
 
-    @skip_py3
     def test_ticket_creation(self):
         # type: () -> None
         """
@@ -830,7 +829,6 @@ Priority: **High** => **Low**"""
         # type: () -> None
         self.note_change("public_note", "public")
 
-    @skip_py3
     def test_inline_image(self):
         # type: () -> None
         """
@@ -934,7 +932,6 @@ class PagerDutyHookTests(WebhookTestCase):
         expected_message = u':grinning: Incident [48219](https://dropbox.pagerduty.com/incidents/PJKGZF9) resolved\n\n>mp_error_block_down_critical\u2119\u01b4'
         self.send_and_test_stream_message('mp_fail', u"incident 48219", expected_message)
 
-    @skip_py3
     def test_bad_message(self):
         # type: () -> None
         expected_message = 'Unknown pagerduty message\n``` py\n{u\'type\': u\'incident.triggered\'}\n```'

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -10,7 +10,7 @@ from zerver.models import (
 )
 from zerver.lib.actions import create_stream_if_needed, do_add_subscription
 from zerver.lib.test_helpers import (
-    AuthedTestCase, POSTRequestMock, skip_py3,
+    AuthedTestCase, POSTRequestMock,
     get_user_messages, message_ids, queries_captured,
 )
 from zerver.views.messages import (
@@ -629,7 +629,6 @@ class GetOldMessagesTest(AuthedTestCase):
                 return
         self.fail("get_old_messages query not found")
 
-    @skip_py3
     def test_use_first_unread_anchor(self):
         realm = get_realm('zulip.com')
         create_stream_if_needed(realm, 'devel')
@@ -706,7 +705,6 @@ class GetOldMessagesTest(AuthedTestCase):
         self.assertEqual(params['recipient_id_3'], get_recipient_id_for_stream_name(realm, 'devel'))
         self.assertEqual(params['upper_2'], 'css')
 
-    @skip_py3
     def test_get_old_messages_queries(self):
         query_ids = self.get_query_ids()
 
@@ -722,7 +720,6 @@ class GetOldMessagesTest(AuthedTestCase):
         sql = sql_template.format(**query_ids)
         self.common_check_get_old_messages_query({'anchor': 100, 'num_before': 10, 'num_after': 10}, sql)
 
-    @skip_py3
     def test_get_old_messages_with_narrow_queries(self):
         query_ids = self.get_query_ids()
 
@@ -775,7 +772,6 @@ class GetOldMessagesTest(AuthedTestCase):
                                                   'narrow': '[["stream", "Scotland"], ["is", "starred"]]'},
                                                  sql)
 
-    @skip_py3
     def test_get_old_messages_with_search_queries(self):
         query_ids = self.get_query_ids()
 

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -6,7 +6,7 @@ from unittest import skip
 
 from zerver.lib.avatar import avatar_url
 from zerver.lib.bugdown import url_filename
-from zerver.lib.test_helpers import AuthedTestCase, skip_py3
+from zerver.lib.test_helpers import AuthedTestCase
 from zerver.lib.test_runner import slow
 from zerver.lib.upload import sanitize_name, S3UploadBackend, \
     upload_message_image, delete_message_image, LocalUploadBackend
@@ -41,7 +41,6 @@ def destroy_uploads():
 
 class FileUploadTest(AuthedTestCase):
 
-    @skip_py3
     def test_rest_endpoint(self):
         # type: () -> None
         """
@@ -63,14 +62,14 @@ class FileUploadTest(AuthedTestCase):
         # Download file via API
         self.client.post('/accounts/logout/')
         response = self.client.get(uri, **auth_headers)
-        data = "".join(response.streaming_content)
-        self.assertEquals("zulip!", data)
+        data = b"".join(response.streaming_content)
+        self.assertEquals(b"zulip!", data)
 
         # Files uploaded through the API should be accesible via the web client
         self.login("hamlet@zulip.com")
         response = self.client.get(uri)
-        data = "".join(response.streaming_content)
-        self.assertEquals("zulip!", data)
+        data = b"".join(response.streaming_content)
+        self.assertEquals(b"zulip!", data)
 
     def test_multiple_upload_failure(self):
         # type: () -> None
@@ -98,7 +97,6 @@ class FileUploadTest(AuthedTestCase):
 
     # This test will go through the code path for uploading files onto LOCAL storage
     # when zulip is in DEVELOPMENT mode.
-    @skip_py3
     def test_file_upload_authed(self):
         # type: () -> None
         """
@@ -121,8 +119,8 @@ class FileUploadTest(AuthedTestCase):
         # In the future, local file requests will follow the same style as S3
         # requests; they will be first authenthicated and redirected
         response = self.client.get(uri)
-        data = "".join(response.streaming_content)
-        self.assertEquals("zulip!", data)
+        data = b"".join(response.streaming_content)
+        self.assertEquals(b"zulip!", data)
 
         # check if DB has attachment marked as unclaimed
         entry = Attachment.objects.get(file_name='zulip.txt')
@@ -324,7 +322,6 @@ class AvatarTest(AuthedTestCase):
         actual_url = 'https://secure.gravatar.com/avatar/444258b521f152129eb0c162996e572d?d=identicon&foo=bar'
         self.assertEqual(redirect_url, actual_url)
 
-    @skip_py3
     def test_valid_avatars(self):
         # type: () -> None
         """
@@ -346,7 +343,7 @@ class AvatarTest(AuthedTestCase):
 
             rfp = open(os.path.join(TEST_AVATAR_DIR, rfname), 'rb')
             response = self.client.get(url)
-            data = "".join(response.streaming_content)
+            data = b"".join(response.streaming_content)
             self.assertEquals(rfp.read(), data)
 
     def test_invalid_avatars(self):
@@ -409,7 +406,6 @@ def use_s3_backend(method):
 
 class S3Test(AuthedTestCase):
 
-    @skip_py3
     @use_s3_backend
     def test_file_upload_s3(self):
         # type: () -> None
@@ -423,7 +419,7 @@ class S3Test(AuthedTestCase):
         base = '/user_uploads/'
         self.assertEquals(base, uri[:len(base)])
         path_id = re.sub('/user_uploads/', '', uri)
-        self.assertEquals("zulip!", bucket.get_key(path_id).get_contents_as_string())
+        self.assertEquals(b"zulip!", bucket.get_key(path_id).get_contents_as_string())
 
         self.subscribe_to_stream("hamlet@zulip.com", "Denmark")
         body = "First message ...[zulip.txt](http://localhost:9991" + uri + ")"
@@ -443,7 +439,6 @@ class S3Test(AuthedTestCase):
         path_id = re.sub('/user_uploads/', '', uri)
         self.assertTrue(delete_message_image(path_id))
 
-    @skip_py3
     @use_s3_backend
     def test_file_upload_authed(self):
         # type: () -> None
@@ -468,7 +463,7 @@ class S3Test(AuthedTestCase):
         response = self.client.get(uri)
         redirect_url = response['Location']
 
-        self.assertEquals("zulip!", urllib.request.urlopen(redirect_url).read().strip())
+        self.assertEquals(b"zulip!", urllib.request.urlopen(redirect_url).read().strip())
 
         self.subscribe_to_stream("hamlet@zulip.com", "Denmark")
         body = "First message ...[zulip.txt](http://localhost:9991" + uri + ")"

--- a/zerver/views/webhooks/airbrake.py
+++ b/zerver/views/webhooks/airbrake.py
@@ -22,7 +22,7 @@ def api_airbrake_webhook(request, user_profile, client, payload=REQ(argument_typ
         subject = get_subject(payload)
         body = get_body(payload)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(e.message))
+        return json_error(_("Missing key {} in JSON").format(str(e)))
 
     check_send_message(user_profile, client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/views/webhooks/bitbucket2.py
+++ b/zerver/views/webhooks/bitbucket2.py
@@ -46,7 +46,7 @@ def api_bitbucket2_webhook(request, user_profile, client, payload=REQ(argument_t
         type = get_type(request, payload)
         body = get_body_based_on_type(type)(payload)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(e.message))
+        return json_error(_("Missing key {} in JSON").format(str(e)))
 
     check_send_message(user_profile, client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/views/webhooks/codeship.py
+++ b/zerver/views/webhooks/codeship.py
@@ -34,7 +34,7 @@ def api_codeship_webhook(request, user_profile, client, payload=REQ(argument_typ
         subject = get_subject_for_http_request(payload)
         body = get_body_for_http_request(payload)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(e.message))
+        return json_error(_("Missing key {} in JSON").format(str(e)))
 
     check_send_message(user_profile, client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/views/webhooks/crashlytics.py
+++ b/zerver/views/webhooks/crashlytics.py
@@ -34,7 +34,7 @@ def api_crashlytics_webhook(request, user_profile, client, payload=REQ(argument_
             url=issue_body['url']
         )
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON".format(e.message)))
+        return json_error(_("Missing key {} in JSON".format(str(e))))
 
     check_send_message(user_profile, client, 'stream', [stream],
                        subject, body)

--- a/zerver/views/webhooks/pagerduty.py
+++ b/zerver/views/webhooks/pagerduty.py
@@ -75,9 +75,9 @@ def send_raw_pagerduty_json(user_profile, client, stream, message, topic):
     subject = topic or 'pagerduty'
     body = (
         u'Unknown pagerduty message\n'
-        u'``` py\n'
+        u'```\n'
         u'%s\n'
-        u'```') % (pprint.pformat(message),)
+        u'```') % (ujson.dumps(message, indent=2),)
     check_send_message(user_profile, client, 'stream',
                        [stream], subject, body)
 

--- a/zerver/views/webhooks/semaphore.py
+++ b/zerver/views/webhooks/semaphore.py
@@ -34,14 +34,14 @@ def api_semaphore_webhook(request, user_profile, client,
         author_email = payload["commit"]["author_email"]
         message = payload["commit"]["message"]
     except KeyError as e:
-        return json_error(_("Missing key %s in JSON") % (e.message,))
+        return json_error(_("Missing key %s in JSON") % (str(e),))
 
     if event == "build":
         try:
             build_url = payload["build_url"]
             build_number = payload["build_number"]
         except KeyError as e:
-            return json_error(_("Missing key %s in JSON") % (e.message,))
+            return json_error(_("Missing key %s in JSON") % (str(e),))
         content = u"[build %s](%s): %s\n" % (build_number, build_url, result)
 
     elif event == "deploy":
@@ -52,7 +52,7 @@ def api_semaphore_webhook(request, user_profile, client,
             deploy_number = payload["number"]
             server_name = payload["server_name"]
         except KeyError as e:
-            return json_error(_("Missing key %s in JSON") % (e.message,))
+            return json_error(_("Missing key %s in JSON") % (str(e),))
         content = u"[deploy %s](%s) of [build %s](%s) on server %s: %s\n" % \
                   (deploy_number, deploy_url, build_number, build_url, server_name, result)
 

--- a/zerver/views/webhooks/stash.py
+++ b/zerver/views/webhooks/stash.py
@@ -31,7 +31,7 @@ def api_stash_webhook(request, user_profile, payload=REQ(argument_type='body'),
                        entry in commit_entries]
         head_ref = commit_entries[-1]["toCommit"]["displayId"]
     except KeyError as e:
-        return json_error(_("Missing key %s in JSON") % (e.message,))
+        return json_error(_("Missing key %s in JSON") % (str(e),))
 
     subject = "%s/%s: %s" % (project_name, repo_name, branch_name)
 

--- a/zerver/views/webhooks/taiga.py
+++ b/zerver/views/webhooks/taiga.py
@@ -41,9 +41,10 @@ def api_taiga_webhook(request, user_profile, client, message=REQ(argument_type='
     # type: (HttpRequest, UserProfile, Client, Dict[str, Any], six.text_type, six.text_type) -> HttpResponse
     parsed_events = parse_message(message)
 
-    content = ""
+    content_lines = []
     for event in parsed_events:
-        content += generate_content(event) + '\n'
+        content_lines.append(generate_content(event) + '\n')
+    content = "".join(sorted(content_lines))
 
     check_send_message(user_profile, client, 'stream', [stream], topic, content)
 

--- a/zerver/views/webhooks/updown.py
+++ b/zerver/views/webhooks/updown.py
@@ -25,7 +25,7 @@ def send_message_for_event(event, user_profile, client, stream):
         subject = SUBJECT_TEMPLATE.format(service_url=event['check']['url'])
         body = EVENT_TYPE_BODY_MAPPER[event_type](event)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(e.message))
+        return json_error(_("Missing key {} in JSON").format(str(e)))
     check_send_message(user_profile, client, 'stream', [stream], subject, body)
 
 def get_body_for_up_event(event):


### PR DESCRIPTION
Well, almost.

`zerver.tests.tests.BotTest` passes on my computer but doesn't pass on Travis. It could be because of a different version of python or Ubuntu (I run python 3.5 on Ubuntu 16.04, Travis runs python 3.4 on Ubuntu 14.04).