### PR TITLE
(wip) Part/phase 2 of adding Topic model

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -659,6 +659,7 @@ def do_send_messages(messages):
                                         if user_profile.is_active]
         message['message'].maybe_render_content(None)
         message['message'].update_calculated_fields()
+        message['message'].update_topic()
 
     # Save the message receipts in the database
     user_message_flags = defaultdict(dict) # type: Dict[int, Dict[int, List[str]]]

--- a/zerver/management/commands/backfill_topic.py
+++ b/zerver/management/commands/backfill_topic.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from argparse import ArgumentParser
+import sys
+
+from zerver.lib.migrate import (
+    migrate_all_messages,
+    create_topics_for_message_range,
+)
+
+
+class Command(BaseCommand):
+    help = """Backfill Topic froms Message (run with care!)."""
+
+    def add_arguments(self, parser):
+        # type: (ArgumentParser) -> None
+        parser.add_argument('batch_size', type=int,
+                            help='size of range of Message.id')
+        parser.add_argument('max_num_batches', type=int,
+                            help='size of range of Message.id')
+
+    def handle(self, *args, **options):
+        # type: (*Any, **str) -> None
+        batch_size = int(options['batch_size'])
+        max_num_batches = int(options['max_num_batches'])
+        assert batch_size >= 1
+        assert max_num_batches >= 1
+        assert max_num_batches <= 100000
+
+        migrate_all_messages(
+            range_method=create_topics_for_message_range,
+            batch_size=batch_size,
+            max_num_batches=max_num_batches,
+            verbose=True,
+        )

--- a/zerver/migrations/0026_add_topic_table.py
+++ b/zerver/migrations/0026_add_topic_table.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import zerver.lib.str_utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0025_realm_message_content_edit_limit'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Topic',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=60, db_index=True)),
+                ('recipient', models.ForeignKey(to='zerver.Recipient')),
+            ],
+            bases=(zerver.lib.str_utils.ModelReprMixin, models.Model),
+        ),
+        migrations.AlterUniqueTogether(
+            name='topic',
+            unique_together=set([('recipient', 'name')]),
+        ),
+    ]

