### PR TITLE
Migrate legacy url json/bulk_invite_users

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -351,7 +351,7 @@ class InviteUserTest(ZulipTestCase):
         params = {
             'invitee_emails': ujson.dumps(invitees)
         }
-        result = self.client_post('/json/bulk_invite_users', params)
+        result = self.client_post('/json/invite/bulk_invite', params)
         self.assert_json_success(result)
         self.check_sent_emails(invitees)
 

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -2135,7 +2135,7 @@ class MutedTopicsTests(ZulipTestCase):
         email = 'hamlet@zulip.com'
         self.login(email)
 
-        url = '/json/set_muted_topics'
+        url = '/json/muting/topics'
         data = {'muted_topics': '[["stream", "topic"]]'}
         result = self.client_post(url, data)
         self.assert_json_success(result)
@@ -2143,7 +2143,7 @@ class MutedTopicsTests(ZulipTestCase):
         user = get_user_profile_by_email(email)
         self.assertEqual(ujson.loads(user.muted_topics), [["stream", "topic"]])
 
-        url = '/json/set_muted_topics'
+        url = '/json/muting/topics'
         data = {'muted_topics': '[["stream2", "topic2"]]'}
         result = self.client_post(url, data)
         self.assert_json_success(result)

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -61,11 +61,9 @@ def get_invitee_emails_set(invitee_emails_raw):
         invitee_emails.add(email.strip())
     return invitee_emails
 
-@authenticated_json_post_view
+# @authenticated_json_post_view
 @has_request_variables
-def json_bulk_invite_users(request, user_profile,
-                           invitee_emails_list=REQ('invitee_emails',
-                                                   validator=check_list(check_string))):
+def bulk_invite_users(request, user_profile, invitee_emails_list=REQ('invitee_emails', validator=check_list(check_string))):
     # type: (HttpRequest, UserProfile, List[str]) -> HttpResponse
     invitee_emails = set(invitee_emails_list)
     streams = get_default_subs(user_profile)

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -61,9 +61,10 @@ def get_invitee_emails_set(invitee_emails_raw):
         invitee_emails.add(email.strip())
     return invitee_emails
 
-# @authenticated_json_post_view
 @has_request_variables
-def bulk_invite_users(request, user_profile, invitee_emails_list=REQ('invitee_emails', validator=check_list(check_string))):
+def bulk_invite_users(request, user_profile,
+                      invitee_emails_list=REQ('invitee_emails',
+                                              validator=check_list(check_string))):
     # type: (HttpRequest, UserProfile, List[str]) -> HttpResponse
     invitee_emails = set(invitee_emails_list)
     streams = get_default_subs(user_profile)

--- a/zerver/views/muting.py
+++ b/zerver/views/muting.py
@@ -10,11 +10,11 @@ from zerver.lib.response import json_success
 from zerver.lib.validator import check_string, check_list
 from zerver.models import UserProfile
 
-@authenticated_json_post_view
+# @authenticated_json_post_view
 @has_request_variables
-def json_set_muted_topics(request, user_profile,
-                          muted_topics=REQ(validator=check_list(
-                              check_list(check_string, length=2)), default=[])):
+def set_muted_topics(request, user_profile,
+                     muted_topics=REQ(validator=check_list(
+                         check_list(check_string, length=2)), default=[])):
     # type: (HttpRequest, UserProfile, List[List[Text]]) -> HttpResponse
     do_set_muted_topics(user_profile, muted_topics)
     return json_success()

--- a/zproject/legacy_urls.py
+++ b/zproject/legacy_urls.py
@@ -35,5 +35,5 @@ legacy_urls = [
     url(r'^json/report_unnarrow_time$',      zerver.views.report.json_report_unnarrow_time),
     url(r'^json/upload_file$',               zerver.views.upload.json_upload_file),
     url(r'^json/messages_in_narrow$',        zerver.views.messages.json_messages_in_narrow),
-    url(r'^json/set_muted_topics$',          zerver.views.muting.json_set_muted_topics),
+    # url(r'^json/set_muted_topics$',          zerver.views.muting.json_set_muted_topics),
     ]

--- a/zproject/legacy_urls.py
+++ b/zproject/legacy_urls.py
@@ -15,7 +15,6 @@ import zerver.views.muting
 legacy_urls = [
     # These are json format views used by the web client.  They require a logged in browser.
     url(r'^json/invite_users$',              zerver.views.invite.json_invite_users),
-    url(r'^json/bulk_invite_users$',         zerver.views.invite.json_bulk_invite_users),
     url(r'^json/refer_friend$',              zerver.views.invite.json_refer_friend),
     url(r'^json/settings/change$',           zerver.views.user_settings.json_change_settings),
 

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -238,6 +238,10 @@ v1_api_and_json_patterns = [
     url(r'^invite/bulk_invite$', rest_dispatch,
         {'POST': 'zerver.views.invite.bulk_invite_users'}),
 
+    # muting -> zerver.views.muting
+    url(r'^muting/topics$', rest_dispatch,
+        {'POST': 'zerver.views.muting.set_muted_topics'}),
+
     # users/me -> zerver.views
     url(r'^users/me$', rest_dispatch,
         {'GET': 'zerver.views.users.get_profile_backend',

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -234,6 +234,10 @@ v1_api_and_json_patterns = [
     url(r'^user_uploads$', rest_dispatch,
         {'POST': 'zerver.views.upload.upload_file_backend'}),
 
+    # invite -> zerver.views.invite
+    url(r'^invite/bulk_invite$', rest_dispatch,
+        {'POST': 'zerver.views.invite.bulk_invite_users'}),
+
     # users/me -> zerver.views
     url(r'^users/me$', rest_dispatch,
         {'GET': 'zerver.views.users.get_profile_backend',


### PR DESCRIPTION
Moved legacy url to urls.py, changing name to invite/bulk_invite and removing 'json' from function name.