### PR TITLE
message: Use pgroonga.match_positions_character

### DIFF
--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -298,13 +298,13 @@ class NarrowBuilder(object):
 
     def _by_search_pgroonga(self, query, operand, maybe_negate):
         # type: (Query, str, ConditionTransform) -> Query
-        match_positions_byte = func.pgroonga.match_positions_byte
+        match_positions_character = func.pgroonga.match_positions_character
         query_extract_keywords = func.pgroonga.query_extract_keywords
         keywords = query_extract_keywords(operand)
-        query = query.column(match_positions_byte(column("rendered_content"),
-                                                  keywords).label("content_matches"))
-        query = query.column(match_positions_byte(column("subject"),
-                                                  keywords).label("subject_matches"))
+        query = query.column(match_positions_character(column("rendered_content"),
+                                                       keywords).label("content_matches"))
+        query = query.column(match_positions_character(column("subject"),
+                                                       keywords).label("subject_matches"))
         condition = column("search_pgroonga").op("@@")(operand)
         return query.where(maybe_negate(condition))
 
@@ -355,29 +355,9 @@ def highlight_string_text_offsets(text, locs):
     result += string[pos:]
     return result
 
-def highlight_string_bytes_offsets(text, locs):
-    # type: (AnyStr, Iterable[Tuple[int, int]]) -> Text
-    string = force_bytes(text)
-    highlight_start = b'<span class="highlight">'
-    highlight_stop = b'</span>'
-    pos = 0
-    result = b''
-    for loc in locs:
-        (offset, length) = loc
-        result += string[pos:offset]
-        result += highlight_start
-        result += string[offset:offset + length]
-        result += highlight_stop
-        pos = offset + length
-    result += string[pos:]
-    return force_text(result)
-
 def highlight_string(text, locs):
     # type: (AnyStr, Iterable[Tuple[int, int]]) -> Text
-    if settings.USING_PGROONGA:
-        return highlight_string_bytes_offsets(text, locs)
-    else:
-        return highlight_string_text_offsets(text, locs)
+    return highlight_string_text_offsets(text, locs)
 
 def get_search_fields(rendered_content, subject, content_matches, subject_matches):
     # type: (Text, Text, Iterable[Tuple[int, int]], Iterable[Tuple[int, int]]) -> Dict[str, Text]


### PR DESCRIPTION
We can remove byte version text highlight method with this change.

pgroonga.match_positions_character was added in PGroonga 1.1.1:
http://pgroonga.github.io/reference/functions/pgroonga-match-positions-character.html

PGroonga 1.1.1 was released at 2016-08-31. So we can use it.