### PR TITLE
Fix ui.home_tab_obscured to detect modals open.

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -12,12 +12,10 @@ exports.actively_scrolling = function () {
 
 // What, if anything, obscures the home tab?
 exports.home_tab_obscured = function () {
-    if ($('.modal:visible').length > 0) {
+    if ($('.overlay.show').length > 0) {
         return 'modal';
     }
-    if (! $('#home').hasClass('active')) {
-        return 'other_tab';
-    }
+
     return false;
 };
 

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -105,10 +105,6 @@ var page_params = {{ page_params }};
             </div>
                 {% include "zerver/home.html" %}
             </div>
-            <div class="tab-pane new-style" id="administration">
-            </div>
-            <div class="tab-pane new-style" id="settings">
-            </div>
 
             {% if show_debug %}
             <div class="tab-pane" id="debug">


### PR DESCRIPTION
All open modals now should have the selector ".overlay.show",
so checking if a modal is open is as simple as checking the length
of the selection ".overlay.show".