### PR TITLE
tests: Add wrapper for client.logout in ZulipTestCase.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -223,6 +223,10 @@ class ZulipTestCase(TestCase):
         else:
             self.assertFalse(self.client.login(username=email, password=password))
 
+    def logout(self):
+        # type: () -> None
+        self.client.logout()
+
     def register(self, email, password):
         # type: (Text, Text) -> HttpResponse
         self.client_post('/accounts/home/', {'email': email})

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -199,7 +199,7 @@ class UserPresenceTests(ZulipTestCase):
         # type: () -> None
         self.login("espuser@mit.edu")
         self.client_post("/json/users/me/presence", {'status': 'idle'})
-        result = self.client_post("/accounts/logout/")
+        self.logout()
 
         # Ensure we don't see hamlet@zulip.com information leakage
         self.login("hamlet@zulip.com")

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -78,7 +78,7 @@ class ChangeSettingsTest(ZulipTestCase):
         self.check_well_formed_change_settings_response(result)
         self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").
                          full_name, "Foo Bar")
-        self.client_post('/accounts/logout/')
+        self.logout()
         self.login("hamlet@zulip.com", "foobar1")
         user_profile = get_user_profile_by_email('hamlet@zulip.com')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -242,6 +242,7 @@ class LoginTest(ZulipTestCase):
     def test_logout(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
+        # We are Intentionally using logout API endpoint here to test it.
         self.client_post('/accounts/logout/')
         self.assertIsNone(get_session_dict_user(self.client.session))
 
@@ -257,11 +258,11 @@ class LoginTest(ZulipTestCase):
         self.register("test@zulip.com", password)
         user_profile = get_user_profile_by_email(email)
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
-        self.client_post('/accounts/logout/')
+        self.logout()
         self.assertIsNone(get_session_dict_user(self.client.session))
 
         # Logging in succeeds.
-        self.client_post('/accounts/logout/')
+        self.logout()
         self.login(email, password)
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
 

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -77,7 +77,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         self.assertEqual(base, uri[:len(base)])
 
         # Download file via API
-        self.client_post('/accounts/logout/')
+        self.logout()
         response = self.client_get(uri, **auth_headers)
         data = b"".join(response.streaming_content)
         self.assertEqual(b"zulip!", data)
@@ -213,7 +213,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         json = ujson.loads(result.content)
         uri = json["uri"]
 
-        self.client_post('/accounts/logout/')
+        self.logout()
         response = self.client_get(uri)
         self.assert_json_error(response, "Not logged in: API authentication or user session required",
                                status_code=401)
@@ -506,7 +506,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         self.assertEqual(response.status_code, 200)
         data = b"".join(response.streaming_content)
         self.assertEqual(b"zulip!", data)
-        self.client_post('/accounts/logout/')
+        self.logout()
 
         # Confirm other cross-realm users can't read it.
         self.login(user3_email, 'test')
@@ -535,7 +535,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp_path_id = re.sub('/user_uploads/', '', uri)
         body = "First message ...[zulip.txt](http://localhost:9991/user_uploads/" + fp_path_id + ")"
         self.send_message("hamlet@zulip.com", "test-subscribe", Recipient.STREAM, body, "test")
-        self.client_post('/accounts/logout/')
+        self.logout()
 
         # Subscribed user should be able to view file
         for user in subscribed_users:
@@ -544,7 +544,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
             self.assertEqual(response.status_code, 200)
             data = b"".join(response.streaming_content)
             self.assertEqual(b"zulip!", data)
-            self.client_post('/accounts/logout/')
+            self.logout()
 
         # Unsubscribed user should not be able to view file
         for user in unsubscribed_users:
@@ -552,7 +552,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
             response = self.client_get(uri)
             self.assertEqual(response.status_code, 403)
             self.assert_in_response("You are not authorized to view this file.", response)
-            self.client_post('/accounts/logout/')
+            self.logout()
 
     def test_file_download_authorization_public(self):
         # type: () -> None
@@ -570,7 +570,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp_path_id = re.sub('/user_uploads/', '', uri)
         body = "First message ...[zulip.txt](http://localhost:9991/user_uploads/" + fp_path_id + ")"
         self.send_message("hamlet@zulip.com", "test-subscribe", Recipient.STREAM, body, "test")
-        self.client_post('/accounts/logout/')
+        self.logout()
 
         # Now all users should be able to access the files
         for user in subscribed_users + unsubscribed_users:
@@ -578,7 +578,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
             response = self.client_get(uri)
             data = b"".join(response.streaming_content)
             self.assertEqual(b"zulip!", data)
-            self.client_post('/accounts/logout/')
+            self.logout()
 
     def tearDown(self):
         # type: () -> None


### PR DESCRIPTION
In this PR we add a logout wrapper so as to enable developers to just do self.logout instead of doing a post request at API endpoint for logout. This is achieved by adding a wrapper function for the Django's client.logout contained in `TestCase`. We add this by extending `ZulipTestCase` to have a logout function.
I have left one instance of using API endpoints to `logout` in `test_rest_endpoint` function under `test_upload.py`.
@showell can you please take a look at this?