### PR TITLE
admin: Fix Strike-through styling in users and bots tab.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2525,7 +2525,8 @@ button.topic_edit_cancel {
     margin-right: 25px;
 }
 
-.deactivated_user {
+.deactivated_user .user_name,
+.deactivated_user .email {
     text-decoration: line-through;
 }
 


### PR DESCRIPTION
Fixes #2905 

Admin/users tab:
![fix-user](https://cloud.githubusercontent.com/assets/18504232/21472895/49c900f8-cae6-11e6-9390-ce545a5b407a.png)

Admin/bots tab:
![fix-bots](https://cloud.githubusercontent.com/assets/18504232/21472897/524f9c28-cae6-11e6-8eb2-9391fe8275c8.png)