### PR TITLE
Check if the db exists before generating the realm creation url.

### DIFF
--- a/zerver/management/commands/generate_realm_creation_link.py
+++ b/zerver/management/commands/generate_realm_creation_link.py
@@ -4,7 +4,10 @@ from __future__ import print_function
 from typing import Any
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import ProgrammingError
 from confirmation.models import generate_realm_creation_url
+from zerver.models import Realm
+import sys
 
 class Command(BaseCommand):
     help = """Outputs a randomly generated, 1-time-use link for Organization creation.
@@ -16,6 +19,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # type: (*Any, **Any) -> None
+
+        try:
+            # first check if the db has been initalized
+            Realm.objects.first()
+
+        except ProgrammingError:
+            print("The Zulip database does not appear to exist. Have you run initialize-database?")
+            sys.exit(1)
+
         url = generate_realm_creation_url()
         self.stdout.write(
             "\033[1;92mPlease visit the following secure single-use link to register your ")


### PR DESCRIPTION
If `Realm.objects.first()` fails, stop and print a message.
```
 Installation complete!

 Now edit /etc/zulip/settings.py and fill in the mandatory values.

 Once you've done that, please run:

 su zulip -c /home/zulip/deployments/current/scripts/setup/initialize-database

 To configure the initial database.
root@minmi:~# emacs /etc/zulip/zulip.conf 
root@minmi:~# emacs /etc/zulip/settings.py 
root@minmi:~# emacs /etc/zulip/zulip-secrets.conf 
root@minmi:~# su zulip
zulip@minmi:/root$ /home/zulip/deployments/current/manage.py generate_realm_creation_link
The Zulip database does not appear to exist. Have you run initialize-database?
```
The exception that results in this message is `django.db.utils.ProgrammingError: relation "zerver_realm" does not exist`

I made a tarball to test this as a clean prod install. I got the message when expected, and was able to complete the install after I did things in the correct order. 

Fixes #3672