### PR TITLE
Fix several type annotations for mypy 0.4.6 compatibility.

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -189,7 +189,7 @@ def get_user_messages(user_profile):
 
 class DummyHandler(object):
     def __init__(self):
-        # type: (Callable) -> None
+        # type: () -> None
         allocate_handler_id(self)  # type: ignore # this is a testing mock
 
 class POSTRequestMock(object):

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -69,7 +69,7 @@ class RateLimitTests(ZulipTestCase):
         remove_ratelimit_rule(1, 5)
 
     def send_api_message(self, email, content):
-        # type: (text_type, text_type, text_type) -> HttpResponse
+        # type: (text_type, text_type) -> HttpResponse
         return self.client_post("/api/v1/messages", {"type": "stream",
                                                      "to": "Verona",
                                                      "client": "test suite",

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -141,7 +141,7 @@ class ClientDescriptor(object):
         self.finish_current_handler()
 
     def finish_current_handler(self):
-        # type: (bool) -> bool
+        # type: () -> bool
         if self.current_handler_id is not None:
             err_msg = "Got error finishing handler for queue %s" % (self.event_queue.id,)
             try:
@@ -193,7 +193,7 @@ class ClientDescriptor(object):
             self._timeout_handle = ioloop.add_timeout(heartbeat_time, timeout_callback)
 
     def disconnect_handler(self, client_closed=False):
-        # type: (bool, bool) -> None
+        # type: (bool) -> None
         if self.current_handler_id:
             clear_descriptor_by_handler_id(self.current_handler_id, None)
             clear_handler_by_id(self.current_handler_id)


### PR DESCRIPTION
A few functions had arguments removed without having their type
annotations updated accordingly. As a result mypy version 0.4.6
thinks that the first type in the annotation is supposed to be
the type of `self`, a new mypy feature which we are not intending
to use here.