### PR TITLE
eslint: change no-shadow from warning to error and fix violations.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -186,7 +186,7 @@
         "no-iterator": 2,
         "no-mixed-requires": [0, false],
         "no-extra-parens": ["error", "functions"],
-        "no-shadow": 1,
+        "no-shadow": 2,
         "no-use-before-define": 2,
         "no-redeclare": 2,
         "no-regex-spaces": 2,

--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -125,12 +125,12 @@ exports.select_item_via_typeahead = function (field_selector, str, item) {
     casper.then(function () {
         casper.test.info('Looking in ' + field_selector + ' to select ' + str + ', ' + item);
 
-        casper.evaluate(function (field_selector, str, item) {
+        casper.evaluate(function (test_field_selector, test_str, test_item) {
             // Set the value and then send a bogus keyup event to trigger
             // the typeahead.
-            $(field_selector)
+            $(test_field_selector)
                 .focus()
-                .val(str)
+                .val(test_str)
                 .trigger($.Event('keyup', { which: 0 }));
 
             // You might think these steps should be split by casper.then,
@@ -141,9 +141,9 @@ exports.select_item_via_typeahead = function (field_selector, str, item) {
             // Reaching into the guts of Bootstrap Typeahead like this is not
             // great, but I found it very hard to do it any other way.
 
-            var tah = $(field_selector).data().typeahead;
+            var tah = $(test_field_selector).data().typeahead;
             tah.mouseenter({
-                currentTarget: $('.typeahead:visible li:contains("'+item+'")')[0],
+                currentTarget: $('.typeahead:visible li:contains("'+test_item+'")')[0]
             });
             tah.select();
         }, {field_selector:field_selector, str: str, item: item});
@@ -182,8 +182,8 @@ exports.turn_off_press_enter_to_send = function () {
     var enter_send_selector = '#enter_sends';
     casper.waitForSelector(enter_send_selector);
 
-    var is_checked = casper.evaluate(function (enter_send_selector) {
-        return document.querySelector(enter_send_selector).checked;
+    var is_checked = casper.evaluate(function (test_enter_send_selector) {
+        return document.querySelector(test_enter_send_selector).checked;
     }, enter_send_selector);
 
     if (is_checked) {
@@ -233,8 +233,8 @@ exports.then_send_message = function (type, params) {
 // script's context is awkward (c.f. the various appearances of
 // 'table' here).
 exports.get_rendered_messages = function (table) {
-    return casper.evaluate(function (table) {
-        var tbl = $('#'+table);
+    return casper.evaluate(function (test_table) {
+        var tbl = $('#'+test_table);
         return {
             headings: $.map(tbl.find('.recipient_row .message-header-contents'), function (elem) {
                 var $clone = $(elem).clone(true);
@@ -253,8 +253,8 @@ exports.get_rendered_messages = function (table) {
 };
 
 exports.get_form_field_value = function (selector) {
-    return casper.evaluate(function (selector) {
-        return $(selector).val();
+    return casper.evaluate(function (sel) {
+        return $(sel).val();
     }, selector);
 };
 
@@ -262,8 +262,8 @@ exports.get_form_field_value = function (selector) {
 // PhantomJS and CasperJS don't provide a clean way to insert key
 // presses by code, only strings of printable characters.
 exports.keypress = function (code) {
-    casper.evaluate(function (code) {
-        $('body').trigger($.Event('keydown', { which: code }));
+    casper.evaluate(function (test_code) {
+        $('body').trigger($.Event('keydown', { which: test_code }));
     }, {
         code: code,
     });

--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -144,23 +144,23 @@ casper.then(function () {
 
 casper.then(function () {
     casper.waitUntilVisible('.edit_bot_form[data-email="1-bot@zulip.com"]', function test_edit_bot_form_values() {
-        var form_sel = '.edit_bot_form[data-email="1-bot@zulip.com"]';
+        var bot_sel = '.edit_bot_form[data-email="1-bot@zulip.com"]';
         casper.test.info('Testing edit bot form values');
 
     //     casper.test.assertEqual(
-    //         common.get_form_field_value(form_sel + ' [name=bot_name]'),
+    //         common.get_form_field_value(bot_sel + ' [name=bot_name]'),
     //         'Bot 1'
     //     );
     //     casper.test.assertEqual(
-    //         common.get_form_field_value(form_sel + ' [name=bot_default_sending_stream]'),
+    //         common.get_form_field_value(bot_sel + ' [name=bot_default_sending_stream]'),
     //         'Denmark'
     //     );
     //     casper.test.assertEqual(
-    //         common.get_form_field_value(form_sel + ' [name=bot_default_events_register_stream]'),
+    //         common.get_form_field_value(bot_sel + ' [name=bot_default_events_register_stream]'),
     //         'Rome'
     //     );
         casper.test.assertEqual(
-            common.get_form_field_value(form_sel + ' [name=bot_name]'),
+            common.get_form_field_value(bot_sel + ' [name=bot_name]'),
             'Bot 1'
         );
     });

--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -213,10 +213,10 @@ casper.waitUntilVisible('div#admin-filter-pattern-status', function () {
 
 function get_suggestions(str) {
     casper.then(function () {
-        casper.evaluate(function (str) {
+        casper.evaluate(function (test_str) {
             $('.create_default_stream')
             .focus()
-            .val(str)
+            .val(test_str)
             .trigger($.Event('keyup', { which: 0 }));
         }, str);
     });
@@ -224,10 +224,10 @@ function get_suggestions(str) {
 
 function select_from_suggestions(item) {
     casper.then(function () {
-        casper.evaluate(function (item) {
+        casper.evaluate(function (test_item) {
             var tah = $('.create_default_stream').data().typeahead;
             tah.mouseenter({
-                currentTarget: $('.typeahead:visible li:contains("'+item+'")')[0]
+                currentTarget: $('.typeahead:visible li:contains("'+test_item+'")')[0]
             });
             tah.select();
         }, {item: item});
@@ -313,9 +313,9 @@ casper.then(function () {
 var edited_value = 'admin tests: test edit';
 
 casper.waitForSelector(".message_edit_content", function () {
-    casper.evaluate(function (edited_value) {
+    casper.evaluate(function (test_edited_value) {
         var msg = $('#zhome .message_row:last');
-        msg.find('.message_edit_content').val(edited_value);
+        msg.find('.message_edit_content').val(test_edited_value);
         msg.find('.message_edit_save').click();
     }, edited_value);
 });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -411,9 +411,9 @@ var run = (function () {
 
         var clobber_callbacks = [];
 
-        var override = function (module, func_name, f) {
+        var override = function (module, func_name, func) {
             var impl = {};
-            impl[func_name] = f;
+            impl[func_name] = func;
             set_global(module, impl);
 
             clobber_callbacks.push(function () {
@@ -426,8 +426,8 @@ var run = (function () {
 
         f(override, capture, args);
 
-        _.each(clobber_callbacks, function (f) {
-            f();
+        _.each(clobber_callbacks, function (func) {
+            func();
         });
     };
 

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -821,13 +821,13 @@ function render(template_name, args) {
         'tutorial_title',
     ];
     var html = '';
-    _.each(tutorials, function (tutorial) {
+    _.each(tutorials, function (test_tutorial) {
         var args = {
             placement: 'left',
             title: 'Title',
         };
-        html = render(tutorial, args);
-        global.write_handlebars_output(tutorial, html);
+        html = render(test_tutorial, args);
+        global.write_handlebars_output(test_tutorial, html);
     });
 }());
 

--- a/frontend_tests/zjsunit/output.js
+++ b/frontend_tests/zjsunit/output.js
@@ -5,16 +5,16 @@ var exports = {};
 var fs = require('fs');
 var path = require('path');
 
-function mkdir_p(path) {
+function mkdir_p(test_path) {
     // This works like mkdir -p in Unix.
     try {
-        fs.mkdirSync(path);
+        fs.mkdirSync(test_path);
     } catch (e) {
         if ( e.code !== 'EEXIST' ) {
             throw e;
         }
     }
-    return path;
+    return test_path;
 }
 
 function make_output_dir() {
@@ -70,12 +70,12 @@ exports.start_writing = function () {
 };
 
 
-exports.write_test_output = function (label, output) {
+exports.write_test_output = function (label, test_output) {
     var data = '';
 
     data += '<hr>';
     data += '<h3>' + label + '</h3>';
-    data += output;
+    data += test_output;
     data += '\n';
     fs.appendFileSync(output_fn, data);
 };
@@ -83,7 +83,7 @@ exports.write_test_output = function (label, output) {
 exports.write_handlebars_output = (function () {
     var last_label = '';
 
-    return function (label, output) {
+    return function (label, test_output) {
         if (last_label && (last_label >= label)) {
             // This is kind of an odd requirement, but it allows us
             // to render output on the fly in alphabetical order, and
@@ -109,13 +109,13 @@ exports.write_handlebars_output = (function () {
         data += '<style type="text/css">body {width: 500px; margin: auto; overflow: scroll}</style>\n';
         data += '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
         data += '<b>' + href + '</b><hr />\n';
-        data += output;
+        data += test_output;
         fs.writeFileSync(fn, data);
     };
 }());
 
-exports.append_test_output = function (output) {
-    fs.appendFileSync(output_fn, output);
+exports.append_test_output = function (test_output) {
+    fs.appendFileSync(output_fn, test_output);
 };
 
 

--- a/frontend_tests/zjsunit/render.js
+++ b/frontend_tests/zjsunit/render.js
@@ -96,8 +96,8 @@ exports.template_finder = (function () {
             });
 
     self.get = function (name) {
-        var file = files.find(function (file) {
-            return file.name === name;
+        var file = files.find(function (test_file) {
+            return test_file.name === name;
         });
         assert(file);
 

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -348,8 +348,7 @@ function _setup_page() {
                 }
             },
             success: function () {
-                var row = $(".active_default_stream_row");
-                row.remove();
+                $(".active_default_stream_row").remove();
             }
         });
     });
@@ -699,8 +698,8 @@ function _setup_page() {
         });
     });
 
-    $(".admin_user_table, .admin_bot_table").on("click", ".open-user-form", function (e) {
-        var email = $(e.currentTarget).data("email");
+    $(".admin_user_table, .admin_bot_table").on("click", ".open-user-form", function (click_event) {
+        var email = $(click_event.currentTarget).data("email");
         var user_info = get_user_info(email);
         var user_row = user_info.user_row;
         var form_row = user_info.form_row;

--- a/static/js/alert_words.js
+++ b/static/js/alert_words.js
@@ -27,14 +27,14 @@ exports.process_message = function (message) {
         var regex = new RegExp('(' + before_punctuation + ')' +
                                '(' + clean + ')' +
                                '(' + after_punctuation + ')' , 'ig');
-        message.content = message.content.replace(regex, function (match, before, word,
+        message.content = message.content.replace(regex, function (match, before, new_word,
                                                                    after, offset, content) {
             // Don't munge URL hrefs
             var pre_match = content.substring(0, offset);
             if (find_href_backwards.exec(pre_match) || find_title_backwards.exec(pre_match)) {
-                return before + word + after;
+                return before + new_word + after;
             }
-            return before + "<span class='alert-word'>" + word + "</span>" + after;
+            return before + "<span class='alert-word'>" + new_word + "</span>" + after;
         });
     });
 };

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -60,8 +60,7 @@ function call(args, idempotent) {
             // If idempotent, retry
             blueslip.log("Retrying idempotent" + args);
             setTimeout(function () {
-                var jqXHR = $.ajax(args);
-                add_pending_request(jqXHR);
+                add_pending_request($.ajax(args));
             }, 0);
             return;
         }

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -6,9 +6,9 @@ exports.toggle = (function () {
     var keys = {};
 
     var __toggle = function (opts) {
-        var component = (function render_component(opts) {
+        var component = (function render_component(options) {
             var _component = $("<div class='tab-switcher'></div>");
-            opts.values.forEach(function (value, i) {
+            options.values.forEach(function (value, i) {
                 var tab = $("<div class='ind-tab' data-tab-id='" + i + "'>" + value.label + "</div>");
                 if (i === 0) {
                     tab.addClass("first");

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -170,8 +170,8 @@ function select_on_focus(field_id) {
             return;
         }
         in_handler = true;
-        $("#" + field_id).select().one('mouseup', function (e) {
-            e.preventDefault();
+        $("#" + field_id).select().one('mouseup', function (mouse_event) {
+            mouse_event.preventDefault();
         });
         in_handler = false;
     });

--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -26,10 +26,10 @@ function uncondense_row(row) {
     show_condense_link(row);
 }
 
-exports.uncollapse = function (row) {
+exports.uncollapse = function (current_row) {
     // Uncollapse a message, restoring the condensed message [More] or
     // [Condense] link if necessary.
-    var message = current_msg_list.get(rows.id(row));
+    var message = current_msg_list.get(rows.id(current_row));
     message.collapsed = false;
     message_flags.send_collapsed([message], false);
 
@@ -55,16 +55,16 @@ exports.uncollapse = function (row) {
     };
 
     // We also need to collapse this message in the home view
-    var home_row = home_msg_list.get_row(rows.id(row));
+    var home_row = home_msg_list.get_row(rows.id(current_row));
 
-    process_row(row);
+    process_row(current_row);
     process_row(home_row);
 };
 
-exports.collapse = function (row) {
+exports.collapse = function (current_row) {
     // Collapse a message, hiding the condensed message [More] or
     // [Condense] link if necessary.
-    var message = current_msg_list.get(rows.id(row));
+    var message = current_msg_list.get(rows.id(current_row));
     message.collapsed = true;
     message_flags.send_collapsed([message], true);
 
@@ -74,9 +74,9 @@ exports.collapse = function (row) {
     };
 
     // We also need to collapse this message in the home view
-    var home_row = home_msg_list.get_row(rows.id(row));
+    var home_row = home_msg_list.get_row(rows.id(current_row));
 
-    process_row(row);
+    process_row(current_row);
     process_row(home_row);
 };
 exports.clear_message_content_height_cache = function () {

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -58,8 +58,8 @@ function copy_handler() {
         ranges.push(range);
 
         startc = $(range.startContainer);
-        start_data = find_boundary_tr($(startc.parents('.selectable_row, .message_header')[0]), function (row) {
-            return row.next();
+        start_data = find_boundary_tr($(startc.parents('.selectable_row, .message_header')[0]), function (current_row) {
+            return current_row.next();
         });
         if (start_data === undefined) {
             return;
@@ -77,8 +77,8 @@ function copy_handler() {
         } else {
             initial_end_tr = $(endc.parents('.selectable_row')[0]);
         }
-        end_data = find_boundary_tr(initial_end_tr, function (row) {
-            return row.prev();
+        end_data = find_boundary_tr(initial_end_tr, function (current_row) {
+            return current_row.prev();
         });
         if (end_data === undefined) {
             return;
@@ -133,8 +133,8 @@ function copy_handler() {
     window.setTimeout(function () {
         selection = window.getSelection();
         selection.removeAllRanges();
-        _.each(ranges, function (range) {
-            selection.addRange(range);
+        _.each(ranges, function (selection_range) {
+            selection.addRange(selection_range);
         });
         $('#copytempdiv').remove();
     },0);

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -32,16 +32,16 @@ exports.update_emojis = function update_emojis(realm_emojis) {
     });
     exports.emojis_by_name = {};
     exports.emojis_name_to_css_class = {};
-    _.each(exports.emojis, function (emoji) {
-        exports.emojis_by_name[emoji.emoji_name] = emoji.emoji_url;
-        exports.emojis_name_to_css_class[emoji.emoji_name] = emoji.emoji_name;
-        if (emoji.emoji_name.indexOf("+") >= 0) {
-            exports.emojis_name_to_css_class[emoji.emoji_name] = emoji.emoji_name.replace("+", "");
+    _.each(exports.emojis, function (current_emoji) {
+        exports.emojis_by_name[current_emoji.emoji_name] = current_emoji.emoji_url;
+        exports.emojis_name_to_css_class[current_emoji.emoji_name] = current_emoji.emoji_name;
+        if (current_emoji.emoji_name.indexOf("+") >= 0) {
+            exports.emojis_name_to_css_class[current_emoji.emoji_name] = current_emoji.emoji_name.replace("+", "");
         }
     });
     exports.emojis_by_unicode = {};
-    _.each(default_unicode_emojis, function (emoji) {
-        exports.emojis_by_unicode[emoji.emoji_name] = emoji.emoji_url;
+    _.each(default_unicode_emojis, function (current_emoji) {
+        exports.emojis_by_unicode[current_emoji.emoji_name] = current_emoji.emoji_url;
     });
 };
 

--- a/static/js/fenced_code.js
+++ b/static/js/fenced_code.js
@@ -123,7 +123,7 @@ exports.process_fenced_code = function (content) {
         };
     }
 
-    consume_line = function consume_line(output_lines, line) {
+    consume_line = function (output_lines, line) {
         var match = fence_re.exec(line);
         if (match) {
             var fence = match[1];

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -109,7 +109,7 @@ function message_matches_search_term(message, operator, operand) {
     return true; // unknown operators return true (effectively ignored)
 }
 
-
+// eslint-disable-next-line no-shadow
 function Filter(operators) {
     if (operators === undefined) {
         this._operators = [];
@@ -216,7 +216,7 @@ Filter.parse = function (str) {
     }
     _.each(matches, function (token) {
         var parts;
-        var operator;
+        var op;
         parts = token.split(':');
         if (token[0] === '"' || parts.length === 1) {
             // Looks like a normal search term.
@@ -224,22 +224,22 @@ Filter.parse = function (str) {
         } else {
             // Looks like an operator.
             negated = false;
-            operator = parts.shift();
-            if (operator[0] === '-') {
+            op = parts.shift();
+            if (op[0] === '-') {
                 negated = true;
-                operator = operator.slice(1);
+                op = op.slice(1);
             }
-            operand = decodeOperand(parts.join(':'), operator);
+            operand = decodeOperand(parts.join(':'), op);
 
             // We use Filter.operator_to_prefix() checks if the
             // operator is known.  If it is not known, then we treat
             // it as a search for the given string (which may contain
             // a `:`), not as a search operator.
-            if (Filter.operator_to_prefix(operator, negated) === '') {
-                operator = 'search';
+            if (Filter.operator_to_prefix(op, negated) === '') {
+                op = 'search';
                 operand = token;
             }
-            term = {negated: negated, operator: operator, operand: operand};
+            term = {negated: negated, operator: op, operand: operand};
             operators.push(term);
         }
     });

--- a/static/js/floating_recipient_bar.js
+++ b/static/js/floating_recipient_bar.js
@@ -46,10 +46,10 @@ exports.hide = function () {
 };
 
 exports.update = function () {
-    var floating_recipient_bar = $("#floating_recipient_bar");
-    var floating_recipient_bar_top = floating_recipient_bar.offset().top;
+    var floating_recipient_bar_sel = $("#floating_recipient_bar");
+    var floating_recipient_bar_top = floating_recipient_bar_sel.offset().top;
     var floating_recipient_bar_bottom =
-        floating_recipient_bar_top + floating_recipient_bar.outerHeight();
+        floating_recipient_bar_top + floating_recipient_bar_sel.outerHeight();
 
     // Find the last message where the top of the recipient
     // row is at least partially occluded by our box.

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -112,8 +112,9 @@ exports.save = function (row, from_topic_edited_only) {
         },
         error: function (xhr) {
             if (msg_list === current_msg_list) {
-                var message = channel.xhr_error_message("Error saving edit", xhr);
-                row.find(".edit_error").text(message).show();
+                row.find(".edit_error")
+                    .text(channel.xhr_error_message("Error saving edit", xhr))
+                    .show();
             }
         }
     });

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -274,24 +274,24 @@ exports.update_messages = function update_messages(events) {
             }
 
             _.each(event.message_ids, function (id) {
-                var msg = message_store.get(id);
-                if (msg === undefined) {
+                var message = message_store.get(id);
+                if (message === undefined) {
                     return;
                 }
 
                 // Remove the recent topics entry for the old topics;
                 // must be called before we update msg.subject
-                stream_data.process_message_for_recent_topics(msg, true);
+                stream_data.process_message_for_recent_topics(message, true);
                 // Update the unread counts; again, this must be called
                 // before we update msg.subject
-                unread.update_unread_topics(msg, event);
+                unread.update_unread_topics(message, event);
 
-                msg.subject = event.subject;
-                msg.subject_links = event.subject_links;
-                set_topic_edit_properties(msg);
+                message.subject = event.subject;
+                message.subject_links = event.subject_links;
+                set_topic_edit_properties(message);
                 // Add the recent topics entry for the new topics; must
                 // be called after we update msg.subject
-                stream_data.process_message_for_recent_topics(msg);
+                stream_data.process_message_for_recent_topics(message);
             });
         }
 
@@ -468,8 +468,8 @@ exports.load_old_messages = function load_old_messages(opts) {
         url:      '/json/messages',
         data:     data,
         idempotent: true,
-        success: function (data) {
-            get_old_messages_success(data, opts);
+        success: function (messages) {
+            get_old_messages_success(messages, opts);
         },
         error: function (xhr) {
             if (opts.msg_list.narrowed && opts.msg_list !== current_msg_list) {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -552,8 +552,8 @@ exports.register_click_handlers = function () {
             colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options);
         });
 
-        $('.streams_popover').on('click', '.custom_color', function (e) {
-            update_spectrum($(e.target).closest('.streams_popover'), function (colorpicker) {
+        $('.streams_popover').on('click', '.custom_color', function (click_event) {
+            update_spectrum($(click_event.target).closest('.streams_popover'), function (colorpicker) {
                 colorpicker.spectrum("destroy");
                 colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options_full);
                 // In theory this should clean up the old color picker,
@@ -562,7 +562,7 @@ exports.register_click_handlers = function () {
                 // have been hidden.  We work around this by just manually
                 // fixing it up here.
                 colorpicker.parent().find('.sp-container').removeClass('sp-buttons-disabled');
-                $(e.target).hide();
+                $(click_event.target).hide();
             });
 
             $('.streams_popover').on('click', 'a.sp-cancel', function () {

--- a/static/js/socket.js
+++ b/static/js/socket.js
@@ -9,6 +9,7 @@ var CLOSE_REASONS = {
     unsuspend:    {code: 4005, msg: "Got unsuspend event"}
 };
 
+// eslint-disable-next-line no-shadow
 function Socket(url) {
     this.url = url;
     this._is_open = false;

--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -23,8 +23,8 @@ exports.pick_color = function (used_colors) {
         used_color_hash[color] = true;
     });
 
-    var color = _.find(colors, function (color) {
-        return !_.has(used_color_hash, color);
+    var color = _.find(colors, function (current_color) {
+        return !_.has(used_color_hash, current_color);
     });
 
     if (color) {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -21,10 +21,10 @@ function filter_streams_by_search(streams) {
     });
 
     var filtered_streams = _.filter(streams, function (stream) {
-        return _.any(search_terms, function (search_term) {
+        return _.any(search_terms, function (current_search_term) {
             var lower_stream_name = stream.toLowerCase().split(" ");
             return _.any(lower_stream_name, function (name) {
-                return name.indexOf(search_term) === 0;
+                return name.indexOf(current_search_term) === 0;
             });
         });
     });

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -137,15 +137,15 @@ exports.colorize_tab_bar = function () {
 function build_tab_bar() {
     var tabs = make_tab_data();
 
-    var tab_bar = $("#tab_bar");
-    tab_bar.empty();
+    var tab_bar_sel = $("#tab_bar");
+    tab_bar_sel.empty();
 
     tabs[tabs.length - 1].active = "active";
     var rendered =  templates.render('tab_bar', {tabs: tabs});
 
-    tab_bar.append(rendered);
+    tab_bar_sel.append(rendered);
     exports.colorize_tab_bar();
-    tab_bar.removeClass('notdisplayed');
+    tab_bar_sel.removeClass('notdisplayed');
 }
 
 $(function () {

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -103,8 +103,8 @@ exports.render_date = function (time, time_above) {
 // This isn't expected to be called externally except manually for
 // testing purposes.
 exports.update_timestamps = function () {
-    var time = now();
-    if (time >= next_update) {
+    var current_time = now();
+    if (current_time >= next_update) {
         var to_process = update_list;
         update_list = [];
 
@@ -129,7 +129,7 @@ exports.update_timestamps = function () {
             }
         });
 
-        next_update = set_to_start_of_day(time.clone().addDays(1));
+        next_update = set_to_start_of_day(current_time.clone().addDays(1));
     }
 };
 

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -45,7 +45,8 @@ exports.set_count = function (stream_name, topic, count) {
     }
 };
 
-exports.build_widget = function (parent_elem, stream, active_topic, max_topics) {
+exports.build_widget = function (parent_elem, current_stream,
+                                 current_active_topic, current_max_topics) {
     var self = {};
     self.topic_items = new Dict({fold_case: true});
 
@@ -108,11 +109,11 @@ exports.build_widget = function (parent_elem, stream, active_topic, max_topics) 
     };
 
     self.is_for_stream = function (stream_name) {
-        return stream.toLowerCase() === stream_name.toLowerCase();
+        return current_stream.toLowerCase() === stream_name.toLowerCase();
     };
 
     self.get_stream_name = function () {
-        return stream;
+        return current_stream;
     };
 
     self.get_dom = function () {
@@ -135,19 +136,19 @@ exports.build_widget = function (parent_elem, stream, active_topic, max_topics) 
         update_unread_count(unread_count_elem, count);
     };
 
-    self.activate_topic = function (active_topic) {
-        var li = self.topic_items.get(active_topic);
+    self.activate_topic = function (active_topics) {
+        var li = self.topic_items.get(active_topics);
         if (li) {
             li.addClass('active-sub-filter');
         }
     };
 
-    self.dom = build_list(stream, active_topic, max_topics);
+    self.dom = build_list(current_stream, current_active_topic, current_max_topics);
 
     parent_elem.append(self.dom);
 
-    if (active_topic) {
-        self.activate_topic(active_topic);
+    if (current_active_topic) {
+        self.activate_topic(current_active_topic);
     }
 
 

--- a/static/js/tutorial.js
+++ b/static/js/tutorial.js
@@ -187,9 +187,9 @@ var fake_messages = [
     }
 ];
 
-function send_delayed_stream_message(stream, topic, content, delay) {
+function send_delayed_stream_message(current_stream, topic, content, delay) {
     var data = {type: JSON.stringify('stream'),
-                recipient: JSON.stringify(stream),
+                recipient: JSON.stringify(current_stream),
                 topic: JSON.stringify(topic),
                 content: JSON.stringify(content)};
     setTimeout(function () {

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -129,8 +129,7 @@ exports.update_unread_topics = function (msg, event) {
 
 exports.process_loaded_messages = function (messages) {
     _.each(messages, function (message) {
-        var unread = exports.message_unread(message);
-        if (!unread) {
+        if (!exports.message_unread(message)) {
             return;
         }
 


### PR DESCRIPTION
Clean up Javascript code base to comply with eslint rule `no-shadow`. 

There are 2 instances where I disabled the rule (`static/js/filter.js` and `static/js/socket.js`). The constructor and its parent have the same name so it has nothing to do with shadowing. 