### PR TITLE
Tabbott templates

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -177,6 +177,7 @@ if __name__ == "__main__":
         print("\nError: %s templates have no tests!" % (missed_count,))
         for template in templates_not_rendered:
             print('  {}'.format(template))
+        print("See zerver/tests/test_templates.py for the exclude list.")
         failures = True
 
     if options.coverage:

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -357,7 +357,10 @@ def get_all_templates():
 
     def is_valid_template(p, n):
         # type: (text_type, text_type) -> bool
-        return not n.startswith('.') and not n.startswith('__init__') and isfile(p)
+        return (not n.startswith('.') and
+                not n.startswith('__init__') and
+                not n.endswith(".md") and
+                isfile(p))
 
     def process(template_dir, dirname, fnames):
         # type: (str, str, Iterable[str]) -> None

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -163,7 +163,7 @@ class Runner(DiscoverRunner):
         if hasattr(sender, 'template'):
             template_name = sender.template.name
             if template_name not in self.templates_rendered:
-                if context.get('shallow_tested'):
+                if context.get('shallow_tested') and template_name not in self.templates_rendered:
                     self.shallow_tested_templates.add(template_name)
                 else:
                     self.templates_rendered.add(template_name)

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -97,8 +97,6 @@ class TemplateTestCase(ZulipTestCase):
             'zilencer/enterprise_tos_accept_body.txt',
             'zerver/zulipchat_migration_tos.html',
             'zilencer/enterprise_tos_accept_body.txt',
-            'zerver/help/index.md',
-            'zerver/help/missing.md',
             'zerver/closed_realm.html',
             'zerver/topic_is_muted.html',
             'zerver/bankruptcy.html',


### PR DESCRIPTION
@showell this should fix the need to do extra work when adding a new help article for the "all templates were rendered" check.