### PR TITLE
templates: Use trans tag for translators.

### DIFF
--- a/templates/zerver/accounts_accept_terms.html
+++ b/templates/zerver/accounts_accept_terms.html
@@ -39,7 +39,7 @@ the registration flow has its own (nearly identical) copy of the fields below in
                 #}
                 <input id="id_terms" class="required" type="checkbox" name="terms"
                        {% if form.terms.value() %}checked="checked"{% endif %} />
-                {{ _("I agree to the") }} <a href="{{ server_uri }}/terms">{{ _("Terms of Service") }}</a>.
+                {% trans %}I agree to the <a href="{{ server_uri }}/terms">Terms of Service</a>{% endtrans %}.
             </label>
             {% if form.terms.errors %}
                 {% for error in form.terms.errors %}


### PR DESCRIPTION
It's based on "Backend Translations" policy:
https://zulip.readthedocs.io/en/latest/translating.html#backend-translations