### PR TITLE
Advertise Electron app in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ please skim our [commit message style guidelines][doc-commit-style].
 * **Testing**. The Zulip automated tests all run automatically when
 you submit a pull request, but you can also run them all in your
 development environment following the instructions in the [testing
-docs][doc-test].
+docs][doc-test]. You can also try out [our new desktop
+client][electron], which is in alpha; we'd appreciate testing and
+[feedback](https://github.com/zulip/zulip-electron/issues/new).
 
 * **Developer Documentation**.  Zulip has a growing collection of
 developer documentation on [Read The Docs][doc].  Recommended reading
@@ -64,8 +66,9 @@ zulip-security@googlegroups.com.
 
 * **App codebases**. This repository is for the Zulip server and web
 app (including most integrations); the [desktop][], [Android][], and
-[iOS][] apps, are separate repositories, as is [our experimental React
-Native iOS app][ios-exp].
+[iOS][] apps, are separate repositories, as are our [experimental
+React Native iOS app][ios-exp] and [alpha Electron desktop
+app][electron].
 
 * **Glue code**. We maintain a [Hubot adapter][hubot-adapter] and several
 integrations ([Phabricator][phab], [Jenkins][], [Puppet][], [Redmine][],
@@ -84,6 +87,7 @@ contributing!
 [doc-dirstruct]: http://zulip.readthedocs.io/en/latest/directory-structure.html
 [doc-newfeat]: http://zulip.readthedocs.io/en/latest/new-feature-tutorial.html
 [doc-test]: http://zulip.readthedocs.io/en/latest/testing.html
+[electron]: https://github.com/zulip/zulip-electron
 [gg-devel]: https://groups.google.com/forum/#!forum/zulip-devel
 [gh-issues]: https://github.com/zulip/zulip/issues
 [desktop]: https://github.com/zulip/zulip-desktop

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -27,8 +27,11 @@ Our mobile clients are separate code repositories:
 [Android](https://github.com/zulip/zulip-android), [iOS
 (stable)](https://github.com/zulip/zulip-ios), and [our experimental
 React Native iOS app](https://github.com/zulip/zulip-mobile). Our
-[desktop application](https://github.com/zulip/zulip-desktop) is also a
-separate repository.
+[legacy desktop application (implemented in
+QT/WebKit)](https://github.com/zulip/zulip-desktop) and our new, alpha
+[cross-platform desktop app (implemented in
+Electron)](https://github.com/zulip/zulip-electron) are also separate
+repositories.
 
 We use [Transifex](https://www.transifex.com/zulip/zulip/) to do
 translations.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -248,13 +248,18 @@ the app with more specific improvements.
 
 ## Desktop apps
 
-The top goal for the desktop apps is to rebuild it in a modern toolchain
-(probably Electron) so that it's easy for a wide range of developers
-to contribute to the apps.
+The top goal for the desktop apps is to rebuild it in a modern
+toolchain so that it's easy for a wide range of developers to
+contribute to the apps. The new [cross-platform
+app](https://github.com/zulip/zulip-electron) is implemented in
+[Electron](http://electron.atom.io/), a framework (maintained by
+GitHub) that uses Chromium and Node.js, so Zulip developers only need
+to write HTML, CSS, and JavaScript. The new Zulip app is in alpha as of
+early August 2016.
 
 * Migrate platform from QT/webkit to Electron
 * Desktop app doesn't recover well from entering the wrong Zulip server
-* Support having multiple Zulip realms open simultaneously
+* [Support having multiple Zulip realms open simultaneously](https://github.com/zulip/zulip-electron/issues/1)
 * Build an efficient process for testing and releasing new versions of
   the desktop apps
 


### PR DESCRIPTION
Update README, roadmap, and architecture overview to advertise new beta Electron desktop app.