### PR TITLE
Switch from 127.0.0.1 to localhost to avoid problems with IPv6

### DIFF
--- a/bots/irc-mirror.py
+++ b/bots/irc-mirror.py
@@ -18,6 +18,17 @@ if False:
 
 IRC_DOMAIN = "irc.example.com"
 
+import os
+import sys
+
+our_dir = os.path.dirname(os.path.abspath(__file__))
+
+# For dev setups, we can find the API in the repo itself.
+if os.path.exists(os.path.join(our_dir, '../api/zulip')):
+    sys.path.append('../api')
+
+import zulip
+
 def zulip_sender(sender_string):
     # type: (str) -> str
     nick = sender_string.split("!")[0]
@@ -110,7 +121,7 @@ usage = """./irc-mirror.py --server=IRC_SERVER --channel=<CHANNEL> --nick-prefix
 
 Example:
 
-./irc-mirror.py --irc-server=127.0.0.1 --channel='#test' --nick-prefix=username
+./irc-mirror.py --irc-server=localhost --channel='#test' --nick-prefix=username
   --site=https://zulip.example.com --user=irc-bot@example.com
   --api-key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 

--- a/puppet/stdlib/tests/has_interface_with.pp
+++ b/puppet/stdlib/tests/has_interface_with.pp
@@ -2,6 +2,7 @@ include stdlib
 info('has_interface_with(\'lo\'):', has_interface_with('lo'))
 info('has_interface_with(\'loX\'):', has_interface_with('loX'))
 info('has_interface_with(\'ipaddress\', \'127.0.0.1\'):', has_interface_with('ipaddress', '127.0.0.1'))
+info('has_interface_with(\'ipaddress\', \'::1\'):', has_interface_with('ipaddress', '::1'))
 info('has_interface_with(\'ipaddress\', \'127.0.0.100\'):', has_interface_with('ipaddress', '127.0.0.100'))
 info('has_interface_with(\'network\', \'127.0.0.0\'):', has_interface_with('network', '127.0.0.0'))
 info('has_interface_with(\'network\', \'128.0.0.0\'):', has_interface_with('network', '128.0.0.0'))

--- a/puppet/stdlib/tests/has_ip_address.pp
+++ b/puppet/stdlib/tests/has_ip_address.pp
@@ -1,3 +1,4 @@
 include stdlib
 info('has_ip_address(\'192.168.1.256\'):', has_ip_address('192.168.1.256'))
 info('has_ip_address(\'127.0.0.1\'):', has_ip_address('127.0.0.1'))
+info('has_ip_address(\'::1\'):', has_ip_address('::1'))

--- a/puppet/zulip/files/apache/sites/zulip-sso.example
+++ b/puppet/zulip/files/apache/sites/zulip-sso.example
@@ -12,10 +12,10 @@
 # to the app (served by the primary web server). You should configure your
 # authentication module below.
 
-NameVirtualHost 127.0.0.1:8888
-Listen 127.0.0.1:8888
+NameVirtualHost localhost:8888
+Listen localhost:8888
 
-<VirtualHost 127.0.0.1:8888>
+<VirtualHost localhost:8888>
 	# As an example, we've configured this service to use HTTP basic auth.
 	# Insert the configuration for your SSO authentication module here:
 	<Location />

--- a/puppet/zulip/files/rabbitmq/rabbitmq-server
+++ b/puppet/zulip/files/rabbitmq/rabbitmq-server
@@ -8,4 +8,4 @@
 #
 #ulimit -n 1024
 
-export ERL_EPMD_ADDRESS=127.0.0.1
+export ERL_EPMD_ADDRESS=localhost

--- a/puppet/zulip/files/rabbitmq/rabbitmq.config
+++ b/puppet/zulip/files/rabbitmq/rabbitmq.config
@@ -1,4 +1,4 @@
 [{kernel, [{inet_dist_use_interface, {127,0,0,1}}]},
- {rabbit, [{tcp_listeners, [{"127.0.0.1", 5672}]}]},
- {rabbitmq_mochiweb, [{listeners, [{mgmt, [{ip, "127.0.0.1"},
+ {rabbit, [{tcp_listeners, [{"::", 5672}]}]},
+ {rabbitmq_mochiweb, [{listeners, [{mgmt, [{ip, "::"},
                                            {port, 55672}]}]}]}].

--- a/puppet/zulip/files/supervisor/conf.d/zulip.conf
+++ b/puppet/zulip/files/supervisor/conf.d/zulip.conf
@@ -24,7 +24,7 @@ killasgroup=true              ; Without this, we leak processes every restart
 directory=/home/zulip/deployments/current/
 
 [program:zulip-tornado]
-command=env PYTHONUNBUFFERED=1 /home/zulip/deployments/current/manage.py runtornado 127.0.0.1:9993
+command=env PYTHONUNBUFFERED=1 /home/zulip/deployments/current/manage.py runtornado localhost:9993
 priority=200                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)

--- a/puppet/zulip/templates/memcached.conf.template.erb
+++ b/puppet/zulip/templates/memcached.conf.template.erb
@@ -32,7 +32,7 @@ logfile /var/log/memcached.log
 # Specify which IP address to listen on. The default is to listen on all IP addresses
 # This parameter is one of the only security measures that memcached has, so make sure
 # it's listening on a firewalled interface.
--l 127.0.0.1
+-l localhost
 
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
 # -c 1024

--- a/puppet/zulip/templates/rabbitmq-env.conf.template.erb
+++ b/puppet/zulip/templates/rabbitmq-env.conf.template.erb
@@ -13,7 +13,7 @@ NODENAME=rabbit
 # By default RabbitMQ will bind to all interfaces, on IPv4 and IPv6 if
 # available. Set this if you only want to bind to one network interface or#
 # address family.
-#NODE_IP_ADDRESS=127.0.0.1
+#NODE_IP_ADDRESS=localhost
 
 # Defaults to 5672.
 #NODE_PORT=5672

--- a/puppet/zulip_ops/files/apache/sites/graphiti.conf
+++ b/puppet/zulip_ops/files/apache/sites/graphiti.conf
@@ -32,8 +32,8 @@
         Allow from all
     </Proxy>
 
-    ProxyPass / http://127.0.0.1:8088/
-    ProxyPassReverse / http://127.0.0.1:8088/
+    ProxyPass / http://localhost:8088/
+    ProxyPassReverse / http://localhost:8088/
 
     ErrorLog /var/log/apache2/error.log
     LogLevel warn

--- a/puppet/zulip_ops/files/apache/sites/stats.conf
+++ b/puppet/zulip_ops/files/apache/sites/stats.conf
@@ -33,6 +33,6 @@ WSGISocketPrefix /usr/lib/apache2/modules/
         Allow from all
     </Proxy>
 
-    ProxyPass / http://127.0.0.1:8088/
-    ProxyPassReverse /grapiti http://127.0.0.1:8088/
+    ProxyPass / http://localhost:8088/
+    ProxyPassReverse /grapiti http://localhost:8088/
 </VirtualHost>

--- a/puppet/zulip_ops/files/graphite/carbon.conf
+++ b/puppet/zulip_ops/files/graphite/carbon.conf
@@ -196,7 +196,7 @@ REPLICATION_FACTOR = 1
 #
 # If using RELAY_METHOD = rules, all destinations used in relay-rules.conf
 # must be defined in this list
-DESTINATIONS = 127.0.0.1:2004
+DESTINATIONS = localhost:2004
 
 # This defines the maximum "message size" between carbon daemons.
 # You shouldn't need to tune this unless you really know what you're doing.
@@ -241,7 +241,7 @@ PICKLE_RECEIVER_PORT = 2024
 # Note that if the destinations are all carbon-caches then this should
 # exactly match the webapp's CARBONLINK_HOSTS setting in terms of
 # instances listed (order matters!).
-DESTINATIONS = 127.0.0.1:2004
+DESTINATIONS = localhost:2004
 
 # If you want to add redundancy to your data by replicating every
 # datapoint to more than one machine, increase this.

--- a/puppet/zulip_ops/files/munin/munin-node.conf
+++ b/puppet/zulip_ops/files/munin/munin-node.conf
@@ -33,6 +33,7 @@ ignore_file \.pod$
 # may repeat the allow line as many times as you'd like
 
 allow ^127\.0\.0\.1$
+allow ^::1$
 
 # If you have installed the Net::CIDR perl module, you can use one or more
 # cidr_allow and cidr_deny address/mask patterns.  A connecting client must
@@ -47,7 +48,7 @@ allow ^127\.0\.0\.1$
 
 # Which address to bind to;
 #host *
-host 127.0.0.1
+host localhost
 
 # And which port
 port 4949

--- a/puppet/zulip_ops/files/munin/plugin-conf.d/munin-node.conf
+++ b/puppet/zulip_ops/files/munin/plugin-conf.d/munin-node.conf
@@ -103,7 +103,7 @@ env.leasefile /var/lib/dhcp3/dhcpd.leases
 env.configfile /etc/dhcp3/dhcpd.conf
 
 [jmx_*]
-env.ip 127.0.0.1
+env.ip localhost
 env.port 5400
 
 [samba]

--- a/puppet/zulip_ops/files/nagios3/conf.d/localhost.cfg
+++ b/puppet/zulip_ops/files/nagios3/conf.d/localhost.cfg
@@ -2,7 +2,7 @@ define host{
         use                     generic-host
         host_name               nagios
         alias                   nagios
-        address                 127.0.0.1
+        address                 localhost
         hostgroups              all
         }
 

--- a/puppet/zulip_ops/files/postgresql/pg_hba.conf
+++ b/puppet/zulip_ops/files/postgresql/pg_hba.conf
@@ -89,7 +89,7 @@ local   all             postgres                                peer
 # "local" is for Unix domain socket connections only
 local   all             all                                     peer
 # IPv4 local connections:
-host    all             all             127.0.0.1/32            md5
+host    all             all             localhost/32            md5
 # IPv6 local connections:
 host    all             all             ::1/128                 md5
 # Allow replication connections from localhost, by a user with the

--- a/puppet/zulip_ops/files/statsd/redis.conf
+++ b/puppet/zulip_ops/files/statsd/redis.conf
@@ -27,7 +27,7 @@ port 6978
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
-bind 127.0.0.1
+bind localhost
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen

--- a/puppet/zulip_ops/files/supervisor/conf.d/redis_tunnel.conf.staging
+++ b/puppet/zulip_ops/files/supervisor/conf.d/redis_tunnel.conf.staging
@@ -1,5 +1,5 @@
 [program:redis-tunnel]
-command=autossh -M 0 -N -L 127.0.0.1:6379:127.0.0.1:6379 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 redis-staging.zulip.net
+command=autossh -M 0 -N -L localhost:6379:localhost:6379 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 redis-staging.zulip.net
 priority=50
 user=zulip
 autostart=true

--- a/puppet/zulip_ops/templates/nagios3/cgi.cfg.template.erb
+++ b/puppet/zulip_ops/templates/nagios3/cgi.cfg.template.erb
@@ -372,4 +372,4 @@ lock_author_names=1
 
 # This option should be the URL used to access your instance of Splunk
 
-#splunk_url=http://127.0.0.1:8000/
+#splunk_url=http://localhost:8000/

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -87,7 +87,7 @@ if options.interface is None:
         options.interface = None
     else:
         # Otherwise, only listen to requests on localhost for security.
-        options.interface = "127.0.0.1"
+        options.interface = "localhost"
 elif options.interface == "":
     options.interface = None
 
@@ -133,11 +133,11 @@ os.setpgrp()
 # zulip/urls.py.
 cmds = [['./tools/compile-handlebars-templates', 'forever'],
         ['./manage.py', 'rundjango'] +
-        manage_args + ['127.0.0.1:%d' % (django_port,)],
+        manage_args + ['localhost:%d' % (django_port,)],
         ['env', 'PYTHONUNBUFFERED=1', './manage.py', 'runtornado'] +
-        manage_args + ['127.0.0.1:%d' % (tornado_port,)],
+        manage_args + ['localhost:%d' % (tornado_port,)],
         ['./tools/run-dev-queue-processors'] + manage_args,
-        ['env', 'PGHOST=127.0.0.1',  # Force password authentication using .pgpass
+        ['env', 'PGHOST=localhost',  # Force password authentication using .pgpass
          './puppet/zulip/files/postgresql/process_fts_updates']]
 if options.test:
     # Webpack doesn't support 2 copies running on the same system, so
@@ -172,7 +172,7 @@ def fetch_request(url, callback, **kwargs):
 
 class BaseWebsocketHandler(WebSocketHandler):
     # target server ip
-    target_host = '127.0.0.1'  # type: str
+    target_host = 'localhost'  # type: str
     # target server port
     target_port = None  # type: int
 

--- a/tools/test-run-dev
+++ b/tools/test-run-dev
@@ -45,7 +45,7 @@ def test_nagios(nagios_logfile):
         os.path.join(PUPPET_DIR,
                      'zulip/files/nagios_plugins/zulip_app_frontend/check_send_receive_time'),
         '--nagios',
-        '--site=http://127.0.0.1:9991',
+        '--site=http://localhost:9991',
     ]
     result = subprocess.check_output(args, env=my_env, universal_newlines=True,
                                      stderr=nagios_logfile)

--- a/tools/travis/production-helper
+++ b/tools/travis/production-helper
@@ -34,7 +34,7 @@ env TRAVIS=1 /root/zulip/scripts/setup/install
 
 cat >>/etc/zulip/settings.py <<EOF
 # Travis CI override settings above
-EXTERNAL_HOST = '127.0.0.1'
+EXTERNAL_HOST = 'localhost'
 ZULIP_ADMINISTRATOR = 'zulip-travis-admin@travis.example.com'
 AUTHENTICATION_BACKENDS = ( 'zproject.backends.EmailAuthBackend', )
 NOREPLY_EMAIL_ADDRESS = 'noreply@travis.example.com'
@@ -100,8 +100,8 @@ done
 echo; echo "Now running additional Nagios tests"; echo
 if ! /usr/lib/nagios/plugins/zulip_app_frontend/check_queue_worker_errors || \
    ! su zulip -c /usr/lib/nagios/plugins/zulip_postgres_appdb/check_fts_update_log || \
-   ! su zulip -c "/usr/lib/nagios/plugins/zulip_app_frontend/check_send_receive_time --site=https://127.0.0.1/api --nagios --insecure" || \
-   ! su zulip -c "/usr/lib/nagios/plugins/zulip_app_frontend/check_send_receive_time --site=https://127.0.0.1/api --nagios --websocket --insecure"; then
+   ! su zulip -c "/usr/lib/nagios/plugins/zulip_app_frontend/check_send_receive_time --site=https://localhost/api --nagios --insecure" || \
+   ! su zulip -c "/usr/lib/nagios/plugins/zulip_app_frontend/check_send_receive_time --site=https://localhost/api --nagios --websocket --insecure"; then
     set +x
     echo
     echo "FAILURE: Nagios checks don't pass:"

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
             addr, port = '', addrport
 
         if not addr:
-            addr = '127.0.0.1'
+            addr = 'localhost'
 
         if not port.isdigit():
             raise CommandError("%r is not a valid port number." % (port,))
@@ -105,6 +105,8 @@ class Command(BaseCommand):
                                                     xheaders=xheaders,
                                                     no_keep_alive=no_keep_alive)
                 http_server.listen(int(port), address=addr)
+                # http_server.bind(int(port), address='localhost')
+                # http_server.start(1)
 
                 setup_event_queue()
                 add_client_gc_hook(missedmessage_hook)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1246,7 +1246,7 @@ def get_huddle_backend(huddle_hash, id_list):
 
 def clear_database():
     # type: () -> None
-    pylibmc.Client(['127.0.0.1']).flush_all()
+    pylibmc.Client(['localhost']).flush_all()
     model = None # type: Any
     for model in [Message, Stream, UserProfile, Recipient,
                   Realm, Subscription, Huddle, UserMessage, Client,

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -287,7 +287,7 @@ class RateLimitTestCase(TestCase):
 
         class Request(object):
             client = Client()
-            META = {'REMOTE_ADDR': '127.0.0.1'}
+            META = {'REMOTE_ADDR': 'localhost'}
 
         req = Request()
 

--- a/zilencer/management/commands/profile_request.py
+++ b/zilencer/management/commands/profile_request.py
@@ -23,7 +23,7 @@ class MockRequest(HttpRequest):
         self.user = get_user_profile_by_email(email)
         self.path = '/'
         self.method = "POST"
-        self.META = {"REMOTE_ADDR": "127.0.0.1"}
+        self.META = {"REMOTE_ADDR": "localhost"}
         self.REQUEST = {
             "anchor": UserMessage.objects.filter(user_profile=self.user).order_by("-message")[200].message_id,
             "num_before": 1200,

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -361,14 +361,14 @@ CAMO_URI = '/external_content/'
 # but Zulip also supports connecting to memcached over the network;
 # to use a remote Memcached instance, set MEMCACHED_LOCATION here.
 # Format HOST:PORT
-# MEMCACHED_LOCATION = 127.0.0.1:11211
+# MEMCACHED_LOCATION = localhost:11211
 
 # Redis configuration
 #
 # By default, Zulip connects to redis running locally on the machine,
 # but Zulip also supports connecting to redis over the network;
 # to use a remote Redis instance, set REDIS_HOST here.
-# REDIS_HOST = '127.0.0.1'
+# REDIS_HOST = 'localhost'
 # For a different redis port set the REDIS_PORT here.
 # REDIS_PORT = 6379
 # If you set redis_password in zulip-secrets.conf, Zulip will use that password

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -65,7 +65,7 @@ if 'DEBUG' not in globals():
     DEBUG = DEVELOPMENT # and platform.node() != 'your-machine'
 
 if DEBUG:
-    INTERNAL_IPS = ('127.0.0.1',)
+    INTERNAL_IPS = ('127.0.0.1', '::1',)
 
 # Detect whether we're running as a queue worker; this impacts the logging configuration.
 if len(sys.argv) > 2 and sys.argv[0].endswith('manage.py') and sys.argv[1] == 'process_queue':


### PR DESCRIPTION
Ran into this while trying to get the irc bot up and running, and ended up seeing a lot of random errors based on not being able to connect to 'localhost' (where it resolved to ::1 vs. 127.0.0.1).  Think I found all the instances that needed changing.

----

On systems that have both IPv4 and IPv6 'localhost' doesn't,
necessarily, resolve to 127.0.0.1 as it can resolve to ::1.
This causes problems when you bind services to 127.0.0.1 and then
attempt to access them via 'localhost', as 'localhost' will tend to
resolve to ::1 to start with, which then leads to spurious errors.

This attempts to, mostly intelligently, go through and flip references
to 127.0.0.1 to localhost to avoid the problems I tripped over.

Signed-off-by: John 'Warthog9' Hawley <warthog9@eaglescrag.net>