### PR TITLE
Direct new users to the "new members" stream.

### DIFF
--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -371,6 +371,17 @@ exports.populate_stream_topics_for_tests = function (stream_map) {
     recent_topics = Dict.from(stream_map, {fold_case: true});
 };
 
+exports.get_newbie_stream = function () {
+    // This is the stream that we narrow folks to after the tutorial.
+
+    if (exports.is_subscribed("new members")) {
+        return "new members";
+    } else if (exports.in_home_view(page_params.notifications_stream)) {
+        return page_params.notifications_stream;
+    }
+    return undefined;
+};
+
 return exports;
 
 }());

--- a/static/js/tutorial.js
+++ b/static/js/tutorial.js
@@ -345,8 +345,10 @@ function finale(skip) {
     deferred_work = [];
 
     // We start you in a narrow so it's not overwhelming.
-    if (stream_data.in_home_view(page_params.notifications_stream)) {
-        narrow.activate([{operator: "stream", operand: page_params.notifications_stream}]);
+    var newbie_stream = stream_data.get_newbie_stream();
+
+    if (newbie_stream) {
+        narrow.activate([{operator: "stream", operand: newbie_stream}]);
     }
 
     if (page_params.first_in_realm) {


### PR DESCRIPTION
If a new user is auto-subscribed to a stream called "new
members", we will automatically narrow them to that stream
after the tutorial.  Otherwise, we fall back to the code's
previous behavior, which is to direct them to the notifications
stream (often called "announce").

This is somewhat experimental.  If we try this concept out on
the public Zulip realm and it works well, we will create a nice
realm setting for the "new members" stream.