### PR TITLE
Add MirroredMessageUsersTest.

### DIFF
--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -26,9 +26,12 @@ from zerver.lib.actions import (
     check_message, check_send_message,
     create_stream_if_needed,
     do_add_subscription, do_create_user,
+    get_client,
 )
 
 from zerver.lib.upload import create_attachment
+
+from zerver.views.messages import create_mirrored_message_users
 
 import datetime
 import DNS
@@ -899,6 +902,156 @@ class EditMessageTest(AuthedTestCase):
         self.check_message(id4, subject="topic2")
         self.check_message(id5, subject="edited")
         self.check_message(id6, subject="topic3")
+
+class MirroredMessageUsersTest(TestCase):
+    class Request(object):
+        pass
+
+    def test_invalid_sender(self):
+        user = get_user_profile_by_email('hamlet@zulip.com')
+        recipients = []
+        request = self.Request()
+        request.POST = dict() # no sender
+
+        (valid_input, mirror_sender) = \
+            create_mirrored_message_users(request, user, recipients)
+
+        self.assertEqual(valid_input, False)
+        self.assertEqual(mirror_sender, None)
+
+    def test_invalid_client(self):
+        client = get_client(name='banned_mirror') # Invalid!!!
+
+        user = get_user_profile_by_email('hamlet@zulip.com')
+        sender = user
+
+        recipients = []
+        request = self.Request()
+        request.POST = dict(
+            sender=sender.email,
+            type='private')
+        request.client = client
+
+        (valid_input, mirror_sender) = \
+            create_mirrored_message_users(request, user, recipients)
+
+        self.assertEqual(valid_input, False)
+        self.assertEqual(mirror_sender, None)
+
+    def test_invalid_email(self):
+        invalid_email = 'alice AT example.com'
+        recipients = [invalid_email]
+
+        # We use an MIT user here to maximize code coverage
+        user = get_user_profile_by_email('starnine@mit.edu')
+        sender = user
+
+        for client_name in ['zephyr_mirror', 'irc_mirror', 'jabber_mirror']:
+            client = get_client(name=client_name)
+
+            request = self.Request()
+            request.POST = dict(
+                sender=sender.email,
+                type='private')
+            request.client = client
+
+            (valid_input, mirror_sender) = \
+                create_mirrored_message_users(request, user, recipients)
+
+            self.assertEqual(valid_input, False)
+            self.assertEqual(mirror_sender, None)
+
+    def test_zephyr_mirror(self):
+        client = get_client(name='zephyr_mirror')
+
+        sender = get_user_profile_by_email('starnine@mit.edu')
+        user = sender
+
+        # We will set it up so that Alice is pre-existing, but
+        # Bob is a new user not yet in our system.
+        alice = do_create_user(
+                email='alice@mit.edu',
+                password='',
+                realm=user.realm,
+                full_name='',
+                short_name='',
+                active=True,
+        )
+        recipients = [alice.email, 'bob_the_new_user@mit.edu']
+
+        # Now make the request.
+        request = self.Request()
+        request.POST = dict(
+            sender=sender.email,
+            type='private')
+        request.client = client
+
+        (valid_input, mirror_sender) = \
+            create_mirrored_message_users(request, user, recipients)
+
+        self.assertEqual(valid_input, True)
+        self.assertEqual(mirror_sender, sender)
+
+        realm_users = UserProfile.objects.filter(realm=sender.realm)
+        realm_emails = {user.email for user in realm_users}
+        self.assertIn('alice@mit.edu', realm_emails)
+        self.assertIn('bob_the_new_user@mit.edu', realm_emails)
+
+        bob = get_user_profile_by_email('bob_the_new_user@mit.edu')
+        self.assertTrue(bob.is_mirror_dummy)
+
+
+    def test_irc_mirror(self):
+        client = get_client(name='irc_mirror')
+
+        sender = get_user_profile_by_email('hamlet@zulip.com')
+        user = sender
+
+        recipients = ['alice@zulip.com', 'bob@irc.zulip.com', 'cordelia@zulip.com']
+
+        # Now make the request.
+        request = self.Request()
+        request.POST = dict(
+            sender=sender.email,
+            type='private')
+        request.client = client
+
+        (valid_input, mirror_sender) = \
+            create_mirrored_message_users(request, user, recipients)
+
+        self.assertEqual(valid_input, True)
+        self.assertEqual(mirror_sender, sender)
+
+        realm_users = UserProfile.objects.filter(realm=sender.realm)
+        realm_emails = {user.email for user in realm_users}
+        self.assertIn('alice@zulip.com', realm_emails)
+        self.assertIn('bob@irc.zulip.com', realm_emails)
+
+    def test_jabber_mirror(self):
+        client = get_client(name='jabber_mirror')
+
+        sender = get_user_profile_by_email('hamlet@zulip.com')
+        user = sender
+
+        recipients = ['alice@zulip.com', 'bob@zulip.com', 'cordelia@zulip.com']
+
+        # Now make the request.
+        request = self.Request()
+        request.POST = dict(
+            sender=sender.email,
+            type='private')
+        request.client = client
+
+        (valid_input, mirror_sender) = \
+            create_mirrored_message_users(request, user, recipients)
+
+        self.assertEqual(valid_input, True)
+        self.assertEqual(mirror_sender, sender)
+
+        realm_users = UserProfile.objects.filter(realm=sender.realm)
+        realm_emails = {user.email for user in realm_users}
+        self.assertIn('alice@zulip.com', realm_emails)
+        self.assertIn('bob@zulip.com', realm_emails)
 
 class StarTests(AuthedTestCase):
 


### PR DESCRIPTION
See #1006 

Once this hits master, I'll hit some of the more fiddly cases, like ist.mit.edu users and domains that end in "irc" (I think there's a very minor bug in the code that would impact a realm like blirc.com).

FYI I may have sporadic Internet access in the next couple days, so for any simple changes, please just make them on my behalf.