### PR TITLE
settings: fix overflow issues with content.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -755,6 +755,7 @@ input[type=checkbox].inline-block {
     /* the width of the settings sidbar this is right of is 250px + 1px border. */
     width: calc(100% - 250px - 1px);
     height: 100%;
+    overflow: hidden;
 }
 
 #settings_page .content-wrapper .settings-header {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -766,7 +766,7 @@ input[type=checkbox].inline-block {
 
 #settings_page .content-wrapper #settings_content {
     width: 100%;
-    height: calc(100% - 60px);
+    height: calc(100% - 45px);
 
     float: left;
     overflow-y: auto;


### PR DESCRIPTION
This fixes the height of the content body to be 100% - 45px instead
of 100% - 60px which is a fix necessary due to the previous change
in height of the settings navbar.