### PR TITLE
echo: Remove impossible 'quote' 4-space-indented code block type.

### DIFF
--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -443,13 +443,9 @@ $(function () {
     // Configure the marked markdown parser for our usage
     var r = new marked.Renderer();
 
-    // No <code> around our code blocks instead a codehilite <div> and disable class-specific
-    // highlighting. We special-case the 'quote' language and output a blockquote.
-    r.code = function (code, lang) {
-        if (lang === 'quote') {
-            return '<blockquote>\n<p>' + escape(code, true) + '</p>\n</blockquote>\n\n\n';
-        }
-
+    // No <code> around our code blocks instead a codehilite <div> and disable
+    // class-specific highlighting.
+    r.code = function (code) {
         return '<div class="codehilite"><pre>'
           + escape(code, true)
           + '\n</pre></div>\n\n\n';
@@ -458,7 +454,8 @@ $(function () {
     // Our links have title= and target=_blank
     r.link = function (href, title, text) {
         title = title || href;
-        var out = '<a href="' + href + '"' + ' target="_blank" title="' + title + '"' + '>' + text + '</a>';
+        var out = '<a href="' + href + '"' + ' target="_blank" title="' +
+                  title + '"' + '>' + text + '</a>';
         return out;
     };
 


### PR DESCRIPTION
Since it's not possible to manually set the language in 4-space-indented code blocks, there's no point in checking if these blocks' type is "quote".

Note that fenced blocks (the ones that use ` ``` ` or `~~~`) aren't considered "code" blocks, so this doesn't apply to them.