### PR TITLE
Show 'No changes made' message when no changes are made

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -657,6 +657,16 @@ function _setup_page() {
                         ui.report_success(i18n.t("waiting period threshold changed!"), waiting_period_threshold_status);
                     }
                 }
+                // Check if no changes made
+                var no_changes_made = true;
+                for (var key in response_data) {
+                    if (['msg', 'result'].indexOf(key) < 0) {
+                        no_changes_made = false;
+                    }
+                }
+                if (no_changes_made) {
+                    ui.report_success(i18n.t("No changes were made!"), name_status);
+                }
             },
             error: function (xhr) {
                 var reason = $.parseJSON(xhr.responseText).reason;


### PR DESCRIPTION
Fixes #3372 
A 'No changes made' message is displayed in the administrator page when save changes button is clicked even when no changes are made.