### PR TITLE
test-backend: remove trailing forward slash from test suite names.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -77,7 +77,7 @@ if __name__ == "__main__":
 
     # to transform forward slashes '/' present in the argument into dots '.'
     for suite in args:
-        args[args.index(suite)] = suite.replace("/", ".")
+        args[args.index(suite)] = suite.rstrip('/').replace("/", ".")
 
     def rewrite_arguments(search_key):
         for file_name in os.listdir(zerver_test_dir):


### PR DESCRIPTION
Previously, running `tools/test-backend analytics/` (or any other test suite
name ending with a '/') would give a cryptic error about modules not
importing properly. This commit rstrip's the trailing slash from test suite
names given on the command line.