### PR TITLE
Add exception handling for symlink calls with helpful error message.

### DIFF
--- a/tools/provision.py
+++ b/tools/provision.py
@@ -57,6 +57,19 @@ if not os.path.exists(os.path.join(ZULIP_PATH, ".git")):
     print("from GitHub, rather than using a Zulip production release tarball.")
     sys.exit(1)
 
+try:
+    if os.path.exists(os.path.join(VAR_DIR_PATH, 'zulip-test-symlink')):
+        os.remove(os.path.join(VAR_DIR_PATH, 'zulip-test-symlink'))
+    os.symlink(
+        os.path.join(ZULIP_PATH, 'README.md'),
+        os.path.join(VAR_DIR_PATH, 'zulip-test-symlink')
+    )
+    os.remove(os.path.join(VAR_DIR_PATH, 'zulip-test-symlink'))
+except OSError as err:
+    print("Error: Unable to create symlinks. Make sure you have permission to create symbolic links.")
+    print("See this page for more information: http://zulip.readthedocs.io/en/latest/dev-env-first-time-contributors.html#os-symlink-error")
+    sys.exit(1)
+
 if platform.architecture()[0] == '64bit':
     arch = 'amd64'
 elif platform.architecture()[0] == '32bit':

--- a/tools/provision.py
+++ b/tools/provision.py
@@ -57,18 +57,19 @@ if not os.path.exists(os.path.join(ZULIP_PATH, ".git")):
     print("from GitHub, rather than using a Zulip production release tarball.")
     sys.exit(1)
 
-try:
-    if os.path.exists(os.path.join(VAR_DIR_PATH, 'zulip-test-symlink')):
+if 'TRAVIS' not in os.environ:
+    try:
+        if os.path.exists(os.path.join(VAR_DIR_PATH, 'zulip-test-symlink')):
+            os.remove(os.path.join(VAR_DIR_PATH, 'zulip-test-symlink'))
+        os.symlink(
+            os.path.join(ZULIP_PATH, 'README.md'),
+            os.path.join(VAR_DIR_PATH, 'zulip-test-symlink')
+        )
         os.remove(os.path.join(VAR_DIR_PATH, 'zulip-test-symlink'))
-    os.symlink(
-        os.path.join(ZULIP_PATH, 'README.md'),
-        os.path.join(VAR_DIR_PATH, 'zulip-test-symlink')
-    )
-    os.remove(os.path.join(VAR_DIR_PATH, 'zulip-test-symlink'))
-except OSError as err:
-    print("Error: Unable to create symlinks. Make sure you have permission to create symbolic links.")
-    print("See this page for more information: http://zulip.readthedocs.io/en/latest/dev-env-first-time-contributors.html#os-symlink-error")
-    sys.exit(1)
+    except OSError as err:
+        print("Error: Unable to create symlinks. Make sure you have permission to create symbolic links.")
+        print("See this page for more information: http://zulip.readthedocs.io/en/latest/dev-env-first-time-contributors.html#os-symlink-error")
+        sys.exit(1)
 
 if platform.architecture()[0] == '64bit':
     arch = 'amd64'

--- a/tools/setup/emoji_dump/build_emoji
+++ b/tools/setup/emoji_dump/build_emoji
@@ -115,7 +115,13 @@ def main():
 
     print("Using cached emojis from {}".format(source_emoji_dump))
     run(['rm', '-rf', TARGET_EMOJI_DUMP])
-    run(['ln', '-nsf', source_emoji_dump, TARGET_EMOJI_DUMP])
+    try:
+        os.symlink(
+            source_emoji_dump,
+            TARGET_EMOJI_DUMP
+        )
+    except OSError:
+        print("Error: Unable to create symlinks. Make sure you have permission to create symbolic links.")
 
 def get_success_stamp():
     # type: () -> str
@@ -168,10 +174,16 @@ def dump_emojis(cache_path):
                 failed = True
                 continue
 
-        os.symlink(
-            'unicode/{}.png'.format(code_point),
-            'out/{}.png'.format(name)
-        )
+        try:
+            os.symlink(
+                'unicode/{}.png'.format(code_point),
+                'out/{}.png'.format(name)
+            )
+        except OSError:
+            print("Error: Unable to create symlinks. Make sure you have permission to create symbolic links.")
+            failed = True
+            # probably should not try to create additional links
+            break
 
     if failed:
         print("Errors dumping emoji!")


### PR DESCRIPTION
Currently, provisioning with Vagrant on Windows will fail with an unhelpful OSError exception if you don't have permissions to create symlinks. This small change does two things:

- uses `os.symlink` method in place of `run`
- catches OSError exceptions and prints more helpful error message

(Ideally our provisions script would check for the ability to create symlinks at the very beginning and halt if it isn't available. In the meantime, this will at least provide a more helpful error message.)