### PR TITLE
Fixed the broken alert words UI

### DIFF
--- a/static/templates/alert_word_settings_item.handlebars
+++ b/static/templates/alert_word_settings_item.handlebars
@@ -25,7 +25,7 @@
         </div>
     </div>
     {{else}}
-    <div class="alert-word-information-box list-container">
+    <div class="alert-word-information-box grey-bg">
         <div class="alert_word_listing">
             <span class="value">{{word}}</span>
         </div>


### PR DESCRIPTION
The alert words UI list was referencing a non-existent CSS property. This fix updates the CSS property referenced. The new CSS property is grey-bg, this property is also used by other UI elements that show a listing of new settings created, similar to alert words list.

The tests for this fix are being updated in another issue #1269
File changed: alert_word_settings_item.handlebars

Fixes #3823