### PR TITLE
Linkify URL in stream description under /streams page

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -6,6 +6,7 @@ set_global('page_params', {
 });
 
 add_dependencies({
+    marked: 'third/marked/lib/marked.js',
     people: 'js/people.js',
     stream_color: 'js/stream_color.js',
     narrow: 'js/narrow.js',

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -350,6 +350,9 @@ exports.get_streams_for_settings_page = function () {
         sub = exports.add_admin_options(sub);
         sub.preview_url = narrow.by_stream_uri(sub.name);
         exports.update_subscribers_count(sub);
+        if (sub.description) {
+            sub.description = marked(sub.description).replace('<p>', '').replace('</p>', '');
+        }
         sub_rows.push(sub);
     });
 

--- a/static/templates/subscription.handlebars
+++ b/static/templates/subscription.handlebars
@@ -15,7 +15,7 @@
                 <i class="icon-vector-user"></i>
             </div>
         </div>
-        <div class="description" data-no-description="{{t 'No description.'}}">{{description}}</div>
+        <div class="description" data-no-description="{{t 'No description.'}}">{{{description}}}</div>
     </div>
 </div>
 {{/with}}

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -21,7 +21,7 @@
     <a href="{{preview_url}}" class="button small white rounded" id="preview-stream-button" role="button">{{t "View stream"}}</a>
   </div>
   <div class="stream-description" data-no-description="{{t 'No description.' }}">
-      <span class="stream-description-editable editable-section">{{description}}</span>
+      <span class="stream-description-editable editable-section">{{{description}}}</span>
       {{#if is_admin}}
         <span class="editable" data-make-editable=".stream-description-editable"></span>
         <span class="checkmark" data-finish-editing=".stream-description-editable">✓</span>


### PR DESCRIPTION
If a URL is present in stream description, it will be rendered as a clickable link under /streams page.
Fixes #1435.