### PR TITLE
bug fix: Allow renaming streams to different cases.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -264,6 +264,11 @@ class StreamAdminTest(ZulipTestCase):
                                    {'new_name': ujson.dumps('denmark ')})
         self.assert_json_error(result, "Stream name 'denmark' is already taken")
 
+        # Do a rename that is case-only--this should succeed.
+        result = self.client_patch('/json/streams/%d' % (stream.id,),
+                                   {'new_name': ujson.dumps('sTREAm_name1')})
+        self.assert_json_success(result)
+
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             stream_id = get_stream('stream_name1', user_profile.realm).id
@@ -277,7 +282,7 @@ class StreamAdminTest(ZulipTestCase):
             type='stream',
             property='name',
             value='stream_name2',
-            name='stream_name1'
+            name='sTREAm_name1'
         ))
         notified_user_ids = set(events[1]['users'])
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -98,10 +98,12 @@ def update_stream_backend(request, user_profile, stream_id,
         do_change_stream_description(stream, description)
     if new_name is not None:
         new_name = new_name.strip()
-        # Will raise if the new name has invalid characters.
-        if stream.name.lower() == new_name.lower():
+        if stream.name == new_name:
             return json_error(_("Stream already has that name!"))
-        check_stream_name_available(user_profile.realm, new_name)
+        if stream.name.lower() != new_name.lower():
+            # Check that the stream name is available (unless we are
+            # are only changing the casing of the stream name).
+            check_stream_name_available(user_profile.realm, new_name)
         do_rename_stream(stream, new_name)
     if is_private is not None:
         do_change_stream_invite_only(stream, is_private)


### PR DESCRIPTION
Before this change, you could not rename a stream
from "denmark" to "Denmark".