### PR TITLE
search: Fixed autocomplete for "from"

### DIFF
--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -245,6 +245,62 @@ people.init();
     assert.equal(describe('stream:devel'), 'Narrow to stream <strong>devel</strong>');
 }());
 
+(function test_sent_by_me_suggestions() {
+    global.stream_data.subscribed_streams = function () {
+        return [];
+    };
+
+    global.narrow.stream = function () {
+        return undefined;
+    };
+
+    var query = '';
+    var suggestions = search.get_suggestions(query);
+    assert(suggestions.strings.indexOf('sender:bob@zulip.com') !== -1);
+    assert.equal(suggestions.lookup_table['sender:bob@zulip.com'].description,
+                 'Sent by me');
+
+    query = 'sender';
+    suggestions = search.get_suggestions(query);
+    var expected = [
+        "sender",
+        "sender:bob@zulip.com",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'from';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "from",
+        "from:bob@zulip.com",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'sender:bob@zulip.com';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "sender:bob@zulip.com",
+        "is:private",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'from:bob@zulip.com';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "from:bob@zulip.com",
+        "is:private",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'sent';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "sent",
+        "sender:bob@zulip.com",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+}());
+
 (function test_topic_suggestions() {
     var suggestions;
     var expected;

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -175,6 +175,16 @@ global.stream_data.populate_stream_topics_for_tests({});
     ];
     assert.deepEqual(suggestions.strings, expected);
 
+    query = 'from:ted';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "from:ted",
+        "from:ted@zulip.com",
+        "is:private",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+
     // Users can enter bizarre queries, and if they do, we want to
     // be conservative with suggestions.
     query = 'is:private near:3';

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -195,7 +195,7 @@ function encodeOperand(operand) {
 }
 
 function decodeOperand(encoded, operator) {
-    if (operator !== 'pm-with' && operator !== 'sender') {
+    if (operator !== 'pm-with' && operator !== 'sender' && operator !== 'from') {
         encoded = encoded.replace(/\+/g, ' ');
     }
     return util.robust_uri_decode(encoded);

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -397,7 +397,7 @@ exports.get_suggestions = function (query) {
     suggestions = get_person_suggestions(persons, query, 'sender');
     result = result.concat(suggestions);
 
-    suggestions = get_private_suggestions(persons, operators, ['pm-with', 'sender']);
+    suggestions = get_private_suggestions(persons, operators, ['pm-with', 'sender', 'from']);
     result = result.concat(suggestions);
 
     suggestions = get_topic_suggestions(operators);

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -346,10 +346,6 @@ function get_special_filter_suggestions(query, operators) {
             search_string: 'is:alerted',
             description: 'Alerted messages',
         },
-        {
-            search_string: 'sender:' + page_params.email,
-            description: 'Sent by me',
-        },
     ];
 
     query = query.toLowerCase();
@@ -368,6 +364,39 @@ function get_special_filter_suggestions(query, operators) {
     return suggestions;
 }
 
+function get_sent_by_me_suggestions(query, operators) {
+    if (operators.length >= 2) {
+        return [];
+    }
+
+    var sender_query = 'sender:' + page_params.email;
+    var from_query = 'from:' + page_params.email;
+    var description = 'Sent by me';
+
+    query = query.toLowerCase();
+
+    if (query === sender_query || query === from_query) {
+        return [];
+    } else if (query === '' ||
+        sender_query.indexOf(query) === 0 ||
+        description.toLowerCase().indexOf(query) === 0) {
+        return [
+            {
+                search_string: sender_query,
+                description: description,
+            },
+        ];
+    } else if (from_query.indexOf(query) === 0) {
+        return [
+            {
+                search_string: from_query,
+                description: description,
+            },
+        ];
+    }
+    return [];
+}
+
 exports.get_suggestions = function (query) {
     // This method works in tandem with the typeahead library to generate
     // search suggestions.  If you want to change its behavior, be sure to update
@@ -384,6 +413,9 @@ exports.get_suggestions = function (query) {
     result = [suggestion];
 
     suggestions = get_special_filter_suggestions(query, operators);
+    result = result.concat(suggestions);
+
+    suggestions = get_sent_by_me_suggestions(query, operators);
     result = result.concat(suggestions);
 
     suggestions = get_stream_suggestions(operators);


### PR DESCRIPTION
Added autocomplete for the from operator in search.

Used the existing `canonicalize_operator` method which was used elsewhere for the sender/from aliasing.

```
var canonical_operators = {from: "sender", subject: "topic"};

Filter.canonicalize_operator = function (operator) {
    operator = operator.toLowerCase();
    if (canonical_operators.hasOwnProperty(operator)) {
        return canonical_operators[operator];
    }
    return operator;
};
```

Fixes #2932 