### PR TITLE
Remove spaces between file types in editorconfig list

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{sh,py,js, json,yml,xml, css, md,markdown, handlebars,html}]
+[*.{sh,py,js,json,yml,xml,css,md,markdown,handlebars,html}]
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
This makes some EditorConfig plugins not work. (At least the Emacs one wasn't
working)