### PR TITLE
signup: Make error message for a weak password more clear.

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -4,7 +4,7 @@ $(function () {
 
     $.validator.addMethod('password_strength', function (value) {
         return password_quality(value, undefined, $('#id_password, #id_new_password1'));
-    }, 'Password is weak.');
+    }, i18n.t("Password is too weak."));
 
     function highlight(class_to_add) {
         // Set a class on the enclosing control group.


### PR DESCRIPTION
"Password is weak" sounds like an fyi rather than "we're going to stop you
from registering until you fix this".