### PR TITLE
[demo] [WIP] oauth2 as provider prototype

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -191,3 +191,8 @@ git+https://github.com/rafaelmartins/pyoembed.git@eb9901917c2a44b49e2887c077ead8
 # used in development for some tests and in production for things like
 # Nagios checks.
 api/
+
+# Needed for oauth
+django-cors-middleware==1.3.1
+django-oauth-toolkit==0.12.0
+django-braces==1.11.0

--- a/templates/oauth2_provider/application_confirm_delete.html
+++ b/templates/oauth2_provider/application_confirm_delete.html
@@ -1,0 +1,18 @@
+{% extends "oauth2_provider/base.html" %}
+
+
+{% block content %}
+    <div class="block-center">
+        <h3 class="block-center-heading">{{_("Are you sure to delete the application")}} {{ application.name }}?</h3>
+        <form method="post" action="{{ url('oauth2_provider:delete', args=[application.pk]) }}">
+            {% csrf_token %}
+
+            <div class="control-group">
+                <div class="controls">
+                    <a class="btn btn-large" href="{{ url('oauth2_provider:list' }}">{{ _("Cancel") }}</a>
+                    <input type="submit" class="btn btn-large btn-danger" name="allow" value="{{ _("Delete") }}"/>
+                </div>
+            </div>
+        </form>
+    </div>
+{% endblock %}

--- a/templates/oauth2_provider/application_detail.html
+++ b/templates/oauth2_provider/application_detail.html
@@ -1,0 +1,41 @@
+{% extends "oauth2_provider/base.html" %}
+
+
+{% block content %}
+    <div class="block-center">
+        <h3 class="block-center-heading">{{ application.name }}</h3>
+
+        <ul class="unstyled">
+            <li>
+                <p><b>{{_("clinet id")}}</b></p>
+                <input class="input-block-level" type="text" value="{{ application.client_id }}" readonly>
+            </li>
+
+            <li>
+                <p><b>{{_("client secret")}}</b></p>
+                <input class="input-block-level" type="text" value="{{ application.client_secret }}" readonly>
+            </li>
+
+            <li>
+                <p><b>{{_("client type")}}</b></p>
+                <p>{{ application.client_type }}</p>
+            </li>
+
+            <li>
+                <p><b>{{_("Authorization grant type")}}</b></p>
+                <p>{{ application.authorization_grant_type }}</p>
+            </li>
+
+            <li>
+                <p><b>{{_("Redirect uris")}}</b></p>
+                <textarea class="input-block-level" readonly>{{ application.redirect_uris }}</textarea>
+            </li>
+        </ul>
+
+        <div class="btn-toolbar">
+            <a class="btn" href="{{ url('oauth2_provider:list')}}">{{_("Go Back")}}</a>
+            <a class="btn btn-primary" href="{{ url('oauth2_provider:update', args=[application.id]) }}">{{_("Edit")}}</a>
+            <a class="btn btn-danger" href="{{ url('oauth2_provider:delete', args=[application.id]) }}">{{_("Delete")}}</a>
+        </div>
+    </div>
+{% endblock content %}

--- a/templates/oauth2_provider/application_form.html
+++ b/templates/oauth2_provider/application_form.html
@@ -1,0 +1,37 @@
+{% extends "oauth2_provider/base.html" %}
+
+
+{% block content %}
+    <div class="block-center">
+        <form class="form-horizontal" method="post" action="{% block app_form_action_url %}{{ url('oauth2_provider:update', args=[application.id])}}{% endblock %}">
+            <h3 class="block-center-heading">
+                {% block app_form_title %}
+                    {{ _("Edit application") }} {{ application.name }}
+                {% endblock %}
+            </h3>
+            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+            {% for field in form %}
+                <div class="control-group {% if field.errors %}error{% endif %}">
+                    <label class="control-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+                    <div class="controls">
+                        {{ field }}
+                        {% for error in field.errors %}
+                            <span class="help-inline">{{ error }}</span>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endfor %}
+
+
+            <div class="control-group">
+                <div class="controls">
+                    <a class="btn" href="{% block app_form_back_url %}{{ url('oauth2_provider:detail', args=[application.id])}}{% endblock %}">
+                        {{ _("Go back") }}
+                    </a>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+{% endblock %}

