### PR TITLE
Upgrade doc-building dependencies.

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,14 +3,14 @@
 # documentation.
 
 # Needed to build RTD docs
-sphinx==1.4.1
+sphinx==1.4.5
 sphinx-rtd-theme==0.1.9
 
 # Needed to build markdown docs
 recommonmark==0.4.0
 
 # Dependencies of Sphinx
-alabaster==0.7.8
+alabaster==0.7.9
 babel==2.3.4
 CommonMark==0.5.4
 docutils==0.12


### PR DESCRIPTION
Upgrade `alabaster` and `sphinx` to latest version. `commonmark` can't be updated because `recommonmark` uses an old version of `commonmark` which is incompatible with latest version of `commonmark`.