### PR TITLE
Code cleanup: email -> user_id

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ All notable changes to the Zulip server are documented in this file.
 
 ### Unreleased
 
+- Show subscriber counts in Manage Streams.
 - Added support for (optionally) using PGRoonga to support full-text
   search in all languages (not just English).
 - Added GitLab and Sentry integrations.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ All notable changes to the Zulip server are documented in this file.
 
 ### Unreleased
 
+- Have peer_add events send user_id, not email.
 - Show subscriber counts in Manage Streams.
 - Added support for (optionally) using PGRoonga to support full-text
   search in all languages (not just English).

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -1,5 +1,9 @@
 global.stub_out_jquery();
 
+set_global('page_params', {
+    people_list: []
+});
+
 add_dependencies({
     util: 'js/util.js',
     people: 'js/people.js'
@@ -11,22 +15,30 @@ set_global('document', {
     }
 });
 
-global.people.test_set_people_dict({
-    'alice@zulip.com': {
-        full_name: 'Alice Smith'
-    },
-    'fred@zulip.com': {
-        full_name: "Fred Flintstone"
-    },
-    'jill@zulip.com': {
-        full_name: 'Jill Hill'
-    },
-    'mark@zulip.com': {
-        full_name: 'Marky Mark'
-    },
-    'norbert@zulip.com': {
-        full_name: 'Norbert Oswald'
-    }
+global.people.add({
+    email: 'alice@zulip.com',
+    user_id: 1,
+    full_name: 'Alice Smith'
+});
+global.people.add({
+    email: 'fred@zulip.com',
+    user_id: 2,
+    full_name: "Fred Flintstone"
+});
+global.people.add({
+    email: 'jill@zulip.com',
+    user_id: 3,
+    full_name: 'Jill Hill'
+});
+global.people.add({
+    email: 'mark@zulip.com',
+    user_id: 4,
+    full_name: 'Marky Mark'
+});
+global.people.add({
+    email: 'norbert@zulip.com',
+    user_id: 5,
+    full_name: 'Norbert Oswald'
 });
 
 var activity = require('js/activity.js');

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -296,7 +296,7 @@ var event_fixtures = {
     subscription__peer_add: {
         type: 'subscription',
         op: 'peer_add',
-        user_email: 'bob@example.com',
+        user_id: 555,
         subscriptions: [
             {
                 name: 'devel',
@@ -634,6 +634,14 @@ run(function (override, capture, args) {
 
 run(function (override, capture, args) {
     // subscription
+
+    // This next section can go away when we start handling
+    // user_ids more directly in some of subscriptions code.
+    override('people', 'get_person_from_user_id', function (user_id) {
+        assert_same(user_id, 555);
+        return {email: 'bob@example.com'};
+    });
+
     var event = event_fixtures.subscription__add;
     override('subs', 'mark_subscribed', capture(['name', 'sub']));
     dispatch(event);
@@ -644,7 +652,7 @@ run(function (override, capture, args) {
     override('stream_data', 'add_subscriber', capture(['sub', 'email']));
     dispatch(event);
     assert_same(args.sub, event.subscriptions[0]);
-    assert_same(args.email, event.user_email);
+    assert_same(args.email, 'bob@example.com');
 
     event = event_fixtures.subscription__peer_remove;
     override('stream_data', 'remove_subscriber', capture(['sub', 'email']));

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 global.stub_out_jquery();
 
 set_global('page_params', {
+    people_list: [],
     realm_emoji: {
         burrito: {display_url: '/static/third/gemoji/images/emoji/burrito.png',
                   source_url: '/static/third/gemoji/images/emoji/burrito.png'}
@@ -48,8 +49,13 @@ set_global('$', function (obj) {
 
 set_global('feature_flags', {local_echo: true});
 
-var people = require("js/people.js");
-people.test_set_people_name_dict({'Cordelia Lear': {full_name: 'Cordelia Lear', email: 'cordelia@zulip.com'}});
+var people = global.people;
+
+people.add({
+    full_name: 'Cordelia Lear',
+    user_id: 101,
+    email: 'cordelia@zulip.com'
+});
 
 var echo = require('js/echo.js');
 

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -4,10 +4,26 @@ var fs = require('fs');
 
 global.stub_out_jquery();
 
-set_global('page_params', {realm_emoji: {
-  burrito: {display_url: '/static/third/gemoji/images/emoji/burrito.png',
-            source_url: '/static/third/gemoji/images/emoji/burrito.png'}
-}});
+set_global('page_params', {
+    realm_emoji: {
+        burrito: {display_url: '/static/third/gemoji/images/emoji/burrito.png',
+                  source_url: '/static/third/gemoji/images/emoji/burrito.png'}
+    },
+    realm_filters: [
+        [
+            "#(?P<id>[0-9]{2,8})",
+            "https://trac.zulip.net/ticket/%(id)s"
+        ],
+        [
+            "ZBUG_(?P<id>[0-9]{2,8})",
+            "https://trac2.zulip.net/ticket/%(id)s"
+        ],
+        [
+            "ZGROUP_(?P<id>[0-9]{2,8}):(?P<zone>[0-9]{1,8})",
+            "https://zone_%(zone)s.zulip.net/ticket/%(id)s"
+        ]
+    ]
+});
 
 add_dependencies({
     marked: 'third/marked/lib/marked.js',
@@ -28,12 +44,6 @@ set_global('$', function (obj) {
     // Selector usage
     return {on: function () {}};
   }
-});
-
-set_global('page_params', {
-  realm_filters: [["#(?P<id>[0-9]{2,8})", "https://trac.zulip.net/ticket/%(id)s"],
-                  ["ZBUG_(?P<id>[0-9]{2,8})", "https://trac2.zulip.net/ticket/%(id)s"],
-                  ["ZGROUP_(?P<id>[0-9]{2,8}):(?P<zone>[0-9]{1,8})", "https://zone_%(zone)s.zulip.net/ticket/%(id)s"]]
 });
 
 set_global('feature_flags', {local_echo: true});

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -22,6 +22,7 @@ var _ = global._;
 (function test_basics() {
     var orig_person = {
         email: 'orig@example.com',
+        user_id: 31,
         full_name: 'Original'
     };
     people.add(orig_person);
@@ -38,6 +39,7 @@ var _ = global._;
     var email = 'isaac@example.com';
     var isaac = {
         email: email,
+        user_id: 32,
         full_name: full_name
     };
     people.add(isaac);
@@ -84,22 +86,61 @@ var _ = global._;
     assert.equal(person.full_name, 'Original');
 }());
 
+(function test_get_person_from_user_id() {
+    var person = {
+        email: 'mary@example.com',
+        user_id: 42,
+        full_name: 'Mary'
+    };
+    people.add(person);
+    person = people.get_by_email('mary@example.com');
+    assert.equal(person.full_name, 'Mary');
+    person = people.get_person_from_user_id(42);
+    assert.equal(person.email, 'mary@example.com');
+
+    // The semantics for update() are going to eventually
+    // change to use user_id as a key, but now we use email
+    // as a key and change attributes.  With the current
+    // behavior, we don't have to make update() do anything
+    // new.
+    person = {
+        email: 'mary@example.com',
+        user_id: 42,
+        full_name: 'Mary New'
+    };
+    people.update(person);
+    person = people.get_person_from_user_id(42);
+    assert.equal(person.full_name, 'Mary New');
+
+    // remove() should eventually just take a user_id, but
+    // now it takes a full person object
+    people.remove(person);
+    person = people.get_by_email('mary@example.com');
+    assert.equal(person, undefined);
+    person = people.get_person_from_user_id(42);
+    assert.equal(person, undefined);
+}());
+
 (function test_get_rest_of_realm() {
     var myself = {
         email: 'myself@example.com',
+        user_id: 201,
         full_name: 'Yours Truly'
     };
     global.page_params.email = myself.email;
     var alice1 = {
         email: 'alice1@example.com',
+        user_id: 202,
         full_name: 'Alice'
     };
     var alice2 = {
         email: 'alice2@example.com',
+        user_id: 203,
         full_name: 'Alice'
     };
     var bob = {
         email: 'bob@example.com',
+        user_id: 204,
         full_name: 'Bob van Roberts'
     };
     people.add_in_realm(myself);
@@ -130,14 +171,17 @@ var _ = global._;
 (function test_filtered_users() {
      var charles = {
         email: 'charles@example.com',
+        user_id: 301,
         full_name: 'Charles Dickens'
     };
     var maria = {
         email: 'athens@example.com',
+        user_id: 302,
         full_name: 'Maria Athens'
     };
     var ashton = {
         email: 'ashton@example.com',
+        user_id: 303,
         full_name: 'Ashton Smith'
     };
 

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -45,6 +45,7 @@ var _ = global._;
     people.add(isaac);
 
     var person = people.get_by_name(full_name);
+    assert.equal(people.get_user_id(email), 32);
     assert.equal(person.email, email);
     person = people.get_by_email(email);
     assert.equal(person.full_name, full_name);

--- a/frontend_tests/node_tests/presence_list_performance.js
+++ b/frontend_tests/node_tests/presence_list_performance.js
@@ -47,22 +47,30 @@ activity.presence_info = {
 
 
 // TODO: de-dup with activity.js
-people.test_set_people_dict({
-    'alice@zulip.com': {
-        full_name: 'Alice Smith'
-    },
-    'fred@zulip.com': {
-        full_name: "Fred Flintstone"
-    },
-    'jill@zulip.com': {
-        full_name: 'Jill Hill'
-    },
-    'mark@zulip.com': {
-        full_name: 'Marky Mark'
-    },
-    'norbert@zulip.com': {
-        full_name: 'Norbert Oswald'
-    }
+global.people.add({
+    email: 'alice@zulip.com',
+    user_id: 1,
+    full_name: 'Alice Smith'
+});
+global.people.add({
+    email: 'fred@zulip.com',
+    user_id: 2,
+    full_name: "Fred Flintstone"
+});
+global.people.add({
+    email: 'jill@zulip.com',
+    user_id: 3,
+    full_name: 'Jill Hill'
+});
+global.people.add({
+    email: 'mark@zulip.com',
+    user_id: 4,
+    full_name: 'Marky Mark'
+});
+global.people.add({
+    email: 'norbert@zulip.com',
+    user_id: 5,
+    full_name: 'Norbert Oswald'
 });
 
 (function test_presence_list_full_update() {

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -89,6 +89,7 @@ global.stream_data.populate_stream_topics_for_tests({});
     var alice =
     {
         email: 'alice@zulip.com',
+        user_id: 102,
         full_name: 'Alice Ignore'
     };
 
@@ -362,16 +363,19 @@ global.stream_data.populate_stream_topics_for_tests({});
 
     var ted = {
         email: 'ted@zulip.com',
+        user_id: 201,
         full_name: 'Ted Smith'
     };
 
     var bob = {
         email: 'bob@zulip.com',
+        user_id: 202,
         full_name: 'Bob Terry'
     };
 
     var alice = {
         email: 'alice@zulip.com',
+        user_id: 203,
         full_name: 'Alice Ignore'
     };
     people.add(ted);

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -1,14 +1,20 @@
 global.stub_out_jquery();
 
+set_global('page_params', {
+    is_admin: false,
+    people_list: []
+});
+
 add_dependencies({
+    people: 'js/people.js',
     stream_color: 'js/stream_color.js',
     util: 'js/util.js'
 });
 
 set_global('blueslip', {});
-set_global('page_params', {is_admin: false});
 
 var stream_data = require('js/stream_data.js');
+var people= global.people;
 
 (function test_basics() {
     var denmark = {
@@ -91,7 +97,26 @@ var stream_data = require('js/stream_data.js');
 
     stream_data.add_sub('Rome', sub);
 
-    stream_data.set_subscribers(sub, ['fred@zulip.com', 'george@zulip.com']);
+    var fred = {
+        email: 'fred@zulip.com',
+        full_name: 'Fred',
+        user_id: 101
+    };
+    var not_fred = {
+        email: 'not_fred@zulip.com',
+        full_name: 'Not Fred',
+        user_id: 102
+    };
+    var george = {
+        email: 'george@zulip.com',
+        full_name: 'George',
+        user_id: 103
+    };
+    people.add(fred);
+    people.add(not_fred);
+    people.add(george);
+
+    stream_data.set_subscribers(sub, [fred.user_id, george.user_id]);
     assert(stream_data.user_is_subscribed('Rome', 'FRED@zulip.com'));
     assert(stream_data.user_is_subscribed('Rome', 'fred@zulip.com'));
     assert(stream_data.user_is_subscribed('Rome', 'george@zulip.com'));
@@ -100,6 +125,12 @@ var stream_data = require('js/stream_data.js');
     stream_data.set_subscribers(sub, []);
 
     var email = 'brutus@zulip.com';
+    var brutus = {
+        email: email,
+        full_name: 'Brutus',
+        user_id: 104
+    };
+    people.add(brutus);
     assert(!stream_data.user_is_subscribed('Rome', email));
 
     // add

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -62,12 +62,6 @@ var stream_data = require('js/stream_data.js');
 
     assert(stream_data.in_home_view('social'));
     assert(!stream_data.in_home_view('denmark'));
-
-    // Deleting a subscription makes you unsubscribed from the perspective of
-    // the client.
-    // Deleting a subscription is case-insensitive.
-    stream_data.delete_sub('SOCIAL');
-    assert(!stream_data.is_subscribed('social'));
 }());
 
 (function test_get_by_id() {
@@ -84,6 +78,11 @@ var stream_data = require('js/stream_data.js');
     assert.equal(sub.color, 'red');
     sub = stream_data.get_sub_by_id(id);
     assert.equal(sub.color, 'red');
+
+    stream_data.rename_sub(id, 'Sweden');
+    sub = stream_data.get_sub_by_id(id);
+    assert.equal(sub.color, 'red');
+    assert.equal(sub.name, 'Sweden');
 }());
 
 (function test_subscribers() {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -105,9 +105,6 @@ exports.get_by_name = function realm_get(name) {
 
 // TODO: Replace these with the tests setting up page_params before
 // loading people.js
-exports.test_set_people_dict = function (data) {
-    people_dict = new Dict.from(data);
-};
 exports.test_set_people_name_dict = function (data) {
     people_by_name_dict = new Dict.from(data);
 };

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -20,6 +20,21 @@ exports.get_by_email = function get_by_email(email) {
     return people_dict.get(email);
 };
 
+exports.get_user_id = function (email) {
+    var person = people_dict.get(email);
+    if (person === undefined) {
+        blueslip.error('Unknown email for get_user_id: ' + email);
+        return undefined;
+    }
+    var user_id = person.user_id;
+    if (!user_id) {
+        blueslip.error('No userid found for ' + email);
+        return undefined;
+    }
+
+    return user_id;
+};
+
 exports.realm_get = function realm_get(email) {
     return realm_people_dict.get(email);
 };

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -6,10 +6,15 @@ var exports = {};
 // All people we've seen
 var people_dict = new Dict({fold_case: true});
 var people_by_name_dict = new Dict({fold_case: true});
+var people_by_user_id_dict = new Dict();
 // People in this realm
 var realm_people_dict = new Dict({fold_case: true});
 var cross_realm_dict = new Dict({fold_case: true});
 var pm_recipient_count_dict = new Dict({fold_case: true});
+
+exports.get_person_from_user_id = function (user_id) {
+    return people_by_user_id_dict.get(user_id);
+};
 
 exports.get_by_email = function get_by_email(email) {
     return people_dict.get(email);
@@ -114,6 +119,18 @@ exports.get_rest_of_realm = function get_rest_of_realm() {
 };
 
 exports.add = function add(person) {
+    if (person.user_id) {
+        people_by_user_id_dict.set(person.user_id, person);
+    } else {
+        // We eventually want to lock this down completely
+        // and report an error and not update other the data
+        // structures here, but we have a lot of edge cases
+        // with cross-realm bots, zephyr users, etc., deactivated
+        // users, where we are probably fine for now not to
+        // find them via user_id lookups.
+        blueslip.warn('No user_id provided for ' + person.email);
+    }
+
     people_dict.set(person.email, person);
     people_by_name_dict.set(person.full_name, person);
 };
@@ -125,6 +142,7 @@ exports.add_in_realm = function add_in_realm(person) {
 
 exports.remove = function remove(person) {
     people_dict.del(person.email);
+    people_by_user_id_dict.del(person.user_id);
     people_by_name_dict.del(person.full_name);
     realm_people_dict.del(person.email);
 };

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -103,12 +103,6 @@ exports.get_by_name = function realm_get(name) {
     return people_by_name_dict.get(name);
 };
 
-// TODO: Replace these with the tests setting up page_params before
-// loading people.js
-exports.test_set_people_name_dict = function (data) {
-    people_by_name_dict = new Dict.from(data);
-};
-
 function people_cmp(person1, person2) {
     var name_cmp = util.strcmp(person1.full_name, person2.full_name);
     if (name_cmp < 0) {

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -121,6 +121,20 @@ function dispatch_normal_event(event) {
             _.each(event.subscriptions, function (sub) {
                 subs.mark_subscribed(sub.name, sub);
             });
+        } else if (event.op === 'peer_add') {
+            _.each(event.subscriptions, function (sub) {
+                var email = event.user_email;
+                stream_data.add_subscriber(sub, email);
+                $(document).trigger('peer_subscribe.zulip',
+                                    {stream_name: sub, user_email: email});
+            });
+        } else if (event.op === 'peer_remove') {
+            _.each(event.subscriptions, function (sub) {
+                var email = event.user_email;
+                stream_data.remove_subscriber(sub, email);
+                $(document).trigger('peer_unsubscribe.zulip',
+                                    {stream_name: sub, user_email: email});
+            });
         } else if (event.op === 'remove') {
             _.each(event.subscriptions, function (rec) {
                 var sub = stream_data.get_sub_by_id(rec.stream_id);
@@ -128,23 +142,6 @@ function dispatch_normal_event(event) {
             });
         } else if (event.op === 'update') {
             subs.update_subscription_properties(event.name, event.property, event.value);
-        } else if (event.op === 'peer_add' || event.op === 'peer_remove') {
-            _.each(event.subscriptions, function (sub) {
-                var js_event_type;
-                if (event.op === 'peer_add') {
-                    js_event_type = 'peer_subscribe.zulip';
-
-                    stream_data.add_subscriber(sub, event.user_email);
-                } else if (event.op === 'peer_remove') {
-                    js_event_type = 'peer_unsubscribe.zulip';
-
-                    stream_data.remove_subscriber(sub, event.user_email);
-                }
-
-                $(document).trigger(js_event_type, {stream_name: sub,
-                                                    user_email: event.user_email});
-            });
-
         }
         break;
 

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -122,8 +122,11 @@ function dispatch_normal_event(event) {
                 subs.mark_subscribed(sub.name, sub);
             });
         } else if (event.op === 'peer_add') {
+            // TODO: remove email shim here and fix called functions
+            //       to use user_ids
+            var person = people.get_person_from_user_id(event.user_id);
+            var email = person.email;
             _.each(event.subscriptions, function (sub) {
-                var email = event.user_email;
                 stream_data.add_subscriber(sub, email);
                 $(document).trigger('peer_subscribe.zulip',
                                     {stream_name: sub, user_email: email});

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -353,9 +353,6 @@ exports.initialize_from_page_params = function () {
     delete page_params.subbed_info;
     delete page_params.unsubbed_info;
     delete page_params.neversubbed_info;
-
-    // This will be completely deprecated soon.
-    delete page_params.email_dict;
 };
 
 exports.get_recent_topics = function (stream_name) {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -20,6 +20,16 @@ exports.is_active = function (stream_name) {
     return recent_topics.has(stream_name);
 };
 
+exports.rename_sub = function (stream_id, new_name) {
+    var sub = subs_by_stream_id.get(stream_id);
+    var old_name = sub.name;
+    sub.name = new_name;
+    stream_info.del(old_name);
+    stream_info.set(new_name, sub);
+
+    return sub;
+};
+
 exports.add_sub = function (stream_name, sub) {
     if (!_.has(sub, 'subscribers')) {
         sub.subscribers = Dict.from_array([], {fold_case: true});

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -524,8 +524,8 @@ exports.update_dom_with_unread_counts = function (counts) {
     animate_mention_changes(counts.mentioned_message_count);
 };
 
-exports.rename_stream = function (sub) {
-    sub.sidebar_li = build_stream_sidebar_row(sub.name);
+exports.rename_stream = function (sub, new_name) {
+    sub.sidebar_li = build_stream_sidebar_row(new_name);
     exports.build_stream_list(); // big hammer
 };
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -598,12 +598,6 @@ $(function () {
         $("#global_filters li[data-name='home']").addClass('active-filter');
     });
 
-    $(document).on('sub_obj_created.zulip', function (event) {
-        if (event.sub.subscribed) {
-            exports.create_sidebar_row(event.sub);
-        }
-    });
-
     $(document).on('subscription_add_done.zulip', function (event) {
         exports.create_sidebar_row(event.sub);
         exports.build_stream_list();

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -212,13 +212,6 @@ exports.set_color = function (stream_name, color) {
     set_stream_property(stream_name, 'color', color);
 };
 
-function create_sub(stream_name, attrs) {
-    var sub = stream_data.create_sub_from_server_data(stream_name, attrs);
-
-    $(document).trigger($.Event('sub_obj_created.zulip', {sub: sub}));
-    return sub;
-}
-
 function button_for_sub(sub) {
     var id = parseInt(sub.stream_id, 10);
     return $(".stream-row[data-stream-id='" + id + "'] .sub_unsub_button");
@@ -379,10 +372,11 @@ exports.mark_subscribed = function (stream_name, attrs) {
     var sub = stream_data.get_sub(stream_name);
 
     if (sub === undefined) {
-        // Create a new stream.
-        sub = create_sub(stream_name, attrs);
-        add_sub_to_table(sub);
-    } else if (! sub.subscribed) {
+        blueslip.error('Unknown stream in mark_subscribed: ' + stream_name);
+        return;
+    }
+
+    if (! sub.subscribed) {
         // Add yourself to a stream we already know about client-side.
         var color = get_color();
         exports.set_color(stream_name, color);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -150,15 +150,12 @@ function update_stream_pin(sub, value) {
     sub.pin_to_top = value;
 }
 
-function update_stream_name(sub, new_name) {
+function update_stream_name(stream_id, old_name, new_name) {
     // Rename the stream internally.
-    var old_name = sub.name;
-    stream_data.delete_sub(old_name);
-    sub.name = new_name;
-    stream_data.add_sub(new_name, sub);
+    var sub = stream_data.rename_sub(stream_id, new_name);
 
     // Update the left sidebar.
-    stream_list.rename_stream(sub);
+    stream_list.rename_stream(sub, new_name);
 
     // Update the subscriptions page
     var sub_settings_selector = '.stream-row[data-stream-id=' + sub.stream_id + ']';
@@ -576,7 +573,7 @@ exports.update_subscription_properties = function (stream_name, property, value)
         update_stream_audible_notifications(sub, value);
         break;
     case 'name':
-        update_stream_name(sub, value);
+        update_stream_name(sub.stream_id, sub.name, value);
         break;
     case 'description':
         update_stream_description(sub, value);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -378,7 +378,9 @@ exports.mark_subscribed = function (stream_name, attrs) {
         var color = get_color();
         exports.set_color(stream_name, color);
         sub.subscribed = true;
-        sub.subscribers = Dict.from_array(attrs.subscribers);
+        if (attrs) {
+            stream_data.set_subscriber_emails(sub, attrs.subscribers);
+        }
         var settings = settings_for_sub(sub);
         var button = button_for_sub(sub);
         if (button.length !== 0) {

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2859,7 +2859,6 @@ def fetch_initial_state_data(user_profile, event_types, queue_id):
         state['subscriptions'] = subscriptions
         state['unsubscribed'] = unsubscribed
         state['never_subscribed'] = never_subscribed
-        state['email_dict'] = email_dict
 
     if want('update_message_flags'):
         # There's no initial data for message flag updates, client will

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1494,7 +1494,7 @@ def bulk_add_subscriptions(streams, users):
             for added_user in new_users:
                 event = dict(type="subscription", op="peer_add",
                              subscriptions=[stream.name],
-                             user_email=added_user.email)
+                             user_id=added_user.id)
                 send_event(event, peer_user_ids)
 
 
@@ -3021,7 +3021,7 @@ def apply_events(state, events, user_profile):
                     if sub['name'].lower() == event['name'].lower():
                         sub[event['property']] = event['value']
             elif event['op'] == 'peer_add':
-                user_id = get_user_profile_by_email(event['user_email']).id
+                user_id = event['user_id']
                 for sub in state['subscriptions']:
                     if (sub['name'] in event['subscriptions'] and
                         user_id not in sub['subscribers']):

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -751,7 +751,7 @@ class EventsRegisterTest(ZulipTestCase):
         schema_checker = check_dict([
             ('type', equals('subscription')),
             ('op', equals('peer_add')),
-            ('user_email', check_string),
+            ('user_id', check_int),
             ('subscriptions', check_list(check_string)),
         ])
         error = schema_checker('events[2]', events[2])
@@ -791,7 +791,7 @@ class EventsRegisterTest(ZulipTestCase):
         peer_add_schema_checker = check_dict([
             ('type', equals('subscription')),
             ('op', equals('peer_add')),
-            ('user_email', check_string),
+            ('user_id', check_int),
             ('subscriptions', check_list(check_string)),
         ])
         peer_remove_schema_checker = check_dict([

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2023,7 +2023,7 @@ class GetSubscribersTest(ZulipTestCase):
             invite_only=True)
         self.assert_json_success(ret)
         with queries_captured() as queries:
-            subscribed, unsubscribed, never_subscribed, email_dict = gather_subscriptions_helper(self.user_profile)
+            subscribed, unsubscribed, never_subscribed = gather_subscriptions_helper(self.user_profile)
         self.assertTrue(len(never_subscribed) >= 10)
 
         # Invite only stream should not be there in never_subscribed streams
@@ -2031,7 +2031,7 @@ class GetSubscribersTest(ZulipTestCase):
             if stream_dict["name"].startswith("stream_"):
                 self.assertFalse(stream_dict['name'] == "stream_invite_only_1")
                 self.assertTrue(len(stream_dict["subscribers"]) == len(users_to_subscribe))
-        self.assert_length(queries, 4)
+        self.assert_length(queries, 3)
 
     @slow("common_subscribe_to_streams is slow")
     def test_gather_subscriptions_mit(self):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1355,7 +1355,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(len(add_peer_event['users']), 14)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
-        self.assertEqual(add_peer_event['event']['user_email'], self.test_email)
+        self.assertEqual(add_peer_event['event']['user_id'], self.user_profile.id)
 
         stream = get_stream('multi_user_stream', realm)
         self.assertEqual(stream.num_subscribers(), 3)
@@ -1384,7 +1384,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(len(add_peer_event['users']), 14)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
-        self.assertEqual(add_peer_event['event']['user_email'], email3)
+        self.assertEqual(add_peer_event['event']['user_id'], user_profile.id)
 
 
     def test_users_getting_add_peer_event(self):

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1787,7 +1787,6 @@ class HomeTest(ZulipTestCase):
             "domain",
             "domains",
             "email",
-            "email_dict",
             "enable_digest_emails",
             "enable_offline_email_notifications",
             "enable_offline_push_notifications",

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -569,7 +569,6 @@ def home(request):
         subbed_info           = register_ret['subscriptions'],
         unsubbed_info         = register_ret['unsubscribed'],
         neversubbed_info      = register_ret['never_subscribed'],
-        email_dict            = register_ret['email_dict'],
         people_list           = register_ret['realm_users'],
         bot_list              = register_ret['realm_bots'],
         initial_pointer       = register_ret['pointer'],


### PR DESCRIPTION
This series cuts us over to using user_id instead of email for our internal subscribers data structures, plus there's other miscellaneous cleanup.  One win here is we longer need to send email_dict over the wire (there was a shorter path to that than this series, but whatever, it was done in passing).
