### PR TITLE
Added tools/html-grep

### DIFF
--- a/tools/html-grep
+++ b/tools/html-grep
@@ -14,13 +14,63 @@ except ImportError as e:
     print("If you are using Vagrant, you can `vagrant ssh` to enter the Vagrant guest.")
     sys.exit(1)
 
+USAGE = '''
+    This file greps HTML files for keywords in a context-sensitive manner.
+
+    Example:
+
+        $ ./tools/html-grep '#group-pms' '.filters'
+        templates/zerver/right-sidebar.html 45
+
+            div.right-sidebar#right-sidebar
+                div#group-pm-list
+                    ul.filters.scrolling_list#group-pms
+
+    Keyword syntax:
+
+        When supplying keywords, they must correspond to HTML elements,
+        classes, or ids.  Typical keywords are:
+
+            li // search for "<li>"
+            '.modal' // search for '<foo class="modal">'
+            '#intro' // search for '<bar id="intro">'
+
+        Searches are context-sensitive in the sense that the keyword
+        may be found among parent tags of a leaf tag, not just the leaf
+        tag itself.  (Think of this as being similar to the way a
+        browser applies nested CSS styles; it looks at the whole HTML
+        tree.)
+
+    Finding files to search:
+
+        The tool currently searches your git repo for files with
+        the extension .html or .handlebars., and then it does
+        the grep against all those files.
+
+        TODO: allow specific files to be searched.
+    '''
+
 def check_our_files():
     # type: () -> None
-    parser = optparse.OptionParser()
+
+    parser = optparse.OptionParser(usage=USAGE)
     parser.add_option('--modified', '-m',
         action='store_true', default=False,
         help='Only check modified files')
+    parser.add_option('--no-filter', '-a',
+        dest='show_all',
+        action='store_true', default=False,
+        help='Show all HTML files (no filtering)')
     (options, args) = parser.parse_args()
+
+    if options.show_all:
+        keywords = [] # type: List[str]
+    else:
+        if not args:
+            print('No keywords specified...try --help or --no-filter')
+            sys.exit(1)
+        else:
+            keywords = args
 
     files = lister.list_files(
         modified_only=options.modified,
@@ -28,7 +78,7 @@ def check_our_files():
     )
 
     fns = [fn for fn in files if (not 'casperjs' in fn) and (not 'puppet/zulip' in fn)]
-    grep(fns, set(args))
+    grep(fns, set(keywords))
 
 if __name__ == '__main__':
     check_our_files()

--- a/tools/html-grep
+++ b/tools/html-grep
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import print_function
+from lib.html_grep import grep
+import optparse
+import sys
+
+from six.moves import filter
+try:
+    import lister
+except ImportError as e:
+    print("ImportError: {}".format(e))
+    print("You need to run the Zulip linters inside a Zulip dev environment.")
+    print("If you are using Vagrant, you can `vagrant ssh` to enter the Vagrant guest.")
+    sys.exit(1)
+
+def check_our_files():
+    # type: () -> None
+    parser = optparse.OptionParser()
+    parser.add_option('--modified', '-m',
+        action='store_true', default=False,
+        help='Only check modified files')
+    (options, args) = parser.parse_args()
+
+    files = lister.list_files(
+        modified_only=options.modified,
+        ftypes=['handlebars', 'html'],
+    )
+
+    fns = [fn for fn in files if (not 'casperjs' in fn) and (not 'puppet/zulip' in fn)]
+    grep(fns, set(args))
+
+if __name__ == '__main__':
+    check_our_files()

--- a/tools/lib/html_grep.py
+++ b/tools/lib/html_grep.py
@@ -53,7 +53,7 @@ class Grepper(object):
         branches.sort(key=lambda branch: (branch.fn, branch.line))
         for branch in branches:
             print('%s %d' % (branch.fn, branch.line))
-            print('    ' + branch.text())
+            print(branch.staircase_text())
             print('')
 
 def grep(fns, words):

--- a/tools/lib/html_grep.py
+++ b/tools/lib/html_grep.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from collections import defaultdict
+from six.moves import range
+
+from .template_parser import html_branches, Token, HtmlTreeBranch
+
+def show_all_branches(fns):
+    # type: (List[str]) -> None
+    for fn in fns:
+        print(fn)
+        text = open(fn).read()
+        branches = html_branches(text)
+        for branch in branches:
+            print(branch.text())
+        print('---')
+
+class Grepper(object):
+    '''
+    A Grepper object is optimized to do repeated
+    searches of words that can be found in our
+    HtmlTreeBranch objects.
+    '''
+
+    def __init__(self, fns):
+        # type: (List[str]) -> None
+        all_branches = [] # type: List[HtmlTreeBranch]
+
+        for fn in fns:
+            branches = html_branches(fn)
+            all_branches += branches
+
+        self.word_dict = defaultdict(set) # type: Dict[str, Set[HtmlTreeBranch]]
+        for b in all_branches:
+            for word in b.words:
+                self.word_dict[word].add(b)
+
+        self.all_branches = set(all_branches)
+
+    def grep(self, word_set):
+        # type: (Set[str]) -> None
+
+        words = list(word_set) # type: List[str]
+
+        if len(words) == 0:
+            matches = self.all_branches
+        else:
+            matches = self.word_dict[words[0]]
+            for i in range(1, len(words)):
+                matches = matches & self.word_dict[words[i]]
+
+        branches = list(matches)
+        branches.sort(key=lambda branch: (branch.fn, branch.line))
+        for branch in branches:
+            print('%s %d' % (branch.fn, branch.line))
+            print('    ' + branch.text())
+            print('')
+
+def grep(fns, words):
+    # type: (List[str], Set[str]) -> None
+    grepper = Grepper(fns)
+    grepper.grep(words)
+

