### PR TITLE
Run frontend and backend tests on python 3

### DIFF
--- a/docs/install-generic-unix-dev.md
+++ b/docs/install-generic-unix-dev.md
@@ -230,14 +230,35 @@ Make sure you have followed the steps specific for your platform:
 * [OpenBSD 5.8 (experimental)](#on-openbsd-5-8-experimental)
 * [Fedora/CentOS](#common-to-fedora-centos-instructions)
 
-For managing Zulip's python dependencies, we recommend using a
-[virtualenv](https://virtualenv.pypa.io/en/stable/).
+For managing Zulip's python dependencies, we recommend using
+[virtualenvs](https://virtualenv.pypa.io/en/stable/).
 
-Once you have created and activated a virtualenv, do the following:
+You must create two virtualenvs. One for Python 2 and one for Python 3.
+You must also install appropriate python packages in them.
+
+You should either install the virtualenvs in `/srv`, or put symlinks to
+them in `/srv`.  If you don't do that, some scripts might not work correctly.
+
+You can run `tools/setup/setup-venv` to do this.  This script will create two
+virtualenvs - /srv/zulip-venv and /srv/zulip-py3-venv.
+
+If you want to do it manually, here are the steps:
 
 ```
-pip install --upgrade pip # upgrade pip itself because older versions have known issues.
+virtualenv /srv/zulip-venv -p python2 # Create a python2 virtualenv
+source /srv/zulip-venv/bin/activate # Activate python2 virtualenv
+pip install --upgrade pip # upgrade pip itself because older versions have known issues
 pip install --no-deps -r requirements/py2_dev.txt # install python packages required for development
+
+virtualenv /srv/zulip-py3-venv -p python3 # Create a python3 virtualenv
+source /srv/zulip-py3-venv/bin/activate # Activate python3 virtualenv
+pip install --upgrade pip # upgrade pip itself because older versions have known issues
+pip install --no-deps -r requirements/py3_dev.txt # install python packages required for development
+```
+
+Now run these commands:
+
+```
 ./tools/setup/install-phantomjs
 ./tools/install-mypy
 ./tools/setup/download-zxcvbn

--- a/tools/provision.py
+++ b/tools/provision.py
@@ -178,10 +178,7 @@ def main():
             DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py3_dev.txt")
             setup_virtualenv(VENV_PATH, DEV_REQS_FILE, virtualenv_args=['-p', 'python3'])
     else:
-        DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py2_dev.txt")
-        setup_virtualenv(PY2_VENV_PATH, DEV_REQS_FILE)
-        DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py3_dev.txt")
-        setup_virtualenv(PY3_VENV_PATH, DEV_REQS_FILE, virtualenv_args=['-p', 'python3'])
+        run(["tools/setup/setup-venvs"])
 
     # Put Python2 virtualenv activation in our .bash_profile.
     with open(os.path.expanduser('~/.bash_profile'), 'w+') as bash_profile:

--- a/tools/setup/setup-venvs
+++ b/tools/setup/setup-venvs
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import os
+import sys
+from os.path import dirname, abspath
+
+ZULIP_PATH = dirname(dirname(dirname(abspath(__file__))))
+if ZULIP_PATH not in sys.path:
+    sys.path.append(ZULIP_PATH)
+
+from scripts.lib.setup_venv import setup_virtualenv
+
+PY2_DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py2_dev.txt")
+setup_virtualenv("/srv/zulip-venv", PY2_DEV_REQS_FILE)
+
+PY3_DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py3_dev.txt")
+setup_virtualenv("/srv/zulip-py3-venv", PY3_DEV_REQS_FILE, virtualenv_args=['-p', 'python3'])


### PR DESCRIPTION
I think we can now start using Zulip with python 3. Now provision.py installs both python 2 and python 3 venvs. I have also added steps to set up a python 3 venv in the manual install instructions.

I have removed the python3 lint-all warning. We'll now start using python 3 for frontend and backend, so people should be aware about how to run things on python 3. There's no reason to have a special warning about lint-all.

I have also made `./tools/run-dev.py` run on python 2 (even if the currently active virtualenv is a python 3 one) and use `twisted` from`/srv/zulip-venv` or `/srv/zulip-py2-twisted-venv`. The Django and Tornado processes spawned in tools/run-dev.py will however use the python available in the currently active virtualenv.