### PR TITLE
Add an app-internal about page for the project.

### DIFF
--- a/templates/zerver/about.html
+++ b/templates/zerver/about.html
@@ -1,0 +1,124 @@
+{% extends "zerver/portico.html" %}
+{% block portico_content %}
+
+<h1>About Zulip</h1>
+
+<p>
+  This server is an installation of
+  the <a href="https://zulip.org">Zulip open source group chat
+  software</a>.  Written in Python and using the Django web framework,
+  Zulip has an extensive real-time messaging featureset, including
+  both group and private messaging, conversation streams, powerful
+  search, drag-and-drop file uploads, image previews, audible
+  notifications, missed-message emails, markdown formatting, desktop
+  and mobile apps, dozens of integrations, and much, much more.
+</p>
+
+<p>
+  Zulip was designed from the ground up to optimize the productivity
+  of discussions and real-time decision-making.  A key feature that
+  drives this is Zulip's unique threading model and system for
+  tracking unread messages, which makes it easy to have multiple
+  simultaneous conversations in the same stream.  As a result, Zulip
+  is more efficient than any other chat product for catching up on
+  conversations you missed while you were away from your devices.  You
+  can read exactly the threads that are important to you, and it feels
+  natural to follow up on conversations that happened while you were
+  away.
+</p>
+
+<p>
+  Zulip's vision is to create the world's best group chat software,
+  completely open source, so that everyone has the freedom to
+  customize, improve, and run their own copy of this essential piece
+  of collaboration infrastructure.
+</p>
+
+<p>
+  Further information on the Zulip project and <a href="/features">its
+  features</a> can be found on
+  the <a href="https://www.zulip.org">Zulip open source project's
+  website</a> and
+  the <a href="http://zulip.readthedocs.io/en/latest/">Zulip
+  documentation</a>.
+</p>
+
+<h2>Zulip Community</h2>
+
+<p>
+  Zulip is developed by a vibrant community of developers from around
+  the world.  Every month, dozens of people contribute code to Zulip,
+  and dozens more contribute bug reports, feedback, and translations.
+  The Zulip community welcomes new contributors from any background.
+  The Zulip project has an easy to install development environment, an
+  extensive test suite,
+  and <a href="http://zulip.readthedocs.io/en/latest/">over 50,000
+  words of developer documentation</a> to make it easy for new
+  contributors to contribute effectively to the project.
+</p>
+
+<h3>Contributing to Zulip</h3>
+
+<p>
+  If you'd like to join the Zulip community and contribute to Zulip,
+  we'd love to have you!  Please
+  visit <a href="https://github.com/zulip/zulip/#zulip-overview">the
+  main Zulip project on GitHub</a> for details on how to get involved!
+</p>
+
+<h2>Zulip history</h2>
+
+<p>
+  Zulip was originally developed by Zulip, Inc., a small startup in
+  Cambridge, Massachusetts.  Zulip, Inc. was founded by the MIT team
+  that previously created
+  <a href="https://www.ksplice.com">Ksplice</a>, software for
+  live-patching a running Linux kernel.  Zulip was inspired by
+  the <a href="https://barnowl.mit.edu/">Barnowl</a> client for
+  the <a href="https://en.wikipedia.org/wiki/Zephyr_(protocol)">Zephyr</a>
+  protocol, and the incredible community that Zephyr supported at MIT.
+</p>
+
+<p>
+  Zulip, Inc. was acquired by Dropbox in early 2014, while the product
+  was still in private beta. Zulip's beta
+  users <a href="https://www.recurse.com/blog/90-zulip-supporting-oss-at-the-recurse-center">loved
+  Zulip's unique user experience</a> and continued
+  using Zulip despite the fact that Zulip was not being actively
+  developed.  After a year and a half, Dropbox generously decided to release Zulip as open
+  source software so that Zulip's users could continue
+  enjoying the software.
+</p>
+
+<p>
+  As a result, the first time the public had the opportunity to use
+  Zulip was when Dropbox
+  <a href="https://blogs.dropbox.com/tech/2015/09/open-sourcing-zulip-a-dropbox-hack-week-project/">released
+  Zulip as open source software</a> in late 2015.  The Zulip open
+  sourcing announcement was very popular, staying at the top of
+  both <a href="https://news.ycombinator.com/item?id=10279961">Hacker
+  News</a>
+  and <a href="https://www.reddit.com/r/programming/comments/3me9qp/dropbox_has_open_sourced_zulip_group_chat_software/">the
+    programming subreddit</a> for an entire day.
+</p>
+
+<p>
+  Zulip was open sourced with the complete version control history
+  intact because 10 Zulip users visited Dropbox for a full week to
+  help with the technical work required to open source Zulip well.
+  The Zulip community is incredibly grateful to both Dropbox and those
+  enthusiastic early users of Zulip for making the Zulip open source
+  project possible.
+</p>
+
+<p>
+  By the end of 2015, Zulip was already going strong with a community
+  of dozens of developers around the world.  As of
+  mid-2016, <a href="https://en.wikipedia.org/wiki/Zephyr_(protocol)">more
+  than 150 people from all over the world</a> have contributed
+  <a href="https://github.com/zulip/zulip/pulls">almost
+  1000 improvements</a> to the software, and the Zulip project is
+  moving faster than when Zulip, Inc. had 11 full-time engineers.
+</p>
+
+{% endblock %}

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -16,7 +16,7 @@ NOTIFICATION_BOT = "notification-bot@zulip.com"
 ERROR_BOT = "error-bot@zulip.com"
 NEW_USER_BOT = "new-user-bot@zulip.com"
 EMAIL_GATEWAY_BOT = "emailgateway@zulip.com"
-EXTRA_INSTALLED_APPS = ["zilencer", "analytics"]
+EXTRA_INSTALLED_APPS = ["zilencer", "analytics", "corporate"]
 # Disable Camo in development
 CAMO_URI = ''
 OPEN_REALM_CREATION = True

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -96,6 +96,7 @@ i18n_urls = [
     url(r'^api/$', TemplateView.as_view(template_name='zerver/api.html')),
     url(r'^api/endpoints/$', 'zerver.views.api_endpoint_docs'),
     url(r'^integrations/$', IntegrationView.as_view()),
+    url(r'^about/$', TemplateView.as_view(template_name='zerver/about.html')),
     url(r'^apps/$', TemplateView.as_view(template_name='zerver/apps.html')),
 
     url(r'^robots\.txt$', RedirectView.as_view(url='/static/robots.txt')),


### PR DESCRIPTION
I'd love to get a bunch of feedback on this document, since I expect (eventually) it'll be one of the main resources that people read to learn more about Zulip and its community.

TODO: Still need to add this to the portico (or otherwise link to it).