### PR TITLE
HTTP requests from Django=>Tornado on localhost should not respect http_proxy environment variable 

### DIFF
--- a/zerver/lib/event_queue.py
+++ b/zerver/lib/event_queue.py
@@ -36,6 +36,11 @@ import six
 from six import text_type
 
 requests_client = requests.Session()
+for host in ['127.0.0.1', 'localhost']:
+    if settings.TORNADO_SERVER and host in settings.TORNADO_SERVER:
+        # This seems like the only working solution to ignore proxy in
+        # requests library.
+        requests_client.trust_env = False
 
 # The idle timeout used to be a week, but we found that in that
 # situation, queues from dead browser sessions would grow quite large


### PR DESCRIPTION
Fixes: #468

This PR also contains a commit from #391 (https://github.com/zulip/zulip/pull/1738).