### PR TITLE
zerver/lib/actions: Add do_set_realm_property function

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -420,89 +420,21 @@ def active_humans_in_realm(realm):
     # type: (Realm) -> Sequence[UserProfile]
     return UserProfile.objects.filter(realm=realm, is_active=True, is_bot=False)
 
-def do_set_realm_name(realm, name):
-    # type: (Realm, Text) -> None
-    realm.name = name
-    realm.save(update_fields=['name'])
-    event = dict(
-        type="realm",
-        op="update",
-        property='name',
-        value=name,
-    )
-    send_event(event, active_user_ids(realm))
 
-def do_set_realm_description(realm, description):
-    # type: (Realm, Text) -> None
-    realm.description = description
-    realm.save(update_fields=['description'])
+def do_set_realm_property(realm, name, value):
+    # type: (Realm, Text, Union[Text, bool, int]) -> None
+    """Takes in a realm object, the name of an attribute to update, and the value to update.
+    """
+    setattr(realm, name, value)
+    realm.save(update_fields=[name])
     event = dict(
         type='realm',
         op='update',
-        property='description',
-        value=description,
+        property=name,
+        value=value,
     )
     send_event(event, active_user_ids(realm))
 
-def do_set_realm_restricted_to_domain(realm, restricted):
-    # type: (Realm, bool) -> None
-    realm.restricted_to_domain = restricted
-    realm.save(update_fields=['restricted_to_domain'])
-    event = dict(
-        type="realm",
-        op="update",
-        property='restricted_to_domain',
-        value=restricted,
-    )
-    send_event(event, active_user_ids(realm))
-
-def do_set_realm_invite_required(realm, invite_required):
-    # type: (Realm, bool) -> None
-    realm.invite_required = invite_required
-    realm.save(update_fields=['invite_required'])
-    event = dict(
-        type="realm",
-        op="update",
-        property='invite_required',
-        value=invite_required,
-    )
-    send_event(event, active_user_ids(realm))
-
-def do_set_realm_invite_by_admins_only(realm, invite_by_admins_only):
-    # type: (Realm, bool) -> None
-    realm.invite_by_admins_only = invite_by_admins_only
-    realm.save(update_fields=['invite_by_admins_only'])
-    event = dict(
-        type="realm",
-        op="update",
-        property='invite_by_admins_only',
-        value=invite_by_admins_only,
-    )
-    send_event(event, active_user_ids(realm))
-
-def do_set_realm_inline_image_preview(realm, inline_image_preview):
-    # type: (Realm, bool) -> None
-    realm.inline_image_preview = inline_image_preview
-    realm.save(update_fields=['inline_image_preview'])
-    event = dict(
-        type="realm",
-        op="update",
-        property='inline_image_preview',
-        value=inline_image_preview,
-    )
-    send_event(event, active_user_ids(realm))
-
-def do_set_realm_inline_url_embed_preview(realm, inline_url_embed_preview):
-    # type: (Realm, bool) -> None
-    realm.inline_url_embed_preview = inline_url_embed_preview
-    realm.save(update_fields=['inline_url_embed_preview'])
-    event = dict(
-        type="realm",
-        op="update",
-        property='inline_url_embed_preview',
-        value=inline_url_embed_preview,
-    )
-    send_event(event, active_user_ids(realm))
 
 def do_set_realm_authentication_methods(realm, authentication_methods):
     # type: (Realm, Dict[str, bool]) -> None
@@ -518,29 +450,6 @@ def do_set_realm_authentication_methods(realm, authentication_methods):
     )
     send_event(event, active_user_ids(realm))
 
-def do_set_realm_create_stream_by_admins_only(realm, create_stream_by_admins_only):
-    # type: (Realm, bool) -> None
-    realm.create_stream_by_admins_only = create_stream_by_admins_only
-    realm.save(update_fields=['create_stream_by_admins_only'])
-    event = dict(
-        type="realm",
-        op="update",
-        property='create_stream_by_admins_only',
-        value=create_stream_by_admins_only,
-    )
-    send_event(event, active_user_ids(realm))
-
-def do_set_realm_add_emoji_by_admins_only(realm, add_emoji_by_admins_only):
-    # type: (Realm, bool) -> None
-    realm.add_emoji_by_admins_only = add_emoji_by_admins_only
-    realm.save(update_fields=['add_emoji_by_admins_only'])
-    event = dict(
-        type="realm",
-        op="update",
-        property='add_emoji_by_admins_only',
-        value=add_emoji_by_admins_only,
-    )
-    send_event(event, active_user_ids(realm))
 
 def do_set_realm_message_editing(realm, allow_message_editing, message_content_edit_limit_seconds):
     # type: (Realm, bool, int) -> None
