### PR TITLE
Terms of Service: Add ability to update TOS and have users re-sign.

### DIFF
--- a/corporate/terms.md
+++ b/corporate/terms.md
@@ -1,10 +1,10 @@
-# Zulip Terms of Service
+# Kandra Labs Terms of Service
 
-### Welcome to Zulip!
+### Welcome to Kandra Labs!
 
 Thanks for using our products and services ("Services"). The Services are
-provided by Zulip, Inc. ("Zulip"), located at 552 Massachusetts Ave Suite 203,
-Cambridge, MA 02139, United States.
+provided by Kandra Labs, Inc. ("Kandra Labs"), located at
+235 Berry St. Suite 306, San Francisco, CA 94158, United States.
 
 By using our Services, you are agreeing to these terms. Please read them
 carefully.
@@ -31,7 +31,7 @@ permitted by law. These terms do not grant you the right to use any branding or
 logos used in our Services. Don't remove, obscure, or alter any legal notices
 displayed in or along with our Services.
 
-Our Services display some content that is not Zulip's. This content is the
+Our Services display some content that does not belong to Kandra Labs. This content is the
 sole responsibility of the entity that makes it available. We may review
 content to determine whether it is illegal or violates our policies, and we may
 remove or refuse to display content that we reasonably believe violates our
@@ -42,12 +42,12 @@ In connection with your use of the Services, we may send you service
 announcements, administrative messages, and other information. You may opt out
 of some of those communications.
 
-### Your Zulip Account
+### Your Kandra Labs Zulip Account
 
-You may need a Zulip Account in order to use some of our Services. You may
-create your own Zulip Account, or your Zulip Account may be assigned to you
+You may need a Kandra Labs Zulip Account ("Account") in order to use some of our Services. You may
+create your own Account, or your Account may be assigned to you
 by an administrator, such as your employer or educational institution. If you
-are using a Zulip Account assigned to you by an administrator, different or
+are using an Account assigned to you by an administrator, different or
 additional terms may apply and your administrator may be able to access or
 disable your account.
 
@@ -56,9 +56,9 @@ If you learn of any unauthorized use of your password or account, contact
 
 ### Privacy and Copyright Protection
 
-Zulip's [privacy policy](/privacy) explains how we treat your
+The Kandra Labs [privacy policy](/privacy) explains how we treat your
 personal data and protect your privacy when you use our Services. By using our
-Services, you agree that Zulip can use such data in accordance with our
+Services, you agree that Kandra Labs can use such data in accordance with our
 privacy policy.
 
 We respond to notices of alleged copyright infringement and terminate
@@ -68,10 +68,10 @@ Digital Millennium Copyright Act.
 Our designated agent for notice of alleged copyright infringement on the
 Services is:
 
-> Copyright Agent  
-> Zulip, Inc.  
-> 552 Massachusetts Ave Suite 203  
-> Cambridge, MA 02139  
+> Copyright Agent
+> Kandra Labs, Inc.
+> 235 Berry St. Suite 306
+> San Francisco, CA 94158
 > [copyright@zulip.com](mailto:copyright@zulip.com)
 
 ### Your Content in our Services
@@ -80,7 +80,7 @@ Some of our Services allow you to submit content. You retain ownership of
 any intellectual property rights that you hold in that content. In short, what
 belongs to you stays yours.
 
-When you upload or otherwise submit content to our Services, you give Zulip
+When you upload or otherwise submit content to our Services, you give Kandra Labs
 (and those we work with) a worldwide license to use, host, store, reproduce,
 modify, create derivative works (such as those resulting from translations,
 adaptations or other changes we make so that your content works better with our
@@ -88,7 +88,7 @@ Services), communicate, publish, perform, display and distribute such content.
 The rights you grant in this license are for the limited purpose of operating
 and improving our Services, and to develop new ones. This license continues
 even if you stop using our Services (for example, so that we can deliver a
-message that you sent to another Zulip Account before you stopped using our
+message that you sent to another Account before you stopped using our
 Services). Some Services may offer you ways to access and remove content that
 has been provided to that Service. Also, in some of our Services, there may be
 terms or settings that narrow the scope of our use of the content submitted in
@@ -99,7 +99,7 @@ Services to share content with others, anyone you've shared content with
 content.
 
 In order to provide the Services, our servers save a record of the messages
