### PR TITLE
Fix empty invite-only streams shown broken on subs page.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1755,6 +1755,9 @@ def bulk_remove_subscriptions(users, streams):
         if stream.realm.is_zephyr_mirror_realm and not stream.invite_only:
             continue
 
+        if stream.invite_only and stream.num_subscribers() == 0:
+            do_deactivate_stream(stream)
+
         altered_users = altered_user_dict[stream.id]
 
         peer_user_ids = get_peer_user_ids_for_stream_change(


### PR DESCRIPTION
We now mark invite-only streams where the last user left as "deactivated" in the backend.
Now an invite-only stream that has no users left will be effectively deleted, and will not appear in the list of streams, even for an administrator (and thus one won't see the broken view as mentioned in the issue).

Fixes #3657 