### PR TITLE
Fix reactions tracebacks.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -39,7 +39,10 @@ initialize();
         user_id: 32,
         full_name: full_name,
     };
+
+    assert(!people.is_known_user_id(32));
     people.add(isaac);
+    assert(people.is_known_user_id(32));
 
     var person = people.get_by_name(full_name);
     assert.equal(people.get_user_id(email), 32);

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -1,0 +1,79 @@
+set_global('document', {});
+global.stub_out_jquery();
+
+add_dependencies({
+    people: 'js/people.js',
+});
+
+var reactions = require("js/reactions.js");
+
+set_global('emoji', {
+    emoji_name_to_css_class: function (name) {
+        return name + '-css'; // only to make testing easy
+    },
+    realm_emojis: {},
+});
+
+set_global('page_params', {user_id: 1});
+
+(function make_people() {
+    var alice = {
+        email: 'alice@example.com',
+        user_id: 5,
+        full_name: 'Alice',
+    };
+    var bob = {
+        email: 'bob@example.com',
+        user_id: 6,
+        full_name: 'Bob van Roberts',
+    };
+    var cali = {
+        email: 'cali@example.com',
+        user_id: 7,
+        full_name: 'Cali',
+    };
+    people.add_in_realm(alice);
+    people.add_in_realm(bob);
+    people.add_in_realm(cali);
+}());
+
+(function test_basics() {
+    var message = {
+        id: 1001,
+        reactions: [
+            {emoji_name: 'smile', user: {id: 5}},
+            {emoji_name: 'smile', user: {id: 6}},
+            {emoji_name: 'frown', user: {id: 7}},
+        ],
+    };
+
+    set_global('message_store', {
+        get: function (message_id) {
+            assert.equal(message_id, 1001);
+            return message;
+        },
+    });
+    var result = reactions.get_message_reactions(message);
+
+   result.sort(function (a, b) { return a.count - b.count; });
+
+    var expected_result = [
+      {
+         emoji_name: 'frown',
+         emoji_name_css_class: 'frown-css',
+         count: 1,
+         title: 'Cali reacted with :frown:',
+         emoji_alt_code: undefined,
+         class: 'message_reaction',
+      },
+      {
+         emoji_name: 'smile',
+         emoji_name_css_class: 'smile-css',
+         count: 2,
+         title: 'Alice and Bob van Roberts reacted with :smile:',
+         emoji_alt_code: undefined,
+         class: 'message_reaction',
+      },
+   ];
+   assert.deepEqual(result, expected_result);
+}());

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -14,6 +14,10 @@ set_global('emoji', {
     realm_emojis: {},
 });
 
+set_global('blueslip', {
+    warn: function () {},
+});
+
 set_global('page_params', {user_id: 1});
 
 (function make_people() {
@@ -44,6 +48,10 @@ set_global('page_params', {user_id: 1});
             {emoji_name: 'smile', user: {id: 5}},
             {emoji_name: 'smile', user: {id: 6}},
             {emoji_name: 'frown', user: {id: 7}},
+
+            // add some bogus user_ids
+            {emoji_name: 'octopus', user: {id: 8888}},
+            {emoji_name: 'frown', user: {id: 9999}},
         ],
     };
 

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -93,6 +93,17 @@ exports.get_user_id = function (email) {
     return user_id;
 };
 
+exports.is_known_user_id = function (user_id) {
+    /*
+    For certain low-stakes operations, such as emoji reactions,
+    we may get a user_id that we don't know about, because the
+    user may have been deactivated.  (We eventually want to track
+    deactivated users on the client, but until then, this is an
+    expedient thing we can check.)
+    */
+    return people_by_user_id_dict.has(user_id);
+};
+
 exports.huddle_string = function (message) {
     if (message.type !== 'private') {
         return;

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -222,8 +222,15 @@ exports.get_emojis_used_by_user_for_message_id = function (message_id) {
 exports.get_message_reactions = function (message) {
     var message_reactions = new Dict();
     _.each(message.reactions, function (reaction) {
+        var user_id = reaction.user.id;
+        if (!people.is_known_user_id(user_id)) {
+            blueslip.warn('Unknown user_id ' + user_id +
+                          'in reaction for message ' + message.id);
+            return;
+        }
+
         var user_list = message_reactions.setdefault(reaction.emoji_name, []);
-        user_list.push(reaction.user.id);
+        user_list.push(user_id);
     });
     var reactions = message_reactions.items().map(function (item) {
         var emoji_name = item[0];

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -226,11 +226,13 @@ exports.get_message_reactions = function (message) {
         user_list.push(reaction.user.id);
     });
     var reactions = message_reactions.items().map(function (item) {
+        var emoji_name = item[0];
+        var user_ids = item[1];
         var reaction = {
-            emoji_name: item[0],
-            emoji_name_css_class: emoji.emoji_name_to_css_class(item[0]),
-            count: item[1].length,
-            title: generate_title(item[0], item[1]),
+            emoji_name: emoji_name,
+            emoji_name_css_class: emoji.emoji_name_to_css_class(emoji_name),
+            count: user_ids.length,
+            title: generate_title(emoji_name, user_ids),
             emoji_alt_code: page_params.emoji_alt_code,
         };
         if (emoji.realm_emojis[reaction.emoji_name]) {


### PR DESCRIPTION
I think the reactions error scenario is fairly rare, since often users who have made reactions will also have sent messages, so we'll already have the somewhat dubious skeleton records for them.  So, in this fix, I just ignore unknown users ids with a warning.  I made #4322 to address the deeper issue here, which is we need to handle deactivated clients better.