@@ -556,30 +465,6 @@ def do_set_realm_message_editing(realm, allow_message_editing, message_content_e
     )
     send_event(event, active_user_ids(realm))
 
-def do_set_realm_default_language(realm, default_language):
-    # type: (Realm, Text) -> None
-
-    realm.default_language = default_language
-    realm.save(update_fields=['default_language'])
-    event = dict(
-        type="realm",
-        op="update",
-        property="default_language",
-        value=default_language
-    )
-    send_event(event, active_user_ids(realm))
-
-def do_set_realm_waiting_period_threshold(realm, threshold):
-    # type: (Realm, int) -> None
-    realm.waiting_period_threshold = threshold
-    realm.save(update_fields=['waiting_period_threshold'])
-    event = dict(
-        type="realm",
-        op="update",
-        property='waiting_period_threshold',
-        value=threshold,
-    )
-    send_event(event, active_user_ids(realm))
 
 def do_deactivate_realm(realm):
     # type: (Realm) -> None
@@ -3350,7 +3235,7 @@ def do_remove_realm_alias(alias):
         # longer restricted to domain, because the feature doesn't do
         # anything if there are no domains, and this is probably less
         # confusing than the alternative.
-        do_set_realm_restricted_to_domain(realm, False)
+        do_set_realm_property(realm, 'restricted_to_domain', False)
     event = dict(type="realm_domains", op="remove", domain=domain)
     send_event(event, active_user_ids(realm))
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -15,8 +15,13 @@ import mock
 import re
 
 from zerver.forms import HomepageForm
-from zerver.lib.actions import do_deactivate_realm, do_deactivate_user, \
-    do_reactivate_realm, do_reactivate_user, do_set_realm_authentication_methods
+from zerver.lib.actions import (
+    do_deactivate_realm,
+    do_deactivate_user,
+    do_reactivate_realm,
+    do_reactivate_user,
+    do_set_realm_authentication_methods,
+)
 from zerver.lib.initial_password import initial_password
 from zerver.lib.sessions import get_session_dict_user
 from zerver.lib.test_classes import (
@@ -1038,9 +1043,7 @@ class FetchAuthBackends(ZulipTestCase):
                 # Verify correct behavior with a valid subdomain with
                 # some backends disabled for the realm
                 realm = get_realm("zulip")
-                do_set_realm_authentication_methods(realm, dict(Google=False,
-                                                                Email=False,
-                                                                Dev=True))
+                do_set_realm_authentication_methods(realm, dict(Google=False, Email=False, Dev=True))
                 result = self.client_get("/api/v1/get_auth_backends",
                                          HTTP_HOST="zulip.testserver")
                 self.assert_json_success(result)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -43,21 +43,11 @@ from zerver.lib.actions import (
     do_add_default_stream,
     do_remove_default_stream,
     do_set_muted_topics,
-    do_set_realm_create_stream_by_admins_only,
-    do_set_realm_name,
-    do_set_realm_description,
-    do_set_realm_waiting_period_threshold,
-    do_set_realm_add_emoji_by_admins_only,
-    do_set_realm_restricted_to_domain,
-    do_set_realm_invite_required,
-    do_set_realm_invite_by_admins_only,
+    do_set_realm_property,
+    do_set_realm_authentication_methods,
     do_set_name_changes_disabled,
     do_set_email_changes_disabled,
-    do_set_realm_inline_image_preview,
-    do_set_realm_inline_url_embed_preview,
     do_set_realm_message_editing,
-    do_set_realm_default_language,
-    do_set_realm_authentication_methods,
     do_update_message,
     do_update_pointer,
     do_change_twenty_four_hour_time,
@@ -615,7 +605,8 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('name')),
             ('value', check_string),
         ])
