### PR TITLE
Add percentage translated to dropdown in language settings

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -143,10 +143,14 @@ casper.waitForSelector('#create_alert_word_form', function () {
 
 casper.then(function change_default_language() {
     casper.test.info('Changing the default language');
-    casper.evaluate(function () {
-        $('#default_language').val('zh_CN').change();
-    });
+    casper.waitForSelector('#default_language');
 });
+
+casper.thenClick('#default_language');
+
+casper.waitUntilVisible('#default_language_modal');
+
+casper.thenClick('a[data-code="zh_CN"]');
 
 casper.waitUntilVisible('#display-settings-status', function () {
     casper.test.assertSelectorHasText('#display-settings-status', '简体中文 is now the default language');
@@ -157,8 +161,8 @@ casper.waitUntilVisible('#display-settings-status', function () {
 casper.waitForSelector("#default_language", function () {
     casper.test.info("Checking if we are on Chinese page.");
     casper.test.assertEvalEquals(function () {
-        return $('#default_language').val();
-    }, 'zh_CN');
+        return $('#default_language_name').text();
+    }, '简体中文');
     casper.test.info("Opening German page through i18n url.");
 });
 
@@ -170,10 +174,13 @@ casper.waitForSelector("#settings-change-box", function check_url_preference() {
         return document.documentElement.lang;
     }, 'de');
     casper.test.info("Changing language back to English.");
-    casper.evaluate(function () {
-        $('#default_language').val('en').change();
-    });
 });
+
+casper.thenClick('#default_language');
+
+casper.waitUntilVisible('#default_language_modal');
+
+casper.thenClick('a[data-code="en"]');
 
 /*
  * Changing the language back to English so that subsequent tests pass.

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -161,8 +161,6 @@ function _setup_page() {
     $("#show_api_key_box").hide();
     $("#api_key_button_box").show();
 
-    $('#default_language').val(page_params.default_language);
-
     function clear_password_change() {
         // Clear the password boxes so that passwords don't linger in the DOM
         // for an XSS attacker to find.
@@ -419,12 +417,20 @@ function _setup_page() {
         });
     });
 
-    $("#default_language").change(function () {
+    $("#default_language_modal .language").click(function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('#default_language_modal').modal('hide');
+
         var data = {};
-        var setting_value = $("#default_language").val();
+        var setting_value = $(e.target).attr('data-code');
         data.default_language = JSON.stringify(setting_value);
+
+        var new_language = $(e.target).attr('data-name');
+        $('#default_language_name').text(new_language);
+
         var context = {};
-        context.lang = $("#default_language option:selected").text();
+        context.lang = new_language;
 
         channel.patch({
             url: '/json/language_setting',
@@ -439,6 +445,11 @@ function _setup_page() {
         });
     });
 
+    $('#default_language').on('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('#default_language_modal').modal('show');
+    });
 
     $("#get_api_key_box").hide();
     $("#show_api_key_box").hide();

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2300,8 +2300,17 @@ div.floating_recipient {
 }
 
 .settings-section #default_language {
-    width: 150px;
-    margin-left: 20px !important;
+    text-decoration: none;
+    vertical-align: bottom;
+}
+
+.settings-section #default_language_modal table {
+    width: 90%;
+    margin-top: 20px;
+}
+
+.settings-section #default_language_modal td {
+    padding-left: 80px;
 }
 
 .settings-section .inline {

--- a/static/templates/settings_tab.handlebars
+++ b/static/templates/settings_tab.handlebars
@@ -94,12 +94,58 @@
       <div class="display-settings-form">
 
         <div class="control-group">
-          <label for="default_language" class="control-label inline">{{t "Default Language" }}:</label>
-          <select name="default_language" id="default_language" class="controls">
-            {{#each page_params.language_list}}
-            <option value='{{this.code}}'>{{this.name}}</option>
-            {{/each}}
-          </select>
+          <label for="default_language" class="control-label inline">{{t "Default Language" }}: <span id='default_language_name'>{{page_params.default_language_name}}</span></label>
+          <a id="default_language" href="#default_language" title='Change default language'>[Change]</a>
+
+          <div id="default_language_modal" class="modal hide" tabindex="-1" role="dialog"
+                aria-labelledby="default_language_modal_label" aria-hidden="true">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+              <h3 id="default_language_modal_label">{{t "Select Default Language" }}</h3>
+            </div>
+            <div class="modal-body">
+              <p>
+              The following is a few of the languages we have started to
+              support or are hoping to support in the near future. We would
+              love help translating; if you're interested in helping, make an
+              account at <a href='https://www.transifex.com/zulip/zulip/'>
+              https://www.transifex.com/zulip/zulip/</a>, and sign up for a
+              language! You can also request any language we don't currently
+              have. It only takes a few hours to translate the most important
+              parts of the app.
+              </p>
+              <div>
+                <table>
+                  {{#each page_params.language_list_dbl_col}}
+                    <tr>
+                      <td>
+                        <a class="language" data-code="{{this.first.code}}" data-name="{{this.first.name}}">
+                          {{#if this.first.selected}}
+                          <b>{{this.first.percent}}</b>
+                          {{else}}
+                          {{this.first.percent}}
+                          {{/if}}
+                        </a>
+                      </td>
+                      <td>
+                        <a class="language" data-code="{{this.second.code}}" data-name="{{this.second.name}}">
+                          {{#if this.second.selected}}
+                          <b>{{this.second.percent}}</b>
+                          {{else}}
+                          {{this.second.percent}}
+                          {{/if}}
+                        </a>
+                      </td>
+                    </tr>
+                  {{/each}}
+                </table>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">{{t "Close" }}</button>
+            </div>
+          </div>
+
         </div>
 
         <div class="control-group">

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -6,7 +6,7 @@ from django.utils import translation
 from django.utils.translation import ugettext as _
 
 from six import text_type
-from typing import Any
+from typing import Any, List, Dict, Optional
 
 import os
 import ujson
@@ -32,9 +32,14 @@ def get_language_list():
 
         return sorted(lang_list, key=lambda i: i['name'])
 
+def get_language_name(code):
+    # type: (str) -> Optional[text_type]
+    for lang in get_language_list():
+        if lang['code'] == code:
+            return lang['name']
+
 def get_available_language_codes():
     # type: () -> List[text_type]
     language_list = get_language_list()
     codes = [language['code'] for language in language_list]
     return codes
-

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from django.conf import settings
 from django.utils import translation
 from django.utils.translation import ugettext as _
@@ -26,8 +28,6 @@ def get_language_list():
         for lang_info in languages['languages']:
             name = lang_info['name']
             lang_info['name'] = with_language(name, lang_info['code'])
-            if 'percent_translated' not in lang_info:
-                lang_info['percent_translated'] = 'N/A'
             lang_list.append(lang_info)
 
         return sorted(lang_list, key=lambda i: i['name'])
@@ -37,3 +37,4 @@ def get_available_language_codes():
     language_list = get_language_list()
     codes = [language['code'] for language in language_list]
     return codes
+

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import operator
 
 from django.conf import settings
 from django.utils import translation
 from django.utils.translation import ugettext as _
 
 from six import text_type
+from six.moves import urllib, zip_longest, zip, range
 from typing import Any, List, Dict, Optional
 
 import os
@@ -31,6 +33,40 @@ def get_language_list():
             lang_list.append(lang_info)
 
         return sorted(lang_list, key=lambda i: i['name'])
+
+def get_language_list_for_templates(default_language):
+    # type: (text_type) -> List[Dict[str, Dict[str, str]]]
+    language_list = [l for l in get_language_list()
+                     if 'percent_translated' not in l or
+                        l['percent_translated'] >= 5.]
+
+    formatted_list = []
+    lang_len = len(language_list)
+    firsts_end = (lang_len // 2) + operator.mod(lang_len, 2)
+    firsts = list(range(0, firsts_end))
+    seconds = list(range(firsts_end, lang_len))
+    assert len(firsts) + len(seconds) == lang_len
+    for row in zip_longest(firsts, seconds):
+        item = {}
+        for position, ind in zip(['first', 'second'], row):
+            if ind is None:
+                continue
+
+            lang = language_list[ind]
+            percent = name = lang['name']
+            if 'percent_translated' in lang:
+                percent = u"{} ({}%)".format(name, lang['percent_translated'])
+
+            item[position] = {
+                'name': name,
+                'code': lang['code'],
+                'percent': percent,
+                'selected': True if default_language == lang['code'] else False
+            }
+
+        formatted_list.append(item)
+
+    return formatted_list
 
 def get_language_name(code):
     # type: (str) -> Optional[text_type]

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1834,6 +1834,7 @@ class HomeTest(AuthedTestCase):
             "is_admin",
             "is_zephyr_mirror_realm",
             "language_list",
+            "language_list_dbl_col",
             "last_event_id",
             "left_side_userlist",
             "login_page",

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1812,6 +1812,7 @@ class HomeTest(AuthedTestCase):
             "debug_mode",
             "default_desktop_notifications",
             "default_language",
+            "default_language_name",
             "desktop_notifications_enabled",
             "development_environment",
             "domain",

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -47,7 +47,7 @@ from zerver.decorator import require_post, authenticated_json_post_view, \
     JsonableError, get_user_profile_by_email, REQ, \
     zulip_login_required
 from zerver.lib.avatar import avatar_url
-from zerver.lib.i18n import get_language_list
+from zerver.lib.i18n import get_language_list, get_language_name
 from zerver.lib.response import json_success, json_error
 from zerver.lib.str_utils import force_str
 from zerver.lib.utils import statsd, generate_random_token
@@ -947,6 +947,7 @@ def home(request):
         left_side_userlist    = register_ret['left_side_userlist'],
         default_language      = register_ret['default_language'],
         language_list         = get_language_list(),
+        default_language_name = get_language_name(register_ret['default_language']),
         referrals             = register_ret['referrals'],
         realm_emoji           = register_ret['realm_emoji'],
         needs_tutorial        = needs_tutorial,

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -47,7 +47,8 @@ from zerver.decorator import require_post, authenticated_json_post_view, \
     JsonableError, get_user_profile_by_email, REQ, \
     zulip_login_required
 from zerver.lib.avatar import avatar_url
-from zerver.lib.i18n import get_language_list, get_language_name
+from zerver.lib.i18n import get_language_list, get_language_name, \
+    get_language_list_for_templates
 from zerver.lib.response import json_success, json_error
 from zerver.lib.str_utils import force_str
 from zerver.lib.utils import statsd, generate_random_token
@@ -64,7 +65,7 @@ import ujson
 import simplejson
 import re
 from six import text_type
-from six.moves import urllib
+from six.moves import urllib, zip_longest, zip, range
 import base64
 import time
 import logging
@@ -946,8 +947,9 @@ def home(request):
         enter_sends           = user_profile.enter_sends,
         left_side_userlist    = register_ret['left_side_userlist'],
         default_language      = register_ret['default_language'],
-        language_list         = get_language_list(),
         default_language_name = get_language_name(register_ret['default_language']),
+        language_list_dbl_col = get_language_list_for_templates(register_ret['default_language']),
+        language_list         = get_language_list(),
         referrals             = register_ret['referrals'],
         realm_emoji           = register_ret['realm_emoji'],
         needs_tutorial        = needs_tutorial,


### PR DESCRIPTION
The UI looks ugly though. I still need to remove "[ % translated ]" from the success message. I think we should show the translation stats in some tooltip or help popup.