### PR TITLE
api: fix broken link to zulip-js github page

### DIFF
--- a/templates/zerver/api.html
+++ b/templates/zerver/api.html
@@ -5,7 +5,7 @@
 {% block portico_content %}
     <h1 class="api-page-header">We hear you like APIs...</h1>
 
-    <p>We have a <a href="/api/endpoints">well-documented API</a> that allows you to build custom integrations, in addition to our <a href="/integrations">existing integrations</a>. For ease-of-use, we've created a Python module that you can drop in to a project to start interacting with our API. There is also a <a href="github.com/zulip/zulip-js">Javascript library</a> that can be used either in the browser or in Node.js.</p>
+    <p>We have a <a href="/api/endpoints">well-documented API</a> that allows you to build custom integrations, in addition to our <a href="/integrations">existing integrations</a>. For ease-of-use, we've created a Python module that you can drop in to a project to start interacting with our API. There is also a <a href="https://github.com/zulip/zulip-js">Javascript library</a> that can be used either in the browser or in Node.js.</p>
 
     <p><strong>Don't want to make it yourself?</strong> Zulip <a href="/integrations">already integrates with lots of services</a>.</p>
 


### PR DESCRIPTION
In the `https://zulip.tabbott.net/api/` page we have a link to zulip-js github page, this link missed `https://` at its beginning< I added it to fix the error.