### PR TITLE
bug fix: Fix topic unread counts for upper-case streams.

### DIFF
--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -108,7 +108,7 @@ exports.build_widget = function (parent_elem, stream, active_topic, max_topics) 
     };
 
     self.is_for_stream = function (stream_name) {
-        return stream === stream_name;
+        return stream.toLowerCase() === stream_name.toLowerCase();
     };
 
     self.get_stream_name = function () {


### PR DESCRIPTION
If stream names weren't entirely lowercase, then our function
topic_list.is_for_stream() was improperly reporting false and
failing to update unread counts for the active topic widget.

This regression was probably introduced in the fairly recent
53eea250d07e97686460294442daed49a6be4b80 commit.

Fixes #2330.