### PR TITLE
presence.py: Enforce bots cannot use update_active_status_backend.

### DIFF
--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -238,7 +238,7 @@ class SingleUserPresenceTests(ZulipTestCase):
         self.assert_json_error(result, "No such user")
 
         result = self.client_get("/json/users/new-user-bot@zulip.com/presence")
-        self.assert_json_error(result, "No presence for bot users")
+        self.assert_json_error(result, "Presence is not supported for bot users.")
 
         self.login("sipbtest@mit.edu")
         result = self.client_get("/json/users/othello@zulip.com/presence")

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -264,6 +264,12 @@ class SingleUserPresenceTests(ZulipTestCase):
         result = self.client_post("/json/users/me/presence", req)
         self.assertEqual(result.json()['msg'], '')
 
+    def test_bot_post(self):
+        # type: () -> None
+        result = self.client_post("/api/v1/users/me/presence", {'status': 'active'},
+                                  **self.api_auth('default-bot@zulip.com'))
+        self.assert_json_error(result, "Presence is not supported for bot users.")
+
 class UserPresenceAggregationTests(ZulipTestCase):
     def _send_presence_for_aggregated_tests(self, email, status, validate_time):
         # type: (str, str, datetime.datetime) -> Dict[str, Dict[str, Any]]

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -57,6 +57,9 @@ def update_active_status_backend(request, user_profile, status=REQ(),
                                  ping_only=REQ(validator=check_bool, default=False),
                                  new_user_input=REQ(validator=check_bool, default=False)):
     # type: (HttpRequest, UserProfile, str, bool, bool) -> HttpResponse
+    if user_profile.is_bot:
+        return json_error(_('Presence is not supported for bot users.'))
+
     status_val = UserPresence.status_from_string(status)
     if status_val is None:
         raise JsonableError(_("Invalid status: %s") % (status,))

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -35,7 +35,7 @@ def get_presence_backend(request, user_profile, email):
     if not target.is_active:
         return json_error(_('No such user'))
     if target.is_bot:
-        return json_error(_('No presence for bot users'))
+        return json_error(_('Presence is not supported for bot users.'))
 
     presence_dict = UserPresence.get_status_dict_by_user(target)
     if len(presence_dict) == 0:


### PR DESCRIPTION
We need to keep the UserActivity table clean now that we're using it to
compute 15day actives in analytics.