### PR TITLE
[WIP] Sort imports in Python modules.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,18 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
+# isort configuration
+[*.py]
+line_length = 79
+multi_line_output = 0
+balanced_wrapping = true
+known_future_library = future, typing
+known_standard_library = six
+known_django = django
+known_third_party = ujson, sqlalchemy
+known_first_party = zerver, zproject, version
+sections = FUTURE, STDLIB, THIRDPARTY, DJANGO, FIRSTPARTY, LOCALFOLDER
+
 [*.{svg,rb,pp,pl}]
 indent_style = space
 indent_size = 2

--- a/zerver/views/alert_words.py
+++ b/zerver/views/alert_words.py
@@ -1,18 +1,16 @@
 from __future__ import absolute_import
+from typing import List, Text
 
-from django.http import HttpResponse, HttpRequest
+from django.http import HttpRequest, HttpResponse
 
-from typing import List
-from zerver.models import UserProfile
-
-from zerver.decorator import has_request_variables, REQ
+from zerver.decorator import REQ, has_request_variables
+from zerver.lib.actions import (do_add_alert_words, do_remove_alert_words,
+                                do_set_alert_words)
+from zerver.lib.alert_words import user_alert_words
 from zerver.lib.response import json_success
 from zerver.lib.validator import check_list, check_string
+from zerver.models import UserProfile
 
-from zerver.lib.actions import do_add_alert_words, do_remove_alert_words, do_set_alert_words
-from zerver.lib.alert_words import user_alert_words
-
-from typing import Text
 
 def list_alert_words(request, user_profile):
     # type: (HttpRequest, UserProfile) -> HttpResponse

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import
+from typing import Iterable, Optional, Sequence, Text
 
 from django.http import HttpRequest, HttpResponse
-from typing import Text
-from typing import Iterable, Optional, Sequence
 
 from zerver.lib.actions import do_events_register
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
-from zerver.lib.validator import check_string, check_list, check_bool
+from zerver.lib.validator import check_bool, check_list, check_string
 from zerver.models import UserProfile
+
 
 def _default_all_public_streams(user_profile, all_public_streams):
     # type: (UserProfile, Optional[bool]) -> bool
@@ -48,4 +48,3 @@ def events_register_backend(request, user_profile, apply_markdown=True,
                              event_types, queue_lifespan_secs, all_public_streams,
                              narrow=narrow)
     return json_success(ret)
-

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -1,39 +1,44 @@
 from __future__ import absolute_import
-from typing import Any, List, Dict, Optional, Text
-
-from django.conf import settings
-from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect, HttpResponse, HttpRequest
-from django.shortcuts import redirect
-from django.utils import translation
-from django.utils.cache import patch_cache_control
-from six.moves import zip_longest, zip, range
-
-from version import ZULIP_VERSION
-from zerver.decorator import zulip_login_required
-from zerver.forms import ToSForm
-from zerver.models import Message, UserProfile, Stream, Subscription, Huddle, \
-    Recipient, Realm, UserMessage, DefaultStream, RealmEmoji, RealmAlias, \
-    RealmFilter, \
-    PreregistrationUser, get_client, UserActivity, \
-    get_stream, UserPresence, get_recipient, name_changes_disabled, email_to_username, \
-    list_of_domains_for_realm
-from zerver.lib.actions import update_user_presence, do_change_tos_version, \
-    do_events_register, do_update_pointer, get_cross_realm_dicts, realm_user_count
-from zerver.lib.avatar import avatar_url
-from zerver.lib.i18n import get_language_list, get_language_name, \
-    get_language_list_for_templates
-from zerver.lib.push_notifications import num_push_devices_for_user
-from zerver.lib.utils import statsd, get_subdomain
-from zproject.backends import password_auth_enabled
-from zproject.jinja2 import render_to_response
+from typing import Any, Dict, List, Optional, Text
 
 import calendar
 import datetime
 import logging
 import re
-import simplejson
 import time
+from six.moves import range, zip, zip_longest
+
+import simplejson
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.shortcuts import redirect
+from django.utils import translation
+from django.utils.cache import patch_cache_control
+
+from version import ZULIP_VERSION
+from zerver.decorator import zulip_login_required
+from zerver.forms import ToSForm
+from zerver.lib.actions import (do_change_tos_version, do_events_register,
+                                do_update_pointer, get_cross_realm_dicts,
+                                realm_user_count, update_user_presence)
+from zerver.lib.avatar import avatar_url
+from zerver.lib.i18n import (get_language_list,
+                             get_language_list_for_templates,
+                             get_language_name)
+from zerver.lib.push_notifications import num_push_devices_for_user
+from zerver.lib.utils import get_subdomain, statsd
+from zerver.models import (DefaultStream, Huddle, Message, PreregistrationUser,
+                           Realm, RealmAlias, RealmEmoji, RealmFilter,
+                           Recipient, Stream, Subscription, UserActivity,
+                           UserMessage, UserPresence, UserProfile,
+                           email_to_username, get_client, get_recipient,
+                           get_stream, list_of_domains_for_realm,
+                           name_changes_disabled)
+from zproject.backends import password_auth_enabled
+from zproject.jinja2 import render_to_response
+
 
 @zulip_login_required
 def accounts_accept_terms(request):
