### PR TITLE
frontend: Information modals are now responsive on smaller screens.

### DIFF
--- a/static/styles/informational-overlays.css
+++ b/static/styles/informational-overlays.css
@@ -48,3 +48,23 @@
 .informational-overlays td.operator {
     font-size: 0.9em;
 }
+
+@media only screen and (max-width: 768px) {
+    .informational-overlays .overlay-content {
+        width: calc(100% - 20px);
+    }
+    .new-style .tab-switcher.large .ind-tab {
+        width: 100%;
+    }
+    .new-style .tab-switcher {
+        display: flex;
+    }
+    .table.table-condensed.table-striped {
+        margin-left: auto;
+        margin-right: auto;
+    }
+    .hotkeys_table {
+        width: 100%;
+        display: table;
+    }
+}


### PR DESCRIPTION
- Added a media query for `max-width: 768px` where the changes in the
css will take place.
- This fix also makes the navigation menu responsive.

Before:
![Before](https://cloud.githubusercontent.com/assets/17938322/24084112/2c9ee220-0d0a-11e7-9006-a3bcab10dbab.png)


After:
![After](https://cloud.githubusercontent.com/assets/17938322/24084094/d423dc54-0d09-11e7-8f67-9c1208f67b1d.png)

Referencing Issue #4022