### PR TITLE
css parser: Show line numbers for errors.

### DIFF
--- a/tools/check-css
+++ b/tools/check-css
@@ -32,8 +32,12 @@ def check_our_files():
         try:
             validate(fn)
         except CssParserException as e:
-            print('CssParserException raised while parsing file %s' % (fn,))
-            print(e)
+            msg = '''
+                ERROR! Some CSS seems to be misformatted.
+                {}
+                See line {} in file {}
+                '''.format(e.msg, e.token.line, fn)
+            print(msg)
             sys.exit(1)
 
 if __name__ == '__main__':

--- a/tools/tests/test_css_parser.py
+++ b/tools/tests/test_css_parser.py
@@ -193,6 +193,16 @@ class ParserTestSadPath(unittest.TestCase):
         error = 'Missing selector'
         self._assert_error(my_css, error)
 
+    def test_missing_value(self):
+        # type: () -> None
+        my_css = '''
+            h1
+            {
+                bottom:
+            }'''
+        error = 'Missing value'
+        self._assert_error(my_css, error)
+
     def test_disallow_comments_in_selectors(self):
         # type: () -> None
         my_css = '''


### PR DESCRIPTION
This is a fairly major overhaul of the CSS parser to support
line numbers in error messages.

Basically, instead of passing "slices" of tokens around, we pass
indexes into the token arrays to all of our sub-parsers, which
allows them to have access to previous tokens in certain cases.
This is particularly important for errors where stuff is missing
(vs. being wrong).

In testing this out I found a few more places to catch errors.