### PR TITLE
WIP Log what service is being started on which port.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -142,6 +142,17 @@ class Resource(resource.Resource):
 
         return proxy.ReverseProxyResource('127.0.0.1', django_port, '/'+name)
 
+
+    # log which services/ports will be started
+    print("Starting Zulip services on ports:  web proxy: {},".format(proxy_port),
+          "Django: {}, Tornado: {}".format(django_port, tornado_port), end='')
+    if options.test:
+        print("")  # no webpack for --test
+    else:
+        print(", webpack: {}".format(webpack_port))
+
+    print("Note: only port {} is exposed to the host in a Vagrant environment.".format(proxy_port))
+
 try:
     reactor.listenTCP(proxy_port, server.Site(Resource()), interface=options.interface)
     reactor.run()


### PR DESCRIPTION

The new messages make it more obvious which services are started from
run-dev.py, and explicitly call out where to access the web proxy to reach the 
Zulip web UI. This is a common confusion for new administrators/developers. 
Messages are output before the processes are launched, as run-dev.py does
not currently have a way to know if they started successfully.

Example output:
```
Starting Zulip processes on ports:  web proxy: 9991 Django: 9992 Tornado: 9993 webpack: 9994
Note: only port 9991 is exposed to the host in a Vagrant environment.
```
Fixes #1861