--- a/templates/oauth2_provider/application_list.html
+++ b/templates/oauth2_provider/application_list.html
@@ -1,0 +1,18 @@
+{% extends "oauth2_provider/base.html" %}
+
+{% block content %}
+    <div class="block-center">
+        <h3 class="block-center-heading">{{ _("Your application list") }}</h3>
+        {% if applications %}
+            <ul>
+                {% for application in applications %}
+                    <li><a href="{{ application.get_absolute_url() }}">{{ application.name }}</a></li>
+                {% endfor %}
+            </ul>
+
+            <a class="btn btn-success" href="{{ url('oauth2_provider:register') }}">New Application</a>
+        {% else %}
+            <p>{{ _("No application defined") }} <a href="{{ url('oauth2_provider:register') }}">     {{ _("Click here") }}</a> {{ _("If you want to register new one.") }}</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/templates/oauth2_provider/application_registration_form.html
+++ b/templates/oauth2_provider/application_registration_form.html
@@ -1,0 +1,7 @@
+{% extends "oauth2_provider/application_form.html" %}
+
+{% block app_form_title %}{{ _("Register a new application") }} {% endblock %}
+
+{% block app_form_action_url %}{{ url('oauth2_provider:register') }}{% endblock %}
+
+{% block app_form_back_url %}{{ url('oauth2_provider:list') }}{% endblock %}

--- a/templates/oauth2_provider/authorize.html
+++ b/templates/oauth2_provider/authorize.html
@@ -1,0 +1,40 @@
+{% extends "oauth2_provider/base.html" %}
+
+
+{% block content %}
+    <div class="block-center">
+        {% if not error %}
+            <form id="authorizationForm" method="post">
+                <h3 class="block-center-heading">{{ _("Authorize") }} {{ application.name }}?</h3>
+                <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+                {% for field in form %}
+                    {% if field.is_hidden %}
+                        {{ field }}
+                    {% endif %}
+                {% endfor %}
+
+                <p>{{ _("Application requires following permissions") }}</p>
+                <ul>
+                    {% for scope in scopes_descriptions %}
+                        <li>{{ scope }}</li>
+                    {% endfor %}
+                </ul>
+
+                {{ form.errors }}
+                {{ form.non_field_errors }}
+
+                <div class="control-group">
+                    <div class="controls">
+                        <input type="submit" class="btn btn-large" value="Cancel"/>
+                        <input type="submit" class="btn btn-large btn-primary" name="allow" value="Authorize"/>
+                    </div>
+                </div>
+            </form>
+
+        {% else %}
+            <h2>Error: {{ error.error }}</h2>
+            <p>{{ error.description }}</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/templates/oauth2_provider/authorized-token-delete.html
+++ b/templates/oauth2_provider/authorized-token-delete.html
@@ -1,0 +1,9 @@
+{% extends "oauth2_provider/base.html" %}
+
+{% load i18n %}
+{% block content %}
+    <form action="" method="post"><input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+        <p>{{_("Are you sure you want to delete this token?") }}</p>
+        <input type="submit" value="{{_("Delete")}}" />
+    </form>
+{% endblock %}

--- a/templates/oauth2_provider/authorized-tokens.html
+++ b/templates/oauth2_provider/authorized-tokens.html
@@ -1,0 +1,22 @@
+{% extends "oauth2_provider/base.html" %}
+
+{% block content %}
+    <div class="block-center">
+    <h1>{{_("Tokens")}}</h1>
+        <ul>
+        {% for authorized_token in authorized_tokens %}
+            <li>
+                {{ authorized_token.application }}
+                (<a href="{{ url('oauth2_provider:authorized-token-delete' args=[authorized_token.pk]) }}">revoke</a>)
+            </li>
+            <ul>
+            {% for scope_name, scope_description in authorized_token.scopes.items %}
+                <li>{{ scope_name }}: {{ scope_description }}</li>
+            {% endfor %}
+            </ul>
+        {% empty %}
+            <li>{{_("There are no authorized tokens yet.")}}</li>
+        {% endfor %}
+        </ul>
+    </div>
+{% endblock %}

