### PR TITLE
Upgrade Twisted.

### DIFF
--- a/requirements/twisted.txt
+++ b/requirements/twisted.txt
@@ -1,2 +1,4 @@
-Twisted==15.2.1
-zope.interface==4.1.2
+Twisted==16.3.0
+zope.interface==4.2.0
+service-identity==16.0.0
+attrs==16.0.0


### PR DESCRIPTION
I have checked that upgrading Twisted to the latest version (16.3.0) doesn't break code which uses it (tools/run-dev.py and email-mirror.py).

While we want to completely replace twisted because it is not python 3 compatible, we don't know when that'll happen, so we should upgrade twisted for now.

I have also added `service-identity` and its dependencies because not doing so makes Twisted output multiple copies of this warning:
>:0: UserWarning: You do not have a working installation of the service_identity module: 'No module named service_identity'.  Please install it from <https://pypi.python.org/pypi/service_identity> and make sure all of its dependencies are satisfied.  Without the service_identity module and a recent enough pyOpenSSL to support it, Twisted can perform only rudimentary TLS client hostname verification.  Many valid certificate/hostname mappings may be rejected.