-received by each Zulip Account (the "Received Messsage Information" for the
+received by each Account (the "Received Messsage Information" for the
 account). If you are using our Services on behalf of a business and a
 representative of that business sends [data@zulip.com](mailto:data@zulip.com)
 a request to delete all of your business' accounts with us, then within a
@@ -108,11 +108,11 @@ accounts with us and delete the Received Message Information for each such
 account by removing pointers to the information on our active servers and
 overwriting it over time. Notwithstanding the foregoing, deleting the Received
 Message Information for your business' accounts will not require deleting any
-information about messages that were sent or received by any Zulip Accounts that
+information about messages that were sent or received by any Accounts that
 are not one of your business' accounts with us (such as system-wide announcement
-messages or any messages corresponding with the Zulip support team).
+messages or any messages corresponding with the Kandra Labs support team).
 
-You can find more information about how Zulip uses and stores content in
+You can find more information about how Kandra Labs uses and stores content in
 the privacy policy. If you submit feedback or suggestions about our Services,
 we may use your feedback or suggestions without obligation to you.
 
@@ -123,10 +123,10 @@ When a Service requires or includes downloadable software, this software may
 update automatically on your device once a new version or feature is available.
 Some Services may let you adjust your automatic update settings.
 
-Zulip gives you a personal, worldwide, royalty-free, non-assignable and
-non-exclusive license to use the software provided to you by Zulip as part of
+Kandra Labs gives you a personal, worldwide, royalty-free, non-assignable and
+non-exclusive license to use the software provided to you by Kandra Labs as part of
 the Services. This license is for the sole purpose of enabling you to use and
-enjoy the benefit of the Services as provided by Zulip, in the manner
+enjoy the benefit of the Services as provided by Kandra Labs, in the manner
 permitted by these terms. You may not copy, modify, distribute, sell, or lease
 any part of our Services or included software, nor may you reverse engineer or
 attempt to extract the source code of that software, unless laws prohibit those
@@ -144,7 +144,7 @@ functionalities or features, and we may suspend or stop a Service
 altogether.
 
 You can stop using our Services at any time, although we'll be sorry to see
-you go. Zulip may also stop providing Services to you, or add or create new
+you go. Kandra Labs may also stop providing Services to you, or add or create new
 limits to our Services at any time.
 
 We believe that you own your data and preserving your access to such data is
@@ -158,7 +158,7 @@ out of that Service.
 We hope that you will enjoy using our Services, but there are certain things
 that we don't promise about our Services.
 
-OTHER THAN AS EXPRESSLY SET OUT IN THESE TERMS, NEITHER ZULIP NOR ITS
+OTHER THAN AS EXPRESSLY SET OUT IN THESE TERMS, NEITHER KANDRA LABS NOR ITS
 SUPPLIERS OR DISTRIBUTORS MAKE ANY SPECIFIC PROMISES ABOUT THE SERVICES.  FOR
 EXAMPLE, WE DON'T MAKE ANY COMMITMENTS ABOUT THE CONTENT WITHIN THE SERVICES,
 THE SPECIFIC FUNCTION OF THE SERVICES, OR THEIR RELIABILITY, AVAILABILITY, OR
@@ -171,24 +171,24 @@ THE EXTENT PERMITTED BY LAW, WE EXCLUDE ALL WARRANTIES.
 
 ### Liability for our Services
 
-WHEN PERMITTED BY LAW, ZULIP, AND ZULIP'S SUPPLIERS AND DISTRIBUTORS, WILL
+WHEN PERMITTED BY LAW, KANDRA LABS, AND KANDRA LABS'S SUPPLIERS AND DISTRIBUTORS, WILL
 NOT BE RESPONSIBLE FOR LOST PROFITS, REVENUES, OR DATA, FINANCIAL LOSSES OR
 INDIRECT, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES.
 
-TO THE EXTENT PERMITTED BY LAW, THE TOTAL LIABILITY OF ZULIP, AND ITS
+TO THE EXTENT PERMITTED BY LAW, THE TOTAL LIABILITY OF KANDRA LABS, AND ITS
 SUPPLIERS AND DISTRIBUTORS, FOR ANY CLAIM UNDER THESE TERMS, INCLUDING FOR ANY
 IMPLIED WARRANTIES, IS LIMITED TO THE GREATER OF FIVE DOLLARS ($5) OR THE
-AMOUNT PAID BY YOU TO ZULIP FOR THE PAST THREE MONTHS OF THE SERVICES IN
+AMOUNT PAID BY YOU TO KANDRA LABS FOR THE PAST THREE MONTHS OF THE SERVICES IN
 QUESTION.
 
