### PR TITLE
Add is_mobile test and refactor web socket use.

### DIFF
--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -2,6 +2,9 @@
 
 var csrf_token;
 $(function () {
+    // if the client is mobile, do not use web sockets.
+    page_params.use_websockets = !util.is_mobile();
+
     // Display loading indicator.  This disappears after the first
     // get_events completes.
     if (page_params.have_initial_messages && !page_params.needs_tutorial) {

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -228,6 +228,12 @@ exports.move_array_elements_to_front = function util_move_array_elements_to_fron
     return selected_elements.concat(unselected_elements);
 };
 
+// check by the userAgent string if a user's client is likely mobile.
+exports.is_mobile = function () {
+    var regex = "Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini";
+    return new RegExp(regex, "i").test(window.navigator.userAgent);
+};
+
 return exports;
 }());
 if (typeof module !== 'undefined') {


### PR DESCRIPTION
This refactors the is_mobile function into the utils function and sets the page_params.use_websockets to not use web sockets if on a mobile device because iOS doesn’t seem to play nice with the web socket library we are using.