### PR TITLE
test-signup: Change failed signup test to be on an open realm.

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -971,6 +971,8 @@ class UserSignUpTest(ZulipTestCase):
     def test_failed_signup_due_to_restricted_domain(self):
         # type: () -> None
         realm = get_realm('zulip')
+        realm.invite_required = False
+        realm.save()
         with self.settings(REALMS_HAVE_SUBDOMAINS = True):
             request = HostRequestMock(host = realm.host)
             request.session = {} # type: ignore


### PR DESCRIPTION
Previously, test_failed_signup_due_to_restricted_domain used a realm with
restricted domains, but also with invite_required = True. We didn't have a
test that tested for a failed signup in an open realm with restricted
domain, so edited test_failed_signup_due_to_restricted_domain to test for
that.