### PR TITLE
Don't use zulipdev.com when subdomain support is disabled

### DIFF
--- a/frontend_tests/casper_tests/00-realm-creation.js
+++ b/frontend_tests/casper_tests/00-realm-creation.js
@@ -12,7 +12,7 @@ if (REALMS_HAVE_SUBDOMAINS) {
     host = 'zulipdev.com:9981';
     realm_host = subdomain + '.' + host;
 } else {
-    host = realm_host = 'zulipdev.com:9981';
+    host = realm_host = 'localhost:9981';
 }
 
 casper.start('http://' + host + '/create_realm/');

--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -146,11 +146,12 @@ Oops, the frontend tests failed. Tips for debugging:
 
         sys.exit(ret)
 
-os.environ["EXTERNAL_HOST"] = "zulipdev.com:9981"
+os.environ["EXTERNAL_HOST"] = "localhost:9981"
 # First, run all tests with REALMS_HAVE_SUBDOMAINS set to False
 run_tests(False, args)
 # Now run a subset of the tests with REALMS_HAVE_SUBDOMAINS set to True
 os.environ["REALMS_HAVE_SUBDOMAINS"] = "True"
+os.environ["EXTERNAL_HOST"] = "zulipdev.com:9981"
 if len(args) == 0:
     run_tests(True, ["00-realm-creation.js", "01-login.js", "02-site.js"])
 else:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -84,7 +84,7 @@ def login_or_register_remote_user(request, remote_username, user_profile, full_n
         return maybe_send_to_registration(request, remote_user_to_email(remote_username), full_name)
     else:
         login(request, user_profile)
-        if settings.OPEN_REALM_CREATION and user_profile.realm.subdomain is not None:
+        if settings.REALMS_HAVE_SUBDOMAINS and user_profile.realm.subdomain is not None:
             return HttpResponseRedirect("%s%s.%s" % (settings.EXTERNAL_URI_SCHEME,
                                                      user_profile.realm.subdomain,
                                                      settings.EXTERNAL_HOST))
@@ -287,7 +287,7 @@ def dev_direct_login(request, **kwargs):
     if user_profile is None:
         raise Exception("User cannot login")
     login(request, user_profile)
-    if settings.OPEN_REALM_CREATION and settings.DEVELOPMENT:
+    if settings.REALMS_HAVE_SUBDOMAINS and settings.DEVELOPMENT:
         if user_profile.realm.subdomain is not None:
             return HttpResponseRedirect("%s%s.%s" % (settings.EXTERNAL_URI_SCHEME,
                                                      user_profile.realm.subdomain,

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -7,7 +7,7 @@ import os
 LOCAL_UPLOADS_DIR = 'var/uploads'
 # We check the environment to support test_settings.py controlling
 # EXTERNAL_HOST.
-EXTERNAL_HOST = os.getenv('EXTERNAL_HOST', 'zulipdev.com:9991')
+EXTERNAL_HOST = os.getenv('EXTERNAL_HOST', 'localhost:9991')
 ALLOWED_HOSTS = ['*']
 AUTHENTICATION_BACKENDS = ('zproject.backends.DevAuthBackend',)
 # Add some of the below if you're testing other backends
@@ -25,6 +25,7 @@ CAMO_URI = ''
 OPEN_REALM_CREATION = True
 # Default to subdomains disabled in development until we can update
 # the development documentation to make sense with subdomains.
+# Change EXTERNAL_HOST to "zulipdev.com:9991" if you set REALMS_HAVE_SUBDOMAINS to True
 REALMS_HAVE_SUBDOMAINS = False
 TERMS_OF_SERVICE = 'zproject/terms.md.template'
 


### PR DESCRIPTION
This will fix the redirect of localhost to zulipdev.com when `REALMS_HAVE_SUBDOMAINS` is set to `False`