### PR TITLE
[wip] [post-August-conversion] Implement part 1 of adding Topics (do write-only bits)

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -659,6 +659,7 @@ def do_send_messages(messages):
                                         if user_profile.is_active]
         message['message'].maybe_render_content(None)
         message['message'].update_calculated_fields()
+        message['message'].update_topic()
 
     # Save the message receipts in the database
     user_message_flags = defaultdict(dict) # type: Dict[int, Dict[int, List[str]]]

--- a/zerver/migrations/0027_add_topic_table.py
+++ b/zerver/migrations/0027_add_topic_table.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import zerver.lib.str_utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0026_delete_mituser'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Topic',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=60, db_index=True)),
+                ('recipient', models.ForeignKey(to='zerver.Recipient', db_index=True)),
+            ],
+            bases=(zerver.lib.str_utils.ModelReprMixin, models.Model),
+        ),
+        migrations.RunSQL(
+            "CREATE UNIQUE INDEX topic_name_recipient ON "
+            "zerver_topic ((upper(name)), recipient_id);",
+            reverse_sql="DROP INDEX topic_name_recipient;"),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -778,6 +778,26 @@ def to_dict_cache_key(message, apply_markdown):
     # type: (Message, bool) -> text_type
     return to_dict_cache_key_id(message.id, apply_markdown)
 
+class Topic(ModelReprMixin, models.Model):
+    """
+    This model is not in active use yet, but it is here as part
+    of a four-phase migration toward storing message topics in
+    a Topic table.  More details can be found here:
+
+    https://github.com/zulip/zulip/pull/1289#issuecomment-233773078
+
+    The table essentially defines a unique tuple of recipient id
+    (aka stream) and topic name.  The index for this is created
+    using migrations.RunSQL instead of using a Meta tag, because
+    we need the `name` field to be case insensitve.
+    """
+    recipient = models.ForeignKey(Recipient, db_index=True) # type: Recipient
+    name = models.CharField(max_length=MAX_SUBJECT_LENGTH, db_index=True) # type: text_type
+
+    def __unicode__(self):
+        # type: () -> text_type
+        return u"<Topic: recipient %d, %s>" % (self.recipient_id, self.name)
+
 class Message(ModelReprMixin, models.Model):
     sender = models.ForeignKey(UserProfile) # type: UserProfile
     recipient = models.ForeignKey(Recipient) # type: Recipient

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -780,7 +780,7 @@ def to_dict_cache_key(message, apply_markdown):
 
 class Topic(ModelReprMixin, models.Model):
     """
-    This model is not in active use yet, but it is here as part
+    This model is currently write-only, but it is here as part
     of a four-phase migration toward storing message topics in
     a Topic table.  More details can be found here:
 
@@ -790,6 +790,13 @@ class Topic(ModelReprMixin, models.Model):
     (aka stream) and topic name.  The index for this is created
     using migrations.RunSQL instead of using a Meta tag, because
     we need the `name` field to be case insensitve.
+
+    We currently write to the Topic tables on message
+    saves and updates, but we don't link the Topic row back
+    to Message, and none of our "reading" code looks at the
+    Topic table.  Subsequent phases of our migration will
+    backfill the table and have read-only features start to
+    pull names from the Topic table instead of Message.subject.
     """
     recipient = models.ForeignKey(Recipient, db_index=True) # type: Recipient
     name = models.CharField(max_length=MAX_SUBJECT_LENGTH, db_index=True) # type: text_type
@@ -1177,12 +1184,27 @@ class Message(ModelReprMixin, models.Model):
         self.has_image = bool(Message.content_has_image(content))
         self.has_link = bool(Message.content_has_link(content))
 
+    def update_topic(self):
+        # type: () -> None
+        if self.subject:
+            # Note that for our case-insensitive strategy, we
+            # currently keep the original casing of Topic.name;
+            # we don't replace an existing name if there is a new
+            # casing.
+            name = self.subject
+            Topic.objects.get_or_create(
+                name__iexact=name,
+                recipient=self.recipient,
+                defaults=dict(name=name)
+            )
+
 @receiver(pre_save, sender=Message)
 def pre_save_message(sender, **kwargs):
     # type: (Any, **Any) -> None
     if kwargs['update_fields'] is None or "content" in kwargs['update_fields']:
         message = kwargs['instance']
         message.update_calculated_fields()
+        message.update_topic()
 
 def get_context_for_message(message):
     # type: (Message) -> Sequence[Message]

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -19,7 +19,8 @@ from zerver.lib.test_helpers import (
 
 from zerver.models import (
     MAX_MESSAGE_LENGTH, MAX_SUBJECT_LENGTH,
-    Client, Message, Realm, Recipient, Stream, UserMessage, UserProfile, Attachment,
+    Client, Message, Realm, Recipient,
+    Stream, UserMessage, UserProfile, Attachment, Topic,
     get_realm, get_stream, get_user_profile_by_email,
 )
 
@@ -339,7 +340,7 @@ class StreamMessagesTest(AuthedTestCase):
         with queries_captured() as queries:
             send_message()
 
-        self.assert_length(queries, 7)
+        self.assert_length(queries, 8)
 
     def test_message_mentions(self):
         # type: () -> None
@@ -405,6 +406,41 @@ class StreamMessagesTest(AuthedTestCase):
 
         self.assert_stream_message(non_ascii_stream_name, subject=u"hümbüǵ",
                                    content=u"hümbüǵ")
+
+class MessageTopicTest(TestCase):
+    def test_message_hooks(self):
+        # type: () -> None
+        realm = get_realm("zulip.com")
+        sender = get_user_profile_by_email('othello@zulip.com')
+        stream, _ = create_stream_if_needed(realm, 'devel')
+        stream_recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
+        sending_client, _ = Client.objects.get_or_create(name="test suite")
+
+        messages = [] # type: List[Message]
+        for i in range(3):
+            message = Message(
+                sender=sender,
+                recipient=stream_recipient,
+                subject='lunch',
+                content='whatever %d' % (i,),
+                pub_date=datetime.datetime.now(),
+                sending_client=sending_client,
+                last_edit_time=datetime.datetime.now(),
+                edit_history='[]'
+            )
+            message.save()
+            messages.append(message)
+
+        lunch_topics = Topic.objects.filter(
+            name='lunch',
+            recipient=stream_recipient,
+        )
+        self.assertEqual(len(lunch_topics), 1)
+
+        # Make sure we write legacy/new fields.
+        for message in messages:
+            msg = Message.objects.get(id=message.id)
+            self.assertEqual(msg.subject, 'lunch')
 
 class MessageDictTest(AuthedTestCase):
     @slow('builds lots of messages')


### PR DESCRIPTION
@timabbott This is the first of the four phases that I outlined to you on Zulip.  Just building the Topic model and having our code write to it should be pretty low risk.  If the build passes and you are happy with everything, I'm hoping to get this to master.
