### PR TITLE
Message edit: Alter behavior of topic edit

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -10,7 +10,6 @@ var is_composing_message = false;
 var user_acknowledged_all_everyone;
 
 var message_snapshot;
-var empty_topic_placeholder = "(no topic)";
 
 var uploads_domain = document.location.protocol + '//' + document.location.host;
 var uploads_path = '/user_uploads';
@@ -315,7 +314,7 @@ exports.cancel = function () {
 };
 
 exports.empty_topic_placeholder = function () {
-    return empty_topic_placeholder;
+    return i18n.t("(no topic)");
 };
 
 function create_message_object() {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -165,6 +165,7 @@ function edit_message (row, raw_content) {
          is_editable: is_editable,
          has_been_editable: (editability !== editability_types.NO),
          topic: message.subject,
+         empty_topic_placeholder: compose.empty_topic_placeholder(),
          content: raw_content,
          minutes_to_edit: Math.floor(page_params.realm_message_content_edit_limit_seconds / 60)}));
 
@@ -254,6 +255,7 @@ function edit_message (row, raw_content) {
     if (!is_editable) {
         edit_row.find(".message_edit_close").focus();
     } else if (message.type === 'stream' && message.subject === compose.empty_topic_placeholder()) {
+        edit_row.find(".message_edit_topic").val('');
         edit_row.find(".message_edit_topic").focus();
     } else if (editability === editability_types.TOPIC_ONLY) {
         edit_row.find(".message_edit_cancel").focus();
@@ -273,7 +275,7 @@ function edit_message (row, raw_content) {
         var original_topic = message.subject;
         topic_input.keyup( function () {
             var new_topic = topic_input.val();
-            row.find('.message_edit_topic_propagate').toggle(new_topic !== original_topic);
+            row.find('.message_edit_topic_propagate').toggle(new_topic !== original_topic && new_topic !== "" );
         });
     }
 }

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -5,7 +5,7 @@
     <div class="control-group no-margin">
         <label class="control-label edit-control-label" for="message_edit_topic">{{t "Topic" }}</label>
         <div class="controls edit-controls">
-          <input type="text" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" />
+          <input type="text" placeholder="{{empty_topic_placeholder}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" />
           <select class='message_edit_topic_propagate' style='display:none;'>
             <option selected="selected" value="change_one"> {{t "Change only this message topic" }}</option>
             <option value="change_later"> {{t "Change later messages to this topic" }}</option>


### PR DESCRIPTION
The following is the changes made to the behavior of topic edit box when we choose to edit a message:
- If there is already a topic: value={{topic}}, and when you click on the box, all of the text gets selected.
- If there isn't already a topic: placeholder=(no topic).

Fixes #1273 .
