### PR TITLE
stats: Change popover font size and weight to be more readable.

### DIFF
--- a/static/styles/stats.css
+++ b/static/styles/stats.css
@@ -303,7 +303,13 @@ svg {
 }
 
 .tooltip-inner {
+    padding: 10px;
     max-width: 350px;
+
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-align: left;
+    line-height: 1.4;
 }
 
 @media (max-width: 1127px) {


### PR DESCRIPTION
This changes the font size and weight of the popver at the bottom
of the screen (hover over "?" to see) to be a larger font size
(increased to 0.75rem from 11px) and to a bolder font weight
(500 from 300) which improves the readability of it.