### PR TITLE
markdown: Backend isn't rendering second level markdown.

### DIFF
--- a/zerver/fixtures/bugdown-data.json
+++ b/zerver/fixtures/bugdown-data.json
@@ -91,6 +91,12 @@
       "bugdown_matches_marked": true
     },
     {
+      "name": "ulist_nested_ulist_two_space_indent",
+      "input": "Nested list\n* I am outer list\n  * I am inner nested list first item\n  * I am inner nested list second item",
+      "expected_output": "<p>Nested list</p>\n<ul>\n<li>I am outer list<ul>\n<li>I am inner nested list first item</li>\n<li>I am inner nested list second item</li>\n</ul>\n</li>\n</ul>",
+      "bugdown_matches_marked": true
+    },
+    {
       "name": "ulist_codeblock",
       "input": "~~~\nint x = 3\n* 4;\n~~~",
       "expected_output": "<div class=\"codehilite\"><pre><span></span>int x = 3\n* 4;\n</pre></div>",

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1264,6 +1264,7 @@ def make_md_engine(key, opts):
     # type: (int, Dict[str, Any]) -> None
     md_engines[key] = markdown.Markdown(
         output_format = 'html',
+        tab_length = 2,
         extensions    = [
             'markdown.extensions.nl2br',
             'markdown.extensions.tables',


### PR DESCRIPTION
This is a work in progress.

There are couple of things to consider. The second level markdown works so as long as 4 spaces or a tab is used, but not t2 spaces. It seems this is correct according to what is stated in Python markdown docs https://pythonhosted.org/Markdown/index.html#Features,

"The syntax rules clearly state that when a list item consists of multiple paragraphs, “each subsequent paragraph in a list item must be indented by either 4 spaces or one tab” (emphasis added)...The implementers of Python-Markdown consider it a bug to not enforce this rule. This applies to any block level elements nested in a list, including paragraphs, sub-lists, blockquotes, code blocks, etc. They must always be indented by at least four spaces (or one tab) for each level of nesting."

So if I am to make the js markdown resemble the backend then either the js markdown must enforce the rule above, or the backend markup be adjusted to allow 2 space indentation. (The cheatsheat provided in Zulip docs specifies 2 spaces for nested lists.) Which approach should be taken? 

fixes issue #4252