### PR TITLE
Clean up some email -> user_id stuff.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -143,6 +143,14 @@ var _ = global._;
     people.remove(bob);
 }());
 
+(function test_recipient_counts() {
+    var email = 'anybody@example.com';
+    assert.equal(people.get_recipient_count({email: email}), 0);
+    people.incr_recipient_count(email);
+    people.incr_recipient_count(email);
+    assert.equal(people.get_recipient_count({email: email}), 2);
+}());
+
 (function test_filtered_users() {
      var charles = {
         email: 'charles@example.com',

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -84,30 +84,6 @@ var _ = global._;
     assert.equal(person.full_name, 'Original');
 }());
 
-(function test_reify() {
-    var full_person = {
-        email: 'foo@example.com',
-        full_name: 'Foo Barson'
-    };
-
-    // If we don't have a skeleton object, this should quietly succeed.
-    people.reify(full_person);
-
-    var skeleton = {
-        email: 'foo@example.com',
-        full_name: 'foo@example.com',
-        skeleton: true
-    };
-    people.add(skeleton);
-
-    people.reify(full_person);
-    var person = people.get_by_email('foo@example.com');
-    assert.equal(person.full_name, 'Foo Barson');
-
-    // Our follow-up reify() call should also quietly succeed.
-    people.reify(full_person);
-}());
-
 (function test_get_rest_of_realm() {
     var myself = {
         email: 'myself@example.com',

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -111,6 +111,7 @@ function add_message_metadata(message) {
         stream_data.process_message_for_recent_topics(message);
 
         involved_people = [{'full_name': message.sender_full_name,
+                            'user_id': message.sender_id,
                             'email': message.sender_email}];
         set_topic_edit_properties(message);
         break;
@@ -130,7 +131,13 @@ function add_message_metadata(message) {
     _.each(involved_people, function (person) {
         if (!person.unknown_local_echo_user) {
             if (! people.get_by_email(person.email)) {
-                people.add(person);
+                people.add({
+                    email: person.email,
+                    user_id: person.user_id || person.id,
+                    full_name: person.full_name,
+                    is_admin: person.is_realm_admin || false,
+                    is_bot: person.is_bot || false
+                });
             }
 
             if (message.type === 'private' && message.sent_by_me) {

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -128,19 +128,15 @@ function add_message_metadata(message) {
 
     // Add new people involved in this message to the people list
     _.each(involved_people, function (person) {
-        // Do the hasOwnProperty() call via the prototype to avoid problems
-        // with keys like "hasOwnProperty"
-        if (! people.get_by_email(person.email)) {
-            people.add(person);
-        }
+        if (!person.unknown_local_echo_user) {
+            if (! people.get_by_email(person.email)) {
+                people.add(person);
+            }
 
-        if (people.get_by_email(person.email).full_name !== person.full_name) {
-            people.reify(person);
-        }
-
-        if (message.type === 'private' && message.sent_by_me) {
-            // Track the number of PMs we've sent to this person to improve autocomplete
-            people.incr_recipient_count(person.email);
+            if (message.type === 'private' && message.sent_by_me) {
+                // Track the number of PMs we've sent to this person to improve autocomplete
+                people.incr_recipient_count(person.email);
+            }
         }
     });
 

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -140,7 +140,7 @@ function add_message_metadata(message) {
 
         if (message.type === 'private' && message.sent_by_me) {
             // Track the number of PMs we've sent to this person to improve autocomplete
-            people.get_by_email(person.email).pm_recipient_count += 1;
+            people.incr_recipient_count(person.email);
         }
     });
 

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -129,35 +129,6 @@ exports.remove = function remove(person) {
     realm_people_dict.del(person.email);
 };
 
-exports.reify = function reify(person) {
-    // If a locally sent message is a PM to
-    // an out-of-realm recipient, a people_dict
-    // entry is created with simply an email address
-    // Once we've received the full person object, replace
-    // it
-    if (! people_dict.has(person.email)) {
-        return;
-    }
-
-    var old_person = people_dict.get(person.email);
-
-    // Only overwrite skeleton objects here.  If the object
-    // had already been reified, exit early.
-    if (!old_person.skeleton) {
-        return;
-    }
-
-    var new_person = _.extend({}, old_person, person);
-    new_person.skeleton = false;
-
-    people_dict.set(person.email, person);
-    people_by_name_dict.set(person.full_name, person);
-
-    if (people_by_name_dict.has(person.email)) {
-        people_by_name_dict.del(person.email);
-    }
-};
-
 exports.update = function update(person) {
     if (! people_dict.has(person.email)) {
         blueslip.error("Got update_person event for unexpected user",

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -9,6 +9,7 @@ var people_by_name_dict = new Dict({fold_case: true});
 // People in this realm
 var realm_people_dict = new Dict({fold_case: true});
 var cross_realm_dict = new Dict({fold_case: true});
+var pm_recipient_count_dict = new Dict({fold_case: true});
 
 exports.get_by_email = function get_by_email(email) {
     return people_dict.get(email);
@@ -28,6 +29,24 @@ exports.get_realm_persons = function () {
 
 exports.is_cross_realm_email = function (email) {
     return cross_realm_dict.has(email);
+};
+
+exports.get_recipient_count = function (person) {
+    // We can have fake person objects like the "all"
+    // pseudo-person in at-mentions.  They will have
+    // the pm_recipient_count on the object itself.
+    if (person.pm_recipient_count) {
+        return person.pm_recipient_count;
+    }
+
+    var count = pm_recipient_count_dict.get(person.email);
+
+    return count || 0;
+};
+
+exports.incr_recipient_count = function (email) {
+    var old_count = pm_recipient_count_dict.get(email) || 0;
+    pm_recipient_count_dict.set(email, old_count + 1);
 };
 
 exports.filter_people_by_search_terms = function (users, search_terms) {
@@ -97,7 +116,6 @@ exports.get_rest_of_realm = function get_rest_of_realm() {
 exports.add = function add(person) {
     people_dict.set(person.email, person);
     people_by_name_dict.set(person.full_name, person);
-    person.pm_recipient_count = 0;
 };
 
 exports.add_in_realm = function add_in_realm(person) {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -101,9 +101,12 @@ exports.sorter = function (query, objs, get_item) {
 };
 
 exports.compare_by_pms = function (user_a, user_b) {
-    if (user_a.pm_recipient_count > user_b.pm_recipient_count) {
+    var count_a = people.get_recipient_count(user_a);
+    var count_b = people.get_recipient_count(user_b);
+
+    if (count_a > count_b) {
         return -1;
-    } else if (user_a.pm_recipient_count < user_b.pm_recipient_count) {
+    } else if (count_a < count_b) {
         return 1;
     }
 


### PR DESCRIPTION
Encapsulating pm_recipient_count allows us to bump counts before storing actual people objects.

The second commit removes some strange moving parts before we introduce the new moving part of user_id lookups.

Finally, the message store commit makes new users have user_id available.