### PR TITLE
Changes in Login

### DIFF
--- a/docs/dev-setup-non-vagrant.md
+++ b/docs/dev-setup-non-vagrant.md
@@ -379,6 +379,8 @@ links for somebody new in Docker are:
 
 * [Get Started](https://docs.docker.com/engine/installation/linux/)
 * [Understand the architecture](https://docs.docker.com/engine/understanding-docker/)
+* [Docker run reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
 
 [docker-install]: https://docs.docker.com/engine/installation/
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -320,6 +320,11 @@ class LoginTest(ZulipTestCase):
         self.login(email, password)
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
 
+    def test_login_page_redirects_when_logged_in(self):
+	self.login("cordelia@zulip.com")
+	response = self.client_get("/login/")
+	self.assertEqual(response["Location"], "/")
+
 class InviteUserTest(ZulipTestCase):
 
     def invite(self, users, streams):

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -327,10 +327,13 @@ def log_into_subdomain(request):
 
 def login_page(request, **kwargs):
     # type: (HttpRequest, **Any) -> HttpResponse
+
     if is_subdomain_root_or_alias(request) and settings.REALMS_HAVE_SUBDOMAINS:
         redirect_url = reverse('zerver.views.registration.find_my_team')
         return HttpResponseRedirect(redirect_url)
 
+    if request.user.is_authenticated():
+        return HttpResponseRedirect("/")
     extra_context = kwargs.pop('extra_context', {})
     if dev_auth_enabled():
         # Development environments usually have only a few users, but


### PR DESCRIPTION
The changes will redirect the user to chat.zulip.org if the user is already logged in; if not, normal log in prompt.