### PR TITLE
i18n: Add linter to ensure handlebars strings are line-wrapped properly

### DIFF
--- a/static/templates/settings/bot-list-admin.handlebars
+++ b/static/templates/settings/bot-list-admin.handlebars
@@ -12,7 +12,7 @@
                 {{/if}}
             </thead>
             <tbody id="admin_bots_table" class="admin_bot_table required-text thick"
-                   data-empty="{{ t 'No bots match your current filter.' }}"></tbody>
+                   data-empty="{{t 'No bots match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_bots_loading_indicator"></div>

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -355,6 +355,10 @@ def build_custom_checkers(by_lang):
          'description': "Period should be part of the translatable string."},
         {'pattern': '{{t ("|\') ',
          'description': 'Translatable strings should not have leading spaces.'},
+        {'pattern': "{{t '[^']+ ' }}",
+         'description': 'Translatable strings should not have trailing spaces.'},
+        {'pattern': '{{t "[^"]+ " }}',
+         'description': 'Translatable strings should not have trailing spaces.'},
     ]
     jinja2_rules = html_rules + [
         {'pattern': "{% endtrans %}[\.\?!]",

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -347,6 +347,8 @@ def build_custom_checkers(by_lang):
     handlebars_rules = html_rules + [
         {'pattern': "[<]script",
          'description': "Do not use inline <script> tags here; put JavaScript in static/js instead."},
+        {'pattern': '{{ t ("|\')',
+         'description': 'There should be no spaces before the "t" in a translation tag.'},
         {'pattern': "{{t '.*' }}[\.\?!]",
          'description': "Period should be part of the translatable string."},
         {'pattern': '{{t ".*" }}[\.\?!]',

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -353,6 +353,8 @@ def build_custom_checkers(by_lang):
          'description': "Period should be part of the translatable string."},
         {'pattern': "{{/tr}}[\.\?!]",
          'description': "Period should be part of the translatable string."},
+        {'pattern': '{{t ("|\') ',
+         'description': 'Translatable strings should not have leading spaces.'},
     ]
     jinja2_rules = html_rules + [
         {'pattern': "{% endtrans %}[\.\?!]",


### PR DESCRIPTION
tabbott edited the description to focus on the remaining piece of this

--------------

This adds some strings to translate that weren't internationalized.

It also fixes a couple issues that were making some strings impossible to translate (e.g. specified in CSS).