### PR TITLE
admin: Remove 200px width limitation on .grid label.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -35,10 +35,6 @@ label {
     margin-top: 10px;
 }
 
-.new-style .grid label {
-    width: 200px;
-}
-
 .new-style .grid .warning {
     display: inline-block;
     vertical-align: top;


### PR DESCRIPTION
This removes the 200px width limitation that was part of a previous
style guide for the settings/administration pages. It force-wraps
lines that shouldn't be wrapped and no longer serves its original
purpose.

Fixes: #4312.