### PR TITLE
Fix tests problem with backward incompatible function name.

### DIFF
--- a/tools/tests/test_css_parser.py
+++ b/tools/tests/test_css_parser.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from typing import cast
+from typing import cast, Any
 
 import sys
 import unittest
@@ -17,6 +17,14 @@ except ImportError:
     sys.exit(1)
 
 class ParserTestHappyPath(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        # This method should be remove when we quit from python2
+        import six
+        if six.PY2:
+            self.assertRaisesRegex = self.assertRaisesRegexp  # type: ignore
+        super(ParserTestHappyPath, self).__init__(*args, **kwargs)
+
     def test_basic_parse(self):
         # type: () -> None
         my_selector = 'li.foo'
@@ -126,6 +134,13 @@ class ParserTestSadPath(unittest.TestCase):
     of selectors.  Some of this is just for expediency;
     some of this is to enforce consistent formatting.
     '''
+    def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        # This method should be remove when we quit from python2
+        import six
+        if six.PY2:
+            self.assertRaisesRegex = self.assertRaisesRegexp  # type: ignore
+        super(ParserTestSadPath, self).__init__(*args, **kwargs)
 
     def _assert_error(self, my_css, error):
         # type: (str, str) -> None

--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from typing import Optional
+from typing import Optional, Any
 
 import sys
 import unittest
@@ -18,6 +18,14 @@ except ImportError:
     sys.exit(1)
 
 class ParserTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        # This method should be remove when we quit from python2
+        import six
+        if six.PY2:
+            self.assertRaisesRegex = self.assertRaisesRegexp  # type: ignore
+        super(ParserTest, self).__init__(*args, **kwargs)
+
     def _assert_validate_error(self, error, fn=None, text=None, check_indent=True):
         # type: (str, Optional[str], Optional[str], bool) -> None
         with self.assertRaisesRegex(TemplateParserException, error): # type: ignore # See https://github.com/python/typeshed/issues/372

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -78,6 +78,13 @@ class ZulipTestCase(TestCase):
     functions have to fake out the linter by using a local variable called
     django_client to fool the regext.
     '''
+    def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        # This method should be remove when we quit from python2
+        import six
+        if six.PY2:
+            self.assertRaisesRegex = self.assertRaisesRegexp
+        super(ZulipTestCase, self).__init__(*args, **kwargs)
 
     DEFAULT_REALM = Realm.objects.get(string_id='zulip')
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -38,6 +38,14 @@ from zerver.models import \
 import ujson
 
 class DecoratorTestCase(TestCase):
+    def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        # This method should be remove when we quit from python2
+        import six
+        if six.PY2:
+            self.assertRaisesRegex = self.assertRaisesRegexp
+        super(TestCase, self).__init__(*args, **kwargs)
+
     def test_get_client_name(self):
         class Request(object):
             def __init__(self, GET, POST, META):


### PR DESCRIPTION
Add __init__ methods to some of testing clases with overriding method name.