### PR TITLE
css: Make thirdparty-fonts.css load before Zulip stylesheets.

### DIFF
--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -694,6 +694,7 @@ PIPELINE = {
             'source_filenames': (
                 'third/bootstrap-notify/css/bootstrap-notify.css',
                 'third/spectrum/spectrum.css',
+                'third/thirdparty-fonts.css',
                 'styles/components.css',
                 'styles/zulip.css',
                 'styles/settings.css',
@@ -707,7 +708,6 @@ PIPELINE = {
                 'styles/lightbox.css',
                 'styles/popovers.css',
                 'styles/pygments.css',
-                'third/thirdparty-fonts.css',
                 'styles/media.css',
                 'styles/typing_notifications.css',
                 # We don't want fonts.css on QtWebKit, so its omitted here
@@ -718,6 +718,7 @@ PIPELINE = {
             'source_filenames': (
                 'third/bootstrap-notify/css/bootstrap-notify.css',
                 'third/spectrum/spectrum.css',
+                'third/thirdparty-fonts.css',
                 'third/jquery-perfect-scrollbar/css/perfect-scrollbar.css',
                 'node_modules/katex/dist/katex.css',
                 'styles/components.css',
@@ -733,7 +734,6 @@ PIPELINE = {
                 'styles/lightbox.css',
                 'styles/popovers.css',
                 'styles/pygments.css',
-                'third/thirdparty-fonts.css',
                 'styles/fonts.css',
                 'styles/media.css',
                 'styles/typing_notifications.css',


### PR DESCRIPTION
Reason to push this file up: Custom CSS rules are supposed to be given higher priority than generic CSS rules.

In case some css bug is detected later, this is the list of files that are likely causes.

```bash
$ git grep icon-vector- static/styles | cat | clip
static/styles/compose.css:.compose_table .right_part .icon-vector-narrow {
static/styles/left-sidebar.css:#share-the-love .icon-vector-heart {
static/styles/media.css:    #searchbox .input-append .icon-vector-search {
static/styles/portico.css:.markdown .back-to-home .icon-vector-chevron-left {
static/styles/reactions.css:.reaction-popover-top .icon-vector-search {
static/styles/stats.css:.last-update .icon-vector-question-sign {
static/styles/subscriptions.css:.subscriptions-header .icon-vector-chevron-left {
static/styles/subscriptions.css:.subscriptions-header.slide-left .icon-vector-chevron-left {
static/styles/subscriptions.css:.stream-creation-body #make-invite-only label span.icon-vector-globe {
static/styles/subscriptions.css:.stream-creation-body #make-invite-only label span.icon-vector-lock {
static/styles/subscriptions.css:.stream-row .icon .icon-vector-lock {
static/styles/subscriptions.css:    .subscriptions-header .icon-vector-chevron-left {
static/styles/zulip.css:.message_header .icon-vector-narrow {
static/styles/zulip.css:#searchbox .input-append .icon-vector-search {
```

Relevant discussion in [this topic on Zulip chat](https://chat.zulip.org/#narrow/stream/design/topic/UX.20Bug.20in.20Streams.20list)