### PR TITLE
Removed irrelevant 'Updated settings' message at the bottom of admin page.

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -99,12 +99,6 @@ casper.then(function () {
     });
 });
 
-casper.then(function () {
-    casper.waitUntilVisible('#settings-status', function () {
-        casper.test.assertSelectorHasText('#settings-status', 'Updated settings!');
-    });
-});
-
 casper.then(function create_bot() {
     casper.test.info('Filling out the create bot form');
 

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -3,6 +3,7 @@
     <i class="icon-vector-user settings-section-icon"></i>
     {{t "Your account" }}
   </div>
+  <div class="alert" id="settings-status"></div>
   <div class="account-settings-form">
     <form class="email-change-form">
       <p for="change_email" class="inline-block title">

--- a/static/templates/settings_tab.handlebars
+++ b/static/templates/settings_tab.handlebars
@@ -1,6 +1,4 @@
 <div id="settings-change-box" class="new-style">
-    <div class="alert" id="settings-status"></div>
-
     {{ partial "account-settings" }}
 
     {{ partial "display-settings" }}


### PR DESCRIPTION
The 'Updated Settings' message we get at the bottom
of admin-page when we change the name is removed.
Fixes #3815.