### PR TITLE
Fixes: Show markdown help in message editing UI

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2368,6 +2368,7 @@ button.topic_edit_cancel {
 #message_edit_form .edit-controls {
     margin-left: 35px; /* Match .message_content padding less 7px textarea padding and border */
     margin-right: -7px;
+    margin-top: 10px;
 }
 #message_edit_form textarea {
     width: 100%;
@@ -2378,6 +2379,19 @@ button.topic_edit_cancel {
 }
 #message_edit_form .control-group.no-margin {
     margin-bottom: 0px;
+}
+
+#message_edit_form a.message-control-button {
+    display: inline;
+    color: #777;
+    text-decoration: none;
+    font-size: 12px;
+    width: 12px;
+    height: 14px;
+    text-align: center;
+    float: right;
+    padding-left: 5px;
+    padding-top: 3px;
 }
 
 #topic_edit_form {

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -14,8 +14,7 @@
         </div>
     </div>
 {{/if}}
-
-    <div class="control-group">
+    <div class="control-group no-margin">
         <div class="controls edit-controls">
             <textarea class="message_edit_content" id="message_edit_content">{{content}}</textarea>
         </div>
@@ -31,6 +30,9 @@
             {{#if has_been_editable}}
             <div class="message-edit-timer-control-group">
                 <span class="message_edit_countdown_timer"></span>
+                <div class="message-edit-timer-control-group">
+                <a class="message-control-button icon-vector-font" href="#markdown-help" title="Formatting" data-toggle="modal" ></a>
+                </div>
                 <span><i id="message_edit_tooltip" class="message_edit_tooltip icon-vector-question-sign" data-toggle="tooltip"
                          title="This organization is configured to restrict editing of message content to {{minutes_to_edit}} minutes after it is sent."></i>
                 </span>


### PR DESCRIPTION
Adds markdown help button under the message edit textarea #2578 