### PR TITLE
Change Day 2 email to be sent 24 hours after the user signs up.

### DIFF
--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -492,14 +492,10 @@ def enqueue_welcome_emails(email, name):
                                          tags=["followup-emails"],
                                          sender=sender)
     # Send day 2 email
-    tomorrow = datetime.datetime.utcnow() + datetime.timedelta(hours=24)
-    # 11 AM EDT
-    tomorrow_morning = datetime.datetime(tomorrow.year, tomorrow.month, tomorrow.day, 15, 0)
-    assert(datetime.datetime.utcnow() < tomorrow_morning)
     send_local_email_template_with_delay([{'email': email, 'name': name}],
                                          "zerver/emails/followup/day2",
                                          template_payload,
-                                         tomorrow_morning - datetime.datetime.utcnow(),
+                                         datetime.timedelta(days=1),
                                          tags=["followup-emails"],
                                          sender=sender)
 


### PR DESCRIPTION
Old behavior is to do something tricky that relies on the server being on
Pacific Time and the users being in the US. The goal is to have this message
appear during business hours, since click through rates are higher during
business hours. Our server is now on the East Coast though and our users are
in every timezone, so until we do something smarter this seems like a better
heuristic. We're also trying to cleanse our codebase of non-timezone-aware
datetime.datetime objects.