### PR TITLE
logging: Skip log records originated in site packages.

### DIFF
--- a/zerver/lib/logging_util.py
+++ b/zerver/lib/logging_util.py
@@ -73,3 +73,11 @@ def skip_200_and_304(record):
         return False
 
     return True
+
+def skip_site_packages_logs(record):
+    # type: (logging.LogRecord) -> bool
+    # This skips the log records that are generated from libraries
+    # installed in site packages.
+    if 'site-packages' in record.pathname:
+        return False
+    return True

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -992,6 +992,10 @@ LOGGING = {
             '()': 'django.utils.log.CallbackFilter',
             'callback': zerver.lib.logging_util.skip_200_and_304,
         },
+        'skip_site_packages_logs': {
+            '()': 'django.utils.log.CallbackFilter',
+            'callback': zerver.lib.logging_util.skip_site_packages_logs,
+        },
     },
     'handlers': {
         'zulip_admins': {
@@ -1062,7 +1066,7 @@ LOGGING = {
         },
         'django.template': {
             'handlers': ['console'],
-            'filters': ['require_debug_true'],
+            'filters': ['require_debug_true', 'skip_site_packages_logs'],
             'level': 'DEBUG',
             'propagate': False,
         },


### PR DESCRIPTION
This fixes the huge exception we get in our logs from django.template
logger. This exception is a known bug in Django, see
https://code.djangoproject.com/ticket/26886

Fixes #3974

@timabbott, please review.