### PR TITLE
Access realm by `string_id` in management commands.

### DIFF
--- a/analytics/management/commands/client_activity.py
+++ b/analytics/management/commands/client_activity.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 from django.db.models import Count, QuerySet
 
 from zerver.models import UserActivity, UserProfile, Realm, \
-    get_realm, get_user_profile_by_email
+    get_realm_by_string_id, get_user_profile_by_email
 
 import datetime
 
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 Usage examples:
 
 python manage.py client_activity
-python manage.py client_activity zulip.com
+python manage.py client_activity zulip
 python manage.py client_activity jesstess@zulip.com"""
 
     def add_arguments(self, parser):
@@ -73,7 +73,7 @@ python manage.py client_activity jesstess@zulip.com"""
             except UserProfile.DoesNotExist:
                 try:
                     # Report activity for a realm.
-                    realm = get_realm(arg)
+                    realm = get_realm_by_string_id(arg)
                     self.compute_activity(UserActivity.objects.filter(
                             user_profile__realm=realm))
                 except Realm.DoesNotExist:

--- a/analytics/management/commands/realm_stats.py
+++ b/analytics/management/commands/realm_stats.py
@@ -11,7 +11,7 @@ import pytz
 from django.core.management.base import BaseCommand
 from django.db.models import Count
 from zerver.models import UserProfile, Realm, Stream, Message, Recipient, UserActivity, \
-    Subscription, UserMessage, get_realm
+    Subscription, UserMessage, get_realm_by_string_id
 
 MOBILE_CLIENT_LIST = ["Android", "ios"]
 HUMAN_CLIENT_LIST = MOBILE_CLIENT_LIST + ["website"]
@@ -86,7 +86,7 @@ class Command(BaseCommand):
         # type: (*Any, **Any) -> None
         if options['realms']:
             try:
-                realms = [get_realm(domain) for domain in options['realms']]
+                realms = [get_realm_by_string_id(string_id) for string_id in options['realms']]
             except Realm.DoesNotExist as e:
                 print(e)
                 exit(1)
@@ -94,7 +94,7 @@ class Command(BaseCommand):
             realms = Realm.objects.all()
 
         for realm in realms:
-            print(realm.domain)
+            print(realm.string_id)
 
             user_profiles = UserProfile.objects.filter(realm=realm, is_active=True)
             active_users = self.active_users(realm)

--- a/analytics/management/commands/stream_stats.py
+++ b/analytics/management/commands/stream_stats.py
@@ -6,7 +6,7 @@ from typing import Any
 from argparse import ArgumentParser
 from django.core.management.base import BaseCommand
 from django.db.models import Q
-from zerver.models import Realm, Stream, Message, Subscription, Recipient, get_realm
+from zerver.models import Realm, Stream, Message, Subscription, Recipient, get_realm_by_string_id
 
 class Command(BaseCommand):
     help = "Generate statistics on the streams for a realm."
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         # type: (*Any, **str) -> None
         if options['realms']:
             try:
-                realms = [get_realm(domain) for domain in options['realms']]
+                realms = [get_realm_by_string_id(string_id) for string_id in options['realms']]
             except Realm.DoesNotExist as e:
                 print(e)
                 exit(1)
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             realms = Realm.objects.all()
 
         for realm in realms:
-            print(realm.domain)
+            print(realm.string_id)
             print("------------")
             print("%25s %15s %10s" % ("stream", "subscribers", "messages"))
             streams = Stream.objects.filter(realm=realm).exclude(Q(name__istartswith="tutorial-"))

--- a/analytics/management/commands/user_stats.py
+++ b/analytics/management/commands/user_stats.py
@@ -7,7 +7,7 @@ import pytz
 from typing import Any
 
 from django.core.management.base import BaseCommand
-from zerver.models import UserProfile, Realm, Stream, Message, get_realm
+from zerver.models import UserProfile, Realm, Stream, Message, get_realm_by_string_id
 from six.moves import range
 
 class Command(BaseCommand):
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         # type: (*Any, **Any) -> None
         if options['realms']:
             try:
