### PR TITLE
drafts: Move the draft empty placeholder logic to template render path.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -81,11 +81,7 @@ exports.snapshot_message = function () {
         message.private_message_recipient = recipient;
     } else {
         message.stream = compose.stream_name();
-        var subject = compose.subject();
-        if (subject === "") {
-          subject = compose.empty_topic_placeholder();
-        }
-        message.subject = subject;
+        message.subject = compose.subject();
     }
     return message;
 };
@@ -173,14 +169,19 @@ exports.setup_page = function (callback) {
                 // single space char for proper rendering of the stream label
                 var space_string = new Handlebars.SafeString("&nbsp;");
                 var stream = (draft.stream.length > 0 ? draft.stream : space_string);
+                var draft_topic = draft.subject.length === 0 ?
+                        compose.empty_topic_placeholder() : draft.subject;
+
                 formatted = {
                     draft_id: id,
                     is_stream: true,
                     stream: stream,
                     stream_color: stream_data.get_color(draft.stream),
-                    topic: draft.subject,
+                    topic: draft_topic,
                     raw_content: draft.content,
+
                 };
+
                 echo.apply_markdown(formatted);
             } else {
                 var emails = util.extract_pm_recipients(draft.private_message_recipient);


### PR DESCRIPTION
This moves the logic to embed the translated string “(no topic)” to
only render in the handlebars template rather than saving in
localStorage and therefore being added to the message topic and
eventually put in the database if not changed.

Fixes: #4378.