### PR TITLE
Fixed popover menu positioning. Tighter assumed bound for popover height now.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -209,9 +209,9 @@ exports.toggle_actions_popover = function (element, id) {
             narrowed: narrow.active(),
         };
 
-        var ypos = elt.offset().top - message_viewport.scrollTop();
+        var ypos = elt.offset().top;
         elt.popover({
-            placement: (ypos > (message_viewport.height() - 300)) ? 'top' : 'bottom',
+            placement: ((message_viewport.height() - ypos) < 200) ? 'top' : 'bottom',
             title:     "",
             content:   templates.render('actions_popover_content', args),
             trigger:   "manual",


### PR DESCRIPTION
**NOTE:** This commit *partially* fixes #3741 :warning: 

As discussed in [this comment](https://github.com/zulip/zulip/issues/3741#issuecomment-281984557), this commit fixes the first problem by:
+ Fixing the `ypos` parameter to actually give the correct height of the element from the `viewport` top.
+ Presenting a tighter bound for height of the popover (200 instead of 300).

Recent change-sets seem to have mitigated the second problem to some extent. However for unreasonably small `viewport`s, scrolling the element automatically is still required to make sure the `ypos` changes sufficiently to provide correct positioning to the popover so that it fits.

Tested on Google Chrome `v56.0.2924.87` (Official Build) (64-bit). Works well for me. Let me know if something doesn't check out. Till then, cheers! :tada: 