### PR TITLE
compose: Add inline autocompletion for typeahead

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -208,6 +208,34 @@ exports.compose_content_begins_typeahead = function (query) {
     }
     var current_token = strings[strings.length-1];
 
+    var element = this.$element;
+    // Wait for completions to be computed (to account for menu width change)
+    setTimeout(function () {
+        var typeahead_menu = element.data().typeahead.$menu;
+
+        var mirror_cursor = $('<span>.</span>');
+        var mirror = $('<div></div>').text(q.slice(0, -current_token.length)).append(mirror_cursor);
+        // Transfer most important properties over, to linewrap correctly
+        mirror.css(element.css([
+            'direction',
+            'box-sizing',
+            'width', 'height', 'max-width', 'max-height', 'overflow-x', 'overflow-y',
+            'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width', 'border-style',
+            'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+            'font-style', 'font-variant', 'font-weight', 'font-stretch', 'font-size', 'font-size-adjust', 'line-height', 'font-family', 'text-align',
+            'text-transform', 'text-indent', 'text-decoration', 'letter-spacing', 'word-spacing', 'tab-size', 'white-space', 'line-break', 'word-break', 'word-wrap'
+        ]));
+        $(document.body).append(mirror);
+
+        var left_offset = mirror_cursor.offset().left- mirror.offset().left - element.scrollLeft();
+        left_offset  = Math.min(left_offset, element.outerWidth() - typeahead_menu.outerWidth());
+
+        typeahead_menu.css('margin-left', left_offset);
+        typeahead_menu.css('margin-top', mirror_cursor.offset().top - mirror.offset().top - element.scrollTop());
+
+        mirror.remove();
+    }, 1);
+
     // Only start the emoji autocompleter if : is directly after one
     // of the whitespace or punctuation chars we split on.
     if (this.options.completions.emoji && current_token[0] === ':') {


### PR DESCRIPTION
Overall idea for getting the caret position has been taken from [JQuery-textcomplete](https://github.com/yuku-t/jquery-textcomplete/blob/a74c434e15acd33ff26aeb7bf6857a8fc1022123/src/vendor/textarea_caret.js)

Closes #2629

A few "obligatory" screenshots:
![Middle of the line](https://cloud.githubusercontent.com/assets/5276727/21329255/75580f16-c640-11e6-8782-2896bf142b1c.png)
![End of line](https://cloud.githubusercontent.com/assets/5276727/21329304/b62587da-c640-11e6-9504-ff6770556d57.png)
