### PR TITLE
Add tooltips for Mac keyboard shorcuts.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -82,17 +82,6 @@ body {
     text-shadow: 0 0 0;
 }
 
-.markdown h1[id]:before,
-.markdown h2[id]:before,
-.markdown h3[id]:before,
-.markdown h4[id]:before {
-    display: block;
-    content: " ";
-    margin-top: -40px;
-    height: 40px;
-    visibility: hidden;
-}
-
 .markdown ul,
 .markdown ol {
     margin-left: 30px;
@@ -359,6 +348,58 @@ label.text-error {
 input.text-error {
     border-color: red;
     outline-color: red;
+}
+
+a.tooltips span>code {
+    font-weight: normal;
+}
+
+a.tooltips {
+    position: relative;
+    display: inline;
+}
+
+a:active.tooltips {
+    pointer-events: none;
+}
+
+a.tooltips span {
+    padding: 5px 4px;
+    position: absolute;
+    min-width: 120px;
+    color: #FFFFFF;
+    background: #52C2AF;
+    height: 30px;
+    line-height: 30px;
+    text-align: center;
+    visibility: hidden;
+    border-radius: 6px;
+}
+
+a.tooltips span:after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -8px;
+    width: 0;
+    height: 0;
+    border-top: 8px solid #52C2AF;
+    border-right: 8px solid transparent;
+    border-left: 8px solid transparent;
+}
+
+a:hover.tooltips {
+    text-decoration: none;
+}
+
+a:hover.tooltips span {
+    visibility: visible;
+    opacity: 1;
+    bottom: 30px;
+    left: 50%;
+    margin-left: -65px;
+    z-index: 999;
 }
 
 .header, .footer {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1927,6 +1927,55 @@ div.floating_recipient {
     max-width: 200px;
 }
 
+a.tooltips {
+    position: relative;
+    display: inline;
+}
+
+a.tooltips span {
+    font-size: 12px;
+    padding: 2px 8px;
+    position: absolute;
+    min-width: 50px;
+    color: #FFFFFF;
+    background: #52C2AF;
+    height: 20px;
+    line-height: 20px;
+    text-align: center;
+    visibility: hidden;
+    border-radius: 6px;
+}
+
+a.tooltips span:after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -6px;
+    width: 0;
+    height: 0;
+    border-top: 6px solid #52C2AF;
+    border-right: 6px solid transparent;
+    border-left: 6px solid transparent;
+}
+
+a:active.tooltips {
+    pointer-events: none;
+}
+
+a:hover.tooltips {
+    text-decoration: none;
+}
+
+a:hover.tooltips span {
+    visibility: visible;
+    opacity: 1;
+    bottom: 22px;
+    left: 50%;
+    margin-left: -33px;
+    z-index: 999;
+}
+
 .hotkeys_table {
     width: 245px;
     margin-right: 10px;

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -4,88 +4,89 @@ Keyboard shortcuts allow a user to use Zulip easily and efficiently
 for a better user experience.
 
 Zulip keyboard shortcuts are divided into four categories:
+
 * [Navigation](#navigation)
+
 * [Composing messages](#composing-messages)
+
 * [Narrowing](#narrowing)
+
 * [Menus](#menus)
 
-!!! warn ""
-    Note: We note how to enter keyboard shortcuts using keys not
-    present on MacOS keyboard in parentheticals below.
+!!! tip ""
+    Hover over bolded keys to view their Mac keyboard shortcut equivalents.
 
 ## Navigation
 
-* **Initiate a search**: `/` - This shortcut moves the user's cursor to
+* **Initiate a search**: `/` — This shortcut moves the user's cursor to
   the message search bar at the top of the window to allow them to
   begin searching for messages belonging to a specific topic, stream,
   view, etc. in the organization.
-* **Search people**: `q` - This shortcut moves the user's cursor to the
+* **Search people**: `q` — This shortcut moves the user's cursor to the
   user search bar in the right sidebar to to allow them to begin
   searching for a particular user in the organization.
-* **Search streams**: `w` - This shortcut moves the user's cursor to
+* **Search streams**: `w` — This shortcut moves the user's cursor to
   the stream search bar in the left sidebar to to allow them to begin
   searching for a particular stream in the organization.
-* **Previous message**: `k` or `↑` - This shortcut allows the user
+* **Previous message**: `k` or `↑` — This shortcut allows the user
   to scroll up to the previous message in their view.
-* **Next message**: `j` or `↓` - This shortcut allows the user to
+* **Next message**: `j` or `↓` — This shortcut allows the user to
   scroll down to the next message in their view.
-* **Scroll up**: `K` or `PgUp` (`Fn` + `↑` on Mac) - This shortcut
+* **Scroll up**: `K` or <a href="#" class="tooltips">`PgUp`<span>Mac: `Fn` + `↑`</span></a> — This shortcut
   allows the user to scroll up through the messages in their view.
-* **Scroll down**: `J`, `Spacebar`, or `PgDn` (`Fn` + `↓` on Mac) -
+* **Scroll down**: `J`, `Spacebar`, or <a href="#" class="tooltips">`PgDn`<span>Mac: `Fn` + `↓`</span></a> —
   This shortcut allows the user to scroll down through the messages in
   their view.
-* **Last message**: `End` (`Fn`+`⇾` on Mac) - This shortcut
-  allows the user to scroll to the most recent message in their view.
-* **First message in view**: `Home` (`Fn`+`⇽` on Mac) - This shortcut
+* **Last message**: <a href="#" class="tooltips">`End`<span>Mac: `Fn` + `⇾`</span></a> — This shortcut
   allows the user to scroll to the most recent message in their view.
 
 ## Composing messages
-* **Reply to message**: `r` or `Enter` (`Return` on Mac) - This
+* **Reply to message**: `r` or <a href="#" class="tooltips">`Enter`<span>Mac: `Return`</span></a> — This
   shortcut allows the user to begin replying to the selected message
   (outlined in blue).
-* **Reply to author**: `R` - This shortcut allows the user to begin
+* **Reply to author**: `R` — This shortcut allows the user to begin
   writing a private message to the author of the selected message
   (outlined in blue).
-* **Reply to message mentioning the author**: `@` - This
+* **Reply to message mentioning the author**: `@` — This
   shortcut allows the user to begin replying to the selected message
-  (outlined in blue), @-mentioning the author of the selected message.
-* **New stream message**: `c` - This shortcut allows the user to begin
+  (outlined in blue), @—mentioning the author of the selected message.
+* **New stream message**: `c` — This shortcut allows the user to begin
   composing a new stream message.
-* **New private message**: `C` - This shortcut allows the user to begin
+* **New private message**: `C` — This shortcut allows the user to begin
   composing a new private message.
-* **Send message**: `Tab key` then `Enter` (`Return` on Mac) - This
+* **Send message**: `Tab key` then <a href="#" class="tooltips">`Enter`<span>Mac: `Return`</span></a> — This
   shortcut allows the user to send the message that they've written.
-* **Cancel compose**: `Esc` - This shortcut allows the user to cancel
+* **Cancel compose**: `Esc` — This shortcut allows the user to cancel
   and discard their unsent message.
 
 ## Narrowing
 
-* **Narrow by stream**: `s` - This shortcut narrows the view to show
+* **Narrow by stream**: `s` — This shortcut narrows the view to show
   all messages in the stream of the selected message (outlined in
   blue).
-* **Narrow by topic**: `S` - This shortcut narrows the view to show all
+* **Narrow by topic**: `S` — This shortcut narrows the view to show all
   messages with the topic of the selected message (outlined in blue).
-* **Narrow to all private messages**: `v` - This shortcut narrows the
+* **Narrow to all private messages**: `v` — This shortcut narrows the
   view to show all of the user's private messages.
-* **Cycle between stream narrows**: `A` and `D` - This shortcut allows the
+* **Cycle between stream narrows**: `A` and `D` — This shortcut allows the
   user to cycle through the narrows showing the messages of a stream
   according to Stream order in the left sidebar. `A` allows the user
   to navigate to the previous stream narrow, and `D` allows the user
   to navigate to the next stream narrow.
-* **Return to home view**: `Esc` - This shortcut makes the user return
+* **Return to home view**: `Esc` — This shortcut makes the user return
   to the Home view, showing all messages in the organization.
 
 ## Menus
 
-* **Open message actions menu**: `i` - This shortcut shows the
+* **Open message actions menu**: `i` — This shortcut shows the
   available message actions of the selected message (outlined in
   blue).
-* **Edit last message you sent**: `⇽` - This starts editing the
+* **Edit last message you sent**: `⇽` — This starts editing the
   last editable message that you sent in the current view (if any).
-* **Edit selected message**: `i` then `Enter` (`Return` on Mac) -
+* **Edit selected message**: `i` then <a href="#" class="tooltips">`Enter`<span>Mac: `Return`</span></a> —
   This shortcut allows the user to edit the selected message (outlined
   in blue) if the user authored the selected message. If the selected
   message was written by another user, this shortcut will enable the
   user to view the source code of the message.
-* **Show the keyboard shortcuts**: `?` - This shortcut makes a modal
+* **Show the keyboard shortcuts**: `?` — This shortcut makes a modal
   window with a guide to all possible keyboard shortcuts appear.

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -2,6 +2,7 @@
      aria-labelledby="keyboard-shortcuts-label" aria-hidden="true">
   <div class="modal-body">
     <div>
+        <p>Hover over highlighted keys to view their Mac keyboard shortcut equivalents.</p>
       <table class="hotkeys_table table table-striped table-bordered table-condensed">
         <thead>
           <tr>
@@ -29,15 +30,15 @@
           <td class="definition">{% trans %}Next message{% endtrans %}</td>
         </tr>
         <tr>
-          <td class="hotkey">PgUp, K</td>
+          <td class="hotkey"><a href="#" class="tooltips">PgUp<span>Fn + ↑</span></a>, K</td>
           <td class="definition">{% trans %}Scroll up{% endtrans %}</td>
         </tr>
         <tr>
-          <td class="hotkey">PgDn, J, Spacebar</td>
+          <td class="hotkey"><a href="#" class="tooltips">PgDn<span>Fn + ↓</span></a>, J, Spacebar</td>
           <td class="definition">{% trans %}Scroll down{% endtrans %}</td>
         </tr>
         <tr>
-          <td class="hotkey">End</td>
+          <td class="hotkey"><a href="#" class="tooltips">End<span>Fn + ⇾</span></a></td>
           <td class="definition">{% trans %}Last message{% endtrans %}</td>
         </tr>
       </table>
@@ -49,7 +50,7 @@
           </tr>
         </thead>
         <tr>
-          <td class="hotkey">Enter or r</td>
+          <td class="hotkey"><a href="#" class="tooltips">Enter<span>Return</span></a> or r</td>
           <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
         </tr>
         <tr>
@@ -65,7 +66,7 @@
           <td class="definition">{% trans %}New private message{% endtrans %}</td>
         </tr>
         <tr>
-          <td class="hotkey">Tab then Enter</td>
+          <td class="hotkey">Tab then <a href="#" class="tooltips">Enter<span>Return</span></a></td>
           <td class="definition">{% trans %}Send message{% endtrans %}</td>
         </tr>
         <tr>
@@ -115,7 +116,7 @@
           </tr>
         </thead>
         <tr>
-          <td class="hotkey">Left</td>
+          <td class="hotkey">⇽</td>
           <td class="definition">{% trans %}Edit your last message{% endtrans %}</td>
         </tr>
         <tr>
@@ -123,7 +124,7 @@
           <td class="definition">{% trans %}Open message menu{% endtrans %}</td>
         </tr>
         <tr id="edit-message-hotkey-help">
-          <td class="hotkey">i then Enter</td>
+          <td class="hotkey">i then <a href="#" class="tooltips">Enter<span>Return</span></a></td>
           <td class="definition">{% trans %}Edit selected message{% endtrans %}</td>
         </tr>
         <tr>


### PR DESCRIPTION
Add tooltips for Mac keyboard shortcuts in the **Keyboard shortcuts** user doc guide and **Keyboard shortcuts** modal.

Fixes issue #3577