### PR TITLE
settings: Settings modal overflow fix.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -121,7 +121,6 @@ td .button {
     background-color: #fafafa;
     border-radius: 2px;
     margin: 20px;
-    overflow: hidden;
     border: 1px solid #dfdfdf;
     border-top: 5px solid #dfdfdf;
 }


### PR DESCRIPTION
This `overflow: hidden` constraint would make it so that modals
embedded in the sections would have their edges cut off. This fixes
that and doesn’t seem to cause any other regressions.