### PR TITLE
WIP: Push alerts to screen top and add namespaces to views.

### DIFF
--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -15,6 +15,8 @@ exports.initialize = function () {
         // Save the position of our old tab away, before we switch
         var old_tab = $(e.relatedTarget).attr('href');
         scroll_positions[old_tab] = viewport.scrollTop();
+
+        ui.change_namespace(old_tab);
     });
     $('#gear-menu a[data-toggle="tab"]').on('shown', function (e) {
         var target_tab = $(e.target).attr('href');
@@ -31,6 +33,7 @@ exports.initialize = function () {
             browser_url = "";
         }
         hashchange.changehash(browser_url);
+        ui.change_namespace(target_tab);
 
         // After we show the new tab, restore its old scroll position
         // (we apparently have to do this after setting the hash,

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -131,6 +131,9 @@ function do_hashchange(from_reload) {
     // Even if the URL bar says #%41%42%43%44, the value here will
     // be #ABCD.
     var hash = window.location.hash.split("/");
+
+    ui.change_namespace(hash);
+
     switch (hash[0]) {
     case "#narrow":
         ui.change_tab_to("#home");

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -21,7 +21,27 @@ exports.home_tab_obscured = function () {
     return false;
 };
 
+exports.change_namespace = function (tabname) {
+    var tabs = {
+      "#subscriptions": "subscriptions",
+      "#settings": "settings",
+      "#administration": "administration",
+      "#": "home"
+    },
+        body = document.body,
+        classes = body.className.split(/\s+/g);
+
+    tabname = tabs[tabname] || "home";
+
+    if (classes.indexOf(tabname + "-namespace") === -1) {
+      body.className = classes.filter(function (o) {
+        return !/-namespace/g.test(o) && o;
+      }).concat(tabname + "-namespace").join(" ");
+    }
+};
+
 exports.change_tab_to = function (tabname) {
+    exports.change_namespace(tabname);
     $('#gear-menu a[href="' + tabname + '"]').tab('show');
 };
 
@@ -144,6 +164,13 @@ exports.report_message = function (response, status_box, cls, type) {
     if (type === undefined) {
         type = ' ';
     }
+
+    // make alerts-dropdown a single-reference.
+    // check if there are any alerts left, and if not then hide the dropdown.
+
+    // create reports for testing.. --> delete after of course.
+    // possibly add an alerts icon that greys out when you open the dropdown
+    // and then turns red when you close it. Clicking toggles it.
 
     if (type === 'subscriptions-status') {
         status_box.removeClass(status_classes).addClass(cls).children('#response')
@@ -354,6 +381,10 @@ $(function () {
         // the tab to scroll normally.
     });
 
+    $(window).on("hashchange load", function () {
+      ui.change_namespace(window.location.hash);
+    });
+
     $(window).resize($.throttle(50, resize.handler));
 
     // Scrolling in modals, input boxes, and other elements that
@@ -427,6 +458,8 @@ $(function () {
     $(window).on('focus', function () {
         $(document.body).removeClass('window_blurred');
     });
+
+    ui.change_namespace(window.location.hash);
 
     $(document).on('message_selected.zulip', function (event) {
         if (current_msg_list !== event.msg_list) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1,6 +1,6 @@
 
 #settings {
-    margin-top: 55px;
+    margin-top: 0px;
     margin-left: 15px;
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -47,8 +47,9 @@ a {
 }
 
 .header {
-    position: fixed;
-    z-index: 101;
+    position: static;
+    z-index: 102;
+
     width: 100%;
     background: #ffffff;
     border-bottom: 1px solid #dadada;
@@ -105,13 +106,14 @@ a {
 .app-main .column-left .left-sidebar,
 .app-main .column-right .right-sidebar {
     position: fixed;
-    margin-top: 50px;
     z-index: 100;
+    margin-top: 10px;
 }
 
 .app-main .column-left .left-sidebar {
     width: 242px;
     padding-left: 0px;
+    margin-top: 10px;
 }
 
 .app-main .column-right .right-sidebar {
@@ -128,6 +130,35 @@ a {
     margin-right: 250px;
     margin-left: 250px;
     position: relative;
+}
+
+#alerts-dropdown {
+    position: relative;
+    max-height: 200px;
+    width: 100%;
+    z-index: 101;
+
+    background-color: #FAFAFA;
+    border-bottom: 1px solid #dadada;
+
+    overflow: hidden;
+
+    transition: all 0.3s ease;
+}
+
+#alerts-dropdown .alert {
+    width: 100%;
+}
+
+#alerts-dropdown .home-error-bar {
+  margin: 0;
+  border: none;
+  border-radius: 0px;
+}
+
+#alerts-dropdown .alert {
+  padding: 3px;
+  text-align: center;
 }
 
 textarea,
@@ -713,7 +744,7 @@ ul.filters li.out_of_home_view li.muted_topic {
 
 .message_area_padder {
     /* The height of the header and the tabbar plus a small gap */
-    margin-top: 68px;
+    margin-top: 45px;
     /* This is needed for the floating recipient bar
      in Firefox only, for some reason; otherwise it gets
      a scrollbar */
@@ -966,7 +997,7 @@ td.pointer {
 
 .messages-expand,
 .messages-collapse {
-  cursor: pointer;
+    cursor: pointer;
 }
 
 /*
@@ -1977,7 +2008,7 @@ input.recipient_box {
 #tab_bar_underpadding {
     position: absolute;
     width: 100%;
-    top: 40px;
+    top: 0px;
     height: 20px;
     z-index: 99;
 }
@@ -2222,7 +2253,14 @@ div.floating_recipient {
 }
 
 #floating_recipient_bar {
-    top: 50px;
+    display: none;
+    position: absolute;
+    top: 5px;
+    z-index: 100;
+}
+
+.home-namespace #floating_recipient_bar {
+    display: block;
 }
 
 .message-header-contents {
@@ -2468,7 +2506,7 @@ div.floating_recipient {
 
 .administration,
 .subscriptions {
-    margin-top: 55px;
+    margin-top: 0px;
     padding-left: 15px;
 }
 
@@ -3257,10 +3295,6 @@ li.expanded_private_message {
 #subscriptions h1 {
     font-size: 25px;
     font-weight: 300;
-}
-
-#subscriptions h1 {
-    padding-top: 40px;
 }
 
 #administration .administration-icon,

--- a/templates/zerver/alerts.html
+++ b/templates/zerver/alerts.html
@@ -1,0 +1,31 @@
+<div id="alerts-dropdown">
+  <div class="alert alert_sidebar alert-error home-error-bar" id="connection-error">
+    <strong>{{ _('Unable to connect to') }} {{product_name}}.</strong>  {{ _('Updates may be delayed') }}.
+    {{ _('Retrying soon') }}...<a class="restart_get_updates_button"> {{ _('Try now') }}</a>.
+  </div>
+  <div class="alert alert_sidebar alert-error home-error-bar" id="get_old_messages_error">
+    <strong>{{ _('Unable to connect to') }} {{product_name}}.</strong>  {{ _('Could not fetch messages') }}.
+    <br /><br /> {{ _('Retrying soon') }}... <br /><br />
+  </div>
+  <div class="alert alert_sidebar alert-error home-error-bar" id="zephyr-mirror-error">
+    <strong>{{ _('Your Zephyr mirror is not working') }}.</strong>
+    <span id="normal-zephyr-mirror-error-text">
+      {% trans %}
+      We recommend that you
+      <a class="webathena_login">give
+        {{product_name}} the ability to mirror the messages for you via
+        WebAthena
+      </a>. If you'd prefer, you can instead
+      <a href="/zephyr-mirror" target="_blank">run the Zephyr mirror script yourself</a>
+      in a screen session.
+      {% endtrans %}
+    </span>
+    <span id="desktop-zephyr-mirror-error-text" class="notdisplayed">
+      {% trans %}
+      To fix this, you'll need to use <a href="https://zephyr.zulip.com">the web interface</a>
+      {% endtrans %}
+    </span>
+  </div>
+  <div class="alert alert_sidebar alert-error home-error-bar" id="home-error"></div>
+  <div class="alert alert_sidebar alert-error home-error-bar" id="reloading-application"></div>
+</div>

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -58,38 +58,42 @@ var page_params = {{ page_params }};
 <div id="right-screen" class="screen"></div>
 <div id="clear-screen" class="screen"></div>
 
+{% include "zerver/alerts.html" %}
+
 {% include "zerver/navbar.html" %}
 
 <div class="fixed-app">
   <div class="app-main">
     <div class="column-middle column-overlay">
-        <div id="tab_bar_underpadding"></div>
+      <div class="fixed-app" id="floating_recipient_bar">
+        <div class="recipient_bar_content">
+          <div class="column-overlay recipient-bar-main">
+              <div class="floating_recipient">
+                <div style="display: none;" id="current_label_stream" class="recipient_row">
+                 <div class="message_label_clickable message_header message_header_stream right_part"></div>
+                </div>
+                <div style="display: none;" id="current_label_private_message" class="recipient_row">
+                  <div class="message_label_clickable message_header message_header_private_message right_part"></div>
+                </div>
+              </div>
+          </div>
+        </div>
+      </div>
+      <div id="tab_bar_underpadding"></div>
     </div>
   </div>
 </div>
 
 <div class="app">
 <div class="app-main">
+    {% include "zerver/alerts.html" %}
+
     <div class="column-left">
           {% include "zerver/left-sidebar.html" %}
     </div>
     <div class="column-middle">
         <div class="column-middle-inner tab-content">
             <div class="tab-pane active" id="home">
-            <div class="fixed-app" id="floating_recipient_bar">
-              <div class="app-main recipient_bar_content">
-                <div class="column-middle column-overlay recipient-bar-main">
-                    <div class="floating_recipient">
-                      <div style="display: none;" id="current_label_stream" class="recipient_row">
-                       <div class="message_label_clickable message_header message_header_stream right_part"></div>
-                      </div>
-                      <div style="display: none;" id="current_label_private_message" class="recipient_row">
-                        <div class="message_label_clickable message_header message_header_private_message right_part"></div>
-                      </div>
-                    </div>
-                </div>
-              </div>
-            </div>
             <div id="alert-bar-container" class="alert-bar-container" style='display: none;'>
               <div id="alert-bar" class="alert-bar">
                 <div id="alert-bar-contents" class="alert-bar-contents">

--- a/templates/zerver/right-sidebar.html
+++ b/templates/zerver/right-sidebar.html
@@ -1,26 +1,4 @@
           <div class="right-sidebar" id="right-sidebar">
-              <div class="alert alert_sidebar alert-error home-error-bar" id="connection-error">
-                <strong>{{ _('Unable to connect to') }} {{product_name}}.</strong>  {{ _('Updates may be delayed') }}.
-                <br /><br /> {{ _('Retrying soon') }}... <br /><br /> <a class="restart_get_updates_button">{{ _('Try now') }}</a>.
-              </div>
-              <div class="alert alert_sidebar alert-error home-error-bar" id="get_old_messages_error">
-                <strong>{{ _('Unable to connect to') }} {{product_name}}.</strong>  {{ _('Could not fetch messages') }}.
-                <br /><br /> {{ _('Retrying soon') }}... <br /><br />
-              </div>
-              <div class="alert alert_sidebar alert-error home-error-bar" id="zephyr-mirror-error">
-                <strong>{{ _('Your Zephyr mirror is not working') }}.</strong>
-                  <span id="normal-zephyr-mirror-error-text">{% trans %}We
-                  recommend that you <a class="webathena_login">give
-                  {{product_name}} the ability to mirror the messages for you via
-                  WebAthena</a>.  If you'd prefer, you can instead
-                  <a href="/zephyr-mirror" target="_blank">run the Zephyr mirror script yourself</a>
-                  in a screen session{% endtrans %}.</span>
-                  <span id="desktop-zephyr-mirror-error-text" class="notdisplayed">{% trans %}To fix
-                  this, you'll need
-                  to use <a href="https://zephyr.zulip.com">the web interface</a>{% endtrans %}</span>
-              </div>
-              <div class="alert alert_sidebar alert-error home-error-bar" id="home-error"></div>
-              <div class="alert alert_sidebar alert-error home-error-bar" id="reloading-application"></div>
               {% if enable_feedback %}
               <div id="feedback_section">
                 <button type="button" class="btn btn-default btn-large" id="feedback_button">


### PR DESCRIPTION
These changes push the alerts that were previously in the right sidebar
to the top of the screen.

Along with that, the namespace of the current view is also added to the
<body> element so that you can use CSS to deterministically style a
particular view.

A few major things were changed including changing the navbar from a fixed to static position. This means there may be design bugs that I haven’t encountered yet with this.
