### PR TITLE
Prevent private message suggestion pop up from displaying already added recipients.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -429,6 +429,10 @@ exports.initialize = function () {
             if (! current_recipient.match(/\S/)) {
                 return false;
             }
+            var recipients = util.extract_pm_recipients(this.query);
+            if (recipients.indexOf(item.email) > -1) {
+                return false;
+            }
 
             return query_matches_person(current_recipient, item);
         },


### PR DESCRIPTION
This matches the recipients and displays the ones which haven't been added
already.

Fixes: #2499.