### PR TITLE
[WIP] messages: Add a prompt for muted streams and topics.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -8,6 +8,8 @@ add_dependencies({
     templates: 'js/templates',
     emoji: 'js/emoji',
     i18n: 'i18next',
+    subs: 'js/subs',
+    muting: 'js/muting',
 });
 
 var i18n = global.i18n;
@@ -332,6 +334,30 @@ function render(template_name, args) {
     assert.equal(button.text(), "YES");
     var error_msg = $(html).find('span.compose-all-everyone-msg').text().trim();
     assert.equal(error_msg, "Are you sure you want to mention all 101 people in this stream?");
+}());
+
+(function compose_muted_context() {
+    // muted stream
+    var unmute_context = [ "stream", "all" ];
+    subs.toggle_home(unmute_context[1]);
+    var html = render('compose_muted_context', unmute_context[0]);
+    global.write_handlebars_output("compose_all_everyone", html);
+    var button_yes = $(html).find("button:first");
+    assert.equal(button_yes.text(), "YES");
+    var button_no = $(html).find("button:second");
+    assert.equal(button_no.text(), "NO");
+    var error_msg = $(html).find('span.compose-muted-context-msg').text().trim();
+    assert.equal(error_msg, "You are sending a message in a muted stream. Would you like to unmute it?");
+
+    // muted topic
+    unmute_context = [ "topic", "all", "muting" ];
+    subs.toggle_home(unmute_context[1]);
+    muting.mute_topic(unmute_context[1], unmute_context[2]);
+    html = render('compose_muted_context', unmute_context[0]);
+    global.write_handlebars_output("compose_all_everyone", html);
+    assert.equal(button_yes.text(), "YES");
+    assert.equal(button_no.text(), "NO");
+    assert.equal(error_msg, "You are sending a message in a muted topic. Would you like to unmute it?");
 }());
 
 (function compose_notification() {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -193,7 +193,8 @@ table.compose_table {
 }
 
 .compose-all-everyone-controls,
-.compose_invite_user_controls {
+.compose_invite_user_controls,
+.compose-muted-context-controls {
     float: right;
 }
 

--- a/static/templates/compose_muted_context.handlebars
+++ b/static/templates/compose_muted_context.handlebars
@@ -1,0 +1,9 @@
+<div class="compose-muted-context">
+    <span class="compose-muted-context-msg">
+        {{#tr this}}You are sending a message in a <strong>muted __context__</strong>. Would you like to unmute it?{{/tr}}
+    </span>
+    <span class="compose-muted-context-controls">
+        <button type="button" class="compose-muted-context-confirm">{{t "YES" }}</button>
+        <button type="button" class="compose-muted-context-decline">{{t "NO" }}</button>
+    </span>
+</div>

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -27,6 +27,7 @@
       </div>
       <div  id="compose_invite_users" class="alert home-error-bar"></div>
       <div  id="compose-all-everyone" class="alert home-error-bar"></div>
+      <div  id="compose-muted-context" class="alert home-error-bar"></div>
       <div  id="out-of-view-notification" class="notification-alert"></div>
      <div class="composition-area">
       <button type="button" class="close" id='compose_close'>×</button>


### PR DESCRIPTION
### Purpose
This PR creates a prompt that appears when a user tries to send a message to a stream or topic they've muted and asks them if they want to unmute it (yes/no) - in response to #2083.

### Description
This is mostly based on existing functionality for a similar prompt for `@all`/`@everyone` mentions. I've considered rewriting them into a single function, but decided against it, since we have a `util.is_all_or_everyone_mentioned` and we're using it both when the `@mention` is completed and when the user sends a message - with muted streams/topics I'm not sure we want to check them as soon as the user unfocuses the field (but we can also rewrite it to support this).

The main differences are thus:
- the stream/topic muted status is checked when the user tries to send a message,
- there is no additional error prompt, since the `util.is_all_or_everyone_mentioned` additional prompt works with checking the status when the `@mention` is completed,
- agreeing to this prompt changes muted/unmuted status of a stream/topic.

### WIP

@timabbott @showell 

* Is this the implementation we're looking for in terms of usability and consistency?
* Node tests are failing, since I was unable to gracefully import `js/subs` and `js/muting` (now I've realized I probably should use `var muting = require('js/muting.js');`). Is this the right place to test this feature or should I move it to `node_tests/muting.js`? I guess we could argue both approaches, as this is a feature both for composing messages and muting.
* We currently don't have Casper tests for muting features and I was wondering if it should be a part of this PR, or should we think about creating a whole group of Casper tests for muting.
* This PR requires refactoring and refining.