### PR TITLE
migration: Change deactivated realm page to a migration-specific page.

### DIFF
--- a/templates/zerver/sunset.html
+++ b/templates/zerver/sunset.html
@@ -1,0 +1,12 @@
+{% extends "zerver/portico.html" %}
+{% block portico_content %}
+
+
+<h3>{{ _('Zulip is moving! &nbsp;&#128666;') }}</h3>
+
+
+<p>
+  This server is being shut down as a part of the transition from the Dropbox Zulip service to the Kandra Labs Zulip service. Your organization has elected not to transition to the new service. If you believe you are recieving this message in error, please contact your organization's administrator or <a href="mailto:support@zulip.com">support@zulip.com</a>.
+</p>
+
+{% endblock %}

--- a/templates/zerver/transition.html
+++ b/templates/zerver/transition.html
@@ -10,7 +10,7 @@ This server is being shut down as a part of the transition from the Dropbox Zuli
 </p>
 
 <p>
-If it's past August 14 and that isn't working, please contact the zulipchat.com administrators at <a href="mailto:support@zulip.com">support@zulip.com</a>.
+If it's past August 14 and that isn't working, please contact the zulipchat.com administrators at <a href="mailto:support@zulipchat.com">support@zulipchat.com</a>.
 </p>
 
 {% endblock %}

--- a/templates/zerver/transition.html
+++ b/templates/zerver/transition.html
@@ -1,0 +1,16 @@
+{% extends "zerver/portico.html" %}
+{% block portico_content %}
+
+
+<h3>{{ _('Zulip is moving! &nbsp;&#128666;') }}</h3>
+
+
+<p>
+This server is being shut down as a part of the transition from the Dropbox Zulip service to the Kandra Labs Zulip service. Your account should be active on <a href="http://zulipchat.com">zulipchat.com</a> by Sunday, August 14, San Francisco time (UTC -7).
+</p>
+
+<p>
+If it's past August 14 and that isn't working, please contact the zulipchat.com administrators at <a href="mailto:support@zulip.com">support@zulip.com</a>.
+</p>
+
+{% endblock %}

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -120,6 +120,14 @@ def accounts_register(request):
         realm = get_realm(domain)
 
     if realm and realm.deactivated:
+        # The user could be trying to access a realm that was deactivated in the
+        # transition from zulip.com to zulipchat.com.
+        if hasattr(settings, 'ZULIPCOM_MIGRATORS'):
+            if realm.domain in settings.ZULIPCOM_MIGRATORS:
+                return render_to_response("zerver/transition.html")
+            else:
+                return render_to_response("zerver/sunset.html")
+
         # The user is trying to register for a deactivated realm. Advise them to
         # contact support.
         return render_to_response("zerver/deactivated.html",

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -122,7 +122,7 @@ def accounts_register(request):
     if realm and realm.deactivated:
         # The user could be trying to access a realm that was deactivated in the
         # transition from zulip.com to zulipchat.com.
-        if hasattr(settings, 'ZULIPCOM_MIGRATORS'):
+        if settings.ZULIPCOM_MIGRATORS is not None:
             if realm.domain in settings.ZULIPCOM_MIGRATORS:
                 return render_to_response("zerver/transition.html")
             else:
@@ -578,7 +578,12 @@ def finish_google_oauth2(request):
     else:
         raise Exception('Google oauth2 account email not found %r' % (body,))
     email_address = email['value']
-    user_profile = authenticate(username=email_address, use_dummy_backend=True)
+    return_data = {} # type: Dict[str, bool]
+    user_profile = authenticate(username=email_address, use_dummy_backend=True, return_data=return_data)
+    if user_profile is None:
+        response = migration_response(email_address, return_data)
+        if response:
+            return response
     return login_or_register_remote_user(request, email_address, user_profile, full_name)
 
 def login_page(request, **kwargs):
@@ -603,6 +608,20 @@ def login_page(request, **kwargs):
 
     return template_response
 
+def migration_response(email, return_data):
+    # type: (text_type, Dict[str, bool]) -> Optional[HttpResponse]
+    user_profile = get_user_profile_by_email(email)
+    if not user_profile or not return_data.get('inactive_realm', False):
+        return None
+    if settings.ZULIPCOM_MIGRATORS is not None:
+        if user_profile.realm.domain in settings.ZULIPCOM_MIGRATORS:
+            return render_to_response("zerver/transition.html")
+        else:
+            return render_to_response("zerver/sunset.html")
+    return render_to_response("zerver/deactivated.html",
+                              {"deactivated_domain_name": user_profile.realm.name,
+                               "zulip_administrator": settings.ZULIP_ADMINISTRATOR})
+
 def dev_direct_login(request, **kwargs):
     # type: (HttpRequest, **Any) -> HttpResponse
     # This function allows logging in without a password and should only be called in development environments.
@@ -611,9 +630,13 @@ def dev_direct_login(request, **kwargs):
         # This check is probably not required, since authenticate would fail without an enabled DevAuthBackend.
         raise Exception('Direct login not supported.')
     email = request.POST['direct_email']
-    user_profile = authenticate(username=email)
+    return_data = {} # type: Dict[str, bool]
+    user_profile = authenticate(username=email, return_data=return_data)
     if user_profile is None:
-        raise Exception("User cannot login")
+        response = migration_response(email, return_data)
+        if response:
+            return response
+        raise Exception("User cannot login.")
     login(request, user_profile)
     return HttpResponseRedirect("%s%s" % (settings.EXTERNAL_URI_SCHEME,
                                           request.get_host()))
@@ -1149,7 +1172,11 @@ def api_get_auth_backends(request):
 def json_fetch_api_key(request, user_profile, password=REQ(default='')):
     # type: (HttpRequest, UserProfile, str) -> HttpResponse
     if password_auth_enabled(user_profile.realm):
-        if not authenticate(username=user_profile.email, password=password):
+        return_data = {} # type: Dict[str, bool]
+        if not authenticate(username=user_profile.email, password=password, return_data=return_data):
+            response = migration_response(user_profile.email, return_data)
+            if response:
+                return response
             return json_error(_("Your username or password is incorrect."))
     return json_success({"api_key": user_profile.api_key})
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -170,7 +170,8 @@ DEFAULT_SETTINGS = {'TWITTER_CONSUMER_KEY': '',
                     'TERMS_OF_SERVICE': None,
                     'TOS_VERSION': None,
                     'SYSTEM_ONLY_REALMS': {"zulip.com"},
-                    'FIRST_TIME_TOS_TEMPLATE': None
+                    'FIRST_TIME_TOS_TEMPLATE': None,
+                    'ZULIPCOM_MIGRATORS': None
                     }
 
 for setting_name, setting_val in six.iteritems(DEFAULT_SETTINGS):


### PR DESCRIPTION
Page that users logging in to zulip.com will see if their organization
has elected to {transition, not transition} to zulipchat.com

Reads in a new setting: settings.ZULIPCOM_MIGRATORS
