### PR TITLE
Type debug

### DIFF
--- a/docs/mypy.md
+++ b/docs/mypy.md
@@ -30,6 +30,43 @@ You can learn more about it at:
 The mypy type checker is run automatically as part of Zulip's Travis
 CI testing process in the 'static-analysis' build.
 
+## `type_debug.py`
+
+`zerver/lib/type_debug.py` has a useful decorator `print_types`.  It prints the
+types of the parameters of the decorated function and the return type whenever
+that function is called.  This can help find out what parameter types a function
+is supposed to accept, or if wrong types are being passed to a function.
+
+Here is an example using the interactive console:
+
+```
+>>> from zerver.lib.type_debug import print_types
+>>>
+>>> @print_types
+... def func(x, y):
+...     return x + y
+...
+>>> func(1.0, 2)
+func(float, int) -> float
+3.0
+>>> func('a', 'b')
+func(str, str) -> str
+'ab'
+>>> func((1, 2), (3,))
+func((int, int), (int,)) -> (int, int, int)
+(1, 2, 3)
+>>> func([1, 2, 3], [4, 5, 6, 7])
+func([int, ...], [int, ...]) -> [int, ...]
+[1, 2, 3, 4, 5, 6, 7]
+```
+
+`print_all` prints the type of the first item of lists.  So `[int, ...]` represents
+a list whose first element's type is `int`.  Types of all items are not printed
+because a list can have many elements, which would make the output too large.
+
+Similarly in dicts, one key's type and the corresponding value's type are printed.
+So `{1: 'a', 2: 'b', 3: 'c'}` will be printed as `{int: str, ...}`.
+
 ## Zulip goals
 
 Zulip is hoping to reach 100% of the codebase annotated with mypy

--- a/zerver/lib/type_debug.py
+++ b/zerver/lib/type_debug.py
@@ -1,0 +1,45 @@
+from __future__ import print_function
+
+import sys
+import functools
+
+from typing import Any, Callable, IO, TypeVar
+
+def get_type_str(x):
+    # type: (Any) -> str
+    if x is None:
+        return 'None'
+    elif isinstance(x, tuple):
+        types = []
+        for v in x:
+            types.append(get_type_str(v))
+        if len(x) == 1:
+            return '(' + types[0] + ',)'
+        else:
+            return '(' + ', '.join(types) + ')'
+    else:
+        return type(x).__name__
+
+FuncT = TypeVar('FuncT', bound=Callable)
+
+def print_types_to(file_obj):
+    # type: (IO[str]) -> Callable[[FuncT], FuncT]
+    def decorator(func):
+        # type: (FuncT) -> FuncT
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # type: (*Any, **Any) -> Any
+            arg_types = [get_type_str(arg) for arg in args]
+            kwarg_types = [key + "=" + get_type_str(value) for key, value in kwargs.items()]
+            ret_val = func(*args, **kwargs)
+            output = "%s(%s) -> %s" % (func.__name__,
+                                    ", ".join(arg_types + kwarg_types),
+                                    get_type_str(ret_val))
+            print(output, file=file_obj)
+            return ret_val
+        return wrapper # type: ignore # https://github.com/python/mypy/issues/1927
+    return decorator
+
+def print_types(func):
+    # type: (FuncT) -> FuncT
+    return print_types_to(sys.stdout)(func) # type: ignore # https://github.com/python/mypy/issues/1551

