### PR TITLE
email-mirror: Move postfix email mirror integration to separate script.

### DIFF
--- a/puppet/zulip/files/postfix/master.cf
+++ b/puppet/zulip/files/postfix/master.cf
@@ -111,4 +111,4 @@ mailman   unix  -       n       n       -       -       pipe
   flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
   ${nexthop} ${user}
 zulip unix  -       n       n       -       -       pipe
-  flags= user=zulip argv=/home/zulip/deployments/current/manage.py email_mirror ${original_recipient}
+  flags= user=zulip argv=/home/zulip/deployments/current/scripts/email-mirror-postfix -r ${original_recipient}

--- a/scripts/email-mirror-postfix
+++ b/scripts/email-mirror-postfix
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+"""
+Forward messages sent to the configured email gateway to Zulip.
+
+For zulip.com, messages to that address go to the Inbox of emailgateway@zulip.com.
+Zulip voyager configurations will differ.
+
+Messages meant for Zulip have a special recipient form of
+
+    <stream name>+<regenerable stream token>@streams.zulip.com
+
+This pattern is configurable via the EMAIL_GATEWAY_PATTERN settings.py
+variable.
+
+Configure your MTA to execute this script on message
+receipt with the contents of the message piped to standard input. The
+script will queue the message for processing. In this mode of invocation,
+you should pass the destination email address in the ORIGINAL_RECIPIENT
+environment variable.
+
+In Postfix, you can express that via an /etc/aliases entry like this:
+ |/home/zulip/deployments/current/scripts/email-mirror-postfix -r ${original_recipient}
+
+Also you can use optional keys to configure the script and change default values:
+
+-s SHARED_SECRET    For adding shared secret key if it is not contained in
+                    "/etc/zulip/zulip-secrets.conf".
+
+-d HOST             Destination Zulip host for email uploading. Address must contain type of
+                    HTTP protocol, i.e "https://example.com". Default value: "https://127.0.0.1".
+
+-u URL             Destination relative for email uploading. Default value: "/email_mirror_message".
+
+-n                  Disable checking ssl certificate. This option is used for
+                    self-signed certificates. Default value: False.
+
+-t                  Disable sending request to the Zulip server. Default value: False.
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import sys
+
+from optparse import OptionParser
+from os.path import dirname, abspath
+
+BASE_DIR = dirname(dirname(abspath(__file__)))
+sys.path.append(BASE_DIR)
+import scripts.lib.setup_path_on_import
+
+import posix
+import requests
+import ujson
+
+from six.moves import urllib
+from six.moves import configparser
+from typing import Text
+
+from zerver.lib.str_utils import force_text
+
+parser = OptionParser()
+
+parser.add_option('-r', '--recipient', dest="recipient", type='string', default='',
+                  help="Original recipient.")
+
+parser.add_option('-s', '--shared-secret', dest="shared_secret", type='string', default='',
+                  help="Secret access key.")
+
+parser.add_option('-d', '--dst-host', dest="host", type='string', default='https://127.0.0.1',
+                  help="Destination server address for uploading email from email mirror. "
+                       "Address must contain a HTTP protocol.")
+
+parser.add_option('-u', '--dst-url', dest="url", type='string', default='/email_mirror_message',
+                  help="Destination relative url for uploading email from email mirror.")
+
+parser.add_option('-n', '--not-verify-ssl', dest="verify_ssl", action='store_false', default=True,
+                  help="Disable ssl certificate verifying for self-signed certificates")
+
+parser.add_option('-t', '--test', dest="test", action='store_true', default=False,
+                  help="Test mode.")
+
+(options, args) = parser.parse_args(args=None, values=None)
+
+
+def send_email_mirror(rcpt_to, shared_secret, host, url, test, verify_ssl):
+    # type: (Text, Text, Text, Text, bool, bool) -> None
+    if not rcpt_to:
+        print("5.1.1 Bad destination mailbox address: No missed message email address.")
+        exit(posix.EX_NOUSER) # type: ignore # There are no stubs for posix in python 3
+    msg_text = sys.stdin.read(25*1024*1024)
+    if len(sys.stdin.read(1)) != 0:
+        # We're not at EOF, reject large mail.
+        print("5.3.4 Message too big for system: Max size is 25MiB")
+        exit(posix.EX_DATAERR)  # type: ignore # There are no stubs for posix in python 3
+
+    secrets_file = configparser.RawConfigParser()
+    secrets_file.read("/etc/zulip/zulip-secrets.conf")
+    if not shared_secret:
+        shared_secret = secrets_file.get('secrets', 'shared_secret')
+
+    request_data = {
+        "recipient": rcpt_to,
+        "msg_text": msg_text
+    }
+    if test:
+        exit(0)
+    response = requests.post(urllib.parse.urljoin(host, url),
+                             data={"data": ujson.dumps(request_data),
+                                   "secret": shared_secret}, verify=verify_ssl)
+    if response.status_code == 400:
+        response_data = ujson.loads(response.content)
+        print(response_data['msg'])
+        exit(posix.EX_NOUSER)  # type: ignore # There are no stubs for posix in python 3
+    elif response.status_code != 200:
+        print("4.4.2 Connection dropped: Internal server error.")
+        exit(1)
+
+
+recipient = force_text(os.environ.get("ORIGINAL_RECIPIENT", options.recipient))
+send_email_mirror(recipient, options.shared_secret, options.host, options.url, options.test,
+                  options.verify_ssl)

--- a/zerver/management/commands/email_mirror.py
+++ b/zerver/management/commands/email_mirror.py
@@ -13,23 +13,13 @@ Messages meant for Zulip have a special recipient form of
 This pattern is configurable via the EMAIL_GATEWAY_PATTERN settings.py
 variable.
 
-This script can be used via two mechanisms:
+Run this in a cronjob every N minutes if you have configured Zulip to poll
+an external IMAP mailbox for messages. The script will then connect to
+your IMAP server and batch-process all messages.
 
-  1) Run this in a cronjob every N minutes if you have configured Zulip to poll
-     an external IMAP mailbox for messages. The script will then connect to
-     your IMAP server and batch-process all messages.
+We extract and validate the target stream from information in the
+recipient address and retrieve, forward, and archive the message.
 
-     We extract and validate the target stream from information in the
-     recipient address and retrieve, forward, and archive the message.
-
-  2) Alternatively, configure your MTA to execute this script on message
-     receipt with the contents of the message piped to standard input. The
-     script will queue the message for processing. In this mode of invocation,
-     you should pass the destination email address in the ORIGINAL_RECIPIENT
-     environment variable.
-
-     In Postfix, you can express that via an /etc/aliases entry like this:
-         |/home/zulip/deployments/current/manage.py email_mirror
 """
 
 
