### PR TITLE
linters: Handle comments better in template parser.

### DIFF
--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -59,6 +59,14 @@ class ParserTest(unittest.TestCase):
             '''
         validate(text=my_html)
 
+    def test_validate_comment(self):
+        # type: () -> None
+        my_html = '''
+            <!---
+                <h1>foo</h1>
+            -->'''
+        validate(text=my_html)
+
     def test_validate_django(self):
         # type: () -> None
         my_html = '''


### PR DESCRIPTION
We now properly parse HTML comments that have HTML
block tags or handlebars/Django blocks within them.