### PR TITLE
Ignore spaces in names when matching mention autocomplete

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -67,6 +67,8 @@ global.people.add({
     assert_typeahead_equals("test @o", people_with_all);
     assert_typeahead_equals("test @z", people_with_all);
     assert_typeahead_equals("@zuli", people_with_all);
+    assert_typeahead_equals("test @cordeliale", people_with_all);
+    assert_typeahead_equals("test @moorofvenice", people_with_all);
 
     assert_typeahead_equals("hi emoji :", false);
     assert_typeahead_equals("hi emoji :ta", emoji_list);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -63,7 +63,7 @@ function query_matches_person(query, person) {
     query = query.toLowerCase();
 
     return ( person.email    .toLowerCase().indexOf(query) !== -1
-         ||  person.full_name.toLowerCase().indexOf(query) !== -1);
+         ||  person.full_name.toLowerCase().replace(" ", "").indexOf(query) !== -1);
 }
 
 function query_matches_stream(query, stream) {
@@ -333,7 +333,7 @@ exports.initialize_compose_typeahead = function (selector, completions) {
             if (this.completing === 'emoji') {
                 return query_matches_emoji(this.token, item);
             } else if (this.completing === 'mention') {
-                return query_matches_person(this.token, item);
+                return query_matches_person(this.token.replace(" ", ""), item.replace(" ", ""));
             } else if (this.completing === 'stream') {
                 return query_matches_stream(this.token, item);
             }


### PR DESCRIPTION
Fixes #3384 
Now the mentions autocomplete matches the full names of the members ignoring the space between their names.