### PR TITLE
Make get_user_id blueslip errors clear again.

### DIFF
--- a/static/js/people.js
+++ b/static/js/people.js
@@ -80,17 +80,8 @@ exports.update_email = function (user_id, new_email) {
 exports.get_user_id = function (email) {
     var person = people.get_by_email(email);
     if (person === undefined) {
-        // Our blueslip reporting here is a bit complicated, but
-        // there are known race conditions after reload, and we
-        // expect occasional failed lookups, but they should resolve
-        // after five seconds.
         var error_msg = 'Unknown email for get_user_id: ' + email;
-        blueslip.debug(error_msg);
-        setTimeout(function () {
-            if (!people_dict.has(email)) {
-                blueslip.error(error_msg);
-            }
-        }, 5000);
+        blueslip.error(error_msg);
         return undefined;
     }
     var user_id = person.user_id;


### PR DESCRIPTION
We had a theory that get_user_id() errors were often due to race
conditions related to reloads, so we would only report missing
user ids if subsequent lookups failed 5 seconds later.  It turns
out we still get the blueslip errors, and now we don't get
meaningful tracebacks.  This change makes it so that errors
get reported immediately again.