### PR TITLE
Extract topic_list.js

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -20,6 +20,9 @@ set_global('message_store', {
 
 var stream_list = require('js/stream_list.js');
 
+// TODO: split out topic_list stuff to its own test module.
+var topic_list = require('js/topic_list.js');
+
 var jsdom = require("jsdom");
 var window = jsdom.jsdom().defaultView;
 global.$ = require('jquery')(window);
@@ -33,7 +36,7 @@ global.use_template('sidebar_private_message_list');
 global.use_template('stream_sidebar_row');
 global.use_template('stream_privacy');
 
-(function test_build_subject_list() {
+(function test_topic_list_build_list() {
     var stream = "devel";
     var active_topic = "testing";
     var max_topics = 5;
@@ -46,8 +49,8 @@ global.use_template('stream_privacy');
         return 1;
     };
 
-    var topic_html = stream_list._build_subject_list(stream, active_topic, max_topics);
-    global.write_test_output("test_build_subject_list", topic_html);
+    var topic_html = topic_list.build_list(stream, active_topic, max_topics);
+    global.write_test_output("test_topic_list_build_list", topic_html);
 
     var topic = $(topic_html).find('a').text().trim();
     assert.equal(topic, 'coding');

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -399,16 +399,8 @@ exports._build_private_messages_list = function (active_conversation, max_privat
 function rebuild_recent_topics(stream, active_topic) {
     // TODO: Call rebuild_recent_topics less, not on every new
     // message.
-    topic_list.remove_expanded_topics();
-    var max_subjects = 5;
     var stream_li = get_filter_li('stream', stream);
-
-    var topic_dom = topic_list.build_list(stream, active_topic, max_subjects);
-    stream_li.append(topic_dom);
-
-    if (active_topic) {
-        topic_list.activate_topic(stream_li, active_topic);
-    }
+    topic_list.rebuild(stream_li, stream, active_topic);
 }
 
 function rebuild_recent_private_messages(active_conversation) {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -226,11 +226,6 @@ function reset_to_unnarrowed(narrowed_within_same_stream) {
     remove_expanded_private_messages();
 }
 
-function get_subject_filter_li(stream, subject) {
-    var stream_li = get_filter_li('stream', stream);
-    return iterate_to_find(".expanded_subjects li.expanded_subject", subject, stream_li);
-}
-
 function get_private_message_filter_li(conversation) {
     var pm_li = get_filter_li('global', 'private');
     return iterate_to_find(".expanded_private_messages li.expanded_private_message",
@@ -353,19 +348,6 @@ function set_count_toggle_button(elem, count) {
     }
 }
 
-exports.set_subject_count = function (stream, subject, count) {
-    var subject_li = get_subject_filter_li(stream, subject);
-    var count_span = subject_li.find('.subject_count');
-    var value_span = count_span.find('.value');
-
-    if (count_span.length === 0 || value_span.length === 0) {
-        return;
-    }
-
-    topic_list.update_count_in_dom(count_span, value_span, count);
-};
-
-
 exports.set_pm_conversation_count = function (conversation, count) {
     var pm_li = get_private_message_filter_li(conversation);
     var count_span = pm_li.find('.private_message_count');
@@ -470,7 +452,7 @@ function rebuild_recent_topics(stream, active_topic) {
     stream_li.append(topic_dom);
 
     if (active_topic) {
-        get_subject_filter_li(stream, active_topic).addClass('active-sub-filter');
+        topic_list.activate_topic(stream_li, active_topic);
     }
 }
 
@@ -574,8 +556,9 @@ exports.update_dom_with_unread_counts = function (counts) {
 
     // counts.subject_count maps streams to hashes of subjects to counts
     counts.subject_count.each(function (subject_hash, stream) {
+        var stream_li = get_filter_li('stream', stream);
         subject_hash.each(function (count, subject) {
-            exports.set_subject_count(stream, subject, count);
+            topic_list.set_count(stream_li, subject, count);
         });
     });
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -371,7 +371,6 @@ exports._build_private_messages_list = function (active_conversation, max_privat
         var replies_to = private_message_obj.reply_to;
         var num_unread = unread.num_unread_for_person(private_message_obj.reply_to);
 
-        // Show the most recent subjects, as well as any with unread messages
         var always_visible = (idx < max_private_messages) || (num_unread > 0)
             || (replies_to === active_conversation);
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -362,8 +362,7 @@ exports.set_subject_count = function (stream, subject, count) {
         return;
     }
 
-    count_span.removeClass("zero_count");
-    update_count_in_dom(count_span, value_span, count);
+    topic_list.update_count_in_dom(count_span, value_span, count);
 };
 
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -204,11 +204,6 @@ function zoom_out() {
     $("#stream_filters li.narrow-filter").show();
 }
 
-function remove_expanded_topics() {
-    popovers.hide_topic_sidebar_popover();
-    $("ul.expanded_subjects").remove();
-}
-
 function remove_expanded_private_messages() {
     popovers.hide_topic_sidebar_popover();
     $("ul.expanded_private_messages").remove();
@@ -222,7 +217,7 @@ function reset_to_unnarrowed(narrowed_within_same_stream) {
 
     private_messages_open = false;
     $("ul.filters li").removeClass('active-filter active-sub-filter');
-    remove_expanded_topics();
+    topic_list.remove_expanded_topics();
     remove_expanded_private_messages();
 }
 
@@ -444,7 +439,7 @@ exports._build_private_messages_list = function (active_conversation, max_privat
 function rebuild_recent_topics(stream, active_topic) {
     // TODO: Call rebuild_recent_topics less, not on every new
     // message.
-    remove_expanded_topics();
+    topic_list.remove_expanded_topics();
     var max_subjects = 5;
     var stream_li = get_filter_li('stream', stream);
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -360,46 +360,6 @@ exports.remove_narrow_filter = function (name, type) {
     get_filter_li(type, name).remove();
 };
 
-exports._build_subject_list = function (stream, active_topic, max_subjects) {
-    var subjects = stream_data.recent_subjects.get(stream) || [];
-
-    if (active_topic) {
-        active_topic = active_topic.toLowerCase();
-    }
-
-    var display_subjects = [];
-    var hiding_topics = false;
-
-    _.each(subjects, function (subject_obj, idx) {
-        var topic_name = subject_obj.subject;
-        var num_unread = unread.num_unread_for_subject(stream, subject_obj.canon_subject);
-
-        // Show the most recent subjects, as well as any with unread messages
-        var always_visible = (idx < max_subjects) || (num_unread > 0) || (active_topic === topic_name);
-
-        if (!always_visible) {
-            hiding_topics = true;
-        }
-
-        var display_subject = {
-            topic_name: topic_name,
-            unread: num_unread,
-            is_zero: num_unread === 0,
-            is_muted: muting.is_topic_muted(stream, topic_name),
-            zoom_out_hide: !always_visible,
-            url: narrow.by_stream_subject_uri(stream, topic_name)
-        };
-        display_subjects.push(display_subject);
-    });
-
-    var topic_dom = templates.render('sidebar_subject_list',
-                                      {subjects: display_subjects,
-                                       want_show_more_topics_links: hiding_topics,
-                                       stream: stream});
-
-    return topic_dom;
-};
-
 exports._build_private_messages_list = function (active_conversation, max_private_messages) {
 
     var private_messages = message_store.recent_private_messages || [];
@@ -443,7 +403,7 @@ function rebuild_recent_topics(stream, active_topic) {
     var max_subjects = 5;
     var stream_li = get_filter_li('stream', stream);
 
-    var topic_dom = exports._build_subject_list(stream, active_topic, max_subjects);
+    var topic_dom = topic_list.build_list(stream, active_topic, max_subjects);
     stream_li.append(topic_dom);
 
     if (active_topic) {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -539,6 +539,14 @@ exports.refresh_pinned_or_unpinned_stream = function (sub) {
 };
 
 $(function () {
+    // TODO, Eventually topic_list won't be a big singleton,
+    // and we can create more component-based click handlers for
+    // each stream.
+    topic_list.set_click_handlers({
+        zoom_in: zoom_in,
+        zoom_out: zoom_out
+    });
+
     $(document).on('narrow_activated.zulip', function (event) {
         reset_to_unnarrowed(active_stream_name() === zoomed_stream);
 
@@ -610,21 +618,6 @@ $(function () {
         previous_unpinned_order = undefined;
     });
 
-    $('.show-all-streams').on('click', function (e) {
-        zoom_out();
-        e.preventDefault();
-        e.stopPropagation();
-    });
-
-    $('#stream_filters').on('click', '.show-more-topics', function (e) {
-        var stream = $(e.target).parents('.show-more-topics').attr('data-name');
-
-        zoom_in();
-
-        e.preventDefault();
-        e.stopPropagation();
-    });
-
     $('#global_filters').on('click', '.show-more-private-messages', function (e) {
         popovers.hide_all();
         $(".expanded_private_messages").expectOne().removeClass("zoom-out").addClass("zoom-in");
@@ -649,24 +642,6 @@ $(function () {
 
         e.preventDefault();
         e.stopPropagation();
-    });
-
-    $('#stream_filters').on('click', '.subject_box', function (e) {
-        if (e.metaKey || e.ctrlKey) {
-            return;
-        }
-        if (ui.home_tab_obscured()) {
-            ui.change_tab_to('#home');
-        }
-
-        var stream = $(e.target).parents('ul').attr('data-stream');
-        var subject = $(e.target).parents('li').attr('data-name');
-
-        narrow.activate([{operator: 'stream',  operand: stream},
-                         {operator: 'topic', operand: subject}],
-                        {select_first_unread: true, trigger: 'sidebar'});
-
-        e.preventDefault();
     });
 
 });

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -55,6 +55,46 @@ exports.set_count = function (stream_li, topic, count) {
     exports.update_count_in_dom(count_span, value_span, count);
 };
 
+exports.build_list = function (stream, active_topic, max_topics) {
+    var subjects = stream_data.recent_subjects.get(stream) || [];
+
+    if (active_topic) {
+        active_topic = active_topic.toLowerCase();
+    }
+
+    var display_subjects = [];
+    var hiding_topics = false;
+
+    _.each(subjects, function (subject_obj, idx) {
+        var topic_name = subject_obj.subject;
+        var num_unread = unread.num_unread_for_subject(stream, subject_obj.canon_subject);
+
+        // Show the most recent subjects, as well as any with unread messages
+        var always_visible = (idx < max_topics) || (num_unread > 0) || (active_topic === topic_name);
+
+        if (!always_visible) {
+            hiding_topics = true;
+        }
+
+        var display_subject = {
+            topic_name: topic_name,
+            unread: num_unread,
+            is_zero: num_unread === 0,
+            is_muted: muting.is_topic_muted(stream, topic_name),
+            zoom_out_hide: !always_visible,
+            url: narrow.by_stream_subject_uri(stream, topic_name)
+        };
+        display_subjects.push(display_subject);
+    });
+
+    var topic_dom = templates.render('sidebar_subject_list',
+                                      {subjects: display_subjects,
+                                       want_show_more_topics_links: hiding_topics,
+                                       stream: stream});
+
+    return topic_dom;
+};
+
 
 return exports;
 }());

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -108,6 +108,43 @@ exports.rebuild = function (stream_li, stream, active_topic) {
     }
 };
 
+exports.set_click_handlers = function (callbacks) {
+    $('#stream_filters').on('click', '.show-more-topics', function (e) {
+        callbacks.zoom_in();
+
+        e.preventDefault();
+        e.stopPropagation();
+    });
+
+    $('.show-all-streams').on('click', function (e) {
+        callbacks.zoom_out();
+
+        e.preventDefault();
+        e.stopPropagation();
+    });
+
+    $('#stream_filters').on('click', '.subject_box', function (e) {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
+        // In a more componentized world, we would delegate some
+        // of this stuff back up to our parents.
+        if (ui.home_tab_obscured()) {
+            ui.change_tab_to('#home');
+        }
+
+        var stream = $(e.target).parents('ul').attr('data-stream');
+        var topic = $(e.target).parents('li').attr('data-name');
+
+        narrow.activate([{operator: 'stream',  operand: stream},
+                         {operator: 'topic', operand: topic}],
+                        {select_first_unread: true, trigger: 'sidebar'});
+
+        e.preventDefault();
+    });
+};
+
 
 return exports;
 }());

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -95,6 +95,19 @@ exports.build_list = function (stream, active_topic, max_topics) {
     return topic_dom;
 };
 
+exports.rebuild = function (stream_li, stream, active_topic) {
+    var max_topics = 5;
+
+    exports.remove_expanded_topics();
+
+    var topic_dom = exports.build_list(stream, active_topic, max_topics);
+    stream_li.append(topic_dom);
+
+    if (active_topic) {
+        exports.activate_topic(stream_li, active_topic);
+    }
+};
+
 
 return exports;
 }());

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -1,0 +1,20 @@
+var topic_list = (function () {
+
+var exports = {};
+
+exports.update_count_in_dom = function (count_span, value_span, count) {
+    if (count === 0) {
+        count_span.hide();
+        value_span.text('');
+    } else {
+        count_span.removeClass("zero_count");
+        count_span.show();
+        value_span.text(count);
+    }
+};
+
+return exports;
+}());
+if (typeof module !== 'undefined') {
+    module.exports = topic_list;
+}

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -2,6 +2,31 @@ var topic_list = (function () {
 
 var exports = {};
 
+function iterate_to_find(selector, name_to_find, context) {
+    // This code is duplicated with stream_list.js, but we should
+    // not try to de-dup this; instead, we should try to make it sane
+    // for topics and avoid O(N) iteration.
+    //
+    // We could start by using canonical lowercase values for the
+    // data-name attributes (and eventually use topic ids when the
+    // back end allows).  Either that, or we should have a data
+    // structure that links topic names to list items, so that we
+    // don't have to search the DOM at all.
+    var lowercase_name = name_to_find.toLowerCase();
+    var found = _.find($(selector, context), function (elem) {
+        return $(elem).attr('data-name').toLowerCase() === lowercase_name;
+    });
+    return found ? $(found) : $();
+}
+
+function get_topic_filter_li(stream_li, topic) {
+    return iterate_to_find(".expanded_subjects li.expanded_subject", topic, stream_li);
+}
+
+exports.activate_topic = function (stream_li, active_topic) {
+    get_topic_filter_li(stream_li, active_topic).addClass('active-sub-filter');
+};
+
 exports.update_count_in_dom = function (count_span, value_span, count) {
     if (count === 0) {
         count_span.hide();
@@ -12,6 +37,19 @@ exports.update_count_in_dom = function (count_span, value_span, count) {
         value_span.text(count);
     }
 };
+
+exports.set_count = function (stream_li, topic, count) {
+    var topic_li = get_topic_filter_li(stream_li, topic);
+    var count_span = topic_li.find('.subject_count');
+    var value_span = count_span.find('.value');
+
+    if (count_span.length === 0 || value_span.length === 0) {
+        return;
+    }
+
+    exports.update_count_in_dom(count_span, value_span, count);
+};
+
 
 return exports;
 }());

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -19,6 +19,11 @@ function iterate_to_find(selector, name_to_find, context) {
     return found ? $(found) : $();
 }
 
+exports.remove_expanded_topics = function () {
+    popovers.hide_topic_sidebar_popover();
+    $("ul.expanded_subjects").remove();
+};
+
 function get_topic_filter_li(stream_li, topic) {
     return iterate_to_find(".expanded_subjects li.expanded_subject", topic, stream_li);
 }

--- a/tools/jslint/check-all.js
+++ b/tools/jslint/check-all.js
@@ -29,7 +29,7 @@ var globals =
     + ' avatar feature_flags search_suggestion referral stream_color Dict'
     + ' Filter summary admin stream_data muting WinChan muting_ui Socket channel gear_menu'
     + ' message_flags bot_data loading favicon resize scroll_bar condense floating_recipient_bar'
-    + ' copy_and_paste click_handlers'
+    + ' copy_and_paste click_handlers topic_list'
 
     // colorspace.js
     + ' colorspace'

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -760,6 +760,7 @@ JS_SPECS = {
             'js/viewport.js',
             'js/rows.js',
             'js/unread.js',
+            'js/topic_list.js',
             'js/stream_list.js',
             'js/filter.js',
             'js/message_list_view.js',


### PR DESCRIPTION
This extracts 153 lines of code into topic_list.js.  All changes were fairly minor.  I did a fair amount of renaming, but mostly s/subject/topic/.  Most functions were moved over more or less wholesale, but there are a few places where I left a two-line wrapper or something similar in stream_list.js.

Moving this into a module is great, but we still have a lot of DOM-lookup coupling between stream_list and topic_list.  Also, topic_list is still a singleton, whereas ideally you would instantiate a different object for each stream.  And popover logic is still in popover.js, but the topic popover logic is pretty minimal.

It may make sense to squash this all into one commit, but the individual pieces were all atomic, and I tested them pretty meticulously.