### PR TITLE
Use user_id in admin_user_list.handlebars.

### DIFF
--- a/frontend_tests/casper_tests/13-user-deactivation.js
+++ b/frontend_tests/casper_tests/13-user-deactivation.js
@@ -18,9 +18,9 @@ casper.then(function () {
 
 // Test user deactivation and reactivation
 casper.then(function () {
-    casper.waitUntilVisible('.user_row[id="user_cordelia@zulip.com"]', function () {
-        casper.test.assertSelectorHasText('.user_row[id="user_cordelia@zulip.com"]', 'Deactivate');
-        casper.click('.user_row[id="user_cordelia@zulip.com"] .deactivate');
+    casper.waitUntilVisible('.user_row[data-email="cordelia@zulip.com"]', function () {
+        casper.test.assertSelectorHasText('.user_row[data-email="cordelia@zulip.com"]', 'Deactivate');
+        casper.click('.user_row[data-email="cordelia@zulip.com"] .deactivate');
         casper.test.assertTextExists('Deactivate cordelia@zulip.com', 'Deactivate modal has right user');
         casper.test.assertTextExists('Deactivate now', 'Deactivate now button available');
         casper.click('#do_deactivate_user_button');
@@ -28,23 +28,23 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.user_row[id="user_cordelia@zulip.com"].deactivated_user', function () {
-        casper.test.assertSelectorHasText('.user_row[id="user_cordelia@zulip.com"]', 'Reactivate');
-        casper.click('.user_row[id="user_cordelia@zulip.com"] .reactivate');
+    casper.waitUntilVisible('.user_row[data-email="cordelia@zulip.com"].deactivated_user', function () {
+        casper.test.assertSelectorHasText('.user_row[data-email="cordelia@zulip.com"]', 'Reactivate');
+        casper.click('.user_row[data-email="cordelia@zulip.com"] .reactivate');
     });
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.user_row[id="user_cordelia@zulip.com"]:not(.deactivated_user)', function () {
-        casper.test.assertSelectorHasText('.user_row[id="user_cordelia@zulip.com"]', 'Deactivate');
+    casper.waitUntilVisible('.user_row[data-email="cordelia@zulip.com"]:not(.deactivated_user)', function () {
+        casper.test.assertSelectorHasText('.user_row[data-email="cordelia@zulip.com"]', 'Deactivate');
     });
 });
 
 casper.then(function () {
     // Test Deactivated users section of admin page
-    casper.waitUntilVisible('.user_row[id="user_cordelia@zulip.com"]', function () {
-        casper.test.assertSelectorHasText('.user_row[id="user_cordelia@zulip.com"]', 'Deactivate');
-        casper.click('.user_row[id="user_cordelia@zulip.com"] .deactivate');
+    casper.waitUntilVisible('.user_row[data-email="cordelia@zulip.com"]', function () {
+        casper.test.assertSelectorHasText('.user_row[data-email="cordelia@zulip.com"]', 'Deactivate');
+        casper.click('.user_row[data-email="cordelia@zulip.com"] .deactivate');
         casper.test.assertTextExists('Deactivate cordelia@zulip.com', 'Deactivate modal has right user');
         casper.test.assertTextExists('Deactivate now', 'Deactivate now button available');
         casper.click('#do_deactivate_user_button');
@@ -62,15 +62,15 @@ casper.then(function () {
     casper.click("li[data-section='deactivated-users-admin']");
 
 
-    casper.waitUntilVisible('#admin_deactivated_users_table .user_row[id="user_cordelia@zulip.com"] .reactivate', function () {
-        casper.test.assertSelectorHasText('#admin_deactivated_users_table .user_row[id="user_cordelia@zulip.com"]', 'Reactivate');
-        casper.click('#admin_deactivated_users_table .user_row[id="user_cordelia@zulip.com"] .reactivate');
+    casper.waitUntilVisible('#admin_deactivated_users_table .user_row[data-email="cordelia@zulip.com"] .reactivate', function () {
+        casper.test.assertSelectorHasText('#admin_deactivated_users_table .user_row[data-email="cordelia@zulip.com"]', 'Reactivate');
+        casper.click('#admin_deactivated_users_table .user_row[data-email="cordelia@zulip.com"] .reactivate');
     });
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('#admin_deactivated_users_table .user_row[id="user_cordelia@zulip.com"] button:not(.reactivate)', function () {
-        casper.test.assertSelectorHasText('#admin_deactivated_users_table .user_row[id="user_cordelia@zulip.com"]', 'Deactivate');
+    casper.waitUntilVisible('#admin_deactivated_users_table .user_row[data-email="cordelia@zulip.com"] button:not(.reactivate)', function () {
+        casper.test.assertSelectorHasText('#admin_deactivated_users_table .user_row[data-email="cordelia@zulip.com"]', 'Deactivate');
     });
 });
 
@@ -81,22 +81,22 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.user_row[id="user_new-user-bot@zulip.com"]', function () {
-        casper.test.assertSelectorHasText('.user_row[id="user_new-user-bot@zulip.com"]', 'Deactivate');
-        casper.click('.user_row[id="user_new-user-bot@zulip.com"] .deactivate');
+    casper.waitUntilVisible('.user_row[data-email="new-user-bot@zulip.com"]', function () {
+        casper.test.assertSelectorHasText('.user_row[data-email="new-user-bot@zulip.com"]', 'Deactivate');
+        casper.click('.user_row[data-email="new-user-bot@zulip.com"] .deactivate');
     });
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.user_row[id="user_new-user-bot@zulip.com"].deactivated_user', function () {
-        casper.test.assertSelectorHasText('.user_row[id="user_new-user-bot@zulip.com"]', 'Reactivate');
-        casper.click('.user_row[id="user_new-user-bot@zulip.com"] .reactivate');
+    casper.waitUntilVisible('.user_row[data-email="new-user-bot@zulip.com"].deactivated_user', function () {
+        casper.test.assertSelectorHasText('.user_row[data-email="new-user-bot@zulip.com"]', 'Reactivate');
+        casper.click('.user_row[data-email="new-user-bot@zulip.com"] .reactivate');
     });
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.user_row[id="user_new-user-bot@zulip.com"]:not(.deactivated_user)', function () {
-        casper.test.assertSelectorHasText('.user_row[id="user_new-user-bot@zulip.com"]', 'Deactivate');
+    casper.waitUntilVisible('.user_row[data-email="new-user-bot@zulip.com"]:not(.deactivated_user)', function () {
+        casper.test.assertSelectorHasText('.user_row[data-email="new-user-bot@zulip.com"]', 'Deactivate');
     });
 });
 

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -200,6 +200,7 @@ var event_fixtures = {
         op: 'update',
         bot: {
             email: 'the-bot@example.com',
+            user_id: 4321,
             full_name: 'The Bot Has A New Name',
         },
     },
@@ -546,11 +547,11 @@ run(function (override, capture, args) {
 
     event = event_fixtures.realm_bot__update;
     override('bot_data', 'update', capture(['email', 'bot']));
-    override('admin', 'update_user_full_name', capture(['update_email', 'name']));
+    override('admin', 'update_user_full_name', capture(['update_user_id', 'name']));
     dispatch(event);
     assert_same(args.email, event.bot.email);
     assert_same(args.bot, event.bot);
-    assert_same(args.update_email, event.bot.email);
+    assert_same(args.update_user_id, event.bot.user_id);
     assert_same(args.name, event.bot.full_name);
 
 });

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -17,10 +17,10 @@ exports.show_or_hide_menu_item = function () {
     }
 };
 
-function get_user_info(email) {
+function get_user_info(user_id) {
     var self = {};
-    self.user_row = $("tr[id='user_" + email + "']");
-    self.form_row = $("tr[id='user_form_" + email + "']");
+    self.user_row = $("tr.user_row[data-user-id='" + user_id + "']");
+    self.form_row = $("tr.user-name-form[data-user-id='" + user_id + "']");
 
     return self;
 }
@@ -30,12 +30,12 @@ function get_email_for_user_row(row) {
     return email;
 }
 
-exports.update_user_full_name = function (email, new_full_name) {
+exports.update_user_full_name = function (user_id, new_full_name) {
     if (!meta.loaded) {
         return;
     }
 
-    var user_info = get_user_info(email);
+    var user_info = get_user_info(user_id);
 
     var user_row = user_info.user_row;
     var form_row = user_info.form_row;
@@ -772,14 +772,20 @@ function _setup_page() {
     });
 
     $(".admin_user_table, .admin_bot_table").on("click", ".open-user-form", function (e) {
-        var email = $(e.currentTarget).data("email");
-        var user_info = get_user_info(email);
+        var user_id = $(e.currentTarget).attr("data-user-id");
+        var user_info = get_user_info(user_id);
         var user_row = user_info.user_row;
         var form_row = user_info.form_row;
         var reset_button = form_row.find(".reset_edit_user");
         var submit_button = form_row.find(".submit_name_changes");
         var full_name = form_row.find("input[name='full_name']");
         var admin_status = $('#administration-status').expectOne();
+
+        var person = people.get_person_from_user_id(user_id);
+
+        if (!person) {
+            return;
+        }
 
         // Show user form.
         user_row.hide();
@@ -794,7 +800,7 @@ function _setup_page() {
             e.preventDefault();
             e.stopPropagation();
 
-            var url = "/json/users/" + encodeURIComponent(email);
+            var url = "/json/users/" + encodeURIComponent(person.email);
             var data = {
                 full_name: JSON.stringify(full_name.val()),
             };

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -92,7 +92,7 @@ function dispatch_normal_event(event) {
             bot_data.remove(event.bot.email);
         } else if (event.op === 'update') {
             bot_data.update(event.bot.email, event.bot);
-            admin.update_user_full_name(event.bot.email, event.bot.full_name);
+            admin.update_user_full_name(event.bot.user_id, event.bot.full_name);
         }
         break;
 

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -19,7 +19,7 @@ exports.update_person = function update(person) {
     if (_.has(person, 'full_name')) {
         people.set_full_name(person_obj, person.full_name);
 
-        admin.update_user_full_name(person.email, person.full_name);
+        admin.update_user_full_name(person.user_id, person.full_name);
         activity.redraw();
         message_live_update.update_user_full_name(person.user_id, person.full_name);
         pm_list.update_private_messages();

--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -1,5 +1,5 @@
 {{#with user}}
-<tr class="user_row" id="user_{{email}}">
+<tr class="user_row" data-user-id="{{user_id}}" data-email="{{email}}">
   <td>
     <span class="user_name">{{full_name}}</span>
   </td>
@@ -35,7 +35,7 @@
       {{/if}}
     </span>
     {{#if is_active}}
-      <button class="button btn-primary open-user-form" title="{{t 'Edit User' }}" data-email="{{email}}">
+      <button class="button btn-primary open-user-form" title="{{t 'Edit User' }}" data-user-id="{{user_id}}">
           <i class="icon-vector-pencil"></i>
       </button>
     {{/if}}
@@ -44,7 +44,7 @@
   </td>
 </tr>
 {{#if is_active}}
-<tr class="user-name-form display-none" id="user_form_{{email}}">
+<tr class="user-name-form display-none" data-user-id="{{user_id}}">
   <td colspan="{{#if is_bot}}4{{else}}3{{/if}}">
     <form class="form-horizontal name-setting">
       <input type="hidden" name="is_full_name" value="true" />

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -823,6 +823,7 @@ class BotTest(ZulipTestCase):
         self.assertEqual(len(bots), 1)
         bot = bots[0]
         self.assertEqual(bot['bot_owner'], 'hamlet@zulip.com')
+        self.assertEqual(bot['user_id'], get_user_profile_by_email('hambot-bot@zulip.com').id)
 
     def test_add_bot_with_username_in_use(self):
         # type: () -> None

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -301,6 +301,7 @@ def get_members_backend(request, user_profile):
                   "is_active": profile.is_active,
                   "is_admin": (profile in admins),
                   "email": profile.email,
+                  "user_id": profile.id,
                   "avatar_url": avatar_url}
         if profile.is_bot and profile.bot_owner is not None:
             member["bot_owner"] = profile.bot_owner.email


### PR DESCRIPTION
For our user administration, we now primarily work with user ids
that get put into data-user-id attributes.  We still put emails in the
tags to make our Casper tests easy to maintain.

This requires a minor change to the back end to pass down user ids
for the /users endpoint (in get_members_backend).