### PR TITLE
Partial match previous search terms in streams page.

### DIFF
--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -72,7 +72,7 @@ i18n.init({
     assert(elem_3.hasClass("notdisplayed"));
 
     subs.filter_table({input: "Den, Pol", subscribed_only: false});
-    assert(elem_1.hasClass("notdisplayed"));
+    assert(!elem_1.hasClass("notdisplayed"));
     assert(!elem_2.hasClass("notdisplayed"));
     assert(elem_3.hasClass("notdisplayed"));
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -494,10 +494,10 @@ function stream_matches_query(query, sub) {
     var flag = true;
     flag = flag && (function () {
         var sub_name = sub.name.toLowerCase();
-        var matches_list = search_terms.indexOf(sub_name) > -1;
-        var matches_last_val = sub_name.match(search_terms[search_terms.length - 1]);
 
-        return matches_list || matches_last_val;
+        return _.any(search_terms, function (o) {
+            return new RegExp(o).test(sub_name);
+        });
     }());
     flag = flag && ((sub.subscribed || !query.subscribed_only) ||
                     sub.data_temp_view === "true");


### PR DESCRIPTION
Before in a query string like:

“all, s, verona”

It would only strong match the first two terms, but now it’ll partial
string match all terms equally.