### PR TITLE
frontend: Added exit class to the cancel button in invite_user.html

### DIFF
--- a/templates/zerver/invite_user.html
+++ b/templates/zerver/invite_user.html
@@ -33,7 +33,7 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">{{ _('Cancel') }}</button>
+                <button class="btn btn-default exit" data-dismiss="modal" aria-hidden="true">{{ _('Cancel') }}</button>
                 <button id="submit-invitation" class="btn btn-primary"
                 data-loading-text="{{ _('Inviting...') }}" type="submit">{{ _('Invite') }}</button>
             </div>


### PR DESCRIPTION
- Previously, in the invite users modal, the click event of Cancel
(button) triggered the submit-invitation event. (Naturally, if the form
is empty, this throws the validators and doesn’t exit the modal)
- Fixed the abnormal action by including the ‘exit’ class to the cancel
button in invite_user.html, line 36.