--- a/zerver/tests/test_type_debug.py
+++ b/zerver/tests/test_type_debug.py
@@ -1,0 +1,121 @@
+from __future__ import print_function
+
+import sys
+from unittest import TestCase
+from six.moves import cStringIO as StringIO
+
+from zerver.lib.type_debug import print_types
+
+from typing import Any, Callable, Dict, Iterable, Tuple, TypeVar
+
+T = TypeVar('T')
+
+def add(x=0, y=0):
+    # type: (Any, Any) -> Any
+    return x + y
+
+def to_dict(l=[]):
+    # type: (Iterable[Tuple[Any, Any]]) -> Dict[Any, Any]
+    return dict(l)
+
+class TypesPrintTest(TestCase):
+
+    # These 2 methods are needed to run tests with our custom test-runner
+    def _pre_setup(self):
+        # type: () -> None
+        pass
+    def _post_teardown(self):
+        # type: () -> None
+        pass
+
+    def check_signature(self, signature, retval, func, *args, **kwargs):
+        # type: (str, T, Callable[..., T], *Any, **Any) -> None
+        """
+        Checks if print_types outputs `signature` when func is called with *args and **kwargs.
+        Do not decorate func with print_types before passing into this function.
+        func will be decorated with print_types within this function.
+        """
+        try:
+            original_stdout = sys.stdout
+            sys.stdout = StringIO()
+            self.assertEqual(retval, print_types(func)(*args, **kwargs))
+            self.assertEqual(sys.stdout.getvalue().strip(), signature)
+        finally:
+            sys.stdout = original_stdout
+
+    def test_empty(self):
+        # type: () -> None
+        def empty_func():
+            # type: () -> None
+            pass
+        self.check_signature("empty_func() -> None", None, empty_func) # type: ignore # https://github.com/python/mypy/issues/1932
+        self.check_signature("<lambda>() -> None", None, (lambda: None)) # type: ignore # https://github.com/python/mypy/issues/1932
+
+    def test_basic(self):
+        # type: () -> None
+        self.check_signature("add(float, int) -> float",
+                             5.0, add, 2.0, 3)
+        self.check_signature("add(float, y=int) -> float",
+                             5.0, add, 2.0, y=3)
+        self.check_signature("add(x=int) -> int", 2, add, x=2)
+        self.check_signature("add() -> int", 0, add)
+
+    def test_list(self):
+        # type: () -> None
+        self.check_signature("add([], [str]) -> [str]",
+                             ['two'], add, [], ['two'])
+        self.check_signature("add([int], [str]) -> [int, ...]",
+                             [2, 'two'], add, [2], ['two'])
+        self.check_signature("add([int, ...], y=[]) -> [int, ...]",
+                             [2, 'two'], add, [2, 'two'], y=[])
+
+    def test_dict(self):
+        # type: () -> None
+        self.check_signature("to_dict() -> {}", {}, to_dict)
+        self.check_signature("to_dict([(int, str)]) -> {int: str}",
+                             {2: 'two'}, to_dict, [(2, 'two')])
+        self.check_signature("to_dict(((int, str),)) -> {int: str}",
+                             {2: 'two'}, to_dict, ((2, 'two'),))
+        self.check_signature("to_dict([(int, str), ...]) -> {int: str, ...}",
+                             {1: 'one', 2: 'two'}, to_dict, [(1, 'one'), (2, 'two')])
+
+    def test_tuple(self):
+        # type: () -> None
+        self.check_signature("add((), ()) -> ()",
+                             (), add, (), ())
+        self.check_signature("add((int,), (str,)) -> (int, str)",
+                             (1, 'one'), add, (1,), ('one',))
+        self.check_signature("add(((),), ((),)) -> ((), ())",
+                             ((), ()), add, ((),), ((),))
+
+    def test_class(self):
+        # type: () -> None
+        class A(object): pass
+        class B(str): pass
+        self.check_signature("<lambda>(A) -> str", 'A', (lambda x: x.__class__.__name__), A())
+        self.check_signature("<lambda>(B) -> int", 5, (lambda x: len(x)), B("hello"))
+
+    def test_sequence(self):
+        # type: () -> None
+        class A(list): pass
+        class B(list): pass
+        self.check_signature("add(A([]), B([str])) -> [str]",
+                             ['two'], add, A([]), B(['two']))
+        self.check_signature("add(A([int]), B([str])) -> [int, ...]",
+                             [2, 'two'], add, A([2]), B(['two']))
+        self.check_signature("add(A([int, ...]), y=B([])) -> [int, ...]",
+                             [2, 'two'], add, A([2, 'two']), y=B([]))
+
+    def test_mapping(self):
+        # type: () -> None
+        class A(dict): pass
+        def to_A(l=[]):
+            # type: (Iterable[Tuple[Any, Any]]) -> A
+            return A(l)
+        self.check_signature("to_A() -> A([])", A(()), to_A)
+        self.check_signature("to_A([(int, str)]) -> A([(int, str)])",
+                             {2: 'two'}, to_A, [(2, 'two')])
+        self.check_signature("to_A([(int, str), ...]) -> A([(int, str), ...])",
+                             {1: 'one', 2: 'two'}, to_A, [(1, 'one'), (2, 'two')])
+        self.check_signature("to_A(((int, str), (int, str))) -> A([(int, str), ...])",
+                             {1: 'one', 2: 'two'}, to_A, ((1, 'one'), (2, 'two')))


### PR DESCRIPTION
Add decorator to print the types of parameters passed to a function at runtime. This can be helpful in debugging and adding or fixing mypy annotations.