### PR TITLE
Patch activate script to set VIRTUAL_ENV correctly.

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -34,6 +34,21 @@ VENV_DEPENDENCIES = [
     "libpq-dev",            # Needed by psycopg2
 ]
 
+def patch_activate_script(venv_path):
+    # venv_path should be what we want to have in VIRTUAL_ENV after patching
+    script_path = os.path.join(venv_path, "bin", "activate")
+
+    file_obj = open(script_path)
+    lines = file_obj.readlines()
+    for i, line in enumerate(lines):
+        if line.startswith('VIRTUAL_ENV='):
+            lines[i] = 'VIRTUAL_ENV="%s"\n' % (venv_path,)
+    file_obj.close()
+
+    file_obj = open(script_path, 'w')
+    file_obj.write("".join(lines))
+    file_obj.close()
+
 def setup_virtualenv(target_venv_path, requirements_file, virtualenv_args=None):
     # type: (Optional[str], str, Optional[List[str]]) -> str
 
@@ -53,6 +68,7 @@ def setup_virtualenv(target_venv_path, requirements_file, virtualenv_args=None):
     print("Using cached Python venv from %s" % (cached_venv_path,))
     if target_venv_path is not None:
         run(["sudo", "ln", "-nsf", cached_venv_path, target_venv_path])
+        patch_activate_script(target_venv_path)
     activate_this = os.path.join(cached_venv_path, "bin", "activate_this.py")
     exec(open(activate_this).read(), {}, dict(__file__=activate_this)) # type: ignore # https://github.com/python/mypy/issues/1577
     return cached_venv_path

--- a/tools/provision.py
+++ b/tools/provision.py
@@ -169,14 +169,17 @@ def main():
     if TRAVIS:
         if PY2:
             MYPY_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "mypy.txt")
-            setup_virtualenv(PY3_VENV_PATH, MYPY_REQS_FILE, virtualenv_args=['-p', 'python3'])
+            setup_virtualenv(PY3_VENV_PATH, MYPY_REQS_FILE, patch_activate_script=True,
+                             virtualenv_args=['-p', 'python3'])
             DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py2_dev.txt")
-            setup_virtualenv(PY2_VENV_PATH, DEV_REQS_FILE)
+            setup_virtualenv(PY2_VENV_PATH, DEV_REQS_FILE, patch_activate_script=True)
         else:
             TWISTED_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "twisted.txt")
-            setup_virtualenv("/srv/zulip-py2-twisted-venv", TWISTED_REQS_FILE)
+            setup_virtualenv("/srv/zulip-py2-twisted-venv", TWISTED_REQS_FILE,
+                             patch_activate_script=True)
             DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py3_dev.txt")
-            setup_virtualenv(VENV_PATH, DEV_REQS_FILE, virtualenv_args=['-p', 'python3'])
+            setup_virtualenv(VENV_PATH, DEV_REQS_FILE, patch_activate_script=True,
+                             virtualenv_args=['-p', 'python3'])
     else:
         # Import tools/setup_venv.py instead of running it so that we get an
         # activated virtualenv for the rest of the provisioning process.

--- a/tools/setup/setup_venvs.py
+++ b/tools/setup/setup_venvs.py
@@ -13,10 +13,11 @@ from scripts.lib.setup_venv import setup_virtualenv
 def main():
     # type: () -> None
     PY2_DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py2_dev.txt")
-    setup_virtualenv("/srv/zulip-venv", PY2_DEV_REQS_FILE)
+    setup_virtualenv("/srv/zulip-venv", PY2_DEV_REQS_FILE, patch_activate_script=True)
 
     PY3_DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py3_dev.txt")
-    setup_virtualenv("/srv/zulip-py3-venv", PY3_DEV_REQS_FILE, virtualenv_args=['-p', 'python3'])
+    setup_virtualenv("/srv/zulip-py3-venv", PY3_DEV_REQS_FILE, patch_activate_script=True,
+                     virtualenv_args=['-p', 'python3'])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Patch a virtualenv's activate script to not resolve symlinks when setting the environment variable `VIRTUAL_ENV`.

Fixes #1190.