### PR TITLE
Rerun add-apt-repository for ppa:groonga/ppa

### DIFF
--- a/tools/provision.py
+++ b/tools/provision.py
@@ -164,8 +164,14 @@ def main():
     os.chdir(ZULIP_PATH)
 
     run(["sudo", "./scripts/lib/setup-apt-repo"])
-    # Add groonga repository to get the pgroonga packages
-    run(["sudo", "add-apt-repository", "-y", "ppa:groonga/ppa"])
+
+    # Add groonga repository to get the pgroonga packages; retry if it fails :/
+    try:
+        run(["sudo", "add-apt-repository", "-y", "ppa:groonga/ppa"])
+    except subprocess.CalledProcessError:
+        print(WARNING + "`Could not add groonga; retrying..." + ENDC)
+        run(["sudo", "add-apt-repository", "-y", "ppa:groonga/ppa"])
+
     run(["sudo", "apt-get", "update"])
     run(["sudo", "apt-get", "-y", "install", "--no-install-recommends"] + APT_DEPENDENCIES[codename])
 


### PR DESCRIPTION
On occasion, provisioning will fail because groonga is not added. Add a
check to see if the command fails and retry.