### PR TITLE
Add .editorconfig for most file extensions with more than one use

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{sh,py,js, json,yml,xml, css, md,markdown}]
+indent_style = space
+indent_size = 4
+
+[*.{handlebars,html, svg,rb,pp,pl}]
+indent_style = space
+indent_size = 2
+
+[*.{cfg}]
+indent_style = space
+indent_size = 8


### PR DESCRIPTION
I didn't add anything about the following extensions since they had way too many different styles:
- .txt
- .conf
- .erb (saw tab, 2-spaced, 4-spaced and 8-spaced files around the codebase)

Closes #3099