### PR TITLE
Fix filter breaking in stream filtering.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -494,7 +494,9 @@ function stream_matches_query(query, sub) {
         var sub_name = sub.name.toLowerCase();
 
         return _.any(search_terms, function (o) {
-            return new RegExp(o).test(sub_name);
+            if (sub_name.indexOf(o) !== -1) {
+                return true;
+            }
         });
     }());
     flag = flag && ((sub.subscribed || !query.subscribed_only) ||


### PR DESCRIPTION
Filter breaking in stream filtering was fixed by removing RegExp. It was replaced by simply testing whether the term appears in stream name. Files modified: `subs.js`.

Fixes #3559