### PR TITLE
Add up/down arrow tab sections to home page.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -61,6 +61,25 @@ var hotkeys_shift_insensitive = {
     119: {name: 'query_streams', message_view_only: false} // 'w'
 };
 
+var tab_up_down = (function () {
+    var list = ["#group-pm-list", "#stream_filters", "#global_filters", "#user_presences"];
+
+    return function (e) {
+        var $target = $(e.target);
+        var flag = $target.closest(list.join(", "));
+
+        return {
+            flag: flag,
+            next: function () {
+                return $target.closest("li").next().find("a");
+            },
+            prev: function () {
+                return $target.closest("li").prev().find("a");
+            }
+        };
+    };
+}());
+
 function get_hotkey_from_event(e) {
 
     // We're in the middle of a combo; stop processing because
@@ -93,6 +112,17 @@ function process_hotkey(e) {
 
     if (ui.home_tab_obscured() && hotkey.message_view_only) {
         return false;
+    }
+
+    var tab_list = tab_up_down(e);
+    if (tab_list.flag) {
+      if (hotkey.name === "up_arrow") {
+        tab_list.prev().focus();
+        return false;
+      } else if (hotkey.name === "down_arrow") {
+        tab_list.next().focus();
+        return false;
+      }
     }
 
     if (event_name === 'ignore') {


### PR DESCRIPTION
This lets you use up and down arrows in certain sections on the site to
navigate lists. It also prevents potentially unwanted actions caused by
using up/down arrows in those sections.

Fixes: #1696.