### PR TITLE
Improve check-templates error handling.

### DIFF
--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -112,42 +112,51 @@ class ParserTest(unittest.TestCase):
         my_html = '''
             {{# foo
         '''
-        self._assert_validate_error('Tag missing }}', text=my_html)
+        self._assert_validate_error('''Tag missing "}}" at Line 2 Col 13:"{{# foo
+        "''', text=my_html)
 
     def test_validate_incomplete_handlebars_tag_2(self):
         # type: () -> None
         my_html = '''
             {{# foo }
         '''
-        self._assert_validate_error('Tag missing }}', text=my_html)
+        self._assert_validate_error('Tag missing "}}" at Line 2 Col 13:"{{# foo }\n"', text=my_html)
 
     def test_validate_incomplete_django_tag_1(self):
         # type: () -> None
         my_html = '''
             {% foo
         '''
-        self._assert_validate_error('Tag missing %}', text=my_html)
+        self._assert_validate_error('''Tag missing "%}" at Line 2 Col 13:"{% foo
+        "''', text=my_html)
 
     def test_validate_incomplete_django_tag_2(self):
         # type: () -> None
         my_html = '''
             {% foo %
         '''
-        self._assert_validate_error('Tag missing %}', text=my_html)
+        self._assert_validate_error('Tag missing "%}" at Line 2 Col 13:"{% foo %\n"', text=my_html)
 
     def test_validate_incomplete_html_tag_1(self):
         # type: () -> None
         my_html = '''
             <b
         '''
-        self._assert_validate_error('Tag missing >', text=my_html)
+        self._assert_validate_error('''Tag missing ">" at Line 2 Col 13:"<b
+        "''', text=my_html)
 
     def test_validate_incomplete_html_tag_2(self):
         # type: () -> None
         my_html = '''
             <a href="
         '''
-        self._assert_validate_error('Tag missing >', text=my_html)
+        my_html1 = '''
+            <a href=""
+        '''
+        self._assert_validate_error('''Tag missing ">" at Line 2 Col 13:"<a href=""
+        "''', text=my_html1)
+        self._assert_validate_error('''Unbalanced Quotes at Line 2 Col 13:"<a href="
+        "''', text=my_html)
 
     def test_validate_empty_html_tag(self):
         # type: () -> None


### PR DESCRIPTION
In this commit we improve the way errors are handled in our
template parser and thus improving the displayed messages in
case of errors. Eg. Errors in case of unbalanced quotes now
makes more sense displaying line and column information
including line where error might be sourced.
A Traceback will look something like this 
```
Traceback (most recent call last):
  File "tools/check-templates", line 153, in <module>
    check_our_files()
  File "tools/check-templates", line 42, in check_our_files
    check_handlebar_templates(by_lang['handlebars'], args.modified)
  File "tools/check-templates", line 150, in check_handlebar_templates
    validate(fn=fn, check_indent=True)
  File "/srv/zulip/tools/lib/template_parser.py", line 156, in validate
    tokens = tokenize(text)
  File "/srv/zulip/tools/lib/template_parser.py", line 132, in tokenize
    e.line_content))
lib.template_parser.TemplateParserException: Unbalanced Quotes at Line 2 Col 1:"<ul class="nav nav-list actions_popover" pull-right">
  <"
```
This will Fix #1268.