### PR TITLE
Cancel button does not update bot-name

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -675,6 +675,7 @@ function _setup_page() {
         }
 
         reset_edit_bot.click(function (event) {
+            form.find(".edit_bot_name").val(old_full_name);
             show_row_again();
             $(this).off(event);
         });

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -65,7 +65,7 @@
               <div class="control-group">
                <div class="controls">
                   <input type="submit" class="btn btn-primary edit_bot_button" value="{{t 'Save' }}" />
-                  <button type="submit" class="btn btn-default reset_edit_bot">Cancel</button>
+                  <button type="button" class="btn btn-default reset_edit_bot">Cancel</button>
                </div>
                <div class="edit_bot_spinner"></div>
               </div>


### PR DESCRIPTION
Fixes #3412 
The PR fixes the bug associated with renaming the bot. Now the bot-name does not get updated on pressing cancel button