### PR TITLE
Fix email-mirror instructions in prod_settings_template.py.

### DIFF
--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -228,7 +228,7 @@ EMAIL_GATEWAY_PATTERN = ""
 # You will need to configure authentication for the email mirror
 # command to access the IMAP mailbox below and in zulip-secrets.conf.
 #
-# The IMAP login; username here and password as email_gateway_login in
+# The IMAP login; username here and password as email_gateway_password in
 # zulip-secrets.conf.
 EMAIL_GATEWAY_LOGIN = ""
 # The IMAP server & port to connect to


### PR DESCRIPTION
When email mirroring is done via polling, the IMAP account's password should be stored in zulip-secrets.conf in `email_gateway_password`, not in `email_gateway_login`.