### PR TITLE
WIP: Improve visual formatting of message edit history.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -16,6 +16,14 @@ var editability_types = {
 };
 exports.editability_types = editability_types;
 
+// To convert the time into a string of desired format
+function stringify_time(time) {
+    if (page_params.twenty_four_hour_time) {
+        return time.toString('HH:mm');
+    }
+    return time.toString('h:mm TT');
+}
+
 function get_editability(message, edit_limit_seconds_buffer) {
     edit_limit_seconds_buffer = edit_limit_seconds_buffer || 0;
     if (!(message && message.sent_by_me)) {
@@ -393,8 +401,12 @@ exports.show_history = function (message) {
                     return;
                 }
 
+                var time = new XDate(msg.timestamp * 1000);
                 // Format timestamp nicely for display
                 var item = {timestamp: timerender.get_full_time(msg.timestamp)};
+                // item.show_date = stringify_time(time);
+                item.show_day = (timerender.render_date(time))[0].outerHTML;
+                item.show_time = stringify_time(time);
                 if (index === 0) {
                     item.posted_or_edited = "Posted by";
                     item.posted_not_edited = true;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -397,9 +397,11 @@ exports.show_history = function (message) {
                 var item = {timestamp: timerender.get_full_time(msg.timestamp)};
                 if (index === 0) {
                     item.posted_or_edited = "Posted by";
+                    item.posted_not_edited = true;
                     item.body_to_render = msg.rendered_content;
                 } else {
                     item.posted_or_edited = "Edited by";
+                    item.posted_not_edited = false;
                     item.body_to_render = msg.content_html_diff;
                 }
                 if (msg.user_id) {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1231,6 +1231,12 @@ div.focused_table {
     text-align: right;
 }
 
+#message-edit-history #message-history-label{
+    text-align: center;
+    font-size: 1.1em;
+    text-transform: uppercase;
+}
+
 .message_content.condensed {
     max-height: 8.5em;
     overflow: hidden;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2247,6 +2247,7 @@ button.topic_edit_cancel {
 .date_row {
     text-align: center;
     padding-bottom: 10px;
+    margin-top: 20px;
 }
 
 .date_row .date-direction {

--- a/static/templates/message_edit_history.handlebars
+++ b/static/templates/message_edit_history.handlebars
@@ -7,7 +7,15 @@
       <div class="messagebox-content">
         <div class="message_top_line"><span class="message_time">{{ timestamp }}</span></div>
         <div class="message_edit_content">{{{ body_to_render }}}</div>
-        <div class="message_author"><div class="author_details">{{ posted_or_edited }} {{ edited_by }}</div></div>
+        <div class="message_author">
+        	<div class="author_details">
+        		{{#if posted_not_edited}}
+        		<i class="icon-vector-share-alt"></i> {{ edited_by }}
+        		{{else}}
+        		<i class="icon-vector-pencil"></i> {{ edited_by }}
+     			{{/if}}
+        	</div>
+        </div>
       </div>
     </div>
 </div>

--- a/static/templates/message_edit_history.handlebars
+++ b/static/templates/message_edit_history.handlebars
@@ -5,14 +5,14 @@
 <div class="">
     <div class="messagebox-border">
       <div class="messagebox-content">
-        <div class="message_top_line"><span class="message_time">{{ timestamp }}</span></div>
+        <div class="message_top_line"><span class="message_time">{{{ show_day }}} {{ show_time }}</span></div>
         <div class="message_edit_content">{{{ body_to_render }}}</div>
         <div class="message_author">
         	<div class="author_details">
         		{{#if posted_not_edited}}
-        		<i class="icon-vector-share-alt"></i> {{ edited_by }}
+        			<i class="icon-vector-share-alt"></i> {{ edited_by }}
         		{{else}}
-        		<i class="icon-vector-pencil"></i> {{ edited_by }}
+        			<i class="icon-vector-pencil"></i> {{ edited_by }}
      			{{/if}}
         	</div>
         </div>

--- a/zerver/lib/html_diff.py
+++ b/zerver/lib/html_diff.py
@@ -105,7 +105,8 @@ def highlight_html_differences(s1, s2):
             retval += highlight_chunks(chunks, highlight_replaced)
             idx += 1
         elif op == diff_match_patch.DIFF_DELETE:
-            retval += highlight_deleted('&nbsp;')
+            chunks, in_tag = chunkize(text, in_tag)
+            retval += highlight_chunks(chunks, highlight_deleted)
         elif op == diff_match_patch.DIFF_INSERT:
             chunks, in_tag = chunkize(text, in_tag)
             retval += highlight_chunks(chunks, highlight_inserted)


### PR DESCRIPTION
This work is aimed at making the message edit history UI look nicer. The main tasks to be covered include optimization of timestamp display, display of topic edits, improvement in color combination, optional display for deleted part of the message.

Fixes #3731 