### PR TITLE
Blur Active Element

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -128,6 +128,11 @@ $(function () {
         e.stopPropagation();
         popovers.hide_all();
     });
+    $("body").on("click", "a", function (e) {
+        if (document.activeElement === this) {
+            ui.blur_active_element();
+        }
+    });
 
     $(window).on("focus", function (e) {
         meta.focusing = true;

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -248,6 +248,7 @@ exports.initialize = function () {
 
 exports.exit_settings = function (callback) {
     if (should_ignore(window.location.hash)) {
+        ui.blur_active_element();
         ignore.flag = true;
         window.location.hash = ignore.prev || "#";
         if (typeof callback === "function") {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -35,6 +35,11 @@ exports.focus_on = function (field_id) {
     $("#" + field_id).focus();
 };
 
+exports.blur_active_element = function () {
+    // this blurs anything that may perhaps be actively focused on.
+    document.activeElement.blur();
+};
+
 function amount_to_paginate() {
     // Some day we might have separate versions of this function
     // for Page Up vs. Page Down, but for now it's the same


### PR DESCRIPTION
When closing a modal or clicking a link, blur the activeElement so the browser retains no state of focus.