### PR TITLE
[Fix]: Change escape key interception with subscription overlay.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -195,7 +195,7 @@ function process_hotkey(e) {
         if ($("#overlay").hasClass("show")) {
             ui.exit_lightbox_photo();
             return true;
-        } else if ($("#subscription_overlay").css("display") === "block") {
+        } else if ($("#subscription_overlay").hasClass("show")) {
             $("#subscription_overlay").click();
             return true;
         }


### PR DESCRIPTION
The escape key used to be intercepted if the subscription pay display
was set to “block”, but now since we use the class “show” and lack to
hide and show the overlay, the query needs to change.