### PR TITLE
Inital steps in adding logic to filter messages, keeping only those u…

### DIFF
--- a/analytics/management/commands/realm_stats.py
+++ b/analytics/management/commands/realm_stats.py
@@ -147,6 +147,16 @@ class Command(BaseCommand):
             active_user_subs = Subscription.objects.filter(
                 user_profile__in=user_profiles, active=True)
 
+            # Unread messages
+            nonreaders = UserMessage.objects.filter(user_profile__in=user_profiles,
+                                                  flags=UserMessage.flags.unread).values(
+                "user_profile").annotate(count=Count("user_profile"))
+            print("%d users have %d unread messages" % (
+                len(nonreaders), sum([elt["count"] for elt in nonreaders])))
+
+            active_user_subs = Subscription.objects.filter(
+                user_profile__in=user_profiles, active=True)
+
             # Streams not in home view
             non_home_view = active_user_subs.filter(in_home_view=False).values(
                 "user_profile").annotate(count=Count("user_profile"))

--- a/frontend_tests/casper_tests/15-unread.js
+++ b/frontend_tests/casper_tests/15-unread.js
@@ -1,0 +1,68 @@
+var common = require('../casper_lib/common.js').common;
+
+function count() {
+    return casper.evaluate(function () {
+        return $("#zhome").length;
+    });
+}
+function unread_count() {
+    return casper.evaluate(function () {
+        return $("#zhome .icon-vector-unread:not(.read)").length;
+    });
+}
+
+function toggle_last_unread() {
+    casper.evaluate(function () {
+        $("#zhome .unread").last().click();
+    });
+}
+
+var num_messages = count();
+
+common.start_and_log_in();
+
+casper.then(function () {
+    casper.test.info("Sending test message");
+});
+
+common.then_send_message('stream', {
+        stream:  'Verona',
+        subject: 'unread',
+        content: 'test unread',
+});
+
+casper.waitForText("test unread");
+
+casper.then(function () {
+    casper.test.info("Checking unread counts");
+
+    // Initially, all messages are unread.
+    casper.test.assertEquals(unread_count(), count(),
+                             "Got expected full unread count.");
+
+    // Clicking on a message (or its unread icon) makes it read.
+    toggle_last_unread();
+    casper.test.assertEquals(unread_count(), count() - 1,
+                             "Got expected almost full unread count.");
+
+    casper.click('a[href^="#narrow/is/unread"]');
+});
+
+casper.waitUntilVisible('#zfilt', function () {
+    // You can narrow to your unread messages.
+    common.expected_messages('zfilt', ['Verona > unread'], ['<p>test unread</p>']);
+    common.un_narrow();
+});
+
+casper.then(function () {
+    // Clicking on a read message's unread icon makes it read.
+    toggle_last_unread();
+    casper.test.assertEquals(unread_count(), count(),
+                             "Got expected re-full unread count.");
+});
+
+common.then_log_out();
+
+casper.run(function () {
+    casper.test.done();
+});

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -240,6 +240,10 @@ function get_predicate(operators) {
     assert(predicate({starred: true}));
     assert(!predicate({starred: false}));
 
+    predicate = get_predicate([['is', 'unread']]);
+    assert(predicate({unread: true}));
+    assert(!predicate({unread: false}));
+
     predicate = get_predicate([['is', 'alerted']]);
     assert(predicate({alerted: true}));
     assert(!predicate({alerted: false}));
@@ -467,6 +471,7 @@ function get_predicate(operators) {
     narrow = [
         {operator: 'stream', operand: 'devel'},
         {operator: 'is', operand: 'starred'},
+        {operator: 'is', operand: 'unread'},
     ];
     string = 'Narrow to stream devel, Narrow to starred messages';
     assert.equal(Filter.describe(narrow), string);
@@ -540,6 +545,13 @@ function get_predicate(operators) {
         {operator: 'is', operand: 'starred', negated: true},
     ];
     string = 'Narrow to stream devel, Exclude starred messages';
+    assert.equal(Filter.describe(narrow), string);
+
+    narrow = [
+        {operator: 'stream', operand: 'devel'},
+        {operator: 'is', operand: 'unread', negated: true},
+    ];
+    string = 'Narrow to stream devel, Exclude unread messages';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -165,6 +165,11 @@ function set_filter(operators) {
     assert.equal(hide_id,'.empty_feed_notice');
     assert.equal(show_id, '#empty_star_narrow_message');
 
+    set_filter([['is', 'unread']]);
+    narrow.show_empty_narrow_message();
+    assert.equal(hide_id,'.empty_feed_notice');
+    assert.equal(show_id, '#empty_unread_narrow_message');
+
     set_filter([['is', 'mentioned']]);
     narrow.show_empty_narrow_message();
     assert.equal(hide_id,'.empty_feed_notice');

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -343,6 +343,7 @@ init();
         "in:all",
         "is:private",
         "is:starred",
+        "is:unread",
         "is:mentioned",
         "is:alerted",
         "sender:bob@zulip.com",
@@ -358,6 +359,7 @@ init();
     assert.equal(describe('in:all'), 'All messages');
     assert.equal(describe('is:private'), 'Private messages');
     assert.equal(describe('is:starred'), 'Starred messages');
+    assert.equal(describe('is:unread'), 'Unread messages');
     assert.equal(describe('is:mentioned'), '@-mentions');
     assert.equal(describe('is:alerted'), 'Alerted messages');
     assert.equal(describe('sender:bob@zulip.com'), 'Sent by me');

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -537,6 +537,7 @@ function render(template_name, args) {
             content: 'This is message one.',
             last_edit_timestr: '11:00',
             starred: true,
+            unread: false,
         },
     };
 
@@ -552,6 +553,10 @@ function render(template_name, args) {
 
     var starred_title = first_message.find(".star").attr("title");
     assert.equal(starred_title, "Unstar this message");
+}());
+
+    var unread_title = first_message.find(".unread").attr("title");
+    assert.equal(unread_title, "Mark this message read");
 }());
 
 (function message_edit_form() {
@@ -574,6 +579,7 @@ function render(template_name, args) {
                 id: 1,
                 match_content: 'This is message one.',
                 starred: true,
+                unread: false,
                 is_stream: true,
                 content: 'This is message one.',
             },

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -554,6 +554,9 @@ function pick_empty_narrow_banner() {
         if (first_operand === "starred") {
             // You have no starred messages.
             return $("#empty_star_narrow_message");
+        } else if (first_operand === "unread") {
+            // You have no unread messages.
+            return $("#empty_unread_narrow_message");
         } else if (first_operand === "mentioned") {
             return $("#empty_narrow_all_mentioned");
         } else if (first_operand === "private") {

--- a/static/locale/bg/translations.json
+++ b/static/locale/bg/translations.json
@@ -374,5 +374,6 @@
   "more topics": "more topics", 
   "right": "right", 
   "waiting period threshold changed!": "waiting period threshold changed!", 
+  "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}": "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}",
   "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message"
 }

--- a/static/locale/en/translations.json
+++ b/static/locale/en/translations.json
@@ -374,5 +374,6 @@
   "more topics": "more topics", 
   "right": "right", 
   "waiting period threshold changed!": "waiting period threshold changed!", 
-  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message"
+  "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}": "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}",
+  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message",
 }

--- a/static/locale/fr/translations.json
+++ b/static/locale/fr/translations.json
@@ -374,5 +374,6 @@
   "more topics": "more topics", 
   "right": "right", 
   "waiting period threshold changed!": "waiting period threshold changed!", 
-  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message"
+  "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}": "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}",
+  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message",
 }

--- a/static/locale/it/translations.json
+++ b/static/locale/it/translations.json
@@ -374,5 +374,6 @@
   "more topics": "more topics", 
   "right": "right", 
   "waiting period threshold changed!": "waiting period threshold changed!", 
-  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message"
+  "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}": "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}",
+  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message",
 }