-                realms = [get_realm(domain) for domain in options['realms']]
+                realms = [get_realm_by_string_id(string_id) for string_id in options['realms']]
             except Realm.DoesNotExist as e:
                 print(e)
                 exit(1)
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             realms = Realm.objects.all()
 
         for realm in realms:
-            print(realm.domain)
+            print(realm.string_id)
             user_profiles = UserProfile.objects.filter(realm=realm, is_active=True)
             print("%d users" % (len(user_profiles),))
             print("%d streams" % (len(Stream.objects.filter(realm=realm)),))

--- a/zerver/management/commands/add_users_to_streams.py
+++ b/zerver/management/commands/add_users_to_streams.py
@@ -8,7 +8,7 @@ from typing import Any
 from django.core.management.base import BaseCommand, CommandParser
 
 from zerver.lib.actions import create_stream_if_needed, bulk_add_subscriptions
-from zerver.models import UserProfile, get_realm, get_user_profile_by_email
+from zerver.models import UserProfile, get_realm_by_string_id, get_user_profile_by_email
 
 class Command(BaseCommand):
     help = """Add some or all users in a realm to a set of streams."""
@@ -16,8 +16,8 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         # type: (CommandParser) -> None
         parser.add_argument(
-            '-d', '--domain',
-            dest='domain',
+            '-r', '--realm',
+            dest='string_id',
             type=str,
             help='The name of the realm in which you are adding people to streams.')
 
@@ -42,13 +42,13 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         # type: (**Any) -> None
-        if options["domain"] is None or options["streams"] is None or \
+        if options["string_id"] is None or options["streams"] is None or \
                 (options["users"] is None and options["all_users"] is None):
             self.print_help("python manage.py", "add_users_to_streams")
             exit(1)
 
         stream_names = set([stream.strip() for stream in options["streams"].split(",")])
-        realm = get_realm(options["domain"])
+        realm = get_realm_by_string_id(options["string_id"])
 
         if options["all_users"]:
             user_profiles = UserProfile.objects.filter(realm=realm)

--- a/zerver/management/commands/create_stream.py
+++ b/zerver/management/commands/create_stream.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 
 from zerver.lib.actions import do_create_stream
 from zerver.lib.str_utils import force_text
-from zerver.models import Realm, get_realm
+from zerver.models import Realm, get_realm_by_string_id
 
 from argparse import ArgumentParser
 import sys
