### PR TITLE
uwsgi: Add master mode to the main uwsgi process.

### DIFF
--- a/puppet/zulip/templates/uwsgi.ini.template.erb
+++ b/puppet/zulip/templates/uwsgi.ini.template.erb
@@ -2,6 +2,7 @@
 socket=/home/zulip/deployments/uwsgi-socket
 module=zproject.wsgi:application
 chdir=/home/zulip/deployments/current/
+master=true
 chmod-socket=700
 chown-socket=zulip:zulip
 processes=<%= @uwsgi_processes %>


### PR DESCRIPTION
Enable `master` parameter for `uswgi` configuration.
It allows cleaning leaked processes if the parent
process is closed unexpectedly or with SIGKILL command.
Child processes follow to the master and kill themselves
after the main process.

Fixes #3855