--- a/tools/lib/template_parser.py
+++ b/tools/lib/template_parser.py
@@ -271,9 +271,9 @@ class TagInfo(object):
         # type: () -> str
         s = self.tag
         if self.classes:
-            s += '(.' + ','.join(self.classes) + ')'
+            s += '.' + '.'.join(self.classes)
         if self.ids:
-            s += '(#' + ','.join(self.ids) + ')'
+            s += '#' + '#'.join(self.ids)
         return s
 
 def get_tag_info(token):
@@ -316,8 +316,30 @@ class HtmlTreeBranch(object):
             for word in tag.words:
                 self.words.add(word)
 
+    def staircase_text(self):
+        # type: () -> str
+        '''
+        produces representation of a node in staircase-like format:
+
+            html
+                body.main-section
+                    p#intro
+
+        '''
+        res = '\n'
+        indent = ' ' * 4
+        for t in self.tags:
+            res += indent + t.text() + '\n'
+            indent += ' ' * 4
+        return res
+
     def text(self):
         # type: () -> str
+        '''
+        produces one-line representation of branch:
+
+        html body.main-section p#intro
+        '''
         return ' '.join(t.text() for t in self.tags)
 
 def html_branches(fn):

--- a/tools/lib/template_parser.py
+++ b/tools/lib/template_parser.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
-from typing import Callable
+from typing import Callable, Optional
 from six.moves import range
+import re
 
 class TokenizerState(object):
     def __init__(self):
@@ -246,4 +247,122 @@ def get_html_tag(text, i):
         raise Exception('Tag missing >')
     s = text[i:end+1]
     return s
+
+class Node(object):
+    def __init__(self, token, parent):
+        # type: (Token, Node) -> None
+        self.token = token
+        self.children = [] # type: List[Node]
+        self.parent = None # type: Optional[Node]
+
+class TagInfo(object):
+    def __init__(self, tag, classes, ids, token):
+        # type: (str, List[str], List[str], Token) -> None
+        self.tag = tag
+        self.classes = classes
+        self.ids = ids
+        self.token = token
+        self.words = \
+            [self.tag] + \
+            ['.' + s for s in classes] + \
+            ['#' + s for s in ids]
+
+    def text(self):
+        # type: () -> str
+        s = self.tag
+        if self.classes:
+            s += '(.' + ','.join(self.classes) + ')'
+        if self.ids:
+            s += '(#' + ','.join(self.ids) + ')'
+        return s
+
+def get_tag_info(token):
+    # type: (Token) -> TagInfo
+    s = token.s
+    tag = token.tag
+    classes = [] # type: List[str]
+    ids = [] # type: List[str]
+
+    searches = [
+        (classes, ' class="(.*?)"'),
+        (classes, " class='(.*?)'"),
+        (ids, ' id="(.*?)"'),
+        (ids, " id='(.*?)'"),
+    ]
+
+    for lst, regex in searches:
+        m = re.search(regex, s)
+        if m:
+            for g in m.groups():
+                lst += g.split()
+
+    return TagInfo(tag=tag, classes=classes, ids=ids, token=token)
+
+class HtmlTreeBranch(object):
+    '''
+    For <p><div id='yo'>bla<span class='bar'></span></div></p>, store a representation
+    of the tags all the way down to the leaf, which would
+    conceptually be something like "p div(#yo) span(.bar)".
+    '''
+
+    def __init__(self, tags, fn):
+        # type: (List[TagInfo], str) -> None
+        self.tags = tags
+        self.fn = fn
+        self.line = tags[-1].token.line
+
+        self.words = set() # type: Set[str]
+        for tag in tags:
+            for word in tag.words:
+                self.words.add(word)
+
+    def text(self):
+        # type: () -> str
+        return ' '.join(t.text() for t in self.tags)
+
+def html_branches(fn):
+    # type: (str) -> List[HtmlTreeBranch]
+
+    text = open(fn).read()
+    tree = html_tag_tree(text)
+    branches = [] # type: List[HtmlTreeBranch]
+
+    def walk(node, tag_info_list=None):
+        # type: (Node, Optional[List[TagInfo]]) -> Node
+
+        info = get_tag_info(node.token)
+        if tag_info_list is None:
+            tag_info_list = [info]
+        else:
+            tag_info_list = tag_info_list[:] + [info]
+
+        if node.children:
+            for child in node.children:
+                walk(node=child, tag_info_list=tag_info_list)
+        else:
+            tree_branch = HtmlTreeBranch(tags=tag_info_list, fn=fn)
+            branches.append(tree_branch)
+
+    for node in tree.children:
+        walk(node, None)
+
+    return branches
+
+def html_tag_tree(text):
+    # type: (str) -> Node
+    tokens = tokenize(text)
+    top_level = Node(token=None, parent=None)
+    stack = [top_level]
+
+    for token in tokens:
+        if token.kind == 'html_start':
+            if not is_special_html_tag(token.s, token.tag):
+                parent = stack[-1]
+                node= Node(token=token, parent=parent)
+                parent.children.append(node)
+                stack.append(node)
+        elif token.kind == 'html_end':
+            stack.pop()
+
+    return top_level
 


### PR DESCRIPTION
This tool shows the tag/class/id elements of all our HTML files.  Occasionally templates parameterize class/id names, so this is slightly noisy, but it's sort of a "feature" for now to show those parameterized classes.  When this rolls into the HTML/CSS cross checker, there might be a bit more work to do on that front.