### PR TITLE
[Fix]: Re-add "Delete Avatar" button to "Your account".

### DIFF
--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -72,6 +72,7 @@
         </div>
         <div class="inline-block">
             <button class="button sea-green w-200 m-t-20 block input-size" id="user_avatar_upload_button">{{t 'Upload New Avatar' }}</button>
+            <button class="button btn-danger w-200 m-t-20 block input-size" id="user_avatar_delete_button">{{t 'Delete Avatar' }}</button>
             <div class="w-200 dark-grey center m-t-20">
               Upload a small (1024x1024) avatar of yourself here.
             </div>


### PR DESCRIPTION
This re-adds the deleted "Delete Avatar" button back to the
settings/your-account tab view in the overlay, which only appears
if you do not currently have a gravitar.

Fixes: #3757.