### PR TITLE
Make message time more readable

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -538,7 +538,7 @@ td.pointer {
     color: #a1a1a1;
     vertical-align: middle;
     padding: 1px;
-    font-weight: 300;
+    font-weight: 400;
     position: absolute;
     right: -105px;
     line-height: 20px;


### PR DESCRIPTION
Very light gray with the combination of light font weight makes the message text hard to read.
Increasing font-weight from 300 (light) to 400 (normal) but keeping the light gray makes it readable but still subdued.