### PR TITLE
Fix position of restore draft.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -359,10 +359,11 @@ input.recipient_box {
 }
 
 #restore-draft {
-    float: left;
     display: none;
+    position: relative;
     margin-right: 1em;
-    padding-top: 2px;
+    margin-left: 5px;
+    top: 2px;
 }
 
 #sending-indicator {


### PR DESCRIPTION
The **Restore draft** button currently appears before **Markdown preview** button. This PR moves restore draft to right most position..

**Current position**
![restore-draft-before](https://cloud.githubusercontent.com/assets/7190633/21433897/c8eac368-c897-11e6-99ec-1a49dee0b2bb.png)

**After moving to right**

![restore-draft](https://cloud.githubusercontent.com/assets/7190633/21433915/e3c67ab0-c897-11e6-8c37-7973e367650b.png)

@timabbott @brockwhittaker 
