### PR TITLE
Fix information overlay issues.

### DIFF
--- a/static/js/components.js
+++ b/static/js/components.js
@@ -42,22 +42,21 @@ exports.toggle = (function () {
         // store once a copy of the tabs inside the parent in a jQuery object/array.
         var meta = {
             $ind_tab: component.find(".ind-tab"),
+            last_value: null,
         };
 
         (function () {
-            var last_value = null;
-            meta.$ind_tab.each(function () {
-                $(this).click(function () {
-                    meta.$ind_tab.removeClass("selected");
-                    $(this).addClass("selected");
-                    if (opts.callback) {
-                        var id = +$(this).data("tab-id");
-                        if (last_value !== opts.values[id].label) {
-                            last_value = opts.values[id].label;
-                            opts.callback(last_value, opts.values[id].key);
-                        }
+            meta.$ind_tab.click(function () {
+                meta.$ind_tab.removeClass("selected");
+                $(this).addClass("selected");
+                if (opts.callback) {
+                    var id = +$(this).data("tab-id");
+
+                    if (meta.last_value !== opts.values[id].label) {
+                        meta.last_value = opts.values[id].label;
+                        opts.callback(meta.last_value, opts.values[id].key);
                     }
-                });
+                }
             });
             if (typeof opts.selected === "number") {
                 $(component).find(".ind-tab[data-tab-id='" + opts.selected + "']").click();
@@ -86,11 +85,13 @@ exports.toggle = (function () {
 
                 var idx = opts.values.indexOf(value);
 
-                if (idx !== -1) {
+                if (idx !== -1 && idx !== meta.last_value) {
                     meta.$ind_tab.removeClass("selected");
                     meta.$ind_tab.filter("[data-tab-id='" + idx + "']").addClass("selected");
 
                     opts.callback(value.label, value.key);
+
+                    meta.last_value = idx;
                 }
             },
         };

--- a/static/styles/informational-overlays.css
+++ b/static/styles/informational-overlays.css
@@ -22,7 +22,7 @@
 .informational-overlays .overlay-content {
     /* because zoom breaks at 525px perhaps due to rounding errors, so add a
        trivial amount of width so it doesn't break. */
-    width: 525.03px;
+    width: 550px;
     margin: 0 auto;
     position: relative;
     top: calc((30vh - 50px) / 2);
@@ -72,4 +72,5 @@
 /* Hack to fix scrollbars on Linux */
 .informational-overlays #keyboard-shortcuts .modal-body {
     overflow-y: hidden;
+    text-align: center;
 }


### PR DESCRIPTION
There is a particular case in which when a user clicks on a tab, then
uses the goto method to go to another, and then clicks on the original
tab again, it will not load the original tab. This is due to the fact
that the goto function that is used to navigate to a tab without
clicking does not set the last_value, therefore leaving a state that is
incorrect and denying a view update in the case that a user performs
the following:

Click B -> Goto A -> Click B

In this case, it saves the last_value as “B” and so when a user clicks
back on “B” it does not trigger any change as it thinks the user is
going from “B” to “B”.

This also fixes the design issues from scrollbars pushing inline-block elements to the next line.