### PR TITLE
Use current_msg_list to ensures msgs are sent in frontend tests

### DIFF
--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -101,6 +101,10 @@ exports.then_log_out = function () {
         casper.test.info('Logging out');
         casper.click('li[title="Log out"] a');
     });
+
+    casper.waitForSelector(".login-page-header", function () {
+        casper.test.info("Logged out");
+    });
 };
 
 // Put the specified string into the field_selector, then

--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -158,6 +158,14 @@ exports.check_form = function (form_selector, expected, test_name) {
     }
 };
 
+exports.wait_for_message_actually_sent = function () {
+    casper.waitFor(function () {
+        return casper.evaluate(function () {
+            return current_msg_list.last().local_id === undefined;
+        });
+    });
+};
+
 // Wait for any previous send to finish, then send a message.
 exports.then_send_message = function (type, params) {
     casper.then(function () {
@@ -181,6 +189,7 @@ exports.then_send_message = function (type, params) {
         casper.waitFor(function emptyComposeBox() {
             return casper.getFormValues('form[action^="/json/messages"]').content === '';
         });
+        exports.wait_for_message_actually_sent();
     });
 
     casper.then(function () {

--- a/frontend_tests/casper_tests/08-edit.js
+++ b/frontend_tests/casper_tests/08-edit.js
@@ -13,14 +13,6 @@ function then_edit_last_message() {
     casper.waitForSelector(".message_edit_content");
 }
 
-function wait_for_message_actually_sent() {
-    casper.waitFor(function () {
-        return casper.evaluate(function () {
-            return current_msg_list.last().local_id === undefined;
-        });
-    });
-}
-
 // Send and edit a stream message
 
 common.then_send_message('stream', {
@@ -30,7 +22,7 @@ common.then_send_message('stream', {
 });
 
 casper.waitForText("test editing");
-wait_for_message_actually_sent();
+common.wait_for_message_actually_sent();
 
 then_edit_last_message();
 
@@ -54,7 +46,7 @@ common.then_send_message('stream', {
 });
 
 casper.waitForText("test editing one line with me");
-wait_for_message_actually_sent();
+common.wait_for_message_actually_sent();
 
 then_edit_last_message();
 
@@ -77,7 +69,7 @@ common.then_send_message('private', {
 });
 
 casper.waitForText("test editing pm");
-wait_for_message_actually_sent();
+common.wait_for_message_actually_sent();
 then_edit_last_message();
 
 casper.then(function () {


### PR DESCRIPTION
@timabbott, if this doesn't work then I think I'll change the way we are sending messages; I am hopefull though that this might do it.