### PR TITLE
Fix subscriptions overlay exit button pointer events.

### DIFF
--- a/static/styles/overlay.css
+++ b/static/styles/overlay.css
@@ -81,7 +81,7 @@
     transition: all 0.2s ease;
 }
 
-#overlay .exit {
+#overlay.show .exit {
     pointer-events: auto;
     opacity: 1;
 }


### PR DESCRIPTION
This was intercepting pointer events even though the lightbox was
closed. This fixes the issue with the streams exit not working in some
responsive cases.