### PR TITLE
upgrade: Create prod_settings symlink in step 2 if it doesn't exist.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -42,6 +42,10 @@ if not args.skip_puppet:
     subprocess.check_call(["apt-get", "update"])
     subprocess.check_call(["apt-get", "-y", "upgrade"])
 
+if not os.path.exists((os.path.join(deploy_path, "zproject/prod_settings"))):
+    subprocess.check_call(["ln", "-nsf", "/etc/zulip/settings.py",
+                           os.path.join(deploy_path, "zproject/prod_settings.py")])
+
 subprocess.check_call([os.path.join(deploy_path, "scripts", "lib", "create-production-venv"),
                        os.path.join(deploy_path, "zulip-venv")])
 

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -46,6 +46,10 @@ if not os.path.exists((os.path.join(deploy_path, "zproject/prod_settings"))):
     subprocess.check_call(["ln", "-nsf", "/etc/zulip/settings.py",
                            os.path.join(deploy_path, "zproject/prod_settings.py")])
 
+# delete local_settings.py symlink if it exists, as it is now prod_settings.py
+if os.path.exists((os.path.join(deploy_path, "zproject/local_settings.py"))):
+    subprocess.check_call(["rm", os.path.join(deploy_path, "zproject/local_settings.py")])
+
 subprocess.check_call([os.path.join(deploy_path, "scripts", "lib", "create-production-venv"),
                        os.path.join(deploy_path, "zulip-venv")])
 


### PR DESCRIPTION
Fixes #1731.

Between releases 1.3.13 and 1.4, `local_settings.py` was renamed to `prod_settings.py`. The upgrade scripts were adjusted to reflect this name change. But because the first part of the upgrade script is run with the currently installed version's code, the symlink to `/etc/zulip/settings.py` is created with the old name. This was causing `upgrade-zulip-stage-2` to fail.

Now `upgrade-zulip-stage-2` creates the symlink at `zproject/prod_settings.py` if it doesn't already exist.

Should `upgrade-zulip-stage-2` also delete the symlink `zproject/local_settings.py` if it exists? 