### PR TITLE
Live-update subscriber events.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -1179,10 +1179,18 @@ $(function () {
     $(document).on('peer_subscribe.zulip', function (e, data) {
         var sub = stream_data.get_sub(data.stream_name);
         exports.rerender_subscribers_count(sub);
+        var sub_row = settings_for_sub(sub);
+        prepend_subscriber(sub_row, data.user_email);
     });
     $(document).on('peer_unsubscribe.zulip', function (e, data) {
         var sub = stream_data.get_sub(data.stream_name);
         exports.rerender_subscribers_count(sub);
+
+        var sub_row = settings_for_sub(sub);
+        var tr = sub_row.find("tr[data-subscriber-email='" +
+                              data.user_email +
+                              "']");
+        tr.remove();
     });
 
 });

--- a/static/templates/stream_member_list_entry.handlebars
+++ b/static/templates/stream_member_list_entry.handlebars
@@ -1,4 +1,4 @@
-<tr>
+<tr data-subscriber-email="{{email}}">
     <td class="subscriber-name">{{name}}</td>
     <td class="subscriber-email">{{email}}</td>
     {{#if displaying_for_admin}}


### PR DESCRIPTION
The last two commits should technically be squashed, since live-updating adds without removes looks buggy.