### PR TITLE
Support for setting user timezone and display local time in popover

### DIFF
--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -28,6 +28,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
     {{ csrf_input }}
         <div class="input-box no-validation">
             <input type='hidden' name='key' value='{{ key }}' />
+            <input type='hidden' name='timezone' id='timezone'/>
             <input id="id_email" type='text' disabled="true" placeholder="{{ email }}" required />
             <label for="id_email" class="inline-block label-title">{{ _('Email') }}</label>
             <div class="required"></div>
@@ -223,6 +224,8 @@ $("[name=realm_org_type]").on("change", function () {
     $(".blob").hide();
     $("#org_type_blob_" + this.value).show();
 });
+
+$("#timezone").val(moment.tz.guess());
 </script>
 
 {% endblock %}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -402,15 +402,15 @@ def notify_created_bot(user_profile):
 
 def do_create_user(email, password, realm, full_name, short_name,
                    active=True, bot_type=None, bot_owner=None, tos_version=None,
-                   avatar_source=UserProfile.AVATAR_FROM_GRAVATAR,
+                   timezone=u"", avatar_source=UserProfile.AVATAR_FROM_GRAVATAR,
                    default_sending_stream=None, default_events_register_stream=None,
                    default_all_public_streams=None, prereg_user=None,
                    newsletter_data=None):
-    # type: (Text, Text, Realm, Text, Text, bool, Optional[int], Optional[UserProfile], Optional[Text], Text, Optional[Stream], Optional[Stream], bool, Optional[PreregistrationUser], Optional[Dict[str, str]]) -> UserProfile
+    # type: (Text, Text, Realm, Text, Text, bool, Optional[int], Optional[UserProfile], Optional[Text], Text, Text, Optional[Stream], Optional[Stream], bool, Optional[PreregistrationUser], Optional[Dict[str, str]]) -> UserProfile
     user_profile = create_user(email=email, password=password, realm=realm,
                                full_name=full_name, short_name=short_name,
                                active=active, bot_type=bot_type, bot_owner=bot_owner,
-                               tos_version=tos_version, avatar_source=avatar_source,
+                               tos_version=tos_version, timezone=timezone, avatar_source=avatar_source,
                                default_sending_stream=default_sending_stream,
                                default_events_register_stream=default_events_register_stream,
                                default_all_public_streams=default_all_public_streams)

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -6,8 +6,8 @@ from zerver.models import Realm, Stream, UserProfile, Huddle, \
     Subscription, Recipient, Client, RealmAuditLog, get_huddle_hash
 from zerver.lib.create_user import create_user_profile
 
