### PR TITLE
Remove data logic from subs.js.

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -1,7 +1,8 @@
 global.stub_out_jquery();
 
 add_dependencies({
-    stream_color: 'js/stream_color.js'
+    stream_color: 'js/stream_color.js',
+    util: 'js/util.js'
 });
 
 set_global('blueslip', {});
@@ -186,4 +187,38 @@ var stream_data = require('js/stream_data.js');
     assert(sub.is_admin);
     assert(sub.can_make_public);
     assert(!sub.can_make_private);
+}());
+
+(function test_stream_settings() {
+    var cinnamon = {
+        stream_id: 1,
+        name: 'c',
+        color: 'cinnamon',
+        subscribed: true
+    };
+
+    var blue = {
+        stream_id: 2,
+        name: 'b',
+        color: 'blue',
+        subscribed: false
+    };
+
+    var amber = {
+        stream_id: 3,
+        name: 'a',
+        color: 'amber',
+        subscribed: true
+    };
+    var public_streams = {streams: [cinnamon, blue, amber]};
+    stream_data.clear_subscriptions();
+    stream_data.add_sub(cinnamon.name, cinnamon);
+    stream_data.add_sub(amber.name, amber);
+    // we don't know about "blue"
+
+    var sub_rows = stream_data.get_streams_for_settings_page(public_streams);
+    assert.equal(sub_rows[0].color, 'amber');
+    assert.equal(sub_rows[1].color, 'cinnamon');
+    assert.equal(sub_rows[2].color, 'blue');
+
 }());

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -76,8 +76,8 @@ global.use_template('stream_privacy');
 }());
 
 
