### PR TITLE
#1125: Switch some tools from optparse to argparse.

### DIFF
--- a/tools/check-templates
+++ b/tools/check-templates
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from lib.template_parser import validate
-import optparse
+import argparse
 import sys
 
 from six.moves import filter
@@ -17,21 +17,21 @@ except ImportError as e:
 
 def check_our_files():
     # type: () -> None
-    parser = optparse.OptionParser()
-    parser.add_option('--modified', '-m',
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-m', '--modified',
         action='store_true', default=False,
-        help='Only check modified files')
-    (options, _) = parser.parse_args()
+        help='only check modified files')
+    args = parser.parse_args()
 
     by_lang = cast(
         Dict[str, List[str]],
         lister.list_files(
-            modified_only=options.modified,
+            modified_only=args.modified,
             ftypes=['handlebars', 'html'],
             group_by_ftype=True))
 
-    check_handlebar_templates(by_lang['handlebars'], options.modified)
-    check_html_templates(by_lang['html'], options.modified)
+    check_handlebar_templates(by_lang['handlebars'], args.modified)
+    check_html_templates(by_lang['html'], args.modified)
 
 def check_html_templates(templates, modified_only):
     # type: (Iterable[str], bool) -> None

--- a/tools/find-add-class
+++ b/tools/find-add-class
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 from lib.find_add_class import display, find
 import glob
-import optparse
+import argparse
 import sys
 
 from six.moves import filter
@@ -20,7 +20,7 @@ except ImportError as e:
 def process_files():
     # type: () -> None
 
-    usage = '''
+    description = '''
         Use this tool to find HTML classes that we use in our JS code.
         This looks for calls to addClass, and if you use the -v option,
         you will get a display of (fn, html_class) tuples that
@@ -31,14 +31,14 @@ def process_files():
         call.
         '''
 
-    parser = optparse.OptionParser(usage=usage)
-    parser.add_option('--verbose', '-v',
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('-v', '--verbose',
         action='store_true', default=False,
-        help='Show where calls are.')
-    (options, _) = parser.parse_args()
+        help='show where calls are')
+    args = parser.parse_args()
 
     fns = glob.glob('static/js/*.js')
-    if options.verbose:
+    if args.verbose:
         display(fns)
     else:
         find(fns)

--- a/tools/minify-js
+++ b/tools/minify-js
@@ -7,17 +7,17 @@ from __future__ import print_function
 
 import os
 import subprocess
-import optparse
+import argparse
 import sys
 import six
 
 from typing import Optional, Set
 
-parser = optparse.OptionParser()
-parser.add_option('--prev-deploy', nargs=1, metavar='DIR',
-                  help='A previous deploy from which to reuse files if possible')
-(options, args) = parser.parse_args()
-prev_deploy = options.prev_deploy
+parser = argparse.ArgumentParser()
+parser.add_argument('--prev-deploy', metavar='DIR',
+                  help='a previous deploy from which to reuse files if possible')
+args = parser.parse_args()
+prev_deploy = args.prev_deploy
 
 # We have to pull out JS_SPECS, defined in our settings file, so we know what
 # JavaScript source files to minify (and what output files to create).

--- a/tools/test-tools
+++ b/tools/test-tools
@@ -3,17 +3,17 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import optparse
+import argparse
 import os
 import sys
 import unittest
 
 if __name__ == '__main__':
-    parser = optparse.OptionParser()
-    parser.add_option('--coverage', dest='coverage',
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--coverage', dest='coverage',
                       action="store_true",
-                      default=False, help='Compute test coverage.')
-    (options, _) = parser.parse_args()
+                      default=False, help='compute test coverage')
+    args = parser.parse_args()
 
     def dir_join(dir1, dir2):
         # type: (str, str) -> str
@@ -27,7 +27,7 @@ if __name__ == '__main__':
 
     loader = unittest.TestLoader() # type: ignore # https://github.com/python/typeshed/issues/372
 
-    if options.coverage:
+    if args.coverage:
         import coverage
         cov = coverage.Coverage(omit="*/zulip-venv-cache/*")
         cov.start()
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     if result.errors or result.failures:
         raise Exception('Test failed!')
 
-    if options.coverage:
+    if args.coverage:
         cov.stop()
         cov.save()
         cov.html_report(directory='var/tools_coverage')

--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import os
 import subprocess
-import optparse
+import argparse
 import sys
 
 # We need settings so we can figure out where the prod-static directory is.
@@ -15,11 +15,11 @@ import scripts.lib.setup_path_on_import
 os.environ['DJANGO_SETTINGS_MODULE'] = 'zproject.settings'
 from django.conf import settings
 
-parser = optparse.OptionParser()
-parser.add_option('--prev-deploy', nargs=1, metavar='DIR',
-                  help='A previous deploy from which to reuse files if possible')
-(options, args) = parser.parse_args()
-prev_deploy = options.prev_deploy
+parser = argparse.ArgumentParser()
+parser.add_argument('--prev-deploy', metavar='DIR',
+                  help='a previous deploy from which to reuse files if possible')
+args = parser.parse_args()
+prev_deploy = args.prev_deploy
 
 os.chdir(settings.DEPLOY_ROOT)
 

--- a/tools/webpack
+++ b/tools/webpack
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
 
-import optparse
+import argparse
 import os
 import subprocess
 import sys
@@ -23,17 +23,17 @@ def run_watch(port):
     subprocess.Popen(['tools/node', 'node_modules/.bin/webpack-dev-server'] +
         ['--config', 'tools/webpack.config.js', '--watch-poll', '--port', port])
 
-parser = optparse.OptionParser()
-parser.add_option('--watch',
+parser = argparse.ArgumentParser()
+parser.add_argument('--watch',
                   action='store_true', dest='watch', default=False,
                   help='watch for changes to source files (for development)')
-parser.add_option('--port',
+parser.add_argument('--port',
                   action='store', dest='port',
-                  default='9994', help='Set the port for the webpack server to run on')
-(options, args) = parser.parse_args()
+                  default='9994', help='set the port for the webpack server to run on')
+args = parser.parse_args()
 
-if options.watch:
-    run_watch(options.port)
+if args.watch:
+    run_watch(args.port)
 else:
     run()
 


### PR DESCRIPTION
In an effort to make progress on #1125, this PR switches the following scripts from optparse to argparse:

* tools/find-add-class
* tools/check-templates
* tools/minify-js
* tools/test-tools
* tools/update-prod-static
* tools/webpack