### PR TITLE
edit: Remove More/Collapse when in message edit/view source mode.

### DIFF
--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -98,6 +98,18 @@ function get_message_height(elem, message_id) {
     return height;
 }
 
+exports.hide_message_expander = function (row) {
+    if (row.find(".could-be-condensed").length !== 0) {
+        row.find(".message_expander").hide();
+    }
+};
+
+exports.show_message_expander = function (row) {
+    if (row.find(".could-be-condensed").length !== 0) {
+        row.find(".message_expander").show();
+    }
+};
+
 exports.condense_and_collapse = function (elems) {
     var height_cutoff = message_viewport.height() * 0.65;
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -157,6 +157,7 @@ function timer_text(seconds_left) {
 
 function edit_message(row, raw_content) {
     row.find(".message_reactions").hide();
+    condense.hide_message_expander(row);
     var content_top = row.find('.message_content')[0]
         .getBoundingClientRect().top;
 
@@ -355,6 +356,7 @@ exports.end = function (row) {
     if (row !== undefined) {
         current_msg_list.hide_edit_topic(row);
     }
+    condense.show_message_expander(row);
     row.find(".message_reactions").show();
 };
 


### PR DESCRIPTION
This entails displaying it when the editing mode ends.

Fixes #3871.