### PR TITLE
Fix horizontal scroll for super long lines in bullet lists.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -366,7 +366,7 @@ code {
     font-size: 0.857em;
 }
 
-.message_content p code {
+.message_content code {
     white-space: pre-wrap;
     padding: 0px 4px;
     background-color: #fff;


### PR DESCRIPTION
In this commit we just add a css property to zulip.css so that super long lines in bullet lists could be wrapped down to next line.
Fixes: #4245.