### PR TITLE
compose: Rename 'New stream message' to 'New topic'.

### DIFF
--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -153,8 +153,8 @@ populated and where the focus is placed.
     - use C to compose a new PM
 
 - Buttons
-    - Narrow to a stream and click on "New stream message"
-    - Narrow "Private Messages" and click on "New stream message"
+    - Narrow to a stream and click on "New topic"
+    - Narrow "Private Messages" and click on "New topic"
     - Narrow to a stream and click on "New private message"
     - Narrow "Private Messages" and click on "New private message"
 

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -13,8 +13,8 @@
             </span>
             <span class="new_message_button">
               <button type="button" class="button white small rounded compose_stream_button"
-                      id="left_bar_compose_stream_button_big" title="{{ _('New stream message (c)') }}">
-                <span class="compose_stream_button_label">{{ _('New stream message') }}</span>
+                      id="left_bar_compose_stream_button_big" title="{{ _('New topic (c)') }}">
+                <span class="compose_stream_button_label">{{ _('New topic') }}</span>
               </button>
             </span>
             {% if not embedded %}


### PR DESCRIPTION
This doesn't update documentation, because we need to update that
anyway to show screenshots of the new compose box.