### PR TITLE
Remove legacy URL for left_side_userlist

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -408,7 +408,7 @@ function _setup_page() {
         }
 
         channel.patch({
-            url: '/json/left_side_userlist',
+            url: '/json/settings/display',
             data: data,
             success: function () {
                 ui.report_success(i18n.t("User list will appear on the __side__ hand side! You will need to reload the window for your changes to take effect.", context),

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1638,7 +1638,7 @@ class ChangeSettingsTest(ZulipTestCase):
 
     def test_toggling_left_side_userlist(self):
         # type: () -> None
-        self.check_for_toggle_param("/json/left_side_userlist", "left_side_userlist")
+        self.check_for_toggle_param_patch("/json/settings/display", "left_side_userlist")
 
     def test_time_setting(self):
         # type: () -> None

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1552,23 +1552,23 @@ class ChangeSettingsTest(ZulipTestCase):
 
     # TODO: requires method consolidation, right now, there's no alternative
     # for check_for_toggle_param for PATCH.
-    def check_for_toggle_param_patch(self, pattern, url):
+    def check_for_toggle_param_patch(self, pattern, param):
         # type: (str, str) -> None
         self.login("hamlet@zulip.com")
         user_profile = get_user_profile_by_email("hamlet@zulip.com")
         json_result = self.client_patch(pattern,
-                                        {url: ujson.dumps(True)})
+                                        {param: ujson.dumps(True)})
         self.assert_json_success(json_result)
         # refetch user_profile object to correctly handle caching
         user_profile = get_user_profile_by_email("hamlet@zulip.com")
-        self.assertEqual(getattr(user_profile, url), True)
+        self.assertEqual(getattr(user_profile, param), True)
 
         json_result = self.client_patch(pattern,
-                                        {url: ujson.dumps(False)})
+                                        {param: ujson.dumps(False)})
         self.assert_json_success(json_result)
         # refetch user_profile object to correctly handle caching
         user_profile = get_user_profile_by_email("hamlet@zulip.com")
-        self.assertEqual(getattr(user_profile, url), False)
+        self.assertEqual(getattr(user_profile, param), False)
 
     def test_successful_change_settings(self):
         # type: () -> None

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -95,27 +95,12 @@ def json_change_settings(request, user_profile,
 
     return json_success(result)
 
-@authenticated_json_post_view
-@has_request_variables
-def json_left_side_userlist(request, user_profile, left_side_userlist=REQ(validator=check_bool, default=None)):
-    # type: (HttpRequest, UserProfile, Optional[bool]) -> HttpResponse
-    result = {}
-    if (left_side_userlist is not None and
-            user_profile.left_side_userlist != left_side_userlist):
-
-        do_change_left_side_userlist(user_profile, left_side_userlist)
-
-    result['left_side_userlist'] = left_side_userlist
-
-    return json_success(result)
-
-# TODO: Merge json_left_side_userlist endpoint
-# into this one; it should be straightforward
 @has_request_variables
 def update_display_settings_backend(request, user_profile,
                                     twenty_four_hour_time=REQ(validator=check_bool, default=None),
-                                    default_language=REQ(validator=check_string, default=None)):
-    # type: (HttpRequest, UserProfile, Optional[bool], Optional[str]) -> HttpResponse
+                                    default_language=REQ(validator=check_string, default=None),
+                                    left_side_userlist=REQ(validator=check_bool, default=None)):
+    # type: (HttpRequest, UserProfile, Optional[bool], Optional[str], Optional[bool]) -> HttpResponse
     if (default_language is not None and
             default_language not in get_available_language_codes()):
         raise JsonableError(_("Invalid language '%s'" % (default_language,)))
@@ -130,6 +115,11 @@ def update_display_settings_backend(request, user_profile,
             user_profile.twenty_four_hour_time != twenty_four_hour_time):
         do_change_twenty_four_hour_time(user_profile, twenty_four_hour_time)
         result['twenty_four_hour_time'] = twenty_four_hour_time
+
+    elif (left_side_userlist is not None and
+            user_profile.left_side_userlist != left_side_userlist):
+        do_change_left_side_userlist(user_profile, left_side_userlist)
+        result['left_side_userlist'] = left_side_userlist
 
     return json_success(result)
 

--- a/zproject/legacy_urls.py
+++ b/zproject/legacy_urls.py
@@ -42,5 +42,4 @@ legacy_urls = [
     url(r'^json/messages_in_narrow$',        zerver.views.messages.json_messages_in_narrow),
     url(r'^json/update_message$',            zerver.views.messages.json_update_message),
     url(r'^json/set_muted_topics$',          zerver.views.json_set_muted_topics),
-    url(r'^json/left_side_userlist$',        zerver.views.user_settings.json_left_side_userlist),
     ]


### PR DESCRIPTION
* Switched to PATCH endpoint for left_side_userlist settings change.

This includes some of the changes in https://github.com/zulip/zulip/pull/2822 so that the tests can run properly. If that PR is merged first, this PR will need to be rebased to remove conflicts.