### PR TITLE
subs: Modify css to fix stream description cut off.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -600,7 +600,7 @@ form#add_new_subscription {
 }
 
 .stream-row {
-    padding: 15px 10px;
+    padding: 15px 10px 14px 10px;
     border-bottom: 1px solid #eee;
     cursor: pointer;
 }
@@ -694,7 +694,7 @@ form#add_new_subscription {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    line-height: 1;
+    line-height: 1.1;
 }
 
 #subscription_overlay .stream-description:empty:after,


### PR DESCRIPTION
Fixes the cut off of Stream descriptions at the bottom of
subscriptions page if they have `g`s in them.
Fixes #3277.