### PR TITLE
On stream click, blur so key events unbind from sidebar.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -241,6 +241,14 @@ $(function () {
         e.preventDefault();
     });
 
+    (function () {
+        var sel = ["#group-pm-list", "#stream_filters", "#global_filters", "#user_presences"].join(", ");
+
+        $(sel).on("click", "a", function () {
+            this.blur();
+        });
+    }());
+
     popovers.register_click_handlers();
     notifications.register_click_handlers();
 


### PR DESCRIPTION
Unblur the link that was clicked so that when a user presses up/down
buttons it will automatically go back over to the individual messages
rather than tabbing up and down the sidebar.

Fixes: #1875.