### PR TITLE
translations: Improve the Spanish style guide.

### DIFF
--- a/docs/spanish.md
+++ b/docs/spanish.md
@@ -1,6 +1,6 @@
 # Spanish Translation Style Guide
 
-Use formal Spanish for translation:
+Use informal Spanish for translation:
 
 * Informal "you" (*tú*) instead of formal form *usted*. Many top software
   companies (e.g. Google) use the informal one, because it's much more common in
@@ -25,27 +25,54 @@ Some terms are very tricky to translate, so be sure to communicate
 with other Spanish speakers in the community. It's all about making
 Zulip friendly and usable.
 
-## Términos especiales usados en Zulip
-
-* mention - **@mención**
-* customization - **personalización**
-* view / filter - **vista**
-* (Group) PM / Private Message - **MP (grupal) / Mensaje Privado**
-* Home - **Inicio**: We never use the term "Hogar" (literally home) in Spanish.
-* message table - **tabla de mensajes**
-* muting a stream - **silenciar un canal**
-* narrow - **filtrar**: there's no other word that's common enough in
-  Spanish for "to narrow" except for "filtrar". This is why we'll use
-  "filtrar" for "to narrow" and not for the english Zulip meaning
-  "filter", fo which we'll use "view" instead
-* pinning - **fijar** (lit. to fixate)
-* stream - **canal** The use of the literal Spanish word for stream
-  "Flujo" is very confusing and not the correct metaphor for Spanish
-  speaking people. The correct term would be "canal" (channel).
-* realm - **instancia**: The literal Spanish of realm is "reino",
+## Términos
+* Message - **Mensaje**
+* Private message (PM) - **Mensaje privado (MP)**
+* Group PM - **mensaje privado grupal**: even though "MP grupal" is the most
+  precise translation, preferrably don't use that one. Many users may not
+  associate "MP" with *private message* in a group context. Better use it
+  without abbreviations.
+* Realm - **Instancia**: the literal Spanish of realm is "reino",
   which is not a term that's charged with computer
   terminology. "Instancia" is much clearer.
+* Stream - **Canal**: the use of the literal Spanish word for stream
+  "Flujo" is very confusing and not the correct metaphor for Spanish
+  speaking people. The correct term would be "canal" (*channel*).
+* Topic - **Tema**
+* Private/invite-only stream - **Canal privado/limitado por invitación**: (lit.
+  *channel limited by invitation*)
+* Public stream - **Canal público**
+* Bot - **Bot**
+* Integration - **Integración**
+* Notification - **Notificación**
+* Alert word - **Alerta**: this is only *alert*. Nonetheless, adding *word* may
+  make the term confusing (something like *danger!* could be a "palabra de
+  alerta" as well). Google Alerts uses "alerta" in its Spanish translation.
+* View / Filter - **Vista**
+* Home - **Inicio**: we never use the term "Hogar" (literally home) in Spanish.
+* Emoji - **Emoticono** (plural: **emoticonos**)
 
-* **thread** - tema: We use "tema" instead of the Spanish translation
-  for thread "hilo" because, again, "hilo" is not a commonly
-  technical term and would only serve to confuse users.
+## Frases
+* Subscribe/Unsubscribe to a stream - **Suscribirte/Desuscribirte a un canal**
+* Narrow to - **Filtrar solo**: this is *filter only*, because there's no other
+  word that's common enough in Spanish for "to narrow" except for "filtrar".
+  This is why we'll use "filtrar" for "to narrow" and not for the English Zulip
+  meaning "filter", for which we'll use "view" instead.
+* Mute/Unmute - **Silenciar/No silenciar**
+* Deactivate/Reactivate - **Desactivar/Reactivar**
+* Search - **Buscar**
+* Pin - **Fijar** (lit. *to fixate*)
+* Mention/@mention - **Mención/@mención**
+* Invalid - **Inválido**
+* Customization - **Personalización**
+* I want - **Yo quiero**
+* User - **Usuario**
+* Person/People - **Persona/Personas**: "personas" is the correct plural for
+  "person", but when talking of *people* referring to it as a crowd, we use
+  "gente" instead.
+
+## Otros
+* You - **Tú**: also "vosotros" if it's in plural.
+* We - **Nosotros**
+* Message table - **Tablón de mensajes**
+* Enter/Intro - **Enter/Intro**

--- a/docs/spanish.md
+++ b/docs/spanish.md
@@ -2,9 +2,10 @@
 
 Use formal Spanish for translation:
 
-* Formal "you" (*usted*) instead of informal form *tu*. Software
-  translated to Spanish using the informal "you" form comes off as
-  unprofessional and childish.
+* Informal "you" (*tú*) instead of formal form *usted*. Many top software
+  companies (e.g. Google) use the informal one, because it's much more common in
+  the daily language and avoids making translations look like they were written
+  by machines.
 
 * Imperative, active, and continuous verbs, e.g. *manage streams* -
   *manejar canales*, not *manejo de canales*.
@@ -24,12 +25,12 @@ Some terms are very tricky to translate, so be sure to communicate
 with other Spanish speakers in the community. It's all about making
 Zulip friendly and usable.
 
-## Términos Especiales Usados en Zulip
+## Términos especiales usados en Zulip
 
 * mention - **@mención**
 * customization - **personalización**
 * view / filter - **vista**
-* PM / Private Message - **MP grupal**
+* (Group) PM / Private Message - **MP (grupal) / Mensaje Privado**
 * Home - **Inicio**: We never use the term "Hogar" (literally home) in Spanish.
 * message table - **tabla de mensajes**
 * muting a stream - **silenciar un canal**
@@ -43,7 +44,7 @@ Zulip friendly and usable.
   speaking people. The correct term would be "canal" (channel).
 * realm - **instancia**: The literal Spanish of realm is "reino",
   which is not a term that's charged with computer
-  terminology. Instancia es much clearer.
+  terminology. "Instancia" is much clearer.
 
 * **thread** - tema: We use "tema" instead of the Spanish translation
   for thread "hilo" because, again, "hilo" is not a commonly


### PR DESCRIPTION
Some modifications have been made to the Spanish style guide, including new words, reordering and minor clarifications.

 - *thread* has been removed and replaced with the new *topic*, which also fits better with the previous translation.
- *solo* hasn't been accentuated, following the [latest rule](http://www.rae.es/consultas/el-adverbio-solo-y-los-pronombres-demostrativos-sin-tilde).
- Now the informal *you* is preferred over the formal one, because it's feels way more natural, and it's what other "big" companies have been using.