### PR TITLE
Fix view source and edit message popover behavior.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -173,7 +173,13 @@ exports.toggle_actions_popover = function (element, id) {
         var editability = message_edit.get_editability(message);
         var use_edit_icon;
         var editability_menu_item;
-        if (editability === message_edit.editability_types.FULL) {
+        var cancel_editability_icon = false;
+        var row = current_msg_list.get_row(id);
+        if ($(row[0]).find('.message_content').css('display') === 'none') {
+            use_edit_icon = false;
+            cancel_editability_icon = true;
+            editability_menu_item = i18n.t("Back to Message");
+        } else if (editability === message_edit.editability_types.FULL) {
             use_edit_icon = true;
             editability_menu_item = i18n.t("Edit");
         } else if (editability === message_edit.editability_types.TOPIC_ONLY) {
@@ -200,6 +206,7 @@ exports.toggle_actions_popover = function (element, id) {
             message: message,
             use_edit_icon: use_edit_icon,
             editability_menu_item: editability_menu_item,
+            cancel_editability_icon: cancel_editability_icon,
             can_mute_topic: can_mute_topic,
             can_unmute_topic: can_unmute_topic,
             should_display_add_reaction_option: message.sent_by_me,
@@ -825,8 +832,13 @@ exports.register_click_handlers = function () {
     $('body').on('click', '.popover_edit_message', function (e) {
         var msgid = $(e.currentTarget).data('message-id');
         var row = current_msg_list.get_row(msgid);
-        popovers.hide_actions_popover();
-        message_edit.start(row);
+        // To close message source/edit if it is open, else open it.
+        if ($(row[0]).find('.message_content').css('display') === 'none') {
+            message_edit.end(row);
+        } else {
+            message_edit.start(row);
+            popovers.hide_actions_popover();
+        }
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/templates/actions_popover_content.handlebars
+++ b/static/templates/actions_popover_content.handlebars
@@ -3,7 +3,7 @@
   <li>
     <a href="#" class="popover_edit_message" data-message-id="{{message.id}}">
       {{! Can consider http://fontawesome.io/icon/file-code-o/ when we upgrade to font awesome 4.}}
-      <i class="{{#if use_edit_icon}}icon-vector-pencil{{else}}icon-vector-file-text-alt{{/if}}"></i> {{editability_menu_item}}
+      <i class="{{#if use_edit_icon}}icon-vector-pencil{{else}}{{#if cancel_editability_icon}}icon-vector-arrow-left{{else}}icon-vector-file-text-alt{{/if}}{{/if}}"></i> {{editability_menu_item}}
     </a>
   </li>
 


### PR DESCRIPTION
We now make sure that `View Source` and `Edit Message` options don't misbehave upon selection when feature is already active.
Earlier if `View Souce` and `Edit Message` were chosen after being chosen once, then the message narrow shifted to next message. Now we make sure that upon re-selection, the feature is closed.

Fixes #3802 