### PR TITLE
docs: Add user guide for *About streams and topics* feature

### DIFF
--- a/templates/zerver/help/about-stream-topic.md
+++ b/templates/zerver/help/about-stream-topic.md
@@ -1,0 +1,61 @@
+# About streams and topics
+
+In Zulip, conversations are organized by conversation **streams** and
+**topics**.
+
+## About streams
+On Zulip, users communicate with each other in group chats by sending messages
+to streams, which are similar to conversation threads.
+
+Streams are either:
+
+* **Public** - Public streams are for open discussions. All users can subscribe
+to public streams and discuss topics there. Any Zulip user can join any public
+stream in the realm, and they can view the complete message history of any
+public stream without joining the stream.  
+* **Private** - Private streams are for confidential discussions and are only
+visible to users who've been invited to subscribe to them. Users who are not
+members of a private stream cannot subscribe to the stream, and they also cannot
+read or send messages to the stream.
+
+Users are subscribed to specific streams in the realm by default, such as the
+[#announce](announce-stream) stream. Users can easily
+[view messages](/help/viewing-messages-from-stream) from a specific stream; in
+addition, they can [browse](/help/browse-and-join-streams#browse-streams) their
+stream subscriptions using the Zulip stream browser.
+
+If they wish to read messages from a stream that they're not subscribed to,
+users can choose to [join](/help/browse-and-join-streams#subscribing-to-streams)
+a stream. Similarly, if they are not interested in the topics being discussed in
+a stream, users can choose to [unsubscribe](/help/unsubscribe-stream) from a
+stream.
+
+Users can also customize their stream settings; they can
+[pin](/help/pin-a-stream) or star important streams,
+[change the colors](/help/change-stream-color) of streams, and enable desktop
+notifications or muting for streams in order to create a better Zulip
+environment.
+
+If enabled by the realm administrators, users can
+[create](/help/create-a-stream) streams and [invite](/help/add-invite-stream)
+other users to a stream.
+
+Only realm administrators can make edits to a stream, such as
+[renaming](/help/rename-stream), [deleting](help/delete-a-stream), changing the
+description of a stream, [removing users](/help/remove-from-stream) from a
+stream, or changing the accessibility of a stream.
+
+## About topics  
+In each stream, messages are sorted by topics. Topics are
+specific, fine-grained subjects that fit with the overall subject of the
+stream that they're sent to. Topics ensure sequential messages
+about the same thing are threaded together, allowing for better consumption
+by users.
+
+The best stream topics are short and specific. For example, for a bug tracker
+integration, a good topic would be the bug number; for an integration like
+Nagios, the service would serve as a good topic.
+
+Users can easily [change the topics](/help/change-topic) of the sent messages if
+they sent the message to the wrong topic or if some messages in a topic have
+gone off-topic.

--- a/templates/zerver/help/index.md
+++ b/templates/zerver/help/index.md
@@ -82,7 +82,7 @@ as a “**realm**”.
 * Send a group of people a private message
 
 ## Streams & Topics
-* About streams and topics
+* [About streams and topics](/help/about-stream-topic)
 * [Browse and join streams](/help/browse-and-join-streams)
 * [Create a stream](/help/create-a-stream)
 * [View your current stream subscriptions](/help/browse-and-join-streams#browse-streams)


### PR DESCRIPTION
Blurb repeats:
1. Lines 10-13 were a slightly modified version from `/help/streams-and-private-messages` lines 6-8