### PR TITLE
bug fix: Fix error when admin renames a bot after reactivating it.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -381,7 +381,7 @@ def notify_created_bot(user_profile):
                           default_events_register_stream=default_events_register_stream_name,
                           default_all_public_streams=user_profile.default_all_public_streams,
                           avatar_url=avatar_url(user_profile),
-                          owner=user_profile.bot_owner.email,
+                          owner=user_profile.bot_owner.email if (user_profile.bot_owner is not None) else None,
                           ))
     send_event(event, bot_owner_userids(user_profile))
 
@@ -1860,6 +1860,9 @@ def do_reactivate_user(user_profile):
                'domain': domain})
 
     notify_created_user(user_profile)
+
+    if user_profile.is_bot:
+        notify_created_bot(user_profile)
 
 def do_change_password(user_profile, password, log=True, commit=True,
                        hashed_password=False):

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -30,6 +30,7 @@ from zerver.lib.actions import (
     do_create_user,
     do_deactivate_stream,
     do_deactivate_user,
+    do_reactivate_user,
     do_regenerate_api_key,
     do_remove_alert_words,
     do_remove_realm_emoji,
@@ -999,6 +1000,22 @@ class EventsRegisterTest(ZulipTestCase):
         action = lambda: do_deactivate_user(bot)
         events = self.do_test(action)
         error = bot_deactivate_checker('events[1]', events[1])
+        self.assert_on_error(error)
+
+    def test_do_reactivate_user(self):
+        # type: () -> None
+        bot_reactivate_checker = check_dict([
+            ('type', equals('realm_bot')),
+            ('op', equals('add')),
+            ('bot', check_dict([
+                ('email', check_string),
+                ('full_name', check_string),
+            ])),
+        ])
+        bot = self.create_bot('foo-bot@zulip.com')
+        action = lambda: do_reactivate_user(bot)
+        events = self.do_test(action)
+        error = bot_reactivate_checker('events[1]', events[1])
         self.assert_on_error(error)
 
     def test_rename_stream(self):


### PR DESCRIPTION
Fix administration page javascript issue of TypeError that occurs
due to undefined variable access in static/js/bot_data.js file.
Call add op on reactivating a bot fixes this issue.
Fixes: #2840