### PR TITLE
Make translator friendly

### DIFF
--- a/static/js/custom_markdown.js
+++ b/static/js/custom_markdown.js
@@ -45,13 +45,13 @@ var exports = {};
     }
 
     function display_subscribe($button, stream_name) {
-        $button.text(i18n.t('Subscribe to') + ' ' + stream_data.canonicalized_name(stream_name))
+        $button.text(i18n.t('Subscribe to __stream__', {'stream': stream_data.canonicalized_name(stream_name)}))
             .removeClass('btn-success')
             .addClass('btn-default');
     }
 
     function display_unsubscribe($button, stream_name) {
-        $button.text(i18n.t('Unsubscribe from') + ' ' + stream_data.canonicalized_name(stream_name))
+        $button.text(i18n.t('Unsubscribe from __stream__', {'stream': stream_data.canonicalized_name(stream_name)}))
             .removeClass('btn-default')
             .addClass('btn-success');
     }


### PR DESCRIPTION
Some languages such as Japanese use different word order with
English. If the stream name must be the last word, translating to these
languages is difficult.