### PR TITLE
Apps page arrow transition fix.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -455,8 +455,6 @@ a:not(.no-style):hover:before {
     top: 21px;
     opacity: 0;
     transform: translateX(3px);
-
-    transition: all 0.3s ease;
 }
 
 .portico-landing.apps .main ul.sidebar li.active::after {


### PR DESCRIPTION
The issue is that stacking the two transitions appears to make the
::after pseudo-element slower for some reason than its parent. This
visually appears to fix it.