### PR TITLE
Puppet nagios check

### DIFF
--- a/puppet/zulip/files/nagios_plugins/zulip_base/check_puppet
+++ b/puppet/zulip/files/nagios_plugins/zulip_base/check_puppet
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+PUPPET_PATH=/root/zulip
+if [ -L "$PUPPET_PATH" ]; then
+    echo "$PUPPET_PATH is a symlink; not running"
+    exit 1
+fi
+
+cd "$PUPPET_PATH"
+git fetch
+if ! git diff --exit-code; then
+    echo "$PUPPET_PATH repository is not clean; not running"
+    exit 1
+fi
+
+if ! git branch | grep -q '^[*] master$'; then
+    echo "master is not checked out in $PUPPET_PATH repository"
+    exit 1
+fi
+
+if ! git merge-base --is-ancestor master origin/master; then
+    echo "master is not an ancestor of origin/master"
+    exit 1
+fi
+
+git pull --rebase
+
+if ! /root/zulip/scripts/zulip-puppet-apply --test; then
+    echo "Puppet changes available!"
+    exit 1
+fi
+
+echo "Puppet state is up-to-date."
+exit 0

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -29,11 +29,20 @@ include apt
 for pclass in re.split(r'\s*,\s*', config.get('machine', 'puppet_classes')):
     puppet_config += "include %s\n" % (pclass,)
 
-puppet_cmd = ["puppet", "apply", "--modulepath=/root/zulip/puppet", "-e", puppet_config]
+puppet_cmd = ["puppet", "apply", "--detailed-exitcodes",
+              "--modulepath=/root/zulip/puppet", "-e", puppet_config]
 puppet_cmd += extra_args
 
+
 if not force:
-    subprocess.check_call(puppet_cmd + ['--noop', '--show_diff'])
+    ret = subprocess.call(puppet_cmd + ['--noop', '--show_diff'])
+    if ret == 0:
+        print("puppet: No changes detected.")
+        sys.exit(0)
+    elif ret in [4, 6]:
+        print("puppet: There were errors, aborting.")
+        sys.exit(1)
+    # Now ret=2, so there were changes but no errors
 
     do_apply = None
     while do_apply != 'y':
@@ -42,7 +51,7 @@ if not force:
         if do_apply == '' or do_apply == 'n':
             sys.exit(0)
 
-ret = subprocess.call(puppet_cmd + ['--detailed-exitcodes'])
+ret = subprocess.call(puppet_cmd)
 # ret = 0 => no changes, no errors
 # ret = 2 => changes, no errors
 # ret = 4 => no changes, yes errors

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -8,10 +8,14 @@ import six.moves.configparser as configparser
 import re
 
 force = False
+test = False
 extra_args = sys.argv[1:]
 
 if len(extra_args) and extra_args[0] in ('-f', '--force'):
     force = True
+    extra_args = extra_args[1:]
+if len(extra_args) and extra_args[0] in ('-t', '--test'):
+    test = True
     extra_args = extra_args[1:]
 
 config = configparser.RawConfigParser()
@@ -43,6 +47,9 @@ if not force:
         print("puppet: There were errors, aborting.")
         sys.exit(1)
     # Now ret=2, so there were changes but no errors
+    elif test:
+        print("puppet: changes detected.")
+        sys.exit(1)
 
     do_apply = None
     while do_apply != 'y':


### PR DESCRIPTION
This attempts to implement a Nagios check for whether Zulip puppet is up to date.  However, it does not work, because of https://tickets.puppetlabs.com/browse/PUP-686.  Another user reports on that thread that they have an alternative approach for extracting from puppet whether changes are available not using the exit codes; we will want to pursue that to make this work.
