### PR TITLE
docs: change zulip.tabbott.net to chat.zulip.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ at https://www.zulip.org.
 
 There are several places online where folks discuss Zulip.
 
-One of those places is our [public Zulip instance](https://zulip.tabbott.net/).
+One of those places is our [public Zulip instance](https://chat.zulip.org/).
 You can go through the simple signup process at that link, and then you
 will soon be talking to core Zulip developers and other users.  To get
 help in real time, you will have the best luck finding core developers

--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -21,7 +21,7 @@ If you encounter errors installing the Zulip development environment,
 check [Troubleshooting & Common
 Errors](#troubleshooting-common-errors). If that doesn't help, please
 visit [the `provision` stream in the Zulip developers'
-chat](https://zulip.tabbott.net/#narrow/stream/provision) for realtime
+chat](https://chat.zulip.org/#narrow/stream/provision) for realtime
 help, or send a note to the [Zulip-devel Google
 group](https://groups.google.com/forum/#!forum/zulip-devel) or [file
 an issue](https://github.com/zulip/zulip/issues).
@@ -249,7 +249,7 @@ processes. (See [Specifying a
 proxy](brief-install-vagrant-dev.html#specifying-a-proxy) if you need
 a proxy to access the internet.) And if you're running into any
 problems, please come chat with us [in the `provision` stream of our
-developers' chat](https://zulip.tabbott.net/#narrow/stream/provision).
+developers' chat](https://chat.zulip.org/#narrow/stream/provision).
 
 Once `vagrant up` has completed, connect to the dev environment with `vagrant
 ssh`:

--- a/docs/life-of-a-request.md
+++ b/docs/life-of-a-request.md
@@ -120,7 +120,7 @@ identifier, the user's email.
 The OPTIONS method will yield the allowed methods.
 
 This request:
-`OPTIONS https://zulip.tabbott.net/api/v1/users`
+`OPTIONS https://chat.zulip.org/api/v1/users`
 yields a response with this HTTP header:
 `Allow: PUT, GET`
 

--- a/docs/prod-install.md
+++ b/docs/prod-install.md
@@ -164,6 +164,6 @@ If you get an error after `scripts/setup/install` completes, check
 [troubleshooting section](prod-troubleshooting.html) for advice on
 how to debug.  If that doesn't help, please visit [the "installation
 help" stream in the Zulip developers'
-chat](https://zulip.tabbott.net/#narrow/stream/installation.20help)
+chat](https://chat.zulip.org/#narrow/stream/installation.20help)
 for realtime help or email zulip-help@googlegroups.com with the
 traceback and we'll try to help you out!

--- a/docs/prod-requirements.md
+++ b/docs/prod-requirements.md
@@ -6,7 +6,7 @@ following [these
 instructions](readme-symlink.html#installing-the-zulip-development-environment),
 since then you don't need to worry about setting up SSL certificates and an
 authentication mechanism. Or, you can check out the
-[developers' chatroom](http://zulip.tabbott.net/) (a public, running Zulip
+[developers' chatroom](http://chat.zulip.org/) (a public, running Zulip
 instance).
 
 ## Server

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -11,7 +11,7 @@ translating Zulip would be greatly appreciated!
 
 If you're interested in contributing translations to Zulip, please
 [join the "translation" stream in our developers' Zulip
-chat](https://zulip.tabbott.net/#narrow/stream/translation), and say
+chat](https://chat.zulip.org/#narrow/stream/translation), and say
 hello. And please join the [Zulip project on
 Transifex](https://www.transifex.com/zulip/zulip/) and ask to join any
 languages you'd like to contribute to (or add new ones).  Transifex's


### PR DESCRIPTION
docs: change zulip.tabbott.net to chat.zulip.org 
please checkout @timabbott 
