### PR TITLE
analytics: Remove sidebar from /stats.

### DIFF
--- a/static/styles/stats.css
+++ b/static/styles/stats.css
@@ -27,34 +27,8 @@ svg {
     font-size: 36px;
 }
 
-.sidebar {
-    width: 300px;
-    height: calc(100vh - 94px);
-    z-index: 2;
-    display: inline-block;
-    vertical-align: top;
-    border-right: 1px solid #eee;
-}
-
-.nav {
-    margin-left: 20px;
-}
-
-.nav-subtitle {
-    font-size: 20px;
-    font-weight: 300;
-    margin-top: 40px;
-    margin-bottom: 7px;
-}
-
-.nav-link {
-    display: block;
-    font-size: 17px;
-    margin-left: 25px;
-}
-
 .page-content {
-    width: calc(100% - 300px - 8px);
+    width: 100%;
     overflow: auto;
     display: inline-block;
     vertical-align: top;

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -10,16 +10,6 @@
 {{ minified_js('stats')|safe }}
 {% stylesheet 'stats' %}
 
-<div class="sidebar">
-    <nav class="nav">
-        <p class="nav-subtitle">Messages Sent</p>
-        <a href="#messages_timescale_anchor" class="nav-link">Messages Sent Over Time</a>
-        <a href="#messages_by_client_anchor" class="nav-link">Messages Sent by Client</a>
-        <a href="#messages_by_type_anchor" class="nav-link">Messages Sent by Recipient Type</a>
-        <p class="nav-subtitle">Users</p>
-        <a href="#users_anchor" class="nav-link">Number of Users</a>
-    </nav>
-</div>
 <div class="page-content">
   <div id="id_stats_errors" class="alert alert-error"></div>
   <h1 class="analytics-page-header">Zulip Analytics for {{ realm_name }}</h1>


### PR DESCRIPTION
It's currently broken (e.g. see Issue #3713) and non-responsive. The whole
page needs to be styled anyway, so these can be added back once that
happens.