### PR TITLE
[settings] Fix user edit form not being shown.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -891,15 +891,14 @@ function _setup_page() {
         var owner_select = $(templates.render("bot_owner_select", {users_list: users_list}));
         var admin_status = $('#administration-status').expectOne();
         var person = people.get_person_from_user_id(user_id);
-
         if (!person) {
             return;
+        } else if (person.is_bot) {
+            // Dynamically add the owner select control in order to
+            // avoid performance issues in case of large number of users.
+            owner_select.val(bot_data.get(person.email).owner || "");
+            form_row.find(".edit_bot_owner_container").append(owner_select);
         }
-
-        // Dynamically add the owner select control in order to
-        // avoid performance issues in case of large number of users.
-        owner_select.val(bot_data.get(person.email).owner || "");
-        form_row.find(".edit_bot_owner_container").append(owner_select);
 
         // Show user form.
         user_row.hide();


### PR DESCRIPTION
**The bug:**
Previously, the edit button in *Users* section in _Administration_ panel wasn't showing the _user-form_ to edit the full name.

**Inspection:**
On inspecting, I found out that the same click handling function is being used for both _Bot table_ and _User Table_. Inside the function, bot owner is fetched this line in *admin.js*
 `bot_data.get(person.email).owner`
This works perfectly if we are clicking the Edit button in Admin Bot Settings. But when you do the same in Admin User Settings, the line throws an error because the _get method_ returns undefined. This prevented the button from showing up.

**Fix:**
I have added an if condition in _admin.js_ which checks whether **person.is_bot** is true before executing the line. This fixes the bug.
