### PR TITLE
bugdown: Restore data-user-email to user mention spans.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -940,9 +940,11 @@ class UserMentionPattern(markdown.inlinepatterns.Pattern):
 
             if wildcard:
                 current_message.mentions_wildcard = True
+                email = '*'
                 user_id = "*"
             elif user:
                 current_message.mentions_user_ids.add(user['id'])
+                email = user['email']
                 name = user['full_name']
                 user_id = str(user['id'])
             else:
@@ -951,6 +953,7 @@ class UserMentionPattern(markdown.inlinepatterns.Pattern):
 
             el = markdown.util.etree.Element("span")
             el.set('class', 'user-mention')
+            el.set('data-user-email', email)
             el.set('data-user-id', user_id)
             el.text = "@%s" % (name,)
             return el

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -586,7 +586,9 @@ class BugdownTest(TestCase):
 
         content = "@all test"
         self.assertEqual(render_markdown(msg, content),
-                         '<p><span class="user-mention" data-user-id="*">@all</span> test</p>')
+                         '<p><span class="user-mention" data-user-email="*" data-user-id="*">'
+                         '@all'
+                         '</span> test</p>')
         self.assertTrue(msg.mentions_wildcard)
 
     def test_mention_everyone(self):
@@ -596,7 +598,7 @@ class BugdownTest(TestCase):
 
         content = "@everyone test"
         self.assertEqual(render_markdown(msg, content),
-                         '<p><span class="user-mention" data-user-id="*">@everyone</span> test</p>')
+                         '<p><span class="user-mention" data-user-email="*" data-user-id="*">@everyone</span> test</p>')
         self.assertTrue(msg.mentions_wildcard)
 
     def test_mention_single(self):
@@ -608,7 +610,10 @@ class BugdownTest(TestCase):
 
         content = "@**King Hamlet**"
         self.assertEqual(render_markdown(msg, content),
-                         '<p><span class="user-mention" data-user-id="%s">@King Hamlet</span></p>' % (user_id,))
+                         '<p><span class="user-mention" '
+                         'data-user-email="%s" '
+                         'data-user-id="%s">'
+                         '@King Hamlet</span></p>' % ('hamlet@zulip.com', user_id))
         self.assertEqual(msg.mentions_user_ids, set([user_profile.id]))
 
     def test_mention_shortname(self):
@@ -620,7 +625,9 @@ class BugdownTest(TestCase):
 
         content = "@**hamlet**"
         self.assertEqual(render_markdown(msg, content),
-                         '<p><span class="user-mention" data-user-id="%s">@King Hamlet</span></p>' % (user_id,))
+                         '<p><span class="user-mention" '
+                         'data-user-email="%s" data-user-id="%s">'
+                         '@King Hamlet</span></p>' % ('hamlet@zulip.com', user_id))
         self.assertEqual(msg.mentions_user_ids, set([user_profile.id]))
 
     def test_mention_multiple(self):
@@ -634,10 +641,12 @@ class BugdownTest(TestCase):
         self.assertEqual(render_markdown(msg, content),
                          '<p>'
                          '<span class="user-mention" '
+                         'data-user-email="%s" '
                          'data-user-id="%s">@King Hamlet</span> and '
                          '<span class="user-mention" '
+                         'data-user-email="%s" '
                          'data-user-id="%s">@Cordelia Lear</span>, '
-                         'check this out</p>' % (hamlet.id, cordelia.id))
+                         'check this out</p>' % (hamlet.email, hamlet.id, cordelia.email, cordelia.id))
         self.assertEqual(msg.mentions_user_ids, set([hamlet.id, cordelia.id]))
 
     def test_mention_invalid(self):
@@ -869,7 +878,7 @@ class BugdownApiTests(ZulipTestCase):
         data = ujson.loads(result.content)
         user_id = get_user_profile_by_email('hamlet@zulip.com').id
         self.assertEqual(data['rendered'],
-                         u'<p>This mentions <a class="stream" data-stream-id="%s" href="/#narrow/stream/Denmark">#Denmark</a> and <span class="user-mention" data-user-id="%s">@King Hamlet</span>.</p>' % (get_stream("Denmark", get_realm("zulip")).id, user_id))
+                         u'<p>This mentions <a class="stream" data-stream-id="%s" href="/#narrow/stream/Denmark">#Denmark</a> and <span class="user-mention" data-user-email="%s" data-user-id="%s">@King Hamlet</span>.</p>' % (get_stream("Denmark", get_realm("zulip")).id, 'hamlet@zulip.com', user_id))
 
 class BugdownErrorTests(ZulipTestCase):
     def test_bugdown_error_handling(self):


### PR DESCRIPTION
(The commit q7ef4e40258280e202325c9295579c93fb948b replaced
data-user-email with data-user-id, but we still need to
support data-user-email for old clients like non-updated
androids and we still want to start the migration forward
to data-user-id.)