### PR TITLE
docs: Fix minor link formatting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ previews, group private messages, audible notifications,
 missed-message emails, desktop apps, and much more.
 
 Further information on the Zulip project and its features can be found
-at [https://www.zulip.org](https://www.zulip.org).
+at <https://www.zulip.org>.
 
 [![Build Status](https://travis-ci.org/zulip/zulip.svg?branch=master)](https://travis-ci.org/zulip/zulip) [![Coverage Status](https://coveralls.io/repos/github/zulip/zulip/badge.svg?branch=master)](https://coveralls.io/github/zulip/zulip?branch=master) [![docs](https://readthedocs.org/projects/zulip/badge/?version=latest)](http://zulip.readthedocs.io/en/latest/) [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org)
 
@@ -66,7 +66,7 @@ installation guide][dev-install].
 Zulip in production supports Ubuntu 14.04 Trusty and Ubuntu 16.04
 Xenial. Work is ongoing on adding support for additional
 platforms. The installation process is documented at
-https://zulip.org/server.html and in more detail in [the
+<https://zulip.org/server.html> and in more detail in [the
 documentation](https://zulip.readthedocs.io/en/latest/prod-install.html).
 
 ## Ways to contribute
@@ -213,7 +213,7 @@ Another way to find issues in Zulip is to take advantage of our
 our issues into areas like admin, compose, emoji, hotkeys, i18n,
 onboarding, search, etc.  You can see this here:
 
-[https://github.com/zulip/zulip/labels]
+<https://github.com/zulip/zulip/labels>
 
 Click on any of the "area:" labels and you will see all the tickets
 related to your area of interest.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -226,13 +226,13 @@ when writing this sort of code to have a lot of semi-repeated code blocks
 
 Tips and tricks:
 
-- Use $.get to fetch data from the backend. You can grep through stats.js to
-  find examples of this.
+- Use `$.get` to fetch data from the backend. You can grep through stats.js
+  to find examples of this.
 - The Plotly documentation is at
-  [https://plot.ly/javascript/](https://plot.ly/javascript/) (check out the
-  full reference, event reference, and function reference). The
-  documentation pages seem to work better in chrome than in firefox, though
-  this hasn't been extensively verified.
+  <https://plot.ly/javascript/> (check out the full reference, event
+  reference, and function reference). The documentation pages seem to work
+  better in Chrome than in Firefox, though this hasn't been extensively
+  verified.
 - Unless a graph has a ton of data, it is typically better to just redraw it
   when something changes (e.g. in the various aggregation click handlers)
   rather than to use retrace or relayout or do other complicated

--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -67,13 +67,13 @@ Jump to:
 #### macOS
 
 1. Install [Vagrant][vagrant-dl-macos] (1.8.4-1.8.6, do not use 1.8.7).
-2. Install [VirtualBox][vbox-dl] (>= 5.1.8)
+2. Install [VirtualBox][vbox-dl] (>= 5.1.8).
 
 (For a non-free option, but better performance, you can also use [VMWare
 Fusion][vmware-fusion-dl] with the [VMWare Fusion Vagrant
 plugin][vagrant-vmware-fusion-dl].)
 
-Now you are ready for [Step 2: Get Zulip Code.](#step-2-get-zulip-code)
+Now you are ready for [Step 2: Get Zulip Code.](#step-2-get-zulip-code).
 
 #### Ubuntu
 
@@ -220,9 +220,11 @@ If you haven't already created an ssh key and added it to your GitHub account,
 you should do that now by following [these
 instructions](https://help.github.com/articles/generating-an-ssh-key/).
 
-1. In your browser, visit [https://github.com/zulip/zulip](https://github.com/zulip/zulip)
-   and click the `fork` button. You will need to be logged in to GitHub to do this.
-2. Open Terminal (macOS/Ubuntu) or Git BASH (Windows; must **run as an Administrator**)
+1. In your browser, visit <https://github.com/zulip/zulip>
+   and click the `fork` button. You will need to be logged in to GitHub to
+   do this.
+2. Open Terminal (macOS/Ubuntu) or Git BASH (Windows; must
+   **run as an Administrator**).
 3. In Terminal/Git BASH, clone your fork:
 ```
 git clone git@github.com:YOURUSERNAME/zulip.git
@@ -378,8 +380,7 @@ webpack: bundle is now VALID.
 ```
 
 Now the Zulip server should be running and accessible. Verify this by
-navigating to [http://localhost:9991/](http://localhost:9991/) in your browser
-on your main machine.
+navigating to <http://localhost:9991/> in the browser on your main machine.
 
 You should see something like this:
 

--- a/docs/dev-setup-non-vagrant.md
+++ b/docs/dev-setup-non-vagrant.md
@@ -343,7 +343,7 @@ To start the development server:
 ./tools/run-dev.py
 ```
 
-… and visit [http://localhost:9991/](http://localhost:9991/).
+… and visit <http://localhost:9991/>.
 
 #### Proxy setup for by-hand installation
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -96,7 +96,7 @@ New Zulip webhook integrations can take just a few hours to write,
 including tests and documentation, if you use the right process.
 Here's how we recommend doing it:
 
-* First, use http://requestb.in/ or a similar site to capture an
+* First, use <http://requestb.in/> or a similar site to capture an
   example webhook payload from the service you're integrating.  You
   can use these captured payloads to create a set of test fixtures for
   your integration under `zerver/fixtures`.

--- a/docs/prod-maintain-secure-upgrade.md
+++ b/docs/prod-maintain-secure-upgrade.md
@@ -20,8 +20,7 @@ You may also want to read this related content:
 upgrade.**
 
 To upgrade to a new version of the zulip server, download the appropriate
-release tarball from
-[https://www.zulip.org/dist/releases/](https://www.zulip.org/dist/releases/)
+release tarball from <https://www.zulip.org/dist/releases/>.
 
 You also have the option of creating your own release tarballs from a
 copy of the zulip.git repository using
@@ -170,8 +169,7 @@ into S3 using [wal-e](https://github.com/wal-e/wal-e) in
 `puppet/zulip_internal/manifests/postgres_common.pp` (that's what we
 use for zulip.com's database backups).  Note that this module isn't
 part of the Zulip server releases since it's part of the zulip.com
-configuration (see
-[https://github.com/zulip/zulip/issues/293](https://github.com/zulip/zulip/issues/293)
+configuration (see <https://github.com/zulip/zulip/issues/293>
 for a ticket about fixing this to make life easier for running
 backups).
 

--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -8,11 +8,11 @@ maintaining such documentation highly efficient.
 ## Editing and testing
 
 The user documentation is available under `/help/` on any Zulip server;
-(e.g. [https://chat.zulip.org/help/](https://chat.zulip.org/help/) or
-`http://localhost:9991/help/` in the Zulip development environment). The
-user documentation is not hosted on ReadTheDocs, since Zulip supports
-running a server completely disconnected from the Internet, and we'd like
-the documentation to be available in that environment.
+(e.g. <https://chat.zulip.org/help/> or `http://localhost:9991/help/` in
+the Zulip development environment). The user documentation is not hosted on
+ReadTheDocs, since Zulip supports running a server completely disconnected
+from the Internet, and we'd like the documentation to be available in that
+environment.
 
  The source for this user documentation is the Markdown files under
 `templates/zerver/help/` in the

--- a/docs/webhook-walkthrough.md
+++ b/docs/webhook-walkthrough.md
@@ -13,7 +13,7 @@ integration.
 The first step in creating a webhook is to examine the data that the
 service you want to integrate will be sending to Zulip.
 
-You can use [requestb.in](http://requestb.in/) or a similar tool to capture
+You can use <http://requestb.in> or a similar tool to capture
 webhook payload(s) from the service you are integrating. Examining this
 data allows you to do two things:
 
@@ -319,8 +319,7 @@ DONE!
 ## Step 5: Create documentation
 
 Next, we add end-user documentation for our webhook integration.  You
-can see the existing examples at
-[https://zulipchat.com/integrations](https://zulipchat.com/integrations)
+can see the existing examples at <https://zulipchat.com/integrations>
 or by accessing `/integrations` in your Zulip development environment.
 
 There are two parts to the end-user documentation on this page.


### PR DESCRIPTION
Some links weren't linkified or used a redundant structure (`[URL](URL)`). These have been properly formatted using `<URL>`.