### PR TITLE
Navbar full name and organization name additions.

### DIFF
--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -5,6 +5,9 @@
 
 /* This max-width must be synced with viewport.is_narrow */
 @media (max-width: 975px) {
+    #user-info .username {
+        display: none;
+    }
 
     .screen-full-show {
         display: none !important;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -198,6 +198,27 @@ li,
     width: auto;
 }
 
+.header-main .column-right #user-info {
+    float: right;
+    margin-right: 40px;
+    padding-bottom: 10px;
+    padding-right: 10px;
+
+    border-right: 1px solid #dadada;
+}
+
+#user-info .username {
+    margin-top: 10px;
+
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+#user-info .username {
+    max-width: 170px;
+}
+
 #user-settings-avatar {
     width: 100px;
     height: 100px;
@@ -233,6 +254,9 @@ strong {
     font-weight: 600;
 }
 
+.light {
+    font-weight: 300;
+}
 
 /* Inline and block code */
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -207,12 +207,22 @@ li,
     border-right: 1px solid #dadada;
 }
 
+.header-main .column-left #org-info {
+    vertical-align: top;
+    display: inline-block;
+}
+
+#org-info .organization,
 #user-info .username {
     margin-top: 10px;
 
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+}
+
+#org-info .organization {
+    max-width: 155px;
 }
 
 #user-info .username {

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -129,6 +129,9 @@
               </li>
             </ul>
         </div>
+        <div id="user-info">
+          <div class="username light">{{ full_name }}</div>
+        </div>
   </div>
 </div>
 </div>

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -2,6 +2,9 @@
 <div class="header-main rightside-userlist" id="top_navbar">
   <div class="column-left">
     <a class="brand logo" href="#"><img src="/static/images/logo/zulipcornerlogo@2x.png" class="logoimage" alt="{{product_name}}" content="{{product_name}}" /></a>
+    <div id="org-info">
+      <div class="organization light">{{ realm_name }}</div>
+    </div>
   </div>
   <div class="column-middle" id="navbar-middle">
     <div class="column-middle-inner">

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -12,12 +12,18 @@ def add_settings(request):
     if hasattr(request.user, "realm"):
         realm = request.user.realm
         realm_uri = realm.uri
+        full_name = request.user.full_name
+        realm_name = realm.name
     else:
         realm = None
+        full_name = None
+        realm_name = None
         # TODO: Figure out how to add an assertion that this is not used
         realm_uri = settings.SERVER_URI
 
     return {
+        'full_name':                 full_name,
+        'realm_name':                realm_name,
         'custom_logo_url':           settings.CUSTOM_LOGO_URL,
         'register_link_disabled':    settings.REGISTER_LINK_DISABLED,
         'show_oss_announcement':     settings.SHOW_OSS_ANNOUNCEMENT,


### PR DESCRIPTION
These commits apply the styling, markup, and backend templating additions required to present the organization name on the left-hand column of the navbar and the full name of the user on the right-hand column.

Long names should be gracefully truncated with trailing ellipses. At 975px the full name on the right-hand column will be set to hidden as the right column is collapsed, and at 775px the organization name in the left-hand column will disappear as that column is also collapsed.