### PR TITLE
doc: Add version number to Trusty in prod requirements.

### DIFF
--- a/docs/prod-requirements.md
+++ b/docs/prod-requirements.md
@@ -1,6 +1,6 @@
 # Requirements for Zulip in production
 
-* Server running Ubuntu Trusty
+* Server running Ubuntu Trusty (14.04)
 * At least 2 CPUs for production use with 100+ users
 * At least 4GB of RAM for production use with 100+ users.  We **strongly
   recommend against installing with less than 2GB of RAM**, as you will


### PR DESCRIPTION
We mention that Trusty is the same as 14.04 in a bunch of other places and I'd like to continue that here to avoid making people have to look stuff up (like I just did).