### PR TITLE
Add padding to checkboxes and fix HTML.

### DIFF
--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -19,19 +19,19 @@ casper.waitForText('Waseemio', function () {
     casper.test.assertTextExists('Create stream Waseemio', 'Modal for specifying new stream users');
 });
 casper.then(function () {
-    casper.test.assertExists('#user-checkboxes [for="cordelia@zulip.com"]', 'Original user list contains Cordelia');
-    casper.test.assertExists('#user-checkboxes [for="hamlet@zulip.com"]', 'Original user list contains King Hamlet');
+    casper.test.assertExists('#user-checkboxes [data-name="cordelia@zulip.com"]', 'Original user list contains Cordelia');
+    casper.test.assertExists('#user-checkboxes [data-name="hamlet@zulip.com"]', 'Original user list contains King Hamlet');
 });
 casper.then(function () {
     casper.test.info("Filtering user list with keyword 'cor'");
     casper.fill('form#stream_creation_form', {user_list_filter: 'cor'});
 });
 casper.then(function () {
-    casper.test.assertEquals(casper.visible('#user-checkboxes [for="cordelia@zulip.com"]'),
+    casper.test.assertEquals(casper.visible('#user-checkboxes [data-name="cordelia@zulip.com"]'),
                              true,
                              "Cordelia is visible"
     );
-    casper.test.assertEquals(casper.visible('#user-checkboxes [for="hamlet@zulip.com"]'),
+    casper.test.assertEquals(casper.visible('#user-checkboxes [data-name="hamlet@zulip.com"]'),
                              false,
                              "King Hamlet is not visible"
     );
@@ -41,11 +41,11 @@ casper.then(function () {
     casper.fill('form#stream_creation_form', {user_list_filter: ''});
 });
 casper.then(function () {
-    casper.test.assertEquals(casper.visible('#user-checkboxes [for="cordelia@zulip.com"]'),
+    casper.test.assertEquals(casper.visible('#user-checkboxes [data-name="cordelia@zulip.com"]'),
                              true,
                              "Cordelia is visible again"
     );
-    casper.test.assertEquals(casper.visible('#user-checkboxes [for="hamlet@zulip.com"]'),
+    casper.test.assertEquals(casper.visible('#user-checkboxes [data-name="hamlet@zulip.com"]'),
                              true,
                              "King Hamlet is visible again"
     );

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -807,7 +807,7 @@ $(function () {
         // Hide users which aren't in filtered users
         _.each(users, function (user) {
             var display_type = filtered_users.hasOwnProperty(user.email)? "block" : "none";
-            $("label[for='" + user.email + "']").css({"display":display_type});
+            $("label[data-name='" + user.email + "']").css({"display":display_type});
         });
 
         update_announce_stream_state();

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2661,8 +2661,17 @@ div.floating_recipient {
     margin: 0 30px 5px 20px;
 }
 
+#user-checkboxes {
+    margin-top: 10px;
+}
+
 #user-checkboxes .checkbox {
     display: block;
+}
+
+#user-checkboxes .checkbox input[type=checkbox] {
+    margin: 5px 0px;
+    float: none;
 }
 
 .muted-sub {

--- a/static/templates/new_stream_users.handlebars
+++ b/static/templates/new_stream_users.handlebars
@@ -4,7 +4,7 @@
 <input class="add-user-list-filter" name="user_list_filter" type="text" placeholder="{{t "Filter users" }}" />
 <div id="user-checkboxes">
   {{#each users}}
-  <label class="checkbox">
+  <label class="checkbox" data-name="{{this.email}}">
     <input type="checkbox" name="user" value="{{this.email}}" /> {{this.full_name}} ({{this.email}})
   </label>
   {{/each}}

--- a/static/templates/new_stream_users.handlebars
+++ b/static/templates/new_stream_users.handlebars
@@ -4,7 +4,7 @@
 <input class="add-user-list-filter" name="user_list_filter" type="text" placeholder="{{t "Filter users" }}" />
 <div id="user-checkboxes">
   {{#each users}}
-  <label class="checkbox" for="{{this.email}}">
+  <label class="checkbox">
     <input type="checkbox" name="user" value="{{this.email}}" /> {{this.full_name}} ({{this.email}})
   </label>
   {{/each}}


### PR DESCRIPTION
The HTML element for label had an invalid for={{target}} argument. Removing it now allows you to click the label to toggle the checkbox.

The checkboxes no longer float-left so the issue with right leaning stacks should disappear.

Fixes: #1491.