### PR TITLE
tools: Update pre-commit hook so it works with vagrant dev setup.

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,1 +1,22 @@
+#!/bin/bash
+
+# This hook runs the Zulip code linter ./tools/lint-all and returns true
+# regardless of linter results so that your commit may continue.
+
+# Messages from the linter will output to screen.
+#
+# If you are using the vagrant method for your Zulip dev setup, the linter will
+# be run through vagrant ssh.
+
+if ! [[ "$VIRTUAL_ENV" == "/srv/zulip-venv" ]] && `which vagrant > /dev/null` && [ -e .vagrant ]
+then
+  vcmd='/srv/zulip/tools/lint-all $(cd /srv/zulip && git diff --cached --name-only --diff-filter=ACM) || true'
+  echo "Running lint-all using vagrant..."
+  vagrant ssh -c "$vcmd"
+  exit 0
+fi
+
+echo "Running lint-all..."
 ./tools/lint-all $(git diff --cached --name-only --diff-filter=ACM) || true
+exit 0
+


### PR DESCRIPTION
Details:

Previously this hook required that you either be inside the vagrant
Zulip dev virtual machine when you ran git commit or that you had setup
your Zulip dev environment manually.

Now the script checks to see if vagrant is available and runs the linter
via vagrant ssh if the vagrant machine has been created as is running.
If the vagrant box has been created but is not running, linting is
skipped. Otherwise, the linter is run exactly as before.