### PR TITLE
Realm-level default settings for language settings

### DIFF
--- a/docs/new-feature-tutorial.md
+++ b/docs/new-feature-tutorial.md
@@ -215,12 +215,12 @@ Since this feature also adds a checkbox to the admin page, and adds a
 new property the Realm model that can be modified from there, you also
 need to make changes to the `update_realm` function in the same file: :
 
-    # zerver/views/__init__.py
+    # zerver/views/realm.py
 
-    def update_realm(request, user_profile,
-      name=REQ(validator=check_string, default=None),
-      restricted_to_domain=REQ(validator=check_bool, default=None),
-      invite_by_admins_only=REQ(validator=check_bool,default=None)):
+    def update_realm(request, user_profile, name=REQ(validator=check_string, default=None),
+                     restricted_to_domain=REQ(validator=check_bool, default=None),
+                     invite_required=REQ(validator=check_bool, default=None),
+                     ...more arguments):
 
       # ...
 


### PR DESCRIPTION

- Adds a new field default_language in the zerver_realm model.
- New users in the realm will have realm level default language as their default language.
- Realm level default language can be changed from the administration page.