### PR TITLE
scroll-bar: Fix perfect-scrollbar improper scrolling in more topics.

### DIFF
--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -171,8 +171,9 @@ exports.zoom_in = function () {
         blueslip.error('Cannot find widget for topic history zooming.');
         return;
     }
-
     exports.rebuild(active_widget.get_parent(), active_widget.get_stream_name());
+    $('#stream-filters-container').scrollTop(0);
+    $('#stream-filters-container').perfectScrollbar('update');
 };
 
 exports.zoom_out = function (options) {


### PR DESCRIPTION
In this commit we fix the issue of scrollbar occasionally scrolling down too far when we click more topics option. Upon scrolling to top the scroll gets reset everything returns to normal. This sometimes leads to big blank space upon clicking more topics. This has been fixed by resetting the scroll upon clicking more topics.
Screens:
Before:
![before-fix-scrollbar](https://cloud.githubusercontent.com/assets/17237412/24796382/62e46126-1baa-11e7-8247-4b8960c55c50.gif)
After:
![after-fix-scrollbar](https://cloud.githubusercontent.com/assets/17237412/24796401/74acdbea-1baa-11e7-8f02-400bf708d049.gif)
Fixes: #4440.