-def bulk_create_users(realm, users_raw, bot_type=None, tos_version=None):
-    # type: (Realm, Set[Tuple[Text, Text, Text, bool]], Optional[int], Optional[Text]) -> None
+def bulk_create_users(realm, users_raw, bot_type=None, tos_version=None, timezone=u""):
+    # type: (Realm, Set[Tuple[Text, Text, Text, bool]], Optional[int], Optional[Text], Text) -> None
     """
     Creates and saves a UserProfile with the given email.
     Has some code based off of UserManage.create_user, but doesn't .save()
@@ -21,7 +21,7 @@ def bulk_create_users(realm, users_raw, bot_type=None, tos_version=None):
         profile = create_user_profile(realm, email,
                                       initial_password(email), active, bot_type,
                                       full_name, short_name, None, False, tos_version,
-                                      tutorial_status=UserProfile.TUTORIAL_FINISHED,
+                                      timezone, tutorial_status=UserProfile.TUTORIAL_FINISHED,
                                       enter_sends=True)
         profiles_to_create.append(profile)
     UserProfile.objects.bulk_create(profiles_to_create)

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -26,9 +26,9 @@ def random_api_key():
 # Recipient objects
 def create_user_profile(realm, email, password, active, bot_type, full_name,
                         short_name, bot_owner, is_mirror_dummy, tos_version,
-                        tutorial_status=UserProfile.TUTORIAL_WAITING,
+                        timezone, tutorial_status=UserProfile.TUTORIAL_WAITING,
                         enter_sends=False):
-    # type: (Realm, Text, Optional[Text], bool, Optional[int], Text, Text, Optional[UserProfile], bool, Optional[Text], Optional[Text], bool) -> UserProfile
+    # type: (Realm, Text, Optional[Text], bool, Optional[int], Text, Text, Optional[UserProfile], bool, Text, Optional[Text], Optional[Text], bool) -> UserProfile
     now = timezone_now()
     email = UserManager.normalize_email(email)
 
@@ -37,7 +37,7 @@ def create_user_profile(realm, email, password, active, bot_type, full_name,
                                last_login=now, date_joined=now, realm=realm,
                                pointer=-1, is_bot=bool(bot_type), bot_type=bot_type,
                                bot_owner=bot_owner, is_mirror_dummy=is_mirror_dummy,
-                               tos_version=tos_version,
+                               tos_version=tos_version, timezone=timezone,
                                tutorial_status=tutorial_status,
                                enter_sends=enter_sends,
                                onboarding_steps=ujson.dumps([]),
@@ -53,15 +53,16 @@ def create_user_profile(realm, email, password, active, bot_type, full_name,
 
 def create_user(email, password, realm, full_name, short_name,
                 active=True, bot_type=None, bot_owner=None, tos_version=None,
-                avatar_source=UserProfile.AVATAR_FROM_GRAVATAR,
+                timezone=u"", avatar_source=UserProfile.AVATAR_FROM_GRAVATAR,
                 is_mirror_dummy=False, default_sending_stream=None,
                 default_events_register_stream=None,
                 default_all_public_streams=None, user_profile_id=None):
-    # type: (Text, Text, Realm, Text, Text, bool, Optional[int], Optional[UserProfile], Optional[Text], Text, bool, Optional[Stream], Optional[Stream], Optional[bool], Optional[int]) -> UserProfile
+    # type: (Text, Text, Realm, Text, Text, bool, Optional[int], Optional[UserProfile], Optional[Text], Text, Text, bool, Optional[Stream], Optional[Stream], Optional[bool], Optional[int]) -> UserProfile
     user_profile = create_user_profile(realm, email, password, active, bot_type,
                                        full_name, short_name, bot_owner,
-                                       is_mirror_dummy, tos_version)
+                                       is_mirror_dummy, tos_version, timezone)
     user_profile.avatar_source = avatar_source
+    user_profile.timezone = timezone
     user_profile.default_sending_stream = default_sending_stream
     user_profile.default_events_register_stream = default_events_register_stream
     # Allow the ORM default to be used if not provided

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -234,8 +234,8 @@ class ZulipTestCase(TestCase):
 
     def submit_reg_form_for_user(self, email, password, realm_name="Zulip Test",
                                  realm_subdomain="zuliptest", realm_org_type=Realm.COMMUNITY,
-                                 from_confirmation='', full_name=None, **kwargs):
-        # type: (Text, Text, Optional[Text], Optional[Text], int, Optional[Text], Optional[Text], **Any) -> HttpResponse
+                                 from_confirmation='', full_name=None, timezone=u'', **kwargs):
+        # type: (Text, Text, Optional[Text], Optional[Text], int, Optional[Text], Optional[Text], Optional[Text], **Any) -> HttpResponse
         """
         Stage two of the two-step registration process.
 
@@ -253,6 +253,7 @@ class ZulipTestCase(TestCase):
                                  'realm_subdomain': realm_subdomain,
                                  'key': find_key_by_email(email),
                                  'realm_org_type': realm_org_type,
