### PR TITLE
docs: Add user guide for *Configure audible notifications* feature

### DIFF
--- a/templates/zerver/help/configure-audible-notifications.md
+++ b/templates/zerver/help/configure-audible-notifications.md
@@ -1,0 +1,20 @@
+# Configure audible notifications
+
+You can configure your settings to receive audible notifications for messages
+sent when Zulip is offscreen.
+
+{!settings1.md!} [Notifications](/#settings/notifications)
+{!settings2.md!}
+
+2.    If you want to receive notifications for each new message from a stream,
+select the **Audible notifications** option under **Stream messages**.
+
+    If you want to receive notifications for private messages and @-mentions,
+    select the **Audible notifications** option under **Private messages and @-mentions**.
+
+3. Click on the **Save Changes** button at the bottom to save any changes you
+made to your notification settings.
+
+!!! tip ""
+    You can change your notification settings for individual streams on your
+    [Streams](/#subscriptions) page.

--- a/templates/zerver/help/include/settings1.md
+++ b/templates/zerver/help/include/settings1.md
@@ -1,0 +1,1 @@
+1. Go to the

--- a/templates/zerver/help/include/settings2.md
+++ b/templates/zerver/help/include/settings2.md
@@ -1,0 +1,1 @@
+tab of the [Settings](/help/edit-settings) page.

--- a/templates/zerver/help/index.md
+++ b/templates/zerver/help/index.md
@@ -107,7 +107,7 @@ as a “**realm**”.
 * [Mute a topic](/help/mute-a-topic)
 * Set notifications for a single stream
 * [Configure desktop notifications](/help/configure-desktop-notifications)
-* Configure audible notifications
+* [Configure audible notifications](/help/configure-audible-notifications)
 * Configure email notifications
 * Configure mobile push notifications
 * [Add an alert word](/help/alert-words)


### PR DESCRIPTION
Please note: this doc uses the unmerged Settings macro to fit with the new documentation styling guide; thus, there is a "Create *Settings* macro" commit and considerably less content in this doc.