### PR TITLE
Send user_ids to the client.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -513,12 +513,14 @@ def do_deactivate_user(user_profile, log=True, _cascade=True):
 
     event = dict(type="realm_user", op="remove",
                  person=dict(email=user_profile.email,
+                             user_id=user_profile.id,
                              full_name=user_profile.full_name))
     send_event(event, active_user_ids(user_profile.realm))
 
     if user_profile.is_bot:
         event = dict(type="realm_bot", op="remove",
                      bot=dict(email=user_profile.email,
+                              user_id=user_profile.id,
                               full_name=user_profile.full_name))
         send_event(event, bot_owner_userids(user_profile))
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -269,6 +269,7 @@ def notify_created_user(user_profile):
     # type: (UserProfile) -> None
     event = dict(type="realm_user", op="add",
                  person=dict(email=user_profile.email,
+                             user_id=user_profile.id,
                              is_admin=user_profile.is_realm_admin,
                              full_name=user_profile.full_name,
                              is_bot=user_profile.is_bot))
@@ -288,6 +289,7 @@ def notify_created_bot(user_profile):
 
     event = dict(type="realm_bot", op="add",
                  bot=dict(email=user_profile.email,
+                          user_id=user_profile.id,
                           full_name=user_profile.full_name,
                           api_key=user_profile.api_key,
                           default_sending_stream=default_sending_stream_name,
@@ -2783,6 +2785,7 @@ def get_status_dict(requesting_user_profile):
 def get_realm_user_dicts(user_profile):
     # type: (UserProfile) -> List[Dict[str, text_type]]
     return [{'email'     : userdict['email'],
+             'user_id'   : userdict['id'],
              'is_admin'  : userdict['is_realm_admin'],
              'is_bot'    : userdict['is_bot'],
              'full_name' : userdict['full_name']}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1679,6 +1679,7 @@ def do_change_full_name(user_profile, full_name, log=True):
                    'full_name': full_name})
 
     payload = dict(email=user_profile.email,
+                   user_id=user_profile.id,
                    full_name=user_profile.full_name)
     send_event(dict(type='realm_user', op='update', person=payload),
                active_user_ids(user_profile.realm))
@@ -1708,7 +1709,9 @@ def do_regenerate_api_key(user_profile, log=True):
         send_event(dict(type='realm_bot',
                         op='update',
                         bot=dict(email=user_profile.email,
-                                api_key=user_profile.api_key,)),
+                                 user_id=user_profile.id,
+                                 api_key=user_profile.api_key,
+                                 )),
                     bot_owner_userids(user_profile))
 
 def do_change_avatar_source(user_profile, avatar_source, log=True):
@@ -1725,13 +1728,15 @@ def do_change_avatar_source(user_profile, avatar_source, log=True):
         send_event(dict(type='realm_bot',
                         op='update',
                         bot=dict(email=user_profile.email,
-                                avatar_url=avatar_url(user_profile),)),
+                                 user_id=user_profile.id,
+                                 avatar_url=avatar_url(user_profile),
+                                 )),
                     bot_owner_userids(user_profile))
     else:
         payload = dict(
             email=user_profile.email,
             avatar_url=avatar_url(user_profile),
-            id=user_profile.id
+            user_id=user_profile.id
         )
 
         send_event(dict(type='realm_user',
@@ -1768,7 +1773,9 @@ def do_change_default_sending_stream(user_profile, stream, log=True):
         send_event(dict(type='realm_bot',
                         op='update',
                         bot=dict(email=user_profile.email,
-                                default_sending_stream=stream_name,)),
+                                 user_id=user_profile.id,
+                                 default_sending_stream=stream_name,
+                                 )),
                     bot_owner_userids(user_profile))
 
 def do_change_default_events_register_stream(user_profile, stream, log=True):
@@ -1789,7 +1796,9 @@ def do_change_default_events_register_stream(user_profile, stream, log=True):
         send_event(dict(type='realm_bot',
                         op='update',
                         bot=dict(email=user_profile.email,
-                                 default_events_register_stream=stream_name,)),
+                                 user_id=user_profile.id,
+                                 default_events_register_stream=stream_name,
+                                 )),
                     bot_owner_userids(user_profile))
 
 def do_change_default_all_public_streams(user_profile, value, log=True):
@@ -1804,7 +1813,9 @@ def do_change_default_all_public_streams(user_profile, value, log=True):
         send_event(dict(type='realm_bot',
                         op='update',
                         bot=dict(email=user_profile.email,
-                                default_all_public_streams=user_profile.default_all_public_streams,)),
+                                 user_id=user_profile.id,
+                                 default_all_public_streams=user_profile.default_all_public_streams,
+                                 )),
                     bot_owner_userids(user_profile))
 
 def do_change_is_admin(user_profile, value, permission='administer'):

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1065,6 +1065,7 @@ def get_owned_bot_dicts(user_profile, include_all_realm_bots_if_admin=True):
     from zerver.lib.avatar import get_avatar_url
 
     return [{'email': botdict['email'],
+             'user_id': botdict['id'],
              'full_name': botdict['full_name'],
              'api_key': botdict['api_key'],
              'default_sending_stream': botdict['default_sending_stream__name'],

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -222,6 +222,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('op', equals('update')),
             ('bot', check_dict([
                 ('email', check_string),
+                ('user_id', check_int),
                 (field_name, check),
             ])),
         ])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -624,6 +624,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('op', equals('add')),
             ('bot', check_dict([
                 ('email', check_string),
+                ('user_id', check_int),
                 ('full_name', check_string),
                 ('api_key', check_string),
                 ('default_sending_stream', check_none_or(check_string)),


### PR DESCRIPTION
Once these back end changes are in place, we can start to fix the JS side to be more userid-aware.  And then eventually we may come back and remove emails for remove/update events that don't touch email.