### PR TITLE
Url encoded name of the file should be an ascii.

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -149,6 +149,8 @@ def get_file_info(request, user_file):
     # type: (HttpRequest, File) -> Tuple[text_type, Optional[text_type]]
 
     uploaded_file_name = user_file.name
+    assert isinstance(uploaded_file_name, str)
+
     content_type = request.GET.get('mimetype')
     if content_type is None:
         guessed_type = guess_type(uploaded_file_name)[0]

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -299,6 +299,20 @@ class FileUploadTest(ZulipTestCase):
         self.assertTrue(message not in f2_attachment.messages.all())
         self.assertTrue(message not in f3_attachment.messages.all())
 
+    def test_file_name(self):
+        # type: () -> None
+        """
+        Unicode filenames should be processed correctly.
+        """
+        self.login("hamlet@zulip.com")
+        for expected in ["Здравейте.txt", "test"]:
+            fp = StringIO("bah!")
+            fp.name = urllib.parse.quote(expected)
+
+            result = self.client_post("/json/upload_file", {'f1': fp})
+            content = ujson.loads(result.content)
+            assert sanitize_name(expected) in content['uri']
+
     def tearDown(self):
         # type: () -> None
         destroy_uploads()


### PR DESCRIPTION
The url encoded name of the file should not be a unicode. This
results in an error when we later try to unquote it.

Fixes: #1803 

@timabbott 