### PR TITLE
Doc tweaks

### DIFF
--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -483,7 +483,9 @@ $ vagrant ssh
 #### Next Steps
 
 At this point you should [read about using the development
-environment][using-dev-environment.html].
+environment][using-dev].
+
+[using-dev]: using-dev-environment.html
 
 ### Troubleshooting & Common Errors
 

--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -379,9 +379,9 @@ to see your changes, all you usually have to do is reload your
 browser.  More details on how this works are available below.
 
 Don't forget to read through the [code style
-guidelines](https://zulip.readthedocs.io/en/latest/code-style.html#general) for
-details about how to configure your editor for Zulip. For example, indentation
-should be set to 4 spaces rather than tabs.
+guidelines](code-style.html#general) for details about how to configure your
+editor for Zulip. For example, indentation should be set to 4 spaces rather
+than tabs.
 
 #### Understanding run-dev.py debugging output
 
@@ -389,8 +389,8 @@ It's good to have the terminal running `run-dev.py` up as you work since error
 messages including tracebacks along with every backend request will be printed
 there.
 
-See [Logging](http://zulip.readthedocs.io/en/latest/logging.html) for
-further details on the run-dev.py console output.
+See [Logging](logging.html) for further details on the run-dev.py console
+output.
 
 #### Committing and pushing changes with git
 
@@ -414,8 +414,8 @@ re-provision your vagrant machine using `vagrant provision`
 guest); this should be pretty fast and we're working to make it faster.
 
 See also the documentation on the [testing
-page](http://zulip.readthedocs.io/en/latest/testing.html#manual-testing-local-app-web-browser)
-for how to destroy and rebuild your database if you want to clear out test data.
+page](testing.html#manual-testing-local-app-web-browser) for how to destroy and
+rebuild your database if you want to clear out test data.
 
 #### Rebuilding the dev environment
 

--- a/docs/life-of-a-request.md
+++ b/docs/life-of-a-request.md
@@ -18,7 +18,7 @@ itself for static content).
 In development, `tools/run-dev.py` fills the role of nginx. Static files
 are in your git checkout under `static`, and are served unminified.
 
-## Nginx secures traffic with [SSL](https://zulip.readthedocs.io/en/latest/prod-install.html)
+## Nginx secures traffic with [SSL](prod-install.html)
 
 If you visit your Zulip server in your browser and discover that your
 traffic isn't being properly encrypted, an [nginx misconfiguration](https://github.com/zulip/zulip/blob/master/puppet/zulip/files/nginx/sites-available/zulip-enterprise) is the
@@ -36,7 +36,7 @@ location /static/ {
 }
 ```
 
-## Nginx routes other requests [between tornado and django](http://zulip.readthedocs.io/en/latest/architecture-overview.html?highlight=tornado#tornado-and-django)
+## Nginx routes other requests [between tornado and django](architecture-overview.html?highlight=tornado#tornado-and-django)
 
 All our connected clients hold open long-polling connections so that
 they can recieve events (messages, presence notifications, and so on) in
@@ -50,7 +50,7 @@ application.
 ## Django routes the request to a view in urls.py files
 
 There are various [urls.py](https://docs.djangoproject.com/en/1.8/topics/http/urls/) files throughout the server codebase, which are
-covered in more detail in [the directory structure doc](http://zulip.readthedocs.io/en/latest/directory-structure.html).
+covered in more detail in [the directory structure doc](directory-structure.html).
 
 The main Zulip Django app is `zerver`. The routes are found in
 ```
@@ -167,7 +167,7 @@ find the correct view to show: `zerver.views.users.create_user_backend`.
 
 ## The view will authorize the user, extract request variables, and validate them
 
-This is covered in good detail in the [writing views doc](https://zulip.readthedocs.io/en/latest/writing-views.html)
+This is covered in good detail in the [writing views doc](writing-views.html).
 
 ## Results are given as JSON
 

--- a/docs/using-dev-environment.md
+++ b/docs/using-dev-environment.md
@@ -51,5 +51,5 @@ restart if it crashes, and `upgrade-zulip` will take care of running
 migrations and then cleanly restaring the server for you).
 
 [django-runserver]: https://docs.djangoproject.com/en/1.8/ref/django-admin/#runserver-port-or-address-port
-[new-feature-tutorial]: http://zulip.readthedocs.io/en/latest/new-feature-tutorial.html
-[testing-docs]: http://zulip.readthedocs.io/en/latest/testing.html
+[new-feature-tutorial]: new-feature-tutorial.html
+[testing-docs]: testing.html

--- a/docs/writing-views.md
+++ b/docs/writing-views.md
@@ -3,16 +3,16 @@
 ## What this covers
 
 This page documents how views work in Zulip. You may want to read the
-[new feature tutorial](https://zulip.readthedocs.io/en/latest/new-feature-tutorial.html)
-or the [integration guide](https://zulip.readthedocs.io/en/latest/integration-guide.html),
+[new feature tutorial](new-feature-tutorial.html)
+or the [integration guide](integration-guide.html),
 and treat this as a reference.
 
 If you have experience with Django, much of this will be familiar, but
 you may want to read about how REST requests are dispatched, and how
 request authentication works.
 
-This document supplements the [new feature tutorial](https://zulip.readthedocs.io/en/latest/new-feature-tutorial.html)
-and the [testing](https://zulip.readthedocs.io/en/latest/testing.html)
+This document supplements the [new feature tutorial](new-feature-tutorial.html)
+and the [testing](testing.html)
 documentation.
 
 ## What is a view?


### PR DESCRIPTION
Two mildly related things:
* fix some broken markdown syntax
* don't include zulip.readthedocs.io hostname in internal links
