### PR TITLE
Require stream list shown in the invite users modal to display default streams.

### DIFF
--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -8,7 +8,8 @@ function update_subscription_checkboxes() {
     // checkboxes are saved from invocation to invocation (which is
     // nice if I want to invite a bunch of people at once)
     var streams = [];
-    _.each(stream_data.subscribed_streams(), function (value) {
+
+    _.each(stream_data.invite_streams(), function (value) {
         var is_notifications_stream = value === page_params.notifications_stream;
         if ((stream_data.subscribed_streams().length === 1) ||
             !is_notifications_stream ||
@@ -16,7 +17,13 @@ function update_subscription_checkboxes() {
             // You can't actually elect not to invite someone to the
             // notifications stream. We won't even show it as a choice unless
             // it's the only stream you have, or if you've made it private.
-            streams.push({name: value, invite_only: stream_data.get_invite_only(value)});
+            var default_status = stream_data.get_default_status(value);
+            var invite_status = stream_data.get_invite_only(value);
+            streams.push({name: value, invite_only: invite_status, default_stream: default_status});
+            // Sort by default status.
+            streams.sort(function (a, b) {
+                return b.default_stream - a.default_stream;
+            });
         }
     });
     $('#streams_to_add').html(templates.render('invite_subscription', {streams: streams}));

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -9,6 +9,8 @@ var stream_info;
 var subs_by_stream_id;
 var recent_topics = new Dict({fold_case: true});
 
+var defaults = {};
+
 exports.clear_subscriptions = function () {
     stream_info = new Dict({fold_case: true});
     subs_by_stream_id = new Dict();
@@ -79,6 +81,12 @@ exports.subscribed_streams = function () {
     return _.pluck(exports.subscribed_subs(), 'name');
 };
 
+exports.invite_streams = function () {
+    var invite_list = exports.subscribed_streams();
+    var default_list = _.pluck(page_params.realm_default_streams, 'name');
+    return _.union(invite_list, default_list);
+};
+
 exports.get_colors = function () {
     return _.pluck(exports.subscribed_subs(), 'color');
 };
@@ -132,6 +140,10 @@ exports.get_invite_only = function (stream_name) {
         return false;
     }
     return sub.invite_only;
+};
+
+exports.get_default_status = function (stream_name) {
+    return defaults.hasOwnProperty(stream_name);
 };
 
 exports.get_name = function (stream_name) {
@@ -372,6 +384,10 @@ exports.initialize_from_page_params = function () {
             exports.create_sub_from_server_data(stream_name, sub);
         });
     }
+
+    page_params.realm_default_streams.forEach(function (stream) {
+        defaults[stream.name] = true;
+    });
 
     populate_subscriptions(page_params.subbed_info, true);
     populate_subscriptions(page_params.unsubbed_info, false);

--- a/static/templates/invite_subscription.handlebars
+++ b/static/templates/invite_subscription.handlebars
@@ -5,7 +5,7 @@
     {{#each streams}}
     <label class="checkbox">
         <input type="checkbox" name="stream" value="{{name}}"
-               {{#unless invite_only}}checked="checked"{{/unless}} /> {{name}}
+               {{#if default_stream}}checked="checked"{{/if}} /> {{name}}
         {{#if invite_only}}<i class="icon-vector-lock"></i>{{/if}}
     </label>
     {{/each}}


### PR DESCRIPTION
This fixes a bug where if a user is not subscribed to a default stream,
he or she would not be have the option to invite users to that default
stream.

Fixes: #4209