### PR TITLE
[Fix]: Remove unecessaary subscriptions header arrow.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -389,6 +389,8 @@ form#add_new_subscription {
 }
 
 .subscriptions-header .icon-vector-chevron-left {
+    display: none;
+
     position: relative;
     transform: translate(-50px, 0px);
     opacity: 0;
@@ -920,6 +922,10 @@ form#add_new_subscription {
 @media (max-width: 700px) {
     .subscriptions-container {
         position: relative;
+    }
+
+    .subscriptions-header .icon-vector-chevron-left {
+        display: block;
     }
 
     #subscription_overlay .left,


### PR DESCRIPTION
This removes the arrow from the subscriptions header at full
widths where the arrow is not required because the subscription
settings/stream creation prompt don't take up the full width of
the screen and require an arrow to go back to the streams list.

Fixes: #3762.