### PR TITLE
Migrated json/subscribtions/remove to REST endpoint

### DIFF
--- a/static/js/custom_markdown.js
+++ b/static/js/custom_markdown.js
@@ -30,8 +30,8 @@ var exports = {};
     }
 
     function remove_sub(stream_name, $status_message) {
-        channel.post({
-            url: '/json/subscriptions/remove',
+        channel.del({
+            url: '/json/users/me/subscriptions',
             data: {
                 subscriptions: JSON.stringify([stream_name])
             }

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -703,8 +703,8 @@ function ajaxSubscribe(stream) {
 }
 
 function ajaxUnsubscribe(stream) {
-    return channel.post({
-        url: "/json/subscriptions/remove",
+    return channel.del({
+        url: "/json/users/me/subscriptions",
         data: {subscriptions: JSON.stringify([stream]) },
         success: function () {
             $("#subscriptions-status").hide();
@@ -786,8 +786,8 @@ exports.invite_user_to_stream = function (user_email, stream_name, success, fail
 };
 
 exports.remove_user_from_stream = function (user_email, stream_name, success, failure) {
-    return channel.post({
-        url: "/json/subscriptions/remove",
+    return channel.del({
+        url: "/json/users/me/subscriptions",
         data: {subscriptions: JSON.stringify([stream_name]),
                principals: JSON.stringify([user_email])},
         success: success,

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -99,7 +99,6 @@ class PublicURLTest(ZulipTestCase):
                      401: ["/json/messages",
                            "/json/invite_users",
                            "/json/settings/change",
-                           "/json/subscriptions/remove",
                            "/json/subscriptions/exists",
                            "/json/subscriptions/property",
                            "/json/get_subscribers",

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -493,8 +493,8 @@ class StreamAdminTest(ZulipTestCase):
         if other_user_subbed:
             self.subscribe_to_stream(other_user_profile.email, stream_name)
 
-        result = self.client_post(
-            "/json/subscriptions/remove",
+        result = self.client_delete(
+            "/json/users/me/subscriptions",
             {"subscriptions": ujson.dumps([stream_name]),
              "principals": ujson.dumps([other_email])})
 
@@ -627,9 +627,9 @@ class StreamAdminTest(ZulipTestCase):
         stream_name = u"hümbüǵ"
         self.make_stream(stream_name)
 
-        result = self.client_post("/json/subscriptions/remove",
-                                  {"subscriptions": ujson.dumps([stream_name]),
-                                   "principals": ujson.dumps(["baduser@zulip.com"])})
+        result = self.client_delete("/json/users/me/subscriptions",
+                                    {"subscriptions": ujson.dumps([stream_name]),
+                                     "principals": ujson.dumps(["baduser@zulip.com"])})
         self.assert_json_error(
             result,
             "User not authorized to execute queries on behalf of 'baduser@zulip.com'",
@@ -1711,8 +1711,8 @@ class SubscriptionAPITest(ZulipTestCase):
          "removed": ["Denmark", "Scotland", "Verona"],
          "not_subscribed": ["Rome"], "result": "success"}
         """
-        result = self.client_post("/json/subscriptions/remove",
-                                  {"subscriptions": ujson.dumps(subscriptions)})
+        result = self.client_delete("/json/users/me/subscriptions",
+                                    {"subscriptions": ujson.dumps(subscriptions)})
         self.assert_json_success(result)
         json = ujson.loads(result.content)
         for key, val in six.iteritems(json_dict):
@@ -1723,7 +1723,7 @@ class SubscriptionAPITest(ZulipTestCase):
     def test_successful_subscriptions_remove(self):
         # type: () -> None
         """
-        Calling /json/subscriptions/remove should successfully remove streams,
+        Calling DELETE /json/users/me/subscriptions should successfully remove streams,
         and should determine which were removed vs which weren't subscribed to.
         We cannot randomly generate stream names because the remove code
         verifies whether streams exist.
@@ -1746,14 +1746,14 @@ class SubscriptionAPITest(ZulipTestCase):
     def test_subscriptions_remove_fake_stream(self):
         # type: () -> None
         """
-        Calling /json/subscriptions/remove on a stream that doesn't exist
+        Calling DELETE /json/users/me/subscriptions on a stream that doesn't exist
         should return a JSON error.
         """
         random_streams = self.make_random_stream_names(self.streams)
         self.assertNotEqual(len(random_streams), 0)  # necessary for full test coverage
         streams_to_remove = random_streams[:1]  # pick only one fake stream, to make checking the error message easy
-        result = self.client_post("/json/subscriptions/remove",
-                                  {"subscriptions": ujson.dumps(streams_to_remove)})
+        result = self.client_delete("/json/users/me/subscriptions",
+                                    {"subscriptions": ujson.dumps(streams_to_remove)})
         self.assert_json_error(result, "Stream(s) (%s) do not exist" % (random_streams[0],))
 
     def helper_subscriptions_exists(self, stream, exists, subscribed):

--- a/zproject/legacy_urls.py
+++ b/zproject/legacy_urls.py
@@ -21,7 +21,6 @@ legacy_urls = [
     url(r'^json/settings/change$',           zerver.views.user_settings.json_change_settings),
     url(r'^json/notify_settings/change$',    zerver.views.user_settings.json_change_notify_settings),
     url(r'^json/ui_settings/change$',        zerver.views.user_settings.json_change_ui_settings),
-    url(r'^json/subscriptions/remove$',      zerver.views.streams.json_remove_subscriptions),
 
     # We should remove this endpoint and all code related to it.
     # It returns a 404 if the stream doesn't exist, which is confusing

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -278,7 +278,8 @@ v1_api_and_json_patterns = [
     url(r'^users/me/subscriptions$', rest_dispatch,
         {'GET': 'zerver.views.streams.list_subscriptions_backend',
          'POST': 'zerver.views.streams.add_subscriptions_backend',
-         'PATCH': 'zerver.views.streams.update_subscriptions_backend'}),
+         'PATCH': 'zerver.views.streams.update_subscriptions_backend',
+         'DELETE': 'zerver.views.streams.remove_subscriptions_backend'}),
 
     # used to register for an event queue in tornado
     url(r'^register$', rest_dispatch,


### PR DESCRIPTION
I've migrated json/subscribtions/remove to a REST endpoint at DELETE /json/users/me/subscriptions
I've tested and the intended features still work.