### PR TITLE
Change the settings .content-wrapper to be absolutely positioned.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -755,9 +755,10 @@ input[type=checkbox].inline-block {
 }
 
 #settings_page .content-wrapper {
-    position: relative;
-    float: left;
-    width: calc(100% - 250px - 2px);
+    position: absolute;
+    left: 251px;
+    /* the width of the settings sidbar this is right of is 250px + 1px border. */
+    width: calc(100% - 250px - 1px);
     height: 100%;
 }
 
@@ -779,7 +780,7 @@ input[type=checkbox].inline-block {
     position: absolute;
     top: 45px;
     right: 0px;
-    transform: translateX(301px);
+    transform: translateX(303px);
     width: 300px;
     height: calc(100% - 45px);
 


### PR DESCRIPTION
The settings .content-wrapper element would break its float sometimes with browser zoom due to pixel rounding errors. By changing its positioning to absolute, the issue is fixed by forcing it to always reside next to the sidebar.