-IN ALL CASES, ZULIP, AND ITS SUPPLIERS AND DISTRIBUTORS, WILL NOT BE LIABLE
+IN ALL CASES, KANDRA LABS, AND ITS SUPPLIERS AND DISTRIBUTORS, WILL NOT BE LIABLE
 FOR ANY LOSS OR DAMAGE THAT IS NOT REASONABLY FORESEEABLE.
 
 
 ### Business uses of our Services
 
 If you are using our Services on behalf of a business, that business accepts
-these terms. It will hold harmless and indemnify Zulip and its affiliates,
+these terms. It will hold harmless and indemnify Kandra Labs and its affiliates,
 officers, agents, and employees from any claim, suit or action arising from or
 related to the use of the Services or violation of these terms, including any
 liability or expense arising from claims, losses, damages, suits, judgments,
@@ -220,25 +220,25 @@ If you do not comply with these terms, and we don't take action right away,
 this doesn't mean that we are giving up any rights that we may have (such as
 taking action in the future).
 
-These terms control the relationship between Zulip and you. They do not
+These terms control the relationship between Kandra Labs and you. They do not
 create any third party beneficiary rights.
 
-The laws of Massachusetts, U.S.A., excluding Massachusetts's conflict of
+The laws of California, U.S.A., excluding California's conflict of
 laws rules, will apply to any disputes arising out of or relating to these
 terms or the Services. All claims arising out of or relating to these terms or
 the Services will be litigated exclusively in the applicable federal or state
-courts of Massachusetts, and you and Zulip consent to personal jurisdiction in
+courts of California, and you and Kandra Labs consent to personal jurisdiction in
 those courts.
 
-Zulip reserves the right to amend or modify these terms at any time and in
+Kandra Labs reserves the right to amend or modify these terms at any time and in
 any manner by providing reasonable notice to you. You agree that reasonable
-notice may be provided by posting on Zulip's web site, email, or other written
+notice may be provided by posting on Kandra Labs's web site, email, or other written
 notice.   By continuing to access or use the Services after revisions become
 effective, you agree to be bound by the revised terms. If you do not agree to
 the new terms, please stop using the Services.
 
-These terms constitute the whole legal agreement between you and Zulip, and
-completely replace any prior agreements between you and Zulip in relation to
+These terms constitute the whole legal agreement between you and Kandra Labs, and
+completely replace any prior agreements between you and Kandra Labs in relation to
 the Services.
 
-Last modified: October 4, 2013
+Last modified: August 12, 2016

--- a/templates/corporate/privacy.html
+++ b/templates/corporate/privacy.html
@@ -25,7 +25,7 @@ information.</p>
 <ul>
 
 <li><p><strong>Information you give us.</strong> For example, many of our
-services require you to sign up for a Zulip Account. When you do, we’ll ask
+services require you to sign up for a Kandra Labs Zulip Account. When you do, we’ll ask
 for personal information, like your name, email address, or telephone
 number.</p></li>
 
@@ -39,14 +39,14 @@ like when you interact with our content.  This information includes:</p>
 <p><strong>Device information</strong></p>
 <p>We may collect device-specific information (such as your hardware model,
 operating system version, unique device identifiers, and mobile network
-information including phone number). Zulip may associate your device
-identifiers or phone number with your Zulip Account.</p>
+information including phone number). Kandra Labs may associate your device
+identifiers or phone number with your Kandra Labs Zulip Account.</p>
 </li>
 
 <li>
 <p><strong>Log information</strong></p>
 
-<p>When you use our services or view content provided by Zulip, we may
+<p>When you use our services or view content provided by Kandra Labs, we may
 automatically collect and store certain information in server logs. This may
 include:</p>
 
@@ -60,7 +60,7 @@ include:</p>
 settings, browser type, browser language, the date and time of your request and
 referral URL.</p></li>
 
-<li><p>cookies that may uniquely identify your browser or your Zulip
+<li><p>cookies that may uniquely identify your browser or your Kandra Labs Zulip
 Account.</p></li>
 
 </ul>
@@ -71,7 +71,7 @@ Account.</p></li>
 <p><strong>Unique application numbers</strong></p>
 <p>Certain services include a unique application number. This number and
 information about your installation (for example, the operating system type and
-application version number) may be sent to Zulip when you install or uninstall
+application version number) may be sent to Kandra Labs when you install or uninstall
 that service or when that service periodically contacts our servers, such as
 for automatic updates.</p>
 </li>
