### PR TITLE
(wip) Add Topic table

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -659,6 +659,7 @@ def do_send_messages(messages):
                                         if user_profile.is_active]
         message['message'].maybe_render_content(None)
         message['message'].update_calculated_fields()
+        message['message'].update_topic()
 
     # Save the message receipts in the database
     user_message_flags = defaultdict(dict) # type: Dict[int, Dict[int, List[str]]]

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2441,7 +2441,10 @@ def do_update_message(user_profile, message, subject, propagate_mode, content, r
         subject = truncate_topic(subject)
         event["orig_subject"] = orig_subject
         event["propagate_mode"] = propagate_mode
-        message.subject = subject
+        if getattr(settings, 'CATCH_TOPIC_MIGRATION_BUGS', False):
+            message.subject = 'CATCH_TOPIC_MIGRATION_BUGS'
+        else:
+            message.subject = subject
 
         # We always create a new topic now for topic edits.  For the
         # "change_all" case, you could argue we should just reuse the old
@@ -2479,8 +2482,11 @@ def do_update_message(user_profile, message, subject, propagate_mode, content, r
             for m in messages_list:
                 # The cached ORM object is not changed by messages.update()
                 # and the remote cache update requires the new value
-                m.subject = subject
                 m.topic_id = new_topic_id
+                if getattr(settings, 'CATCH_TOPIC_MIGRATION_BUGS', False):
+                    m.subject = 'CATCH_TOPIC_MIGRATION_BUGS'
+                else:
+                    m.subject = subject
 
             changed_messages += messages_list
 
@@ -2494,7 +2500,7 @@ def do_update_message(user_profile, message, subject, propagate_mode, content, r
     message.edit_history = ujson.dumps(edit_history)
 
     log_event(event)
-    message.save(update_fields=["topic_id", "subject", "content", "rendered_content",
+    message.save(update_fields=["topic_id", "content", "rendered_content",
                                 "rendered_content_version", "last_edit_time",
                                 "edit_history"])
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2434,6 +2434,10 @@ def do_update_message(user_profile, message, subject, propagate_mode, content, r
 
     if subject is not None:
         orig_subject = message.topic_name()
+        orig_topic_id = message.topic_id
+        if not orig_topic_id:
+            raise JsonableError(_('This message is locked due to migration.'))
+
         subject = truncate_topic(subject)
         event["orig_subject"] = orig_subject
         event["propagate_mode"] = propagate_mode
@@ -2455,7 +2459,7 @@ def do_update_message(user_profile, message, subject, propagate_mode, content, r
         edit_history_event["prev_subject"] = orig_subject
 
         if propagate_mode in ["change_later", "change_all"]:
-            propagate_query = Q(recipient = message.recipient, subject = orig_subject)
+            propagate_query = Q(recipient = message.recipient, topic_id = orig_topic_id)
             # We only change messages up to 2 days in the past, to avoid hammering our
             # DB by changing an unbounded amount of messages
             if propagate_mode == 'change_all':

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2256,8 +2256,8 @@ def do_update_pointer(user_profile, pointer, update_flags=False):
     event = dict(type='pointer', pointer=pointer)
     send_event(event, [user_profile.id])
 
-def do_update_message_flags(user_profile, operation, flag, messages, all, stream_obj, topic_name):
-    # type: (UserProfile, str, str, Sequence[Message], bool, Optional[Stream], Optional[text_type]) -> int
+def do_update_message_flags(user_profile, operation, flag, messages, all, stream_obj, topic_id):
+    # type: (UserProfile, str, str, Sequence[Message], bool, Optional[Stream], Optional[int]) -> int
     flagattr = getattr(UserMessage.flags, flag)
 
     if all:
@@ -2265,10 +2265,10 @@ def do_update_message_flags(user_profile, operation, flag, messages, all, stream
         msgs = UserMessage.objects.filter(user_profile=user_profile)
     elif stream_obj is not None:
         recipient = get_recipient(Recipient.STREAM, stream_obj.id)
-        if topic_name:
-            msgs = UserMessage.objects.filter(message__recipient=recipient,
+        if topic_id:
+            msgs = UserMessage.objects.filter(message__topic_id=topic_id,
                                               user_profile=user_profile,
-                                              message__subject__iexact=topic_name)
+                                              )
         else:
             msgs = UserMessage.objects.filter(message__recipient=recipient, user_profile=user_profile)
     else:

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -187,6 +187,10 @@ def get_user_messages(user_profile):
         order_by('message')
     return [um.message for um in query]
 
+def subject_topic_awareness(test_obj):
+    return test_obj.settings(CATCH_TOPIC_MIGRATION_BUGS=False)
+
+
 class DummyHandler(object):
     def __init__(self):
         # type: (Callable) -> None

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -187,8 +187,8 @@ def get_user_messages(user_profile):
         order_by('message')
     return [um.message for um in query]
 
-def subject_topic_awareness(test_obj):
-    return test_obj.settings(CATCH_TOPIC_MIGRATION_BUGS=False)
+def subject_topic_awareness(test_obj, new_topics=False):
+    return test_obj.settings(CATCH_TOPIC_MIGRATION_BUGS=new_topics)
 
 
 class DummyHandler(object):

--- a/zerver/management/commands/backfill_topic.py
+++ b/zerver/management/commands/backfill_topic.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from argparse import ArgumentParser
+import sys
+
+from zerver.lib.migrate import (
+    migrate_all_messages,
+    create_topics_for_message_range,
+)
+
+
+class Command(BaseCommand):
+    help = """Backfill Topic froms Message (run with care!)."""
+
+    def add_arguments(self, parser):
+        # type: (ArgumentParser) -> None
+        parser.add_argument('batch_size', type=int,
+                            help='size of range of Message.id')
+        parser.add_argument('max_num_batches', type=int,
+                            help='size of range of Message.id')
+
+    def handle(self, *args, **options):
+        # type: (*Any, **str) -> None
+        batch_size = int(options['batch_size'])
+        max_num_batches = int(options['max_num_batches'])
+        assert batch_size >= 1
+        assert max_num_batches >= 1
+        assert max_num_batches <= 100000
+
+        migrate_all_messages(
+            range_method=create_topics_for_message_range,
+            batch_size=batch_size,
+            max_num_batches=max_num_batches,
+            verbose=True,
+        )

--- a/zerver/migrations/0026_add_topic_table.py
+++ b/zerver/migrations/0026_add_topic_table.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import zerver.lib.str_utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0025_realm_message_content_edit_limit'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Topic',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=60, db_index=True)),
+                ('recipient', models.ForeignKey(to='zerver.Recipient')),
+            ],
+            bases=(zerver.lib.str_utils.ModelReprMixin, models.Model),
+        ),
+        migrations.AlterUniqueTogether(
+            name='topic',
+            unique_together=set([('recipient', 'name')]),
+        ),
+    ]

--- a/zerver/migrations/0027_topics_backfill.py
+++ b/zerver/migrations/0027_topics_backfill.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from zerver.lib.migrate import (
+    create_topics_for_message_range,
+    migrate_all_messages,
+)
+from zerver.models import (
+    Message,
+)
+
+# These are to to help type-check the target of RunPython (backfill_topics).
+from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+def backfill_topics(apps, schema_editor):
+    # type: (StateApps, DatabaseSchemaEditor) -> None
+    if Message.objects.all().count():
+        migrate_all_messages(
+            range_method=create_topics_for_message_range,
+            batch_size=10000,
+            max_num_batches=99999,
+            verbose=True,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0026_add_topic_table'),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_topics),
+    ]

--- a/zerver/migrations/0028_add_message_topic.py
+++ b/zerver/migrations/0028_add_message_topic.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import zerver.lib.str_utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0027_topics_backfill'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='message',
+            name='topic',
+            field=models.ForeignKey(to='zerver.Topic', null=True),
+        ),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1177,7 +1177,7 @@ def get_context_for_message(message):
     # TODO: Change return type to QuerySet[Message]
     return Message.objects.filter(
         recipient_id=message.recipient_id,
-        subject=message.subject,
+        topic_id=message.topic_id,
         id__lt=message.id,
         pub_date__gt=message.pub_date - timedelta(minutes=15),
     ).order_by('-id')[:10]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -782,6 +782,7 @@ class Topic(ModelReprMixin, models.Model):
 class Message(ModelReprMixin, models.Model):
     sender = models.ForeignKey(UserProfile) # type: UserProfile
     recipient = models.ForeignKey(Recipient) # type: Recipient
+    topic = models.ForeignKey(Topic, null=True)
     subject = models.CharField(max_length=MAX_SUBJECT_LENGTH, db_index=True) # type: text_type
     content = models.TextField() # type: text_type
     rendered_content = models.TextField(null=True) # type: Optional[text_type]
@@ -1155,8 +1156,8 @@ class Message(ModelReprMixin, models.Model):
 
     def update_topic(self):
         # type: () -> None
-        if self.subject:
-            Topic.objects.get_or_create(
+        if self.subject and not self.topic:
+            self.topic, _ = Topic.objects.get_or_create(
                 name=self.subject,
                 recipient=self.recipient)
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -902,7 +902,7 @@ class Message(ModelReprMixin, models.Model):
                 last_edit_time = self.last_edit_time,
                 edit_history = self.edit_history,
                 content = self.content,
-                subject = self.subject,
+                subject = self.topic_name(),
                 pub_date = self.pub_date,
                 rendered_content = self.rendered_content,
                 rendered_content_version = self.rendered_content_version,
@@ -920,6 +920,14 @@ class Message(ModelReprMixin, models.Model):
         )
 
     @staticmethod
+    def get_topic_name_from_raw_data(row):
+        # TODO: inline this when topic id transition finishes
+        if row['topic__name']:
+            return row['topic__name']
+        else:
+            return row['subject']
+
+    @staticmethod
     def build_dict_from_raw_db_row(row, apply_markdown):
         # type: (Dict[str, Any], bool) -> Dict[str, Any]
         '''
@@ -933,7 +941,7 @@ class Message(ModelReprMixin, models.Model):
                 last_edit_time = row['last_edit_time'],
                 edit_history = row['edit_history'],
                 content = row['content'],
-                subject = row['subject'],
+                subject = Message.get_topic_name_from_raw_data(row),
                 pub_date = row['pub_date'],
                 rendered_content = row['rendered_content'],
                 rendered_content_version = row['rendered_content_version'],
@@ -1102,6 +1110,7 @@ class Message(ModelReprMixin, models.Model):
             'sender__realm__domain',
             'sender__avatar_source',
             'sender__is_mirror_dummy',
+            'topic__name',
         ]
         return Message.objects.filter(id__in=needed_ids).values(*fields)
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1153,12 +1153,21 @@ class Message(ModelReprMixin, models.Model):
         self.has_image = bool(Message.content_has_image(content))
         self.has_link = bool(Message.content_has_link(content))
 
+    def update_topic(self):
+        # type: () -> None
+        if self.subject:
+            Topic.objects.get_or_create(
+                name=self.subject,
+                recipient=self.recipient)
+
+
 @receiver(pre_save, sender=Message)
 def pre_save_message(sender, **kwargs):
     # type: (Any, **Any) -> None
     if kwargs['update_fields'] is None or "content" in kwargs['update_fields']:
         message = kwargs['instance']
         message.update_calculated_fields()
+        message.update_topic()
 
 def get_context_for_message(message):
     # type: (Message) -> Sequence[Message]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -797,11 +797,10 @@ class Message(ModelReprMixin, models.Model):
 
     def topic_name(self):
         # type: () -> text_type
-        """
-        Please start using this helper to facilitate an
-        eventual switch over to a separate topic table.
-        """
-        return self.subject
+        if self.topic:
+            return self.topic.name
+        else:
+            return self.subject
 
     def __unicode__(self):
         # type: () -> text_type
@@ -1160,6 +1159,9 @@ class Message(ModelReprMixin, models.Model):
             self.topic, _ = Topic.objects.get_or_create(
                 name=self.subject,
                 recipient=self.recipient)
+        if self.subject:
+            if getattr(settings, 'CATCH_TOPIC_MIGRATION_BUGS', False):
+                self.subject = 'CATCH_TOPIC_MIGRATION_BUGS'
 
 
 @receiver(pre_save, sender=Message)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -768,6 +768,17 @@ def to_dict_cache_key(message, apply_markdown):
     # type: (Message, bool) -> text_type
     return to_dict_cache_key_id(message.id, apply_markdown)
 
+class Topic(ModelReprMixin, models.Model):
+    recipient = models.ForeignKey(Recipient) # type: Recipient
+    name = models.CharField(max_length=MAX_SUBJECT_LENGTH, db_index=True) # type: text_type
+
+    class Meta(object):
+        unique_together = ("recipient", "name")
+
+    def __unicode__(self):
+        # type: () -> text_type
+        return u"<Topic: recipient %d, %s>" % (self.recipient_id, self.name)
+
 class Message(ModelReprMixin, models.Model):
     sender = models.ForeignKey(UserProfile) # type: UserProfile
     recipient = models.ForeignKey(Recipient) # type: Recipient

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -14,6 +14,7 @@ from zerver.lib.test_helpers import (
     message_ids, message_stream_count,
     most_recent_message,
     queries_captured,
+    subject_topic_awareness,
 )
 
 from zerver.models import (
@@ -439,7 +440,8 @@ class MessageDictTest(AuthedTestCase):
                     last_edit_time=datetime.datetime.now(),
                     edit_history='[]'
                 )
-                message.save()
+                with subject_topic_awareness(self):
+                    message.save()
 
         ids = [row['id'] for row in Message.objects.all().values('id')]
         num_ids = len(ids)
@@ -779,10 +781,11 @@ class EditMessageTest(AuthedTestCase):
         self.assert_json_success(result)
         self.check_message(msg_id, content="after edit")
 
-        result = self.client.post("/json/update_message", {
-            'message_id': msg_id,
-            'subject': 'edited'
-        })
+        with subject_topic_awareness(self): # edit
+            result = self.client.post("/json/update_message", {
+                'message_id': msg_id,
+                'subject': 'edited'
+            })
         self.assert_json_success(result)
         self.check_message(msg_id, subject="edited")
 
@@ -830,7 +833,8 @@ class EditMessageTest(AuthedTestCase):
             params_dict = { 'message_id': id_, 'subject': new_subject }
             if not topic_only:
                 params_dict['content'] = new_content
-            result = self.client.post("/json/update_message", params_dict)
+            with subject_topic_awareness(self): # edit
+                result = self.client.post("/json/update_message", params_dict)
             self.assert_json_success(result)
             if topic_only:
                 self.check_message(id_, subject=new_subject)
@@ -846,7 +850,8 @@ class EditMessageTest(AuthedTestCase):
             params_dict = { 'message_id': id_, 'subject': new_subject }
             if not topic_only:
                 params_dict['content'] = new_content
-            result = self.client.post("/json/update_message", params_dict)
+            with subject_topic_awareness(self): # edit
+                result = self.client.post("/json/update_message", params_dict)
             message = Message.objects.get(id=id_)
             self.assert_json_error(result, error)
             self.check_message(id_, subject=old_subject, content=old_content)
@@ -883,22 +888,23 @@ class EditMessageTest(AuthedTestCase):
 
     def test_propagate_topic_forward(self):
         self.login("hamlet@zulip.com")
-        id1 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
-            subject="topic1")
-        id2 = self.send_message("iago@zulip.com", "Scotland", Recipient.STREAM,
-            subject="topic1")
-        id3 = self.send_message("iago@zulip.com", "Rome", Recipient.STREAM,
-            subject="topic1")
-        id4 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
-            subject="topic2")
-        id5 = self.send_message("iago@zulip.com", "Scotland", Recipient.STREAM,
-            subject="topic1")
+        with subject_topic_awareness(self): # edit
+            id1 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
+                subject="topic1")
+            id2 = self.send_message("iago@zulip.com", "Scotland", Recipient.STREAM,
+                subject="topic1")
+            id3 = self.send_message("iago@zulip.com", "Rome", Recipient.STREAM,
+                subject="topic1")
+            id4 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
+                subject="topic2")
+            id5 = self.send_message("iago@zulip.com", "Scotland", Recipient.STREAM,
+                subject="topic1")
 
-        result = self.client.post("/json/update_message", {
-            'message_id': id1,
-            'subject': 'edited',
-            'propagate_mode': 'change_later'
-        })
+            result = self.client.post("/json/update_message", {
+                'message_id': id1,
+                'subject': 'edited',
+                'propagate_mode': 'change_later'
+            })
         self.assert_json_success(result)
 
         self.check_message(id1, subject="edited")
@@ -909,24 +915,25 @@ class EditMessageTest(AuthedTestCase):
 
     def test_propagate_all_topics(self):
         self.login("hamlet@zulip.com")
-        id1 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
-            subject="topic1")
-        id2 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
-            subject="topic1")
-        id3 = self.send_message("iago@zulip.com", "Rome", Recipient.STREAM,
-            subject="topic1")
-        id4 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
-            subject="topic2")
-        id5 = self.send_message("iago@zulip.com", "Scotland", Recipient.STREAM,
-            subject="topic1")
-        id6 = self.send_message("iago@zulip.com", "Scotland", Recipient.STREAM,
-            subject="topic3")
+        with subject_topic_awareness(self): # edit
+            id1 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
+                subject="topic1")
+            id2 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
+                subject="topic1")
+            id3 = self.send_message("iago@zulip.com", "Rome", Recipient.STREAM,
+                subject="topic1")
+            id4 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
+                subject="topic2")
+            id5 = self.send_message("iago@zulip.com", "Scotland", Recipient.STREAM,
+                subject="topic1")
+            id6 = self.send_message("iago@zulip.com", "Scotland", Recipient.STREAM,
+                subject="topic3")
 
-        result = self.client.post("/json/update_message", {
-            'message_id': id2,
-            'subject': 'edited',
-            'propagate_mode': 'change_all'
-        })
+            result = self.client.post("/json/update_message", {
+                'message_id': id2,
+                'subject': 'edited',
+                'propagate_mode': 'change_all'
+            })
         self.assert_json_success(result)
 
         self.check_message(id1, subject="edited")

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -403,7 +403,7 @@ class MessageTopicTest(TestCase):
                 last_edit_time=datetime.datetime.now(),
                 edit_history='[]'
             )
-            with subject_topic_awareness(self):
+            with subject_topic_awareness(self, new_topics=True):
                 message.save()
             messages.append(message)
 
@@ -418,7 +418,7 @@ class MessageTopicTest(TestCase):
         for message in messages:
             msg = Message.objects.get(id=message.id)
             self.assertEqual(msg.topic_id, topic_id)
-            self.assertEqual(msg.subject, 'lunch')
+            self.assertNotEqual(msg.subject, 'lunch')
 
 class MessageDictTest(AuthedTestCase):
     @slow(1.6, 'builds lots of messages')

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -411,10 +411,12 @@ class MessageTopicTest(TestCase):
             recipient=stream_recipient,
         )
         self.assertEqual(len(lunch_topics), 1)
+        topic_id = lunch_topics[0].id
 
         # Make sure we write legacy/new fields.
         for message in messages:
             msg = Message.objects.get(id=message.id)
+            self.assertEqual(msg.topic_id, topic_id)
             self.assertEqual(msg.subject, 'lunch')
 
 class MessageDictTest(AuthedTestCase):

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -759,13 +759,15 @@ class MessagePOSTTest(AuthedTestCase):
         user.realm.save()
 
 class EditMessageTest(AuthedTestCase):
-    def check_message(self, msg_id, subject=None, content=None):
+    def check_message(self, msg_id, subject=None, content=None, edited=True):
         msg = Message.objects.get(id=msg_id)
         cached = msg.to_dict(False)
         uncached = msg.to_dict_uncached_helper(False)
         self.assertEqual(cached, uncached)
         if subject:
             self.assertEqual(msg.topic_name(), subject)
+            if edited:
+                self.assertEqual(msg.topic.name, subject)
         if content:
             self.assertEqual(msg.content, content)
         return msg
@@ -911,8 +913,8 @@ class EditMessageTest(AuthedTestCase):
 
         self.check_message(id1, subject="edited")
         self.check_message(id2, subject="edited")
-        self.check_message(id3, subject="topic1")
-        self.check_message(id4, subject="topic2")
+        self.check_message(id3, subject="topic1", edited=False)
+        self.check_message(id4, subject="topic2", edited=False)
         self.check_message(id5, subject="edited")
 
     def test_propagate_all_topics(self):
@@ -940,10 +942,10 @@ class EditMessageTest(AuthedTestCase):
 
         self.check_message(id1, subject="edited")
         self.check_message(id2, subject="edited")
-        self.check_message(id3, subject="topic1")
-        self.check_message(id4, subject="topic2")
+        self.check_message(id3, subject="topic1", edited=False)
+        self.check_message(id4, subject="topic2", edited=False)
         self.check_message(id5, subject="edited")
-        self.check_message(id6, subject="topic3")
+        self.check_message(id6, subject="topic3", edited=False)
 
 class StarTests(AuthedTestCase):
 

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -786,7 +786,7 @@ class EditMessageTest(AuthedTestCase):
         self.assert_json_success(result)
         self.check_message(msg_id, content="after edit")
 
-        with subject_topic_awareness(self): # edit
+        with subject_topic_awareness(self, new_topics=True): # edit
             result = self.client.post("/json/update_message", {
                 'message_id': msg_id,
                 'subject': 'edited'
@@ -893,7 +893,7 @@ class EditMessageTest(AuthedTestCase):
 
     def test_propagate_topic_forward(self):
         self.login("hamlet@zulip.com")
-        with subject_topic_awareness(self): # edit
+        with subject_topic_awareness(self, new_topics=True): # edit
             id1 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
                 subject="topic1")
             id2 = self.send_message("iago@zulip.com", "Scotland", Recipient.STREAM,
@@ -920,7 +920,7 @@ class EditMessageTest(AuthedTestCase):
 
     def test_propagate_all_topics(self):
         self.login("hamlet@zulip.com")
-        with subject_topic_awareness(self): # edit
+        with subject_topic_awareness(self, new_topics=True): # edit
             id1 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
                 subject="topic1")
             id2 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -443,7 +443,7 @@ class MessageDictTest(AuthedTestCase):
                     last_edit_time=datetime.datetime.now(),
                     edit_history='[]'
                 )
-                with subject_topic_awareness(self):
+                with subject_topic_awareness(self, new_topics=True):
                     message.save()
 
         ids = [row['id'] for row in Message.objects.all().values('id')]

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -403,7 +403,8 @@ class MessageTopicTest(TestCase):
                 last_edit_time=datetime.datetime.now(),
                 edit_history='[]'
             )
-            message.save()
+            with subject_topic_awareness(self):
+                message.save()
             messages.append(message)
 
         lunch_topics = Topic.objects.filter(

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -18,7 +18,8 @@ from zerver.lib.test_helpers import (
 
 from zerver.models import (
     MAX_MESSAGE_LENGTH, MAX_SUBJECT_LENGTH,
-    Client, Message, Realm, Recipient, Stream, UserMessage, UserProfile, Attachment,
+    Client, Message, Realm, Recipient,
+    Stream, UserMessage, UserProfile, Attachment, Topic,
     get_realm, get_stream, get_user_profile_by_email,
 )
 
@@ -379,6 +380,41 @@ class StreamMessagesTest(AuthedTestCase):
 
         self.assert_stream_message(non_ascii_stream_name, subject=u"hümbüǵ",
                                    content=u"hümbüǵ")
+
+class MessageTopicTest(TestCase):
+    def test_message_hooks(self):
+        # type: () -> None
+        realm = get_realm("zulip.com")
+        sender = get_user_profile_by_email('othello@zulip.com')
+        stream, _ = create_stream_if_needed(realm, 'devel')
+        stream_recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
+        sending_client, _ = Client.objects.get_or_create(name="test suite")
+
+        messages = []
+        for i in range(3):
+            message = Message(
+                sender=sender,
+                recipient=stream_recipient,
+                subject='lunch',
+                content='whatever %d' % (i,),
+                pub_date=datetime.datetime.now(),
+                sending_client=sending_client,
+                last_edit_time=datetime.datetime.now(),
+                edit_history='[]'
+            )
+            message.save()
+            messages.append(message)
+
+        lunch_topics = Topic.objects.filter(
+            name='lunch',
+            recipient=stream_recipient,
+        )
+        self.assertEqual(len(lunch_topics), 1)
+
+        # Make sure we write legacy/new fields.
+        for message in messages:
+            msg = Message.objects.get(id=message.id)
+            self.assertEqual(msg.subject, 'lunch')
 
 class MessageDictTest(AuthedTestCase):
     @slow(1.6, 'builds lots of messages')

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -318,7 +318,7 @@ class StreamMessagesTest(AuthedTestCase):
         with queries_captured() as queries:
             send_message()
 
-        self.assert_length(queries, 7)
+        self.assert_length(queries, 8)
 
     def test_message_mentions(self):
         user_profile = get_user_profile_by_email("iago@zulip.com")

--- a/zerver/tests/test_migrate.py
+++ b/zerver/tests/test_migrate.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from django.test import TestCase
+
+import datetime
+import mock
+from six.moves import range
+
+from zerver.lib.actions import (
+    create_stream_if_needed,
+)
+from zerver.lib.migrate import (
+    create_topics_for_message_range,
+)
+from zerver.models import (
+    Client,
+    Message,
+    Recipient,
+    Topic,
+    get_realm,
+    get_user_profile_by_email,
+)
+
+class TestTopicMigration(TestCase):
+    def test_create_topics_for_message_range(self):
+        # type: () -> None
+        realm = get_realm("zulip.com")
+        sending_client, _ = Client.objects.get_or_create(name="test suite")
+        sender = get_user_profile_by_email('othello@zulip.com')
+
+        num_streams = 10
+        num_topics = 3
+        num_msgs_per_topic = 5
+
+        low_msg_id = Message.objects.order_by('-id')[0].id + 1
+
+        for i in range(num_streams):
+            stream_name = 'stream %d' % (i,)
+            stream, _ = create_stream_if_needed(realm, stream_name)
+            stream_recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
+
+            for j in range(num_topics):
+                topic_name = 'subject %d' % (j,)
+
+                for k in range(num_msgs_per_topic):
+                    content = 'msg (%d,%d,%d)' % (i, j, k)
+
+                    message = Message(
+                        sender=sender,
+                        recipient=stream_recipient,
+                        subject=topic_name,
+                        content=content,
+                        pub_date=datetime.datetime.now(),
+                        sending_client=sending_client,
+                        last_edit_time=datetime.datetime.now(),
+                        edit_history='[]'
+                    )
+                    with mock.patch('zerver.models.Message.update_topic'):
+                        message.save()
+
+        high_msg_id = Message.objects.order_by('-id')[0].id + 1
+
+        # Do some sanity checking on our message range.
+        # Our message id range may be greater than expected_num_saved,
+        # due to rollbacks from prior running tests, but that is ok
+        # for our purposes.
+        expected_num_saved = num_streams * num_topics * num_msgs_per_topic
+        self.assertTrue((high_msg_id - low_msg_id) >= expected_num_saved)
+
+        # Blow away Topic objects, because some may have been
+        # created by our pre-save hooks.
+        Topic.objects.all().delete()
+        self.assertEqual(Topic.objects.count(), 0)
+
+        status_update = create_topics_for_message_range(
+            low_msg_id=low_msg_id,
+            high_msg_id=high_msg_id,
+        ) # type: str
+
+        expected_num_topics = num_streams * num_topics # type: int
+        self.assertEqual(Topic.objects.count(), expected_num_topics)
+        expected_status_update = '%d Topic rows created' % (expected_num_topics,)
+        self.assertEqual(status_update, expected_status_update)
+
+        # Now, test idempotency..we can run this again, and it
+        # won't try to create new topics.
+        status_update = create_topics_for_message_range(
+            low_msg_id=low_msg_id,
+            high_msg_id=high_msg_id,
+        )
+        self.assertEqual(status_update, '0 Topic rows created')
+
+        expected_num_topics = num_streams * num_topics
+        self.assertEqual(Topic.objects.count(), expected_num_topics)
+
+        # Make sure 'subject 1' has entries for each of its streams.
+        self.assertEqual(Topic.objects.filter(name='subject 1').count(), num_streams)

--- a/zerver/tests/test_migrate.py
+++ b/zerver/tests/test_migrate.py
@@ -11,6 +11,7 @@ from zerver.lib.actions import (
 )
 from zerver.lib.migrate import (
     create_topics_for_message_range,
+    migrate_all_messages,
 )
 from zerver.models import (
     Client,
@@ -95,3 +96,15 @@ class TestTopicMigration(TestCase):
 
         # Make sure 'subject 1' has entries for each of its streams.
         self.assertEqual(Topic.objects.filter(name='subject 1').count(), num_streams)
+
+    def test_full_migration(self):
+        # type: () -> None
+        # This is mostly a don't-explode test.  To debug
+        # migrate_all_messages() while you are in test mode,
+        # you can set verbose to True here.
+        migrate_all_messages(
+            range_method=create_topics_for_message_range,
+            batch_size=10,
+            max_num_batches=3,
+            verbose=False,
+        )

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -18,6 +18,7 @@ from zerver.lib.test_helpers import (
     AuthedTestCase, POSTRequestMock,
     TestCase,
     get_user_messages, message_ids, queries_captured,
+    subject_topic_awareness,
 )
 from zerver.views.messages import (
     exclude_muting_conditions,
@@ -453,10 +454,11 @@ class GetOldMessagesTest(AuthedTestCase):
         do_add_subscription(get_user_profile_by_email("starnine@mit.edu"),
                             stream, no_log=True)
 
-        self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
-                          subject=u"\u03bb-topic")
-        self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
-                          subject=u"\u03bb-topic.d")
+        with subject_topic_awareness(self): # narrow
+            self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
+                              subject=u"\u03bb-topic")
+            self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
+                              subject=u"\u03bb-topic.d")
 
         narrow = [dict(operator='topic', operand=u'\u03bb-topic')]
         result = self.post_with_params(dict(num_after=2, narrow=ujson.dumps(narrow)))

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -504,14 +504,15 @@ class GetOldMessagesTest(AuthedTestCase):
             ('dinner', 'Anybody staying late tonight?'),
         ]
 
-        for topic, content in messages_to_search:
-            self.send_message(
-                sender_name="cordelia@zulip.com",
-                raw_recipients="Verona",
-                message_type=Recipient.STREAM,
-                content=content,
-                subject=topic,
-            )
+        with subject_topic_awareness(self): # search
+            for topic, content in messages_to_search:
+                self.send_message(
+                    sender_name="cordelia@zulip.com",
+                    raw_recipients="Verona",
+                    message_type=Recipient.STREAM,
+                    content=content,
+                    subject=topic,
+                )
 
         # We use brute force here and update our text search index
         # for the entire zerver_message table (which is small in test

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -7,7 +7,11 @@ from zerver.models import (
     get_user_profile_by_email, Recipient, UserMessage
 )
 
-from zerver.lib.test_helpers import AuthedTestCase, tornado_redirected_to_list
+from zerver.lib.test_helpers import (
+    AuthedTestCase,
+    subject_topic_awareness,
+    tornado_redirected_to_list,
+)
 import ujson
 
 class PointerTest(AuthedTestCase):
@@ -206,7 +210,8 @@ class UnreadCountTests(AuthedTestCase):
         user_profile = get_user_profile_by_email("hamlet@zulip.com")
         self.subscribe_to_stream(user_profile.email, "test_stream", user_profile.realm)
 
-        message_id = self.send_message("hamlet@zulip.com", "test_stream", Recipient.STREAM, "hello", "test_topic")
+        with subject_topic_awareness(self): # unread
+            message_id = self.send_message("hamlet@zulip.com", "test_stream", Recipient.STREAM, "hello", "test_topic")
         unrelated_message_id = self.send_message("hamlet@zulip.com", "Denmark", Recipient.STREAM, "hello", "Denmark2")
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -210,7 +210,7 @@ class UnreadCountTests(AuthedTestCase):
         user_profile = get_user_profile_by_email("hamlet@zulip.com")
         self.subscribe_to_stream(user_profile.email, "test_stream", user_profile.realm)
 
-        with subject_topic_awareness(self): # unread
+        with subject_topic_awareness(self, new_topics=True): # unread
             message_id = self.send_message("hamlet@zulip.com", "test_stream", Recipient.STREAM, "hello", "test_topic")
         unrelated_message_id = self.send_message("hamlet@zulip.com", "Denmark", Recipient.STREAM, "hello", "Denmark2")
         events = [] # type: List[Dict[str, Any]]

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -12,6 +12,7 @@ from zerver.lib.test_helpers import (
     queries_captured, simulated_empty_cache,
     simulated_queue_client, tornado_redirected_to_list, AuthedTestCase,
     most_recent_usermessage, most_recent_message,
+    subject_topic_awareness,
 )
 from zerver.lib.test_runner import slow
 
@@ -1899,19 +1900,20 @@ class TestMissedMessages(AuthedTestCase):
         tokens = [str(random.getrandbits(32)) for _ in range(30)]
         mock_random_token.side_effect = tokens
 
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '0')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '1')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '2')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '3')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '4')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '5')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '6')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '7')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '8')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '9')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '10')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '11', subject='test2')
-        msg_id = self.send_message("othello@zulip.com", "denmark", Recipient.STREAM, '@**hamlet**')
+        with subject_topic_awareness(self): # emails
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '0')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '1')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '2')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '3')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '4')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '5')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '6')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '7')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '8')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '9')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '10')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '11', subject='test2')
+            msg_id = self.send_message("othello@zulip.com", "denmark", Recipient.STREAM, '@**hamlet**')
 
         othello = get_user_profile_by_email('othello@zulip.com')
         hamlet = get_user_profile_by_email('hamlet@zulip.com')
@@ -1937,9 +1939,10 @@ class TestMissedMessages(AuthedTestCase):
         tokens = [str(random.getrandbits(32)) for _ in range(30)]
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
-                                   Recipient.PERSONAL,
-                                   'Extremely personal message!')
+        with subject_topic_awareness(self): # emails
+            msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
+                                       Recipient.PERSONAL,
+                                       'Extremely personal message!')
 
         othello = get_user_profile_by_email('othello@zulip.com')
         hamlet = get_user_profile_by_email('hamlet@zulip.com')

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1900,7 +1900,7 @@ class TestMissedMessages(AuthedTestCase):
         tokens = [str(random.getrandbits(32)) for _ in range(30)]
         mock_random_token.side_effect = tokens
 
-        with subject_topic_awareness(self): # emails
+        with subject_topic_awareness(self, new_topics=True): # emails
             self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '0')
             self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '1')
             self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '2')
@@ -1939,7 +1939,7 @@ class TestMissedMessages(AuthedTestCase):
         tokens = [str(random.getrandbits(32)) for _ in range(30)]
         mock_random_token.side_effect = tokens
 
-        with subject_topic_awareness(self): # emails
+        with subject_topic_awareness(self, new_topics=True): # emails
             msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
                                        Recipient.PERSONAL,
                                        'Extremely personal message!')

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -179,10 +179,14 @@ class NarrowBuilder(object):
             else:
                 regex = r'^%s(\.d)*$' % (self._pg_re_escape(base_topic),)
 
-            cond = column("subject").op("~*")(regex)
+            topics = Topic.objects.filter(name__iregex=regex)
+            topic_ids = [topic.id for topic in topics]
+            cond = column("topic_id").in_(topic_ids)
             return query.where(maybe_negate(cond))
 
-        cond = func.upper(column("subject")) == func.upper(literal(operand))
+        topics = Topic.objects.filter(name__iexact=operand)
+        topic_ids = [topic.id for topic in topics]
+        cond = column("topic_id").in_(topic_ids)
         return query.where(maybe_negate(cond))
 
     def by_sender(self, query, operand, maybe_negate):

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -51,6 +51,8 @@ USING_RABBITMQ = False
 # Disable the tutorial because it confuses the client tests.
 TUTORIAL_ENABLED = False
 
+CATCH_TOPIC_MIGRATION_BUGS = True
+
 # Disable use of memcached for caching
 CACHES['database'] = {
     'BACKEND':  'django.core.cache.backends.dummy.DummyCache',


### PR DESCRIPTION
This series takes the place of #1209.  You can refer back to that ticket for early discussion between me and @timabbott, but if you're new to this pull request, you're probably ok to start here and just ask me questions as needed.

Every commit here should be deployable in theory for devs, but the backfill is not production-ready, and none of this code has been thoroughly monkey-tested in any fashion.

I touch the message cache here a little bit (indirectly), but I'm not completely confident that this new code works with the cache, because I didn't have good failing tests for that.  I'm generally confident that most things will work well enough to start developing off of this branch.

@timabbott The very first commit in this series is something that I'm hoping to get on to master relatively soon, just to fend off possible merge conflicts.  I haven't decided whether it's really that important to get it to master, but it's just test code, so it should be mostly harmless.

I'll probably add a few more commits here to add testing, both in terms of simply adding unit tests and also more aggressively deprecating the old subject field.  But this shouldn't be a hold up for anybody.