--- a/templates/oauth2_provider/base.html
+++ b/templates/oauth2_provider/base.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}{% endblock title %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    {% block css %}
+        <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.no-icons.min.css" rel="stylesheet">
+    {% endblock css %}
+
+    <style>
+        body {
+            padding-top: 40px;
+            padding-bottom: 40px;
+            background-color: #f5f5f5;
+        }
+        .block-center {
+            max-width: 500px;
+            padding: 19px 29px 29px;
+            margin: 0 auto 20px;
+            background-color: #fff;
+            border: 1px solid #e5e5e5;
+            -webkit-border-radius: 5px;
+            -moz-border-radius: 5px;
+            border-radius: 5px;
+            -webkit-box-shadow: 0 1px 2px rgba(0,0,0,.05);
+            -moz-box-shadow: 0 1px 2px rgba(0,0,0,.05);
+            box-shadow: 0 1px 2px rgba(0,0,0,.05);
+        }
+        .block-center .block-center-heading {
+            margin-bottom: 10px;
+        }
+
+    </style>
+</head>
+
+<body>
+
+<div class="container">
+    {% block content %}
+    {% endblock content %}
+</div>
+
+</body>
+</html>

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -328,6 +328,8 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    # django oauth toolkit
+    'corsheaders.middleware.CorsMiddleware',
 )
 
 ANONYMOUS_USER_ID = None
@@ -354,6 +356,8 @@ INSTALLED_APPS = [
     'pipeline',
     'zerver',
     'social_django',
+    # oatuh toolkit
+    'oauth2_provider',
 ]
 if USING_PGROONGA:
     INSTALLED_APPS += ['pgroonga']
@@ -1152,8 +1156,8 @@ AUTHENTICATION_BACKENDS += ('zproject.backends.ZulipDummyBackend',)
 
 # Redirect to /devlogin by default in dev mode
 if DEVELOPMENT:
-    HOME_NOT_LOGGED_IN = '/devlogin'
-    LOGIN_URL = '/devlogin'
+    HOME_NOT_LOGGED_IN = '/login'
+    LOGIN_URL = '/login'
 
 POPULATE_PROFILE_VIA_LDAP = bool(AUTH_LDAP_SERVER_URI)
 
@@ -1216,3 +1220,7 @@ PROFILE_ALL_REQUESTS = False
 CROSS_REALM_BOT_EMAILS = set(('feedback@zulip.com', 'notification-bot@zulip.com'))
 
 CONTRIBUTORS_DATA = os.path.join(STATIC_ROOT, 'generated/github-contributors.json')
+
+
+# allow cors request from all domains for demo propose
+CORS_ORIGIN_ALLOW_ALL = True

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -429,6 +429,9 @@ urls += [
 # Python Social Auth
 urls += [url(r'^', include('social_django.urls', namespace='social'))]
 
+# django oauth toolkit
+urls += [url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),]
+
 # User documentation site
 urls += [url(r'^help/(?P<article>.*)$', HelpView.as_view(template_name='zerver/help/main.html'))]
 


### PR DESCRIPTION
This is prototype of a basic oauth-2 provider and tested on ```http://django-oauth-toolkit.herokuapp.com```.

1. Hit ```localhost:9991/o/applications/``` . If user is not logged in then user will be redirected to login page else it will be redirected to page having application list. 
![1-oauth](https://cloud.githubusercontent.com/assets/9110208/24428113/e87099ea-142a-11e7-89f7-8d11c88a141d.png)

2. click on create new application and register properly as requirements. Client ID and Client Secret will be generated automatically. 
![2-outh](https://cloud.githubusercontent.com/assets/9110208/24428765/1baaefac-142d-11e7-8cd5-429642b9568a.png)

3. Then we can test it on [http://django-oauth-toolkit.herokuapp.com/consumer/](uhttp://django-oauth-toolkit.herokuapp.com/consumer/) with client ID and authorization url.

