### PR TITLE
tooling: Add script to automatically renumber migrations.

### DIFF
--- a/docs/migration-renumbering.md
+++ b/docs/migration-renumbering.md
@@ -10,6 +10,9 @@ conflicts, I am about to narrate an exercise
 where I bring my development branch called
 showell-topic up to date with master.
 
+**Note:** You can also use the command `./tools/renumber-migrations` to
+automatically perform migration renumbering.
+
 In this example,
 there is a migration on master called
 `0024_realm_allow_message_editing.py`, and

--- a/docs/schema-migrations.md
+++ b/docs/schema-migrations.md
@@ -18,11 +18,11 @@ migrations.
 * **Numbering conflicts across branches**: If you've done your schema
   change in a branch, and meanwhile another schema change has taken
   place, Django will now have two migrations with the same number. To
-  fix this, you need to renumber your migration(s), fix up
-  the "dependencies" entries in your migration(s), and rewrite your
-  git history as needed.  There is a tutorial
-  [here](migration-renumbering.html) that walks you though that
-  process.
+  fix this, you can either run `./tools/renumber-migrations` which
+  renumbers your migration(s) and fixes up the "dependencies" entries in your
+  migration(s), and then rewrite your git history as needed, or you can do it
+  manually. There is a tutorial [here](migration-renumbering.html) that
+  walks you though that process.
 
 * **Atomicity**.  By default, each Django migration is run atomically
   inside a transaction.  This can be problematic if one wants to do

--- a/tools/renumber-migrations
+++ b/tools/renumber-migrations
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import print_function
+from six.moves import input, map, range
+import glob
+import os
+import sys
+import fileinput
+import re
+
+from typing import List
+
+def validate_order(order, length):
+    # type: (List[int], int) -> None
+    if len(order) != length:
+        print("Please enter the sequence of all the conflicting files at once")
+        sys.exit(1)
+
+    for i in order:
+        if i > length or i < 1 or order.count(i) > 1:
+            print("Incorrect input")
+            sys.exit(1)
+
+def renumber_migration(conflicts, order, last_correct_migration):
+    # type: (List[str], List[int], str) -> None
+    stack = [] # type: List[str]
+    for i in order:
+        if conflicts[i-1][0:4] not in stack:
+            stack.append(conflicts[i-1][0:4])
+        else:
+            # Replace dependencies with the last correct migration
+            file = fileinput.FileInput('zerver/migrations/' + conflicts[i-1], inplace=True)
+            for line in file:
+                print(re.sub(r'[\d]+(_[a-z0-9]+)+', last_correct_migration, line), end='')
+
+            # Rename the migration indexing at the end
+            new_name = conflicts[i-1].replace(conflicts[i-1][0:4], '00' + str(int(last_correct_migration[0:4]) + 1))
+            os.rename('zerver/migrations/' + conflicts[i-1], 'zerver/migrations/' + new_name)
+
+            last_correct_migration = new_name
+
+def resolve_conflicts(conflicts, files_list):
+    # type: (List[str], List[str]) -> None
+    print("Conflicting migrations:")
+    for i in range(0, len(conflicts)):
+        print(str(i+1) + '. ' + conflicts[i])
+
+    order_input = input("Enter the order in which these migrations should be arranged: ")
+    order = list(map(int, order_input.split()))
+    validate_order(order, len(conflicts))
+
+    last_correct_migration = str(input('Enter the name of last correct migration file: '))
+    if last_correct_migration not in files_list:
+        print("File not found!")
+        sys.exit(1)
+
+    last_correct_migration = last_correct_migration.replace('.py', '')
+    renumber_migration(conflicts, order, last_correct_migration)
+
+if __name__ == '__main__':
+
+    while True:
+        conflicts = [] # type: list[str]
+        stack = [] # type: list[str]
+        files_list = [os.path.basename(path) for path in glob.glob("zerver/migrations/????_*.py")]
+        file_index = [file[0:4] for file in files_list]
+
+        for file in file_index:
+            counter = file_index.count(file[0:4])
+            if counter > 1 and file[0:4] not in stack:
+                conflicts += [file_name for file_name in files_list if file[0:4] in file_name]
+                stack.append(file[0:4])
+
+        if len(conflicts) > 0:
+            resolve_conflicts(conflicts, files_list)
+        else:
+            break
+
+    print("All conflicts resolved")

--- a/tools/test-migrations
+++ b/tools/test-migrations
@@ -3,7 +3,8 @@ set -e
 echo 'Testing whether migrations are consistent with models'
 if ! ./manage.py makemigrations --check --dry-run; then
     echo
-    echo 'ERROR: Migrations are not consistent with models!  Fix with `./manage.py makemigrations`.'
+    echo 'ERROR: Migrations are not consistent with models!  Fix with `./tools/renumber-migrations`.'
+    echo 'See http://zulip.readthedocs.io/en/latest/schema-migrations.html for details.'
     echo
     exit 1
 else


### PR DESCRIPTION
Previously, if you have a branch with a new migration,
and you rebase onto master past someone else's migration,
you have to manually renumber your migration.

Added a script that automatically renumbers the migrations.