### PR TITLE
integrations: Fixup inconsistent lozenge heights.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -768,7 +768,7 @@ a:not(.no-style):hover:before {
 }
 
 .portico-landing.integrations .integration-lozenge {
-    height: 180px;
+    height: 170px;
     transition: all 0.3s ease;
 }
 

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -690,6 +690,10 @@ a.bottom-signup-button {
     margin-top: 5px;
 }
 
+.integration-lozenge .square-wrapper {
+    height: 100px;
+}
+
 .integration-lozenge-static:hover {
     box-shadow: none;
     background: #ededed;

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -67,7 +67,9 @@
         {% if integration.is_enabled() %}
           <div class="integration-lozenge integration-{{ integration.name }}">
              <a class="integration-link integration-{{ integration.name }}" href="#{{ integration.name }}">
-                <img class="integration-logo" src="/{{ integration.logo }}" alt="{{ integration.display_name }} logo" />
+                 <div class="square-wrapper">
+                     <img class="integration-logo" src="/{{ integration.logo }}" alt="{{ integration.display_name }} logo" />
+                 </div>
                {% if integration.secondary_line_text %}
                  <span class="integration-label" style="padding-bottom: 0px;">{{ integration.display_name }}</span>
                  <span class="integration-label-secondary">{{ integration.secondary_line_text }}</span>
@@ -89,7 +91,9 @@
     {% for integration in hubot_lozenges_dict.values() %}
         <div class="integration-lozenge integration-{{ integration.name }}">
            <a class="integration-link integration-{{ integration.name }}" href="{{ integration.git_url }}">
-              <img class="integration-logo" src="/{{ integration.logo }}" alt="{{ integration.logo_alt }} logo" />
+               <div class="square-wrapper">
+                   <img class="integration-logo" src="/{{ integration.logo }}" alt="{{ integration.logo_alt }} logo" />
+               </div>
                <span class="integration-label">{{ integration.display_name}}</span>
            </a>
         </div>


### PR DESCRIPTION
This normalizes images to all take up 100px even if they fall short
so that the text that is underneath will always be horizontally
aligned.