### PR TITLE
Set umask 022 before starting prod install.

### DIFF
--- a/scripts/setup/install
+++ b/scripts/setup/install
@@ -4,6 +4,7 @@ if [ "$EUID" -ne 0 ]; then
     echo "Error: The installation script must be run as root" >&2
     exit 1
 fi
+umask 022
 mkdir -p /var/log/zulip
 
 "$(dirname "$(dirname "$0")")/lib/install" "$@" 2>&1 | tee -a /var/log/zulip/install.log


### PR DESCRIPTION
Added it after the running as root check but before anything gets started. Local testing looks good and everything installs smoothly now. 

```
root@minmi:~# ls -ltr /srv
total 12
drwxr-xr-x 3 root  root  4096 Mar 26 03:43 zulip-venv-cache
drwxr-xr-x 2 zulip zulip 4096 Mar 26 03:44 zulip-npm-cache
drwxr-xr-x 2 zulip zulip 4096 Mar 26 03:44 zulip-emoji-cache
root@minmi:~# ls -ltr /srv/zulip-venv-cache/
total 4
drwxr-xr-x 3 root root 4096 Mar 26 03:43 27ae06af0f1e1022553ce4c635e88440c06a6263
root@minmi:~# umask
0077
```

Fixes #2373