### PR TITLE
Fix the position of the edit message label.

### DIFF
--- a/frontend_tests/casper_tests/04-compose.js
+++ b/frontend_tests/casper_tests/04-compose.js
@@ -171,7 +171,7 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitWhileVisible("#markdown_preview", function () {
+    casper.waitForSelectorTextChange("#preview_content", function () {
         casper.test.assertEquals(casper.getHTML('#preview_content'), "<p><strong>Markdown Preview</strong> &gt;&gt; Test for markdown preview</p>", "Check markdown is previewed properly");
     });
 });

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2250,6 +2250,10 @@ button.topic_edit_cancel {
     margin-right: -50%;
 }
 
+.include-sender .message_edit {
+    margin-top: -14px;
+}
+
 .message_edit {
     display: none;
     margin-top: 5px;
@@ -2257,18 +2261,18 @@ button.topic_edit_cancel {
 }
 
 /* Reduce some of the heavy padding from Bootstrap. */
+#message_edit_form {
+    margin-bottom: 10px;
+}
 #message_edit_form .edit-control-label {
-    width: auto;
-    float: left;
-    font-size: 80%;
     vertical-align: top;
     padding-top: 0px;
     margin-right: 10px;
+    font-size: 80%;
 }
 #message_edit_form .edit-controls {
-    margin-left: 35px; /* Match .message_content padding less 7px textarea padding and border */
-    margin-right: -7px;
-    margin-top: 10px;
+    margin-left: 0px;
+    margin-top: 0px;
 }
 #message_edit_form textarea {
     width: 100%;
@@ -2292,6 +2296,10 @@ button.topic_edit_cancel {
     float: right;
     padding-left: 5px;
     padding-top: 3px;
+}
+
+#message_edit_form .action-buttons {
+    margin: 10px 0px;
 }
 
 #topic_edit_form {

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -3,7 +3,7 @@
 <form id="message_edit_form" class="form-horizontal">
 {{#if is_stream}}
     <div class="control-group no-margin">
-        <label class="control-label edit-control-label" for="message_edit_topic">{{t "Topic" }}</label>
+        <label class="edit-control-label" for="message_edit_topic">{{t "Topic" }}</label>
         <div class="controls edit-controls">
           <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" />
           <select class='message_edit_topic_propagate' style='display:none;'>
@@ -16,10 +16,11 @@
 {{/if}}
     <div class="control-group no-margin">
         <div class="controls edit-controls">
+            <label class="edit-control-label" for="message_edit_topic">{{t "Content" }}</label>
             <textarea class="message_edit_content" id="message_edit_content">{{content}}</textarea>
         </div>
     </div>
-    <div class="control-group">
+    <div class="control-group action-buttons">
         <div class="controls edit-controls">
             {{#if is_editable}}
             <button type="button" class="message_edit_save btn btn-primary btn-small">{{t "Save" }}</button>


### PR DESCRIPTION
This fixes the position of the "Topic" label to be above
the input and adds a "Content" label to improve consistency.