### PR TITLE
Migrate use to send_mail from EmailMultiAlternatives.

### DIFF
--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -22,14 +22,6 @@ from zerver.lib.utils import generate_random_token
 from zerver.models import PreregistrationUser
 from typing import Optional, Union, Any, Text
 
-try:
-    import mailer
-    send_mail = mailer.send_mail
-except ImportError:
-    # no mailer app present, stick with default
-    pass
-
-
 B16_RE = re.compile('^[a-f0-9]{40}$')
 
 def check_key_is_valid(creation_key):

--- a/static/third/bootstrap/js/bootstrap.js
+++ b/static/third/bootstrap/js/bootstrap.js
@@ -1033,7 +1033,7 @@
       }
 
     , removeBackdrop: function () {
-        if (this !== null) {
+        if (this.$backdrop && this.$backdrop.remove) {
           this.$backdrop.remove();
         }
         this.$backdrop = null

--- a/zerver/management/commands/deliver_email.py
+++ b/zerver/management/commands/deliver_email.py
@@ -58,7 +58,7 @@ def send_email_job(job):
     message = data["email_text"]
     from_email = get_sender_as_string(data)
     to_email = get_recipient_as_string(data)
-    
+
     if data["email_html"]:
         html_message = data["email_html"]
         return send_mail(subject, message, from_email, [to_email], html_message=html_message) > 0

--- a/zerver/management/commands/deliver_email.py
+++ b/zerver/management/commands/deliver_email.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.core.mail import EmailMultiAlternatives, get_connection
+from django.core.mail import get_connection, send_mail
 from django.utils.html import format_html
 
 from zerver.models import ScheduledJob
@@ -54,15 +54,15 @@ def get_sender_as_string(dictionary):
 def send_email_job(job):
     # type: (ScheduledJob) -> bool
     data = loads(job.data)
-    fields = {'subject': data["email_subject"],
-              'body': data["email_text"],
-              'from_email': get_sender_as_string(data),
-              'to': [get_recipient_as_string(data)]}
-
-    msg = EmailMultiAlternatives(**fields)
+    subject = data["email_subject"]
+    message = data["email_text"]
+    from_email = get_sender_as_string(data)
+    to_email = get_recipient_as_string(data)
+    
     if data["email_html"]:
-        msg.attach_alternative(data["email_html"], "text/html")
-    return msg.send() > 0
+        html_message = data["email_html"]
+        return send_mail(subject, message, from_email, [to_email], html_message=html_message) > 0
+    return send_mail(subject, message, from_email, [to_email]) > 0
 
 class Command(BaseCommand):
     help = """Deliver emails queued by various parts of Zulip

--- a/zerver/management/commands/send_password_reset_email.py
+++ b/zerver/management/commands/send_password_reset_email.py
@@ -66,11 +66,11 @@ class Command(BaseCommand):
 
             logging.warning("Sending %s email to %s" % (email_template_name, user_profile.email,))
             self.send_email(subject_template_name, email_template_name,
-                           context, from_email, user_profile.email,
-                           html_email_template_name=html_email_template_name)
+                            context, from_email, user_profile.email,
+                            html_email_template_name=html_email_template_name)
 
     def send_email(self, subject_template_name, email_template_name,
-                  context, from_email, to_email, html_email_template_name=None):
+                   context, from_email, to_email, html_email_template_name=None):
         # type: (str, str, Dict[str, Any], Text, Text, Optional[str]) -> None
         """
         Sends a django.core.mail.send_mail to `to_email`.

--- a/zerver/management/commands/send_password_reset_email.py
+++ b/zerver/management/commands/send_password_reset_email.py
@@ -10,7 +10,6 @@ from django.core.mail import send_mail, BadHeaderError
 from zerver.forms import PasswordResetForm
 from zerver.models import UserProfile, get_user_profile_by_email, get_realm
 from django.template import loader
-from django.core.mail import EmailMultiAlternatives
 
 from django.utils.http import urlsafe_base64_encode
 from django.utils.encoding import force_bytes
@@ -66,24 +65,25 @@ class Command(BaseCommand):
             }
 
             logging.warning("Sending %s email to %s" % (email_template_name, user_profile.email,))
-            self.send_mail(subject_template_name, email_template_name,
+            self.send_email(subject_template_name, email_template_name,
                            context, from_email, user_profile.email,
                            html_email_template_name=html_email_template_name)
 
-    def send_mail(self, subject_template_name, email_template_name,
+    def send_email(self, subject_template_name, email_template_name,
                   context, from_email, to_email, html_email_template_name=None):
         # type: (str, str, Dict[str, Any], Text, Text, Optional[str]) -> None
         """
-        Sends a django.core.mail.EmailMultiAlternatives to `to_email`.
+        Sends a django.core.mail.send_mail to `to_email`.
         """
         subject = loader.render_to_string(subject_template_name, context)
         # Email subject *must not* contain newlines
         subject = ''.join(subject.splitlines())
         body = loader.render_to_string(email_template_name, context)
 
-        email_message = EmailMultiAlternatives(subject, body, from_email, [to_email])
         if html_email_template_name is not None:
             html_email = loader.render_to_string(html_email_template_name, context)
-            email_message.attach_alternative(html_email, 'text/html')
+            send_mail(subject, body, from_email, [to_email], html_message=html_email)
+        else:
+            send_mail(subject, body, from_email, [to_email])
 
-        email_message.send()
+

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -368,13 +368,6 @@ def generate_204(request):
     # type: (HttpRequest) -> HttpResponse
     return HttpResponse(content=None, status=204)
 
-try:
-    import mailer
-    send_mail = mailer.send_mail
-except ImportError:
-    # no mailer app present, stick with default
-    pass
-
 def send_find_my_team_emails(user_profile):
     # type: (UserProfile) -> None
     text_template = 'zerver/emails/find_team/find_team_email.txt'


### PR DESCRIPTION
To Fix #3132 i.e., migrating use to `send_mail` from `EmailMultiAlternatives`. Made changes in the code which can be seen in the above commits. As @rishig suggested earlier, I tried building it upon PR #3137 , which now has been merged. Therefore there are commits by @rishig too. Hope it wouldn't be a problem.

Changes are made in files `zerver/management/commands/deliver_email.py` and `zerver/management/commands/send_password_reset_email.py` which were using `EmailMultiAlternatives`. Couldn't be made in `zerver/lib/notifications.py` as headers are being sent.

Please suggest changes. :)