--- a/static/locale/ko/translations.json
+++ b/static/locale/ko/translations.json
@@ -374,5 +374,6 @@
   "more topics": "more topics", 
   "right": "right", 
   "waiting period threshold changed!": "waiting period threshold changed!", 
-  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message"
+  "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}": "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}",
+  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message",
 }

--- a/static/locale/ml/translations.json
+++ b/static/locale/ml/translations.json
@@ -374,5 +374,6 @@
   "more topics": "\u0d15\u0d42\u0d1f\u0d41\u0d24\u0d7d \u0d35\u0d3f\u0d37\u0d2f\u0d19\u0d4d\u0d19\u0d7e", 
   "right": "right", 
   "waiting period threshold changed!": "waiting period threshold changed!", 
-  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": " \u0d08 \u0d38\u0d28\u0d4d\u0d26\u0d47\u0d36\u0d02 {{#if msg/starred}}Unstar{{else}}Star{{/if}} \u0d1a\u0d46\u0d2f\u0d4d\u0d2f\u0d41\u0d15"
+  "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}": "{{#if msg/unread}}Read{{else}}Unread{{/if}}",
+  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": " \u0d08 \u0d38\u0d28\u0d4d\u0d26\u0d47\u0d36\u0d02 {{#if msg/starred}}Unstar{{else}}Star{{/if}} \u0d1a\u0d46\u0d2f\u0d4d\u0d2f\u0d41\u0d15",
 }

--- a/static/locale/nl/translations.json
+++ b/static/locale/nl/translations.json
@@ -374,5 +374,6 @@
   "more topics": "meer onderwerpen", 
   "right": "rechts", 
   "waiting period threshold changed!": "wachtperiode drempelwaarde gewijzigd!", 
-  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Demarkeer{{else}}Markeer{{/if}} dit bericht"
+  "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}": "Markeer dit bericht als {{#if msg/unread}}Gelezen{{else}}Un Lezen{{/if}}",
+  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Demarkeer{{else}}Markeer{{/if}} dit bericht",
 }

--- a/static/locale/pt/translations.json
+++ b/static/locale/pt/translations.json
@@ -374,5 +374,6 @@
   "more topics": "more topics", 
   "right": "right", 
   "waiting period threshold changed!": "waiting period threshold changed!", 
-  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message"
+  "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}": "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}}",
+  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message",
 }

--- a/static/locale/sr/translations.json
+++ b/static/locale/sr/translations.json
@@ -374,5 +374,6 @@
   "more topics": "more topics", 
   "right": "right", 
   "waiting period threshold changed!": "waiting period threshold changed!", 
-  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message"
+  "Mark this message as {{#if msg/unread}}Read{{else}}Unread{{/if}} this message": "Mark this message as {{#if msg/unreadd}}Read{{else}}Unread{{/if}}",
+  "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message": "{{#if msg/starred}}Unstar{{else}}Star{{/if}} this message",
 }

