### PR TITLE
Add Lint Rule to Disallow python calls with versions

### DIFF
--- a/tools/lint-all
+++ b/tools/lint-all
@@ -334,7 +334,14 @@ def build_custom_checkers(by_lang):
          '''Do not call self.client directly for put/patch/post/get.
     See WRAPPER_COMMENT in test_helpers.py for details.
     '''},
-
+        # This rule might give false positives in virtualenv setup files which should be excluded,
+        # and comments which should be rewritten to avoid use of "python2", "python3", etc.
+        {'pattern': 'python[23]',
+         'exclude': set(['tools/provision.py',
+                         'tools/setup/setup_venvs.py',
+                         'scripts/lib/setup_venv.py',
+                         'tools/lint-all']),
+         'description': 'Explicit python invocations should not include a version'}
         ]) + whitespace_rules
     bash_rules = [
         {'pattern': '#!.*sh [-xe]',

--- a/tools/tests/test_css_parser.py
+++ b/tools/tests/test_css_parser.py
@@ -19,7 +19,7 @@ except ImportError:
 class ParserTestHappyPath(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
-        # This method should be remove when we quit from python2
+        # This method should be removed when we migrate to version 3 of Python
         import six
         if six.PY2:
             self.assertRaisesRegex = self.assertRaisesRegexp  # type: ignore
@@ -136,7 +136,7 @@ class ParserTestSadPath(unittest.TestCase):
     '''
     def __init__(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
-        # This method should be remove when we quit from python2
+        # This method should be removed when we migrate to version 3 of Python
         import six
         if six.PY2:
             self.assertRaisesRegex = self.assertRaisesRegexp  # type: ignore

--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -20,7 +20,7 @@ except ImportError:
 class ParserTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
-        # This method should be remove when we quit from python2
+        # This method should be removed when we migrate to version 3 of Python
         import six
         if six.PY2:
             self.assertRaisesRegex = self.assertRaisesRegexp  # type: ignore

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -312,7 +312,7 @@ def user_profile_by_id_cache_key(user_profile_id):
     return u"user_profile_by_id:%s" % (user_profile_id,)
 
 # TODO: Refactor these cache helpers into another file that can import
-# models.py so that python3-style type annotations can also work.
+# models.py so that python v3 style type annotations can also work.
 
 def cache_save_user_profile(user_profile):
     # type: (UserProfile) -> None

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -80,7 +80,7 @@ class ZulipTestCase(TestCase):
     '''
     def __init__(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
-        # This method should be remove when we quit from python2
+        # This method should be removed when we migrate to version 3 of Python
         import six
         if six.PY2:
             self.assertRaisesRegex = self.assertRaisesRegexp

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -40,7 +40,7 @@ import ujson
 class DecoratorTestCase(TestCase):
     def __init__(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
-        # This method should be remove when we quit from python2
+        # This method should be removed when we migrate to version 3 of Python
         import six
         if six.PY2:
             self.assertRaisesRegex = self.assertRaisesRegexp


### PR DESCRIPTION
Discussion with @showell on the issue: https://chat.zulip.org/#narrow/stream/GCI.20help/topic/Issue.20.232435

We decided to add a simple rule to disallow `python2` and `python3` in .py files. Any comments which would trigger this would have to be re-written, and files which deal with virtualenv stuff are excluded.

Fixes #2435