### PR TITLE
Link to zulip js

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ app][electron].
 
 * **Glue code**. We maintain a [Hubot adapter][hubot-adapter] and several
 integrations ([Phabricator][phab], [Jenkins][], [Puppet][], [Redmine][],
-and [Trello][]), plus [node.js API bindings][node], an [isomorphic javascript library][javascript], and a [full-text search
-PostgreSQL extension][tsearch], as separate repos.
+and [Trello][]), plus [node.js API bindings][node], an [isomorphic 
+JavaScript library][zulip-js], and a [full-text search PostgreSQL 
+extension][tsearch], as separate repos.
 
 * **Translations**.  Zulip is in the process of being translated into
 10+ languages, and we love contributions to our translations.  See our
@@ -122,7 +123,7 @@ contributing!
 [hubot-adapter]: https://github.com/zulip/hubot-zulip
 [jenkins]: https://github.com/zulip/zulip-jenkins-plugin
 [node]: https://github.com/zulip/zulip-node
-[javascript]: https://github.com/zulip/zulip-js
+[zulip-js]: https://github.com/zulip/zulip-js
 [phab]: https://github.com/zulip/phabricator-to-zulip
 [puppet]: https://github.com/matthewbarr/puppet-zulip
 [redmine]: https://github.com/zulip/zulip-redmine-plugin

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ app][electron].
 
 * **Glue code**. We maintain a [Hubot adapter][hubot-adapter] and several
 integrations ([Phabricator][phab], [Jenkins][], [Puppet][], [Redmine][],
-and [Trello][]), plus [node.js API bindings][node], an [isomorphic 
-JavaScript library][zulip-js], and a [full-text search PostgreSQL 
-extension][tsearch], as separate repos.
+and [Trello][]), plus [node.js API bindings][node], an [isomorphic
+ JavaScript library][zulip-js], and a [full-text search PostgreSQL
+ extension][tsearch], as separate repos.
 
 * **Translations**.  Zulip is in the process of being translated into
 10+ languages, and we love contributions to our translations.  See our

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ app][electron].
 
 * **Glue code**. We maintain a [Hubot adapter][hubot-adapter] and several
 integrations ([Phabricator][phab], [Jenkins][], [Puppet][], [Redmine][],
-and [Trello][]), plus [node.js API bindings][node], and a [full-text search
+and [Trello][]), plus [node.js API bindings][node], an [isomorphic javascript library][javascript], and a [full-text search
 PostgreSQL extension][tsearch], as separate repos.
 
 * **Translations**.  Zulip is in the process of being translated into
@@ -122,6 +122,7 @@ contributing!
 [hubot-adapter]: https://github.com/zulip/hubot-zulip
 [jenkins]: https://github.com/zulip/zulip-jenkins-plugin
 [node]: https://github.com/zulip/zulip-node
+[javascript]: https://github.com/zulip/zulip-js
 [phab]: https://github.com/zulip/phabricator-to-zulip
 [puppet]: https://github.com/matthewbarr/puppet-zulip
 [redmine]: https://github.com/zulip/zulip-redmine-plugin

--- a/templates/zerver/api.html
+++ b/templates/zerver/api.html
@@ -133,8 +133,8 @@ to pull out the resulting HTML :)
       <p>See also the <a href="/api/endpoints">full API endpoint documentation.</a></p>
     </div>
 
-      <div class="tab-pane" id="javascript">
-	      <p>More examples and documentation can be found <a href="https://github.com/zulip/zulip-js">here</a>.</p>
+<div class="tab-pane" id="javascript">
+<p>More examples and documentation can be found <a href="https://github.com/zulip/zulip-js">here</a>.</p>
 
 <div class="codehilite"><pre><span class="kr">const</span> <span class="nx">zulip</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'zulip'</span><span class="p">);</span>
 
@@ -175,7 +175,7 @@ to pull out the resulting HTML :)
 <span class="p">});</span>
 </pre></div>
 
-      </div>
+</div>
     <p>&nbsp;</p>
 
     <h3>API Keys</h3>

--- a/templates/zerver/api.html
+++ b/templates/zerver/api.html
@@ -5,7 +5,7 @@
 {% block portico_content %}
     <h1 class="api-page-header">We hear you like APIs...</h1>
 
-    <p>We have a <a href="/api/endpoints">well-documented API</a> that allows you to build custom integrations, in addition to our <a href="/integrations">existing integrations</a>. For ease-of-use, we've created a Python module that you can drop in to a project to start interacting with our API.</p>
+    <p>We have a <a href="/api/endpoints">well-documented API</a> that allows you to build custom integrations, in addition to our <a href="/integrations">existing integrations</a>. For ease-of-use, we've created a Python module that you can drop in to a project to start interacting with our API. There is also a <a href="github.com/zulip/zulip-js">Javascript library</a> that can be used either in the browser or in Node.js.</p>
 
     <p><strong>Don't want to make it yourself?</strong> Zulip <a href="/integrations">already integrates with lots of services</a>.</p>
 
@@ -18,6 +18,7 @@
     <p>&nbsp;</p>
 
     <h3>Installation instructions</h3>
