### PR TITLE
informational-overlays: Focus overlay body on shortcut "?".

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -452,6 +452,10 @@ exports.process_hotkey = function (e, hotkey) {
         return reactions.reaction_navigate(e, event_name);
     }
 
+    if (ui.is_info_overlay()) {
+        return false;
+    }
+
     if (hotkey.message_view_only && ui_state.home_tab_obscured()) {
         return false;
     }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -143,6 +143,12 @@ exports.show_info_overlay = function (target) {
     if (target) {
         components.toggle.lookup("info-overlay-toggle").goto(target);
     }
+
+    $(".overlay-modal:not(.hide)").find(".modal-body").focus();
+};
+
+exports.is_info_overlay = function () {
+    return ($(".informational-overlays").hasClass("show"));
 };
 
 var loading_more_messages_indicator_showing = false;

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -1,6 +1,6 @@
 <div class="overlay-modal" id="keyboard-shortcuts" tabindex="-1" role="dialog"
      aria-labelledby="keyboard-shortcuts-label" aria-hidden="true">
-  <div class="modal-body">
+  <div class="modal-body" tabindex="1">
     <div>
       <table class="hotkeys_table table table-striped table-bordered table-condensed">
         <thead>

--- a/templates/zerver/markdown_help.html
+++ b/templates/zerver/markdown_help.html
@@ -1,6 +1,6 @@
 <div class="overlay-modal hide" id="markdown-help" tabindex="-1" role="dialog"
     aria-labelledby="markdown-help-label" aria-hidden="true">
-    <div class="modal-body">
+    <div class="modal-body" tabindex="1">
         <div id="markdown-instructions">
             <table class="table table-striped table-condensed table-rounded table-bordered help-table">
                 <thead><tr>

--- a/templates/zerver/search_operators.html
+++ b/templates/zerver/search_operators.html
@@ -1,6 +1,6 @@
 <div class="overlay-modal hide" id="search-operators" tabindex="-1" role="dialog"
     aria-labelledby="search-operators-label" aria-hidden="true">
-    <div class="modal-body">
+    <div class="modal-body" tabindex="1">
         <table class="table table-striped table-condensed table-rounded table-bordered help-table">
             <thead>
                 <tr>


### PR DESCRIPTION
This focuses the body content of the informational overlay after
going to it from "?" so that you can use up and down arrows to then
scroll the content easily.

Fixes: #4480.