### PR TITLE
Update GSoC section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,7 @@ is valuable.
 ## Google Summer of Code
 
 We participated in
-[GSoC](https://developers.google.com/open-source/gsoc/) last year and
-hope to do so again in 2017.  For guidance, please read
+[GSoC](https://developers.google.com/open-source/gsoc/) last year and participating in 2017 too.  For guidance, please read
 [our GSoC instructions and ideas page](https://github.com/zulip/zulip.github.io/blob/master/gsoc-ideas.md)
 and feel free to email
 [our GSoC mailing list](https://groups.google.com/forum/#!forum/zulip-gsoc).


### PR DESCRIPTION
Updated GSoC section to indicate about zulip participating again in 2017.