### PR TITLE
irc-mirror.py : updated the installation link

### DIFF
--- a/bots/irc-mirror.py
+++ b/bots/irc-mirror.py
@@ -4,7 +4,7 @@
 # IRC <=> Zulip mirroring bot
 #
 # Setup: First, you need to install python-irc version 8.5.3
-# (https://bitbucket.org/jaraco/irc)
+# (https://github.com/jaraco/irc)
 
 from __future__ import print_function
 import irc.bot


### PR DESCRIPTION
The link to download python-irc module now lives at github instead of bitbucket.