### PR TITLE
Huge performance update for subscriber list in streams.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -349,9 +349,12 @@ function show_subscription_settings(sub_row) {
                 }
                 return format_member_list_elem(elem);
             });
-            _.each(subscribers.sort(), function (elem) {
-                list.append(elem);
-            });
+
+            var list_html = _.reduce(subscribers.sort(), function (accumulator, item) {
+                return accumulator + item;
+            }, "");
+
+            list.append(list_html);
         },
         error: function () {
             loading.destroy_indicator(indicator_elem);


### PR DESCRIPTION
Previously the mechanism worked such that the innerHTML was being
appended to directly potentially thousands of times which has horrific
performance implications. By concating all the strings together before
appending to the HTML it all gets rendered in one chunk without forcing
a re-render of previous elements. Performance is ~15x-20x faster now.