### PR TITLE
Django 1.10: Url pattern doesn't use _callback_str.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -84,7 +84,6 @@ not_yet_fully_covered = {
     # they don't!  There are open issues for all of these.
     'zerver/tests/test_narrow.py',
     'zerver/tests/test_tornado.py',
-    'zerver/tests/test_urls.py',
     # Getting views file coverage to 100% is a major project goal
     'zerver/views/auth.py',
     'zerver/views/home.py',


### PR DESCRIPTION
Fixes #3941