### PR TITLE
style: Increase messagebox inter-paragraph spacing

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1343,7 +1343,11 @@ blockquote p {
 }
 
 .messagebox p {
-    margin: 3px 0px 3px 0px;
+    margin: 3px 0px 10px 0px;
+}
+
+.messagebox p:last-of-type {
+    margin-bottom: 3px;
 }
 
 .messagebox blockquote {


### PR DESCRIPTION
The default is too tight for easily distinguishing paragraphs. This
change increases it slightly, while keeping the last paragraph's
margin at the original value.