### PR TITLE
Remove muting logic in approximate_unread_count().

### DIFF
--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -792,18 +792,14 @@ def approximate_unread_count(user_profile):
                                        Subscription.objects.filter(
             user_profile=user_profile, in_home_view=False)]
 
-    muted_topics = ujson.loads(user_profile.muted_topics)
-    # If muted_topics is empty, it looks like []. If it is non-empty, it look
-    # like [[u'devel', u'test']]. We should switch to a consistent envelope, but
-    # until we do we still have both in the database.
-    if muted_topics:
-        muted_topics = muted_topics[0]
-
+    # TODO: We may want to exclude muted messages from this count.
+    #       It was attempted in the past, but the original attempt
+    #       was broken.  When we re-architect muting, we may
+    #       want to to revisit this (see git issue #1019).
     return UserMessage.objects.filter(
         user_profile=user_profile, message_id__gt=user_profile.pointer).exclude(
         message__recipient__type=Recipient.STREAM,
         message__recipient__id__in=not_in_home_view_recipients).exclude(
-        message__subject__in=muted_topics).exclude(
         flags=UserMessage.flags.read).count()
 
 def sent_time_in_epoch_seconds(user_message):


### PR DESCRIPTION
The muting logic in approximate_unread_count() was confusing
stream/subject and only using the first of many stream/subject
pairs, so it was rarely excluding rows from the count, and when
it did exclude rows, they were the wrong rows.

This fixes part of #1300, but we may want to keep the issue open.