### PR TITLE
lightbox: Modify lightbox to only display valid images and YT Videos.

### DIFF
--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -10,7 +10,7 @@ var asset_map = {
 
 function render_lightbox_list_images(preview_source) {
     if (!is_open) {
-        var images = Array.prototype.slice.call($(".focused_table .messagebox-content img"));
+        var images = Array.prototype.slice.call($(".focused_table .message_inline_image img"));
         var $image_list = $("#lightbox_overlay .image-list").html("");
 
         images.forEach(function (img) {


### PR DESCRIPTION
This modifies the lightbox to only display images inside the
".message_inline_image" class, rather than all images inside the
message body, which currently includes things like the bot icon.