### PR TITLE
Added MacOSX keyboard shortcuts in shortcuts document

### DIFF
--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -1,6 +1,6 @@
 # Keyboard shortcuts
 
-tKeyboard shortcuts allow a user to use Zulip easily and efficiently
+Keyboard shortcuts allow a user to use Zulip easily and efficiently
 for a better user experience.
 
 Zulip keyboard shortcuts are divided into four categories:
@@ -40,14 +40,14 @@ Note: Keyboard shortcuts for MacOSX have been enclosed in paranthesis
 * **Reply to author** `R` - This shortcut allows the user to begin
   writing a private message to the author of the selected message
   (outlined in blue).
-* **Reply to message mentioning the author** `Enter` `@` (`Ret` `@`) - This
+* **Reply to message mentioning the author** `Enter` `@` (`Return` `@`) - This
   shortcut allows the user to begin replying to the selected message
   (outlined in blue), @-mentioning the author of the selected message.
 * **New stream message** `c` - This shortcut allows the user to begin
   composing a new stream message.
 * **New private message** `C` - This shortcut allows the user to begin
   composing a new private message.
-* **Send message** `Tab key` then `Enter` - This shortcut allows the
+* **Send message** `Tab key` then `Enter` (`Tab key` then `Return`) - This shortcut allows the
   user to send the message that they've written.
 * **Cancel compose** `Esc` - This shortcut allows the user to cancel
   and discard their unsent message.
@@ -74,7 +74,7 @@ Note: Keyboard shortcuts for MacOSX have been enclosed in paranthesis
 * **Open message actions menu** `i` - This shortcut shows the
   available message actions of the selected message (outlined in
   blue).
-* **Edit a message you sent** `i` then `Enter` - This shortcut allows
+* **Edit a message you sent** `i` then `Enter` (`i` then `Return`) - This shortcut allows
   the user to edit the selected message (outlined in blue) if the user
   authored the selected message. If the selected message was written
   by another user, this shortcut will enable the user to view the

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -1,6 +1,6 @@
 # Keyboard shortcuts
 
-Keyboard shortcuts allow a user to use Zulip easily and efficiently
+tKeyboard shortcuts allow a user to use Zulip easily and efficiently
 for a better user experience.
 
 Zulip keyboard shortcuts are divided into four categories:
@@ -8,6 +8,8 @@ Zulip keyboard shortcuts are divided into four categories:
 * [Composing messages](#composing-messages)
 * [Narrowing](#narrowing)
 * [Menus](#menus)
+
+Note: Keyboard shortcuts for MacOSX have been enclosed in paranthesis
 
 ## Navigation
 
@@ -25,20 +27,20 @@ Zulip keyboard shortcuts are divided into four categories:
   to scroll up to the previous message in their view.
 * **Next message** `j` `Down arrow` - This shortcut allows the user to
   scroll down to the next message in their view.
-* **Scroll up** `K` `PgUp` - This shortcut allows the user to scroll
+* **Scroll up** `K` `PgUp` (`K` `Fn` `Up arrow`) - This shortcut allows the user to scroll
   up through the messages in their view.
-* **Scroll down** `J` `PgDn` `Spacebar` - This shortcut allows the
+* **Scroll down** `J` `PgDn` `Spacebar` (`J` `Fn` `Down arrow` `Spacebar`) - This shortcut allows the
   user to scroll down through the messages in their view.
-* **Last message** `End` - This shortcut allows the user to scroll to
+* **Last message** `End` (`Fn` `Right arrow`) - This shortcut allows the user to scroll to
   the most recent message in their view.
 
 ## Composing messages
-* **Reply to message** `Enter` `r` - This shortcut allows the user to
+* **Reply to message** `Enter` `r` (`Return` `r`) - This shortcut allows the user to
   begin replying to the selected message (outlined in blue).
 * **Reply to author** `R` - This shortcut allows the user to begin
   writing a private message to the author of the selected message
   (outlined in blue).
-* **Reply to message mentioning the author** `Enter` `@` - This
+* **Reply to message mentioning the author** `Enter` `@` (`Ret` `@`) - This
   shortcut allows the user to begin replying to the selected message
   (outlined in blue), @-mentioning the author of the selected message.
 * **New stream message** `c` - This shortcut allows the user to begin

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -9,7 +9,8 @@ Zulip keyboard shortcuts are divided into four categories:
 * [Narrowing](#narrowing)
 * [Menus](#menus)
 
-Note: Keyboard shortcuts for MacOSX have been enclosed in paranthesis
+!!! warn ""
+    Note: Keyboard shortcuts for Mac OS X have been enclosed in parenthesis.
 
 ## Navigation
 

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -27,11 +27,11 @@ Note: Keyboard shortcuts for MacOSX have been enclosed in paranthesis
   to scroll up to the previous message in their view.
 * **Next message** `j` `Down arrow` - This shortcut allows the user to
   scroll down to the next message in their view.
-* **Scroll up** `K` `PgUp` (`K` `Fn` `Up arrow`) - This shortcut allows the user to scroll
+* **Scroll up** `K` `PgUp` (`K`,`Fn`+`Up arrow`) - This shortcut allows the user to scroll
   up through the messages in their view.
-* **Scroll down** `J` `PgDn` `Spacebar` (`J` `Fn` `Down arrow` `Spacebar`) - This shortcut allows the
+* **Scroll down** `J` `PgDn` `Spacebar` (`J`,`Fn`+`Down arrow`,`Spacebar`) - This shortcut allows the
   user to scroll down through the messages in their view.
-* **Last message** `End` (`Fn` `Right arrow`) - This shortcut allows the user to scroll to
+* **Last message** `End` (`Fn`+`Right arrow`) - This shortcut allows the user to scroll to
   the most recent message in their view.
 
 ## Composing messages


### PR DESCRIPTION
Keyboards shortcuts for MacOSX have been added to the keyboard-shortcuts.md. The shortcuts have been placed inside parenthesis.