@@ -339,4 +344,3 @@ def is_buggy_ua(agent):
     """
     return ("Humbug Desktop/" in agent or "Zulip Desktop/" in agent or "ZulipDesktop/" in agent) and \
         "Mac" not in agent
-

--- a/zerver/views/integrations.py
+++ b/zerver/views/integrations.py
@@ -1,17 +1,20 @@
 from __future__ import absolute_import
-from typing import Optional, Any, Dict
-from collections import OrderedDict
-from django.views.generic import TemplateView
-from django.conf import settings
-from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
+from typing import Any, Dict, Optional
 
 import os
+from collections import OrderedDict
+
 import ujson
 
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
+from django.views.generic import TemplateView
+
 from zerver.lib import bugdown
-from zerver.lib.integrations import INTEGRATIONS, HUBOT_LOZENGES
+from zerver.lib.integrations import HUBOT_LOZENGES, INTEGRATIONS
 from zerver.lib.utils import get_subdomain
 from zproject.jinja2 import render_to_response
+
 
 def add_api_uri_context(context, request):
     # type: (Dict[str, Any], HttpRequest) -> None

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -1,21 +1,21 @@
 from __future__ import absolute_import
+from typing import Set, Text
+
+import re
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
-from typing import Text
-from typing import Set
 
 from zerver.decorator import authenticated_json_post_view
-from zerver.lib.actions import do_invite_users, do_refer_friend, \
-    get_default_subs, internal_send_message
-from zerver.lib.request import REQ, has_request_variables, JsonableError
-from zerver.lib.response import json_success, json_error
-from zerver.lib.validator import check_string, check_list
+from zerver.lib.actions import (do_invite_users, do_refer_friend,
+                                get_default_subs, internal_send_message)
+from zerver.lib.request import REQ, JsonableError, has_request_variables
+from zerver.lib.response import json_error, json_success
+from zerver.lib.validator import check_list, check_string
 from zerver.models import PreregistrationUser, Stream, UserProfile, get_stream
 
-import re
 
 @authenticated_json_post_view
 @has_request_variables
@@ -95,4 +95,3 @@ def json_refer_friend(request, user_profile, email=REQ()):
     do_refer_friend(user_profile, email)
 
     return json_success()
-

--- a/zerver/views/muting.py
+++ b/zerver/views/muting.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import
-
-from django.http import HttpResponse, HttpRequest
 from typing import List, Text
+
+from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import authenticated_json_post_view
 from zerver.lib.actions import do_set_muted_topics
-from zerver.lib.request import has_request_variables, REQ
+from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
-from zerver.lib.validator import check_string, check_list
+from zerver.lib.validator import check_list, check_string
 from zerver.models import UserProfile
+
 
 @authenticated_json_post_view
 @has_request_variables
@@ -18,4 +19,3 @@ def json_set_muted_topics(request, user_profile,
     # type: (HttpRequest, UserProfile, List[List[Text]]) -> HttpResponse
     do_set_muted_topics(user_profile, muted_topics)
     return json_success()
-

--- a/zerver/views/pointer.py
+++ b/zerver/views/pointer.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import
+from typing import Text
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
-from typing import Text
 
 from zerver.decorator import to_non_negative_int
 from zerver.lib.actions import do_update_pointer
-from zerver.lib.request import has_request_variables, JsonableError, REQ
+from zerver.lib.request import REQ, JsonableError, has_request_variables
 from zerver.lib.response import json_success
-from zerver.models import UserProfile, UserMessage
+from zerver.models import UserMessage, UserProfile
+
 
 def get_pointer_backend(request, user_profile):
     # type: (HttpRequest, UserProfile) -> HttpResponse

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
+from typing import Any
 
 import datetime
 import time
-from typing import Any
 
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
@@ -10,10 +10,11 @@ from django.utils.translation import ugettext as _
 
 from zerver.decorator import authenticated_json_post_view
 from zerver.lib.actions import get_status_dict, update_user_presence
-from zerver.lib.request import has_request_variables, REQ, JsonableError
-from zerver.lib.response import json_success, json_error
+from zerver.lib.request import REQ, JsonableError, has_request_variables
+from zerver.lib.response import json_error, json_success
 from zerver.lib.validator import check_bool
 from zerver.models import UserActivity, UserPresence, UserProfile
+
 
 def get_status_list(requesting_user_profile):
     # type: (UserProfile) -> Dict[str, Any]

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-
 from typing import Optional
 
 from django.conf import settings
@@ -7,10 +6,11 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now
 from django.utils.translation import ugettext as _
 
-from zerver.lib.request import has_request_variables, REQ
-from zerver.lib.response import json_success, json_error
-from zerver.lib.validator import check_string, check_list, check_bool
+from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.response import json_error, json_success
+from zerver.lib.validator import check_bool, check_list, check_string
 from zerver.models import PushDeviceToken, UserProfile
+
 
 def add_push_device_token(request, user_profile, token_str, kind, ios_app_id=None):
     # type: (HttpRequest, UserProfile, str, int, Optional[str]) -> HttpResponse

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -1,17 +1,18 @@
 from __future__ import absolute_import
+from typing import Text
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
-from typing import Text
 
-from zerver.decorator import authenticated_json_post_view,\
-    has_request_variables, REQ, to_non_negative_int
+from zerver.decorator import (REQ, authenticated_json_post_view,
+                              has_request_variables, to_non_negative_int)
 from zerver.lib.actions import do_add_reaction, do_remove_reaction
 from zerver.lib.bugdown import emoji_list
 from zerver.lib.message import access_message
 from zerver.lib.request import JsonableError
 from zerver.lib.response import json_success
 from zerver.models import Reaction, Realm, UserProfile
+
 
 def check_valid_emoji(realm, emoji_name):
     # type: (Realm, Text) -> None

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -1,27 +1,26 @@
 from __future__ import absolute_import
-
 from typing import Any, Optional
+
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
 from zerver.decorator import require_realm_admin, to_non_negative_int
-from zerver.lib.actions import (
-    do_set_realm_create_stream_by_admins_only,
-    do_set_realm_name,
-    do_set_realm_invite_by_admins_only,
-    do_set_realm_add_emoji_by_admins_only,
-    do_set_realm_invite_required,
-    do_set_realm_message_editing,
-    do_set_realm_restricted_to_domain,
-    do_set_realm_default_language,
-    do_set_realm_waiting_period_threshold,
-    do_set_realm_authentication_methods
-)
+from zerver.lib.actions import (do_set_realm_add_emoji_by_admins_only,
+                                do_set_realm_authentication_methods,
+                                do_set_realm_create_stream_by_admins_only,
+                                do_set_realm_default_language,
+                                do_set_realm_invite_by_admins_only,
+                                do_set_realm_invite_required,
+                                do_set_realm_message_editing,
+                                do_set_realm_name,
+                                do_set_realm_restricted_to_domain,
+                                do_set_realm_waiting_period_threshold)
 from zerver.lib.i18n import get_available_language_codes
-from zerver.lib.request import has_request_variables, REQ, JsonableError
-from zerver.lib.response import json_success, json_error
-from zerver.lib.validator import check_string, check_dict, check_bool
+from zerver.lib.request import REQ, JsonableError, has_request_variables
+from zerver.lib.response import json_error, json_success
+from zerver.lib.validator import check_bool, check_dict, check_string
 from zerver.models import UserProfile
+
 
 @require_realm_admin
 @has_request_variables

--- a/zerver/views/realm_aliases.py
+++ b/zerver/views/realm_aliases.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import
+from typing import Text
 
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
-from zerver.decorator import has_request_variables, REQ, require_realm_admin
-from zerver.lib.actions import do_add_realm_alias, do_get_realm_aliases, \
-    do_remove_realm_alias
+from zerver.decorator import REQ, has_request_variables, require_realm_admin
+from zerver.lib.actions import (do_add_realm_alias, do_get_realm_aliases,
+                                do_remove_realm_alias)
 from zerver.lib.response import json_error, json_success
-from zerver.models import can_add_alias, RealmAlias, UserProfile
+from zerver.models import RealmAlias, UserProfile, can_add_alias
 
-from typing import Text
 
 def list_aliases(request, user_profile):
     # type: (HttpRequest, UserProfile) -> (HttpResponse)

--- a/zerver/views/realm_emoji.py
+++ b/zerver/views/realm_emoji.py
@@ -1,13 +1,15 @@
 from __future__ import absolute_import
-from django.http import HttpRequest, HttpResponse
-from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
 from typing import Text
 
-from zerver.models import UserProfile
-from zerver.lib.request import JsonableError
-from zerver.lib.response import json_success, json_error
+from django.core.exceptions import ValidationError
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
 from zerver.lib.actions import check_add_realm_emoji, do_remove_realm_emoji
+from zerver.lib.request import JsonableError
+from zerver.lib.response import json_error, json_success
+from zerver.models import UserProfile
+
 
 def check_emoji_admin(user_profile):
     # type: (UserProfile) -> None

--- a/zerver/views/realm_filters.py
+++ b/zerver/views/realm_filters.py
@@ -1,17 +1,17 @@
 from __future__ import absolute_import
-
 from typing import Text
+
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
-from django.views.decorators.csrf import csrf_exempt
 from django.utils.translation import ugettext as _
+from django.views.decorators.csrf import csrf_exempt
 
-from zerver.decorator import has_request_variables, REQ, require_realm_admin
+from zerver.decorator import REQ, has_request_variables, require_realm_admin
 from zerver.lib.actions import do_add_realm_filter, do_remove_realm_filter
-from zerver.lib.response import json_success, json_error
+from zerver.lib.response import json_error, json_success
 from zerver.lib.rest import rest_dispatch as _rest_dispatch
 from zerver.lib.validator import check_string
-from zerver.models import realm_filters_for_realm, UserProfile, RealmFilter
+from zerver.models import RealmFilter, UserProfile, realm_filters_for_realm
 
 
 # Custom realm filters

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -1,22 +1,20 @@
 from __future__ import absolute_import
-from typing import Any
+from typing import Any, Text
+
+import os
+import subprocess
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 
-from zerver.decorator import authenticated_json_post_view, has_request_variables, REQ, \
-    to_non_negative_int
-from zerver.lib.response import json_success
+from zerver.decorator import (REQ, authenticated_json_post_view,
+                              has_request_variables, to_non_negative_int)
 from zerver.lib.queue import queue_json_publish
+from zerver.lib.response import json_success
 from zerver.lib.unminify import SourceMap
 from zerver.lib.utils import statsd, statsd_key
 from zerver.lib.validator import check_bool, check_dict
 from zerver.models import UserProfile
-
-from typing import Text
-
-import subprocess
-import os
 
 # Read the source map information for decoding JavaScript backtraces
 js_source_map = None

--- a/zerver/views/tutorial.py
+++ b/zerver/views/tutorial.py
@@ -1,13 +1,15 @@
 from __future__ import absolute_import
 
-from django.utils.translation import ugettext as _
 from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
 
-from zerver.decorator import authenticated_json_post_view, has_request_variables, REQ
+from zerver.decorator import (REQ, authenticated_json_post_view,
+                              has_request_variables)
 from zerver.lib.actions import internal_send_message
 from zerver.lib.response import json_error, json_success
 from zerver.lib.validator import check_string
 from zerver.models import UserProfile
+
 
 @authenticated_json_post_view
 @has_request_variables

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import
-
-from django.http import HttpRequest, HttpResponse
 from typing import Text
 
-from zerver.decorator import authenticated_json_post_view,\
-    has_request_variables, REQ, JsonableError
-from zerver.lib.actions import check_send_typing_notification, \
-    extract_recipients
+from django.http import HttpRequest, HttpResponse
+
+from zerver.decorator import (REQ, JsonableError, authenticated_json_post_view,
+                              has_request_variables)
+from zerver.lib.actions import (check_send_typing_notification,
+                                extract_recipients)
 from zerver.lib.response import json_success
 from zerver.models import UserProfile
+
 
 @has_request_variables
 def send_notification_backend(request, user_profile, operator=REQ('op'),

--- a/zerver/views/unsubscribe.py
+++ b/zerver/views/unsubscribe.py
@@ -1,15 +1,17 @@
 from __future__ import absolute_import
+from typing import Callable
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
-from typing import Callable
 
 from confirmation.models import Confirmation
-from zerver.lib.actions import do_change_enable_offline_email_notifications, \
-    do_change_enable_digest_emails, clear_followup_emails_queue
-from zerver.models import UserProfile
 from zerver.context_processors import common_context
+from zerver.lib.actions import (clear_followup_emails_queue,
+                                do_change_enable_digest_emails,
+                                do_change_enable_offline_email_notifications)
+from zerver.models import UserProfile
 from zproject.jinja2 import render_to_response
+
 
 def process_unsubscribe(token, subscription_type, unsubscribe_function):
     # type: (HttpRequest, str, Callable[[UserProfile], None]) -> HttpResponse

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, FileResponse, \
-    HttpResponseNotFound
+from django.conf import settings
+from django.http import (FileResponse, HttpRequest, HttpResponse,
+                         HttpResponseForbidden, HttpResponseNotFound)
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 
 from zerver.decorator import authenticated_json_post_view, zulip_login_required
-from zerver.lib.request import has_request_variables, REQ
-from zerver.lib.response import json_success, json_error
-from zerver.lib.upload import upload_message_image_from_request, get_local_file_path, \
-    get_signed_upload_url, get_realm_for_filename
+from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.response import json_error, json_success
+from zerver.lib.upload import (get_local_file_path, get_realm_for_filename,
+                               get_signed_upload_url,
+                               upload_message_image_from_request)
 from zerver.lib.validator import check_bool
 from zerver.models import UserProfile
-from django.conf import settings
+
 
 def serve_s3(request, user_profile, realm_id_str, filename):
     # type: (HttpRequest, UserProfile, str, str) -> HttpResponse

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -1,30 +1,39 @@
 from __future__ import absolute_import
-from typing import Optional, Any
-from typing import Text
+from typing import Any, Optional, Text
 
-from django.utils.translation import ugettext as _
 from django.conf import settings
 from django.contrib.auth import authenticate, update_session_auth_hash
 from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
 
-from zerver.decorator import authenticated_json_post_view, has_request_variables, REQ
-from zerver.lib.actions import do_change_password, \
-    do_change_full_name, do_change_enable_desktop_notifications, \
-    do_change_enter_sends, do_change_enable_sounds, \
-    do_change_enable_offline_email_notifications, do_change_enable_digest_emails, \
-    do_change_enable_offline_push_notifications, do_change_enable_online_push_notifications, \
-    do_change_default_desktop_notifications, do_change_autoscroll_forever, \
-    do_change_enable_stream_desktop_notifications, do_change_enable_stream_sounds, \
-    do_regenerate_api_key, do_change_avatar_source, do_change_twenty_four_hour_time, \
-    do_change_left_side_userlist, do_change_default_language, \
-    do_change_pm_content_in_desktop_notifications
+from zerver.decorator import (REQ, authenticated_json_post_view,
+                              has_request_variables)
+from zerver.lib.actions import (do_change_autoscroll_forever,
+                                do_change_avatar_source,
+                                do_change_default_desktop_notifications,
+                                do_change_default_language,
+                                do_change_enable_desktop_notifications,
+                                do_change_enable_digest_emails,
+                                do_change_enable_offline_email_notifications,
+                                do_change_enable_offline_push_notifications,
+                                do_change_enable_online_push_notifications,
+                                do_change_enable_sounds,
+                                do_change_enable_stream_desktop_notifications,
+                                do_change_enable_stream_sounds,
+                                do_change_enter_sends, do_change_full_name,
+                                do_change_left_side_userlist,
+                                do_change_password,
+                                do_change_pm_content_in_desktop_notifications,
+                                do_change_twenty_four_hour_time,
+                                do_regenerate_api_key)
 from zerver.lib.avatar import avatar_url
 from zerver.lib.i18n import get_available_language_codes
-from zerver.lib.response import json_success, json_error
+from zerver.lib.request import JsonableError
+from zerver.lib.response import json_error, json_success
 from zerver.lib.upload import upload_avatar_image
 from zerver.lib.validator import check_bool, check_string
-from zerver.lib.request import JsonableError
-from zerver.models import UserProfile, Realm, name_changes_disabled
+from zerver.models import Realm, UserProfile, name_changes_disabled
+
 
 @has_request_variables
 def json_change_ui_settings(request, user_profile,

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -1,28 +1,32 @@
 from __future__ import absolute_import
+from typing import Any, Dict, Optional, Text
 
-from django.http import HttpRequest, HttpResponse
-
-from django.utils.translation import ugettext as _
-from django.shortcuts import redirect
 from six.moves import map
 
-from zerver.decorator import has_request_variables, REQ, JsonableError, \
-    require_realm_admin
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, JsonableError, has_request_variables,
+                              require_realm_admin)
 from zerver.forms import CreateUserForm
-from zerver.lib.actions import do_change_full_name, do_change_is_admin, \
-    do_create_user, subscribed_to_stream, do_deactivate_user, do_reactivate_user, \
-    do_change_default_events_register_stream, do_change_default_sending_stream, \
-    do_change_default_all_public_streams, do_regenerate_api_key, do_change_avatar_source
+from zerver.lib.actions import (do_change_avatar_source,
+                                do_change_default_all_public_streams,
+                                do_change_default_events_register_stream,
+                                do_change_default_sending_stream,
+                                do_change_full_name, do_change_is_admin,
+                                do_create_user, do_deactivate_user,
+                                do_reactivate_user, do_regenerate_api_key,
+                                subscribed_to_stream)
 from zerver.lib.avatar import avatar_url, get_avatar_url
 from zerver.lib.response import json_error, json_success
 from zerver.lib.upload import upload_avatar_image
-from zerver.lib.validator import check_bool, check_string
 from zerver.lib.utils import generate_random_token
-from zerver.models import UserProfile, Stream, Realm, Message, get_user_profile_by_email, \
-    get_stream, email_allowed_for_realm
+from zerver.lib.validator import check_bool, check_string
+from zerver.models import (Message, Realm, Stream, UserProfile,
+                           email_allowed_for_realm, get_stream,
+                           get_user_profile_by_email)
 
-from typing import Text
-from typing import Optional, Dict, Any
 
 def deactivate_user_backend(request, user_profile, email):
     # type: (HttpRequest, UserProfile, Text) -> HttpResponse

--- a/zerver/views/webhooks/airbrake.py
+++ b/zerver/views/webhooks/airbrake.py
@@ -1,11 +1,14 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from typing import Dict, Any, Text
+from typing import Any, Dict, Text
+
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
+from zerver.lib.response import json_error, json_success
 from zerver.models import Client, UserProfile
 
 AIRBRAKE_SUBJECT_TEMPLATE = '{project_name}'

--- a/zerver/views/webhooks/appfollow.py
+++ b/zerver/views/webhooks/appfollow.py
@@ -1,16 +1,18 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Any, Dict, Text
+
 import re
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
-from typing import Dict, Any, Text
 
 @api_key_only_webhook_view("AppFollow")
 @has_request_variables

--- a/zerver/views/webhooks/beanstalk.py
+++ b/zerver/views/webhooks/beanstalk.py
@@ -1,20 +1,22 @@
 # Webhooks for external integrations.
 
 from __future__ import absolute_import
-from django.http import HttpRequest, HttpResponse
-from zerver.models import get_client, UserProfile
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success
-from zerver.lib.validator import check_dict
-from zerver.decorator import REQ, has_request_variables, authenticated_rest_api_view
+from typing import Any, Callable, Dict, TypeVar
 
 import base64
 from functools import wraps
 
-from .github import build_message_from_gitlog
+from django.http import HttpRequest, HttpResponse
 
-from typing import Any, Callable, Dict, TypeVar
-from zerver.lib.str_utils import force_str, force_bytes
+from zerver.decorator import (REQ, authenticated_rest_api_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_success
+from zerver.lib.str_utils import force_bytes, force_str
+from zerver.lib.validator import check_dict
+from zerver.models import UserProfile, get_client
+
+from .github import build_message_from_gitlog
 
 ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
 

--- a/zerver/views/webhooks/bitbucket.py
+++ b/zerver/views/webhooks/bitbucket.py
@@ -1,15 +1,16 @@
 from __future__ import absolute_import
-
 from typing import Any, Mapping, Text
 
 from django.http import HttpRequest, HttpResponse
 
-from zerver.models import get_client, UserProfile
+from zerver.decorator import (REQ, authenticated_rest_api_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
 from zerver.lib.validator import check_dict
-from zerver.decorator import REQ, has_request_variables, authenticated_rest_api_view
-from zerver.lib.webhooks.git import get_push_commits_event_message, SUBJECT_WITH_BRANCH_TEMPLATE
+from zerver.lib.webhooks.git import (SUBJECT_WITH_BRANCH_TEMPLATE,
+                                     get_push_commits_event_message)
+from zerver.models import UserProfile, get_client
 
 
 @authenticated_rest_api_view(is_webhook=True)

--- a/zerver/views/webhooks/bitbucket2.py
+++ b/zerver/views/webhooks/bitbucket2.py
@@ -1,20 +1,28 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Any, Callable, Optional, Text
+
 import re
 from functools import partial
 from six.moves import zip
-from typing import Any, Callable, Optional, Text
+
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import Client, UserProfile
-from zerver.lib.webhooks.git import get_push_commits_event_message, SUBJECT_WITH_BRANCH_TEMPLATE,\
-    get_force_push_commits_event_message, get_remove_branch_event_message, get_pull_request_event_message,\
-    SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE, get_issue_event_message, get_commits_comment_action_message,\
-    get_push_tag_event_message
 
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.lib.webhooks.git import (SUBJECT_WITH_BRANCH_TEMPLATE,
+                                     SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE,
+                                     get_commits_comment_action_message,
+                                     get_force_push_commits_event_message,
+                                     get_issue_event_message,
+                                     get_pull_request_event_message,
+                                     get_push_commits_event_message,
+                                     get_push_tag_event_message,
+                                     get_remove_branch_event_message)
+from zerver.models import Client, UserProfile
 
 BITBUCKET_SUBJECT_TEMPLATE = '{repository_name}'
 USER_PART = 'User {display_name}(login: {username})'

--- a/zerver/views/webhooks/circleci.py
+++ b/zerver/views/webhooks/circleci.py
@@ -1,16 +1,16 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-
-from django.http import HttpRequest, HttpResponse
 from typing import Any, Text
-
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
 
 import ujson
 
+from django.http import HttpRequest, HttpResponse
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
 CIRCLECI_SUBJECT_TEMPLATE = u'{repository_name}'
 CIRCLECI_MESSAGE_TEMPLATE = u'[Build]({build_url}) triggered by {username} on {branch} branch {status}.'

--- a/zerver/views/webhooks/codeship.py
+++ b/zerver/views/webhooks/codeship.py
@@ -1,17 +1,17 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-
-from django.utils.translation import ugettext as _
-from django.http import HttpRequest, HttpResponse
 from typing import Any
-
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
 
 import ujson
 
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
 CODESHIP_SUBJECT_TEMPLATE = '{project_name}'
 CODESHIP_MESSAGE_TEMPLATE = '[Build]({build_url}) triggered by {committer} on {branch} branch {status}.'

--- a/zerver/views/webhooks/crashlytics.py
+++ b/zerver/views/webhooks/crashlytics.py
@@ -1,12 +1,15 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import Client, UserProfile
-from django.http import HttpRequest, HttpResponse
 from typing import Any, Text
+
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
 CRASHLYTICS_SUBJECT_TEMPLATE = '{display_id}: {title}'
 CRASHLYTICS_MESSAGE_TEMPLATE = '[Issue]({url}) impacts at least {impacted_devices_count} device(s).'

--- a/zerver/views/webhooks/delighted.py
+++ b/zerver/views/webhooks/delighted.py
@@ -1,14 +1,17 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
+from typing import Any, Dict, Optional
 
-from zerver.models import Client, UserProfile
+from six import text_type
 
 from django.http import HttpRequest, HttpResponse
-from six import text_type
-from typing import Dict, Any, Optional
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
+
 
 def body_template(score):
     # type: (int) -> str

--- a/zerver/views/webhooks/deskdotcom.py
+++ b/zerver/views/webhooks/deskdotcom.py
@@ -1,12 +1,15 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Text
+
 from django.http import HttpRequest, HttpResponse
-from zerver.models import get_client, UserProfile
+
+from zerver.decorator import (REQ, authenticated_rest_api_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
-from zerver.decorator import REQ, has_request_variables, authenticated_rest_api_view
+from zerver.models import UserProfile, get_client
 
-from typing import Text
 
 # Desk.com's integrations all make the user supply a template, where it fills
 # in stuff like {{customer.name}} and posts the result as a "data" parameter.

--- a/zerver/views/webhooks/freshdesk.py
+++ b/zerver/views/webhooks/freshdesk.py
@@ -1,19 +1,20 @@
 """Webhooks for external integrations."""
 from __future__ import absolute_import
+from typing import Any, Dict, Optional, Text, Tuple, Union
+
+import logging
+
+import ujson
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
-from zerver.models import get_client, UserProfile
+from zerver.decorator import (REQ, authenticated_rest_api_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
 from zerver.lib.notifications import convert_html_to_markdown
-from zerver.decorator import REQ, has_request_variables, authenticated_rest_api_view
-
-import logging
-import ujson
-
-from typing import Any, Dict, Optional, Tuple, Union, Text
+from zerver.lib.response import json_error, json_success
+from zerver.models import UserProfile, get_client
 
 
 class TicketDict(dict):

--- a/zerver/views/webhooks/github.py
+++ b/zerver/views/webhooks/github.py
@@ -1,22 +1,29 @@
 from __future__ import absolute_import
-from django.conf import settings
-from zerver.models import get_client, UserProfile
-from zerver.lib.response import json_success
-from zerver.lib.validator import check_dict
-from zerver.decorator import authenticated_api_view, REQ, has_request_variables, to_non_negative_int, flexible_boolean
-from zerver.views.messages import send_message_backend
-from zerver.lib.webhooks.git import get_push_commits_event_message,\
-    SUBJECT_WITH_BRANCH_TEMPLATE, get_force_push_commits_event_message, \
-    get_remove_branch_event_message, get_pull_request_event_message,\
-    get_issue_event_message, SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE,\
-    get_commits_comment_action_message
+from typing import Any, Mapping, Optional, Sequence, Text, Tuple
+
 import logging
 import re
+
 import ujson
 
-from typing import Any, Mapping, Optional, Sequence, Tuple, Text
-from zerver.lib.str_utils import force_str
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse
+
+from zerver.decorator import (REQ, authenticated_api_view, flexible_boolean,
+                              has_request_variables, to_non_negative_int)
+from zerver.lib.response import json_success
+from zerver.lib.str_utils import force_str
+from zerver.lib.validator import check_dict
+from zerver.lib.webhooks.git import (SUBJECT_WITH_BRANCH_TEMPLATE,
+                                     SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE,
+                                     get_commits_comment_action_message,
+                                     get_force_push_commits_event_message,
+                                     get_issue_event_message,
+                                     get_pull_request_event_message,
+                                     get_push_commits_event_message,
+                                     get_remove_branch_event_message)
+from zerver.models import UserProfile, get_client
+from zerver.views.messages import send_message_backend
 
 ZULIP_TEST_REPO_NAME = 'zulip-test'
 ZULIP_TEST_REPO_ID = 6893087

--- a/zerver/views/webhooks/github_dispatcher.py
+++ b/zerver/views/webhooks/github_dispatcher.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
+
 from django.http import HttpRequest, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
-from .github_webhook import api_github_webhook
+
 from .github import api_github_landing
+from .github_webhook import api_github_webhook
+
 
 # Since this dispatcher is an API-style endpoint, it needs to be
 # explicitly marked as CSRF-exempt

--- a/zerver/views/webhooks/github_webhook.py
+++ b/zerver/views/webhooks/github_webhook.py
@@ -1,17 +1,25 @@
 from __future__ import absolute_import
+from typing import Any, Callable, Text
+
 import re
 from functools import partial
-from typing import Any, Callable, Text
+
 from django.http import HttpRequest, HttpResponse
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
+from zerver.lib.webhooks.git import (CONTENT_MESSAGE_TEMPLATE,
+                                     SUBJECT_WITH_BRANCH_TEMPLATE,
+                                     SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE,
+                                     get_commits_comment_action_message,
+                                     get_issue_event_message,
+                                     get_pull_request_event_message,
+                                     get_push_commits_event_message,
+                                     get_push_tag_event_message)
 from zerver.models import Client, UserProfile
-from zerver.decorator import api_key_only_webhook_view, REQ, has_request_variables
 
-from zerver.lib.webhooks.git import get_issue_event_message, SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE,\
-    get_pull_request_event_message, SUBJECT_WITH_BRANCH_TEMPLATE,\
-    get_push_commits_event_message, CONTENT_MESSAGE_TEMPLATE,\
-    get_commits_comment_action_message, get_push_tag_event_message
 
 class UnknownEventType(Exception):
     pass

--- a/zerver/views/webhooks/gitlab.py
+++ b/zerver/views/webhooks/gitlab.py
@@ -1,16 +1,23 @@
 from __future__ import absolute_import
+from typing import Any, Dict, Iterable, Optional, Text
+
 from functools import partial
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success
-from zerver.decorator import api_key_only_webhook_view, REQ, has_request_variables
-from zerver.lib.webhooks.git import get_push_commits_event_message, EMPTY_SHA,\
-    get_remove_branch_event_message, get_pull_request_event_message,\
-    get_issue_event_message, SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE,\
-    get_commits_comment_action_message, get_push_tag_event_message
-from zerver.models import Client, UserProfile
 
 from django.http import HttpRequest, HttpResponse
-from typing import Dict, Any, Iterable, Optional, Text
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_success
+from zerver.lib.webhooks.git import (EMPTY_SHA,
+                                     SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE,
+                                     get_commits_comment_action_message,
+                                     get_issue_event_message,
+                                     get_pull_request_event_message,
+                                     get_push_commits_event_message,
+                                     get_push_tag_event_message,
+                                     get_remove_branch_event_message)
+from zerver.models import Client, UserProfile
 
 
 class UnknownEventType(Exception):

--- a/zerver/views/webhooks/gosquared.py
+++ b/zerver/views/webhooks/gosquared.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-
-from zerver.models import Client, UserProfile
+from typing import Any, Dict, Optional, Text
 
 from django.http import HttpRequest, HttpResponse
-from typing import Text
-from typing import Dict, Any, Optional
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
 BODY_TEMPLATE = '[{website_name}]({website_url}) has {user_num} visitors online.'
 

--- a/zerver/views/webhooks/hellosign.py
+++ b/zerver/views/webhooks/hellosign.py
@@ -1,15 +1,18 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
+from typing import Any, Dict, Optional, Tuple, Union
 
-from zerver.models import Client, UserProfile
-
-from django.http import HttpRequest, HttpResponse
 from six import text_type
 from six.moves import range
-from typing import Dict, Any, Optional, Tuple, Union
+
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
+
 
 def format_body(signatories, model_payload):
     # type: (List[Dict[str, Any]], Dict[str, Any]) -> str

--- a/zerver/views/webhooks/helloworld.py
+++ b/zerver/views/webhooks/helloworld.py
@@ -1,14 +1,17 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Any, Dict, Iterable, Optional, Text
+
+from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
+from zerver.lib.response import json_error, json_success
 from zerver.lib.validator import check_dict, check_string
 from zerver.models import Client, UserProfile
 
-from django.http import HttpRequest, HttpResponse
-from typing import Dict, Any, Iterable, Optional, Text
 
 @api_key_only_webhook_view('HelloWorld')
 @has_request_variables

--- a/zerver/views/webhooks/heroku.py
+++ b/zerver/views/webhooks/heroku.py
@@ -4,10 +4,11 @@ from typing import Text
 
 from django.http import HttpRequest, HttpResponse
 
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import Client, UserProfile
 
 
 @api_key_only_webhook_view("Heroku")

--- a/zerver/views/webhooks/ifttt.py
+++ b/zerver/views/webhooks/ifttt.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
 from typing import Any, Callable, Dict
+
 from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
 
 @api_key_only_webhook_view('IFTTT')

--- a/zerver/views/webhooks/jira.py
+++ b/zerver/views/webhooks/jira.py
@@ -2,20 +2,21 @@
 from __future__ import absolute_import
 from typing import Any, Optional, Text, Tuple
 
-from django.utils.translation import ugettext as _
-from django.db.models import Q
-from django.conf import settings
-from django.http import HttpRequest, HttpResponse
-
-from zerver.models import Client, UserProfile, get_user_profile_by_email, Realm
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import api_key_only_webhook_view, has_request_variables, REQ
-
 import logging
 import re
+
 import ujson
 
+from django.conf import settings
+from django.db.models import Q
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, Realm, UserProfile, get_user_profile_by_email
 
 IGNORED_EVENTS = [
     'comment_created',  # we handle issue_update event instead

--- a/zerver/views/webhooks/librato.py
+++ b/zerver/views/webhooks/librato.py
@@ -1,18 +1,19 @@
 from __future__ import absolute_import
+from typing import Any, Callable, Optional, Text, Tuple
 
-from typing import Any, Optional, Callable, Tuple, Text
 from six.moves import zip
 
-from django.utils.translation import ugettext as _
-from django.utils.datetime_safe import datetime
-from django.http import HttpRequest, HttpResponse
-
-from zerver.decorator import api_key_only_webhook_view, REQ, has_request_variables
-from zerver.lib.response import json_success, json_error
-from zerver.lib.actions import check_send_message
-from zerver.models import Client, UserProfile
-
 import ujson
+
+from django.http import HttpRequest, HttpResponse
+from django.utils.datetime_safe import datetime
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
 ALERT_CLEAR = 'clear'
 ALERT_VIOLATION = 'violations'

--- a/zerver/views/webhooks/mention.py
+++ b/zerver/views/webhooks/mention.py
@@ -1,14 +1,17 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Any, Dict, Iterable, Optional, Text
+
+from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
+from zerver.lib.response import json_error, json_success
 from zerver.lib.validator import check_dict, check_string
 from zerver.models import Client, UserProfile
 
-from django.http import HttpRequest, HttpResponse
-from typing import Dict, Any, Iterable, Optional, Text
 
 @api_key_only_webhook_view('Mention')
 @has_request_variables

--- a/zerver/views/webhooks/newrelic.py
+++ b/zerver/views/webhooks/newrelic.py
@@ -2,14 +2,15 @@
 from __future__ import absolute_import
 from typing import Any, Callable, Iterable, Optional, Tuple
 
-from django.utils.translation import ugettext as _
 from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
 
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
+from zerver.lib.response import json_error, json_success
 from zerver.lib.validator import check_dict
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Stream, Client
+from zerver.models import Client, Stream, UserProfile
 
 
 @api_key_only_webhook_view("NewRelic")

--- a/zerver/views/webhooks/pagerduty.py
+++ b/zerver/views/webhooks/pagerduty.py
@@ -1,17 +1,18 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Any, Dict, Iterable, Optional, Text
 
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import Client, UserProfile
+import pprint
+
+import ujson
 
 from django.http import HttpRequest, HttpResponse
 
-import pprint
-import ujson
-from typing import Dict, Any, Iterable, Optional, Text
-
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_success
+from zerver.models import Client, UserProfile
 
 PAGER_DUTY_EVENT_NAMES = {
     'incident.trigger': 'triggered',

--- a/zerver/views/webhooks/papertrail.py
+++ b/zerver/views/webhooks/papertrail.py
@@ -1,15 +1,16 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.lib.validator import check_dict, check_string
-
-from zerver.models import Client, UserProfile
+from typing import Any, Dict, Iterable, Optional, Text
 
 from django.http import HttpRequest, HttpResponse
-from typing import Text
-from typing import Dict, Any, Iterable, Optional
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.lib.validator import check_dict, check_string
+from zerver.models import Client, UserProfile
+
 
 @api_key_only_webhook_view('Papertrail')
 @has_request_variables

--- a/zerver/views/webhooks/pingdom.py
+++ b/zerver/views/webhooks/pingdom.py
@@ -2,16 +2,16 @@
 from __future__ import absolute_import
 from typing import Any, Text
 
-from django.utils.translation import ugettext as _
-from django.http import HttpRequest, HttpResponse
-
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import Client, UserProfile
-
 import ujson
 
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
 PINGDOM_SUBJECT_TEMPLATE = '{name} status.'
 PINGDOM_MESSAGE_TEMPLATE = 'Service {service_url} changed its {type} status from {previous_state} to {current_state}.'

--- a/zerver/views/webhooks/pivotal.py
+++ b/zerver/views/webhooks/pivotal.py
@@ -1,20 +1,21 @@
 """Webhooks for external integrations."""
 from __future__ import absolute_import
+from typing import List, Optional, Text, Tuple
+
+import logging
+import re
+
+import ujson
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import api_key_only_webhook_view, REQ, has_request_variables
-from zerver.models import UserProfile, Client
-
 from defusedxml.ElementTree import fromstring as xml_fromstring
-
-import logging
-import re
-import ujson
-from typing import List, Optional, Tuple, Text
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
 
 def api_pivotal_webhook_v3(request, user_profile, stream):

--- a/zerver/views/webhooks/semaphore.py
+++ b/zerver/views/webhooks/semaphore.py
@@ -1,17 +1,18 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Any, Dict
+
+import ujson
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
-from zerver.models import get_client, get_user_profile_by_email
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
-import ujson
-
-from typing import Any, Dict
+from zerver.lib.response import json_error, json_success
+from zerver.models import (Client, UserProfile, get_client,
+                           get_user_profile_by_email)
 
 
 @api_key_only_webhook_view('Semaphore')

--- a/zerver/views/webhooks/sentry.py
+++ b/zerver/views/webhooks/sentry.py
@@ -1,11 +1,15 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Any
+
 from django.http import HttpRequest, HttpResponse
-from zerver.models import UserProfile, Client
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from typing import Any
+from zerver.models import Client, UserProfile
+
 
 @api_key_only_webhook_view('Sentry')
 @has_request_variables

--- a/zerver/views/webhooks/solano.py
+++ b/zerver/views/webhooks/solano.py
@@ -1,17 +1,18 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Any, Callable, Optional
+
+import ujson
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
+from zerver.lib.response import json_error, json_success
 from zerver.lib.validator import check_dict, check_list, check_string
-from zerver.models import UserProfile, Client
-
-from typing import Any, Callable, Optional
-import ujson
+from zerver.models import Client, UserProfile
 
 
 @api_key_only_webhook_view('SolanoLabs')

--- a/zerver/views/webhooks/stash.py
+++ b/zerver/views/webhooks/stash.py
@@ -1,17 +1,17 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Any, Dict, Text
+
+import ujson
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
-from zerver.models import get_client
+from zerver.decorator import (REQ, authenticated_rest_api_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, authenticated_rest_api_view
-from zerver.models import UserProfile
-import ujson
-
-from typing import Any, Dict, Text
+from zerver.lib.response import json_error, json_success
+from zerver.models import UserProfile, get_client
 
 
 @authenticated_rest_api_view(is_webhook=True)

--- a/zerver/views/webhooks/stripe.py
+++ b/zerver/views/webhooks/stripe.py
@@ -1,15 +1,18 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import Client, UserProfile
-
-from django.http import HttpRequest, HttpResponse
-from typing import Dict, Any, Optional, Text
+from typing import Any, Dict, Optional, Text
 
 from datetime import datetime
+
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
+
 
 @api_key_only_webhook_view('Stripe')
 @has_request_variables

--- a/zerver/views/webhooks/taiga.py
+++ b/zerver/views/webhooks/taiga.py
@@ -19,18 +19,20 @@ subject of US/task should be in bold.
 """
 
 from __future__ import absolute_import
