### PR TITLE
activity.js: Stop opening compose box in user search.

### DIFF
--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -503,6 +503,7 @@ function maybe_select_person(e) {
 
         // Prevent a newline from being entered into the soon-to-be-opened composebox
         e.preventDefault();
+        e.stopPropagation();
 
         var topPerson = $('#user_presences li.user_sidebar_entry').first().attr('data-user-id');
         var user_list = $(".user-list-filter");


### PR DESCRIPTION
This prevents compose box from opening when you
just press enter with an empty search field in
user search.

Fixes #4376.