### PR TITLE
Hide favorite and menu options for messages until hover.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -894,40 +894,43 @@ td.pointer {
     content: ")";
 }
 
-.include-sender .message_time {
-    top: -4px;
-}
-
-.message_time {
-    display: block;
-    font-size: 11px;
-    color: #a1a1a1;
-    vertical-align: middle;
-    padding: 1px;
-    font-weight: 300;
-    position: absolute;
-    right: -80px;
-    line-height: 20px;
-    text-align: right;
-    -webkit-transition: background-color 2.7s ease-in, color 2.7s ease-in;
-    -moz-transition: background-color 2.7s ease-in, color 2.7s ease-in;
-    -o-transition: background-color 2.7s ease-in, color 2.7s ease-in;
-    transition: background-color 2.7s ease-in, color 2.7s ease-in;
-}
-
 .status-time {
     top: 8px !important;
 }
 
-.message_controls {
-    display: inline-block;
-    position: absolute;
-    top: 2px;
-    right: -38px;
+.message_hovered .info,
+.message_hovered .empty-star {
+    visibility: visible;
 }
 
-.include-sender .message_controls {
-    top: -3px;
+.upper-info-box {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 2px 10px;
+}
+
+.message_time {
+    display: inline-block;
+    font-size: 11px;
+    color: #a1a1a1;
+}
+
+.message_controls {
+    display: none;
+}
+
+.message_controls div {
+    margin: 0px 2px;
+    color: #888;
+}
+
+.message_hovered .message_controls {
+    display: inline-block;
+}
+
+.message_hovered .message_time {
+    display: none;
 }
 
 .message_data {
@@ -1476,11 +1479,6 @@ a.dark_background:hover,
 .actions_hovered .info {
     color: #0088CC;
     cursor: pointer;
-}
-
-.message_hovered .info,
-.message_hovered .empty-star {
-    visibility: visible;
 }
 
 .actions_hovered .actions_link {
@@ -3206,7 +3204,7 @@ li.expanded_private_message {
     display: inline-block;
     opacity: 1;
     font-size: 14px;
-    color: #2c8211;
+    color: #888;
 }
 
 .empty-star {
@@ -3228,7 +3226,7 @@ li.expanded_private_message {
 
 .star:hover {
     cursor:  pointer;
-    color: #0d7245;
+    color: #666;
 }
 
 /* FIXME: Combine this rule with the one in portico.css somehow? */

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -4,6 +4,26 @@
   <div class="messagebox{{^include_sender}} prev_is_same_sender{{/include_sender}}{{^msg/is_stream}} private-message{{/msg/is_stream}} {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
        style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">
     <div class="messagebox-border">
+      <div class="upper-info-box">
+        <div class="message_time{{#if msg.local_id}} notvisible{{/if}}{{#if status_message}} status-time{{/if}}">{{timestr}}</div>
+        {{#if_and last_edit_timestr include_sender}}
+          {{#unless status_message}}
+              <div class="message_edit_notice" title="Edited ({{last_edit_timestr}})">{{t "EDITED" }}</div>
+          {{/unless}}
+        {{/if_and}}
+        <div class="message_controls{{#status_message}} sender-status-controls{{/status_message}}">
+          <div class="star">
+            <span class="message_star {{#if msg/starred}}icon-vector-star{{else}}icon-vector-star-empty empty-star{{/if}}"
+                  title="{{#tr this}}{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message{{/tr}}"></span>
+          </div>
+          <div class="info actions_hover">
+            <i class="icon-vector-ellipsis-horizontal"></i>
+          </div>
+          <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">
+            <span class="failed_text">Not delivered </span><i class="icon-vector-refresh refresh-failed-message"></i><i class="icon-vector-pencil edit-failed-message"></i><i class="icon-vector-remove-sign remove-failed-message"></i>
+          </div>
+        </div>
+      </div>
       <div class="messagebox-content">
         <div class="message_top_line">
           {{#include_sender}}
@@ -27,24 +47,6 @@
           </span>
           </span>
           {{/include_sender}}
-          <span class="message_time{{#if msg.local_id}} notvisible{{/if}}{{#if status_message}} status-time{{/if}}">{{timestr}}</span>
-          {{#if_and last_edit_timestr include_sender}}
-            {{#unless status_message}}
-                <div class="message_edit_notice" title="Edited ({{last_edit_timestr}})">{{t "EDITED" }}</div>
-            {{/unless}}
-          {{/if_and}}
-          <div class="message_controls{{#status_message}} sender-status-controls{{/status_message}}">
-            <div class="star">
-              <span class="message_star {{#if msg/starred}}icon-vector-star{{else}}icon-vector-star-empty empty-star{{/if}}"
-                    title="{{#tr this}}{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message{{/tr}}"></span>
-            </div>
-            <div class="info actions_hover">
-              <i class="icon-vector-chevron-down"></i>
-            </div>
-            <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">
-              <span class="failed_text">Not delivered </span><i class="icon-vector-refresh refresh-failed-message"></i><i class="icon-vector-pencil edit-failed-message"></i><i class="icon-vector-remove-sign remove-failed-message"></i>
-            </div>
-          </div>
         </div>
         <div class="message_content">{{#unless status_message}}{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}{{/unless}}</div>
         {{#if last_edit_timestr}}


### PR DESCRIPTION
This is a change to hide the favorite button and “more options” trigger
until someone is hovering over a particular message.

This replaces the default behavior of showing these options next to the
timestamp at all times.
