### PR TITLE
Add permanent scrollbar to code blocks.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -261,7 +261,25 @@ pre {
     margin-bottom: 5px;
 }
 
+pre::-webkit-scrollbar {
+    height: 8px;
+
+    background-color: rgba(0,0,0,0.05);
+}
+
+pre::-webkit-scrollbar-thumb {
+    background-color: rgba(0,0,0,0.3);
+    border-radius: 20px;
+
+    transition: all 0.2s ease;
+}
+
+pre::-webkit-scrollbar-thumb:hover {
+    background-color: rgb(0,0,0,0.6);
+}
+
 pre code {
+    overflow-x: scroll;
     white-space: pre;
 }
 


### PR DESCRIPTION
This adds a permanent scrollbar to code blocks to get around some
Chrome on Mac issues where scrollbars won’t appear with particular
combinations of hardware.

Fixes: #1565.