### PR TITLE
run-dev: Fix regression ignoring --interface argument.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -77,7 +77,7 @@ if options.interface is None:
         # In the Vagrant development environment, we need to listen on
         # all ports, and it's safe to do so, because Vagrant is only
         # exposing certain guest ports (by default just 9991) to the host.
-        options.interface = ""
+        options.interface = None
     else:
         # Otherwise, only listen to requests on localhost for security.
         options.interface = "127.0.0.1"
@@ -360,7 +360,7 @@ print("".join((WARNING,
 
 try:
     app = Application()
-    app.listen(proxy_port)
+    app.listen(proxy_port, address=options.interface)
     ioloop = IOLoop.instance()
     for s in (signal.SIGINT, signal.SIGTERM):
         signal.signal(s, shutdown_handler)


### PR DESCRIPTION
When we migrated run-dev.py from Twisted to Tornado a few weeks ago,
the --interface argument wasn't properly ported and thus was ignored.

This restores the original functionality of defaulting to only
listening on localhost.

@christi3k we should add something (maybe just a file we check for the existence of) in the new remote dev VMs to change this default for that environment (so we can keep the  instructions simple).