@@ -21,20 +21,20 @@ the command."""
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
-        parser.add_argument('domain', metavar='<domain>', type=str,
-                            help='domain in which to create the stream')
+        parser.add_argument('realm', metavar='<realm>', type=str,
+                            help='realm in which to create the stream')
         parser.add_argument('stream_name', metavar='<stream name>', type=str,
                             help='name of stream to create')
 
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
-        domain = options['domain']
+        string_id = options['realm']
         encoding = sys.getfilesystemencoding()
         stream_name = options['stream_name']
 
-        realm = get_realm(force_text(domain, encoding))
+        realm = get_realm_by_string_id(force_text(string_id, encoding))
         if realm is None:
-            print("Unknown domain %s" % (domain,))
+            print("Unknown string_id %s" % (string_id,))
             exit(1)
         else:
             do_create_stream(realm, force_text(stream_name, encoding))

--- a/zerver/management/commands/create_user.py
+++ b/zerver/management/commands/create_user.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from django.core import validators
 
-from zerver.models import Realm, get_realm, email_to_username
+from zerver.models import Realm, get_realm_by_string_id, email_to_username
 from zerver.lib.actions import do_create_user
 from zerver.lib.actions import notify_new_user
 from zerver.lib.initial_password import initial_password
@@ -33,8 +33,8 @@ Omit both <email> and <full name> for interactive user creation.
                             action="store_true",
                             default=False,
                             help='Acknowledgement that the user has already accepted the ToS.')
-        parser.add_argument('--domain',
-                            dest='domain',
+        parser.add_argument('--realm',
+                            dest='string_id',
                             type=str,
                             help='The name of the existing realm to which to add the user.')
         parser.add_argument('email', metavar='<email>', type=str, nargs='?', default=argparse.SUPPRESS,
@@ -48,11 +48,11 @@ Omit both <email> and <full name> for interactive user creation.
             raise CommandError("""You must confirm that this user has accepted the
 Terms of Service by passing --this-user-has-accepted-the-tos.""")
 
-        if not options["domain"]:
-            raise CommandError("""Please specify a realm by passing --domain.""")
+        if not options["string_id"]:
+            raise CommandError("""Please specify a realm by passing --realm.""")
 
         try:
-            realm = get_realm(options["domain"])
+            realm = get_realm_by_string_id(options["string_id"])
         except Realm.DoesNotExist:
             raise CommandError("Realm does not exist.")
 

--- a/zerver/management/commands/deactivate_realm.py
+++ b/zerver/management/commands/deactivate_realm.py
@@ -9,22 +9,22 @@ from argparse import ArgumentParser
 import sys
 
 from zerver.lib.actions import do_deactivate_realm
-from zerver.models import get_realm
+from zerver.models import get_realm_by_string_id
 
 class Command(BaseCommand):
     help = """Script to deactivate a realm."""
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
-        parser.add_argument('domain', metavar='<domain>', type=str,
-                            help='domain of realm to deactivate')
+        parser.add_argument('string_id', metavar='<string_id>', type=str,
+                            help='string_id of realm to deactivate')
 
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
-        realm = get_realm(options["domain"])
+        realm = get_realm_by_string_id(options["string_id"])
         if realm is None:
-            print("Could not find realm %s" % (options["domain"],))
+            print("Could not find realm %s" % (options["string_id"],))
             sys.exit(1)
-        print("Deactivating", options["domain"])
+        print("Deactivating", options["string_id"])
         do_deactivate_realm(realm)
         print("Done!")

--- a/zerver/management/commands/dump_messages.py
+++ b/zerver/management/commands/dump_messages.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from optparse import make_option
 from django.core.management.base import BaseCommand, CommandParser
-from zerver.models import get_realm, Message, Realm, Stream, Recipient
+from zerver.models import get_realm_by_string_id, Message, Realm, Stream, Recipient
 
 import datetime
 import time
@@ -14,10 +14,10 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         # type: (CommandParser) -> None
         default_cutoff = time.time() - 60 * 60 * 24 * 30 # 30 days.
-        parser.add_argument('--domain',
-                            dest='domain',
+        parser.add_argument('--realm',
+                            dest='string_id',
                             type=str,
-                            help='The domain whose public streams you want to dump.')
+                            help='The subdomain/string_id of realm whose public streams you want to dump.')
 
         parser.add_argument('--since',
                             dest='since',
@@ -27,7 +27,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # type: (*Any, **Any) -> None
-        realm = get_realm(options["domain"])
+        realm = get_realm_by_string_id(options["string_id"])
         streams = Stream.objects.filter(realm=realm, invite_only=False)
         recipients = Recipient.objects.filter(
             type=Recipient.STREAM, type_id__in=[stream.id for stream in streams])

--- a/zerver/management/commands/enqueue_digest_emails.py
+++ b/zerver/management/commands/enqueue_digest_emails.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from zerver.lib.queue import queue_json_publish
-from zerver.models import UserActivity, UserProfile, get_realm, Realm
+from zerver.models import UserActivity, UserProfile, get_realm_by_string_id, Realm
 
 ## Logging setup ##
 
@@ -102,8 +102,9 @@ in a while.
             if not should_process_digest(domain, deployment_domains):
                 continue
 
+            string_id = realm.string_id
             user_profiles = UserProfile.objects.filter(
-                realm=get_realm(domain), is_active=True, is_bot=False,
+                realm=get_realm_by_string_id(string_id), is_active=True, is_bot=False,
                 enable_digest_emails=True)
 
             for user_profile in user_profiles:

--- a/zerver/management/commands/export.py
+++ b/zerver/management/commands/export.py
@@ -16,7 +16,7 @@ import ujson
 from zerver.lib.export import (
     do_export_realm, do_write_stats_file_for_realm_export
 )
-from zerver.models import get_realm
+from zerver.models import get_realm_by_string_id
 
 class Command(BaseCommand):
     help = """Exports all data from a Zulip realm
