### PR TITLE
Add (default enabled) option to not include subscribers in events_register data

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -245,8 +245,8 @@ def apply_events(state, events, user_profile, include_subscribers=True):
 
             if event['op'] in ["add"]:
                 if include_subscribers:
-                    # Convert the user_profile IDs to emails since that's what register() returns
-                    # TODO: Clean up this situation
+                    # Convert the emails to user_profile IDs since that's what register() returns
+                    # TODO: Clean up this situation by making the event also have IDs
                     for item in event["subscriptions"]:
                         item["subscribers"] = [get_user_profile_by_email(email).id for email in item["subscribers"]]
                 else:

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -28,14 +28,15 @@ def _default_narrow(user_profile, narrow):
 def events_register_backend(request, user_profile,
                             apply_markdown=REQ(default=False, validator=check_bool),
                             all_public_streams=REQ(default=None, validator=check_bool),
+                            include_subscribers=REQ(default=False, validator=check_bool),
                             event_types=REQ(validator=check_list(check_string), default=None),
                             narrow=REQ(validator=check_list(check_list(check_string, length=2)), default=[]),
                             queue_lifespan_secs=REQ(converter=int, default=0)):
-    # type: (HttpRequest, UserProfile, bool, Optional[bool], Optional[Iterable[str]], Iterable[Sequence[Text]], int) -> HttpResponse
+    # type: (HttpRequest, UserProfile, bool, Optional[bool], bool, Optional[Iterable[str]], Iterable[Sequence[Text]], int) -> HttpResponse
     all_public_streams = _default_all_public_streams(user_profile, all_public_streams)
     narrow = _default_narrow(user_profile, narrow)
 
     ret = do_events_register(user_profile, request.client, apply_markdown,
                              event_types, queue_lifespan_secs, all_public_streams,
-                             narrow=narrow)
+                             narrow=narrow, include_subscribers=include_subscribers)
     return json_success(ret)

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -24,19 +24,10 @@ def _default_narrow(user_profile, narrow):
         narrow = [['stream', default_stream.name]]
     return narrow
 
-# Does not need to be authenticated because it's called from rest_dispatch
 @has_request_variables
-def api_events_register(request, user_profile,
-                        apply_markdown=REQ(default=False, validator=check_bool),
-                        all_public_streams=REQ(default=None, validator=check_bool)):
-    # type: (HttpRequest, UserProfile, bool, Optional[bool]) -> HttpResponse
-    return events_register_backend(request, user_profile,
-                                   apply_markdown=apply_markdown,
-                                   all_public_streams=all_public_streams)
-
-@has_request_variables
-def events_register_backend(request, user_profile, apply_markdown=True,
-                            all_public_streams=None,
+def events_register_backend(request, user_profile,
+                            apply_markdown=REQ(default=False, validator=check_bool),
+                            all_public_streams=REQ(default=None, validator=check_bool),
                             event_types=REQ(validator=check_list(check_string), default=None),
                             narrow=REQ(validator=check_list(check_list(check_string, length=2)), default=[]),
                             queue_lifespan_secs=REQ(converter=int, default=0)):

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -327,7 +327,7 @@ v1_api_and_json_patterns = [
 
     # used to register for an event queue in tornado
     url(r'^register$', rest_dispatch,
-        {'POST': 'zerver.views.events_register.api_events_register'}),
+        {'POST': 'zerver.views.events_register.events_register_backend'}),
 
     # events -> zerver.tornado.views
     url(r'^events$', rest_dispatch,


### PR DESCRIPTION
The subscribers data is an enormous fraction of the total data set, and many API clients don't have a use case for it, so I've moved it behind the `apply_subscribers=True` option. 

I checked the mobile apps and neither uses the data (and some of the subscriber data is fairly new in the first place), so I think this change is likely safe/harmless to do.

@showell can you review this one?  The race avoidance piece is messy, but I think complete (I added some `else: pass` statements and test coverage to check we used all the code paths).