### PR TITLE
[WIP] popovers: fix image size and margin in userprofile popover

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -85,10 +85,8 @@ ul.actions_popover i {
 }
 
 .sender_info_popover .popover_info {
-  /* width : popover_container width - (popover_content padding) - (navlist padding)*/
     width: calc(240px - (15px*2) - (14px * 2));
-
-}
+}/* width : popover_container width - (popover_content padding) - (navlist padding)*/
 
 .sender_info_popover .popover_info li {
     word-wrap: break-word;

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -84,6 +84,16 @@ ul.actions_popover i {
     position: relative;
 }
 
+.sender_info_popover .popover_info {
+  /* width : popover_container width - (popover_content padding) - (navlist padding)*/
+    width: calc(240px - (15px*2) - (14px * 2));
+
+}
+
+.sender_info_popover .popover_info li {
+    word-wrap: break-word;
+}
+
 .message-info-popover {
     padding: 0;
 }


### PR DESCRIPTION
Observation:
- White-space appears on right side of image in userprofile popover due to extra margin.
- Userprofile popover container's width increases along-with the size of email-address mentioned in the popover which also adds more white-space between image and boundary of container.

Changes:
- Set width and margin correctly for `.popover-avatar` in `static/styles/popovers.css`.