### PR TITLE
Clean up node tests

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -18,8 +18,7 @@ set_global('document', {
     }
 });
 
-var people = require("js/people.js");
-people.test_set_people_dict({
+global.people.test_set_people_dict({
     'alice@zulip.com': {
         full_name: 'Alice Smith'
     },

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -1,11 +1,4 @@
-set_global('$', function () {
-    return {
-        on: function () {
-            return;
-        }
-    };
-});
-$.fn = {};
+global.stub_out_jquery();
 
 add_dependencies({
     util: 'js/util.js',

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -2,6 +2,14 @@
 var path = require('path');
 var fs = require('fs');
 
+set_global('$', function () {
+    return {
+        on: function () {
+            return;
+        }
+    };
+});
+
 set_global('page_params', {realm_emoji: {
   burrito: {display_url: '/static/third/gemoji/images/emoji/burrito.png',
             source_url: '/static/third/gemoji/images/emoji/burrito.png'}

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -2,13 +2,7 @@
 var path = require('path');
 var fs = require('fs');
 
-set_global('$', function () {
-    return {
-        on: function () {
-            return;
-        }
-    };
-});
+global.stub_out_jquery();
 
 set_global('page_params', {realm_emoji: {
   burrito: {display_url: '/static/third/gemoji/images/emoji/burrito.png',

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -10,12 +10,8 @@ add_dependencies({
 
 
 set_global('document', null);
-set_global('$', function () {
-    return {
-        on: function () {},
-        trigger: function () {}
-    };
-});
+
+global.stub_out_jquery();
 
 set_global('feature_flags', {});
 set_global('Filter', function () {});

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -2,13 +2,7 @@ add_dependencies({
     util: 'js/util.js'
 });
 
-set_global('$', function () {
-    return {
-        on: function () {
-            return;
-        }
-    };
-});
+global.stub_out_jquery();
 
 var people = require("js/people.js");
 

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -2,6 +2,14 @@ add_dependencies({
     util: 'js/util.js'
 });
 
+set_global('$', function () {
+    return {
+        on: function () {
+            return;
+        }
+    };
+});
+
 var people = require("js/people.js");
 
 set_global('page_params', {

--- a/frontend_tests/node_tests/presence_list_performance.js
+++ b/frontend_tests/node_tests/presence_list_performance.js
@@ -1,4 +1,13 @@
-set_global('$', function () {});
+// TODO: de-dup with activity.js
+set_global('$', function () {
+    return {
+        on: function () {
+            return;
+        }
+    };
+});
+$.fn = {};
+
 set_global('document', {
     hasFocus: function () {
         return true;
@@ -43,6 +52,26 @@ activity.presence_info = {
     'mark@zulip.com': {status: activity.IDLE},
     'norbert@zulip.com': {status: activity.ACTIVE}
 };
+
+
+// TODO: de-dup with activity.js
+people.test_set_people_dict({
+    'alice@zulip.com': {
+        full_name: 'Alice Smith'
+    },
+    'fred@zulip.com': {
+        full_name: "Fred Flintstone"
+    },
+    'jill@zulip.com': {
+        full_name: 'Jill Hill'
+    },
+    'mark@zulip.com': {
+        full_name: 'Marky Mark'
+    },
+    'norbert@zulip.com': {
+        full_name: 'Norbert Oswald'
+    }
+});
 
 (function test_presence_list_full_update() {
     var users = activity.update_users();

--- a/frontend_tests/node_tests/presence_list_performance.js
+++ b/frontend_tests/node_tests/presence_list_performance.js
@@ -1,12 +1,5 @@
 // TODO: de-dup with activity.js
-set_global('$', function () {
-    return {
-        on: function () {
-            return;
-        }
-    };
-});
-$.fn = {};
+global.stub_out_jquery();
 
 set_global('document', {
     hasFocus: function () {

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -11,13 +11,8 @@ set_global('document', {});
 set_global('window', {
     addEventListener: noop
 });
-set_global('$', function () {
-    return {
-        hide: noop,
-        trigger: noop
-    };
-});
-global.$.now = noop;
+
+global.stub_out_jquery();
 
 // Prevent the get_events loop and watchdog from running
 patch_builtin('setTimeout', noop);

--- a/frontend_tests/node_tests/stream_color.js
+++ b/frontend_tests/node_tests/stream_color.js
@@ -1,4 +1,4 @@
-set_global('$', function (f) {});
+global.stub_out_jquery();
 
 var stream_color = require('js/stream_color.js');
 

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -1,4 +1,4 @@
-set_global('$', function () {});
+global.stub_out_jquery();
 
 add_dependencies({
     Handlebars: 'handlebars',

--- a/frontend_tests/zjsunit/finder.js
+++ b/frontend_tests/zjsunit/finder.js
@@ -1,0 +1,53 @@
+var finder = (function () {
+
+var exports = {};
+
+var _ = require('third/underscore/underscore.js');
+var fs = require('fs');
+var path = require('path');
+
+exports.find_files_to_run = function () {
+    var oneFileFilter = [];
+    var testsDifference = [];
+    if (process.argv[2] ) {
+        oneFileFilter = process.argv
+          .slice(2)
+          .map(function (filename) {return filename.replace(/\.js$/i, '');});
+    }
+
+    // tests_dir is where we find our specific unit tests (as opposed
+    // to framework code)
+    var tests_dir = __dirname.replace(/zjsunit/, 'node_tests');
+
+    var tests = fs.readdirSync(tests_dir)
+      .filter(function (filename) {return (/\.js$/i).test(filename);})
+      .map(function (filename) {return filename.replace(/\.js$/i, '');});
+
+    if (oneFileFilter.length > 0) {
+        tests = tests.filter(function (filename) {
+            return oneFileFilter.indexOf(filename) !== -1;
+        });
+        testsDifference = _.difference(oneFileFilter, tests);
+    }
+
+    testsDifference.forEach(function (filename) {
+        console.log(filename + " does not exist");
+    });
+
+    tests.sort();
+
+    var files = tests.map(function (fn) {
+        var obj = {};
+        obj.name = fn;
+        obj.full_name = path.join(tests_dir, fn);
+        return obj;
+    });
+
+    return files;
+};
+
+
+return exports;
+}());
+module.exports = finder;
+

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -1,7 +1,6 @@
 global.assert = require('assert');
 var fs = require('fs');
 var path = require('path');
-var Handlebars = require('handlebars');
 require('third/string-prototype-codepointat/codepointat.js');
 
 global.Dict = require('js/dict');
@@ -13,6 +12,11 @@ var namespace = require('./namespace.js');
 global.set_global = namespace.set_global;
 global.patch_builtin = namespace.patch_builtin;
 global.add_dependencies = namespace.add_dependencies;
+
+// Set up helpers to render templates.
+var render = require('./render.js');
+global.use_template = render.use_template;
+global.make_sure_all_templates_have_been_compiled = render.make_sure_all_templates_have_been_compiled;
 
 // Run all the JS scripts in our test directory.  Tests do NOT run
 // in isolation.
@@ -40,32 +44,6 @@ if (oneFileFilter.length > 0) {
     testsDifference = _.difference(oneFileFilter, tests);
 }
 tests.sort();
-
-function template_dir() {
-    return __dirname + '/../../static/templates/';
-}
-
-global.make_sure_all_templates_have_been_compiled = function () {
-    var dir = template_dir();
-    var fns = fs.readdirSync(dir).filter(function (fn) {
-        return (/\.handlebars/).test(fn);
-    });
-
-    _.each(fns, function (fn) {
-        var name = fn.split('.')[0];
-        if (!Handlebars.templates[name]) {
-            throw "The file " + fn + " has no test coverage.";
-        }
-    });
-};
-
-global.use_template = function (name) {
-    if (Handlebars.templates === undefined) {
-        Handlebars.templates = {};
-    }
-    var data = fs.readFileSync(template_dir() + name + '.handlebars').toString();
-    Handlebars.templates[name] = Handlebars.compile(data);
-};
 
 function stylesheets() {
     // TODO: Automatically get all relevant styles.

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -18,6 +18,12 @@ var render = require('./render.js');
 global.use_template = render.use_template;
 global.make_sure_all_templates_have_been_compiled = render.make_sure_all_templates_have_been_compiled;
 
+// Set up helpers to output HTML
+var output = require('./output.js');
+global.write_handlebars_output = output.write_handlebars_output;
+global.write_test_output = output.write_test_output;
+global.append_test_output = output.append_test_output;
+
 // Run all the JS scripts in our test directory.  Tests do NOT run
 // in isolation.
 
@@ -45,108 +51,7 @@ if (oneFileFilter.length > 0) {
 }
 tests.sort();
 
-function stylesheets() {
-    // TODO: Automatically get all relevant styles.
-    var data = '';
-    data += '<link href="../../static/styles/fonts.css" rel="stylesheet">\n';
-    data += '<link href="../../static/styles/portico.css" rel="stylesheet">\n';
-    data += '<link href="../../static/styles/thirdparty-fonts.css" rel="stylesheet">\n';
-    data += '<link href="../../static/styles/zulip.css" rel="stylesheet">\n';
-    data += '<link href="../../static/third/bootstrap/css/bootstrap.css" rel="stylesheet">\n';
-    data += '<link href="../../static/third/bootstrap-notify/css/bootstrap-notify.css" rel="stylesheet">\n';
-
-    return data;
-}
-
-var mkdir_p = function (path) {
-    // This works like mkdir -p in Unix.
-    try {
-        fs.mkdirSync(path);
-    } catch(e) {
-        if ( e.code !== 'EEXIST' ) {
-            throw e;
-        }
-    }
-    return path;
-};
-
-var output_dir = (function () {
-    mkdir_p('var');
-    var dir = mkdir_p('var/test-js-with-node');
-    return dir;
-}());
-
-var output_fn = path.join(output_dir, 'output.html');
-var index_fn = path.join(output_dir, 'index.html');
-
-(function () {
-    var data = '';
-
-    data += stylesheets();
-    data += '<style type="text/css">.collapse {height: inherit}</style>\n';
-    data += '<style type="text/css">body {width: 500px; margin: auto; overflow: scroll}</style>\n';
-    data += '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
-    data += '<h1>Output of node unit tests</h1>\n';
-    fs.writeFileSync(output_fn, data);
-
-    data = '';
-    data += '<style type="text/css">body {width: 500px; margin: auto; overflow: scroll}</style>\n';
-    data += '<h2>Regular output</h2>\n';
-    data += '<p>Any test can output HTML to be viewed here:</p>\n';
-    data += '<a href="output.html">Output of non-template.js tests</a><br />';
-    data += '<hr />\n';
-    data += '<h2>Handlebar output</h2>\n';
-    data += '<p>These are specifically from templates.js</p>\n';
-    fs.writeFileSync(index_fn, data);
-}());
-
-global.write_test_output = function (label, output) {
-    var data = '';
-
-    data += '<hr>';
-    data += '<h3>' + label + '</h3>';
-    data += output;
-    data += '\n';
-    fs.appendFileSync(output_fn, data);
-};
-
-global.write_handlebars_output = (function () {
-    var last_label = '';
-
-    return function (label, output) {
-        if (last_label && (last_label >= label)) {
-            // This is kind of an odd requirement, but it allows us
-            // to render output on the fly in alphabetical order, and
-            // it has a nice side effect of making our source code
-            // easier to scan.
-
-            console.info(last_label);
-            console.info(label);
-            throw "Make sure your template tests are alphabetical in templates.js";
-        }
-        last_label = label;
-
-        var href = label + '.handlebars.html';
-        var fn = path.join(output_dir, href);
-
-        // Update the index
-        var a = '<a href="' + href +  '">' + label + '</a><br />';
-        fs.appendFileSync(index_fn, a);
-
-        // Write out own HTML file.
-        var data = '';
-        data += stylesheets();
-        data += '<style type="text/css">body {width: 500px; margin: auto; overflow: scroll}</style>\n';
-        data += '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
-        data += '<b>' + href + '</b><hr />\n';
-        data += output;
-        fs.writeFileSync(fn, data);
-    };
-}());
-
-global.append_test_output = function (output) {
-    fs.appendFileSync(output_fn, output);
-};
+output.start_writing();
 
 tests.forEach(function (filename) {
     console.info('running tests for ' + filename);
@@ -159,8 +64,8 @@ if (oneFileFilter.length > 0 && testsDifference.length > 0) {
         console.log(filename + " does not exist");
     });
     if (oneFileFilter.length > testsDifference.length) {
-        console.info("To see more output, open " + index_fn);
+        console.info("To see more output, open " + output.index_fn);
     }
 } else {
-    console.info("To see more output, open " + index_fn);
+    console.info("To see more output, open " + output.index_fn);
 }

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -17,6 +17,7 @@ var namespace = require('./namespace.js');
 global.set_global = namespace.set_global;
 global.patch_builtin = namespace.patch_builtin;
 global.add_dependencies = namespace.add_dependencies;
+global.stub_out_jquery = namespace.stub_out_jquery;
 
 // Set up helpers to render templates.
 var render = require('./render.js');

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -19,7 +19,11 @@ if (process.argv[2] ) {
       .map(function (filename) {return filename.replace(/\.js$/i, '');});
 }
 
-var tests = fs.readdirSync(__dirname)
+// tests_dir is where we find our specific unit tests (as opposed
+// to framework code)
+var tests_dir = __dirname.replace(/zjsunit/, 'node_tests');
+
+var tests = fs.readdirSync(tests_dir)
   .filter(function (filename) {return (/\.js$/i).test(filename);})
   .map(function (filename) {return filename.replace(/\.js$/i, '');});
 
@@ -184,11 +188,8 @@ global.append_test_output = function (output) {
 };
 
 tests.forEach(function (filename) {
-    if (filename === 'index') {
-        return;
-    }
     console.info('running tests for ' + filename);
-    require('./' + filename);
+    require(path.join(tests_dir, filename));
 
     dependencies.forEach(function (name) {
         delete global[name];

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -1,11 +1,16 @@
 global.assert = require('assert');
-var fs = require('fs');
-var path = require('path');
 require('third/string-prototype-codepointat/codepointat.js');
 
 global.Dict = require('js/dict');
 global._ = require('third/underscore/underscore.js');
 var _ = global._;
+
+// Find the files we need to run.
+var finder = require('./finder.js');
+var files = finder.find_files_to_run(); // may write to console
+if (_.isEmpty(files)) {
+    throw "No tests found";
+}
 
 // Set up our namespace helpers.
 var namespace = require('./namespace.js');
@@ -24,48 +29,13 @@ global.write_handlebars_output = output.write_handlebars_output;
 global.write_test_output = output.write_test_output;
 global.append_test_output = output.append_test_output;
 
-// Run all the JS scripts in our test directory.  Tests do NOT run
-// in isolation.
-
-var oneFileFilter = [];
-var testsDifference = [];
-if (process.argv[2] ) {
-    oneFileFilter = process.argv
-      .slice(2)
-      .map(function (filename) {return filename.replace(/\.js$/i, '');});
-}
-
-// tests_dir is where we find our specific unit tests (as opposed
-// to framework code)
-var tests_dir = __dirname.replace(/zjsunit/, 'node_tests');
-
-var tests = fs.readdirSync(tests_dir)
-  .filter(function (filename) {return (/\.js$/i).test(filename);})
-  .map(function (filename) {return filename.replace(/\.js$/i, '');});
-
-if (oneFileFilter.length > 0) {
-    tests = tests.filter(function (filename) {
-        return oneFileFilter.indexOf(filename) !== -1;
-    });
-    testsDifference = _.difference(oneFileFilter, tests);
-}
-tests.sort();
 
 output.start_writing();
 
-tests.forEach(function (filename) {
-    console.info('running tests for ' + filename);
-    require(path.join(tests_dir, filename));
+files.forEach(function (file) {
+    console.info('running tests for ' + file.name);
+    require(file.full_name);
     namespace.restore();
 });
 
-if (oneFileFilter.length > 0 && testsDifference.length > 0) {
-    testsDifference.forEach(function (filename) {
-        console.log(filename + " does not exist");
-    });
-    if (oneFileFilter.length > testsDifference.length) {
-        console.info("To see more output, open " + output.index_fn);
-    }
-} else {
-    console.info("To see more output, open " + output.index_fn);
-}
+console.info("To see more output, open " + output.index_fn);

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -39,6 +39,18 @@ exports.restore = function () {
     old_builtins = {};
 };
 
+exports.stub_out_jquery = function () {
+    set_global('$', function () {
+        return {
+            on: function () {},
+            trigger: function () {},
+            hide: function () {}
+        };
+    });
+    $.fn = {};
+    $.now = function () {};
+};
+
 return exports;
 }());
 module.exports = namespace;

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -4,6 +4,7 @@ var _ = require('third/underscore/underscore.js');
 var exports = {};
 
 var dependencies = [];
+var requires = [];
 var old_builtins = {};
 
 exports.set_global = function (name, val) {
@@ -21,6 +22,7 @@ exports.patch_builtin = function (name, val) {
 exports.add_dependencies = function (dct) {
     _.each(dct, function (fn, name) {
         var obj = require(fn);
+        requires.push(fn);
         set_global(name, obj);
     });
 };
@@ -28,6 +30,9 @@ exports.add_dependencies = function (dct) {
 exports.restore = function () {
     dependencies.forEach(function (name) {
         delete global[name];
+    });
+    requires.forEach(function (fn) {
+        delete require.cache[require.resolve(fn)];
     });
     dependencies = [];
     _.extend(global, old_builtins);

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -1,0 +1,40 @@
+var namespace = (function () {
+
+var _ = require('third/underscore/underscore.js');
+var exports = {};
+
+var dependencies = [];
+var old_builtins = {};
+
+exports.set_global = function (name, val) {
+    global[name] = val;
+    dependencies.push(name);
+    return val;
+};
+
+exports.patch_builtin = function (name, val) {
+    old_builtins[name] = global[name];
+    global[name] = val;
+    return val;
+};
+
+exports.add_dependencies = function (dct) {
+    _.each(dct, function (fn, name) {
+        var obj = require(fn);
+        set_global(name, obj);
+    });
+};
+
+exports.restore = function () {
+    dependencies.forEach(function (name) {
+        delete global[name];
+    });
+    dependencies = [];
+    _.extend(global, old_builtins);
+    old_builtins = {};
+};
+
+return exports;
+}());
+module.exports = namespace;
+

--- a/frontend_tests/zjsunit/output.js
+++ b/frontend_tests/zjsunit/output.js
@@ -1,0 +1,121 @@
+var output = (function () {
+
+var exports = {};
+
+var fs = require('fs');
+var path = require('path');
+
+function mkdir_p(path) {
+    // This works like mkdir -p in Unix.
+    try {
+        fs.mkdirSync(path);
+    } catch(e) {
+        if ( e.code !== 'EEXIST' ) {
+            throw e;
+        }
+    }
+    return path;
+}
+
+function make_output_dir() {
+    mkdir_p('var');
+    var dir = mkdir_p('var/test-js-with-node');
+    return dir;
+}
+
+// TODO, move these actions with side effects to some kind
+//       of init() function.
+var output_dir = make_output_dir();
+var output_fn = path.join(output_dir, 'output.html');
+var index_fn = path.join(output_dir, 'index.html');
+
+exports.index_fn = index_fn;
+
+function stylesheets() {
+    // TODO: Automatically get all relevant styles.
+    var data = '';
+    data += '<link href="../../static/styles/fonts.css" rel="stylesheet">\n';
+    data += '<link href="../../static/styles/portico.css" rel="stylesheet">\n';
+    data += '<link href="../../static/styles/thirdparty-fonts.css" rel="stylesheet">\n';
+    data += '<link href="../../static/styles/zulip.css" rel="stylesheet">\n';
+    data += '<link href="../../static/third/bootstrap/css/bootstrap.css" rel="stylesheet">\n';
+    data += '<link href="../../static/third/bootstrap-notify/css/bootstrap-notify.css" rel="stylesheet">\n';
+
+    return data;
+}
+
+exports.start_writing = function () {
+    var data = '';
+
+    data += stylesheets();
+    data += '<style type="text/css">.collapse {height: inherit}</style>\n';
+    data += '<style type="text/css">body {width: 500px; margin: auto; overflow: scroll}</style>\n';
+    data += '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
+    data += '<h1>Output of node unit tests</h1>\n';
+    fs.writeFileSync(output_fn, data);
+
+    data = '';
+    data += '<style type="text/css">body {width: 500px; margin: auto; overflow: scroll}</style>\n';
+    data += '<h2>Regular output</h2>\n';
+    data += '<p>Any test can output HTML to be viewed here:</p>\n';
+    data += '<a href="output.html">Output of non-template.js tests</a><br />';
+    data += '<hr />\n';
+    data += '<h2>Handlebar output</h2>\n';
+    data += '<p>These are specifically from templates.js</p>\n';
+    fs.writeFileSync(index_fn, data);
+};
+
+
+exports.write_test_output = function (label, output) {
+    var data = '';
+
+    data += '<hr>';
+    data += '<h3>' + label + '</h3>';
+    data += output;
+    data += '\n';
+    fs.appendFileSync(output_fn, data);
+};
+
+exports.write_handlebars_output = (function () {
+    var last_label = '';
+
+    return function (label, output) {
+        if (last_label && (last_label >= label)) {
+            // This is kind of an odd requirement, but it allows us
+            // to render output on the fly in alphabetical order, and
+            // it has a nice side effect of making our source code
+            // easier to scan.
+
+            console.info(last_label);
+            console.info(label);
+            throw "Make sure your template tests are alphabetical in templates.js";
+        }
+        last_label = label;
+
+        var href = label + '.handlebars.html';
+        var fn = path.join(output_dir, href);
+
+        // Update the index
+        var a = '<a href="' + href +  '">' + label + '</a><br />';
+        fs.appendFileSync(index_fn, a);
+
+        // Write out own HTML file.
+        var data = '';
+        data += stylesheets();
+        data += '<style type="text/css">body {width: 500px; margin: auto; overflow: scroll}</style>\n';
+        data += '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
+        data += '<b>' + href + '</b><hr />\n';
+        data += output;
+        fs.writeFileSync(fn, data);
+    };
+}());
+
+exports.append_test_output = function (output) {
+    fs.appendFileSync(output_fn, output);
+};
+
+
+return exports;
+}());
+module.exports = output;
+

--- a/frontend_tests/zjsunit/render.js
+++ b/frontend_tests/zjsunit/render.js
@@ -1,0 +1,38 @@
+var render = (function () {
+
+var exports = {};
+
+var fs = require('fs');
+var _ = require('third/underscore/underscore.js');
+var Handlebars = require('handlebars');
+
+function template_dir() {
+    return __dirname + '/../../static/templates/';
+}
+
+exports.make_sure_all_templates_have_been_compiled = function () {
+    var dir = template_dir();
+    var fns = fs.readdirSync(dir).filter(function (fn) {
+        return (/\.handlebars/).test(fn);
+    });
+
+    _.each(fns, function (fn) {
+        var name = fn.split('.')[0];
+        if (!Handlebars.templates[name]) {
+            throw "The file " + fn + " has no test coverage.";
+        }
+    });
+};
+
+exports.use_template = function (name) {
+    if (Handlebars.templates === undefined) {
+        Handlebars.templates = {};
+    }
+    var data = fs.readFileSync(template_dir() + name + '.handlebars').toString();
+    Handlebars.templates[name] = Handlebars.compile(data);
+};
+
+return exports;
+}());
+module.exports = render;
+

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"/..
 
 export NODE_PATH=/usr/lib/nodejs:static
 
-INDEX_JS=frontend_tests/node_tests/index.js
+INDEX_JS=frontend_tests/zjsunit/index.js
 NODEJS=$(which nodejs || which node)
 if [ "$1" = "cover" ]; then
   # Run a coverage test with Istanbul.

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -591,7 +591,7 @@ PIPELINE = {
     'YUI_BINARY': '/usr/bin/env yui-compressor',
     'STYLESHEETS': {
         # If you add a style here, please update stylesheets()
-        # in frontend_tests/node_tests/index.js as needed.
+        # in frontend_tests/zjsunit/output.js as needed.
         'activity': {
             'source_filenames': ('styles/activity.css',),
             'output_filename':  'min/activity.css'


### PR DESCRIPTION
In summary:

- Move index.js into zjsunit directory (separate framework code from tests)
- Refactor index.js into several modules
- Fix the nagging bug with leaky requires
- Clean up some of the tests to not require leaks
- Add a little helper to stub out jquery

I'll turn my attention to the docs next.

(I used the name zjsunit because it seemed untaken on Google, but this is just an internal name for now.)