### PR TITLE
upgrade: Create prod_settings symlink in step 2 if it doesn't exist.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -42,6 +42,14 @@ if not args.skip_puppet:
     subprocess.check_call(["apt-get", "update"])
     subprocess.check_call(["apt-get", "-y", "upgrade"])
 
+if not os.path.exists((os.path.join(deploy_path, "zproject/prod_settings"))):
+    subprocess.check_call(["ln", "-nsf", "/etc/zulip/settings.py",
+                           os.path.join(deploy_path, "zproject/prod_settings.py")])
+
+# delete local_settings.py symlink if it exists, as it is now prod_settings.py
+if os.path.exists((os.path.join(deploy_path, "zproject/local_settings.py"))):
+    subprocess.check_call(["rm", os.path.join(deploy_path, "zproject/local_settings.py")])
+
 subprocess.check_call([os.path.join(deploy_path, "scripts", "lib", "create-production-venv"),
                        os.path.join(deploy_path, "zulip-venv")])
 

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -155,7 +155,7 @@ INLINE_IMAGE_PREVIEW = True
 # https://github.com/zulip/zulip/issues/291 for discussion of a better
 # solution that won't be automatically reverted by the Zulip upgrade
 # script), and then restart nginx.
-LOCAL_UPLOADS_DIR = "/home/zulip/var/uploads"
+LOCAL_UPLOADS_DIR = "/home/zulip/uploads"
 #S3_AUTH_UPLOADS_BUCKET = ""
 #S3_AVATAR_BUCKET = ""
 


### PR DESCRIPTION
Between releases 1.3.13 and 1.4.0, local_settings.py was renamed to
prod_settings.py. The upgrade scripts were adjusted to reflect this name
change. But because the first part of the upgrade script is run with the
currently installed version's code, the symlink to /etc/zulip/settings.py is
created with the old name. This was causing upgrade-zulip-stage-2 to fail.

Now upgrade-zulip-stage-2 creates the symlink at zproject/prod_settings.py
if it doesn't already exist.

Fixes #1731.