### PR TITLE
run-dev-proxy: Fix twisted py3 compatibility.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,9 @@
 -r moto.txt
 -r py3k.txt
 
+# Needed for running tools/run-dev.py
+-r twisted.txt
+
 # Needed to compute test coverage
 coverage==4.2
 

--- a/requirements/py2_dev.txt
+++ b/requirements/py2_dev.txt
@@ -1,5 +1,2 @@
 -r py2_common.txt
 -r dev.txt
-
-# Needed for running tools/run-dev.py
--r twisted.txt


### PR DESCRIPTION
 - All necessary strings was converted to bytestring
 - Added twisted as py3 dependency

Fixes #1256