### PR TITLE
Add ordered list styling for /help/ pages.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -57,8 +57,49 @@ body {
     font-size: 17px;
 }
 
-li {
+.markdown ul,
+.markdown ol {
+    margin-left: 30px;
+}
+
+.markdown li {
     line-height: 150%;
+}
+
+.markdown ol {
+    counter-reset: item;
+    list-style: none;
+}
+
+.markdown ol li {
+    counter-increment: item;
+    margin-bottom: 5px;
+}
+
+.markdown ol li:before {
+    content: counter(item);
+
+    display: inline-block;
+    vertical-align: top;
+
+    padding: 2px 5.5px 2px 6.5px;
+    margin-right: 5px;
+    background-color: #52c2af;
+    color: white;
+    border-radius: 100%;
+    font-size: 0.9em;
+    line-height: 1.1;
+    text-align: center;
+}
+
+.markdown ol li p {
+    display: inline-block;
+    vertical-align: top;
+
+    max-width: calc(100% - 25px);
+
+    position: relative;
+    top: -2px;
 }
 
 .title {

--- a/templates/zerver/help/main.html
+++ b/templates/zerver/help/main.html
@@ -5,7 +5,7 @@
 {% block portico_content %}
 
 <div class="app terms-page">
-    <div class="app-main terms-page-container markdown">
+    <div class="app-main markdown">
     {{ article|render_markdown_path }}
         <div id="footer">
         <hr />
@@ -24,4 +24,3 @@
 
 
 {% endblock %}
-


### PR DESCRIPTION
This adds a styling that puts the numbers in a Zulip brand green bubble
with white text for the number.