### PR TITLE
Fix: /me breaks message layout when entered with a single subsequent space.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -99,7 +99,7 @@ exports.save = function (row, from_topic_edited_only) {
 
     if (new_content !== message.raw_content && !from_topic_edited_only) {
         request.content = new_content;
-        message.is_me_message = new_content.lastIndexOf('/me', 0) === 0;
+        message.is_me_message = new_content.lastIndexOf('/me ', 0) === 0;
         changed = true;
     }
     if (!changed) {

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -931,7 +931,7 @@ MessageListView.prototype = {
     _maybe_format_me_message: function MessageListView__maybe_format_me_message(message_container) {
         if (message_container.msg.is_me_message) {
             // Slice the '<p>/me ' off the front, and '</p>' off the end
-            message_container.status_message = message_container.msg.content.slice(4 + 3, -4);
+            message_container.status_message = message_container.msg.content.slice(4 + 2, -4);
             message_container.include_sender = true;
         } else {
             message_container.status_message = false;


### PR DESCRIPTION
#3294