### PR TITLE
python3: Add test-management to py3-backend and gracefully give up in email-mirror

### DIFF
--- a/tools/travis/py3-backend
+++ b/tools/travis/py3-backend
@@ -20,3 +20,4 @@ set -x
 
 tools/test-migrations
 tools/test-backend --nonfatal-errors
+tools/test-management


### PR DESCRIPTION
Running `./manage.py email-mirror` used to fail on python 3 because `twisted.mail.imap4` is not python 3 compatible. Display a message informing the user that email-mirror is not available on python 3 instead of failing with a traceback.

Also add tools/test-management to py3-backend.