### PR TITLE
Fixes a few bugs associated with admin-bots section

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -510,19 +510,29 @@ with_overrides(function (override) {
 with_overrides(function (override) {
     // realm_bot
     var event = event_fixtures.realm_bot__add;
-    global.with_stub(function (stub) {
-        override('bot_data.add', stub.f);
-        dispatch(event);
-        var args = stub.get_args('bot');
-        assert_same(args.bot, event.bot);
+    global.with_stub(function (bot_stub) {
+        global.with_stub(function (admin_stub) {
+            override('bot_data.add', bot_stub.f);
+            override('admin.update_user_data', admin_stub.f);
+            dispatch(event);
+            var args = bot_stub.get_args('bot');
+            assert_same(args.bot, event.bot);
+
+            args = admin_stub.get_args('update_user_id', 'update_bot_data');
+        });
     });
 
     event = event_fixtures.realm_bot__remove;
-    global.with_stub(function (stub) {
-        override('bot_data.deactivate', stub.f);
-        dispatch(event);
-        var args = stub.get_args('email');
-        assert_same(args.email, event.bot.email);
+    global.with_stub(function (bot_stub) {
+        global.with_stub(function (admin_stub) {
+            override('bot_data.deactivate', bot_stub.f);
+            override('admin.update_user_data', admin_stub.f);
+            dispatch(event);
+            var args = bot_stub.get_args('email');
+            assert_same(args.email, event.bot.email);
+
+            args = admin_stub.get_args('update_user_id', 'update_bot_data');
+        });
     });
 
     event = event_fixtures.realm_bot__update;

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -30,6 +30,29 @@ function get_email_for_user_row(row) {
     return email;
 }
 
+function update_view_on_deactivate(row) {
+    var button = row.find("button.deactivate");
+    row.find('button.open-user-form').hide();
+    button.addClass("btn-warning");
+    button.removeClass("btn-danger");
+    button.addClass("reactivate");
+    button.removeClass("deactivate");
+    button.text(i18n.t("Reactivate"));
+    row.addClass("deactivated_user");
+}
+
+function update_view_on_reactivate(row) {
+    row.find(".user-admin-settings").show();
+    var button = row.find("button.reactivate");
+    row.find("button.open-user-form").show();
+    button.addClass("btn-danger");
+    button.removeClass("btn-warning");
+    button.addClass("deactivate");
+    button.removeClass("reactivate");
+    button.text(i18n.t("Deactivate"));
+    row.removeClass("deactivated_user");
+}
+
 exports.update_user_data = function (user_id, new_data) {
     if (!meta.loaded) {
         return;
@@ -502,6 +525,7 @@ function _setup_page() {
                 button.addClass("btn-warning reactivate").removeClass("btn-danger deactivate");
                 button.text(i18n.t("Reactivate"));
                 meta.current_deactivate_user_modal_row.addClass("deactivated_user");
+                meta.current_deactivate_user_modal_row.find('button.open-user-form').hide();
                 meta.current_deactivate_user_modal_row.find(".user-admin-settings").hide();
             },
         });
@@ -527,13 +551,7 @@ function _setup_page() {
                 }
             },
             success: function () {
-                var button = row.find("button.deactivate");
-                button.addClass("btn-warning");
-                button.removeClass("btn-danger");
-                button.addClass("reactivate");
-                button.removeClass("deactivate");
-                button.text(i18n.t("Reactivate"));
-                row.addClass("deactivated_user");
+                update_view_on_deactivate(row);
             },
         });
     });
@@ -559,14 +577,7 @@ function _setup_page() {
                 }
             },
             success: function () {
-                row.find(".user-admin-settings").show();
-                var button = row.find("button.reactivate");
-                button.addClass("btn-danger");
-                button.removeClass("btn-warning");
-                button.addClass("deactivate");
-                button.removeClass("reactivate");
-                button.text(i18n.t("Deactivate"));
-                row.removeClass("deactivated_user");
+                update_view_on_reactivate(row);
             },
         });
     });

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -73,6 +73,16 @@ exports.update_user_data = function (user_id, new_data) {
         user_row.find(".owner").text(new_data.owner);
     }
 
+    if (new_data.is_active !== undefined) {
+        if (new_data.is_active === false) {
+            // Deactivate the bot in the table
+            update_view_on_deactivate(user_row);
+        } else {
+            // Reactivate the bot in the table
+            update_view_on_reactivate(user_row);
+        }
+    }
+
     // Remove the bot owner select control.
     form_row.find(".edit_bot_owner_container select").remove();
 

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -97,8 +97,11 @@ function dispatch_normal_event(event) {
     case 'realm_bot':
         if (event.op === 'add') {
             bot_data.add(event.bot);
+            admin.update_user_data(event.bot.user_id, event.bot);
         } else if (event.op === 'remove') {
             bot_data.deactivate(event.bot.email);
+            event.bot.is_active = false;
+            admin.update_user_data(event.bot.user_id, event.bot);
         } else if (event.op === 'update') {
             if (_.has(event.bot, 'owner_id')) {
                 event.bot.owner = people.get_person_from_user_id(event.bot.owner_id).email;

--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -1,5 +1,5 @@
 {{#with user}}
-<tr class="user_row" data-user-id="{{user_id}}" data-email="{{email}}">
+<tr class="user_row{{#unless is_active}} deactivated_user{{/unless}}" data-user-id="{{user_id}}" data-email="{{email}}">
   <td>
     <span class="user_name">{{full_name}}</span>
   </td>
@@ -34,16 +34,13 @@
         {{/if}}
       {{/if}}
     </span>
-    {{#if is_active}}
-      <button class="button btn-primary open-user-form" title="{{t 'Edit user' }}" data-user-id="{{user_id}}">
-          <i class="icon-vector-pencil"></i>
-      </button>
-    {{/if}}
+    <button class="button btn-primary open-user-form{{#unless is_active}} display-none{{/unless}}" title="{{t 'Edit user' }}" data-user-id="{{user_id}}">
+        <i class="icon-vector-pencil"></i>
+    </button>
     <div class='admin-user-status'>
     </div>
   </td>
 </tr>
-{{#if is_active}}
 <tr class="user-name-form display-none" data-user-id="{{user_id}}">
   <td colspan="{{#if is_bot}}4{{else}}3{{/if}}">
     <form class="form-horizontal name-setting">
@@ -64,5 +61,4 @@
     </form>
   </td>
 </tr>
-{{/if}}
 {{/with}}


### PR DESCRIPTION
The PR resolves the frontend issue associated with #3413 : 

- On deactivating test bot, the edit-bot button gets removed.
- Bot name and email remains striked out if deactivated.
- After reactivating a deactivated bot, the edit-bot button works fine.

Todo : 
- Reactivating a bot should relist it in "Your Bots" section in settings page without reload.
I am not sure how to fix this. It would be great if anyone could help.