### PR TITLE
Fix modals dependency cycle.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -210,6 +210,12 @@ exports.launch = function () {
 };
 
 $(function () {
+
+    function drafts_close_modal() {
+        hashchange.exit_modal();
+    }
+    modals.set_close_handler("drafts", drafts_close_modal);
+
     window.addEventListener("beforeunload", function () {
         exports.update_draft();
     });

--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -126,6 +126,12 @@ $(function () {
         $('#streams_to_add :checkbox').prop('checked', false);
         e.preventDefault();
     });
+
+    function invite_close_modal() {
+        hashchange.exit_modal();
+    }
+
+    modals.set_close_handler("invite", invite_close_modal);
 });
 
 return exports;

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -183,6 +183,15 @@ $(function () {
             lightbox[direction]();
         }
     });
+
+    function lightbox_close_modal() {
+        $(".player-container iframe").remove();
+        lightbox.is_open = false;
+        document.activeElement.blur();
+    }
+
+    modals.set_close_handler("lightbox", lightbox_close_modal);
+
 });
 
 return exports;

--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -2,32 +2,10 @@ var modals = (function () {
     "use strict";
 
     var exports = {
-        close: {
-            subscriptions: function () {
-                subs.close();
-            },
+        close : {},
 
-            drafts: function () {
-                hashchange.exit_modal();
-            },
-
-            informationalOverlays: function () {
-                $(".informational-overlays").removeClass("show");
-            },
-
-            settings: function () {
-                hashchange.exit_modal();
-            },
-
-            lightbox: function () {
-                $(".player-container iframe").remove();
-                lightbox.is_open = false;
-                document.activeElement.blur();
-            },
-
-            invite: function () {
-                hashchange.exit_modal();
-            },
+        set_close_handler : function (name, handler) {
+            exports.close[name] = handler;
         },
 
         close_modal: function (name) {
@@ -35,6 +13,8 @@ var modals = (function () {
 
             if (exports.close[name]) {
                 exports.close[name]();
+            } else {
+                blueslip.error("Modal close handler for " + name + " not properly setup." );
             }
         },
     };

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -201,6 +201,11 @@ $("body").ready(function () {
     });
 
     $("body").on("click", "[data-sidebar-form-close]", close_sidebar);
+
+    function settings_close_modal() {
+        hashchange.exit_modal();
+    }
+    modals.set_close_handler("settings", settings_close_modal);
 });
 
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -1380,6 +1380,12 @@ $(function () {
         tr.remove();
     });
 
+    function subscriptions_close_modal() {
+        exports.close();
+    }
+
+    modals.set_close_handler("subscriptions", subscriptions_close_modal);
+
 });
 
 function focus_on_narrowed_stream() {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -147,6 +147,13 @@ exports.show_failed_message_success = function (message_id) {
 };
 
 $(document).ready(function () {
+
+    function info_overlay_close_modal() {
+        $(".informational-overlays").removeClass("show");
+    }
+
+    modals.set_close_handler("informationalOverlays", info_overlay_close_modal);
+
     var info_overlay_toggle = components.toggle({
         name: "info-overlay-toggle",
         selected: 0,


### PR DESCRIPTION
This commit forces the files that create modals to create their own modal closing function instead of creating all of them in the modals file. These functions are then passed to the modals.close object. This is intended to remove modals.js's dependencies on these other files.