### PR TITLE
Eslint: add rules for GCI and turn on rules that do not error on our codebase

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -90,6 +90,24 @@
         "unread_ui": false
     },
     "rules": {
+	"no-restricted-syntax": 1,
+	"no-nested-ternary": 1,
+	"spaced-comment": 1,
+	"space-infix-ops": 1,
+	"newline-per-chained-call": 1,
+	"no-whitespace-before-property": 1,
+	"padded-blocks": 1,
+	"space-in-parens": 1,
+	"eol-last": ["error", "always"],
+	"no-unneeded-ternary": ["error", { "defaultAssignment": false }],
+	"no-case-declarations": "error",
+	"eqeqeq": ["error", "allow-null"],
+	"no-duplicate-imports": "error",
+	"no-undef": "error",
+	"dot-notation": ["error", { "allowKeywords": true }],
+	"no-iterator": "error",
+	"no-dupe-class-members": "error",
+        "no-useless-constructor": "error",
         "prefer-const": ["error", {
 	    "destructuring": "any",
             "ignoreReadBeforeAssign": true
@@ -174,7 +192,6 @@
         "complexity": [0, 4],
         "curly": 2,
         "dot-notation": 2,
-        "eqeqeq": 2,
         "guard-for-in": 2,
         "max-depth": [0, 4],
         "max-len": ["error", 100, 2, {

--- a/frontend_tests/.eslintrc.json
+++ b/frontend_tests/.eslintrc.json
@@ -11,6 +11,6 @@
 	"window": false
     },
     "rules": {
-	"no-sync": 1
+	"no-sync": 0
     }
 }


### PR DESCRIPTION
This commit adds rules for GCI, turns on rules that do not error
on our codebase, and changes frontend_tests/.eslintrc.json's no-sync
rule to off (as per AirBnB's style guide).

Rules for GCI:
no-restricted-syntax, no-nested-ternary, spaced-comment,
space-infix-ops, newline-per-chained-call, padded-blocks,
no-whitespace-before-property, space-in-parens

Rules that do not error:
no-useless-constructor, no-dupe-class-members, no-duplicate-imports,
no-iterator, no-undef, dot-notation, no-case-declarations, no-unneeded-ternary,
eol-last,

Finally, eqeqeq is changed from 2 to ['error', 'allow-null'], going
from jslint defaults to airbnb's recommendation (there were no errors)