### PR TITLE
Simplify cross-realm validation in recipient_for_emails().

### DIFF
--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -136,6 +136,12 @@ class TestCrossRealmPMs(ZulipTestCase):
         self.send_message(user1_email, [support_email], Recipient.PERSONAL)
         assert_message_received(support_bot, user1)
 
+        # Users can't email two cross-realm bots at once. (This is just
+        # an anomaly of the current implementation.)
+        with assert_disallowed():
+            self.send_message(user1_email, [feedback_email, support_email],
+                              Recipient.PERSONAL)
+
         # Users on three different realms can't PM each other,
         # even if one of the users is a cross-realm bot.
         with assert_disallowed():

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -109,6 +109,10 @@ class TestCrossRealmPMs(ZulipTestCase):
         self.create_user(user3_email)
         cross_bot = self.create_user(cross_email)
 
+        """Users can PM themselves"""
+        self.send_message(user1_email, user1_email, Recipient.PERSONAL)
+        assert_message_received(user1, user1)
+
         """Users on the same realm can PM each other"""
         self.send_message(user1_email, user1a_email, Recipient.PERSONAL)
         assert_message_received(user1a, user1)

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -112,7 +112,7 @@ class TestCrossRealmPMs(ZulipTestCase):
         user1 = self.create_user(user1_email)
         user1a = self.create_user(user1a_email)
         user2 = self.create_user(user2_email)
-        self.create_user(user3_email)
+        user3 = self.create_user(user3_email)
         feedback_bot = self.create_user(feedback_email)
         support_bot = self.create_user(support_email)
 
@@ -136,6 +136,14 @@ class TestCrossRealmPMs(ZulipTestCase):
         # (The support bot represents some theoretical bot that we may
         # create in the future that does not have zulip.com as its realm.)
         self.send_message(user1_email, [support_email], Recipient.PERSONAL)
+        assert_message_received(support_bot, user1)
+
+        # We have a loophole where I can send PMs to other users as long
+        # as I copy a cross-realm bot from the same realm.  In practice this
+        # not a bug, since our only cross-realm bots are on the zulip.com
+        # realm.
+        self.send_message(user1_email, [user3_email, support_email], Recipient.PERSONAL)
+        assert_message_received(user3, user1)
         assert_message_received(support_bot, user1)
 
         # Users can't email two cross-realm bots at once. (This is just

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -109,26 +109,24 @@ class TestCrossRealmPMs(ZulipTestCase):
         self.create_user(user3_email)
         cross_bot = self.create_user(cross_email)
 
-        """Users can PM themselves"""
+        # Users can PM themselves
         self.send_message(user1_email, user1_email, Recipient.PERSONAL)
         assert_message_received(user1, user1)
 
-        """Users on the same realm can PM each other"""
+        # Users on the same realm can PM each other
         self.send_message(user1_email, user1a_email, Recipient.PERSONAL)
         assert_message_received(user1a, user1)
 
-        """OG Users in the zulip.com realm can PM any realm"""
+        # Cross-realm bots in the zulip.com realm can PM any realm
         self.send_message(cross_email, user2_email, Recipient.PERSONAL)
         assert_message_received(user2, cross_bot)
 
-        """All users can PM users in the zulip.com realm"""
-
+        # All users can PM cross-realm bots in the zulip.com realm
         self.send_message(user1_email, cross_email, Recipient.PERSONAL)
         assert_message_received(cross_bot, user1)
 
         # Users on three different realms can't PM each other,
         # even if one of the users is a cross-realm bot.
-
         with assert_disallowed():
             self.send_message(user1_email, [user2_email, cross_email],
                               Recipient.PERSONAL)

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -58,8 +58,6 @@ class TestCrossRealmPMs(ZulipTestCase):
 
     def setUp(self):
         # type: () -> None
-        settings.CROSS_REALM_BOT_EMAILS.add('test-og-bot@zulip.com')
-
         dep = Deployment()
         dep.base_api_url = "https://zulip.com/api/"
         dep.base_site_url = "https://zulip.com/"
@@ -101,13 +99,15 @@ class TestCrossRealmPMs(ZulipTestCase):
         user1a_email = 'user1a@1.example.com'
         user2_email = 'user2@2.example.com'
         user3_email = 'user3@3.example.com'
-        cross_email = 'test-og-bot@zulip.com'
+        feedback_email = 'feedback@zulip.com'
+
+        settings.CROSS_REALM_BOT_EMAILS.add('feedback@zulip.com')
 
         user1 = self.create_user(user1_email)
         user1a = self.create_user(user1a_email)
         user2 = self.create_user(user2_email)
         self.create_user(user3_email)
-        cross_bot = self.create_user(cross_email)
+        feedback_bot = self.create_user(feedback_email)
 
         # Users can PM themselves
         self.send_message(user1_email, user1_email, Recipient.PERSONAL)
@@ -118,17 +118,17 @@ class TestCrossRealmPMs(ZulipTestCase):
         assert_message_received(user1a, user1)
 
         # Cross-realm bots in the zulip.com realm can PM any realm
