### PR TITLE
topic_edit_form: Rename message_edit_topic to inline_topic_edit.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -56,10 +56,13 @@ exports.save = function (row, from_topic_edited_only) {
     var topic_changed = false;
     var new_topic;
     if (message.type === "stream") {
-        new_topic = row.find(".message_edit_topic").val();
+        if (from_topic_edited_only) {
+            new_topic = row.find(".inline_topic_edit").val();
+        } else {
+            new_topic = row.find(".message_edit_topic").val();
+        }
         topic_changed = (new_topic !== message.subject && new_topic.trim() !== "");
     }
-
     // Editing a not-yet-acked message (because the original send attempt failed)
     // just results in the in-memory message being changed
     if (message.local_id !== undefined) {
@@ -309,7 +312,7 @@ exports.start_topic_edit = function (recipient_row) {
     if (topic === compose.empty_topic_placeholder()) {
         topic = '';
     }
-    form.find(".message_edit_topic").val(topic).select().focus();
+    form.find(".inline_topic_edit").val(topic).select().focus();
 };
 
 exports.is_editing = function (id) {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1551,11 +1551,12 @@ div.focused_table {
     line-height: 22px;
 }
 
+#inline_topic_edit,
 #message_edit_topic {
     margin-bottom: 5px;
 }
 
-#message_edit_topic.header-v {
+#inline_topic_edit.header-v {
     height: 18px;
     display: inline-block;
     margin: -2px 0 0 0;
@@ -1569,6 +1570,7 @@ div.focused_table {
     box-shadow: none;
 }
 
+#inline_topic_edit:focus,
 #message_edit_topic:focus {
     outline: none;
 }

--- a/static/templates/topic_edit_form.handlebars
+++ b/static/templates/topic_edit_form.handlebars
@@ -2,7 +2,7 @@
 
 <form id="topic_edit_form" class="form-horizontal">
 {{!        <div class="controls edit-controls"> }}
-          <input type="text" value="" class="message_edit_topic header-v" id="message_edit_topic" />
+          <input type="text" value="" class="inline_topic_edit header-v" id="inline_topic_edit" />
             <button type="button" class="topic_edit_save primary"><i class="icon-vector-ok"></i></button>
             <button type="button" class="topic_edit_cancel primary"><i class="icon-vector-remove"></i></button>
 {{!        </div> }}


### PR DESCRIPTION
message_edit_form.handlebars already has a message_edit_topic that refers to
something else.