### PR TITLE
logging: Increase logging in Casper.

### DIFF
--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -100,6 +100,11 @@ CACHES['database'] = {
 if CASPER_TESTS:
     # Don't auto-restart Tornado server during casper tests
     AUTORELOAD = False
+    LOGGING['loggers']['django.request'] = {
+        'handlers': ['console'],
+        'level': 'INFO',
+        'propagate': False
+    }
 else:
     # Use local memory cache for backend tests.
     CACHES['default'] = {


### PR DESCRIPTION
Enable django.request logger for Casper tests. This allows
us to show tracebacks in the server.log.

Fixes: #4127