### PR TITLE
Wrap code on long lines.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -328,6 +328,11 @@ code {
     font-size: 0.857em;
 }
 
+.message_content p code {
+    white-space: pre-wrap;
+    padding: 0px 4px;
+}
+
 .codehilite {
     display: block !important;
     border: none !important;
@@ -1214,11 +1219,6 @@ div.focused_table {
     padding-left: 46px;
     display: block;
     position: relative;
-}
-
-.message_content p {
-    overflow-x: auto;
-    overflow-y: hidden;
 }
 
 .message_edit_content {


### PR DESCRIPTION
Wrap the code without setting overflow to hidden for paragraphs. This
fixes the emoji overflow issue. Our octopi finally have legs again.