### PR TITLE
Add note about the email_password setting

### DIFF
--- a/docs/prod-install.md
+++ b/docs/prod-install.md
@@ -80,9 +80,10 @@ These settings include:
 - `EMAIL_*`, `DEFAULT_FROM_EMAIL`, and `NOREPLY_EMAIL_ADDRESS`:
   Regardless of which authentication backends you enable, you must
   provide settings for an outgoing SMTP server so Zulip can send
-  emails when needed.  We highly recommend testing your configuration
-  using `manage.py send_test_email` to confirm your outgoing email
-  configuration is working correctly.
+  emails when needed (and don't forget to set `email_password` in
+  the `zulip-secrets.conf` file).  We highly recommend testing
+  your configuration using `manage.py send_test_email` to confirm
+  your outgoing email configuration is working correctly.
 
 - `ALLOWED_HOSTS`: Replace `*` with the fully qualified DNS name for
   your Zulip server here.


### PR DESCRIPTION
This is documented in the comments in settings.py, but when I was setting an instance up myself, I missed those comments because I was following the instructions here instead, and then just scanning settings.py for variables. Think this will help people not miss that.