### PR TITLE
tests: Change doc file in run-casper 'Tips for debugging'

### DIFF
--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -152,7 +152,7 @@ def run_tests(realms_have_subdomains, files):
 Oops, the frontend tests failed. Tips for debugging:
  * Check the frontend test server logs at %s
  * Check the screenshots of failed tests at var/casper/casper-failure*.png
- * Try remote debugging the test web browser as described in docs/testing.rst
+ * Try remote debugging the test web browser as described in docs/testing-with-casper.md
 """ % (LOG_FILE,), file=sys.stderr)
 
         sys.exit(ret)


### PR DESCRIPTION
Change `docs/testing.rst` to `docs/testing-with-casper.md` in
'Tips for debugging' because there is no `testing.rst` file, and
remote debugging description is placed in `testing-with-casper.md`.