### PR TITLE
settings-bots: Text overflow fix.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -472,11 +472,11 @@ input[type=checkbox].inline-block {
 
 .bots_list .image {
     vertical-align: top;
-    width: calc(100% - 85px);
 }
 
 .bots_list .bot-information-box .details {
     display: inline-block;
+    width: calc(100% - 75px);
 }
 
 .bots_list .name {


### PR DESCRIPTION
This fixes the styling of the container so that the text will not
overflow to the next line but instead will just wrap around the
container correctly.