### PR TITLE
[Fix]: Show date correctly on message headers.

### DIFF
--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -54,9 +54,11 @@ function add_display_time(group, message_container, prev) {
         var prev_time = new XDate(prev.msg.timestamp * 1000);
         if (time.toDateString() !== prev_time.toDateString()) {
             // NB: show_date is HTML, inserted into the document without escaping.
+            message_container.show_date = (timerender.render_date(time, prev_time))[0].outerHTML;
             group.show_date = (timerender.render_date(time, prev_time))[0].outerHTML;
         }
     } else {
+        message_container.show_date = (timerender.render_date(time))[0].outerHTML;
         group.show_date = (timerender.render_date(time))[0].outerHTML;
     }
 
@@ -333,6 +335,7 @@ MessageListView.prototype = {
             } else if (first_group !== undefined && second_group !== undefined) {
                 var last_msg_container = _.last(first_group.message_containers);
                 var first_msg_container = _.first(second_group.message_containers);
+
                 if (same_day(last_msg_container, first_msg_container)) {
                     // Clear the date if it is the same as the last group
                     second_group.show_date = undefined;


### PR DESCRIPTION
This shows a date on a message header whenever the date of that message
is different than the date of the previous message.