### PR TITLE
Fix to issue #3952 (Duplicate emoji entries in emoji picker.)

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -358,7 +358,7 @@ function render_emoji_popover() {
             realm_emoji: emoji.realm_emojis,
         });
     }());
-
+    $('.emoji_popover').empty();
     $('.emoji_popover').append(content);
 
     $('.drag').show();


### PR DESCRIPTION
Fix to #3952 . The the content of emoji_popover was not being cleared. And each time the content was being appended. so, this resulted in multiple copies of the same emoji appearing in the emoji_popover. This has been resolved by clearing the content emoji_popover before appending the emoji content.