### PR TITLE
Clean up node tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -194,7 +194,27 @@ asserts, the *actual* value comes first, the *expected* value second.
 The test runner (`index.js`) automatically runs all .js files in the
 frontend\_tests/node directory.
 
-## Coverage reports
+#### HTML output
+
+The JavaScript unit tests can generate output to be viewed in the
+browser.  The best examples of this are in `frontend_tests/node_tests/templates.js`.
+
+The main use case for this mechanism is to be able to unit test
+templates and see how they are rendered without the complications
+of the surrounding app.  (Obviously, you still need to test the
+app itself!)  The HTML output can also help to debug the unit tests.
+
+Each test calls a method named `write_handlebars_output` after it
+renders a template with similar data.  This API is still evolving,
+but you should be able to look at existing code for patterns.
+
+When you run `tools/test-js-with-node`, it will present you with a
+message like "To see more output, open var/test-js-with-node/index.html."
+Basically, you just need to open the file in the browser.  (If you are
+running a VM, this might require switching to another terminal window
+to launch the `open` command.)
+
+#### Coverage reports
 
 You can automatically generate coverage reports for the JavaScript unit
 tests. To do so, install istanbul:

--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -78,10 +78,8 @@ function render(template_name, args) {
         }
     };
 
-    var html = '<div style="height: 250px">';
-    html += render('settings_tab', args);
-    html += "</div>";
+    var html = render('settings_tab', args);
     var div = $(html).find("div.notification-reminder");
     assert.equal(div.text().trim(), 'Some French text with Zulip');
-    global.write_test_output("actions_popover_content.handlebars", html);
+    global.write_test_output("test_tr_tag settings", html);
 }());

--- a/frontend_tests/node_tests/index.js
+++ b/frontend_tests/node_tests/index.js
@@ -123,6 +123,10 @@ global.write_test_output = function (label, output) {
     fs.appendFileSync(output_fn, data);
 };
 
+global.write_handlebars_output = function (label, output) {
+    global.write_test_output(label + '.handlebars', output);
+};
+
 global.append_test_output = function (output) {
     fs.appendFileSync(output_fn, output);
 };

--- a/frontend_tests/node_tests/index.js
+++ b/frontend_tests/node_tests/index.js
@@ -1,5 +1,6 @@
 global.assert = require('assert');
 var fs = require('fs');
+var path = require('path');
 var Handlebars = require('handlebars');
 require('third/string-prototype-codepointat/codepointat.js');
 
@@ -79,14 +80,32 @@ global.use_template = function (name) {
     Handlebars.templates[name] = Handlebars.compile(data);
 };
 
-var output_fn = 'var/.test-js-with-node.html';
+var mkdir_p = function (path) {
+    // This works like mkdir -p in Unix.
+    try {
+        fs.mkdirSync(path);
+    } catch(e) {
+        if ( e.code !== 'EEXIST' ) {
+            throw e;
+        }
+    }
+    return path;
+};
+
+var output_dir = (function () {
+    mkdir_p('var');
+    var dir = mkdir_p('var/test-js-with-node');
+    return dir;
+}());
+
+var output_fn = path.join(output_dir, 'output.html');
 
 (function () {
     var data = '';
 
-    data += '<link href="./static/styles/zulip.css" rel="stylesheet">\n';
-    data += '<link href="./static/styles/thirdparty-fonts.css" rel="stylesheet">\n';
-    data += '<link href="./static/third/bootstrap/css/bootstrap.css" rel="stylesheet">\n';
+    data += '<link href="../../static/styles/zulip.css" rel="stylesheet">\n';
+    data += '<link href="../../static/styles/thirdparty-fonts.css" rel="stylesheet">\n';
+    data += '<link href="../../static/third/bootstrap/css/bootstrap.css" rel="stylesheet">\n';
     data += '<style type="text/css">.collapse {height: inherit}</style>\n';
     data += '<style type="text/css">body {width: 500px; margin: auto; overflow: scroll}</style>\n';
     data += '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -493,6 +493,15 @@ function render(template_name, args) {
     assert.equal(title.text().trim(), 'You have a notification');
 }());
 
