### PR TITLE
left-sidebar: Remove extra "Unsubscribe" on left-sidebar stream popover.

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -29,10 +29,6 @@
     max-width: 200px;
 }
 
-.streams_popover .popover_sub_unsub_button::after {
-    content: " Unsubscribe";
-}
-
 .streams_popover .sp-container {
     background: white;
     cursor: pointer;


### PR DESCRIPTION
An extra "Unsubscribe" was left over from when it was a CSS :pseudo
content rather than text in the templates.