### PR TITLE
Vagrantfile: Enable developer to change host IP used by Vagrant in development environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # The Zulip development environment runs on 9991 on the guest.
   host_port = 9991
   http_proxy = https_proxy = no_proxy = ""
+  host_ip_addr = "127.0.0.1"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/srv/zulip"
@@ -42,11 +43,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       when "HTTPS_PROXY"; https_proxy = value
       when "NO_PROXY"; no_proxy = value
       when "HOST_PORT"; host_port = value.to_i
+      when "HOST_IP_ADDR"; host_ip_addr = value
       end
     end
   end
 
-  config.vm.network "forwarded_port", guest: 9991, host: host_port, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 9991, host: host_port, host_ip: host_ip_addr
 
   if Vagrant.has_plugin?("vagrant-proxyconf")
     if http_proxy != ""

--- a/docs/brief-install-vagrant-dev.md
+++ b/docs/brief-install-vagrant-dev.md
@@ -105,3 +105,16 @@ HOST_PORT 9971
 
 (and halt and restart the Vagrant guest), then you would visit
 http://localhost:9971/ to connect to your development server.
+
+
+If you'd like to be able to connect to your development environment from other
+machines than the VM host, you can manually set the host IP address in the
+'~/.zulip-vagrant-config' file as well. For example, if you set:
+
+```
+HOST_IP_ADDR 0.0.0.0
+```
+
+(and restart the Vagrant guest), your host IP would be 0.0.0.0, a special value
+for the IP address that means any IP address can connect to your development server.
+

--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -864,6 +864,18 @@ HOST_PORT 9971
 (and halt and restart the Vagrant guest), then you would visit
 http://localhost:9971/ to connect to your development server.
 
+If you'd like to be able to connect to your development environment from other
+machines than the VM host, you can manually set the host IP address in the
+'~/.zulip-vagrant-config' file as well. For example, if you set:
+
+```
+HOST_IP_ADDR 0.0.0.0
+```
+
+(and restart the Vagrant guest), your host IP would be 0.0.0.0, a special value
+for the IP address that means any IP address can connect to your development server.
+
+
 [cygwin-dl]: http://cygwin.com/
 [vagrant-dl]: https://www.vagrantup.com/downloads.html
 [vagrant-dl-win]: https://releases.hashicorp.com/vagrant/1.8.6/vagrant_1.8.6.msi


### PR DESCRIPTION
I was trying to install the development server with Vagrant on a separate Ubuntu server and then access it in my browser from another client. This is not possible due to Vagrant only exposing port 9991 to the localhost. My PR allows the developer to change the host_ip in .zulip-vagrant-config. The developer can change the host IP address to an address such as 0.0.0.0, which will expose port 9991 to the public network and enable the development server to be accessed from other clients..