### PR TITLE
event_queue: Improve error message for ConnectionError exception

### DIFF
--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -573,10 +573,17 @@ def request_event_queue(user_profile, user_client, apply_markdown,
                'lifespan_secs': queue_lifespan_secs}
         if event_types is not None:
             req['event_types'] = ujson.dumps(event_types)
-        resp = requests_client.get(settings.TORNADO_SERVER + '/api/v1/events',
-                                   auth=requests.auth.HTTPBasicAuth(
-                                       user_profile.email, user_profile.api_key),
-                                   params=req)
+
+        try:
+            resp = requests_client.get(settings.TORNADO_SERVER + '/api/v1/events',
+                                       auth=requests.auth.HTTPBasicAuth(
+                                           user_profile.email, user_profile.api_key),
+                                       params=req)
+        except requests.adapters.ConnectionError:
+            logging.error('Tornado server does not seem to be running, check /var/log/zulip/tornado.log '
+                          'for more information')
+            raise requests.adapters.ConnectionError('Cannot connect to Zulip\'s Tornado server (%s)'
+                                                    % (settings.TORNADO_SERVER))
 
         resp.raise_for_status()
 


### PR DESCRIPTION
Improve error message for "ConnectionError:
HTTPConnectionPool(host='localhost', port=9993): Max retries
exceeded" exception.

Fixes #215.