### PR TITLE
Add preview button to subscriptions page.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -337,6 +337,7 @@ exports.mark_subscribed = function (stream_name, attrs) {
         var button = button_for_sub(sub);
         if (button.length !== 0) {
             button.text(i18n.t("Subscribed")).addClass("subscribed-button").addClass("btn-success");
+            button.parent().children(".preview-stream").text("Narrow");
             // Add the user to the member list if they're currently
             // viewing the members of this stream
             if (sub.render_subscribers && settings.hasClass('in')) {
@@ -379,7 +380,11 @@ exports.mark_sub_unsubscribed = function (sub) {
     } else if (sub.subscribed) {
         stream_list.remove_narrow_filter(sub.name, 'stream');
         sub.subscribed = false;
-        button_for_sub(sub).removeClass("subscribed-button").removeClass("btn-success").removeClass("btn-danger").text(i18n.t("Subscribe"));
+
+        var button = button_for_sub(sub);
+        button.removeClass("subscribed-button").removeClass("btn-success").removeClass("btn-danger").text(i18n.t("Subscribe"));
+        button.parent().children(".preview-stream").text("Preview");
+
         var settings = settings_for_sub(sub);
         if (settings.hasClass('in')) {
             settings.collapse('hide');

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2746,6 +2746,23 @@ div.floating_recipient {
     margin-right: 10px;
 }
 
+.subscription_row:hover .preview-stream {
+    display: inherit;
+}
+
+.preview-stream {
+    display: none;
+    float: right;
+    padding: 3px 10px;
+    border: 1px solid #ccc;
+    margin: 9px 10px 0px 0px;
+    color: #333;
+}
+
+.preview-stream:hover {
+    text-decoration: none;
+}
+
 .sub_unsub_button {
     min-width: 140px;
     float: right;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2525,7 +2525,7 @@ div.floating_recipient {
 .subscription-info-container {
     display: inline-block;
     /* subtract out the width of the subscribe button and arrow. */
-    width: calc(100% - 230px);
+    width: calc(100% - 260px);
     /* to center the container vertically. */
     margin-top: 13px;
 }
@@ -2747,7 +2747,7 @@ div.floating_recipient {
 }
 
 .subscription_row:hover .preview-stream {
-    display: inherit;
+    display: inline-block;
 }
 
 .preview-stream {
@@ -2760,10 +2760,14 @@ div.floating_recipient {
 }
 
 .preview-stream:hover {
+    color: #333;
     text-decoration: none;
+    background-color: #ebebeb;
+    border: 1px solid #adadad;
 }
 
 .sub_unsub_button {
+    display: inline-block;
     min-width: 140px;
     float: right;
     margin-top: 9px;

--- a/static/templates/subscription.handlebars
+++ b/static/templates/subscription.handlebars
@@ -22,6 +22,7 @@
         {{t "Subscribe" }}
         {{/subscribed}}
       </button>
+      <a class="preview-stream" href="#narrow/stream/{{name}}" target="_blank">Preview</a>
     </div>
 
     <div id="subscription_settings_{{stream_id}}" class="collapse subscription_settings">

--- a/static/templates/subscription.handlebars
+++ b/static/templates/subscription.handlebars
@@ -22,7 +22,14 @@
         {{t "Subscribe" }}
         {{/subscribed}}
       </button>
-      <a class="preview-stream" href="#narrow/stream/{{name}}" target="_blank">Preview</a>
+      <a class="preview-stream" href="#narrow/stream/{{name}}">
+        {{#subscribed}}
+          Narrow
+        {{/subscribed}}
+        {{^subscribed}}
+          Preview
+        {{/subscribed}}
+      </a>
     </div>
 
     <div id="subscription_settings_{{stream_id}}" class="collapse subscription_settings">


### PR DESCRIPTION
This adds a preview button to the subscriptions page to allow a user to
check out the stream.

The button’s default state is hidden but on subscription row hover it
shows itself.

Fixes: #1519.