@@ -86,7 +86,7 @@ HTML 5) and application data caches.</p>
 <li>
 <p><strong>Cookies and anonymous identifiers</strong></p>
 <p>We use various technologies to collect and store information when you visit
-a Zulip service, and this may include sending one or more cookies or anonymous
+our Zulip service, and this may include sending one or more cookies or anonymous
 identifiers to your device. We may also use cookies and anonymous identifiers
 when you interact with services we offer to our partners, such as Zulip
 features that may appear on other sites.</p>
@@ -102,16 +102,16 @@ features that may appear on other sites.</p>
 <h3>How we use information we collect</h3>
 
 <p>We use the information we collect from all of our services to provide,
-maintain, protect and improve them, to develop new ones, and to protect Zulip
+maintain, protect and improve them, to develop new ones, and to protect Kandra Labs
 and our users.</p>
 
-<p>We may use the name you provide for your Zulip Account across all of the
-services we offer that require a Zulip Account. In addition, we may replace
-past names associated with your Zulip Account so that you are represented
+<p>We may use the name you provide for your Kandra Labs Zulip Account across all of the
+services we offer that require an account. In addition, we may replace
+past names associated with your account so that you are represented
 consistently across all our services.  We may show other users your publicly
-visible Zulip Account information, such as your name.</p>
+visible account information, such as your name.</p>
 
-<p>When you contact Zulip, we may keep a record of your communication to help
+<p>When you contact Kandra Labs, we may keep a record of your communication to help
 solve any issues you might be facing. We may use your email address to inform
 you about our services, such as letting you know about upcoming changes or
 improvements.</p>
@@ -120,9 +120,9 @@ improvements.</p>
 your user experience and the overall quality of our services.</p>
 
 <p>We may combine personal information from one service with information,
-including personal information, from other Zulip services.</p>
+including personal information, from other Kandra Labs services.</p>
 
-<p>Zulip processes personal information on our servers in many countries
+<p>Kandra Labs processes personal information on our servers in many countries
 around the world. We may process your personal information on a server located
 outside the country where you live.</p>
 
@@ -153,7 +153,7 @@ and may not remove information from our backup systems.</p>
 <h3>Information we share</h3>
 
 <p>We do not share personal information with companies, organizations and
-individuals outside of Zulip unless one of the following circumstances
+individuals outside of Kandra Labs unless one of the following circumstances
 apply:</p>
 
 <ul>
@@ -161,16 +161,16 @@ apply:</p>
 <li>
 <p><strong>With your consent</strong></p>
 <p>We will share personal information with companies, organizations or
-individuals outside of Zulip when we have your consent to do so. We require
+individuals outside of Kandra Labs when we have your consent to do so. We require
 opt-in consent for the sharing of any sensitive personal information.</p>
 </li>
 
 <li>
 <p><strong>With domain administrators</strong></p>
 
-<p>If your Zulip Account is managed for you by a domain administrator then
+<p>If your Kandra Labs Zulip Account is managed for you by a domain administrator then
 your domain administrator and resellers who provide user support to your
