### PR TITLE
tests: Bump up max length queries in test_bulk_message_fetching()

### DIFF
--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -559,11 +559,9 @@ class MessageDictTest(ZulipTestCase):
         delay = time.time() - t
         # Make sure we don't take longer than 1ms per message to extract messages.
         self.assertTrue(delay < 0.001 * num_ids)
-        # Note, this fails if you run
-        # tools/test-backend zerver.tests.test_messages.MessageDictTest or
-        # tools/test-backend zerver.tests.test_messages.MessageDictTest.test_bulk_message_fetching.
-        # You need to run the full suite as tools/test-backend zerver.tests.test_messages.
-        self.assert_max_length(queries, 7)
+        # The number of queries varies between 6 and 10 in practice, depending on what's in cache.
+        # If this increases significantly, please investigate.
+        self.assert_max_length(queries, 11)
         self.assertEqual(len(rows), num_ids)
 
     def test_applying_markdown(self):


### PR DESCRIPTION
Bump up max length queries in `test_bulk_message_fetching()` to 11
in `zerver/tests/test_messages.py` to avoid test failing when run
this test alone.

Fixes #3087.

----------------

Another approach for this issue is https://github.com/rafidaslam/zulip/commit/8f525487336a6643e483380c24e35bd6a150ce48

We think bump up the queries max length to 11 is pretty reasonable here, since we think this test is preventing us from doing like 600 queries.