### PR TITLE
subs.js : Extract people.filter_people_by_search_terms() into people.js

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -17,6 +17,8 @@ set_global('admin', {
     show_or_hide_menu_item: function () {}
 });
 
+var _ = global._;
+
 (function test_basics() {
     var orig_person = {
         email: 'orig@example.com',
@@ -123,4 +125,46 @@ set_global('admin', {
         { email: 'bob@example.com', full_name: 'Bob van Roberts' }
     ];
     assert.deepEqual(others, expected);
+
+    people.remove(alice1);
+    people.remove(alice2);
+    people.remove(bob);
+}());
+
+(function test_filtered_users() {
+     var charles = {
+        email: 'charles@example.com',
+        full_name: 'Charles Dickens'
+    };
+    var maria = {
+        email: 'athens@example.com',
+        full_name: 'Maria Athens'
+    };
+    var ashton = {
+        email: 'ashton@example.com',
+        full_name: 'Ashton Smith'
+    };
+
+    people.add_in_realm(charles);
+    people.add_in_realm(maria);
+    people.add_in_realm(ashton);
+    var search_term = 'a';
+    var users = people.get_rest_of_realm();
+    var filtered_people = people.filter_people_by_search_terms(users, search_term);
+    var expected = [
+        { email: 'athens@example.com', full_name: 'Maria Athens' },
+        { email: 'ashton@example.com', full_name: 'Ashton Smith' }
+    ];
+    assert.equal(filtered_people["ashton@example.com"], true);
+    assert.equal(filtered_people["athens@example.com"], true);
+    assert.equal(_.keys(filtered_people).length, 2);
+    assert(!_.has(filtered_people, 'charles@example.com'));
+
+    search_term = '';
+    filtered_people = people.filter_people_by_search_terms(users, search_term);
+    assert(_.isEmpty(filtered_people));
+
+    people.remove(charles);
+    people.remove(maria);
+    people.remove(ashton);
 }());

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -17,6 +17,36 @@ exports.realm_get = function realm_get(email) {
     return realm_people_dict.get(email);
 };
 
+exports.filter_people_by_search_terms = function (users, search_terms) {
+        var filtered_users = {};
+
+        // Loop through users and populate filtered_users only
+        // if they include search_terms
+        _.each(users, function (user) {
+            var person = exports.get_by_email(user.email);
+            // Get person object (and ignore errors)
+            if (!person || !person.full_name) {
+                return;
+            }
+
+            // Remove extra whitespace
+            var names = person.full_name.toLowerCase().split(/\s+/);
+            names = _.map(names, function (name) {
+                return name.trim();
+            });
+
+            // Return user emails that include search terms
+            return _.any(search_terms, function (search_term) {
+                return _.any(names, function (name) {
+                    if (name.indexOf(search_term.trim()) === 0) {
+                        filtered_users[user.email] = true;
+                    }
+                });
+            });
+        });
+        return filtered_users;
+};
+
 exports.get_by_name = function realm_get(name) {
     return people_by_name_dict.get(name);
 };

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -695,25 +695,7 @@ $(function () {
         }
         var search_term = user_list.expectOne().val().trim();
         var search_terms = search_term.toLowerCase().split(",");
-
-        var filtered_users = {};
-        _.each(users, function (user) {
-            var person = people.get_by_email(user.email);
-            if (!person || !person.full_name) {
-                return;
-            }
-            var names = person.full_name.toLowerCase().split(/\s+/);
-            names = _.map(names, function (s) {
-                return s.trim();
-            });
-            return _.any(search_terms, function (search_term) {
-                return _.any(names, function (name) {
-                    if (name.indexOf(search_term.trim()) === 0) {
-                        filtered_users[user.email] = true;
-                    }
-                });
-            });
-        });
+        var filtered_users = people.filter_people_by_search_terms(users, search_terms);
 
         // Hide users which aren't in filtered users
         _.each(users, function (user) {


### PR DESCRIPTION
Extract people.filter_people_by_search_terms().
This code used to be in `static/js/subs.js` , but now it's in `static/js/people.js` and has
some unit tests in `frontend_tests/node_tests/people.js` .
I did this with [Steve Howell](https://github.com/showell) as part of live coding on [Zulip.](https://zulip.tabbott.net/#narrow/stream/live.20coding)
We did this to clean up `static/jssubs.js` so that it majorly handles UI work and filtering can be handled by `static/js/people.js` .