### PR TITLE
[Fix]: Allow users to resize the message compose box.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -227,6 +227,8 @@ function show_box_for_msg_type(msg_type, opts) {
 }
 
 exports.start = function (msg_type, opts) {
+    $("#new_message_content").autosize();
+
     if (reload.is_in_progress()) {
         return;
     }
@@ -284,6 +286,8 @@ function abort_xhr() {
 }
 
 exports.cancel = function () {
+    $("#new_message_content").height(40 + "px");
+
     if (page_params.narrow !== undefined) {
         // Never close the compose box in narrow embedded windows, but
         // at least clear the subject and unfade.
@@ -896,7 +900,31 @@ exports.validate = function () {
 };
 
 $(function () {
-    $("#new_message_content").autosize();
+    (function on_compose_resize(cb) {
+        var meta = {
+            compose_box: document.querySelector("#new_message_content"),
+            height: null,
+            mousedown: false,
+        };
+
+        meta.compose_box.addEventListener("mousedown", function () {
+            meta.mousedown = true;
+            meta.height = meta.compose_box.clientHeight;
+        });
+
+        document.body.addEventListener("mouseup", function () {
+            if (meta.mousedown === true) {
+                meta.mousedown = false;
+                if (meta.height !== meta.compose_box.clientHeight) {
+                    meta.height = meta.compose_box.clientHeight;
+                    cb.call(meta.compose_box, meta.height);
+                }
+            }
+        });
+    }(function (height) {
+        $("#new_message_content").trigger("autosize.destroy")
+            .height(height + "px");
+    }));
 
     // Run a feature test and decide whether to display
     // the "Attach files" button

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -289,7 +289,7 @@ textarea.new_message_textarea {
     height: 1.5em;
     max-height: 22em;
     margin-bottom: 0px;
-    resize: none;
+    resize: vertical !important;
     margin-top: 5px;
 }
 


### PR DESCRIPTION
This allows for users to resize the message compose box without it
collapsing back down to jQuery autosize’s preferred height.

When you hide the compose box and then re-show it, it keeps the
previous height but reactivates the jQuery module.

Fixes: #2236.