### PR TITLE
install, puppet: Handle RabbitMQ node name changes

### DIFF
--- a/puppet/zulip/manifests/rabbit.pp
+++ b/puppet/zulip/manifests/rabbit.pp
@@ -44,7 +44,7 @@ class zulip::rabbit {
   if $rabbitmq_nodename != "" {
     file { "/etc/rabbitmq/rabbitmq-env.conf":
       require => Package[rabbitmq-server],
-      before => Service[rabbitmq-server],
+      notify => Service[rabbitmq-server],
       ensure => file,
       owner  => "root",
       group  => "root",

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -30,7 +30,7 @@ fi
 mkdir -p /etc/zulip
 (
     echo -e "[machine]\npuppet_classes = $PUPPET_CLASSES\ndeploy_type = $DEPLOYMENT_TYPE";
-    if [ -n "$TRAVIS" ]; then
+    if [ -n "$TRAVIS" ] || [ -z "$(pgrep -f rabbitmq-server)" ]; then
         echo -e "\n[rabbitmq]\nnodename = zulip@localhost"
     fi
 ) > /etc/zulip/zulip.conf


### PR DESCRIPTION
Change the configured node name only when there are no running RabbitMQ processes. Also in case of a node name change restart the RabbitMQ service after the fact, since by that time RabbitMQ would have been installed and started.
