### PR TITLE
Suppress jQuery warning related to settings menu.

### DIFF
--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -39,7 +39,7 @@
         <div id="navbar-buttons" {%if embedded %} style="visibility: hidden"{% endif %}>
             <ul class="nav" role="navigation">
               <li class="dropdown actual-dropdown-menu" id="gear-menu">
-                <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle" data-toggle="dropdown">
+                <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle" data-target="nada" data-toggle="dropdown">
                   <i class="icon-vector-cog"></i><i class="icon-vector-caret-down settings-dropdown-caret"></i>
                 </a>
                 <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">


### PR DESCRIPTION
If you develop with Firefox, before this commit, you would
get jQuery warnings about empty selectors every time you clicked
in the app, due to a glitch with our old version of bootstrap.js.

This commit makes the error go away by setting
`data-toggle` to 'nada' for the settings-dropdown
element.

This was the error:

    Empty string passed to getElementById().

More details here:

    https://github.com/twbs/bootstrap/issues/5566