### PR TITLE
Painting Performance Fixes.

### DIFF
--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -330,11 +330,11 @@ function actually_update_users_for_search() {
 var update_users_for_search = _.throttle(actually_update_users_for_search, 50);
 
 function show_huddles() {
-    $('#group-pm-list').expectOne().show();
+    $('#group-pm-list').addClass("show");
 }
 
 function hide_huddles() {
-    $('#group-pm-list').expectOne().hide();
+    $('#group-pm-list').removeClass("show");
 }
 
 exports.update_huddles = function () {

--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -92,7 +92,8 @@ function get_message_height(elem, message_id) {
         return _message_content_height_cache.get(message_id);
     }
 
-    var height = elem.getBoundingClientRect().height;
+    // shown to be ~2.5x faster than Node.getBoundingClientRect().
+    var height = elem.offsetHeight;
     _message_content_height_cache.set(message_id, height);
     return height;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2402,6 +2402,10 @@ button.topic_edit_cancel {
     display: none;
 }
 
+#group-pm-list.show {
+    display: block;
+}
+
 #userlist-header,
 #group-pm-header {
     border-top: 1px solid #e2e2e2;


### PR DESCRIPTION
This fixes two performance related issues:

1. The #group-pm-list now only should change state from hidden to
displayed once, which removes time spent recalculating styles in the
DOM.

2. By referencing offsetHeight, only the height of the node needs to be
calculated, not the width and other offset measures.