### PR TITLE
avatar live updates: Do full re-render.

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -564,6 +564,19 @@ exports.MessageList.prototype = {
         this.view.rerender_the_whole_thing();
     },
 
+    update_user_avatar: function (user_id, avatar_url) {
+        // TODO:
+        // We may want to de-dup some logic with update_user_full_name,
+        // especially if we want to optimize this with some kind of
+        // hash that maps sender_id -> messages.
+        _.each(this._items, function (item) {
+            if (item.sender_id && (item.sender_id === user_id)) {
+                item.small_avatar_url = avatar_url;
+            }
+        });
+        this.view.rerender_the_whole_thing();
+    },
+
     update_stream_name: function MessageList_update_stream_name(stream_id,
                                                                 new_stream_name) {
         _.each(this._items, function (item) {

--- a/static/js/message_live_update.js
+++ b/static/js/message_live_update.js
@@ -14,12 +14,12 @@ exports.update_user_full_name = function (user_id, full_name) {
     });
 };
 
-exports.update_avatar = function (person) {
-    var url = person.avatar_url;
+exports.update_avatar = function (user_id, avatar_url) {
+    var url = avatar_url;
     url = people.format_small_avatar_url(url);
 
-    $(".inline_profile_picture.u-" + person.user_id).css({
-      "background-image": "url(" + url + ")",
+    _.each([home_msg_list, current_msg_list, message_list.all], function (list) {
+        list.update_user_avatar(user_id, url);
     });
 };
 

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -57,7 +57,7 @@ exports.update_person = function update(person) {
           $("#user-settings-avatar").attr("src", url);
         }
 
-        message_live_update.update_avatar(person_obj);
+        message_live_update.update_avatar(person_obj.user_id, person.avatar_url);
     }
 };
 


### PR DESCRIPTION
We now sweep all active messages for avatar changes and update
the message items and re-render, rather than patching the
DOM.  This avoids some quirks that happen when subsequent messages
get sent and we re-render previous messages out of the message
store.

Our approach here is similar to how we do full-name updates.