### PR TITLE
Trim whitespace around alert words

### DIFF
--- a/static/js/alert_words_ui.js
+++ b/static/js/alert_words_ui.js
@@ -16,7 +16,7 @@ function update_alert_words() {
 }
 
 function add_alert_word(word, event) {
-    if (word === '') {
+    if ($.trim(word) === '') {
         $("#empty_alert_word_error").show();
         return;
     }

--- a/zerver/views/alert_words.py
+++ b/zerver/views/alert_words.py
@@ -22,6 +22,7 @@ def list_alert_words(request, user_profile):
 def set_alert_words(request, user_profile,
                     alert_words=REQ(validator=check_list(check_string), default=[])):
     # type: (HttpRequest, UserProfile, List[Text]) -> HttpResponse
+    alert_words = [w for w in alert_words if w.strip()]
     do_set_alert_words(user_profile, alert_words)
     return json_success()
 


### PR DESCRIPTION
Fixes #3369 
"Add a new alert word" box now displays an alert when filled with only spaces.