### PR TITLE
Add server error response for a failed handlebars templates compilation.

### DIFF
--- a/templates/zerver/handlebars_compilation_failed.html
+++ b/templates/zerver/handlebars_compilation_failed.html
@@ -1,0 +1,15 @@
+{% extends "zerver/portico.html" %}
+
+{% block customhead %}
+{{ super() }}
+<meta http-equiv="refresh" content="60;URL='/'">
+{% endblock %}
+
+{% block portico_content %}
+
+<br/>
+<p class="lead">500: Internal server error.</p>
+
+<p>{% trans %}Error: Invalid handlebars templates. Please check server log files for details.{% endtrans %}</p>
+
+{% endblock %}

--- a/tools/compile-handlebars-templates
+++ b/tools/compile-handlebars-templates
@@ -33,12 +33,28 @@ def run():
                           ['--output', os.path.join(STATIC_PATH, 'templates/compiled.js'),
                            '--known', 'if,unless,each,with'])
 
+
+def add_error_stamp_file(file_path):
+    # type: (str) -> None
+    file_dir = os.path.dirname(file_path)
+    if not os.path.exists(file_dir):
+        os.makedirs(file_dir)
+    open(file_path, 'a').close()
+
+
+def remove_error_stamp_file(file_path):
+    # type: (str) -> None
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+
 def run_forever():
     # type: () -> None
     # Keep polling for file changes, similar to how Django does it in
     # django/utils/autoreload.py.  If any of our templates change, rebuild
     # compiled.js
     mtimes = {} # type: Dict[str, float]
+    error_file_path = os.path.join(settings.DEPLOY_ROOT, 'var/handlebars-templates/compile.error')
     while True:
         changed = False
         for fn in get_templates():
@@ -50,9 +66,12 @@ def run_forever():
             print('Recompiling templates')
             try:
                 run()
+                remove_error_stamp_file(error_file_path)
                 print('done')
             except:
-                print('\n\n\nPLEASE FIX!!\n\n')
+                add_error_stamp_file(error_file_path)
+                print('\n\n\n\033[91mPLEASE FIX!!\033[0m\n\n')
+
         time.sleep(0.200)
 
 if __name__ == '__main__':

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -107,6 +107,7 @@ class TemplateTestCase(ZulipTestCase):
             'zerver/debug.html',
             'zerver/base.html',
             'zerver/api_content.json',
+            'zerver/handlebars_compilation_failed.html',
         ]
         skip = covered + defer + logged_out + logged_in + unusual + ['tests/test_markdown.html', 'zerver/terms.html']
         templates = [t for t in get_all_templates() if t not in skip]

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -33,6 +33,7 @@ from zproject.jinja2 import render_to_response
 import calendar
 import datetime
 import logging
+import os
 import re
 import simplejson
 import time
@@ -86,6 +87,14 @@ def sent_time_in_epoch_seconds(user_message):
 
 def home(request):
     # type: (HttpRequest) -> HttpResponse
+    if settings.DEVELOPMENT and os.path.exists('var/handlebars-templates/compile.error'):
+        error_text = """Error: Invalid handlebars templates.
+        Please check server log files for details.
+        """
+        response = render_to_response('zerver/handlebars_compilation_failed.html',
+                                      {'error_text': error_text}, request=request)
+        response.status_code = 500
+        return response
     if not settings.SUBDOMAINS_HOMEPAGE:
         return home_real(request)
 


### PR DESCRIPTION
- Add stamp file creation for the failed templates compilation.
- Add error response to `home` route if stamp file exists. It works
  just for development environment.
- Add `error_text` parameter to jinja template for 500 HTTP error.

Fixes #3650