### PR TITLE
/me: Fix presentation and markup for /me statuses.

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -480,7 +480,7 @@ exports.MessageList.prototype = {
     },
 
     hide_edit_message: function MessageList_hide_edit_message(row) {
-        row.find(".message_content").show();
+        row.find(".message_content, .status-message").show();
         row.find(".message_edit").hide();
     },
 

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -474,7 +474,7 @@ exports.MessageList.prototype = {
 
     show_edit_message: function MessageList_show_edit_message(row, edit_obj) {
         row.find(".message_edit_form").empty().append(edit_obj.form);
-        row.find(".message_content").hide();
+        row.find(".message_content, .status-message").hide();
         row.find(".message_edit").show();
         row.find(".message_edit_content").autosize();
     },

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1083,15 +1083,15 @@ td.pointer {
 }
 
 .sender-status {
-    display: block;
-    left: 46px;
-    top: -26px;
-    padding-bottom: 6px;
-    padding-right: 35px;
+    display: inline-block;
+    margin: 8px 0px;
+    /* this normalizes the margin of the emoji reactions with normal messages. */
+    padding-bottom: 5px;
     vertical-align: middle;
     line-height: 18px;
     font-size: 14px;
     position: relative;
+    max-width: calc(100% - 50px);
 }
 
 .message_controls.sender-status-controls {
@@ -1274,7 +1274,7 @@ div.focused_table {
     display: block;
 }
 
-.include-sender .message_content {
+.include-sender .message_content:not(:empty) {
     margin-top: -16px;
 }
 
@@ -1284,6 +1284,10 @@ div.focused_table {
     margin-left: 46px;
     display: block;
     position: relative;
+}
+
+.message_content:empty {
+    display: none;
 }
 
 .message_edit_content {

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -17,7 +17,9 @@
                                 {{#if sender_is_bot}}
                                 <img class="bot-icon" title="{{t 'Bot' }}" src="/static/images/bot.svg" />
                                 {{/if}}
-                                {{{ status_message }}}
+                                <span class="status-message">
+                                    {{{ status_message }}}
+                                </span>
                                 {{#if_and last_edit_timestr include_sender}}
                                 <div class="message_edit_notice" title="{{#tr this}}Edited (__last_edit_timestr__){{/tr}}">{{t "EDITED" }}</div>
                                 {{/if_and}}


### PR DESCRIPTION
This fixes the /me elements to be display inline-block and inline
rather than display block with top and left properties.

This also fixes an unrelated issue with emoji reactions not being
able to be clicked on with /me messages.

Fixes: #4218.