### PR TITLE
ModelReprMixin: Return string error message when __unicode__ is not i…

### DIFF
--- a/zerver/lib/str_utils.py
+++ b/zerver/lib/str_utils.py
@@ -83,7 +83,9 @@ class ModelReprMixin(object):
     """
     def __unicode__(self):
         # type: () -> text_type
-        raise NotImplementedError("__unicode__ is not implemented in subclass of ModelReprMixin")
+        # Originally raised an exception, but Django (e.g. the ./manage.py shell)
+        # was catching the exception and not displaying any sort of error
+        return u"Implement __unicode__ in your subclass of ModelReprMixin!"
 
     def __str__(self):
         # type: () -> str


### PR DESCRIPTION
…mplemented.

Old behavior was to raise an exception, but Django was catching the
exception and doing unexpected things. For instance, in the manage.py shell,
printing out a ModelReprMixin object (with __unicode__ not implemented)
would result in nothing being printed, rather than it raising a error or
otherwise alerting the programmer as to what was going on.