### PR TITLE
remove horizontal scroll bar in messages caused by trailing whitespace in fence code blocks

### DIFF
--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -38,6 +38,7 @@ add_dependencies({
     hashchange: 'js/hashchange',
     fenced_code: 'js/fenced_code.js',
     katex: 'node_modules/katex/dist/katex.min.js',
+    util: 'js/util.js',
 });
 
 var doc = "";
@@ -184,6 +185,8 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
     {input: '__hello__', expected: '<p>__hello__</p>'},
     {input: '\n```\nfenced code\n```\n\nand then after\n',
      expected: '<div class="codehilite"><pre><span></span>fenced code\n</pre></div>\n\n\n<p>and then after</p>'},
+     {input: '\n```\n    fenced code trailing whitespace            \n```\n\nand then after\n',
+     expected: '<div class="codehilite"><pre><span></span>    fenced code trailing whitespace\n</pre></div>\n\n\n<p>and then after</p>'},
     {input: '* a\n* list \n* here',
      expected: '<ul>\n<li>a</li>\n<li>list </li>\n<li>here</li>\n</ul>'},
     {input: 'Some text first\n* a\n* list \n* here\n\nand then after',

--- a/static/js/fenced_code.js
+++ b/static/js/fenced_code.js
@@ -127,7 +127,7 @@ exports.process_fenced_code = function (content) {
                     if (line === fence) {
                         this.done();
                     } else {
-                        lines.push(line);
+                        lines.push(util.rtrim(line));
                     }
                 },
 

--- a/zerver/fixtures/bugdown-data.json
+++ b/zerver/fixtures/bugdown-data.json
@@ -19,6 +19,12 @@
       "bugdown_matches_marked": true
     },
     {
+      "name": "codeblock_trailing_whitespace",
+      "input": "Hamlet once said\n~~~~\ndef func():\n    x = 1\n\n    y = 2\t\t\n\n    z = 3       \n~~~~\nAnd all was good.",
+      "expected_output": "<p>Hamlet once said</p>\n<div class=\"codehilite\"><pre><span></span>def func():\n    x = 1\n\n    y = 2\n\n    z = 3\n</pre></div>\n\n\n<p>And all was good.</p>",
+      "bugdown_matches_marked": true
+    },
+    {
       "name": "codeblock_backticks",
       "input": "\n```\nfenced code\n```\n\n```inline code```\n",
       "expected_output": "<div class=\"codehilite\"><pre><span></span>fenced code\n</pre></div>\n\n\n<p><code>inline code</code></p>",

--- a/zerver/lib/bugdown/fenced_code.py
+++ b/zerver/lib/bugdown/fenced_code.py
@@ -37,6 +37,21 @@ Include tilde's in a code block and wrap with blank lines:
     ~~~~
     </code></pre>
 
+Removes trailing whitespace from code blocks that cause horizontal scrolling
+    >>> import markdown
+    >>> text = '''
+    ... A paragraph before a fenced code block:
+    ...
+    ... ~~~
+    ... Fenced code block    \t\t\t\t\t\t\t
+    ... ~~~
+    ... '''
+    >>> html = markdown.markdown(text, extensions=['fenced_code'])
+    >>> print html
+    <p>A paragraph before a fenced code block:</p>
+    <pre><code>Fenced code block
+    </code></pre>
+
 Language tags:
 
     >>> text = '''
@@ -92,7 +107,7 @@ FENCE_RE = re.compile(u"""
     """, re.VERBOSE)
 
 
-CODE_WRAP = u'<pre><code%s>%s</code></pre>'
+CODE_WRAP = u'<pre><code%s>%s\n</code></pre>'
 LANG_TAG = u' class="%s"'
 
 class FencedCodeExtension(markdown.Extension):
@@ -193,7 +208,7 @@ class FencedBlockPreprocessor(markdown.preprocessors.Preprocessor):
                 if line.rstrip() == self.fence:
                     self.done()
                 else:
-                    self.lines.append(line)
+                    self.lines.append(line.rstrip())
 
             def done(self):
                 # type: () -> None


### PR DESCRIPTION
I removed trailing whitespace from fence code blocks on the backend and frontend. A backend doctest was added for this addition as well as a shared test and frontend test.

Fixes #3998