### PR TITLE
WIP Typing indicators frontend

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
         "settings": false,
         "resize": false,
         "loading": false,
+        "typing": false,
         "compose": false,
         "compose_fade": false,
         "subs": false,

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -831,6 +831,24 @@ function render(template_name, args) {
     });
 }());
 
+(function typing_notifications() {
+    var args = {
+        users: [{
+            full_name: 'Hamlet',
+            email: 'hamlet@zulip.com'
+        }]
+    };
+
+    var html = '';
+    html += '<ul>';
+    html += render('typing_notifications', args);
+    html += '</ul>';
+
+    global.write_handlebars_output('typing_notifications', html);
+    var li = $(html).find('li:first');
+    assert.equal(li.text(), 'Hamlet is typing...');
+}());
+
 (function user_presence_rows() {
     var args = {
         users: [

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -160,6 +160,14 @@ function dispatch_normal_event(event) {
         }
         break;
 
+    case 'typing':
+        if (event.op === 'start') {
+            typing.display_notification(event);
+        } else if (event.op === 'stop') {
+            typing.hide_notification(event);
+        }
+        break;
+
     case 'update_display_settings':
         if (event.setting_name === 'twenty_four_hour_time') {
             page_params.twenty_four_hour_time = event.setting;

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -1,0 +1,163 @@
+var typing = (function () {
+var exports = {};
+// How long before we assume a client has gone away
+// and expire its typing status
+var TYPING_STARTED_EXPIRY_PERIOD = 15000; // 15s
+// How frequently 'still typing' notifications are sent
+// to extend the expiry
+var TYPING_STARTED_SEND_FREQUENCY = 10000; // 10s
+// How long after someone stops editing in the compose box
+// do we send a 'stopped typing' notification
+var TYPING_STOPPED_WAIT_PERIOD = 5000; // 5s
+
+var current_recipient;
+var users_currently_typing = new Dict();
+
+function send_typing_notification_ajax(recipients, operation) {
+    channel.post({
+        url: '/json/typing',
+        data: {
+            to: recipients,
+            op: operation
+        },
+        success: function () {},
+        error: function (xhr) {
+            var response = channel.xhr_error_message("Error sending typing notification", xhr);
+            blueslip.error(JSON.stringify(xhr));
+            blueslip.error(response);
+        }
+    });
+}
+
+function check_and_send(operation) {
+    if (operation === 'start') {
+        if (compose.recipient() && compose.message_content()) {
+            if (current_recipient !== undefined && current_recipient !== compose.recipient()) {
+                // When the recipient is changed, a stop message is sent to the old recipient
+                // before the start message is sent to the new recipient
+                send_typing_notification_ajax(current_recipient, 'stop');
+            }
+            current_recipient = compose.recipient();
+            send_typing_notification_ajax(compose.recipient(), operation);
+        }
+    } else if (operation === 'stop' && current_recipient) {
+        send_typing_notification_ajax(current_recipient, operation);
+        current_recipient = undefined;
+    }
+}
+
+function check_and_send_start() {
+    check_and_send('start');
+}
+
+function get_throttled_function() {
+    return _.throttle(check_and_send_start,
+        TYPING_STARTED_SEND_FREQUENCY,
+        {trailing: false});
+}
+
+function check_and_send_stop() {
+    check_and_send('stop');
+    exports.send_start_notification = get_throttled_function();
+    $(document).on('input', '#new_message_content', exports.send_start_notification);
+}
+
+exports.send_start_notification = get_throttled_function();
+exports.send_stop_notification = _.debounce(check_and_send_stop, TYPING_STOPPED_WAIT_PERIOD);
+
+$(document).on('compose_canceled.zulip', check_and_send_stop);
+$(document).on('compose_finished.zulip', check_and_send_stop);
+$(document).on('blur', '#new_message_content', check_and_send_stop);
+$(document).on('input', '#new_message_content', exports.send_start_notification);
+$(document).on('input', '#new_message_content', exports.send_stop_notification);
+
+function full_name(email) {
+    return people.get_by_email(email).full_name;
+}
+
+function get_users_typing_for_narrow() {
+    if (!narrow.narrowed_to_pms()) {
+        // Narrow is neither pm-with nor is: private
+        return [];
+    }
+    if (narrow.operators()[0].operator === 'pm-with') {
+        // Get list of users typing in this conversation
+        var narrow_emails_string = narrow.operators()[0].operand;
+        var narrow_user_ids_string = people.emails_strings_to_user_ids_string(narrow_emails_string);
+        var narrow_user_ids = narrow_user_ids_string.split(',').map(function (user_id_string) {
+            return parseInt(user_id_string, 10);
+        });
+        var group = narrow_user_ids.concat([page_params.user_id]);
+        group.sort();
+        return users_currently_typing.setdefault(group, []);
+    }
+    // Get all users typing (in all private conversations with current user)
+    var all_typing_users = [];
+    users_currently_typing.each(function (users_typing) {
+        all_typing_users = all_typing_users.concat(users_typing);
+    });
+    return all_typing_users;
+}
+
+function render_notifications_for_narrow() {
+    var user_ids = get_users_typing_for_narrow();
+    var users_typing = user_ids.map(people.get_person_from_user_id);
+    if (users_typing.length === 0) {
+        $('#typing_notifications').hide();
+    } else {
+        $('#typing_notifications').html(templates.render('typing_notifications', {users: users_typing}));
+        $('#typing_notifications').show();
+    }
+}
+
+$(document).on('narrow_activated.zulip', render_notifications_for_narrow);
+$(document).on('narrow_deactivated.zulip', render_notifications_for_narrow);
+
+exports.hide_notification = function (event) {
+    if (event.sender.user_id === page_params.user_id) {
+        // The typing notification is also sent to the user who is typing
+        // In this case the notification is not displayed
+        return;
+    }
+    var recipients = event.recipients.map(function (user) {
+        return user.user_id;
+    });
+    recipients.sort();
+    var users_typing = users_currently_typing.get(recipients);
+    var i = users_typing.indexOf(event.sender.user_id);
+    if (i !== -1) {
+        users_typing.splice(i);
+    }
+    render_notifications_for_narrow();
+};
+
+var debounced_hide_notification = _.debounce(exports.hide_notification,
+    TYPING_STARTED_EXPIRY_PERIOD);
+
+exports.display_notification = function (event) {
+    var recipients = event.recipients.map(function (user) {
+        return user.user_id;
+    });
+    recipients.sort();
+    if (event.sender.user_id === page_params.user_id) {
+        // The typing notification is also sent to the user who is typing
+        // In this case the notification is not displayed
+        return;
+    }
+    event.sender.name = full_name(event.sender.email);
+    var users_typing = users_currently_typing.setdefault(recipients, []);
+    var i = users_typing.indexOf(event.sender.user_id);
+    if (i === -1) {
+      // Add sender to list of users currently typing in conversation
+      users_typing.push(event.sender.user_id);
+    }
+    render_notifications_for_narrow();
+    debounced_hide_notification(event);
+};
+
+return exports;
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = typing;
+}

--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -67,6 +67,10 @@
         margin-right: 7px;
     }
 
+    #typing_notifications {
+        margin-right: 7px;
+    }
+
     .nav .dropdown-menu {
         min-width: 180px;
         -webkit-box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.2);
@@ -157,6 +161,11 @@
     }
 
     .compose-content {
+        margin-right: 7px;
+        margin-left: 7px;
+    }
+
+    #typing_notifications {
         margin-right: 7px;
         margin-left: 7px;
     }

--- a/static/styles/typing_notifications.css
+++ b/static/styles/typing_notifications.css
@@ -1,0 +1,11 @@
+#typing_notifications {
+    display: none;
+    margin-left: 10px;
+    font-style: italic;
+    color: #888;
+}
+
+#typing_notification_list {
+    list-style: none;
+    margin: 0;
+}

