### PR TITLE
settings: Fix avatar settings 'float' property.

### DIFF
--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -109,6 +109,7 @@
             <button class="button btn-danger w-200 m-t-20 block input-size" id="user_avatar_delete_button">{{t 'Delete avatar' }}</button>
         </div>
       </div>
+      <div class="clear-float"></div>
 
     </form>
 


### PR DESCRIPTION
This fixes the float of the avatar box so it does not visually
extend past the .settings-section container.