### PR TITLE
Bump user_profile.avatar_version when we change avatars.

### DIFF
--- a/static/js/message_live_update.js
+++ b/static/js/message_live_update.js
@@ -15,9 +15,8 @@ exports.update_user_full_name = function (user_id, full_name) {
 };
 
 exports.update_avatar = function (person) {
-    var sent_by_me = people.is_my_user_id(person.user_id);
     var url = person.avatar_url;
-    url = people.format_small_avatar_url(url, sent_by_me);
+    url = people.format_small_avatar_url(url);
 
     $(".inline_profile_picture.u-" + person.user_id).css({
       "background-image": "url(" + url + ")",

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -356,11 +356,8 @@ exports.slug_to_emails = function (slug) {
     }
 };
 
-exports.format_small_avatar_url = function (raw_url, sent_by_me) {
+exports.format_small_avatar_url = function (raw_url) {
     var url = raw_url + "&s=50";
-    if (sent_by_me) {
-        url += "&stamp=" + settings.avatar_stamp;
-    }
     return url;
 };
 
@@ -405,7 +402,7 @@ exports.small_avatar_url = function (message) {
     }
 
     if (url) {
-        url = exports.format_small_avatar_url(url, message.sent_by_me);
+        url = exports.format_small_avatar_url(url);
     }
 
     return url;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -148,9 +148,6 @@ exports.generate_zuliprc_content = function (email, api_key) {
            "\n";
 };
 
-// Choose avatar stamp fairly randomly, to help get old avatars out of cache.
-exports.avatar_stamp = Math.floor(Math.random()*100);
-
 function _setup_page() {
     // To build the edit bot streams dropdown we need both the bot and stream
     // API results. To prevent a race streams will be initialized to a promise
@@ -584,10 +581,8 @@ function _setup_page() {
             contentType: false,
             success: function (data) {
                 loading.destroy_indicator($("#upload_avatar_spinner"));
-                var url = data.avatar_url + '&stamp=' + exports.avatar_stamp;
-                $("#user-settings-avatar").expectOne().attr("src", url);
+                $("#user-settings-avatar").expectOne().attr("src", data.avatar_url);
                 $("#user_avatar_delete_button").show();
-                exports.avatar_stamp += 1;
             },
         });
 

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -49,7 +49,7 @@ exports.update_person = function update(person) {
     }
 
     if (_.has(person, 'avatar_url')) {
-        var url = person.avatar_url + "&y=" + new Date().getTime();
+        var url = person.avatar_url;
         person_obj.avatar_url = url;
 
         if (people.is_my_user_id(person.user_id)) {

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1885,10 +1885,11 @@ def do_regenerate_api_key(user_profile, log=True):
                                  )),
                    bot_owner_userids(user_profile))
 
-def do_change_avatar_source(user_profile, avatar_source, log=True):
+def do_change_avatar_fields(user_profile, avatar_source, log=True):
     # type: (UserProfile, Text, bool) -> None
     user_profile.avatar_source = avatar_source
-    user_profile.save(update_fields=["avatar_source"])
+    user_profile.avatar_version += 1
+    user_profile.save(update_fields=["avatar_source", "avatar_version"])
 
     if log:
         log_event({'type': 'user_change_avatar_source',

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -40,7 +40,7 @@ from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, 
     Reaction
 
 from zerver.lib.alert_words import alert_words_in_realm
-from zerver.lib.avatar import get_avatar_url, avatar_url
+from zerver.lib.avatar import avatar_url
 
 from django.db import transaction, IntegrityError, connection
 from django.db.models import F, Q
@@ -3048,7 +3048,7 @@ def handle_push_notification(user_profile_id, missed_message):
                     'content_truncated': content_truncated,
                     'sender_email': message.sender.email,
                     'sender_full_name': message.sender.full_name,
-                    'sender_avatar_url': get_avatar_url(message.sender.avatar_source, message.sender.email),
+                    'sender_avatar_url': avatar_url(message.sender),
                 }
 
                 if message.recipient.type == Recipient.STREAM:

--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -14,9 +14,19 @@ def avatar_url(user_profile, medium=False):
     return get_avatar_url(
         user_profile.avatar_source,
         user_profile.email,
+        user_profile.avatar_version,
         medium=medium)
 
-def get_avatar_url(avatar_source, email, medium=False):
+def get_avatar_url(avatar_source, email, avatar_version, medium=False):
+    # type: (Text, Text, int, bool) -> Text
+    url = _get_unversioned_avatar_url(
+        avatar_source,
+        email,
+        medium)
+    url += '&version=%d' % (avatar_version,)
+    return url
+
+def _get_unversioned_avatar_url(avatar_source, email, medium=False):
     # type: (Text, Text, bool) -> Text
     if avatar_source == u'U':
         hash_key = user_avatar_hash(email)

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -322,7 +322,9 @@ active_bot_dict_fields = ['id', 'full_name', 'short_name',
                           'email', 'default_sending_stream__name',
                           'default_events_register_stream__name',
                           'default_all_public_streams', 'api_key',
-                          'bot_owner__email', 'avatar_source'] # type: List[str]
+                          'bot_owner__email', 'avatar_source',
+                          'avatar_version'] # type: List[str]
+
 def active_bot_dicts_in_realm_cache_key(realm):
     # type: (Realm) -> Text
     return u"active_bot_dicts_in_realm:%s" % (realm.id,)

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -151,7 +151,11 @@ class MessageDict(object):
     ):
         # type: (bool, Optional[Message], int, Optional[datetime.datetime], Optional[Text], Text, Text, datetime.datetime, Optional[Text], Optional[int], int, Text, int, Text, Text, Text, Text, int, bool, Text, int, int, int, List[Dict[str, Any]]) -> Dict[str, Any]
 
-        avatar_url = get_avatar_url(sender_avatar_source, sender_email)
+        avatar_url = get_avatar_url(
+            sender_avatar_source,
+            sender_email,
+            sender_avatar_version
+        )
 
         display_recipient = get_display_recipient_by_id(
             recipient_id,

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -79,6 +79,7 @@ class MessageDict(object):
             sender_full_name = message.sender.full_name,
             sender_short_name = message.sender.short_name,
             sender_avatar_source = message.sender.avatar_source,
+            sender_avatar_version = message.sender.avatar_version,
             sender_is_mirror_dummy = message.sender.is_mirror_dummy,
             sending_client_name = message.sending_client.name,
             recipient_id = message.recipient.id,
@@ -112,6 +113,7 @@ class MessageDict(object):
             sender_full_name = row['sender__full_name'],
             sender_short_name = row['sender__short_name'],
             sender_avatar_source = row['sender__avatar_source'],
+            sender_avatar_version = row['sender__avatar_version'],
             sender_is_mirror_dummy = row['sender__is_mirror_dummy'],
             sending_client_name = row['sending_client__name'],
             recipient_id = row['recipient_id'],
@@ -139,6 +141,7 @@ class MessageDict(object):
             sender_full_name,
             sender_short_name,
             sender_avatar_source,
+            sender_avatar_version,
             sender_is_mirror_dummy,
             sending_client_name,
             recipient_id,
@@ -146,7 +149,7 @@ class MessageDict(object):
             recipient_type_id,
             reactions
     ):
-        # type: (bool, Optional[Message], int, Optional[datetime.datetime], Optional[Text], Text, Text, datetime.datetime, Optional[Text], Optional[int], int, Text, int, Text, Text, Text, Text, bool, Text, int, int, int, List[Dict[str, Any]]) -> Dict[str, Any]
+        # type: (bool, Optional[Message], int, Optional[datetime.datetime], Optional[Text], Text, Text, datetime.datetime, Optional[Text], Optional[int], int, Text, int, Text, Text, Text, Text, int, bool, Text, int, int, int, List[Dict[str, Any]]) -> Dict[str, Any]
 
         avatar_url = get_avatar_url(sender_avatar_source, sender_email)
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1212,7 +1212,8 @@ def get_owned_bot_dicts(user_profile, include_all_realm_bots_if_admin=True):
              'default_events_register_stream': botdict['default_events_register_stream__name'],
              'default_all_public_streams': botdict['default_all_public_streams'],
              'owner': botdict['bot_owner__email'],
-             'avatar_url': get_avatar_url(botdict['avatar_source'], botdict['email']),
+             'avatar_url': get_avatar_url(botdict['avatar_source'], botdict['email'],
+                                          botdict['avatar_version']),
              }
             for botdict in result]
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -983,6 +983,7 @@ class Message(ModelReprMixin, models.Model):
             'sender__realm__id',
             'sender__realm__domain',
             'sender__avatar_source',
