### PR TITLE
Improve test coverage for tools.

### DIFF
--- a/tools/lib/template_parser.py
+++ b/tools/lib/template_parser.py
@@ -211,16 +211,8 @@ def validate(fn=None, text=None, check_indent=True):
         elif kind == 'django_end':
             state.matcher(token)
 
-    null_token = Token(
-        kind=None,
-        s='(NO TAG)',
-        tag='NO TAG',
-        line=0,
-        col=0,
-    )
-
     if state.depth != 0:
-        state.matcher(null_token)
+        raise TemplateParserException('Missing end tag')
 
 def is_special_html_tag(s, tag):
     # type: (str, str) -> bool

--- a/tools/lib/template_parser.py
+++ b/tools/lib/template_parser.py
@@ -69,7 +69,13 @@ def tokenize(text):
     while state.i < len(text):
         if looking_at_html_start():
             s = get_html_tag(text, state.i)
-            tag = s[1:-1].split()[0]
+            tag_parts = s[1:-1].split()
+
+            if not tag_parts:
+                raise TemplateParserException("Tag name missing")
+
+            tag = tag_parts[0]
+
             if is_special_html_tag(s, tag):
                 kind = 'html_special'
             elif s.endswith('/>'):

--- a/tools/lib/template_parser.py
+++ b/tools/lib/template_parser.py
@@ -4,6 +4,10 @@ from typing import Callable, Optional
 from six.moves import range
 import re
 
+class TemplateParserException(Exception):
+    # TODO: Have callers pass in line numbers.
+    pass
+
 class TokenizerState(object):
     def __init__(self):
         # type: () -> None
@@ -128,7 +132,7 @@ def validate(fn=None, text=None, check_indent=True):
 
     def no_start_tag(token):
         # type: (Token) -> None
-        raise Exception('''
+        raise TemplateParserException('''
             No start tag
             fn: %s
             end tag:
@@ -167,7 +171,7 @@ def validate(fn=None, text=None, check_indent=True):
                 if end_col != start_col:
                     problem = 'Bad indentation.'
             if problem:
-                raise Exception('''
+                raise TemplateParserException('''
                     fn: %s
                     %s
                     start:
@@ -238,7 +242,7 @@ def get_handlebars_tag(text, i):
     while end < len(text) -1 and text[end] != '}':
         end += 1
     if text[end] != '}' or text[end+1] != '}':
-        raise Exception('Tag missing }}')
+        raise TemplateParserException('Tag missing }}')
     s = text[i:end+2]
     return s
 
@@ -248,7 +252,7 @@ def get_django_tag(text, i):
     while end < len(text) -1 and text[end] != '%':
         end += 1
     if text[end] != '%' or text[end+1] != '}':
-        raise Exception('Tag missing %}')
+        raise TemplateParserException('Tag missing %}')
     s = text[i:end+2]
     return s
 
@@ -261,7 +265,7 @@ def get_html_tag(text, i):
             quote_count += 1
         end += 1
     if end == len(text) or text[end] != '>':
-        raise Exception('Tag missing >')
+        raise TemplateParserException('Tag missing >')
     s = text[i:end+1]
     return s
 

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -248,6 +248,9 @@ def build_custom_checkers(by_lang):
         # rare; if we find any, they can be added to the exclude list for
         # this rule.
         {'pattern': '% [a-zA-Z0-9_.]*\)?$',
+         'exclude_line': set([
+             ('tools/tests/test_template_parser.py', '{% foo'),
+         ]),
          'description': 'Used % comprehension without a tuple'},
         # To avoid json_error(_variable) and json_error(_(variable))
         {'pattern': '\Wjson_error\(_\(?\w+\)',

--- a/tools/test-tools
+++ b/tools/test-tools
@@ -29,7 +29,7 @@ if __name__ == '__main__':
 
     if options.coverage:
         import coverage
-        cov = coverage.Coverage(omit="*/zulip-venv-cache/*")
+        cov = coverage.Coverage(omit=[ "*/zulip-venv-cache/*", dir_join(tools_test_dir, "*") ])
         cov.start()
 
     suite = loader.discover(start_dir=tools_test_dir, top_level_dir=root_dir)

--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -85,6 +85,13 @@ class ParserTest(unittest.TestCase):
         '''
         self._assert_validate_error('Bad indentation.', text=my_html, check_indent=True)
 
+    def test_validate_state_depth(self):
+        # type: () -> None
+        my_html = '''
+            <b>
+        '''
+        self._assert_validate_error('Missing end tag', text=my_html)
+
     def test_validate_incomplete_handlebars_tag_1(self):
         # type: () -> None
         my_html = '''

--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -127,6 +127,13 @@ class ParserTest(unittest.TestCase):
         '''
         self._assert_validate_error('Tag missing >', text=my_html)
 
+    def test_validate_empty_html_tag(self):
+        # type: () -> None
+        my_html = '''
+            < >
+        '''
+        self._assert_validate_error('Tag name missing', text=my_html)
+
     def test_code_blocks(self):
         # type: () -> None
 


### PR DESCRIPTION
Improves test coverage for tools (particularly tools/lib/template_parser.py) by:
* Adding tests to cover untested lines.
* Removing the tests directory from the coverage calculation. (Testing the tests seems redundant.)

This PR also adds an exclusion line to the naïve pattern for checking for missing tuples in format strings, to keep the linter happy.