### PR TITLE
api: Add default protocol for localhost.

### DIFF
--- a/api/zulip/__init__.py
+++ b/api/zulip/__init__.py
@@ -213,7 +213,9 @@ class Client(object):
         self.email = email
         self.verbose = verbose
         if site is not None:
-            if not site.startswith("http"):
+            if site.startswith("localhost:9991"):
+                site = "http://" + site
+            elif not site.startswith("http"):
                 site = "https://" + site
             # Remove trailing "/"s from site to simplify the below logic for adding "/api"
             site = site.rstrip("/")


### PR DESCRIPTION
Add default "http://" to site argument locally if it is not specified in
an api call.