### PR TITLE
Pass list of user ids to send_event - to fix issue #2151

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -821,17 +821,18 @@ def do_send_typing_notification(notification):
     # type: (Dict[str, Any]) -> None
     recipient_user_profiles = get_recipient_user_profiles(notification['recipient'],
                                                           notification['sender'].id)
-    recipients = [{'id': profile.id, 'email': profile.email} for profile in recipient_user_profiles]
-    active_recipients = [profile for profile in recipient_user_profiles if profile.is_active]
-    sender = {'id': notification['sender'].id, 'email': notification['sender'].email}
+    # Only deliver the notification to active user recipients
+    user_ids_to_notify = [profile.id for profile in recipient_user_profiles if profile.is_active]
+    sender_dict = {'user_id': notification['sender'].id, 'email': notification['sender'].email}
+    # Include a list of recipients in the event body to help identify where the typing is happening
+    recipient_dicts = [{'user_id': profile.id, 'email': profile.email} for profile in recipient_user_profiles]
     event = dict(
             type            = 'typing',
             op              = notification['op'],
-            sender          = sender,
-            recipients      = recipients)
+            sender          = sender_dict,
+            recipients      = recipient_dicts)
 
-    # Only deliver the notification to active user recipients
-    send_event(event, active_recipients)
+    send_event(event, user_ids_to_notify)
 
 # check_send_typing_notification:
 # Checks the typing notification and sends it

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 from six import string_types
 
 from zerver.lib.test_helpers import ZulipTestCase, tornado_redirected_to_list, get_display_recipient
+from zerver.models import get_user_profile_by_email
 
 class TypingNotificationOperatorTest(ZulipTestCase):
     def test_missing_parameter(self):
@@ -59,7 +60,8 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
         """
         sender = 'hamlet@zulip.com'
         recipient = 'othello@zulip.com'
-        expected_recipients = set([sender, recipient])
+        expected_recipient_emails = set([sender, recipient])
+        expected_recipient_ids = set([get_user_profile_by_email(email).id for email in expected_recipient_emails])
 
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
@@ -67,15 +69,19 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
                                                          'op': 'start'},
                                       **self.api_auth(sender))
         self.assert_json_success(result)
-        self.assertTrue(len(events) == 1)
+        self.assertEqual(len(events), 1)
 
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
+        event_user_ids = set(events[0]['users'])
+        event_recipient_user_ids = set(user['user_id'] for user in event['recipients'])
 
-        self.assertTrue(event['sender']['email'] == sender)
-        self.assertTrue(event_recipient_emails == expected_recipients)
-        self.assertTrue(event['type'] == 'typing')
-        self.assertTrue(event['op'] == 'start')
+        self.assertEqual(expected_recipient_ids, event_recipient_user_ids)
+        self.assertEqual(expected_recipient_ids, event_user_ids)
+        self.assertEqual(event['sender']['email'], sender)
+        self.assertEqual(event_recipient_emails, expected_recipient_emails)
+        self.assertEqual(event['type'], 'typing')
+        self.assertEqual(event['op'], 'start')
 
     def test_multiple_recipients(self):
         # type: () -> None
@@ -84,23 +90,27 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
         """
         sender = 'hamlet@zulip.com'
         recipient = ['othello@zulip.com', 'cordelia@zulip.com']
-        expected_recipients = set(recipient) | set([sender])
-
+        expected_recipient_emails = set(recipient) | set([sender])
+        expected_recipient_ids = set([get_user_profile_by_email(email).id for email in expected_recipient_emails])
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             result = self.client_post('/api/v1/typing', {'to': ujson.dumps(recipient),
                                                          'op': 'start'},
                                       **self.api_auth(sender))
         self.assert_json_success(result)
-        self.assertTrue(len(events) == 1)
+        self.assertEqual(len(events), 1)
 
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
+        event_user_ids = set(events[0]['users'])
+        event_recipient_user_ids = set(user['user_id'] for user in event['recipients'])
 
-        self.assertTrue(event['sender']['email'] == sender)
-        self.assertTrue(event_recipient_emails == expected_recipients)
-        self.assertTrue(event['type'] == 'typing')
-        self.assertTrue(event['op'] == 'start')
+        self.assertEqual(expected_recipient_ids, event_recipient_user_ids)
+        self.assertEqual(expected_recipient_ids, event_user_ids)
+        self.assertEqual(event['sender']['email'], sender)
+        self.assertEqual(event_recipient_emails, expected_recipient_emails)
+        self.assertEqual(event['type'], 'typing')
+        self.assertEqual(event['op'], 'start')
 
 class TypingStartedNotificationTest(ZulipTestCase):
     def test_send_notification_to_self_event(self):
