### PR TITLE
provision.py: Don't create py2 venv in py3 mode.

### DIFF
--- a/tools/provision.py
+++ b/tools/provision.py
@@ -144,9 +144,6 @@ def main():
             DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py2_dev.txt")
             setup_virtualenv(PY2_VENV_PATH, DEV_REQS_FILE, patch_activate_script=True)
         else:
-            TWISTED_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "twisted.txt")
-            setup_virtualenv("/srv/zulip-py2-twisted-venv", TWISTED_REQS_FILE,
-                             patch_activate_script=True)
             DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "py3_dev.txt")
             setup_virtualenv(VENV_PATH, DEV_REQS_FILE, patch_activate_script=True,
                              virtualenv_args=['-p', 'python3'])


### PR DESCRIPTION
When running tools/provision.py in python3 mode, we used to create a python2 venv called zulip-py2-twisted-venv. This was needed because Zulip couldn't run tools/run-dev.py in python3. So we switched to
this virtualenv when running tools/run-dev.py.

Now that Zulip can run tools/run-dev.py in python3, we don't need to create this virtualenv anymore.