### PR TITLE
Extract ui_report.js.

### DIFF
--- a/static/js/shim.js
+++ b/static/js/shim.js
@@ -18,7 +18,3 @@ compose_state.has_message_content = compose.has_message_content;
 compose_state.recipient = compose.recipient;
 compose_state.composing = compose.composing;
 
-var ui_report = {};
-ui_report.success = ui.report_success;
-ui_report.error = ui.report_error;
-ui_report.message= ui.report_message;

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -18,47 +18,6 @@ exports.replace_emoji_with_text = function (element) {
     });
 };
 
-/* Arguments used in the report_* functions are,
-   response- response that we want to display
-   status_box- element being used to display the response
-   cls- class that we want to add/remove to/from the status_box
-   type- used to define more complex logic for special cases (currently being
-         used only for subscriptions-status) */
-
-exports.report_message = function (response, status_box, cls, type) {
-    if (cls === undefined) {
-        cls = 'alert';
-    }
-
-    if (type === undefined) {
-        type = ' ';
-    }
-
-    if (type === 'subscriptions-status') {
-        status_box.removeClass(status_classes).addClass(cls).children('#response')
-              .text(response).stop(true).fadeTo(0, 1);
-    } else {
-        status_box.removeClass(status_classes).addClass(cls)
-              .text(response).stop(true).fadeTo(0, 1);
-    }
-
-    status_box.show();
-};
-
-exports.report_error = function (response, xhr, status_box, type) {
-    if (xhr && xhr.status.toString().charAt(0) === "4") {
-        // Only display the error response for 4XX, where we've crafted
-        // a nice response.
-        response += ": " + JSON.parse(xhr.responseText).msg;
-    }
-
-    ui_report.message(response, status_box, 'alert-error', type);
-};
-
-exports.report_success = function (response, status_box, type) {
-    ui_report.message(response, status_box, 'alert-success', type);
-};
-
 function update_message_in_all_views(message_id, callback) {
     _.each([message_list.all, home_msg_list, message_list.narrowed], function (list) {
         if (list === undefined) {

--- a/static/js/ui_report.js
+++ b/static/js/ui_report.js
@@ -1,0 +1,51 @@
+var ui_report = (function () {
+
+var exports = {};
+
+/* Arguments used in the report_* functions are,
+   response- response that we want to display
+   status_box- element being used to display the response
+   cls- class that we want to add/remove to/from the status_box
+   type- used to define more complex logic for special cases (currently being
+         used only for subscriptions-status) */
+
+exports.message = function (response, status_box, cls, type) {
+    if (cls === undefined) {
+        cls = 'alert';
+    }
+
+    if (type === undefined) {
+        type = ' ';
+    }
+
+    if (type === 'subscriptions-status') {
+        status_box.removeClass(status_classes).addClass(cls).children('#response')
+              .text(response).stop(true).fadeTo(0, 1);
+    } else {
+        status_box.removeClass(status_classes).addClass(cls)
+              .text(response).stop(true).fadeTo(0, 1);
+    }
+
+    status_box.show();
+};
+
+exports.error = function (response, xhr, status_box, type) {
+    if (xhr && xhr.status.toString().charAt(0) === "4") {
+        // Only display the error response for 4XX, where we've crafted
+        // a nice response.
+        response += ": " + JSON.parse(xhr.responseText).msg;
+    }
+
+    exports.message(response, status_box, 'alert-error', type);
+};
+
+exports.success = function (response, status_box, type) {
+    exports.message(response, status_box, 'alert-success', type);
+};
+
+return exports;
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = ui_report;
+}

--- a/tools/lib/find_add_class.py
+++ b/tools/lib/find_add_class.py
@@ -88,7 +88,7 @@ def find(fns):
                         continue
                     elif fn == 'signup.js' and 'class_to_add' in line:
                         html_classes = ['error', 'success']
-                    elif fn == 'ui.js' and 'status_classes' in line:
+                    elif fn == 'ui_report.js' and 'status_classes' in line:
                         html_classes = ['alert']
 
                 if not html_classes:

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -859,6 +859,7 @@ JS_SPECS = {
             'js/floating_recipient_bar.js',
             'js/lightbox.js',
             'js/ui_state.js',
+            'js/ui_report.js',
             'js/ui.js',
             'js/ui_util.js',
             'js/pointer.js',


### PR DESCRIPTION
This moves the implementations of error/report/message from
ui.js to ui_report.js.  They had been shimmed before, so calling
modules still use the same names to call the functions, but we
no longer need the shims.