### PR TITLE
lint: Ban redundant linkified URLs.

### DIFF
--- a/tools/lint-all
+++ b/tools/lint-all
@@ -505,7 +505,10 @@ def build_custom_checkers(by_lang):
     json_rules = [] # type: RuleList # fix newlines at ends of files
     # It is okay that json_rules is empty, because the empty list
     # ensures we'll still check JSON files for whitespace.
-    markdown_rules = markdown_whitespace_rules + prose_style_rules
+    markdown_rules = markdown_whitespace_rules + prose_style_rules + [
+        {'pattern': '\[(?P<url>[^\]]+)\]\((?P=url)\)',
+         'description': 'Linkified URLs should be surrounded by <>.'}
+    ]
     help_markdown_rules = markdown_rules + [
         {'pattern': '[a-z][.][A-Z]',
          'description': "Likely missing space after end of sentence"},


### PR DESCRIPTION
This way, `[zulip.org](zulip.org)` should become `<zulip.org>`.