### PR TITLE
provision: Handle VENV_CACHE_PATH not existing.

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -93,6 +93,9 @@ def try_to_copy_venv(venv_path, new_packages):
         virtualenv-clone.
         3. Delete all .pyc files in the new virtual environment.
     """
+    if not os.path.exists(VENV_CACHE_PATH):
+        return False
+
     venv_name = os.path.basename(venv_path)
 
     overlaps = []  # type: List[Tuple[int, str, Set[str]]]


### PR DESCRIPTION
If VENV_CACHE_PATH does not exist (which can happen if you destroy
your vagrant environment), then do a short circuit return in
try_to_copy_venv().