### PR TITLE
WIP Reactions backend: removing reactions

### DIFF
--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -4,7 +4,7 @@ from six import text_type
 
 from zerver.decorator import authenticated_json_post_view,\
     has_request_variables, REQ, to_non_negative_int
-from zerver.lib.actions import do_add_reaction
+from zerver.lib.actions import do_add_reaction, do_remove_reaction
 from zerver.lib.bugdown import emoji_list
 from zerver.lib.message import access_message
 from zerver.lib.request import JsonableError
@@ -32,5 +32,29 @@ def add_reaction_backend(request, user_profile, emoji_name=REQ('emoji'),
         raise JsonableError(_("Reaction already exists"))
 
     do_add_reaction(user_profile, message, emoji_name)
+
+    return json_success()
+
+@has_request_variables
+def remove_reaction_backend(request, user_profile, emoji_name=REQ('emoji'),
+                            message_id = REQ('message_id', converter=to_non_negative_int)):
+    # type: (HttpRequest, UserProfile, text_type, int) -> HttpResponse
+
+    # access_message will throw a JsonableError exception if the user
+    # cannot see the message (e.g. for messages to private streams).
+    message = access_message(user_profile, message_id)[0]
+
+    existing_emojis = set(message.sender.realm.get_emoji().keys()) or set(emoji_list)
+    if emoji_name not in existing_emojis:
+        raise JsonableError(_("Emoji '%s' does not exist" % (emoji_name,)))
+
+    # We could probably just make this check be a try/except for the
+    # IntegrityError from it already existing, but this is a bit cleaner.
+    if not Reaction.objects.filter(user_profile=user_profile,
+                                   message=message,
+                                   emoji_name=emoji_name).exists():
+        raise JsonableError(_("Reaction does not exist"))
+
+    do_remove_reaction(user_profile, message, emoji_name)
 
     return json_success()

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -200,8 +200,10 @@ v1_api_and_json_patterns = [
 
     # reactions -> zerver.view.reactions
     # POST adds a reaction to a message
+    # DELETE removes a reaction from a message
     url(r'^reactions$', rest_dispatch,
-        {'POST': 'zerver.views.reactions.add_reaction_backend'}),
+        {'POST': 'zerver.views.reactions.add_reaction_backend',
+         'DELETE': 'zerver.views.reactions.remove_reaction_backend'}),
 
     # typing -> zerver.views.typing
     # POST sends a typing notification event to recipients


### PR DESCRIPTION
This PR adds support for removing reactions via `DELETE` requests to the `/reactions` endpoint with parameters `emoji_name` and `message_id`.

The reaction is deleted from the db and a reaction event is sent out with `op` set to `remove`.

Tests are added to check that you can't remove a reaction that does not exist and to check that the event payload and users are correct for a delete request.
