### PR TITLE
refactor realm name length in backend

### DIFF
--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -83,7 +83,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
             <input id="id_team_name" class="required" type="text"
                 placeholder="Acme"
                 value="{% if form.realm_name.value() %}{{ form.realm_name.value() }}{% endif %}"
-                name="realm_name" maxlength="40" />
+                name="realm_name" maxlength={{ MAX_REALM_NAME_LENGTH }} />
                 {% if form.realm_name.errors %}
                     {% for error in form.realm_name.errors %}
                         <div class="help-inline text-error">{{ error }}</div>

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -38,7 +38,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
             {% else %}
                 <input id="id_full_name" class="required" type="text" name="full_name" placeholder='{{ "Wile E. Coyote" }}'
                 value="{% if full_name %}{{ full_name }}{% elif form.full_name.value() %}{{ form.full_name.value() }}{% endif %}"
-                    maxlength="100" />
+                maxlength={{ MAX_NAME_LENGTH}} />
                 {% if form.full_name.errors %}
                     {% for error in form.full_name.errors %}
                         <div class="help-inline text-error">{{ error }}</div>
@@ -56,7 +56,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
             <label for="id_password" class="inline-block">{{ _('Password') }}</label>
             <input id="id_password" class="required" type="password" name="password"
                    value="{% if form.password.value() %}{{ form.password.value() }}{% endif %}"
-                   maxlength="100"
+                   maxlength={{ MAX_PASSWORD_LENGTH }}
                    data-min-length="{{password_min_length}}"
                    data-min-quality="{{password_min_quality}}"/>
             {% if full_name %}
@@ -106,7 +106,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                 <input id="id_team_subdomain" class="required" type="text"
                     placeholder="acme"
                     value="{% if form.realm_subdomain.value() %}{{ form.realm_subdomain.value() }}{% endif %}"
-                    name="realm_subdomain" maxlength="40" />
+                    name="realm_subdomain" maxlength={{ MAX_REALM_SUBDOMAIN_LENGTH }} />
                 {% if realms_have_subdomains %}
                 <b> .{{ external_host }}</b>
                 {% endif %}

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -51,14 +51,13 @@ def email_is_not_mit_mailing_list(email):
 
 class RegistrationForm(forms.Form):
     MAX_PASSWORD_LENGTH = 100
-    MAX_REALM_SUBDOMAIN_LENGTH = 40
     full_name = forms.CharField(max_length=100)
     # The required-ness of the password field gets overridden if it isn't
     # actually required for a realm
     password = forms.CharField(widget=forms.PasswordInput, max_length=MAX_PASSWORD_LENGTH,
                                required=False)
     realm_name = forms.CharField(max_length=Realm.MAX_REALM_NAME_LENGTH, required=False)
-    realm_subdomain = forms.CharField(max_length=MAX_REALM_SUBDOMAIN_LENGTH, required=False)
+    realm_subdomain = forms.CharField(max_length=Realm.MAX_REALM_SUBDOMAIN_LENGTH, required=False)
     realm_org_type = forms.ChoiceField(((Realm.COMMUNITY, 'Community'),
                                         (Realm.CORPORATE, 'Corporate')),
                                        initial=Realm.COMMUNITY, required=False)

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -50,13 +50,15 @@ def email_is_not_mit_mailing_list(email):
                 raise
 
 class RegistrationForm(forms.Form):
+    MAX_PASSWORD_LENGTH = 100
+    MAX_REALM_SUBDOMAIN_LENGTH = 40
     full_name = forms.CharField(max_length=100)
     # The required-ness of the password field gets overridden if it isn't
     # actually required for a realm
