### PR TITLE
Simplify pin/unpin code path.

### DIFF
--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -128,9 +128,6 @@ function dispatch_normal_event(event) {
             });
         } else if (event.op === 'update') {
             subs.update_subscription_properties(event.name, event.property, event.value);
-            if (event.property === 'pin_to_top') {
-                subs.pin_or_unpin_stream(event.name);
-            }
         } else if (event.op === 'peer_add' || event.op === 'peer_remove') {
             _.each(event.subscriptions, function (sub) {
                 var js_event_type;

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -602,9 +602,9 @@ exports.rename_stream = function (sub) {
     exports.build_stream_list(); // big hammer
 };
 
-exports.refresh_stream_in_sidebar = function (sub) {
-    // used by subs.pin_or_unpin_stream,
-    // since pinning/unpinning requires reordering of streams in the sidebar
+exports.refresh_pinned_or_unpinned_stream = function (sub) {
+    // Pinned/unpinned streams require re-ordering.
+    // We use kind of brute force now, which is probably fine.
     sub.sidebar_li = build_stream_sidebar_row(sub.name);
     exports.build_stream_list();
     exports.update_streams_sidebar();

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -377,15 +377,6 @@ exports.mark_sub_unsubscribed = function (sub) {
     $(document).trigger($.Event('subscription_remove_done.zulip', {sub: sub}));
 };
 
-exports.pin_or_unpin_stream = function (stream_name) {
-    var sub = stream_data.get_sub(stream_name);
-    if (stream_name === undefined) {
-        return;
-    } else {
-        stream_list.refresh_stream_in_sidebar(sub);
-    }
-};
-
 exports.filter_table = function (query) {
     var sub_name_elements = $('#subscriptions_table .subscription_name');
 
@@ -521,6 +512,7 @@ exports.update_subscription_properties = function (stream_name, property, value)
         break;
     case 'pin_to_top':
         update_stream_pin(sub, value);
+        stream_list.refresh_pinned_or_unpinned_stream(sub);
         break;
     default:
         blueslip.warn("Unexpected subscription property type", {property: property,


### PR DESCRIPTION
I make server_events slimmer by not handling a specific
property when subs.update_subscription_properties() should
do all the dispatching (and mostly did).

And then since update_subscription_properties() has
a "sub" already, I can call directly to stream_list code
and remove a function from subs.js.  Since I lose the
wrapper function in subs.js, I rename the stream_list
function as part of this commit.

The only code that gets slightly heavier here is that
we have two lines in the 'pin_to_top' case instead of one.