### PR TITLE
interactive bots: Use dev API when in a dev setup.

### DIFF
--- a/contrib_bots/run.py
+++ b/contrib_bots/run.py
@@ -11,7 +11,7 @@ our_dir = os.path.dirname(os.path.abspath(__file__))
 
 # For dev setups, we can find the API in the repo itself.
 if os.path.exists(os.path.join(our_dir, '../api/zulip')):
-    sys.path.append('../api')
+    sys.path.insert(0, '../api')
 
 from zulip import Client
 


### PR DESCRIPTION
Now the development API (which is inside the repo, `api/`) is used when the envionment is a development one.

Credits to Steve Howell (@showell) for the instructions on how to fix this.