### PR TITLE
narrow: Allow searching by emoji

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -309,18 +309,19 @@ def render_markdown(message, content, realm_id=None, realm_alert_words=None, mes
     else:
         message_user_ids = {u.id for u in message_users}
 
-    message.mentions_wildcard = False
-    message.is_me_message = False
-    message.mentions_user_ids = set()
-    message.alert_words = set()
-    message.links_for_preview = set()
+    if message is not None:
+        message.mentions_wildcard = False
+        message.is_me_message = False
+        message.mentions_user_ids = set()
+        message.alert_words = set()
+        message.links_for_preview = set()
 
-    if realm_id is None:
-        realm_id = message.sender.realm_id
-    if message.sending_client.name == "zephyr_mirror" and message.sender.realm.is_zephyr_mirror_realm:
-        # Use slightly customized Markdown processor for content
-        # delivered via zephyr_mirror
-        realm_id = bugdown.ZEPHYR_MIRROR_BUGDOWN_KEY
+        if realm_id is None:
+            realm_id = message.sender.realm_id
+        if message.sending_client.name == "zephyr_mirror" and message.sender.realm.is_zephyr_mirror_realm:
+            # Use slightly customized Markdown processor for content
+            # delivered via zephyr_mirror
+            realm_id = bugdown.ZEPHYR_MIRROR_BUGDOWN_KEY
 
     possible_words = set() # type: Set[Text]
     if realm_alert_words is not None:
@@ -332,14 +333,15 @@ def render_markdown(message, content, realm_id=None, realm_alert_words=None, mes
     rendered_content = bugdown.convert(content, realm_id=realm_id, message=message,
                                        possible_words=possible_words)
 
-    message.user_ids_with_alert_words = set()
+    if message is not None:
+        message.user_ids_with_alert_words = set()
 
-    if realm_alert_words is not None:
-        for user_id, words in realm_alert_words.items():
-            if user_id in message_user_ids:
-                if set(words).intersection(message.alert_words):
-                    message.user_ids_with_alert_words.add(user_id)
+        if realm_alert_words is not None:
+            for user_id, words in realm_alert_words.items():
+                if user_id in message_user_ids:
+                    if set(words).intersection(message.alert_words):
+                        message.user_ids_with_alert_words.add(user_id)
 
-    message.is_me_message = Message.is_status_message(content, rendered_content)
+        message.is_me_message = Message.is_status_message(content, rendered_content)
 
     return rendered_content

--- a/zerver/migrations/0050_tsearch_emoji.py
+++ b/zerver/migrations/0050_tsearch_emoji.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0049_userprofile_pm_content_in_desktop_notifications'),
+    ]
+
+    operations = [
+        migrations.RunSQL("""
+ALTER TEXT SEARCH CONFIGURATION zulip.english_us_search
+ALTER MAPPING FOR tag, entity
+WITH english_us_hunspell, english_stem;
+""")
+    ]


### PR DESCRIPTION
Closes #2994

I implemented it by:
1. Making the highlighter aware of HTML tags (hopefully the algorithm there is good, though I tested it well)
2. Rendering the search query as markdown (not necessary for emoji search with pgroonga)
    * This means that now one can search for, e.g. `**bold text**` to get all messages with `bold text` in **bold**
    * Note that while pgroonga can find emojis that are incomplete (e.g. `:office`), tsearch can't (e.g. only `:office:` would be accepted by it)
3. Add `tag` and `entity` parsers, so that `tsearch` works fine as well

*Sidenote:* Searching for `br` with pgroonga would find all kinds of `br` tags here and there... (even on current master)