### PR TITLE
Fixing Notification Click Events.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -95,9 +95,13 @@ $(function () {
 
     // NOTIFICATION CLICK
 
-    $('body').on('click', '.top-right', function () {
-        ui.change_tab_to('#home');
-        narrow.activate($(this)['0'].raw_operators_notif, $(this)['0'].opts_notif);
+    $('body').on('click', '.notification', function () {
+        var payload = $(this).data("narrow");
+
+        if (payload) {
+            ui.change_tab_to('#home');
+            narrow.activate(payload.raw_operators, payload.opts_notif);
+        }
     });
 
 

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -93,6 +93,14 @@ $(function () {
         window.location.href = $(this).attr('href');
     });
 
+    // NOTIFICATION CLICK
+
+    $('body').on('click', '.top-right', function () {
+        ui.change_tab_to('#home');
+        narrow.activate($(this)['0'].raw_operators_notif, $(this)['0'].opts_notif);
+    });
+
+
     // MESSAGE EDITING
 
     $('body').on('click', '.edit_content_button', function (e) {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -218,15 +218,26 @@ exports.window_has_focus = function () {
 };
 
 function in_browser_notify(message, title, content, raw_operators, opts) {
-    var notification_html = $(templates.render('notification', {gravatar_url: ui.small_avatar_url(message),
-                                                                title: title,
-                                                                content: content}));
-    $('.top-right').notify({
-        message: {html: notification_html},
-        fadeOut: {enabled: true, delay: 4000}
+    var notification_html = $(templates.render('notification', {
+        gravatar_url: ui.small_avatar_url(message),
+        title: title,
+        content: content
+    }));
+
+    $(".top-right").notify({
+        message: {
+            html: notification_html
+        },
+        fadeOut: {
+            enabled: true,
+            delay: 4000
+        }
     }).show();
-    $('.top-right')['0'].raw_operators_notif = raw_operators;
-    $('.top-right')['0'].opts_notif = opts;
+
+    $(".notification").last().data("narrow", {
+        raw_operators: raw_operators,
+        opts_notif: opts
+    });
 }
 
 exports.notify_above_composebox = function (note, link_class, link_msg_id, link_text) {
@@ -297,17 +308,24 @@ function process_notification(notification) {
         cancel_notification_object(notification_object);
     }
 
-    if (message.type === "private" && message.display_recipient.length > 2) {
-        // If the message has too many recipients to list them all...
-        if (content.length + title.length + other_recipients.length > 230) {
-            // Then count how many people are in the conversation and summarize
-            // by saying the conversation is with "you and [number] other people"
-            other_recipients = other_recipients.replace(/[^,]/g, "").length +
-                               " other people";
+    if (message.type === "private") {
+        if (message.display_recipient.length > 2) {
+            // If the message has too many recipients to list them all...
+            if (content.length + title.length + other_recipients.length > 230) {
+                // Then count how many people are in the conversation and summarize
+                // by saying the conversation is with "you and [number] other people"
+                other_recipients = other_recipients.replace(/[^,]/g, "").length +
+                                   " other people";
+            }
+
+            title += " (to you and " + other_recipients + ")";
+        } else {
+            title += " (to you)";
         }
-        title += " (to you and " + other_recipients + ")";
+
         raw_operators = [{operand: message.reply_to, operator: "pm-with"}];
     }
+
     if (message.type === "stream") {
         title += " (to " + message.stream + " > " + message.subject + ")";
         raw_operators = [{operand: message.stream, operator: "stream"}, {operand: message.subject, operator: "topic"}];

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -225,11 +225,8 @@ function in_browser_notify(message, title, content, raw_operators, opts) {
         message: {html: notification_html},
         fadeOut: {enabled: true, delay: 4000}
     }).show();
-    $('.top-right').on('click', function () {
-        ui.change_tab_to('#home');
-        narrow.activate(raw_operators, opts);
-    });
-    setTimeout(function () {$('.top-right').unbind("click");}, 5000);
+    $('.top-right')['0'].raw_operators_notif = raw_operators;
+    $('.top-right')['0'].opts_notif = opts;
 }
 
 exports.notify_above_composebox = function (note, link_class, link_msg_id, link_text) {
@@ -313,8 +310,7 @@ function process_notification(notification) {
     }
     if (message.type === "stream") {
         title += " (to " + message.stream + " > " + message.subject + ")";
-        raw_operators = [{operand: message.stream, operator: "stream"}];
-        if (message.subject !== "(no topic)") {raw_operators[1] = {operand: message.subject, operator: "topic"};}
+        raw_operators = [{operand: message.stream, operator: "stream"}, {operand: message.subject, operator: "topic"}];
     }
 
     if (window.bridge === undefined && notification.webkit_notify === true) {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2249,6 +2249,10 @@ button.topic_edit_cancel {
     text-align: center;
 }
 
+.notification {
+    cursor: pointer;
+}
+
 #empty_narrow_private_message p,
 #empty_narrow_message p {
     text-align: center;

--- a/static/templates/notification.handlebars
+++ b/static/templates/notification.handlebars
@@ -1,5 +1,5 @@
 {{! Content of in-browser notifications }}
-<div>
+<div class="notification">
     <div class="notifications-gravatar">
         <img src="{{gravatar_url}}" />
     </div>


### PR DESCRIPTION
This refactors the notification on click by storing values through the
jQuery $.fn.data option and associating it with the correct element.

This also now works with private message streams.

Fixes: #2940.