### PR TITLE
Followup test avatar

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -273,6 +273,12 @@ class ZulipTestCase(TestCase):
 
         return [subscription.user_profile for subscription in subscriptions]
 
+    def assert_url_serves_contents_of_file(self, url, result):
+        # type: (str, bytes) -> None
+        response = self.client_get(url)
+        data = b"".join(response.streaming_content)
+        self.assertEquals(result, data)
+
     def assert_json_success(self, result):
         # type: (HttpResponse) -> Dict[str, Any]
         """

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from contextlib import contextmanager
 from typing import (cast, Any, Callable, Dict, Generator, Iterable, Iterator, List, Mapping,
-                    Optional, Sized, Tuple, Union)
+                    Optional, Sized, Tuple, Union, IO)
 
 from django.core.urlresolvers import LocaleRegexURLResolver
 from django.conf import settings
@@ -15,6 +15,7 @@ from django.http import HttpResponse
 from django.db.utils import IntegrityError
 from django.utils.translation import ugettext as _
 
+from zerver.lib.avatar import avatar_url
 from zerver.lib.initial_password import initial_password
 from zerver.lib.db import TimeTrackingCursor
 from zerver.lib.str_utils import force_text
@@ -141,6 +142,17 @@ def queries_captured(include_savepoints=False):
     TimeTrackingCursor.execute = old_execute # type: ignore # https://github.com/JukkaL/mypy/issues/1167
     TimeTrackingCursor.executemany = old_executemany # type: ignore # https://github.com/JukkaL/mypy/issues/1167
 
+def get_test_image_file(filename):
+    # type: (str) -> IO[Any]
+    test_avatar_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../tests/images'))
+    return open(os.path.join(test_avatar_dir, filename), 'rb')
+
+def avatar_disk_path(user_profile, medium=False):
+    # type: (UserProfile, bool) -> str
+    avatar_url_path = avatar_url(user_profile, medium)
+    avatar_disk_path = os.path.join(settings.LOCAL_UPLOADS_DIR, "avatars",
+                                    avatar_url_path.split("/")[-1].split("?")[0])
+    return avatar_disk_path
 
 def make_client(name):
     # type: (str) -> Client

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -74,9 +74,7 @@ class FileUploadTest(ZulipTestCase):
 
         # Files uploaded through the API should be accesible via the web client
         self.login("hamlet@zulip.com")
-        response = self.client_get(uri)
-        data = b"".join(response.streaming_content)
-        self.assertEqual(b"zulip!", data)
+        self.assert_url_serves_contents_of_file(uri, b"zulip!")
 
     def test_file_too_big_failure(self):
         # type: () -> None
@@ -171,9 +169,7 @@ class FileUploadTest(ZulipTestCase):
 
         # In the future, local file requests will follow the same style as S3
         # requests; they will be first authenthicated and redirected
-        response = self.client_get(uri)
-        data = b"".join(response.streaming_content)
-        self.assertEqual(b"zulip!", data)
+        self.assert_url_serves_contents_of_file(uri, b"zulip!")
 
         # check if DB has attachment marked as unclaimed
         entry = Attachment.objects.get(file_name='zulip.txt')


### PR DESCRIPTION
Add test about avatar image was uploaded properly or not in
`tests.BotTest.test_add_bot_with_user_avatar` and
`tests.BotTest.test_patch_bot_avatar`.

Add `get_test_image_file()` and `avatar_disk_path()` in
`zerver.lib.test_helpers` and deduplicate some codes.

Add `assertUrlServesContentsOfFile()` in `ZulipTestCase` class
and deduplicate some codes.

Fixes #1276.