### PR TITLE
Enlargen settings page loading spinner.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1796,6 +1796,13 @@ div.floating_recipient {
     line-height: 38px;
 }
 
+.settings-section #admin_page_users_loading_indicator,
+.settings-section #admin_page_deactivated_users_loading_indicator,
+.settings-section #admin_page_bots_loading_indicator,
+.settings-section #admin_page_streams_loading_indicator {
+    margin: 0 auto;
+}
+
 .settings-section .loading_indicator_text {
     font-size: 12px;
     font-weight: 400;
@@ -1806,8 +1813,8 @@ div.floating_recipient {
 }
 
 .settings-section .loading_indicator_spinner {
-    width: 12px;
-    height: 12px;
+    width: 100%;
+    height: 100%;
     vertical-align: middle;
     display: inline-block;
 }


### PR DESCRIPTION
Currently the loading spinner on the settings page is too small
and is in the left corner of the parent box. This changes the width
to the same as the main page: 100% fill inside a 38px square container.