### PR TITLE
docs: Copyedit docs/chat-zulip-org.html.

### DIFF
--- a/docs/chat-zulip-org.md
+++ b/docs/chat-zulip-org.md
@@ -7,8 +7,8 @@ You can go through the simple signup process at that link, and then
 you will soon be talking to core Zulip developers and other users.  To
 get help in real time, you will have the best luck finding core
 developers roughly between 16:00 UTC and 23:59 UTC, but the sun never
-sleeps on the Zulip development community.  Most questions get a reply
-within minutes to a few hours, depending on time of day.
+sleeps on the Zulip community.  Most questions get a reply
+within minutes to a few hours, depending on the time of day.
 
 ## This is a bleeding edge development server
 
@@ -37,10 +37,10 @@ secret/embarrassing, etc.
   need to mention your conversation partner in every reply.
   Mentioning other users is great for timely questions or making sure
   someone who is not online sees your message.
-* Converse informally; there's no need to use titles like "Sir".
+* Converse informally; there's no need to use titles like "Sir" or "Madam".
 * Follow the [community code of conduct](code-of-conduct.html).
 * Participate!  Zulip is a friendly and welcoming community, and we
-  love meeting new people and hearing about what brought them to Zulip
+  love meeting new people, hearing about what brought them to Zulip,
   and getting their feedback.  If you're not sure where to start,
   introduce yourself and your interests in
   [#new members](https://chat.zulip.org/#narrow/stream/new.20members),
@@ -62,9 +62,6 @@ everyone, even non-developers:
   documentation.
 * [#production help](https://chat.zulip.org/#narrow/stream/production.20help)
   is for production environment related discussions.
-* [#design](https://chat.zulip.org/#narrow/stream/design) is where we
-  discuss Zulip's UI design and collect feedback on potential design
-  changes.  We love feedback, so don't hesitate to speak up.
 * [#test here](https://chat.zulip.org/#narrow/stream/test.20here) is
   for sending test messages without inconveniencing other users :).
   We recommend muting this stream when not using it.
@@ -77,12 +74,12 @@ page to see the descriptions for all of them.  Relevant to almost
 everyone are these:
 
 * [#checkins](https://chat.zulip.org/#narrow/stream/checkins) is for
-  progress updates on what you're working on and it's status; usually
+  progress updates on what you're working on and its status; usually
   folks post with their name as the topic.  Everyone is welcome to
   participate!
 * [#development help](https://chat.zulip.org/#narrow/stream/development.20help)
   is for asking for help with any Zulip server/webapp development work
-  (using the app streams for help working on one of the apps).
+  (use the app streams for help working on one of the apps).
 * [#peer review](https://chat.zulip.org/#narrow/stream/peer.20review)
   is for getting feedback on your work.  We encourage all developers
   to comment on work posted here, even if you're new to the Zulip


### PR DESCRIPTION
Removed the blurb on "#design" since it appears twice.