### PR TITLE
tests: Improve coverage of cross-realm bot limitations.

### DIFF
--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -156,6 +156,10 @@ class TestCrossRealmPMs(ZulipTestCase):
             self.send_message(user1_email, [user2_email, feedback_email],
                               Recipient.PERSONAL)
 
+        with assert_disallowed():
+            self.send_message(feedback_email, [user1_email, user2_email],
+                              Recipient.PERSONAL)
+
         # Users on the different realms can not PM each other
         with assert_disallowed():
             self.send_message(user1_email, user2_email, Recipient.PERSONAL)


### PR DESCRIPTION
We recently made it so that a cross-realm bot can only send
messages to one realm at a time.  (It can send to a realm
outside of its offical realm, but only one of them.)  This
test adds coverage for that.