### PR TITLE
Fixes for running the vagrant instance on Fedora 25

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,6 +80,11 @@ $provision_script = <<SCRIPT
 set -x
 set -e
 set -o pipefail
+# If the host is running SELinux remount the /sys/fs/selinux directory as read only,
+# needed for apt-get to work.
+if [ -d "/sys/fs/selinux" ]; then
+  sudo mount -o remount,ro /sys/fs/selinux
+fi
 ln -nsf /srv/zulip ~/zulip
 /usr/bin/python /srv/zulip/tools/provision.py | sudo tee -a /var/log/zulip_provision.log
 SCRIPT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,6 +85,8 @@ set -o pipefail
 if [ -d "/sys/fs/selinux" ]; then
   sudo mount -o remount,ro /sys/fs/selinux
 fi
+# Set default locale, this prevents errors on vagrant ssh
+echo "LC_ALL=en_US.UTF-8" | sudo tee -a /etc/default/locale
 ln -nsf /srv/zulip ~/zulip
 /usr/bin/python /srv/zulip/tools/provision.py | sudo tee -a /var/log/zulip_provision.log
 SCRIPT


### PR DESCRIPTION
This pull request fixes the vagrant LXC instance when:
- the host system runs SELinux;
- the locale of the host system is one not defined in the LXC os.