### PR TITLE
[Fix]: Lightbox Text Overflow.

### DIFF
--- a/static/styles/overlay.css
+++ b/static/styles/overlay.css
@@ -125,21 +125,33 @@
 
 #overlay .image-description {
     /* approx width of screen minus action buttons on the side. */
-    width: calc(100% - 320px);
+    width: calc(100% - 260px);
+    /* add some extra margin top and remove some bottom to keep the
+       height the same. and vertically center the text with the buttons. */
+    margin-top: 25px;
+    margin-bottom: 15px;
 
     font-size: 1.3rem;
     color: #fff;
 }
 
 #overlay .image-description .title {
+    display: inline-block;
+    vertical-align: top;
+
     font-weight: 500;
     line-height: normal;
-    max-width: calc(100%);
+    max-width: calc(100% - 210px);
 
     /* Required for text-overflow */
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+#overlay .image-description .user::before {
+    margin-right: 5px;
+    content: "\2014";
 }
 
 #overlay .player-container {
@@ -157,7 +169,14 @@
 }
 
 #overlay .image-description .user {
+    max-width: 200px;
+    display: inline-block;
+    vertical-align: top;
     font-weight: 300;
+    line-height: normal;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: pre;
 }
 
 .image-actions .button {
@@ -197,5 +216,9 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    #overlay .image-description .title {
+        max-width: calc(100% - 60px);
     }
 }

--- a/templates/zerver/image-overlay.html
+++ b/templates/zerver/image-overlay.html
@@ -2,8 +2,7 @@
   <div class="image-info-wrapper">
     <div class="image-description">
       <div class="title"></div>
-      &mdash;
-      <span class="user"></span>
+      <div class="user"></div>
     </div>
     <div class="exit">x</div>
     <div class="image-actions">


### PR DESCRIPTION
The issue present on master is that the author name overflows to the next line by default because the div that the title is in is not set to display: inline-block. This is fixed by setting all elements in the .image-description block to be il-block but also by enforcing strict maximum widths on the elements so they overflow to ellipsis properly.