+(function propagate_notification_change() {
+    var html = render('propagate_notification_change');
+    global.write_handlebars_output("propagate_notification_change", html);
+
+    var button_area = $(html).find(".propagate-notifications-controls");
+    assert.equal(button_area.find(".yes_propagate_notifications").text().trim(), 'Yes');
+    assert.equal(button_area.find(".no_propagate_notifications").text().trim(), 'No');
+}());
+
 (function sidebar_subject_list() {
     var args = {
         want_show_more_topics_links: true,
@@ -754,15 +763,6 @@ function render(template_name, args) {
 
     var a = $(html).find("a.narrow_to_private_messages");
     assert.equal(a.text().trim(), 'Narrow to private messages with Hamlet');
-}());
-
-(function notification_docs() {
-    var html = render('propagate_notification_change');
-    global.write_handlebars_output("propagate_notification_change", html);
-
-    var button_area = $(html).find(".propagate-notifications-controls");
-    assert.equal(button_area.find(".yes_propagate_notifications").text().trim(), 'Yes');
-    assert.equal(button_area.find(".no_propagate_notifications").text().trim(), 'No');
 }());
 
 (function settings_tab() {

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -99,6 +99,30 @@ function render(template_name, args) {
     global.write_handlebars_output("admin_default_streams_list", html);
 }());
 
+(function admin_emoji_list() {
+    global.use_template('admin_emoji_list');
+    var args = {
+        emoji: {
+            "name": "MouseFace",
+            "display_url": "http://emojipedia-us.s3.amazonaws.com/cache/46/7f/467fe69069c408e07517621f263ea9b5.png",
+            "source_url": "http://emojipedia-us.s3.amazonaws.com/cache/46/7f/467fe69069c408e07517621f263ea9b5.png"
+        }
+    };
+
+    var html = '';
+    html += '<tbody id="admin_emoji_table">';
+    html += render('admin_emoji_list', args);
+    html += '</tbody>';
+
+    global.write_handlebars_output('admin_emoji_list', html);
+
+    var emoji_name = $(html).find('tr.emoji_row:first span.emoji_name');
+    var emoji_url = $(html).find('tr.emoji_row:first span.emoji_image img');
+
+    assert.equal(emoji_name.text(), 'MouseFace');
+    assert.equal(emoji_url.attr('src'), 'http://emojipedia-us.s3.amazonaws.com/cache/46/7f/467fe69069c408e07517621f263ea9b5.png');
+}());
+
 (function admin_streams_list() {
     var html = '<table>';
     var streams = ['devel', 'trac', 'zulip'];
@@ -777,30 +801,6 @@ function render(template_name, args) {
         assert.equal($(html).find("#" + checkbox).is(":checked"), false);
     });
 
-}());
-
-(function admin_emoji_list() {
-    global.use_template('admin_emoji_list');
-    var args = {
-        emoji: {
-            "name": "MouseFace",
-            "display_url": "http://emojipedia-us.s3.amazonaws.com/cache/46/7f/467fe69069c408e07517621f263ea9b5.png",
-            "source_url": "http://emojipedia-us.s3.amazonaws.com/cache/46/7f/467fe69069c408e07517621f263ea9b5.png"
-        }
-    };
-
-    var html = '';
-    html += '<tbody id="admin_emoji_table">';
-    html += render('admin_emoji_list', args);
-    html += '</tbody>';
-
-    global.write_handlebars_output('admin_emoji_list', html);
-
-    var emoji_name = $(html).find('tr.emoji_row:first span.emoji_name');
-    var emoji_url = $(html).find('tr.emoji_row:first span.emoji_image img');
-
-    assert.equal(emoji_name.text(), 'MouseFace');
-    assert.equal(emoji_url.attr('src'), 'http://emojipedia-us.s3.amazonaws.com/cache/46/7f/467fe69069c408e07517621f263ea9b5.png');
 }());
 
 // By the end of this test, we should have compiled all our templates.  Ideally,

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -502,6 +502,49 @@ function render(template_name, args) {
     assert.equal(button_area.find(".no_propagate_notifications").text().trim(), 'No');
 }());
 
+(function settings_tab() {
+    var page_param_checkbox_options = {
+        stream_desktop_notifications_enabled: true,
+        stream_sounds_enabled: true, desktop_notifications_enabled: true,
+        sounds_enabled: true, enable_offline_email_notifications: true,
+        enable_offline_push_notifications: true, enable_digest_emails: true,
+        autoscroll_forever: true, default_desktop_notifications: true
+    };
+    var page_params = $.extend(page_param_checkbox_options, {
+        fullname: "Alyssa P. Hacker", password_auth_enabled: true,
+        avatar_url: "https://google.com",
+        domain: "zulip.com"
+    });
+
+    var checkbox_ids = ["enable_stream_desktop_notifications",
+                        "enable_stream_sounds", "enable_desktop_notifications",
+                        "enable_sounds", "enable_offline_push_notifications",
+                        "enable_digest_emails", "autoscroll_forever",
+                        "default_desktop_notifications"];
+
+    // Render with all booleans set to true.
+    var html = render('settings_tab', {page_params: page_params});
+    global.write_handlebars_output("settings_tab", html);
+
+    // All checkboxes should be checked.
+    _.each(checkbox_ids, function (checkbox) {
+        assert.equal($(html).find("#" + checkbox).is(":checked"), true);
+    });
+
+    // Re-render with checkbox booleans set to false.
+    _.each(page_param_checkbox_options, function (value, option) {
+        page_params[option] = false;
+    });
+
+    html = render('settings_tab', {page_params: page_params});
+
+    // All checkboxes should be unchecked.
+    _.each(checkbox_ids, function (checkbox) {
+        assert.equal($(html).find("#" + checkbox).is(":checked"), false);
+    });
+
+}());
+
 (function sidebar_subject_list() {
     var args = {
         want_show_more_topics_links: true,
@@ -763,49 +806,6 @@ function render(template_name, args) {
 
     var a = $(html).find("a.narrow_to_private_messages");
     assert.equal(a.text().trim(), 'Narrow to private messages with Hamlet');
-}());
-
-(function settings_tab() {
-    var page_param_checkbox_options = {
-        stream_desktop_notifications_enabled: true,
-        stream_sounds_enabled: true, desktop_notifications_enabled: true,
-        sounds_enabled: true, enable_offline_email_notifications: true,
-        enable_offline_push_notifications: true, enable_digest_emails: true,
-        autoscroll_forever: true, default_desktop_notifications: true
-    };
-    var page_params = $.extend(page_param_checkbox_options, {
-        fullname: "Alyssa P. Hacker", password_auth_enabled: true,
-        avatar_url: "https://google.com",
-        domain: "zulip.com"
-    });
-
-    var checkbox_ids = ["enable_stream_desktop_notifications",
-                        "enable_stream_sounds", "enable_desktop_notifications",
-                        "enable_sounds", "enable_offline_push_notifications",
-                        "enable_digest_emails", "autoscroll_forever",
-                        "default_desktop_notifications"];
-
-    // Render with all booleans set to true.
-    var html = render('settings_tab', {page_params: page_params});
-    global.write_handlebars_output("settings_tab", html);
-
-    // All checkboxes should be checked.
-    _.each(checkbox_ids, function (checkbox) {
-        assert.equal($(html).find("#" + checkbox).is(":checked"), true);
-    });
-
-    // Re-render with checkbox booleans set to false.
-    _.each(page_param_checkbox_options, function (value, option) {
-        page_params[option] = false;
-    });
-
-    html = render('settings_tab', {page_params: page_params});
-
-    // All checkboxes should be unchecked.
-    _.each(checkbox_ids, function (checkbox) {
-        assert.equal($(html).find("#" + checkbox).is(":checked"), false);
-    });
-
 }());
 
 // By the end of this test, we should have compiled all our templates.  Ideally,

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -72,20 +72,6 @@ function render(template_name, args) {
     global.write_handlebars_output("actions_popover_content", html);
 }());
 
-(function admin_tab() {
-    var args = {
-        realm_name: 'Zulip'
-    };
-    var html = render('admin_tab', args);
-    var admin_features = ["admin_users_table", "admin_bots_table",
-                          "admin_streams_table", "admin_deactivated_users_table"];
-    _.each(admin_features, function (admin_feature) {
-        assert.notEqual($(html).find("#" + admin_feature).length, 0);
-    });
-    assert.equal($(html).find("input.admin-realm-name").val(), 'Zulip');
-    global.write_handlebars_output("admin_tab", html);
-}());
-
 (function admin_default_streams_list() {
     var html = '<table>';
     var streams = ['devel', 'trac', 'zulip'];
@@ -134,6 +120,20 @@ function render(template_name, args) {
     var span = $(html).find(".stream_name:first");
     assert.equal(span.text(), "devel");
     global.write_handlebars_output("admin_streams_list", html);
+}());
+
+(function admin_tab() {
+    var args = {
+        realm_name: 'Zulip'
+    };
+    var html = render('admin_tab', args);
+    var admin_features = ["admin_users_table", "admin_bots_table",
+                          "admin_streams_table", "admin_deactivated_users_table"];
+    _.each(admin_features, function (admin_feature) {
+        assert.notEqual($(html).find("#" + admin_feature).length, 0);
+    });
+    assert.equal($(html).find("input.admin-realm-name").val(), 'Zulip');
+    global.write_handlebars_output("admin_tab", html);
 }());
 
 (function admin_user_list() {

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -69,7 +69,7 @@ function render(template_name, args) {
     html += "</div>";
     var link = $(html).find("a.respond_button");
     assert.equal(link.text().trim(), 'Reply');
-    global.write_test_output("actions_popover_content.handlebars", html);
+    global.write_handlebars_output("actions_popover_content", html);
 }());
 
 (function admin_tab() {
@@ -83,7 +83,7 @@ function render(template_name, args) {
         assert.notEqual($(html).find("#" + admin_feature).length, 0);
     });
     assert.equal($(html).find("input.admin-realm-name").val(), 'Zulip');
-    global.write_test_output("admin_tab.handlebars", html);
+    global.write_handlebars_output("admin_tab", html);
 }());
 
 (function admin_default_streams_list() {
@@ -96,7 +96,7 @@ function render(template_name, args) {
     html += "</table>";
     var span = $(html).find(".default_stream_name:first");
     assert.equal(span.text(), "devel");
-    global.write_test_output("admin_default_streams_list.handlebars", html);
+    global.write_handlebars_output("admin_default_streams_list", html);
 }());
 
 (function admin_streams_list() {
@@ -109,7 +109,7 @@ function render(template_name, args) {
     html += "</table>";
     var span = $(html).find(".stream_name:first");
     assert.equal(span.text(), "devel");
-    global.write_test_output("admin_streams_list.handlebars", html);
+    global.write_handlebars_output("admin_streams_list", html);
 }());
 
 (function admin_user_list() {
@@ -136,7 +136,7 @@ function render(template_name, args) {
     assert.equal(button.text().trim(), "Make admin");
     assert(button.hasClass("make-admin"));
 
-    global.write_test_output("admin_user_list.handlebars", html);
+    global.write_handlebars_output("admin_user_list", html);
 }());
 
 (function alert_word_settings_item() {
@@ -149,14 +149,14 @@ function render(template_name, args) {
         html += render('alert_word_settings_item', args);
     });
     html += "</ul>";
-    global.write_test_output("alert_word_settings_item.handlebars", html);
+    global.write_handlebars_output("alert_word_settings_item", html);
     var li = $(html).find("li.alert-word-item:first");
     assert.equal(li.attr('data-word'),'lunch');
 }());
 
 (function announce_stream_docs() {
     var html = render('announce_stream_docs');
-    global.write_test_output("announce_stream_docs.handlebars", html);
+    global.write_handlebars_output("announce_stream_docs", html);
 }());
 
 (function bankruptcy_modal() {
@@ -164,7 +164,7 @@ function render(template_name, args) {
         unread_count: 99
     };
     var html = render('bankruptcy_modal', args);
-    global.write_test_output("bankruptcy_modal.handlebars", html);
+    global.write_handlebars_output("bankruptcy_modal", html);
     var count = $(html).find("p b");
     assert.equal(count.text(), 99);
 }());
@@ -187,7 +187,7 @@ function render(template_name, args) {
     html += '</div>';
     html += '</div>';
 
-    global.write_test_output("bot_avatar_row.handlebars", html);
+    global.write_handlebars_output("bot_avatar_row", html);
     var img = $(html).find("img");
     assert.equal(img.attr('src'), '/hamlet/avatar/url');
 }());
@@ -198,7 +198,7 @@ function render(template_name, args) {
         name: 'Hamlet'
     };
     var html = render('compose-invite-users', args);
-    global.write_test_output("compose-invite-users.handlebars", html);
+    global.write_handlebars_output("compose-invite-users", html);
     var button = $(html).find("button:first");
     assert.equal(button.text(), "Subscribe");
 }());
@@ -209,7 +209,7 @@ function render(template_name, args) {
         name: 'all'
     };
     var html = render('compose_all_everyone', args);
-    global.write_test_output("compose_all_everyone.handlebars", html);
+    global.write_handlebars_output("compose_all_everyone", html);
     var button = $(html).find("button:first");
     assert.equal(button.text(), "YES");
     var error_msg = $(html).find('span.compose-all-everyone-msg').text().trim();
@@ -226,14 +226,14 @@ function render(template_name, args) {
     var html = '<div  id="out-of-view-notification" class="notification-alert">';
     html += render('compose_notification', args);
     html += '</div>';
-    global.write_test_output("compose_notification.handlebars", html);
+    global.write_handlebars_output("compose_notification", html);
     var a = $(html).find("a.compose_notification_narrow_by_subject");
     assert.equal(a.text(), "Narrow to here");
 }());
 
 (function email_address_hint() {
     var html = render('email_address_hint');
-    global.write_test_output("email_address_hint.handlebars", html);
+    global.write_handlebars_output("email_address_hint", html);
     var li = $(html).find("li:first");
     assert.equal(li.text(), 'The email will be forwarded to this stream');
 }());
@@ -250,7 +250,7 @@ function render(template_name, args) {
         ]
     };
     var html = render('group_pms', args);
