### PR TITLE
left-sidebar: Fix +(plus) icon click and appearance of stream-search box.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -353,7 +353,9 @@ $(function () {
         compose.cancel();
     });
 
-    $("#join_unsub_stream").click(function () {
+    $("#join_unsub_stream").click(function (e) {
+        e.preventDefault();
+        e.stopPropagation();
         subs.launch();
         components.toggle.lookup("stream-filter-toggle").goto("All streams");
     });

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -564,6 +564,7 @@ exports.transmit_message = function (request, success, error) {
 };
 
 function send_message(request) {
+    console.log("Reached Here!");
     if (request === undefined) {
         request = create_message_object();
     }

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -564,7 +564,6 @@ exports.transmit_message = function (request, success, error) {
 };
 
 function send_message(request) {
-    console.log("Reached Here!");
     if (request === undefined) {
         request = create_message_object();
     }


### PR DESCRIPTION
Appearance (or disappearance) of stream-search box in left-sidebar on click of +(plus) icon was fixed  (Issue #3517). Changes were made in `click_handlers.js` by adding `e.stopPropagation` and `e.preventDefault` in appropriate click handler.

Improved functionality:
![optimised](https://cloud.githubusercontent.com/assets/18065231/22445658/77a70fac-e76e-11e6-8d73-3d8dab7a7311.gif)


Thanks!