### PR TITLE
dev-setup-non-vagrant.md: Added missing install step

### DIFF
--- a/docs/dev-setup-non-vagrant.md
+++ b/docs/dev-setup-non-vagrant.md
@@ -81,6 +81,7 @@ sudo apt-get install postgresql-9.5-pgroonga
 # If on 14.04 or 16.04, you can use the Zulip PPA for tsearch-extras:
 cd zulip
 sudo apt-add-repository -ys ppa:tabbott/zulip
+sudo apt-get update
 # On 14.04
 sudo apt-get install postgresql-9.3-tsearch-extras
 # On 16.04


### PR DESCRIPTION
For the GCI task. Based on the conversation on zulip.org, it looks like the missing step was `sudo apt-get update`, which has now been added.

On a separate note, it looks a little confusing that Ubuntu has instructions for installing PGroonga and Debian doesn't. If Debian doesn't require PGroonga, that should probably be clarified in the docs.