### PR TITLE
invalid_realm: Add period to message for translators.

### DIFF
--- a/templates/zerver/invalid_realm.html
+++ b/templates/zerver/invalid_realm.html
@@ -3,7 +3,7 @@
 
 <h3>{{ _('Organization Does Not Exist') }}</h3>
 
-<p>{{ _('Hi there! Thank you for your interest in Zulip') }}.</p>
-<p>{% trans %}There is no Zulip organization hosted at this subdomain{% endtrans %}.</p>
+<p>{{ _('Hi there! Thank you for your interest in Zulip.') }}</p>
+<p>{% trans %}There is no Zulip organization hosted at this subdomain.{% endtrans %}</p>
 
 {% endblock %}


### PR DESCRIPTION
Period may be different with languages. For example, "U+3002 IDEOGRAPHIC
FULL STOP" is used in Japanese.