### PR TITLE
Add Zulip version number to page_params.

### DIFF
--- a/version.py
+++ b/version.py
@@ -1,0 +1,1 @@
+ZULIPVERSION = "1.4.1+git"

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1957,6 +1957,7 @@ class HomeTest(ZulipTestCase):
             "unread_count",
             "unsubbed_info",
             "user_id",
+            "zulip_version",
         ]
 
         email = "hamlet@zulip.com"

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -51,6 +51,7 @@ from zerver.lib.i18n import get_language_list, get_language_name, \
     get_language_list_for_templates
 from zerver.lib.response import json_success, json_error
 from zerver.lib.utils import statsd, generate_random_token
+from version import ZULIPVERSION
 from zproject.backends import password_auth_enabled, dev_auth_enabled, google_auth_enabled
 
 from confirmation.models import Confirmation, RealmCreationKey, check_key_is_valid
@@ -877,6 +878,7 @@ def home(request):
     # Pass parameters to the client-side JavaScript code.
     # These end up in a global JavaScript Object named 'page_params'.
     page_params = dict(
+        zulip_version         = ZULIPVERSION,
         share_the_love        = settings.SHARE_THE_LOVE,
         development_environment = settings.DEVELOPMENT,
         debug_mode            = settings.DEBUG,


### PR DESCRIPTION
This is a basic version of adding a user-readable version number to Zulip.

I put it in page_params (so you can access it via `page_params.zulip_version` since I don't have a clear idea for where in the visible UI it should go where it wouldn't be cluttery (maybe in an "about Zulip" help page that doesn't exist yet?) but this seems worth adding even in this develop-only form for now.

But thoughts are welcome!