### PR TITLE
css linter: Report empty declarations more clearly.

### DIFF
--- a/tools/lib/css_parser.py
+++ b/tools/lib/css_parser.py
@@ -208,7 +208,11 @@ def parse_declaration_block(tokens):
 def parse_declaration(tokens):
     # type: (List[Token]) -> CssDeclaration
     i, pre_fluff = get_whitespace_and_comments(tokens, 0)
-    css_property = tokens[i].s
+    try:
+        css_property = tokens[i].s
+    except IndexError:
+        raise CssParserException('Empty declaration')
+
     if tokens[i+1].s != ':':
         # print(css_property)
         raise CssParserException('We expect a colon here')

--- a/tools/tests/test_css_parser.py
+++ b/tools/tests/test_css_parser.py
@@ -62,6 +62,15 @@ class ParserTestHappyPath(unittest.TestCase):
 
         self.assertFalse(section.declaration_block.declarations[0].semicolon)
 
+    def test_empty_block(self):
+        # type: () -> None
+        my_css = '''
+            div {
+            }'''
+        error = 'Empty declaration'
+        with self.assertRaisesRegexp(CssParserException, error): # type: ignore # See https://github.com/python/typeshed/issues/372
+            res = parse(my_css)
+
     def test_multi_line_selector(self):
         # type: () -> None
         my_css = '''


### PR DESCRIPTION
Raise a CssParserException when declarations are empty.