### PR TITLE
[Fix] Hide the popover once the muting button is clicked.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -632,6 +632,11 @@ exports.register_click_handlers = function () {
         var stream = $(e.currentTarget).data('msg-stream');
         var topic = $(e.currentTarget).data('msg-topic');
         exports.topic_ops.mute(stream, topic);
+
+        // hide the popover becuase it shouldn't be visible after a click action
+        // has taken place.
+        popovers.hide_actions_popover();
+
         e.stopPropagation();
         e.preventDefault();
     });


### PR DESCRIPTION
The popover shouldn’t still display once a valid action on the popover
has been taken.

Fixes: #2366.