### PR TITLE
Change the "top of messages" logo to SVG from PNG.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -79,11 +79,6 @@ p.n-margin {
     top: 67px;
     width: 24px;
     height: 24px;
-    background-image: url(../images/logo/zulip-icon-128x128.png);
-    background-size: 100%;
-    background-repeat: no-repeat;
-    -webkit-filter: saturate(0) invert(1) brightness(1.3);
-    filter: saturate(0) invert(1) brightness(1.3);
 }
 
 #unmute_muted_topic_notification {

--- a/templates/zerver/home.html
+++ b/templates/zerver/home.html
@@ -1,6 +1,13 @@
 {# Home tab of the app, containing messages. #}
     <div class="message_area_padder message_list" id="main_div">
-      <div class="top-messages-logo"></div>
+      <div class="top-messages-logo">
+          <svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 40" version="1.1">
+              <g transform="translate(-297.14285,-466.64792)">
+              <circle cx="317.14285" cy="486.64792" r="19.030317" style="fill:#444;stroke-width:1.93936479;stroke:#444"/>
+              <path d="m309.24286 477.14791 14.2 0 1.6 3.9-11.2 11.9 9.6 0 1.6 3.2-14.2 0-1.6-3.9 11.2-11.9-9.6 0z" style="fill:#fff;stroke:#fff"/>
+              </g>
+          </svg>
+      </div>
       <div id="loading_more_messages_indicator"></div>
       <div id="page_loading_indicator"></div>
       <div id="first_run_message" class="empty_feed_notice">


### PR DESCRIPTION
This changes the logo that sits at the top of the messages to an SVG
rather than a PNG used as the current navbar logo that is filtered to
be grayscale.

Thanks to @rishig for generating the SVG!