### PR TITLE
Center icons in gear-menu.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -463,6 +463,7 @@ li.actual-dropdown-menu i {
     /* In gear menu, make icons the same width so labels line up. */
     display: inline-block;
     width: 14px;
+    text-align: center;
 }
 
 .message_area_padder {


### PR DESCRIPTION
This centers the icons in the gear menu so they are naturally in line and centered.