### PR TITLE
Clarify the install process's use of the root and zulip users.

### DIFF
--- a/docs/prod-install.md
+++ b/docs/prod-install.md
@@ -50,7 +50,7 @@ Then, run the Zulip install script:
 ```
 
 This may take a while to run, since it will install a large number of
-dependencies.
+dependencies. It also creates a user `zulip` for you.
 
 The Zulip install script is designed to be idempotent, so if it fails,
 you can just rerun it after correcting the issue that caused it to
@@ -92,8 +92,9 @@ These settings include:
 
 ## Step 4: Initialize Zulip database
 
-At this point, you are done doing things as root.  To initialize the
-Zulip database for your production install, run:
+At this point, you are done doing things as root. The remaining commands
+are run as user `zulip` using `su zulip`. To initialize the Zulip database
+for your production install, run:
 
 ```
 su zulip -c /home/zulip/deployments/current/scripts/setup/initialize-database


### PR DESCRIPTION
I ran into this, and noticed someone else had a similar confusion. Explicitly mentioning the zulip user should make it easier.

https://chat.zulip.org/#narrow/near/144527/stream/production.20help/topic/New.20Installation

Fixes #3680 