### PR TITLE
Error better when handlebars template is missing

### DIFF
--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -6,6 +6,12 @@ exports.render = function (name, arg) {
     if (Handlebars.templates === undefined) {
         throw "Cannot find compiled templates!";
     }
+    if (Handlebars.templates[name] === undefined) {
+        throw "Cannot find a template with this name: " + name
+              + ". If you are developing a new feature, this likely"
+              + "means you need to add the file static/templates/"
+              + name + ".handlerbars";
+    }
 
     // The templates should be compiled into compiled.js.  In
     // prod we build compiled.js as part of the deployment process,


### PR DESCRIPTION
Currently if you try to use a non-existent handlebars
template, you get this error:

Uncaught TypeError: Handlebars.templates[name] is not a function

This change makes it a little more clear what the issue is
and what the fix would be.