### PR TITLE
Reverting changes to Docker development to original instructions. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:trusty
 
+EXPOSE 9991
+
 RUN apt-get update && apt-get install -y \
   python-pbs \
   wget
@@ -15,9 +17,3 @@ RUN ln -nsf /srv/zulip ~/zulip
 RUN echo 'export LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8"' >> ~zulip/.bashrc
 
 WORKDIR /srv/zulip
-
-CMD ["/srv/zulip/tools/provision.py", "--docker"]
-CMD ["source /srv/zulip-venv/bin/activate"]
-CMD ["./srv/zulip/tools/start-dockers"]
-
-EXPOSE 9991

--- a/docs/install-docker-dev.md
+++ b/docs/install-docker-dev.md
@@ -26,8 +26,11 @@ go to the directory with the Zulip source code:
 docker build -t user/zulipdev .
 ```
 
+
 Commit and tag the provisioned images. The below will install Zulip's dependencies:
 ```
+docker run -itv $(pwd):/srv/zulip -p 9991:9991 user/zulipdev /bin/bash
+$ /usr/bin/python /srv/zulip/tools/provision.py --docker
 docker ps -af ancestor=user/zulipdev
 docker commit -m "Zulip installed" <container id> user/zulipdev:v2
 ```
@@ -45,6 +48,7 @@ to understand how to use the Zulip development.  Note that
 `start-dockers` automatically runs `tools/run-dev.py` inside the
 container; you can then visit http://localhost:9991 to connect to your
 new Zulip Docker container.
+
 
 To view the container's `run-dev.py` console logs to get important
 debugging information (and e.g. outgoing emails) printed by the Zulip


### PR DESCRIPTION
Issues with reproducing Zulip Docker build with latest docker file and instructions from clean build.

Per conversation here, better to split into a later contribution. 

https://github.com/zulip/zulip/pull/2386/files/8cd4b826181b9b0e4599e6e8becb729239cb9035