### PR TITLE
Upgrade some dependencies

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -96,7 +96,7 @@ pycparser==2.14
 pycrypto==2.6.1
 
 # Needed for memcached usage
-pylibmc==1.4.3
+pylibmc==1.5.1
 
 # Needed for timezone work
 pytz==2015.4

--- a/requirements/emailmirror.txt
+++ b/requirements/emailmirror.txt
@@ -2,4 +2,4 @@ git+https://github.com/mailgun/talon.git@7cdd7a8f35aa066d56af5c918b6f7dd6ee084ce
 cchardet==1.0.0
 cssselect==0.9.2
 lxml==3.6.0
-regex==2016.6.19
+regex==2016.7.21

--- a/requirements/py2_common.txt
+++ b/requirements/py2_common.txt
@@ -6,7 +6,7 @@ enum34==1.1.6
 pydns==2.3.6
 
 # Needed for LDAP integration
-python-ldap==2.4.19
+python-ldap==2.4.26
 
 # need for ipython, only on python 2
 backports.shutil_get_terminal_size==1.0.0

--- a/requirements/py2_common.txt
+++ b/requirements/py2_common.txt
@@ -1,6 +1,6 @@
 -r common.txt
 
-enum34==1.0.4
+enum34==1.1.6
 
 # Used for Hesiod lookups, etc.
 pydns==2.3.6


### PR DESCRIPTION
These dependencies are not used directly by us. `pylibmc` is used through django, `regex` is used through `talon`, `python-ldap` is used through `django-auth-ldap`, `enum34` is used through `service-identity`.