### PR TITLE
analytics: Remove incorrect filter args for stat.

### DIFF
--- a/analytics/lib/counts.py
+++ b/analytics/lib/counts.py
@@ -330,5 +330,5 @@ COUNT_STATS = {
     'messages_sent:client': CountStat('messages_sent:client', zerver_count_message_by_user, {},
                                          (Message, 'sending_client_id'), CountStat.HOUR, False),
     'messages_sent_to_stream:is_bot': CountStat('messages_sent_to_stream:is_bot', zerver_count_message_by_stream,
-                                              {'is_active': True}, (UserProfile, 'is_bot'), CountStat.HOUR, False)
+                                              {}, (UserProfile, 'is_bot'), CountStat.HOUR, False)
     }


### PR DESCRIPTION
@rishig 

The filter args dictionary applies to the X table in a count X by Y query,
which in this case is the zerver_message table. This stat had an incorrect set
of arguments meant for the zerver_userprofile table.
