### PR TITLE
bug fix: Fix recent regression with at-mentioning.

### DIFF
--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -64,6 +64,14 @@ people.add({
     email: 'cordelia@zulip.com',
 });
 
+people.add({
+    full_name: 'Leo',
+    user_id: 102,
+    email: 'leo@zulip.com',
+});
+
+people.initialize_current_user(101);
+
 var stream_data = global.stream_data;
 var denmark = {
     subscribed: false,

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -46,7 +46,9 @@ exports.apply_markdown = function apply_markdown(message) {
         userMentionHandler: function (name) {
             var person = people.get_by_name(name);
             if (person !== undefined) {
-                push_uniquely(message.flags, 'mentioned');
+                if (people.is_my_user_id(person.user_id)) {
+                    push_uniquely(message.flags, 'mentioned');
+                }
                 return '<span class="user-mention" data-user-id="' + person.user_id + '">' +
                        '@' + person.full_name +
                        '</span>';


### PR DESCRIPTION
One of my commits from yesterday erroneously set the
"mentioned" flag on messages that weren't mentioning
the current user, so you would get the pink/salmon
background when you sent at-mentions to other people.

Now we check the user_id before setting the flag.