### PR TITLE
Fix: change mobile sidebar click target to call new popover function.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -225,7 +225,7 @@ $(function () {
         var sidebarHidden = !$(".app-main .column-left").hasClass("expanded");
         popovers.hide_all();
         if (sidebarHidden) {
-            popovers.show_streamlist_sidebar();
+            stream_popover.show_streamlist_sidebar();
         }
     });
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -32,7 +32,7 @@ exports.hide_topic_popover = function () {
 // These are the only two functions that is really shared by the
 // two popovers, so we could split out topic stuff to
 // another module pretty easily.
-exports.resize_stream_list = function () {
+exports.show_streamlist_sidebar = function () {
     $(".app-main .column-left").addClass("expanded");
     resize.resize_page_components();
 };
@@ -82,7 +82,7 @@ function build_stream_popover(e) {
     }
 
     popovers.hide_all();
-    exports.resize_stream_list();
+    exports.show_streamlist_sidebar();
 
     var stream = $(elt).parents('li').attr('data-name');
 
@@ -130,7 +130,7 @@ function build_topic_popover(e) {
     }
 
     popovers.hide_all();
-    exports.resize_stream_list();
+    exports.show_streamlist_sidebar();
 
     var is_muted = muting.is_topic_muted(stream_name, topic_name);
     var can_mute_topic = !is_muted;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -156,6 +156,7 @@ p.n-margin {
     height: 100%;
     overflow-y: scroll;
     z-index: 99;
+    -webkit-overflow-scrolling: touch;
 }
 
 .app-main,


### PR DESCRIPTION
This changes the click target that opens the mobile sidebar to call the
new popover function in stream_popover rather than the old popovers
object.