### PR TITLE
Fix reactions addition feature broken with /me messages.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1195,6 +1195,10 @@ div.focused_table {
     position: relative;
 }
 
+.message_content:empty {
+    display: none;
+}
+
 .message_edit_content {
     line-height: 18px;
 }


### PR DESCRIPTION
It was broken because the `message_content` div was overlapping the `message_reactions` div which was causing it hard to interact reactions.

Fixes: #4218.