### PR TITLE
admin: limit bots in settings page.

### DIFF
--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -72,32 +72,6 @@ assert.equal(bot_data.get('bot0@zulip.com').full_name, 'Bot 0');
         assert.equal(undefined, bot);
     }());
 
-    (function test_owner_can_admin() {
-        var bot;
-
-        bot_data.add(_.extend({owner: 'owner@zulip.com'}, test_bot));
-
-        bot = bot_data.get('bot1@zulip.com');
-        assert(bot.can_admin);
-
-        bot_data.add(_.extend({owner: 'notowner@zulip.com'}, test_bot));
-
-        bot = bot_data.get('bot1@zulip.com');
-        assert.equal(false, bot.can_admin);
-    }());
-
-    (function test_admin_can_admin() {
-        var bot;
-        page_params.is_admin = true;
-
-        bot_data.add(test_bot);
-
-        bot = bot_data.get('bot1@zulip.com');
-        assert(bot.can_admin);
-
-        page_params.is_admin = false;
-    }());
-
     (function test_get_editable() {
         var can_admin;
 

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -10,20 +10,9 @@ var bot_data = (function () {
         $(document).trigger('zulip.bot_data_changed');
     }, 50);
 
-    var set_can_admin = function bot_data__set_can_admin(bot) {
-        if (page_params.is_admin) {
-            bot.can_admin = true;
-        } else if (bot.owner !== undefined && util.is_current_user(bot.owner)) {
-            bot.can_admin = true;
-        } else {
-            bot.can_admin = false;
-        }
-    };
-
     exports.add = function bot_data__add(bot) {
         var clean_bot = _.pick(bot, bot_fields);
         bots[bot.email] = clean_bot;
-        set_can_admin(clean_bot);
         send_change_event();
     };
 
@@ -35,7 +24,6 @@ var bot_data = (function () {
     exports.update = function bot_data__update(email, bot_update) {
         var bot = bots[email];
         _.extend(bot, _.pick(bot_update, bot_fields));
-        set_can_admin(bot);
         send_change_event();
     };
 


### PR DESCRIPTION
Only show bots created by the admin in the settings page. Modification to user's bots is still possible in the Administration console.
This closes #2657.