### PR TITLE
Live-update user list for name changes.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -11,7 +11,7 @@ set_global('page_params', {
     email: 'hamlet@example.com',
 });
 set_global('activity', {
-    set_user_statuses: function () {},
+    redraw: function () {},
 });
 set_global('admin', {
     show_or_hide_menu_item: function () {},

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -496,6 +496,11 @@ exports.set_user_statuses = function (users, server_time) {
     exports.update_huddles();
 };
 
+exports.redraw = function () {
+    exports.update_users();
+    exports.update_huddles();
+};
+
 exports.searching = function () {
     return $('.user-list-filter').expectOne().is(':focus');
 };

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -288,6 +288,10 @@ exports.update = function update(person) {
         if (util.is_current_user(person.email)) {
             page_params.fullname = person.full_name;
         }
+
+        activity.redraw();
+        // TODO: update sender names on messages
+
     }
 
     if (_.has(person, 'is_admin')) {
@@ -312,10 +316,6 @@ exports.update = function update(person) {
           "background-image": "url(" + url + ")"
         });
     }
-
-    activity.set_user_statuses([]);
-
-    // TODO: update sender names on messages
 };
 
 $(function () {


### PR DESCRIPTION
When somebody changes their name, we will now update
the buddy list right away.  The old code was trying
to do this through a code path that was designed for
true presence updates, but it was also passing in an
empty array, instead of undefined, which caused it to
fail to invoke the intended part of the codepath to
redraw the buddy list.

Now we just call the new activity.redraw() function,
which does the right thing for the buddy list.

The group PM list was live-updating before this change,
and it continues to live-update as part of the new
activity.redraw() function.