### PR TITLE
build-release-tarball: Add --py3 option for python3 shebang lines

### DIFF
--- a/tools/build-release-tarball
+++ b/tools/build-release-tarball
@@ -1,12 +1,27 @@
 #!/usr/bin/env bash
-set -e
-set -x
+set -eux
+
+usage() {
+    echo "Usage: $0 [--py3] <ZULIP_VERSION>" >&2
+    exit 1
+}
+
+args="$(getopt -o '' -l 'py3' -n "$0" -- "$@")"
+eval "set -- $args"
+
+py3=
+while true; do
+    case "$1" in
+        --py3) py3=t; shift;;
+        --) shift; break;;
+        *) usage;;
+    esac
+done
 
 GITID=$(git rev-parse HEAD)
 
-if [ -z "$1" ]; then
-    echo "Usage: $0 <ZULIP_VERSION>"
-    exit 1
+if [ -z "${1:-}" ]; then
+    usage
 fi
 version="$1"
 prefix="zulip-server-$version"
@@ -38,6 +53,13 @@ if tar -tf "$TARBALL" | grep -q -e zilencer -e zproject/local_settings.py -e pup
 	exit 1;
 else
 	echo "Check for excluded files passed";
+fi
+
+if [ "$py3" ]; then
+    tools/replace-tarball-shebang \
+        '#!/usr/bin/env python' '#!/usr/bin/env python3' \
+        < "$TARBALL" > "$TARBALL.new"
+    mv "$TARBALL.new" "$TARBALL"
 fi
 
 # Check out a temporary full copy of the index to generate static files

--- a/tools/replace-tarball-shebang
+++ b/tools/replace-tarball-shebang
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import six
+import sys
+import tarfile
+
+stdin = getattr(sys.stdin, 'buffer', sys.stdin)
+stdout = getattr(sys.stdout, 'buffer', sys.stdout)
+
+try:
+    progname, old_shebang, new_shebang = sys.argv
+except ValueError:
+    sys.exit("usage: replace-tarball-shebang '#!OLDSHEBANG' '#!NEWSHEBANG' < IN.tar[.gz] > OUT.tar")
+
+old_shebang_bytes = old_shebang.encode()
+new_shebang_bytes = new_shebang.encode()
+
+with tarfile.open(fileobj=stdin, mode='r|*') as in_tar, \
+     tarfile.open(fileobj=stdout, mode='w', format=tarfile.PAX_FORMAT, pax_headers=in_tar.pax_headers) as out_tar:
+    for info in in_tar: # type: ignore # https://github.com/python/typeshed/pull/693
+        if info.isfile():
+            file = in_tar.extractfile(info)
+            data = file.read()
+            if data.startswith(old_shebang_bytes + b' ') or data.startswith(old_shebang_bytes + b'\n'):
+                print('editing', info.name, file=sys.stderr)
+                assert info.size == len(data)
+                data = new_shebang_bytes + data[len(old_shebang_bytes):]
+                info.size = len(data)
+            out_tar.addfile(info, six.BytesIO(data))
+        else:
+            out_tar.addfile(info)

--- a/tools/travis/setup-production
+++ b/tools/travis/setup-production
@@ -14,7 +14,15 @@ sudo apt-get remove postgresql-9.1 postgresql-client-9.1 postgresql-9.1-postgis-
 tools/provision.py --travis --production-travis
 cp -a tools/travis/success-http-headers.txt ~/
 source tools/travis/activate-venv
-if ! ./tools/build-release-tarball travis; then
+
+py_version="$(python -c 'import sys; print(sys.version_info[0])')"
+if [ "$py_version" = 2 ]; then
+    build_options=()
+else
+    build_options=(--py3)
+fi
+
+if ! ./tools/build-release-tarball "${build_options[@]}" travis; then
     echo "Attempting to output failure logging data"
     cat /tmp/tmp.*/zulip-server-travis/update-prod-static.log || true
     exit 1


### PR DESCRIPTION
(Split from #2378 and updated with a new option for `build-release-tarball`.)