### PR TITLE
Split out compose_actions.js (and add node tests).

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -93,19 +93,3 @@ people.add(bob);
     assert.equal(message.content, 'burrito');
 
 }());
-
-(function test_get_focus_area() {
-    assert.equal(compose._get_focus_area('private', {}), 'private_message_recipient');
-    assert.equal(compose._get_focus_area('private', {
-        private_message_recipient: 'bob@example.com'}), 'new_message_content');
-    assert.equal(compose._get_focus_area('stream', {}), 'stream');
-    assert.equal(compose._get_focus_area('stream', {stream: 'fun'}),
-                 'subject');
-    assert.equal(compose._get_focus_area('stream', {stream: 'fun',
-                                                    subject: 'more'}),
-                 'new_message_content');
-    assert.equal(compose._get_focus_area('stream', {stream: 'fun',
-                                                    subject: 'more',
-                                                    trigger: 'new topic button'}),
-                 'subject');
-}());

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -24,10 +24,8 @@ var compose_actions = require('js/compose_actions.js');
 var start = compose_actions.start;
 var cancel = compose_actions.cancel;
 var get_focus_area = compose_actions._get_focus_area;
-var respond_to_message = global.compose.respond_to_message;
-var reply_with_mention = global.compose.reply_with_mention;
-
-set_global('compose_actions', compose_actions); // This is hacky--we'll fix in the next commit.
+var respond_to_message = compose_actions.respond_to_message;
+var reply_with_mention = compose_actions.reply_with_mention;
 
 set_global('reload', {
     is_in_progress: return_false,

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -1,0 +1,189 @@
+var noop = function () {};
+var return_false = function () { return false; };
+
+set_global('document', {
+    location: {
+    },
+});
+
+add_dependencies({
+    util: 'js/util',
+});
+
+set_global('page_params', {
+    use_websockets: false,
+});
+
+set_global('$', function () {
+});
+
+var compose = require('js/compose.js');
+
+var start = compose.start;
+var cancel = compose.cancel;
+
+set_global('reload', {
+    is_in_progress: return_false,
+});
+
+set_global('notifications', {
+    clear_compose_notifications: noop,
+});
+
+set_global('compose_fade', {
+    clear_compose: noop,
+});
+
+set_global('resize', {
+    resize_bottom_whitespace: noop,
+});
+
+set_global('narrow_state', {
+    set_compose_defaults: noop,
+});
+
+// these are shimmed in shim.js
+set_global('compose_state', {
+    composing: compose.composing,
+    recipient: compose.recipient,
+});
+
+set_global('status_classes', 'status_classes');
+
+var fake_jquery = function () {
+    var elems = {};
+
+    function new_elem(selector) {
+        var value;
+        var shown = false;
+        var self = {
+            val: function () {
+                if (arguments.length === 0) {
+                    return value || '';
+                }
+                value = arguments[0];
+            },
+            css: noop,
+            data: noop,
+            empty: noop,
+            height: noop,
+            removeAttr: noop,
+            removeData: noop,
+            trigger: noop,
+            show: function () {
+                shown = true;
+            },
+            hide: function () {
+                shown = false;
+            },
+            addClass: function (class_name) {
+                assert.equal(class_name, 'active');
+                shown = true;
+            },
+            removeClass: function (class_name) {
+                if (class_name === 'status_classes') {
+                    return self;
+                }
+                assert.equal(class_name, 'active');
+                shown = false;
+            },
+            debug: function () {
+                return {
+                    value: value,
+                    shown: shown,
+                    selector: selector,
+                };
+            },
+            visible: function () {
+                return shown;
+            },
+        };
+        return self;
+    }
+
+    var $ = function (selector) {
+        if (elems[selector] === undefined) {
+            var elem = new_elem(selector);
+            elems[selector] = elem;
+        }
+        return elems[selector];
+    };
+
+    $.trim = function (s) { return s; };
+
+    $.state = function () {
+        // useful for debugging
+        var res =  _.map(elems, function (v) {
+            return v.debug();
+        });
+
+        res = _.map(res, function (v) {
+            return [v.selector, v.value, v.shown];
+        });
+
+        res.sort();
+
+        return res;
+    };
+
+    $.Event = noop;
+
+    return $;
+};
+
+set_global('$', fake_jquery());
+var $ = global.$;
+
+function assert_visible(sel) {
+    assert($(sel).visible());
+}
+
+function assert_hidden(sel) {
+    assert(!$(sel).visible());
+}
+
+(function test_start() {
+    compose.autosize_message_content = noop;
+    compose.expand_compose_box = noop;
+    compose.set_focus = noop;
+    compose.complete_starting_tasks = noop;
+    compose.blur_textarea = noop;
+    compose.clear_textarea = noop;
+
+    // Start stream message
+    global.narrow_state.set_compose_defaults = function (opts) {
+        opts.stream = 'stream1';
+        opts.subject = 'topic1';
+    };
+
+    var opts = {};
+    start('stream', opts);
+
+    assert_visible('#stream-message');
+    assert_hidden('#private-message');
+
+    assert.equal($('#stream').val(), 'stream1');
+    assert.equal($('#subject').val(), 'topic1');
+
+    // Start PM
+    global.narrow_state.set_compose_defaults = function (opts) {
+        opts.private_message_recipient = 'foo@example.com';
+    };
+
+    opts = {
+        content: 'hello',
+    };
+    start('private', opts);
+
+    assert_hidden('#stream-message');
+    assert_visible('#private-message');
+
+    assert.equal($('#private_message_recipient').val(), 'foo@example.com');
+    assert.equal($('#new_message_content').val(), 'hello');
+
+    // Cancel compose.
+    assert_hidden('#compose_controls');
+    cancel();
+    assert_visible('#compose_controls');
+    assert_hidden('#private-message');
+}());

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -6,10 +6,6 @@ set_global('document', {
     },
 });
 
-add_dependencies({
-    util: 'js/util',
-});
-
 set_global('page_params', {
     use_websockets: false,
 });
@@ -17,10 +13,16 @@ set_global('page_params', {
 set_global('$', function () {
 });
 
-var compose = require('js/compose.js');
+add_dependencies({
+    compose: 'js/compose',
+    util: 'js/util',
+});
 
-var start = compose.start;
-var cancel = compose.cancel;
+var compose_actions = require('js/compose_actions.js');
+
+var start = compose_actions.start;
+var cancel = compose_actions.cancel;
+var get_focus_area = compose_actions._get_focus_area;
 
 set_global('reload', {
     is_in_progress: return_false,
@@ -44,8 +46,8 @@ set_global('narrow_state', {
 
 // these are shimmed in shim.js
 set_global('compose_state', {
-    composing: compose.composing,
-    recipient: compose.recipient,
+    composing: global.compose.composing,
+    recipient: global.compose.recipient,
 });
 
 set_global('status_classes', 'status_classes');
@@ -143,12 +145,12 @@ function assert_hidden(sel) {
 }
 
 (function test_start() {
-    compose.autosize_message_content = noop;
-    compose.expand_compose_box = noop;
-    compose.set_focus = noop;
-    compose.complete_starting_tasks = noop;
-    compose.blur_textarea = noop;
-    compose.clear_textarea = noop;
+    compose_actions.autosize_message_content = noop;
+    compose_actions.expand_compose_box = noop;
+    compose_actions.set_focus = noop;
+    compose_actions.complete_starting_tasks = noop;
+    compose_actions.blur_textarea = noop;
+    compose_actions.clear_textarea = noop;
 
     // Start stream message
     global.narrow_state.set_compose_defaults = function (opts) {
@@ -186,4 +188,21 @@ function assert_hidden(sel) {
     cancel();
     assert_visible('#compose_controls');
     assert_hidden('#private-message');
+}());
+
+
+(function test_get_focus_area() {
+    assert.equal(get_focus_area('private', {}), 'private_message_recipient');
+    assert.equal(get_focus_area('private', {
+        private_message_recipient: 'bob@example.com'}), 'new_message_content');
+    assert.equal(get_focus_area('stream', {}), 'stream');
+    assert.equal(get_focus_area('stream', {stream: 'fun'}),
+                 'subject');
+    assert.equal(get_focus_area('stream', {stream: 'fun',
+                                           subject: 'more'}),
+                 'new_message_content');
+    assert.equal(get_focus_area('stream', {stream: 'fun',
+                                           subject: 'more',
+                                           trigger: 'new topic button'}),
+                 'subject');
 }());

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -217,11 +217,11 @@ function stubbing(func_name_to_stub, test_function) {
 
     // TODO: Similar check for being in the subs page
 
-    assert_mapping('@', 'compose.reply_with_mention');
+    assert_mapping('@', 'compose_actions.reply_with_mention');
     assert_mapping('*', 'message_flags.toggle_starred');
     assert_mapping('+', 'reactions.toggle_reaction');
-    assert_mapping('r', 'compose.respond_to_message');
-    assert_mapping('R', 'compose.respond_to_message', true);
+    assert_mapping('r', 'compose_actions.respond_to_message');
+    assert_mapping('R', 'compose_actions.respond_to_message', true);
     assert_mapping('j', 'navigate.down');
     assert_mapping('J', 'navigate.page_down');
     assert_mapping('k', 'navigate.up');

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -57,7 +57,7 @@ $(function () {
             }
 
             current_msg_list.select_id(id);
-            compose.respond_to_message({trigger: 'message click'});
+            compose_actions.respond_to_message({trigger: 'message click'});
             e.stopPropagation();
             popovers.hide_all();
         }

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -313,14 +313,14 @@ exports.complete_starting_tasks = function (msg_type, opts) {
     resize.resize_bottom_whitespace();
 };
 
-function abort_xhr() {
+exports.abort_xhr = function () {
     $("#compose-send-button").removeAttr("disabled");
     var xhr = $("#compose").data("filedrop_xhr");
     if (xhr !== undefined) {
         xhr.abort();
         $("#compose").removeData("filedrop_xhr");
     }
-}
+};
 
 exports.cancel = function () {
     $("#new_message_content").height(40 + "px");
@@ -1141,7 +1141,7 @@ $(function () {
         $("#compose-send-button").attr("disabled", "");
         $("#send-status").addClass("alert-info")
                          .show();
-        $(".send-status-close").one('click', abort_xhr);
+        $(".send-status-close").one('click', exports.abort_xhr);
         $("#error-msg").html(
             $("<p>").text(i18n.t("Uploading…"))
                     .after('<div class="progress progress-striped active">' +

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -3,6 +3,10 @@ var compose = (function () {
 var exports = {};
 var is_composing_message = false;
 
+exports.set_message_type = function (msg_type) {
+    is_composing_message = msg_type;
+};
+
 /* Track the state of the @all warning. The user must acknowledge that they are spamming the entire
    stream before the warning will go away. If they try to send before explicitly dismissing the
    warning, they will get an error message too.
@@ -47,43 +51,6 @@ exports.autosize_textarea = function () {
     $("#new_message_content").trigger("autosize.resize");
 };
 
-// Show the compose box.
-function show_box(msg_type, opts) {
-    if (msg_type === "stream") {
-        $('#private-message').hide();
-        $('#stream-message').show();
-        $("#stream_toggle").addClass("active");
-        $("#private_message_toggle").removeClass("active");
-    } else {
-        $('#private-message').show();
-        $('#stream-message').hide();
-        $("#stream_toggle").removeClass("active");
-        $("#private_message_toggle").addClass("active");
-    }
-    $("#send-status").removeClass(status_classes).hide();
-    $('#compose').css({visibility: "visible"});
-    $(".new_message_textarea").css("min-height", "3em");
-
-    exports.set_focus(msg_type, opts);
-}
-
-exports.maybe_scroll_up_selected_message = function () {
-    // If the compose box is obscuring the currently selected message,
-    // scroll up until the message is no longer occluded.
-    if (current_msg_list.selected_id() === -1) {
-        // If there's no selected message, there's no need to
-        // scroll the compose box to avoid it.
-        return;
-    }
-    var selected_row = current_msg_list.selected_row();
-    var cover = selected_row.offset().top + selected_row.height()
-        - $("#compose").offset().top;
-    if (cover > 0) {
-        message_viewport.user_initiated_animate_scroll(cover+5);
-    }
-
-};
-
 function show_all_everyone_warnings() {
     var current_stream = stream_data.get_sub(compose.stream_name());
     var stream_count = current_stream.subscribers.num_items();
@@ -100,30 +67,20 @@ function show_all_everyone_warnings() {
     user_acknowledged_all_everyone = false;
 }
 
-function clear_all_everyone_warnings() {
+exports.clear_all_everyone_warnings = function () {
     $("#compose-all-everyone").hide();
     $("#compose-all-everyone").empty();
     $("#send-status").hide();
-}
-
-function clear_invites() {
-    $("#compose_invite_users").hide();
-    $("#compose_invite_users").empty();
-}
-
-exports.clear_textarea = function () {
-    $("#compose").find('input[type=text], textarea').val('');
 };
 
-function clear_box() {
-    clear_invites();
-    clear_all_everyone_warnings();
+exports.clear_invites = function () {
+    $("#compose_invite_users").hide();
+    $("#compose_invite_users").empty();
+};
+
+exports.reset_user_acknowledged_all_everyone_flag = function () {
     user_acknowledged_all_everyone = undefined;
-    exports.clear_textarea();
-    $("#new_message_content").removeData("draft-id");
-    exports.autosize_textarea();
-    $("#send-status").hide(0);
-}
+};
 
 exports.clear_preview_area = function () {
     $("#new_message_content").show();
@@ -131,46 +88,6 @@ exports.clear_preview_area = function () {
     $("#preview_message_area").hide();
     $("#preview_content").empty();
     $("#markdown_preview").show();
-};
-
-exports.blur_textarea = function () {
-    $('.message_comp').find('input, textarea, button').blur();
-};
-
-function hide_box() {
-    exports.blur_textarea();
-    $('#stream-message').hide();
-    $('#private-message').hide();
-    $(".new_message_textarea").css("min-height", "");
-    compose_fade.clear_compose();
-    $('.message_comp').hide();
-    $("#compose_controls").show();
-    exports.clear_preview_area();
-}
-
-function update_lock_icon_for_stream(stream_name) {
-    var icon = $("#compose-lock-icon");
-    var streamfield = $("#stream");
-    if (stream_data.get_invite_only(stream_name)) {
-        icon.show();
-        streamfield.addClass("lock-padding");
-    } else {
-        icon.hide();
-        streamfield.removeClass("lock-padding");
-    }
-}
-
-// In an attempt to decrease mixing, make the composebox's
-// stream bar look like what you're replying to.
-// (In particular, if there's a color associated with it,
-//  have that color be reflected here too.)
-exports.decorate_stream_bar = function (stream_name) {
-    var color = stream_data.get_color(stream_name);
-    update_lock_icon_for_stream(stream_name);
-    $("#stream-message .message_header_stream")
-        .css('background-color', color)
-        .removeClass(stream_color.color_classes)
-        .addClass(stream_color.get_color_class(color));
 };
 
 function update_fade() {
@@ -191,128 +108,6 @@ $(function () {
     });
 });
 
-function fill_in_opts_from_current_narrowed_view(msg_type, opts) {
-    var default_opts = {
-        message_type:     msg_type,
-        stream:           '',
-        subject:          '',
-        private_message_recipient: '',
-        trigger:          'unknown',
-    };
-
-    // Set default parameters based on the current narrowed view.
-    narrow_state.set_compose_defaults(default_opts);
-    opts = _.extend(default_opts, opts);
-    return opts;
-}
-
-function same_recipient_as_before(msg_type, opts) {
-    return (compose_state.composing() === msg_type) &&
-            ((msg_type === "stream" &&
-              opts.stream === compose.stream_name() &&
-              opts.subject === compose.subject()) ||
-             (msg_type === "private" &&
-              opts.private_message_recipient === compose_state.recipient()));
-}
-
-function get_focus_area(msg_type, opts) {
-    // Set focus to "Topic" when narrowed to a stream+topic and "New topic" button clicked.
-    if (msg_type === 'stream' && opts.stream && ! opts.subject) {
-        return 'subject';
-    } else if ((msg_type === 'stream' && opts.stream)
-               || (msg_type === 'private' && opts.private_message_recipient)) {
-        if (opts.trigger === "new topic button") {
-            return 'subject';
-        }
-        return 'new_message_content';
-    }
-
-    if (msg_type === 'stream') {
-        return 'stream';
-    }
-    return 'private_message_recipient';
-}
-// Export for testing
-exports._get_focus_area = get_focus_area;
-
-exports.set_focus = function (msg_type, opts) {
-    var focus_area = get_focus_area(msg_type, opts);
-    if (focus_area === undefined) {
-        return;
-    }
-
-    if (window.getSelection().toString() === "" ||
-         opts.trigger !== "message click") {
-        var elt = $('#' + focus_area);
-        elt.focus().select();
-    }
-};
-
-exports.autosize_message_content = function () {
-    $("#new_message_content").autosize();
-};
-
-exports.expand_compose_box = function () {
-    $("#compose_close").show();
-    $("#compose_controls").hide();
-    $('.message_comp').show();
-};
-
-exports.start = function (msg_type, opts) {
-    exports.autosize_message_content();
-
-    if (reload.is_in_progress()) {
-        return;
-    }
-    notifications.clear_compose_notifications();
-    exports.expand_compose_box();
-
-    opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
-    // If we are invoked by a compose hotkey (c or C), do not assume that we know
-    // what the message's topic or PM recipient should be.
-    if (opts.trigger === "compose_hotkey") {
-        opts.subject = '';
-        opts.private_message_recipient = '';
-    }
-
-    if (compose_state.composing() && !same_recipient_as_before(msg_type, opts)) {
-        // Clear the compose box if the existing message is to a different recipient
-        clear_box();
-    }
-
-    compose.stream_name(opts.stream);
-    compose.subject(opts.subject);
-
-    // Set the recipients with a space after each comma, so it looks nice.
-    compose_state.recipient(opts.private_message_recipient.replace(/,\s*/g, ", "));
-
-    // If the user opens the compose box, types some text, and then clicks on a
-    // different stream/subject, we want to keep the text in the compose box
-    if (opts.content !== undefined) {
-        compose.message_content(opts.content);
-    }
-
-    is_composing_message = msg_type;
-
-    // Show either stream/topic fields or "You and" field.
-    show_box(msg_type, opts);
-
-    exports.complete_starting_tasks(msg_type, opts);
-};
-
-exports.complete_starting_tasks = function (msg_type, opts) {
-    // This is sort of a kitchen sink function, and it's called only
-    // by compose.start() for now.  Having this as a separate function
-    // makes testing a bit easier.
-
-    exports.maybe_scroll_up_selected_message();
-    ui_util.change_tab_to("#home");
-    compose_fade.start_compose(msg_type);
-    exports.decorate_stream_bar(opts.stream);
-    $(document).trigger($.Event('compose_started.zulip', opts));
-    resize.resize_bottom_whitespace();
-};
-
 exports.abort_xhr = function () {
     $("#compose-send-button").removeAttr("disabled");
     var xhr = $("#compose").data("filedrop_xhr");
@@ -320,30 +115,6 @@ exports.abort_xhr = function () {
         xhr.abort();
         $("#compose").removeData("filedrop_xhr");
     }
-};
-
-exports.cancel = function () {
-    $("#new_message_content").height(40 + "px");
-
-    if (page_params.narrow !== undefined) {
-        // Never close the compose box in narrow embedded windows, but
-        // at least clear the subject and unfade.
-        compose_fade.clear_compose();
-        if (page_params.narrow_topic !== undefined) {
-            compose.subject(page_params.narrow_topic);
-        } else {
-            compose.subject("");
-        }
-        return;
-    }
-    hide_box();
-    $("#compose_close").hide();
-    resize.resize_bottom_whitespace();
-    clear_box();
-    notifications.clear_compose_notifications();
-    abort_xhr();
-    is_composing_message = false;
-    $(document).trigger($.Event('compose_canceled.zulip'));
 };
 
 exports.empty_topic_placeholder = function () {
@@ -698,7 +469,7 @@ exports.test_send_many_messages = function (stream, subject, count) {
 };
 
 exports.finish = function () {
-    clear_invites();
+    exports.clear_invites();
 
     if (! compose.validate()) {
         return false;
@@ -811,7 +582,7 @@ function validate_stream_message_mentions(stream_name) {
         }
     } else {
         // the message no longer contains @all or @everyone
-        clear_all_everyone_warnings();
+        exports.clear_all_everyone_warnings();
     }
     // at this point, the user has either acknowledged the warning or removed @all / @everyone
     user_acknowledged_all_everyone = undefined;
@@ -1006,7 +777,7 @@ $(function () {
 
         $(event.target).parents('.compose-all-everyone').remove();
         user_acknowledged_all_everyone = true;
-        clear_all_everyone_warnings();
+        exports.clear_all_everyone_warnings();
         compose.finish();
     });
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -133,8 +133,12 @@ function clear_preview_area() {
     $("#markdown_preview").show();
 }
 
-function hide_box() {
+exports.blur_textarea = function () {
     $('.message_comp').find('input, textarea, button').blur();
+};
+
+function hide_box() {
+    exports.blur_textarea();
     $('#stream-message').hide();
     $('#private-message').hide();
     $(".new_message_textarea").css("min-height", "");

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -111,11 +111,15 @@ function clear_invites() {
     $("#compose_invite_users").empty();
 }
 
+exports.clear_textarea = function () {
+    $("#compose").find('input[type=text], textarea').val('');
+};
+
 function clear_box() {
     clear_invites();
     clear_all_everyone_warnings();
     user_acknowledged_all_everyone = undefined;
-    $("#compose").find('input[type=text], textarea').val('');
+    exports.clear_textarea();
     $("#new_message_content").removeData("draft-id");
     exports.autosize_textarea();
     $("#send-status").hide(0);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -125,13 +125,13 @@ function clear_box() {
     $("#send-status").hide(0);
 }
 
-function clear_preview_area() {
+exports.clear_preview_area = function () {
     $("#new_message_content").show();
     $("#undo_markdown_preview").hide();
     $("#preview_message_area").hide();
     $("#preview_content").empty();
     $("#markdown_preview").show();
-}
+};
 
 exports.blur_textarea = function () {
     $('.message_comp').find('input, textarea, button').blur();
@@ -145,7 +145,7 @@ function hide_box() {
     compose_fade.clear_compose();
     $('.message_comp').hide();
     $("#compose_controls").show();
-    clear_preview_area();
+    exports.clear_preview_area();
 }
 
 function update_lock_icon_for_stream(stream_name) {
@@ -608,7 +608,7 @@ function send_message(request) {
 }
 
 exports.enter_with_preview_open = function () {
-    clear_preview_area();
+    exports.clear_preview_area();
     if (page_params.enter_sends) {
         // If enter_sends is enabled, we just send the message
         send_message();
@@ -704,7 +704,7 @@ exports.finish = function () {
         return false;
     }
     send_message();
-    clear_preview_area();
+    exports.clear_preview_area();
     // TODO: Do we want to fire the event even if the send failed due
     // to a server-side error?
     $(document).trigger($.Event('compose_finished.zulip'));
@@ -1116,7 +1116,7 @@ $(function () {
 
     $("#compose").on("click", "#undo_markdown_preview", function (e) {
         e.preventDefault();
-        clear_preview_area();
+        exports.clear_preview_area();
     });
 
     $("#compose").on("click", "#attach_dropbox_files", function (e) {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -389,58 +389,6 @@ exports.enter_with_preview_open = function () {
     }
 };
 
-exports.respond_to_message = function (opts) {
-    var message;
-    var msg_type;
-    // Before initiating a reply to a message, if there's an
-    // in-progress composition, snapshot it.
-    drafts.update_draft();
-
-    message = current_msg_list.selected_message();
-
-    if (message === undefined) {
-        return;
-    }
-
-    unread_ops.mark_message_as_read(message);
-
-    var stream = '';
-    var subject = '';
-    if (message.type === "stream") {
-        stream = message.stream;
-        subject = message.subject;
-    }
-
-    var pm_recipient = message.reply_to;
-    if (message.type === "private") {
-        if (opts.reply_type === "personal") {
-            // reply_to for private messages is everyone involved, so for
-            // personals replies we need to set the private message
-            // recipient to just the sender
-            pm_recipient = people.get_person_from_user_id(message.sender_id).email;
-        } else {
-            pm_recipient = people.pm_reply_to(message);
-        }
-    }
-    if (opts.reply_type === 'personal' || message.type === 'private') {
-        msg_type = 'private';
-    } else {
-        msg_type = message.type;
-    }
-    compose_actions.start(msg_type, {stream: stream, subject: subject,
-                             private_message_recipient: pm_recipient,
-                             replying_to_message: message,
-                             trigger: opts.trigger});
-
-};
-
-exports.reply_with_mention = function (opts) {
-    exports.respond_to_message(opts);
-    var message = current_msg_list.selected_message();
-    var mention = '@**' + message.sender_full_name + '**';
-    $('#new_message_content').val(mention + ' ');
-};
-
 // This function is for debugging / data collection only.  Arguably it
 // should live in debug.js, but then it wouldn't be able to call
 // send_message() directly below.

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -1,0 +1,252 @@
+var compose_actions = (function () {
+
+var exports = {};
+
+function update_lock_icon_for_stream(stream_name) {
+    var icon = $("#compose-lock-icon");
+    var streamfield = $("#stream");
+    if (stream_data.get_invite_only(stream_name)) {
+        icon.show();
+        streamfield.addClass("lock-padding");
+    } else {
+        icon.hide();
+        streamfield.removeClass("lock-padding");
+    }
+}
+
+exports.blur_textarea = function () {
+    $('.message_comp').find('input, textarea, button').blur();
+};
+
+function hide_box() {
+    exports.blur_textarea();
+    $('#stream-message').hide();
+    $('#private-message').hide();
+    $(".new_message_textarea").css("min-height", "");
+    compose_fade.clear_compose();
+    $('.message_comp').hide();
+    $("#compose_controls").show();
+    compose.clear_preview_area();
+}
+
+function get_focus_area(msg_type, opts) {
+    // Set focus to "Topic" when narrowed to a stream+topic and "New topic" button clicked.
+    if (msg_type === 'stream' && opts.stream && ! opts.subject) {
+        return 'subject';
+    } else if ((msg_type === 'stream' && opts.stream)
+               || (msg_type === 'private' && opts.private_message_recipient)) {
+        if (opts.trigger === "new topic button") {
+            return 'subject';
+        }
+        return 'new_message_content';
+    }
+
+    if (msg_type === 'stream') {
+        return 'stream';
+    }
+    return 'private_message_recipient';
+}
+// Export for testing
+exports._get_focus_area = get_focus_area;
+
+exports.set_focus = function (msg_type, opts) {
+    var focus_area = get_focus_area(msg_type, opts);
+    if (focus_area === undefined) {
+        return;
+    }
+
+    if (window.getSelection().toString() === "" ||
+         opts.trigger !== "message click") {
+        var elt = $('#' + focus_area);
+        elt.focus().select();
+    }
+};
+
+
+// Show the compose box.
+function show_box(msg_type, opts) {
+    if (msg_type === "stream") {
+        $('#private-message').hide();
+        $('#stream-message').show();
+        $("#stream_toggle").addClass("active");
+        $("#private_message_toggle").removeClass("active");
+    } else {
+        $('#private-message').show();
+        $('#stream-message').hide();
+        $("#stream_toggle").removeClass("active");
+        $("#private_message_toggle").addClass("active");
+    }
+    $("#send-status").removeClass(status_classes).hide();
+    $('#compose').css({visibility: "visible"});
+    $(".new_message_textarea").css("min-height", "3em");
+
+    exports.set_focus(msg_type, opts);
+}
+
+exports.clear_textarea = function () {
+    $("#compose").find('input[type=text], textarea').val('');
+};
+
+function clear_box() {
+    compose.clear_invites();
+
+    // TODO: Better encapsulate at-mention warnings.
+    compose.clear_all_everyone_warnings();
+    compose.reset_user_acknowledged_all_everyone_flag();
+
+    exports.clear_textarea();
+    $("#new_message_content").removeData("draft-id");
+    compose.autosize_textarea();
+    $("#send-status").hide(0);
+}
+
+exports.autosize_message_content = function () {
+    $("#new_message_content").autosize();
+};
+
+exports.expand_compose_box = function () {
+    $("#compose_close").show();
+    $("#compose_controls").hide();
+    $('.message_comp').show();
+};
+
+exports.complete_starting_tasks = function (msg_type, opts) {
+    // This is sort of a kitchen sink function, and it's called only
+    // by compose.start() for now.  Having this as a separate function
+    // makes testing a bit easier.
+
+    exports.maybe_scroll_up_selected_message();
+    ui_util.change_tab_to("#home");
+    compose_fade.start_compose(msg_type);
+    exports.decorate_stream_bar(opts.stream);
+    $(document).trigger($.Event('compose_started.zulip', opts));
+    resize.resize_bottom_whitespace();
+};
+
+// In an attempt to decrease mixing, make the composebox's
+// stream bar look like what you're replying to.
+// (In particular, if there's a color associated with it,
+//  have that color be reflected here too.)
+exports.decorate_stream_bar = function (stream_name) {
+    var color = stream_data.get_color(stream_name);
+    update_lock_icon_for_stream(stream_name);
+    $("#stream-message .message_header_stream")
+        .css('background-color', color)
+        .removeClass(stream_color.color_classes)
+        .addClass(stream_color.get_color_class(color));
+};
+
+exports.maybe_scroll_up_selected_message = function () {
+    // If the compose box is obscuring the currently selected message,
+    // scroll up until the message is no longer occluded.
+    if (current_msg_list.selected_id() === -1) {
+        // If there's no selected message, there's no need to
+        // scroll the compose box to avoid it.
+        return;
+    }
+    var selected_row = current_msg_list.selected_row();
+    var cover = selected_row.offset().top + selected_row.height()
+        - $("#compose").offset().top;
+    if (cover > 0) {
+        message_viewport.user_initiated_animate_scroll(cover+5);
+    }
+
+};
+
+function fill_in_opts_from_current_narrowed_view(msg_type, opts) {
+    var default_opts = {
+        message_type:     msg_type,
+        stream:           '',
+        subject:          '',
+        private_message_recipient: '',
+        trigger:          'unknown',
+    };
+
+    // Set default parameters based on the current narrowed view.
+    narrow_state.set_compose_defaults(default_opts);
+    opts = _.extend(default_opts, opts);
+    return opts;
+}
+
+function same_recipient_as_before(msg_type, opts) {
+    return (compose_state.composing() === msg_type) &&
+            ((msg_type === "stream" &&
+              opts.stream === compose.stream_name() &&
+              opts.subject === compose.subject()) ||
+             (msg_type === "private" &&
+              opts.private_message_recipient === compose_state.recipient()));
+}
+
+exports.start = function (msg_type, opts) {
+    exports.autosize_message_content();
+
+    if (reload.is_in_progress()) {
+        return;
+    }
+    notifications.clear_compose_notifications();
+    exports.expand_compose_box();
+
+    opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
+    // If we are invoked by a compose hotkey (c or C), do not assume that we know
+    // what the message's topic or PM recipient should be.
+    if (opts.trigger === "compose_hotkey") {
+        opts.subject = '';
+        opts.private_message_recipient = '';
+    }
+
+    if (compose_state.composing() && !same_recipient_as_before(msg_type, opts)) {
+        // Clear the compose box if the existing message is to a different recipient
+        clear_box();
+    }
+
+    compose.stream_name(opts.stream);
+    compose.subject(opts.subject);
+
+    // Set the recipients with a space after each comma, so it looks nice.
+    compose_state.recipient(opts.private_message_recipient.replace(/,\s*/g, ", "));
+
+    // If the user opens the compose box, types some text, and then clicks on a
+    // different stream/subject, we want to keep the text in the compose box
+    if (opts.content !== undefined) {
+        compose.message_content(opts.content);
+    }
+
+    compose.set_message_type(msg_type);
+
+    // Show either stream/topic fields or "You and" field.
+    show_box(msg_type, opts);
+
+    exports.complete_starting_tasks(msg_type, opts);
+};
+
+exports.cancel = function () {
+    $("#new_message_content").height(40 + "px");
+
+    if (page_params.narrow !== undefined) {
+        // Never close the compose box in narrow embedded windows, but
+        // at least clear the subject and unfade.
+        compose_fade.clear_compose();
+        if (page_params.narrow_topic !== undefined) {
+            compose.subject(page_params.narrow_topic);
+        } else {
+            compose.subject("");
+        }
+        return;
+    }
+    hide_box();
+    $("#compose_close").hide();
+    resize.resize_bottom_whitespace();
+    clear_box();
+    notifications.clear_compose_notifications();
+    compose.abort_xhr();
+    compose.set_message_type(false);
+    $(document).trigger($.Event('compose_canceled.zulip'));
+};
+
+
+return exports;
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = compose_actions;
+}

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -355,7 +355,7 @@ exports.process_enter_key = function (e) {
     // view and there is a "current" message, so in that case
     // "enter" is the hotkey to respond to a message.  Note that
     // "r" has same effect, but that is handled in process_hotkey().
-    compose.respond_to_message({trigger: 'hotkey enter'});
+    compose_actions.respond_to_message({trigger: 'hotkey enter'});
     return true;
 };
 
@@ -648,13 +648,13 @@ exports.process_hotkey = function (e, hotkey) {
         case 'reply_message': // 'r': respond to message
             // Note that you can "enter" to respond to messages as well,
             // but that is handled in process_enter_key().
-            compose.respond_to_message({trigger: 'hotkey'});
+            compose_actions.respond_to_message({trigger: 'hotkey'});
             return true;
         case 'respond_to_author': // 'R': respond to author
-            compose.respond_to_message({reply_type: "personal", trigger: 'hotkey pm'});
+            compose_actions.respond_to_message({reply_type: "personal", trigger: 'hotkey pm'});
             return true;
         case 'compose_reply_with_mention': // '@': respond to message with mention to author
-            compose.reply_with_mention({trigger: 'hotkey'});
+            compose_actions.reply_with_mention({trigger: 'hotkey'});
             return true;
         case 'show_lightbox':
             lightbox.show_from_selected_message();

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -583,7 +583,7 @@ exports.register_click_handlers = function () {
     });
 
     $('body').on('click', '.sender_info_popover .mention_user', function (e) {
-        compose.respond_to_message({trigger: 'user sidebar popover'});
+        compose_actions.respond_to_message({trigger: 'user sidebar popover'});
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var name = people.get_person_from_user_id(user_id).full_name;
         var textarea = $("#new_message_content");
@@ -645,7 +645,7 @@ exports.register_click_handlers = function () {
         var textarea = $("#new_message_content");
         var msgid = $(e.currentTarget).data("message-id");
 
-        compose.respond_to_message({trigger: 'popover respond'});
+        compose_actions.respond_to_message({trigger: 'popover respond'});
         channel.get({
             url: '/json/messages/' + msgid,
             idempotent: true,
@@ -663,7 +663,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
     $('body').on('click', '.respond_personal_button', function (e) {
-        compose.respond_to_message({reply_type: 'personal', trigger: 'popover respond pm'});
+        compose_actions.respond_to_message({reply_type: 'personal', trigger: 'popover respond pm'});
         popovers.hide_all();
         e.stopPropagation();
         e.preventDefault();

--- a/static/js/shim.js
+++ b/static/js/shim.js
@@ -9,10 +9,6 @@ that still refer to the old name.
 var narrow_state = {}; // global, should be made into module
 narrow_state.set_compose_defaults = narrow.set_compose_defaults;
 
-var compose_actions = {};
-compose_actions.start = compose.start;
-compose_actions.cancel = compose.cancel;
-
 var compose_state = {};
 compose_state.has_message_content = compose.has_message_content;
 compose_state.recipient = compose.recipient;

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -145,7 +145,7 @@ $(function () {
         $(this).removeClass("active");
     });
 
-    $("#stream").on('blur', function () { compose.decorate_stream_bar(this.value); });
+    $("#stream").on('blur', function () { compose_actions.decorate_stream_bar(this.value); });
 
     $(window).on('blur', function () {
         $(document.body).addClass('window_blurred');

--- a/tools/js-dep-visualizer.py
+++ b/tools/js-dep-visualizer.py
@@ -171,6 +171,8 @@ def find_edges_to_remove(graph, methods):
         ('activity', 'narrow'),
         ('compose', 'compose_actions'),
         ('compose', 'subs'),
+        ('compose_actions', 'drafts'),
+        ('compose_actions', 'unread_ops'),
         ('drafts', 'compose'),
         ('drafts', 'echo'),
         ('echo', 'compose'),

--- a/tools/js-dep-visualizer.py
+++ b/tools/js-dep-visualizer.py
@@ -133,6 +133,8 @@ def find_edges_to_remove(graph, methods):
         ('ui', 'message_fetch'),
         ('ui', 'unread_ops'),
         ('condense', 'message_viewport'),
+        ('compose_actions', 'compose'),
+        ('compose_actions', 'resize'),
     ] # type: List[Edge]
 
     def is_exempt(edge):
@@ -167,6 +169,7 @@ def find_edges_to_remove(graph, methods):
         ('message_fetch', 'tutorial'),
         ('settings', 'subs'),
         ('activity', 'narrow'),
+        ('compose', 'compose_actions'),
         ('compose', 'subs'),
         ('drafts', 'compose'),
         ('drafts', 'echo'),
@@ -209,7 +212,8 @@ def find_edges_to_remove(graph, methods):
     def cut_is_legal(edge):
         # type: (Edge) -> bool
         parent, child = edge
-        if child in ['reload', 'popovers', 'modals', 'notifications', 'server_events']:
+        if child in ['reload', 'popovers', 'modals', 'notifications',
+                     'server_events', 'compose_actions']:
             return True
         return edge in APPROVED_CUTS
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -850,6 +850,7 @@ JS_SPECS = {
             'js/fenced_code.js',
             'js/echo.js',
             'js/socket.js',
+            'js/compose_actions.js',
             'js/compose.js',
             'js/stream_color.js',
             'js/stream_data.js',


### PR DESCRIPTION
This PR removes the compose_actions shims by actually extracting out the module.

If this get merged, we will only have one JS module with >= 1000 lines!  (You can probably guess which one it is.)

I added some unit tests for compose.start and friends.  There's not 100% coverage, and there are lots of stubs, but the tests exercise the basics.

