### PR TITLE
Switch yoda eslint rule from warning to error (in .eslintrc)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -209,6 +209,6 @@
         "valid-typeof": ["error", { "requireStringLiterals": true }],
         "wrap-iife": 2,
         "wrap-regex": 0,
-        "yoda": 1
+        "yoda": 2
     }
 }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -377,7 +377,7 @@ function process_hotkey(e) {
 $(document).keydown(function (e) {
     // Restrict to non-alphanumeric keys
     // check if 27 (esc) because it doesn't register under .keypress()
-    if (48 > e.which || 90 < e.which || e.which === 27) {
+    if (e.which < 48 || e.which > 90 || e.which === 27) {
         if (process_hotkey(e)) {
             e.preventDefault();
         }

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -526,7 +526,7 @@ function toggle_filter_displayed(e) {
     if (e.target.id === 'streams_inline_cog') {
         return;
     }
-    if (0 === $('.stream-list-filter.notdisplayed').length) {
+    if ($('.stream-list-filter.notdisplayed').length === 0) {
         exports.clear_and_hide_search();
     } else {
         exports.initiate_search();


### PR DESCRIPTION
The three errors that needed to be fixed were in static/js/hotkey.js and static/js/stream_list.js. The errors were fixed with ```eslint --fix```.