### PR TITLE
WIP: 'Remote Server' for push notification bouncer

### DIFF
--- a/scripts/setup/generate_secrets.py
+++ b/scripts/setup/generate_secrets.py
@@ -16,6 +16,7 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'zproject.settings'
 from django.utils.crypto import get_random_string
 import six
 import argparse
+import uuid
 from zerver.lib.str_utils import force_str
 from zerver.lib.utils import generate_random_token
 
@@ -83,6 +84,12 @@ def generate_secrets(development=False):
 
     camo_key = old_conf.get('camo_key', get_random_string(64))
     lines.append(config_line('camo_key', camo_key))
+
+    zulip_org_key = old_conf.get('zulip_org_key', get_random_string(32))
+    lines.append(config_line('zulip_org_key', zulip_org_key))
+
+    zulip_org_id = old_conf.get('zulip_org_id', str(uuid.uuid4()))
+    lines.append(config_line('zulip_org_id', zulip_org_id))
 
     if not development:
         # Write the Camo config file directly

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -30,11 +30,13 @@ from io import BytesIO
 from zerver.lib.mandrill_client import get_mandrill_client
 from six.moves import zip, urllib
 
-from typing import Union, Any, Callable, Sequence, Dict, Optional, TypeVar, Text
+<<<<<<< b90e9d320022d024f427b35a2c266d21f81de81b
+from six import text_type
+from typing import Union, Any, Callable, Sequence, Dict, Optional, TypeVar, Text, cast
 from zerver.lib.str_utils import force_bytes
 
 if settings.ZILENCER_ENABLED:
-    from zilencer.models import get_remote_server_by_uuid, RemoteZulipServer 
+    from zilencer.models import get_remote_server_by_uuid, RemoteZulipServer
 else:
     from mock import Mock
     get_remote_server_by_uuid = Mock()
@@ -186,7 +188,7 @@ def validate_api_key(request, role, api_key, is_webhook=False):
     if isinstance(profile, RemoteZulipServer):
       return profile
 
-    # further validation required for UserProfiles
+    profile = cast(UserProfile, profile) # is UserProfile
     if not profile.is_active:
         raise JsonableError(_("Account not active"))
     if profile.is_incoming_webhook and not is_webhook:
@@ -383,7 +385,7 @@ def authenticated_rest_api_view(is_webhook=False):
 
             # Now we try to do authentication or die
             try:
-                # Could be a UserProfile or a RemoteZulipServer 
+                # Could be a UserProfile or a RemoteZulipServer
                 profile = validate_api_key(request, role, api_key, is_webhook)
             except JsonableError as e:
                 return json_unauthorized(e.error)

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -34,18 +34,18 @@ from typing import Union, Any, Callable, Sequence, Dict, Optional, TypeVar, Text
 from zerver.lib.str_utils import force_bytes
 
 if settings.ZILENCER_ENABLED:
-    from zilencer.models import get_deployment_by_domain, Deployment
+    from zilencer.models import get_remote_server_by_uuid, RemoteZulipServer 
 else:
     from mock import Mock
-    get_deployment_by_domain = Mock()
-    Deployment = Mock() # type: ignore # https://github.com/JukkaL/mypy/issues/1188
+    get_remote_server_by_uuid = Mock()
+    RemoteZulipServer = Mock() # type: ignore # https://github.com/JukkaL/mypy/issues/1188
 
 FuncT = TypeVar('FuncT', bound=Callable[..., Any])
 ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
 
-def get_deployment_or_userprofile(role):
-    # type: (Text) -> Union[UserProfile, Deployment]
-    return get_user_profile_by_email(role) if "@" in role else get_deployment_by_domain(role)
+def get_remote_server_or_userprofile(role):
+    # type: (text_type) -> Union[UserProfile, RemoteZulipServer]
+    return get_user_profile_by_email(role) if "@" in role else get_remote_server_by_uuid(role)
 
 class _RespondAsynchronously(object):
     pass
@@ -163,16 +163,16 @@ def process_client(request, user_profile, is_json_view=False, client_name=None):
     update_user_activity(request, user_profile)
 
 def validate_api_key(request, role, api_key, is_webhook=False):
-    # type: (HttpRequest, Text, Text, bool) -> Union[UserProfile, Deployment]
+    # type: (HttpRequest, text_type, text_type, bool) -> Union[UserProfile, RemoteZulipServer]
     # Remove whitespace to protect users from trivial errors.
     role, api_key = role.strip(), api_key.strip()
 
     try:
-        profile = get_deployment_or_userprofile(role)
+        profile = get_remote_server_or_userprofile(role)
     except UserProfile.DoesNotExist:
         raise JsonableError(_("Invalid user: %s") % (role,))
-    except Deployment.DoesNotExist:
-        raise JsonableError(_("Invalid deployment: %s") % (role,))
+    except RemoteZulipServer.DoesNotExist:
+        raise JsonableError(_("Invalid Zulip server: %s") % (role,))
 
     if api_key != profile.api_key:
         if len(api_key) != 32:
@@ -181,16 +181,18 @@ def validate_api_key(request, role, api_key, is_webhook=False):
         else:
             reason = _("Invalid API key for role '%s'")
         raise JsonableError(reason % (role,))
+
+    # early exit for RemoteZulipServers
+    if isinstance(profile, RemoteZulipServer):
+      return profile
+
+    # further validation required for UserProfiles
     if not profile.is_active:
         raise JsonableError(_("Account not active"))
     if profile.is_incoming_webhook and not is_webhook:
         raise JsonableError(_("Account is not valid to post webhook messages"))
