### PR TITLE
message edit: Change the empty topic placeholder to be the original t…

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -175,7 +175,6 @@ function edit_message(row, raw_content) {
          is_editable: is_editable,
          has_been_editable: (editability !== editability_types.NO),
          topic: message.subject,
-         empty_topic_placeholder: compose.empty_topic_placeholder(),
          content: raw_content,
          minutes_to_edit: Math.floor(page_params.realm_message_content_edit_limit_seconds / 60)}));
 

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -5,7 +5,7 @@
     <div class="control-group no-margin">
         <label class="control-label edit-control-label" for="message_edit_topic">{{t "Topic" }}</label>
         <div class="controls edit-controls">
-          <input type="text" placeholder="{{empty_topic_placeholder}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" />
+          <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" />
           <select class='message_edit_topic_propagate' style='display:none;'>
             <option selected="selected" value="change_one"> {{t "Change only this message topic" }}</option>
             <option value="change_later"> {{t "Change later messages to this topic" }}</option>


### PR DESCRIPTION
…opic.

If a user removes the topic in the message edit form, we use the original
topic, not the empty topic.