### PR TITLE
Encode the stream name before sending the request

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -1091,6 +1091,8 @@ $(function () {
 
         var $sub_row = $(e.target).closest('.subscription_row');
         var stream_name = $sub_row.find('.subscription_name').text();
+        // Stream name might contain unsafe characters so we must encode it first.
+        stream_name = encodeURIComponent(stream_name);
         var description = $sub_row.find('input[name="description"]').val();
 
         $('#subscriptions-status').hide();


### PR DESCRIPTION
The API uses this endpoint /json/streams/<stream_name> to update
stream information such as description, since the stream_name is
part of the URI it should be encoded to escape unsafe characters.