### PR TITLE
Remove hack for old mobile clients

### DIFF
--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -969,17 +969,6 @@ class GetOldMessagesTest(ZulipTestCase):
             self.assert_json_error(result,
                                    "Bad value for 'narrow': %s" % (type,))
 
-    def test_old_empty_narrow(self):
-        # type: () -> None
-        """
-        '{}' is accepted to mean 'no narrow', for use by old mobile clients.
-        """
-        self.login("hamlet@zulip.com")
-        all_result    = self.get_and_check_messages({}) # type: Dict[str, Dict]
-        narrow_result = self.get_and_check_messages({'narrow': '{}'}) # type: Dict[str, Dict]
-
-        self.assertEqual(message_ids(all_result), message_ids(narrow_result))
-
     def test_bad_narrow_operator(self):
         # type: () -> None
         """

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -386,10 +386,6 @@ def get_search_fields(rendered_content, subject, content_matches, subject_matche
 def narrow_parameter(json):
     # type: (str) -> Optional[List[Dict[str, Any]]]
 
-    # FIXME: A hack to support old mobile clients
-    if json == '{}':
-        return None
-
     data = ujson.loads(json)
     if not isinstance(data, list):
         raise ValueError("argument is not a list")


### PR DESCRIPTION
This FIXME was added in 50d229fe11d0da46dfa38e7943074d2cdf70d02b.
Considering it's been more than 4 years, we can probably safely remove
it now.