+    <h4>Python</h4>
     <p>This package uses <tt>distutils</tt>, so you can just run <code>python setup.py install</code> after downloading.</p>
     <p>If you have <tt>setuptools</tt> installed on your system then the application's dependencies will be downloaded and installed automatically from <a href="https://pypi.python.org/">PyPI</a>. Otherwise, you'll need to make sure you have these Python libraries installed:</p>
     <ul>
@@ -25,6 +26,9 @@
       <li><tt>requests</tt> (0.12.1 or later)</li>
     </ul>
     <p>&nbsp;</p>
+    <h4>Javascript</h4>
+    <p>Install it with <a href="https://www.npmjs.com/package/zulip-js">npm</a>:</p>
+    <pre><code>npm install zulip-js</code></pre>
 
     <h3>Usage examples</h3>
 
@@ -32,6 +36,7 @@
       <li class="active"><a href="#curl" data-toggle="tab">curl</a></li>
       <li><a href="#python" data-toggle="tab">Python</a></li>
       <li><a href="#commandline" data-toggle="tab">zulip-send</a></li>
+      <li><a href="#javascript" data-toggle="tab">Javascript</a></li>
     </ul>
 
     <div class="tab-content">
@@ -128,7 +133,49 @@ to pull out the resulting HTML :)
       <p>See also the <a href="/api/endpoints">full API endpoint documentation.</a></p>
     </div>
 
+      <div class="tab-pane" id="javascript">
+	      <p>More examples and documentation can be found <a href="https://github.com/zulip/zulip-js">here</a>.</p>
 
+<div class="codehilite"><pre><span class="kr">const</span> <span class="nx">zulip</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'zulip'</span><span class="p">);</span>
+
+<span class="kr">const</span> <span class="nx">config</span> <span class="o">=</span> <span class="p">{</span>
+  <span class="nx">username</span><span class="o">:</span> <span class="s1">'othello-bot@example.com'</span><span class="p">,</span>
+  <span class="nx">apiKey</span><span class="o">:</span> <span class="s1">'a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5'</span><span class="p">,</span>
+  <span class="nx">realm</span><span class="o">:</span> <span class="s1">'https://yourZulipDomain.zulipchat.com'</span>
+<span class="p">};</span>
+
+<span class="kr">const</span> <span class="nx">client</span> <span class="o">=</span> <span class="nx">zulip</span><span class="p">(</span><span class="nx">config</span><span class="p">);</span>
+
+<span class="c1">// Send a message</span>
+<span class="nx">client</span><span class="p">.</span><span class="nx">messages</span><span class="p">.</span><span class="nx">send</span><span class="p">({</span>
+  <span class="nx">to</span><span class="o">:</span> <span class="s1">'Denmark'</span><span class="p">,</span>
+  <span class="nx">type</span><span class="o">:</span> <span class="s1">'stream'</span><span class="p">,</span>
+  <span class="nx">subject</span><span class="o">:</span> <span class="s1">'Castle'</span><span class="p">,</span>
+  <span class="nx">content</span><span class="o">:</span> <span class="s1">'Something is rotten in the state of Denmark.'</span>
+<span class="p">});</span>
+
+<span class="c1">// Send a private message</span>
+<span class="nx">client</span><span class="p">.</span><span class="nx">messages</span><span class="p">.</span><span class="nx">send</span><span class="p">({</span>
+  <span class="nx">to</span><span class="o">:</span> <span class="s1">'hamlet@example.com'</span><span class="p">,</span>
+  <span class="nx">type</span><span class="o">:</span> <span class="s1">'private'</span><span class="p">,</span>
+  <span class="nx">content</span><span class="o">:</span> <span class="s1">'I come not, friends, to steal away your hearts.'</span>
+<span class="p">});</span>
+
+<span class="c1">// Register queue to receive messages for user</span>
+<span class="nx">zulip</span><span class="p">.</span><span class="nx">queues</span><span class="p">.</span><span class="nx">register</span><span class="p">({</span>
+  <span class="nx">event_types</span><span class="o">:</span> <span class="p">[</span><span class="s1">'message'</span><span class="p">]</span>
+<span class="p">}).</span><span class="nx">then</span><span class="p">((</span><span class="nx">res</span><span class="p">)</span> <span class="o">=&gt;</span> <span class="p">{</span>
+  <span class="c1">// Retrieve events from a queue</span>
+  <span class="c1">// Blocking until there is an event (or the request times out)</span>
+  <span class="nx">zulip</span><span class="p">.</span><span class="nx">events</span><span class="p">.</span><span class="nx">retrieve</span><span class="p">({</span>
+    <span class="nx">queue_id</span><span class="o">:</span> <span class="nx">res</span><span class="p">.</span><span class="nx">queue_id</span><span class="p">,</span>
+    <span class="nx">last_event_id</span><span class="o">:</span> <span class="o">-</span><span class="mi">1</span><span class="p">,</span>
+    <span class="nx">dont_block</span><span class="o">:</span> <span class="kc">false</span>
+  <span class="p">}).</span><span class="nx">then</span><span class="p">(</span><span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">);</span>
+<span class="p">});</span>
+</pre></div>
+
+      </div>
     <p>&nbsp;</p>
 
     <h3>API Keys</h3>


### PR DESCRIPTION
Add link to [zulip-js](github.com/zulip/zulip-js) in README.md, and add link, installation and usage guide to the API documentation.