### PR TITLE
WIP Integrate Swagger UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ static/generated/emoji
 static/generated/pygments_data.js
 static/generated/github-contributors.json
 static/locale/language_options.json
+static/swagger
 static/third/emoji-data
 static/webpack-bundles
 /node_modules

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "string.prototype.codepointat": "0.2.0",
     "ts-loader": "2.1.0",
     "typescript": "2.3.3",
+    "swagger-ui-dist": "3.0.12",
     "underscore": "1.8.3",
     "webpack": "2.5.1",
     "webpack-bundle-tracker": "0.2.0",

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -56,6 +56,9 @@ git+https://github.com/umairwaheed/django-guardian.git@a81edc9f8ef8268f3edb73dea
 # Django extension for sending data to statsd
 django-statsd-mozilla==0.3.16
 
+# Django extension for Cross-Origin Resource Sharing (needed for Swagger integration)
+django-cors-headers==2.0.0
+
 docopt==0.6.2
 fonttools==3.10.0
 

--- a/scripts/lib/node_cache.py
+++ b/scripts/lib/node_cache.py
@@ -31,6 +31,7 @@ def setup_node_modules(npm_args=None, stdout=None, stderr=None, copy_modules=Fal
     swagger_dist_path = os.path.join(cached_node_modules, 'swagger-ui-dist')
     swagger_zulip_path = os.path.join(ZULIP_PATH, 'static', 'swagger')
     swagger_html_path = os.path.join(ZULIP_PATH, 'static', 'html', 'swaggerindex.html')
+    swagger_default_index_path = os.path.join(ZULIP_PATH, 'static', 'swagger', 'index.html')
 
     # Check if a cached version already exists
     if not os.path.exists(success_stamp):
@@ -47,6 +48,7 @@ def setup_node_modules(npm_args=None, stdout=None, stderr=None, copy_modules=Fal
         ["ln", "-nsf", cached_node_modules, 'node_modules'],
         ["cp", "-r", swagger_dist_path, swagger_zulip_path],
         ["cp", swagger_html_path, swagger_zulip_path],
+        ['rm', swagger_default_index_path],
     ]
     for cmd in cmds:
         run(cmd, stdout=stdout, stderr=stderr)

--- a/scripts/lib/node_cache.py
+++ b/scripts/lib/node_cache.py
@@ -48,7 +48,7 @@ def setup_node_modules(npm_args=None, stdout=None, stderr=None, copy_modules=Fal
         ["ln", "-nsf", cached_node_modules, 'node_modules'],
         ["cp", "-r", swagger_dist_path, swagger_zulip_path],
         ["cp", swagger_html_path, swagger_zulip_path],
-        ['rm', swagger_default_index_path],
+        ['rm', '-f', swagger_default_index_path],
     ]
     for cmd in cmds:
         run(cmd, stdout=stdout, stderr=stderr)

--- a/scripts/lib/node_cache.py
+++ b/scripts/lib/node_cache.py
@@ -28,6 +28,10 @@ def setup_node_modules(npm_args=None, stdout=None, stderr=None, copy_modules=Fal
     npm_cache = os.path.join(NPM_CACHE_PATH, sha1sum.hexdigest())
     cached_node_modules = os.path.join(npm_cache, 'node_modules')
     success_stamp = os.path.join(cached_node_modules, '.success-stamp')
+    swagger_dist_path = os.path.join(cached_node_modules, 'swagger-ui-dist')
+    swagger_zulip_path = os.path.join(ZULIP_PATH, 'static', 'swagger')
+    swagger_html_path = os.path.join(ZULIP_PATH, 'static', 'html', 'swaggerindex.html')
+
     # Check if a cached version already exists
     if not os.path.exists(success_stamp):
         do_npm_install(npm_cache,
@@ -41,6 +45,8 @@ def setup_node_modules(npm_args=None, stdout=None, stderr=None, copy_modules=Fal
     cmds = [
         ['rm', '-rf', 'node_modules'],
         ["ln", "-nsf", cached_node_modules, 'node_modules'],
+        ["cp", "-r", swagger_dist_path, swagger_zulip_path],
+        ["cp", swagger_html_path, swagger_zulip_path],
     ]
     for cmd in cmds:
         run(cmd, stdout=stdout, stderr=stderr)

--- a/static/html/swaggerindex.html
+++ b/static/html/swaggerindex.html
@@ -1,0 +1,93 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Swagger UI</title>
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
+  <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
+  <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+  <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+  </style>
+</head>
+
+<body>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
+  <defs>
+    <symbol viewBox="0 0 20 20" id="unlocked">
+          <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="locked">
+      <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8zM12 8H8V5.199C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="close">
+      <path d="M14.348 14.849c-.469.469-1.229.469-1.697 0L10 11.819l-2.651 3.029c-.469.469-1.229.469-1.697 0-.469-.469-.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-.469-.469-.469-1.228 0-1.697.469-.469 1.228-.469 1.697 0L10 8.183l2.651-3.031c.469-.469 1.228-.469 1.697 0 .469.469.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c.469.469.469 1.229 0 1.698z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="large-arrow">
+      <path d="M13.25 10L6.109 2.58c-.268-.27-.268-.707 0-.979.268-.27.701-.27.969 0l7.83 7.908c.268.271.268.709 0 .979l-7.83 7.908c-.268.271-.701.27-.969 0-.268-.269-.268-.707 0-.979L13.25 10z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="large-arrow-down">
+      <path d="M17.418 6.109c.272-.268.709-.268.979 0s.271.701 0 .969l-7.908 7.83c-.27.268-.707.268-.979 0l-7.908-7.83c-.27-.268-.27-.701 0-.969.271-.268.709-.268.979 0L10 13.25l7.418-7.141z"/>
+    </symbol>
+
+
+    <symbol viewBox="0 0 24 24" id="jump-to">
+      <path d="M19 7v4H5.83l3.58-3.59L8 6l-6 6 6 6 1.41-1.41L5.83 13H21V7z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 24 24" id="expand">
+      <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
+    </symbol>
+
+  </defs>
+</svg>
+
+<div id="swagger-ui"></div>
+
+<script src="./swagger-ui-bundle.js"> </script>
+<script src="./swagger-ui-standalone-preset.js"> </script>
+<script>
+window.onload = function() {
+  // Build a system
+  const ui = SwaggerUIBundle({
+    url: "/static/yaml/zulip.yaml",
+    dom_id: '#swagger-ui',
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset
+    ],
+    plugins: [
+      SwaggerUIBundle.plugins.DownloadUrl
+    ],
+    layout: "StandaloneLayout"
+  })
+
+  window.ui = ui
+}
+</script>
+</body>
+
+</html>

--- a/tools/check-templates
+++ b/tools/check-templates
@@ -20,6 +20,7 @@ from typing import cast, Callable, Dict, Iterable, List
 EXCLUDED_FILES = [
     ## Test data Files for testing modules in tests
     "tools/tests/test_template_data",
+    "static/swagger",
 ]
 
 def check_our_files(modified_only, all_dups, targets):

--- a/tools/lint
+++ b/tools/lint
@@ -24,6 +24,8 @@ EXCLUDED_FILES = [
     "puppet/apt/.forge-release",
     "puppet/apt/README.md",
     "static/third",
+    "static/swagger",
+    "static/html/swaggerindex.html",
     # Transifex syncs translation.json files without trailing
     # newlines; there's nothing other than trailing newlines we'd be
     # checking for in these anyway.

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -63,6 +63,17 @@ class DocPageTest(ZulipTestCase):
                 ''.join(str(x) for x in list(result.streaming_content))
             )
 
+            result = self.client_get('/apidocs/')
+            self.assertEqual(result.status_code, 302)
+            self.assertIn('swagger', result['Location'])
+
+            result = self.client_get('/static/swagger/swaggerindex.html')
+            self.assertEqual(result.status_code, 200)
+            self.assertIn(
+                'Swagger UI',
+                ''.join(str(x) for x in list(result.streaming_content))
+            )
+
 class IntegrationTest(TestCase):
     def test_check_if_every_integration_has_logo_that_exists(self):
         # type: () -> None

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -332,6 +332,7 @@ MIDDLEWARE_CLASSES = (
     'zerver.middleware.JsonErrorHandler',
     'zerver.middleware.RateLimitMiddleware',
     'zerver.middleware.FlushDisplayRecipientCache',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'zerver.middleware.SessionHostDomainMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -364,6 +365,7 @@ INSTALLED_APPS = [
     'webpack_loader',
     'zerver',
     'social_django',
+    'corsheaders',
 ]
 if USING_PGROONGA:
     INSTALLED_APPS += ['pgroonga']
@@ -1292,3 +1294,11 @@ PROFILE_ALL_REQUESTS = False
 CROSS_REALM_BOT_EMAILS = set(('feedback@zulip.com', 'notification-bot@zulip.com'))
 
 CONTRIBUTORS_DATA = os.path.join(STATIC_ROOT, 'generated/github-contributors.json')
+
+# cross-site headers for Swagger UI
+CORS_URLS_REGEX = r'^/apidocs/.*$'
+CORS_ALLOW_METHODS = (
+    'GET',
+    'OPTIONS',
+    'POST',
+)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -143,6 +143,9 @@ i18n_urls = [
     url(r'^about/$', TemplateView.as_view(template_name='zerver/about.html')),
     url(r'^apps/$', TemplateView.as_view(template_name='zerver/apps.html')),
 
+    # Swagger API doc viewer
+    url(r'^apidocs/$', RedirectView.as_view(url='/static/swagger/swaggerindex.html?url=/static/yaml/zulip.yaml')),
+
     url(r'^robots\.txt$', RedirectView.as_view(url='/static/robots.txt', permanent=True)),
 
     # Landing page, features pages, signup form, etc.


### PR DESCRIPTION
PR notes: this version should work, for anyone who would like to try it out. Both Swagger UI and django-cors-headers recently released new versions, so I will test those and update accordingly. If you would like to see a working instance, I can set one up on my droplet. The issue for this PR is https://github.com/zulip/zulip/issues/3474

Generate REST API documentation, with working examples.

New directories:
* static/swagger/
* static/yaml/

New dependancies:
* Swagger UI 2.2.10
* django-cors-headers 2.0.0

Configuration:
* yaml/zulip.yaml: Zulip API definitions
* zproject/settings.py: configuration for django-cors-headers

The new documentation is available in Zulip at /apidocs/

Swagger UI is an open source package that provides a graphical front-end
for REST API documentation, including examples against a live backend. The
API is described in a YAML file using the format defined by the Swagger/OpenAPI
specification.

For Zulip, I have integrated Swagger UI in its simplest form by using the
dist directory provided in the github project, putting its contents in a new
static/swagger directory in the Zulip directory structure, and creating a new
url in zproject/urls.py.

The API definition file, zulip.yaml, is in a new static/yaml directory to keep
it separate from files that come from the Swagger UI project. This first
version documents the /messages endpoint. Additional endpoint documentation
can be added by including new definitions in zulip.yaml.

Note: There is not currently an automated way to update the dist files
from the Swagger UI project. To do this, replace the contents of the
static/swagger directory with new dist contents from the Swagger UI project.

Swagger UI requires the target backend support Cross-Origin Resource Sharing
(CORS) headers. To do this, I have added django-cors-headers as a dependancy
(with its configuration) in zproject/settings.py.

This change has been tested on a clean host with a new Zulip installation from
my feature branch. The new doc UI is available at /apidocs/, which redirects
to /static/swagger/index.html?url=/static/yaml/zulip.yaml.

How to access the new docs from the Zulip UI has yet to be decided. No Zulip
UI changes are included here.

References:

* Swagger UI and the Swagger/OpenAPI spec:
  * http://swagger.io
* Swagger UI github project:
  * https://github.com/swagger-api/swagger-ui
* django-cors-headers github project:
  * https://github.com/ottoyiu/django-cors-headers