### PR TITLE
Add user setting option to always send push notifications.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -510,7 +510,8 @@ function render(template_name, args) {
         stream_desktop_notifications_enabled: true,
         stream_sounds_enabled: true, desktop_notifications_enabled: true,
         sounds_enabled: true, enable_offline_email_notifications: true,
-        enable_offline_push_notifications: true, enable_digest_emails: true,
+        enable_offline_push_notifications: true, enable_online_push_notifications: true,
+        enable_digest_emails: true,
         autoscroll_forever: true, default_desktop_notifications: true
     };
     var page_params = $.extend(page_param_checkbox_options, {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -609,6 +609,8 @@ exports.handle_global_notification_updates = function (notification_name, settin
         page_params.enable_offline_email_notifications = setting;
     } else if (notification_name === "enable_offline_push_notifications") {
         page_params.enable_offline_push_notifications= setting;
+    } else if (notification_name === "enable_online_push_notifications") {
+        page_params.enable_online_push_notifications = setting;
     } else if (notification_name === "enable_digest_emails") {
         page_params.enable_digest_emails = setting;
     }

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -284,6 +284,10 @@ function _setup_page() {
             page_params.enable_offline_push_notifications = result.enable_offline_push_notifications;
         }
 
+        if (result.enable_online_push_notifications !== undefined) {
+            page_params.enable_online_push_notifications = result.enable_online_push_notifications;
+        }
+
         // Other notification settings.
 
         if (result.enable_digest_emails !== undefined) {
@@ -312,7 +316,8 @@ function _setup_page() {
         _.each(["enable_stream_desktop_notifications", "enable_stream_sounds",
                 "enable_desktop_notifications", "enable_sounds",
                 "enable_offline_email_notifications",
-                "enable_offline_push_notifications", "enable_digest_emails"],
+                "enable_offline_push_notifications", "enable_online_push_notifications",
+                "enable_digest_emails"],
                function (setting) {
                    updated_settings[setting] = $("#" + setting).is(":checked");
                });

--- a/static/templates/settings_tab.handlebars
+++ b/static/templates/settings_tab.handlebars
@@ -266,6 +266,18 @@
           </label>
         </div>
 
+        <div class="control-group">
+          <div class="controls">
+            <input type="checkbox" name="enable_online_push_notifications" id="enable_online_push_notifications"
+                   {{#if page_params.enable_online_push_notifications}}
+                   checked="checked"
+                   {{/if}} />
+          </div>
+          <label for="enable_online_push_notifications" class="control-label">
+            {{t "Mobile push notifications when online" }}
+          </label>
+        </div>
+
         <div id="other_notifications">
         <h4>{{t "Other notifications" }}</h4>
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -23,7 +23,7 @@ from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, 
     UserActivityInterval, get_active_user_dicts_in_realm, get_active_streams, \
     realm_filters_for_domain, RealmFilter, receives_offline_notifications, \
     ScheduledJob, realm_filters_for_domain, get_owned_bot_dicts, \
-    get_old_unclaimed_attachments, get_cross_realm_users
+    get_old_unclaimed_attachments, get_cross_realm_users, receives_online_notifications
 
 from zerver.lib.avatar import get_avatar_url, avatar_url
 
@@ -2019,6 +2019,18 @@ def do_change_enable_offline_push_notifications(user_profile, offline_push_notif
         log_event(event)
     send_event(event, [user_profile.id])
 
+def do_change_enable_online_push_notifications(user_profile, online_push_notifications, log=True):
+    # type: (UserProfile, bool, bool) -> None
+    user_profile.enable_online_push_notifications = online_push_notifications
+    user_profile.save(update_fields=["enable_online_push_notifications"])
+    event = {'type': 'update_global_notifications',
+             'user': user_profile.email,
+             'notification_name': 'online_push_notifications',
+             'setting': online_push_notifications}
+    if log:
+        log_event(event)
+    send_event(event, [user_profile.id])
+
 def do_change_enable_digest_emails(user_profile, enable_digest_emails, log=True):
     # type: (UserProfile, bool, bool) -> None
     user_profile.enable_digest_emails = enable_digest_emails
@@ -3057,7 +3069,7 @@ def handle_push_notification(user_profile_id, missed_message):
     # type: (int, Dict[str, Any]) -> None
     try:
         user_profile = get_user_profile_by_id(user_profile_id)
-        if not receives_offline_notifications(user_profile):
+        if not (receives_offline_notifications(user_profile) or receives_online_notifications(user_profile)):
             return
 
         umessage = UserMessage.objects.get(user_profile=user_profile,

--- a/zerver/migrations/0029_userprofile_enable_online_push_notifications.py
+++ b/zerver/migrations/0029_userprofile_enable_online_push_notifications.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0028_userprofile_tos_version'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='enable_online_push_notifications',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -414,6 +414,7 @@ class UserProfile(ModelReprMixin, AbstractBaseUser, PermissionsMixin):
     enable_sounds = models.BooleanField(default=True) # type: bool
     enable_offline_email_notifications = models.BooleanField(default=True) # type: bool
     enable_offline_push_notifications = models.BooleanField(default=True) # type: bool
+    enable_online_push_notifications = models.BooleanField(default=False) # type: bool
 
     enable_digest_emails = models.BooleanField(default=True) # type: bool
 
@@ -533,6 +534,11 @@ def receives_offline_notifications(user_profile):
     # type: (UserProfile) -> bool
     return ((user_profile.enable_offline_email_notifications or
              user_profile.enable_offline_push_notifications) and
+            not user_profile.is_bot)
+
+def receives_online_notifications(user_profile):
+    # type: (UserProfile) -> bool
+    return (user_profile.enable_online_push_notifications and
             not user_profile.is_bot)
 
 # Make sure we flush the UserProfile object from our remote cache

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1532,6 +1532,7 @@ class ChangeSettingsTest(ZulipTestCase):
         self.check_for_toggle_param("/json/notify_settings/change", "enable_sounds")
         self.check_for_toggle_param("/json/notify_settings/change", "enable_offline_email_notifications")
         self.check_for_toggle_param("/json/notify_settings/change", "enable_offline_push_notifications")
+        self.check_for_toggle_param("/json/notify_settings/change", "enable_online_push_notifications")
         self.check_for_toggle_param("/json/notify_settings/change", "enable_digest_emails")
 
     def test_ui_settings(self):
@@ -1930,6 +1931,7 @@ class HomeTest(ZulipTestCase):
             "enable_digest_emails",
             "enable_offline_email_notifications",
             "enable_offline_push_notifications",
+            "enable_online_push_notifications",
             "enter_sends",
             "event_queue_id",
             "first_in_realm",

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -908,6 +908,8 @@ def home(request):
             user_profile.enable_offline_email_notifications,
         enable_offline_push_notifications =
             user_profile.enable_offline_push_notifications,
+        enable_online_push_notifications =
+            user_profile.enable_online_push_notifications,
         twenty_four_hour_time = register_ret['twenty_four_hour_time'],
 
         enable_digest_emails  = user_profile.enable_digest_emails,

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -12,8 +12,8 @@ from zerver.lib.actions import do_change_password, \
     do_change_full_name, do_change_enable_desktop_notifications, \
     do_change_enter_sends, do_change_enable_sounds, \
     do_change_enable_offline_email_notifications, do_change_enable_digest_emails, \
-    do_change_enable_offline_push_notifications, do_change_autoscroll_forever, \
-    do_change_default_desktop_notifications, \
+    do_change_enable_offline_push_notifications, do_change_enable_online_push_notifications, \
+    do_change_default_desktop_notifications, do_change_autoscroll_forever, \
     do_change_enable_stream_desktop_notifications, do_change_enable_stream_sounds, \
     do_regenerate_api_key, do_change_avatar_source, do_change_twenty_four_hour_time, \
     do_change_left_side_userlist, do_change_default_language
@@ -142,9 +142,11 @@ def json_change_notify_settings(request, user_profile,
                                                                        default=None),
                                 enable_offline_push_notifications=REQ(validator=check_bool,
                                                                       default=None),
+                                enable_online_push_notifications=REQ(validator=check_bool,
+                                                                     default=None),
                                 enable_digest_emails=REQ(validator=check_bool,
                                                          default=None)):
-    # type: (HttpRequest, UserProfile, Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool]) -> HttpResponse
     result = {}
 
     # Stream notification settings.
@@ -181,6 +183,11 @@ def json_change_notify_settings(request, user_profile,
             user_profile.enable_offline_push_notifications != enable_offline_push_notifications:
         do_change_enable_offline_push_notifications(user_profile, enable_offline_push_notifications)
         result['enable_offline_push_notifications'] = enable_offline_push_notifications
+
+    if enable_online_push_notifications is not None and \
+            user_profile.enable_online_push_notifications != enable_online_push_notifications:
+        do_change_enable_online_push_notifications(user_profile, enable_online_push_notifications)
+        result['enable_online_push_notifications'] = enable_online_push_notifications
 
     if enable_digest_emails is not None and \
             user_profile.enable_digest_emails != enable_digest_emails:

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -614,6 +614,12 @@ def restore_saved_messages():
                 old_message["enable_offline_push_notifications"] != "false")
             user_profile.save(update_fields=["enable_offline_push_notifications"])
             continue
+        elif message_type == "enable_online_push_notifications_changed":
+            user_profile = users[old_message["user"]]
+            user_profile.enable_online_push_notifications_changed = (
+                old_message["enable_online_push_notifications_changed"] != "false")
+            user_profile.save(update_fields=["enable_online_push_notifications_changed"])
+            continue
         elif message_type == "default_streams":
             set_default_streams(get_realm(old_message["domain"]),
                                 old_message["streams"])

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -25,4 +25,4 @@ TERMS_OF_SERVICE = 'zproject/terms.md.template'
 SAVE_FRONTEND_STACKTRACES = True
 EVENT_LOGS_ENABLED = True
 SYSTEM_ONLY_REALMS = set() # type: Set[str]
-USING_PGROONGA = True
+USING_PGROONGA = False


### PR DESCRIPTION
Add option in user's settings for getting push notifications
even if zulip clinet is online. Default option is False.
Fixes: #1596.