### PR TITLE
Replace settings v1 toggle with v2 component toggle.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -12,7 +12,7 @@ exports.show_or_hide_menu_item = function () {
         item.show();
     } else {
         item.hide();
-        $(".ind-tab[data-name='admin']").addClass("disabled");
+        $(".ind-tab[data-tab-key='administration']").addClass("disabled");
         $(".settings-list li.admin").hide();
     }
 };
@@ -354,6 +354,8 @@ function _setup_page() {
     if (tab) {
         exports.launch_page(tab);
     }
+
+    exports.show_or_hide_menu_item();
 
     $("#id_realm_default_language").val(page_params.realm_default_language);
 

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -629,21 +629,28 @@ $(function () {
     });
 
     (function () {
-        var $parent = $("#settings_overlay_container .sidebar .tab-switcher");
-        var $tabs = $parent.find(".ind-tab");
-        $tabs.click(function () {
-            $tabs.removeClass("selected");
-            $(this).addClass("selected");
+        var info_overlay_toggle = components.toggle({
+            name: "info-overlay-toggle",
+            selected: 0,
+            values: [
+                { label: "Settings", key: "settings" },
+                { label: "Administration", key: "administration" },
+            ],
+            callback: function (name, key) {
+                $(".sidebar li").hide();
 
-            $(".sidebar li").hide();
-            if ($(this).data("name") === "admin") {
-                $("li.admin").show();
-                $("li[data-section='organization-settings']").click();
-            } else {
-                $("li:not(.admin)").show();
-                $("li[data-section='your-account']").click();
-            }
-        });
+                if (key === "administration") {
+                    $("li.admin").show();
+                    $("li[data-section='organization-settings']").click();
+                } else {
+                    $("li:not(.admin)").show();
+                    $("li[data-section='your-account']").click();
+                }
+            },
+        }).get();
+
+        $("#settings_overlay_container .tab-container")
+            .append($(info_overlay_toggle));
     }());
 });
 

--- a/templates/zerver/settings_overlay.html
+++ b/templates/zerver/settings_overlay.html
@@ -1,12 +1,7 @@
 <div id="settings_page" class="new-style">
   <div class="sidebar">
     <div class="sidebar-list dark-grey small-text">
-      <div class="center tab-container">
-        <div class="tab-switcher">
-          <div class="ind-tab first selected" data-name="settings">{{ _('Settings') }}</div>
-          <div class="ind-tab second" data-name="admin">{{ _('Administration') }} </div>
-        </div>
-      </div>
+      <div class="center tab-container"></div>
       <ul class="settings-list">
         <li tabindex="1" class="active" data-section="your-account">
           <div class="icon icon-vector-user"></div>


### PR DESCRIPTION
This replaces the settings toggle which had the same markup as the
current component toggle, but not the same JavaScript, along with
having an issue with inline-block spacing, with the new JS generated
one.