### PR TITLE
Add linter rule to capitalize GitHub

### DIFF
--- a/tools/lint-all
+++ b/tools/lint-all
@@ -324,6 +324,8 @@ def build_custom_checkers(by_lang):
     prose_style_rules = [
         {'pattern': '[^\/\#\-\"]([jJ]avascript)', # exclude usage in hrefs/divs
          'description': "javascript should be spelled JavaScript"},
+         {'pattern': '[^\/\-\.\"\']([gG]ithub)[^\.\-\_\"]', # exclude usage in hrefs/divs
+         'description': "github should be spelled GitHub"},
     ] # type: RuleList
     html_rules = whitespace_rules + prose_style_rules + [
         {'pattern': 'placeholder="[^{]',


### PR DESCRIPTION
As mentioned in #2032 , added linter rule to flag an error whenever `Github` / `github` is encountered in .md or .html files. This will ignore the cases where `github` occurs in links or division names. This was accomplished with the help of the thought-process at https://zulip.tabbott.net/#narrow/stream/test.20suites/topic/watch.20over.20my.20shoulder.20as.20I.20improve.20the.20linter 