### PR TITLE
Simplify, document, and fix the API code.

### DIFF
--- a/api/examples/recent-messages
+++ b/api/examples/recent-messages
@@ -35,7 +35,7 @@ Example: recent-messages --count=101 --user=username@example.com --api-key=a0b1c
 
 You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
 """
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 import zulip
 
 parser = optparse.OptionParser(usage=usage)
@@ -45,7 +45,7 @@ parser.add_option_group(zulip.generate_option_group(parser))
 
 client = zulip.init_from_options(options)
 
-req = {
+request = {
     'narrow': [["stream", "Denmark"]],
     'num_before': options.count,
     'num_after': 0,
@@ -53,7 +53,12 @@ req = {
     'apply_markdown': False
 }
 
-old_messages = client.do_api_query(req, zulip.API_VERSTRING + 'messages', method='GET')
+old_messages = client.call_endpoint(
+    url='messages',
+    method='GET',
+    request=request,
+)
+
 if 'messages' in old_messages:
     for message in old_messages['messages']:
         print(json.dumps(message, indent=4))

--- a/bots/check-mirroring
+++ b/bots/check-mirroring
@@ -117,7 +117,7 @@ def send_zulip(message):
     if result["result"] != "success":
         logger.error("Error sending zulip, args were:")
         logger.error(str(message))
-        logger.error(result)
+        logger.error(str(result))
         print_status_and_exit(1)
 
 # Returns True if and only if we "Detected server failure" sending the zephyr.

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -36,7 +36,8 @@ api/integrations/rss/rss-bot
 api/integrations/svn/post-commit
 api/integrations/twitter/twitter-bot
 api/integrations/twitter/twitter-search-bot
-api/zulip/__init__.py
+bots/jabber_mirror_backend.py
+tools/deprecated/iframe-bot/show-last-messages
 tools/deprecated/inject-messages/inject-messages
 zproject/settings.py
 zproject/test_settings.py

--- a/tools/zulip-export/zulip-export
+++ b/tools/zulip-export/zulip-export
@@ -53,16 +53,24 @@ if options.stream == "":
 
 client.add_subscriptions([{"name": options.stream}])
 queue = client.register(event_types=['message'])
-client._register('get_old_messages', method='GET', url='messages')
 max_id = queue['max_message_id']
 messages = []
+request = {
+    'anchor': 0,
+    'num_before': 0,
+    'num_after': max_id,
+    'narrow': [{'operator': 'stream',
+                'operand': options.stream}],
+    'apply_markdown': False,
+}
+
 print("Fetching messages...")
-result = client.get_old_messages({'anchor': 0,
-                                  'num_before': 0,
-                                  'num_after': max_id,
-                                  'narrow': [{'operator': 'stream',
-                                             'operand': options.stream}],
-                                  'apply_markdown': False})
+result = client.call_endpoint(
+    url='messages',
+    method='GET',
+    request=request,
+)
+
 if result['result'] != 'success':
     print("Unfortunately, there was an error fetching some old messages.")
     print(result)


### PR DESCRIPTION
We used to create endpoints with Client._register.

Now we now have explicit methods for the endpoints.

This allows us to add docstrings and stricter mypy annotations.

I fixed a bug with create_users where it now uses PUT instead
of POST.

I also removed export(), which was just broken.

This fix also introduces a call_endpoint() method that avoids
the need for manually building urls with API_VERSTRING.