### PR TITLE
Upload casper failure images to S3 in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ sudo: required
 services:
 - docker
 addons:
+  artifacts:
+    paths:
+      - $(ls var/casper/* | tr "\n" ":")
   postgresql: "9.3"
 after_success:
   coveralls

--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -52,7 +52,7 @@ exports.initialize_casper = function (viewport) {
     var casper_failure_count = 1;
     casper.test.on('fail', function failure() {
         if (casper_failure_count <= 10) {
-            casper.capture("/tmp/casper-failure" + casper_failure_count + ".png");
+            casper.capture("var/casper/casper-failure" + casper_failure_count + ".png");
             casper_failure_count++;
         }
     });

--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -43,9 +43,9 @@ os.chdir(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
 
 subprocess.check_call('tools/setup/generate-test-credentials')
 
-subprocess.check_call(['rm', '-f'] + glob.glob('/tmp/casper-failure*.png'))
-
 subprocess.check_call(['mkdir', '-p', 'var/casper'])
+
+subprocess.check_call(['rm', '-f'] + glob.glob('var/casper/casper-failure*.png'))
 
 log = open('var/casper/server.log', 'w')
 
@@ -109,7 +109,7 @@ def run_tests(files):
         print("""
 Oops, the frontend tests failed. Tips for debugging:
  * Check the frontend test server logs at var/casper/server.log
- * Check the screenshots of failed tests at /tmp/casper-failure*.png
+ * Check the screenshots of failed tests at var/casper/casper-failure*.png
  * Try remote debugging the test web browser as described in docs/testing.rst
 """, file=sys.stderr)
 


### PR DESCRIPTION
You need to define the following settings in Travis:
- ARTIFACTS_KEY
- ARTIFACTS_SECRET
- ARTIFACTS_BUCKET
- ARTIFACTS_REGION (if it's other than standard)

Fixes: #1263 
@timabbott 
![screen shot 2016-09-22 at 4 22 26 pm](https://cloud.githubusercontent.com/assets/641763/18746442/da75b60a-80e0-11e6-95ec-5634b9adce2d.png)
