### PR TITLE
Advertise clearly that we support names in every language in Zulip "full name" input

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -789,7 +789,7 @@ function _setup_page() {
             }
         });
     });
-    
+
     $('#hover-message, i[data-toggle="tooltip"]').tooltip();
 }
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -789,6 +789,8 @@ function _setup_page() {
             }
         });
     });
+    
+    $('#hover-message, i[data-toggle="tooltip"]').tooltip();
 }
 
 function _update_page() {

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -10,7 +10,7 @@
           <div class="container">
             <span for="full_name">{{t "Full name" }}</span>
             <i data-toggle="tooltip" title="{{t 'Zulip has full unicode support, so feel free to spell your name however you\'d like it to appear.' }}" class="icon-vector-question-sign"></i>
-        </div>
+          </div>
         <input type="text" name="full_name" value="{{ page_params.fullname }}" />
       </div>
 

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -9,7 +9,7 @@
       <div class="input-group name_change_container">
           <div class="container">
             <span for="full_name">{{t "Full name" }}</span>
-            <i data-toggle="tooltip" title="{{t 'Zulip has full unicode support, so feel free to spell your name however you\'d like it to appear.' }}" class="icon-vector-question-sign"></i>
+            <i data-toggle="tooltip" title="{{t 'Zulip has full unicode support, so feel free to spell your name however you\'d like it to appear.' }}" class="icon-vector-question-sign" id="hover-message"></i>
           </div>
         <input type="text" name="full_name" value="{{ page_params.fullname }}" />
       </div>
@@ -83,8 +83,3 @@
 
   </div>
 </div>
-<script>
-$(function () {
-    $('[data-toggle="tooltip"]').tooltip();
-});
-</script>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -7,7 +7,10 @@
     <form action="/json/settings/change" method="post"
           class="form-horizontal your-account-settings">
       <div class="input-group name_change_container">
-        <label for="full_name">{{t "Full name" }}</label>
+          <div class="container">
+            <span for="full_name">{{t "Full name" }}</span>
+            <i data-toggle="tooltip" title="{{t 'Zulip has full unicode support, so feel free to spell your name however you\'d like it to appear.' }}" class="icon-vector-question-sign"></i>
+        </div>
         <input type="text" name="full_name" value="{{ page_params.fullname }}" />
       </div>
 
@@ -80,3 +83,8 @@
 
   </div>
 </div>
+<script>
+$(function () {
+$('[data-toggle="tooltip"]').tooltip();   
+});
+</script>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -85,6 +85,6 @@
 </div>
 <script>
 $(function () {
-$('[data-toggle="tooltip"]').tooltip();   
+    $('[data-toggle="tooltip"]').tooltip();
 });
 </script>

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -33,6 +33,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
 
         <div class="input-group grid">
             <label for="id_full_name" class="inline-block label-title">{{ _('Full name') }}</label>
+            <i class="icon-vector-question-sign" id="hover-message" data-toggle="tooltip" title="{{ 'Zulip has full unicode support, so feel free to spell your name however you\'d like it to appear.' }}"></i>
             {% if lock_name %}
                 <p class="fakecontrol">{{ full_name }}</p>
             {% else %}
@@ -198,6 +199,10 @@ if ($('#id_email:visible').length) {
 $("[name=realm_org_type]").on("change", function () {
     $(".blob").hide();
     $("#org_type_blob_" + this.value).show();
+});
+
+$(function (){
+    $("#hover-message, i[data-toggle='tooltip']").tooltip();
 });
 </script>
 

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -33,7 +33,6 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
 
         <div class="input-group grid">
             <label for="id_full_name" class="inline-block label-title">{{ _('Full name') }}</label>
-            <i class="icon-vector-question-sign" id="hover-message" data-toggle="tooltip" title="{{ 'Zulip has full unicode support, so feel free to spell your name however you\'d like it to appear.' }}"></i>
             {% if lock_name %}
                 <p class="fakecontrol">{{ full_name }}</p>
             {% else %}
@@ -46,6 +45,9 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                     {% endfor %}
                 {% endif %}
             {% endif %}
+            <div class="help-box">
+                {{ _('Zulip has full unicode support, so feel free to spell your name however you\'d like!') }}
+            </div>
         </div>
 
 
@@ -199,10 +201,6 @@ if ($('#id_email:visible').length) {
 $("[name=realm_org_type]").on("change", function () {
     $(".blob").hide();
     $("#org_type_blob_" + this.value).show();
-});
-
-$(function (){
-    $("#hover-message, i[data-toggle='tooltip']").tooltip();
 });
 </script>
 


### PR DESCRIPTION
This displays a ? symbol next to the "full name" input field of the settings page and the registration form, which on mouseover displays the pop up message- "Zulip has full unicode support, so feel free to spell your name however you'd like it to appear."
The corresponding conversation can be found at: #2944