### PR TITLE
Fix setting tests

### DIFF
--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1324,19 +1324,6 @@ class ChangeSettingsTest(AuthedTestCase):
         # type: () -> None
         self.check_for_toggle_param('/json/users/me/enter-sends', "enter_sends")
 
-    def test_missing_params(self):
-        # type: () -> None
-        """
-        full_name is a required POST parameter for json_change_settings.
-        (enable_desktop_notifications is false by default, and password is
-        only required if you are changing it)
-        """
-        self.login("hamlet@zulip.com")
-
-        result = self.client.post("/json/settings/change", {})
-        self.assert_json_error(result,
-                "Missing '%s' argument" % ("full_name",))
-
     def test_mismatching_passwords(self):
         # type: () -> None
         """
@@ -1345,7 +1332,6 @@ class ChangeSettingsTest(AuthedTestCase):
         self.login("hamlet@zulip.com")
         result = self.client.post("/json/settings/change",
             dict(
-                full_name="", # TODO, make this a default in prod code
                 new_password="mismatched_password",
                 confirm_password="not_the_same",
             )
@@ -1361,7 +1347,6 @@ class ChangeSettingsTest(AuthedTestCase):
         self.login("hamlet@zulip.com")
         result = self.client.post("/json/settings/change",
             dict(
-                full_name="", # TODO, make this a default in prod code
                 old_password='bad_password',
                 new_password="ignored",
                 confirm_password="ignored",
@@ -1380,7 +1365,6 @@ class ChangeSettingsTest(AuthedTestCase):
         self.login("hamlet@zulip.com")
         result = self.client.post("/json/settings/change",
             dict(
-                full_name="", # TODO, make this a default in prod code
                 old_password='ignored',
             )
         )

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1354,13 +1354,12 @@ class ChangeSettingsTest(AuthedTestCase):
         )
         self.assert_json_error(result, "Wrong password!")
 
-    def test_changing_nothing_still_returns_success(self):
+    def test_changing_nothing_returns_error(self):
         # type: () -> None
         """
-        This test just verifies the current behavior of the system.
-        If we want to change this use case to result in an error,
-        it's probably a good thing, and we'll just need to make
-        sure that there isn't client code that relies on this loophole.
+        We need to supply at least one non-empty parameter
+        to this API, or it should fail.  (Eventually, we should
+        probably use a patch interface for these changes.)
         """
         self.login("hamlet@zulip.com")
         result = self.client.post("/json/settings/change",
@@ -1368,7 +1367,7 @@ class ChangeSettingsTest(AuthedTestCase):
                 old_password='ignored',
             )
         )
-        self.assert_json_success(result)
+        self.assert_json_error(result, "No new data supplied")
 
 class GetProfileTest(AuthedTestCase):
 

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1369,6 +1369,23 @@ class ChangeSettingsTest(AuthedTestCase):
         )
         self.assert_json_error(result, "Wrong password!")
 
+    def test_changing_nothing_still_returns_success(self):
+        # type: () -> None
+        """
+        This test just verifies the current behavior of the system.
+        If we want to change this use case to result in an error,
+        it's probably a good thing, and we'll just need to make
+        sure that there isn't client code that relies on this loophole.
+        """
+        self.login("hamlet@zulip.com")
+        result = self.client.post("/json/settings/change",
+            dict(
+                full_name="", # TODO, make this a default in prod code
+                old_password='ignored',
+            )
+        )
+        self.assert_json_success(result)
+
 class GetProfileTest(AuthedTestCase):
 
     def common_update_pointer(self, email, pointer):

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -53,7 +53,7 @@ def json_change_ui_settings(request, user_profile,
 @authenticated_json_post_view
 @has_request_variables
 def json_change_settings(request, user_profile,
-                         full_name=REQ(),
+                         full_name=REQ(default=""),
                          old_password=REQ(default=""),
                          new_password=REQ(default=""),
                          confirm_password=REQ(default="")):

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -58,6 +58,9 @@ def json_change_settings(request, user_profile,
                          new_password=REQ(default=""),
                          confirm_password=REQ(default="")):
     # type: (HttpRequest, UserProfile, text_type, text_type, text_type, text_type) -> HttpResponse
+    if not (full_name or new_password):
+        return json_error(_("No new data supplied"))
+
     if new_password != "" or confirm_password != "":
         if new_password != confirm_password:
             return json_error(_("New password must match confirmation password!"))


### PR DESCRIPTION
These address #1315, and the last two commits make minor changes to the production code.  The 3rd commit makes full_name have a default, but then the 4th commit raises an error neither full_name or new_password is provided.  They seem like contradictory goals, but I want to make it so that somebody submitting a new password doesn't have to submit full_name and possibly spuriously create a name change.  But then I also don't want people to confused by apparently successful post requests that don't actually change any data.

In the long run, the better plan here might be to just throw out the legacy API and go to a "patch" strategy, but that's more work.  But if that is the end goal, it might be fine to just take the first two commit series from the series and abandon the last two for now.

Because I wanted you to weigh in on the last commit, I didn't put any auto-close wording in the commit messages, but if you push the first two, you can close #1315.