### PR TITLE
eslint: advance in complying with the rule no-useless-escape

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -122,6 +122,8 @@
         "no-array-constructor": "error",
         "array-callback-return": "error",
         "template-curly-spacing": "error",
+        //The Zulip codebase complies partially with the "no-useless-escape" rule; only regex expressions haven't been updated yet.
+        //Updated regex expressions are currently being tested in casper files and will decide about a potential future enforcement of this rule.
         "no-useless-escape": 1,
         "func-style": ["off", "expression"],
         "wrap-iife": ["error", "outside", { "functionPrototypeMethods": false }],

--- a/frontend_tests/casper_tests/00-realm-creation.js
+++ b/frontend_tests/casper_tests/00-realm-creation.js
@@ -26,7 +26,7 @@ casper.then(function () {
     });
     // Make sure confirmation email is send
     this.waitWhileSelector('form[action^="/create_realm/"]', function () {
-         var regex = new RegExp('^http:\/\/[^\/]+\/accounts\/send_confirm\/' + email);
+         var regex = new RegExp('^http://[^/]+/accounts/send_confirm/' + email);
          this.test.assertUrlMatch(regex, 'Confirmation mail send');
     });
 });

--- a/frontend_tests/casper_tests/01-login.js
+++ b/frontend_tests/casper_tests/01-login.js
@@ -12,7 +12,7 @@ common.init_viewport();
 casper.start(realm_url, common.initialize_casper);
 
 casper.then(function () {
-    casper.test.assertUrlMatch(/^http:\/\/[^\/]+\/login/, 'Redirected to /login');
+    casper.test.assertUrlMatch(/^http:\/\/[^/]+\/login/, 'Redirected to /login');
 });
 
 common.then_log_in();

--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -205,7 +205,7 @@ function search_non_existing_user(str, item) {
 casper.then(function () {
     common.wait_for_receive(function () {
         casper.test.info('Narrowing by clicking stream');
-        casper.click('*[title="Narrow to stream \\\"Verona\\\""]');
+        casper.click('*[title="Narrow to stream \\"Verona\\""]');
     });
 });
 
@@ -219,7 +219,7 @@ expect_home();
 
 casper.then(function () {
     casper.test.info('Narrowing by clicking subject');
-    casper.click('*[title="Narrow to stream \\\"Verona\\\", topic \\\"frontend test\\\""]');
+    casper.click('*[title="Narrow to stream \\"Verona\\", topic \\"frontend test\\""]');
 });
 
 expect_stream_subject();

--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -12,7 +12,7 @@ casper.then(function () {
         casper.then(function () {
             casper.click('a[href^="#subscriptions"]');
             casper.test.assertUrlMatch(
-                /^http:\/\/[^\/]+\/#subscriptions/,
+                /^http:\/\/[^/]+\/#subscriptions/,
                 'URL suggests we are on subscriptions page');
             casper.test.assertExists('#subscriptions.tab-pane.active', 'Subscriptions page is active');
         });

--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -22,7 +22,7 @@ casper.then(function () {
 
 casper.then(function () {
     casper.waitUntilVisible("#settings-change-box", function () {
-        casper.test.assertUrlMatch(/^http:\/\/[^\/]+\/#settings/, 'URL suggests we are on settings page');
+        casper.test.assertUrlMatch(/^http:\/\/[^/]+\/#settings/, 'URL suggests we are on settings page');
         casper.test.assertExists('#settings.tab-pane.active', 'Settings page is active');
 
         casper.test.assertNotVisible("#pw_change_controls");

--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -17,7 +17,7 @@ casper.then(function () {
 
 casper.waitForSelector('#administration.tab-pane.active', function () {
     casper.test.info('Administration page is active');
-    casper.test.assertUrlMatch(/^http:\/\/[^\/]+\/#administration/, 'URL suggests we are on administration page');
+    casper.test.assertUrlMatch(/^http:\/\/[^/]+\/#administration/, 'URL suggests we are on administration page');
 });
 
 // Test only admins may create streams Setting
@@ -462,7 +462,7 @@ casper.waitForSelector('input[type="checkbox"][id="id_realm_allow_message_editin
 casper.then(function () {
     casper.test.info('Administration page');
     casper.click('a[href^="#administration"]');
-    casper.test.assertUrlMatch(/^http:\/\/[^\/]+\/#administration/, 'URL suggests we are on administration page');
+    casper.test.assertUrlMatch(/^http:\/\/[^/]+\/#administration/, 'URL suggests we are on administration page');
     casper.test.assertExists('#administration.tab-pane.active', 'Administration page is active');
 });
 

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -172,7 +172,7 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
     {input: 'And this is a #**wrong** stream link',
      expected: '<p>And this is a #**wrong** stream link</p>'},
     {input: 'mmm...:burrito:s',
-     expected: '<p>mmm...<img alt=\":burrito:\" class=\"emoji\" src=\"/static/third/gemoji/images/emoji/burrito.png\" title=\":burrito:\">s</p>'},
+     expected: '<p>mmm...<img alt=":burrito:" class="emoji" src="/static/third/gemoji/images/emoji/burrito.png" title=":burrito:">s</p>'},
     {input: 'This is an :poop: message',
      expected: '<p>This is an <img alt=":poop:" class="emoji" src="/static/third/gemoji/images/emoji/poop.png" title=":poop:"> message</p>'},
     {input: "\ud83d\udca9",


### PR DESCRIPTION
This commit does not entirely make the zulip codebase comply with the "no-useless-escape" rule, but makes some progress towards this goal. By removing detected "unnessecary" escape sequences from casper regex expressions, we will be able to observe their impact and decide about a complete compliance of critical regex expressions.