### PR TITLE
Scroll to top of streams list when new stream added.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -287,12 +287,19 @@ function add_email_hint(row, email_address_hint_content) {
     });
 }
 
+// The `meta.stream_created` flag is a distinguishing factor for subs added after
+// the fact. These should be appended to the top of the list so they are more
+//  distinguisable.
 function add_sub_to_table(sub) {
     sub = stream_data.add_admin_options(sub);
     stream_data.update_subscribers_count(sub);
     var html = templates.render('subscription', sub);
     var settings_html = templates.render('subscription_settings', sub);
-    $(".streams-list").append(html);
+    if (meta.stream_created) {
+        $(".streams-list").prepend(html).scrollTop(0);
+    } else {
+        $(".streams-list").append(html);
+    }
     $(".subscriptions .settings").append($(settings_html));
 
     var email_address_hint_content = templates.render('email_address_hint', { page_params: page_params });


### PR DESCRIPTION
This prepends new streams that are created to the top of the list so
that they are more visible when being created.