### PR TITLE
docs: Fix user documentation

### DIFF
--- a/templates/zerver/help/chat-with-zulip-button.md
+++ b/templates/zerver/help/chat-with-zulip-button.md
@@ -1,11 +1,19 @@
-# **Chat button for zulip**
-* This button redirects user to zulip chat [Zulip Chat Portal for Developers](https://chat.zulip.org).
-* This is displayed in Zulip's [GitHub](https://github.com/zulip/zulip) README.md page.
-* To embed this badge, simply copy and paste the following markdown:
+# Join Zulip Chat button
 
-~~~
+[![Zulip
+chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org)
+
+This button, displayed in Zulip's [GitHub](https://github.com/zulip/zulip)
+`README.md` page, redirects user to the [Zulip chat for developers](https://chat.zulip.org).
+
+To embed this badge in a Markdown document, simply copy and paste the
+following Markdown:
+
+```
 [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org)
-~~~
+```
 
-* This badge is dynamically generated, visit shields.io for detail information about customizing it.
-* A static version is available in `/static/images/help/chat_on_zulip.[png|svg]`.
+!!! tip ""
+    This badge is dynamically generated; visit
+    [shields.io](https://shields.io) for detail information about
+    customizing it.

--- a/templates/zerver/help/index.md
+++ b/templates/zerver/help/index.md
@@ -158,5 +158,4 @@ as an **organization**.
 ---
 
 # Include Zulip
-
-* [Chat with zulip button](/help/chat-with-zulip-button)
+* [Join Zulip Chat button](/help/chat-with-zulip-button)

--- a/templates/zerver/help/verify-that-your-message-has-been-successfully-sent.md
+++ b/templates/zerver/help/verify-that-your-message-has-been-successfully-sent.md
@@ -1,22 +1,23 @@
 # Verify that your message has been succesfully sent
 
-When you send a message in a chat tool, depending on where you are
-located in relation to the relevant server, it can take a few hundred
-milliseconds for your message to transmitted to the server, stored,
-and transmitted to active clients by the server.  Like most other chat
-tools, Zulip optimizes the experience for the sender by "locally
-echoing" the message, i.e. displaying it in your Zulip feed
-immediately, even though your browser may only get confirmation that
-the message was received by the server a few hundred milliseconds
-later.
+When you send a message in a chat tool, it can take a few hundred milliseconds
+for your message to transmitted to the server, stored, and transmitted to active
+clients by the server, depending on where you are located in relation to the
+relevant server.
 
-In Zulip, locally echoed messages are displayed without a visible
-timestamp, so that (for debugging purposes) one can visually tell them
-apart from messages that have been confirmed by the server.  Once the
-client is able to deliver the message to the server, and the server
-confirms receipt of the message, Zulip rerenders the message to
-display the timestamp.  You can see this in action by using the
-following procedure:
+Like most other chat tools, Zulip optimizes the experience for the sender by
+"locally echoing" the message, i.e. displaying it in your Zulip feed
+immediately, even though your browser may only get confirmation that the message
+was received by the server a few hundred milliseconds later.
+
+In Zulip, locally echoed messages are displayed without a visible timestamp to
+allow you to visually tell them apart from messages that have been confirmed by
+the server.  Once the client is able to deliver the message to the server, and
+the server confirms receipt of the message, Zulip rerenders the message to
+display the timestamp  to avoid issues where messages users thought they sent
+are lost.
+
+You can see this in action by using the following procedure:
 
 1. Disconnect your computer from the Internet.
 
@@ -34,8 +35,4 @@ error in your browser window.
 5. A few seconds later, your message will be updated to contain the
 timestamp on the right side of the message body.
 
-![Message time](/static/images/help/message-exact-time.png)
-
-Zulip is designed to store locally echoed message content in local
-storage and replay it when your browser reconnects to the Internet, to
-avoid issues where messages users thought they sent are lost.
+    ![Message time](/static/images/help/message-exact-time.png)


### PR DESCRIPTION
**Summary:**

* Remove **Chat with Zulip button** doc; the images referenced in this doc have been
deleted for some reason, rendering it almost useless with the missing
images.

* Fix formatting errors in various docs.

* Change wording in various docs for better clarification.

* Conform old and new docs to documentation styling guidelines.