### PR TITLE
Remove second background from #lighbox_overlay.

### DIFF
--- a/static/styles/lightbox.css
+++ b/static/styles/lightbox.css
@@ -14,8 +14,6 @@
     height: calc(100% - 65px - 30px);
     margin: 0px;
 
-    background-color: #19203a;
-
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center center;


### PR DESCRIPTION
The child ".image-preview" has a background which is ordinarily
invisible (as it is the same color as the #lightbox_overlay bg,
however when fading in it is noticeable.