### PR TITLE
Changed "Choose a user" to "Click on a user to log in"

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -732,6 +732,10 @@ a.bottom-signup-button {
     margin-bottom: 50px;
 }
 
+.login-page-header {
+    width: 100%;
+}
+
 .login-page-subheader {
     font-weight: 300;
     font-size: 24px;

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -44,7 +44,7 @@ autofocus('#id_username');
     {% if dev_auth_enabled %}
     <h3 class="login-page-header">{{ _('Development login') }}</h3>
     {% if not password_auth_enabled %}
-    <h4 class="login-page-subheader">{{ _('Choose a user:') }}</h4>
+    <h4 class="login-page-subheader">{{ _('Click on a user to log in') }}</h4>
     {% endif %}
     {% else %}
     <h3 class="login-page-header">{{ _('You look familiar.') }}</h3>


### PR DESCRIPTION
- I've also set the width of .login-page-header to 100% to make it responsive on
smaller screens. Previously, the header went off screen for screen
widths <360 px. This fix is similar to #4096 

Here are the screenshots for the above responsive fix: 

Before:
![Before](https://cloud.githubusercontent.com/assets/17938322/24080533/89980f8a-0cc7-11e7-8fc5-86f5c4b733e6.png)

After:
![After](https://cloud.githubusercontent.com/assets/17938322/24080537/914f5832-0cc7-11e7-9028-04bd17a05ff3.png)



Referencing issue #4106 