### PR TITLE
Prevent cursor jump to the end while editing stream-description

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -468,7 +468,6 @@ $(function () {
             // wrong.
             if (this.hasChildNodes()) {
                 this.innerText = this.innerText;
-                place_caret_at_end(this);
             }
         });
 

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -456,6 +456,13 @@ $(function () {
 
         $(document).on("keydown", ".editable-section", function (e) {
             e.stopPropagation();
+            // Cancel editing description if Escape key is pressed.
+            if (e.which === 27) {
+                $("[data-finish-editing='.stream-description-editable']").hide();
+                $(this).attr("contenteditable", false);
+                $(this).text($(this).attr("data-prev-text"));
+                $("[data-make-editable]").html("");
+            }
         });
 
         $(document).on("drop", ".editable-section", function () {


### PR DESCRIPTION
This prevents the cursor to jump at the end of the content-editable area when the user types in the middle.
Also fix the escape key bug.
Fixes #4202 