### PR TITLE
Remove transition on compose box height.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -300,7 +300,7 @@ textarea.new_message_textarea,
     border: 1px solid #ddd;
     box-shadow: none;
     -webkit-box-shadow: none;
-    transition: all 0.2s ease;
+    transition: border 0.2s ease;
 }
 
 textarea.new_message_textarea:focus,


### PR DESCRIPTION
The transition "all" by default also affected the transition
on the height change of the compose box which ended up making the
compose box appear to be laggy and choppy.