### PR TITLE
Fix inline code lines that are too long in .message_content.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1418,6 +1418,10 @@ div.focused_table {
     position: relative;
 }
 
+.message_content p {
+    overflow: auto;
+}
+
 .message_edit_content {
     line-height: 18px;
 }


### PR DESCRIPTION
The issue is that if you post a very long line of code it will overflow
the .message_content div and force the width of the main message page
to be as long as the line of code.

Fixes: #2156.