### PR TITLE
eslint: change space-before-function-paren from warning to error and fix violations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -108,7 +108,7 @@
 	"func-style": ["off", "expression"],
 	"wrap-iife": ["error", "outside", { "functionPrototypeMethods": false }],
 	"no-new-func": "error",
-	"space-before-function-paren": 1,
+	"space-before-function-paren": ["error", { "anonymous": "always", "named": "never", "asyncArrow": "always" }],
 	"no-param-reassign": 1,
 	"prefer-spread": "error",
 	"arrow-spacing": ["error", { "before": true, "after": true }],

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -31,7 +31,7 @@ global.people.add({
     full_name: "Deactivated User",
 });
 
-(function test_add_topic () {
+(function test_add_topic() {
     ct.add_topic('Denmark', 'civil fears');
     ct.add_topic('devel', 'fading');
     ct.add_topic('denmark', 'acceptance');
@@ -41,7 +41,7 @@ global.people.add({
     assert.deepEqual(ct.topics_seen_for('Denmark'), ['With Twisted Metal', 'acceptance', 'civil fears']);
 }());
 
-(function test_begins_typeahead () {
+(function test_begins_typeahead() {
     // Stub out split_at_cursor that uses $(':focus')
     ct.split_at_cursor = function (word) { return [word, '']; };
 

--- a/frontend_tests/node_tests/stream_color.js
+++ b/frontend_tests/node_tests/stream_color.js
@@ -2,7 +2,7 @@ global.stub_out_jquery();
 
 var stream_color = require('js/stream_color.js');
 
-(function test_pick_color () {
+(function test_pick_color() {
     var used_colors = ["#76ce90", "#fae589"];
 
     // Colors are assigned randomly, so this test is a little vague and brittle,

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -33,7 +33,7 @@ function render(template_name, args) {
     return global.render_template(template_name, args);
 }
 
-(function test_finding_partials () {
+(function test_finding_partials() {
     var fns = global.find_included_partials('settings_tab');
     assert.deepEqual(fns, [
         'account-settings',
@@ -45,7 +45,7 @@ function render(template_name, args) {
     ]);
 }());
 
-(function test_handlebars_bug () {
+(function test_handlebars_bug() {
     // There was a bug in 1.0.9 where identically structured
     // blocks get confused, so when foo is false, it still
     // renders the foo-is-true block.

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -41,7 +41,7 @@ var _ = global._;
 
     arr = [{x: 10}, {x: 20}, {x:30}];
 
-    function compare (a, b) {
+    function compare(a, b) {
         return a.x < b;
     }
 

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -329,11 +329,11 @@ function actually_update_users_for_search() {
 
 var update_users_for_search = _.throttle(actually_update_users_for_search, 50);
 
-function show_huddles () {
+function show_huddles() {
     $('#group-pm-list').expectOne().show();
 }
 
-function hide_huddles () {
+function hide_huddles() {
     $('#group-pm-list').expectOne().hide();
 }
 
@@ -519,7 +519,7 @@ exports.blur_search = function () {
     $('.user-list-filter').blur();
 };
 
-function maybe_select_person (e) {
+function maybe_select_person(e) {
     if (e.keyCode === 13) {
         // Enter key was pressed
 
@@ -538,7 +538,7 @@ function maybe_select_person (e) {
     }
 }
 
-function focus_user_filter (e) {
+function focus_user_filter(e) {
     e.stopPropagation();
 }
 

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -58,7 +58,7 @@ function failed_changing_name(xhr, error) {
     ui.report_error(i18n.t("Error changing name"), xhr, $("#administration-status"));
 }
 
-function populate_users (realm_people_data) {
+function populate_users(realm_people_data) {
     var users_table = $("#admin_users_table");
     var deactivated_users_table = $("#admin_deactivated_users_table");
     var bots_table = $("#admin_bots_table");

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -3,7 +3,7 @@ var channel = (function () {
 var exports = {};
 var pending_requests = [];
 
-function add_pending_request (jqXHR) {
+function add_pending_request(jqXHR) {
     if (!feature_flags.cleanup_before_reload) { return; }
 
     pending_requests.push(jqXHR);
@@ -13,7 +13,7 @@ function add_pending_request (jqXHR) {
     }
 }
 
-function remove_pending_request (jqXHR) {
+function remove_pending_request(jqXHR) {
     if (!feature_flags.cleanup_before_reload) { return; }
 
     var pending_request_index = _.indexOf(pending_requests, jqXHR);

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -6,7 +6,7 @@ exports.toggle = (function () {
     var keys = {};
 
     var __toggle = function (opts) {
-        var component = (function render_component (opts) {
+        var component = (function render_component(opts) {
             var _component = $("<div class='tab-switcher'></div>");
             opts.values.forEach(function (value, i) {
                 var tab = $("<div class='ind-tab' data-tab-id='" + i + "'>" + value.label + "</div>");

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -130,7 +130,7 @@ function clear_box() {
     $("#send-status").hide(0);
 }
 
-function clear_preview_area () {
+function clear_preview_area() {
     $("#new_message_content").show();
     $("#undo_markdown_preview").hide();
     $("#preview_message_area").hide();
@@ -174,7 +174,7 @@ exports.decorate_stream_bar = function (stream_name) {
         .addClass(stream_color.get_color_class(color));
 };
 
-function update_fade () {
+function update_fade() {
     if (!is_composing_message) {
         return;
     }
@@ -281,7 +281,7 @@ exports.start = function (msg_type, opts) {
     resize.resize_bottom_whitespace();
 };
 
-function abort_xhr () {
+function abort_xhr() {
     $("#compose-send-button").removeAttr("disabled");
     var xhr = $("#compose").data("filedrop_xhr");
     if (xhr !== undefined) {
@@ -655,7 +655,7 @@ exports.respond_to_message = function (opts) {
 exports.test_send_many_messages = function (stream, subject, count) {
     var num_sent = 0;
 
-    function do_send_one () {
+    function do_send_one() {
         var message = {};
         num_sent += 1;
 

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -45,7 +45,7 @@ exports.update_emojis = function update_emojis(realm_emojis) {
     });
 };
 
-exports.initialize = function initialize () {
+exports.initialize = function initialize() {
     // Load the sprite image in the background so that the browser
     // can cache it for later use.
     var sprite = new Image();

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -194,7 +194,7 @@ function get_main_hash(hash) {
     return hash.replace(/^#/, "").split(/\//)[0];
 }
 
-function should_ignore (hash) {
+function should_ignore(hash) {
     // an array of hashes to ignore (eg. ["subscriptions", "settings", "administration"]).
     var ignore_list = [];
     var main_hash = get_main_hash(hash);

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -16,7 +16,7 @@ var editability_types = {
 };
 exports.editability_types = editability_types;
 
-function get_editability (message, edit_limit_seconds_buffer) {
+function get_editability(message, edit_limit_seconds_buffer) {
     edit_limit_seconds_buffer = edit_limit_seconds_buffer || 0;
     if (!(message && message.sent_by_me)) {
         return editability_types.NO;
@@ -150,7 +150,7 @@ function timer_text(seconds_left) {
     return i18n.t("__seconds__ sec to edit", {seconds: seconds.toString()});
 }
 
-function edit_message (row, raw_content) {
+function edit_message(row, raw_content) {
     var content_top = row.find('.message_content')[0]
         .getBoundingClientRect().top;
 

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -215,7 +215,7 @@ exports.MessageList.prototype = {
     // nature of local message IDs in the message list
     _lower_bound: function MessageList__lower_bound(id) {
         var self = this;
-        function less_func (msg, ref_id, a_idx) {
+        function less_func(msg, ref_id, a_idx) {
             if (self._is_localonly_id(msg.id)) {
                 // First non-local message before this one
                 var effective = self._next_nonlocal_message(self._items, a_idx,

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -40,7 +40,7 @@ if (window.webkitNotifications) {
 }
 
 
-function browser_desktop_notifications_on () {
+function browser_desktop_notifications_on() {
     return (notifications_api &&
             // Firefox on Ubuntu claims to do webkitNotifications but its notifications are terrible
             /webkit/i.test(navigator.userAgent) &&
@@ -50,7 +50,7 @@ function browser_desktop_notifications_on () {
         (window.bridge !== undefined);
 }
 
-function cancel_notification_object (notification_object) {
+function cancel_notification_object(notification_object) {
         // We must remove the .onclose so that it does not trigger on .cancel
         notification_object.onclose = function () {};
         notification_object.onclick = function () {};

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -43,7 +43,7 @@ exports.get_li_for_user_ids_string = function (user_ids_string) {
     return convo_li;
 };
 
-function set_pm_conversation_count (conversation, count) {
+function set_pm_conversation_count(conversation, count) {
     var pm_li = pm_list.get_conversation_li(conversation);
     var count_span = pm_li.find('.private_message_count');
     var value_span = count_span.find('.value');

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -228,7 +228,7 @@ exports.initiate = function (options) {
     var compose_done_handler;
     var compose_started_handler;
 
-    function reload_from_idle () {
+    function reload_from_idle() {
         do_reload_app(false,
                       options.save_pointer,
                       options.save_narrow,

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -204,7 +204,7 @@ function get_events_success(events) {
     var messages_to_update = [];
     var new_pointer;
 
-    var clean_event = function clean_event (event) {
+    var clean_event = function clean_event(event) {
         // Only log a whitelist of the event to remove private data
         return _.pick(event, 'id', 'type', 'op');
     };

--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -105,7 +105,7 @@ exports.update_stream_color = function (sub, stream_name, color, opts) {
     tab_bar.colorize_tab_bar();
 };
 
-function picker_do_change_color (color) {
+function picker_do_change_color(color) {
     var stream_id = $(this).attr('stream_id');
     var hex_color = color.toHexString();
     subs.set_color(stream_id, hex_color);

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -500,11 +500,11 @@ exports.clear_and_hide_search = function () {
     filter.addClass('notdisplayed');
 };
 
-function focus_stream_filter (e) {
+function focus_stream_filter(e) {
     e.stopPropagation();
 }
 
-function maybe_select_stream (e) {
+function maybe_select_stream(e) {
     if (e.keyCode === 13) {
         // Enter key was pressed
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -67,7 +67,7 @@ exports.set_all_stream_audible_notifications_to = function (new_setting) {
 
 // Finds the stream name of a jquery object that's inside a
 // .stream-row or .subscription_settings element.
-function get_stream_name (target) {
+function get_stream_name(target) {
     if (target.constructor !== jQuery) {
         target = $(target);
     }
@@ -850,7 +850,7 @@ $(function () {
         selectText(this);
     });
 
-    function sub_or_unsub (stream_name) {
+    function sub_or_unsub(stream_name) {
         var sub = stream_data.get_sub(stream_name);
 
         if (sub.subscribed) {

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -8,7 +8,7 @@ var set_to_start_of_day = function (time) {
     return time.setMilliseconds(0).setSeconds(0).setMinutes(0).setHours(0);
 };
 
-function now () { return new XDate(); }
+function now() { return new XDate(); }
 
 // Given an XDate object 'time', return a two-element list containing
 //   - a string for the current human-formatted version
@@ -56,7 +56,7 @@ $(function () {
 
 // time_above is an optional argument, to support dates that look like:
 // --- ▲ Yesterday ▲ ------ ▼ Today ▼ ---
-function maybe_add_update_list_entry (needs_update, id, time, time_above) {
+function maybe_add_update_list_entry(needs_update, id, time, time_above) {
     if (needs_update) {
         if (time_above !== undefined) {
             update_list.push([id, time, time_above]);

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -227,7 +227,7 @@ exports.mark_all_as_read = function mark_all_as_read(cont) {
 };
 
 // Takes a list of messages and marks them as read
-exports.mark_messages_as_read = function mark_messages_as_read (messages, options) {
+exports.mark_messages_as_read = function mark_messages_as_read(messages, options) {
     options = options || {};
     var processed = false;
 

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -164,7 +164,7 @@ exports.strcmp = (function () {
         // continue regardless of error
     }
 
-    return function util_strcmp (a, b) {
+    return function util_strcmp(a, b) {
         return (a < b ? -1 : (a > b ? 1 : 0));
     };
 }());

--- a/static/js/viewport.js
+++ b/static/js/viewport.js
@@ -193,7 +193,7 @@ exports.visible_messages = function (require_fully_visible) {
     return _visible_divs(selected_row, 25, row_to_id, "message_row", require_fully_visible);
 };
 
-exports.scrollTop = function viewport_scrollTop (target_scrollTop) {
+exports.scrollTop = function viewport_scrollTop(target_scrollTop) {
     var orig_scrollTop = exports.message_pane.scrollTop();
     if (target_scrollTop === undefined) {
         return orig_scrollTop;


### PR DESCRIPTION
There were 38 errors in static/js and frontend_tests. 24 of them were fixed with ```eslint --fix```, the others returned warnings.