-    password = forms.CharField(widget=forms.PasswordInput, max_length=100,
+    password = forms.CharField(widget=forms.PasswordInput, max_length=MAX_PASSWORD_LENGTH,
                                required=False)
-    realm_name = forms.CharField(max_length=100, required=False)
-    realm_subdomain = forms.CharField(max_length=40, required=False)
+    realm_name = forms.CharField(max_length=Realm.MAX_REALM_NAME_LENGTH, required=False)
+    realm_subdomain = forms.CharField(max_length=MAX_REALM_SUBDOMAIN_LENGTH, required=False)
     realm_org_type = forms.ChoiceField(((Realm.COMMUNITY, 'Community'),
                                         (Realm.CORPORATE, 'Corporate')),
                                        initial=Realm.COMMUNITY, required=False)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -110,10 +110,11 @@ class Realm(ModelReprMixin, models.Model):
     # name is the user-visible identifier for the realm. It has no required
     # structure.
     MAX_REALM_NAME_LENGTH = 40
+    MAX_REALM_SUBDOMAIN_LENGTH = 40
     AUTHENTICATION_FLAGS = [u'Google', u'Email', u'GitHub', u'LDAP', u'Dev', u'RemoteUser']
 
-    name = models.CharField(max_length=40, null=True) # type: Optional[Text]
-    string_id = models.CharField(max_length=40, unique=True) # type: Text
+    name = models.CharField(max_length=MAX_REALM_NAME_LENGTH, null=True) # type: Optional[Text]
+    string_id = models.CharField(max_length=MAX_REALM_SUBDOMAIN_LENGTH, unique=True) # type: Text
     restricted_to_domain = models.BooleanField(default=False) # type: bool
     invite_required = models.BooleanField(default=True) # type: bool
     invite_by_admins_only = models.BooleanField(default=False) # type: bool

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -109,6 +109,7 @@ class Realm(ModelReprMixin, models.Model):
     domain = models.CharField(max_length=40, db_index=True, unique=True) # type: Text
     # name is the user-visible identifier for the realm. It has no required
     # structure.
+    MAX_REALM_NAME_LENGTH = 40
     AUTHENTICATION_FLAGS = [u'Google', u'Email', u'GitHub', u'LDAP', u'Dev', u'RemoteUser']
 
     name = models.CharField(max_length=40, null=True) # type: Optional[Text]

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -245,7 +245,7 @@ def accounts_register(request):
                  'creating_new_team': realm_creation,
                  'realms_have_subdomains': settings.REALMS_HAVE_SUBDOMAINS,
                  'password_auth_enabled': password_auth_enabled(realm),
-                 'MAX_REALM_NAME_LENGTH': str(MAX_REALM_NAME_LENGTH)
+                 'MAX_REALM_NAME_LENGTH': str(Realm.MAX_REALM_NAME_LENGTH)
                  }
     )
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -248,7 +248,7 @@ def accounts_register(request):
                  'MAX_REALM_NAME_LENGTH': str(Realm.MAX_REALM_NAME_LENGTH),
                  'MAX_NAME_LENGTH': str(UserProfile.MAX_NAME_LENGTH),
                  'MAX_PASSWORD_LENGTH': str(form.MAX_PASSWORD_LENGTH),
-                 'MAX_REALM_SUBDOMAIN_LENGTH': str(form.MAX_REALM_SUBDOMAIN_LENGTH)
+                 'MAX_REALM_SUBDOMAIN_LENGTH': str(Realm.MAX_REALM_SUBDOMAIN_LENGTH)
                  }
     )
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -245,6 +245,7 @@ def accounts_register(request):
                  'creating_new_team': realm_creation,
                  'realms_have_subdomains': settings.REALMS_HAVE_SUBDOMAINS,
                  'password_auth_enabled': password_auth_enabled(realm),
+                 'MAX_REALM_NAME_LENGTH': str(MAX_REALM_NAME_LENGTH)
                  }
     )
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -245,7 +245,10 @@ def accounts_register(request):
                  'creating_new_team': realm_creation,
                  'realms_have_subdomains': settings.REALMS_HAVE_SUBDOMAINS,
                  'password_auth_enabled': password_auth_enabled(realm),
-                 'MAX_REALM_NAME_LENGTH': str(Realm.MAX_REALM_NAME_LENGTH)
+                 'MAX_REALM_NAME_LENGTH': str(Realm.MAX_REALM_NAME_LENGTH),
+                 'MAX_NAME_LENGTH': str(UserProfile.MAX_NAME_LENGTH),
+                 'MAX_PASSWORD_LENGTH': str(form.MAX_PASSWORD_LENGTH),
+                 'MAX_REALM_SUBDOMAIN_LENGTH': str(form.MAX_REALM_SUBDOMAIN_LENGTH)
                  }
     )
 


### PR DESCRIPTION
Fix #4211 

- Replace `maxlength` value of `realm-name` in frontend with constant value from backend.