### PR TITLE
Changes cursor to pointer on hover over stream name section

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -195,7 +195,6 @@ ul.filters .arrow {
 
 ul.filters li:hover .arrow {
     display: inline;
-    cursor: pointer;
     color: #888;
 }
 
@@ -245,6 +244,7 @@ ul.filters li.out_of_home_view li.muted_topic {
     padding-top: 4px;
     margin-right: 15px;
     padding-left: 33px;
+    cursor: pointer;
 }
 
 #stream_filters .subscription_block .stream-name {


### PR DESCRIPTION
When the cursor hovers over the stream name it changes to a pointer.
Since the entire area is clickable (and results in the stream being opened),
the cursor style should be set to pointer for the entire area.

Fixes #1992.