### PR TITLE
refactor: Make compose.js more testable.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -273,16 +273,22 @@ exports.start = function (msg_type, opts) {
         compose.message_content(opts.content);
     }
 
-    ui_util.change_tab_to("#home");
-
     is_composing_message = msg_type;
 
     // Show either stream/topic fields or "You and" field.
     var focus_area = get_focus_area(msg_type, opts);
     show_box(msg_type, $("#" + focus_area), opts);
 
-    compose_fade.start_compose(msg_type);
+    exports.complete_starting_tasks(msg_type, opts);
+};
 
+exports.complete_starting_tasks = function (msg_type, opts) {
+    // This is sort of a kitchen sink function, and it's called only
+    // by compose.start() for now.  Having this as a separate function
+    // makes testing a bit easier.
+
+    ui_util.change_tab_to("#home");
+    compose_fade.start_compose(msg_type);
     exports.decorate_stream_bar(opts.stream);
     $(document).trigger($.Event('compose_started.zulip', opts));
     resize.resize_bottom_whitespace();

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -48,8 +48,8 @@ exports.autosize_textarea = function () {
 };
 
 // Show the compose box.
-function show_box(tabname, focus_area, opts) {
-    if (tabname === "stream") {
+function show_box(msg_type, opts) {
+    if (msg_type === "stream") {
         $('#private-message').hide();
         $('#stream-message').show();
         $("#stream_toggle").addClass("active");
@@ -64,11 +64,7 @@ function show_box(tabname, focus_area, opts) {
     $('#compose').css({visibility: "visible"});
     $(".new_message_textarea").css("min-height", "3em");
 
-    if (focus_area !== undefined &&
-        (window.getSelection().toString() === "" ||
-         opts.trigger !== "message click")) {
-        focus_area.focus().select();
-    }
+    exports.set_focus(msg_type, opts);
 }
 
 exports.maybe_scroll_up_selected_message = function () {
@@ -231,6 +227,19 @@ function get_focus_area(msg_type, opts) {
 // Export for testing
 exports._get_focus_area = get_focus_area;
 
+exports.set_focus = function (msg_type, opts) {
+    var focus_area = get_focus_area(msg_type, opts);
+    if (focus_area === undefined) {
+        return;
+    }
+
+    if (window.getSelection().toString() === "" ||
+         opts.trigger !== "message click") {
+        var elt = $('#' + focus_area);
+        elt.focus().select();
+    }
+};
+
 exports.autosize_message_content = function () {
     $("#new_message_content").autosize();
 };
@@ -278,8 +287,7 @@ exports.start = function (msg_type, opts) {
     is_composing_message = msg_type;
 
     // Show either stream/topic fields or "You and" field.
-    var focus_area = get_focus_area(msg_type, opts);
-    show_box(msg_type, $("#" + focus_area), opts);
+    show_box(msg_type, opts);
 
     exports.complete_starting_tasks(msg_type, opts);
 };

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -229,8 +229,12 @@ function get_focus_area(msg_type, opts) {
 // Export for testing
 exports._get_focus_area = get_focus_area;
 
-exports.start = function (msg_type, opts) {
+exports.autosize_message_content = function () {
     $("#new_message_content").autosize();
+};
+
+exports.start = function (msg_type, opts) {
+    exports.autosize_message_content();
 
     if (reload.is_in_progress()) {
         return;

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -69,7 +69,9 @@ function show_box(tabname, focus_area, opts) {
          opts.trigger !== "message click")) {
         focus_area.focus().select();
     }
+}
 
+exports.maybe_scroll_up_selected_message = function () {
     // If the compose box is obscuring the currently selected message,
     // scroll up until the message is no longer occluded.
     if (current_msg_list.selected_id() === -1) {
@@ -84,7 +86,7 @@ function show_box(tabname, focus_area, opts) {
         message_viewport.user_initiated_animate_scroll(cover+5);
     }
 
-}
+};
 
 function show_all_everyone_warnings() {
     var current_stream = stream_data.get_sub(compose.stream_name());
@@ -287,6 +289,7 @@ exports.complete_starting_tasks = function (msg_type, opts) {
     // by compose.start() for now.  Having this as a separate function
     // makes testing a bit easier.
 
+    exports.maybe_scroll_up_selected_message();
     ui_util.change_tab_to("#home");
     compose_fade.start_compose(msg_type);
     exports.decorate_stream_bar(opts.stream);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -233,6 +233,12 @@ exports.autosize_message_content = function () {
     $("#new_message_content").autosize();
 };
 
+exports.expand_compose_box = function () {
+    $("#compose_close").show();
+    $("#compose_controls").hide();
+    $('.message_comp').show();
+};
+
 exports.start = function (msg_type, opts) {
     exports.autosize_message_content();
 
@@ -240,9 +246,7 @@ exports.start = function (msg_type, opts) {
         return;
     }
     notifications.clear_compose_notifications();
-    $("#compose_close").show();
-    $("#compose_controls").hide();
-    $('.message_comp').show();
+    exports.expand_compose_box();
 
     opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
     // If we are invoked by a compose hotkey (c or C), do not assume that we know


### PR DESCRIPTION
This series of commits should make the code a bit more organized, and it will also make it easier to stub out certain methods when we test `compose.start()`.

Some followups to this will be to actually extract `compose_actions.js` (there's a shim now) and to actually write unit tests. :)

These are all refactorings.