--- a/templates/zerver/home.html
+++ b/templates/zerver/home.html
@@ -74,6 +74,9 @@
       <div id="empty_star_narrow_message" class="empty_feed_notice">
         <h4>{{ _("You haven't starred anything yet!") }}</h4>
       </div>
+      <div id="empty_unread_narrow_message" class="empty_feed_notice">
+        <h4>{{ _("You've read all your messages!") }}</h4>
+      </div>
       <div id="empty_narrow_all_mentioned" class="empty_feed_notice">
         <h4>{{ _("You haven't been mentioned yet!") }}</h4>
       </div>

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -133,6 +133,9 @@ class NarrowBuilder(object):
         elif operand == 'starred':
             cond = column("flags").op("&")(UserMessage.flags.starred.mask) != 0
             return query.where(maybe_negate(cond))
+        elif operand == 'unread':
+            cond = column("flags").op("&")(UserMessage.flags.unread.mask) != 0
+            return query.where(maybe_negate(cond))
         elif operand == 'mentioned' or operand == 'alerted':
             cond = column("flags").op("&")(UserMessage.flags.mentioned.mask) != 0
             return query.where(maybe_negate(cond))


### PR DESCRIPTION
…nread as in issue #1423.

Went through grep of occurrences of "starred", adding corresponding occurrences of "unread".  I only made it up to "/static/locale/ml/translations.json", the first language with character codes in the translation.

Watch out for possible inconsistencies between using "read" vs "unread" in names.  Also watch out for the possibility of double-entry of the same logic.  Both since I hadn't initially realized that some logic was already present.

Some considerations:
Perhaps it should be possile to mark an entire thread as unread as well as marking it as read.
Messages need to be marked as read automatically when they are read (this is probably already happening).
I'm assuming that it is also possible to toggle this indicator.