### PR TITLE
right-sidebar: Remove border on the top of user list

### DIFF
--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -197,8 +197,6 @@
 
 #userlist-header,
 #group-pm-header {
-    border-top: 1px solid #e2e2e2;
-    margin-top: 5px;
     margin-right: 10px;
 }
 
@@ -208,7 +206,9 @@
 
 #feedback_section {
     text-align: left;
-    padding-bottom: 10px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid #e2e2e2;
+    margin-right: 10px;
 }
 
 .user-list-filter ,


### PR DESCRIPTION
Remove the border on the top of user list, especially on the top
of "USERS" word. The border is moved to bottom of feedback section.

Zulip conversation: https://chat.zulip.org/#narrow/stream/frontend/subject/border.20at.20top.20of.20users/near/126756  

------------

Before:
![before1](https://cloud.githubusercontent.com/assets/20320125/21940553/7abc6f18-d9f7-11e6-8af4-6ad8d9b58468.png)
![before2](https://cloud.githubusercontent.com/assets/20320125/21940556/7d45ed22-d9f7-11e6-90b2-4c46e82c8e4b.png)

After:
![after1](https://cloud.githubusercontent.com/assets/20320125/21940576/8724f838-d9f7-11e6-825b-d03b1784913c.png)
![after2](https://cloud.githubusercontent.com/assets/20320125/21940581/8bcc8270-d9f7-11e6-8713-6dc494303f3f.png)
