### PR TITLE
Fix pressing escape should close the markdown help dialog but not the…

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -200,7 +200,7 @@ function process_hotkey(e) {
             return true;
         } else if ($('#markdown-help').hasClass('in') ||
             $('#keyboard-shortcuts').hasClass('in') ||
-            $('#search-operators').hasClass('in') || 
+            $('#search-operators').hasClass('in') ||
             $('#invite-user').hasClass('in')) {
             return false;
         }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -198,6 +198,8 @@ function process_hotkey(e) {
         } else if ($("#subscription_overlay").is(":visible")) {
             subs.close();
             return true;
+        } else if ($('#markdown-help').hasClass('in')) {
+            return false;
         }
     }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -198,7 +198,10 @@ function process_hotkey(e) {
         } else if ($("#subscription_overlay").is(":visible")) {
             subs.close();
             return true;
-        } else if ($('#markdown-help').hasClass('in')) {
+        } else if ($('#markdown-help').hasClass('in') ||
+            $('#keyboard-shortcuts').hasClass('in') ||
+            $('#search-operators').hasClass('in') || 
+            $('#invite-user').hasClass('in')) {
             return false;
         }
     }


### PR DESCRIPTION
Issue #3472 was fixed. Now pressing ESC will not close the message box when markdown_help is open. I will submit a gif explaining the fix in some time.

Thanks!