### PR TITLE
docs:Fixed incorrect use of warning markdown

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -183,7 +183,7 @@ indenting them.
       Cheat Sheet for a complete list.
   * Example **warning**:
       ```
-      !!! warning ""
+      !!! warn ""
           If you attempt to input a nonexistent stream name, an error
           message will appear.
       ```


### PR DESCRIPTION
I changed `!!! warning` to `!!! warn` in the example warning block because `!!! warning` doesn't create a warning block.