### PR TITLE
requirements: Add comment explaining why CommonMark can't be upgraded.

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,6 +12,8 @@ recommonmark==0.4.0
 # Dependencies of Sphinx
 alabaster==0.7.9
 babel==2.3.4
+# Upgrading to the latest version of CommonMark breaks the compatibility with recommonmark.
+# See https://github.com/rtfd/recommonmark/issues/24 
 CommonMark==0.5.4
 docutils==0.12
 imagesize==0.7.1


### PR DESCRIPTION
Fixes #3398