### PR TITLE
Lint yaml files using text file rules.

### DIFF
--- a/tools/lint-all
+++ b/tools/lint-all
@@ -481,6 +481,10 @@ def build_custom_checkers(by_lang):
             if custom_check_file(fn, txt_rules):
                 failed = True
 
+        for fn in by_lang['yaml']:
+            if custom_check_file(fn, txt_rules):
+                failed = True
+
         return failed
 
     return (check_custom_checks_py, check_custom_checks_nonpy)
@@ -525,7 +529,7 @@ def run():
     by_lang = cast(Dict[str, List[str]],
                    lister.list_files(args, modified_only=options.modified,
                                      ftypes=['py', 'sh', 'js', 'pp', 'css', 'handlebars',
-                                             'html', 'json', 'md', 'txt', 'text'],
+                                             'html', 'json', 'md', 'txt', 'text', 'yaml'],
                                      use_shebang=True, group_by_ftype=True, exclude=EXCLUDED_FILES))
 
     # Invoke the appropriate lint checker for each language,


### PR DESCRIPTION
This was easy after I figured out that the list of files in `by_lang` only contains ones that have been checked in. Took a bit to figure out why my perfectly good test file wasn't being noticed. It works if the branch you are using has a yaml file (and the one I created to make this change doesn't.)

Fixes #3404 