### PR TITLE
eslint: change space-before-blocks from warning to error and fix violations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -179,7 +179,7 @@
                 "case": { "after": true }
             }
         }],
-        "space-before-blocks": 1,
+        "space-before-blocks": 2,
         "strict": 1,
         "unnecessary-strict": 0,
         "use-isnan": 2,

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -791,7 +791,7 @@ function _setup_page() {
         e.stopPropagation();
         var emoji_status = $('#admin-emoji-status');
         var emoji = {};
-        $(this).serializeArray().map(function (x){emoji[x.name] = x.value;});
+        $(this).serializeArray().map(function (x) {emoji[x.name] = x.value;});
 
         channel.put({
             url: "/json/realm/emoji",
@@ -843,7 +843,7 @@ function _setup_page() {
         pattern_status.hide();
         format_status.hide();
         var filter = {};
-        $(this).serializeArray().map(function (x){filter[x.name] = x.value;});
+        $(this).serializeArray().map(function (x) {filter[x.name] = x.value;});
 
         channel.post({
             url: "/json/realm/filters",


### PR DESCRIPTION
Enabled errors for eslint rule `space-before-blocks` and changed `admin.js` to enforce it.