### PR TITLE
settings: Fix backdrop leak when hitting esc with modal open.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -236,6 +236,10 @@ function process_hotkey(e) {
             }
             return true;
         } else if (event_name === 'escape') {
+            // To avoid backdrop leak when a modal is opened and "escape" is clicked
+            if ($(document.activeElement).hasClass('modal hide in')) {
+                return false;
+            }
             $("#settings_overlay_container .exit").click();
             return true;
         }


### PR DESCRIPTION
We now avoid the backdrop leak which occurred on hitting escape on settings page when a modal was open (e.g. "change email").

Fixes #3791 