### PR TITLE
Switch no-empty eslint rule from warning to error (in .eslintrc)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -124,7 +124,7 @@
         "no-div-regex": 2,
         "no-dupe-keys": 2,
         "no-else-return": 2,
-        "no-empty": 1,
+        "no-empty": 2,
         "no-empty-character-class": 2,
         "no-eq-null": 2,
         "no-eval": 2,

--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -337,4 +337,5 @@ return exports;
 try {
     exports.common = common;
 } catch (e) {
+    // continue regardless of error
 }

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -161,6 +161,7 @@ exports.strcmp = (function () {
         var collator = new Intl.Collator();
         return collator.compare;
     } catch (e) {
+        // continue regardless of error
     }
 
     return function util_strcmp (a, b) {


### PR DESCRIPTION
The two errors that needed to be fixed were in frontend_tests/casper_lib/common.js and static/js/util.js. Their empty block statements were replaced with a block statement with the comment ("// continue regardless of error").