### PR TITLE
run-dev: Add pid file to development server.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -129,6 +129,16 @@ if options.clear_memcached:
 # and all of the processes they spawn.
 os.setpgrp()
 
+# Save pid of parent process to the pid file. It can be used
+pid_file_path = os.path.join(os.path.join(os.getcwd(), 'var/run/run_dev.pid'))
+
+# Required for compatibility python versions.
+if not os.path.exists(os.path.dirname(pid_file_path)):
+    os.makedirs(os.path.dirname(pid_file_path))
+pid_file = open(pid_file_path, 'w+')
+pid_file.write(str(os.getpgrp()))
+pid_file.close()
+
 # Pass --nostatic because we configure static serving ourselves in
 # zulip/urls.py.
 cmds = [['./tools/compile-handlebars-templates', 'forever'],
@@ -388,3 +398,5 @@ except:
 finally:
     # Kill everything in our process group.
     os.killpg(0, signal.SIGTERM)
+    # Remove pid file when development server closed correctly.
+    os.remove(pid_file_path)

--- a/tools/stop_dev_server
+++ b/tools/stop_dev_server
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import os
+import signal
+import sys
+
+os.chdir(os.path.join(os.path.dirname(__file__), '..'))
+pid_file_path = os.path.join(os.path.join(os.getcwd(), 'var/run/run_dev.pid'))
+
+try:
+    with open(pid_file_path, 'r') as pid_file:
+        try:
+            pid = int(pid_file.read())
+        except ValueError:
+            print('PID value is not correct!')
+            sys.exit(1)
+except Exception as e:
+    print("PID file can't be open!")
+    print(e)
+    sys.exit(1)
+
+# Kill development processes group.
+try:
+    os.killpg(pid, signal.SIGTERM)
+except OSError as e:
+    print(e)
+    sys.exit(1)
+
+print("Done")


### PR DESCRIPTION
- Add pid file of development processes group, which allows to
  manage development processes group with os utils. Also it allows to
  kill subprocesses  when parent process was closed incorrectly.
- Add tool 'stop_dev_server' to stop development server by pid file.

Fixes #1547