### PR TITLE
Fix Hiding Stream Creation Prompt on "Enter".

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -859,7 +859,10 @@ $(function () {
 
     $(".subscriptions").on("click", "[data-dismiss]", function (e) {
         e.preventDefault();
-        show_subs_pane.nothing_selected();
+        // we want to make sure that the click is not just a simulated click.
+        if (e.clientY !== 0) {
+            show_subs_pane.nothing_selected();
+        }
     });
 
     // 'Check all' and 'Uncheck all' links


### PR DESCRIPTION
The stream creation prompt would be hidden if someone clicked “Enter”
and the form failed. This is presumably due to some bootstrap magic.