### PR TITLE
streams: Restore stream name in 'Create streams' on changing tab

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -729,7 +729,10 @@ exports.close = function () {
 exports.switch_rows = function (event) {
     var active_data = get_active_data();
     var switch_row;
-    if (!active_data.id || active_data.row.hasClass('notdisplayed')) {
+    if (window.location.hash === '#streams/new') {
+        // Prevent switching stream rows when creating new stream
+        return;
+    } else if (!active_data.id || active_data.row.hasClass('notdisplayed')) {
         switch_row = $('div.stream-row:not(.notdisplayed):first');
     } else if (event === 'up_arrow') {
         switch_row = active_data.row.prev();


### PR DESCRIPTION
On filling out the name and description for new stream,
and changing the tab (e.g. by clicking on a stream on the left),
then come back to 'Create streams', it should restore stream name
similar to the stream description.

Fix #4311.