-organization will have access to your Zulip Account information (including
+organization will have access to your account information (including
 your email and other data). Your domain administrator may be able to:</p>
 
 <ul>
@@ -206,7 +206,7 @@ compliance with our Privacy Policy.</p>
 <p><strong>For legal reasons</strong></p>
 
 <p>We will share personal information with companies, organizations or
-individuals outside of Zulip if we, in our sole discretion, determine that
+individuals outside of Kandra Labs if we, in our sole discretion, determine that
 that access, use, preservation or disclosure of the information is necessary
 to:</p>
 
@@ -221,7 +221,7 @@ potential violations.</p></li>
 <li><p>detect, prevent, or otherwise address fraud, security or technical
 issues.</p></li>
 
-<li><p>protect against harm to the rights, property or safety of Zulip, our
+<li><p>protect against harm to the rights, property or safety of Kandra Labs, our
 users or the public as required or permitted by law.</p></li>
 
 </ul>
@@ -242,7 +242,7 @@ and becomes subject to a substantially different privacy policy.</p>
 
 <h3>Application</h3>
 
-<p>Our Privacy Policy applies to all of the services offered by Zulip, Inc.
+<p>Our Privacy Policy applies to all of the services offered by Kandra Labs, Inc.
 and its affiliates, including services offered on other sites, but excludes
 services that have separate privacy policies that do not incorporate this
 Privacy Policy.</p>
@@ -261,6 +261,6 @@ version of our privacy policy on this page.</p>
 
 <br />
 
-<p>Last modified: July 15, 2013</p>
+<p>Last modified: August 12, 2016</p>
 
 {% endblock %}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -277,12 +277,12 @@ def notify_created_bot(user_profile):
     send_event(event, bot_owner_userids(user_profile))
 
 def do_create_user(email, password, realm, full_name, short_name,
-                   active=True, bot_type=None, bot_owner=None,
+                   active=True, bot_type=None, bot_owner=None, tos_version=None,
                    avatar_source=UserProfile.AVATAR_FROM_GRAVATAR,
                    default_sending_stream=None, default_events_register_stream=None,
                    default_all_public_streams=None, prereg_user=None,
                    newsletter_data=None):
-    # type: (text_type, text_type, Realm, text_type, text_type, bool, Optional[int], Optional[UserProfile], text_type, Optional[Stream], Optional[Stream], bool, Optional[PreregistrationUser], Optional[Dict[str, str]]) -> UserProfile
+    # type: (text_type, text_type, Realm, text_type, text_type, bool, Optional[int], Optional[UserProfile], Optional[text_type], text_type, Optional[Stream], Optional[Stream], bool, Optional[PreregistrationUser], Optional[Dict[str, str]]) -> UserProfile
     event = {'type': 'user_created',
              'timestamp': time.time(),
              'full_name': full_name,
@@ -297,7 +297,7 @@ def do_create_user(email, password, realm, full_name, short_name,
     user_profile = create_user(email=email, password=password, realm=realm,
                                full_name=full_name, short_name=short_name,
                                active=active, bot_type=bot_type, bot_owner=bot_owner,
-                               avatar_source=avatar_source,
+                               tos_version=tos_version, avatar_source=avatar_source,
                                default_sending_stream=default_sending_stream,
                                default_events_register_stream=default_events_register_stream,
                                default_all_public_streams=default_all_public_streams)
@@ -1579,8 +1579,9 @@ def do_activate_user(user_profile, log=True, join_date=timezone.now()):
     user_profile.is_mirror_dummy = False
     user_profile.set_unusable_password()
     user_profile.date_joined = join_date
+    user_profile.tos_version = settings.TOS_VERSION
     user_profile.save(update_fields=["is_active", "date_joined", "password",
-                                     "is_mirror_dummy"])
+                                     "is_mirror_dummy", "tos_version"])
 
     if log:
         domain = user_profile.realm.domain

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -18,8 +18,8 @@ def bulk_create_realms(realm_list):
             existing_realms.add(domain)
     Realm.objects.bulk_create(realms_to_create)
 
-def bulk_create_users(realms, users_raw, bot_type=None):
-    # type: (Mapping[text_type, Realm], Set[Tuple[text_type, text_type, text_type, bool]], Optional[int]) -> None
+def bulk_create_users(realms, users_raw, bot_type=None, tos_version=None):
+    # type: (Mapping[text_type, Realm], Set[Tuple[text_type, text_type, text_type, bool]], Optional[int], Optional[text_type]) -> None
     """
     Creates and saves a UserProfile with the given email.
     Has some code based off of UserManage.create_user, but doesn't .save()
@@ -39,7 +39,7 @@ def bulk_create_users(realms, users_raw, bot_type=None):
         domain = resolve_email_to_domain(email)
         profile = create_user_profile(realms[domain], email,
                                       initial_password(email), active, bot_type,
-                                      full_name, short_name, None, False)
+                                      full_name, short_name, None, False, tos_version)
         profiles_to_create.append(profile)
     UserProfile.objects.bulk_create(profiles_to_create)
 

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -26,8 +26,8 @@ def random_api_key():
 # create_user (below) which will also make the Subscription and
 # Recipient objects
 def create_user_profile(realm, email, password, active, bot_type, full_name,
-                        short_name, bot_owner, is_mirror_dummy):
-    # type: (Realm, text_type, text_type, bool, Optional[int], text_type, text_type, Optional[UserProfile], bool) -> UserProfile
+                        short_name, bot_owner, is_mirror_dummy, tos_version):
+    # type: (Realm, text_type, text_type, bool, Optional[int], text_type, text_type, Optional[UserProfile], bool, Optional[text_type]) -> UserProfile
     now = timezone.now()
     email = UserManager.normalize_email(email)
 
@@ -54,15 +54,15 @@ def create_user_profile(realm, email, password, active, bot_type, full_name,
     return user_profile
 
 def create_user(email, password, realm, full_name, short_name,
-                active=True, bot_type=None, bot_owner=None,
+                active=True, bot_type=None, bot_owner=None, tos_version=None,
                 avatar_source=UserProfile.AVATAR_FROM_GRAVATAR,
                 is_mirror_dummy=False, default_sending_stream=None,
                 default_events_register_stream=None,
                 default_all_public_streams=None, user_profile_id=None):
-    # type: (text_type, text_type, Realm, text_type, text_type, bool, Optional[int], Optional[UserProfile], text_type, bool, Optional[Stream], Optional[Stream], Optional[bool], Optional[int]) -> UserProfile
+    # type: (text_type, text_type, Realm, text_type, text_type, bool, Optional[int], Optional[UserProfile], Optional[text_type], text_type, bool, Optional[Stream], Optional[Stream], Optional[bool], Optional[int]) -> UserProfile
     user_profile = create_user_profile(realm, email, password, active, bot_type,
                                        full_name, short_name, bot_owner,
-                                       is_mirror_dummy)
+                                       is_mirror_dummy, tos_version)
     user_profile.avatar_source = avatar_source
     user_profile.default_sending_stream = default_sending_stream
     user_profile.default_events_register_stream = default_events_register_stream

--- a/zerver/migrations/0028_userprofile_tos_version.py
+++ b/zerver/migrations/0028_userprofile_tos_version.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='userprofile',
             name='tos_version',
-            field=models.CharField(default=None, max_length=10, null=True),
+            field=models.CharField(max_length=10, null=True),
         ),
     ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -391,7 +391,7 @@ class UserProfile(ModelReprMixin, AbstractBaseUser, PermissionsMixin):
     last_pointer_updater = models.CharField(max_length=64) # type: text_type
     realm = models.ForeignKey(Realm) # type: Realm
     api_key = models.CharField(max_length=32) # type: text_type
-    tos_version = models.CharField(null=True, max_length=10, default=settings.TOS_VERSION) # type: text_type
+    tos_version = models.CharField(null=True, max_length=10) # type: text_type
 
     ### Notifications settings. ###
 

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -216,6 +216,7 @@ def accounts_register(request):
                 do_activate_user(user_profile)
                 do_change_password(user_profile, password)
                 do_change_full_name(user_profile, full_name)
+                do_change_tos_version(user_profile, settings.TOS_VERSION)
             except UserProfile.DoesNotExist:
                 user_profile = do_create_user(email, password, realm, full_name, short_name,
                                               prereg_user=prereg_user,
@@ -224,7 +225,6 @@ def accounts_register(request):
             user_profile = do_create_user(email, password, realm, full_name, short_name,
                                           prereg_user=prereg_user,
                                           newsletter_data={"IP": request.META['REMOTE_ADDR']})
-        do_change_tos_version(user_profile, settings.TOS_VERSION)
 
         # This logs you in using the ZulipDummyBackend, since honestly nothing
         # more fancy than this is required.

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -42,7 +42,8 @@ def create_users(realms, name_list, bot_type=None):
     for full_name, email in name_list:
         short_name = email_to_username(email)
         user_set.add((email, full_name, short_name, True))
-    bulk_create_users(realms, user_set, bot_type)
+    tos_version = settings.TOS_VERSION if bot_type is None else None
+    bulk_create_users(realms, user_set, bot_type, tos_version)
 
 def create_streams(realms, realm, stream_list):
     # type: (Mapping[text_type, Realm], Realm, Iterable[text_type]) -> None
@@ -428,7 +429,7 @@ def restore_saved_messages():
                            streams[recipient.type_id].name.lower())] = recipient
 
     print(datetime.datetime.now(), "Creating users...")
-    bulk_create_users(realms, user_set)
+    bulk_create_users(realms, user_set, None, settings.TOS_VERSION)
 
     users = {} # type: Dict[text_type, UserProfile]
     users_by_id = {} # type: Dict[int, UserProfile]


### PR DESCRIPTION
Most directly useful for the migration to zulipchat.com.

Creates a new field in UserProfile to store the tos_version, as well as a
special MIGRATION_TOS_VERSION that triggers slightly different text on
accounts_accept_terms.html. We check for a version mismatch between what the
user has signed and the current settings.TOS_VERSION whenever the user hits
the home page, and redirect them if needed.

Note that accounts_accept_terms.html and zerver.views.accounts_accept_terms
were unused before this commit (I'm guessing they are from the Dropbox
migration in 2014.)