-from typing import Any, Mapping, Optional, Tuple, Text
+from typing import Any, Mapping, Optional, Text, Tuple
 
-from django.utils.translation import ugettext as _
-from django.http import HttpRequest, HttpResponse
-
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from six.moves import range
 
 import ujson
-from six.moves import range
+
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
 
 @api_key_only_webhook_view('Taiga')

--- a/zerver/views/webhooks/teamcity.py
+++ b/zerver/views/webhooks/teamcity.py
@@ -1,18 +1,20 @@
 # Webhooks for teamcity integration
 from __future__ import absolute_import
+from typing import Any, Optional
+
+import logging
+
+import ujson
 
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
-from typing import Any, Optional
 
-from zerver.models import Client, UserProfile, Realm
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, Realm, UserProfile
 
-
-import logging
-import ujson
 
 def guess_zulip_user_from_teamcity(teamcity_username, realm):
     # type: (str, Realm) -> Optional[UserProfile]

--- a/zerver/views/webhooks/transifex.py
+++ b/zerver/views/webhooks/transifex.py
@@ -1,12 +1,16 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
-from django.http import HttpRequest, HttpResponse
-from zerver.models import UserProfile, Client
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 from typing import Optional
+
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
+
 
 @api_key_only_webhook_view('Transifex')
 @has_request_variables

