### PR TITLE
Fixed Preview message failure for long messages

### DIFF
--- a/api/zulip/__init__.py
+++ b/api/zulip/__init__.py
@@ -681,7 +681,7 @@ class Client(object):
         '''
         return self.call_endpoint(
             url='messages/render',
-            method='GET',
+            method='POST',
             request=request,
         )
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1038,7 +1038,7 @@ $(function () {
                 // incorrect wrong, users will see a brief flicker).
                 $("#preview_content").html(echo.apply_markdown(message));
             }
-            channel.get({
+            channel.post({
                 url: '/json/messages/render',
                 idempotent: true,
                 data: {content: message},

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -839,7 +839,7 @@ class BugdownApiTests(ZulipTestCase):
     def test_render_message_api(self):
         # type: () -> None
         content = 'That is a **bold** statement'
-        result = self.client_get(
+        result = self.client_post(
             '/api/v1/messages/render',
             dict(content=content),
             **self.api_auth('othello@zulip.com')
@@ -853,7 +853,7 @@ class BugdownApiTests(ZulipTestCase):
         # type: () -> None
         """Determines whether we're correctly passing the realm context"""
         content = 'This mentions #**Denmark** and @**King Hamlet**.'
-        result = self.client_get(
+        result = self.client_post(
             '/api/v1/messages/render',
             dict(content=content),
             **self.api_auth('othello@zulip.com')

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -213,7 +213,7 @@ v1_api_and_json_patterns = [
         {'GET': 'zerver.views.messages.json_fetch_raw_message',
          'PATCH': 'zerver.views.messages.json_update_message'}),
     url(r'^messages/render$', rest_dispatch,
-        {'GET': 'zerver.views.messages.render_message_backend'}),
+        {'POST': 'zerver.views.messages.render_message_backend'}),
     url(r'^messages/flags$', rest_dispatch,
         {'POST': 'zerver.views.messages.update_message_flags'}),
 


### PR DESCRIPTION
Fixes #3271 

Moved `/messages/render` endpoint to POST so that it would work for messages with length greater than the GET request length limit.