### PR TITLE
eslint: change max-len from warning to error and fix violations.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -154,7 +154,13 @@
         "eqeqeq": 2,
         "guard-for-in": 2,
         "max-depth": [0, 4],
-        "max-len": [0, 80, 4],
+        "max-len": ["error", 100, 2, {
+            "ignoreUrls": true,
+            "ignoreComments": false,
+            "ignoreRegExpLiterals": true,
+            "ignoreStrings": true,
+            "ignoreTemplateLiterals": true
+        }],
         "max-params": [0, 3],
         "max-statements": [0, 10],
         "new-cap": 1,

--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -241,9 +241,10 @@ casper.then(function () {
     casper.click('a[href^="#subscriptions"]');
     casper.click('#settings-dropdown');
     casper.click('a[href^="#administration"]');
-    // It matches with all the stream names which has 'O' as a substring (Rome, Scotland, Verona etc).
-    // I used 'O' to make sure that it works even if there are multiple suggestions.
-    // Capital 'O' is used instead of small 'o' to make sure that the suggestions are not case sensitive.
+    // It matches with all the stream names which has 'O' as a substring (Rome, Scotland, Verona
+    // etc). 'O' is used to make sure that it works even if there are multiple suggestions.
+    // Uppercase 'O' is used instead of the lowercase version to make sure that the suggestions
+    // are case insensitive.
     get_suggestions("O");
     select_from_suggestions(stream_name);
     casper.waitForSelector('.default_stream_row[id='+stream_name+']', function () {
@@ -382,7 +383,9 @@ casper.then(function () {
 
 // // make sure we get the right error message, and that the message hasn't actually changed
 // casper.waitForSelector("div.edit_error", function () {
-//     casper.test.assertSelectorHasText('div.edit_error', 'Error saving edit: Your organization has turned off message editing.');
+//     casper.test.assertSelectorHasText(
+//         'div.edit_error',
+//         'Error saving edit: Your organization has turned off message editing.');
 //     casper.test.assertSelectorHasText(".last_message .message_content", "test edited");
 // });
 

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -142,8 +142,10 @@ var MessageList = require('js/message_list').MessageList;
 
 
     list = new MessageList(table, filter);
-    list.append([{id:10}, {id:20}, {id:30}, {id:20.02}, {id:20.03}, {id:40}, {id:50}, {id: 50.01}, {id: 50.02}, {id:60}]);
-    list._local_only= {20.02: {id:20.02}, 20.03: {id:20.03}, 50.01: {id: 50.01}, 50.02: {id: 50.02}};
+    list.append([{id:10}, {id:20}, {id:30}, {id:20.02}, {id:20.03}, {id:40},
+                 {id:50}, {id: 50.01}, {id: 50.02}, {id:60}]);
+    list._local_only= {20.02: {id:20.02}, 20.03: {id:20.03},
+                       50.01: {id: 50.01}, 50.02: {id: 50.02}};
 
     assert.equal(list.closest_id(10), 10);
     assert.equal(list.closest_id(20), 20);

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -21,7 +21,8 @@ global.stub_out_jquery = namespace.stub_out_jquery;
 
 // Set up helpers to render templates.
 var render = require('./render.js');
-global.make_sure_all_templates_have_been_compiled = render.make_sure_all_templates_have_been_compiled;
+global.make_sure_all_templates_have_been_compiled =
+    render.make_sure_all_templates_have_been_compiled;
 global.find_included_partials = render.find_included_partials;
 global.compile_template = render.compile_template;
 global.render_template = render.render_template;

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -278,7 +278,8 @@ function _setup_page() {
         realm_authentication_methods: page_params.realm_authentication_methods,
         realm_create_stream_by_admins_only: page_params.realm_create_stream_by_admins_only,
         realm_allow_message_editing: page_params.realm_allow_message_editing,
-        realm_message_content_edit_limit_minutes: Math.ceil(page_params.realm_message_content_edit_limit_seconds / 60),
+        realm_message_content_edit_limit_minutes:
+            Math.ceil(page_params.realm_message_content_edit_limit_seconds / 60),
         language_list: page_params.language_list,
         realm_default_language: page_params.realm_default_language
     };
@@ -539,7 +540,8 @@ function _setup_page() {
             if ((parseInt(new_message_content_edit_limit_minutes, 10).toString() !==
                  new_message_content_edit_limit_minutes) ||
                 new_message_content_edit_limit_minutes < 0) {
-            new_message_content_edit_limit_minutes = 10; // Realm.DEFAULT_MESSAGE_CONTENT_EDIT_LIMIT_SECONDS / 60
+            // Realm.DEFAULT_MESSAGE_CONTENT_EDIT_LIMIT_SECONDS / 60
+            new_message_content_edit_limit_minutes = 10;
             }
         }
 
@@ -552,7 +554,8 @@ function _setup_page() {
             authentication_methods: JSON.stringify(new_auth_methods),
             create_stream_by_admins_only: JSON.stringify(new_create_stream_by_admins_only),
             allow_message_editing: JSON.stringify(new_allow_message_editing),
-            message_content_edit_limit_seconds: JSON.stringify(parseInt(new_message_content_edit_limit_minutes, 10) * 60),
+            message_content_edit_limit_seconds:
+                JSON.stringify(parseInt(new_message_content_edit_limit_minutes, 10) * 60),
             default_language: JSON.stringify(new_default_language)
         };
 
@@ -599,7 +602,8 @@ function _setup_page() {
                 if (response_data.allow_message_editing !== undefined) {
                     // We expect message_content_edit_limit_seconds was sent in the
                     // response as well
-                    var data_message_content_edit_limit_minutes = Math.ceil(response_data.message_content_edit_limit_seconds / 60);
+                    var data_message_content_edit_limit_minutes =
+                        Math.ceil(response_data.message_content_edit_limit_seconds / 60);
                     if (response_data.allow_message_editing) {
                         if (response_data.message_content_edit_limit_seconds > 0) {
                             ui.report_success(i18n.t("Users can now edit topics for all their messages, and the content of messages which are less than __num_minutes__ minutes old.",

--- a/static/js/alert_words.js
+++ b/static/js/alert_words.js
@@ -29,7 +29,8 @@ exports.process_message = function (message) {
         var regex = new RegExp('(' + before_punctuation + ')' +
                                '(' + clean + ')' +
                                '(' + after_punctuation + ')' , 'ig');
-        message.content = message.content.replace(regex, function (match, before, word, after, offset, content) {
+        message.content = message.content.replace(regex, function (match, before, word,
+                                                                   after, offset, content) {
             // Don't munge URL hrefs
             var pre_match = content.substring(0, offset);
             if (find_href_backwards.exec(pre_match) || find_title_backwards.exec(pre_match)) {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -3,10 +3,13 @@ var compose = (function () {
 var exports = {};
 var is_composing_message = false;
 
-// Track the state of the @all warning. The user must acknowledge that they are spamming the entire stream
-// before the warning will go away. If they try to send before explicitly dismissing the warning, they will
-// get an error message too.
-// undefined: no @all/@everyone in message; false: user typed @all/@everyone; true: user clicked YES
+/* Track the state of the @all warning. The user must acknowledge that they are spamming the entire
+   stream before the warning will go away. If they try to send before explicitly dismissing the
+   warning, they will get an error message too.
+
+   undefined: no @all/@everyone in message;
+   false: user typed @all/@everyone;
+   true: user clicked YES */
 var user_acknowledged_all_everyone;
 
 var message_snapshot;
@@ -826,7 +829,8 @@ function validate_stream_message() {
 
     return true;
 }
-// The function checks whether the recipients are users of the realm or cross realm users (bots for now)
+// The function checks whether the recipients are users of the realm or cross realm users (bots
+// for now)
 function validate_private_message() {
     if (exports.recipient() === "") {
         compose_error(i18n.t("Please specify at least one recipient"), $("#private_message_recipient"));
@@ -930,8 +934,8 @@ $(function () {
             }
 
             if (compose_fade.would_receive_message(email) === false) {
-                var new_row = templates.render("compose-invite-users", {email: email,
-                                                                        name: data.mentioned.full_name});
+                var new_row = templates.render("compose-invite-users",
+                                               {email: email, name: data.mentioned.full_name});
                 var error_area = $("#compose_invite_users");
 
                 var existing_invites = _.map($(".compose_invite_user", error_area), function (user_row) {
@@ -1189,7 +1193,8 @@ $(function () {
         if (exports.send_times_data[event.old_id] !== undefined) {
             var value = exports.send_times_data[event.old_id];
             delete exports.send_times_data[event.old_id];
-            exports.send_times_data[event.new_id] = _.extend({}, exports.send_times_data[event.old_id], value);
+            exports.send_times_data[event.new_id] =
+                _.extend({}, exports.send_times_data[event.old_id], value);
         }
     });
 });

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -85,7 +85,8 @@ function _fade_messages() {
         // sorted as it would be displayed in the message view
         for (i = 0; i < all_groups.length; i += 1) {
             var group_elt = $(all_groups[i]);
-            should_fade_group = !fade_heuristic(focused_recipient, rows.recipient_from_group(group_elt));
+            should_fade_group = !fade_heuristic(focused_recipient,
+                                                rows.recipient_from_group(group_elt));
             change_fade_state(group_elt, should_fade_group);
         }
 

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -302,8 +302,8 @@ exports.content_typeahead_selected = function (item) {
         $(document).trigger('streamname_completed.zulip', {stream: item});
     }
 
-    // Keep the cursor after the newly inserted text, as Bootstrap will call textbox.change() to overwrite the text
-    // in the textbox.
+    // Keep the cursor after the newly inserted text, as Bootstrap will call textbox.change() to
+    // overwrite the text in the textbox.
     setTimeout(function () {
         $('#new_message_content').caret(beginning.length, beginning.length);
     }, 0);

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -428,8 +428,8 @@ $(function () {
     // Configure the marked markdown parser for our usage
     var r = new marked.Renderer();
 
-    // No <code> around our code blocks instead a codehilite <div>, and disable class-specific highlighting
-    // We special-case the 'quote' language and output a blockquote
+    // No <code> around our code blocks instead a codehilite <div> and disable class-specific
+    // highlighting. We special-case the 'quote' language and output a blockquote.
     r.code = function (code, lang) {
         if (lang === 'quote') {
             return '<blockquote>\n<p>' + escape(code, true) + '</p>\n</blockquote>\n\n\n';

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -457,7 +457,8 @@ Filter.describe = function (operators) {
                 return verb + 'alerted messages';
             }
         } else {
-            var prefix_for_operator = Filter.operator_to_prefix(canonicalized_operator, elem.negated);
+            var prefix_for_operator = Filter.operator_to_prefix(canonicalized_operator,
+                                                                elem.negated);
             if (prefix_for_operator !== '') {
                 return prefix_for_operator + ' ' + operand;
             }

--- a/static/js/floating_recipient_bar.js
+++ b/static/js/floating_recipient_bar.js
@@ -46,7 +46,8 @@ exports.hide = function () {
 exports.update = function () {
     var floating_recipient_bar = $("#floating_recipient_bar");
     var floating_recipient_bar_top = floating_recipient_bar.offset().top;
-    var floating_recipient_bar_bottom = floating_recipient_bar_top + floating_recipient_bar.outerHeight();
+    var floating_recipient_bar_bottom =
+        floating_recipient_bar_top + floating_recipient_bar.outerHeight();
 
     // Find the last message where the top of the recipient
     // row is at least partially occluded by our box.

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -104,7 +104,8 @@ function get_hotkey_from_event(e) {
 //
 // Returns true if we handled it, false if the browser should.
 function process_hotkey(e) {
-    var row, alert_words_content, focused_message_edit_content, focused_message_edit_save, message_edit_form;
+    var row, alert_words_content, focused_message_edit_content,
+        focused_message_edit_save, message_edit_form;
 
     var hotkey = get_hotkey_from_event(e);
     var event_name = hotkey.name;

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -220,7 +220,8 @@ exports.MessageList.prototype = {
         function less_func (msg, ref_id, a_idx) {
             if (self._is_localonly_id(msg.id)) {
                 // First non-local message before this one
-                var effective = self._next_nonlocal_message(self._items, a_idx, function (idx) { return idx - 1; });
+                var effective = self._next_nonlocal_message(self._items, a_idx,
+                                                            function (idx) { return idx - 1; });
                 if (effective) {
                     // Turn the 10.02 in [11, 10.02, 12] into 11.02
                     var decimal = parseFloat((msg.id % 1).toFixed(0.02));
@@ -268,8 +269,8 @@ exports.MessageList.prototype = {
         if (closest === items.length) {
             closest = closest - 1;
         } else {
-            // Any of the ids that we skipped over (due to them being local-only) might be the closest ID to the desired one,
-            // in case there is no exact match.
+            // Any of the ids that we skipped over (due to them being local-only) might be the
+            // closest ID to the desired one, in case there is no exact match.
             potential_closest_matches.unshift(_.last(potential_closest_matches) - 1);
             var best_match = items[closest].id;
 
@@ -546,7 +547,8 @@ exports.MessageList.prototype = {
         return id % 1 !== 0;
     },
 
-    _next_nonlocal_message: function MessageList__next_nonlocal_message(item_list, start_index, op) {
+    _next_nonlocal_message: function MessageList__next_nonlocal_message(item_list,
+                                                                        start_index, op) {
         var cur_idx = start_index;
         do {
             cur_idx = op(cur_idx);
@@ -602,8 +604,10 @@ exports.MessageList.prototype = {
                 return;
             }
 
-            var next = self._next_nonlocal_message(self._items, index, function (idx) { return idx + 1; });
-            var prev = self._next_nonlocal_message(self._items, index, function (idx) { return idx - 1; });
+            var next = self._next_nonlocal_message(self._items, index,
+                                                   function (idx) { return idx + 1; });
+            var prev = self._next_nonlocal_message(self._items, index,
+                                                   function (idx) { return idx - 1; });
 
             if ((next !== undefined && current_message.id > next.id) ||
                 (prev !== undefined && current_message.id < prev.id)) {

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -104,21 +104,25 @@ MessageListView.prototype = {
         }
     },
 
-    add_subscription_marker: function MessageListView__add_subscription_marker(group, last_msg_container, first_msg_container) {
+    add_subscription_marker: function MessageListView__add_subscription_marker(
+                                group, last_msg_container, first_msg_container) {
         if (last_msg_container !== undefined &&
             first_msg_container.msg.historical !== last_msg_container.msg.historical) {
             group.bookend_top = true;
             if (first_msg_container.msg.historical) {
                 group.unsubscribed = first_msg_container.msg.stream;
-                group.bookend_content = this.list.unsubscribed_bookend_content(first_msg_container.msg.stream);
+                group.bookend_content =
+                    this.list.unsubscribed_bookend_content(first_msg_container.msg.stream);
             } else {
                 group.subscribed = first_msg_container.msg.stream;
-                group.bookend_content = this.list.subscribed_bookend_content(first_msg_container.msg.stream);
+                group.bookend_content =
+                    this.list.subscribed_bookend_content(first_msg_container.msg.stream);
             }
         }
     },
 
-    build_message_groups: function MessageListView__build_message_groups(message_containers, message_id_prefix) {
+    build_message_groups: function MessageListView__build_message_groups(message_containers,
+                                                                         message_id_prefix) {
         function start_group() {
             return {
                 message_containers: [],
@@ -140,8 +144,11 @@ MessageListView.prototype = {
 
         function finish_group() {
             if (current_group.message_containers.length > 0) {
-                populate_group_from_message_container(current_group, current_group.message_containers[0]);
-                current_group.message_containers[current_group.message_containers.length - 1].include_footer = true;
+                populate_group_from_message_container(current_group,
+                                                      current_group.message_containers[0]);
+                current_group
+                   .message_containers[current_group.message_containers.length - 1]
+                   .include_footer = true;
                 new_message_groups.push(current_group);
             }
         }
@@ -150,8 +157,10 @@ MessageListView.prototype = {
             message_container.include_recipient = false;
             message_container.include_footer    = false;
 
-            if (same_recipient(prev, message_container) && self.collapse_messages &&
-               prev.msg.historical === message_container.msg.historical && same_day(prev, message_container)) {
+            if (same_recipient(prev, message_container) &&
+                self.collapse_messages &&
+                prev.msg.historical === message_container.msg.historical &&
+                same_day(prev, message_container)) {
                 add_message_container_to_group(message_container);
             } else {
                 finish_group();
@@ -171,10 +180,14 @@ MessageListView.prototype = {
                 }
 
                 if (message_container.msg.stream) {
-                    message_container.stream_url = narrow.by_stream_uri(message_container.msg.stream);
-                    message_container.topic_url = narrow.by_stream_subject_uri(message_container.msg.stream, message_container.msg.subject);
+                    message_container.stream_url =
+                        narrow.by_stream_uri(message_container.msg.stream);
+                    message_container.topic_url =
+                        narrow.by_stream_subject_uri(message_container.msg.stream,
+                                                     message_container.msg.subject);
                 } else {
-                    message_container.pm_with_url = narrow.pm_with_uri(message_container.msg.reply_to);
+                    message_container.pm_with_url =
+                        narrow.pm_with_uri(message_container.msg.reply_to);
                 }
             }
 
@@ -191,10 +204,12 @@ MessageListView.prototype = {
 
             message_container.small_avatar_url = ui.small_avatar_url(message_container.msg);
             if (message_container.msg.stream !== undefined) {
-                message_container.background_color = stream_data.get_color(message_container.msg.stream);
+                message_container.background_color =
+                    stream_data.get_color(message_container.msg.stream);
             }
 
-            message_container.contains_mention = notifications.speaking_at_me(message_container.msg);
+            message_container.contains_mention =
+                notifications.speaking_at_me(message_container.msg);
             message_container.msg.unread = unread.message_unread(message_container.msg);
             self._maybe_format_me_message(message_container);
 
@@ -219,24 +234,30 @@ MessageListView.prototype = {
         var first_msg_container = _.first(second_group.message_containers);
 
         // Join two groups into one.
-        if (this.collapse_messages && same_recipient(last_msg_container, first_msg_container) && same_day(last_msg_container, first_msg_container) && (last_msg_container.msg.historical === first_msg_container.msg.historical)) {
-            if (!last_msg_container.status_message && !first_msg_container.msg.is_me_message && same_sender(last_msg_container, first_msg_container)) {
+        if (this.collapse_messages && same_recipient(last_msg_container, first_msg_container) &&
+            same_day(last_msg_container, first_msg_container) &&
+            last_msg_container.msg.historical === first_msg_container.msg.historical) {
+            if (!last_msg_container.status_message && !first_msg_container.msg.is_me_message
+                && same_sender(last_msg_container, first_msg_container)) {
                 first_msg_container.include_sender = false;
             }
             if (same_sender(last_msg_container, first_msg_container)) {
                 last_msg_container.next_is_same_sender = true;
             }
-            first_group.message_containers = first_group.message_containers.concat(second_group.message_containers);
+            first_group.message_containers =
+                first_group.message_containers.concat(second_group.message_containers);
             return true;
         // Add a subscription marker
-        } else if (this.list !== home_msg_list && last_msg_container.msg.historical !== first_msg_container.msg.historical) {
+        } else if (this.list !== home_msg_list &&
+                   last_msg_container.msg.historical !== first_msg_container.msg.historical) {
             first_group.bookend_bottom = true;
             this.add_subscription_marker(first_group, last_msg_container, first_msg_container);
         }
         return false;
     },
 
-    merge_message_groups: function MessageListView__merge_message_groups(new_message_groups, where) {
+    merge_message_groups: function MessageListView__merge_message_groups(new_message_groups,
+                                                                         where) {
         // merge_message_groups takes a list of new messages groups to add to
         // this._message_groups and a location where to merge them currently
         // top or bottom. It returns an object of changes which needed to be
@@ -274,14 +295,15 @@ MessageListView.prototype = {
                 this._message_groups.unshift(first_group);
 
                 new_message_groups = _.initial(new_message_groups);
-            } else if (!same_day(second_group.message_containers[0], first_group.message_containers[0])) {
+            } else if (!same_day(second_group.message_containers[0],
+                       first_group.message_containers[0])) {
                 // The groups did not merge, so we need up update the date row for the old group
                 add_display_time(
                     second_group,
                     _.first(second_group.message_containers),
                     _.last(first_group.message_containers)
                 );
-                // We could add an action to just update the date row, but for now rerender the group.
+                // We could add an action to update the date row, but for now rerender the group.
                 message_actions.rerender_groups.push(second_group);
             }
             message_actions.prepend_groups = new_message_groups;
@@ -292,7 +314,9 @@ MessageListView.prototype = {
             if (this.join_message_groups(first_group, second_group)) {
                 // rerender the last message
                 message_actions.rerender_messages.push(
-                    first_group.message_containers[first_group.message_containers.length - second_group.message_containers.length - 1]
+                    first_group.message_containers[
+                        first_group.message_containers.length
+                        - second_group.message_containers.length - 1]
                 );
                 message_actions.append_messages = _.first(new_message_groups).message_containers;
                 new_message_groups = _.rest(new_message_groups);
@@ -502,7 +526,8 @@ MessageListView.prototype = {
 
         var last_message_group = _.last(self._message_groups);
         if (last_message_group !== undefined) {
-            list.last_message_historical = _.last(last_message_group.message_containers).msg.historical;
+            list.last_message_historical =
+                _.last(last_message_group.message_containers).msg.historical;
         }
 
         var stream_name = narrow.stream();
@@ -536,7 +561,8 @@ MessageListView.prototype = {
     },
 
 
-    _maybe_autoscroll: function MessageListView__maybe_autoscroll(rendered_elems, last_message_was_selected) {
+    _maybe_autoscroll: function MessageListView__maybe_autoscroll(rendered_elems,
+                                                                  last_message_was_selected) {
         // If we are near the bottom of our feed (the bottom is visible) and can
         // scroll up without moving the pointer out of the viewport, do so, by
         // up to the amount taken up by the new message.
@@ -585,8 +611,11 @@ MessageListView.prototype = {
         var info = viewport.message_viewport_info();
         var available_space_for_scroll = selected_row_offset - info.visible_top;
 
+        var rows_offset = rows.last_visible().offset().top - this.list.selected_row().offset().top;
+
         // autoscroll_forever: if we've sent a message, move pointer at least that far.
-        if (page_params.autoscroll_forever && id_of_last_message_sent_by_us > -1 && (rows.last_visible().offset().top - this.list.selected_row().offset().top) < (viewport.height())) {
+        if (page_params.autoscroll_forever && id_of_last_message_sent_by_us > -1 &&
+            rows_offset < (viewport.height())) {
             this.list.select_id(id_of_last_message_sent_by_us, {from_rendering: true});
             navigate.scroll_to_selected();
             return;
@@ -641,7 +670,8 @@ MessageListView.prototype = {
         this._render_win_end = 0;
     },
 
-    update_render_window: function MessageListView__update_render_window(selected_idx, check_for_changed) {
+    update_render_window: function MessageListView__update_render_window(selected_idx,
+                                                                         check_for_changed) {
         var new_start = Math.max(selected_idx - this._RENDER_WINDOW_SIZE / 2, 0);
         if (check_for_changed && new_start === this._render_win_start) {
             return false;
@@ -707,7 +737,8 @@ MessageListView.prototype = {
                 this.list.select_id(this.list.selected_id(), {use_closest: true});
             }
             // Must get this.list.selected_row() again since it is now a new DOM element
-            viewport.scrollTop(viewport.scrollTop() + this.selected_row().offset().top - scrolltop_offset);
+            viewport.scrollTop(
+                    viewport.scrollTop() + this.selected_row().offset().top - scrolltop_offset);
         }
     },
 
@@ -776,7 +807,8 @@ MessageListView.prototype = {
         var message_groups = [];
         var current_group = [];
         _.each(message_containers, function (message_container) {
-            if (current_group.length === 0 || same_recipient(current_group[current_group.length - 1], message_container)) {
+            if (current_group.length === 0 ||
+                same_recipient(current_group[current_group.length - 1], message_container)) {
                 current_group.push(message_container);
             } else {
                 message_groups.push(current_group);
@@ -850,7 +882,8 @@ MessageListView.prototype = {
         trailing_bookend.remove();
     },
 
-    render_trailing_bookend: function MessageListView_render_trailing_bookend(trailing_bookend_content, subscribed) {
+    render_trailing_bookend: function MessageListView_render_trailing_bookend(
+                                trailing_bookend_content, subscribed) {
         var rendered_trailing_bookend = $(templates.render('bookend', {
             bookend_content: trailing_bookend_content,
             trailing: true,

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -39,7 +39,8 @@ exports.get_private_message_recipient = function (message, attr, fallback_attr) 
     return recipient;
 };
 
-exports.process_message_for_recent_private_messages = function process_message_for_recent_private_messages(message, remove_message) {
+exports.process_message_for_recent_private_messages =
+    function process_message_for_recent_private_messages(message, remove_message) {
     var current_timestamp = 0;
 
     var user_ids_string = people.emails_strings_to_user_ids_string(message.reply_to);
@@ -51,7 +52,8 @@ exports.process_message_for_recent_private_messages = function process_message_f
 
     // If this conversation is already tracked, we'll replace with new timestamp,
     // so remove it from the current list.
-    exports.recent_private_messages = _.filter(exports.recent_private_messages, function (recent_pm) {
+    exports.recent_private_messages = _.filter(exports.recent_private_messages,
+                                               function (recent_pm) {
         return recent_pm.user_ids_string !== user_ids_string;
     });
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -238,7 +238,8 @@ exports.activate = function (raw_operators, opts) {
             blueslip.debug("narrow.activate missing selected row", {
                 selected_id: current_msg_list.selected_id(),
                 selected_idx: current_msg_list.selected_idx(),
-                selected_idx_exact: current_msg_list._items.indexOf(current_msg_list.get(current_msg_list.selected_id())),
+                selected_idx_exact: current_msg_list._items.indexOf(
+                                        current_msg_list.get(current_msg_list.selected_id())),
                 render_start: current_msg_list.view._render_win_start,
                 render_end: current_msg_list.view._render_win_end
             });
@@ -275,7 +276,8 @@ exports.activate = function (raw_operators, opts) {
         if (! message_list.narrowed.empty()) {
             if (opts.select_first_unread) {
                 then_select_id = message_list.narrowed.last().id;
-                var first_unread = _.find(message_list.narrowed.all_messages(), unread.message_unread);
+                var first_unread =
+                    _.find(message_list.narrowed.all_messages(), unread.message_unread);
                 if (first_unread) {
                     then_select_id = first_unread.id;
                 }
@@ -306,7 +308,8 @@ exports.activate = function (raw_operators, opts) {
     // the message we want anyway or if the filter can't be applied
     // locally.
     if (message_list.all.get(then_select_id) !== undefined && current_filter.can_apply_locally()) {
-        message_store.add_messages(message_list.all.all_messages(), message_list.narrowed, {delay_render: true});
+        message_store.add_messages(message_list.all.all_messages(), message_list.narrowed,
+                                   {delay_render: true});
     }
 
     var defer_selecting_closest = message_list.narrowed.empty();
@@ -654,7 +657,8 @@ exports.narrowed_to_search = function () {
 };
 
 exports.muting_enabled = function () {
-    return (!exports.narrowed_to_topic() && !exports.narrowed_to_search() && !exports.narrowed_to_pms());
+    return (!exports.narrowed_to_topic() && !exports.narrowed_to_search() &&
+            !exports.narrowed_to_pms());
 };
 
 return exports;

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -249,8 +249,8 @@ exports.hide_user_sidebar_popover = function () {
         // this hide_* method looks different from all the others since
         // the presence list may be redrawn. Due to funkiness with jquery's .data()
         // this would confuse $.popover("destroy"), which looks at the .data() attached
-        // to a certain element. We thus save off the .data("popover") in the show_user_sidebar_popover
-        // and inject it here before calling destroy.
+        // to a certain element. We thus save off the .data("popover") in the
+        // show_user_sidebar_popover and inject it here before calling destroy.
         $('#user_presences').data("popover", current_user_sidebar_popover);
         $('#user_presences').popover("destroy");
         current_user_sidebar_user_id = undefined;
@@ -702,7 +702,8 @@ exports.register_click_handlers = function () {
 
 exports.any_active = function () {
     // True if any popover (that this module manages) is currently shown.
-    return popovers.actions_popped() || user_sidebar_popped() || stream_sidebar_popped() || topic_sidebar_popped() || message_info_popped() || emoji_map_is_open;
+    return popovers.actions_popped() || user_sidebar_popped() || stream_sidebar_popped() ||
+           topic_sidebar_popped() || message_info_popped() || emoji_map_is_open;
 };
 
 exports.hide_all = function () {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -88,7 +88,8 @@ function add_bot_row(info) {
     $('#bots_list').show();
 }
 
-function add_bot_default_streams_to_form(formData, default_sending_stream, default_events_register_stream) {
+function add_bot_default_streams_to_form(formData, default_sending_stream,
+                                         default_events_register_stream) {
     if (!feature_flags.new_bot_ui) { return; }
 
     if (default_sending_stream !== '') {
@@ -261,7 +262,8 @@ function _setup_page() {
         // Stream notification settings.
 
         if (result.enable_stream_desktop_notifications !== undefined) {
-            page_params.stream_desktop_notifications_enabled = result.enable_stream_desktop_notifications;
+            page_params.stream_desktop_notifications_enabled =
+                result.enable_stream_desktop_notifications;
         }
         if (result.enable_stream_sounds !== undefined) {
             page_params.stream_sounds_enabled = result.enable_stream_sounds;
@@ -277,11 +279,13 @@ function _setup_page() {
         }
 
         if (result.enable_offline_email_notifications !== undefined) {
-            page_params.enable_offline_email_notifications = result.enable_offline_email_notifications;
+            page_params.enable_offline_email_notifications =
+                result.enable_offline_email_notifications;
         }
 
         if (result.enable_offline_push_notifications !== undefined) {
-            page_params.enable_offline_push_notifications = result.enable_offline_push_notifications;
+            page_params.enable_offline_push_notifications =
+                result.enable_offline_push_notifications;
         }
 
         if (result.enable_online_push_notifications !== undefined) {
@@ -560,7 +564,8 @@ function _setup_page() {
             formData.append('csrfmiddlewaretoken', csrf_token);
             formData.append('full_name', full_name);
             formData.append('short_name', short_name);
-            add_bot_default_streams_to_form(formData, default_sending_stream, default_events_register_stream);
+            add_bot_default_streams_to_form(formData, default_sending_stream,
+                                            default_events_register_stream);
             jQuery.each($('#bot_avatar_file_input')[0].files, function (i, file) {
                 formData.append('file-'+i, file);
             });
@@ -669,7 +674,8 @@ function _setup_page() {
 
                 formData.append('csrfmiddlewaretoken', csrf_token);
                 formData.append('full_name', full_name);
-                add_bot_default_streams_to_form(formData, default_sending_stream, default_events_register_stream);
+                add_bot_default_streams_to_form(formData, default_sending_stream,
+                                                default_events_register_stream);
                 jQuery.each(file_input[0].files, function (i, file) {
                     formData.append('file-'+i, file);
                 });

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -276,7 +276,8 @@ exports.add_admin_options = function (sub) {
     });
 };
 
-exports.process_message_for_recent_topics = function process_message_for_recent_topics(message, remove_message) {
+exports.process_message_for_recent_topics = function process_message_for_recent_topics(
+                                                message, remove_message) {
     var current_timestamp = 0;
     var count = 0;
     var stream = message.stream;

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -122,8 +122,9 @@ exports.build_stream_list = function () {
 
     streams = pinned_streams.concat(unpinned_streams);
 
-    if (previous_sort_order !== undefined && util.array_compare(previous_sort_order, streams)
-                                          && util.array_compare(previous_unpinned_order, unpinned_streams)) {
+    if (previous_sort_order !== undefined &&
+        util.array_compare(previous_sort_order, streams) &&
+        util.array_compare(previous_unpinned_order, unpinned_streams)) {
         return;
     }
     previous_sort_order = streams;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -125,9 +125,9 @@ function update_in_home_view(sub, value) {
             }
         }
 
-        // In case we added messages to what's visible in the home view, we need to re-scroll to make
-        // sure the pointer is still visible. We don't want the auto-scroll handler to move our pointer
-        // to the old scroll location before we have a chance to update it.
+        // In case we added messages to what's visible in the home view, we need to re-scroll to
+        // make sure the pointer is still visible. We don't want the auto-scroll handler to move
+        // our pointer to the old scroll location before we have a chance to update it.
         pointer.recenter_pointer_on_display = true;
         pointer.suppress_scroll_pointer_update = true;
 

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -139,7 +139,8 @@ function identity(item) {
 exports.sort_recipients = function (matches, query) {
     var name_results =  prefix_sort(query, matches, function (x) { return x.full_name; });
     var email_results = prefix_sort(query, name_results.rest, function (x) { return x.email; });
-    var matches_sorted_by_pms = exports.sort_by_pms(name_results.matches.concat(email_results.matches));
+    var matches_sorted_by_pms =
+        exports.sort_by_pms(name_results.matches.concat(email_results.matches));
     var rest_sorted_by_pms = exports.sort_by_pms(email_results.rest);
     return matches_sorted_by_pms.concat(rest_sorted_by_pms);
 };

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -117,7 +117,8 @@ function message_hover(message_row) {
     message = current_msg_list.get(rows.id(message_row));
     message_unhover();
     message_row.addClass('message_hovered');
-    if ((message_edit.get_editability(message) === message_edit.editability_types.FULL) && !message.status_message) {
+    if ((message_edit.get_editability(message) === message_edit.editability_types.FULL) &&
+        !message.status_message) {
         message_row.find(".edit_content").html('<i class="icon-vector-pencil edit_content_button"></i>');
     } else {
         message_row.find(".edit_content").html('<i class="icon-vector-file-text-alt edit_content_button" data-msgid="' + id + '"></i>');

--- a/static/js/viewport.js
+++ b/static/js/viewport.js
@@ -145,7 +145,8 @@ var bottom_of_feed = new util.CachedValue({
     }
 });
 
-function _visible_divs(selected_row, row_min_height, row_to_output, div_class, require_fully_visible) {
+function _visible_divs(selected_row, row_min_height, row_to_output, div_class,
+                       require_fully_visible) {
     // Note that when using getBoundingClientRect() we are getting offsets
     // relative to the visible window, but when using jQuery's offset() we are
     // getting offsets relative to the full scrollable window. You can't try to
@@ -158,12 +159,12 @@ function _visible_divs(selected_row, row_min_height, row_to_output, div_class, r
     var visible = [];
     var above_pointer = selected_row.prevAll("div." + div_class + ":lt(" + num_neighbors + ")");
     var below_pointer = selected_row.nextAll("div." + div_class + ":lt(" + num_neighbors + ")");
-    add_to_visible(selected_row, visible,
-                            top_of_feed.get(), bottom_of_feed.get(), require_fully_visible, row_to_output);
-    add_to_visible(above_pointer, visible,
-                            top_of_feed.get(), bottom_of_feed.get(), require_fully_visible, row_to_output);
-    add_to_visible(below_pointer, visible,
-                            top_of_feed.get(), bottom_of_feed.get(), require_fully_visible, row_to_output);
+    add_to_visible(selected_row, visible, top_of_feed.get(), bottom_of_feed.get(),
+            require_fully_visible, row_to_output);
+    add_to_visible(above_pointer, visible, top_of_feed.get(), bottom_of_feed.get(),
+            require_fully_visible, row_to_output);
+    add_to_visible(below_pointer, visible, top_of_feed.get(), bottom_of_feed.get(),
+            require_fully_visible, row_to_output);
 
     return visible;
 }


### PR DESCRIPTION
Clean up Javascript code base to match eslint style for rule `max-len` with option:
```.js
"keyword-spacing": ["error", {
      "before": true,
      "after": true,
      "overrides": {
        "return": { "after": true },
        "throw": { "after": true },
        "case": { "after": true }
      }
    }],
```