### PR TITLE
left-sidebar: Sort pinned streams by lowercase stream name.

### DIFF
--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -137,6 +137,8 @@ exports.build_stream_list = function () {
         }
     });
 
+    pinned_streams.sort(util.strcmp);
+
     unpinned_streams.sort(function (a, b) {
         if (sort_recent) {
             if (stream_data.is_active(b) && ! stream_data.is_active(a)) {


### PR DESCRIPTION
The pinned streams were sorted in alphabetic order (i.e. Verona appears
before devel). The reason is that after we plucked pinned streams out from
stream_data.subscribed_streams(), we didn't sort them again, so they
remained in the alphabetic order used in stream_data.

However, we did sort unpinned streams explicitly by lowercase stream name
using custom compare function in stream_list.js, that's why this issue only
relates to pinned streams.

Changes were made to sort pinned streams by lowercase stream names.
Tests were added to check both pinned and unpinned streams are sorted by
lowercase stream names.

Fixes #3701