-        self.send_message(cross_email, user2_email, Recipient.PERSONAL)
-        assert_message_received(user2, cross_bot)
+        self.send_message(feedback_email, user2_email, Recipient.PERSONAL)
+        assert_message_received(user2, feedback_bot)
 
         # All users can PM cross-realm bots in the zulip.com realm
-        self.send_message(user1_email, cross_email, Recipient.PERSONAL)
-        assert_message_received(cross_bot, user1)
+        self.send_message(user1_email, feedback_email, Recipient.PERSONAL)
+        assert_message_received(feedback_bot, user1)
 
         # Users on three different realms can't PM each other,
         # even if one of the users is a cross-realm bot.
         with assert_disallowed():
-            self.send_message(user1_email, [user2_email, cross_email],
+            self.send_message(user1_email, [user2_email, feedback_email],
                               Recipient.PERSONAL)
 
         # Users on the different realms can not PM each other

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -95,6 +95,7 @@ class TestCrossRealmPMs(ZulipTestCase):
                 JsonableError,
                 'You can\'t send private messages outside of your organization.')
 
+        random_zulip_email = 'random@zulip.com'
         user1_email = 'user1@1.example.com'
         user1a_email = 'user1a@1.example.com'
         user2_email = 'user2@2.example.com'
@@ -107,6 +108,7 @@ class TestCrossRealmPMs(ZulipTestCase):
             support_email,
         ]
 
+        self.create_user(random_zulip_email)
         user1 = self.create_user(user1_email)
         user1a = self.create_user(user1a_email)
         user2 = self.create_user(user2_email)
@@ -151,6 +153,10 @@ class TestCrossRealmPMs(ZulipTestCase):
         # Users on the different realms can not PM each other
         with assert_disallowed():
             self.send_message(user1_email, user2_email, Recipient.PERSONAL)
+
+        # Users on non-zulip realms can't PM "ordinary" Zulip users
+        with assert_disallowed():
+            self.send_message(user1_email, random_zulip_email, Recipient.PERSONAL)
 
         # Users on three different realms can not PM each other
         with assert_disallowed():

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -100,14 +100,19 @@ class TestCrossRealmPMs(ZulipTestCase):
         user2_email = 'user2@2.example.com'
         user3_email = 'user3@3.example.com'
         feedback_email = 'feedback@zulip.com'
+        support_email = 'support@3.example.com' # note: not zulip.com
 
-        settings.CROSS_REALM_BOT_EMAILS.add('feedback@zulip.com')
+        settings.CROSS_REALM_BOT_EMAILS = [
+            feedback_email,
+            support_email,
+        ]
 
         user1 = self.create_user(user1_email)
         user1a = self.create_user(user1a_email)
         user2 = self.create_user(user2_email)
         self.create_user(user3_email)
         feedback_bot = self.create_user(feedback_email)
+        support_bot = self.create_user(support_email)
 
         # Users can PM themselves
         self.send_message(user1_email, user1_email, Recipient.PERSONAL)
@@ -124,6 +129,12 @@ class TestCrossRealmPMs(ZulipTestCase):
         # All users can PM cross-realm bots in the zulip.com realm
         self.send_message(user1_email, feedback_email, Recipient.PERSONAL)
         assert_message_received(feedback_bot, user1)
+
+        # Users can PM cross-realm bots on non-zulip realms.
+        # (The support bot represents some theoretical bot that we may
+        # create in the future that does not have zulip.com as its realm.)
+        self.send_message(user1_email, [support_email], Recipient.PERSONAL)
+        assert_message_received(support_bot, user1)
 
         # Users on three different realms can't PM each other,
         # even if one of the users is a cross-realm bot.

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -111,14 +111,6 @@ class TestCrossRealmPMs(ZulipTestCase):
         self.assertEqual(len(messages), 1)
         self.assertEquals(messages[0].sender.pk, user1.pk)
 
-        """Users on the different realms can not PM each other"""
-        with assert_disallowed():
-            self.send_message(user1_email, user2_email, Recipient.PERSONAL)
-
-        """Users on three different realms can not PM each other"""
-        with assert_disallowed():
-            self.send_message(user1_email, [user2_email, user3_email], Recipient.PERSONAL)
-
         """OG Users in the zulip.com realm can PM any realm"""
         self.send_message(cross_email, user2_email, Recipient.PERSONAL)
 
@@ -139,6 +131,14 @@ class TestCrossRealmPMs(ZulipTestCase):
         with assert_disallowed():
             self.send_message(user1_email, [user2_email, cross_email],
                               Recipient.PERSONAL)
+
+        # Users on the different realms can not PM each other
+        with assert_disallowed():
+            self.send_message(user1_email, user2_email, Recipient.PERSONAL)
+
+        # Users on three different realms can not PM each other
+        with assert_disallowed():
+            self.send_message(user1_email, [user2_email, user3_email], Recipient.PERSONAL)
 
 class PersonalMessagesTest(ZulipTestCase):
 


### PR DESCRIPTION
We now simply exclude all cross-realm bots from the set of emails
under consideration, and then if the remaining emails are all in
the same realm, we're good.