### PR TITLE
Z-Index Fix for Proper Ordering.

### DIFF
--- a/static/styles/overlay.css
+++ b/static/styles/overlay.css
@@ -11,7 +11,7 @@
 
     background-color: #19203a;
     box-shadow: 0 0 20px rgba(0,0,0,0.2);
-    z-index: 101;
+    z-index: 110;
 
     transition: all 0.2s ease;
     overflow: auto;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -84,7 +84,7 @@ p.n-margin {
     background-color: #FAFAFA;
     border-radius: 5px;
     box-shadow: 0px 0px 30px rgba(0,0,0,0.25);
-    z-index: 101;
+    z-index: 110;
 
     animation-name: pulse;
     animation-iteration-count: infinite;


### PR DESCRIPTION
This fixes the z-index of the lightbox overlay which now appears behind
the header, and the muting notification to be above everything else on
the page.