### PR TITLE
Fixed typo in munin.conf.erb

### DIFF
--- a/puppet/zulip_ops/templates/munin/munin.conf.erb
+++ b/puppet/zulip_ops/templates/munin/munin.conf.erb
@@ -108,7 +108,7 @@ end
 # [fay.foo.com]
 #       address fay
 #
-## IPv6 host. note that the ip adress has to be in brackets
+## IPv6 host. note that the ip address has to be in brackets
 # [ip6.foo.com]
 #       address [2001::1234:1]
 #


### PR DESCRIPTION
Fixed a typo with the word "address" in munin.conf.erb