### PR TITLE
Update ultra-compact CSS (<= 500 px wide) for new hover controls.

### DIFF
--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -269,7 +269,6 @@
         height: 20px;
         background: rgba(255,255,255,0.8);
         z-index: 10;
-        border: 1px solid #e2e2e2;
     }
 
     .selected_message .message_controls {
@@ -290,12 +289,14 @@
 
     .star {
         position: absolute;
-        left: 4px;
+        left: 0px;
+        top: -1px;
     }
 
     .info {
         position: absolute;
-        left: 20px;
+        left: 17px;
+        top: -1px;
     }
 
     .edit_content, .reactions_hover {

--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -262,10 +262,10 @@
     .message_controls {
         right: -16px;
         top: -2px;
+        width: 51px;
     }
 
     .message_hovered .message_controls {
-        width: 51px;
         height: 20px;
         background: rgba(255,255,255,0.8);
         z-index: 10;

--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -265,13 +265,11 @@
     }
 
     .message_hovered .message_controls {
-        width: 35px;
+        width: 51px;
         height: 20px;
         background: rgba(255,255,255,0.8);
         z-index: 10;
         border: 1px solid #e2e2e2;
-        right: -16px;
-        top: -2px;
     }
 
     .selected_message .message_controls {
@@ -290,18 +288,24 @@
         right: -5px;
     }
 
-    .include-sender .message_controls {
-        right: 36px;
-    }
-
     .star {
         position: absolute;
-        right: 2px;
+        left: 4px;
     }
 
     .info {
         position: absolute;
-        right: 18px;
+        left: 20px;
+    }
+
+    .edit_content, .reactions_hover {
+        position: absolute;
+        left: 34px;
+    }
+
+    .edit_content i, .reactions_hover i {
+        top: 0px;
+        left: 0px;
     }
 
     .sender_name {


### PR DESCRIPTION
I just did some tweaks to make it look decent again. This is still
all more complicated than it should be, but it's not easy to fix
because the edit/reaction icon is positioned differently than the
star and info icons in the main Zulip CSS.