### PR TITLE
Switch new-cap eslint rule from warning to custom error and fix violations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -164,7 +164,7 @@
         }],
         "max-params": [0, 3],
         "max-statements": [0, 10],
-        "new-cap": 1,
+        "new-cap": ["error", { "newIsCap": true, "capIsNew": false }],
         "new-parens": 2,
         "one-var": ["error", "never"],
         "quotes": [1, "single"],

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -368,7 +368,7 @@ exports.get_recent_topics = function (stream_name) {
 
 exports.populate_stream_topics_for_tests = function (stream_map) {
     // This is only used by tests.
-    recent_topics = new Dict.from(stream_map, {fold_case: true});
+    recent_topics = Dict.from(stream_map, {fold_case: true});
 };
 
 return exports;


### PR DESCRIPTION
Now `new-cap` rule is set as desired [here](https://github.com/zulip/zulip-gci/blob/master/tasks/eslint.md#rules-that-need-fixing):

```js
"new-cap": ["error", { "newIsCap": true, "capIsNew": false }]
```