### PR TITLE
Add avatar versioning to update cache.

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -353,6 +353,9 @@ class LocalUploadBackend(ZulipUploadBackend):
         resized_medium = resize_avatar(image_data, MEDIUM_AVATAR_SIZE)
         write_local_file('avatars', email_hash+'-medium.png', resized_medium)
 
+        user_profile.avatar_version += 1
+        user_profile.save()
+
     def get_avatar_url(self, hash_key, medium=False):
         # type: (Text, bool) -> Text
         # ?x=x allows templates to append additional parameters with &s

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -397,6 +397,7 @@ class AvatarTest(ZulipTestCase):
         """
         A PUT request to /json/users/me/avatar with a valid file should return a url and actually create an avatar.
         """
+        version = 2
         for fname, rfname in self.correct_files:
             # TODO: use self.subTest once we're exclusively on python 3 by uncommenting the line below.
             # with self.subTest(fname=fname):
@@ -428,6 +429,10 @@ class AvatarTest(ZulipTestCase):
             zerver.lib.upload.upload_backend.ensure_medium_avatar_image(user_profile.email)
             self.assertTrue(os.path.exists(medium_avatar_disk_path))
 
+            # Verify whether the avatar_version gets incremented with every new upload
+            self.assertEqual(user_profile.avatar_version, version)
+            version += 1
+
     def test_invalid_avatars(self):
         # type: () -> None
         """
@@ -440,6 +445,8 @@ class AvatarTest(ZulipTestCase):
                 result = self.client_put_multipart("/json/users/me/avatar", {'file': fp})
 
             self.assert_json_error(result, "Could not decode avatar image; did you upload an image file?")
+            user_profile = get_user_profile_by_email("hamlet@zulip.com")
+            self.assertEqual(user_profile.avatar_version, 1)
 
     def test_delete_avatar(self):
         # type: () -> None

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1202,11 +1202,16 @@ class BotTest(ZulipTestCase):
                 dict(file1=fp1, file2=fp2))
         self.assert_json_error(result, 'You may only upload one file at a time')
 
+        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        self.assertEqual(user_profile.avatar_version, 1)
+
         # HAPPY PATH
         with get_test_image_file('img.png') as fp:
             result = self.client_patch_multipart(
                 '/json/bots/hambot-bot@zulip.com',
                 dict(file=fp))
+            user_profile = get_user_profile_by_email("hamlet@zulip.com")
+            self.assertEqual(user_profile.avatar_version, 2)
             profile = get_user_profile_by_email('hambot-bot@zulip.com')
             # Make sure that avatar image that we've uploaded is same with avatar image in the server
             self.assertTrue(filecmp.cmp(fp.name,


### PR DESCRIPTION
Avatar versioning is used to update the cache every time the
user updates their avatar, avatar_version gets incremented each time.
Corresponding tests for feature are at test_upload.py