### PR TITLE
hotkeys: escape key press dismiss "invite-users" modal.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -231,6 +231,9 @@ function process_hotkey(e) {
         } else if ($(".informational-overlays").hasClass("show")) {
             ui.hide_info_overlay();
             return true;
+        } else if ($("#invite-user").css("display") === "block") {
+            $("#invite-user").modal("hide");
+            return true;
         }
     }
 


### PR DESCRIPTION
Pressing escape key dismiss the invite-user modal.
Fixes #4008.