### PR TITLE
Add subject_topic_awareness().

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -187,6 +187,10 @@ def get_user_messages(user_profile):
         order_by('message')
     return [um.message for um in query]
 
+def subject_topic_awareness(test_obj):
+    return test_obj.settings(CATCH_TOPIC_MIGRATION_BUGS=False)
+
+
 class DummyHandler(object):
     def __init__(self):
         # type: (Callable) -> None

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -12,6 +12,7 @@ from zerver.lib.actions import create_stream_if_needed, do_add_subscription
 from zerver.lib.test_helpers import (
     AuthedTestCase, POSTRequestMock,
     get_user_messages, message_ids, queries_captured,
+    subject_topic_awareness,
 )
 from zerver.views.messages import (
     exclude_muting_conditions, get_sqlalchemy_connection,
@@ -430,10 +431,11 @@ class GetOldMessagesTest(AuthedTestCase):
         do_add_subscription(get_user_profile_by_email("starnine@mit.edu"),
                             stream, no_log=True)
 
-        self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
-                          subject=u"\u03bb-topic")
-        self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
-                          subject=u"\u03bb-topic.d")
+        with subject_topic_awareness(self): # narrow
+            self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
+                              subject=u"\u03bb-topic")
+            self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
+                              subject=u"\u03bb-topic.d")
 
         narrow = [dict(operator='topic', operand=u'\u03bb-topic')]
         result = self.post_with_params(dict(num_after=2, narrow=ujson.dumps(narrow)))

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -7,7 +7,11 @@ from zerver.models import (
     get_user_profile_by_email, Recipient, UserMessage
 )
 
-from zerver.lib.test_helpers import AuthedTestCase, tornado_redirected_to_list
+from zerver.lib.test_helpers import (
+    AuthedTestCase,
+    subject_topic_awareness,
+    tornado_redirected_to_list,
+)
 import ujson
 
 class PointerTest(AuthedTestCase):
@@ -206,7 +210,8 @@ class UnreadCountTests(AuthedTestCase):
         user_profile = get_user_profile_by_email("hamlet@zulip.com")
         self.subscribe_to_stream(user_profile.email, "test_stream", user_profile.realm)
 
-        message_id = self.send_message("hamlet@zulip.com", "test_stream", Recipient.STREAM, "hello", "test_topic")
+        with subject_topic_awareness(self): # unread
+            message_id = self.send_message("hamlet@zulip.com", "test_stream", Recipient.STREAM, "hello", "test_topic")
         unrelated_message_id = self.send_message("hamlet@zulip.com", "Denmark", Recipient.STREAM, "hello", "Denmark2")
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -12,6 +12,7 @@ from zerver.lib.test_helpers import (
     queries_captured, simulated_empty_cache, skip_py3,
     simulated_queue_client, tornado_redirected_to_list, AuthedTestCase,
     most_recent_usermessage, most_recent_message,
+    subject_topic_awareness,
 )
 
 from zerver.models import UserProfile, Recipient, \
@@ -1775,19 +1776,20 @@ class TestMissedMessages(AuthedTestCase):
         tokens = [str(random.getrandbits(32)) for _ in range(30)]
         mock_random_token.side_effect = tokens
 
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '0')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '1')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '2')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '3')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '4')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '5')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '6')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '7')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '8')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '9')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '10')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '11', subject='test2')
-        msg_id = self.send_message("othello@zulip.com", "denmark", Recipient.STREAM, '@**hamlet**')
+        with subject_topic_awareness(self): # emails
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '0')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '1')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '2')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '3')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '4')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '5')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '6')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '7')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '8')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '9')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '10')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '11', subject='test2')
+            msg_id = self.send_message("othello@zulip.com", "denmark", Recipient.STREAM, '@**hamlet**')
 
         othello = get_user_profile_by_email('othello@zulip.com')
         hamlet = get_user_profile_by_email('hamlet@zulip.com')
@@ -1813,9 +1815,10 @@ class TestMissedMessages(AuthedTestCase):
         tokens = [str(random.getrandbits(32)) for _ in range(30)]
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
-                                   Recipient.PERSONAL,
-                                   'Extremely personal message!')
+        with subject_topic_awareness(self): # emails
+            msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
+                                       Recipient.PERSONAL,
+                                       'Extremely personal message!')
 
         othello = get_user_profile_by_email('othello@zulip.com')
         hamlet = get_user_profile_by_email('hamlet@zulip.com')


### PR DESCRIPTION
This is a purely tactical commit that adds a context
manager called subject_topic_awareness().  It is intended
to reduce merge conflicts when we start moving over to a
world where topics are stored in a Topic table.

All tests that use this context manager do meaningful
writes/edits to the zerver_message table that touch
Message.subject.