### PR TITLE
Minor Lightbox Style Fixes.

### DIFF
--- a/static/styles/overlay.css
+++ b/static/styles/overlay.css
@@ -26,7 +26,7 @@
 
 #overlay .image-preview {
     position: relative;
-    width: calc(100% - 20px);
+    width: 100%;
     height: calc(100% - 65px - 30px);
     margin: 0px;
 
@@ -43,7 +43,7 @@
     color: rgba(255,255,255,0.8);
     font-size: 2rem;
     font-weight: 200;
-    margin: 22px 20px;
+    margin: 24px 20px 0px 0px;
 
     transform: scaleY(0.75);
     font-weight: 300;

--- a/static/styles/overlay.css
+++ b/static/styles/overlay.css
@@ -145,3 +145,13 @@
 #overlay .clear-float {
     clear: both;
 }
+
+@media (max-width: 450px) {
+    #overlay .image-actions {
+        display: none;
+    }
+
+    #overlay .image-description {
+        width: calc(100% - 100px);
+    }
+}


### PR DESCRIPTION
This fixes two things:

1. The image-preview width should not any longer be (100% - 20px), it
should just be 100% to be centered.

2. The .exit button was not totally vertically centered nor
horizontally centered between the edge of the page and the nearest
button. This fixes both issues.