### PR TITLE
sidebar: Make icon clickable for '< All Streams' in left sidebar.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -452,3 +452,7 @@ li.show-more-private-messages a {
 .zoom-in .zoom-in-hide {
     display: none;
 }
+
+.show-all-streams .icon-vector-chevron-left {
+    text-decoration: none;
+}

--- a/templates/zerver/left_sidebar.html
+++ b/templates/zerver/left_sidebar.html
@@ -22,7 +22,7 @@
                           <div class="all-streams-padding">
                             <ul class="filters">
                               <li data-name="all-streams">
-                                <i class="icon-vector-chevron-left"></i> <a href="" class="show-all-streams">{{ _('All streams') }}</a>
+                                <a href="" class="show-all-streams"> <i class="icon-vector-chevron-left"></i>{{ _('All streams') }}</a>
                               </li>
                             </ul>
                           </div>


### PR DESCRIPTION
Minor fix for making the Chevron Icon alongside "All streams" text clickable.

Had to use `!important` to prevent the icon from getting underlined. Further, this class `icon-link` could be used in other cases of such icons as well from now on.
![](https://chat.zulip.org/user_uploads/2/72/NPvyREqih9McJYHcS95r_f-c/pasted_image.png)

Discussion in https://chat.zulip.org/#narrow/stream/design/topic/UX.20Bug.20in.20Streams.20list