### PR TITLE
Typing backend: use dict instead of user profile for sender in event.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -823,10 +823,11 @@ def do_send_typing_notification(notification):
                                                           notification['sender'].id)
     recipients = [{'id': profile.id, 'email': profile.email} for profile in recipient_user_profiles]
     active_recipients = [profile for profile in recipient_user_profiles if profile.is_active]
+    sender = {'id': notification['sender'].id, 'email': notification['sender'].email}
     event = dict(
             type            = 'typing',
             op              = notification['op'],
-            sender          = notification['sender'],
+            sender          = sender,
             recipients      = recipients)
 
     # Only deliver the notification to active user recipients

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -5,8 +5,6 @@ import ujson
 from typing import Any, Dict, List
 from six import string_types
 
-from zerver.models import get_user_profile_by_email
-
 from zerver.lib.test_helpers import ZulipTestCase, tornado_redirected_to_list, get_display_recipient
 
 class TypingNotificationOperatorTest(ZulipTestCase):
@@ -74,7 +72,7 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
 
-        self.assertTrue(event['sender'] == get_user_profile_by_email(sender))
+        self.assertTrue(event['sender']['email'] == sender)
         self.assertTrue(event_recipient_emails == expected_recipients)
         self.assertTrue(event['type'] == 'typing')
         self.assertTrue(event['op'] == 'start')
@@ -99,7 +97,7 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
 
-        self.assertTrue(event['sender'] == get_user_profile_by_email(sender))
+        self.assertTrue(event['sender']['email'] == sender)
         self.assertTrue(event_recipient_emails == expected_recipients)
         self.assertTrue(event['type'] == 'typing')
         self.assertTrue(event['op'] == 'start')
@@ -124,7 +122,7 @@ class TypingStartedNotificationTest(ZulipTestCase):
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
 
-        self.assertTrue(event['sender'] == get_user_profile_by_email(email))
+        self.assertTrue(event['sender']['email'] == email)
         self.assertTrue(event_recipient_emails == set([email]))
         self.assertTrue(event['type'] == 'typing')
         self.assertTrue(event['op'] == 'start')
@@ -148,7 +146,7 @@ class TypingStartedNotificationTest(ZulipTestCase):
 
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
-        self.assertTrue(event['sender'] == get_user_profile_by_email(sender))
+        self.assertTrue(event['sender']['email'] == sender)
         self.assertTrue(event_recipient_emails == expected_recipients)
         self.assertTrue(event['type'] == 'typing')
         self.assertTrue(event['op'] == 'start')
@@ -172,7 +170,7 @@ class StoppedTypingNotificationTest(ZulipTestCase):
 
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
-        self.assertTrue(event['sender'] == get_user_profile_by_email(email))
+        self.assertTrue(event['sender']['email'] == email)
         self.assertTrue(event_recipient_emails == set([email]))
         self.assertTrue(event['type'] == 'typing')
         self.assertTrue(event['op'] == 'stop')
@@ -197,7 +195,7 @@ class StoppedTypingNotificationTest(ZulipTestCase):
 
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
-        self.assertTrue(event['sender'] == get_user_profile_by_email(sender))
+        self.assertTrue(event['sender']['email'] == sender)
         self.assertTrue(event_recipient_emails == expected_recipients)
         self.assertTrue(event['type'] == 'typing')
         self.assertTrue(event['op'] == 'stop')


### PR DESCRIPTION
The typing notification event contained a userprofile for the sender. Replacing this with a dict containing the email and id for the sender (similar to the recipient) fixes #2110.