-    try:
-        if profile.realm.deactivated:
-            raise JsonableError(_("Realm for account has been deactivated"))
-    except AttributeError:
-        # Deployment objects don't have realms
-        pass
+    if profile.realm.deactivated:
+        raise JsonableError(_("Realm for account has been deactivated"))
     if (not check_subdomain(get_subdomain(request), profile.realm.subdomain)
         # Allow access to localhost for Tornado
         and not (settings.RUNNING_INSIDE_TORNADO and
@@ -381,7 +383,7 @@ def authenticated_rest_api_view(is_webhook=False):
 
             # Now we try to do authentication or die
             try:
-                # Could be a UserProfile or a Deployment
+                # Could be a UserProfile or a RemoteZulipServer 
                 profile = validate_api_key(request, role, api_key, is_webhook)
             except JsonableError as e:
                 return json_unauthorized(e.error)
@@ -390,8 +392,8 @@ def authenticated_rest_api_view(is_webhook=False):
             if isinstance(profile, UserProfile):
                 request._email = profile.email
             else:
-                assert isinstance(profile, Deployment)
-                request._email = "deployment:" + role
+                assert isinstance(profile, RemoteZulipServer)
+                request._email = "zulip-server:" + role
                 profile.rate_limits = ""
             # Apply rate limiting
             return rate_limit()(view_func)(request, profile, *args, **kwargs)

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -30,7 +30,6 @@ from io import BytesIO
 from zerver.lib.mandrill_client import get_mandrill_client
 from six.moves import zip, urllib
 
-<<<<<<< b90e9d320022d024f427b35a2c266d21f81de81b
 from six import text_type
 from typing import Union, Any, Callable, Sequence, Dict, Optional, TypeVar, Text, cast
 from zerver.lib.str_utils import force_bytes

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -43,6 +43,7 @@ from zerver.models import (
 )
 
 from zerver.lib.request import JsonableError
+from zilencer.models import get_remote_server_by_uuid
 
 import collections
 import base64
@@ -384,6 +385,414 @@ def write_instrumentation_reports(full_suite):
             for untested_pattern in sorted(untested_patterns):
                 print("   %s" % (untested_pattern,))
             sys.exit(1)
+
+
+class ZulipTestCase(TestCase):
+    '''
+    WRAPPER_COMMENT:
+
+    We wrap calls to self.client.{patch,put,get,post,delete} for various
+    reasons.  Some of this has to do with fixing encodings before calling
+    into the Django code.  Some of this has to do with providing a future
+    path for instrumentation.  Some of it's just consistency.
+
+    The linter will prevent direct calls to self.client.foo, so the wrapper
+    functions have to fake out the linter by using a local variable called
+    django_client to fool the regext.
+    '''
+
+    DEFAULT_REALM_NAME = 'zulip.com'
+
+    @instrument_url
+    def client_patch(self, url, info={}, **kwargs):
+        # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
+        """
+        We need to urlencode, since Django's function won't do it for us.
+        """
+        encoded = urllib.parse.urlencode(info)
+        django_client = self.client # see WRAPPER_COMMENT
+        return django_client.patch(url, encoded, **kwargs)
+
+    @instrument_url
+    def client_patch_multipart(self, url, info={}, **kwargs):
+        # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
+        """
+        Use this for patch requests that have file uploads or
+        that need some sort of multi-part content.  In the future
+        Django's test client may become a bit more flexible,
+        so we can hopefully eliminate this.  (When you post
+        with the Django test client, it deals with MULTIPART_CONTENT
+        automatically, but not patch.)
+        """
+        encoded = encode_multipart(BOUNDARY, info)
+        django_client = self.client # see WRAPPER_COMMENT
+        return django_client.patch(
+            url,
+            encoded,
+            content_type=MULTIPART_CONTENT,
+            **kwargs)
+
+    @instrument_url
+    def client_put(self, url, info={}, **kwargs):
+        # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
+        encoded = urllib.parse.urlencode(info)
+        django_client = self.client # see WRAPPER_COMMENT
+        return django_client.put(url, encoded, **kwargs)
+
+    @instrument_url
+    def client_delete(self, url, info={}, **kwargs):
+        # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
+        encoded = urllib.parse.urlencode(info)
+        django_client = self.client # see WRAPPER_COMMENT
+        return django_client.delete(url, encoded, **kwargs)
+
+    @instrument_url
+    def client_post(self, url, info={}, **kwargs):
+        # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
+        django_client = self.client # see WRAPPER_COMMENT
+        return django_client.post(url, info, **kwargs)
+
+    @instrument_url
+    def client_get(self, url, info={}, **kwargs):
+        # type: (text_type, Dict[str, Any], **Any) -> HttpResponse
+        django_client = self.client # see WRAPPER_COMMENT
+        return django_client.get(url, info, **kwargs)
+
+    def login_with_return(self, email, password=None):
+        # type: (text_type, Optional[text_type]) -> HttpResponse
+        if password is None:
+            password = initial_password(email)
+        return self.client_post('/accounts/login/',
+                                {'username': email, 'password': password})
+
+    def login(self, email, password=None, fails=False):
+        # type: (text_type, Optional[text_type], bool) -> HttpResponse
+        if password is None:
+            password = initial_password(email)
+        if not fails:
+            self.assertTrue(self.client.login(username=email, password=password))
+        else:
+            self.assertFalse(self.client.login(username=email, password=password))
+
+    def register(self, username, password, domain="zulip.com"):
+        # type: (text_type, text_type, text_type) -> HttpResponse
+        self.client_post('/accounts/home/',
+                         {'email': username + "@" + domain})
+        return self.submit_reg_form_for_user(username, password, domain=domain)
+
+    def submit_reg_form_for_user(self, username, password, domain="zulip.com",
+                                 realm_name="Zulip Test", realm_subdomain="zuliptest",
+                                 realm_org_type=Realm.COMMUNITY,
+                                 from_confirmation='', **kwargs):
+        # type: (text_type, text_type, text_type, Optional[text_type], Optional[text_type], int, Optional[text_type], **Any) -> HttpResponse
+        """
+        Stage two of the two-step registration process.
+
+        If things are working correctly the account should be fully
+        registered after this call.
+
+        You can pass the HTTP_HOST variable for subdomains via kwargs.
+        """
+        return self.client_post('/accounts/register/',
+                                {'full_name': username, 'password': password,
+                                 'realm_name': realm_name,
+                                 'realm_subdomain': realm_subdomain,
+                                 'key': find_key_by_email(username + '@' + domain),
+                                 'realm_org_type': realm_org_type,
+                                 'terms': True,
+                                 'from_confirmation': from_confirmation},
+                                **kwargs)
+
+    def get_confirmation_url_from_outbox(self, email_address, path_pattern="(\S+)>"):
+        # type: (text_type, text_type) -> text_type
+        from django.core.mail import outbox
+        for message in reversed(outbox):
+            if email_address in message.to:
+                return re.search(settings.EXTERNAL_HOST + path_pattern,
+                                 message.body).groups()[0]
+        else:
+            raise ValueError("Couldn't find a confirmation email.")
+
+    def get_api_key(self, email):
+        # type: (text_type) -> text_type
+        if email not in API_KEYS:
+            API_KEYS[email] = get_user_profile_by_email(email).api_key
+        return API_KEYS[email]
+
+    def get_server_api_key(self, server_uuid):
+        # type: (text_type) -> text_type
+        if server_uuid not in API_KEYS:
+            API_KEYS[server_uuid] = get_remote_server_by_uuid(server_uuid).api_key
+
+        return API_KEYS[server_uuid]
+
+    def api_auth(self, email):
+        # type: (text_type) -> Dict[str, text_type]
+
+        if "@" not in email:
+            api_key = self.get_server_api_key(email)
+        else:
+            api_key = self.get_api_key(email)
+
+        credentials = u"%s:%s" % (email, api_key)
+        return {
+            'HTTP_AUTHORIZATION': u'Basic ' + base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
+        }
+
+    def get_streams(self, email):
+        # type: (text_type) -> List[text_type]
+        """
+        Helper function to get the stream names for a user
+        """
+        user_profile = get_user_profile_by_email(email)
+        subs = Subscription.objects.filter(
+            user_profile=user_profile,
+            active=True,
+            recipient__type=Recipient.STREAM)
+        return [cast(text_type, get_display_recipient(sub.recipient)) for sub in subs]
+
+    def send_message(self, sender_name, raw_recipients, message_type,
+                     content=u"test content", subject=u"test", **kwargs):
+        # type: (text_type, Union[text_type, List[text_type]], int, text_type, text_type, **Any) -> int
+        sender = get_user_profile_by_email(sender_name)
+        if message_type == Recipient.PERSONAL:
+            message_type_name = "private"
+        else:
+            message_type_name = "stream"
+        if isinstance(raw_recipients, six.string_types):
+            recipient_list = [raw_recipients]
+        else:
+            recipient_list = raw_recipients
+        (sending_client, _) = Client.objects.get_or_create(name="test suite")
+
+        return check_send_message(
+            sender, sending_client, message_type_name, recipient_list, subject,
+            content, forged=False, forged_timestamp=None,
+            forwarder_user_profile=sender, realm=sender.realm, **kwargs)
+
+    def get_old_messages(self, anchor=1, num_before=100, num_after=100):
+        # type: (int, int, int) -> List[Dict[str, Any]]
+        post_params = {"anchor": anchor, "num_before": num_before,
+                       "num_after": num_after}
+        result = self.client_get("/json/messages", dict(post_params))
+        data = ujson.loads(result.content)
+        return data['messages']
+
+    def users_subscribed_to_stream(self, stream_name, realm_domain):
+        # type: (text_type, text_type) -> List[UserProfile]
+        realm = get_realm(realm_domain)
+        stream = Stream.objects.get(name=stream_name, realm=realm)
+        recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
+        subscriptions = Subscription.objects.filter(recipient=recipient, active=True)
+
+        return [subscription.user_profile for subscription in subscriptions]
+
+    def assert_json_success(self, result):
+        # type: (HttpResponse) -> Dict[str, Any]
+        """
+        Successful POSTs return a 200 and JSON of the form {"result": "success",
+        "msg": ""}.
+        """
+        self.assertEqual(result.status_code, 200, result)
+        json = ujson.loads(result.content)
+        self.assertEqual(json.get("result"), "success")
+        # We have a msg key for consistency with errors, but it typically has an
+        # empty value.
+        self.assertIn("msg", json)
+        return json
+
+    def get_json_error(self, result, status_code=400):
+        # type: (HttpResponse, int) -> Dict[str, Any]
+        self.assertEqual(result.status_code, status_code)
+        json = ujson.loads(result.content)
+        self.assertEqual(json.get("result"), "error")
+        return json['msg']
+
+    def assert_json_error(self, result, msg, status_code=400):
+        # type: (HttpResponse, text_type, int) -> None
+        """
+        Invalid POSTs return an error status code and JSON of the form
+        {"result": "error", "msg": "reason"}.
+        """
+        self.assertEqual(self.get_json_error(result, status_code=status_code), msg)
+
+    def assert_length(self, queries, count):
+        # type: (Sized, int) -> None
+        actual_count = len(queries)
+        return self.assertTrue(actual_count == count,
+                                   "len(%s) == %s, != %s" % (queries, actual_count, count))
+
+    def assert_max_length(self, queries, count):
+        # type: (Sized, int) -> None
+        actual_count = len(queries)
+        return self.assertTrue(actual_count <= count,
+                               "len(%s) == %s, > %s" % (queries, actual_count, count))
+
+    def assert_json_error_contains(self, result, msg_substring, status_code=400):
+        # type: (HttpResponse, text_type, int) -> None
+        self.assertIn(msg_substring, self.get_json_error(result, status_code=status_code))
+
+    def assert_equals_response(self, string, response):
+        # type: (text_type, HttpResponse) -> None
+        self.assertEqual(string, response.content.decode('utf-8'))
+
+    def assert_in_response(self, substring, response):
+        # type: (text_type, HttpResponse) -> None
+        self.assertIn(substring, response.content.decode('utf-8'))
+
+    def fixture_data(self, type, action, file_type='json'):
+        # type: (text_type, text_type, text_type) -> text_type
+        return force_text(open(os.path.join(os.path.dirname(__file__),
+                                            "../fixtures/%s/%s_%s.%s" % (type, type, action, file_type))).read())
+
+    def make_stream(self, stream_name, realm=None, invite_only=False):
+        # type: (text_type, Optional[Realm], Optional[bool]) -> Stream
+        if realm is None:
+            realm = get_realm(self.DEFAULT_REALM_NAME)
+
+        try:
+            stream = Stream.objects.create(
+                realm=realm,
+                name=stream_name,
+                invite_only=invite_only,
+            )
+        except IntegrityError:
+            raise Exception('''
+                %s already exists
+
+                Please call make_stream with a stream name
+                that is not already in use.''' % (stream_name,))
+
+        Recipient.objects.create(type_id=stream.id, type=Recipient.STREAM)
+        return stream
+
+    # Subscribe to a stream directly
+    def subscribe_to_stream(self, email, stream_name, realm=None):
+        # type: (text_type, text_type, Optional[Realm]) -> None
+        if realm is None:
+            realm = get_realm(resolve_email_to_domain(email))
+        stream = get_stream(stream_name, realm)
+        if stream is None:
+            stream, _ = create_stream_if_needed(realm, stream_name)
+        user_profile = get_user_profile_by_email(email)
+        bulk_add_subscriptions([stream], [user_profile])
+
+    def unsubscribe_from_stream(self, email, stream_name):
+        # type: (text_type, text_type) -> None
+        user_profile = get_user_profile_by_email(email)
+        stream = get_stream(stream_name, user_profile.realm)
+        bulk_remove_subscriptions([user_profile], [stream])
+
+    # Subscribe to a stream by making an API request
+    def common_subscribe_to_streams(self, email, streams, extra_post_data={}, invite_only=False):
+        # type: (text_type, Iterable[text_type], Dict[str, Any], bool) -> HttpResponse
+        post_data = {'subscriptions': ujson.dumps([{"name": stream} for stream in streams]),
+                     'invite_only': ujson.dumps(invite_only)}
+        post_data.update(extra_post_data)
+        result = self.client_post("/api/v1/users/me/subscriptions", post_data, **self.api_auth(email))
+        return result
+
+    def send_json_payload(self, email, url, payload, stream_name=None, **post_params):
+        # type: (text_type, text_type, Union[text_type, Dict[str, Any]], Optional[text_type], **Any) -> Message
+        if stream_name is not None:
+            self.subscribe_to_stream(email, stream_name)
+
+        result = self.client_post(url, payload, **post_params)
+        self.assert_json_success(result)
+
+        # Check the correct message was sent
+        msg = self.get_last_message()
+        self.assertEqual(msg.sender.email, email)
+        if stream_name is not None:
+            self.assertEqual(get_display_recipient(msg.recipient), stream_name)
+        # TODO: should also validate recipient for private messages
+
+        return msg
+
+    def get_last_message(self):
+        # type: () -> Message
+        return Message.objects.latest('id')
+
+    def get_second_to_last_message(self):
+        # type: () -> Message
+        return Message.objects.all().order_by('-id')[1]
+
+    @contextmanager
+    def simulated_markdown_failure(self):
+        # type: () -> Generator[None, None, None]
+        '''
+        This raises a failure inside of the try/except block of
+        bugdown.__init__.do_convert.
+        '''
+        with \
+                self.settings(ERROR_BOT=None), \
+                mock.patch('zerver.lib.bugdown.timeout', side_effect=KeyError('foo')), \
+                mock.patch('zerver.lib.bugdown.log_bugdown_error'):
+            yield
+
+class WebhookTestCase(ZulipTestCase):
+    """
+    Common for all webhooks tests
+
+    Override below class attributes and run send_and_test_message
+    If you create your url in uncommon way you can override build_webhook_url method
+    In case that you need modify body or create it without using fixture you can also override get_body method
+    """
+    STREAM_NAME = None # type: Optional[text_type]
+    TEST_USER_EMAIL = 'webhook-bot@zulip.com'
+    URL_TEMPLATE = None # type: Optional[text_type]
+    FIXTURE_DIR_NAME = None # type: Optional[text_type]
+
+    def setUp(self):
+        # type: () -> None
+        self.url = self.build_webhook_url()
+
+    def send_and_test_stream_message(self, fixture_name, expected_subject=None,
+                                     expected_message=None, content_type="application/json", **kwargs):
+        # type: (text_type, Optional[text_type], Optional[text_type], Optional[text_type], **Any) -> Message
+        payload = self.get_body(fixture_name)
+        if content_type is not None:
+            kwargs['content_type'] = content_type
+        msg = self.send_json_payload(self.TEST_USER_EMAIL, self.url, payload,
+                                     self.STREAM_NAME, **kwargs)
+        self.do_test_subject(msg, expected_subject)
+        self.do_test_message(msg, expected_message)
+
+        return msg
+
+    def send_and_test_private_message(self, fixture_name, expected_subject=None,
+                                      expected_message=None, content_type="application/json", **kwargs):
+        # type: (text_type, text_type, text_type, str, **Any) -> Message
+        payload = self.get_body(fixture_name)
+        if content_type is not None:
+            kwargs['content_type'] = content_type
+
+        msg = self.send_json_payload(self.TEST_USER_EMAIL, self.url, payload,
+                                     stream_name=None, **kwargs)
+        self.do_test_message(msg, expected_message)
+
+        return msg
+
+    def build_webhook_url(self):
+        # type: () -> text_type
+        api_key = self.get_api_key(self.TEST_USER_EMAIL)
+        return self.URL_TEMPLATE.format(stream=self.STREAM_NAME, api_key=api_key)
+
+    def get_body(self, fixture_name):
+        # type: (text_type) -> Union[text_type, Dict[str, text_type]]
+        """Can be implemented either as returning a dictionary containing the
+        post parameters or as string containing the body of the request."""
+        return ujson.dumps(ujson.loads(self.fixture_data(self.FIXTURE_DIR_NAME, fixture_name)))
+
+    def do_test_subject(self, msg, expected_subject):
+        # type: (Message, Optional[text_type]) -> None
+        if expected_subject is not None:
+            self.assertEqual(msg.topic_name(), expected_subject)
+
+    def do_test_message(self, msg, expected_message):
+        # type: (Message, Optional[text_type]) -> None
+        if expected_message is not None:
+            self.assertEqual(msg.content, expected_message)
 
 def get_all_templates():
     # type: () -> List[str]

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -72,7 +72,7 @@ class PushBouncerNotificationTest(ZulipTestCase):
       # Auth on this user
       email = "cordelia@zulip.com"
       auth = self.api_auth(email)
-      endpoint = '/api/v1/remotes/push/unregister'
+      endpoint = '/api/v1/remotes/push/register'
 
       result = self.client_post(endpoint, {'user_id': user_id, 'token': token, 'token_kind': token_kind}, **auth)
       self.assert_json_error(result, "Missing 'server_uuid' argument")

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -41,79 +41,79 @@ class MockRedis(object):
         pass
 
 class PushBouncerNotificationTest(ZulipTestCase):
-  def test_unregister_remote_push_user_params(self):
-    # type: () -> None
-    server_uuid = "1234-abcd"
-    token = "111222"
-    token_kind = PushDeviceToken.GCM
+    def test_unregister_remote_push_user_params(self):
+        # type: () -> None
+        server_uuid = "1234-abcd"
+        token = "111222"
+        token_kind = PushDeviceToken.GCM
 
-    # Auth on this user
-    email = "cordelia@zulip.com"
-    auth = self.api_auth(email)
+        # Auth on this user
+        email = "cordelia@zulip.com"
+        auth = self.api_auth(email)
 
-    endpoint = '/api/v1/remotes/push/unregister'
-    result = self.client_post(endpoint, {'token': token, 'token_kind': token_kind}, **auth)
-    self.assert_json_error(result, "Missing 'server_uuid' argument")
-    result = self.client_post(endpoint, {'server_uuid': server_uuid, 'token_kind': token_kind}, **auth)
-    self.assert_json_error(result, "Missing 'token' argument")
-    result = self.client_post(endpoint, {'server_uuid': server_uuid, 'token': token}, **auth)
-    self.assert_json_error(result, "Missing 'token_kind' argument")
-    # Verify successful parsing
-    result = self.client_post(endpoint, {'server_uuid': server_uuid, 'token_kind': token_kind, 'token': token}, **auth)
-    self.assert_json_success(result)
+        endpoint = '/api/v1/remotes/push/unregister'
+        result = self.client_post(endpoint, {'token': token, 'token_kind': token_kind}, **auth)
+        self.assert_json_error(result, "Missing 'server_uuid' argument")
+        result = self.client_post(endpoint, {'server_uuid': server_uuid, 'token_kind': token_kind}, **auth)
+        self.assert_json_error(result, "Missing 'token' argument")
+        result = self.client_post(endpoint, {'server_uuid': server_uuid, 'token': token}, **auth)
+        self.assert_json_error(result, "Missing 'token_kind' argument")
+        # Verify successful parsing
+        result = self.client_post(endpoint, {'server_uuid': server_uuid, 'token_kind': token_kind, 'token': token}, **auth)
+        self.assert_json_success(result)
 
-  def test_register_remote_push_user_paramas(self):
-    # type: () -> None
-      server_uuid = "1234-abcd"
-      token = "111222"
-      user_id = 11
-      token_kind = PushDeviceToken.GCM
+    def test_register_remote_push_user_paramas(self):
+        # type: () -> None
+        server_uuid = "1234-abcd"
+        token = "111222"
+        user_id = 11
+        token_kind = PushDeviceToken.GCM
 
-      # Auth on this user
-      email = "cordelia@zulip.com"
-      auth = self.api_auth(email)
-      endpoint = '/api/v1/remotes/push/register'
+        # Auth on this user
+        email = "cordelia@zulip.com"
+        auth = self.api_auth(email)
+        endpoint = '/api/v1/remotes/push/register'
 
-      result = self.client_post(endpoint, {'user_id': user_id, 'token': token, 'token_kind': token_kind}, **auth)
-      self.assert_json_error(result, "Missing 'server_uuid' argument")
-      result = self.client_post(endpoint, {'server_uuid': server_uuid, 'user_id': user_id, 'token_kind': token_kind}, **auth)
-      self.assert_json_error(result, "Missing 'token' argument")
-      result = self.client_post(endpoint, {'server_uuid': server_uuid, 'user_id': user_id, 'token': token}, **auth)
-      self.assert_json_error(result, "Missing 'token_kind' argument")
-      result = self.client_post(endpoint, {'server_uuid': server_uuid, 'token': token, 'token_kind': token_kind}, **auth)
-      self.assert_json_error(result, "Missing 'user_id' argument")
+        result = self.client_post(endpoint, {'user_id': user_id, 'token': token, 'token_kind': token_kind}, **auth)
+        self.assert_json_error(result, "Missing 'server_uuid' argument")
+        result = self.client_post(endpoint, {'server_uuid': server_uuid, 'user_id': user_id, 'token_kind': token_kind}, **auth)
+        self.assert_json_error(result, "Missing 'token' argument")
+        result = self.client_post(endpoint, {'server_uuid': server_uuid, 'user_id': user_id, 'token': token}, **auth)
+        self.assert_json_error(result, "Missing 'token_kind' argument")
+        result = self.client_post(endpoint, {'server_uuid': server_uuid, 'token': token, 'token_kind': token_kind}, **auth)
+        self.assert_json_error(result, "Missing 'user_id' argument")
 
-      # Verify correct results are success
-      result = self.client_post(endpoint, {'user_id': user_id,'server_uuid': server_uuid, 'token': token, 'token_kind': token_kind}, **auth)
-      self.assert_json_success(result)
+        # Verify correct results are success
+        result = self.client_post(endpoint, {'user_id': user_id,'server_uuid': server_uuid, 'token': token, 'token_kind': token_kind}, **auth)
+        self.assert_json_success(result)
 
-  def test_register_new_remote_push_user(self):
-    # type: () -> None
+    def test_register_new_remote_push_user(self):
+        # type: () -> None
 
-    # Auth on this user
-    email = "cordelia@zulip.com"
-    auth = self.api_auth(email)
+        # Auth on this user
+        email = "cordelia@zulip.com"
+        auth = self.api_auth(email)
 
-    endpoints = [
-          ('/api/v1/remotes/push/register', 'register'),
-      ]
+        endpoints = [
+            ('/api/v1/remotes/push/register', 'register'),
+        ]
 
-    for endpoint, method in endpoints:
-      payload = self.get_generic_payload(method)
-      broken_token = "x" * 5000 # too big
-      payload['token'] = broken_token
-      # Try adding/removing tokens that are too big...
-      result = self.client_post(endpoint, payload, **auth)
-      #self.assert_json_error(result, 'Empty or invalid length token')
+        for endpoint, method in endpoints:
+          payload = self.get_generic_payload(method)
+          broken_token = "x" * 5000 # too big
+          payload['token'] = broken_token
+          # Try adding/removing tokens that are too big...
+          result = self.client_post(endpoint, payload, **auth)
+          #self.assert_json_error(result, 'Empty or invalid length token')
 
-  def get_generic_payload(self, method='register'):
-    #type: (text_type) -> Dict[str, Any]
-    server_uuid = "1234-abcd"
-    user_id = 10
-    token = "111222"
-    token_kind = PushDeviceToken.GCM
+    def get_generic_payload(self, method='register'):
+        #type: (text_type) -> Dict[str, Any]
+        server_uuid = "1234-abcd"
+        user_id = 10
+        token = "111222"
+        token_kind = PushDeviceToken.GCM
 
-    return {'user_id':user_id,'server_uuid':server_uuid, 'token':token,'token_kind':token_kind}
+        return {'user_id':user_id,'server_uuid':server_uuid, 'token':token,'token_kind':token_kind}
 
 
 class PushNotificationTest(TestCase):

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import requests
+import json
+
 from typing import Optional
 
 from django.conf import settings
@@ -30,11 +33,17 @@ def add_push_device_token(request, user_profile, token_str, kind, ios_app_id=Non
     if not created:
         token.last_updated = now()
         token.save(update_fields=['last_updated'])
+  
+    # If we're sending things to the push notification bouncer
+    # register this user with them here
+    if settings.PUSH_NOTIFICATION_BOUNCER_URL != '':
+      return send_to_push_bouncer(user_profile, token_str, kind, ios_app_id)
 
-    # register user with push.zulip.org
-    # send secret, UUID, user_id & token
+    return json_success()
+
+def send_to_push_bouncer(user_profile, token_str, kind, ios_app_id=None):
+  # type: (UserProfile, text_type, int, text_type) -> HTTPResponse
     post_data = {
-      'api_key' : settings.ZULIP_ORG_KEY,
       'server_uuid': settings.ZULIP_ORG_ID,
       'user_id': user_profile.id,
       'token': token_str,
@@ -44,7 +53,7 @@ def add_push_device_token(request, user_profile, token_str, kind, ios_app_id=Non
     if kind == PushDeviceToken.APNS:
       post_data['ios_app_id'] = ios_app_id
 
-    api_auth=request.auth.HTTPBasicAuth(settings.ZULIP_ORG_ID, settings.ZULIP_ORG_KEY)
+    api_auth=requests.auth.HTTPBasicAuth(settings.ZULIP_ORG_ID, settings.ZULIP_ORG_KEY)
     # todo: what to do about verify & cert
     # todo: user agent ?
     res = requests.post(settings.PUSH_NOTIFICATION_BOUNCER_URL,
@@ -52,13 +61,12 @@ def add_push_device_token(request, user_profile, token_str, kind, ios_app_id=Non
       auth=api_auth,
       timeout=30,
       headers={"User-agent":"todo", "X-Zulip-Install-ID" : settings.ZULIP_ORG_ID})
-    
-    #todo: much better error handling/ should we retry?
+
+    # todo: much better error handling/ should we retry?
     if res.status_code >= 500:
-      return json_error("Fatal error received from Zulip.org bouncer")
+        return json_error(_("Fatal error received from Zulip.org bouncer"))
     elif res.status_code >= 400:
-      return json_error("Error received from Zulip.org bouncer")
-      
+        return json_error(_("Error received from Zulip.org notification bouncer"))
     return json_success()
 
 @has_request_variables
@@ -81,6 +89,8 @@ def remove_push_device_token(request, user_profile, token_str, kind):
         token.delete()
     except PushDeviceToken.DoesNotExist:
         return json_error(_("Token does not exist"))
+
+    # todo: remove token from bouncer as well
 
     return json_success()
 

--- a/zilencer/migrations/0002_auto_20161027_1755.py
+++ b/zilencer/migrations/0002_auto_20161027_1755.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zilencer', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RemotePushDeviceToken',
+            fields=[
+                ('id', models.AutoField(serialize=False, auto_created=True, verbose_name='ID', primary_key=True)),
+                ('user_id', models.BigIntegerField()),
+                ('kind', models.PositiveSmallIntegerField(choices=[(1, 'apns'), (2, 'gcm')])),
+                ('token', models.CharField(unique=True, max_length=4096)),
+                ('last_updated', models.DateTimeField(auto_now=True)),
+                ('ios_app_id', models.TextField(null=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='RemoteZulipServer',
+            fields=[
+                ('id', models.AutoField(serialize=False, auto_created=True, verbose_name='ID', primary_key=True)),
+                ('uuid', models.CharField(unique=True, max_length=36)),
+                ('api_key', models.CharField(max_length=32)),
+                ('hostname', models.CharField(unique=True, max_length=128)),
+                ('contact_email', models.EmailField(max_length=254, blank=True)),
+                ('last_updated', models.DateTimeField(verbose_name='last updated')),
+            ],
+        ),
+        migrations.AddField(
+            model_name='remotepushdevicetoken',
+            name='server',
+            field=models.ForeignKey(to='zilencer.RemoteZulipServer'),
+        ),
+    ]

--- a/zilencer/models.py
+++ b/zilencer/models.py
@@ -8,6 +8,28 @@ def get_deployment_by_domain(domain):
     # type: (Text) -> Deployment
     return Deployment.objects.get(realms__domain=domain)
 
+class RemoteZulipServer(models.Model):
+    uuid = models.CharField(max_length=36, unique=True) # type: text_type
+    api_key = models.CharField(max_length=32) # type: text_type
+
+    hostname = models.CharField(max_length=128, unique=True) # type: text_type
+    contact_email = models.EmailField(blank=True, null=False) # type: text_type
+    last_updated = models.DateTimeField('last updated') # type: datetime.datetime
+
+# Variant of PushDeviceToken for a remote server.
+class RemotePushDeviceToken(models.Model):
+    server = models.ForeignKey(RemoteZulipServer)
+    # The user id on the remote server for this device device this is
+    user_id = models.BigIntegerField() # type: int
+
+    kind = models.PositiveSmallIntegerField(choices=zerver.models.PushDeviceToken.KINDS) # type: int
+
+    token = models.CharField(max_length=4096, unique=True) # type: text_type
+    last_updated = models.DateTimeField(auto_now=True) # type: datetime.datetime
+
+    # [optional] Contains the app id of the device if it is an iOS device
+    ios_app_id = models.TextField(null=True) # type: Optional[text_type]
+
 class Deployment(models.Model):
     realms = models.ManyToManyField(zerver.models.Realm,
                                     related_name="_deployments") # type: Manager

--- a/zilencer/models.py
+++ b/zilencer/models.py
@@ -4,9 +4,9 @@ from typing import Text
 
 import zerver.models
 
-def get_deployment_by_domain(domain):
-    # type: (Text) -> Deployment
-    return Deployment.objects.get(realms__domain=domain)
+def get_remote_server_by_uuid(uuid):
+    # type: (text_type) -> RemoteZulipServer 
+    return RemoteZulipServer.objects.get(uuid=uuid)
 
 class RemoteZulipServer(models.Model):
     uuid = models.CharField(max_length=36, unique=True) # type: text_type

--- a/zilencer/models.py
+++ b/zilencer/models.py
@@ -1,11 +1,13 @@
 from django.db import models
 from django.db.models import Manager
-from typing import Text
+from typing import Text, Optional
+from six import text_type
 
 import zerver.models
+import datetime
 
 def get_remote_server_by_uuid(uuid):
-    # type: (text_type) -> RemoteZulipServer 
+    # type: (text_type) -> RemoteZulipServer
     return RemoteZulipServer.objects.get(uuid=uuid)
 
 class RemoteZulipServer(models.Model):
@@ -54,5 +56,5 @@ class Deployment(models.Model):
         # TODO: This only does the right thing for prod because prod authenticates to
         # staging with the zulip.com deployment key, while staging is technically the
         # deployment for the zulip.com realm.
-        # This also doesn't necessarily handle other multi-realm deployments correctly.
+        # This also doesn't necessarily handle other multi-realm deployments correctly
         return self.realms.order_by('pk')[0].domain

--- a/zilencer/urls.py
+++ b/zilencer/urls.py
@@ -21,6 +21,14 @@ v1_api_and_json_patterns = [
         {'POST': 'zilencer.views.report_error'}),
     url('^deployment/endpoints$', zilencer.views.lookup_endpoints_for_user,
         name='zilencer.views.lookup_endpoints_for_user'),
+    url('^remotes/push/register$', rest_dispatch,
+          {'POST': 'zilencer.views.remote_server_register_push'}),
+    url('^remotes/push/unregister$', rest_dispatch,
+          {'POST': 'zilencer.views.remote_server_unregister_push'}),
+    url('^remotes/push/message$', rest_dispatch,
+          {'POST': 'zilencer.views.remote_server_push_message'}),
+    url('^remotes/update$', rest_dispatch,
+          {'POST': 'zilencer.views.update_remote_server'}),
 ]
 
 urlpatterns = [

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -7,7 +7,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.views import login as django_login_page
 from django.http import HttpResponseRedirect
 
-from zilencer.models import Deployment, RemotePushDeviceToken
+from zilencer.models import Deployment, RemotePushDeviceToken, RemoteZulipServer
 
 from zerver.decorator import has_request_variables, REQ
 from zerver.lib.actions import internal_send_message
@@ -47,51 +47,63 @@ def get_ticket_number():
     return ticket_number
 
 @has_request_variables
-def remote_server_register_push(request, server_uuid=REQ(), user_id=REQ(), token=REQ(), token_kind=REQ(), ios_app_id=None):
-  # type: (HttpRequest, text_type, int, text_type, int, text_type) -> HttpResponse
-  if token == '' or len(token) > 4096:
-    return json_error(_("Empty or invalid length token"))
+def remote_server_register_push(request, entity_profile, server_uuid=REQ(), user_id=REQ(), token=REQ(), token_kind=REQ(), ios_app_id=None):
+    # type: (HttpRequest, text_type, int, text_type, int, text_type) -> HttpResponse
+    if token == '' or len(token) > 4096:
+        return json_error(_("Empty or invalid length token"))
 
-  # If a user logged out on a device and failed to unregister,
-  # we should delete any other user associations for this token
-  # & RemoteServer pair
-  RemotePushDeviceToken.objects.filter(token=token,kind=token_kind,server=server_uuid).exclude(user_id=user_id).delete()
+    server_ids = RemoteZulipServer.objects.filter(uuid=server_uuid)
+    if len(server_ids) == 0:
+        # No server found for that uuid
+        return json_error(_("Server not registered. UUID:" + server_uuid))
 
-  # Save or update
-  token, created = RemotePushDeviceToken.objects.get_or_create(user_id=user_id,
-                                              server=server_uuid,
+
+    # If a user logged out on a device and failed to unregister,
+    # we should delete any other user associations for this token
+    # & RemoteServer pair
+    RemotePushDeviceToken.objects.filter(token=token,kind=token_kind,server_id__in=server_ids).exclude(user_id=user_id).delete()
+
+    # Save or update
+    remote_token, created = RemotePushDeviceToken.objects.get_or_create(user_id=user_id,
+                                              server=server_ids[0],
                                               kind=token_kind,
                                               token=token,
                                               ios_app_id=ios_app_id,
                                               last_updated=now())
 
-  return json_success()
+    return json_success()
 
 @has_request_variables
-def remote_server_unregister_push(request, server_uuid=REQ(), token=REQ(), token_kind=REQ(), ios_app_id=None):
-  # type: (HttpRequest, text_type, text_type, int, text_type) -> HttpResponse
-  if token == '' or len(token) > 4096:
-    return json_error(_("Empty or invalid length token"))
+def remote_server_unregister_push(request, entity_profile, server_uuid=REQ(), token=REQ(), token_kind=REQ(), ios_app_id=None):
+    # type: (HttpRequest, text_type, text_type, int, text_type) -> HttpResponse
+    if token == '' or len(token) > 4096:
+        return json_error(_("Empty or invalid length token"))
 
-  # Note that this doesn't filter by user_id;
-  # any token unregistration should remove that device for that
-  # server completely (it's impossible to have multiple users
-  # logged in to the same app on a single device)
-  RemotePushDeviceToken.objects.filter(token=token,kind=token_kind,server=server_uuid).delete()
+    # Note that this doesn't filter by user_id;
+    # any token unregistration should remove that device for that
+    # server completely (it's impossible to have multiple users
+    # logged in to the same app on a single device)
+    server_ids = RemoteZulipServer.objects.filter(uuid=server_uuid)
 
-  return json_success()
+    if len(server_ids) == 0:
+        # No server found for that uuid
+        return json_error(_("Server not registered. UUID:" + server_uuid))
+
+    RemotePushDeviceToken.objects.filter(token=token,kind=token_kind,server_id__in=server_ids).delete()
+
+    return json_success()
 
 @has_request_variables
 def remote_server_push_message(request):
-  # type: (HttpRequest) -> HttpResponse
-  # stub. todo: write this method
-  return json_success()
+    # type: (HttpRequest) -> HttpResponse
+    # stub. todo: write this method
+    return json_success()
 
 @has_request_variables
 def update_remote_server(request):
-  # type: (HttpRequest) -> HttpResponse
-  # stub. todo: write this method (either update or save a new remote server object)
-  return json_success()
+    # type: (HttpRequest) -> HttpResponse
+    # stub. todo: write this method (either update or save a new remote server object)
+    return json_success()
 
 @has_request_variables
 def submit_feedback(request, deployment, message=REQ(validator=check_dict([]))):

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -46,6 +46,22 @@ def get_ticket_number():
     return ticket_number
 
 @has_request_variables
+def remote_server_push_message():
+  # stub. todo: write this method
+
+@has_request_variables
+def remote_server_register_push():
+  # stub. todo: write this method
+
+@has_request_variables
+def remote_server_unregister_push():
+  # stub. todo: write this method
+
+@has_request_variables
+def update_remote_server():
+  # stub. todo: write this method (either update or save a new remote server object)
+
+@has_request_variables
 def submit_feedback(request, deployment, message=REQ(validator=check_dict([]))):
     # type: (HttpRequest, Deployment, Dict[str, Text]) -> HttpResponse
     domainish = message["sender_domain"]

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -60,6 +60,10 @@ AVATAR_SALT = get_secret("avatar_salt")
 # restarted for triggering browser clients to reload.
 SERVER_GENERATION = int(time.time())
 
+# Key to authenticate this server to zulip.org for push notifications, etc.
+ZULIP_ORG_KEY = get_secret("zulip_org_key")
+ZULIP_ORG_ID = get_secret("zulip_org_id")
+
 if 'DEBUG' not in globals():
     # Uncomment end of next line to test JS/CSS minification.
     DEBUG = DEVELOPMENT # and platform.node() != 'your-machine'

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -64,6 +64,9 @@ SERVER_GENERATION = int(time.time())
 ZULIP_ORG_KEY = get_secret("zulip_org_key")
 ZULIP_ORG_ID = get_secret("zulip_org_id")
 
+# URL for the Push Notification Bouncer
+PUSH_NOTIFICATION_BOUNCER_URL=""
+
 if 'DEBUG' not in globals():
     # Uncomment end of next line to test JS/CSS minification.
     DEBUG = DEVELOPMENT # and platform.node() != 'your-machine'


### PR DESCRIPTION
This PR encapsulates the beginning of work on building a bouncer for push notifications.  As a general overview, there's a limitation from Google that for a single Android application, only a single server app can be registered to send push notifications.  As a work around for 3rd party Zulip installations (aka self-hosted), we'd like to provide a service on Zulip 'central' that allows self-hosted installs to send their users' devices push notifications via their apps.

Quick overview of intended functionality:
- On install, a 3rd party Zulip installation would create it's own identifier (`zulip_org_key` and `zulip_org_id`)
- On start, it would register this ID & key with the 'central' Zulip servers.
- Any time a device registers or unregisters for push notifications, the 3rd party would forward the device details to the 'central' Zulip server, using their id & key as auth.  The central server saves the details for this user & server_id.  The user data is also stored locally on the 3rd party server.  Most of this registration/unregistration work is covered by this PR.
- When a 3rd party server wants to send a push notification to a user they'd call the endpoint on the 'central' zulip server with that users' id and a message.  Currently a stub.  
- There's an endpoint for 3rd party servers to update their registration information; currently a stub.

Further work: (not stubbed)
- Messages are currently send in plaintext.  Some amount of encryption would be nice.
- Passing back success or failure of push notification messages from 'central' Zulip to the 3rd party install.
- Retry logic for how often the 3rd party servers should update their information with central.