### PR TITLE
Add Lightbox YouTube Support.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -387,14 +387,26 @@ $(function () {
         $("#main_div").on("click", ".message_inline_image a", function (e) {
             var img = e.target,
                 row = rows.id($(img).closest(".message_row")),
-                user = current_msg_list.get(row).sender_full_name;
+                user = current_msg_list.get(row).sender_full_name,
+                $target = $(this);
 
             // prevent the link from opening in a new page.
             e.preventDefault();
             // prevent the message compose dialog from happening.
             e.stopPropagation();
 
-            ui.lightbox_photo(img, user);
+            if ($target.parent().hasClass("youtube-video")) {
+                ui.lightbox({
+                    type: "youtube",
+                    id: $target.data("id")
+                });
+            } else {
+                ui.lightbox({
+                    type: "photo",
+                    image: img,
+                    user: user
+                });
+            }
         });
 
         $("#overlay .exit").click(function (e) {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -281,25 +281,58 @@ exports.small_avatar_url = function (message) {
     }
 };
 
+exports.lightbox = function (data) {
+    switch (data.type) {
+        case "photo":
+            exports.lightbox_photo(data.image, data.user);
+            break;
+        case "youtube":
+            exports.youtube_video(data.id);
+            break;
+        default:
+            break;
+    }
+
+    $("#overlay").addClass("show");
+};
+
 exports.lightbox_photo = function (image, user) {
     // image should be an Image Object in JavaScript.
     var url = $(image).attr("src"),
         title = $(image).parent().attr("title");
 
+    $("#overlay .player-container").hide();
+    $("#overlay .image-actions, .image-description, .download").show();
+
     $("#overlay .image-preview")
+        .show()
         .css("background-image", "url(" + url + ")");
 
-    $("#overlay").addClass("show");
-
-    $(".title").text(title || "N/A");
-    $(".user").text(user);
+    $(".image-description .title").text(title || "N/A");
+    $(".image-description .user").text(user);
 
     $(".image-actions .open, .image-actions .download").attr("href", url);
 };
 
 exports.exit_lightbox_photo = function (image) {
     $("#overlay").removeClass("show");
+    $(".player-container iframe").remove();
 };
+
+exports.youtube_video = function (id) {
+    $("#overlay .image-preview, .image-description, .download").hide();
+
+    var iframe = document.createElement("iframe");
+    iframe.width = window.innerWidth;
+    iframe.height = window.innerWidth * 0.5625;
+    iframe.src = "https://www.youtube.com/embed/" + id;
+    iframe.setAttribute("frameborder", 0);
+    iframe.setAttribute("allowfullscreen", true);
+
+    $("#overlay .player-container").html("").show().append(iframe);
+    $(".image-actions .open").attr("href", "https://youtu.be/" + id);
+};
+// k3O01EfM5fU
 
 var loading_more_messages_indicator_showing = false;
 exports.show_loading_more_messages_indicator = function () {

--- a/static/styles/overlay.css
+++ b/static/styles/overlay.css
@@ -14,6 +14,7 @@
     z-index: 101;
 
     transition: all 0.2s ease;
+    overflow: auto;
 
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -113,6 +114,20 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+#overlay .player-container {
+    height: calc(100vh - 71px);
+    display: flex;
+    text-align: center;
+    justify-content: center;
+    align-items: center;
+}
+
+#overlay .player-container iframe {
+    width: 80vw;
+    height: 45vw;
+    margin: auto;
 }
 
 #overlay .image-description .user {

--- a/templates/zerver/image-overlay.html
+++ b/templates/zerver/image-overlay.html
@@ -18,4 +18,5 @@
   </div>
 
   <div class="image-preview"></div>
+  <div class="player-container"></div>
 </div>

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -100,7 +100,7 @@ def walk_tree(root, processor, stop_after_first=False):
 
 # height is not actually used
 def add_a(root, url, link, height="", title=None, desc=None,
-          class_attr="message_inline_image"):
+          class_attr="message_inline_image", data_id=None):
     # type: (Element, text_type, text_type, text_type, Optional[text_type], Optional[text_type], text_type) -> None
     title = title if title is not None else url_filename(link)
     title = title if title else ""
@@ -111,7 +111,9 @@ def add_a(root, url, link, height="", title=None, desc=None,
     a = markdown.util.etree.SubElement(div, "a")
     a.set("href", link)
     a.set("target", "_blank")
-    a.set("title", title )
+    a.set("title", title)
+    if data_id is not None:
+        a.set("data-id", data_id)
     img = markdown.util.etree.SubElement(a, "img")
     img.set("src", url)
     if class_attr == "message_inline_ref":
@@ -343,7 +345,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             return image_info
         return None
 
-    def youtube_image(self, url):
+    def youtube_id(self, url):
         # type: (text_type) -> Optional[text_type]
         if not settings.INLINE_IMAGE_PREVIEW:
             return None
@@ -355,7 +357,14 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
         match = re.match(youtube_re, url)
         if match is None:
             return None
-        return "https://i.ytimg.com/vi/%s/default.jpg" % (match.group(2),)
+        return match.group(2)
+
+    def youtube_image(self, url):
+        # type: (text_type) -> Optional[text_type]
+        yt_id = self.youtube_id(url)
+
+        if yt_id is not None:
+            return "https://i.ytimg.com/vi/%s/default.jpg" % (yt_id,)
 
     def twitter_text(self, text, urls, user_mentions, media):
         # type: (text_type, List[Dict[text_type, text_type]], List[Dict[text_type, Any]], List[Dict[text_type, Any]]) -> Element
@@ -564,7 +573,8 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                 continue
             youtube = self.youtube_image(url)
             if youtube is not None:
-                add_a(root, youtube, url)
+                yt_id = self.youtube_id(url)
+                add_a(root, youtube, url, None, None, None, "youtube-video message_inline_image", yt_id)
                 continue
 
 class Avatar(markdown.inlinepatterns.Pattern):

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -212,7 +212,7 @@ class BugdownTest(TestCase):
         msg = 'Check out the debate: http://www.youtube.com/watch?v=hx1mjT73xYE'
         converted = bugdown_convert(msg)
 
-        self.assertEqual(converted, '<p>Check out the debate: <a href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE">http://www.youtube.com/watch?v=hx1mjT73xYE</a></p>\n<div class="message_inline_image"><a href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE"><img src="https://i.ytimg.com/vi/hx1mjT73xYE/default.jpg"></a></div>')
+        self.assertEqual(converted, '<p>Check out the debate: <a href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE">http://www.youtube.com/watch?v=hx1mjT73xYE</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE"><img src="https://i.ytimg.com/vi/hx1mjT73xYE/default.jpg"></a></div>')
 
     def test_inline_dropbox(self):
         # type: () -> None


### PR DESCRIPTION
The lightbox will now distinguish between whether or not something is a
photo and a YouTube video by the class name of the message inline
preview. It embeds the YouTube video in the lightbox as an iFrame
rather than previewing the video screenshot.