### PR TITLE
Add debugging device to check for duplicate IDs in markup.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -179,7 +179,7 @@
         "no-loop-func": 2,
         "no-labels": 2,
         "no-unused-vars": ["error", { "vars": "local", "args": "after-used",
-                                      "varsIgnorePattern": "print_elapsed_time"
+                                      "varsIgnorePattern": "print_elapsed_time|check_duplicate_ids"
                                     }],
         "no-script-url": 2,
         "no-proto": 2,

--- a/static/js/debug.js
+++ b/static/js/debug.js
@@ -23,6 +23,41 @@ function print_elapsed_time(name, fun) {
     return out;
 }
 
+function check_duplicate_ids() {
+    var ids = {};
+    var collisions = [];
+    var total_collisions = 0;
+
+    Array.prototype.slice.call(document.querySelectorAll("*")).forEach(function (o) {
+        if (o.id && ids[o.id]) {
+            var el = collisions.find(function (c) {
+                return c.id === o.id;
+            });
+
+            ids[o.id] += 1;
+            total_collisions += 1;
+
+            if (!el) {
+                var tag = o.tagName.toLowerCase();
+                collisions.push({
+                    id: o.id,
+                    count: 1,
+                    node: "<" + tag + " className='" + o.className + "' id='" + o.id + "'>" +
+                          "</" + tag + ">"
+                });
+            } else {
+                el.count += 1;
+            }
+        } else if (o.id) {
+            ids[o.id] = 1;
+        }
+    });
+
+    return {
+        collisions: collisions,
+        total_collisions: total_collisions
+    };
+}
 
 /* An IterationProfiler is used for profiling parts of looping
  * constructs (like a for loop or _.each).  You mark sections of the


### PR DESCRIPTION
This checks for duplicate IDs in the markup of the body.

To use this, enable debug mode and then click around a bit on the site to get all the templates to compile and add themselves to the DOM. Then check if there’s any duplicated IDs.