### PR TITLE
Fix Enter key not deleting selected text in compose box #3889.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -141,17 +141,16 @@ function handle_keydown(e) {
             // send and the Shift/Ctrl/Cmd/Alt keys are not pressed.
             // Otherwise, make sure to insert a newline instead
             if (e.target.id === "new_message_content" && code === 13) {
-                e.preventDefault();
 
                 if ((!page_params.enter_sends && (e.metaKey || e.ctrlKey)) ||
                     (page_params.enter_sends && !(e.shiftKey || e.ctrlKey || e.metaKey || e.altKey))
                 ) {
+                    e.preventDefault();
                     if ($("#compose-send-button").attr('disabled') !== "disabled") {
                         $("#compose-send-button").attr('disabled', 'disabled');
                         compose.finish();
                     }
                 } else {
-                    $("#new_message_content").caret('\n');
                     compose.autosize_textarea();
                 }
             }


### PR DESCRIPTION
Fixes #3889 
Before pressing enter
![before_enter](https://cloud.githubusercontent.com/assets/10217472/23582152/0b0aeee0-014a-11e7-9f5d-bd534226db70.png)
After pressing enter
![after_enter](https://cloud.githubusercontent.com/assets/10217472/23582155/13401f22-014a-11e7-978a-efd5bbc54809.png)
