### PR TITLE
Fix errors on stream rename to existing stream.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -477,6 +477,7 @@ $(function () {
             var edit_area = $(this).parent().find(selector);
             if (edit_area.attr("contenteditable") === "true") {
                 $("[data-finish-editing='" + selector + "']").hide();
+                $(".name-change-error").hide();
                 edit_area.attr("contenteditable", false);
                 edit_area.text(edit_area.attr("data-prev-text"));
                 $(this).html("");

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -909,11 +909,13 @@ exports.change_stream_description = function (e) {
 exports.change_stream_name = function (e) {
     e.preventDefault();
     var sub_settings = $(e.target).closest('.subscription_settings');
+    var name_div = $(e.target).closest('.stream-name');
     var stream_id = $(e.target).closest(".subscription_settings").attr("data-stream-id");
     var new_name_box = sub_settings.find('.stream-name-editable');
     var new_name = $.trim(new_name_box.text());
 
     $("#subscriptions-status").hide();
+    $("#name_change_error_" + stream_id).hide();
 
     channel.patch({
         // Stream names might contain unsafe characters so we must encode it first.
@@ -927,6 +929,12 @@ exports.change_stream_name = function (e) {
         error: function (xhr) {
             ui.report_error(i18n.t("Error renaming stream"), xhr,
                             $("#subscriptions-status"), 'subscriptions-status');
+            new_name_box.attr("contenteditable", "true").focus();
+            name_div.find(".checkmark").show();
+            name_div.find(".editable").text("×");
+            ui.report_error(i18n.t("Error renaming stream"), xhr,
+                            $("#name_change_error_" + stream_id));
+            $("#name_change_error_" + stream_id).show();
         },
     });
 };

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -265,6 +265,13 @@ form#add_new_subscription {
     color: #FF0000;
 }
 
+.name-change-error {
+    display: none;
+    margin-left: 2px;
+    color: #FF0000;
+    font-size: 12px;
+}
+
 .sub_settings_title {
     line-height: 30px;
     margin: 10px 0;

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -14,6 +14,7 @@
       {{#if is_admin}}
         <span class="editable" data-make-editable=".stream-name-editable"></span>
         <span class="checkmark" data-finish-editing=".stream-name-editable">✓</span>
+        <div id="name_change_error_{{stream_id}}" class="name-change-error"></div>
       {{/if}}
     </div>
     <button class="button small white rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button">


### PR DESCRIPTION
Now, when a stream is renamed, we check if the new name has already been taken up by any of the existing streams. If the name has been taken up, appropriate error message is shown upon rename action.

Fixes #3662 