-(function test_add_stream_to_sidebar() {
-    // Make a couple calls to add_stream_to_sidebar() and make sure they
+(function test_create_sidebar_row() {
+    // Make a couple calls to create_sidebar_row() and make sure they
     // generate the right markup as well as play nice with get_stream_li().
 
     var stream_filters = $('<ul id="stream_filters">');
@@ -85,27 +85,27 @@ global.use_template('stream_privacy');
 
     var stream = "devel";
 
-    var sub = {
+    var devel = {
         name: 'devel',
         stream_id: 1000,
         color: 'blue',
         id: 5
     };
-    global.stream_data.add_sub('devel', sub);
+    global.stream_data.add_sub('devel', devel);
 
-    sub = {
+    var social = {
         name: 'social',
         stream_id: 2000,
         color: 'green',
         id: 6
     };
-    global.stream_data.add_sub('social', sub);
+    global.stream_data.add_sub('social', social);
 
-    stream_list.add_stream_to_sidebar('devel');
-    stream_list.add_stream_to_sidebar('social');
+    stream_list.create_sidebar_row(devel);
+    stream_list.create_sidebar_row(social);
 
     var html = $("body").html();
-    global.write_test_output("test_add_stream_to_sidebar", html);
+    global.write_test_output("test_create_sidebar_row", html);
 
     var li = stream_list.get_stream_li('social');
     assert.equal(li.attr('data-name'), 'social');
@@ -138,9 +138,9 @@ global.use_template('stream_privacy');
         color: 'blue',
         id: 5,
         pin_to_top: false,
-        subscribed: true,
-        sidebar_li: stream_list.add_stream_to_sidebar('devel')
+        subscribed: true
     };
+    stream_list.create_sidebar_row(develSub);
     global.stream_data.add_sub('devel', develSub);
 
     var socialSub = {
@@ -149,9 +149,9 @@ global.use_template('stream_privacy');
         color: 'green',
         id: 6,
         pin_to_top: true,
-        subscribed: true,
-        sidebar_li: stream_list.add_stream_to_sidebar('social')
+        subscribed: true
     };
+    stream_list.create_sidebar_row(socialSub);
     global.stream_data.add_sub('social', socialSub);
     stream_list.build_stream_list();
     assert.equal(socialSub.sidebar_li.nextAll().find('[ data-name="devel"]').length, 1);

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -400,7 +400,7 @@ function should_send_desktop_notification(message) {
     // For streams, send if desktop notifications are enabled for this
     // stream.
     if ((message.type === "stream") &&
-        subs.receives_desktop_notifications(message.stream)) {
+        stream_data.receives_desktop_notifications(message.stream)) {
         return true;
     }
 
@@ -429,7 +429,7 @@ function should_send_desktop_notification(message) {
 function should_send_audible_notification(message) {
     // For streams, ding if sounds are enabled for this stream.
     if ((message.type === "stream") &&
-        subs.receives_audible_notifications(message.stream)) {
+        stream_data.receives_audible_notifications(message.stream)) {
         return true;
     }
 

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -193,6 +193,22 @@ exports.create_sub_from_server_data = function (stream_name, attrs) {
     return sub;
 };
 
+exports.receives_desktop_notifications = function (stream_name) {
+    var sub = exports.get_sub(stream_name);
+    if (sub === undefined) {
+        return false;
+    }
+    return sub.desktop_notifications;
+};
+
+exports.receives_audible_notifications = function (stream_name) {
+    var sub = exports.get_sub(stream_name);
+    if (sub === undefined) {
+        return false;
+    }
+    return sub.audible_notifications;
+};
+
 return exports;
 
 }());

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -209,6 +209,15 @@ exports.receives_audible_notifications = function (stream_name) {
     return sub.audible_notifications;
 };
 
+exports.add_admin_options = function (sub) {
+    return _.extend(sub, {
+        'is_admin': page_params.is_admin,
+        'can_make_public': page_params.is_admin && sub.invite_only && sub.subscribed,
+        'can_make_private': page_params.is_admin && !sub.invite_only
+    });
+};
+
+
 return exports;
 
 }());

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -263,6 +263,34 @@ exports.get_streams_for_settings_page = function (public_streams) {
     return sub_rows;
 };
 
+exports.initialize_from_page_params = function () {
+    function populate_subscriptions(subs, subscribed) {
+        subs.forEach(function (sub) {
+            var stream_name = sub.name;
+            sub.subscribed = subscribed;
+
+            // When we get subscriber lists from the back end,
+            // they are sent as user ids to save bandwidth,
+            // but the legacy JS code wants emails.
+            if (sub.subscribers) {
+                sub.subscribers = _.map(sub.subscribers, function (subscription) {
+                    return page_params.email_dict[subscription];
+                });
+            }
+            exports.create_sub_from_server_data(stream_name, sub);
+        });
+    }
+
+    populate_subscriptions(page_params.subbed_info, true);
+    populate_subscriptions(page_params.unsubbed_info, false);
+
+    // Garbage collect data structures that were only used for initialization.
+    delete page_params.subbed_info;
+    delete page_params.unsubbed_info;
+    delete page_params.email_dict;
+};
+
+
 return exports;
 
 }());

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -247,12 +247,17 @@ function build_stream_sidebar_row(name) {
     return list_item;
 }
 
-exports.add_stream_to_sidebar = function (stream_name) {
+exports.create_sidebar_row = function (sub) {
+    var stream_name = sub.name;
+
     if (exports.get_stream_li(stream_name).length) {
         // already exists
-        return false;
+        return;
     }
-    return build_stream_sidebar_row(stream_name);
+    var li = build_stream_sidebar_row(stream_name);
+    if (li) {
+        sub.sidebar_li = li;
+    }
 };
 
 exports.redraw_stream_privacy = function (stream_name) {
@@ -645,20 +650,12 @@ $(function () {
 
     $(document).on('sub_obj_created.zulip', function (event) {
         if (event.sub.subscribed) {
-            var stream_name = event.sub.name;
-            var li = exports.add_stream_to_sidebar(stream_name);
-            if (li) {
-                event.sub.sidebar_li = li;
-            }
+            exports.create_sidebar_row(event.sub);
         }
     });
 
     $(document).on('subscription_add_done.zulip', function (event) {
-        var stream_name = event.sub.name;
-        var li = exports.add_stream_to_sidebar(stream_name);
-        if (li) {
-            event.sub.sidebar_li = li;
-        }
+        exports.create_sidebar_row(event.sub);
         exports.build_stream_list();
     });
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -46,7 +46,22 @@ function filter_streams_by_search(streams) {
     return filtered_streams;
 }
 
+exports.create_initial_sidebar_rows = function () {
+    // This code is slightly opaque, but it ends up building
+    // up list items and attaching them to the "sub" data
+    // structures that are kept in stream_data.js.
+    var subs = stream_data.subscribed_subs();
+
+    _.each(subs, function (sub) {
+        exports.create_sidebar_row(sub);
+    });
+};
+
 exports.build_stream_list = function () {
+    // This function assumes we have already created the individual
+    // sidebar rows.  Our job here is to build the bigger widget,
+    // which largely is a matter of arranging the individual rows in
+    // the right order.
     var streams = stream_data.subscribed_streams();
     if (streams.length === 0) {
         return;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -381,22 +381,6 @@ exports.pin_or_unpin_stream = function (stream_name) {
     }
 };
 
-exports.receives_desktop_notifications = function (stream_name) {
-    var sub = stream_data.get_sub(stream_name);
-    if (sub === undefined) {
-        return false;
-    }
-    return sub.desktop_notifications;
-};
-
-exports.receives_audible_notifications = function (stream_name) {
-    var sub = stream_data.get_sub(stream_name);
-    if (sub === undefined) {
-        return false;
-    }
-    return sub.audible_notifications;
-};
-
 function populate_subscriptions(subs, subscribed) {
     var sub_rows = [];
     subs.sort(function (a, b) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -449,45 +449,7 @@ exports.setup_page = function () {
 
     function _populate_and_fill(public_streams) {
 
-        // Build up our list of subscribed streams from the data we already have.
-        var subscribed_rows = stream_data.subscribed_subs();
-
-        // To avoid dups, build a set of names we already subscribed to.
-        var subscribed_set = new Dict({fold_case: true});
-        _.each(subscribed_rows, function (sub) {
-            subscribed_set.set(sub.name, true);
-        });
-
-        // Right now the back end gives us all public streams; we really only
-        // need to add the ones we haven't already subscribed to.
-        var unsubscribed_streams = _.reject(public_streams.streams, function (stream) {
-            return subscribed_set.has(stream.name);
-        });
-
-        // Build up our list of unsubscribed rows.
-        var unsubscribed_rows = [];
-        _.each(unsubscribed_streams, function (stream) {
-            var sub = stream_data.get_sub(stream.name);
-            if (!sub) {
-                sub = create_sub(stream.name, _.extend({subscribed: false}, stream));
-            }
-            unsubscribed_rows.push(sub);
-        });
-
-        // Sort and combine all our streams.
-        function by_name(a,b) {
-            return util.strcmp(a.name, b.name);
-        }
-        subscribed_rows.sort(by_name);
-        unsubscribed_rows.sort(by_name);
-        var all_subs = subscribed_rows.concat(unsubscribed_rows);
-
-        // Add in admin options.
-        var sub_rows = [];
-        _.each(all_subs, function (sub) {
-            sub = stream_data.add_admin_options(sub);
-            sub_rows.push(sub);
-        });
+        var sub_rows = stream_data.get_streams_for_settings_page(public_streams);
 
         $('#subscriptions_table').empty();
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -373,29 +373,6 @@ exports.pin_or_unpin_stream = function (stream_name) {
     }
 };
 
-function populate_subscriptions(subs, subscribed) {
-    var sub_rows = [];
-    subs.sort(function (a, b) {
-        return util.strcmp(a.name, b.name);
-    });
-    subs.forEach(function (elem) {
-        var stream_name = elem.name;
-        var sub = create_sub(stream_name, {color: elem.color, in_home_view: elem.in_home_view,
-                                           invite_only: elem.invite_only,
-                                           desktop_notifications: elem.desktop_notifications,
-                                           audible_notifications: elem.audible_notifications,
-                                           pin_to_top: elem.pin_to_top,
-                                           subscribed: subscribed,
-                                           email_address: elem.email_address,
-                                           stream_id: elem.stream_id,
-                                           subscribers: elem.subscribers,
-                                           description: elem.description});
-        sub_rows.push(sub);
-    });
-
-    return sub_rows;
-}
-
 exports.filter_table = function (query) {
     var sub_name_elements = $('#subscriptions_table .subscription_name');
 
@@ -663,31 +640,11 @@ exports.remove_user_from_stream = function (user_email, stream_name, success, fa
     });
 };
 
-function inline_emails_into_subscriber_list(subs, email_dict) {
-    // When we get subscriber lists from the back end, they are sent as user ids to
-    // save bandwidth, but the legacy JS code wants emails.
-    _.each(subs, function (sub) {
-        if (sub.subscribers) {
-            sub.subscribers = _.map(sub.subscribers, function (subscription) {
-                return email_dict[subscription];
-            });
-        }
-    });
-}
-
 $(function () {
     var i;
 
-    inline_emails_into_subscriber_list(page_params.subbed_info, page_params.email_dict);
-    inline_emails_into_subscriber_list(page_params.unsubbed_info, page_params.email_dict);
-
-    // Populate stream_info with data handed over to client-side template.
-    populate_subscriptions(page_params.subbed_info, true);
-    populate_subscriptions(page_params.unsubbed_info, false);
-
-    // Garbage collect data structures that were only used for initialization.
-    delete page_params.subbed_info;
-    delete page_params.unsubbed_info;
+    stream_data.initialize_from_page_params();
+    stream_list.create_initial_sidebar_rows();
 
     // We build the stream_list now.  It may get re-built again very shortly
     // when new messages come in, but it's fairly quick.

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -36,15 +36,6 @@ function should_list_all_streams() {
     return !page_params.is_zephyr_mirror_realm;
 }
 
-exports.stream_id = function (stream_name) {
-    var sub = stream_data.get_sub(stream_name);
-    if (sub === undefined) {
-        blueslip.error("Tried to get subs.stream_id for a stream user is not subscribed to!");
-        return 0;
-    }
-    return parseInt(sub.stream_id, 10);
-};
-
 function set_stream_property(stream_name, property, value) {
     var sub_data = {stream: stream_name, property: property, value: value};
     return channel.post({

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -2,14 +2,6 @@ var subs = (function () {
 
 var exports = {};
 
-function add_admin_options(sub) {
-    return _.extend(sub, {
-        'is_admin': page_params.is_admin,
-        'can_make_public': page_params.is_admin && sub.invite_only && stream_data.is_subscribed(sub.name),
-        'can_make_private': page_params.is_admin && !sub.invite_only
-    });
-}
-
 function get_color() {
     var used_colors = stream_data.get_colors();
     var color = stream_color.pick_color(used_colors);
@@ -255,7 +247,7 @@ function add_email_hint(row, email_address_hint_content) {
 }
 
 function add_sub_to_table(sub) {
-    sub = add_admin_options(sub);
+    sub = stream_data.add_admin_options(sub);
     var html = templates.render('subscription', sub);
     $('#create_or_filter_stream_row').after(html);
     settings_for_sub(sub).collapse('show');
@@ -493,7 +485,7 @@ exports.setup_page = function () {
         // Add in admin options.
         var sub_rows = [];
         _.each(all_subs, function (sub) {
-            sub = add_admin_options(sub);
+            sub = stream_data.add_admin_options(sub);
             sub_rows.push(sub);
         });
 
@@ -1125,7 +1117,7 @@ $(function () {
     function redraw_privacy_related_stuff(sub_row, sub) {
         var html;
 
-        sub = add_admin_options(sub);
+        sub = stream_data.add_admin_options(sub);
 
         html = templates.render('subscription_setting_icon', sub);
         sub_row.find('.subscription-setting-icon').expectOne().html(html);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -381,14 +381,6 @@ exports.pin_or_unpin_stream = function (stream_name) {
     }
 };
 
-exports.sub_pinned_or_unpinned = function (stream_name) {
-    var sub = stream_data.get_sub(stream_name);
-    if (stream_name === undefined) {
-        return;
-    }
-    return sub.pin_to_top;
-};
-
 exports.receives_desktop_notifications = function (stream_name) {
     var sub = stream_data.get_sub(stream_name);
     if (sub === undefined) {


### PR DESCRIPTION
This series of commits removes most of the data-specific logic from subs.js, so that it's now mostly just orchestrating UI stuff, which is a big enough job for it.  There are a few tiny exceptions where I could probably have extracted 2 or 3 lines to stream_data.js, but I didn't bother with them.  I believe now the only data-centric heavy lifting done by subs.js is firing off and handling various Ajax calls.  I don't want stream_data.js to be in the business of doing Ajax (at least not without thinking about it some more), but I do think we want to consider pulling that logic out of subs.js somehow.