### PR TITLE
Improve error checking for peer_add/peer_remove events.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -394,6 +394,7 @@ function capture_args(res, arg_names) {
         _.each(arg_names, function (name, i) {
             res[name] = my_arguments[i];
         });
+        return true;
     };
 }
 

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -166,7 +166,8 @@ var people = global.people;
     assert(!stream_data.user_is_subscribed('Rome', email));
 
     // add
-    stream_data.add_subscriber('Rome', brutus.user_id);
+    var ok = stream_data.add_subscriber('Rome', brutus.user_id);
+    assert(ok);
     assert(stream_data.user_is_subscribed('Rome', email));
     sub = stream_data.get_sub('Rome');
     stream_data.update_subscribers_count(sub);
@@ -180,7 +181,8 @@ var people = global.people;
     assert.equal(sub.subscriber_count, 1);
 
     // remove
-    stream_data.remove_subscriber('Rome', brutus.user_id);
+    ok = stream_data.remove_subscriber('Rome', brutus.user_id);
+    assert(ok);
     assert(!stream_data.user_is_subscribed('Rome', email));
     sub = stream_data.get_sub('Rome');
     stream_data.update_subscribers_count(sub);
@@ -191,7 +193,8 @@ var people = global.people;
     global.blueslip.warn = function () {};
 
     // verify that removing an already-removed subscriber is a noop
-    stream_data.remove_subscriber('Rome', brutus.user_id);
+    ok = stream_data.remove_subscriber('Rome', brutus.user_id);
+    assert(!ok);
     assert(!stream_data.user_is_subscribed('Rome', email));
     sub = stream_data.get_sub('Rome');
     stream_data.update_subscribers_count(sub);
@@ -207,11 +210,20 @@ var people = global.people;
 
     // Verify that we noop and don't crash when unsubscribed.
     sub.subscribed = false;
-    stream_data.add_subscriber('Rome', brutus.user_id);
+    ok = stream_data.add_subscriber('Rome', brutus.user_id);
+    assert(ok);
     assert.equal(stream_data.user_is_subscribed('Rome', email), undefined);
     stream_data.remove_subscriber('Rome', brutus.user_id);
     assert.equal(stream_data.user_is_subscribed('Rome', email), undefined);
 
+    // Verify that we don't crash and return false for a bad stream.
+    ok = stream_data.add_subscriber('UNKNOWN', brutus.user_id);
+    assert(!ok);
+
+    // Verify that we don't crash and return false for a bad user id.
+    global.blueslip.error = function () {};
+    ok = stream_data.add_subscriber('Rome', 9999999);
+    assert(!ok);
 }());
 
 (function test_process_message_for_recent_topics() {

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -183,9 +183,13 @@ function dispatch_normal_event(event) {
             person = people.get_person_from_user_id(event.user_id);
             email = person.email;
             _.each(event.subscriptions, function (sub) {
-                stream_data.add_subscriber(sub, event.user_id);
-                $(document).trigger('peer_subscribe.zulip',
-                                    {stream_name: sub, user_email: email});
+                if (stream_data.add_subscriber(sub, event.user_id)) {
+                    $(document).trigger(
+                        'peer_subscribe.zulip',
+                        {stream_name: sub, user_email: email});
+                } else {
+                    blueslip.warn('Cannot process peer_add event');
+                }
             });
         } else if (event.op === 'peer_remove') {
             // TODO: remove email shim here and fix called functions
@@ -193,9 +197,13 @@ function dispatch_normal_event(event) {
             person = people.get_person_from_user_id(event.user_id);
             email = person.email;
             _.each(event.subscriptions, function (sub) {
-                stream_data.remove_subscriber(sub, event.user_id);
-                $(document).trigger('peer_unsubscribe.zulip',
-                                    {stream_name: sub, user_email: email});
+                if (stream_data.remove_subscriber(sub, event.user_id)) {
+                    $(document).trigger(
+                        'peer_unsubscribe.zulip',
+                        {stream_name: sub, user_email: email});
+                } else {
+                    blueslip.warn('Cannot process peer_remove event.');
+                }
             });
         } else if (event.op === 'remove') {
             _.each(event.subscriptions, function (rec) {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -169,28 +169,32 @@ exports.add_subscriber = function (stream_name, user_id) {
     var sub = exports.get_sub(stream_name);
     if (typeof sub === 'undefined') {
         blueslip.warn("We got an add_subscriber call for a non-existent stream.");
-        return;
+        return false;
     }
     var person = people.get_person_from_user_id(user_id);
     if (person === undefined) {
         blueslip.error("We tried to add invalid subscriber: " + user_id);
-        return;
+        return false;
     }
     sub.subscribers.set(user_id, true);
+
+    return true;
 };
 
 exports.remove_subscriber = function (stream_name, user_id) {
     var sub = exports.get_sub(stream_name);
     if (typeof sub === 'undefined') {
         blueslip.warn("We got a remove_subscriber call for a non-existent stream " + stream_name);
-        return;
+        return false;
     }
     if (!sub.subscribers.has(user_id)) {
         blueslip.warn("We tried to remove invalid subscriber: " + user_id);
-        return;
+        return false;
     }
 
     sub.subscribers.del(user_id);
+
+    return true;
 };
 
 exports.user_is_subscribed = function (stream_name, user_email) {


### PR DESCRIPTION
If we get invalid events related to stream subscribers, we now
exit earlier to prevent ugly tracebacks.  We may eventually
want to upgrade some of these warnings to errors, once we fix some
of our live-update bugs.  In particular, we don't yet live-update
users when streams go from private to public, so if you add/remove
subscribers to a newly-public stream that a user still thinks is
private, they will not be able to handle the event through no
fault of the codepath that happens during the add/remove.