+            'sender__avatar_version',
             'sender__is_mirror_dummy',
         ]
         messages = Message.objects.filter(id__in=needed_ids).values(*fields)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -18,7 +18,7 @@ from zerver.lib.actions import (
     do_add_alert_words,
     check_add_realm_emoji,
     do_add_realm_filter,
-    do_change_avatar_source,
+    do_change_avatar_fields,
     do_change_default_all_public_streams,
     do_change_default_events_register_stream,
     do_change_default_sending_stream,
@@ -877,7 +877,7 @@ class EventsRegisterTest(ZulipTestCase):
 
     def test_change_bot_avatar_source(self):
         # type: () -> None
-        action = lambda: do_change_avatar_source(self.bot, self.bot.AVATAR_FROM_USER)
+        action = lambda: do_change_avatar_fields(self.bot, self.bot.AVATAR_FROM_USER)
         events = self.do_test(action)
         error = self.realm_bot_schema('avatar_url', check_string)('events[0]', events[0])
         self.assert_on_error(error)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -397,6 +397,7 @@ class AvatarTest(ZulipTestCase):
         """
         A PUT request to /json/users/me/avatar with a valid file should return a url and actually create an avatar.
         """
+        version = 2
         for fname, rfname in self.correct_files:
             # TODO: use self.subTest once we're exclusively on python 3 by uncommenting the line below.
             # with self.subTest(fname=fname):
@@ -428,6 +429,10 @@ class AvatarTest(ZulipTestCase):
             zerver.lib.upload.upload_backend.ensure_medium_avatar_image(user_profile.email)
             self.assertTrue(os.path.exists(medium_avatar_disk_path))
 
+            # Verify whether the avatar_version gets incremented with every new upload
+            self.assertEqual(user_profile.avatar_version, version)
+            version += 1
+
     def test_invalid_avatars(self):
         # type: () -> None
         """
@@ -440,6 +445,8 @@ class AvatarTest(ZulipTestCase):
                 result = self.client_put_multipart("/json/users/me/avatar", {'file': fp})
 
             self.assert_json_error(result, "Could not decode avatar image; did you upload an image file?")
+            user_profile = get_user_profile_by_email("hamlet@zulip.com")
+            self.assertEqual(user_profile.avatar_version, 1)
 
     def test_delete_avatar(self):
         # type: () -> None
@@ -460,6 +467,7 @@ class AvatarTest(ZulipTestCase):
         self.assertEqual(json["avatar_url"], avatar_url(user_profile))
 
         self.assertEqual(user_profile.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
+        self.assertEqual(user_profile.avatar_version, 2)
 
     def tearDown(self):
         # type: () -> None

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -389,7 +389,7 @@ class AvatarTest(ZulipTestCase):
 
         response = self.client_get("/avatar/nonexistent_user@zulip.com?foo=bar")
         redirect_url = response['Location']
-        actual_url = 'https://secure.gravatar.com/avatar/444258b521f152129eb0c162996e572d?d=identicon&foo=bar'
+        actual_url = 'https://secure.gravatar.com/avatar/444258b521f152129eb0c162996e572d?d=identicon&version=1&foo=bar'
         self.assertEqual(redirect_url, actual_url)
 
     def test_valid_avatars(self):

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -25,7 +25,7 @@ from zerver.models import UserProfile, Recipient, \
     get_user_profile_by_email, get_realm, get_client, get_stream, \
     Message, get_unique_open_realm, completely_open
 
-from zerver.lib.avatar import get_avatar_url
+from zerver.lib.avatar import avatar_url
 from zerver.lib.initial_password import initial_password
 from zerver.lib.email_mirror import create_missed_message_address
 from zerver.lib.actions import \
@@ -36,7 +36,6 @@ from zerver.lib.actions import \
 from zerver.lib.notifications import handle_missedmessage_emails
 from zerver.lib.session_user import get_session_dict_user
 from zerver.middleware import is_slow_query
-from zerver.lib.avatar import avatar_url
 from zerver.lib.utils import split_by
 
 from zerver.worker import queue_processors
@@ -1832,7 +1831,7 @@ class GetProfileTest(ZulipTestCase):
             if user['email'] == 'hamlet@zulip.com':
                 self.assertEqual(
                     user['avatar_url'],
-                    get_avatar_url(user_profile.avatar_source, user_profile.email),
+                    avatar_url(user_profile),
                 )
 
 class HomeTest(ZulipTestCase):

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1203,12 +1203,16 @@ class BotTest(ZulipTestCase):
                 dict(file1=fp1, file2=fp2))
         self.assert_json_error(result, 'You may only upload one file at a time')
 
+        profile = get_user_profile_by_email("hambot-bot@zulip.com")
+        self.assertEqual(profile.avatar_version, 1)
+
         # HAPPY PATH
         with get_test_image_file('img.png') as fp:
             result = self.client_patch_multipart(
                 '/json/bots/hambot-bot@zulip.com',
                 dict(file=fp))
             profile = get_user_profile_by_email('hambot-bot@zulip.com')
+            self.assertEqual(profile.avatar_version, 2)
             # Make sure that avatar image that we've uploaded is same with avatar image in the server
             self.assertTrue(filecmp.cmp(fp.name,
                                         os.path.splitext(avatar_disk_path(profile))[0] +

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -15,7 +15,7 @@ from zerver.lib.actions import do_change_password, \
     do_change_enable_offline_push_notifications, do_change_enable_online_push_notifications, \
     do_change_default_desktop_notifications, do_change_autoscroll_forever, \
     do_change_enable_stream_desktop_notifications, do_change_enable_stream_sounds, \
-    do_regenerate_api_key, do_change_avatar_source, do_change_twenty_four_hour_time, \
+    do_regenerate_api_key, do_change_avatar_fields, do_change_twenty_four_hour_time, \
     do_change_left_side_userlist, do_change_default_language, \
     do_change_pm_content_in_desktop_notifications
 from zerver.lib.avatar import avatar_url
@@ -203,7 +203,7 @@ def set_avatar_backend(request, user_profile):
 
     user_file = list(request.FILES.values())[0]
     upload_avatar_image(user_file, user_profile, user_profile.email)
-    do_change_avatar_source(user_profile, UserProfile.AVATAR_FROM_USER)
+    do_change_avatar_fields(user_profile, UserProfile.AVATAR_FROM_USER)
     user_avatar_url = avatar_url(user_profile)
 
     json_result = dict(
@@ -213,7 +213,7 @@ def set_avatar_backend(request, user_profile):
 
 def delete_avatar_backend(request, user_profile):
     # type: (HttpRequest, UserProfile) -> HttpResponse
-    do_change_avatar_source(user_profile, UserProfile.AVATAR_FROM_GRAVATAR)
+    do_change_avatar_fields(user_profile, UserProfile.AVATAR_FROM_GRAVATAR)
     gravatar_url = avatar_url(user_profile)
 
     json_result = dict(

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -116,10 +116,11 @@ def avatar(request, email):
     # type: (HttpRequest, str) -> HttpResponse
     try:
         user_profile = get_user_profile_by_email(email)
-        avatar_source = user_profile.avatar_source
+        url = avatar_url(user_profile)
     except UserProfile.DoesNotExist:
         avatar_source = 'G'
-    url = get_avatar_url(avatar_source, email)
+        avatar_version = 1
+        url = get_avatar_url(avatar_source, email, avatar_version)
 
     # We can rely on the url already having query parameters. Because
     # our templates depend on being able to use the ampersand to
@@ -292,17 +293,13 @@ def get_members_backend(request, user_profile):
     admins = set(user_profile.realm.get_admin_users())
     members = []
     for profile in UserProfile.objects.select_related().filter(realm=realm):
-        avatar_url = get_avatar_url(
-            profile.avatar_source,
-            profile.email
-        )
         member = {"full_name": profile.full_name,
                   "is_bot": profile.is_bot,
                   "is_active": profile.is_active,
                   "is_admin": (profile in admins),
                   "email": profile.email,
                   "user_id": profile.id,
-                  "avatar_url": avatar_url}
+                  "avatar_url": avatar_url(profile)}
         if profile.is_bot and profile.bot_owner is not None:
             member["bot_owner"] = profile.bot_owner.email
         members.append(member)

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -17,7 +17,7 @@ from zerver.forms import CreateUserForm
 from zerver.lib.actions import do_change_is_admin, \
     do_create_user, do_deactivate_user, do_reactivate_user, \
     do_change_default_events_register_stream, do_change_default_sending_stream, \
-    do_change_default_all_public_streams, do_regenerate_api_key, do_change_avatar_source
+    do_change_default_all_public_streams, do_regenerate_api_key, do_change_avatar_fields
 from zerver.lib.avatar import avatar_url, get_avatar_url
 from zerver.lib.response import json_error, json_success
 from zerver.lib.streams import access_stream_by_name
@@ -175,7 +175,7 @@ def patch_bot_backend(request, user_profile, email,
         user_file = list(request.FILES.values())[0]
         upload_avatar_image(user_file, user_profile, bot.email)
         avatar_source = UserProfile.AVATAR_FROM_USER
-        do_change_avatar_source(bot, avatar_source)
+        do_change_avatar_fields(bot, avatar_source)
     else:
         return json_error(_("You may only upload one file at a time"))
 


### PR DESCRIPTION
We do this in do_change_avatar_fields(), which was
do_change_avatar_source() before this change.

Avatar versioning is used to update the cache every time the
user updates their avatar or their bot's avatar, avatar_version gets
incremented each time. Corresponding tests for features are at tests.py
and test_upload.py

Adarsh did the initial work here, and Steve Howell (showell) also
made changes.