### PR TITLE
Compose-Box: Show restore-draft option in write mode only.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -139,6 +139,9 @@ function clear_preview_area() {
     $("#preview_message_area").hide();
     $("#preview_content").empty();
     $("#markdown_preview").show();
+    if (message_snapshot !== undefined) {
+        $('#restore-draft').show();
+    }
 }
 
 function hide_box() {
@@ -1019,6 +1022,7 @@ $(function () {
         var message = $("#new_message_content").val();
         $("#new_message_content").hide();
         $("#markdown_preview").hide();
+        $("#restore-draft").hide();
         $("#undo_markdown_preview").show();
         $("#preview_message_area").show();
 


### PR DESCRIPTION
Restore Draft will now be available in write mode only. The option will be hidden when in preview mode. This change should take care of issue #3491.

![optimised](https://cloud.githubusercontent.com/assets/18065231/22472830/c898320e-e7fc-11e6-89d4-f9506ffe4432.gif)


Please let me know improvements, if any.

Thanks!