### PR TITLE
Fix enter key behavior for stream/settings/admin.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -112,6 +112,7 @@ function process_hotkey(e) {
     var message_edit_form;
     var hotkey = get_hotkey_from_event(e);
     var event_name = hotkey.name;
+    var current_view = window.location.hash;
     activity.new_user_input = true;
 
     if (ui.home_tab_obscured() && hotkey.message_view_only) {
@@ -357,6 +358,10 @@ function process_hotkey(e) {
         case 'narrow_by_subject':
             return do_narrow_action(narrow.by_subject);
         case  'enter': // Enter: respond to message (unless we need to do something else)
+            if (current_view === "#settings" || current_view === "#administration" ||
+                current_view === "#subscriptions") {
+                return false; //Enter: Nothing triggered when user on stream/settings/admin
+            }
             compose.respond_to_message({trigger: 'hotkey enter'});
             return true;
         case 'reply_message': // 'r': respond to message


### PR DESCRIPTION
We no longer intercept the enter key in `hotkey.js` when the user is in `Manage Streams`, `Settings`, or
`Administration`.

Fixes #2412