### PR TITLE
Rename "Administration" to "Organization".

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -596,7 +596,7 @@ $(function () {
             name: "settings-toggle",
             values: [
                 { label: "Settings", key: "settings" },
-                { label: "Administration", key: "administration" },
+                { label: "Organization", key: "administration" },
             ],
             callback: function (name, key) {
                 $(".sidebar li").hide();

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -59,9 +59,9 @@
                       <i class="icon-vector-wrench"></i> {{ _('Settings') }}
                     </a>
                   </li>
-                  <li title="{{ _('Administration') }}" class="admin-menu-item">
+                  <li title="{{ _('Organization') }}" class="admin-menu-item">
                     <a href="#administration" role="button">
-                      <i class="icon-vector-bolt"></i> {{ _('Administration') }}
+                      <i class="icon-vector-bolt"></i> {{ _('Organization') }}
                     </a>
                   </li>
                   <li class="divider"></li>


### PR DESCRIPTION
Rename "Administration" tab in Settings to "Organization" for all users.
Also rename the same in navigation-bar for admin-users.