### PR TITLE
Reduce mailing list links in README for GSoC funnelling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,19 @@ help in real time, you will have the best luck finding core developers
 roughly between 16:00 UTC and 23:59 UTC.  Most questions get a reply
 within minutes to a few hours, depending on time of day.
 
-We have a
-[Google mailing list](https://groups.google.com/forum/#!forum/zulip-devel)
-that is currently pretty low traffic because a lot of discussions
-happen in our public Zulip instance.  We use it to announce Zulip
-developer community gatherings and ask for feedback on technical or
-design decisions.  You can use it to ask questions about features or
-possible bugs.  Zulip also has a [blog](https://blog.zulip.org/).
+For Google Summer of Code students and applicants, we have [a mailing
+list](https://groups.google.com/forum/#!forum/zulip-gsoc) for help,
+questions, and announcements.
+
+We have [a Google mailing
+list](https://groups.google.com/forum/#!forum/zulip-devel) that is
+currently pretty low traffic because a lot of discussions happen in
+our public Zulip instance.  We use it to announce Zulip developer
+community gatherings and ask for feedback on technical or design
+decisions.  You can use it to ask questions about features or possible
+bugs, but not to ask about Google Summer of Code.
+
+Zulip also has a [blog](https://blog.zulip.org/).
 
 Last but not least, we use [GitHub](https://github.com/zulip/zulip) to
 track Zulip-related issues (and store our code, of course).
@@ -85,7 +91,7 @@ and [new feature tutorial][doc-newfeat]. You can also improve
 [Zulip.org][z-org].
 
 * **Mailing lists and bug tracker**. Zulip has a [development
-discussion mailing list][gg-devel] and uses [GitHub issues
+discussion mailing list](#community) and uses [GitHub issues
 ][gh-issues].  There are also lists for the [Android][email-android]
 and [iOS][email-ios] apps.  Feel free to send any questions or
 suggestions of areas where you'd love to see more documentation to the
@@ -118,7 +124,6 @@ contributing!
 [doc-newfeat]: http://zulip.readthedocs.io/en/latest/new-feature-tutorial.html
 [doc-test]: http://zulip.readthedocs.io/en/latest/testing.html
 [electron]: https://github.com/zulip/zulip-electron
-[gg-devel]: https://groups.google.com/forum/#!forum/zulip-devel
 [gh-issues]: https://github.com/zulip/zulip/issues
 [desktop]: https://github.com/zulip/zulip-desktop
 [android]: https://github.com/zulip/zulip-android
@@ -150,7 +155,7 @@ and feel free to email
 ## How to get involved with contributing to Zulip
 
 First, subscribe to the Zulip [development discussion mailing
-list][gg-devel].
+list](#community).
 
 The Zulip project uses a system of labels in our [issue
 tracker][gh-issues] to make it easy to find a project if you don't


### PR DESCRIPTION
The zulip-devel mailing list is receiving enough low-quality interest emails from people interested in GSoC that we are reducing the number of links to the list in the README, and adding more wording to funnel GSoC applicants to the appropriate venues.

Let me know whether the new anchor links work for you. I think the only reason they get tetchy in my browser when I'm viewing them on GitHub is because I'm in a branch, but I could be wrong.