### PR TITLE
docs: Fix markup

### DIFF
--- a/docs/full-text-search.md
+++ b/docs/full-text-search.md
@@ -52,7 +52,7 @@ The following processes should be executed as the root user. Run:
 This section describes how to enable using PGroonga to back the
 full-text search feature.
 
-* To install PGroonga, add `pgroonga = enabled` in the `[machine]`
+To install PGroonga, add `pgroonga = enabled` in the `[machine]`
 section in `/etc/zulip/zulip.conf`:
 
     [machine]


### PR DESCRIPTION
We can confirm that the current markup is broken at http://zulip.readthedocs.io/en/latest/full-text-search.html#how-to-enable-full-text-search-across-all-languages .