### PR TITLE
puppet: Add another missing dependency on postgresql-common

### DIFF
--- a/puppet/zulip/manifests/postgres_common.pp
+++ b/puppet/zulip/manifests/postgres_common.pp
@@ -37,6 +37,7 @@ class zulip::postgres_common {
     group => "postgres",
     mode => 750,
     source => "puppet:///modules/zulip/postgresql/env-wal-e",
+    require => Package["postgresql-${zulip::base::postgres_version}"],
   }
 
   file { "/usr/local/bin/pg_backup_and_purge.py":


### PR DESCRIPTION
The postgres group must exist before we give files to it.