### PR TITLE
missed-emails-sending: Move email sending to separate queue worker.

### DIFF
--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -42,6 +42,7 @@ class zulip::base {
              'error_reports',
              'feedback_messages',
              'invites',
+             'missedmessage_email_senders',
              'missedmessage_emails',
              'missedmessage_mobile_notifications',
              'signups',

--- a/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
+++ b/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
@@ -521,6 +521,15 @@ define service {
 
 define service {
         use                             generic-service
+        service_description             Check missedmessage_email_senders queue processor
+        check_command                   check_remote_arg_string!manage.py process_queue --queue_name=missedmessage_email_senders!1:1!1:1
+        max_check_attempts              3
+        hostgroup_name                  frontends
+        contact_groups                  admins
+}
+
+define service {
+        use                             generic-service
         service_description             Check slow_queries queue processor
         check_command                   check_remote_arg_string!manage.py process_queue --queue_name=slow_queries!1:1!1:1
         max_check_attempts              3

--- a/tools/test-queue-worker-reload
+++ b/tools/test-queue-worker-reload
@@ -30,6 +30,7 @@ successful_worker_launches = [
     'launching queue worker thread test',
     'launching queue worker thread message_sender',
     'launching queue worker thread missedmessage_emails',
+    'launching queue worker thread missedmessage_email_senders',
     'launching queue worker thread email_mirror',
     'launching queue worker thread user_activity_interval',
     'launching queue worker thread invites',

--- a/tools/travis/production-helper
+++ b/tools/travis/production-helper
@@ -87,7 +87,7 @@ fi
 echo; echo "Now confirming all the RabbitMQ queue processors are correctly registered!"; echo
 # These hacky shell scripts just extract the sorted list of queue processors, running and expected
 supervisorctl status | cut -f1 -dR | cut -f2- -d: | grep events | cut -f1 -d" " | cut -f3- -d_ | cut -f1 -d- | sort -u > /tmp/running_queue_processors.txt
-su zulip -c /home/zulip/deployments/current/scripts/lib/queue_workers.py | grep -v ^test$ > /tmp/expected_queue_processors.txt
+su zulip -c /home/zulip/deployments/current/scripts/lib/queue_workers.py | grep -v ^test$ | sort -u > /tmp/expected_queue_processors.txt
 if ! diff /tmp/expected_queue_processors.txt /tmp/running_queue_processors.txt >/dev/null; then
     set +x
     echo "FAILURE: Runnable queue processors declared in zerver/worker/queue_processors.py "

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1083,7 +1083,7 @@ def pre_save_message(sender, **kwargs):
         message.update_calculated_fields()
 
 def get_context_for_message(message):
-    # type: (Message) -> Sequence[Message]
+    # type: (Message) -> QuerySet[Message]
     # TODO: Change return type to QuerySet[Message]
     return Message.objects.filter(
         recipient_id=message.recipient_id,

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -2,7 +2,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, TypeVar, Text
+from typing import (Any, Callable, Dict, Iterable, List, Mapping,
+                    Optional, Tuple, TypeVar, Text, Union)
 from mock import patch, MagicMock
 
 from django.http import HttpResponse
@@ -23,7 +24,7 @@ from zerver.forms import WRONG_SUBDOMAIN_ERROR
 from zerver.models import UserProfile, Recipient, \
     Realm, RealmAlias, UserActivity, \
     get_user_profile_by_email, get_realm, get_client, get_stream, \
-    Message, get_unique_open_realm, completely_open
+    Message, get_unique_open_realm, completely_open, get_context_for_message
 
 from zerver.lib.avatar import avatar_url
 from zerver.lib.initial_password import initial_password
@@ -33,7 +34,8 @@ from zerver.lib.actions import \
     do_change_is_admin, extract_recipients, \
     do_set_realm_name, do_deactivate_realm, \
     do_change_stream_invite_only
-from zerver.lib.notifications import handle_missedmessage_emails
+from zerver.lib.notifications import handle_missedmessage_emails, \
+    send_missedmessage_email
 from zerver.lib.session_user import get_session_dict_user
 from zerver.middleware import is_slow_query
 from zerver.lib.utils import split_by
@@ -2330,9 +2332,8 @@ class TestMissedMessages(ZulipTestCase):
         othello = get_user_profile_by_email('othello@zulip.com')
         hamlet = get_user_profile_by_email('hamlet@zulip.com')
         handle_missedmessage_emails(hamlet.id, [{'message_id': msg_id}])
-
-        msg = mail.outbox[0]
         reply_to_addresses = [settings.EMAIL_GATEWAY_PATTERN % (u'mm' + t) for t in tokens]
+        msg = mail.outbox[0]
         sender = 'Zulip <{}>'.format(settings.NOREPLY_EMAIL_ADDRESS)
         from_email = sender
         self.assertEqual(len(mail.outbox), 1)

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -13,7 +13,8 @@ from zerver.lib.error_notify import do_report_error
 from zerver.lib.queue import SimpleQueueClient, queue_json_publish
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.notifications import handle_missedmessage_emails, enqueue_welcome_emails, \
-    clear_followup_emails_queue, send_local_email_template_with_delay
+    clear_followup_emails_queue, send_local_email_template_with_delay, \
+    send_missedmessage_email
 from zerver.lib.push_notifications import handle_push_notification
 from zerver.lib.actions import do_send_confirmation_email, \
     do_update_user_activity, do_update_user_activity_interval, do_update_user_presence, \
@@ -217,6 +218,12 @@ class MissedMessageWorker(QueueProcessingWorker):
             # Aggregate all messages received every 2 minutes to let someone finish sending a batch
             # of messages
             time.sleep(2 * 60)
+
+@assign_queue('missedmessage_email_senders')
+class MissedMessageSendingWorker(QueueProcessingWorker):
+    def consume(self, data):
+        # type: (Mapping[str, Any]) -> None
+        send_missedmessage_email(data)
 
 @assign_queue('missedmessage_mobile_notifications')
 class PushNotificationsWorker(QueueProcessingWorker):


### PR DESCRIPTION
- Add new 'missedmessage_email_senders' queue for sending missed messages emails.
- Add the new worker to process 'missedmessage_email_senders' queue.
- Split aggregation missed messages and sending missed messages email
  to separate queue workers.
- Adapt tests for sending missed emails to the new logic.

Fixes #2607