-    global.write_test_output("group_pms.handlebars", html);
+    global.write_handlebars_output("group_pms", html);
 
     var a = $(html).find("a:first");
     assert.equal(a.text(), 'Alice and Bob');
@@ -268,7 +268,7 @@ function render(template_name, args) {
         ]
     };
     var html = render('invite_subscription', args);
-    global.write_test_output("invite_subscription.handlebars", html);
+    global.write_handlebars_output("invite_subscription", html);
 
     var input = $(html).find("label:first");
     assert.equal(input.text().trim(), "devel");
@@ -290,7 +290,7 @@ function render(template_name, args) {
     var html = render('single_message', message);
     html = '<div class="message_table focused_table" id="zfilt">' + html + '</div>';
 
-    global.write_test_output("message.handlebars", html);
+    global.write_handlebars_output("message", html);
 
     var first_message = $(html).find("div.messagebox:first");
 
@@ -353,7 +353,7 @@ function render(template_name, args) {
     var highlighted_subject_word = $(html).find('a.narrows_by_subject .highlight').text();
     assert.equal(highlighted_subject_word, 'two');
 
-    global.write_test_output("message_group.handlebars", html);
+    global.write_handlebars_output("message_group", html);
 }());
 
 (function message_edit_form() {
@@ -363,7 +363,7 @@ function render(template_name, args) {
         "is_stream": true
     };
     var html = render('message_edit_form', args);
-    global.write_test_output("message_edit_form.handlebars", html);
+    global.write_handlebars_output("message_edit_form", html);
 
     var textarea = $(html).find("textarea.message_edit_content");
     assert.equal(textarea.text(), "Let's go to lunch!");
@@ -382,7 +382,7 @@ function render(template_name, args) {
     };
 
     var html = render('message_info_popover_content', args);
-    global.write_test_output("message_info_popover_content.handlebars", html);
+    global.write_handlebars_output("message_info_popover_content", html);
 
     var a = $(html).find("a.respond_personal_button");
     assert.equal(a.text().trim(), 'Send Alice Smith a private message');
@@ -398,7 +398,7 @@ function render(template_name, args) {
     };
 
     var html = render('message_info_popover_title', args);
-    global.write_test_output("message_info_popover_title.handlebars", html);
+    global.write_handlebars_output("message_info_popover_title", html);
 
     assert($(html).text().trim(), "Message to stream devel");
 }());
