### PR TITLE
user docs: Add user guide for *View messages containing files or links*.

### DIFF
--- a/templates/zerver/help/index.md
+++ b/templates/zerver/help/index.md
@@ -79,6 +79,7 @@ as an **organization**.
 * [View messages from a stream](/help/view-messages-from-a-stream)
 * [View messages from a topic](/help/view-messages-from-a-topic)
 * [View messages from a user](/help/view-messages-from-a-user)
+* [View messages containing files or links](/help/view-messages-containing-files-or-links)
 * [The #announce stream](/help/the-announce-stream)
 * [Add or invite someone to a stream](/help/add-or-invite-someone-to-a-stream)
 * [Change the stream description](/help/change-the-stream-description)

--- a/templates/zerver/help/view-messages-containing-files-or-links.md
+++ b/templates/zerver/help/view-messages-containing-files-or-links.md
@@ -1,0 +1,10 @@
+# View messages containing files or links
+
+By using Zulip's [search feature](/help/search-for-messages), you can search
+your messages for any messages that contain files or links.
+
+* Enter the search operator `has:attachment` in the search bar to narrow your
+view to any messages with a file attachment or upload.
+
+* Enter the search operator `has:link` in the search bar to narrow your
+view to any messages with an external link.


### PR DESCRIPTION
Document viewing messages with files or links in user guide documentation.

Fixes #3754