### PR TITLE
Add missing unicode range to text: replace(inline.breaks.text)

### DIFF
--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -543,7 +543,7 @@ inline.zulip = merge({}, inline.breaks, {
   gravatar: /^!gravatar\(([^)]+)\)/,
   realm_filters: [],
   text: replace(inline.breaks.text)
-    ('|', '|(\ud83c[\udf00-\udfff]|\ud83d[\udc00-\ude4f]|\ud83d[\ude80-\udeff])|')
+    ('|', '|(\ud83c[\udf00-\udfff]|\ud83d[\udc00-\ude4f]|\ud83d[\ude80-\udeff]|[\u2600-\u26FF]|[\u2700-\u27BF])|')
     (']|', '#@:]|')
     ()
 });


### PR DESCRIPTION
This is a followup of #2297. I didn't notice the unicode range appearing in   `text: replace(inline.breaks.text)`. I have added the same missing range here too.
