### PR TITLE
css: Show the right border on PM headers.

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -77,8 +77,8 @@
 .draft-row .draft-info-box {
     width: 100%;
     background: #f1f1f1;
-    border-bottom: 1px solid #e2e2e2;
-    border-top: 1px solid #e2e2e2;
+    border: 1px solid #e2e2e2;
+    border-left: none;
     margin-bottom: 10px;
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -639,8 +639,8 @@ td.pointer {
 
 .message_list .recipient_row {
     background: #f1f1f1;
-    border-bottom: 1px solid #e2e2e2;
-    border-top: 1px solid #e2e2e2;
+    border: 1px solid #e2e2e2;
+    border-left: none;
     margin-bottom: 10px;
 }
 
@@ -897,10 +897,6 @@ td.pointer {
 .private-message .messagebox,
 .message_header_private_message .message-header-contents {
     background-color: #feffe0;
-}
-
-.floating_recipient .message-header-contents {
-    border-right: 1px solid #e2e2e2;
 }
 
 .mention .messagebox-content {
@@ -1172,7 +1168,6 @@ div.message_table {
 .message_row {
     position: relative;
     border-left: 1px solid #e2e2e2;
-    border-right: 1px solid #e2e2e2;
 }
 
 .message_row.selected_message {


### PR DESCRIPTION
Until now, private messages' headers didn't have the border in the right hand side:

![PM header w/o right border](https://cloud.githubusercontent.com/assets/7356565/24671274/3ad51bde-1971-11e7-8df7-ee29a22ce9d7.png)

*(Note the missing border at the right end)*

I thought this was also a good opportunity to join all message's borders in the same block (couldn't split it in different commits because it directly affects the PR's main fix).