@@ -418,7 +418,7 @@ function render(template_name, args) {
     };
 
     var html = render('new_stream_users', args);
-    global.write_test_output("new_stream_users.handlebars", html);
+    global.write_handlebars_output("new_stream_users", html);
 
     var label = $(html).find("label:first");
     assert.equal(label.text().trim(), 'King Lear (lear@zulip.com)');
@@ -432,7 +432,7 @@ function render(template_name, args) {
     };
 
     var html = render('notification', args);
-    global.write_test_output("notification.handlebars", html);
+    global.write_handlebars_output("notification", html);
 
     var title = $(html).find(".title");
     assert.equal(title.text().trim(), 'You have a notification');
@@ -466,7 +466,7 @@ function render(template_name, args) {
     html += '</li>';
     html += '</ul>';
 
-    global.write_test_output("sidebar_subject_list.handlebars", html);
+    global.write_handlebars_output("sidebar_subject_list", html);
 
     var li = $(html).find("li.expanded_subject:first");
     assert.equal(li.attr('data-name'), 'lunch');
@@ -497,7 +497,7 @@ function render(template_name, args) {
         assert.equal($(html).find("." + item).length, 1);
     });
 
-    global.write_test_output("stream_member_list_entry.handlebars", html);
+    global.write_handlebars_output("stream_member_list_entry", html);
 }());
 
 (function stream_sidebar_actions() {
@@ -511,7 +511,7 @@ function render(template_name, args) {
     };
 
     var html = render('stream_sidebar_actions', args);
-    global.write_test_output("stream_sidebar_actions.handlebars", html);
+    global.write_handlebars_output("stream_sidebar_actions", html);
 
     var li = $(html).find("li:first");
     assert.equal(li.text().trim(), 'Narrow to stream devel');
@@ -530,7 +530,7 @@ function render(template_name, args) {
     html += render('stream_sidebar_row', args);
     html += '</ul>';
 
-    global.write_test_output("stream_sidebar_row.handlebars", html);
+    global.write_handlebars_output("stream_sidebar_row", html);
 
     var swatch = $(html).find(".streamlist_swatch");
     assert.equal(swatch.attr('id'), 'stream_sidebar_swatch_999');
@@ -571,7 +571,7 @@ function render(template_name, args) {
     html += render('subscription_table_body', args);
     html += '</div>';
 
-    global.write_test_output("subscription_table_body.handlebars", html);
+    global.write_handlebars_output("subscription_table_body", html);
 
     var span = $(html).find(".subscription_name:first");
     assert.equal(span.text(), 'devel');
@@ -604,7 +604,7 @@ function render(template_name, args) {
 
     var html = render('tab_bar', args);
 
-    global.write_test_output("tab_bar.handlebars", html);
+    global.write_handlebars_output("tab_bar", html);
 
     var a = $(html).find("li:first");
     assert.equal(a.text().trim(), 'Home');
@@ -613,7 +613,7 @@ function render(template_name, args) {
 (function topic_edit_form() {
     var html = render('topic_edit_form');
 
-    global.write_test_output("topic_edit_form.handlebars", html);
+    global.write_handlebars_output("topic_edit_form", html);
 
     var button = $(html).find("button:first");
     assert.equal(button.find("i").attr("class"), 'icon-vector-ok');
@@ -627,7 +627,7 @@ function render(template_name, args) {
     };
     var html = render('topic_sidebar_actions', args);
 
-    global.write_test_output("topic_sidebar_actions.handlebars", html);
+    global.write_handlebars_output("topic_sidebar_actions", html);
 
     var a = $(html).find("a.narrow_to_topic");
     assert.equal(a.text().trim(), 'Narrow to topic lunch');
@@ -643,7 +643,7 @@ function render(template_name, args) {
     var html = '';
     html += render('bookend', args);
 
-    global.write_test_output("bookend.handlebars", html);
+    global.write_handlebars_output("bookend", html);
     assert.equal($(html).text().trim(), "subscribed to stream\n    \n        \n            \n            Unsubscribe");
 }());
 
@@ -656,7 +656,7 @@ function render(template_name, args) {
     var html = '';
     html += render('bookend', args);
 
-    global.write_test_output("bookend.handlebars", html);
+    global.write_handlebars_output("bookend", html);
     assert.equal($(html).text().trim(), 'Not subscribed to stream\n    \n        \n            \n            Subscribe');
 }());
 
@@ -676,7 +676,7 @@ function render(template_name, args) {
             title: 'Title'
         };
         html = render(tutorial, args);
-        global.write_test_output(tutorial + '.handlebars', html);
+        global.write_handlebars_output(tutorial, html);
     });
 }());
 
@@ -707,7 +707,7 @@ function render(template_name, args) {
     html += render('user_presence_rows', args);
     html += '</ul>';
 
-    global.write_test_output("user_presence_rows.handlebars", html);
+    global.write_handlebars_output("user_presence_rows", html);
 
     var a = $(html).find("a.my_fullname:first");
     assert.equal(a.text(), 'King Lear');
@@ -721,7 +721,7 @@ function render(template_name, args) {
 
     var html = render('user_sidebar_actions', args);
 
-    global.write_test_output("user_sidebar_actions.handlebars", html);
+    global.write_handlebars_output("user_sidebar_actions", html);
 
     var a = $(html).find("a.narrow_to_private_messages");
     assert.equal(a.text().trim(), 'Narrow to private messages with Hamlet');
@@ -729,7 +729,7 @@ function render(template_name, args) {
 
 (function notification_docs() {
     var html = render('propagate_notification_change');
-    global.write_test_output("propagate_notification_change.handlebars", html);
+    global.write_handlebars_output("propagate_notification_change", html);
 
     var button_area = $(html).find(".propagate-notifications-controls");
     assert.equal(button_area.find(".yes_propagate_notifications").text().trim(), 'Yes');
@@ -758,7 +758,7 @@ function render(template_name, args) {
 
     // Render with all booleans set to true.
     var html = render('settings_tab', {page_params: page_params});
-    global.write_test_output("settings_tab.handlebars", html);
+    global.write_handlebars_output("settings_tab", html);
 
     // All checkboxes should be checked.
     _.each(checkbox_ids, function (checkbox) {
@@ -794,7 +794,7 @@ function render(template_name, args) {
     html += render('admin_emoji_list', args);
     html += '</tbody>';
 
-    global.write_test_output('admin_emoji_list.handlebars', html);
+    global.write_handlebars_output('admin_emoji_list', html);
 
     var emoji_name = $(html).find('tr.emoji_row:first span.emoji_name');
     var emoji_url = $(html).find('tr.emoji_row:first span.emoji_image img');

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -193,6 +193,37 @@ function render(template_name, args) {
     assert.equal(count.text(), 99);
 }());
 
+(function bookend() {
+    // Do subscribed/unsubscribed cases here.
+    var args = {
+        bookend_content: "subscribed to stream",
+        trailing: true,
+        subscribed: true
+    };
+    var html;
+    var all_html = '';
+
+    html = render('bookend', args);
+
+    assert.equal($(html).text().trim(), "subscribed to stream\n    \n        \n            \n            Unsubscribe");
+
+    all_html += html;
+
+    args = {
+        bookend_content: "Not subscribed to stream",
+        trailing: true,
+        subscribed: false
+    };
+
+    html = render('bookend', args);
+    assert.equal($(html).text().trim(), 'Not subscribed to stream\n    \n        \n            \n            Subscribe');
+
+    all_html += '<hr />';
+    all_html += html;
+
+    global.write_handlebars_output("bookend", all_html);
+}());
+
 (function bot_avatar_row() {
     var html = '';
     html += '<div id="settings">';
@@ -656,32 +687,6 @@ function render(template_name, args) {
     var a = $(html).find("a.narrow_to_topic");
     assert.equal(a.text().trim(), 'Narrow to topic lunch');
 
-}());
-
-(function subscribed_trailing_bookend() {
-    var args = {
-        bookend_content: "subscribed to stream",
-        trailing: true,
-        subscribed: true
-    };
-    var html = '';
-    html += render('bookend', args);
-
-    global.write_handlebars_output("bookend", html);
-    assert.equal($(html).text().trim(), "subscribed to stream\n    \n        \n            \n            Unsubscribe");
-}());
-
-(function unsubscribed_trailing_bookend() {
-    var args = {
-        bookend_content: "Not subscribed to stream",
-        trailing: true,
-        subscribed: false
-    };
-    var html = '';
-    html += render('bookend', args);
-
-    global.write_handlebars_output("bookend", html);
-    assert.equal($(html).text().trim(), 'Not subscribed to stream\n    \n        \n            \n            Subscribe');
 }());
 
 (function tutorial() {

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -356,6 +356,19 @@ function render(template_name, args) {
     assert.equal(starred_title, "Unstar this message");
 }());
 
+(function message_edit_form() {
+    var args = {
+        "topic": "lunch",
+        "content": "Let's go to lunch!",
+        "is_stream": true
+    };
+    var html = render('message_edit_form', args);
+    global.write_handlebars_output("message_edit_form", html);
+
+    var textarea = $(html).find("textarea.message_edit_content");
+    assert.equal(textarea.text(), "Let's go to lunch!");
+}());
+
 (function message_group() {
     var messages = [
         {
@@ -409,19 +422,6 @@ function render(template_name, args) {
     assert.equal(highlighted_subject_word, 'two');
 
     global.write_handlebars_output("message_group", html);
-}());
-
-(function message_edit_form() {
-    var args = {
-        "topic": "lunch",
-        "content": "Let's go to lunch!",
-        "is_stream": true
-    };
-    var html = render('message_edit_form', args);
-    global.write_handlebars_output("message_edit_form", html);
-
-    var textarea = $(html).find("textarea.message_edit_content");
-    assert.equal(textarea.text(), "Let's go to lunch!");
 }());
 
 (function message_info_popover_content() {

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -588,6 +588,8 @@ PIPELINE = {
     'CSS_COMPRESSOR': 'pipeline.compressors.yui.YUICompressor',
     'YUI_BINARY': '/usr/bin/env yui-compressor',
     'STYLESHEETS': {
+        # If you add a style here, please update stylesheets()
+        # in frontend_tests/node_tests/index.js as needed.
         'activity': {
             'source_filenames': ('styles/activity.css',),
             'output_filename':  'min/activity.css'


### PR DESCRIPTION
Two main things from this series:
* the output from running the node tests is now easier to view in the browser, particularly for handlebar templates rendered by templates.js
* The source in templates.js is cosmetically cleaned up

This code is still far from perfect, but it cleans up a regression in how the HTML was formatted, as well as making general improvements.