### PR TITLE
Make backend tests pass on python 3

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -12,7 +12,6 @@ from django.shortcuts import resolve_url
 from django.utils.decorators import available_attrs
 from django.utils.timezone import now
 from django.conf import settings
-from six.moves import cStringIO as StringIO
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.utils import statsd
@@ -26,6 +25,7 @@ from functools import wraps
 import base64
 import logging
 import cProfile
+from io import BytesIO
 from zerver.lib.mandrill_client import get_mandrill_client
 from six.moves import zip, urllib
 
@@ -396,7 +396,7 @@ def process_as_post(view_func):
                 # Note that request._files is just the private attribute that backs the
                 # FILES property, so we are essentially setting request.FILES here.  (In
                 # Django 1.5 FILES was still a read-only property.)
-                request.POST, request._files = MultiPartParser(request.META, StringIO(request.body),
+                request.POST, request._files = MultiPartParser(request.META, BytesIO(request.body),
                         request.upload_handlers, request.encoding).parse()
             else:
                 request.POST = QueryDict(request.body, encoding=request.encoding)

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -37,9 +37,12 @@ def create_user_profile(realm, email, password, active, bot_type, full_name,
                                full_name=full_name, short_name=short_name,
                                last_login=now, date_joined=now, realm=realm,
                                pointer=-1, is_bot=bool(bot_type), bot_type=bot_type,
-                               bot_owner=bot_owner, is_mirror_dummy=is_mirror_dummy,
+                               is_mirror_dummy=is_mirror_dummy,
                                enable_stream_desktop_notifications=enable_stream_desktop_notifications,
                                onboarding_steps=ujson.dumps([]))
+    if bot_owner is not None:
+        # `user_profile.bot_owner = bot_owner` doesn't work on python 3.4
+        user_profile.bot_owner_id = bot_owner.id
 
     if bot_type or not active:
         password = None

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse
 from django.test import TestCase
 
 from zerver.lib.test_helpers import (
-    queries_captured, simulated_empty_cache, skip_py3,
+    queries_captured, simulated_empty_cache,
     simulated_queue_client, tornado_redirected_to_list, AuthedTestCase,
     most_recent_usermessage, most_recent_message,
 )
@@ -531,7 +531,6 @@ class ActivateTest(AuthedTestCase):
         result = self.client.post('/json/users/hamlet@zulip.com/reactivate')
         self.assert_json_error(result, 'Insufficient permission')
 
-@skip_py3
 class BotTest(AuthedTestCase):
     def assert_num_bots_equal(self, count):
         # type: (int) -> None


### PR DESCRIPTION
Use `BytesIO` instead of `StringIO` to get a file-like object on `request.body`.