@@ -112,7 +112,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # type: (*Any, **Any) -> None
         try:
-            realm = get_realm(options["realm"])
+            realm = get_realm_by_string_id(options["realm"])
         except ValidationError:
             raise CommandError("No such realm.")
 

--- a/zerver/management/commands/generate_invite_links.py
+++ b/zerver/management/commands/generate_invite_links.py
@@ -7,15 +7,15 @@ from argparse import ArgumentParser
 from django.core.management.base import BaseCommand
 from confirmation.models import Confirmation
 from zerver.models import UserProfile, PreregistrationUser, \
-    get_user_profile_by_email, get_realm, email_allowed_for_realm
+    get_user_profile_by_email, get_realm_by_string_id, email_allowed_for_realm
 
 class Command(BaseCommand):
     help = "Generate activation links for users and print them to stdout."
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
-        parser.add_argument('--domain',
-                            dest='domain',
+        parser.add_argument('--realm',
+                            dest='string_id',
                             type=str,
                             help='The realm in which to generate the invites (use for open realms).')
         parser.add_argument('--force',
@@ -42,11 +42,11 @@ class Command(BaseCommand):
             return
 
         realm = None
-        domain = options["domain"]
-        if domain:
-            realm = get_realm(domain)
+        string_id = options["string_id"]
+        if string_id:
+            realm = get_realm_by_string_id(string_id)
         if not realm:
-            print("The realm %s doesn't exist yet, please create it first." % (domain,))
+            print("The realm %s doesn't exist yet, please create it first." % (string_id,))
             print("Don't forget default streams!")
             exit(1)
 
@@ -54,7 +54,7 @@ class Command(BaseCommand):
             if realm:
                 if not email_allowed_for_realm(email, realm) and not options["force"]:
                     print("You've asked to add an external user (%s) to a closed realm (%s)." % (
-                        email, domain))
+                        email, string_id))
                     print("Are you sure? To do this, pass --force.")
                     exit(1)
                 else:

--- a/zerver/management/commands/logout_all_users.py
+++ b/zerver/management/commands/logout_all_users.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand
 
 from zerver.lib.actions import delete_all_user_sessions, \
     delete_realm_user_sessions, delete_all_deactivated_user_sessions
-from zerver.models import get_realm
+from zerver.models import get_realm_by_string_id
 
 class Command(BaseCommand):
     help = "Log out all users."
@@ -28,7 +28,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # type: (*Any, **Any) -> None
         if options["realm"]:
-            realm = get_realm(options["realm"])
+            realm = get_realm_by_string_id(options["realm"])
             delete_realm_user_sessions(realm)
         elif options["deactivated_only"]:
             delete_all_deactivated_user_sessions()

--- a/zerver/management/commands/reactivate_realm.py
+++ b/zerver/management/commands/reactivate_realm.py
@@ -9,22 +9,22 @@ from django.core.management.base import BaseCommand
 import sys
 
 from zerver.lib.actions import do_reactivate_realm
