### PR TITLE
(experimental) Show topic history in middle pane.

### DIFF
--- a/static/js/full_topic_list.js
+++ b/static/js/full_topic_list.js
@@ -1,0 +1,56 @@
+var full_topic_list = (function () {
+
+var exports = {};
+
+exports.widget = function (stream_name) {
+    var self = {};
+
+    self.topic_items = new Dict({fold_case: true});
+
+    self.build = function () {
+        console.info('here');
+        var heading = $('<h3 class="topics-for-heading">');
+        heading.text('Topics for ' + stream_name);
+
+        $('#topic-history').html(heading);
+        $('#topic-history').append(self.make_list());
+    };
+
+    self.make_list = function () {
+        var topics = stream_data.get_recent_topics(stream_name) || [];
+
+        var ul = $('<ul class="full-topic-list">');
+        ul.attr('data-stream', stream);
+
+        _.each(topics, function (subject_obj, idx) {
+            var topic_name = subject_obj.subject;
+            var num_unread = unread.num_unread_for_subject(stream_name, subject_obj.canon_subject);
+
+            var topic_info = {
+                topic_name: topic_name,
+                unread: num_unread,
+                is_zero: num_unread === 0,
+                is_muted: muting.is_topic_muted(stream_name, topic_name),
+                url: narrow.by_stream_subject_uri(stream_name, topic_name)
+            };
+            var li = $(templates.render('full_topic_list_item', topic_info));
+            self.topic_items.set(topic_name, li);
+            ul.append(li);
+        });
+
+        return ul;
+    };
+
+    return self;
+};
+        
+exports.build = function (stream_name) {
+    var widget = exports.widget(stream_name);
+    widget.build();
+};
+
+return exports;
+}());
+if (typeof module !== 'undefined') {
+    module.exports = topic_list;
+}

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -135,7 +135,12 @@ exports.rebuild = function (stream_li, stream, active_topic) {
 
 exports.set_click_handlers = function (callbacks) {
     $('#stream_filters').on('click', '.show-more-topics', function (e) {
-        callbacks.zoom_in();
+        ui.change_tab_to('#topic-history');
+
+        var stream_name = $(e.target).parents('ul').attr('data-stream');
+        console.info(stream_name);
+
+        full_topic_list.build(stream_name);
 
         e.preventDefault();
         e.stopPropagation();

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -432,3 +432,63 @@ li.show-more-private-messages a {
 .zoom-in .zoom-in-hide {
     display: none;
 }
+
+/* topic history stuff follows */
+
+a.full-topic-list-link {
+    text-decoration: none;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-block;
+    color: #333;
+}
+
+ul.full-topic-list {
+    list-style-type: none;
+    padding: 7px;
+}
+
+ul.full-topic-list li {
+    padding-left: 10px;
+    padding-bottom: 7px;
+    padding-top: 6px;
+    border-bottom: 1px solid #ddd;
+}
+
+ul.full-topic-list li.muted-topic {
+    opacity: 0.30;
+}
+    
+.topics-for-heading {
+    padding-top: 20px;
+    font-size: 25px;
+    font-weight: 300;
+}
+
+.topic-unread-count,
+.topic-no-unread {
+    padding: 2px 3px 1px 3px;
+    width: 15px;
+    display: inline-block;
+}
+
+.topic-unread-count {
+    background: #80837f;
+    border-radius: 0px;
+    color: #ffffff;
+    font-size: 12px;
+    font-weight: normal;
+    letter-spacing: 0.6px;
+    text-align: right;
+}
+
+.topic-no-unread {
+    background: #fffff;
+    color: #ffffff;
+}
+
+ul.full-topic-list .mute-topic,
+ul.full-topic-list .unmute-topic {
+    padding-left: 3px;
+    padding-right: 3px;
+}

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2441,6 +2441,10 @@ button.topic_edit_cancel {
     font-size: 20px;
 }
 
+#topic-history {
+    margin-top: 60px;
+}
+
 #home {
     margin-top: 41px;
 }

--- a/static/templates/full_topic_list_item.handlebars
+++ b/static/templates/full_topic_list_item.handlebars
@@ -1,0 +1,21 @@
+<li class='{{#if is_muted}}muted-topic{{/if}}' data-name='{{topic_name}}'>
+    <span class='topic-box'>
+        <div class="{{#if is_zero}}topic-no-unread{{else}}topic-unread-count{{/if}}">
+            <div class="value">{{unread}}</div>
+        </div>
+
+        {{#if is_muted}}
+            <a href="#" class="unmute-topic" data-stream-name="{{ stream_name }}" data-topic-name="{{ topic_name }}">
+                <i class="icon-vector-eye-open"></i>
+            </a>
+        {{else}}
+            <a href="#" class="mute-topic" data-stream-name="{{ stream_name }}" data-topic-name="{{ topic_name }}">
+                <i class="icon-vector-eye-close"></i>
+            </a>
+        {{/if}}
+
+        <a href='{{url}}' class="full-topic-list-link">
+            {{topic_name}}
+        </a>
+    </span>
+</li>

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -105,6 +105,9 @@ var page_params = {{ page_params }};
             <div class="tab-pane" id="subscriptions">
                 {% include "zerver/subscriptions.html" %}
             </div>
+            <div class="tab-pane new-style" id="topic-history">
+                TOPICS
+            </div>
             <div class="tab-pane new-style" id="administration">
             </div>
             <div class="tab-pane new-style" id="settings">

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -49,6 +49,7 @@
                   anymore
                   #}
                   <li style="display:none;"><a href="#home" data-toggle="tab"></a></li>
+                  <li style="display:none;"><a href="#topic-history" data-toggle="tab"></a></li>
                   <li title="Manage Streams">
                     <a href="#subscriptions" data-toggle="tab">
                       <i class="icon-vector-exchange"></i> {{ _('Manage Streams') }}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -40,7 +40,7 @@ from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, 
 from zerver.lib.alert_words import alert_words_in_realm
 from zerver.lib.avatar import get_avatar_url, avatar_url
 
-from django.db import transaction, IntegrityError
+from django.db import transaction, IntegrityError, connection
 from django.db.models import F, Q
 from django.db.models.query import QuerySet
 from django.core.exceptions import ValidationError
@@ -166,6 +166,48 @@ def bot_owner_userids(user_profile):
 def realm_user_count(realm):
     # type: (Realm) -> int
     return UserProfile.objects.filter(realm=realm, is_active=True, is_bot=False).count()
+
+def get_topic_history_for_stream(user_profile, recipient):
+    # type: (UserProfile, Recipient) -> List[Tuple[str, int]]
+
+    # We tested the below query on some large prod datasets, and we never
+    # saw more than 50ms to execute it, so we think that's acceptable,
+    # but we will monitor it, and we may later optimize it further.
+    query = '''
+        SELECT topic, read, count(*)
+        FROM (
+            SELECT
+                ("zerver_usermessage"."flags" & 1) as read,
+                lower("zerver_message"."subject") as topic,
+                "zerver_message"."id" as message_id
+            FROM "zerver_usermessage"
+            INNER JOIN "zerver_message" ON (
+                "zerver_usermessage"."message_id" = "zerver_message"."id"
+            ) WHERE (
+                "zerver_usermessage"."user_profile_id" = %s AND
+                "zerver_message"."recipient_id" = %s
+            ) ORDER BY "zerver_usermessage"."message_id" DESC
+        ) messages_for_stream
+        GROUP BY topic, read
+        ORDER BY max(message_id) desc
+    '''
+    cursor = connection.cursor()
+    cursor.execute(query, [user_profile.id, recipient.id])
+    rows = cursor.fetchall()
+    cursor.close()
+
+    topic_counts = dict() # type: Dict[str, int]
+    topics = []
+    for row in rows:
+        topic_name, read, count = row
+        if topic_name not in topic_counts:
+            topic_counts[topic_name] = 0
+            topics.append(topic_name)
+        if not read:
+            topic_counts[topic_name] += count
+
+    history = [(topic, topic_counts[topic]) for topic in topics]
+    return history
 
 def send_signup_message(sender, signups_stream, user_profile,
                         internal=False, realm=None):

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -4,6 +4,8 @@ from django.db.models import Q
 from django.conf import settings
 from django.http import HttpResponse
 from django.test import TestCase, override_settings
+from django.utils import timezone
+
 from zerver.lib import bugdown
 from zerver.decorator import JsonableError
 from zerver.lib.test_runner import slow
@@ -34,6 +36,7 @@ from zerver.lib.actions import (
     check_message, check_send_message,
     do_create_user,
     get_client,
+    get_recipient,
 )
 
 from zerver.lib.upload import create_attachment
@@ -48,6 +51,95 @@ import ujson
 from six import text_type
 from six.moves import range
 from typing import Any, Optional
+
+class TopicHistoryTest(ZulipTestCase):
+    def test_topics_history(self):
+        # type: () -> None
+        # verified: int(UserMessage.flags.read) == 1
+        email = 'iago@zulip.com'
+        stream_name = 'Verona'
+        self.login(email)
+
+        user_profile = get_user_profile_by_email(email)
+        stream = Stream.objects.get(name=stream_name)
+        recipient = get_recipient(Recipient.STREAM, stream.id)
+
+        def create_test_message(topic, read, starred=False):
+            # type: (str, bool, bool) -> None
+
+            hamlet = get_user_profile_by_email('hamlet@zulip.com')
+            message = Message.objects.create(
+                sender=hamlet,
+                recipient=recipient,
+                subject=topic,
+                content='whatever',
+                pub_date=timezone.now(),
+                sending_client=get_client('whatever'),
+            )
+            flags = 0
+            if read:
+                flags |= UserMessage.flags.read
+
+            # use this to make sure our query isn't confused
+            # by other flags
+            if starred:
+                flags |= UserMessage.flags.starred
+
+            UserMessage.objects.create(
+                user_profile=user_profile,
+                message=message,
+                flags=flags,
+            )
+
+        create_test_message('topic2', read=False)
+        create_test_message('toPIc1', read=False, starred=True)
+        create_test_message('topic2', read=False)
+        create_test_message('topic2', read=True)
+        create_test_message('topic2', read=False, starred=True)
+        create_test_message('topic2', read=False)
+        create_test_message('already_read', read=True)
+
+        endpoint = '/json/users/me/%d/topics' % (stream.id,)
+        result = self.client_get(endpoint, dict())
+        self.assert_json_success(result)
+        history = ujson.loads(result.content)['topics']
+
+        # We only look at the most recent three topics, because
+        # the prior fixture data may be unreliable.
+        self.assertEqual(history[:3], [
+            [u'already_read', 0],
+            [u'topic2', 4],
+            [u'topic1', 1],
+        ])
+
+    def test_bad_stream_id(self):
+        # type: () -> None
+        email = 'iago@zulip.com'
+        self.login(email)
+
+        # non-sensible stream id
+        endpoint = '/json/users/me/9999999999/topics'
+        result = self.client_get(endpoint, dict())
+        self.assert_json_error(result, 'Invalid stream id')
+
+        # out of realm
+        bad_stream = self.make_stream(
+            'mit_stream',
+            realm=get_realm('mit.edu')
+        )
+        endpoint = '/json/users/me/%s/topics' % (bad_stream.id,)
+        result = self.client_get(endpoint, dict())
+        self.assert_json_error(result, 'Invalid stream id')
+
+        # private stream to which I am not subscribed
+        private_stream = self.make_stream(
+            'private_stream',
+            invite_only=True
+        )
+        endpoint = '/json/users/me/%s/topics' % (private_stream.id,)
+        result = self.client_get(endpoint, dict())
+        self.assert_json_error(result, 'Invalid stream id')
+
 
 class TestCrossRealmPMs(ZulipTestCase):
     def make_realm(self, domain):

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -31,6 +31,12 @@ from six.moves import urllib
 import six
 from six import text_type
 
+def is_active_subscriber(user_profile, recipient):
+    # type: (UserProfile, Recipient) -> bool
+    return Subscription.objects.filter(user_profile=user_profile,
+                                       recipient=recipient,
+                                       active=True).exists()
+
 def list_to_streams(streams_raw, user_profile, autocreate=False, invite_only=False):
     # type: (Iterable[text_type], UserProfile, Optional[bool], Optional[bool]) -> Tuple[List[Stream], List[Stream]]
     """Converts plaintext stream names to a list of Streams, validating input in the process
@@ -464,9 +470,10 @@ def stream_exists_backend(request, user_profile, stream_name, autosubscribe):
         recipient = get_recipient(Recipient.STREAM, stream.id)
         if autosubscribe:
             bulk_add_subscriptions([stream], [user_profile])
-        result["subscribed"] = Subscription.objects.filter(user_profile=user_profile,
-                                                           recipient=recipient,
-                                                           active=True).exists()
+        result["subscribed"] = is_active_subscriber(
+                user_profile=user_profile,
+                recipient=recipient)
+
         return json_success(result) # results are ignored for HEAD requests
     return json_response(data=result, status=404)
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -770,6 +770,7 @@ JS_SPECS = {
             'js/rows.js',
             'js/people.js',
             'js/unread.js',
+            'js/full_topic_list.js',
             'js/topic_list.js',
             'js/stream_list.js',
             'js/filter.js',

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -211,6 +211,10 @@ v1_api_and_json_patterns = [
          'PUT': 'zerver.views.alert_words.add_alert_words',
          'DELETE': 'zerver.views.alert_words.remove_alert_words'}),
 
+    url(r'^users/me/(?P<stream_id>\d+)/topics$', 'zerver.lib.rest.rest_dispatch',
+        {'GET': 'zerver.views.streams.get_topics_backend'}),
+
+
     # streams -> zerver.views.streams
     # (this API is only used externally)
     url(r'^streams$', 'zerver.lib.rest.rest_dispatch',


### PR DESCRIPTION
This isn't completely wired up yet, but it has enough functionality to demonstrate the basic concept of having full topic history in the middle pane.  I show the icons for muting, and we'd also want icons to make messages as read.  The popover menu also has an icon for narrowing, but I don't think we really need to borrow that, since clicking on the topic does the narrowing.

The idea behind this is to give us more real estate for expanding this feature over time.  For example, it would be nice to see all the participants on a topic.

Also, I think this could play nicely with "Manage Streams," where for a stream that you're managing you could also zoom into its topics and mute/unmute, etc.