### PR TITLE
Extract compose_state.js.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -11,16 +11,13 @@ set_global('document', {
 });
 
 add_dependencies({
+    compose_state: 'js/compose_state',
     people: 'js/people',
     stream_data: 'js/stream_data',
     util: 'js/util',
 });
 
 var compose = require('js/compose.js');
-
-set_global('compose_state', {
-    recipient: compose.recipient,
-});
 
 var me = {
     email: 'me@example.com',

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -102,16 +102,16 @@ var draft_2 = {
         global.compose_state.composing = function () {
             return draft.type;
         };
-        global.compose.message_content = function () {
+        global.compose_state.message_content = function () {
             return draft.content;
         };
         global.compose_state.recipient = function () {
             return draft.private_message_recipient;
         };
-        global.compose.stream_name = function () {
+        global.compose_state.stream_name = function () {
             return draft.stream;
         };
-        global.compose.subject = function () {
+        global.compose_state.subject = function () {
             return draft.subject;
         };
     }

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -171,8 +171,8 @@ function fill_in_opts_from_current_narrowed_view(msg_type, opts) {
 function same_recipient_as_before(msg_type, opts) {
     return (compose_state.composing() === msg_type) &&
             ((msg_type === "stream" &&
-              opts.stream === compose.stream_name() &&
-              opts.subject === compose.subject()) ||
+              opts.stream === compose_state.stream_name() &&
+              opts.subject === compose_state.subject()) ||
              (msg_type === "private" &&
               opts.private_message_recipient === compose_state.recipient()));
 }
@@ -199,8 +199,8 @@ exports.start = function (msg_type, opts) {
         clear_box();
     }
 
-    compose.stream_name(opts.stream);
-    compose.subject(opts.subject);
+    compose_state.stream_name(opts.stream);
+    compose_state.subject(opts.subject);
 
     // Set the recipients with a space after each comma, so it looks nice.
     compose_state.recipient(opts.private_message_recipient.replace(/,\s*/g, ", "));
@@ -208,10 +208,10 @@ exports.start = function (msg_type, opts) {
     // If the user opens the compose box, types some text, and then clicks on a
     // different stream/subject, we want to keep the text in the compose box
     if (opts.content !== undefined) {
-        compose.message_content(opts.content);
+        compose_state.message_content(opts.content);
     }
 
-    compose.set_message_type(msg_type);
+    compose_state.set_message_type(msg_type);
 
     // Show either stream/topic fields or "You and" field.
     show_box(msg_type, opts);
@@ -227,9 +227,9 @@ exports.cancel = function () {
         // at least clear the subject and unfade.
         compose_fade.clear_compose();
         if (page_params.narrow_topic !== undefined) {
-            compose.subject(page_params.narrow_topic);
+            compose_state.subject(page_params.narrow_topic);
         } else {
-            compose.subject("");
+            compose_state.subject("");
         }
         return;
     }
@@ -239,7 +239,7 @@ exports.cancel = function () {
     clear_box();
     notifications.clear_compose_notifications();
     compose.abort_xhr();
-    compose.set_message_type(false);
+    compose_state.set_message_type(false);
     $(document).trigger($.Event('compose_canceled.zulip'));
 };
 

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -1,0 +1,57 @@
+var compose_state = (function () {
+
+var exports = {};
+
+var message_type = false; // 'stream', 'private', or false-y
+
+exports.set_message_type = function (msg_type) {
+    message_type = msg_type;
+};
+
+exports.get_message_type = function () {
+    return message_type;
+};
+
+exports.composing = function () {
+    // For legacy reasons, this is the same as get_message_type.
+    // Most callers use this in a boolean context, but there are
+    // some stragglers that inspect the string value.
+    //
+    // TODO: Fix callers who care about stream/private to use
+    //       get_message_type(), and then convert this to return
+    //       `!!message_type` or something like that.
+    return message_type;
+};
+
+function get_or_set(fieldname, keep_leading_whitespace) {
+    // We can't hoist the assignment of 'elem' out of this lambda,
+    // because the DOM element might not exist yet when get_or_set
+    // is called.
+    return function (newval) {
+        var elem = $('#'+fieldname);
+        var oldval = elem.val();
+        if (newval !== undefined) {
+            elem.val(newval);
+        }
+        return keep_leading_whitespace ? util.rtrim(oldval) : $.trim(oldval);
+    };
+}
+
+// TODO: Break out setters and getter into their own functions.
+exports.stream_name     = get_or_set('stream');
+exports.subject         = get_or_set('subject');
+// We can't trim leading whitespace in `new_message_content` because
+// of the indented syntax for multi-line code blocks.
+exports.message_content = get_or_set('new_message_content', true);
+exports.recipient       = get_or_set('private_message_recipient');
+
+exports.has_message_content = function () {
+    return exports.message_content() !== "";
+};
+
+return exports;
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = compose_state;
+}

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -359,7 +359,8 @@ exports.initialize_compose_typeahead = function (selector, completions) {
             if (this.completing === 'emoji') {
                 return typeahead_helper.sort_emojis(matches, this.token);
             } else if (this.completing === 'mention') {
-                return typeahead_helper.sort_recipients(matches, this.token, compose.stream_name());
+                return typeahead_helper.sort_recipients(matches, this.token,
+                                                        compose_state.stream_name());
             } else if (this.completing === 'stream') {
                 return typeahead_helper.sort_streams(matches, this.token);
             }
@@ -468,7 +469,7 @@ exports.initialize = function () {
             return query_matches_person(current_recipient, item);
         },
         sorter: function (matches) {
-            var current_stream = compose.stream_name();
+            var current_stream = compose_state.stream_name();
             return typeahead_helper.sort_recipientbox_typeahead(
                 this.query, matches, current_stream);
         },

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -64,7 +64,7 @@ var draft_model = (function () {
 exports.draft_model = draft_model;
 
 exports.snapshot_message = function () {
-    if (!compose_state.composing() || (compose.message_content() === "")) {
+    if (!compose_state.composing() || (compose_state.message_content() === "")) {
         // If you aren't in the middle of composing the body of a
         // message, don't try to snapshot.
         return;
@@ -73,15 +73,15 @@ exports.snapshot_message = function () {
     // Save what we can.
     var message = {
         type: compose_state.composing(),
-        content: compose.message_content(),
+        content: compose_state.message_content(),
     };
     if (message.type === "private") {
         var recipient = compose_state.recipient();
         message.reply_to = recipient;
         message.private_message_recipient = recipient;
     } else {
-        message.stream = compose.stream_name();
-        message.subject = compose.subject();
+        message.stream = compose_state.stream_name();
+        message.subject = compose_state.subject();
     }
     return message;
 };

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -11,7 +11,7 @@ function do_narrow_action(action) {
 function focus_in_empty_compose() {
     return (
         compose_state.composing() &&
-        compose.message_content() === "" &&
+        compose_state.message_content() === "" &&
         $('#new_message_content').is(':focus'));
 }
 

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -143,12 +143,12 @@ exports.update_messages = function update_messages(events) {
             var going_forward_change = _.indexOf(['change_later', 'change_all'], event.propagate_mode) >= 0;
 
             var stream_name = stream_data.get_sub_by_id(event.stream_id).name;
-            var compose_stream_name = compose.stream_name();
+            var compose_stream_name = compose_state.stream_name();
 
             if (going_forward_change && stream_name && compose_stream_name) {
                 if (stream_name.toLowerCase() === compose_stream_name.toLowerCase()) {
-                    if (event.orig_subject === compose.subject()) {
-                        compose.subject(event.subject);
+                    if (event.orig_subject === compose_state.subject()) {
+                        compose_state.subject(event.subject);
                     }
                 }
             }

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -24,15 +24,15 @@ function preserve_state(send_after_reload, save_pointer, save_narrow, save_compo
     if (save_compose) {
         if (compose_state.composing() === 'stream') {
             url += "+msg_type=stream";
-            url += "+stream=" + encodeURIComponent(compose.stream_name());
-            url += "+subject=" + encodeURIComponent(compose.subject());
+            url += "+stream=" + encodeURIComponent(compose_state.stream_name());
+            url += "+subject=" + encodeURIComponent(compose_state.subject());
         } else if (compose_state.composing() === 'private') {
             url += "+msg_type=private";
             url += "+recipient=" + encodeURIComponent(compose_state.recipient());
         }
 
         if (compose_state.composing()) {
-            url += "+msg=" + encodeURIComponent(compose.message_content());
+            url += "+msg=" + encodeURIComponent(compose_state.message_content());
         }
     }
 

--- a/static/js/shim.js
+++ b/static/js/shim.js
@@ -9,8 +9,3 @@ that still refer to the old name.
 var narrow_state = {}; // global, should be made into module
 narrow_state.set_compose_defaults = narrow.set_compose_defaults;
 
-var compose_state = {};
-compose_state.has_message_content = compose.has_message_content;
-compose_state.recipient = compose.recipient;
-compose_state.composing = compose.composing;
-

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -349,7 +349,7 @@ function show_subscription_settings(sub_row) {
                 (item.full_name.toLowerCase().indexOf(query) !== -1);
         },
         sorter: function (matches) {
-            var current_stream = compose.stream_name();
+            var current_stream = compose_state.stream_name();
             return typeahead_helper.sort_recipientbox_typeahead(
                 this.query, matches, current_stream);
         },

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -852,6 +852,7 @@ JS_SPECS = {
             'js/fenced_code.js',
             'js/echo.js',
             'js/socket.js',
+            'js/compose_state.js',
             'js/compose_actions.js',
             'js/compose.js',
             'js/stream_color.js',


### PR DESCRIPTION
This is mostly just moving methods out of compose.js.

The variable `is_composing_message`, which isn't a boolean, has
been renamed to `message_type`, and there are new functions
set_message_type() and get_message_type() that wrap it.

This commit removes some shims related to the global variable
`compose_state`; now, `compose_state` is a typical global
variable with a 1:1 relationship with the module by the same
name.

The new module has 100% line coverage, most of it coming
via the tests on compose_actions.js.  (The methods here are
super simple, so it's a good thing that the tests are somewhat
integrated with a higher layer.)