### PR TITLE
typeahead_helper.js: Order streams by activity in typeahead.

### DIFF
--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -8,12 +8,23 @@ add_dependencies({
     stream_data: 'js/stream_data.js',
     people: 'js/people.js',
     typeahead_helper: 'js/typeahead_helper.js',
+    util: 'js/util.js',
 });
 
+var popular = {num_items: function () {
+    return 10;
+}};
+
+var unpopular = {num_items: function () {
+    return 2;
+}};
+
 var test_streams = [
-    {name: 'Dev', pin_to_top: false},
-    {name: 'Denmark', pin_to_top: true},
-    {name: 'dead', pin_to_top: false},
+    {name: 'Dev', pin_to_top: false, subscribers: unpopular},
+    {name: 'Docs', pin_to_top: false, subscribers: popular},
+    {name: 'Derp', pin_to_top: false, subscribers: unpopular},
+    {name: 'Denmark', pin_to_top: true, subscribers: popular},
+    {name: 'dead', pin_to_top: false, subscribers: unpopular},
 ];
 
 stream_data.create_streams([
@@ -27,8 +38,10 @@ global.stream_data.is_active = function (stream_name) {
 
 test_streams = typeahead_helper.sort_streams(test_streams, 'd');
 assert.deepEqual(test_streams[0].name, "Denmark"); // Pinned streams first
-assert.deepEqual(test_streams[1].name, "Dev"); // Active streams next
-assert.deepEqual(test_streams[2].name, "dead"); // Inactive streams last
+assert.deepEqual(test_streams[1].name, "Docs"); // Active streams next
+assert.deepEqual(test_streams[2].name, "Derp"); // Less subscribers
+assert.deepEqual(test_streams[3].name, "Dev"); // Alphabetically last
+assert.deepEqual(test_streams[4].name, "dead"); // Inactive streams last
 
 var matches = [
     {

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -7,12 +7,28 @@ set_global('page_params', {is_zephyr_mirror_realm: false});
 add_dependencies({
     stream_data: 'js/stream_data.js',
     people: 'js/people.js',
+    typeahead_helper: 'js/typeahead_helper.js',
 });
+
+var test_streams = [
+    {name: 'Dev', pin_to_top: false},
+    {name: 'Denmark', pin_to_top: true},
+    {name: 'dead', pin_to_top: false},
+];
 
 stream_data.create_streams([
     {name: 'Dev', subscribed: true, color: 'blue', stream_id: 1},
     {name: 'Linux', subscribed: true, color: 'red', stream_id: 2},
 ]);
+
+global.stream_data.is_active = function (stream_name) {
+    return stream_name !== 'dead';
+};
+
+test_streams = typeahead_helper.sort_streams(test_streams, 'd');
+assert.deepEqual(test_streams[0].name, "Denmark"); // Pinned streams first
+assert.deepEqual(test_streams[1].name, "Dev"); // Active streams next
+assert.deepEqual(test_streams[2].name, "dead"); // Inactive streams last
 
 var matches = [
     {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -223,7 +223,11 @@ exports.compare_by_activity = function (stream_a, stream_b) {
     if (diff !== 0) {
         return diff;
     }
-    return stream_a.subscribers.num_items() < stream_b.subscribers.num_items();
+    diff = stream_b.subscribers.num_items() - stream_a.subscribers.num_items();
+    if (diff !== 0) {
+        return diff;
+    }
+    return util.strcmp(stream_a.name, stream_b.name);
 };
 
 exports.sort_streams = function (matches, query) {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -203,10 +203,6 @@ exports.sort_emojis = function (matches, query) {
     return results.matches.concat(results.rest);
 };
 
-exports.compare_by_sub_count = function (stream_a, stream_b) {
-    return stream_a.subscribers.num_items() < stream_b.subscribers.num_items();
-};
-
 // Gives stream a score from 0 to 3 based on its activity
 function activity_score(stream) {
     var stream_score = 0;
@@ -220,13 +216,14 @@ function activity_score(stream) {
     return stream_score;
 }
 
-// Find which stream comes first in the sidebar listing order
-exports.compare_by_sidebar = function (stream_a, stream_b) {
+// Sort streams by ranking them by activity. If activity is equal,
+// as defined bv activity_score, decide based on subscriber count.
+exports.compare_by_activity = function (stream_a, stream_b) {
     var diff = activity_score(stream_b) - activity_score(stream_a);
     if (diff !== 0) {
         return diff;
     }
-    return exports.compare_by_sub_count(stream_a, stream_b);
+    return stream_a.subscribers.num_items() < stream_b.subscribers.num_items();
 };
 
 exports.sort_streams = function (matches, query) {
@@ -235,11 +232,11 @@ exports.sort_streams = function (matches, query) {
         = prefix_sort(query, name_results.rest, function (x) { return x.description; });
 
     // Streams that start with the query.
-    name_results.matches = name_results.matches.sort(exports.compare_by_sidebar);
+    name_results.matches = name_results.matches.sort(exports.compare_by_activity);
     // Streams with descriptions that start with the query.
-    desc_results.matches = desc_results.matches.sort(exports.compare_by_sidebar);
+    desc_results.matches = desc_results.matches.sort(exports.compare_by_activity);
     // Streams with names and descriptions that don't start with the query.
-    desc_results.rest = desc_results.rest.sort(exports.compare_by_sidebar);
+    desc_results.rest = desc_results.rest.sort(exports.compare_by_activity);
 
     return name_results.matches.concat(desc_results.matches.concat(desc_results.rest));
 };

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -207,14 +207,26 @@ exports.compare_by_sub_count = function (stream_a, stream_b) {
     return stream_a.subscribers.num_items() < stream_b.subscribers.num_items();
 };
 
+// Gives stream a score from 0 to 3 based on its activity
+function activity_score(stream) {
+    var stream_score = 0;
+    if (stream.pin_to_top) {
+        stream_score += 2;
+    }
+    // Note: A pinned stream may accumulate a 3rd point if it is active
+    if (stream_data.is_active(stream.name)) {
+        stream_score += 1;
+    }
+    return stream_score;
+}
+
 // Find which stream comes first in the sidebar listing order
 exports.compare_by_sidebar = function (stream_a, stream_b) {
-    var a_score = stream_data.is_active(stream_a.name) + stream_a.pin_to_top * 2;
-    var b_score = stream_data.is_active(stream_b.name) + stream_b.pin_to_top * 2;
-    if (a_score === b_score) {
-        return util.strcmp(stream_a.name, stream_b.name);
+    var diff = activity_score(stream_b) - activity_score(stream_a);
+    if (diff !== 0) {
+        return diff;
     }
-    return a_score < b_score;
+    return exports.compare_by_sub_count(stream_a, stream_b);
 };
 
 exports.sort_streams = function (matches, query) {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -207,17 +207,27 @@ exports.compare_by_sub_count = function (stream_a, stream_b) {
     return stream_a.subscribers.num_items() < stream_b.subscribers.num_items();
 };
 
+// Find which stream comes first in the sidebar listing order
+exports.compare_by_sidebar = function (stream_a, stream_b) {
+    var a_score = stream_data.is_active(stream_a.name) + stream_a.pin_to_top * 2;
+    var b_score = stream_data.is_active(stream_b.name) + stream_b.pin_to_top * 2;
+    if (a_score === b_score) {
+        return util.strcmp(stream_a.name, stream_b.name);
+    }
+    return a_score < b_score;
+};
+
 exports.sort_streams = function (matches, query) {
     var name_results = prefix_sort(query, matches, function (x) { return x.name; });
     var desc_results
         = prefix_sort(query, name_results.rest, function (x) { return x.description; });
 
     // Streams that start with the query.
-    name_results.matches = name_results.matches.sort(exports.compare_by_sub_count);
+    name_results.matches = name_results.matches.sort(exports.compare_by_sidebar);
     // Streams with descriptions that start with the query.
-    desc_results.matches = desc_results.matches.sort(exports.compare_by_sub_count);
+    desc_results.matches = desc_results.matches.sort(exports.compare_by_sidebar);
     // Streams with names and descriptions that don't start with the query.
-    desc_results.rest = desc_results.rest.sort(exports.compare_by_sub_count);
+    desc_results.rest = desc_results.rest.sort(exports.compare_by_sidebar);
 
     return name_results.matches.concat(desc_results.matches.concat(desc_results.rest));
 };


### PR DESCRIPTION
The first order sort of streams is still based on whether a match is found in the name, start of description, middle of description, etc.
But now the second order sort is by activity -- more specifically, the same exact order found in the left sidebar. This means pinned streams first, active streams, then inactive streams.

Fixes #4508 