### PR TITLE
docs: Fix broken link in "About Stream Topic" documentation

### DIFF
--- a/templates/zerver/help/about-stream-topic.md
+++ b/templates/zerver/help/about-stream-topic.md
@@ -41,7 +41,7 @@ If enabled by the realm administrators, users can
 other users to a stream.
 
 Only realm administrators can make edits to a stream, such as
-[renaming](/help/rename-stream), [deleting](help/delete-a-stream), changing the
+[renaming](/help/rename-stream), [deleting](/help/delete-a-stream), changing the
 description of a stream, [removing users](/help/remove-from-stream) from a
 stream, or changing the accessibility of a stream.
 


### PR DESCRIPTION
* The link to deleting a stream was broken, fixed that.

Any reason why we do not include `tools/test-help-documentation.py` in the travis tests, I found this error because this test was failing. It hardly takes 5 - 10 seconds and it checks through all the help documentation which is a nice thing.