### PR TITLE
Fixes #3296: CSS bug in sidebar scroll

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -47,6 +47,7 @@
     overflow-y: hidden;
     position: relative;
     z-index: 0;
+    width: 100%;
 }
 
 #stream-filters-container .ps-scrollbar-y-rail {


### PR DESCRIPTION
The PR closes #3296 
Fixes the extra white space present in the stream sidebar with/-out zooming