### PR TITLE
Stream settings: sets zero margin for 'Streams Deletion' table. 

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -35,6 +35,10 @@ label {
     padding: 0px 20px;
 }
 
+.table.table-condensed.table-striped {
+    margin: 0px;
+}
+
 .table tbody {
     border-bottom: 1px solid #ddd;
 }
@@ -75,6 +79,10 @@ td .button {
 
 .settings-section .no-padding {
     padding: 0;
+}
+
+.settings-section .table.table-condensed.table-striped tbody {
+    border-bottom: none;
 }
 
 .dynamic-input {


### PR DESCRIPTION
Removes the extra space from the bottom of the 'Stream Deletion' table when the margin of the table is set as '0px'

Fixes #2077.