### PR TITLE
test_bugdown: Fix i18n test flakiness with markdown rendering tests.

### DIFF
--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -578,5 +578,7 @@ class BugdownErrorTests(ZulipTestCase):
 
         message = 'whatever'
         with self.simulated_markdown_failure():
-            with self.assertRaisesRegexp(JsonableError, 'Unable to render message'):
+            # We don't use assertRaisesRegexp because it seems to not
+            # handle i18n properly here on some systems.
+            with self.assertRaises(JsonableError):
                 self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, message)


### PR DESCRIPTION
It appears that the assertRaisesRegexp approach we had before didn't
work properly on some systems, likely due to a bad interact with a
i18n (we haven't definitively determined the cause).