### PR TITLE
frontend: Fix edit header display height.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -30,12 +30,13 @@
 
 .header {
     padding: 6px 0px;
+    height: 29px;
 }
 
 .header .stripes,
 .header .darker {
     position: absolute;
-    height: 40px;
+    height: 100%;
     width: 100%;
     top: 0px;
 


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/15116870/23183309/7b012c3c-f830-11e6-8321-96341225eeda.png)

Header navbar covers the entire Mac OS X Zulip application page; this should fix that error.