--- a/static/templates/typing_notification.handlebars
+++ b/static/templates/typing_notification.handlebars
@@ -1,0 +1,1 @@
+<li data-email="{{this.email}}" class="typing_notification">{{this.full_name}} is typing...</li>

--- a/static/templates/typing_notifications.handlebars
+++ b/static/templates/typing_notifications.handlebars
@@ -1,0 +1,6 @@
+{{! Typing Notifications }}
+<ul id="typing_notification_list">
+{{#each users}}
+{{partial "typing_notification"}}
+{{/each}}
+</ul>

--- a/templates/zerver/home.html
+++ b/templates/zerver/home.html
@@ -73,6 +73,8 @@
       </div>
       <div class="message_table" id="zfilt">
       </div>
+      <div id="typing_notifications">
+      </div>
       <div id="bottom_whitespace"></div>
     </div>
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -684,6 +684,7 @@ PIPELINE = {
                 'styles/pygments.css',
                 'styles/thirdparty-fonts.css',
                 'styles/media.css',
+                'styles/typing_notifications.css',
                 # We don't want fonts.css on QtWebKit, so its omitted here
             ),
             'output_filename': 'min/app-fontcompat.css'
@@ -704,6 +705,7 @@ PIPELINE = {
                 'styles/thirdparty-fonts.css',
                 'styles/fonts.css',
                 'styles/media.css',
+                'styles/typing_notifications.css',
             ),
             'output_filename': 'min/app.css'
         },
@@ -838,6 +840,7 @@ JS_SPECS = {
             'js/referral.js',
             'js/custom_markdown.js',
             'js/bot_data.js',
+            'js/typing.js',
             # JS bundled by webpack is also included here if PIPELINE_ENABLED setting is true
         ],
         'output_filename': 'min/app.js'


### PR DESCRIPTION
There are two goals for this PR:
1. POST to /typing
   1. When a user begins typing, send a typing started notification
   2. When a user stops typing, send a typing stopped notification
2. Listen to typing events and display an indicator
Send typing notification events when user types in the compose box.
Listen for these events and display a notification.

### Sending notifications:
Underscore's throttle is used for the start notifications (trailing set
to false) and debounce is used for stop notifications.
This is so that start notifications are sent every 10 seconds
and the stop notifications is sent 5 seconds after typing stops.
When a stop notification is sent, a fresh throttled start notification
is assigned to compose area's input event. This is so that once a stop
notification is sent, if the user starts typing again the start
notification is sent immediately.

### Displaying notifications:
When a typing notification is received, if the current narrow is private
messages or is: pm-with and the user is not the sender,
"Othello is typing..." is displayed underneath the last message. This notification is
removed after 15 seconds. If another notification is received during this period, the
expiration is extended. When a stop notification is received the notification is removed.

Internally, a list of users currently typing is maintained for each
conversation. When an event is received the list (for the appropriate
conversation) is updated and the notifications template is re-rendered
based on the narrow information. This template is also re-rendered when
the narrow changes.

This is to fix #150!
