### PR TITLE
Avoid opening the compose box for sidebar clicks.

### DIFF
--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -375,14 +375,6 @@ exports.activate = function (raw_operators, opts) {
     $('#search_query').val(Filter.unparse(operators));
     search.update_button_visibility();
 
-    if (!had_message_content && opts.trigger === 'sidebar' && exports.narrowed_by_reply()) {
-        if (exports.narrowed_to_topic()) {
-            compose_actions.start('stream');
-        } else {
-            compose_actions.start('private');
-        }
-    }
-
     $(document).trigger($.Event('narrow_activated.zulip', {msg_list: message_list.narrowed,
                                                             filter: current_filter,
                                                             trigger: opts.trigger}));


### PR DESCRIPTION
We no longer automatically open the compose box for sidebar
actions.  The logic behind this is that most users spend more time
reading messages than composing messages, and opening the compose
box can interfere with efficient browsing.  On a mobile device, the
compose box takes up a significant chunk of your screen real estate.
On a bigger device, the compose box intercepts important navigation
keys like page-up and end, and even when it allows them, it can be
jarring.

This change definitely introduces a tradeoff, as there will be
slightly more friction for users to compose new messages.  My
judgment is that we have plenty of other options available:

- hotkeys: enter, r, c, C
- clicking on the message you're replying to
- click on "New topic"
- click on "New private message"
- use stream chevron send-message option
- use topic chevron send-message option
- use buddy list chevron send-message option
- use message info menu option
- use buddy list search and hit enter for the first user
  in the search results (I think we should change this too)

This commit also simplifies our code, since it's purely removing
code.  If we want to re-introduce auto-open capability, we will
probably want to use an approach that is more testable.  The logic
that was removed here was part of a function that is 200+ lines in
length, so it was never unit tested. It also seemed to have a logic
flaw in terms of assuming that the `else` clause for the
`narrowed_to_topic()` test implied we were dealing with private
messages.  That may have been true in the context it was originally
written, but it was a ticking time bomb, because what if you are
just narrowed to a stream?

Fixes #3886