### PR TITLE
Flush stdout prior to exiting child process

### DIFF
--- a/tools/lint-all
+++ b/tools/lint-all
@@ -374,6 +374,7 @@ def run_parallel():
             result = func()
             logging.info("finish " + name)
             sys.stdout.flush()
+            sys.stderr.flush()
             os._exit(result)
         pids.append(pid)
     failed = False

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -373,6 +373,7 @@ def run_parallel():
             logging.info("start " + name)
             result = func()
             logging.info("finish " + name)
+            sys.stdout.flush()
             os._exit(result)
         pids.append(pid)
     failed = False


### PR DESCRIPTION
Flushing stdout prior to existing child processes will ensure all output from those child processes continues along any redirects. Otherwise data is output to screen, but otherwise lost. This was causing output to be lost upon redirection or when lint is run via ssh. 