### PR TITLE
Adds banned characters in name function

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -489,6 +489,7 @@ class UserProfile(ModelReprMixin, AbstractBaseUser, PermissionsMixin):
 
     USERNAME_FIELD = 'email'
     MAX_NAME_LENGTH = 100
+    NAME_INVALID_CHARS = ['*', '`', '\'', '>', '\"', '@']
 
     # Our custom site-specific fields
     full_name = models.CharField(max_length=MAX_NAME_LENGTH) # type: Text

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -82,6 +82,8 @@ def json_change_settings(request, user_profile,
             new_full_name = full_name.strip()
             if len(new_full_name) > UserProfile.MAX_NAME_LENGTH:
                 return json_error(_("Name too long!"))
+            elif list(set(new_full_name).intersection(UserProfile.NAME_INVALID_CHARS)):
+                return json_error(_("Invalid characters in name!"))
             do_change_full_name(user_profile, new_full_name)
             result['full_name'] = new_full_name
 


### PR DESCRIPTION
By default, `, @, ', *, ", and > are banned from use in your username, as they interfere with markup functions. Although the username field is sanitized so it doesn't show up completely broken, using @ pings is broken if you have any of those in your name.