### PR TITLE
Live update new avatar across users.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -326,6 +326,7 @@ function create_message_object() {
                    stream: compose.stream_name(),
                    private_message_recipient: compose.recipient(),
                    content: content,
+                   sender_id: page_params.user_id,
                    queue_id: page_params.event_queue_id};
 
     if (message.type === "private") {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -143,6 +143,20 @@ exports.update = function update(person) {
         }
     }
 
+    if (_.has(person, 'avatar_url')) {
+        var url = person.avatar_url;
+        person_obj.avatar_url = url;
+
+        if (util.is_current_user(person.email)) {
+          page_params.avatar_url = url;
+          $("#user-settings-avatar").attr("src", url);
+        }
+
+        $(".inline_profile_picture").css({
+          "background-image": "url(" + url + ")"
+        });
+    }
+
     activity.set_user_statuses([]);
 
     // TODO: update sender names on messages

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -144,7 +144,7 @@ exports.update = function update(person) {
     }
 
     if (_.has(person, 'avatar_url')) {
-        var url = person.avatar_url;
+        var url = person.avatar_url + "&y=" + new Date().getTime();
         person_obj.avatar_url = url;
 
         if (util.is_current_user(person.email)) {
@@ -152,7 +152,7 @@ exports.update = function update(person) {
           $("#user-settings-avatar").attr("src", url);
         }
 
-        $(".inline_profile_picture").css({
+        $(".inline_profile_picture.u-" + person.id).css({
           "background-image": "url(" + url + ")"
         });
     }

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -110,10 +110,6 @@ exports.reify = function reify(person) {
 };
 
 exports.update = function update(person) {
-    // Currently the only attribute that can change is full_name, so
-    // we just push out changes to that field.  As we add more things
-    // that can change, this will need to either get complicated or be
-    // replaced by MVC
     if (! people_dict.has(person.email)) {
         blueslip.error("Got update_person event for unexpected user",
                        {email: person.email});

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -9,7 +9,7 @@
           {{#include_sender}}
           <span class="message_sender{{^status_message}} sender_info_hover{{/status_message}}">
             {{! See ../js/notifications.js for another user of avatar_url. }}
-            <div class="inline_profile_picture{{#status_message}} sender_info_hover{{/status_message}}"
+            <div class="u-{{msg/sender_id}} inline_profile_picture{{#status_message}} sender_info_hover{{/status_message}}"
                  style="background-image: url('{{small_avatar_url}}');"/>
           <span class="{{^status_message}}sender_name{{/status_message}}{{#status_message}}sender-status{{/status_message}}">
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1650,7 +1650,12 @@ def do_change_avatar_source(user_profile, avatar_source, log=True):
                                 avatar_url=avatar_url(user_profile),)),
                     bot_owner_userids(user_profile))
     else:
-        payload = dict(email=user_profile.email,avatar_url=avatar_url(user_profile))
+        payload = dict(
+            email=user_profile.email,
+            avatar_url=avatar_url(user_profile),
+            id=user_profile.id
+        )
+
         send_event(
             dict(type='realm_user',
                  op='update',

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1649,6 +1649,15 @@ def do_change_avatar_source(user_profile, avatar_source, log=True):
                         bot=dict(email=user_profile.email,
                                 avatar_url=avatar_url(user_profile),)),
                     bot_owner_userids(user_profile))
+    else:
+        payload = dict(email=user_profile.email,avatar_url=avatar_url(user_profile))
+        send_event(
+            dict(type='realm_user',
+                 op='update',
+                 person=payload
+            ),
+            active_user_ids(user_profile.realm)
+        )
 
 def _default_stream_permision_check(user_profile, stream):
     # type: (UserProfile, Optional[Stream]) -> None

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -971,6 +971,7 @@ def home(request):
         realm_message_content_edit_limit_seconds = register_ret['realm_message_content_edit_limit_seconds'],
         realm_restricted_to_domain = register_ret['realm_restricted_to_domain'],
         enter_sends           = user_profile.enter_sends,
+        user_id               = user_profile.id,
         left_side_userlist    = register_ret['left_side_userlist'],
         default_language      = register_ret['default_language'],
         language_list         = get_language_list(),


### PR DESCRIPTION
This sends an event when a new avatar is uploaded that refreshes the
avatar on all screens without the need to reload the browser anymore.

Fixes: #1359.