### PR TITLE
Fix bug with tools/html-grep.

### DIFF
--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -35,6 +35,15 @@ class ParserTest(unittest.TestCase):
             </table>'''
         validate(text=my_html)
 
+    def test_validate_handlebars(self):
+        # type: () -> None
+        my_html = '''
+            {{#with stream}}
+                <p>{{stream}}</p>
+            {{/with}}
+            '''
+        validate(text=my_html)
+
     def test_tokenize(self):
         # type: () -> None
         tag = '<meta whatever>bla'

--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -6,6 +6,7 @@ import unittest
 
 try:
     from tools.lib.template_parser import (
+        html_tag_tree,
         is_django_block_tag,
         tokenize,
         validate,
@@ -74,3 +75,11 @@ class ParserTest(unittest.TestCase):
         token = tokenize(tag)[0]
         self.assertEqual(token.kind, 'django_end')
         self.assertEqual(token.tag, 'if')
+
+    def test_html_tag_tree(self):
+        # type: () -> None
+        html = '''
+        <body><p>Hello world</p></body>
+        '''
+        tree = html_tag_tree(html)
+        self.assertEqual(tree.children[0].children[0].token.s, '<p>')

--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -44,6 +44,16 @@ class ParserTest(unittest.TestCase):
             '''
         validate(text=my_html)
 
+    def test_validate_django(self):
+        # type: () -> None
+        my_html = '''
+            {% include "some_other.html" %}
+            {% if foo %}
+                <p>bar</p>
+            {% endif %}
+            '''
+        validate(text=my_html)
+
     def test_tokenize(self):
         # type: () -> None
         tag = '<meta whatever>bla'

--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -7,6 +7,7 @@ import unittest
 try:
     from tools.lib.template_parser import (
         is_django_block_tag,
+        tokenize,
         validate,
     )
 except ImportError:
@@ -32,3 +33,44 @@ class ParserTest(unittest.TestCase):
                 </tr>
             </table>'''
         validate(text=my_html)
+
+    def test_tokenize(self):
+        # type: () -> None
+        tag = '<meta whatever>bla'
+        token = tokenize(tag)[0]
+        self.assertEqual(token.kind, 'html_special')
+
+        tag = '<a>bla'
+        token = tokenize(tag)[0]
+        self.assertEqual(token.kind, 'html_start')
+        self.assertEqual(token.tag, 'a')
+
+        tag = '<br />bla'
+        token = tokenize(tag)[0]
+        self.assertEqual(token.kind, 'html_singleton')
+        self.assertEqual(token.tag, 'br')
+
+        tag = '</a>bla'
+        token = tokenize(tag)[0]
+        self.assertEqual(token.kind, 'html_end')
+        self.assertEqual(token.tag, 'a')
+
+        tag = '{{#with foo}}bla'
+        token = tokenize(tag)[0]
+        self.assertEqual(token.kind, 'handlebars_start')
+        self.assertEqual(token.tag, 'with')
+
+        tag = '{{/with}}bla'
+        token = tokenize(tag)[0]
+        self.assertEqual(token.kind, 'handlebars_end')
+        self.assertEqual(token.tag, 'with')
+
+        tag = '{% if foo %}bla'
+        token = tokenize(tag)[0]
+        self.assertEqual(token.kind, 'django_start')
+        self.assertEqual(token.tag, 'if')
+
+        tag = '{% endif %}bla'
+        token = tokenize(tag)[0]
+        self.assertEqual(token.kind, 'django_end')
+        self.assertEqual(token.tag, 'if')


### PR DESCRIPTION
We were ignoring singleton tags like "input" tags in
html-grep.  This was an artifact of our tokenizer originally
being built to check indentation of templates, for which
singleton tags had been a distraction. This fix actually cleans up
the template checking logic as well, since it can now rely
on the tokenizer to classify special tags and singleton tags.
The tokenizer is more complete and more specific.