### PR TITLE
Remove server calls in Manage Streams

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -222,13 +222,12 @@ var stream_data = require('js/stream_data.js');
         color: 'amber',
         subscribed: true
     };
-    var public_streams = {streams: [cinnamon, blue, amber]};
     stream_data.clear_subscriptions();
     stream_data.add_sub(cinnamon.name, cinnamon);
     stream_data.add_sub(amber.name, amber);
-    // we don't know about "blue"
+    stream_data.add_sub(blue.name, blue);
 
-    var sub_rows = stream_data.get_streams_for_settings_page(public_streams);
+    var sub_rows = stream_data.get_streams_for_settings_page();
     assert.equal(sub_rows[0].color, 'amber');
     assert.equal(sub_rows[1].color, 'cinnamon');
     assert.equal(sub_rows[2].color, 'blue');

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -42,6 +42,10 @@ exports.subscribed_subs = function () {
     return _.where(stream_info.values(), {subscribed: true});
 };
 
+exports.unsubscribed_subs = function () {
+    return _.where(stream_info.values(), {subscribed: false});
+};
+
 exports.subscribed_streams = function () {
     return _.pluck(exports.subscribed_subs(), 'name');
 };
@@ -223,33 +227,10 @@ exports.add_admin_options = function (sub) {
     });
 };
 
-exports.get_streams_for_settings_page = function (public_streams) {
+exports.get_streams_for_settings_page = function () {
     // Build up our list of subscribed streams from the data we already have.
     var subscribed_rows = exports.subscribed_subs();
-
-    // To avoid dups, build a set of names we already subscribed to.
-    var subscribed_set = new Dict({fold_case: true});
-    _.each(subscribed_rows, function (sub) {
-        subscribed_set.set(sub.name, true);
-    });
-
-    // Right now the back end gives us all public streams; we really only
-    // need to add the ones we haven't already subscribed to.
-    var unsubscribed_streams = _.reject(public_streams.streams, function (stream) {
-        return subscribed_set.has(stream.name);
-    });
-
-    // Build up our list of unsubscribed rows.
-    var unsubscribed_rows = [];
-    _.each(unsubscribed_streams, function (stream) {
-        var sub = exports.get_sub(stream.name);
-        if (!sub) {
-            sub = exports.create_sub_from_server_data(
-                    stream.name,
-                    _.extend({subscribed: false}, stream));
-        }
-        unsubscribed_rows.push(sub);
-    });
+    var unsubscribed_rows = exports.unsubscribed_subs();
 
     // Sort and combine all our streams.
     function by_name(a,b) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -438,8 +438,9 @@ exports.setup_page = function () {
     loading.make_indicator($('#subs_page_loading_indicator'));
 
     function _populate_and_fill(public_streams) {
+        // TODO: stop fetching public_streams
 
-        var sub_rows = stream_data.get_streams_for_settings_page(public_streams);
+        var sub_rows = stream_data.get_streams_for_settings_page();
 
         $('#subscriptions_table').empty();
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -435,11 +435,8 @@ function actually_filter_streams() {
 var filter_streams = _.throttle(actually_filter_streams, 50);
 
 exports.setup_page = function () {
-    loading.make_indicator($('#subs_page_loading_indicator'));
 
-    function _populate_and_fill(public_streams) {
-        // TODO: stop fetching public_streams
-
+    function _populate_and_fill() {
         var sub_rows = stream_data.get_streams_for_settings_page();
 
         $('#subscriptions_table').empty();
@@ -457,34 +454,19 @@ exports.setup_page = function () {
             add_email_hint(row, email_address_hint_content);
         });
 
-        loading.destroy_indicator($('#subs_page_loading_indicator'));
         $("#create_or_filter_stream_row input[type='text']").on("input", filter_streams);
         $(document).trigger($.Event('subs_page_loaded.zulip'));
     }
 
-    function populate_and_fill(public_streams) {
+    function populate_and_fill() {
         i18n.ensure_i18n(function () {
-            _populate_and_fill(public_streams);
+            _populate_and_fill();
         });
     }
 
-    function failed_listing(xhr, error) {
-        loading.destroy_indicator($('#subs_page_loading_indicator'));
-        ui.report_error(i18n.t("Error listing streams or subscriptions"), xhr,
-                        $("#subscriptions-status"), 'subscriptions-status');
-    }
+    populate_and_fill();
 
-    if (should_list_all_streams()) {
-        var req = channel.get({
-            url: '/json/streams',
-            data: {"include_subscribed": false},
-            idempotent: true,
-            timeout:  10*1000,
-            success: populate_and_fill,
-            error: failed_listing
-        });
-    } else {
-        populate_and_fill({streams: []});
+    if (!should_list_all_streams()) {
         $('#create_stream_button').val(i18n.t("Subscribe"));
     }
 };

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -64,7 +64,7 @@ class PublicURLTest(ZulipTestCase):
                           "/api/v1/users/me/subscriptions",
                           "/api/v1/messages",
                           "/json/messages",
-                          "/json/streams",
+                          "/api/v1/streams",
                           ],
                 }
         post_urls = {200: ["/accounts/login/"],

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1789,22 +1789,6 @@ class SubscriptionAPITest(ZulipTestCase):
 
 class GetPublicStreamsTest(ZulipTestCase):
 
-    def test_public_streams(self):
-        # type: () -> None
-        """
-        Ensure that streams successfully returns a list of streams
-        """
-        email = 'hamlet@zulip.com'
-        self.login(email)
-
-        result = self.client_get("/json/streams?include_subscribed=false")
-
-        self.assert_json_success(result)
-        json = ujson.loads(result.content)
-
-        self.assertIn("streams", json)
-        self.assertIsInstance(json["streams"], list)
-
     def test_public_streams_api(self):
         # type: () -> None
         """

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -210,8 +210,10 @@ v1_api_and_json_patterns = [
          'DELETE': 'zerver.views.alert_words.remove_alert_words'}),
 
     # streams -> zerver.views.streams
+    # (this API is only used externally)
     url(r'^streams$', 'zerver.lib.rest.rest_dispatch',
         {'GET': 'zerver.views.streams.get_streams_backend'}),
+
     # GET returns "stream info" (undefined currently?), HEAD returns whether stream exists (200 or 404)
     url(r'^streams/(?P<stream_name>.*)/members$', 'zerver.lib.rest.rest_dispatch',
         {'GET': 'zerver.views.streams.get_subscribers_backend'}),


### PR DESCRIPTION
This is stacked on #2118, and we may want to get a little bit of burn-in on those changes before this simplification.  It's not that big a deal, though, because I think these changes make sense for our long term strategy, and any bugs should be easy to address quickly.