### PR TITLE
actions popover: Change "Topic Edit" to "View Source / Topic Edit".

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -246,9 +246,10 @@ function edit_message (row, raw_content) {
     var edit_row = row.find(".message_edit");
     if (!is_editable) {
         edit_row.find(".message_edit_close").focus();
-    } else if ((message.type === 'stream' && message.subject === compose.empty_topic_placeholder()) ||
-        editability === editability_types.TOPIC_ONLY) {
+    } else if (message.type === 'stream' && message.subject === compose.empty_topic_placeholder()) {
         edit_row.find(".message_edit_topic").focus();
+    } else if (editability === editability_types.TOPIC_ONLY) {
+        edit_row.find(".message_edit_cancel").focus();
     } else {
         edit_row.find(".message_edit_content").focus();
     }

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -58,14 +58,16 @@ exports.toggle_actions_popover = function (element, id) {
     if (elt.data('popover') === undefined) {
         var message = current_msg_list.get(id);
         var editability = message_edit.get_editability(message);
-        var is_editable = (editability === message_edit.editability_types.TOPIC_ONLY ||
-                           editability === message_edit.editability_types.FULL);
+        var use_edit_icon;
         var editability_menu_item;
         if (editability === message_edit.editability_types.FULL) {
+            use_edit_icon = true;
             editability_menu_item = i18n.t("Edit");
         } else if (editability === message_edit.editability_types.TOPIC_ONLY) {
-            editability_menu_item = i18n.t("Edit Topic");
+            use_edit_icon = false;
+            editability_menu_item = i18n.t("View Source / Edit Topic");
         } else {
+            use_edit_icon = false;
             editability_menu_item = i18n.t("View Source");
         }
         var can_mute_topic =
@@ -79,7 +81,7 @@ exports.toggle_actions_popover = function (element, id) {
 
         var args = {
             message: message,
-            is_editable: is_editable,
+            use_edit_icon: use_edit_icon,
             editability_menu_item: editability_menu_item,
             can_mute_topic: can_mute_topic,
             can_unmute_topic: can_unmute_topic,

--- a/static/templates/actions_popover_content.handlebars
+++ b/static/templates/actions_popover_content.handlebars
@@ -3,7 +3,7 @@
   <li>
     <a href="#" class="popover_edit_message" data-msgid="{{message.id}}">
       {{! Can consider http://fontawesome.io/icon/file-code-o/ when we upgrade to font awesome 4.}}
-      <i class="{{#if is_editable}}icon-vector-pencil{{else}}icon-vector-file-text-alt{{/if}}"></i> {{editability_menu_item}}
+      <i class="{{#if use_edit_icon}}icon-vector-pencil{{else}}icon-vector-file-text-alt{{/if}}"></i> {{editability_menu_item}}
     </a>
   </li>
 


### PR DESCRIPTION
We also change the focus from the topic editing box to the cancel button
when the topic is non-empty.