### PR TITLE
lint: Improve documentation lint check for JavaScript capitalization.

### DIFF
--- a/templates/zerver/api.html
+++ b/templates/zerver/api.html
@@ -5,7 +5,7 @@
 {% block portico_content %}
     <h1 class="api-page-header">We hear you like APIs...</h1>
 
-    <p>We have a <a href="/api/endpoints">well-documented API</a> that allows you to build custom integrations, in addition to our <a href="/integrations">existing integrations</a>. For ease-of-use, we've created a Python module that you can drop in to a project to start interacting with our API. There is also a <a href="https://github.com/zulip/zulip-js">Javascript library</a> that can be used either in the browser or in Node.js.</p>
+    <p>We have a <a href="/api/endpoints">well-documented API</a> that allows you to build custom integrations, in addition to our <a href="/integrations">existing integrations</a>. For ease-of-use, we've created a Python module that you can drop in to a project to start interacting with our API. There is also a <a href="https://github.com/zulip/zulip-js">JavaScript library</a> that can be used either in the browser or in Node.js.</p>
 
     <p><strong>Don't want to make it yourself?</strong> Zulip <a href="/integrations">already integrates with lots of services</a>.</p>
 
@@ -26,7 +26,7 @@
       <li><tt>requests</tt> (0.12.1 or later)</li>
     </ul>
     <p>&nbsp;</p>
-    <h4>Javascript</h4>
+    <h4>JavaScript</h4>
     <p>Install it with <a href="https://www.npmjs.com/package/zulip-js">npm</a>:</p>
     <pre><code>npm install zulip-js</code></pre>
 
@@ -36,7 +36,7 @@
       <li class="active"><a href="#curl" data-toggle="tab">curl</a></li>
       <li><a href="#python" data-toggle="tab">Python</a></li>
       <li><a href="#commandline" data-toggle="tab">zulip-send</a></li>
-      <li><a href="#javascript" data-toggle="tab">Javascript</a></li>
+      <li><a href="#javascript" data-toggle="tab">JavaScript</a></li>
     </ul>
 
     <div class="tab-content">

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -330,7 +330,9 @@ def build_custom_checkers(by_lang):
         {'pattern': "placeholder='[^{]",
          'description': "`placeholder` value should be translatable."},
         ] # type: RuleList
-    json_rules = [] # type: RuleList # just fix newlines at ends of files
+    json_rules = [] # type: RuleList # fix newlines at ends of files
+    # It is okay that json_rules is empty, because the empty list
+    # ensures we'll still check JSON files for whitespace.
     markdown_rules = markdown_whitespace_rules + prose_style_rules
     txt_rules = whitespace_rules
 

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -320,18 +320,18 @@ def build_custom_checkers(by_lang):
          'description': "Missing whitespace after '{' in CSS (should be newline)."},
         ]) + whitespace_rules # type: RuleList
     handlebars_rules = whitespace_rules
-    html_rules = whitespace_rules + [
+    prose_style_rules = [
+        {'pattern': '[^\/\#\-\"]([jJ]avascript)', # exclude usage in hrefs/divs
+         'description': "javascript should be spelled JavaScript"},
+    ] # type: RuleList
+    html_rules = whitespace_rules + prose_style_rules + [
         {'pattern': 'placeholder="[^{]',
          'description': "`placeholder` value should be translatable."},
         {'pattern': "placeholder='[^{]",
          'description': "`placeholder` value should be translatable."},
         ] # type: RuleList
     json_rules = [] # type: RuleList # just fix newlines at ends of files
-    markdown_rules = markdown_whitespace_rules + [
-        {'pattern': ' [jJ]avascript',
-         'exclude': set(['README.dev.md']), # temporary exclusion to avoid merge conflicts
-         'description': "javascript should be spelled JavaScript"},
-    ] # type: RuleList
+    markdown_rules = markdown_whitespace_rules + prose_style_rules
     txt_rules = whitespace_rules
 
     def check_custom_checks_py():


### PR DESCRIPTION
Move JavaScript capitalization rule to new ruleset for HTML and
Markdown checkers to run, and add exclusion to avoid catching
URLs and divs/hrefs. Also fix affected HTML pages, remove
now-obsolete exclusion for doc that no longer exists, and clarify
comment on empty JSON ruleset to explain that it's catching
whitespace.

For exhaustive thought-process on this change see:
https://zulip.tabbott.net/#narrow/stream/test.20suites/topic/watch.20over.20my.20shoulder.20as.20I.20improve.20the.20linter