### PR TITLE
tests: Add assert_in_success_response in ZulipTestCase.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -325,6 +325,13 @@ class ZulipTestCase(TestCase):
         # type: (text_type, HttpResponse) -> None
         self.assertIn(substring, response.content.decode('utf-8'))
 
+    def assert_in_success_response(self, substrings, response):
+        # type: (Iterable[text_type], HttpResponse) -> None
+        self.assertEqual(response.status_code, 200)
+        decoded = response.content.decode('utf-8')
+        for substring in substrings:
+            self.assertIn(substring, decoded)
+
     def fixture_data(self, type, action, file_type='json'):
         # type: (text_type, text_type, text_type) -> text_type
         return force_text(open(os.path.join(os.path.dirname(__file__),

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -76,8 +76,7 @@ class TestGenerateRealmCreationLink(ZulipTestCase):
         with self.settings(OPEN_REALM_CREATION=False):
             # Check realm creation page is accessible
             result = self.client_get(generated_link)
-            self.assertEquals(result.status_code, 200)
-            self.assert_in_response(u"Let's get started…", result)
+            self.assert_in_success_response([u"Let's get started…"], result)
 
             # Create Realm with generated link
             self.assertIsNone(get_realm_by_string_id('test'))
@@ -90,8 +89,7 @@ class TestGenerateRealmCreationLink(ZulipTestCase):
 
             # Generated link used for creating realm
             result = self.client_get(generated_link)
-            self.assertEquals(result.status_code, 200)
-            self.assert_in_response("The organization creation link has been expired or is not valid.", result)
+            self.assert_in_success_response(["The organization creation link has been expired or is not valid."], result)
 
     def test_realm_creation_with_random_link(self):
         # type: () -> None
@@ -99,8 +97,7 @@ class TestGenerateRealmCreationLink(ZulipTestCase):
             # Realm creation attempt with an invalid link should fail
             random_link = "/create_realm/5e89081eb13984e0f3b130bf7a4121d153f1614b"
             result = self.client_get(random_link)
-            self.assertEquals(result.status_code, 200)
-            self.assert_in_response("The organization creation link has been expired or is not valid.", result)
+            self.assert_in_success_response(["The organization creation link has been expired or is not valid."], result)
 
     def test_realm_creation_with_expired_link(self):
         # type: () -> None
@@ -113,5 +110,4 @@ class TestGenerateRealmCreationLink(ZulipTestCase):
             obj.save()
 
             result = self.client_get(generated_link)
-            self.assertEquals(result.status_code, 200)
-            self.assert_in_response("The organization creation link has been expired or is not valid.", result)
+            self.assert_in_success_response(["The organization creation link has been expired or is not valid."], result)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -196,16 +196,13 @@ class PasswordResetTest(ZulipTestCase):
         tests here.
         '''
         result = self.client_get('/accounts/password/reset/done/')
-        self.assertEqual(result.status_code, 200)
-        self.assertIn('Check your email', result.content.decode("utf-8"))
+        self.assert_in_success_response(["Check your email"], result)
 
         result = self.client_get('/accounts/password/done/')
-        self.assertEqual(result.status_code, 200)
-        self.assertIn("We've reset your password!", result.content.decode("utf-8"))
+        self.assert_in_success_response(["We've reset your password!"], result)
 
         result = self.client_get('/accounts/send_confirm/alice@example.com')
-        self.assertEqual(result.status_code, 200)
-        self.assertIn("Still no email?", result.content.decode("utf-8"))
+        self.assert_in_success_response(["Still no email?"], result)
 
 class LoginTest(ZulipTestCase):
     """
@@ -854,8 +851,7 @@ class UserSignUpTest(ZulipTestCase):
                                                realm_subdomain=subdomain,
                                                # Pass HTTP_HOST for the target subdomain
                                                HTTP_HOST=subdomain + ".testserver")
-        self.assertEquals(result.status_code, 200)
-        self.assertIn("You're almost there.", result.content.decode('utf8'))
+        self.assert_in_success_response(["You're almost there."], result)
 
     def test_completely_open_domain_success(self):
         # type: () -> None
@@ -898,8 +894,7 @@ class UserSignUpTest(ZulipTestCase):
                                                realm_subdomain=subdomain,
                                                # Pass HTTP_HOST for the target subdomain
                                                HTTP_HOST=subdomain + ".testserver")
-        self.assertEquals(result.status_code, 200)
-        self.assertIn("You're almost there.", result.content.decode('utf8'))
+        self.assert_in_success_response(["You're almost there."], result)
 
     def test_failed_signup_due_to_restricted_domain(self):
         # type: () -> None
@@ -987,10 +982,10 @@ class UserSignUpTest(ZulipTestCase):
                                                    # Pass HTTP_HOST for the target subdomain
                                                    HTTP_HOST=subdomain + ".testserver")
 
-            self.assertEquals(result.status_code, 200)
-            self.assertIn("You're almost there.", result.content.decode('utf8'))
-            self.assertIn("New User Name", result.content.decode('utf8'))
-            self.assertIn("newuser@zulip.com", result.content.decode('utf8'))
+            self.assert_in_success_response(["You're almost there.",
+                                             "New User Name",
+                                             "newuser@zulip.com"],
+                                            result)
 
             # Test the TypeError exception handler
             mock_ldap.directory = {
@@ -1007,10 +1002,10 @@ class UserSignUpTest(ZulipTestCase):
                                                    from_confirmation='1',
                                                    # Pass HTTP_HOST for the target subdomain
                                                    HTTP_HOST=subdomain + ".testserver")
+            self.assert_in_success_response(["You're almost there.",
+                                             "newuser@zulip.com"],
+                                            result)
 
-            self.assertEquals(result.status_code, 200)
-            self.assertIn("You're almost there.", result.content.decode('utf8'))
-            self.assertIn("newuser@zulip.com", result.content.decode('utf8'))
 
         mock_ldap.reset()
         mock_initialize.stop()

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -194,6 +194,7 @@ class TemplateTestCase(ZulipTestCase):
     def test_custom_tos_template(self):
         # type: () -> None
         response = self.client_get("/terms/")
-        self.assertEqual(response.status_code, 200)
-        self.assert_in_response(u"Thanks for using our products and services (\"Services\"). ", response)
-        self.assert_in_response(u"By using our Services, you are agreeing to these terms", response)
+
+        self.assert_in_success_response([u"Thanks for using our products and services (\"Services\"). ",
+                                         u"By using our Services, you are agreeing to these terms"],
+                                        response)

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1764,8 +1764,7 @@ class HelpTest(ZulipTestCase):
     def test_browser_window_help(self):
         # type: () -> None
         result = self.client_get('/help/#the-browser-window')
-        self.assertEqual(result.status_code, 200)
-        self.assertIn("There are three panes", result.content.decode("utf-8"))
+        self.assert_in_success_response(["There are three panes"], result)
 
 class HomeTest(ZulipTestCase):
     @slow('big method')


### PR DESCRIPTION
Clean up the instances of self.assertIn("string", result.content.decode("utf-8")),
and replace them with self.assert_in_response("string").

Fixes: #2313