+                                 'timezone': timezone,
                                  'terms': True,
                                  'from_confirmation': from_confirmation},
                                 **kwargs)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1025,7 +1025,7 @@ class RealmCreationTest(ZulipTestCase):
 
 class UserSignUpTest(ZulipTestCase):
 
-    def test_user_default_language(self):
+    def test_user_default_language_and_timezone(self):
         # type: () -> None
         """
         Check if the default language of new user is the default language
@@ -1033,6 +1033,7 @@ class UserSignUpTest(ZulipTestCase):
         """
         email = "newguy@zulip.com"
         password = "newpassword"
+        timezone = "US/Mountain"
         realm = get_realm('zulip')
         do_set_realm_property(realm, 'default_language', u"de")
 
@@ -1049,11 +1050,12 @@ class UserSignUpTest(ZulipTestCase):
         self.assertEqual(result.status_code, 200)
 
         # Pick a password and agree to the ToS.
-        result = self.submit_reg_form_for_user(email, password)
+        result = self.submit_reg_form_for_user(email, password, timezone=timezone)
         self.assertEqual(result.status_code, 302)
 
         user_profile = get_user_profile_by_email(email)
         self.assertEqual(user_profile.default_language, realm.default_language)
+        self.assertEqual(user_profile.timezone, timezone)
         from django.core.mail import outbox
         outbox.pop()
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -24,12 +24,13 @@ from zerver.lib.actions import do_change_password, do_change_full_name, do_chang
     compute_mit_user_fullname
 from zerver.forms import RegistrationForm, HomepageForm, RealmCreationForm, \
     CreateUserForm, FindMyTeamForm
-from zerver.lib.actions import is_inactive
+from zerver.lib.actions import is_inactive, do_set_user_display_setting
 from django_auth_ldap.backend import LDAPBackend, _LDAPUser
 from zerver.decorator import require_post, has_request_variables, \
     JsonableError, get_user_profile_by_email, REQ
 from zerver.lib.response import json_success
 from zerver.lib.utils import get_subdomain
+from zerver.lib.timezone import get_all_timezones
 from zproject.backends import password_auth_enabled
 
 from confirmation.models import Confirmation, RealmCreationKey, check_key_is_valid
@@ -197,16 +198,22 @@ def accounts_register(request):
         short_name = email_to_username(email)
         first_in_realm = len(UserProfile.objects.filter(realm=realm, is_bot=False)) == 0
 
+        timezone = u""
+        if 'timezone' in request.POST and request.POST['timezone'] in get_all_timezones():
+                timezone = request.POST['timezone']
+
         # FIXME: sanitize email addresses and fullname
         if existing_user_profile is not None and existing_user_profile.is_mirror_dummy:
             user_profile = existing_user_profile
             do_activate_user(user_profile)
             do_change_password(user_profile, password)
             do_change_full_name(user_profile, full_name)
+            do_set_user_display_setting(user_profile, 'timezone', timezone)
         else:
             user_profile = do_create_user(email, password, realm, full_name, short_name,
                                           prereg_user=prereg_user,
                                           tos_version=settings.TOS_VERSION,
+                                          timezone=timezone,
                                           newsletter_data={"IP": request.META['REMOTE_ADDR']})
 
         if first_in_realm:


### PR DESCRIPTION
- [X] Add option for setting timzone in user settings.
- [X] Show local time of user in user_popover.
- [x] Show the time in the correct format 12 / 24 hour as per user settings
- [x] Set user timezone automatically during signup

Fixes https://github.com/zulip/zulip/issues/1506

**UI for setting the Time Zone**
![screenshot from 2017-04-03 03 06 16](https://cloud.githubusercontent.com/assets/7190633/24591239/b692b568-181a-11e7-8d1f-0b45fba1c4c2.png)

**Local time of user being shown in the popover**
![screenshot from 2017-04-03 00 41 36](https://cloud.githubusercontent.com/assets/7190633/24590180/59ce2bfa-1806-11e7-9a4b-133703388f96.png)
