### PR TITLE
Log Management in DE Setup : Added a check for if log directory exists

### DIFF
--- a/scripts/lib/log-management-command
+++ b/scripts/lib/log-management-command
@@ -12,10 +12,14 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "zproject.settings")
 from django.conf import settings
 
 logger = logging.getLogger("zulip.management")
+if not os.path.exists(settings.MANAGEMENT_LOG_PATH):
+    dir = os.path.dirname(settings.MANAGEMENT_LOG_PATH)
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+
 file_handler = logging.FileHandler(settings.MANAGEMENT_LOG_PATH)
 formatter = logging.Formatter("%(asctime)s: %(message)s")
 file_handler.setFormatter(formatter)
 logger.addHandler(file_handler)
 logger.setLevel(logging.INFO)
-
 logger.info("Ran '%s'" % (sys.argv[1],))


### PR DESCRIPTION
Since the default behaviour of FileHandler is to create the log file if it does not exist but not whether the directory 'log' exists, this commit adds a check for the same in scripts/lib/log-management-command    and create the directory 'log' inside 'var' if it does not.
