### PR TITLE
bug fix: Handle empty at-mentions gracefully.

### DIFF
--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -165,6 +165,8 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
      expected: '<blockquote>\n<p>quote this for me</p>\n</blockquote>\n<p>thanks</p>'},
     {input: 'This is a @**Cordelia Lear** mention',
      expected: '<p>This is a <span class="user-mention" data-user-email="cordelia@zulip.com">@Cordelia Lear</span> mention</p>'},
+    {input: 'These @ @**** are not mentions',
+     expected: '<p>These @ @<em>**</em> are not mentions</p>'},
     {input: 'This is a #**Denmark** stream link',
      expected: '<p>This is a <a class="stream" data-stream-id="1" href="http://zulip.zulipdev.com/#narrow/stream/Denmark">#Denmark</a> stream link</p>'},
     {input: 'This is #**Denmark** and #**social** stream links',

--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -537,7 +537,7 @@ inline.breaks = merge({}, inline.gfm, {
 inline.zulip = merge({}, inline.breaks, {
   emoji: /^:([A-Za-z0-9_\-\+]+?):/,
   unicodeemoji: /^(\ud83c[\udf00-\udfff]|\ud83d[\udc00-\ude4f]|\ud83d[\ude80-\udeff]|[\u2600-\u26FF]|[\u2700-\u27BF])/,
-  usermention: /^(@(?:\*\*([^\*]+)?\*\*|(\w+)?))/m, // Match multi-word string between @** ** or match any one-word
+  usermention: /^(@(?:\*\*([^\*]+)\*\*|(\w+)))/m, // Match multi-word string between @** ** or match any one-word
   stream: /^#\*\*([^\*]+)\*\*/m,
   avatar: /^!avatar\(([^)]+)\)/,
   gravatar: /^!gravatar\(([^)]+)\)/,


### PR DESCRIPTION
An exception in the webapp was trown when an empty mention was sent.
Examples of problematic messages are "@" or "@****".

In order to fix this, the regex that identifies mentions has been modified, so it now requires the mention to have a "content" (by replacing the ? quantifier by +).