### PR TITLE
Subscriptions overlay haschange fix.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -659,6 +659,7 @@ Object.defineProperty(exports, "is_open", {
 });
 
 exports.close = function () {
+    hashchange.exit_settings();
     meta.is_open = false;
     $("#subscription_overlay").fadeOut(500);
     subs.remove_miscategorized_streams();


### PR DESCRIPTION
This applies a fix that when a user uses the Esc key the subscriptions
hash does not get restored to its previous state.