### PR TITLE
puppet: Fix missing dependency for supervisor enabling.

### DIFF
--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -44,6 +44,7 @@ class zulip::supervisor {
     exec {"enable supervisor":
       unless => "systemctl is-enabled supervisor",
       command => "systemctl enable supervisor",
+      require => Package["supervisor"],
     }
   }
 }


### PR DESCRIPTION
You can't run `systemctl enable` on a service before the package
containing the service is installed.