### PR TITLE
analytics: Change time_range to not include current day/hour.

### DIFF
--- a/analytics/lib/time_utils.py
+++ b/analytics/lib/time_utils.py
@@ -1,20 +1,20 @@
-from zerver.lib.timestamp import ceiling_to_hour, ceiling_to_day, timestamp_to_datetime
+from zerver.lib.timestamp import floor_to_hour, floor_to_day, timestamp_to_datetime
 from analytics.lib.counts import CountStat
 
 from datetime import datetime, timedelta
 from typing import List, Optional
 
-# If min_length is None, returns end_times from ceiling(start) to ceiling(end), inclusive.
+# If min_length is None, returns end_times from ceiling(start) to floor(end), inclusive.
 # If min_length is greater than 0, pads the list to the left.
 # So informally, time_range(Sep 20, Sep 22, day, None) returns [Sep 20, Sep 21, Sep 22],
 # and time_range(Sep 20, Sep 22, day, 5) returns [Sep 18, Sep 19, Sep 20, Sep 21, Sep 22]
 def time_range(start, end, frequency, min_length):
     # type: (datetime, datetime, str, Optional[int]) -> List[datetime]
     if frequency == CountStat.HOUR:
-        end = ceiling_to_hour(end)
+        end = floor_to_hour(end)
         step = timedelta(hours=1)
     elif frequency == CountStat.DAY:
-        end = ceiling_to_day(end)
+        end = floor_to_day(end)
         step = timedelta(days=1)
     else:
         raise ValueError("Unknown frequency: %s" % (frequency,))

--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -13,25 +13,24 @@ class TestTimeRange(ZulipTestCase):
         DAY = timedelta(days=1)
         TZINFO = get_fixed_timezone(-100) # 100 minutes west of UTC
 
-        # Using 22:59 so that converting to UTC and applying ceiling_to_{hour,day} do not commute
+        # Using 22:59 so that converting to UTC and applying floor_to_{hour,day} do not commute
         a_time = datetime(2016, 3, 14, 22, 59).replace(tzinfo=TZINFO)
-        # Round up to hour and day
-        ceiling_hour = datetime(2016, 3, 14, 23).replace(tzinfo=TZINFO)
-        ceiling_day = datetime(2016, 3, 15).replace(tzinfo=TZINFO)
+        floor_hour = datetime(2016, 3, 14, 22).replace(tzinfo=TZINFO)
+        floor_day = datetime(2016, 3, 14).replace(tzinfo=TZINFO)
 
         # test start == end
-        self.assertEqual(time_range(a_time, a_time, CountStat.HOUR, None), [ceiling_hour])
-        self.assertEqual(time_range(a_time, a_time, CountStat.DAY, None), [ceiling_day])
+        self.assertEqual(time_range(a_time, a_time, CountStat.HOUR, None), [])
+        self.assertEqual(time_range(a_time, a_time, CountStat.DAY, None), [])
         # test start == end == boundary, and min_length == 0
-        self.assertEqual(time_range(ceiling_hour, ceiling_hour, CountStat.HOUR, 0), [ceiling_hour])
-        self.assertEqual(time_range(ceiling_day, ceiling_day, CountStat.DAY, 0), [ceiling_day])
+        self.assertEqual(time_range(floor_hour, floor_hour, CountStat.HOUR, 0), [floor_hour])
+        self.assertEqual(time_range(floor_day, floor_day, CountStat.DAY, 0), [floor_day])
         # test start and end on different boundaries
-        self.assertEqual(time_range(ceiling_hour, ceiling_hour+HOUR, CountStat.HOUR, None),
-                         [ceiling_hour, ceiling_hour+HOUR])
-        self.assertEqual(time_range(ceiling_day, ceiling_day+DAY, CountStat.DAY, None),
-                         [ceiling_day, ceiling_day+DAY])
+        self.assertEqual(time_range(floor_hour, floor_hour+HOUR, CountStat.HOUR, None),
+                         [floor_hour, floor_hour+HOUR])
+        self.assertEqual(time_range(floor_day, floor_day+DAY, CountStat.DAY, None),
+                         [floor_day, floor_day+DAY])
         # test min_length
-        self.assertEqual(time_range(ceiling_hour, ceiling_hour+HOUR, CountStat.HOUR, 4),
-                         [ceiling_hour-2*HOUR, ceiling_hour-HOUR, ceiling_hour, ceiling_hour+HOUR])
-        self.assertEqual(time_range(ceiling_day, ceiling_day+DAY, CountStat.DAY, 4),
-                         [ceiling_day-2*DAY, ceiling_day-DAY, ceiling_day, ceiling_day+DAY])
+        self.assertEqual(time_range(floor_hour, floor_hour+HOUR, CountStat.HOUR, 4),
+                         [floor_hour-2*HOUR, floor_hour-HOUR, floor_hour, floor_hour+HOUR])
+        self.assertEqual(time_range(floor_day, floor_day+DAY, CountStat.DAY, 4),
+                         [floor_day-2*DAY, floor_day-DAY, floor_day, floor_day+DAY])


### PR DESCRIPTION
Current day/hour will always be 0, since we haven't computed it yet for the
CountStat tables.