### PR TITLE
Fix EXTERNAL_HOST computations in test_settings.py.

### DIFF
--- a/zerver/tests/test_integrations.py
+++ b/zerver/tests/test_integrations.py
@@ -23,22 +23,22 @@ class IntegrationTest(TestCase):
         # type: () -> None
         context = dict()  # type: Dict[str, Any]
         add_api_uri_context(context, HostRequestMock())
-        self.assertEqual(context["external_api_path_subdomain"], "zulipdev.com:9991/api")
-        self.assertEqual(context["external_api_uri_subdomain"], "http://zulipdev.com:9991/api")
+        self.assertEqual(context["external_api_path_subdomain"], "testserver/api")
+        self.assertEqual(context["external_api_uri_subdomain"], "http://testserver/api")
 
     @override_settings(REALMS_HAVE_SUBDOMAINS=True)
     def test_api_url_view_subdomains_base(self):
         # type: () -> None
         context = dict()  # type: Dict[str, Any]
         add_api_uri_context(context, HostRequestMock())
-        self.assertEqual(context["external_api_path_subdomain"], "yourZulipDomain.zulipdev.com:9991/api")
-        self.assertEqual(context["external_api_uri_subdomain"], "http://yourZulipDomain.zulipdev.com:9991/api")
+        self.assertEqual(context["external_api_path_subdomain"], "yourZulipDomain.testserver/api")
+        self.assertEqual(context["external_api_uri_subdomain"], "http://yourZulipDomain.testserver/api")
 
-    @override_settings(REALMS_HAVE_SUBDOMAINS=True, EXTERNAL_HOST="zulipdev.com")
+    @override_settings(REALMS_HAVE_SUBDOMAINS=True)
     def test_api_url_view_subdomains_full(self):
         # type: () -> None
         context = dict()  # type: Dict[str, Any]
-        request = HostRequestMock(host="mysubdomain.zulipdev.com")
+        request = HostRequestMock(host="mysubdomain.testserver")
         add_api_uri_context(context, request)
-        self.assertEqual(context["external_api_path_subdomain"], "mysubdomain.zulipdev.com:9991/api")
-        self.assertEqual(context["external_api_uri_subdomain"], "http://mysubdomain.zulipdev.com:9991/api")
+        self.assertEqual(context["external_api_path_subdomain"], "mysubdomain.testserver/api")
+        self.assertEqual(context["external_api_uri_subdomain"], "http://mysubdomain.testserver/api")

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -2,9 +2,10 @@
 # For the Dev VM environment, we use the same settings as the
 # sample prod_settings.py file, with a few exceptions.
 from .prod_settings_template import *
+import os
 
 LOCAL_UPLOADS_DIR = 'var/uploads'
-EXTERNAL_HOST = 'zulipdev.com:9991'
+EXTERNAL_HOST = os.getenv('EXTERNAL_HOST', 'zulipdev.com:9991')
 ALLOWED_HOSTS = ['*']
 AUTHENTICATION_BACKENDS = ('zproject.backends.DevAuthBackend',)
 # Add some of the below if you're testing other backends

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
-from .settings import *
 import os
+if os.getenv("EXTERNAL_HOST") is None:
+    os.environ["EXTERNAL_HOST"] = "testserver"
+from .settings import *
 
 DATABASES["default"] = {"NAME": "zulip_test",
                         "USER": "zulip_test",
@@ -82,7 +84,6 @@ LOCAL_UPLOADS_DIR = 'var/test_uploads'
 S3_KEY = 'test-key'
 S3_SECRET_KEY = 'test-secret-key'
 S3_AUTH_UPLOADS_BUCKET = 'test-authed-bucket'
-EXTERNAL_HOST = os.getenv('EXTERNAL_HOST', "testserver")
 REALMS_HAVE_SUBDOMAINS = bool(os.getenv('REALMS_HAVE_SUBDOMAINS', False))
 
 # Test Custom TOS template rendering


### PR DESCRIPTION
test_settings.py was setting EXTERNAL_HOST after importing settings.py,
which has several variables (like SERVER_URI) that are computed from
EXTERNAL_HOST.