### PR TITLE
Fix regression for running migrations during tests.

### DIFF
--- a/tools/setup/generate-fixtures
+++ b/tools/setup/generate-fixtures
@@ -9,7 +9,7 @@ template_grep_error_code=$(echo "SELECT 1 from pg_database WHERE datname='zulip_
 
 if [ "$template_grep_error_code" == "0" ]; then
     migration_status var/available-migrations
-    if [ -e zerver/fixtures/migration-status ] &&
+    if [ -e var/migration-status ] &&
         cmp -s var/available-migrations var/migration-status &&
         [ "$1" != "--force" ]; then
         "$(dirname "$0")/../../scripts/setup/terminate-psql-sessions" zulip zulip_test zulip_test_base zulip_test_template


### PR DESCRIPTION
When running ./tools/test-backend, the script to generate
fixtures, ./tools/setup/generate-fixtures, looks for a file
called migration-status to determine whether it can short
circuit doing database migrations.  This file got moved as
part of the effort to put files in "var," but the existence
check was still looking for that file in its old location.