### PR TITLE
Fix for possible webkit painting bug.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -41,6 +41,7 @@
 #stream-filters-container {
     overflow-y: hidden;
     position: relative;
+    z-index: 0;
 }
 
 #stream-filters-container .ps-scrollbar-y-rail {


### PR DESCRIPTION
The left sidebar will overflow its bounds (even when set to overflow:
hidden) and go behind other text on the sidebar above. By setting the
z-index to 0 we seem to solve the problem.

How to replicate this:

1. Choose a category with a lot of topics.
2. Click “more topics”.
3. Keep scrolling on either Safari or Chrome and you’ll see that the list paints itself behind other elements as well.