-from zerver.models import get_realm
+from zerver.models import get_realm_by_string_id
 
 class Command(BaseCommand):
     help = """Script to reactivate a deactivated realm."""
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
-        parser.add_argument('domain', metavar='<domain>', type=str,
+        parser.add_argument('string_id', metavar='<string_id>', type=str,
                             help='domain of realm to reactivate')
 
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
-        realm = get_realm(options["domain"])
+        realm = get_realm_by_string_id(options["string_id"])
         if realm is None:
-            print("Could not find realm %s" % (options["domain"],))
+            print("Could not find realm %s" % (options["string_id"],))
             sys.exit(1)
-        print("Reactivating", options["domain"])
+        print("Reactivating", options["string_id"])
         do_reactivate_realm(realm)
         print("Done!")

--- a/zerver/management/commands/realm_alias.py
+++ b/zerver/management/commands/realm_alias.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from argparse import ArgumentParser
 from django.core.management.base import BaseCommand
-from zerver.models import Realm, RealmAlias, get_realm, can_add_alias
+from zerver.models import Realm, RealmAlias, get_realm_by_string_id, can_add_alias
 from zerver.lib.actions import realm_aliases
 import sys
 
@@ -15,10 +15,10 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
         parser.add_argument('-r', '--realm',
-                            dest='domain',
+                            dest='string_id',
                             type=str,
                             required=True,
-                            help='The name of the realm.')
+                            help='The subdomain or string_id of the realm.')
         parser.add_argument('--op',
                             dest='op',
                             type=str,
@@ -29,7 +29,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
-        realm = get_realm(options["domain"])
+        realm = get_realm_by_string_id(options["string_id"])
         if options["op"] == "show":
             print("Aliases for %s:" % (realm.domain,))
             for alias in realm_aliases(realm):

--- a/zerver/management/commands/realm_emoji.py
+++ b/zerver/management/commands/realm_emoji.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from argparse import ArgumentParser
 from django.core.management.base import BaseCommand, CommandParser
-from zerver.models import Realm, get_realm
+from zerver.models import Realm, get_realm_by_string_id
 from zerver.lib.actions import check_add_realm_emoji, do_remove_realm_emoji
 import sys
 import six
@@ -30,10 +30,10 @@ Example: python manage.py realm_emoji --realm=zulip.com --op=show
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
         parser.add_argument('-r', '--realm',
-                            dest='domain',
+                            dest='string_id',
                             type=str,
                             required=True,
-                            help='The name of the realm.')
+                            help='The subdomain or string_id of the realm.')
         parser.add_argument('--op',
                             dest='op',
                             type=str,
@@ -46,7 +46,7 @@ Example: python manage.py realm_emoji --realm=zulip.com --op=show
 
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
-        realm = get_realm(options["domain"])
+        realm = get_realm_by_string_id(options["string_id"])
         if options["op"] == "show":
             for name, url in six.iteritems(realm.get_emoji()):
                 print(name, url)

--- a/zerver/management/commands/realm_filters.py
+++ b/zerver/management/commands/realm_filters.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
-from zerver.models import RealmFilter, all_realm_filters, get_realm
+from zerver.models import RealmFilter, all_realm_filters, get_realm_by_string_id
 from zerver.lib.actions import do_add_realm_filter, do_remove_realm_filter
 import sys
 
@@ -20,18 +20,18 @@ NOTE: Regexes must be simple enough that they can be easily translated to JavaSc
       * Named groups will be converted to numbered groups automatically
       * Inline-regex flags will be stripped, and where possible translated to RegExp-wide flags
 
-Example: python manage.py realm_filters --realm=zulip.com --op=add '#(?P<id>[0-9]{2,8})' 'https://trac.humbughq.com/ticket/%(id)s'
-Example: python manage.py realm_filters --realm=zulip.com --op=remove '#(?P<id>[0-9]{2,8})'
-Example: python manage.py realm_filters --realm=zulip.com --op=show
+Example: python manage.py realm_filters --realm=zulip --op=add '#(?P<id>[0-9]{2,8})' 'https://trac.humbughq.com/ticket/%(id)s'
+Example: python manage.py realm_filters --realm=zulip --op=remove '#(?P<id>[0-9]{2,8})'
+Example: python manage.py realm_filters --realm=zulip --op=show
 """
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
         parser.add_argument('-r', '--realm',
-                            dest='domain',
+                            dest='string_id',
                             type=str,
                             required=True,
-                            help='The name of the realm to adjust filters for.')
+                            help='The subdomain or string_id of the realm to adjust filters for.')
         parser.add_argument('--op',
                             dest='op',
                             type=str,
@@ -44,7 +44,7 @@ Example: python manage.py realm_filters --realm=zulip.com --op=show
 
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
-        realm = get_realm(options["domain"])
+        realm = get_realm_by_string_id(options["string_id"])
         if options["op"] == "show":
             print("%s: %s" % (realm.domain, all_realm_filters().get(realm.domain, [])))
             sys.exit(0)

--- a/zerver/management/commands/remove_users_from_stream.py
+++ b/zerver/management/commands/remove_users_from_stream.py
@@ -9,7 +9,7 @@ from optparse import make_option
 from django.core.management.base import BaseCommand, CommandParser
 
 from zerver.lib.actions import bulk_remove_subscriptions
-from zerver.models import Realm, UserProfile, get_realm, get_stream, \
+from zerver.models import Realm, UserProfile, get_realm_by_string_id, get_stream, \
     get_user_profile_by_email
 
 class Command(BaseCommand):
@@ -17,10 +17,10 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         # type: (CommandParser) -> None
-        parser.add_argument('-d', '--domain',
-                            dest='domain',
+        parser.add_argument('-r', '--realm',
+                            dest='string_id',
                             type=str,
-                            help='The name of the realm in which you are '
+                            help='The subdomain or string_id of the realm in which you are '
                                  'removing people.')
 
         parser.add_argument('-s', '--stream',
@@ -41,12 +41,12 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         # type: (*Any, **Any) -> None
-        if options["domain"] is None or options["stream"] is None or \
+        if options["string_id"] is None or options["stream"] is None or \
                 (options["users"] is None and options["all_users"] is None):
             self.print_help("python manage.py", "remove_users_from_stream")
             exit(1)
 
-        realm = get_realm(options["domain"])
+        realm = get_realm_by_string_id(options["string_id"])
         stream_name = options["stream"].strip()
         stream = get_stream(stream_name, realm)
 

--- a/zerver/management/commands/rename_stream.py
+++ b/zerver/management/commands/rename_stream.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 
 from zerver.lib.actions import do_rename_stream
 from zerver.lib.str_utils import force_text
-from zerver.models import Realm, get_realm
+from zerver.models import Realm, get_realm_by_string_id
 
 import sys
 
@@ -17,8 +17,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
-        parser.add_argument('domain', metavar='<domain>', type=str,
-                            help="domain to operate on")
+        parser.add_argument('string_id', metavar='<string_id>', type=str,
+                            help="subdomain or string_id to operate on")
         parser.add_argument('old_name', metavar='<old name>', type=str,
                             help='name of stream to be renamed')
         parser.add_argument('new_name', metavar='<new name>', type=str,
@@ -26,14 +26,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
-        domain = options['domain']
+        string_id = options['string_id']
         old_name = options['old_name']
         new_name = options['new_name']
         encoding = sys.getfilesystemencoding()
 
-        realm = get_realm(force_text(domain, encoding))
+        realm = get_realm_by_string_id(force_text(string_id, encoding))
         if realm is None:
-            print("Unknown domain %s" % (domain,))
+            print("Unknown subdomain or string_id %s" % (string_id,))
             exit(1)
 
         do_rename_stream(realm, force_text(old_name, encoding),

--- a/zerver/management/commands/send_password_reset_email.py
+++ b/zerver/management/commands/send_password_reset_email.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 from django.core.mail import send_mail, BadHeaderError
 from zerver.forms import PasswordResetForm
-from zerver.models import UserProfile, get_user_profile_by_email, get_realm
+from zerver.models import UserProfile, get_user_profile_by_email, get_realm_by_string_id
 from django.template import loader
 from django.core.mail import EmailMultiAlternatives
 
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         if options["to"]:
             users = [get_user_profile_by_email(options["to"])]
         elif options["realm"]:
-            realm = get_realm(options["realm"])
+            realm = get_realm_by_string_id(options["realm"])
             users = UserProfile.objects.filter(realm=realm, is_active=True, is_bot=False,
                                                is_mirror_dummy=False)
         elif options["server"] == "YES":

--- a/zerver/management/commands/set_default_streams.py
+++ b/zerver/management/commands/set_default_streams.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser
 
-from zerver.models import get_realm
+from zerver.models import get_realm_by_string_id
 from zerver.lib.actions import set_default_streams
 
 from optparse import make_option
@@ -21,17 +21,17 @@ streams.
 
 For example:
 
-python manage.py set_default_streams --domain=foo.com --streams=foo,bar,baz
-python manage.py set_default_streams --domain=foo.com --streams="foo,bar,baz with space"
-python manage.py set_default_streams --domain=foo.com --streams=
+python manage.py set_default_streams --realm=foo --streams=foo,bar,baz
+python manage.py set_default_streams --realm=foo --streams="foo,bar,baz with space"
+python manage.py set_default_streams --realm=foo --streams=
 """
 
     def add_arguments(self, parser):
         # type: (CommandParser) -> None
-        parser.add_argument('-d', '--domain',
-                            dest='domain',
+        parser.add_argument('-r', '--realm',
+                            dest='string_id',
                             type=str,
-                            help='The name of the existing realm to which to '
+                            help='The subdomain or string_id of the existing realm to which to '
                                  'attach default streams.')
 
         parser.add_argument('-s', '--streams',
@@ -41,11 +41,11 @@ python manage.py set_default_streams --domain=foo.com --streams=
 
     def handle(self, **options):
         # type: (*Any, **str) -> None
-        if options["domain"] is None or options["streams"] is None:
-            print("Please provide both a domain name and a default \
+        if options["string_id"] is None or options["streams"] is None:
+            print("Please provide both a subdomain name or string_id and a default \
 set of streams (which can be empty, with `--streams=`).", file=sys.stderr)
             exit(1)
 
         stream_names = [stream.strip() for stream in options["streams"].split(",")]
-        realm = get_realm(options["domain"])
+        realm = get_realm_by_string_id(options["string_id"])
         set_default_streams(realm, stream_names)

--- a/zerver/management/commands/show_admins.py
+++ b/zerver/management/commands/show_admins.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from argparse import ArgumentParser
 from django.core.management.base import BaseCommand
-from zerver.models import get_realm, Realm
+from zerver.models import get_realm_by_string_id, Realm
 import sys
 
 class Command(BaseCommand):
@@ -21,7 +21,7 @@ class Command(BaseCommand):
         realm_name = options['realm']
 
         try:
-            realm = get_realm(realm_name)
+            realm = get_realm_by_string_id(realm_name)
         except Realm.DoesNotExist:
             print('There is no realm called %s.' % (realm_name,))
             sys.exit(1)

--- a/zerver/management/commands/turn_off_digests.py
+++ b/zerver/management/commands/turn_off_digests.py
@@ -8,15 +8,15 @@ from optparse import make_option
 from django.core.management.base import BaseCommand, CommandParser
 
 from zerver.lib.actions import do_change_enable_digest_emails
-from zerver.models import Realm, UserProfile, get_realm, get_user_profile_by_email
+from zerver.models import Realm, UserProfile, get_realm_by_string_id, get_user_profile_by_email
 
 class Command(BaseCommand):
-    help = """Turn off digests for a domain or specified set of email addresses."""
+    help = """Turn off digests for a subdomain/string_id or specified set of email addresses."""
 
     def add_arguments(self, parser):
         # type: (CommandParser) -> None
-        parser.add_argument('-d', '--domain',
-                            dest='domain',
+        parser.add_argument('-r', '--realm',
+                            dest='string_id',
                             type=str,
                             help='Turn off digests for all users in this domain.')
 
@@ -28,12 +28,12 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         # type: (**str) -> None
-        if options["domain"] is None and options["users"] is None:
+        if options["string_id"] is None and options["users"] is None:
             self.print_help("python manage.py", "turn_off_digests")
             exit(1)
 
-        if options["domain"]:
-            realm = get_realm(options["domain"])
+        if options["string_id"]:
+            realm = get_realm_by_string_id(options["string_id"])
             user_profiles = UserProfile.objects.filter(realm=realm)
         else:
             emails = set([email.strip() for email in options["users"].split(",")])

--- a/zilencer/management/commands/create_deployment.py
+++ b/zilencer/management/commands/create_deployment.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser
 
-from zerver.models import get_realm
+from zerver.models import get_realm_by_string_id
 from zerver.lib.create_user import random_api_key
 from zerver.management.commands.create_realm import Command as CreateRealm
 
@@ -24,15 +24,15 @@ class Command(BaseCommand):
                             default=False,
                             help='Do not create a new realm; associate with '
                                  'an existing one. In this case, only the '
-                                 'domain and URLs need to be specified.')
+                                 'realm and URLs need to be specified.')
 
         parser.add_argument('-a', '--api-url', dest='api', type=str)
         parser.add_argument('-w', '--web-url', dest='web', type=str)
 
     def handle(self, *args, **options):
         # type: (*Any, **Any) -> None
-        if None in (options["api"], options["web"], options["domain"]):
-            print("\033[1;31mYou must provide a domain, an API URL, and a web URL.\033[0m\n", file=sys.stderr)
+        if None in (options["api"], options["web"], options["string_id"]):
+            print("\033[1;31mYou must provide a subdomain or string_id, an API URL, and a web URL.\033[0m\n", file=sys.stderr)
             self.print_help("python manage.py", "create_realm")
             exit(1)
 
@@ -40,7 +40,7 @@ class Command(BaseCommand):
             CreateRealm().handle(*args, **options)
             print() # Newline
 
-        realm = get_realm(options["domain"])
+        realm = get_realm_by_string_id(options["string_id"])
         if realm is None:
             print("\033[1;31mRealm does not exist!\033[0m\n", file=sys.stderr)
             exit(2)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -12,8 +12,12 @@ from zerver.models import Message, UserProfile, Stream, Recipient, \
 from zerver.lib.actions import STREAM_ASSIGNMENT_COLORS, do_send_message, \
     do_change_is_admin
 from django.conf import settings
-from zerver.lib.bulk_create import bulk_create_streams, bulk_create_users
-from zerver.models import DefaultStream, get_stream, get_realm
+from zerver.lib.bulk_create import bulk_create_realms, \
+    bulk_create_streams, bulk_create_users, bulk_create_huddles, \
+    bulk_create_clients
+from zerver.lib.timestamp import timestamp_to_datetime
+from zerver.models import MAX_MESSAGE_LENGTH
+from zerver.models import DefaultStream, get_stream, get_realm, get_realm_by_string_id
 from zilencer.models import Deployment
 
 import random
@@ -166,7 +170,7 @@ class Command(BaseCommand):
                     subscriptions_to_add.append(s)
             Subscription.objects.bulk_create(subscriptions_to_add)
         else:
-            zulip_realm = get_realm("zulip.com")
+            zulip_realm = get_realm_by_string_id("zulip")
             recipient_streams = [klass.type_id for klass in
                                  Recipient.objects.filter(type=Recipient.STREAM)]
 


### PR DESCRIPTION
Replaces `Realm.domain` with `Realm.string_id` in the management commands.

Fixes #2325.