### PR TITLE
Message editing: add explanation when past message edit deadline.

### DIFF
--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -27,7 +27,7 @@
             <div class="message-edit-timer-control-group">
                 <span class="message_edit_countdown_timer"></span>
                 <span><i id="message_edit_tooltip" class="message_edit_tooltip icon-vector-question-sign" data-toggle="tooltip"
-                         title="Message content can only be edited for {{minutes_to_edit}} minutes after it is sent."></i>
+                         title="This organization is configured to restrict editing of message content to {{minutes_to_edit}} minutes after it is sent."></i>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
Adds "Topic editing only" along with the tooltip explanation to lower right
of message editing box when it's past the message content editing deadline.

![message-editing-past-deadline](https://cloud.githubusercontent.com/assets/890911/19011191/9d7db3ba-8743-11e6-92d9-46ae8ea60da7.png)

The extra space between the bottom of the message content box and the Save/Cancel row is an unrelated bug.