### PR TITLE
Fix @all spam warning when typing @all in backticks.

### DIFF
--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -140,3 +140,57 @@ var _ = global._;
     assert.throws(function () { eaf3('foo'); }, /called with \d+ arguments/);
     assert.throws(function () { eaf3('foo','bar', 'baz'); }, /called with \d+ arguments/);
 }());
+
+(function test_all_and_everyone_mentions_regexp() {
+    var messages_with_all_mentions = [
+      '@all',
+      'some text before @all some text after',
+      '@all some text after only',
+      'some text before only @all',
+      '@**all**',
+      'some text before @**all** some text after',
+      '@**all** some text after only',
+      'some text before only @**all**'
+    ];
+
+    var messages_with_everyone_mentions = [
+      '@everyone',
+      'some text before @everyone some text after',
+      '@everyone some text after only',
+      'some text before only @everyone',
+      '@**everyone**',
+      'some text before @**everyone** some text after',
+      '@**everyone** some text after only',
+      'some text before only @**everyone**'
+    ];
+
+    var messages_without_all_mentions = [
+      '`@everyone`',
+      'some_email@everyone.com',
+      '`@**everyone**`',
+      'some_email@**everyone**.com'
+    ];
+
+    var messages_without_everyone_mentions = [
+      '`@everyone`',
+      'some_email@everyone.com',
+      '`@**everyone**`',
+      'some_email@**everyone**.com'
+    ];
+    var i;
+    for(i=0; i<messages_with_all_mentions.length; i++) {
+        assert(util.is_all_or_everyone_mentioned(messages_with_all_mentions[i]));
+    }
+
+    for(i=0; i<messages_with_everyone_mentions.length; i++) {
+        assert(util.is_all_or_everyone_mentioned(messages_with_everyone_mentions[i]));
+    }
+
+    for(i=0; i<messages_without_all_mentions.length; i++) {
+        assert(!util.is_all_or_everyone_mentioned(messages_without_everyone_mentions[i]));
+    }
+
+    for(i=0; i<messages_without_everyone_mentions.length; i++) {
+        assert(!util.is_all_or_everyone_mentioned(messages_without_everyone_mentions[i]));
+    }
+}());

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -8,7 +8,6 @@ var is_composing_message = false;
 // get an error message too.
 // undefined: no @all/@everyone in message; false: user typed @all/@everyone; true: user clicked YES
 var user_acknowledged_all_everyone;
-var all_everyone_re = /(@\*{2}(all|everyone)\*{2})|(@(all|everyone))/;
 
 var message_snapshot;
 var empty_subject_placeholder = "(no topic)";
@@ -376,7 +375,7 @@ exports.restore_message = function () {
     compose.start(snapshot_copy.type, snapshot_copy);
 
     if (snapshot_copy.content !== undefined &&
-        all_everyone_re.test(snapshot_copy.content)) {
+        util.is_all_or_everyone_mentioned(snapshot_copy.content)) {
         show_all_everyone_warnings();
     }
 };
@@ -774,7 +773,7 @@ function validate_stream_message() {
     }
 
     // check if @all or @everyone is in the message
-    if (all_everyone_re.test(exports.message_content())) {
+    if (util.is_all_or_everyone_mentioned(exports.message_content())) {
         if (user_acknowledged_all_everyone === undefined ||
             user_acknowledged_all_everyone === false) {
             // user has not seen a warning message yet if undefined

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -232,6 +232,11 @@ exports.execute_early = function (func) {
     }
 };
 
+exports.is_all_or_everyone_mentioned = function (message_content) {
+    var all_everyone_re = /(@\*{2}(all|everyone)\*{2})|(@(all|everyone))/;
+    return all_everyone_re.test(message_content);
+};
+
 return exports;
 }());
 if (typeof module !== 'undefined') {

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -233,7 +233,7 @@ exports.execute_early = function (func) {
 };
 
 exports.is_all_or_everyone_mentioned = function (message_content) {
-    var all_everyone_re = /(@\*{2}(all|everyone)\*{2})|(@(all|everyone))/;
+    var all_everyone_re = /(^|\s)(@\*{2}(all|everyone)\*{2})|(@(all|everyone))($|\s)/;
     return all_everyone_re.test(message_content);
 };
 


### PR DESCRIPTION
When user'd like to send a message with @all in backticks
they see spam warning in spite of the fact that nobody
would be alerted.

Fixes: #1505.