### PR TITLE
Eslint: add rules that do not error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -90,6 +90,28 @@
         "unread_ui": false
     },
     "rules": {
+        "prefer-const": ["error", {
+	    "destructuring": "any",
+            "ignoreReadBeforeAssign": true
+        }],
+	"no-const-assign": "error",
+	"no-new-object": 2,
+	"quote-props": ["error", "as-needed", {
+	    "keywords": false,
+	    "unnecessary": true,
+	    "numbers": false
+	}],
+	"no-array-constructor": "error",
+	"array-callback-return": 1,
+	"template-curly-spacing": "error",
+	"no-useless-escape": 1,
+	"func-style": ["off", "expression"],
+	"wrap-iife": ["error", "outside", { "functionPrototypeMethods": false }],
+	"no-new-func": "error",
+	"space-before-function-paren": 1,
+	"no-param-reassign": 1,
+	"prefer-spread": "error",
+	"arrow-spacing": ["error", { "before": true, "after": true }],
         "no-alert": 2,
         "no-array-constructor": 2,
         "no-caller": 2,


### PR DESCRIPTION
The following rules do not error on our code and are part of the AirBnB style guide. This PR turns them on.
prefer-const, no-const-assign, quote-props, no-new-object, no-array-constructor, template-curly-spacing, func-style, wrap-iife, no-new-func, prefer-spread

The commit also includes rules set to warning for GCI in https://github.com/zulip/zulip/pull/2568, I can split it up if necessary.