### PR TITLE
markdown: Load KaTeX in the app.

### DIFF
--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -377,7 +377,10 @@ function handleTex(tex, fullmatch) {
     try {
         return katex.renderToString(tex);
     } catch (ex) {
-        return '<span class="tex-error">' + escape(fullmatch) + '</span>';
+        if (ex.message.startsWith('KaTeX parse error')) { // TeX syntax error
+            return '<span class="tex-error">' + escape(fullmatch) + '</span>';
+        }
+        blueslip.error(ex);
     }
 }
 

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -28,6 +28,7 @@
         </script>
         {% endblock %}
         {{ minified_js('common')|safe }}
+        {{ minified_js('katex')|safe }}
         {% block customhead %}
         {% endblock %}
     </head>


### PR DESCRIPTION
Looks like this got lost when merging the changes in #3330 (this was in the original PR, but surprisingly wasn't in the codebase after closing it).

Probably this will fix the performance issues we were having while using the new TeX syntax (we weren't using local rendering ;)).

We probably could've caught this way sooner if we had been able to see the exceptions raised when calling `katex`. The second commit in the PR fixes this, by hiding only the exceptions triggered by syntax errors in the users' TeX expressions.

I used `console.error`, hence the tests flake. I remember reading somewhere that we used blueslip to manage JS exceptions, maybe? Flagging as WIP until we sort that part out.