### PR TITLE
requirements: Install the Zulip API bindings by default.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,3 +17,7 @@ transifex-client==0.12.2
 
 # Dependency of transifex-client
 urllib3==1.16
+
+# Install the Zulip API bindings into the virtualenv in edit mode, so
+# that we're always running the latest version in git.
+-e api/


### PR DESCRIPTION
Fixes: #1957.