### PR TITLE
integrations: Add code for OpenShift.

### DIFF
--- a/api/integrations/openshift/post_deploy
+++ b/api/integrations/openshift/post_deploy
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Zulip notification post-receive hook.
+# Copyright © 2012-2017 Zulip, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import zulip_openshift_config as config
+VERSION = '0.1'
+
+if config.ZULIP_API_PATH is not None:
+    sys.path.append(config.ZULIP_API_PATH)
+
+import zulip
+client = zulip.Client(
+    email=config.ZULIP_USER,
+    site=config.ZULIP_SITE,
+    api_key=config.ZULIP_API_KEY,
+    client='ZulipOpenShift/' + VERSION)
+
+def get_deployment_details():
+    # type: () -> Dict[str, str]
+    # "gear deployments" output example:
+    #   Activation time - Deployment ID - Git Ref - Git SHA1
+    #   2017-01-07 15:40:30 -0500 - 9e2b7143 - master - b9ce57c - ACTIVE
+    dep = subprocess.check_output(['gear', 'deployments']).splitlines()[1]
+    splits = dep.split(' - ')
+
+    return dict(app_name=os.environ['OPENSHIFT_APP_NAME'],
+                url=os.environ['OPENSHIFT_APP_DNS'],
+                branch=splits[2],
+                commit_id=splits[3])
+
+def send_bot_message(deployment):
+    # type: (Dict[str, str]) -> None
+    destination = config.deployment_notice_destination(deployment['branch'])
+    if destination is None:
+        # No message should be sent
+        return
+    message = config.format_deployment_message(**deployment)
+
+    client.send_message({
+        'type': 'stream',
+        'to': destination['stream'],
+        'subject': destination['subject'],
+        'content': message,
+    })
+
+    return
+
+deployment = get_deployment_details()
+send_bot_message(deployment)

--- a/api/integrations/openshift/zulip_openshift_config.py
+++ b/api/integrations/openshift/zulip_openshift_config.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Zulip, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# https://github.com/python/mypy/issues/1141
+from typing import Text
+
+# Change these values to configure authentication for the plugin
+ZULIP_USER = 'openshift-bot@example.com'
+ZULIP_API_KEY = '0123456789abcdef0123456789abcdef'
+
+# deployment_notice_destination() lets you customize where deployment notices
+# are sent to with the full power of a Python function.
+#
+# It takes the following arguments:
+# * branch = the name of the branch where the deployed commit was
+#            pushed to
+#
+# Returns a dictionary encoding the stream and subject to send the
+# notification to (or None to send no notification).
+#
+# The default code below will send every commit pushed to "master" to
+# * stream "deployments"
+# * topic "master"
+# And similarly for branch "test-post-receive" (for use when testing).
+def deployment_notice_destination(branch):
+    # type: (str) -> Dict[str, Text]
+    if branch in ['master', 'test-post-receive']:
+        return dict(stream  = 'deployments',
+                    subject = u'%s' % (branch,))
+
+    # Return None for cases where you don't want a notice sent
+    return None
+
+# Modify this function to change how deployments are displayed
+#
+# It takes the following arguments:
+# * app_name  = the name of the app being deployed
+# * url       = the FQDN (Fully Qualified Domain Name) where the app
+#                can be found
+# * branch    = the name of the branch where the deployed commit was
+#                pushed to
+# * commit_id = hash of the commit that triggered the deployment
+# * dep_id    = deployment id
+# * dep_time  = deployment timestamp
+def format_deployment_message(
+        app_name='', url='', branch='', commit_id='', dep_id='', dep_time=''):
+    # type: (str, str, str, str, str, str) -> str
+    return 'Deployed commit `%s` (%s) in [%s](%s)' % (
+        commit_id, branch, app_name, url)
+
+## If properly installed, the Zulip API should be in your import
+## path, but if not, set a custom path below
+ZULIP_API_PATH = None # type: str
+
+# Set this to your Zulip server's API URI
+ZULIP_SITE = 'https://zulip.example.com'


### PR DESCRIPTION
Python script integration for OpenShift.

In order to use it, the files in `api/integrations/openshift` should be copied into the deployed application's repo, inside `.openshift/action_hooks`.

This can't be made through a webhook integration, thus the Git-like approach (see [this PR](https://github.com/zulip/zulip-gci/pull/255) for the research notes).

The messages look like this:
![OpenShift integration message](https://cloud.githubusercontent.com/assets/7356565/21746579/5fcf253a-d54a-11e6-833b-f96179f508c5.png)

There isn't any commit message or author because of OpenShift's limitations (there's no way to get it from inside the deployment machine).

The link in the application name takes you to the URL where it's currently deployed.
