### PR TITLE
Remove "prefer spread" option in ESLint.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -135,7 +135,6 @@
         "no-new-func": "error",
         "space-before-function-paren": ["error", { "anonymous": "always", "named": "never", "asyncArrow": "always" }],
         "no-param-reassign": 0,
-        "prefer-spread": "error",
         "arrow-spacing": ["error", { "before": true, "after": true }],
         "no-alert": 2,
         "no-array-constructor": 2,


### PR DESCRIPTION
This removes the “prefer spread” option which prefers
the (…args) syntax over using Array.prototype.apply. This
however is part of ES6 syntax and is incompatible with
IE*, Opera*, < Safari 8; and old Chrome, FF versions.