### PR TITLE
settings: Fixes positioning of user upload spinner.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1871,7 +1871,7 @@ div.floating_recipient {
 .loading_indicator_text {
     /* If you change these, make sure to adjust the constants in
        loading.make_indicator as well */
-    margin-left: 20px;
+    margin-left: 5px;
     font-size: 1.2em;
     font-weight: 300;
     line-height: 38px;
@@ -1891,11 +1891,13 @@ div.floating_recipient {
     line-height: 20px;
     display: inline-block;
     float: none;
+    margin-top: 9px;
 }
 
 .settings-section .loading_indicator_spinner {
-    width: 100%;
-    height: 100%;
+    width: 20%;
+    height: 20px;
+    margin-top: 7px;
     vertical-align: middle;
     display: inline-block;
 }

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -105,8 +105,8 @@
           <div id="upload_avatar_spinner"></div>
         </div>
         <div class="inline-block">
-            <button class="button sea-green w-200 m-t-20 block input-size" id="user_avatar_upload_button">{{t 'Upload new avatar' }}</button>
-            <button class="button btn-danger w-200 m-t-20 block input-size" id="user_avatar_delete_button">{{t 'Delete avatar' }}</button>
+            <button class="button sea-green w-200 m-t-20 block" id="user_avatar_upload_button">{{t 'Upload new avatar' }}</button>
+            <button class="button btn-danger w-200 m-t-20 block" id="user_avatar_delete_button">{{t 'Delete avatar' }}</button>
         </div>
       </div>
       <div class="clear-float"></div>


### PR DESCRIPTION
Previously the User avatar upload spinner was going off the upload box while uploading and the Avatar box wasn't symmetrical with the padding on the right being more than the padding on the left.

![Before](https://cloud.githubusercontent.com/assets/3889675/24580113/2e200bb8-1720-11e7-96dd-36fa6e91227b.jpg)

I have fixed this by:
- Changing the width of `.loading_indicator_spinner`.
- Adding a margin-top for `.loading_indicator_text`
- Removing the class `input-size` from the upload/delete buttons so that buttons and the image had equal widths (200px). 

![After](https://cloud.githubusercontent.com/assets/3889675/24580158/d12fc794-1720-11e7-9734-8661c8fbe649.jpg)

Fixes #4223 .