### PR TITLE
Change bot domains to string_id.EXTERNAL_HOST.

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -115,12 +115,19 @@ casper.then(function create_bot() {
         bot_default_events_register_stream: 'Rome',
     });
 
-    casper.test.info('Submiting the create bot form');
+    casper.test.info('Submitting the create bot form');
     casper.click('#create_bot_button');
 });
 
+var bot_email;
+if (REALMS_HAVE_SUBDOMAINS) {
+    bot_email = '1-bot@zulip.zulipdev.com';
+} else {
+    bot_email = '1-bot@zulip.localhost';
+}
+
 casper.then(function () {
-    var button_sel = '.download_bot_zuliprc[data-email="1-bot@zulip.com"]';
+    var button_sel = '.download_bot_zuliprc[data-email="' + bot_email + '"]';
 
     casper.waitUntilVisible(button_sel, function () {
         casper.click(button_sel);
@@ -135,15 +142,15 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.open_edit_bot_form[data-email="1-bot@zulip.com"]', function open_edit_bot_form() {
+    casper.waitUntilVisible('.open_edit_bot_form[data-email="' + bot_email + '"]', function open_edit_bot_form() {
         casper.test.info('Opening edit bot form');
-        casper.click('.open_edit_bot_form[data-email="1-bot@zulip.com"]');
+        casper.click('.open_edit_bot_form[data-email="' + bot_email + '"]');
     });
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.edit_bot_form[data-email="1-bot@zulip.com"]', function test_edit_bot_form_values() {
-        var form_sel = '.edit_bot_form[data-email="1-bot@zulip.com"]';
+    casper.waitUntilVisible('.edit_bot_form[data-email="' + bot_email + '"]', function test_edit_bot_form_values() {
+        var form_sel = '.edit_bot_form[data-email="' + bot_email + '"]';
         casper.test.info('Testing edit bot form values');
 
     //     casper.test.assertEqual(

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -24,13 +24,13 @@
           <div class="input-group">
             <label for="create_bot_name">{{t "Full name" }}</label>
             <input type="text" name="bot_name" id="create_bot_name" class="required"
-                   maxlength=100 placeholder="{{t 'Full bot name' }}" value="" />
+                   maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />
             <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
           </div>
           <div class="input-group">
             <label for="bot_short_name">{{t "Username" }}</label>
             <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part"
-                   placeholder="bot_user_name" value="" />
+                   placeholder="cookie" value="" />
                    -bot@{{ page_params.realm_bot_domain }}
             <div>
               <label for="create_bot_short_name" generated="true" class="text-error"></label>

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -31,7 +31,7 @@
             <label for="bot_short_name">{{t "Username" }}</label>
             <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part"
                    placeholder="bot_user_name" value="" />
-                   -{{t "bot" }}@{{ page_params.domain }}
+                   -bot@{{ page_params.realm_bot_domain }}
             <div>
               <label for="create_bot_short_name" generated="true" class="text-error"></label>
             </div>

--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -52,7 +52,8 @@ def server_is_up(server, log_file):
         return False
 
 @contextmanager
-def test_server_running(force=False, external_host='testserver', log_file=None, dots=False, use_db=True):
+def test_server_running(force=False, external_host='testserver',
+                        log_file=None, dots=False, use_db=True):
     # type: (bool, str, str, bool, bool) -> Iterator[None]
     if log_file:
         if os.path.exists(log_file) and os.path.getsize(log_file) < 100000:

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -107,6 +107,7 @@ def fetch_initial_state_data(user_profile, event_types, queue_id,
         state['realm_icon_source'] = user_profile.realm.icon_source
         state['realm_email_changes_disabled'] = user_profile.realm.email_changes_disabled
         state['max_icon_file_size'] = settings.MAX_ICON_FILE_SIZE
+        state['realm_bot_domain'] = user_profile.realm.get_bot_domain()
 
     if want('realm_domain'):
         state['realm_domain'] = user_profile.realm.domain

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -191,6 +191,16 @@ class Realm(ModelReprMixin, models.Model):
         # TODO: Change return type to QuerySet[UserProfile]
         return UserProfile.objects.filter(realm=self, is_active=True).select_related()
 
+    def get_bot_domain(self):
+        # type: () -> str
+        # Remove the port. Mainly needed for development environment.
+        external_host = settings.EXTERNAL_HOST.split(':')[0]
+        if settings.REALMS_HAVE_SUBDOMAINS or \
+           Realm.objects.filter(deactivated=False) \
+                        .exclude(string_id__in=settings.SYSTEM_ONLY_REALMS).count() > 1:
+            return "%s.%s" % (self.string_id, external_host)
+        return external_host
+
     @property
     def subdomain(self):
         # type: () -> Optional[Text]

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1091,7 +1091,8 @@ class TestZulipRemoteUserBackend(ZulipTestCase):
         with self.settings(REALMS_HAVE_SUBDOMAINS=True,
                            AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
             with mock.patch('zerver.views.auth.get_subdomain', return_value='acme'):
-                result = self.client_post('http://testserver:9080/accounts/login/sso/', REMOTE_USER=email)
+                result = self.client_post('http://testserver:9080/accounts/login/sso/',
+                                          REMOTE_USER=email)
                 self.assertEqual(result.status_code, 200)
                 self.assertIs(get_session_dict_user(self.client.session), None)
                 self.assertIn(b"Let's get started", result.content)
@@ -1102,7 +1103,8 @@ class TestZulipRemoteUserBackend(ZulipTestCase):
         with self.settings(REALMS_HAVE_SUBDOMAINS=True,
                            AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
             with mock.patch('zerver.views.auth.get_subdomain', return_value=''):
-                result = self.client_post('http://testserver:9080/accounts/login/sso/', REMOTE_USER=email)
+                result = self.client_post('http://testserver:9080/accounts/login/sso/',
+                                          REMOTE_USER=email)
                 self.assertEqual(result.status_code, 200)
                 self.assertIs(get_session_dict_user(self.client.session), None)
                 self.assertIn(b"Let's get started", result.content)

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -97,6 +97,7 @@ class HomeTest(ZulipTestCase):
             "realm_add_emoji_by_admins_only",
             "realm_allow_message_editing",
             "realm_authentication_methods",
+            "realm_bot_domain",
             "realm_create_stream_by_admins_only",
             "realm_default_language",
             "realm_default_streams",

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1025,12 +1025,12 @@ class MessagePOSTTest(ZulipTestCase):
         result = self.client_post("/json/bots", bot_info)
         self.assert_json_success(result)
 
-        email = "irc-bot@zulip.com"
+        email = "irc-bot@zulip.testserver"
         user = get_user_profile_by_email(email)
         user.is_api_super_user = True
         user.save()
         user = get_user_profile_by_email(email)
-        self.subscribe_to_stream(email, "#IRCland")
+        self.subscribe_to_stream(email, "#IRCland", realm=user.realm)
         result = self.client_post("/api/v1/messages",
                                   {"type": "stream",
                                    "forged": "true",

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -291,6 +291,7 @@ def home_real(request):
         'realm_add_emoji_by_admins_only',
         'realm_allow_message_editing',
         'realm_authentication_methods',
+        'realm_bot_domain',
         'realm_create_stream_by_admins_only',
         'realm_default_language',
         'realm_default_streams',

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -238,7 +238,7 @@ def add_bot_backend(request, user_profile, full_name_raw=REQ("full_name"), short
     # type: (HttpRequest, UserProfile, Text, Text, Optional[Text], Optional[Text], Optional[bool]) -> HttpResponse
     short_name += "-bot"
     full_name = check_full_name(full_name_raw)
-    email = short_name + "@" + user_profile.realm.domain
+    email = '%s@%s' % (short_name, user_profile.realm.get_bot_domain())
     form = CreateUserForm({'full_name': full_name, 'email': email})
     if not form.is_valid():
         # We validate client-side as well


### PR DESCRIPTION
Change applies to both subdomains and non-subdomains case, though we use
just the EXTERNAL_HOST in the non-subdomains case if there is only 1 realm.

Fixes #3903.