### PR TITLE
Margin Fixes for Subscriptions Overlay.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -412,7 +412,11 @@ form#add_new_subscription {
     vertical-align: top;
     width: 50%;
     height: calc(100% - 45px);
-    margin: 0px -1px;
+    margin: 0px -2px;
+}
+
+.subscriptions-container .right {
+    width: calc(50% + 1px);
 }
 
 .subscriptions-container .right .nothing-selected {
@@ -764,7 +768,7 @@ form#add_new_subscription {
     }
 
     #subscription_overlay .right {
-        width: 60%;
+        width: calc(60% - 1px);
     }
 
     #search_stream_name {


### PR DESCRIPTION
There is a case with browser soom that the inline-block split view breaks down and the two 50% tabs fall below each other. This prevents that issue from happening.