### PR TITLE
frontend: Fix translation string.

### DIFF
--- a/static/templates/message_info_popover_content.handlebars
+++ b/static/templates/message_info_popover_content.handlebars
@@ -1,7 +1,7 @@
 {{! Contents of the "message info" popup }}
 <ul class="nav nav-list actions_popover sender_info_popover" data-user-id="{{message.sender_id}}">
     <div class="popover_info">
-        <li>{{#tr this}}<b>__message.sender_full_name__</b>{{/tr}}</li>
+        <li><b>{{message.sender_full_name}}</b></li>
         <li class='my_email'>{{sender_email}}</li>
 
         {{#if message.historical}}


### PR DESCRIPTION
There was a string flagged for translation, that was just a variable. This should fix it.