### PR TITLE
frontend: Add the error message in new line.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -1547,6 +1547,23 @@ label.label-title {
     margin-top: 1px;
 }
 
+input#id_email,
+input#id_new_password1,
+input#id_new_password2,
+input#id_full_name {
+    margin-bottom: 10px;
+}
+
+p#id_full_name-error {
+    margin-left: 200px;
+    display: block;
+}
+
+p#terms-error {
+    display: block;
+    padding-left: 0px;
+}
+
 .display-none {
     display: none;
 }


### PR DESCRIPTION
This adds some space between the text input and the error message.
fix: #3664