### PR TITLE
Improve English grammar in bitbucket integration modify comment message.

### DIFF
--- a/zerver/tests/webhooks/test_bitbucket.py
+++ b/zerver/tests/webhooks/test_bitbucket.py
@@ -127,7 +127,7 @@ class Bitbucket2HookTests(WebhookTestCase):
 
     def test_bitbucket2_on_pull_request_comment_updated_event(self):
         # type: () -> None
-        expected_message = u"kolaszek updated [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3)\n\n~~~ quote\nComment1\n~~~"
+        expected_message = u"kolaszek updated a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3)\n\n~~~ quote\nComment1\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:comment_updated'
         }
@@ -135,7 +135,7 @@ class Bitbucket2HookTests(WebhookTestCase):
 
     def test_bitbucket2_on_pull_request_comment_deleted_event(self):
         # type: () -> None
-        expected_message = u"kolaszek deleted [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3)\n\n~~~ quote\nComment1\n~~~"
+        expected_message = u"kolaszek deleted a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3)\n\n~~~ quote\nComment1\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:comment_deleted'
         }

--- a/zerver/views/webhooks/bitbucket2.py
+++ b/zerver/views/webhooks/bitbucket2.py
@@ -250,7 +250,7 @@ def get_pull_request_comment_created_action_body(payload):
 
 def get_pull_request_deleted_or_updated_comment_action_body(payload, action):
     # type: (Dict[str, Any], text_type) -> text_type
-    action = "{} [comment]({})".format(action, payload['comment']['links']['html']['href'])
+    action = "{} a [comment]({})".format(action, payload['comment']['links']['html']['href'])
     return get_pull_request_comment_action_body(payload, action)
 
 def get_pull_request_comment_action_body(payload, action):


### PR DESCRIPTION
Add `a` between verb and comment word i.e. updated a [comment] instead of
updated [comment].