### PR TITLE
day2 email: Soften advice against using long topics.

### DIFF
--- a/templates/zerver/emails/followup/day2.html
+++ b/templates/zerver/emails/followup/day2.html
@@ -20,8 +20,8 @@
 <p>Topics are like email subject lines. The big difference, though, is that they're really short and lightweight. One or two words will do it. Don't overthink 'em&mdash;you can always edit the message later!</p>
 
 <ul>
-    <li>Bad topics: "What do people think of this new screenshot?", "I'm looking at Bug 345",  "Where should we go to lunch?"</li>
     <li>Good topics: screenshot, Bug 345, lunch</li>
+    <li>Not recommended: "What do people think of this new screenshot?", "I'm looking at Bug 345", "Where should we go to lunch?"</li>
 </ul>
 
 <p>Why bother with topics? Well, two reasons: it makes conversations clearer (imagine if email didn't have them!), and it lets you more efficiently catch up on what's happened while you're away&mdash;read the topics that are relevant to you, and ignore the ones that aren't!</p>

--- a/templates/zerver/emails/followup/day2.txt
+++ b/templates/zerver/emails/followup/day2.txt
@@ -4,9 +4,9 @@ I wanted to share one last thing with you: a few tips about topics, since master
 
 Topics are like email subject lines. The big difference, though, is that they're really short and lightweight. One or two words will do it. Don't overthink 'em -- you can always edit the message later!
 
-* Bad topics: "What do people think of this new screenshot?", "I'm looking at Bug 345",  "Where should we go to lunch?"
-
 * Good topics: screenshot, Bug 345, lunch
+
+* Not recommended: "What do people think of this new screenshot?", "I'm looking at Bug 345", "Where should we go to lunch?"
 
 Why bother with topics? Well, two reasons: it makes conversations clearer (imagine if email didn't have them!), and it lets you more efficiently catch up on what's happened while you're away -- read the topics that are relevant to you, and ignore the ones that aren't!
 


### PR DESCRIPTION
In response to feedback that joining (and sending a first message to) a new
chat platform/org is already intimidating enough, and "Not Recommended" gets
the point across in a gentler way.