### PR TITLE
css: Properly wrap text inside tabs.

### DIFF
--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -160,9 +160,26 @@
     width: 90px;
     margin: 0px -0.5px;
     text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    vertical-align: bottom; /* See http://stackoverflow.com/a/43266155/ */
     padding: 3px 10px;
     background-color: #fff;
     cursor: pointer;
+    justify-content: center;
+    align-items: center;
+}
+
+.informational-overlays .tab-switcher {
+    display: flex;
+}
+
+.informational-overlays .tab-switcher .ind-tab {
+    display: flex;
+    text-overflow: initial;
+    white-space: initial;
+    vertical-align: middle;
 }
 
 .new-style .tab-switcher.large .ind-tab {


### PR DESCRIPTION
The tabs can have text inside them that is wider than 90px, especially in some unexpected cases (e.g. a translation longer than the original English string).

Now tabs resize to take more space if needed, but stay at 90px if the content inside is narrower.

**Before:**
![Tab with too wide content](https://cloud.githubusercontent.com/assets/7356565/24274366/07da7dca-1028-11e7-9f45-84cfb8e7d347.png)

**After:**
![Fixed tab](https://cloud.githubusercontent.com/assets/7356565/24274387/270d1324-1028-11e7-9f47-f2b40b30a65a.png)
