### PR TITLE
compose: Focus on topic when narrowed to a stream+topic.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -335,7 +335,7 @@ $(function () {
 
 
     $('.compose_stream_button').click(function () {
-        compose.start('stream');
+        compose.start('stream', {trigger: 'new topic button'});
     });
     $('.compose_private_button').click(function () {
         compose.start('private');

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -264,8 +264,13 @@ exports.start = function (msg_type, opts) {
 
     is_composing_message = msg_type;
 
-    // Show either stream/topic fields or "You and" field.
-    show_box_for_msg_type(msg_type, opts);
+    // Set focus to "Topic" when narrowed to a stream+topic and "New topic" button clicked.
+    if (opts.trigger === "new topic button") {
+        show_box('stream', $("#subject"), opts);
+    } else {
+        // Show either stream/topic fields or "You and" field.
+        show_box_for_msg_type(msg_type, opts);
+    }
 
     compose_fade.start_compose(msg_type);
 


### PR DESCRIPTION
When narrowed to a stream+topic and clicking the "new topic" button, focus in on topic and the text remains selected.
Fixes #3888.