### PR TITLE
image-overlay: Fix long image alt text overlapping

### DIFF
--- a/templates/zerver/image-overlay.html
+++ b/templates/zerver/image-overlay.html
@@ -1,7 +1,7 @@
 <div id="overlay" class="new-style">
   <div class="image-info-wrapper">
     <div class="image-description">
-      <span class="title"></span>
+      <div class="title"></div>
       &mdash;
       <span class="user"></span>
     </div>


### PR DESCRIPTION
Fix long image alt text overlaps `Download` and `Open` buttons
by changing `<span>` to `<div>`.

Fixes #2912.
  
----
I think the reason of `text-overflow: ellipsis` doesn't take effect is because `<span>` is an `in-line` tag, so we need to change it to `block-line` tag such as `<div>`.

Before:
![before](https://cloud.githubusercontent.com/assets/20320125/21483864/109f1f34-cbbc-11e6-911b-ff8f337cd148.png)
After:
![after](https://cloud.githubusercontent.com/assets/20320125/21483865/15e3dfe8-cbbc-11e6-8bd9-22d21988be94.png)
