### PR TITLE
sidebar: Move chevron in the stream list further from the scrollbar.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -151,6 +151,7 @@ li.hidden-filter {
     display: block;
     line-height: 1.3em;
     width: 100%;
+    max-width: 170px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -125,7 +125,7 @@ li.hidden-filter {
 #global_filters .count,
 #stream_filters .count {
     position: absolute;
-    right: 20px;
+    right: 25px;
     top: 2px;
     padding: 2px 3px 1px 3px;
     background: #80837f;
@@ -172,7 +172,7 @@ li.hidden-filter {
 }
 
 .topic-unread-count {
-    right: 20px;
+    right: 25px;
 }
 
 .private_message_count {
@@ -190,6 +190,7 @@ ul.filters .arrow {
     position: absolute;
     right: 0px;
     top: 2px;
+    right: 4px;
     font-size: 0.8em;
     display: none;
 }
@@ -245,7 +246,7 @@ ul.filters li.out_of_home_view li.muted_topic {
     line-height: 12px;
     padding-top: 4px;
     margin-right: 15px;
-    padding-left: 33px;
+    padding-left: 28px;
 }
 
 #stream_filters .subscription_block .stream-name {
@@ -297,7 +298,8 @@ ul.expanded_private_messages {
 li.show-more-topics,
 li.topic-list-item {
     position: relative;
-    padding-left: 33px;
+    padding-left: 28px;
+    padding-right: 5px;
 }
 
 li.show-more-private-messages,


### PR DESCRIPTION
Previously the chevrons were too close to the scrollbar.
I have fixed this by moving the _chevron_ and _count_ to right by 5px. Also reduced the length of the topic title div to accommodate the change.

![screen shot 2017-04-18 at 22 23 05](https://cloud.githubusercontent.com/assets/3889675/25146135/72ed140c-2490-11e7-88b9-41ee4ebc3518.jpg)

Fixes #4435.