### PR TITLE
Fix test_valid_api_key_if_user_is_on_wrong_subdomain.

### DIFF
--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -734,27 +734,28 @@ class TestValidateApiKey(ZulipTestCase):
     def test_valid_api_key_if_user_is_on_wrong_subdomain(self):
         # type: () -> None
         with self.settings(REALMS_HAVE_SUBDOMAINS=True):
-            with mock.patch('logging.warning') as mock_warning:
-                with self.assertRaisesRegex(JsonableError,
-                                            "Account is not associated with this subdomain"):
-                    validate_api_key(HostRequestMock(host=settings.EXTERNAL_HOST),
-                                     self.default_bot.email,
-                                     self.default_bot.api_key)
+            with self.settings(RUNNING_INSIDE_TORNADO=False):
+                with mock.patch('logging.warning') as mock_warning:
+                    with self.assertRaisesRegex(JsonableError,
+                                                "Account is not associated with this subdomain"):
+                        validate_api_key(HostRequestMock(host=settings.EXTERNAL_HOST),
+                                         self.default_bot.email,
+                                         self.default_bot.api_key)
 
-                mock_warning.assert_called_with(
-                    "User {} attempted to access API on wrong "
-                    "subdomain {}".format(self.default_bot.email, ''))
+                    mock_warning.assert_called_with(
+                        "User {} attempted to access API on wrong "
+                        "subdomain {}".format(self.default_bot.email, ''))
 
-            with mock.patch('logging.warning') as mock_warning:
-                with self.assertRaisesRegex(JsonableError,
-                                            "Account is not associated with this subdomain"):
-                    validate_api_key(HostRequestMock(host='acme.' + settings.EXTERNAL_HOST),
-                                     self.default_bot.email,
-                                     self.default_bot.api_key)
+                with mock.patch('logging.warning') as mock_warning:
+                    with self.assertRaisesRegex(JsonableError,
+                                                "Account is not associated with this subdomain"):
+                        validate_api_key(HostRequestMock(host='acme.' + settings.EXTERNAL_HOST),
+                                         self.default_bot.email,
+                                         self.default_bot.api_key)
 
-                mock_warning.assert_called_with(
-                    "User {} attempted to access API on wrong "
-                    "subdomain {}".format(self.default_bot.email, 'acme'))
+                    mock_warning.assert_called_with(
+                        "User {} attempted to access API on wrong "
+                        "subdomain {}".format(self.default_bot.email, 'acme'))
 
     def _change_is_active_field(self, profile, value):
         # type: (UserProfile, bool) -> None


### PR DESCRIPTION
This test would fail if settings.RUNNING_INSIDE_TORNADO
was True, which seemed to happen due to other tests changing
that setting, although I did not fully investigate.