### PR TITLE
server-version: Add server version to api endpoints.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -32,6 +32,8 @@ from zerver.models import Client, Message, UserProfile, \
     get_user_profile_by_email, get_user_profile_by_id, \
     get_active_user_dicts_in_realm, realm_filters_for_realm, \
     get_owned_bot_dicts
+from version import ZULIP_VERSION
+
 
 def get_realm_user_dicts(user_profile):
     # type: (UserProfile) -> List[Dict[str, Text]]
@@ -159,6 +161,9 @@ def fetch_initial_state_data(user_profile, event_types, queue_id,
         state['enable_offline_push_notifications'] = user_profile.enable_offline_push_notifications
         state['enable_online_push_notifications'] = user_profile.enable_online_push_notifications
         state['enable_digest_emails'] = user_profile.enable_digest_emails
+
+    if want('zulip_version'):
+        state['zulip_version'] = ZULIP_VERSION
 
     return state
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -35,6 +35,7 @@ from zproject.backends import ZulipDummyBackend, EmailAuthBackend, \
     SocialAuthMixin, AUTH_BACKEND_NAME_MAP
 
 from zerver.views.auth import maybe_send_to_registration
+from version import ZULIP_VERSION
 
 from social_core.exceptions import AuthFailed
 from social_django.strategy import DjangoStrategy
@@ -965,8 +966,8 @@ class FetchAuthBackends(ZulipTestCase):
         self.assert_json_success(result)
         data = ujson.loads(result.content)
         self.assertEqual(set(data.keys()),
-                         {'msg', 'password', 'google', 'dev', 'result'})
-        for backend in set(data.keys()) - {'msg', 'result'}:
+                         {'msg', 'password', 'google', 'dev', 'result', 'zulip_version'})
+        for backend in set(data.keys()) - {'msg', 'result', 'zulip_version'}:
             self.assertTrue(isinstance(data[backend], bool))
 
     def test_fetch_auth_backend(self):
@@ -982,6 +983,7 @@ class FetchAuthBackends(ZulipTestCase):
                 'google': True,
                 'dev': True,
                 'result': 'success',
+                'zulip_version': ZULIP_VERSION
             })
 
 class TestDevAuthBackend(ZulipTestCase):

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -28,6 +28,7 @@ from zerver.views.registration import create_preregistration_user, get_realm_fro
     redirect_and_log_into_subdomain
 from zproject.backends import password_auth_enabled, dev_auth_enabled, google_auth_enabled
 from zproject.jinja2 import render_to_response
+from version import ZULIP_VERSION
 
 import hashlib
 import hmac
@@ -463,6 +464,7 @@ def api_get_auth_backends(request):
     return json_success({"password": password_auth_enabled(None),
                          "dev": dev_auth_enabled(),
                          "google": google_auth_enabled(),
+                         "zulip_version": ZULIP_VERSION
                          })
 
 @authenticated_json_post_view

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -9,7 +9,6 @@ from django.utils import translation
 from django.utils.cache import patch_cache_control
 from six.moves import zip_longest, zip, range
 
-from version import ZULIP_VERSION
 from zerver.decorator import zulip_login_required, process_client
 from zerver.forms import ToSForm
 from zerver.lib.realm_icon import realm_icon_url
@@ -190,7 +189,7 @@ def home_real(request):
     # Pass parameters to the client-side JavaScript code.
     # These end up in a global JavaScript Object named 'page_params'.
     page_params = dict(
-        zulip_version         = ZULIP_VERSION,
+        zulip_version         = register_ret['zulip_version'],
         share_the_love        = settings.SHARE_THE_LOVE,
         development_environment = settings.DEVELOPMENT,
         debug_mode            = settings.DEBUG,


### PR DESCRIPTION
- Add server version to `fetch_initial_state_data`.
- Add server version to register event queue api endpoint.
- Add server version to `get_auth_backends` api endpoint.
- Change source for server version in `home` endpoint.
- Fix tests.

Fixes #3663