### PR TITLE
[zephyr_mirror] add support for zcrypt'ed classes with colons

### DIFF
--- a/bots/zephyr_mirror_backend.py
+++ b/bots/zephyr_mirror_backend.py
@@ -313,7 +313,7 @@ def parse_crypt_table(zephyr_class, instance):
         if line.strip() == "":
             # Ignore blank lines
             continue
-        match = re.match("^crypt-(?P<class>[^:]+):\s+((?P<algorithm>(AES|DES)):\s+)?(?P<keypath>\S+)$", line)
+        match = re.match("^crypt-(?P<class>\S+):\s+((?P<algorithm>(AES|DES)):\s+)?(?P<keypath>\S+)$", line)
         if match is None:
             # Malformed crypt_table line
             logger.debug("Invalid crypt_table line!")


### PR DESCRIPTION
The regex used for parsing .crypt-table didn't allow colons in class
names. This commit changes the [^:] token with \S, meaning that class
names can now contain colons but can no longer contain whitespace.

I think this should be fine, since zcrypt is only used for MIT zephyr,
where (by convention) class names do not contain whitespace.

Additionally, it should not be possible for us to accidentally consume a
field-separating colon as part of the class capture group because the
regex enforces that all field-separating colons are followed by one or
more whitespace characters, whereas the class name cannot contain
whitespace.