### PR TITLE
Fix draft responsiveness issues.

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -48,7 +48,7 @@
 
 .drafts-list {
     overflow: auto;
-    height: calc(100% - 90px);
+    height: calc(100% - 55px);
     width: 100%;
     margin-top: 10px;
 }
@@ -163,8 +163,16 @@
     }
 }
 
+@media (max-width: 500px) {
+    .draft-row .draft-info-box .draft_controls {
+        right: 0px;
+    }
+}
+
 @media (max-width: 700px) {
     #draft_overlay .drafts-container {
         height: 95%;
+        max-width: none;
+        width: 90%;
     }
 }


### PR DESCRIPTION
The drafts container was too skinny on mobiles, so the enforced
max-width of 60% should be ignored in favor of expanding to 90%
of the screen width.

This also fixes an issue where the content does not reach the bottom
of the container due to having too short of a height.

Fixes: #3867.