### PR TITLE
Color Picker positioning fix on subscription page.

### DIFF
--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -84,7 +84,7 @@ var subscriptions_table_colorpicker_options = {
 
 exports.set_colorpicker_color = function (colorpicker, color) {
     colorpicker.spectrum(_.extend(subscriptions_table_colorpicker_options,
-                         {color: color}));
+                         {color: color, container: "#subscriptions_table"}));
 };
 
 exports.update_stream_color = function (sub, stream_name, color, opts) {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2675,6 +2675,10 @@ div.floating_recipient {
     border: none;
 }
 
+.sp-container {
+  z-index: 100;
+}
+
 .streams_popover .sp-palette-container {
     border-right: none;
 }

--- a/static/third/spectrum/spectrum.js
+++ b/static/third/spectrum/spectrum.js
@@ -32,7 +32,10 @@
         showAlpha: false,
         theme: "sp-light",
         palette: ['fff', '000'],
-        selectionPalette: []
+        selectionPalette: [],
+
+        // user-specified container
+        container: null
     },
     spectrums = [],
     IE = !!/msie/i.exec( window.navigator.userAgent ),
@@ -165,7 +168,7 @@
             draggingClass = "sp-dragging";
 
         var doc = element.ownerDocument,
-            body = doc.body,
+            body = opts.container || doc.body,
             boundElement = $(element),
             container = $(markup, doc).addClass(theme),
             dragger = container.find(".sp-color"),


### PR DESCRIPTION
This fixes the color picker positioning by appending the color picker to the #subscriptions_table element rather than the document body. This is a fresh commit that also applies the change from a three-parameter spectrum function to allowing the container parameter to be an attribute in the options object, which is the second parameter of the spectrum function.