--- a/zerver/views/webhooks/travis.py
+++ b/zerver/views/webhooks/travis.py
@@ -1,15 +1,16 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
 
+import ujson
+
 from django.http import HttpRequest, HttpResponse
 
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
 from zerver.lib.validator import check_dict, check_string
-from zerver.models import UserProfile, Client
-
-import ujson
+from zerver.models import Client, UserProfile
 
 
 @api_key_only_webhook_view('Travis')

--- a/zerver/views/webhooks/trello/board_actions.py
+++ b/zerver/views/webhooks/trello/board_actions.py
@@ -1,6 +1,7 @@
-from typing import Mapping, Any, Tuple, Optional, MutableMapping, Text
+from typing import Any, Mapping, MutableMapping, Optional, Text, Tuple
+
 from .exceptions import UnknownUpdateBoardAction
-from .templates import TRELLO_SUBJECT_TEMPLATE, TRELLO_MESSAGE_TEMPLATE
+from .templates import TRELLO_MESSAGE_TEMPLATE, TRELLO_SUBJECT_TEMPLATE
 
 SUPPORTED_BOARD_ACTIONS = [
     u'removeMemberFromBoard',

--- a/zerver/views/webhooks/trello/card_actions.py
+++ b/zerver/views/webhooks/trello/card_actions.py
@@ -1,7 +1,9 @@
-from typing import Dict, Tuple, Any, Optional, MutableMapping, Mapping, Text
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Text, Tuple
+
 from datetime import datetime
+
 from .exceptions import UnknownUpdateCardAction
-from .templates import TRELLO_SUBJECT_TEMPLATE, TRELLO_MESSAGE_TEMPLATE
+from .templates import TRELLO_MESSAGE_TEMPLATE, TRELLO_SUBJECT_TEMPLATE
 
 SUPPORTED_CARD_ACTIONS = [
     u'updateCard',

--- a/zerver/views/webhooks/updown.py
+++ b/zerver/views/webhooks/updown.py
@@ -1,16 +1,19 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
+from typing import Any, Dict
+
 import re
 from datetime import datetime
-from typing import Any, Dict
+
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success, json_error
-from zerver.lib.request import JsonableError
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
 
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.request import JsonableError
+from zerver.lib.response import json_error, json_success
+from zerver.models import Client, UserProfile
 
 SUBJECT_TEMPLATE = "{service_url}"
 

--- a/zerver/views/webhooks/yo.py
+++ b/zerver/views/webhooks/yo.py
@@ -1,13 +1,17 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from zerver.lib.actions import check_send_message
-from zerver.lib.response import json_success
-from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
-from django.http import HttpRequest, HttpResponse
 from typing import Optional
 
 import ujson
+
+from django.http import HttpRequest, HttpResponse
+
+from zerver.decorator import (REQ, api_key_only_webhook_view,
+                              has_request_variables)
+from zerver.lib.actions import check_send_message
+from zerver.lib.response import json_success
+from zerver.models import Client, UserProfile
+
 
 @api_key_only_webhook_view('Yo')
 @has_request_variables

--- a/zerver/views/webhooks/zendesk.py
+++ b/zerver/views/webhooks/zendesk.py
@@ -1,11 +1,15 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from zerver.models import get_client, UserProfile
+from typing import Text
+
+from django.http import HttpRequest, HttpResponse
+
+from zerver.decorator import (REQ, authenticated_rest_api_view,
+                              has_request_variables)
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
-from zerver.decorator import authenticated_rest_api_view, REQ, has_request_variables
-from django.http import HttpRequest, HttpResponse
-from typing import Text
+from zerver.models import UserProfile, get_client
+
 
 def truncate(string, length):
     # type: (Text, int) -> Text

--- a/zerver/views/zephyr.py
+++ b/zerver/views/zephyr.py
@@ -1,20 +1,23 @@
 from __future__ import absolute_import
-from typing import Any, List, Dict, Optional, Callable, Tuple, Iterable, Sequence, Text
-
-from django.conf import settings
-from django.http import HttpResponse, HttpRequest
-from django.utils.translation import ugettext as _
-from zerver.decorator import authenticated_json_view
-from zerver.lib.ccache import make_ccache
-from zerver.lib.request import has_request_variables, REQ, JsonableError
-from zerver.lib.response import json_success, json_error
-from zerver.lib.str_utils import force_str
-from zerver.models import UserProfile
+from typing import (Any, Callable, Dict, Iterable, List,
+                    Optional, Sequence, Text, Tuple)
 
 import base64
 import logging
 import subprocess
+
 import ujson
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import ugettext as _
+
+from zerver.decorator import authenticated_json_view
+from zerver.lib.ccache import make_ccache
+from zerver.lib.request import REQ, JsonableError, has_request_variables
+from zerver.lib.response import json_error, json_success
+from zerver.lib.str_utils import force_str
+from zerver.models import UserProfile
 
 
 @authenticated_json_view


### PR DESCRIPTION
- Sort imports in Python modules using [isort](https://github.com/timothycrosley/isort).
- Added isort section in `.editorconfig`.

Currently done `zerver/views/*` just as an example to see if this config suits our style guide.

Issue from #2665.