### PR TITLE
Move edit button to underneath message timestamp.

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -107,8 +107,8 @@ function message_unhover() {
 
 function message_hover(message_row) {
     var message;
-    var edit_content_button = '<i class="icon-vector-pencil edit_content_button"></i>';
 
+    var id = parseInt(message_row.attr("zid"), 10);
     if (current_message_hover && message_row && current_message_hover.attr("zid") === message_row.attr("zid")) {
         return;
     }
@@ -119,9 +119,10 @@ function message_hover(message_row) {
     message = current_msg_list.get(rows.id(message_row));
     message_unhover();
     message_row.addClass('message_hovered');
-    if ((message_edit.get_editability(message) === message_edit.editability_types.FULL) &&
-        !message.status_message) {
-            message_row.find(".edit_content").html(edit_content_button);
+    if ((message_edit.get_editability(message) === message_edit.editability_types.FULL) && !message.status_message) {
+        message_row.find(".edit_content").html('<i class="icon-vector-pencil edit_content_button"></i>');
+    } else {
+        message_row.find(".edit_content").html('<i class="icon-vector-file-text-alt edit_content_button" data-msgid="' + id + '"></i>');
     }
     current_message_hover = message_row;
 }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -99,7 +99,7 @@ function message_unhover() {
     }
     message = current_msg_list.get(rows.id(current_message_hover));
     if (message && message.sent_by_me) {
-        current_message_hover.find('.message_content').find('span.edit_content').remove();
+        current_message_hover.find('span.edit_content').html("");
     }
     current_message_hover.removeClass('message_hovered');
     current_message_hover = undefined;
@@ -107,7 +107,8 @@ function message_unhover() {
 
 function message_hover(message_row) {
     var message;
-    var edit_content_button = '<span class="edit_content"><i class="icon-vector-pencil edit_content_button"></i></span>';
+    var edit_content_button = '<i class="icon-vector-pencil edit_content_button"></i>';
+
     if (current_message_hover && message_row && current_message_hover.attr("zid") === message_row.attr("zid")) {
         return;
     }
@@ -120,7 +121,7 @@ function message_hover(message_row) {
     message_row.addClass('message_hovered');
     if ((message_edit.get_editability(message) === message_edit.editability_types.FULL) &&
         !message.status_message) {
-        message_row.find('.message_content').find('p:last').append(edit_content_button);
+            message_row.find(".edit_content").html(edit_content_button);
     }
     current_message_hover = message_row;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -702,7 +702,7 @@ td.pointer {
     display: inline-block;
     position: absolute;
     top: 2px;
-    right: -38px;
+    right: -55px;
 }
 
 .include-sender .message_controls {
@@ -1119,10 +1119,10 @@ a.message_label_clickable:hover {
 .edit_content {
     display: inline-block;
     position: relative;
-    left: 15px;
+    left: 22px;
     width: 0px;
     height: 0px;
-    opacity: .4;
+    color: #bbb;
 }
 
 .edit_content i {
@@ -1185,7 +1185,7 @@ a.dark_background:hover,
 .info {
     display: inline-block;
     position: relative;
-    left: 40px;
+    left: 3px;
     font-size: 15px;
     color: #bbb;
     visibility: hidden;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -737,6 +737,10 @@ td.pointer {
     margin-bottom: 10px;
 }
 
+.message_list .message_row:hover .message_time {
+    display: none;
+}
+
 .stream_label {
     display: inline-block;
     padding: 3px 4px 2px 4px;
@@ -1113,22 +1117,21 @@ a.message_label_clickable:hover {
 }
 
 .edit_content {
-    opacity: .4;
-    width: 0px;
-    height: 0px;
     display: inline-block;
     position: relative;
+    left: 15px;
+    width: 0px;
+    height: 0px;
+    opacity: .4;
 }
 
 .edit_content i {
     position: absolute;
     display: block;
-    background: #ffffff;
     top: -0.9em;
     left: 0.4em;
     border-radius: 1px;
     padding: 1px 2px;
-    border: 1px dotted #ccc;
 }
 
 .edit_content:hover {
@@ -1177,6 +1180,15 @@ a.dark_background:hover,
 .message_hovered .info,
 .message_hovered .empty-star {
     visibility: visible;
+}
+
+.info {
+    display: inline-block;
+    position: relative;
+    left: 40px;
+    font-size: 15px;
+    color: #bbb;
+    visibility: hidden;
 }
 
 .actions_hovered .actions_link {
@@ -2244,13 +2256,6 @@ button.topic_edit_cancel {
 .empty-star:hover {
     cursor: pointer;
     color: #565656;
-}
-
-.info {
-    display: inline-block;
-    font-size: 15px;
-    color: #bbb;
-    visibility: hidden;
 }
 
 .star:hover {

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -39,6 +39,7 @@
                     title="{{#tr this}}{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message{{/tr}}"></span>
             </div>
             <div class="info actions_hover">
+              <span class="edit_content"></span>
               <i class="icon-vector-chevron-down"></i>
             </div>
             <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -38,8 +38,8 @@
               <span class="message_star {{#if msg/starred}}icon-vector-star{{else}}icon-vector-star-empty empty-star{{/if}}"
                     title="{{#tr this}}{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message{{/tr}}"></span>
             </div>
+            <span class="edit_content"></span>
             <div class="info actions_hover">
-              <span class="edit_content"></span>
               <i class="icon-vector-chevron-down"></i>
             </div>
             <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">


### PR DESCRIPTION
This moves the edit button to underneath the timestamp such that when
you hover over a message now the timestamp hides itself and the edit
button appears (if editing is allowed).

This fixes the issue where the edit icon would sometimes move down to the next line when you hovered.

Fixes: #1733, more issues.