### PR TITLE
Switch no-loop-func eslint rule from warning to error (in .eslintrc)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -133,7 +133,7 @@
         "no-self-compare": 2,
         "no-sync": 2,
         "no-underscore-dangle": 1,
-        "no-loop-func": 1,
+        "no-loop-func": 2,
         "no-labels": 2,
         "no-unused-vars": 1,
         "no-script-url": 2,

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -95,13 +95,16 @@ function add_subject_links(message) {
         var url = realm_filter[1];
         var match;
         while ((match = pattern.exec(subject)) !== null) {
-            var current_group = 1;
             var link_url = url;
-            _.each(match.slice(1), function (matched_group) {
+            var matched_groups = match.slice(1);
+            var i = 0;
+            while (i < matched_groups.length) {
+                var matched_group = matched_groups[i];
+                var current_group = i + 1;
                 var back_ref = "\\" + current_group;
                 link_url = link_url.replace(back_ref, matched_group);
-                current_group++;
-            });
+                i++;
+            }
             links.push(link_url);
         }
     });


### PR DESCRIPTION
The one error that needed to be fixed was in static/js/echo.js.
The function in the loop was being used by _.each(). This has been
replaced by iterating through the array using a while loop instead.