### PR TITLE
Support backend emoji rendering without whitespace.

### DIFF
--- a/zerver/fixtures/bugdown-data.json
+++ b/zerver/fixtures/bugdown-data.json
@@ -187,6 +187,12 @@
       "bugdown_matches_marked": true
     },
     {
+      "name": "emojis_without_space",
+      "input": ":cat:hello:dog::rabbit:",
+      "expected_output": "<p><img alt=\":cat:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/cat.png\" title=\":cat:\">hello<img alt=\":dog:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/dog.png\" title=\":dog:\"><img alt=\":rabbit:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/rabbit.png\" title=\":rabbit:\"></p>",
+      "bugdown_matches_marked": true
+    },
+    {
       "name": "not_emoji",
       "input": ":not_an_emoji:",
       "expected_output": "<p>:not_an_emoji:</p>",

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1032,7 +1032,7 @@ class Bugdown(markdown.Extension):
                         \*\*                         # ends by double asterisks
                        """
         md.inlinePatterns.add('stream', StreamPattern(stream_group), '>backtick')
-        md.inlinePatterns.add('emoji', Emoji(r'(?<!\w)(?P<syntax>:[^:\s]+:)(?!\w)'), '_end')
+        md.inlinePatterns.add('emoji', Emoji(r'(?P<syntax>:[\w\-\+]+:)'), '_end')
         md.inlinePatterns.add('unicodeemoji', UnicodeEmoji(
             u'(?<!\\w)(?P<syntax>[\U0001F300-\U0001F64F\U0001F680-\U0001F6FF\u2600-\u26FF\u2700-\u27BF])(?!\\w)'),
             '_end')


### PR DESCRIPTION
Emoji without whitespace surrounding it produce different results in bugdown and marked.

**Text**: `mmm...:burrito:s`
**Marked**: `<p>mmm...<img alt=":burrito:" class="emoji" src="/static/third/gemoji/images/emoji/burrito.png" title=":burrito:">s</p>` 
**Bugdown**: `<p>mmm...:burrito:s</p>`
