### PR TITLE
Check if pip is outdated in provision.py.

### DIFF
--- a/tools/provision.py
+++ b/tools/provision.py
@@ -6,6 +6,7 @@ import logging
 import argparse
 import platform
 import subprocess
+import re
 
 os.environ["PYTHONUNBUFFERED"] = "y"
 
@@ -163,6 +164,15 @@ def main(options):
     run(["sudo", "./scripts/lib/setup-apt-repo"])
     run(["sudo", "apt-get", "-y", "install", "--no-install-recommends"] + APT_DEPENDENCIES[codename])
 
+    # Check if the current version of pip is outdated.In some edge cases, the previous command
+    # doesn't update pip correctly, which may lead to failing provisions if the current version
+    # is too old.
+    pip_version = re.search(r'\d+', subprocess_text_output(["pip", "--version"])).group()
+    if int(pip_version) < 9:
+        logging.critical("Your pip version is outdated!"
+                         " Is your system path to pip set up correctly?")
+        sys.exit(1)
+
     if options.is_travis:
         if PY2:
             MYPY_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "mypy.txt")
@@ -283,3 +293,4 @@ if __name__ == "__main__":
 
     options = parser.parse_args()
     sys.exit(main(options))
+


### PR DESCRIPTION
Since the automatic update in provision.py doesn't work for
some edge cases, we need to manually check if the pip version
used is recent enough for provisioning (see discussion in #3237
for further details).