### PR TITLE
Move event logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.pyc
 *~
-/all_messages_log.*
 /prod-static
 /errors/*
 *.sw[po]

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.pyc
 *~
 /all_messages_log.*
-/event_log/*
 /prod-static
 /errors/*
 *.sw[po]

--- a/tools/deprecated/backup
+++ b/tools/deprecated/backup
@@ -2,6 +2,7 @@
 set -ex
 
 cd /home/tabbott/zulip-backups
+mkdir -p var/event_log
 log="$(pwd)"/log
 
 # Redirect output to a log file, with timestamps.
@@ -23,7 +24,7 @@ function commit {
 
 cd message_logs
 for h in staging.zulip.net prod0.zulip.net; do
-    rsync -v zulip@$h:logs/event_log/events.* .
+    rsync -v zulip@$h:var/event_log/events.* .
 done
 git add events.*
 commit


### PR DESCRIPTION
This PR reference Issue #1132. It moves `event_log` to `var/event_log` and also updates `gitignore` to remove `all_messages_log.*`