### PR TITLE
Prevent dragging of Click/Unclick-all links.

### DIFF
--- a/static/templates/new_stream_users.handlebars
+++ b/static/templates/new_stream_users.handlebars
@@ -23,8 +23,8 @@
 
 
 <div>
-<a href="#" class="subs_set_all_users">{{t "Check all" }}</a> |
-<a href="#" class="subs_unset_all_users">{{t "Uncheck all" }}</a>
+<a href="#" draggable="false" class="subs_set_all_users">{{t "Check all" }}</a> |
+<a href="#" draggable="false" class="subs_unset_all_users">{{t "Uncheck all" }}</a>
 </div>
 
 <div id="user-checkboxes">


### PR DESCRIPTION
We have links when to create a stream to "Click all" or
"Unclick all" for checkboxes.

In FF it's easy to accidentally start dragging these links,
which has no real value (since their href is uninteresting)
and is confusing.

Perhaps these should just be buttons.