### PR TITLE
Private message group styling changes.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1145,6 +1145,10 @@ just a temporary hack.
     background-color: #a4bed2;
 }
 
+.message_header_private_message .message-header-contents .recipient_row_date {
+    color: #fff;
+}
+
 .floating_recipient .message_header_private_message .message-header-contents {
     background-color: #a4bed2;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1137,9 +1137,16 @@ just a temporary hack.
     position: relative;
 }
 
-.private-message .messagebox,
+.private-message .messagebox {
+    background-color: #edf3f9;
+}
+
 .message_header_private_message .message-header-contents {
-    background-color: #feffe0;
+    background-color: #a4bed2;
+}
+
+.floating_recipient .message_header_private_message .message-header-contents {
+    background-color: #a4bed2;
 }
 
 .message_header_private_message .message-header-contents {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -842,6 +842,7 @@ td.pointer {
 .message_list .recipient_row {
     background: #f1f1f1;
     border-bottom: 1px solid #e2e2e2;
+    border-top: 1px solid #e2e2e2;
     margin-bottom: 10px;
 }
 
@@ -1143,7 +1144,6 @@ just a temporary hack.
 
 .message_header_private_message .message-header-contents {
     border-right: 1px solid #e2e2e2;
-    border-top: 1px solid #e2e2e2;
 }
 
 .mention .messagebox-content {


### PR DESCRIPTION
This changes the color of the private message groups to a light blue
with a darker blue header.

This also applies a fix that ensures the private message floating container is the same height as the normal containers by unbinding the border-top from the header and moving to the message group container.