### PR TITLE
settings: Add submit button to Default Streams. 

### DIFF
--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -113,17 +113,19 @@ function make_stream_default(stream_name) {
     var data = {
         stream_name: stream_name,
     };
+    var default_stream_status = $("#admin-default-stream-status");
+    default_stream_status.hide();
 
     channel.post({
         url: '/json/default_streams',
         data: data,
         error: function (xhr) {
             if (xhr.status.toString().charAt(0) === "4") {
-                $(".active_stream_row button").closest("td").html(
-                    $("<p>").addClass("text-error").text(JSON.parse(xhr.responseText).msg));
+                ui_report.error(i18n.t("Failed!"), xhr, default_stream_status);
             } else {
-                $(".active_stream_row button").text(i18n.t("Failed!"));
+                ui_report.error(i18n.t("Failed!"), default_stream_status);
             }
+            default_stream_status.show();
         },
     });
 }

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -181,6 +181,15 @@ exports.on_load_success = function (streams_data) {
         },
     });
 
+    $(".default-stream-form").on("click", "#do_submit_stream", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var default_stream_input = $(".create_default_stream");
+        make_stream_default(default_stream_input.val());
+        // Clear value inside input box
+        default_stream_input[0].value = "";
+    });
+
     $("#do_deactivate_stream_button").click(function () {
         if ($("#deactivation_stream_modal .stream_name").text() !== $(".active_stream_row").find('.stream_name').text()) {
             blueslip.error("Stream deactivation canceled due to non-matching fields.");

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -168,6 +168,9 @@ exports.on_load_success = function (streams_data) {
         if (e.which === 13) {
             e.preventDefault();
             e.stopPropagation();
+            var default_stream_input = $(".create_default_stream");
+            make_stream_default(default_stream_input.val());
+            default_stream_input[0].value = "";
         }
     });
 

--- a/static/templates/settings/default-streams-list-admin.handlebars
+++ b/static/templates/settings/default-streams-list-admin.handlebars
@@ -23,6 +23,7 @@
       <div class="control-group" id="default_stream_inputs">
         <label for="default_stream_name" class="control-label">{{t "Stream name" }}</label>
         <input class="create_default_stream" type="text" placeholder="{{t "Stream name" }}" name="stream_name" autocomplete="off"></input>
+        <div class="alert" id="admin-default-stream-status"></div>
       </div>
       <div class="control-group">
         <div class="controls">

--- a/static/templates/settings/default-streams-list-admin.handlebars
+++ b/static/templates/settings/default-streams-list-admin.handlebars
@@ -24,6 +24,11 @@
         <label for="default_stream_name" class="control-label">{{t "Stream name" }}</label>
         <input class="create_default_stream" type="text" placeholder="{{t "Stream name" }}" name="stream_name" autocomplete="off"></input>
       </div>
+      <div class="control-group">
+        <div class="controls">
+          <button type="submit" id="do_submit_stream" class="button white rounded sea-green">{{t "Add stream" }}</button>
+        </div>
+      </div>
     </div>
   </form>
 {{/if}}


### PR DESCRIPTION
Changes:
- Added a `submit` button in Administration/Default Streams section as a backup in case using enter doesn't work.
- The errors weren't being displayed if the `make_stream_default` function failed as the element _.active_stream_row_ wasn't present. I have fixed this by creating a new `div` in the template to display the errors. I have made sure that this is consistent with how errors in other widgets are displayed. 

Fixes #4232 