### PR TITLE
Fix duplicate HTML id: fmt_help_table.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1938,7 +1938,7 @@ div.floating_recipient {
     color: white;
 }
 
-#fmt_help_table {
+.help-table {
     table-layout: fixed;
 }
 

--- a/templates/zerver/markdown_help.html
+++ b/templates/zerver/markdown_help.html
@@ -6,7 +6,7 @@
   </div>
   <div class="modal-body">
     <div id="markdown-instructions">
-      <table class="table table-striped table-condensed table-rounded table-bordered" id="fmt_help_table">
+      <table class="table table-striped table-condensed table-rounded table-bordered help-table">
         <thead><tr>
           <th>{% trans %}You type{% endtrans %}</th>
           <th>{% trans %}You get{% endtrans %}</th>

--- a/templates/zerver/search_operators.html
+++ b/templates/zerver/search_operators.html
@@ -5,7 +5,7 @@
     <h3 id="search-operators-label">{{ _('Search help') }}</h3>
   </div>
   <div class="modal-body">
-    <table class="table table-striped table-condensed table-rounded table-bordered" id="fmt_help_table">
+    <table class="table table-striped table-condensed table-rounded table-bordered help-table">
       <thead>
         <tr>
           <th>{{ _('Operator') }}</th>


### PR DESCRIPTION
We replace the id with a class called help-table.