### PR TITLE
user docs + templates: Clarify how to insert line breaks or send messages using keyboard shortcuts.

### DIFF
--- a/templates/zerver/help/enable-or-disable-pressing-enter-to-send.md
+++ b/templates/zerver/help/enable-or-disable-pressing-enter-to-send.md
@@ -3,18 +3,14 @@
 Zulip supports configuring whether the **Enter** key on your keyboard
 sends a message that you are composing.
 
-By default, with the **Press Enter to send** checkbox disabled:
+By default, the `Enter` (or `Return`) key simply adds a blank line to the
+message when the **Press Enter to send** checkbox is disabled. This is great if
+you want to write multi-line messages that include blank lines, which is much
+more common in Zulip than in other chat products.
 
-* The **Enter** key simply adds a blank line to the message.  This is
-great if you want to write multi-line messages that include blank
-lines, which is much more common in Zulip than in other chat products.
-* To send your message, you can either press the **Send** button in the
-compose box or from the keyboard, use **Tab** and then **Enter**.
+However, if you check the **Press Enter to send** checkbox in the compose box,
+Zulip sends your message when you press `Enter` (or `Return`) on your keyboard.
 
-However, if you check the **Press Enter to send** checkbox in the
-compose box, the behavior will instead be as follows:
-
-* There is no **Send** button in the compose box; Zulip sends your
-  message when you press **Enter** (or **Return**) on your keyboard.
-* If necessary, you can enter blank lines into your message using
-  **Ctrl+Enter**, **Alt+Enter**, and **Shift+Enter**.
+Whether or not the **Press Enter to send** option is enabled, pressing `Ctrl` +
+`Enter` or `Tab` then `Enter` sends a message while pressing `Shift` + `Enter`
+inserts a new line in your message.

--- a/templates/zerver/help/send-a-private-message.md
+++ b/templates/zerver/help/send-a-private-message.md
@@ -15,6 +15,11 @@ appear.
 
 3. Enter your message in the **Compose your message here...** field.
 
+    !!! tip ""
+        Whether or not the **Press Enter to send** option is enabled, pressing
+        `Ctrl` + `Enter` or `Tab` then `Enter` sends a message while pressing
+        `Shift` + `Enter` inserts a new line in your message.
+
 4. Once you have finished completing your message and adding the recipients,
 you can now send your message to the specified user(s) by pressing the Enter
 key or clicking the **Send** button, depending on your settings.

--- a/templates/zerver/help/send-a-stream-message.md
+++ b/templates/zerver/help/send-a-stream-message.md
@@ -20,6 +20,11 @@ topic for your message in the **Topic** field.
 
 4. Enter your message in the **Compose your message here...** field.
 
+    !!! tip ""
+        Whether or not the **Press Enter to send** option is enabled, pressing
+        `Ctrl` + `Enter` or `Tab` then `Enter` sends a message while pressing
+        `Shift` + `Enter` inserts a new line in your message.
+
 5. Once you have finished completing your message and adding the recipients,
 you can now send your message to the specified stream under the specified
 topic by pressing the Enter key or clicking the **Send** button, depending

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -65,8 +65,12 @@
           <td class="definition">{% trans %}New private message{% endtrans %}</td>
         </tr>
         <tr>
-          <td class="hotkey">Tab then Enter</td>
+          <td class="hotkey"><p>Tab then Enter,</p><p>Ctrl + Enter</p></td>
           <td class="definition">{% trans %}Send message{% endtrans %}</td>
+        </tr>
+        <tr>
+          <td class="hotkey">Shift + Enter</td>
+          <td class="definition">{% trans %}Insert new line{% endtrans %}</td>
         </tr>
         <tr>
           <td class="hotkey">Esc</td>


### PR DESCRIPTION
Updates user guide documentation and **Keyboard shortcuts** modal to show how to insert line breaks or send messages using keyboard shortcuts.

Fixes #156