--- a/zerver/migrations/0027_topics_backfill.py
+++ b/zerver/migrations/0027_topics_backfill.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from zerver.lib.migrate import (
+    create_topics_for_message_range,
+    migrate_all_messages,
+)
+from zerver.models import (
+    Message,
+)
+
+# These are to to help type-check the target of RunPython (backfill_topics).
+from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+def backfill_topics(apps, schema_editor):
+    # type: (StateApps, DatabaseSchemaEditor) -> None
+    if Message.objects.all().count():
+        migrate_all_messages(
+            range_method=create_topics_for_message_range,
+            batch_size=10000,
+            max_num_batches=99999,
+            verbose=True,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0026_add_topic_table'),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_topics),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1153,12 +1153,21 @@ class Message(ModelReprMixin, models.Model):
         self.has_image = bool(Message.content_has_image(content))
         self.has_link = bool(Message.content_has_link(content))
 
+    def update_topic(self):
+        # type: () -> None
+        if self.subject:
+            Topic.objects.get_or_create(
+                name=self.subject,
+                recipient=self.recipient)
+
+
 @receiver(pre_save, sender=Message)
 def pre_save_message(sender, **kwargs):
     # type: (Any, **Any) -> None
     if kwargs['update_fields'] is None or "content" in kwargs['update_fields']:
         message = kwargs['instance']
         message.update_calculated_fields()
+        message.update_topic()
 
 def get_context_for_message(message):
     # type: (Message) -> Sequence[Message]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -768,6 +768,17 @@ def to_dict_cache_key(message, apply_markdown):
     # type: (Message, bool) -> text_type
     return to_dict_cache_key_id(message.id, apply_markdown)
 
+class Topic(ModelReprMixin, models.Model):
+    recipient = models.ForeignKey(Recipient) # type: Recipient
+    name = models.CharField(max_length=MAX_SUBJECT_LENGTH, db_index=True) # type: text_type
+
+    class Meta(object):
+        unique_together = ("recipient", "name")
+
+    def __unicode__(self):
+        # type: () -> text_type
+        return u"<Topic: recipient %d, %s>" % (self.recipient_id, self.name)
+
 class Message(ModelReprMixin, models.Model):
     sender = models.ForeignKey(UserProfile) # type: UserProfile
     recipient = models.ForeignKey(Recipient) # type: Recipient

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -18,7 +18,8 @@ from zerver.lib.test_helpers import (
 
 from zerver.models import (
     MAX_MESSAGE_LENGTH, MAX_SUBJECT_LENGTH,
-    Client, Message, Realm, Recipient, Stream, UserMessage, UserProfile, Attachment,
+    Client, Message, Realm, Recipient,
+    Stream, UserMessage, UserProfile, Attachment, Topic,
     get_realm, get_stream, get_user_profile_by_email,
 )
 
@@ -379,6 +380,41 @@ class StreamMessagesTest(AuthedTestCase):
 
         self.assert_stream_message(non_ascii_stream_name, subject=u"hümbüǵ",
                                    content=u"hümbüǵ")
+
+class MessageTopicTest(TestCase):
+    def test_message_hooks(self):
+        # type: () -> None
+        realm = get_realm("zulip.com")
+        sender = get_user_profile_by_email('othello@zulip.com')
+        stream, _ = create_stream_if_needed(realm, 'devel')
+        stream_recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
+        sending_client, _ = Client.objects.get_or_create(name="test suite")
+
+        messages = []
+        for i in range(3):
+            message = Message(
+                sender=sender,
+                recipient=stream_recipient,
+                subject='lunch',
+                content='whatever %d' % (i,),
+                pub_date=datetime.datetime.now(),
+                sending_client=sending_client,
+                last_edit_time=datetime.datetime.now(),
+                edit_history='[]'
+            )
+            message.save()
+            messages.append(message)
+
+        lunch_topics = Topic.objects.filter(
+            name='lunch',
+            recipient=stream_recipient,
+        )
+        self.assertEqual(len(lunch_topics), 1)
+
+        # Make sure we write legacy/new fields.
+        for message in messages:
+            msg = Message.objects.get(id=message.id)
+            self.assertEqual(msg.subject, 'lunch')
 
 class MessageDictTest(AuthedTestCase):
     @slow(1.6, 'builds lots of messages')

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -318,7 +318,7 @@ class StreamMessagesTest(AuthedTestCase):
         with queries_captured() as queries:
             send_message()
 
-        self.assert_length(queries, 7)
+        self.assert_length(queries, 8)
 
     def test_message_mentions(self):
         user_profile = get_user_profile_by_email("iago@zulip.com")

--- a/zerver/tests/test_migrate.py
+++ b/zerver/tests/test_migrate.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from django.test import TestCase
+
+import datetime
+import mock
+from six.moves import range
+
+from zerver.lib.actions import (
+    create_stream_if_needed,
+)
+from zerver.lib.migrate import (
+    create_topics_for_message_range,
+)
+from zerver.models import (
+    Client,
+    Message,
+    Recipient,
+    Topic,
+    get_realm,
+    get_user_profile_by_email,
+)
+
+class TestTopicMigration(TestCase):
+    def test_create_topics_for_message_range(self):
+        # type: () -> None
+        realm = get_realm("zulip.com")
+        sending_client, _ = Client.objects.get_or_create(name="test suite")
+        sender = get_user_profile_by_email('othello@zulip.com')
+
+        num_streams = 10
+        num_topics = 3
+        num_msgs_per_topic = 5
+
+        low_msg_id = Message.objects.order_by('-id')[0].id + 1
+
+        for i in range(num_streams):
+            stream_name = 'stream %d' % (i,)
+            stream, _ = create_stream_if_needed(realm, stream_name)
+            stream_recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
+
+            for j in range(num_topics):
+                topic_name = 'subject %d' % (j,)
+
+                for k in range(num_msgs_per_topic):
+                    content = 'msg (%d,%d,%d)' % (i, j, k)
+
+                    message = Message(
+                        sender=sender,
+                        recipient=stream_recipient,
+                        subject=topic_name,
+                        content=content,
+                        pub_date=datetime.datetime.now(),
+                        sending_client=sending_client,
+                        last_edit_time=datetime.datetime.now(),
+                        edit_history='[]'
+                    )
+                    with mock.patch('zerver.models.Message.update_topic'):
+                        message.save()
+
+        high_msg_id = Message.objects.order_by('-id')[0].id + 1
+
+        # Do some sanity checking on our message range.
+        # Our message id range may be greater than expected_num_saved,
+        # due to rollbacks from prior running tests, but that is ok
+        # for our purposes.
+        expected_num_saved = num_streams * num_topics * num_msgs_per_topic
+        self.assertTrue((high_msg_id - low_msg_id) >= expected_num_saved)
+
+        # Blow away Topic objects, because some may have been
+        # created by our pre-save hooks.
+        Topic.objects.all().delete()
+        self.assertEqual(Topic.objects.count(), 0)
+
+        status_update = create_topics_for_message_range(
+            low_msg_id=low_msg_id,
+            high_msg_id=high_msg_id,
+        ) # type: str
+
+        expected_num_topics = num_streams * num_topics # type: int
+        self.assertEqual(Topic.objects.count(), expected_num_topics)
+        expected_status_update = '%d Topic rows created' % (expected_num_topics,)
+        self.assertEqual(status_update, expected_status_update)
+
+        # Now, test idempotency..we can run this again, and it
+        # won't try to create new topics.
+        status_update = create_topics_for_message_range(
+            low_msg_id=low_msg_id,
+            high_msg_id=high_msg_id,
+        )
+        self.assertEqual(status_update, '0 Topic rows created')
+
+        expected_num_topics = num_streams * num_topics
+        self.assertEqual(Topic.objects.count(), expected_num_topics)
+
+        # Make sure 'subject 1' has entries for each of its streams.
+        self.assertEqual(Topic.objects.filter(name='subject 1').count(), num_streams)

--- a/zerver/tests/test_migrate.py
+++ b/zerver/tests/test_migrate.py
@@ -11,6 +11,7 @@ from zerver.lib.actions import (
 )
 from zerver.lib.migrate import (
     create_topics_for_message_range,
+    migrate_all_messages,
 )
 from zerver.models import (
     Client,
@@ -95,3 +96,15 @@ class TestTopicMigration(TestCase):
 
         # Make sure 'subject 1' has entries for each of its streams.
         self.assertEqual(Topic.objects.filter(name='subject 1').count(), num_streams)
+
+    def test_full_migration(self):
+        # type: () -> None
+        # This is mostly a don't-explode test.  To debug
+        # migrate_all_messages() while you are in test mode,
+        # you can set verbose to True here.
+        migrate_all_messages(
+            range_method=create_topics_for_message_range,
+            batch_size=10,
+            max_num_batches=3,
+            verbose=False,
+        )


### PR DESCRIPTION
The last four commits here comprise phase 2 of #1191, and they set us to backfill Topic from Message.  This series is not yet phase 3 (where we actually link Message rows to Topic), so the only risk in this series is operational headaches.  To put it another way, running this migration is unlikely to impact app users beyond down time; it just might take a really long time to do the migration.

@timabbott Please review this with a little bit of extra scrutiny, as the approach here does set the template for how we structure code in the phase 3 migration.
