### PR TITLE
[WIP] Prevent closing of more modals when unfocusing compose.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -596,8 +596,12 @@ $(function () {
         // of modals or selecting text (for copy+paste) trigger cancelling.
         if (compose.composing() && !$(e.target).is("a") &&
             ($(e.target).closest(".modal").length === 0) &&
-            window.getSelection().toString() === "" &&
-            ($(e.target).closest('#emoji_map').length === 0)) {
+            ($(e.target).closest(".informational-overlays").length === 0) &&
+            ($(e.target).closest("#draft_overlay").length === 0) &&
+            ($(e.target).closest("#subscription_overlay").length === 0) &&
+            ($(e.target).closest("#settings_overlay_container").length === 0) &&
+            ($(e.target).closest('#emoji_map').length === 0) &&
+            window.getSelection().toString() === "") {
             compose.cancel();
         }
     });


### PR DESCRIPTION
This PR fixes #4029. The code is not really DRY, so I marked it as WIP. Maybe there is a better way with jQuery to "loop" over these 6 CSS class/element lookups. Suggestions?

This could also be postponed, because if #4036 is resolved, this code will probably become cleaner as well.