### PR TITLE
Mobile compose box fix.

### DIFF
--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -325,3 +325,11 @@
     }
 
 }
+
+@media only screen and (min-device-width: 300px) and (max-device-width: 700px) {
+    #unmute_muted_topic_notification {
+        width: calc(90% - 30px);
+        left: 5%;
+        top: 5%;
+    }
+}

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -661,13 +661,13 @@ PIPELINE = {
                 'third/spectrum/spectrum.css',
                 'styles/components.css',
                 'styles/zulip.css',
-                'styles/media.css',
                 'styles/settings.css',
                 'styles/subscriptions.css',
                 'styles/compose.css',
                 'styles/overlay.css',
                 'styles/pygments.css',
                 'styles/thirdparty-fonts.css',
+                'styles/media.css',
                 # We don't want fonts.css on QtWebKit, so its omitted here
             ),
             'output_filename': 'min/app-fontcompat.css'
@@ -679,7 +679,6 @@ PIPELINE = {
                 'third/jquery-perfect-scrollbar/css/perfect-scrollbar.css',
                 'styles/components.css',
                 'styles/zulip.css',
-                'styles/media.css',
                 'styles/settings.css',
                 'styles/subscriptions.css',
                 'styles/compose.css',
@@ -687,6 +686,7 @@ PIPELINE = {
                 'styles/pygments.css',
                 'styles/thirdparty-fonts.css',
                 'styles/fonts.css',
+                'styles/media.css',
             ),
             'output_filename': 'min/app.css'
         },


### PR DESCRIPTION
The media queries should always be last in the pipeline to be delivered
so that other styles don’t override them.