### PR TITLE
Fix errors with narrowing for topics with name 'home' 

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -264,7 +264,7 @@ $(function () {
     // HOME
 
     // Capture both the left-sidebar Home click and the tab breadcrumb Home
-    $(document).on('click', "li[data-name='home']", function (e) {
+    $(document).on('click', ".home-link[data-name='home']", function (e) {
         ui.change_tab_to('#home');
         narrow.deactivate();
         // We need to maybe scroll to the selected message

--- a/static/templates/tab_bar.handlebars
+++ b/static/templates/tab_bar.handlebars
@@ -1,6 +1,6 @@
 <ul id="tab_list">
 {{#each tabs}}
-  <li class="{{active}} {{cls}}"  {{#if data}}data-name="{{data}}"{{/if}}>
+  <li class="{{active}} {{cls}} {{#if home}}home-link{{/if}}" {{#if data}}data-name="{{data}}"{{/if}}>
     {{#if icon}}
       <i class="icon-vector-narrow icon-vector-small"></i>
     {{/if}}

--- a/templates/zerver/left-sidebar.html
+++ b/templates/zerver/left-sidebar.html
@@ -3,7 +3,7 @@
                       <ul id="global_filters" class="filters">
                           {# Special-case this link so we don't actually go to page top. #}
                           <li data-name="home"
-                          class="global-filter active-filter"><span class="filter-icon"><i class="icon-vector-home"></i></span><a href="#">{{ _('Home') }} <span class="count"><span class="value"></span></span></a></li>
+                          class="global-filter active-filter home-link"><span class="filter-icon"><i class="icon-vector-home"></i></span><a href="#">{{ _('Home') }} <span class="count"><span class="value"></span></span></a></li>
                           <li data-name="private" class="global-filter"><span class="filter-icon"><i class="icon-vector-envelope"></i></span><a href="#narrow/is/private">{{ _('Private messages') }} <span class="count"><span class="value"></span></span></a></li>
                           <li data-name="starred" class="global-filter"><span class="filter-icon"><i class="icon-vector-star"></i></span><a href="#narrow/is/starred">{{ _('Starred messages') }}</a></li>
                           <li data-name="mentioned" class="global-filter"><span class="filter-icon"><i class="icon-vector-tag"></i></span><a href="#narrow/is/mentioned">{{ _('@-mentions') }}<span class="count"><span class="value"></span></span></a></li>


### PR DESCRIPTION
Added a `.global-filter` class to 'Home' link click-handler to separate them from topic links

Fixes #3340 