### PR TITLE
Fix overflow of text on Zocial buttons

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -733,7 +733,8 @@ a.bottom-signup-button {
 }
 
 .login-google, .register-google, .login-sso, .login-github {
-    width: 300px;
+    max-width: 100%;
+    min-width: 300px;
     margin: auto;
     text-align: center;
     margin-top: 30px;

--- a/static/third/zocial/zocial.css
+++ b/static/third/zocial/zocial.css
@@ -36,7 +36,7 @@ a.zocial {
 	user-select: none;
 	
 	position: relative;
-	
+	display: inline-flex;
 	-moz-border-radius: .3em;
 	-webkit-border-radius: .3em;
 	border-radius: .3em;


### PR DESCRIPTION
This is a patch for issue #1876 where by a few lines of code has been added to make sure text of different languages fall within the button. 