### PR TITLE
left-sidebar: If the <hr> divider is the top block after removing stream, remove it.

### DIFF
--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -76,7 +76,13 @@ exports.stream_sidebar = (function () {
             blueslip.warn('Cannot remove stream id ' + stream_id);
             return;
         }
+
         widget.remove();
+        var $hr = $("#stream_filters hr");
+
+        if ($hr.prev().length === 0) {
+            $hr.remove();
+        }
         self.rows.del(stream_id);
     };
 


### PR DESCRIPTION
The <hr> is supposed to separate the pinned streams from the unpinned
streams, so if the <hr> is the first element (checked by doing
$hr.prev().length === 0), then it means there are no longer any pinned
streams and therefore it isn’t necessary to have a divider.

Fixes: #4395.