### PR TITLE
Refocus the compose box after clicking a link

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -231,6 +231,17 @@ $(function () {
         $(this).tooltip('hide');
     });
 
+    // Refocus the compose area after clicking links
+    $("body").on("focus", '*', function (e) {
+        if (e.target.id === 'new_message_content') {
+            $(".messagebox-content a").off("click.refocus").on("click.refocus", function () {
+                $("#new_message_content").focus();
+            });
+        } else if (e.target.tagName !== 'A') {
+            $(".messagebox-content a").off("click.refocus");
+        }
+    });
+
     if (!page_params.realm_allow_message_editing) {
         $("#edit-message-hotkey-help").hide();
     }


### PR DESCRIPTION
I add a function after `show_box` in javascript file [https://github.com/zulip/zulip/blob/master/static/js/compose.js](url) to refocus the compose box after clicking a link in a message.
Test in localhost server.
Fixes: #4331.