### PR TITLE
frontend: Add #search-operators link to search icon; Fixes #1369.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1686,6 +1686,16 @@ nav a .no-style {
     visibility: hidden;
 }
 
+#searchbox a.search_icon {
+    color: #ccc;
+    text-decoration: none;
+}
+
+#searchbox a.search_icon:hover {
+    color: #000;
+    text-decoration: none;
+}
+
 .highlight {
     background-color: #FCEA81;
 }

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -20,7 +20,7 @@
             </div>
             <form id="searchbox_form" class="form-search navbar-search">
               <div id="search_arrows" class="input-append">
-                <i class="icon-vector-search"></i>
+                <a class="search_icon" href="#search-operators" data-toggle="modal"><i class="icon-vector-search"></i></a>
                 <input class="search-query input-block-level" id="search_query" type="text" placeholder="{{ _('Search') }}"
                        autocomplete="off" />
                 {# Start the button off disabled since there is no active search #}


### PR DESCRIPTION
This PR changes the UI so that clicking the search icon in the search bar links to the Search help modal. The color of the icon  changes from a light gray to a darker shade on hover, similar to the X icon that appears when your cursor is in the search bar.

Fixes #1369