### PR TITLE
run-dev: Change provisioning error messages to not reference tests.

### DIFF
--- a/tools/lib/test_script.py
+++ b/tools/lib/test_script.py
@@ -38,8 +38,8 @@ Do this: `./tools/provision.py`
 
 NEED_TO_UPGRADE = '''
 It looks like you checked out a branch that has added
-dependencies beyond what you last provisioned.  Your tests
-are likely to fail until you add dependencies by provisioning.
+dependencies beyond what you last provisioned. Your command
+is likely to fail until you add dependencies by provisioning.
 
 Do this: `./tools/provision.py`
 '''

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -60,7 +60,7 @@ parser.add_option('--no-clear-memcached',
 
 parser.add_option('--force', dest='force',
                   action="store_true",
-                  default=False, help='Run tests despite possible problems.')
+                  default=False, help='Run command despite possible problems.')
 
 parser.add_option('--enable-tornado-logging', dest='enable_tornado_logging',
                   action="store_true",


### PR DESCRIPTION
Previously, we got the following as a part of the output when running
`tools/run-dev.py` without provisioning:

    It looks like you checked out a branch that has added
    dependencies beyond what you last provisioned.  Your tests
    are likely to fail until you add dependencies by provisioning.
    
which is a bit confusing.
