### PR TITLE
[Fix/Solution]: Remove manual need to run global.use_template.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -91,7 +91,7 @@ var partial_finder = (function () {
                 // this uses String.prototype.replace which is kind of hacky but
                 // it is the only JS function IIRC that allows you to match all
                 // instances of a pattern AND return capture groups.
-                template.replace(/{{\s*partial\s*"(.+?)"/ig, function (match, $1) {
+                template.replace(/\{\{\s*partial\s*"(.+?)"/ig, function (match, $1) {
                     __prototype__($1, callback);
                 });
             }

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -31,78 +31,8 @@ var _ = global._;
 // When writing these tests, the following command might be helpful:
 // ./tools/get-handlebar-vars static/templates/*.handlebars
 
-var partial_finder = (function () {
-    var meta = {
-        read: []
-    };
-
-    // list all files in a directory and it's subdirectories in a recursive sync way.
-    var walk = function (dir, filelist) {
-        filelist = filelist || [];
-
-        // grab files one level deep.
-        var files = fs.readdirSync(dir);
-
-        // for each file, check if it's a directory. If so, continue recursion.
-        // if not add to the file list.
-        files.forEach(function (file) {
-            if (fs.statSync(dir + "/" + file).isDirectory()) {
-                filelist = walk(dir + "/" + file, filelist);
-            } else {
-                filelist.push({
-                    url: dir + "/" + file,
-                    name: file
-                });
-            }
-        });
-
-        // return all recursively found files.
-        return filelist;
-    };
-
-    // get all files and then map them into friendlier names.
-    var files = walk(path.join(__dirname, "../../static/templates")).map(function (file) {
-        return {
-            url: file.url,
-            name: file.name.replace(/\.handlebars$/, "")
-        };
-    });
-
-    // this is the external function that is called that will recursively search
-    // for partials in a file and partials inside partials until it finds them all.
-    // it then adds them to a maintenance list of already read partials so that
-    // they don't have to be read/searched again.
-    var __prototype__ = function (name, callback) {
-        if (meta.read.indexOf(name) === -1) {
-            if (callback) {
-                callback(name);
-            }
-
-            meta.read.push(name);
-
-            var file = files.find(function (file) {
-                return file.name === name;
-            });
-
-            if (file) {
-                var template = fs.readFileSync(file.url, "utf8");
-
-                // match partial tags.
-                // this uses String.prototype.replace which is kind of hacky but
-                // it is the only JS function IIRC that allows you to match all
-                // instances of a pattern AND return capture groups.
-                template.replace(/\{\{\s*partial\s*"(.+?)"/ig, function (match, $1) {
-                    __prototype__($1, callback);
-                });
-            }
-        }
-    };
-
-    return __prototype__;
-}());
-
 function render(template_name, args) {
-    partial_finder(template_name, function (name) {
+    global.partial_finder(template_name, function (name) {
         global.use_template(name);
     });
     return global.templates.render(template_name, args);

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -23,6 +23,7 @@ global.stub_out_jquery = namespace.stub_out_jquery;
 var render = require('./render.js');
 global.use_template = render.use_template;
 global.make_sure_all_templates_have_been_compiled = render.make_sure_all_templates_have_been_compiled;
+global.partial_finder = render.partial_finder;
 
 // Set up helpers to output HTML
 var output = require('./output.js');

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -24,6 +24,7 @@ var render = require('./render.js');
 global.use_template = render.use_template;
 global.make_sure_all_templates_have_been_compiled = render.make_sure_all_templates_have_been_compiled;
 global.partial_finder = render.partial_finder;
+global.walk = render.walk;
 
 // Set up helpers to output HTML
 var output = require('./output.js');

--- a/frontend_tests/zjsunit/render.js
+++ b/frontend_tests/zjsunit/render.js
@@ -60,37 +60,37 @@ exports.use_template = function (name) {
     Handlebars.templates[name] = Handlebars.compile(data);
 };
 
+// list all files in a directory and it's subdirectories in a recursive sync way.
+exports.walk = function (dir, filelist) {
+    filelist = filelist || [];
+
+    // grab files one level deep.
+    var files = fs.readdirSync(dir);
+
+    // for each file, check if it's a directory. If so, continue recursion.
+    // if not add to the file list.
+    files.forEach(function (file) {
+        if (fs.statSync(dir + "/" + file).isDirectory()) {
+            filelist = exports.walk(dir + "/" + file, filelist);
+        } else {
+            filelist.push({
+                url: dir + "/" + file,
+                name: file
+            });
+        }
+    });
+
+    // return all recursively found files.
+    return filelist;
+};
+
 exports.partial_finder = (function () {
     var meta = {
         read: []
     };
 
-    // list all files in a directory and it's subdirectories in a recursive sync way.
-    var walk = function (dir, filelist) {
-        filelist = filelist || [];
-
-        // grab files one level deep.
-        var files = fs.readdirSync(dir);
-
-        // for each file, check if it's a directory. If so, continue recursion.
-        // if not add to the file list.
-        files.forEach(function (file) {
-            if (fs.statSync(dir + "/" + file).isDirectory()) {
-                filelist = walk(dir + "/" + file, filelist);
-            } else {
-                filelist.push({
-                    url: dir + "/" + file,
-                    name: file
-                });
-            }
-        });
-
-        // return all recursively found files.
-        return filelist;
-    };
-
     // get all files and then map them into friendlier names.
-    var files = walk(path.join(__dirname, "../../static/templates")).map(function (file) {
+    var files = exports.walk(path.join(__dirname, "../../static/templates")).map(function (file) {
         return {
             url: file.url,
             name: file.name.replace(/\.handlebars$/, "")

--- a/frontend_tests/zjsunit/render.js
+++ b/frontend_tests/zjsunit/render.js
@@ -60,6 +60,76 @@ exports.use_template = function (name) {
     Handlebars.templates[name] = Handlebars.compile(data);
 };
 
+exports.partial_finder = (function () {
+    var meta = {
+        read: []
+    };
+
+    // list all files in a directory and it's subdirectories in a recursive sync way.
+    var walk = function (dir, filelist) {
+        filelist = filelist || [];
+
+        // grab files one level deep.
+        var files = fs.readdirSync(dir);
+
+        // for each file, check if it's a directory. If so, continue recursion.
+        // if not add to the file list.
+        files.forEach(function (file) {
+            if (fs.statSync(dir + "/" + file).isDirectory()) {
+                filelist = walk(dir + "/" + file, filelist);
+            } else {
+                filelist.push({
+                    url: dir + "/" + file,
+                    name: file
+                });
+            }
+        });
+
+        // return all recursively found files.
+        return filelist;
+    };
+
+    // get all files and then map them into friendlier names.
+    var files = walk(path.join(__dirname, "../../static/templates")).map(function (file) {
+        return {
+            url: file.url,
+            name: file.name.replace(/\.handlebars$/, "")
+        };
+    });
+
+    // this is the external function that is called that will recursively search
+    // for partials in a file and partials inside partials until it finds them all.
+    // it then adds them to a maintenance list of already read partials so that
+    // they don't have to be read/searched again.
+    var __prototype__ = function (name, callback) {
+        if (meta.read.indexOf(name) === -1) {
+            if (callback) {
+                callback(name);
+            }
+
+            meta.read.push(name);
+
+            var file = files.find(function (file) {
+                return file.name === name;
+            });
+
+            if (file) {
+                var template = fs.readFileSync(file.url, "utf8");
+
+                // match partial tags.
+                // this uses String.prototype.replace which is kind of hacky but
+                // it is the only JS function IIRC that allows you to match all
+                // instances of a pattern AND return capture groups.
+                template.replace(/\{\{\s*partial\s*"(.+?)"/ig, function (match, $1) {
+                    __prototype__($1, callback);
+                });
+            }
+        }
+    };
+
+    return __prototype__;
+}());
+
 fs.readdirSync(path.join(__dirname, "../../static/templates/", "settings")).forEach(function (o) {
     exports.use_template(o.replace(/\.handlebars/, ""));
 });


### PR DESCRIPTION
When the render function is run now, it uses the partial_finder function to search recursively through files for partials and add them so that test writers don’t have to.

(This either fixes or at least helps in relation with #2144.)