@@ -69,6 +59,7 @@ file_handler.setFormatter(formatter)
 logger.setLevel(logging.DEBUG)
 logger.addHandler(file_handler)
 
+
 def get_imap_messages():
     # type: () -> Generator[Message, None, None]
     mbox = IMAP4_SSL(settings.EMAIL_GATEWAY_IMAP_SERVER, settings.EMAIL_GATEWAY_IMAP_PORT)
@@ -92,56 +83,18 @@ def get_imap_messages():
     finally:
         mbox.logout()
 
+
 class Command(BaseCommand):
     help = __doc__
 
-    def add_arguments(self, parser):
-        # type: (ArgumentParser) -> None
-        parser.add_argument('recipient', metavar='<recipient>', type=str, nargs='?', default=None,
-                            help="original recipient")
-
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
-        rcpt_to = force_text(os.environ.get("ORIGINAL_RECIPIENT", options['recipient']))
-        if rcpt_to is not None:
-            if is_missed_message_address(rcpt_to):
-                try:
-                    mark_missed_message_address_as_used(rcpt_to)
-                except ZulipEmailForwardError:
-                    print("5.1.1 Bad destination mailbox address: Bad or expired missed message address.")
-                    exit(posix.EX_NOUSER) # type: ignore # There are no stubs for posix in python 3
-            else:
-                try:
-                    extract_and_validate(rcpt_to)
-                except ZulipEmailForwardError:
-                    print("5.1.1 Bad destination mailbox address: Please use the address specified "
-                          "in your Streams page.")
-                    exit(posix.EX_NOUSER) # type: ignore # There are no stubs for posix in python 3
-
-            # Read in the message, at most 25MiB. This is the limit enforced by
-            # Gmail, which we use here as a decent metric.
-            msg_text = sys.stdin.read(25*1024*1024)
-
-            if len(sys.stdin.read(1)) != 0:
-                # We're not at EOF, reject large mail.
-                print("5.3.4 Message too big for system: Max size is 25MiB")
-                exit(posix.EX_DATAERR) # type: ignore # There are no stubs for posix in python 3
-
-            queue_json_publish(
-                "email_mirror",
-                {
-                    "message": msg_text,
-                    "rcpt_to": rcpt_to
-                },
-                lambda x: None
-            )
-        else:
-            # We're probably running from cron, try to batch-process mail
-            if (not settings.EMAIL_GATEWAY_BOT or not settings.EMAIL_GATEWAY_LOGIN or
-                not settings.EMAIL_GATEWAY_PASSWORD or not settings.EMAIL_GATEWAY_IMAP_SERVER or
-                    not settings.EMAIL_GATEWAY_IMAP_PORT or not settings.EMAIL_GATEWAY_IMAP_FOLDER):
-                print("Please configure the Email Mirror Gateway in /etc/zulip/, "
-                      "or specify $ORIGINAL_RECIPIENT if piping a single mail.")
-                exit(1)
-            for message in get_imap_messages():
-                process_message(message)
+        # We're probably running from cron, try to batch-process mail
+        if (not settings.EMAIL_GATEWAY_BOT or not settings.EMAIL_GATEWAY_LOGIN or
+            not settings.EMAIL_GATEWAY_PASSWORD or not settings.EMAIL_GATEWAY_IMAP_SERVER or
+                not settings.EMAIL_GATEWAY_IMAP_PORT or not settings.EMAIL_GATEWAY_IMAP_FOLDER):
+            print("Please configure the Email Mirror Gateway in /etc/zulip/, "
+                  "or specify $ORIGINAL_RECIPIENT if piping a single mail.")
+            exit(1)
+        for message in get_imap_messages():
+            process_message(message)

