### PR TITLE
Add UTF-8 locale to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,14 @@ RUN apt-get update && apt-get install -y \
   python-pbs \
   wget
 
+RUN locale-gen en_US.UTF-8
+
 RUN useradd -d /home/zulip -m zulip && echo 'zulip ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER zulip
 
 RUN ln -nsf /srv/zulip ~/zulip
+
+RUN echo 'export LC_ALL="en_US.UTF-8"' >> ~zulip/.bashrc
 
 WORKDIR /srv/zulip


### PR DESCRIPTION
This fixes an issue with pip crashing on several package installs due to
non-ASCII charsets.