### PR TITLE
Run mypy on extensionless python scripts in Travis

### DIFF
--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -45,12 +45,45 @@ zerver/lib/ccache.py
 """.split()
 
 exclude_scripts_common = """
+api/integrations/asana/zulip_asana_mirror
+api/integrations/basecamp/zulip_basecamp_mirror
+api/integrations/codebase/zulip_codebase_mirror
+api/integrations/git/post-receive
+api/integrations/nagios/nagios-notify-zulip
+api/integrations/rss/rss-bot
+api/integrations/svn/post-commit
+api/integrations/twitter/twitter-bot
+api/integrations/twitter/twitter-search-bot
+bots/check-mirroring
+bots/gcal-bot
+bots/githook-post-receive
+frontend_tests/run-casper
+puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_send_receive_time
+scripts/nagios/check-rabbitmq-consumers
+scripts/nagios/check-rabbitmq-queue
+scripts/zulip-puppet-apply
+tools/check-templates
+tools/compile-handlebars-templates
+tools/deprecated/inject-messages/inject-messages
+tools/deprecated/review
+tools/get-handlebar-vars
+tools/lint-all
+tools/minify-js
+tools/run-mypy
+tools/test-js-with-casper
+tools/test-run-dev
+tools/update-deployment
+tools/zulip-export/zulip-export
 """.split()
 
 exclude_scripts_py2 = """
+puppet/zulip_internal/files/zulip-ec2-configure-interfaces
 """.split()
 
 exclude_scripts_py3 = """
+bots/process_ccache
+scripts/restart-server
+tools/post-receive
 """.split()
 
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -44,6 +44,15 @@ exclude_py3 = """
 zerver/lib/ccache.py
 """.split()
 
+exclude_scripts_common = """
+""".split()
+
+exclude_scripts_py2 = """
+""".split()
+
+exclude_scripts_py3 = """
+""".split()
+
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
 parser.add_argument('targets', nargs='*', default=[],
                     help="""files and directories to include in the result.
@@ -73,10 +82,16 @@ else:
 
 if args.all:
     exclude = []
-elif py_version == 2:
-    exclude = exclude_common + exclude_py2
+elif args.scripts_only:
+    if py_version == 2:
+        exclude = exclude_scripts_common + exclude_scripts_py2
+    else:
+        exclude = exclude_scripts_common + exclude_scripts_py3
 else:
-    exclude = exclude_common + exclude_py3
+    if py_version == 2:
+        exclude = exclude_common + exclude_py2
+    else:
+        exclude = exclude_common + exclude_py3
 
 # find all non-excluded files in current directory
 files_dict = lister.list_files(targets=args.targets, ftypes=['py', 'pyi'], use_shebang=args.scripts_only,

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -56,6 +56,8 @@ parser.add_argument('--linecoverage-report', dest='linecoverage_report', action=
                     help="""run the linecoverage report to see annotation coverage""")
 parser.add_argument('--disallow-untyped-defs', dest='disallow_untyped_defs', action='store_true', default=False,
                     help="""throw errors when functions are not annotated""")
+parser.add_argument('--scripts-only', dest='scripts_only', action='store_true', default=False,
+                    help="""Only type check extensionless python scripts""")
 
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--py2', default=False, action='store_true', help="Use Python 2 mode")
@@ -77,12 +79,12 @@ else:
     exclude = exclude_common + exclude_py3
 
 # find all non-excluded files in current directory
-files_dict = lister.list_files(targets=args.targets, ftypes=['py', 'pyi'], use_shebang=False,
+files_dict = lister.list_files(targets=args.targets, ftypes=['py', 'pyi'], use_shebang=args.scripts_only,
                                modified_only=args.modified, exclude = exclude + ['stubs'],
-                               group_by_ftype=True)
+                               group_by_ftype=True, extless_only=args.scripts_only)
 pyi_files = set(files_dict['pyi'])
 python_files = [fpath for fpath in files_dict['py']
-                if fpath.endswith('.py') and fpath + 'i' not in pyi_files]
+                if not fpath.endswith('.py') or fpath + 'i' not in pyi_files]
 
 # Use zulip-py3-venv's mypy if it's available and we're on python 2
 PY3_VENV_DIR = "/srv/zulip-py3-venv"
@@ -105,14 +107,20 @@ if args.disallow_untyped_defs:
 
 # run mypy
 if python_files:
-    rc = subprocess.call([mypy_command] + extra_args + python_files)
-    if args.linecoverage_report:
-        # Move the coverage report to where coveralls will look for it.
-        try:
-            os.rename('var/linecoverage-report/coverage.txt', '.coverage')
-        except OSError:
-            # maybe mypy crashed; exit with its error code
-            pass
+    if args.scripts_only:
+        rc = 0
+        for fpath in python_files:
+            print("Checking", fpath)
+            rc = subprocess.call([mypy_command] + extra_args + [fpath]) or rc
+    else:
+        rc = subprocess.call([mypy_command] + extra_args + python_files)
+        if args.linecoverage_report:
+            # Move the coverage report to where coveralls will look for it.
+            try:
+                os.rename('var/linecoverage-report/coverage.txt', '.coverage')
+            except OSError:
+                # maybe mypy crashed; exit with its error code
+                pass
     sys.exit(rc)
 else:
     print("There are no files to run mypy on.")

--- a/tools/travis/static-analysis
+++ b/tools/travis/static-analysis
@@ -4,6 +4,8 @@ retcode=0
 set -x
 ./tools/run-mypy --py2 --linecoverage-report || retcode=1
 ./tools/run-mypy --py3 || retcode=1
+./tools/run-mypy --py2 --scripts-only || retcode=1
+./tools/run-mypy --py3 --scripts-only || retcode=1
 set +x
 
 if [ "$retcode" == "0" ]; then


### PR DESCRIPTION
I have added a `--scripts-only` option to tools/run-mypy. This option runs mypy only on extensionless python scripts.

It takes around 90 seconds on my laptop to run `tools/run-mypy --scripts-only`.