### PR TITLE
message-view: Uncollapsing using [More...] made easier.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1206,6 +1206,8 @@ div.focused_table {
     /* to match .message_content */
     margin-left: 5px;
     margin-right: 35px;
+    /* to make message-uncollapse easier */
+    margin-top: 10px;
 }
 
 .message_length_controller:hover {


### PR DESCRIPTION
The [More...] link for message un-collapse has been made easier to click than it previously was in case of short message. Files changed: `zulip.css`.
Fixes #3313 
 