### PR TITLE
Add check for an empty EMAIL_GATEWAY_PATTERN

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -88,6 +88,11 @@ def get_missed_message_token_from_address(address):
 
 def create_missed_message_address(user_profile, message):
     # type: (UserProfile, Message) -> text_type
+    if settings.EMAIL_GATEWAY_PATTERN == '':
+        logging.warning("EMAIL_GATEWAY_PATTERN is an empty string, using "
+                        "NOREPLY_EMAIL_ADDRESS in the 'from' field.")
+        return settings.NOREPLY_EMAIL_ADDRESS
+
     if message.recipient.type == Recipient.PERSONAL:
         # We need to reply to the sender so look up their personal recipient_id
         recipient_id = get_recipient(Recipient.PERSONAL, message.sender_id).id


### PR DESCRIPTION
@timabbott, for the time being I have just added a check for empty `EMAIL_GATEWAY_PATTERN`.