### PR TITLE
(#2308) Add support for allowing normal users with account age equal or greater

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -280,7 +280,8 @@ function _setup_page() {
         realm_allow_message_editing: page_params.realm_allow_message_editing,
         realm_message_content_edit_limit_minutes: Math.ceil(page_params.realm_message_content_edit_limit_seconds / 60),
         language_list: page_params.language_list,
-        realm_default_language: page_params.realm_default_language
+        realm_default_language: page_params.realm_default_language,
+        realm_waiting_period_threshold: page_params.realm_waiting_period_threshold
     };
     var admin_tab = templates.render('admin_tab', options);
     $("#administration").html(admin_tab);
@@ -293,6 +294,7 @@ function _setup_page() {
     $("#admin-realm-create-stream-by-admins-only-status").expectOne().hide();
     $("#admin-realm-message-editing-status").expectOne().hide();
     $("#admin-realm-default-language-status").expectOne().hide();
+    $('#admin-realm-waiting_period_threshold_status').expectOne().hide();
     $("#admin-emoji-status").expectOne().hide();
     $('#admin-filter-status').expectOne().hide();
     $('#admin-filter-pattern-status').expectOne().hide();
@@ -506,6 +508,7 @@ function _setup_page() {
         var create_stream_by_admins_only_status = $("#admin-realm-create-stream-by-admins-only-status").expectOne();
         var message_editing_status = $("#admin-realm-message-editing-status").expectOne();
         var default_language_status = $("#admin-realm-default-language-status").expectOne();
+        var waiting_period_threshold_status = $("#admin-realm-waiting_period_threshold_status").expectOne();
         var auth_methods_table = $('.admin_auth_methods_table');
         name_status.hide();
         restricted_to_domain_status.hide();
@@ -527,6 +530,7 @@ function _setup_page() {
         var new_allow_message_editing = $("#id_realm_allow_message_editing").prop("checked");
         var new_message_content_edit_limit_minutes = $("#id_realm_message_content_edit_limit_minutes").val();
         var new_default_language = $("#id_realm_default_language").val();
+        var new_waiting_period_threshold = $("#id_realm_waiting_period_threshold").val();
         var new_auth_methods = {};
         _.each($("#admin_auth_methods_table").find('tr.method_row'), function (method_row) {
             new_auth_methods[$(method_row).data('method')] = $(method_row).find('input').prop('checked');
@@ -553,7 +557,8 @@ function _setup_page() {
             create_stream_by_admins_only: JSON.stringify(new_create_stream_by_admins_only),
             allow_message_editing: JSON.stringify(new_allow_message_editing),
             message_content_edit_limit_seconds: JSON.stringify(parseInt(new_message_content_edit_limit_minutes, 10) * 60),
-            default_language: JSON.stringify(new_default_language)
+            default_language: JSON.stringify(new_default_language),
+            waiting_period_threshold: JSON.stringify(parseInt(new_waiting_period_threshold, 10))
         };
 
         channel.patch({
@@ -618,6 +623,11 @@ function _setup_page() {
                 if (response_data.default_language !== undefined) {
                     if (response_data.default_language) {
                         ui.report_success(i18n.t("Default language changed!"), default_language_status);
+                    }
+                }
+                if (response_data.waiting_period_threshold !== undefined) {
+                    if (response_data.waiting_period_threshold > 0) {
+                        ui.report_success(i18n.t("waiting period threshold changed!"), waiting_period_threshold_status);
                     }
                 }
             },

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -70,6 +70,8 @@ function dispatch_normal_event(event) {
         } else if (event.op === 'update' && event.property === 'default_language') {
             page_params.realm_default_language = event.value;
             admin.reset_realm_default_language();
+        } else if (event.op === 'update' && event.property === 'waiting_period_threshold') {
+            page_params.realm_waiting_period_threshold = event.value;
         }
         break;
 

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -9,6 +9,7 @@
     <div class="alert" id="admin-realm-create-stream-by-admins-only-status"></div>
     <div class="alert" id="admin-realm-message-editing-status"></div>
     <div class="alert" id="admin-realm-default-language-status"></div>
+    <div class="alert" id="admin-realm-waiting_period_threshold_status"></div>
 
     <div class="input-group admin-realm">
       <label for="realm_name">{{t "Your organization's name" }}</label>
@@ -82,6 +83,13 @@
         <option value='{{this.code}}'>{{this.name}}</option>
         {{/each}}
       </select>
+    </div>
+    <div class="input-group">
+        <label for="realm_waiting_period_threshold">{{t "Waiting period threshold (in days)" }}</label>
+        <input type="text" id="id_realm_waiting_period_threshold"
+             name="realm_waiting_period_threshold"
+             class="admin-realm-message-content-edit-limit-minutes"
+             value="{{ realm_waiting_period_threshold }}"/>
     </div>
     <div class="input-group organization-submission">
       <input type="submit" class="button" value="{{t 'Save changes' }}" />

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -556,6 +556,18 @@ def do_set_realm_default_language(realm, default_language):
             )
     send_event(event, active_user_ids(realm))
 
+def do_set_realm_waiting_period_threshold(realm, threshold):
+    # type: (Realm, int) -> None
+    realm.waiting_period_threshold = threshold
+    realm.save(update_fields=['waiting_period_threshold'])
+    event = dict(
+        type="realm",
+        op="update",
+        property='waiting_period_threshold',
+        value=threshold,
+    )
+    send_event(event, active_user_ids(realm))
+
 def do_deactivate_realm(realm):
     # type: (Realm) -> None
     """
@@ -2958,6 +2970,7 @@ def fetch_initial_state_data(user_profile, event_types, queue_id):
         state['realm_allow_message_editing'] = user_profile.realm.allow_message_editing
         state['realm_message_content_edit_limit_seconds'] = user_profile.realm.message_content_edit_limit_seconds
         state['realm_default_language'] = user_profile.realm.default_language
+        state['realm_waiting_period_threshold'] = user_profile.realm.waiting_period_threshold
 
     if want('realm_domain'):
         state['realm_domain'] = user_profile.realm.domain

--- a/zerver/migrations/0045_realm_waiting_period_threshold.py
+++ b/zerver/migrations/0045_realm_waiting_period_threshold.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0044_reaction'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='realm',
+            name='waiting_period_threshold',
+            field=models.PositiveIntegerField(default=0),
+        ),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -136,6 +136,7 @@ class Realm(ModelReprMixin, models.Model):
     default_language = models.CharField(default=u'en', max_length=MAX_LANGUAGE_ID_LENGTH) # type: Text
     authentication_methods = BitField(flags=AUTHENTICATION_FLAGS,
                                       default=2**31 - 1) # type: BitHandler
+    waiting_period_threshold = models.PositiveIntegerField(default=0) # type: int
 
     DEFAULT_NOTIFICATION_STREAM_NAME = u'announce'
 
@@ -604,7 +605,8 @@ class UserProfile(ModelReprMixin, AbstractBaseUser, PermissionsMixin):
 
     def can_create_streams(self):
         # type: () -> bool
-        if self.is_realm_admin or not self.realm.create_stream_by_admins_only:
+        diff = (timezone.now() - self.date_joined).days
+        if self.is_realm_admin or not self.realm.create_stream_by_admins_only or diff >= self.realm.waiting_period_threshold:
             return True
         else:
             return False

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1857,6 +1857,7 @@ class HomeTest(ZulipTestCase):
             "realm_name",
             "realm_restricted_to_domain",
             "realm_uri",
+            "realm_waiting_period_threshold",
             "referrals",
             "save_stacktraces",
             "server_generation",

--- a/zerver/views/__init__.py
+++ b/zerver/views/__init__.py
@@ -589,6 +589,7 @@ def home_real(request):
         realm_message_content_edit_limit_seconds = register_ret['realm_message_content_edit_limit_seconds'],
         realm_restricted_to_domain = register_ret['realm_restricted_to_domain'],
         realm_default_language = register_ret['realm_default_language'],
+        realm_waiting_period_threshold = register_ret['realm_waiting_period_threshold'],
         enter_sends           = user_profile.enter_sends,
         user_id               = user_profile.id,
         left_side_userlist    = register_ret['left_side_userlist'],

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -13,6 +13,7 @@ from zerver.lib.actions import (
     do_set_realm_message_editing,
     do_set_realm_restricted_to_domain,
     do_set_realm_default_language,
+    do_set_realm_waiting_period_threshold,
     do_set_realm_authentication_methods
 )
 from zerver.lib.i18n import get_available_language_codes
@@ -31,8 +32,9 @@ def update_realm(request, user_profile, name=REQ(validator=check_string, default
                  allow_message_editing=REQ(validator=check_bool, default=None),
                  message_content_edit_limit_seconds=REQ(converter=to_non_negative_int, default=None),
                  default_language=REQ(validator=check_string, default=None),
+                 waiting_period_threshold=REQ(converter=to_non_negative_int, default=None),
                  authentication_methods=REQ(validator=check_dict([]), default=None)):
-    # type: (HttpRequest, UserProfile, Optional[str], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[int], Optional[str], Optional[dict]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Optional[str], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[int], Optional[str], Optional[int], Optional[dict]) -> HttpResponse
     # Validation for default_language
     if default_language is not None and default_language not in get_available_language_codes():
         raise JsonableError(_("Invalid language '%s'" % (default_language,)))
@@ -73,4 +75,7 @@ def update_realm(request, user_profile, name=REQ(validator=check_string, default
     if default_language is not None and realm.default_language != default_language:
         do_set_realm_default_language(realm, default_language)
         data['default_language'] = default_language
+    if waiting_period_threshold is not None and realm.waiting_period_threshold != waiting_period_threshold:
+        do_set_realm_waiting_period_threshold(realm, waiting_period_threshold)
+        data['waiting_period_threshold'] = waiting_period_threshold
     return json_success(data)


### PR DESCRIPTION
than waiting period threshold to create streams.

If create_stream_by_admins_only setting is set to True, only admin users
were able to create streams. Now normal users with account age greater
or equal than waiting period threshold can also create streams. Account
age is defined as number of days passed since the user had created his
account.

Fixes: #2308.