### PR TITLE
dev: Expose coverage and built documentation to web.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,9 +42,11 @@ cd docs/
 make html
 ```
 
-and then opening `file:///path/to/zulip/docs/_build/html/index.html` in
-your browser (you can also use e.g. `firefox
-docs/_build/html/index.html` from the root of your Zulip checkout).
+and then opening `http://127.0.0.1:9991/docs/index.html` in your
+browser.  The raw files are available at
+`file:///path/to/zulip/docs/_build/html/index.html` in your browser
+(so you can also use e.g. `firefox docs/_build/html/index.html` from
+the root of your Zulip checkout).
 
 If you are adding a new page to the table of contents, you will want
 to modify `docs/index.rst` and run `make clean` before `make html`, so

--- a/docs/testing-with-django.md
+++ b/docs/testing-with-django.md
@@ -242,7 +242,10 @@ typically simulate their behavior using mocks.
 modules.  You can use the `--coverage` option to generate coverage
 reports, and new code should have 100% coverage, which generally requires
 testing not only the "happy path" but also error handling code and
-edge cases.  Note that `test-backend --coverage` will assert that
+edge cases.  It will generate a nice HTML report that you can view in
+a browser that can access your development enviroment.
+
+Note that `test-backend --coverage` will assert that
 various specific files in the project have 100% test coverage and
 throw an error if their coverage has fallen.  One of our project goals
 is to expand that checking to ever-larger parts of the codebase.

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -292,7 +292,7 @@ if __name__ == "__main__":
             print("Printing coverage data")
             cov.report(show_missing=False)
         cov.html_report(directory='var/coverage')
-        print("HTML report saved to var/coverage")
+        print("HTML report saved; visit at http://127.0.0.1:9991/coverage/index.html")
     if full_suite and not failures and options.coverage:
         # Assert that various files have full coverage
         for path in enforce_fully_covered:

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -11,10 +11,18 @@ use_prod_static = getattr(settings, 'PIPELINE_ENABLED', False)
 static_root = os.path.join(settings.DEPLOY_ROOT, 'prod-static/serve' if use_prod_static else 'static')
 
 urls = [
+    url(r'^coverage/(?P<path>.*)$',
+        serve, {'document_root':
+                os.path.join(settings.DEPLOY_ROOT, 'var/coverage'),
+                'show_indexes': True}),
+    url(r'^docs/(?P<path>.*)$',
+        serve, {'document_root':
+                os.path.join(settings.DEPLOY_ROOT, 'docs/_build/html')}),
     url(r'^static/(?P<path>.*)$', serve, {'document_root': static_root}),
     url(r'^devlogin/$', zerver.views.auth.login_page,
         {'template_name': 'zerver/dev_login.html'}, name='zerver.views.auth.login_page'),
 ]
+
 i18n_urls = [
     url(r'^confirmation_key/$', zerver.views.registration.confirmation_key),
 ]


### PR DESCRIPTION
This makes it much more convenient for developers to access coverage
and built developer documentation.