### PR TITLE
/activity: Fix URL route for analytics.views.get_realm_activity.

### DIFF
--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -6,7 +6,7 @@ import analytics.views
 i18n_urlpatterns = [
     url(r'^activity$', analytics.views.get_activity,
         name='analytics.views.get_activity'),
-    url(r'^realm_activity/(?P<realm>[\S]+)/$', analytics.views.get_realm_activity,
+    url(r'^realm_activity/(?P<realm_str>[\S]+)/$', analytics.views.get_realm_activity,
         name='analytics.views.get_realm_activity'),
     url(r'^user_activity/(?P<email>[\S]+)/$', analytics.views.get_user_activity,
         name='analytics.views.get_user_activity'),

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -762,11 +762,11 @@ def user_activity_link(email):
     email_link = '<a href="%s">%s</a>' % (url, email)
     return mark_safe(email_link)
 
-def realm_activity_link(realm):
+def realm_activity_link(realm_str):
     # type: (str) -> mark_safe
     url_name = 'analytics.views.get_realm_activity'
-    url = urlresolvers.reverse(url_name, kwargs=dict(realm=realm))
-    realm_link = '<a href="%s">%s</a>' % (url, realm)
+    url = urlresolvers.reverse(url_name, kwargs=dict(realm_str=realm_str))
+    realm_link = '<a href="%s">%s</a>' % (url, realm_str)
     return mark_safe(realm_link)
 
 def realm_client_table(user_summaries):


### PR DESCRIPTION
analytics.views.get_realm_activity was taking a 'realm_str', but the URL
route was expecting a 'realm'. Changed the URL route to take a 'realm_str'.