### PR TITLE
bug fix: Clean up blue highlighting in the left corner.

### DIFF
--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -76,7 +76,6 @@ function zoom_in() {
 exports.close = function () {
     private_messages_open = false;
     zoomed_in = false;
-    $("ul.filters li").removeClass('active-filter active-sub-filter');
     remove_expanded_private_messages();
 };
 
@@ -166,6 +165,7 @@ exports.update_private_messages = function () {
         exports.rebuild_recent("");
     } else if (is_pm_filter) {
         exports.rebuild_recent("");
+        $("#global_filters li[data-name='private']").addClass('active-filter');
     }
 };
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -391,6 +391,10 @@ exports.refresh_pinned_or_unpinned_stream = function (sub) {
     exports.update_streams_sidebar();
 };
 
+function deselect_top_left_corner_items() {
+    $("ul.filters li").removeClass('active-filter active-sub-filter');
+}
+
 $(function () {
     // TODO, Eventually topic_list won't be a big singleton,
     // and we can create more component-based click handlers for
@@ -403,6 +407,7 @@ $(function () {
     pm_list.set_click_handlers();
 
     $(document).on('narrow_activated.zulip', function (event) {
+        deselect_top_left_corner_items();
         reset_to_unnarrowed(narrow.stream() === zoomed_stream);
 
         // TODO: handle confused filters like "in:all stream:foo"
@@ -439,6 +444,7 @@ $(function () {
     });
 
     $(document).on('narrow_deactivated.zulip', function () {
+        deselect_top_left_corner_items();
         reset_to_unnarrowed();
         pm_list.close();
         $("#global_filters li[data-name='home']").addClass('active-filter');


### PR DESCRIPTION
In a96fdd18b1018bd37f2f88058d01d378ec21dd4d, I introduced a few
regressions related to the blue highlighting that happens
in the top left corner for Home, Private messages, Starred
messages, and @-mentions.  Basically, we weren't clearing
the highlighting when we thought we were, so Home would stay
blue too long and the other filters wouldn't turn blue.

We went a surprising long time before noticing the regression.
This fix adds a function called deselect_top_left_corner_items()
to clear the blue backgrounds, so that will happen more explicitly.

And then I restored a line of code to pm_list.js that puts the
blue in place when you are in an is:private narrow (vs. a
specific PM narrow).