### PR TITLE
[Fix]: Apply consistent styling for compose buttons.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -482,7 +482,6 @@ a#markdown_preview,
 a#undo_markdown_preview {
     text-decoration: none;
     position: relative;
-    top: 3px;
     font-size: 16px;
     color: #777;
 }

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -92,8 +92,8 @@
                   <a class="message-control-button icon-vector-paper-clip notdisplayed"
                      id="attach_files" href="#" title="{{ _('Attach files') }}"></a>
                   <a class="message-control-button icon-vector-font" title="{{ _('Formatting') }}" data-overlay-trigger="markdown-help"></a>
-                  <a id="undo_markdown_preview" class="icon-vector-edit" style="display:none;" title="{{ _('Write') }}"></a>
-                  <a id="markdown_preview" class="icon-vector-eye-open" title="{{ _('Preview') }}"></a>
+                  <a id="undo_markdown_preview" class="message-control-button icon-vector-edit" style="display:none;" title="{{ _('Write') }}"></a>
+                  <a id="markdown_preview" class="message-control-button icon-vector-eye-open" title="{{ _('Preview') }}"></a>
                   <a class="drafts-link" href="#drafts">{{ _('Drafts') }}</a>
                   <span id="sending-indicator">{{ _('Sending...') }}</span>
                   <div id="send_controls" class="new-style">


### PR DESCRIPTION
This applies the consistent :hover effect for all compose buttons.

Fixes: #4239.