### PR TITLE
Fix Small Image Preview Sizing.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1993,9 +1993,14 @@ div.floating_recipient {
 .message_inline_image {
     margin-bottom: 5px;
     margin-left: 5px;
-    height: 100px;
+    max-height: 100px;
     display: block !important;
     border: none !important;
+}
+
+/* this forces the line to have inline-block styling which gives it a height. */
+.message_inline_image a {
+    display: inline-block;
 }
 
 .message_inline_ref {
@@ -2010,7 +2015,7 @@ div.floating_recipient {
 .message_inline_image img,
 .message_inline_ref img {
     height: auto;
-    max-height: 100%;
+    max-height: 100px;
     float: left;
     margin-right: 10px;
 }


### PR DESCRIPTION
Before the sizing of the preview would be 100px in height regardless of
whether the image was that tall. Now it is any value up to 100px.