### PR TITLE
(wip) API: Expose `mentions` in message and add `get_user_profile`

### DIFF
--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1729,6 +1729,23 @@ class GetProfileTest(ZulipTestCase):
         self.assert_length(cache_queries, 1)
         self.assertEqual(user_profile.email, 'hamlet@zulip.com')
 
+    def test_get_user_profile(self):
+        # type: () -> None
+        self.login('hamlet@zulip.com')
+        result = ujson.loads(self.client_get('/json/users/me').content)
+        self.assertEqual(result['short_name'], 'hamlet')
+        self.assertEqual(result['email'], 'hamlet@zulip.com')
+        self.assertEqual(result['full_name'], 'King Hamlet')
+        self.assertFalse(result['is_bot'])
+        self.assertFalse(result['is_admin'])
+        self.login('iago@zulip.com')
+        result = ujson.loads(self.client_get('/json/users/me').content)
+        self.assertEqual(result['short_name'], 'iago')
+        self.assertEqual(result['email'], 'iago@zulip.com')
+        self.assertEqual(result['full_name'], 'Iago')
+        self.assertFalse(result['is_bot'])
+        self.assertTrue(result['is_admin'])
+
     def test_api_get_empty_profile(self):
         # type: () -> None
         """

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -746,6 +746,8 @@ def process_message_event(event_template, users):
             message_dict = message_dict.copy()
             message_dict["invite_only_stream"] = True
 
+        if flags is not None:
+            message_dict['is_mentioned'] = 'mentioned' in flags
         user_event = dict(type='message', message=message_dict, flags=flags) # type: Dict[str, Any]
         if extra_data is not None:
             user_event.update(extra_data)

--- a/zerver/views/pointer.py
+++ b/zerver/views/pointer.py
@@ -45,7 +45,12 @@ def get_profile_backend(request, user_profile):
     # type: (HttpRequest, UserProfile) -> HttpResponse
     result = dict(pointer        = user_profile.pointer,
                   client_id      = generate_client_id(),
-                  max_message_id = -1)
+                  max_message_id = -1,
+                  full_name      = user_profile.full_name,
+                  email          = user_profile.email,
+                  is_bot         = user_profile.is_bot,
+                  is_admin       = user_profile.is_realm_admin,
+                  short_name     = user_profile.short_name)
 
     messages = Message.objects.filter(usermessage__user_profile=user_profile).order_by('-id')[:1]
     if messages:


### PR DESCRIPTION
- Expose `mentions` list in message which contain `full_name` of
those are mentioned in message content.

- Add `get_user_profile` into Client API which exposes user
information like `full_name`, `email`, `is_bot`, `date_joined`
and `short_name` of our user.

Fixes #2667.