### PR TITLE
Css#1270

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1460,7 +1460,6 @@ div.focused_table {
 
 .message_edit_topic_propagate {
     display: inline-block;
-    width: 400px;
 }
 
 .message_content.condensed {
@@ -3493,4 +3492,3 @@ li.show-more-private-messages a {
 .inline-subscribe-error {
     margin-left: 5px;
 }
-

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -1,6 +1,6 @@
 {{! Client-side Mustache template for rendering the message edit form. }}
 
-<form id="message_edit_form" class="form-horizontal">
+<form id="message_edit_form">
 {{#if is_stream}}
     <div class="control-group">
         <label class="control-label edit-control-label" for="message_edit_topic">{{t "Topic" }}</label>


### PR DESCRIPTION
CSS for line wrapping topic edit propagation dropdown ok. Responsive issues also solved using Bootstraps Framework classes