### PR TITLE
docs: Add the Reading list.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,7 @@ Contents:
    new-feature-tutorial
    writing-views
    life-of-a-request
+   reading-list
 
 .. _code-docs:
 

--- a/docs/reading-list.md
+++ b/docs/reading-list.md
@@ -1,0 +1,233 @@
+# Reading list
+
+Here you can find a list of relevant resources that you may find useful for
+learning new skills, or polishing the ones you already have.
+
+The topics cover a wide variety of topics, from basic Python coding to
+general developing guidelines.
+
+Feel free to create a pull request in Zulip's [GitHub repository](
+https://github.com/zulip/zulip/) with any interesting books, articles or
+videos you would like to see in this list.
+
+Some titles have been shortened for organizational purposes.
+
+## General programming/IT
+
+*Book* - [Clean Code: A Handbook of Agile Software Craftsmanship][] *(Not free!)*
+
+[Clean Code: A Handbook of Agile Software Craftsmanship]: https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882
+
+*Books* - [Free programming books list][]
+
+[Free programming books list]: https://github.com/vhf/free-programming-books
+
+*Blog* - [Free Code Camp blog][]
+
+[Free Code Camp blog]: https://medium.freecodecamp.com
+
+*Blog* - [Idle Words talks transcripts][]
+
+[Idle Words talks transcripts]: http://idlewords.com/talks
+
+*Tutorial* - [HTTP Can Do That?!, by Sumana Harihareswara (PyCon 2016)][]
+
+[HTTP Can Do That?!, by Sumana Harihareswara (PyCon 2016)]: https://youtu.be/HsLrXt2l-kg
+
+*Video* - [Minimum Viable Documentation, by Matthew Lyon (WriteTheDocs 2014)][]
+
+[Minimum Viable Documentation, by Matthew Lyon (WriteTheDocs 2014)]: https://youtu.be/bEZcodengwk
+
+*Video* - [NoOps, by Kelsey Hightower (DepOpsDays 2016)][]
+
+[NoOps, by Kelsey Hightower (DepOpsDays 2016)]: https://youtu.be/ajT90pC3ris
+
+*Video* - [The mind behind Linux (TED interview)][]
+
+[The mind behind Linux (TED interview)]: https://youtu.be/o8NPllzkFhE
+
+*Tutorial* - [Learn code the hard way][]
+
+[Learn code the hard way]: https://learncodethehardway.org
+
+*Tutorial* - [What happens when...][]
+
+[What happens when...]: https://github.com/alex/what-happens-when
+
+*Article* - [An Interview With Linus Torvalds][]
+
+[An Interview With Linus Torvalds]: https://techcrunch.com/2012/04/19/an-interview-with-millenium-technology-prize-finalist-linus-torvalds
+
+*Article* - [Effective Learning Strategies for Programmers][]
+
+[Effective Learning Strategies for Programmers]: http://akaptur.com/blog/2015/10/10/effective-learning-strategies-for-programmers/
+
+*Article* - [Readme Driven Development][]
+
+[Readme Driven Development]: http://tom.preston-werner.com/2010/08/23/readme-driven-development.html
+
+*Article* - [Systematic Debugging][]
+
+[Systematic Debugging]: http://akaptur.com/blog/2013/07/24/systematic-debugging
+
+*Paper* - [Floating-Point Arithmetic][]
+
+[Floating-Point Arithmetic]: https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
+
+## Python
+
+*Video* - [Intro to Python for beginners, by Jessica McKellar (PyCon 2013)][]
+
+[Intro to Python for beginners, by Jessica McKellar (PyCon 2013)]: https://youtu.be/rkx5_MRAV3A
+
+*Video* - [Breaking the rules, by Jessica McKellar (PyCon Sweden)][]
+
+[Breaking the rules, by Jessica McKellar (PyCon Sweden)]: https://youtu.be/C0fnHhY9UOc
+
+*Video* - [Build & break a Python sandbox, by Jessica McKellar (PyCon 2014)][]
+
+[Build & break a Python sandbox, by Jessica McKellar (PyCon 2014)]: http://pyvideo.org/pycon-us-2014/building-and-breaking-a-python-sandbox.html
+
+*Video* - [Cache me if you can, by Guillaume Ardaud (PyCon 2014)][]
+
+[Cache me if you can, by Guillaume Ardaud (PyCon 2014)]: http://pyvideo.org/pycon-us-2014/cache-me-if-you-can-memcached-caching-patterns.html
+
+*Video* - [Loop like a native, by Ned Batchelder (PyCon 2013)][]
+
+[Loop like a native, by Ned Batchelder (PyCon 2013)]: https://youtu.be/EnSu9hHGq5o
+
+*Video* - [Modern Dictionaries, by Raymond Hettinger (SF Python)][]
+
+[Modern Dictionaries, by Raymond Hettinger (SF Python)]: https://youtu.be/p33CVV29OG8
+
+*Video* - [Python Language, by Guido van Rossum (PyCon 2016)][]
+
+[Python Language, by Guido van Rossum (PyCon 2016)]: https://youtu.be/YgtL4S7Hrwo
+
+*Video* - [The Mighty Dictionary, by Brandon Rhodes (PyCon 2010)][]
+
+[The Mighty Dictionary, by Brandon Rhodes (PyCon 2010)]: http://pyvideo.org/pycon-us-2010/the-mighty-dictionary-55.html
+
+*Tutorial* - [Code Like a Pythonista: Idiomatic Python][]
+
+[Code Like a Pythonista: Idiomatic Python]: http://python.net/~goodger/projects/pycon/2007/idiomatic/handout.html
+
+*Article* - [Static types in Python, oh my(py)!][]
+
+[Static types in Python, oh my(py)!]: http://blog.zulip.org/2016/10/13/static-types-in-python-oh-mypy
+
+*Guide* - [The Hitchhiker’s Guide to Python!][]
+
+[The Hitchhiker’s Guide to Python!]: http://docs.python-guide.org/en/latest
+
+## C/C++
+
+*Book* [The C Programming Language][]
+
+[The C Programming Language]: https://www.ime.usp.br/~pf/Kernighan-Ritchie/C-Programming-Ebook.pdf
+
+## Java/Android
+
+*Course* - [Android Development for Beginners][]
+
+[Android Development for Beginners]: https://www.udacity.com/course/android-development-for-beginners--ud837
+
+## JavaScript/ECMAScript
+
+*Tutorial* - [clean-code-javascript Software engineering principles][]
+
+[clean-code-javascript Software engineering principles]: https://github.com/ryanmcdermott/clean-code-javascript
+
+*Slides* - [TypeScript vs. CoffeeScript vs. ES6][]
+
+[TypeScript vs. CoffeeScript vs. ES6]: http://www.slideshare.net/NeilGreen1/type-script-vs-coffeescript-vs-es6
+
+## Git/Version Control Systems (VCS)
+
+You may want to take a look first at our [Git and GitHub guide][].
+
+[Git and GitHub guide]: http://zulip.readthedocs.io/en/latest/git-guide.html
+
+*Article* - [Git tips][]
+
+[Git tips]: http://blog.sidhant.me/post/155311539806/stuff-that-i-learnt-in-git-while-working-with
+
+## Computer Science/Algorithms
+
+*Blog* - [GeeksforGeeks][]
+
+[GeeksforGeeks]: http://www.geeksforgeeks.org
+
+*Book* [Introduction to Algorithms][] (*Not free!*)
+
+[Introduction to Algorithms]: https://mitpress.mit.edu/books/introduction-algorithms
+
+*Blog* - [Setosa data visualization and visual explanations][]
+
+[Setosa data visualization and visual explanations]: http://setosa.io
+
+*Course* - [Algorithms, Part I][]
+
+[Algorithms, Part I]: https://www.coursera.org/learn/algorithms-part1
+
+*Course* - [Open Source Society University][]
+
+[Open Source Society University]: https://ossu.firebaseapp.com
+
+*Course* - [MIT CSAIL 6.828: Operative Systems Engineering][]
+
+[MIT CSAIL 6.828: Operative Systems Engineering]: https://pdos.csail.mit.edu/6.828/2016
+
+## Community experience
+
+*Article* - [Advice on Starting And Running A New Open Source Project][]
+
+[Advice on Starting And Running A New Open Source Project]: https://www.harihareswara.net/sumana/2016/08/04/1
+
+*Article* - [How to ask good questions][]
+
+[How to ask good questions]: https://jvns.ca/blog/good-questions
+
+*Article* - [Notes for New FLOSS Contributors][]
+
+[Notes for New FLOSS Contributors]: https://www.harihareswara.net/sumana/2016/10/12/0
+
+*Article* - [To be mentored][]
+
+[To be mentored]: https://trueskawka.github.io/zulip/outreachy/blog/2017/01/02/to-be-mentored.html
+
+*Article* - [To mentor][]
+
+[To mentor]: https://trueskawka.github.io/zulip/outreachy/gci/blog/2017/01/03/to-mentor.html
+
+[List of good projects for new contributors][]
+
+[List of good projects for new contributors]: https://github.com/MunGell/awesome-for-beginners
+
+## Competitions/Camps
+
+[CodeForces][]
+
+[CodeForces]: http://codeforces.com
+
+[Free Code Camp][]
+
+[Free Code Camp]: https://www.freecodecamp.com
+
+## Massive Open Online Courses (MOOC) Platforms
+
+[Coursera][]
+
+[Coursera]: https://www.coursera.org
+
+[edX][]
+
+[edX]: https://www.edx.org
+
+[MIT OpenCourseWare][]
+
+[MIT OpenCourseWare]: http://ocw.mit.edu
+
+[Udacity][]
+
+[Udacity]: https://www.udacity.com


### PR DESCRIPTION
This adds a new *Reading list* section in the developer and sysadmin documentation.

It contains valuable resources, taken from [this](https://chat.zulip.org/#narrow/stream/GCI.20general/topic/reading.20list) Zulip conversation, classified by categories and tagged by the type of the content.

Special effort has been put in making the structure as organised as possible. That's why some content have been set up to follow the same style (e.g. `<title>, by <author> (<event>)`  for talks).