### PR TITLE
Add new button to download ~/.zuliprc from settings page.

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -5,6 +5,7 @@ var REALMS_HAVE_SUBDOMAINS = casper.cli.get('subdomains');
 common.start_and_log_in();
 
 var form_sel = 'form[action^="/json/settings/change"]';
+var regex_zuliprc = /^data:application\/octet-stream;charset=utf-8,\[api\]\nemail=.+\nkey=.+\nsite=.+\n$/;
 
 casper.then(function () {
     var menu_selector = '#settings-dropdown';
@@ -82,6 +83,21 @@ casper.then(function () {
 });
 
 casper.then(function () {
+    casper.waitUntilVisible('#show_api_key_box', function () {
+        casper.test.assertExists('#download_zuliprc', '~/.zuliprc button exists');
+        casper.click('#download_zuliprc');
+
+        casper.waitUntilVisible('#download_zuliprc[href^="data:application"]', function () {
+            casper.test.assertMatch(
+                decodeURIComponent(casper.getElementsAttribute('#download_zuliprc', 'href')),
+                regex_zuliprc,
+                'Looks like a zuliprc file'
+            );
+        });
+    });
+});
+
+casper.then(function () {
     casper.waitUntilVisible('#settings-status', function () {
         casper.test.assertSelectorHasText('#settings-status', 'Updated settings!');
     });
@@ -99,6 +115,22 @@ casper.then(function create_bot() {
 
     casper.test.info('Submiting the create bot form');
     casper.click('#create_bot_button');
+});
+
+casper.then(function () {
+    var button_sel = '.download_bot_zuliprc[data-email="1-bot@zulip.com"]';
+
+    casper.waitUntilVisible(button_sel, function () {
+        casper.click(button_sel);
+
+        casper.waitUntilVisible(button_sel + '[href^="data:application"]', function () {
+            casper.test.assertMatch(
+                decodeURIComponent(casper.getElementsAttribute(button_sel, 'href')),
+                regex_zuliprc,
+                'Looks like a bot ~/.zuliprc file'
+            );
+        });
+    });
 });
 
 casper.then(function () {

--- a/frontend_tests/node_tests/settings.js
+++ b/frontend_tests/node_tests/settings.js
@@ -1,0 +1,37 @@
+var jsdom = require("jsdom");
+var window = jsdom.jsdom().defaultView;
+global.$ = require("jquery")(window);
+
+set_global("page_params", {
+    realm_uri: "https://chat.example.com",
+});
+
+var settings = require("js/settings.js");
+
+(function test_generate_zuliprc_uri() {
+    var bot = {
+        email: "error-bot@zulip.org",
+        api_key: "QadL788EkiottHmukyhHgePUFHREiu8b",
+    };
+    var uri = settings.generate_zuliprc_uri(bot.email, bot.api_key);
+    var expected = "data:application/octet-stream;charset=utf-8," + encodeURIComponent(
+        "[api]\nemail=error-bot@zulip.org\n" +
+        "key=QadL788EkiottHmukyhHgePUFHREiu8b\n" +
+        "site=https://chat.example.com\n"
+    );
+
+    assert.equal(uri, expected);
+}());
+
+(function test_generate_zuliprc_content() {
+    var user = {
+        email: "admin12@chatting.net",
+        api_key: "nSlA0mUm7G42LP85lMv7syqFTzDE2q34"
+    };
+    var content = settings.generate_zuliprc_content(user.email, user.api_key);
+    var expected = "[api]\nemail=admin12@chatting.net\n" +
+                   "key=nSlA0mUm7G42LP85lMv7syqFTzDE2q34\n" +
+                   "site=https://chat.example.com\n";
+
+    assert.equal(content, expected);
+}());

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -23,6 +23,9 @@
            <button type="submit" class="btn btn-primary open_edit_bot_form" title="{{t 'Edit bot' }}" data-email="{{email}}">
             <i class="icon-vector-pencil"></i>
            </button>
+           <a type="submit" download="{{zuliprc}}" class="btn btn-success download_bot_zuliprc" title="{{t 'Download .zuliprc' }}" data-email="{{email}}">
+               <i class="icon-vector-download-alt"></i>
+           </a>
            <button type="submit" class="btn btn-danger delete_bot" title="{{t 'Delete bot' }}" data-email="{{email}}">
             <i class="icon-vector-trash"></i>
            </button>

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -95,6 +95,9 @@
       <button type="submit" class="btn btn-primary regenerate_api_key">
         {{t "Generate new API Key" }}
       </button>
+      <a id="download_zuliprc" download="{{zuliprc}}" class="btn btn-success">
+          {{t "Download .zuliprc" }}
+      </a>
       <div id="user_api_key_error text-error">
       </div>
     </div>


### PR DESCRIPTION
Added new option to download `.zuliprc` file directly from settings page, this should help reduce friction when setting up bots/integration. This new feature is available in the bot cards and the `show your API key
section`. One caveat is that the filename is automatically set to `zuliprc` instead of `.zuliprc` as most browsers do not allow filenames to start with a dot.
Fixes: #2327