### PR TITLE
Fix the grid labels to have a min-width of 200px.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -35,6 +35,10 @@ label {
     margin-top: 10px;
 }
 
+.new-style .grid label {
+    min-width: 200px;
+}
+
 .new-style .grid .warning {
     display: inline-block;
     vertical-align: top;


### PR DESCRIPTION
The labels should respect their original width of 200px but overflow
if the language or content is too long.