### PR TITLE
docs: Add missing /root/zulip creation on upgrading

### DIFF
--- a/docs/prod-maintain-secure-upgrade.md
+++ b/docs/prod-maintain-secure-upgrade.md
@@ -29,6 +29,8 @@ in a Git repository directly](#upgrade-from-a-git-repository).
 Next, run as root:
 
 ```
+rm -rf /root/zulip && mkdir /root/zulip
+tar -xf zulip-server-VERSION.tar.gz --directory=/root/zulip --strip-components=1
 /home/zulip/deployments/current/scripts/upgrade-zulip zulip-server-VERSION.tar.gz
 ```
 


### PR DESCRIPTION
scripts/zulip-puppet-apply requires /root/zulip/puppet to find modules.