@@ -110,22 +120,27 @@ class TypingStartedNotificationTest(ZulipTestCase):
         is successful.
         """
         email = 'hamlet@zulip.com'
-
+        expected_recipient_emails = set([email])
+        expected_recipient_ids = set([get_user_profile_by_email(email).id])
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             result = self.client_post('/api/v1/typing', {'to': email,
                                                          'op': 'start'},
                                       **self.api_auth(email))
         self.assert_json_success(result)
-        self.assertTrue(len(events) == 1)
+        self.assertEqual(len(events), 1)
 
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
+        event_user_ids = set(events[0]['users'])
+        event_recipient_user_ids = set(user['user_id'] for user in event['recipients'])
 
-        self.assertTrue(event['sender']['email'] == email)
-        self.assertTrue(event_recipient_emails == set([email]))
-        self.assertTrue(event['type'] == 'typing')
-        self.assertTrue(event['op'] == 'start')
+        self.assertEqual(expected_recipient_ids, event_recipient_user_ids)
+        self.assertEqual(expected_recipient_ids, event_user_ids)
+        self.assertEqual(event_recipient_emails, expected_recipient_emails)
+        self.assertEqual(event['sender']['email'], email)
+        self.assertEqual(event['type'], 'typing')
+        self.assertEqual(event['op'], 'start')
 
     def test_send_notification_to_another_user_event(self):
         # type: () -> None
@@ -135,21 +150,28 @@ class TypingStartedNotificationTest(ZulipTestCase):
         """
         sender = 'hamlet@zulip.com'
         recipient = 'othello@zulip.com'
-        expected_recipients = set([sender, recipient])
+        expected_recipient_emails = set([sender, recipient])
+        expected_recipient_ids = set([get_user_profile_by_email(email).id for email in expected_recipient_emails])
+
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             result = self.client_post('/api/v1/typing', {'to': recipient,
                                                          'op': 'start'},
                                       **self.api_auth(sender))
         self.assert_json_success(result)
-        self.assertTrue(len(events) == 1)
+        self.assertEqual(len(events), 1)
 
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
-        self.assertTrue(event['sender']['email'] == sender)
-        self.assertTrue(event_recipient_emails == expected_recipients)
-        self.assertTrue(event['type'] == 'typing')
-        self.assertTrue(event['op'] == 'start')
+        event_user_ids = set(events[0]['users'])
+        event_recipient_user_ids = set(user['user_id'] for user in event['recipients'])
+
+        self.assertEqual(expected_recipient_ids, event_recipient_user_ids)
+        self.assertEqual(expected_recipient_ids, event_user_ids)
+        self.assertEqual(event_recipient_emails, expected_recipient_emails)
+        self.assertEqual(event['sender']['email'], sender)
+        self.assertEqual(event['type'], 'typing')
+        self.assertEqual(event['op'], 'start')
 
 class StoppedTypingNotificationTest(ZulipTestCase):
     def test_send_notification_to_self_event(self):
@@ -159,6 +181,8 @@ class StoppedTypingNotificationTest(ZulipTestCase):
         is successful.
         """
         email = 'hamlet@zulip.com'
+        expected_recipient_emails = set([email])
+        expected_recipient_ids = set([get_user_profile_by_email(email).id])
 
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
@@ -166,14 +190,19 @@ class StoppedTypingNotificationTest(ZulipTestCase):
                                                          'op': 'stop'},
                                       **self.api_auth(email))
         self.assert_json_success(result)
-        self.assertTrue(len(events) == 1)
+        self.assertEqual(len(events), 1)
 
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
-        self.assertTrue(event['sender']['email'] == email)
-        self.assertTrue(event_recipient_emails == set([email]))
-        self.assertTrue(event['type'] == 'typing')
-        self.assertTrue(event['op'] == 'stop')
+        event_user_ids = set(events[0]['users'])
+        event_recipient_user_ids = set(user['user_id'] for user in event['recipients'])
+
+        self.assertEqual(expected_recipient_ids, event_recipient_user_ids)
+        self.assertEqual(expected_recipient_ids, event_user_ids)
+        self.assertEqual(event_recipient_emails, expected_recipient_emails)
+        self.assertEqual(event['sender']['email'], email)
+        self.assertEqual(event['type'], 'typing')
+        self.assertEqual(event['op'], 'stop')
 
 
     def test_send_notification_to_another_user_event(self):
@@ -184,18 +213,25 @@ class StoppedTypingNotificationTest(ZulipTestCase):
         """
         sender = 'hamlet@zulip.com'
         recipient = 'othello@zulip.com'
-        expected_recipients = set([sender, recipient])
+        expected_recipient_emails = set([sender, recipient])
+        expected_recipient_ids = set([get_user_profile_by_email(email).id for email in expected_recipient_emails])
+
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             result = self.client_post('/api/v1/typing', {'to': recipient,
                                                          'op': 'stop'},
                                       **self.api_auth(sender))
         self.assert_json_success(result)
-        self.assertTrue(len(events) == 1)
+        self.assertEqual(len(events), 1)
 
         event = events[0]['event']
         event_recipient_emails = set(user['email'] for user in event['recipients'])
-        self.assertTrue(event['sender']['email'] == sender)
-        self.assertTrue(event_recipient_emails == expected_recipients)
-        self.assertTrue(event['type'] == 'typing')
-        self.assertTrue(event['op'] == 'stop')
+        event_user_ids = set(events[0]['users'])
+        event_recipient_user_ids = set(user['user_id'] for user in event['recipients'])
+
+        self.assertEqual(expected_recipient_ids, event_recipient_user_ids)
+        self.assertEqual(expected_recipient_ids, event_user_ids)
+        self.assertEqual(event_recipient_emails, expected_recipient_emails)
+        self.assertEqual(event['sender']['email'], sender)
+        self.assertEqual(event['type'], 'typing')
+        self.assertEqual(event['op'], 'stop')


### PR DESCRIPTION
do_send_typing_notification() was sending a list of user profiles to send_event(). This caused issue #2151 
This PR now sends a list of user ids to send_event(). Variable names have been changed to reflect their content - recipient_ids instead of recipients.
Assertions are added to tests to verify that the tornado event user ids are the same as the recipients.
