### PR TITLE
loading-spinner: Fix position of spinner on home page.

### DIFF
--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -29,7 +29,9 @@ exports.make_indicator = function (outer_container, opts) {
         text_elem.text(opts.text);
         container.append(text_elem);
         // See note, below
-        text_width = 20 + text_elem.width();
+        if (!(opts.abs_positioned !== undefined && opts.abs_positioned)) {
+            text_width = 20 + text_elem.width();
+        }
     }
 
     // These width calculations are tied to the spinner width and

--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -5,6 +5,15 @@ var exports = {};
 exports.make_indicator = function (outer_container, opts) {
     opts = opts || {};
     var container = outer_container;
+
+    // TODO: We set white-space to 'nowrap' because under some
+    // unknown circumstances (it happens on Keegan's laptop) the text
+    // width calculation, above, returns a result that's a few pixels
+    // too small.  The container's div will be slightly too small,
+    // but that's probably OK for our purposes.
+    outer_container.css({display: 'block',
+                         'white-space': 'nowrap'});
+
     container.empty();
 
     if (opts.abs_positioned !== undefined && opts.abs_positioned) {
@@ -36,17 +45,8 @@ exports.make_indicator = function (outer_container, opts) {
 
     // These width calculations are tied to the spinner width and
     // margins defined via CSS
-    //
-    // TODO: We set white-space to 'nowrap' because under some
-    // unknown circumstances (it happens on Keegan's laptop) the text
-    // width calculation, above, returns a result that's a few pixels
-    // too small.  The container's div will be slightly too small,
-    // but that's probably OK for our purposes.
     container.css({width: 38 + text_width,
                    height: 38});
-    outer_container.css({display: 'block',
-                         'white-space': 'nowrap'});
-
 
     outer_container.data("destroying", false);
 };

--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -13,7 +13,7 @@ $(function () {
     // Display loading indicator.  This disappears after the first
     // get_events completes.
     if (page_params.have_initial_messages && !page_params.needs_tutorial) {
-        loading.make_indicator($('#page_loading_indicator'), {text: 'Loading...'});
+        loading.make_indicator($('#page_loading_indicator'), {text: 'Loading...', abs_positioned: true});
     } else if (!page_params.needs_tutorial) {
         $('#first_run_message').show();
     }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2010,6 +2010,21 @@ div.floating_recipient {
     margin: 10px auto;
 }
 
+#page_loading_indicator_box_container {
+    position: absolute;
+    left: 50%;
+}
+
+#page_loading_indicator_box {
+    position: relative;
+    left: -50%;
+    top: -40px;
+    z-index: 1;
+    -webkit-border-radius: 6px;
+    -moz-border-radius: 6px;
+    border-radius: 6px;
+}
+
 .table-striped thead th {
     background-color: #444;
     color: white;


### PR DESCRIPTION
In this we fix the positioning of the loading spinner on the home page
when its loaded for the first time. First time here does not mean first
time use but means first time of a new session.
Behaviour before fix:
![loader-missplaced](https://cloud.githubusercontent.com/assets/17237412/24686715/335a590c-19d3-11e7-9429-77d0dd82fe64.gif)
Behaviour after fix:
![correct_loader](https://cloud.githubusercontent.com/assets/17237412/24686725/419692a6-19d3-11e7-9da2-51518ca97ed0.gif)
