### PR TITLE
reactions: Downgrade blueslip error to a warning.

### DIFF
--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -12,7 +12,12 @@ function send_reaction_ajax(message_id, emoji_name, operation) {
         success: function () {},
         error: function (xhr) {
             var response = channel.xhr_error_message("Error sending reaction", xhr);
-            blueslip.error(response);
+            // Errors are somewhat commmon here, due to race conditions
+            // where the user tries to add/remove the reaction when there is already
+            // an in-flight request.  We eventually want to make this a blueslip
+            // error, rather than a warning, but we need to implement either
+            // #4291 or #4295 first.
+            blueslip.warn(response);
         },
     };
     if (operation === 'add') {


### PR DESCRIPTION
When we get a server error for adding/removing a reaction, we
no longer make a blueslip error, since it is somewhat common for
users to retry actions before the server sends an event.  The
code comment that is part of this commit explains this further.

Fixes #4290