### PR TITLE
Do not close message compose box on drag.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -288,10 +288,7 @@ $(function () {
 
     function handle_compose_click(e) {
         // Emoji clicks should be handled by their own click handler in popover.js
-        if ($(e.target).is("#emoji_map") ||
-            $(e.target).is(".emoji_popover") ||
-            $(e.target).is(".emoji_popover.inner") ||
-            $(e.target).is("img.emoji")) {
+        if ($(e.target).is("#emoji_map, .emoji_popover, .emoji_popover.inner, img.emoji, .drag")) {
             return;
         }
         // Don't let clicks in the compose area count as

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -424,7 +424,7 @@ $(function () {
     // MAIN CLICK HANDLER
 
     $(document).on('click', function (e) {
-        if (e.button !== 0) {
+        if (e.button !== 0 || $(e.target).is(".drag")) {
             // Firefox emits right click events on the document, but not on
             // the child nodes, so the #compose stopPropagation doesn't get a
             // chance to capture right clicks.
@@ -438,7 +438,7 @@ $(function () {
 
         // Unfocus our compose area if we click out of it. Don't let exits out
         // of modals or selecting text (for copy+paste) trigger cancelling.
-        if (compose.composing() && !$(e.target).is("a, .drag") &&
+        if (compose.composing() && !$(e.target).is("a") &&
             ($(e.target).closest(".modal").length === 0) &&
             window.getSelection().toString() === "" &&
             ($(e.target).closest('#emoji_map').length === 0)) {


### PR DESCRIPTION
On the drag to resize emoji box action, do not close the message compose box.

This also makes the height 140px of the emoji box rather than 60px before.
