### PR TITLE
Add tooltips to buttons appearing when message is not delivered.

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -541,6 +541,7 @@ $(function () {
     $('#streams_header i[data-toggle="tooltip"]').tooltip({ placement: 'left',
                                        animation: false });
 
+    $('.message_failed i[data-toggle="tooltip"]').tooltip();
 
     if (!page_params.realm_allow_message_editing) {
         $("#edit-message-hotkey-help").hide();

--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -324,6 +324,14 @@
         top: 40px;
     }
 
+    .message_failed {
+        left: 0px;
+    }
+
+    .message_content {
+        padding-right: 35px;
+    }
+
 }
 
 @media only screen and (min-device-width: 300px) and (max-device-width: 700px) {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1095,6 +1095,8 @@ just a temporary hack.
     font-weight: bold;
     color: red;
     padding: 0px 1px 0px 1px;
+    position: relative;
+    left: 29px;
 }
 
 .message_failed i {

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -43,7 +43,9 @@
               <i class="icon-vector-chevron-down"></i>
             </div>
             <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">
-              <i class="icon-vector-refresh refresh-failed-message" data-toggle="tooltip" title="Not Delivered: Resend"></i><i class="icon-vector-pencil edit-failed-message" data-toggle="tooltip" title="Not Delivered: Edit"></i><i class="icon-vector-remove-sign remove-failed-message" data-toggle="tooltip" title="Not Delivered: Delete"></i>
+              <i class="icon-vector-refresh refresh-failed-message" data-toggle="tooltip" title="Not Delivered: Resend"></i>
+              <i class="icon-vector-pencil edit-failed-message" data-toggle="tooltip" title="Not Delivered: Edit"></i>
+              <i class="icon-vector-remove-sign remove-failed-message" data-toggle="tooltip" title="Not Delivered: Delete"></i>
             </div>
           </div>
         </div>

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -43,7 +43,7 @@
               <i class="icon-vector-chevron-down"></i>
             </div>
             <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">
-              <span class="failed_text">Not delivered </span><i class="icon-vector-refresh refresh-failed-message"></i><i class="icon-vector-pencil edit-failed-message"></i><i class="icon-vector-remove-sign remove-failed-message"></i>
+              <i class="icon-vector-refresh refresh-failed-message" data-toggle="tooltip" title="Not Delivered: Resend"></i><i class="icon-vector-pencil edit-failed-message" data-toggle="tooltip" title="Not Delivered: Edit"></i><i class="icon-vector-remove-sign remove-failed-message" data-toggle="tooltip" title="Not Delivered: Delete"></i>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes #2280 