### PR TITLE
Suppress error output for which command.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 def command?(name)
-  `which #{name}`
+  `which #{name} > /dev/null 2>&1`
   $?.success?
 end
 


### PR DESCRIPTION
The `which` command bundled with Cygwin prints all the paths it searches. As such, this creates pages of extraneous output when `vagrant` commands are run. AFAIK, we don't need the actual output of `which`, so I've redirected both stdout and stderr to /dev/null. Tested on Win 10 with Cygwin, OS X 10.11, and Ubuntu 16.04.