### PR TITLE
Fix casper tests in advance of actual upgrade.

### DIFF
--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -24,6 +24,11 @@ function log_in(credentials) {
     }, true /* submit form */);
 }
 
+
+exports.init_viewport = function () {
+    casper.options.viewportSize = {width: 1280, height: 1024};
+};
+
 exports.initialize_casper = function (viewport) {
     if (casper.zulip_initialized !== undefined) {
         return;
@@ -31,9 +36,6 @@ exports.initialize_casper = function (viewport) {
     casper.zulip_initialized = true;
     // These initialization steps will fail if they run before
     // casper.start has been called.
-
-    // Set default viewport size to something reasonable
-    casper.page.viewportSize = viewport || {width: 1280, height: 1024};
 
     // Fail if we get a JavaScript error in the page's context.
     // Based on the example at http://phantomjs.org/release-1.5.html
@@ -90,6 +92,7 @@ exports.start_and_log_in = function (credentials, viewport) {
     } else {
         log_in_url = "http://localhost:9981/accounts/login";
     }
+    exports.init_viewport();
     casper.start(log_in_url, function () {
         exports.initialize_casper(viewport);
         log_in(credentials);
@@ -97,11 +100,22 @@ exports.start_and_log_in = function (credentials, viewport) {
 };
 
 exports.then_log_out = function () {
-    casper.then(function () {
-        casper.test.info('Logging out');
-        casper.click('li[title="Log out"] a');
-    });
+    var menu_selector = '#settings-dropdown';
+    var logout_selector = 'li[title="Log out"] a';
 
+    casper.waitUntilVisible(menu_selector, function () {
+        casper.click(menu_selector);
+
+        casper.waitUntilVisible(logout_selector, function () {
+            casper.test.info('Logging out');
+            casper.click(logout_selector);
+
+            casper.then(function () {
+                casper.test.assertUrlMatch(/accounts\/login\/$/);
+            });
+        });
+
+    });
     casper.waitForSelector(".login-page-header", function () {
         casper.test.info("Logged out");
     });
@@ -166,6 +180,19 @@ exports.wait_for_message_actually_sent = function () {
     });
 };
 
+exports.turn_off_press_enter_to_send = function () {
+    var enter_send_selector = '#enter_sends';
+    casper.waitForSelector(enter_send_selector);
+
+    var is_checked = casper.evaluate(function (enter_send_selector) {
+        return document.querySelector(enter_send_selector).checked;
+    }, enter_send_selector);
+
+    if (is_checked) {
+        casper.click(enter_send_selector);
+    }
+};
+
 // Wait for any previous send to finish, then send a message.
 exports.then_send_message = function (type, params) {
     casper.then(function () {
@@ -182,7 +209,12 @@ exports.then_send_message = function (type, params) {
             casper.test.assertTrue(false, "send_message got valid message type");
         }
         casper.fill('form[action^="/json/messages"]', params);
-        casper.click('#compose-send-button');
+
+        exports.turn_off_press_enter_to_send();
+
+        casper.then(function () {
+            casper.click('#compose-send-button');
+        });
     });
 
     casper.then(function () {

--- a/frontend_tests/casper_tests/01-login.js
+++ b/frontend_tests/casper_tests/01-login.js
@@ -12,21 +12,12 @@ common.init_viewport();
 casper.start(realm_url, common.initialize_casper);
 
 casper.then(function () {
-    casper.test.assertHttpStatus(302);
     casper.test.assertUrlMatch(/^http:\/\/[^\/]+\/login/, 'Redirected to /login');
 });
 
 common.then_log_in();
 
-casper.waitForSelector('#zhome', function () {
-    casper.test.info('Logging out');
-    casper.click('li[title="Log out"] a');
-});
-
-casper.then(function () {
-    casper.test.assertHttpStatus(200);
-    casper.test.assertUrlMatch(/accounts\/login\/$/);
-});
+common.then_log_out();
 
 // Run the above queued actions.
 casper.run(function () {

--- a/frontend_tests/casper_tests/01-login.js
+++ b/frontend_tests/casper_tests/01-login.js
@@ -8,6 +8,7 @@ if (REALMS_HAVE_SUBDOMAINS) {
     realm_url = "http://localhost:9981/";
 }
 // Start of test script.
+common.init_viewport();
 casper.start(realm_url, common.initialize_casper);
 
 casper.then(function () {

--- a/frontend_tests/casper_tests/04-compose.js
+++ b/frontend_tests/casper_tests/04-compose.js
@@ -21,7 +21,7 @@ casper.waitForText("And reply to this message", function () {
 
 casper.then(function () {
     casper.waitUntilVisible('#compose', function () {
-        casper.test.assertVisible('#stream', 'Stream input box visible');
+        casper.test.assertVisible('#stream-message', 'Stream input box visible');
         common.check_form('#send_message_form', {stream: '', subject: ''}, "Stream empty on new compose");
         casper.click('body');
         casper.page.sendEvent('keypress', "C");
@@ -37,7 +37,7 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('#stream', function () {
+    casper.waitUntilVisible('#stream-message', function () {
         common.check_form('#send_message_form', {stream: '', subject: ''}, "Stream empty on new compose");
 
         // Check that when you reply to a message it pre-populates the stream and subject fields
@@ -46,13 +46,13 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitWhileVisible('#stream', function () {
+    casper.waitWhileVisible('#stream-message', function () {
         casper.clickLabel("We reply to this message");
     });
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('#stream', function () {
+    casper.waitUntilVisible('#stream-message', function () {
         common.check_form('#send_message_form', {stream: "Verona", subject: "Reply test"}, "Stream populated after reply by click");
         // Or recipient field
         casper.click('body');
@@ -71,7 +71,7 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('#stream', function () {
+    casper.waitUntilVisible('#stream-message', function () {
         common.check_form('#send_message_form', {stream: "Verona", subject: "Reply test"}, "Stream populated after reply with `r`");
 
         // Test "closing" the compose box
@@ -80,8 +80,8 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitWhileVisible('#stream', function () {
-        casper.test.assertNotVisible('#stream', 'Close stream compose box');
+    casper.waitWhileVisible('#stream-message', function () {
+        casper.test.assertNotVisible('#stream-message', 'Close stream compose box');
         casper.page.sendEvent('keypress', "C");
         casper.click('body');
     });
@@ -104,7 +104,7 @@ casper.waitUntilVisible('#tab_list li.private_message', function () {
 casper.then(function () {
     casper.waitUntilVisible('#compose', function () {
         casper.test.assertEval(function () {
-            return document.activeElement === $('#stream')[0];
+            return document.activeElement === $('.compose_table #stream')[0];
         }, 'Stream box focused after narrowing to PMs with a user and pressing `c`');
     });
 });

--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -3,13 +3,22 @@ var common = require('../casper_lib/common.js').common;
 common.start_and_log_in();
 
 casper.then(function () {
+    var menu_selector = '#settings-dropdown';
+
     casper.test.info('Subscriptions page');
-    casper.click('a[href^="#subscriptions"]');
-    casper.test.assertUrlMatch(/^http:\/\/[^\/]+\/#subscriptions/, 'URL suggests we are on subscriptions page');
-    casper.test.assertExists('#subscriptions.tab-pane.active', 'Subscriptions page is active');
-    // subscriptions need to load; if they have *any* subs,
-    // the word "Unsubscribe" will appear
+
+    casper.waitUntilVisible(menu_selector, function () {
+        casper.click(menu_selector);
+        casper.then(function () {
+            casper.click('a[href^="#subscriptions"]');
+            casper.test.assertUrlMatch(
+                /^http:\/\/[^\/]+\/#subscriptions/,
+                'URL suggests we are on subscriptions page');
+            casper.test.assertExists('#subscriptions.tab-pane.active', 'Subscriptions page is active');
+        });
+    });
 });
+
 casper.waitForSelector('.sub_unsub_button.subscribed-button', function () {
     casper.test.assertTextExists('Subscribed', 'Initial subscriptions loaded');
     casper.fill('form#add_new_subscription', {stream_name: 'Waseemio'});

--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -6,21 +6,28 @@ common.start_and_log_in();
 
 var form_sel = 'form[action^="/json/settings/change"]';
 
-casper.waitForSelector('a[href^="#settings"]', function () {
+casper.then(function () {
+    var menu_selector = '#settings-dropdown';
+    casper.waitUntilVisible(menu_selector, function () {
+        casper.click(menu_selector);
+    });
+});
+
+casper.waitUntilVisible('a[href^="#settings"]', function () {
     casper.test.info('Settings page');
     casper.click('a[href^="#settings"]');
 });
 
-casper.waitForSelector("#settings-change-box", function () {
+casper.waitUntilVisible("#settings-change-box", function () {
     casper.test.assertUrlMatch(/^http:\/\/[^\/]+\/#settings/, 'URL suggests we are on settings page');
     casper.test.assertExists('#settings.tab-pane.active', 'Settings page is active');
 
-    casper.test.assertNotVisible("#old_password");
+    casper.test.assertNotVisible("#pw_change_controls");
 
     casper.click(".change_password_button");
 });
 
-casper.waitUntilVisible("#old_password", function () {
+casper.waitUntilVisible("#pw_change_controls", function () {
     casper.waitForResource("zxcvbn.js", function () {
         casper.test.assertVisible("#old_password");
         casper.test.assertVisible("#new_password");
@@ -49,7 +56,7 @@ casper.waitUntilVisible('#get_api_key_password', function () {
     casper.click('input[name="view_api_key"]');
 });
 
-casper.waitUntilVisible('#api_key_value', function () {
+casper.waitUntilVisible('#show_api_key_box', function () {
     casper.test.assertMatch(casper.fetchText('#api_key_value'), /[a-zA-Z0-9]{32}/, "Looks like an API key");
 
     // Change it all back so the next test can still log in

--- a/frontend_tests/casper_tests/09-navigation.js
+++ b/frontend_tests/casper_tests/09-navigation.js
@@ -8,28 +8,61 @@ casper.then(function () {
     casper.test.info('Testing navigation');
 });
 
-function then_navigate_to(click_target, tab) {
-    casper.then(function () {
-        casper.test.info('Visiting #' + click_target);
-        casper.click('a[href^="#' + click_target + '"]');
-    });
-
+function wait_for_tab(tab) {
     casper.waitForSelector('#' + tab + '.tab-pane.active', function () {
         casper.test.assertExists('#' + tab + '.tab-pane.active', tab + ' page is active');
     });
 }
 
+function then_navigate_to(click_target, tab) {
+    casper.then(function () {
+        casper.test.info('Visiting #' + click_target);
+        casper.click('a[href^="#' + click_target + '"]');
+        wait_for_tab(tab);
+    });
+}
+
+function then_navigate_to_settings() {
+    casper.then(function () {
+        casper.test.info('Navigate to settings');
+        var menu_selector = '#settings-dropdown';
+        casper.waitUntilVisible(menu_selector, function () {
+            casper.click(menu_selector);
+            casper.waitUntilVisible('a[href^="#settings"]', function () {
+                casper.click('a[href^="#settings"]');
+                wait_for_tab('settings');
+            });
+        });
+    });
+}
+
+function then_navigate_to_subscriptions() {
+    casper.then(function () {
+        casper.test.info('Navigate to subscriptions');
+
+        var menu_selector = '#settings-dropdown';
+        casper.waitUntilVisible(menu_selector, function () {
+            casper.click(menu_selector);
+            casper.then(function () {
+                casper.click('a[href^="#subscriptions"]');
+                wait_for_tab('subscriptions');
+            });
+        });
+    });
+}
+
 // Take a navigation tour of the app.
 // Entries are (click target, tab that should be active after clicking).
-var tabs = [["settings", "settings"], ["home", "home"],
-            ["subscriptions", "subscriptions"], ["", "home"],
-            ["settings", "settings"], ["narrow/stream/Verona", "home"],
-            ["subscriptions", "subscriptions"], ["narrow/is/private", "home"]];
-var i;
 
-for (i=0; i<tabs.length; i++) {
-    then_navigate_to(tabs[i][0], tabs[i][1]);
-}
+then_navigate_to_settings();
+then_navigate_to('narrow/stream/Verona', 'home');
+then_navigate_to('home', 'home');
+then_navigate_to_subscriptions();
+then_navigate_to('', 'home');
+then_navigate_to_settings();
+then_navigate_to('narrow/stream/Verona', 'home');
+then_navigate_to_subscriptions();
+then_navigate_to('narrow/is/private', 'home');
 
 common.then_log_out();
 

--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -5,6 +5,13 @@ var stream_name = "Scotland";
 common.start_and_log_in();
 
 casper.then(function () {
+    var menu_selector = '#settings-dropdown';
+    casper.waitUntilVisible(menu_selector, function () {
+        casper.click(menu_selector);
+    });
+});
+
+casper.then(function () {
     casper.test.info('Administration page');
     casper.click('a[href^="#administration"]');
 });
@@ -230,21 +237,26 @@ casper.then(function () {
     casper.click('.global-filter[data-name="home"]');
 });
 
+// For clarity these should be different than what 08-edit uses, until
+// we find a more robust way to manage DB state between tests.
+var content1 = 'admin: edit test message 1';
+var content2 = 'admin: edit test message 2';
+
 // send two messages
 common.then_send_message('stream', {
     stream:  'Verona',
     subject: 'edits',
-    content: 'test editing 1'
+    content: content1
 });
 common.then_send_message('stream', {
     stream:  'Verona',
     subject: 'edits',
-    content: 'test editing 2'
+    content: content2
 });
 
 casper.then(function () {
-    casper.waitForText("test editing 1");
-    casper.waitForText("test editing 2");
+    casper.waitForText(content1);
+    casper.waitForText(content2);
 });
 
 // wait for message to be sent
@@ -263,18 +275,20 @@ casper.then(function () {
     });
 });
 
+var edited_value = 'admin tests: test edit';
+
 casper.waitForSelector(".message_edit_content", function () {
-    casper.evaluate(function () {
+    casper.evaluate(function (edited_value) {
         var msg = $('#zhome .message_row:last');
-        msg.find('.message_edit_content').val("test edited");
+        msg.find('.message_edit_content').val(edited_value);
         msg.find('.message_edit_save').click();
-    });
+    }, edited_value);
 });
 
 casper.then(function () {
     // check that the message was indeed edited
     casper.waitWhileVisible("textarea.message_edit_content", function () {
-        casper.test.assertSelectorHasText(".last_message .message_content", "test edited");
+        casper.test.assertSelectorHasText(".last_message .message_content", edited_value);
     });
 });
 

--- a/frontend_tests/casper_tests/11-mention.js
+++ b/frontend_tests/casper_tests/11-mention.js
@@ -22,6 +22,7 @@ casper.waitForText("Are you sure you want to message all", function () {
 });
 
 casper.then( function () {
+    common.turn_off_press_enter_to_send();
     casper.test.info('Click Send Button');
     casper.click('#compose-send-button');
 });
@@ -39,7 +40,7 @@ casper.waitForSelector('.compose-all-everyone-confirm', function () {
 casper.waitWhileVisible('.compose-all-everyone-confirm', function () {
     casper.test.info('Check that error messages are gone.');
     casper.test.assertNotVisible('.compose-all-everyone-msg');
-    casper.test.assertNotVisible('#error-msg');
+    casper.test.assertNotVisible('#send-status');
 });
 
 casper.then( function () {


### PR DESCRIPTION
see also #1921.  We want to merge the test changes first, so that we can minimize moving parts for the actual upgrade.  These should all work on the non-upgraded version of casper.

Once these get merged, I will try to clean up #1921 a bit.