### PR TITLE
Display images preceded by exclamation Fixes #387

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -979,7 +979,7 @@ class Bugdown(markdown.Extension):
             u'(?<!\\w)(?P<syntax>[\U0001F300-\U0001F64F\U0001F680-\U0001F6FF\u2600-\u26FF\u2700-\u27BF])(?!\\w)'),
             '_end')
 
-        md.inlinePatterns.add('link', AtomicLinkPattern(markdown.inlinepatterns.LINK_RE[len(markdown.inlinepatterns.NOIMG):], 
+        md.inlinePatterns.add('link', AtomicLinkPattern(markdown.inlinepatterns.LINK_RE[len(markdown.inlinepatterns.NOIMG):],
             md), '>backtick')
 
         for (pattern, format_string) in self.getConfig("realm_filters"):

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -979,7 +979,8 @@ class Bugdown(markdown.Extension):
             u'(?<!\\w)(?P<syntax>[\U0001F300-\U0001F64F\U0001F680-\U0001F6FF\u2600-\u26FF\u2700-\u27BF])(?!\\w)'),
             '_end')
 
-        md.inlinePatterns.add('link', AtomicLinkPattern(markdown.inlinepatterns.LINK_RE, md), '>backtick')
+        md.inlinePatterns.add('link', AtomicLinkPattern(markdown.inlinepatterns.LINK_RE[len(markdown.inlinepatterns.NOIMG):], 
+            md), '>backtick')
 
         for (pattern, format_string) in self.getConfig("realm_filters"):
             md.inlinePatterns.add('realm_filters/%s' % (pattern,),


### PR DESCRIPTION
I have made the necessary changes in the code to resolve the bug. The image link is now displayed even when immediately preceded by an exclamation. 
