### PR TITLE
Made the login page nicer. 

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -816,19 +816,22 @@ a.bottom-signup-button {
     margin-bottom: 0px;
     padding: 8px;
     font-size: 18px;
-    border-radius: 5px;
+    border-radius: 0px;
     min-width: 300px;
-    color: #fff;
 }
 
 .btn-user {
-    background-color: #428bca;
-    border-color: #357ebd;
+    background-color: #ffffff;
+    border-color: #55bdaa;
+    border-style: solid;
+    color: #3f9486;
 }
 
 .btn-admin {
-    background-color: #ff4136;
-    border-color: #bd7e35;
+    background-color: #ffffff;
+    border-color: #00a9f4;
+    border-style: solid;
+    color: #2196f3;
 }
 
 .feature-page-header {


### PR DESCRIPTION
- The buttons now have a flat look (dropped the border-radius) with a
white background color.
- The font colors now match the darker green shade of the navbar.
- The border-colors match the lighter green shade of the navbar.
- Green is used for all the buttons while the admin and non-admin
buttons are still distinguishable from each other (Also neither is
overly emphasized?)
- I’ve `git grep`'d to confirm that changes in .btn-direct only affect
the buttons on login.html

Referencing Issue #4106

![Preview](https://cloud.githubusercontent.com/assets/17938322/24066389/3055de46-0b98-11e7-8ebd-4a105ca10ce0.png)
