### PR TITLE
Prevent HTML from being pasted into the stream name/description box.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -448,10 +448,6 @@ $(function () {
             ".stream-name-editable": subs.change_stream_name,
         };
 
-        $(document).on("keydown", ".editable-section", function (e) {
-            e.stopPropagation();
-        });
-
         // http://stackoverflow.com/questions/4233265/contenteditable-set-caret-at-the-end-of-the-text-cross-browser
         function place_caret_at_end(el) {
             el.focus();
@@ -471,6 +467,24 @@ $(function () {
                 textRange.select();
             }
         }
+
+        $(document).on("keydown", ".editable-section", function (e) {
+            e.stopPropagation();
+        });
+
+        $(document).on("drop", ".editable-section", function () {
+            return false;
+        });
+
+        $(document).on("input", ".editable-section", function () {
+            // if there are any child nodes, inclusive of <br> which means you
+            // have lines in your description or title, you're doing something
+            // wrong.
+            if (this.hasChildNodes()) {
+                this.innerText = this.innerText;
+                place_caret_at_end(this);
+            }
+        });
 
         $("body").on("click", "[data-make-editable]", function () {
             var selector = $(this).attr("data-make-editable");


### PR DESCRIPTION
This prevents users from either dragging formatted markup into content
editable boxes or pasting it in. This uses the “input” event rather
than “paste” because “paste” does not have the end result of the
contents whereas “input” does.

This is not a security vulnerability as it may seem. Processing on the
backend sanitizes input if it contains HTML.