### PR TITLE
Remove stub() test helper.

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -60,14 +60,6 @@ API_KEYS = {} # type: Dict[text_type, text_type]
 skip_py3 = unittest.skipIf(six.PY3, "Expected failure on Python 3")
 
 @contextmanager
-def stub(obj, name, f):
-    # type: (Any, str, Callable[..., Any]) -> Generator[None, None, None]
-    old_f = getattr(obj, name)
-    setattr(obj, name, f)
-    yield
-    setattr(obj, name, old_f)
-
-@contextmanager
 def simulated_queue_client(client):
     # type: (type) -> Generator[None, None, None]
     real_SimpleQueueClient = queue_processors.SimpleQueueClient

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence
 from zerver.lib import cache
 
 from zerver.lib.test_helpers import (
-    AuthedTestCase, queries_captured, stub, tornado_redirected_to_list
+    AuthedTestCase, queries_captured, tornado_redirected_to_list
 )
 
 from zerver.decorator import (
@@ -31,6 +31,7 @@ from zerver.lib.actions import (
 )
 
 from django.http import HttpResponse
+import mock
 import random
 import ujson
 import six
@@ -1111,16 +1112,16 @@ class SubscriptionAPITest(AuthedTestCase):
 
     def test_user_settings_for_adding_streams(self):
         # type: () -> None
-        with stub(UserProfile, 'can_create_streams', lambda self: False):
+        with mock.patch('zerver.models.UserProfile.can_create_streams', return_value=False):
             result = self.common_subscribe_to_streams(self.test_email, ['stream1'])
             self.assert_json_error(result, 'User cannot create streams.')
 
-        with stub(UserProfile, 'can_create_streams', lambda self: True):
+        with mock.patch('zerver.models.UserProfile.can_create_streams', return_value=True):
             result = self.common_subscribe_to_streams(self.test_email, ['stream2'])
             self.assert_json_success(result)
 
         # User should still be able to subscribe to an existing stream
-        with stub(UserProfile, 'can_create_streams', lambda self: False):
+        with mock.patch('zerver.models.UserProfile.can_create_streams', return_value=False):
             result = self.common_subscribe_to_streams(self.test_email, ['stream2'])
             self.assert_json_success(result)
 


### PR DESCRIPTION
The stub() helper was only used in one place, so I just used mock.patch instead.

Our convention seems to be to do `import mock` instead of `from mock import patch`, so I did it that way.