### PR TITLE
Add marked.js support to emojis in miscellaneous and dingbats block.

### DIFF
--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -536,7 +536,7 @@ inline.breaks = merge({}, inline.gfm, {
 
 inline.zulip = merge({}, inline.breaks, {
   emoji: /^:([A-Za-z0-9_\-\+]+?):/,
-  unicodeemoji: /^(\ud83c[\udf00-\udfff]|\ud83d[\udc00-\ude4f]|\ud83d[\ude80-\udeff])/,
+  unicodeemoji: /^(\ud83c[\udf00-\udfff]|\ud83d[\udc00-\ude4f]|\ud83d[\ude80-\udeff]|[\u2600-\u26FF]|[\u2700-\u27BF])/,
   usermention: /^(@(?:\*\*([^\*]+)?\*\*|(\w+)?))/m, // Match multi-word string between @** ** or match any one-word
   stream: /^#\*\*([^\*]+)\*\*/m,
   avatar: /^!avatar\(([^)]+)\)/,

--- a/zerver/fixtures/bugdown-data.json
+++ b/zerver/fixtures/bugdown-data.json
@@ -253,6 +253,12 @@
       "bugdown_matches_marked": true
     },
     {
+      "name": "miscellaneous_and_dingbats_emoji",
+      "input": "\u2693\u2797",
+      "expected_output":"<p><img alt=\"\u2693\" class=\"emoji\" src=\"\/static\/third\/gemoji\/images\/emoji\/unicode\/2693.png\" title=\"\u2693\"><img alt=\"\u2797\" class=\"emoji\" src=\"\/static\/third\/gemoji\/images\/emoji\/unicode\/2797.png\" title=\"\u2797\"><\/p>",
+      "bugdown_matches_marked": true
+    },
+    {
       "name": "emoji_alongside_punctuation",
       "input": ":smile:, :smile:; :smile:",
       "expected_output": "<p><img alt=\":smile:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/smile.png\" title=\":smile:\">, <img alt=\":smile:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/smile.png\" title=\":smile:\">; <img alt=\":smile:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/smile.png\" title=\":smile:\"></p>",


### PR DESCRIPTION
Emojis in  miscellaneous and dingbats block (`[\u2600-\u26FF]|[\u2700-\u27BF]`) were not parsed by js before. So there was a glitch when backend parse these emojis correctly. 
eg☺ 

https://en.wikipedia.org/wiki/Emoji#Unicode_blocks 