### PR TITLE
Portico header selector fix

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -57,7 +57,10 @@ body {
     font-size: 17px;
 }
 
-*[id]:before {
+.markdown h1[id]:before,
+.markdown h2[id]:before,
+.markdown h3[id]:before,
+.markdown h4[id]:before {
     display: block;
     content: " ";
     margin-top: -40px;


### PR DESCRIPTION
This fixes the broad ID selector `*[id]:before` to be a more specific
selection of h{x} tags inside the `.markdown` container.