### PR TITLE
composebox_typeahead.js: Add typeahead cancelling for '# '.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -59,6 +59,8 @@ global.people.add({
     assert_typeahead_equals("test @", false);
     assert_typeahead_equals("test no@o", false);
     assert_typeahead_equals("test :-P", false);
+    assert_typeahead_equals("test # a", false);
+    assert_typeahead_equals("test #", false);
 
     var all_items = [
         {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -181,6 +181,11 @@ function autocomplete_checks(q, char) {
         return false;  // char doesn't appear, or too far back
     }
 
+    // Don't autocomplete if there is a space following a '#'
+    if (char === "#" && q.charAt(last_at + 1) === " ") {
+        return false;
+    }
+
     // Only match if the char follows a space, various punctuation,
     // or is at the beginning of the string.
     if (last_at > 0 && "\n\t \"'(){}[]".indexOf(q[last_at - 1]) === -1) {


### PR DESCRIPTION
If somebody types '# ', then close the typeahead dialog and don't autocomplete. Fixes #4505