### PR TITLE
Add option to set Notifications Stream.

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -19,6 +19,32 @@ casper.waitForSelector('#settings_overlay_container.show', function () {
     casper.test.assertUrlMatch(/^http:\/\/[^/]+\/#organization/, 'URL suggests we are on organization page');
 });
 
+// Test changing notifications stream
+casper.then(function () {
+    casper.test.info('Changing notifications stream to Verona by filtering with "verona"');
+    casper.click("#id_realm_notifications_stream > a.dropdown-toggle");
+
+    casper.waitUntilVisible('ul.dropdown-menu', function () {
+        casper.sendKeys('.dropdown-search > input[type=text]', 'verona');
+        casper.click(".dropdown-list-body li.stream_name");
+    });
+
+    casper.waitUntilVisible('#admin-realm-notifications-stream-status', function () {
+        casper.test.assertSelectorHasText('#admin-realm-notifications-stream-status',
+                                          'Notifications stream changed!');
+        casper.test.assertSelectorHasText('#realm_notifications_stream_name', '#Verona');
+    });
+});
+
+casper.then(function () {
+    casper.click(".notifications-stream-disable");
+    casper.waitUntilVisible('#admin-realm-notifications-stream-status', function () {
+        casper.test.assertSelectorHasText('#admin-realm-notifications-stream-status',
+                                          'Notifications stream disabled!');
+        casper.test.assertSelectorHasText('#realm_notifications_stream_name', 'Disabled');
+    });
+});
+
 // Test permissions setting
 casper.then(function () {
     casper.click("li[data-section='organization-permissions']");

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -119,6 +119,28 @@ function render(template_name, args) {
     global.write_handlebars_output("admin-realm-domains-list", html);
 }());
 
+(function admin_realm_dropdown_stream_list() {
+    var html = "<ul>";
+    var args = {
+        stream: {
+            name: "Italy",
+            subscriber_count: 9,
+            stream_id: 18,
+        },
+    };
+    html += render("admin-realm-dropdown-stream-list", args);
+    html += "</ul>";
+
+    var link = $(html).find("a");
+    var list_item = $(html).find("li");
+
+    assert.equal(link.text().trim(), "Italy");
+    assert(list_item.hasClass("stream_name"));
+    assert.equal(list_item.attr("data-stream-id"), "18");
+
+    global.write_handlebars_output("admin-realm-dropdown-stream-list", html);
+}());
+
 (function admin_default_streams_list() {
     var html = '<table>';
     var streams = ['devel', 'trac', 'zulip'];

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -45,6 +45,7 @@ function _setup_page() {
         language_list: page_params.language_list,
         realm_default_language: page_params.realm_default_language,
         realm_waiting_period_threshold: page_params.realm_waiting_period_threshold,
+        realm_notifications_stream_id: page_params.realm_notifications_stream_id,
         is_admin: page_params.is_admin,
         realm_icon_source: page_params.realm_icon_source,
         realm_icon_url: page_params.realm_icon_url,

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -86,6 +86,9 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             if (event.data.authentication_methods !== undefined) {
                 settings_org.populate_auth_methods(event.data.authentication_methods);
             }
+        } else if (event.op === 'update' && event.property === 'notifications_stream_id') {
+            page_params.realm_notifications_stream_id = event.value;
+            settings_org.render_notifications_stream_ui(page_params.realm_notifications_stream_id);
         } else if (event.op === 'update' && event.property === 'default_language') {
             page_params.realm_default_language = event.value;
             settings_org.reset_realm_default_language();
@@ -187,6 +190,11 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 stream_data.delete_sub(stream.stream_id);
                 settings_streams.remove_default_stream(stream.stream_id);
                 stream_data.remove_default_stream(stream.stream_id);
+                if (page_params.realm_notifications_stream_id === stream.stream_id) {
+                    page_params.realm_notifications_stream_id = -1;
+                    settings_org.render_notifications_stream_ui(
+                        page_params.realm_notifications_stream_id);
+                }
             });
         }
         break;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1006,6 +1006,18 @@ input[type=checkbox].inline-block {
     border-radius: 0px;
 }
 
+#id_realm_notifications_stream .dropdown-search > input[type=text] {
+    margin: 9px;
+}
+
+#id_realm_notifications_stream .dropdown-list-body {
+    height: auto;
+    max-height: 200px;
+    overflow-y: auto;
+    margin-top: 0;
+    display: block;
+}
+
 input[type=text]#settings_search {
     width: calc(100% - 10px - 2px);
     margin: 0px;

--- a/static/templates/settings/admin-realm-dropdown-stream-list.handlebars
+++ b/static/templates/settings/admin-realm-dropdown-stream-list.handlebars
@@ -1,0 +1,8 @@
+{{#with stream}}
+<li class="stream_name" role="presentation"
+    title="{{subscriber_count}} {{t 'Subscribers' }}" data-stream-id="{{stream_id}}">
+    <a role="menuitem" tabindex="0">
+        {{name}}
+    </a>
+</li>
+{{/with}}

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -4,6 +4,7 @@
 
         <div class="alert" id="admin-realm-name-status"></div>
         <div class="alert" id="admin-realm-description-status"></div>
+        <div class="alert" id="admin-realm-notifications-stream-status"></div>
         <div class="alert" id="admin-realm-default-language-status"></div>
         <div class="alert" id="admin-realm-waiting-period-threshold-status"></div>
 
@@ -39,6 +40,27 @@
                     {{t 'Save changes' }}
                 </button>
             </div>
+            {{/if}}
+        </div>
+
+        <div class="input-group">
+            <label for="realm_notifications_stream" id="realm_notifications_stream_label" class="inline-block"
+                title="{{t 'The stream to which new stream notifications go to.' }}">
+                {{t "Notifications stream: " }}
+                <span id="realm_notifications_stream_name"></span>
+            </label>
+            {{#if is_admin }}
+            <span class="dropup actual-dropdown-menu" id="id_realm_notifications_stream"
+                name="realm_notifications_stream" aria-labelledby="realm_notifications_stream_label">
+                <a class="dropdown-toggle" data-toggle="dropdown">{{t "[Change]" }}</a>
+                <ul class="dropdown-menu" role="menu">
+                    <li class="dropdown-search" role="presentation">
+                        <input type="text" role="menuitem" placeholder="{{t 'Filter streams' }}" autofocus/>
+                    </li>
+                    <span class="dropdown-list-body"></span>
+                </ul>
+            </span>
+            <a class="notifications-stream-disable">{{t "[Disable]" }}</a>
             {{/if}}
         </div>
 


### PR DESCRIPTION
Add option to set Notifications Stream from the administration settings.

Did not add a field to models.py. Added function to update realm's notification_stream based on stream name in actions.py. Added a new field in page_params to hold realm notification stream name. Added a dropdown in the administration page. Modified ```populate_db.py``` to have a notificatons_stream during the tests. Altered ```test_signup``` and ```test_subs```.

Fixes: #3708 