### PR TITLE
Set umask 022 before starting prod upgrade.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -24,6 +24,9 @@ if os.getuid() != 0:
     logging.error("Must be run as root.")
     sys.exit(1)
 
+# make sure we have appropriate file permissions
+os.umask(0o22)
+
 parser = argparse.ArgumentParser()
 parser.add_argument("deploy_path", metavar="deploy_path",
                     help="Path to deployment directory")


### PR DESCRIPTION
Follow-on from #2373/ PR https://github.com/zulip/zulip/pull/4316, to set an
appropriate umask also when upgrading.

From experimentation, it seems create-production-venv is the only part that
needs this. If that's not correct, then any other subprocess.check_call can
have the same preexec_fn added. The permissions do propagate down child
subprocesses, but in this case we can't take advantage of that and use it in
lib/upgrade-zulip, because that isn't updated before being used like
upgrade-zulip-stage-2 is.

If in the future it matters, preexec_fn doesn't work for Windows. Also, the
lambda is because normally it won't accept a function with arguments.

I've tested this by starting from a clean install, deleting /srv/* so new files
are downloaded, and then doing an upgrade. It would be nice if someone else can
also test this in a production environment to verify I've not missed anything.