### PR TITLE
Fix problem with too long stream error formatting.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -237,6 +237,10 @@ ul.filters li.out_of_home_view li.muted_topic {
     padding-left: 33px;
 }
 
+#stream_filters .subscription_block .stream-name{
+   overflow-wrap: break-word;
+}
+
 #stream_filters .subscription_block.stream-with-count {
     margin-right: 38px;
 }

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -237,7 +237,7 @@ ul.filters li.out_of_home_view li.muted_topic {
     padding-left: 33px;
 }
 
-#stream_filters .subscription_block .stream-name{
+#stream_filters .subscription_block .stream-name {
    overflow-wrap: break-word;
 }
 

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -36,6 +36,10 @@
     padding-left: 15px;
 }
 
+.subscriptions div #response {
+    overflow-wrap: break-word;
+}
+
 #subscriptions_table .subscription_block {
     padding-left: 0.5em;
     vertical-align: middle;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2429,6 +2429,11 @@ button.topic_edit_cancel {
     font-weight: 300;
 }
 
+#administration #deactivation_stream_modal h3 {
+    overflow-wrap: break-word;
+}
+
+
 #administration .administration-icon,
 #settings .settings-icon {
     margin-right: 10px;


### PR DESCRIPTION
Add `overflow-wrap` rule for long stream names

Linked to #2596 
Screenshots attached in issue.