### PR TITLE
api-docs: Fix JavaScript code sample.

### DIFF
--- a/templates/zerver/api.html
+++ b/templates/zerver/api.html
@@ -48,6 +48,13 @@
 These code snippets are generated using our very own Zulip tool, by
 sending them to myself in a code block, and then using the inspector
 to pull out the resulting HTML :)
+
+Sample steps to do:
+1. Write code in Zulip message box.
+2. Put it in a multiline codeblock and specify a language.
+3. Click on 'preview'.
+4. Inspect and copy the HTML.
+
 #}
 
 <h4>Stream message</h4>
@@ -162,12 +169,12 @@ to pull out the resulting HTML :)
 <span class="p">});</span>
 
 <span class="c1">// Register queue to receive messages for user</span>
-<span class="nx">zulip</span><span class="p">.</span><span class="nx">queues</span><span class="p">.</span><span class="nx">register</span><span class="p">({</span>
+<span class="nx">client</span><span class="p">.</span><span class="nx">queues</span><span class="p">.</span><span class="nx">register</span><span class="p">({</span>
   <span class="nx">event_types</span><span class="o">:</span> <span class="p">[</span><span class="s1">'message'</span><span class="p">]</span>
 <span class="p">}).</span><span class="nx">then</span><span class="p">((</span><span class="nx">res</span><span class="p">)</span> <span class="o">=&gt;</span> <span class="p">{</span>
   <span class="c1">// Retrieve events from a queue</span>
   <span class="c1">// Blocking until there is an event (or the request times out)</span>
-  <span class="nx">zulip</span><span class="p">.</span><span class="nx">events</span><span class="p">.</span><span class="nx">retrieve</span><span class="p">({</span>
+  <span class="nx">client</span><span class="p">.</span><span class="nx">events</span><span class="p">.</span><span class="nx">retrieve</span><span class="p">({</span>
     <span class="nx">queue_id</span><span class="o">:</span> <span class="nx">res</span><span class="p">.</span><span class="nx">queue_id</span><span class="p">,</span>
     <span class="nx">last_event_id</span><span class="o">:</span> <span class="o">-</span><span class="mi">1</span><span class="p">,</span>
     <span class="nx">dont_block</span><span class="o">:</span> <span class="kc">false</span>


### PR DESCRIPTION
The current code sample gives error because of (accidental?) use of `zulip` instead of `client`. Here's the error:
```bash
zulip.queues.register({
            ^

TypeError: Cannot read property 'register' of undefined
    at Object.<anonymous> (/home/rohitt/Documents/gitclones/github-issue-linker/index.js:20:13)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Function.Module.runMain (module.js:442:10)
    at startup (node.js:136:18)
    at node.js:966:3
```
Here's the sample:
```javascript
const zulip = require('zulip');

const config = {
  username: 'othello-bot@example.com',
  apiKey: 'a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5',
  realm: 'https://chat.zulip.org/api'
};

const client = zulip(config);

// Send a message
client.messages.send({
  to: 'Denmark',
  type: 'stream',
  subject: 'Castle',
  content: 'Something is rotten in the state of Denmark.'
});

// Send a private message
client.messages.send({
  to: 'hamlet@example.com',
  type: 'private',
  content: 'I come not, friends, to steal away your hearts.'
});

// Register queue to receive messages for user
zulip.queues.register({
  event_types: ['message']
}).then((res) => {
  // Retrieve events from a queue
  // Blocking until there is an event (or the request times out)
  zulip.events.retrieve({
    queue_id: res.queue_id,
    last_event_id: -1,
    dont_block: false
  }).then(console.log);
});
```