### PR TITLE
hotkeys: Add hotkeys for navigating Streams menu.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -153,7 +153,7 @@ function stubbing(func_name_to_stub, test_function) {
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
     assert_unmapped('abefhlmoptuxyz');
-    assert_unmapped('BEFHILNOQTWXYZ');
+    assert_unmapped('BEFHILNOQTUWXYZ');
 
     // We have to skip some checks due to the way the code is
     // currently organized for mapped keys.
@@ -197,7 +197,9 @@ function stubbing(func_name_to_stub, test_function) {
     modals.settings_open = return_false;
 
     modals.streams_open = return_true;
-    assert_mapping('U', 'subs.keyboard_sub');
+    modals.is_active = return_true;
+    assert_mapping('S', 'subs.keyboard_sub');
+    modals.is_active = return_false;
     assert_mapping('V', 'subs.view_stream');
     assert_mapping('n', 'subs.new_stream_clicked');
     modals.streams_open = return_false;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -95,7 +95,6 @@ var keypress_mappings = {
     80: {name: 'narrow_private', message_view_only: true}, // 'P'
     82: {name: 'respond_to_author', message_view_only: true}, // 'R'
     83: {name: 'narrow_by_subject', message_view_only: true}, //'S'
-    85: {name: 'keyboard_sub', message_view_only: false}, //'U'
     86: {name: 'view_selected_stream', message_view_only: false}, //'V'
     99: {name: 'compose', message_view_only: true}, // 'c'
     100: {name: 'open_drafts', message_view_only: false}, // 'd'
@@ -417,6 +416,17 @@ exports.process_hotkey = function (e, hotkey) {
             }
     }
 
+    if (hotkey.message_view_only && modals.is_active()) {
+        if (exports.processing_text()) {
+            return false;
+        }
+        if (event_name === 'narrow_by_subject' && modals.streams_open()) {
+            subs.keyboard_sub();
+            return true;
+        }
+        return false;
+    }
+
     if (modals.settings_open()) {
         if (exports.processing_text()) {
             return false;
@@ -437,10 +447,6 @@ exports.process_hotkey = function (e, hotkey) {
     }
 
     if (modals.info_overlay_open()) {
-        return false;
-    }
-
-    if (hotkey.message_view_only && modals.is_active()) {
         return false;
     }
 
@@ -564,11 +570,6 @@ exports.process_hotkey = function (e, hotkey) {
             return true;
         case 'stream_cycle_forward':
             navigate.cycle_stream('forward');
-            return true;
-        case 'keyboard_sub':
-            if (modals.streams_open()) {
-                subs.keyboard_sub();
-            }
             return true;
         case 'view_selected_stream':
             if (modals.streams_open()) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -454,9 +454,11 @@ exports.launch = function (hash) {
             overlay: $("#subscription_overlay"),
             on_close: exports.close,
         });
-
         exports.change_state(hash);
     });
+    if (!get_active_data().id) {
+        $('#search_stream_name').focus();
+    }
 };
 
 exports.close = function () {
@@ -472,14 +474,20 @@ exports.switch_rows = function (event) {
         return false;
     } else if (!active_data.id || active_data.row.hasClass('notdisplayed')) {
         switch_row = $('div.stream-row:not(.notdisplayed):first');
+        if ($('#search_stream_name').is(":focus")) {
+            $('#search_stream_name').blur();
+        }
     } else if (event === 'up_arrow') {
         switch_row = active_data.row.prev();
+        if ($('#search_stream_name').is(":focus")) {
+            // remove focus from Filter streams input instead of switching rows
+            // if Filter streams input is focused
+            return $('#search_stream_name').blur();
+        }
     } else if (event === 'down_arrow') {
         switch_row = active_data.row.next();
         if ($('#search_stream_name').is(":focus")) {
-            // When going from the filter box, go the first row.
-            $('#search_stream_name').blur();
-            switch_row = $('div.stream-row:not(.notdisplayed):first');
+            return $('#search_stream_name').blur();
         }
     }
 

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -11,130 +11,181 @@ Zulip keyboard shortcuts are divided into four categories:
 * [Message actions](#message-actions)
 * [Menus](#menus)
 * [Drafts](#drafts)
+* [Streams](#streams)
 
 !!! warn ""
     **Note:** We note how to enter keyboard shortcuts using keys not
-    present on MacOS keyboard in parentheses below.
+    present on the MacOS keyboard in parentheses below.
 
 ## Navigation
 
-* **Initiate a search**: `/` — This shortcut moves the user's cursor to
-  the message search bar at the top of the window to allow them to
-  begin searching for messages belonging to a specific topic, stream,
-  view, etc. in the organization.
-* **Search people**: `q` — This shortcut moves the user's cursor to the
-  user search bar in the right sidebar to to allow them to begin
-  searching for a particular user in the organization.
-* **Search streams**: `w` — This shortcut moves the user's cursor to
-  the stream search bar in the left sidebar to to allow them to begin
-  searching for a particular stream in the organization.
-* **Previous message**: `k` or `↑` — This shortcut allows the user
-  to scroll up to the previous message in their view.
-* **Next message**: `j` or `↓` — This shortcut allows the user to
-  scroll down to the next message in their view.
-* **Scroll up**: `K` or `PgUp` (`Fn` + `↑` on Mac) — This shortcut
-  allows the user to scroll up through the messages in their view.
-* **Scroll down**: `J`, `Spacebar`, or `PgDn` (`Fn` + `↓` on Mac) —
-  This shortcut allows the user to scroll down through the messages in
-  their view.
-* **Last message**: `End` (`Fn`+`⇾` on Mac) or `G` — This shortcut
-  allows the user to scroll to the most recent message in their view.
-* **First message**: `Home` (`Fn`+`⇽` on Mac) — This shortcut
-  allows the user to scroll to the most recent message in their view.
+* **Initiate a search**: `/` — Moves the user's cursor to the message search
+bar at the top of the window to allow them to begin searching for messages with
+specific criteria in the organization.
+
+* **Search people**: `q` — Moves the user's cursor to the user search bar in
+the right sidebar to to allow them to begin searching for a particular user in
+the organization. d * *
+
+* **Search streams**: `w` — Moves the user's cursor to the
+stream search bar in the left sidebar to to allow them to begin searching for a
+particular stream in the organization.
+
+* **Previous message**: `k` or `↑` — Allows the user to scroll up to the
+previous message in their view.
+
+* **Next message**: `j` or `↓` — Allows the user to scroll down to the next
+message in their view.
+
+* **Scroll up**: `K` or `PgUp` (`Fn` + `↑`) — Allows the user to scroll up
+through the messages in their view.
+
+* **Scroll down**: `J`, `Spacebar`, or `PgDn` (`Fn` + `↓`) — Allows the user to
+scroll down through the messages in their view.
+
+* **Last message**: `End` (`Fn` + `⇾`) or `G` — Allows the user to scroll to
+the most recent message in their view.
+
+* **First message**: `Home` (`Fn` + `⇽`) — Allows the user to scroll to the
+most recent message in their view.
 
 ## Composing messages
 
-* **Reply to message**: `r` or `Enter` (`Return` on Mac) — This
-  shortcut allows the user to begin replying to the selected message
-  (outlined in blue).
-* **Reply to author**: `R` — This shortcut allows the user to begin
-  writing a private message to the author of the selected message
-  (outlined in blue).
-* **New stream message**: `c` — This shortcut allows the user to begin
-  composing a new stream message.
-* **New private message**: `C` — This shortcut allows the user to begin
-  composing a new private message.
-* **Reply to message mentioning the author**: `@` — This
-  shortcut allows the user to begin replying to the selected message
-  (outlined in blue), @—mentioning the author of the selected message.
-* **Send message**: `Tab` then `Enter` (`Return` on Mac), `Ctrl` + `Enter`
-  (`Return` on Mac) — This shortcut allows the user to send the message that
-  they've written.
-* **Insert new line**: `Shift` + `Enter` (`Return` on Mac) — This shortcut
-  allows the user to insert a new line break in their message.
-* **Cancel compose**: `Esc` or `Ctrl + [` — This shortcut allows the user to cancel
-  and discard their unsent message.
+
+* **Reply to message**: `r` or `Enter` (`Return`) — Allows the user to begin
+replying to the selected message (outlined in blue).
+
+* **Reply to author**: `R` — Allows the user to begin writing a private message
+to the author of the selected message (outlined in blue).
+
+* **New stream message**: `c` — Allows the user to begin composing a new stream
+message.
+
+* **New private message**: `C` — Allows the user to begin composing a new
+private message.
+
+* **Reply to message mentioning the author**: `@` — Allows the user to begin
+replying to the selected message (outlined in blue), @—mentioning the author of
+the selected message.
+
+* **Send message**: `Tab` then `Enter` (`Return`), `Ctrl` + `Enter` (`Return`) —
+Allows the user to send the message that they've written.
+
+* **Insert new line**: `Shift` + `Enter` (`Return`) — Allowsthe user to insert
+a new line break in their message.
+
+* **Cancel compose**: `Esc` or `Ctrl + [` — Allows the user to cancel and
+discard their unsent message.
 
 ## Narrowing
 
-* **Narrow by stream**: `s` — This shortcut narrows the view to show
-  all messages in the stream of the selected message (outlined in
-  blue).
+* **Narrow by stream**: `s` — This shortcut narrows the view to show all
+messages in the stream of the selected message (outlined in blue).
+
 * **Narrow by topic**: `S` — This shortcut narrows the view to show all
-  messages with the topic of the selected message (outlined in blue).
-* **Narrow to all private messages**: `P` — This shortcut narrows the
-  view to show all of the user's private messages.
-* **Narrow to next unread topic**: `n` — This shortcut narrows the
-  view to the next unread topic in the stream sidebar.
-* **Cycle between stream narrows**: `A` and `D` — This shortcut allows the
-  user to cycle through the narrows showing the messages of a stream
-  according to Stream order in the left sidebar. `A` allows the user
-  to navigate to the previous stream narrow, and `D` allows the user
-  to navigate to the next stream narrow.
-* **Return to home view**: `Esc` or `Ctrl` + `[` — This shortcut allows the user
-  to return to the Home view, showing all messages in the organization.
+messages with the topic of the selected message (outlined in blue).
+
+* **Narrow to all private messages**: `P` — This shortcut narrows the view to
+show all of the user's private messages.
+
+* **Narrow to next unread topic**: `n` — This shortcut narrows the view to the
+next unread topic in the stream sidebar.
+
+* **Cycle between stream narrows**: `A` and `D` — Allows the user to cycle
+through the narrows showing the messages of a stream according to Stream order
+in the left sidebar. `A` allows the user to navigate to the previous stream
+narrow, and `D` allows the user to navigate to the next stream narrow.
+
+* **Return to home view**: `Esc` or `Ctrl` + `[` — Allows the user to return to
+the Home view, showing all messages in the organization.
 
 ## Message actions
 
 * **Edit your last message**: `⇽` — This shortcut opens the last editable
-  message that the user sent in the current view (if any) in the compose box.
-* **Show images in thread**: `v` — This shortcut opens any images or videos
-  (if any) embedded in a message or previous messages within the thread
-  using the lightbox viewer.
-* **Edit selected message**: `i` then `Enter` (`Return` on Mac) —
-  This shortcut allows the user to edit the selected message (outlined
-  in blue) if the user authored the selected message. If the selected
-  message was written by another user, this shortcut will enable the
-  user to view the source code of the message.
-* **Star selected message**: `*` — This shortcut allows the user to star the
-  selected message (outlined in blue).
+message that the user sent in the current view (if any) in the compose box.
+
+* **Show images in thread**: `v` — This shortcut opens any images or videos (if
+any) embedded in a message or previous messages within the thread using the
+lightbox viewer.
+
+* **Edit selected message**: `i` then `Enter` (`Return`) — Allows the user to
+edit the selected message (outlined in blue) if the user authored the selected
+message. If the selected message was written by another user, this shortcut will
+enable the user to view the source code of the message.
+
+* **Star selected message**: `*` — Allows the user to star the selected message
+(outlined in blue).
+
 * **React to selected message with <img alt=":thumbs_up:" class="emoji"
-  src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
-  title=":thumbs_up:"/>**: `+` — This shortcut allows the user to react to the
-  selected message (outlined in blue) with the <img alt=":thumbs_up:"
-  class="emoji" src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
-  title=":thumbs_up:"/> (`:thumbs_up:`) emoji.
-* **Toggle topic mute**: `M` — This shortcut allows the user to mute and unmuted
-  the topic of the selected message (outlined in blue).
+src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
+title=":thumbs_up:"/>**: ` + ` — Allows the user to react to the selected
+message (outlined in blue) with the <img alt=":thumbs_up:" class="emoji"
+src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
+title=":thumbs_up:"/> (`:thumbs_up:`) emoji.
+
+* **Toggle topic mute**: `M` — Allows the user to mute and unmuted the topic of
+the selected message (outlined in blue).
 
 ## Menus
 
 * **Toggle the gear menu**: `g` — This shortcut opens the gear menu located in
-  the upper-right corner of the window.
+the upper-right corner of the window.
+
 * **Open message menu**: `i` — This shortcut opens the message menu with the
-  available message actions of the selected message (outlined in blue).
+available message actions of the selected message (outlined in blue).
+
 * **Open reactions menu**: `:` — This shortcut opens the emoji reactions menu,
-  allowing you to add an emoji reaction to the selected message.
-* **Show keyboard shortcuts**: `?` — This shortcut makes a modal
-  window with a list of all of the keyboard shortcuts appear.
+allowing you to add an emoji reaction to the selected message.
+
+* **Show keyboard shortcuts**: `?` — Makes a modal window with a list of all of
+the keyboard shortcuts appear.
 
 ## Drafts
 
-* **View drafts**: `d` — This shortcut opens the **Drafts** modal with a list of
-  all of the user's drafts.
+* **View drafts**: `d` — This shortcut opens the **Drafts** modal with a list
+of all of the user's drafts.
+
 * **Select previous draft**: `↑` — This shortcut selects the previous draft in
-  the **Drafts** modal.
-* **Select next draft**: `↓` — This shortcut selects the next draft in
-  the **Drafts** modal.
-* **Scroll up**: `PgUp` (`Fn` + `↑` on Mac) — This shortcut allows the user to
-  scroll up through the **Drafts** modal.
-* **Scroll down**: `Spacebar` or `PgDn` (`Fn` + `↓` on Mac) — This shortcut
-  allows the user to scroll down through the **Drafts** modal.
-* **Select first draft**: `Home` (`Fn`+`⇽` on Mac) — This shortcut
-  allows the user to scroll to the first draft in the **Drafts** modal.
-* **Select last draft**: `End` (`Fn`+`⇾` on Mac) or `G` — This shortcut
-  allows the user to scroll to the last draft in the **Drafts** modal.
-* **Edit selected draft**: `Enter` (`Return` on Mac) — This shortcut allows the
-  user to open the selected draft in the compose box for editing.
-* **Delete selected draft**: `Backspace` (`Delete` on Mac) — This shortcut allows the
-  user to delete the selected draft, removing it from the **Drafts** modal.
+the **Drafts** modal.
+
+* **Select next draft**: `↓` — This shortcut selects the next draft in the
+**Drafts** modal.
+
+* **Scroll up**: `PgUp` (`Fn` + `↑`) — Allows the user to scroll up through the
+**Drafts** modal.
+
+* **Scroll down**: `Spacebar` or `PgDn` (`Fn` + `↓`) — Allowsthe user to scroll
+down through the **Drafts** modal.
+
+* **Select first draft**: `Home` (`Fn` + `⇽`) — Allowsthe user to scroll to the
+first draft in the **Drafts** modal.
+
+* **Select last draft**: `End` (`Fn` + `⇾`) or `G` — Allowsthe user to scroll
+to the last draft in the **Drafts** modal.
+
+* **Edit selected draft**: `Enter` (`Return`) — Allows the user to open the
+selected draft in the compose box for editing.
+
+* **Delete selected draft**: `Backspace` (`Delete`) — Allows the user to delete
+the selected draft, removing it from the **Drafts** modal.
+
+## Streams
+
+* **Scroll through streams**: `↑` and `↓` — Allows you to scroll through the
+list of streams shown in the **Streams** modal.
+
+    !!! tip ""
+        Pressing `↑` while the first stream in the list is selected moves
+        your cursor to the **Filter streams** input.
+
+* **Switch between tabs**: `⇽` and `⇾` — Allows you to switch between the
+**Subscribed** and **All streams** tabs in the **Streams** modal.
+
+* **View stream messages**: `V` — This shortcut narrows your view to the
+messages of the selected stream.
+
+* **Subscribe to/unsubscribe from selected stream**: `S` — Allows you to
+subscribe to or unsubscribe from the selected stream.
+
+* **Create new stream**: `n` — This shortcut opens the **Create new stream**
+panel.

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -202,6 +202,36 @@
         </tr>
       </table>
     </div>
+
+    <div>
+      <table class="hotkeys_table table table-striped table-bordered table-condensed">
+        <thead>
+          <tr>
+            <th colspan="2">{{ _("Streams") }}</th>
+          </tr>
+        </thead>
+        <tr>
+          <td class="hotkey">Up, Down</td>
+          <td class="definition">{% trans %}Scroll through streams{% endtrans %}</td>
+        </tr>
+        <tr>
+          <td class="hotkey">Left, Right</td>
+          <td class="definition">{% trans %}Switch between tabs{% endtrans %}</td>
+        </tr>
+        <tr>
+          <td class="hotkey">V</td>
+          <td class="definition">{% trans %}View stream messages{% endtrans %}</td>
+        </tr>
+        <tr>
+          <td class="hotkey">S</td>
+          <td class="definition">{% trans %}Subscribe to/unsubscribe from selected stream{% endtrans %}</td>
+        </tr>
+        <tr>
+          <td class="hotkey">n</td>
+          <td class="definition">{% trans %}Create new stream{% endtrans %}</td>
+        </tr>
+      </table>
+    </div>
     <hr/>
     <a href="/help/keyboard-shortcuts" target="_blank">Detailed keyboard shortcuts documentation</a>
   </div>


### PR DESCRIPTION
* Adds hotkeys for left/right arrow keys to switch tabs in Streams menu (#4228)
* Adds hotkey `U` to subscribe/unsubscribe from selected stream in Streams menu (#4229)
* Moves cursor to "Filter streams" input if current selected stream is the first in the Streams menu (#4227)
* Adds hotkey `V` for viewing/narrowing to messages of selected stream in Streams menu

**To-do:**
* [x] When you open the streams page the first time, the "filter streams" text box should already have focus.
* [x] Is "U" the best key for "subscribe/unsubscribe"?  I'm now wondering whether we should do "S" instead.
* [x] Let's open an issue for the fact that unsubscribing with hotkeys while in the 'Subscribed' tab needs to disappear the row; I don't think that's optimal and probably reflects some sort of subtle bug in how that page works.  
* [x] Right now, we're fetching subscribers from the server on every navigation, which could be really expensive.  I think we actually have all the data on the frontend to render subscribers without contacting the server.  I opened https://github.com/zulip/zulip/issues/4314 for this.
* [x] We need to document these!  I think we want to make a new "Streams overlay" section in the docs.