### PR TITLE
Update webhook doc

### DIFF
--- a/docs/webhook-walkthrough.md
+++ b/docs/webhook-walkthrough.md
@@ -37,8 +37,10 @@ only one fixture, `zerver/fixtures/helloworld/helloworld_hello.json`:
 
 When writing your own webhook integration, you'll want to write a test function
 for each distinct message condition your webhook supports. You'll also need a
-corresponding fixture for each of these tests. See [Step 3: Create
-tests](#step-4-create-tests) or [Testing](testing.html) for further details.
+corresponding fixture for each of these tests. Depending on the type of data
+the 3rd party service sends, your fixture may contain JSON, URL encoded text, or
+some other kind of data. See [Step 4: Create tests](#step-4-create-tests) or
+[Testing](testing.html) for further details.
 
 ## Step 1: Initialize your webhook python package
 
@@ -97,12 +99,20 @@ def api_helloworld_webhook(request, user_profile, client,
 
 The above code imports the required functions and defines the main webhook
 function `api_helloworld_webhook`, decorating it with `api_key_only_webhook_view` and
-`has_request_variables`.
+`has_request_variables`. The `has_request_variables` decorator allows you to
+access request variables with `REQ()`. You can find more about `REQ` and request
+variables in [Writing views](writing-views.html#request-variables).
 
 You must pass the name of your webhook to the `api_key_only_webhook_view`
-decorator. Here we have used `HelloWorld`. To be consistent with Zulip code
+decorator so your webhook can access the `user_profile` and `client` fields
+from the request. Here we have used `HelloWorld`. To be consistent with Zulip code
 style, use the name of the product you are integrating in camel case, spelled
 as the product spells its own name (except always first letter upper-case).
+
+The `api_key_only_webhook_view` decorator indicates that the 3rd party service will
+send the authorization as an API key in the query parameters. If your service uses
+HTTP Basic authentication, you would instead use the `authenticated_rest_api_view`
+decorator.
 
 You should name your webhook function as such `api_webhookname_webhook` where
 `webhookname` is the name of your webhook and is always lower-case.
@@ -116,7 +126,9 @@ of UserAgent). You may also want to define additional parameters using the
 In the example above, we have defined `payload` which is populated
 from the body of the http request, `stream` with a default of `test`
 (available by default in the Zulip development environment), and
-`topic` with a default of `Hello World`.
+`topic` with a default of `Hello World`. If your webhook uses a custom stream,
+it must exist before a message can be created in it. (See
+[Step 4: Create tests](#step-4-create-tests) for how to handle this in tests.)
 
 The line that begins `# type` is a mypy type annotation. See [this
 page](mypy.html) for details about how to properly annotate your webhook
@@ -204,7 +216,7 @@ Using either method will create a message in Zulip:
 Every webhook integration should have a corresponding test file:
 `zerver/webhooks/mywebhook/tests.py`.
 
-The Hello World integration's tests are in zerver/webhooks/helloworld/tests.py
+The Hello World integration's tests are in `zerver/webhooks/helloworld/tests.py`
 
 You should name the class `<WebhookName>HookTests` and have it inherit from
 the base class `WebhookTestCase`. For our HelloWorld webhook, we name the test
@@ -234,7 +246,22 @@ class HelloWorldHookTests(WebhookTestCase):
 
 In the above example, `STREAM_NAME`, `URL_TEMPLATE`, and `FIXTURE_DIR_NAME` refer
 to class attributes from the base class, `WebhookTestCase`. These are needed by
-`send_and_test_stream_message` to determine how to execute your test.
+the helper function `send_and_test_stream_message` to determine how to execute
+your test. `STREAM_NAME` should be set to your default stream. If it doesn't exist,
+`send_and_test_stream_message` will create it while executing your test.
+
+If your test expects a stream name from a test fixture, the value in the fixture
+and the value you set for `STREAM_NAME` must match. The test helpers use `STREAM_NAME`
+to create the destination stream, and then create the message to send using the
+value from the fixture. If these don't match, the test will fail.
+
+`URL_TEMPLATE` defines how the test runner will call your webhook, in the same way
+ you would provide a webhook URL to the 3rd party service. `api_key={api_key}` says
+that an API key is expected.
+
+In `get_body`, the first argument in the call to `self.fixture_data` specifies the
+prefix of your fixture file names, and `file_type` their type. Common types are
+`json` and `txt`.
 
 When writing tests for your webhook, you'll want to include one test function
 (and corresponding fixture) per each distinct message condition that your
@@ -264,6 +291,12 @@ As well as a new fixture `helloworld_goodbye.json` in
   "featured_url":"https://en.wikipedia.org/wiki/Goodbye",
 }
 ```
+
+Also consider if your integration should have negative tests, a test where the
+data from the test fixture should result in an error. You may need to explicitly
+set up a negative test's actions and success condition rather than using a
+helper function like `send_and_test_stream_message`. You can find an example
+of this in the tests for the WordPress webhook integration.
 
 Once you have written some tests, you can run just these new tests from within
 the Zulip development environment with this command:
@@ -306,38 +339,39 @@ Second, you need to write the actual documentation content in
 ```
 <p>Learn how Zulip integrations work with this simple Hello World example!</p>
 
-<p>The Hello World webhook will use the <code>test<code> stream, which is
-created by default in the Zulip development environment. If you are running
-Zulip in production, you should make sure this stream exists.</p>
-
-<p>Next, on your <a href="/#settings" target="_blank">Zulip
-settings page</a>, create a Hello World bot.  Construct the URL for
-the Hello World bot using the API key and stream name:
-  <code>{{ external_api_uri }}/v1/external/helloworld?api_key=abcdefgh&amp;stream=test</code>
+<p>
+    The Hello World webhook will use the <code>test</code> stream, which is
+    created by default in the Zulip dev environment. If you are running
+    Zulip in production, you should make sure this stream exists.
 </p>
 
-<p>To trigger a notication using this webhook, use `send_webhook_fixture_message` from the Zulip command line:</p>
+<p>
+    Next, on your {{ settings_html|safe }}, create a Hello World bot. Construct the
+    URL for the Hello World bot using the API key and stream name:
+    <code>{{ external_api_uri_subdomain }}/v1/external/helloworld?api_key=abcdefgh&amp;stream=test</code>
+</p>
+
+<p>
+    To trigger a notication using this webhook, use `send_webhook_fixture_message`
+    from the Zulip command line:
+</p>
 <div class="codehilite">
-  <pre>(zulip-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$
+      <pre>(zulip-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$
 ./manage.py send_webhook_fixture_message \
 > --fixture=zerver/fixtures/helloworld/helloworld_hello.json \
-> '--url=http://localhost:9991/api/v1/external/helloworld?api_key=<api_key>'</pre>
+> '--url=http://localhost:9991/api/v1/external/helloworld?api_key=&lt;api_key&gt;'
+      </pre>
 </div>
 
 <p>Or, use curl:</p>
 <div class="codehilite">
-  <pre>curl -X POST -H "Content-Type: application/json" -d '{ "featured_title":"Marilyn Monroe", "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe" }' http://localhost:9991/api/v1/external/helloworld\?api_key\=<api_key></pre>
+    <pre>curl -X POST -H "Content-Type: application/json" -d '{ "featured_title":"Marilyn Monroe", "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe" }' http://localhost:9991/api/v1/external/helloworld\?api_key\=&lt;api_key&gt;</pre>
 </div>
 
-<p><b>Congratulations! You're done!</b><br /> Your messages may look like:</p>
+<p><b>Congratulations! You're done!</b><br/> Your messages may look like:</p>
 
-<img class="screenshot" src="/static/images/integrations/helloworld/001.png" />
+<img class="screenshot" src="/static/images/integrations/helloworld/001.png"/>
 ```
-
-These documentation blocks should fall alphabetically. For the
-`integration-lozenge` div this happens automatically when the html is
-generated. For the `integration-instructions` div, we have added the div
-between the blocks for GitHub and Hubot, respectively.
 
 See [Documenting your integration](integration-guide.html#documenting-your-integration) for further
 details, including how to easily create the message screenshot.
@@ -349,7 +383,7 @@ available in the Zulip product, follow these steps to prepare your pull
 request:
 
 1. Run tests including linters and ensure you have addressed any issues they
-   report. See [Testing](testing.html) for details.
+   report. See [Testing](testing.html) and [Linters](linters.html) for details.
 2. Read through [Code styles and conventions](code-style.html) and take a look
    through your code to double-check that you've followed Zulip's guidelines.
 3. Take a look at your git history to ensure your commits have been clear and
@@ -360,5 +394,9 @@ request:
 4. Push code to your fork.
 5. Submit a pull request to zulip/zulip.
 
-If you would like feedback on your integration as you go, feel free to submit
-pull requests as you go, prefixing them with `[WIP]`.
+If you would like feedback on your integration as you go, feel free to post a
+message on the [public Zulip instance](https://chat.zulip.org/#narrow/stream/bots).
+You can also create a [`[WIP]` pull request](readme-symlink.html#ways-to-contribute)
+while you are still working on your integration. See the
+[Git guide](git-guide.html#create-a-pull-request) for more on Zulip's pull
+request process.

--- a/docs/webhook-walkthrough.md
+++ b/docs/webhook-walkthrough.md
@@ -293,10 +293,8 @@ As well as a new fixture `helloworld_goodbye.json` in
 ```
 
 Also consider if your integration should have negative tests, a test where the
-data from the test fixture should result in an error. You may need to explicitly
-set up a negative test's actions and success condition rather than using a
-helper function like `send_and_test_stream_message`. You can find an example
-of this in the tests for the WordPress webhook integration.
+data from the test fixture should result in an error. For details see
+[Negative tests](#negative-tests), below.
 
 Once you have written some tests, you can run just these new tests from within
 the Zulip development environment with this command:
@@ -400,3 +398,116 @@ You can also create a [`[WIP]` pull request](readme-symlink.html#ways-to-contrib
 while you are still working on your integration. See the
 [Git guide](git-guide.html#create-a-pull-request) for more on Zulip's pull
 request process.
+
+## Advanced topics
+
+More complex implementation or testing needs may require additional code, beyond
+what the standard helper functions provide. This section discusses some of
+these situations.
+
+### Negative tests
+
+A negative test is one that should result in an error, such as incorrect data.
+The helper functions may interpret this as a test failure, when it should instead
+be a successful test of an error condition. To correctly test these cases, you
+must explicitly code your test's execution (using other helpers, as needed)
+rather than call the usual helper function.
+
+Here is an example from the WordPress webhook:
+```
+def test_unknown_action_no_data(self):
+    # type: () -> None
+
+    # Mimic send_and_test_stream_message() to manually execute a negative test.
+    # Otherwise its call to send_json_payload() would assert on the non-success
+    # we are testing. The value of result is the error message the webhook should
+    # return if no params are sent. The fixture for this test is an empty file.
+
+    # subscribe to the target stream
+    self.subscribe_to_stream(self.TEST_USER_EMAIL, self.STREAM_NAME)
+
+    # post to the webhook url
+    post_params = {'stream_name': self.STREAM_NAME,
+                   'content_type': 'application/x-www-form-urlencoded'}
+    result = self.client_post(self.url, 'unknown_action', **post_params)
+
+    # check that we got the expected error message
+    self.assert_json_error(result, "Unknown WordPress webhook action: WordPress Action")
+```
+In a normal test, `send_and_test_stream_message` would handle all the setup
+and then check that the webhook's response matches the expected result. If
+the webhook returns an error, the test fails. Instead, explicitly do the
+setup it would have done, and check the result yourself.
+
+Here, `subscribe_to_stream` is a test helper that uses `TEST_USER_EMAIL` and
+`STREAM_NAME` (attributes from the base class) to register the user to receive
+messages in the given stream. If the stream doesn't exist, it creates it.
+
+`client_post`, another helper, performs the HTTP POST that calls the webhook.
+As long as `self.url` is correct, you don't need to construct the webhook
+URL yourself. (In most cases, it is.)
+
+`assert_json_error` then checks if the result matches the expected error.
+If you had used `send_and_test_stream_message`, it would have called
+`send_json_payload`, which checks the result with `assert_json_success`.
+
+### Custom query parameters
+
+Custom arguments passed in URL query parameters work as expected in the webhook
+code, but require special handling in tests.
+
+For example, here is the definition of a webhook function that gets both `stream`
+and `topic` from the query parameters:
+```
+def api_querytest_webhook(request, user_profile, client,
+                          payload=REQ(argument_type='body'), stream=REQ(default='test'),
+                          topic=REQ(default='Default Alert')):
+```
+In actual use, you might configure the 3rd party service to call your Zulip
+integration with a URL like this:
+```
+http://myhost/api/v1/external/querytest?api_key=abcdefgh&stream=alerts&topic=queries
+```
+It provides values for `stream` and `topic`, and the webhook can get those
+using `REQ` without any special handling. How does this work in a test?
+
+The new attribute `TOPIC` exists only in our class, so the default version of
+`build_webhook_url` from `WebhookTestCase` doesn't know how to use it to
+construct the URL. Instead, we provide a custom `build_webhook_url` to
+override the default one:
+```
+class QuerytestHookTests(WebhookTestCase):
+
+    STREAM_NAME = 'querytest'
+    TOPIC = "Default Topic"
+    URL_TEMPLATE = "/api/v1/external/querytest?api_key={api_key}&stream={stream}&topic={topic}"
+    FIXTURE_DIR_NAME = 'querytest'
+
+    # override the base class behavior so we can include TOPIC
+    def build_webhook_url(self):
+        # type: () -> Text
+
+        api_key = self.get_api_key(self.TEST_USER_EMAIL)
+        return self.URL_TEMPLATE.format(stream=self.STREAM_NAME, api_key=api_key, topic=self.TOPIC)
+
+    def test_querytest_test_one(self):
+        # type: () -> None
+
+        # construct the URL used for this test
+        self.TOPIC = u"Query Test"
+        self.url = self.build_webhook_url()
+
+        # define the expected message contents
+        expected_subject = u"Query Test"
+        expected_message = u"This is a test of custom query parameters."
+
+        self.send_and_test_stream_message('test_one', expected_subject, expected_message,
+                                          content_type="application/x-www-form-urlencoded")
+
+    def get_body(self, fixture_name):
+        # type: (Text) -> Text
+        return self.fixture_data("querytest", fixture_name, file_type="json")
+```
+You can also override `get_body` if your test data needs to be constructed in
+an unusual way. For more, see the definition for the base class, `WebhookTestCase`
+in `zerver/lib/test_classes.py.`


### PR DESCRIPTION
Now that the Hello World example is broken out of the integration guide into its own page (https://github.com/zulip/zulip/pull/3599), I'm adding the content I originally planned for a different new page (https://github.com/zulip/zulip/issues/3478) into this one. 

