### PR TITLE
stats: Change time ranges for bar graph and pie chart.

### DIFF
--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -414,18 +414,42 @@ function populate_messages_sent_by_client(data) {
     var plot_data = {
         realm: {
             cumulative: make_plot_data(data.realm, data.end_times.length),
-            thirty: make_plot_data(data.realm, 30),
-            ten: make_plot_data(data.realm, 10),
+            year: make_plot_data(data.realm, 365),
+            month: make_plot_data(data.realm, 30),
+            week: make_plot_data(data.realm, 7),
         },
         user: {
             cumulative: make_plot_data(data.user, data.end_times.length),
-            thirty: make_plot_data(data.user, 30),
-            ten: make_plot_data(data.user, 10),
+            year: make_plot_data(data.user, 365),
+            month: make_plot_data(data.user, 30),
+            week: make_plot_data(data.user, 7),
         },
     };
 
     var user_button = 'realm';
-    var time_button = 'cumulative';
+    var time_button;
+    if (data.end_times.length >= 30) {
+        time_button = 'month';
+        $('#messages_by_client_last_month_button').css('background', button_selected);
+    } else {
+        time_button = 'cumulative';
+        $('#messages_by_client_cumulative_button').css('background', button_selected);
+    }
+
+    function remove_button(button_id) {
+        var elem = document.getElementById(button_id);
+        elem.parentNode.removeChild(elem);
+    }
+
+    if (data.end_times.length < 365) {
+        remove_button('messages_by_client_last_year_button');
+        if (data.end_times.length < 30) {
+            remove_button('messages_by_client_last_month_button');
+            if (data.end_times.length < 7) {
+                remove_button('messages_by_client_last_week_button');
+            }
+        }
+    }
 
     function draw_plot() {
         var data_ = plot_data[user_button][time_button];
@@ -448,8 +472,9 @@ function populate_messages_sent_by_client(data) {
 
     function set_time_button(button) {
         $('#messages_by_client_cumulative_button').css('background', button_unselected);
-        $('#messages_by_client_thirty_days_button').css('background', button_unselected);
-        $('#messages_by_client_ten_days_button').css('background', button_unselected);
+        $('#messages_by_client_last_year_button').css('background', button_unselected);
+        $('#messages_by_client_last_month_button').css('background', button_unselected);
+        $('#messages_by_client_last_week_button').css('background', button_unselected);
         button.css('background', button_selected);
     }
 
@@ -471,15 +496,21 @@ function populate_messages_sent_by_client(data) {
         draw_plot();
     });
 
-    $('#messages_by_client_thirty_days_button').click(function () {
+    $('#messages_by_client_last_year_button').click(function () {
         set_time_button($(this));
-        time_button = 'thirty';
+        time_button = 'year';
         draw_plot();
     });
 
-    $('#messages_by_client_ten_days_button').click(function () {
+    $('#messages_by_client_last_month_button').click(function () {
         set_time_button($(this));
-        time_button = 'ten';
+        time_button = 'month';
+        draw_plot();
+    });
+
+    $('#messages_by_client_last_week_button').click(function () {
+        set_time_button($(this));
+        time_button = 'week';
         draw_plot();
     });
 
@@ -549,19 +580,43 @@ function populate_messages_sent_by_message_type(data) {
     var plot_data = {
         realm: {
             cumulative: make_plot_data(data.realm, data.end_times.length),
-            thirty: make_plot_data(data.realm, 30),
-            ten: make_plot_data(data.realm, 10),
+            year: make_plot_data(data.realm, 365),
+            month: make_plot_data(data.realm, 30),
+            week: make_plot_data(data.realm, 7),
         },
         user: {
             cumulative: make_plot_data(data.user, data.end_times.length),
-            thirty: make_plot_data(data.user, 30),
-            ten: make_plot_data(data.user, 10),
+            year: make_plot_data(data.user, 365),
+            month: make_plot_data(data.user, 30),
+            week: make_plot_data(data.user, 7),
         },
     };
 
     var user_button = 'realm';
-    var time_button = 'cumulative';
+    var time_button;
+    if (data.end_times.length >= 30) {
+        time_button = 'month';
+        $('#messages_by_type_last_month_button').css('background', button_selected);
+    } else {
+        time_button = 'cumulative';
+        $('#messages_by_type_cumulative_button').css('background', button_selected);
+    }
     var totaldiv = document.getElementById('pie_messages_sent_by_type_total');
+
+    function remove_button(button_id) {
+        var elem = document.getElementById(button_id);
+        elem.parentNode.removeChild(elem);
+    }
+
+    if (data.end_times.length < 365) {
+        remove_button('messages_by_type_last_year_button');
+        if (data.end_times.length < 30) {
+            remove_button('messages_by_type_last_month_button');
+            if (data.end_times.length < 7) {
+                remove_button('messages_by_type_last_week_button');
+            }
+        }
+    }
 
     function draw_plot() {
         Plotly.newPlot('id_messages_sent_by_message_type',
@@ -582,8 +637,9 @@ function populate_messages_sent_by_message_type(data) {
 
     function set_time_button(button) {
         $('#messages_by_type_cumulative_button').css('background', button_unselected);
-        $('#messages_by_type_thirty_days_button').css('background', button_unselected);
-        $('#messages_by_type_ten_days_button').css('background', button_unselected);
+        $('#messages_by_type_last_year_button').css('background', button_unselected);
+        $('#messages_by_type_last_month_button').css('background', button_unselected);
+        $('#messages_by_type_last_week_button').css('background', button_unselected);
         button.css('background', button_selected);
     }
 
@@ -605,15 +661,21 @@ function populate_messages_sent_by_message_type(data) {
         draw_plot();
     });
 
-    $('#messages_by_type_thirty_days_button').click(function () {
+    $('#messages_by_type_last_year_button').click(function () {
         set_time_button($(this));
-        time_button = 'thirty';
+        time_button = 'year';
         draw_plot();
     });
 
-    $('#messages_by_type_ten_days_button').click(function () {
+    $('#messages_by_type_last_month_button').click(function () {
         set_time_button($(this));
-        time_button = 'ten';
+        time_button = 'month';
+        draw_plot();
+    });
+
+    $('#messages_by_type_last_week_button').click(function () {
+        set_time_button($(this));
+        time_button = 'week';
         draw_plot();
     });
 }

--- a/static/styles/stats.css
+++ b/static/styles/stats.css
@@ -189,17 +189,22 @@ svg {
 
 #messages_by_client_cumulative_button {
     font-size: 14px;
-    background: #D8D8D8;
-}
-
-#messages_by_client_ten_days_button {
-    font-size: 14px;
-    margin-left: 50px;
     background: #F0F0F0;
 }
 
-#messages_by_client_thirty_days_button {
+#messages_by_client_last_year_button {
     font-size: 14px;
+    background: #F0F0F0;
+}
+
+#messages_by_client_last_month_button {
+    font-size: 14px;
+    background: #F0F0F0;
+}
+
+#messages_by_client_last_week_button {
+    font-size: 14px;
+    margin-left: 50px;
     background: #F0F0F0;
 }
 
@@ -217,21 +222,27 @@ svg {
 
 #messages_by_type_cumulative_button {
     font-size: 14px;
-    background: #D8D8D8;
+    background: #F0F0F0;
     vertical-align: top;
 }
 
-#messages_by_type_ten_days_button {
+#messages_by_type_last_year_button {
+    font-size: 14px;
+    background: #F0F0F0;
+    vertical-align: top;
+}
+
+#messages_by_type_last_month_button {
+    font-size: 14px;
+    background: #F0F0F0;
+    vertical-align: top;
+}
+
+#messages_by_type_last_week_button {
     font-size: 14px;
     background: #F0F0F0;
     vertical-align: top;
     margin-left: 50px;
-}
-
-#messages_by_type_thirty_days_button {
-    font-size: 14px;
-    background: #F0F0F0;
-    vertical-align: top;
 }
 
 #pie_container {

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -51,9 +51,10 @@
       <div id="id_messages_sent_by_client"></div>
       <button class="pie-button" type="button" id='messages_by_client_user_button'> Me </button>
       <button class="pie-button" type="button" id='messages_by_client_realm_button'> Everyone </button>
-      <button class="pie-button" type="button" id='messages_by_client_ten_days_button'> Last 10 Days </button>
-      <button class="pie-button" type="button" id='messages_by_client_thirty_days_button'> Last 30 Days </button>
-      <button class="pie-button" type="button" id='messages_by_client_cumulative_button'> All time </button>
+      <button class="pie-button" type="button" id='messages_by_client_last_week_button'> Last Week </button>
+      <button class="pie-button" type="button" id='messages_by_client_last_month_button'> Last Month </button>
+      <button class="pie-button" type="button" id='messages_by_client_last_year_button'> Last Year </button>
+      <button class="pie-button" type="button" id='messages_by_client_cumulative_button'> All Time </button>
     </div>
     <div id="pie_messages_sent_by_type">
       <p class="graph-title" id="messages_by_type_anchor">Messages Sent by Recipient Type</p>
@@ -61,9 +62,10 @@
       <div id="pie_messages_sent_by_type_total"> </div>
       <button class="pie-button" type="button" id='messages_by_type_user_button'> Me </button>
       <button class="pie-button" type="button" id='messages_by_type_realm_button'> Everyone </button>
-      <button class="pie-button" type="button" id='messages_by_type_ten_days_button'> Last 10 Days </button>
-      <button class="pie-button" type="button" id='messages_by_type_thirty_days_button'> Last 30 Days </button>
-      <button class="pie-button" type="button" id='messages_by_type_cumulative_button'> All time </button>
+      <button class="pie-button" type="button" id='messages_by_type_last_week_button'> Last Week </button>
+      <button class="pie-button" type="button" id='messages_by_type_last_month_button'> Last Month </button>
+      <button class="pie-button" type="button" id='messages_by_type_last_year_button'> Last Year </button>
+      <button class="pie-button" type="button" id='messages_by_type_cumulative_button'> All Time </button>
     </div>
   </div>
   <div class="center-container">


### PR DESCRIPTION
- Change templates/analytics/stats.html to use 'Last
  Week', 'Last Month', 'Last Year' time ranges instead
  of 'Last 10 days', 'Last 30 days'.
- Change static/styles/stats.css to not set background
  color for default time option, for messages sent by
  client and message by recipient type.
- Change static/js/stats/stats.js to show only available
  time range options, and set background color for the
  default. The default is Last Month if it exists, and
  otherwise All Time.

Fixes: #3856