### PR TITLE
admin users: Clean up code

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -21,6 +21,11 @@ function get_user_info(email) {
     return self;
 }
 
+function get_email_for_user_row(row) {
+    var email = row.find('.email').text();
+    return email;
+}
+
 exports.update_user_full_name = function (email, new_full_name) {
     var user_info = get_user_info(email);
 
@@ -314,7 +319,7 @@ function _setup_page() {
         var row = $(e.target).closest(".user_row");
 
         var user_name = row.find('.user_name').text();
-        var email = row.find('.email').text();
+        var email = get_email_for_user_row(row);
 
         $("#deactivation_user_modal .email").text(email);
         $("#deactivation_user_modal .user_name").text(user_name);
@@ -389,7 +394,8 @@ function _setup_page() {
         var row = $(e.target).closest(".user_row");
 
         var user_name = row.find('.user_name').text();
-        var email = row.find('.email').text();
+        var email = get_email_for_user_row(row);
+
         channel.del({
             url: '/json/bots/' + email,
             error: function (xhr, error_type) {
@@ -419,8 +425,8 @@ function _setup_page() {
 
         // Go up the tree until we find the user row, then grab the email element
         var row = $(e.target).closest(".user_row");
+        var email = get_email_for_user_row(row);
 
-        var email = row.find('.email').text();
         channel.post({
             url: '/json/users/' + email + "/reactivate",
             error: function (xhr, error_type) {
@@ -606,7 +612,7 @@ function _setup_page() {
 
         // Go up the tree until we find the user row, then grab the email element
         var row = $(e.target).closest(".user_row");
-        var email = row.find('.email').text();
+        var email = get_email_for_user_row(row);
 
         var url = "/json/users/" + email;
         var data = {
@@ -637,7 +643,7 @@ function _setup_page() {
 
         // Go up the tree until we find the user row, then grab the email element
         var row = $(e.target).closest(".user_row");
-        var email = row.find('.email').text();
+        var email = get_email_for_user_row(row);
 
         var url = "/json/users/" + email;
         var data = {

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -311,9 +311,7 @@ function _setup_page() {
         e.preventDefault();
         e.stopPropagation();
 
-        $(".active_user_row").removeClass("active_user_row");
         var row = $(e.target).closest(".user_row");
-        row.addClass("active_user_row");
 
         var user_name = row.find('.user_name').text();
         var email = row.find('.email').text();
@@ -388,9 +386,7 @@ function _setup_page() {
         e.preventDefault();
         e.stopPropagation();
 
-        $(".active_user_row").removeClass("active_user_row");
         var row = $(e.target).closest(".user_row");
-        row.addClass("active_user_row");
 
         var user_name = row.find('.user_name').text();
         var email = row.find('.email').text();
@@ -422,9 +418,7 @@ function _setup_page() {
         e.stopPropagation();
 
         // Go up the tree until we find the user row, then grab the email element
-        $(".active_user_row").removeClass("active_user_row");
         var row = $(e.target).closest(".user_row");
-        row.addClass("active_user_row");
 
         var email = row.find('.email').text();
         channel.post({
@@ -611,9 +605,7 @@ function _setup_page() {
         e.stopPropagation();
 
         // Go up the tree until we find the user row, then grab the email element
-        $(".active_user_row").removeClass("active_user_row");
         var row = $(e.target).closest(".user_row");
-        row.addClass("active_user_row");
         var email = row.find('.email').text();
 
         var url = "/json/users/" + email;
@@ -644,9 +636,7 @@ function _setup_page() {
         e.stopPropagation();
 
         // Go up the tree until we find the user row, then grab the email element
-        $(".active_user_row").removeClass("active_user_row");
         var row = $(e.target).closest(".user_row");
-        row.addClass("active_user_row");
         var email = row.find('.email').text();
 
         var url = "/json/users/" + email;

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -12,13 +12,23 @@ exports.show_or_hide_menu_item = function () {
     }
 };
 
+function get_user_info(email) {
+    var self = {};
+    self.user_row = $("tr[id='user_" + email + "']");
+    self.form_row = $("tr[id='user_form_" + email + "']");
+
+    return self;
+}
+
 exports.update_user_full_name = function (email, new_full_name) {
-    var user_row = $("tr[id='user_" + email + "']");
-    var user_name = user_row.find(".user_name");
-    var form_row = $("tr[id='user_form_" + email + "']");
+    var user_info = get_user_info(email);
+
+    var user_row = user_info.user_row;
+    var form_row = user_info.form_row;
 
     // Update the full name in the table
-    user_name.text(new_full_name);
+    user_row.find(".user_name").text(new_full_name);
+    form_row.find("input[name='full_name']").val(new_full_name);
 
     // Hide name change form
     form_row.hide();

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -670,8 +670,9 @@ function _setup_page() {
 
     $(".admin_user_table, .admin_bot_table").on("click", ".open-user-form", function (e) {
         var email = $(e.currentTarget).data("email");
-        var user_row = $("tr[id='user_" + email + "']");
-        var form_row = $("tr[id='user_form_" + email + "'");
+        var user_info = get_user_info(email);
+        var user_row = user_info.user_row;
+        var form_row = user_info.form_row;
         var reset_button = form_row.find(".reset_edit_user");
         var submit_button = form_row.find(".submit_name_changes");
         var full_name = form_row.find("input[name='full_name']");


### PR DESCRIPTION
This series cleans up admin.js so that most of the jQuery stuff that we need for email -> user_id is in one place.  We can merge this, but then we still need to figure out some more stuff to make everything user-id-driven.  The problem here is that admin.js has its own data structure for users, which we get from `/json/users`.  The `admin.js` users can be a superset of the users in `people.js`, since admins may be dealing with deactivated users.  I want to decide whether we just keep our own separate userid/email mapping inside of `admin.js`, or maybe we just make sure to download deactivated users for admins during page load.  I'm leaning toward the latter, although things will get tricky if somebody makes you an admin.