### PR TITLE
Adds banned characters in name function

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -483,6 +483,7 @@ class UserProfile(ModelReprMixin, AbstractBaseUser, PermissionsMixin):
 
     USERNAME_FIELD = 'email'
     MAX_NAME_LENGTH = 100
+    NAME_INVALID_CHARS = ['*', '`', '>', '"', '@']
 
     # Our custom site-specific fields
     full_name = models.CharField(max_length=MAX_NAME_LENGTH) # type: Text

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -378,6 +378,14 @@ class PermissionTest(ZulipTestCase):
         result = self.client_patch('/json/users/hamlet@zulip.com', req)
         self.assert_json_error(result, 'Name too long!')
 
+    def test_admin_cannot_set_full_name_with_invalid_characters(self):
+        # type: () -> None
+        new_name = 'Opheli*'
+        self.login('iago@zulip.com')
+        req = dict(full_name=ujson.dumps(new_name))
+        result = self.client_patch('/json/users/hamlet@zulip.com', req)
+        self.assert_json_error(result, 'Invalid characters in name!')
+
 class ZephyrTest(ZulipTestCase):
     def test_webathena_kerberos_login(self):
         # type: () -> None
@@ -1614,6 +1622,16 @@ class ChangeSettingsTest(ZulipTestCase):
         json_result = self.client_post("/json/settings/change",
                                        dict(full_name='x' * 1000))
         self.assert_json_error(json_result, 'Name too long!')
+
+    def test_illegal_characters_in_name_changes(self):
+        # type: () -> None
+        email = 'hamlet@zulip.com'
+        self.login(email)
+
+        # Now try a name with invalid characters
+        json_result = self.client_post("/json/settings/change",
+                                       dict(full_name='Opheli*'))
+        self.assert_json_error(json_result, 'Invalid characters in name!')
 
     # This is basically a don't-explode test.
     def test_notify_settings(self):

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -90,6 +90,8 @@ def json_change_settings(request, user_profile,
             new_full_name = full_name.strip()
             if len(new_full_name) > UserProfile.MAX_NAME_LENGTH:
                 return json_error(_("Name too long!"))
+            elif list(set(new_full_name).intersection(UserProfile.NAME_INVALID_CHARS)):
+                return json_error(_("Invalid characters in name!"))
             do_change_full_name(user_profile, new_full_name)
             result['full_name'] = new_full_name
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -105,6 +105,8 @@ def update_user_backend(request, user_profile, email,
         new_full_name = full_name.strip()
         if len(new_full_name) > UserProfile.MAX_NAME_LENGTH:
             return json_error(_("Name too long!"))
+        elif list(set(new_full_name).intersection(UserProfile.NAME_INVALID_CHARS)):
+            return json_error(_("Invalid characters in name!"))
         do_change_full_name(target, new_full_name)
 
     return json_success()


### PR DESCRIPTION
Disallows you from putting the characters @, *, `, ', and > and " in
your name. Added test cases similar to the MAX_NAME_LENGTH check.

Copied initial code from:
https://github.com/zulip/zulip/pull/2473