### PR TITLE
Fix z-index Issues and hides popovers.

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -290,6 +290,7 @@ exports.lightbox = function (data) {
     }
 
     $("#overlay").addClass("show");
+    popovers.hide_all();
 };
 
 exports.lightbox_photo = function (image, user) {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -69,6 +69,10 @@ p.n-margin {
     border-radius: 4px;
 }
 
+.modal-backdrop {
+    z-index: 102;
+}
+
 #unmute_muted_topic_notification {
     display: none;
     position: absolute;


### PR DESCRIPTION
This fixes the z-index issue with the navbar and the overlays, but also fixes an existing issue where the popovers aren’t closed when you enter the lightbox. Now they are.