### PR TITLE
Move endpoints to use stream_id instead of stream_name in their URLs

### DIFF
--- a/api/zulip/__init__.py
+++ b/api/zulip/__init__.py
@@ -641,13 +641,30 @@ class Client(object):
             request=request,
         )
 
+    def get_stream_id(self, stream):
+        # type: (str) -> Dict[str, Any]
+        '''
+            Example usage: client.get_stream_id('devel')
+        '''
+        stream_encoded = urllib.parse.quote(stream, safe='')
+        url = 'get_stream_id?stream=%s' % (stream_encoded,)
+        return self.call_endpoint(
+            url=url,
+            method='GET',
+            request=None,
+        )
+
     def get_subscribers(self, **request):
         # type: (**Any) -> Dict[str, Any]
         '''
             Example usage: client.get_subscribers(stream='devel')
         '''
-        stream = urllib.parse.quote(request['stream'], safe='')
-        url = 'streams/%s/members' % (stream,)
+        request_stream_id = self.get_stream_id(request['stream'])
+        try:
+            stream_id = request_stream_id['stream_id']
+        except KeyError:
+            return request_stream_id
+        url = 'streams/%d/members' % (stream_id,)
         return self.call_endpoint(
             url=url,
             method='GET',

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -778,8 +778,10 @@ function _setup_page() {
         }
         $("#deactivation_stream_modal").modal("hide");
         $(".active_stream_row button").prop("disabled", true).text("Working…");
+        var stream_name = $(".active_stream_row").find('.stream_name').text();
+        var stream_id = stream_data.get_sub(stream_name).stream_id;
         channel.del({
-            url: '/json/streams/' + encodeURIComponent($(".active_stream_row").find('.stream_name').text()),
+            url: '/json/streams/' + stream_id,
             error: function (xhr) {
                 if (xhr.status.toString().charAt(0) === "4") {
                     $(".active_stream_row button").closest("td").html(

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -396,7 +396,7 @@ function _setup_page() {
         $("#deactivation_user_modal").modal("hide");
         meta.current_deactivate_user_modal_row.find("button").eq(0).prop("disabled", true).text("Working…");
         channel.del({
-            url: '/json/users/' + email,
+            url: '/json/users/' + encodeURIComponent(email),
             error: function (xhr) {
                 if (xhr.status.toString().charAt(0) === "4") {
                     meta.current_deactivate_user_modal_row.find("button").closest("td").html(
@@ -426,7 +426,7 @@ function _setup_page() {
         var email = get_email_for_user_row(row);
 
         channel.del({
-            url: '/json/bots/' + email,
+            url: '/json/bots/' + encodeURIComponent(email),
             error: function (xhr) {
                 if (xhr.status.toString().charAt(0) === "4") {
                     row.find("button").closest("td").html(
@@ -457,7 +457,7 @@ function _setup_page() {
         var email = get_email_for_user_row(row);
 
         channel.post({
-            url: '/json/users/' + email + "/reactivate",
+            url: '/json/users/' + encodeURIComponent(email) + "/reactivate",
             error: function (xhr) {
                 var button = row.find("button");
                 if (xhr.status.toString().charAt(0) === "4") {
@@ -677,7 +677,7 @@ function _setup_page() {
         var row = $(e.target).closest(".user_row");
         var email = get_email_for_user_row(row);
 
-        var url = "/json/users/" + email;
+        var url = "/json/users/" + encodeURIComponent(email);
         var data = {
             is_admin: JSON.stringify(true)
         };
@@ -708,7 +708,7 @@ function _setup_page() {
         var row = $(e.target).closest(".user_row");
         var email = get_email_for_user_row(row);
 
-        var url = "/json/users/" + email;
+        var url = "/json/users/" + encodeURIComponent(email);
         var data = {
             is_admin: JSON.stringify(false)
         };
@@ -754,7 +754,7 @@ function _setup_page() {
             e.preventDefault();
             e.stopPropagation();
 
-            var url = "/json/users/" + email;
+            var url = "/json/users/" + encodeURIComponent(email);
             var data = {
                 full_name: JSON.stringify(full_name.val())
             };

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -317,7 +317,7 @@ function show_subscription_settings(sub_row) {
     loading.make_indicator(indicator_elem);
 
     channel.get({
-        url: "/json/streams/" + encodeURIComponent(sub.name) + "/members",
+        url: "/json/streams/" + stream_id + "/members",
         idempotent: true,
         success: function (data) {
             loading.destroy_indicator(indicator_elem);
@@ -1196,15 +1196,13 @@ $(function () {
         e.preventDefault();
         var sub_settings = $(e.target).closest('.subscription_settings');
         var stream_id = $(e.target).closest(".subscription_settings").attr("data-stream-id");
-        var sub = stream_data.get_sub_by_id(stream_id);
         var new_name_box = sub_settings.find('input[name="new-name"]');
         var new_name = $.trim(new_name_box.val());
 
         $("#subscriptions-status").hide();
 
         channel.patch({
-            // Stream names might contain unsafe characters so we must encode it first.
-            url: "/json/streams/" + encodeURIComponent(sub.name),
+            url: "/json/streams/" + stream_id,
             data: {new_name: JSON.stringify(new_name)},
             success: function () {
                 new_name_box.val('');
@@ -1222,13 +1220,13 @@ $(function () {
         e.preventDefault();
         var sub_settings = $(e.target).closest('.subscription_settings');
         var stream_name = get_stream_name(sub_settings);
+        var stream_id = stream_data.get_sub(stream_name).stream_id;
         var description = sub_settings.find('input[name="description"]').val();
 
         $('#subscriptions-status').hide();
 
         channel.patch({
-            // Stream names might contain unsafe characters so we must encode it first.
-            url: '/json/streams/' + encodeURIComponent(stream_name),
+            url: '/json/streams/' + stream_id,
             data: {
                 description: JSON.stringify(description)
             },
@@ -1282,7 +1280,7 @@ $(function () {
         var data = {stream_name: sub.name, is_private: is_private};
 
         channel.patch({
-            url: "/json/streams/" + encodeURIComponent(sub.name),
+            url: "/json/streams/" + stream_id,
             data: data,
             success: function () {
                 sub = stream_data.get_sub_by_id(stream_id);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -317,7 +317,7 @@ function show_subscription_settings(sub_row) {
     loading.make_indicator(indicator_elem);
 
     channel.get({
-        url: "/json/streams/" + sub.name + "/members",
+        url: "/json/streams/" + encodeURIComponent(sub.name) + "/members",
         idempotent: true,
         success: function (data) {
             loading.destroy_indicator(indicator_elem);
@@ -1282,7 +1282,7 @@ $(function () {
         var data = {stream_name: sub.name, is_private: is_private};
 
         channel.patch({
-            url: "/json/streams/" + sub.name,
+            url: "/json/streams/" + encodeURIComponent(sub.name),
             data: data,
             success: function () {
                 sub = stream_data.get_sub_by_id(stream_id);

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -75,12 +75,13 @@ class PublicURLTest(ZulipTestCase):
         # FIXME: We should also test the Tornado URLs -- this codepath
         # can't do so because this Django test mechanism doesn't go
         # through Tornado.
+        denmark_stream_id = Stream.objects.get(name='Denmark').id
         get_urls = {200: ["/accounts/home/", "/accounts/login/"
                           "/en/accounts/home/", "/ru/accounts/home/",
                           "/en/accounts/login/", "/ru/accounts/login/",
                           "/help/"],
                     302: ["/", "/en/", "/ru/"],
-                    401: ["/json/streams/Denmark/members",
+                    401: ["/json/streams/%d/members" % (denmark_stream_id,),
                           "/api/v1/users/me/subscriptions",
                           "/api/v1/messages",
                           "/json/messages",

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1934,6 +1934,25 @@ class GetPublicStreamsTest(ZulipTestCase):
                                  **self.api_auth(email))
         self.assertEqual(result.status_code, 400)
 
+class StreamIdTest(ZulipTestCase):
+    def setUp(self):
+        # type: () -> None
+        self.email = "hamlet@zulip.com"
+        self.user_profile = get_user_profile_by_email(self.email)
+        self.login(self.email)
+
+    def test_get_stream_id(self):
+        # type: () -> None
+        stream = gather_subscriptions(self.user_profile)[0][0]
+        result = self.client_get("/json/get_stream_id?stream=%s" % (stream['name'],))
+        self.assert_json_success(result)
+        self.assertEqual(result.json()['stream_id'], stream['stream_id'])
+
+    def test_get_stream_id_wrong_name(self):
+        # type: () -> None
+        result = self.client_get("/json/get_stream_id?stream=wrongname")
+        self.assert_json_error(result, u'No such stream name')
+
 class InviteOnlyStreamTest(ZulipTestCase):
     def test_must_be_subbed_to_send(self):
         # type: () -> None

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -487,6 +487,15 @@ def stream_exists_backend(request, user_profile, stream_name, autosubscribe):
         return json_success(result) # results are ignored for HEAD requests
     return json_response(data=result, status=404)
 
+@has_request_variables
+def json_get_stream_id(request, user_profile, stream=REQ()):
+    # type: (HttpRequest, UserProfile, Text) -> HttpResponse
+    try:
+        stream_id = Stream.objects.get(realm=user_profile.realm, name=stream).id
+    except Stream.DoesNotExist:
+        return json_error(_("No such stream name"))
+    return json_success({'stream_id': stream_id})
+
 def get_subscription_or_die(stream_name, user_profile):
     # type: (Text, UserProfile) -> Subscription
     stream = get_stream(stream_name, user_profile.realm)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -293,9 +293,9 @@ v1_api_and_json_patterns = [
         {'GET': 'zerver.views.streams.json_get_stream_id'}),
 
     # GET returns "stream info" (undefined currently?), HEAD returns whether stream exists (200 or 404)
-    url(r'^streams/(?P<stream_name>.*)/members$', rest_dispatch,
+    url(r'^streams/(?P<stream_id>\d+)/members$', rest_dispatch,
         {'GET': 'zerver.views.streams.get_subscribers_backend'}),
-    url(r'^streams/(?P<stream_name>.*)$', rest_dispatch,
+    url(r'^streams/(?P<stream_id>\d+)$', rest_dispatch,
         {'HEAD': 'zerver.views.streams.stream_exists_backend',
          'GET': 'zerver.views.streams.stream_exists_backend',
          'PATCH': 'zerver.views.streams.update_stream_backend',

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -288,6 +288,10 @@ v1_api_and_json_patterns = [
     url(r'^streams$', rest_dispatch,
         {'GET': 'zerver.views.streams.get_streams_backend'}),
 
+    # GET returns `stream_id`, stream name should be encoded in the url query (in `stream` param)
+    url(r'^get_stream_id', rest_dispatch,
+        {'GET': 'zerver.views.streams.json_get_stream_id'}),
+
     # GET returns "stream info" (undefined currently?), HEAD returns whether stream exists (200 or 404)
     url(r'^streams/(?P<stream_name>.*)/members$', rest_dispatch,
         {'GET': 'zerver.views.streams.get_subscribers_backend'}),


### PR DESCRIPTION
- Add missing `encodeURIComponent()` on some API uses

- Change `stream_name` into `stream_id` on some API endpoints that use
`stream_name` in their URLs to prevent confusion of `views` selection.

See https://github.com/zulip/zulip/issues/2930#issuecomment-269576231

Fixes #2930.

Zulip conversation: https://chat.zulip.org/#narrow/stream/GCI.20help/topic/Issue.20.232930