### PR TITLE
Tweaking proxy setting for test-backend and test-js-with-casper Fixes: #971

### DIFF
--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -16,6 +16,8 @@ import glob
 
 os.environ["CASPER_TESTS"] = "1"
 os.environ["PHANTOMJS_EXECUTABLE"] = os.path.join(os.path.dirname(__file__), "../node_modules/.bin/phantomjs")
+os.environ["http_proxy"] = ""
+os.environ["https_proxy"] = ""
 
 usage = """%prog [options]
     test-js-with-casper # Run all test files

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -96,6 +96,11 @@ if __name__ == "__main__":
     TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
     os.chdir(os.path.dirname(TOOLS_DIR))
     sys.path.insert(0, os.path.dirname(TOOLS_DIR))
+
+    # Remove proxy settings for running backend tests
+    os.environ["http_proxy"] = ""
+    os.environ["https_proxy"] = ""
+
     from zerver.lib.test_fixtures import is_template_database_current
 
     from tools.lib.test_script import (


### PR DESCRIPTION
I had changed test-backend to turn off proxy and then turn on.
test-js-with-casper also needed the same so also implemented in it.