### PR TITLE
actions.py: Only admins and bot's owner should recieve bot related events.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -149,14 +149,16 @@ def private_stream_user_ids(stream):
     return {sub['user_profile_id'] for sub in subscriptions.values('user_profile_id')}
 
 def bot_owner_userids(user_profile):
-    # type: (UserProfile) -> Sequence[int]
+    # type: (UserProfile) -> Set[int]
     is_private_bot = (
         user_profile.default_sending_stream and user_profile.default_sending_stream.invite_only or
         user_profile.default_events_register_stream and user_profile.default_events_register_stream.invite_only)
     if is_private_bot:
-        return (user_profile.bot_owner_id,) # TODO: change this to list instead of tuple
+        return {user_profile.bot_owner_id, }
     else:
-        return active_user_ids(user_profile.realm)
+        users = {user.id for user in user_profile.realm.get_admin_users()}
+        users.add(user_profile.bot_owner_id)
+        return users
 
 def realm_user_count(realm):
     # type: (Realm) -> int

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -257,7 +257,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             ),
             event['event']
         )
-        self.assertEqual(event['users'], (user_profile.id,))
+        self.assertEqual(event['users'], {user_profile.id, })
 
     def test_add_bot_with_default_sending_stream_private_denied(self):
         # type: () -> None
@@ -321,7 +321,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             ),
             event['event']
         )
-        self.assertEqual(event['users'], (user_profile.id,))
+        self.assertEqual(event['users'], {user_profile.id, })
 
     def test_add_bot_with_default_events_register_stream_private_denied(self):
         # type: () -> None


### PR DESCRIPTION
Modify `bot_owner_user_ids()` to return the user_ids of only
admins and bot owners instead of all the current active users.
This was causing a traceback on the frontend.

Fixes: #3391.