### PR TITLE
Add medium avatar size.

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -149,6 +149,8 @@ def get_file_info(request, user_file):
     # type: (HttpRequest, File) -> Tuple[text_type, Optional[text_type]]
 
     uploaded_file_name = user_file.name
+    assert isinstance(uploaded_file_name, str)
+
     content_type = request.GET.get('mimetype')
     if content_type is None:
         guessed_type = guess_type(uploaded_file_name)[0]

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1762,6 +1762,7 @@ class HomeTest(ZulipTestCase):
             "alert_words",
             "autoscroll_forever",
             "avatar_url",
+            "avatar_url_medium",
             "bot_list",
             "can_create_streams",
             "cross_realm_user_emails",

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -957,6 +957,7 @@ def home(request):
         autoscroll_forever = user_profile.autoscroll_forever,
         default_desktop_notifications = user_profile.default_desktop_notifications,
         avatar_url            = avatar_url(user_profile),
+        avatar_url_medium     = avatar_url(user_profile, True),
         mandatory_topics      = user_profile.realm.mandatory_topics,
         show_digest_email     = user_profile.realm.show_digest_email,
         presence_disabled     = user_profile.realm.presence_disabled,


### PR DESCRIPTION
This adds a medium (500px) avatar size whenever from this point on a
user uploads an avatar. It can be referenced as `{name}-medium.png`.
