### PR TITLE
Fix enter key behavior to send message in preview mode.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -651,6 +651,20 @@ exports.respond_to_message = function (opts) {
     } else {
         msg_type = message.type;
     }
+    // for sending message from preview on clicking enter, if the checkbox is checked.
+    if ($("#new_message_content")[0].style.display === "none") {
+        $("#new_message_content").show();
+        $("#undo_markdown_preview").hide();
+        $("#preview_message_area").hide();
+        $("#markdown_preview").show();
+        // if the checkbox is not checked, option to edit the message will be enabled.
+        if ($("#enter_sends").is(":checked")) {
+            send_message();
+        } else {
+            $("#new_message_content").focus();
+        }
+        return true;
+    }
     compose.start(msg_type, {stream: stream, subject: subject,
                              private_message_recipient: pm_recipient,
                              replying_to_message: message,


### PR DESCRIPTION
Now messages can be sent directly from message preview on clicking enter, in case the respective checkbox is clicked. In case user has not chosen that clicking enter should send messages, then message editing will resume and message preview will be disabled.

Fixes #3489 