-        events = self.do_test(lambda: do_set_realm_name(self.user_profile.realm, 'New Realm Name'))
+        events = self.do_test(
+            lambda: do_set_realm_property(self.user_profile.realm, 'name', 'New Realm Name'))
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
@@ -627,7 +618,8 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('description')),
             ('value', check_string),
         ])
-        events = self.do_test(lambda: do_set_realm_description(self.user_profile.realm, 'New Realm Description'))
+        events = self.do_test(
+            lambda: do_set_realm_property(self.user_profile.realm, 'description', 'New Realm Description'))
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
@@ -639,7 +631,8 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('waiting_period_threshold')),
             ('value', check_int),
         ])
-        events = self.do_test(lambda: do_set_realm_waiting_period_threshold(self.user_profile.realm, 17))
+        events = self.do_test(
+            lambda: do_set_realm_property(self.user_profile.realm, 'waiting_period_threshold', 17))
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
@@ -651,7 +644,8 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('add_emoji_by_admins_only')),
             ('value', check_bool),
         ])
-        events = self.do_test(lambda: do_set_realm_add_emoji_by_admins_only(self.user_profile.realm, True))
+        events = self.do_test(
+            lambda: do_set_realm_property(self.user_profile.realm, 'add_emoji_by_admins_only', True))
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
@@ -663,9 +657,10 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('restricted_to_domain')),
             ('value', check_bool),
         ])
-        do_set_realm_restricted_to_domain(self.user_profile.realm, True)
+        do_set_realm_property(self.user_profile.realm, 'restricted_to_domain', True)
         for restricted_to_domain in (False, True):
-            events = self.do_test(lambda: do_set_realm_restricted_to_domain(self.user_profile.realm, restricted_to_domain))
+            events = self.do_test(
+                lambda: do_set_realm_property(self.user_profile.realm, 'restricted_to_domain', restricted_to_domain))
             error = schema_checker('events[0]', events[0])
             self.assert_on_error(error)
 
@@ -677,9 +672,11 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('invite_required')),
             ('value', check_bool),
         ])
-        do_set_realm_invite_required(self.user_profile.realm, invite_required=False)
+        invite_required = False
+        do_set_realm_property(self.user_profile.realm, 'invite_required', invite_required)
         for invite_required in (True, False):
-            events = self.do_test(lambda: do_set_realm_invite_required(self.user_profile.realm, invite_required))
+            events = self.do_test(
+                lambda: do_set_realm_property(self.user_profile.realm, 'invite_required', invite_required))
             error = schema_checker('events[0]', events[0])
             self.assert_on_error(error)
 
@@ -691,7 +688,8 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('name_changes_disabled')),
             ('value', check_bool),
         ])
-        do_set_name_changes_disabled(self.user_profile.realm, name_changes_disabled=True)
+        name_changes_disabled = True
+        do_set_name_changes_disabled(self.user_profile.realm, name_changes_disabled)
         for name_changes_disabled in (False, True):
             events = self.do_test(lambda: do_set_name_changes_disabled(self.user_profile.realm, name_changes_disabled))
             error = schema_checker('events[0]', events[0])
@@ -705,7 +703,8 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('email_changes_disabled')),
             ('value', check_bool),
         ])
-        do_set_email_changes_disabled(self.user_profile.realm, email_changes_disabled=True)
+        email_changes_disabled = True
+        do_set_email_changes_disabled(self.user_profile.realm, email_changes_disabled)
         for email_changes_disabled in (False, True):
             events = self.do_test(lambda: do_set_email_changes_disabled(self.user_profile.realm, email_changes_disabled))
             error = schema_checker('events[0]', events[0])
@@ -757,9 +756,11 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('invite_by_admins_only')),
             ('value', check_bool),
         ])
-        do_set_realm_invite_by_admins_only(self.user_profile.realm, invite_by_admins_only=False)
+        invite_by_admins_only = False
+        do_set_realm_property(self.user_profile.realm, 'invite_by_admins_only', invite_by_admins_only)
         for invite_by_admins_only in (True, False):
