### PR TITLE
proof of concept: Generate screenshots

### DIFF
--- a/frontend_tests/casper_tests/01-login.js
+++ b/frontend_tests/casper_tests/01-login.js
@@ -10,12 +10,14 @@ casper.then(function () {
 
 common.then_log_in();
 
+
 casper.waitForSelector('#zhome', function () {
     casper.test.info('Logging out');
     casper.click('li[title="Log out"] a');
 });
 
 casper.then(function () {
+    casper.capture('steve.png');
     casper.test.assertHttpStatus(200);
     casper.test.assertUrlMatch(/accounts\/login\/$/);
 });

--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -48,6 +48,21 @@ common.then_send_many([
 function expect_home() {
     casper.then(function () {
         casper.waitUntilVisible('#zhome', function () {
+            var delay = 400; // ms
+            var widths = [300, 600, 900, 1200];
+            casper.each(widths, function(self, width) {
+                casper.then(function () {
+                    casper.page.viewportSize = {width: width, height: 800};
+                    casper.wait(delay).then(function () {
+                        casper.capture('steve' + width + '.png');
+                        if (width == 900) {
+                            casper.captureSelector(
+                                'steve' + width + '-streams.png',
+                                '#stream_filters');
+                        };
+                    });
+                });
+            });
             common.expected_messages('zhome', [
                 'Verona > frontend test',
                 'You and Cordelia Lear, King Hamlet',

--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -27,6 +27,8 @@ except ImportError as e:
 
 os.environ["TORNADO_SERVER"] = "http://127.0.0.1:9983"
 
+USE_FAST_MODE = os.environ.get('USE_FAST_MODE', False)
+
 usage = """%prog [options]
     test-js-with-casper # Run all test files
     test-js-with-casper 09-navigation.js # Run a single test file
@@ -84,9 +86,13 @@ def run_tests(files):
     else:
         cmd += 'frontend_tests/casper_tests'
 
+    if USE_FAST_MODE:
+        kwargs = {}
+    else:
+        kwargs = dict(stdout=log, stderr=log)
+        
     # Run this not through the shell, so that we have the actual PID.
-    server = subprocess.Popen(('tools/run-dev.py', '--test'),
-                              stdout=log, stderr=log)
+    server = subprocess.Popen(('tools/run-dev.py', '--test'), **kwargs)
 
     ret = 1
 
@@ -94,10 +100,16 @@ def run_tests(files):
         # Wait for the server to start up.
         sys.stdout.write('Waiting for test server')
         while not server_is_up(server):
-            sys.stdout.write('.')
-            sys.stdout.flush()
-            time.sleep(0.1)
+            if USE_FAST_MODE:
+                time.sleep(0.5)
+            else:
+                sys.stdout.write('.')
+                sys.stdout.flush()
+                time.sleep(0.1)
         sys.stdout.write('\n')
+
+        if USE_FAST_MODE:
+            print('\n\nCOMPLETED\n\n')
 
         print("Running %s" % (cmd,))
         ret = subprocess.call(cmd, shell=True)

--- a/steve.html
+++ b/steve.html
@@ -1,0 +1,13 @@
+<h3>streams</h3>
+<img src="steve900-streams.png"><hr>
+
+<br>
+<hr>
+<br>
+
+<h3>whole app</h3>
+
+<img src="steve300.png"><hr>
+<img src="steve600.png"><hr>
+<img src="steve900.png"><hr>
+<img src="steve1200.png"><hr>

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -10,6 +10,8 @@ import os
 
 if False: from typing import Any
 
+USE_FAST_MODE = os.environ.get('USE_FAST_MODE', False)
+
 # find out python version
 major_version = int(subprocess.check_output(['python', '-c', 'import sys; print(sys.version_info[0])']))
 if major_version != 2:
@@ -85,7 +87,8 @@ webpack_port = base_port+3
 os.chdir(os.path.join(os.path.dirname(__file__), '..'))
 
 # Clean up stale .pyc files etc.
-subprocess.check_call('./tools/clean-repo')
+if not USE_FAST_MODE:
+    subprocess.check_call('./tools/clean-repo')
 
 # HACK to fix up node_modules/.bin/handlebars deletion issue
 if not os.path.exists("node_modules/.bin/handlebars") and os.path.exists("node_modules/handlebars"):


### PR DESCRIPTION
@timabbott The last commit in this series does what it looks like--it allows us to capture screenshots from casper as document artifacts (.png files) using different viewport sizes.  Casper conveniently allows us to grab a clipped rectangle corresponding to a particular selector.

The next step is to package this up a bit, and maybe build some kind of diffing engine around it.

I did this in the VM:

```
 time USE_FAST_MODE=1 ./tools/test-js-with-casper 03-narrow.js
```

Then I opened steve.html in the browser.