--- a/zerver/views/email_mirror.py
+++ b/zerver/views/email_mirror.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+import ujson
+
+from django.http import HttpRequest, HttpResponse
+
+from zerver.decorator import internal_notify_view
+from zerver.lib.email_mirror import mirror_email_message
+from zerver.lib.response import json_error, json_success
+
+
+@internal_notify_view(False)
+def email_mirror_message(request):
+    # type: (HttpRequest) -> HttpResponse
+    result = mirror_email_message(ujson.loads(request.POST['data']))
+    if result["status"] == "error":
+        return json_error(result['msg'])
+    return json_success()

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -20,6 +20,7 @@ import zerver.views
 import zerver.views.auth
 import zerver.views.compatibility
 import zerver.views.home
+import zerver.views.email_mirror
 import zerver.views.registration
 import zerver.views.zephyr
 import zerver.views.users
@@ -422,6 +423,12 @@ urls += [
     url(r'^api/v1/fetch_google_client_id$',
         zerver.views.auth.api_fetch_google_client_id,
         name='zerver.views.auth.api_fetch_google_client_id'),
+]
+
+# View for uploading messages from email mirror
+urls += [
+    url(r'^email_mirror_message$', zerver.views.email_mirror.email_mirror_message,
+        name='zerver.views.email_mirror.email_mirror_message'),
 ]
 
 # Include URL configuration files for site-specified extra installed


### PR DESCRIPTION
- Add script wrapper to comunicate postfix pipe with tornado we server
  over HTTP protocol. It uses shared_secret authentication mode.
- Add tornado view to process messages from email mirror server.
- Clean managment command `email-mirror`. Leае just functional
  for cron email processing.
- Add routes for new tornado view.
- Change pipe script in master process postfix config template.
- Add tests.

Fixes #2421