### PR TITLE
cache_flush: Add app to clear cache with post_migration signal.

### DIFF
--- a/zerver/__init__.py
+++ b/zerver/__init__.py
@@ -1,0 +1,2 @@
+# Load AppConfig app subclass by default on django applications initialization
+default_app_config = 'zerver.apps.ZerverConfig'

--- a/zerver/apps.py
+++ b/zerver/apps.py
@@ -1,0 +1,22 @@
+from __future__ import print_function
+
+from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+from django.core.cache import cache
+from django.conf import settings
+from typing import Any, Dict
+
+
+def flush_cache(sender, **kwargs):
+    # type: (AppConfig, **Any) -> None
+    cache.clear()
+    print("Clear cache")
+
+
+class ZerverConfig(AppConfig):
+    name = "zerver"  # type: str
+
+    def ready(self):
+        # type: () -> None
+        if settings.POST_MIGRATION_CACHE_FLUSHING:
+            post_migrate.connect(flush_cache, sender=self)

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -32,3 +32,5 @@ SAVE_FRONTEND_STACKTRACES = True
 EVENT_LOGS_ENABLED = True
 SYSTEM_ONLY_REALMS = set() # type: Set[str]
 USING_PGROONGA = True
+# Flush cache after migration.
+POST_MIGRATION_CACHE_FLUSHING = True  # type: bool

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -178,6 +178,7 @@ DEFAULT_SETTINGS = {'TWITTER_CONSUMER_KEY': '',
                     'SYSTEM_ONLY_REALMS': {"zulip.com"},
                     'FIRST_TIME_TOS_TEMPLATE': None,
                     'USING_PGROONGA': False,
+                    'POST_MIGRATION_CACHE_FLUSHING': False
                     }
 
 for setting_name, setting_val in six.iteritems(DEFAULT_SETTINGS):


### PR DESCRIPTION
- To avoid redefining migrate manage command is added new application
  which emit post_migration signal. This signal require models module inside apllication
  and defined AppConfig Instance as signal sender.
  Documentayion https://docs.djangoproject.com/en/1.8/ref/signals/#post-migrate

Fixes #1084