### PR TITLE
Fixed typo in ruby_spec.rb

### DIFF
--- a/puppet/stdlib/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/puppet/stdlib/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -116,7 +116,7 @@ describe provider_class do
       File.read(@tmpfile).should eql("foo1\nfoo2\n")
     end
 
-    it 'should remove any occurence of the line' do
+    it 'should remove any occurrence of the line' do
       File.open(@tmpfile, 'w') do |fh|
         fh.write("foo1\nfoo\nfoo2\nfoo\nfoo")
       end


### PR DESCRIPTION
Fixed a typo with the word "occurrence" in ruby_spec.rb