### PR TITLE
Improve decorator annotation

### DIFF
--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -450,13 +450,13 @@ def send_local_email_template_with_delay(recipients, template_prefix,
     text_content = loader.render_to_string(template_prefix + ".text", template_payload)
     subject = loader.render_to_string(template_prefix + ".subject", template_payload).strip()
 
-    return send_future_email(recipients,
-                             html_content,
-                             text_content,
-                             subject,
-                             delay=delay,
-                             sender=sender,
-                             tags=tags)
+    send_future_email(recipients,
+                      html_content,
+                      text_content,
+                      subject,
+                      delay=delay,
+                      sender=sender,
+                      tags=tags)
 
 def enqueue_welcome_emails(email, name):
     # type: (text_type, text_type) -> None

--- a/zerver/lib/request.pyi
+++ b/zerver/lib/request.pyi
@@ -1,4 +1,7 @@
-from typing import Any
+from typing import Any, Callable, TypeVar
+from django.http import HttpResponse
+
+ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
 
 class JsonableError(Exception):
     error = ...  # type: Any
@@ -8,4 +11,4 @@ class RequestVariableMissingError(JsonableError): ...
 
 def REQ(*args: Any, **kwargs: Any) -> Any: ...
 
-def has_request_variables(view_func: Any) -> Any: ...
+def has_request_variables(view_func: ViewFuncT) -> ViewFuncT: ...


### PR DESCRIPTION
I improved the annotations of several decorators. However, it is not possible now to have perfect annotations of parametrized decorators because of https://github.com/python/mypy/issues/1551.

The annotations were able to catch 2 issues, which I have fixed in my first 2 commits.