### PR TITLE
Add raised exception output to development tornado running.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -305,7 +305,6 @@ class Application(web.Application):
     def __init__(self):
         # type: () -> None
         handlers = [
-            (r"/sockjs/.*/websocket$", TornadoHandler),
             (r"/json/events.*", TornadoHandler),
             (r"/api/v1/events.*", TornadoHandler),
             (r"/webpack.*", WebPackHandler),


### PR DESCRIPTION
- Rewrite tornado ioloop tracback exception handler in debug mode
  with adding output raised exception to console logging.
- Remove unused route for development tornado proxy server.

Fixes #2150