-            events = self.do_test(lambda: do_set_realm_invite_by_admins_only(self.user_profile.realm, invite_by_admins_only))
+            events = self.do_test(
+                lambda: do_set_realm_property(self.user_profile.realm, 'invite_by_admins_only', invite_by_admins_only))
             error = schema_checker('events[0]', events[0])
             self.assert_on_error(error)
 
@@ -771,9 +772,11 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('inline_image_preview')),
             ('value', check_bool),
         ])
-        do_set_realm_inline_image_preview(self.user_profile.realm, inline_image_preview=False)
+        inline_image_preview = False
+        do_set_realm_property(self.user_profile.realm, 'inline_image_preview', inline_image_preview)
         for inline_image_preview in (True, False):
-            events = self.do_test(lambda: do_set_realm_inline_image_preview(self.user_profile.realm, inline_image_preview))
+            events = self.do_test(
+                lambda: do_set_realm_property(self.user_profile.realm, 'inline_image_preview', inline_image_preview))
             error = schema_checker('events[0]', events[0])
             self.assert_on_error(error)
 
@@ -785,9 +788,11 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('inline_url_embed_preview')),
             ('value', check_bool),
         ])
-        do_set_realm_inline_url_embed_preview(self.user_profile.realm, inline_url_embed_preview=False)
+        inline_url_embed_preview = False
+        do_set_realm_property(self.user_profile.realm, 'inline_url_embed_preview', inline_url_embed_preview)
         for inline_url_embed_preview in (True, False):
-            events = self.do_test(lambda: do_set_realm_inline_url_embed_preview(self.user_profile.realm, inline_url_embed_preview))
+            events = self.do_test(
+                lambda: do_set_realm_property(self.user_profile.realm, 'inline_url_embed_preview', inline_url_embed_preview))
             error = schema_checker('events[0]', events[0])
             self.assert_on_error(error)
 
@@ -799,7 +804,8 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('default_language')),
             ('value', check_string),
         ])
-        events = self.do_test(lambda: do_set_realm_default_language(self.user_profile.realm, 'de'))
+        events = self.do_test(
+            lambda: do_set_realm_property(self.user_profile.realm, 'default_language', 'de'))
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
@@ -811,12 +817,13 @@ class EventsRegisterTest(ZulipTestCase):
             ('property', equals('create_stream_by_admins_only')),
             ('value', check_bool),
         ])
