### PR TITLE
integrations: Clear float after #integration-instruction-block.

### DIFF
--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -60,6 +60,7 @@
     <div id="integration-instruction-block" class="integration-instruction-block">
        <a href="#" id="integration-list-link"><i class="icon-vector-circle-arrow-left"></i><span>Back to list</span></a>
     </div>
+    <div class="clear-float"></div>
 
     <div class="integration-lozenges">
       {% for integration in integrations_dict.values() %}


### PR DESCRIPTION
Clear the float after the instruction block so that the parent
container will respect the height of the child contents.

Fixes: #4425.