### PR TITLE
Closes #3284: Change `Stream.objects.get()` into `get_stream()`

### DIFF
--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -63,7 +63,7 @@ class TopicHistoryTest(ZulipTestCase):
         self.login(email)
 
         user_profile = get_user_profile_by_email(email)
-        stream = Stream.objects.get(name=stream_name)
+        stream = get_stream(stream_name, user_profile.realm)
         recipient = get_recipient(Recipient.STREAM, stream.id)
 
         def create_test_message(topic, read, starred=False):

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -61,7 +61,7 @@ def get_recipient_id_for_stream_name(realm, stream_name):
 
 def mute_stream(realm, user_profile, stream_name):
     # type: (Realm, Text, Text) -> None
-    stream = Stream.objects.get(realm=realm, name=stream_name)
+    stream = get_stream(stream_name, realm)
     recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
     subscription = Subscription.objects.get(recipient=recipient, user_profile=user_profile)
     subscription.in_home_view = False


### PR DESCRIPTION
Closes #3284 
`Stream.objects.get()` has been replaced with `get_stream()` in tests.