-        do_set_realm_create_stream_by_admins_only(self.user_profile.realm, False)
+        do_set_realm_property(self.user_profile.realm, 'create_stream_by_admins_only', False)
 
         for create_stream_by_admins_only in (True, False):
             events = self.do_test(
-                lambda: do_set_realm_create_stream_by_admins_only(
+                lambda: do_set_realm_property(
                     self.user_profile.realm,
+                    'create_stream_by_admins_only',
                     create_stream_by_admins_only))
 
             error = schema_checker('events[0]', events[0])
@@ -853,8 +860,10 @@ class EventsRegisterTest(ZulipTestCase):
             ((True, 0), (False, 0), (True, 0), (False, 1234), (True, 0), (True, 1234), (True, 0),
              (False, 0), (False, 1234), (False, 0), (True, 1234), (False, 0),
              (True, 1234), (True, 600), (False, 600), (False, 1234), (True, 600)):
-            events = self.do_test(lambda: do_set_realm_message_editing(self.user_profile.realm,
-                                                                       allow_message_editing, message_content_edit_limit_seconds))
+            events = self.do_test(
+                lambda: do_set_realm_message_editing(self.user_profile.realm,
+                                                     allow_message_editing,
+                                                     message_content_edit_limit_seconds))
             error = schema_checker('events[0]', events[0])
             self.assert_on_error(error)
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Text
 
 from zerver.lib.actions import (
     do_change_is_admin,
-    do_set_realm_name,
+    do_set_realm_property,
     do_deactivate_realm,
     do_set_name_changes_disabled,
 )
@@ -33,33 +33,48 @@ class RealmTest(ZulipTestCase):
         get_user_profile_by_email('hamlet@zulip.com')
         realm = get_realm('zulip')
         new_name = 'Zed You Elle Eye Pea'
-        do_set_realm_name(realm, new_name)
+        do_set_realm_property(realm, 'name', new_name)
         self.assertEqual(get_realm(realm.string_id).name, new_name)
         self.assert_user_profile_cache_gets_new_name('hamlet@zulip.com', new_name)
 
-    def test_do_set_realm_name_events(self):
+    def test_update_realm_name_events(self):
         # type: () -> None
         realm = get_realm('zulip')
         new_name = 'Puliz'
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
-            do_set_realm_name(realm, new_name)
+            do_set_realm_property(realm, 'name', new_name)
         event = events[0]['event']
         self.assertEqual(event, dict(
-            type = 'realm',
-            op = 'update',
-            property = 'name',
-            value = new_name,
+            type='realm',
+            op='update',
+            property='name',
+            value=new_name,
         ))
 
-    def test_do_set_realm_description(self):
+    def test_update_realm_description_events(self):
+        # type: () -> None
+        realm = get_realm('zulip')
+        new_description = 'zulip dev group'
+        events = []  # type: List[Dict[str, Any]]
+        with tornado_redirected_to_list(events):
+            do_set_realm_property(realm, 'description', new_description)
+        event = events[0]['event']
+        self.assertEqual(event, dict(
+            type='realm',
+            op='update',
+            property='description',
+            value=new_description,
+        ))
+
+    def test_update_realm_description(self):
         # type: () -> None
         email = 'iago@zulip.com'
         self.login(email)
         realm = get_realm('zulip')
         new_description = 'zulip dev group'
         data = dict(description=ujson.dumps(new_description))
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             result = self.client_patch('/json/realm', data)
             self.assert_json_success(result)
@@ -108,7 +123,7 @@ class RealmTest(ZulipTestCase):
             params = {k: ujson.dumps(v) for k, v in kwarg.items()}
             result = self.client_patch('/json/realm', params)
             self.assert_json_success(result)
-            return get_realm('zulip') # refresh data
+            return get_realm('zulip')  # refresh data
 
         # name
         realm = update_with_api(name=new_name)
@@ -237,7 +252,7 @@ class RealmTest(ZulipTestCase):
         user = get_user_profile_by_email('hamlet@zulip.com')
         self.assertTrue(user.realm.deactivated)
 
-    def test_do_set_realm_default_language(self):
+    def test_change_realm_default_language(self):
         # type: () -> None
         new_lang = "de"
         realm = get_realm('zulip')

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -33,8 +33,11 @@ from zerver.lib.actions import (
 )
 
 from zerver.lib.initial_password import initial_password
-from zerver.lib.actions import do_deactivate_realm, do_set_realm_default_language, \
-    add_new_user_history
+from zerver.lib.actions import (
+    do_deactivate_realm,
+    do_set_realm_property,
+    add_new_user_history,
+)
 from zerver.lib.digest import send_digest_email
 from zerver.lib.notifications import (
     enqueue_welcome_emails, one_click_unsubscribe_link, send_local_email_template_with_delay)
@@ -942,7 +945,7 @@ class UserSignUpTest(ZulipTestCase):
         email = "newguy@zulip.com"
         password = "newpassword"
         realm = get_realm('zulip')
-        do_set_realm_default_language(realm, "de")
+        do_set_realm_property(realm, 'default_language', "de")
 
         result = self.client_post('/accounts/home/', {'email': email})
         self.assertEqual(result.status_code, 302)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -38,8 +38,8 @@ from zerver.models import (
 )
 
 from zerver.lib.actions import (
-    do_add_default_stream, do_change_is_admin, do_set_realm_waiting_period_threshold,
-    do_create_realm, do_remove_default_stream, do_set_realm_create_stream_by_admins_only,
+    do_add_default_stream, do_change_is_admin, do_set_realm_property,
+    do_create_realm, do_remove_default_stream,
     gather_subscriptions_helper, bulk_add_subscriptions, bulk_remove_subscriptions,
     gather_subscriptions, get_default_streams_for_realm, get_realm, get_stream,
     get_user_profile_by_email, set_default_streams, check_stream_name,
@@ -609,7 +609,7 @@ class StreamAdminTest(ZulipTestCase):
         email = 'hamlet@zulip.com'
         user_profile = get_user_profile_by_email(email)
         self.login(email)
-        do_set_realm_create_stream_by_admins_only(user_profile.realm, True)
+        do_set_realm_property(user_profile.realm, 'create_stream_by_admins_only', True)
 
         stream_name = ['adminsonlysetting']
         result = self.common_subscribe_to_streams(
@@ -629,7 +629,7 @@ class StreamAdminTest(ZulipTestCase):
         self.login(email)
         do_change_is_admin(user_profile, False)
 
-        do_set_realm_waiting_period_threshold(user_profile.realm, 10)
+        do_set_realm_property(user_profile.realm, 'waiting_period_threshold', 10)
 
         stream_name = ['waitingperiodtest']
         result = self.common_subscribe_to_streams(
@@ -638,7 +638,7 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.assert_json_error(result, 'User cannot create streams.')
 
-        do_set_realm_waiting_period_threshold(user_profile.realm, 0)
+        do_set_realm_property(user_profile.realm, 'waiting_period_threshold', 0)
 
         result = self.common_subscribe_to_streams(
             email,

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -26,9 +26,12 @@ from zerver.models import UserProfile, Recipient, \
 
 from zerver.lib.avatar import avatar_url
 from zerver.lib.email_mirror import create_missed_message_address
-from zerver.lib.actions import \
-    get_emails_from_user_ids, do_deactivate_user, do_reactivate_user, \
-    do_change_is_admin, do_set_realm_name, do_deactivate_realm
+from zerver.lib.actions import (
+    get_emails_from_user_ids,
+    do_deactivate_user,
+    do_reactivate_user,
+    do_change_is_admin,
+)
 
 from django.conf import settings
 import os

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -6,27 +6,16 @@ from django.utils.translation import ugettext as _
 
 from zerver.decorator import require_realm_admin, to_non_negative_int
 from zerver.lib.actions import (
-    do_set_realm_create_stream_by_admins_only,
-    do_set_realm_name,
-    do_set_realm_description,
-    do_set_realm_invite_by_admins_only,
-    do_set_name_changes_disabled,
-    do_set_email_changes_disabled,
-    do_set_realm_inline_image_preview,
-    do_set_realm_inline_url_embed_preview,
-    do_set_realm_add_emoji_by_admins_only,
-    do_set_realm_invite_required,
     do_set_realm_message_editing,
-    do_set_realm_restricted_to_domain,
-    do_set_realm_default_language,
-    do_set_realm_waiting_period_threshold,
-    do_set_realm_authentication_methods
+    do_set_realm_authentication_methods,
+    do_set_realm_property,
 )
 from zerver.lib.i18n import get_available_language_codes
 from zerver.lib.request import has_request_variables, REQ, JsonableError
 from zerver.lib.response import json_success, json_error
 from zerver.lib.validator import check_string, check_dict, check_bool
 from zerver.models import UserProfile
+
 
 @require_realm_admin
 @has_request_variables
@@ -53,33 +42,33 @@ def update_realm(request, user_profile, name=REQ(validator=check_string, default
     realm = user_profile.realm
     data = {} # type: Dict[str, Any]
     if name is not None and realm.name != name:
-        do_set_realm_name(realm, name)
+        do_set_realm_property(realm, 'name', name)
         data['name'] = 'updated'
     if description is not None and realm.description != description:
         if len(description) > 100:
             return json_error(_("Realm description cannot exceed 100 characters."))
-        do_set_realm_description(realm, description)
+        do_set_realm_property(realm, 'description', description)
         data['description'] = 'updated'
     if restricted_to_domain is not None and realm.restricted_to_domain != restricted_to_domain:
-        do_set_realm_restricted_to_domain(realm, restricted_to_domain)
+        do_set_realm_property(realm, 'restricted_to_domain', restricted_to_domain)
         data['restricted_to_domain'] = restricted_to_domain
     if invite_required is not None and realm.invite_required != invite_required:
-        do_set_realm_invite_required(realm, invite_required)
+        do_set_realm_property(realm, 'invite_required', invite_required)
         data['invite_required'] = invite_required
     if invite_by_admins_only is not None and realm.invite_by_admins_only != invite_by_admins_only:
-        do_set_realm_invite_by_admins_only(realm, invite_by_admins_only)
+        do_set_realm_property(realm, 'invite_by_admins_only', invite_by_admins_only)
         data['invite_by_admins_only'] = invite_by_admins_only
     if name_changes_disabled is not None and realm.name_changes_disabled != name_changes_disabled:
-        do_set_name_changes_disabled(realm, name_changes_disabled)
+        do_set_realm_property(realm, 'name_changes_disabled', name_changes_disabled)
         data['name_changes_disabled'] = name_changes_disabled
     if email_changes_disabled is not None and realm.email_changes_disabled != email_changes_disabled:
-        do_set_email_changes_disabled(realm, email_changes_disabled)
+        do_set_realm_property(realm, 'email_changes_disabled', email_changes_disabled)
         data['email_changes_disabled'] = email_changes_disabled
     if inline_image_preview is not None and realm.inline_image_preview != inline_image_preview:
-        do_set_realm_inline_image_preview(realm, inline_image_preview)
+        do_set_realm_property(realm, 'inline_image_preview', inline_image_preview)
         data['inline_image_preview'] = inline_image_preview
     if inline_url_embed_preview is not None and realm.inline_url_embed_preview != inline_url_embed_preview:
-        do_set_realm_inline_url_embed_preview(realm, inline_url_embed_preview)
+        do_set_realm_property(realm, 'inline_url_embed_preview', inline_url_embed_preview)
         data['inline_url_embed_preview'] = inline_url_embed_preview
     if authentication_methods is not None and realm.authentication_methods_dict() != authentication_methods:
         if True not in list(authentication_methods.values()):
@@ -89,10 +78,10 @@ def update_realm(request, user_profile, name=REQ(validator=check_string, default
             do_set_realm_authentication_methods(realm, authentication_methods)
         data['authentication_methods'] = authentication_methods
     if create_stream_by_admins_only is not None and realm.create_stream_by_admins_only != create_stream_by_admins_only:
-        do_set_realm_create_stream_by_admins_only(realm, create_stream_by_admins_only)
+        do_set_realm_property(realm, 'create_stream_by_admins_only', create_stream_by_admins_only)
         data['create_stream_by_admins_only'] = create_stream_by_admins_only
     if add_emoji_by_admins_only is not None and realm.add_emoji_by_admins_only != add_emoji_by_admins_only:
-        do_set_realm_add_emoji_by_admins_only(realm, add_emoji_by_admins_only)
+        do_set_realm_property(realm, 'add_emoji_by_admins_only', add_emoji_by_admins_only)
         data['add_emoji_by_admins_only'] = add_emoji_by_admins_only
     if (allow_message_editing is not None and realm.allow_message_editing != allow_message_editing) or \
        (message_content_edit_limit_seconds is not None and
@@ -105,9 +94,9 @@ def update_realm(request, user_profile, name=REQ(validator=check_string, default
         data['allow_message_editing'] = allow_message_editing
         data['message_content_edit_limit_seconds'] = message_content_edit_limit_seconds
     if default_language is not None and realm.default_language != default_language:
-        do_set_realm_default_language(realm, default_language)
+        do_set_realm_property(realm, 'default_language', default_language)
         data['default_language'] = default_language
     if waiting_period_threshold is not None and realm.waiting_period_threshold != waiting_period_threshold:
-        do_set_realm_waiting_period_threshold(realm, waiting_period_threshold)
+        do_set_realm_property(realm, 'waiting_period_threshold', waiting_period_threshold)
         data['waiting_period_threshold'] = waiting_period_threshold
     return json_success(data)


### PR DESCRIPTION
Refactored zerver/lib/actions: removed do_set_realm_* functions and added
do_set_realm_property, which takes in a realm object and the name and value
of an attribute to update for that realm.

I kept the do_set_realm_authentication_methods and do_set_realm_message_editing
functions because their function signatures are different and will require
additional refactoring.

Updated realm.py and various tests where do_set_realm_* functions were used; replaced
those instances with do_set_realm_property.

Thoughts on next steps for issue #3854: 
- Work on the conditional block in realm.py to remove the repetitive code.
- Refactor do_set_realm_authentication_methods and do_set_realm_message_editing
- Add documentation for do_set_realm_property

Addresses issue #3854.