### PR TITLE
Fix padding issue with user profile popover 

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -95,3 +95,11 @@ ul.actions_popover i {
 .message-info-popover .popover-title {
     padding: 0;
 }
+
+.user_popover {
+    padding: 0;
+}
+
+.user_popover .popover-title {
+    padding: 0;
+}

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -73,7 +73,7 @@ ul.actions_popover i {
 
 .user_popover {
     top: 100px!important;
-    margin: -15px;
+    margin: -14px;
 }
 
 .popover-avatar .popover-inner {


### PR DESCRIPTION
We remove the extra padding appearing around the
user profile images. This can be only reproduced when opening
user profile from buddy list.
we just adjust the position of user profile popover
opened when we click upon buddy from buddy list to view user profile.
The re position ensures that the little blue border visible from back
due to pointed to message is completely hidden by the popover.
Before:
![pasted_image](https://cloud.githubusercontent.com/assets/17237412/24823725/6a2f1636-1c1f-11e7-9b74-8bfe7c090a37.png)
After:
![image](https://cloud.githubusercontent.com/assets/17237412/24823733/7656e326-1c1f-11e7-86f5-f61a52df349b.png)
