### PR TITLE
Show hex input field on color picker

### DIFF
--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -79,6 +79,7 @@ var stream_color_palette = [
 var subscriptions_table_colorpicker_options = {
     clickoutFiresChange: true,
     showPalette: true,
+    showInput: true,
     palette: stream_color_palette
 };
 
@@ -114,6 +115,7 @@ exports.sidebar_popover_colorpicker_options = {
     clickoutFiresChange: true,
     showPaletteOnly: true,
     showPalette: true,
+    showInput: true,
     flat: true,
     palette: stream_color_palette,
     change: picker_do_change_color
@@ -122,6 +124,7 @@ exports.sidebar_popover_colorpicker_options = {
 exports.sidebar_popover_colorpicker_options_full = {
     clickoutFiresChange: true,
     showPalette: true,
+    showInput: true,
     flat: true,
     cancelText: "",
     chooseText: "choose",


### PR DESCRIPTION
This enables the input field in the color pickers that allows users to
specify the hex of the color they would like to apply.

Fixes: #1364.