### PR TITLE
docs: Fix portico header covering anchor links.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -57,6 +57,14 @@ body {
     font-size: 17px;
 }
 
+*[id]:before {
+    display: block;
+    content: " ";
+    margin-top: -40px;
+    height: 40px;
+    visibility: hidden;
+}
+
 .markdown ul,
 .markdown ol {
     margin-left: 30px;


### PR DESCRIPTION
Before all `id` anchor tags, a hidden block is added so that anchor link content won’t be hidden by the header.