### PR TITLE
Add missing exports to js modules

### DIFF
--- a/static/js/blueslip.js
+++ b/static/js/blueslip.js
@@ -405,3 +405,7 @@ exports.fatal = function blueslip_fatal (msg, more_info) {
 
 return exports;
 }());
+
+if (typeof module !== 'undefined') {
+    module.exports = blueslip;
+}

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1201,5 +1201,8 @@ $(function () {
 });
 
 return exports;
-
 }());
+
+if (typeof module !== 'undefined') {
+    module.exports = compose;
+}

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -365,3 +365,7 @@ $(document).on('narrow_deactivated.zulip', function () {
 
 return exports;
 }());
+
+if (typeof module !== 'undefined') {
+    module.exports = message_edit;
+}

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -718,3 +718,7 @@ exports.set_userlist_placement = function (placement) {
 
 return exports;
 }());
+
+if (typeof module !== 'undefined') {
+    module.exports = popovers;
+}

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -632,3 +632,7 @@ $(function () {
 
 return exports;
 }());
+
+if (typeof module !== 'undefined') {
+    module.exports = ui;
+}

--- a/static/js/viewport.js
+++ b/static/js/viewport.js
@@ -342,3 +342,7 @@ $(function () {
 
 return exports;
 }());
+
+if (typeof module !== 'undefined') {
+    module.exports = viewport;
+}


### PR DESCRIPTION
Some js modules build an exports object but do not assign it to module.exports. This PR fixes this.