### PR TITLE
Add option for re-running failed tests

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -2,11 +2,13 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from typing import List
 import glob
 import optparse
 import os
 import sys
 import subprocess
+import ujson
 
 # check for the venv
 from lib import sanity_check
@@ -90,6 +92,23 @@ not_yet_fully_covered = {
 
 enforce_fully_covered = sorted(target_fully_covered - not_yet_fully_covered)
 
+FAILED_TEST_PATH = 'var/last_test_failure.json'
+
+def get_failed_tests():
+    # type: () -> List[str]
+    try:
+        with open(FAILED_TEST_PATH, 'r') as f:
+            return ujson.load(f)
+    except IOError:
+        print("var/last_test_failure.json doesn't exist")
+        return []
+
+def write_failed_tests(failed_tests):
+    # type: (List[str]) -> None
+    if failed_tests:
+        with open(FAILED_TEST_PATH, 'w') as f:
+            ujson.dump(failed_tests, f)
+
 if __name__ == "__main__":
     TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
     os.chdir(os.path.dirname(TOOLS_DIR))
@@ -165,10 +184,29 @@ if __name__ == "__main__":
                       action="store_true",
                       default=False,
                       help="Run tests in reverse order.")
+    parser.add_option('--re-run', dest="re_run",
+                      action = "store_true",
+                      default=False,
+                      help=("Run the tests which failed the last time "
+                            "test-backend was run. --re-run doesn't run along "
+                            "with --force and --nonfatal-error"))
 
     (options, args) = parser.parse_args()
 
+    if options.re_run and (not options.fatal_errors or options.force):
+        print("--re-run doesn't run along with --force or --nonfatal-error, please try again.")
+        sys.exit(0)
+
     zerver_test_dir = 'zerver/tests/'
+
+    # While running --re-run, we access the file containing the
+    # details of the tests which failed in the last run of test-backend
+    # which is stored at zulip/var/last_test_failure.json and runs them
+    if options.re_run:
+        options.fatal_errors  = False
+        failed_tests = get_failed_tests()
+        if failed_tests:
+            args = failed_tests
 
     # to transform forward slashes '/' present in the argument into dots '.'
     for suite in args:
@@ -267,7 +305,8 @@ if __name__ == "__main__":
     test_runner = TestRunner(failfast=options.fatal_errors, verbosity=2,
                              parallel=parallel, reverse=options.reverse,
                              keepdb=True)
-    failures = test_runner.run_tests(suites, full_suite=full_suite)
+    failures, failed_tests = test_runner.run_tests(suites, full_suite=full_suite)
+    write_failed_tests(failed_tests)
 
     templates_not_rendered = test_runner.get_shallow_tested_templates()
     # We only check the templates if all the tests ran and passed

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -167,6 +167,11 @@ class TextTestResult(runner.TextTestResult):
     This class has unpythonic function names because base class follows
     this style.
     """
+    def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        super(TextTestResult, self).__init__(*args, **kwargs)
+        self.failed_tests = []  # type: List[str]
+
     def addInfo(self, test, msg):
         # type: (TestCase, Text) -> None
         self.stream.write(msg)
@@ -193,6 +198,8 @@ class TextTestResult(runner.TextTestResult):
     def addFailure(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
         TestResult.addFailure(self, *args, **kwargs)
+        test_name = full_test_name(args[0])
+        self.failed_tests.append(test_name)
 
     def addSkip(self, test, reason):
         # type: (TestCase, Text) -> None
@@ -364,7 +371,7 @@ class Runner(DiscoverRunner):
 
     def run_tests(self, test_labels, extra_tests=None,
                   full_suite=False, **kwargs):
-        # type: (List[str], Optional[List[TestCase]], bool, **Any) -> bool
+        # type: (List[str], Optional[List[TestCase]], bool, **Any) -> Tuple[bool, List[str]]
         self.setup_test_environment()
         try:
             suite = self.build_suite(test_labels, extra_tests)
@@ -387,7 +394,7 @@ class Runner(DiscoverRunner):
         failed = self.suite_result(suite, result)
         if not failed:
             write_instrumentation_reports(full_suite=full_suite)
-        return failed
+        return failed, result.failed_tests
 
 def get_test_names(suite):
     # type: (TestSuite) -> List[str]


### PR DESCRIPTION
Additional option '--re-run' for testing infrastructure.
To run one or more failed tests during the last 'test-backend' run.
Failed test info stored at zulip/var/last_test_failure.json

Tested on Ubuntu 16.04, would like to hear feedbacks on additions
or issues.

Rebases https://github.com/zulip/zulip/pull/2892

@timabbott, please review.