### PR TITLE
Fix wording and padding in user_info_popover_content.

### DIFF
--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -177,8 +177,8 @@ a new line to be formatted this way.
 
 ### Icons
 
-You can refer to features in the Zulip UI by refrencing their names and
-their [FontAwesome](http://fontawesome.io) (version 3.0.2) text icons within
+You can refer to features in the Zulip UI by referencing their names and
+their [FontAwesome](http://fontawesome.io) (version 4.7.0) text icons within
 parentheses. The source for the text icons is located in
 `static/third/thirdparty-fonts.css`.
 
@@ -197,7 +197,7 @@ class="icon-vector-file-text-alt"></i>) icon`
 * menu (<i class="fa fa-bars"></i>) icon — `menu (<i
 class="icon-vector-reorder"></i>) icon`
 * overflow ( <i class="fa fa-ellipsis-v"></i> ) icon —
-`overflow ( <i class="icon-vector-ellipsis-verical"></i> ) icon`
+`overflow ( <i class="icon-vector-ellipsis-vertical"></i> ) icon`
 * paperclip (<i class="fa fa-paperclip"></i>) icon —
 `paperclip (<i class="icon-vector-paperclip"></i>) icon`
 * pencil (<i class="fa fa-pencil"></i>) icon —

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -85,9 +85,13 @@ ul.actions_popover i {
     width: 240px;
     background-size: cover;
     background-position: center;
-    margin-top: -8px;
-    margin-left: -14px;
-    margin-right: -8px;
-    margin-bottom: -8px;
     position: relative;
+}
+
+.message-info-popover {
+    padding: 0;
+}
+
+.message-info-popover .popover-title {
+    padding: 0;
 }

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -15,6 +15,12 @@
         </a>
     </li>
     <li>
+        <a class="mention_user">
+            <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}}
+        </a>
+    </li>
+    <hr />
+    <li>
         <a href="{{ pm_with_uri }}" class="narrow_to_private_messages">
             <i class="icon-vector-user"></i> {{#tr this}}Private messages with user{{/tr}}
         </a>
@@ -22,11 +28,6 @@
     <li>
         <a href="{{ sent_by_uri }}" class="narrow_to_messages_sent">
             <i class="icon-vector-bullhorn"></i> {{#tr this}}Messages sent by user{{/tr}}
-        </a>
-    </li>
-    <li>
-        <a class="mention_user">
-            <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}}
         </a>
     </li>
 </ul>

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -22,12 +22,12 @@
     <hr />
     <li>
         <a href="{{ pm_with_uri }}" class="narrow_to_private_messages">
-            <i class="icon-vector-user"></i> {{#tr this}}Private messages with user{{/tr}}
+            <i class="icon-vector-user"></i> {{#tr this}}View private messages{{/tr}}
         </a>
     </li>
     <li>
         <a href="{{ sent_by_uri }}" class="narrow_to_messages_sent">
-            <i class="icon-vector-bullhorn"></i> {{#tr this}}Messages sent by user{{/tr}}
+            <i class="icon-vector-bullhorn"></i> {{#tr this}}View messages sent{{/tr}}
         </a>
     </li>
 </ul>


### PR DESCRIPTION
Still some issues, e.g. this will break under i18n if the text is long, and it would be nice to center the block of 4 links with respect to the popover. But hopefully an improvement for now.  