### PR TITLE
casper: Remove then_log_out flakiness and sleep.

### DIFF
--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -110,13 +110,11 @@ exports.then_log_out = function () {
             casper.test.info('Logging out');
             casper.click(logout_selector);
 
-            casper.then(function () {
-                casper.test.assertUrlMatch(/accounts\/login\/$/);
-            });
         });
 
     });
-    casper.waitForSelector(".login-page-header", function () {
+    casper.waitUntilVisible(".login-page-header", function () {
+        casper.test.assertUrlMatch(/accounts\/login\/$/);
         casper.test.info("Logged out");
     });
 };

--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -117,7 +117,6 @@ def run_tests(realms_have_subdomains, files):
             ret = subprocess.call(cmd, shell=True)
             if ret != 0:
                 break
-            time.sleep(0.3) # give a little breathing room for cleanup
     finally:
         assert_server_running(server)
         server.terminate()


### PR DESCRIPTION
We were getting flakes from then_log_out() due to it
making an assert too early.  With this race condition removed,
I can run without the 0.3 sleep.