### PR TITLE
Use different DBs for Casper and backend tests

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -172,10 +172,9 @@ if __name__ == "__main__":
                       action="store_true",
                       default=False,
                       help="Show detailed output")
-    parser.add_option('--no-generate-fixtures', action="store_false", default=True,
+    parser.add_option('--generate-fixtures', action="store_true", default=False,
                       dest="generate_fixtures",
-                      help=("Reduce running time by not calling generate-fixtures. "
-                            "This may cause spurious failures for some tests."))
+                      help=("Force a call to generate-fixtures."))
     parser.add_option('--report-slow-tests', dest='report_slow_tests',
                       action="store_true",
                       default=False,
@@ -283,11 +282,9 @@ if __name__ == "__main__":
     # files, since part of setup is importing the models for all applications in INSTALLED_APPS.
     django.setup()
 
-    if options.generate_fixtures:
+    if options.generate_fixtures or not is_template_database_current():
         generate_fixtures_command = [os.path.join(TOOLS_DIR, 'setup', 'generate-fixtures')]
-        if not is_template_database_current():
-            generate_fixtures_command.append('--force')
-
+        generate_fixtures_command.append('--force')
         subprocess.call(generate_fixtures_command)
 
     TestRunner = get_runner(settings)

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, \
 from unittest import loader, runner  # type: ignore  # Mypy cannot pick these up.
 from unittest.result import TestResult
 
+from django.conf import settings
 from django.db import connections
 from django.test import TestCase
 from django.test import runner as django_runner
@@ -386,6 +387,7 @@ class Runner(DiscoverRunner):
 
     def setup_test_environment(self, *args, **kwargs):
         # type: (*Any, **Any) -> Any
+        settings.DATABASES['default']['NAME'] = settings.BACKEND_DATABASE_TEMPLATE
         destroy_test_databases(self.database_id)
         create_test_databases(self.database_id)
         return super(Runner, self).setup_test_environment(*args, **kwargs)

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -19,6 +19,9 @@ if os.getenv("EXTERNAL_HOST") is None:
     os.environ["EXTERNAL_HOST"] = "testserver"
 from .settings import *
 
+# Used to clone DBs in backend tests.
+BACKEND_DATABASE_TEMPLATE = 'zulip_test_template'
+
 DATABASES["default"] = {
     "NAME": "zulip_test",
     "USER": "zulip_test",


### PR DESCRIPTION
@timabbott, please review. This makes sure that Casper and backend tests use different databases.