### PR TITLE
Use both prominent login and devlogin in dev env

### DIFF
--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -1,0 +1,40 @@
+{% extends "zerver/portico.html" %}
+
+{# Login page. #}
+{% block portico_content %}
+<div class="app login-page">
+    <div class="app-main login-page-container">
+        <h4 class="login-page-header">{{ _('Click on a user to log in!') }}</h4>
+        <form name="direct_login_form" id="direct_login_form" method="post" class="login-form"
+            action="{{ url('zerver.views.auth.dev_direct_login') }}">
+            {{ csrf_input }}
+            <div class="control-group">
+                <div class="controls">
+                    <p>({{ _('Administrators') }})</p>
+                    {% for user_email in direct_admins %}
+                    <p><input type="submit" name="direct_email" class="btn-direct btn-admin" value="{{ user_email }}" /></p>
+                    {% endfor %}
+
+                    <p>({{ _('Normal users') }})</p>
+                    {% for user_email in direct_users %}
+                    <p><input type="submit" name="direct_email" class="btn-direct btn-user" value="{{ user_email }}" /></p>
+                    {% endfor %}
+
+                    <p>({{ _('Community users') }})</p>
+                    {% for user_email in community_users %}
+                    <p><input type="submit" name="direct_email" class="btn-direct btn-user" value="{{ user_email }}" /></p>
+                    {% endfor %}
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="footer-padder"></div>
+
+<script type="text/javascript">
+if (window.location.hash.substring(0, 1) === "#") {
+    document.login_form.action += window.location.hash;
+}
+</script>
+{% endblock %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -40,15 +40,7 @@ autofocus('#id_username');
 
 <div class="app login-page">
   <div class="app-main login-page-container">
-
-    {% if dev_auth_enabled %}
-    <h3 class="login-page-header">{{ _('Development login') }}</h3>
-    {% if not password_auth_enabled %}
-    <h4 class="login-page-subheader">Click on a user to log in!</h4>
-    {% endif %}
-    {% else %}
     <h3 class="login-page-header">{{ _('You look familiar.') }}</h3>
-    {% endif %}
 
 {% if only_sso %}
     {# SSO users don't have a password. #}
@@ -112,33 +104,6 @@ autofocus('#id_username');
                     <span class="login-forgot-password">
                       <a href="{{ url('django.contrib.auth.views.password_reset') }}">{{ _('Forgot password?') }}</a>
                     </span>
-                </div>
-            </div>
-        </form>
-        {% endif %}
-        {% if dev_auth_enabled %}
-        <form name="direct_login_form" id="direct_login_form" method="post" class="login-form"
-              action="{{ url('zerver.views.auth.dev_direct_login') }}">
-            {{ csrf_input }}
-            <div class="control-group">
-                {% if password_auth_enabled %}
-                <label for="direct_email" class="direct-label">{{ _('or Choose a user') }}:</label>
-                {% endif %}
-                <div class="controls">
-                    <p>({{ _('Administrators') }})</p>
-                    {% for user_email in direct_admins %}
-                    <p><input type="submit" name="direct_email" class="btn-direct btn-admin" value="{{ user_email }}" /></p>
-                    {% endfor %}
-
-                    <p>({{ _('Normal users') }})</p>
-                    {% for user_email in direct_users %}
-                    <p><input type="submit" name="direct_email" class="btn-direct btn-user" value="{{ user_email }}" /></p>
-                    {% endfor %}
-
-                    <p>({{ _('Community users') }})</p>
-                    {% for user_email in community_users %}
-                    <p><input type="submit" name="direct_email" class="btn-direct btn-user" value="{{ user_email }}" /></p>
-                    {% endfor %}
                 </div>
             </div>
         </form>

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -36,7 +36,7 @@ class DocPageTest(ZulipTestCase):
             self._test('/features/', 'Talk about multiple topics at once')
             self._test('/hello/', 'workplace chat that actually improves your productivity')
             self._test('/integrations/', 'require creating a Zulip bot')
-            self._test('/login/', '(Normal users)')
+            self._test('/devlogin/', '(Normal users)')
             self._test('/register/', 'get started')
 
             result = self.client_get('/new-user/')

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -17,9 +17,10 @@ if EXTERNAL_HOST is None:
     else:
         EXTERNAL_HOST = 'localhost:9991'
 ALLOWED_HOSTS = ['*']
-AUTHENTICATION_BACKENDS = ('zproject.backends.DevAuthBackend',)
+AUTHENTICATION_BACKENDS = ('zproject.backends.DevAuthBackend',
+                           'zproject.backends.EmailAuthBackend',)
 # Add some of the below if you're testing other backends
-# AUTHENTICATION_BACKENDS = ('zproject.backends.EmailAuthBackend',
+# AUTHENTICATION_BACKENDS = ('zproject.backends.GitHubAuthBackend',
 #                            'zproject.backends.GoogleMobileOauth2Backend',)
 EXTERNAL_URI_SCHEME = "http://"
 EMAIL_GATEWAY_PATTERN = "%s@" + EXTERNAL_HOST

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -3,13 +3,17 @@ from django.conf import settings
 import os.path
 from django.views.static import serve
 import zerver.views.registration
+import zerver.views.auth
 
 # These URLs are available only in the development environment
 
 use_prod_static = getattr(settings, 'PIPELINE_ENABLED', False)
 static_root = os.path.join(settings.DEPLOY_ROOT, 'prod-static/serve' if use_prod_static else 'static')
 
-urls = [url(r'^static/(?P<path>.*)$', serve, {'document_root': static_root})]
+urls = [
+    url(r'^static/(?P<path>.*)$', serve, {'document_root': static_root}),
+    url(r'^devlogin/$', zerver.views.auth.login_page, {'template_name': 'zerver/dev_login.html'}, name='zerver.views.auth.login_page'),
+]
 i18n_urls = [url(r'^confirmation_key/$', zerver.views.registration.confirmation_key)]
 
 # These are used for voyager development. On a real voyager instance,

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1127,6 +1127,11 @@ else:
     ONLY_SSO = False
 AUTHENTICATION_BACKENDS += ('zproject.backends.ZulipDummyBackend',)
 
+# Redirect to /devlogin by default in dev mode
+if DEVELOPMENT:
+    HOME_NOT_LOGGED_IN = '/devlogin'
+    LOGIN_URL = '/devlogin'
+
 POPULATE_PROFILE_VIA_LDAP = bool(AUTH_LDAP_SERVER_URI)
 
 if POPULATE_PROFILE_VIA_LDAP and \

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -125,3 +125,6 @@ REALMS_HAVE_SUBDOMAINS = bool(os.getenv('REALMS_HAVE_SUBDOMAINS', False))
 TERMS_OF_SERVICE = 'corporate/terms.md'
 
 INLINE_URL_EMBED_PREVIEW = False
+
+HOME_NOT_LOGGED_IN = '/login'
+LOGIN_URL = '/accounts/login'


### PR DESCRIPTION
Turn DevAuthBackend on by default on localhost/devlogin url and localhost/login url provide prominent login.

Fixes #3652