### PR TITLE
bug fix: Avoid duplicate prepend_subscriber() call.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -952,9 +952,6 @@ $(function () {
                 if (util.is_current_user(principal)) {
                     // mark_subscribed adds the user to the member list
                     exports.mark_subscribed(stream);
-                } else {
-                    prepend_subscriber(sub_row,
-                                       principal);
                 }
             } else {
                 error_elem.addClass("hide");


### PR DESCRIPTION
We don't want to prepend new subscribers to our list of
subscribers in the settings page when they hit enter; we
want to wait till we get the event from the server.

This is a fairly new regression that was added when we
live-updated peer subscriber changes.
