### PR TITLE
message edit: Remove Topic and Content labels

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -300,9 +300,9 @@ li,
     padding: 5px 10px;
     border: none;
     position: relative;
-    top: 32px;
+    top: 28px;
     left: -5px;
-    margin-top: -8px;
+    margin-top: -24px;
     display: block;
 }
 
@@ -1218,7 +1218,12 @@ a.dark_background:hover,
 }
 
 .message_top_line {
+    pointer-events: none;
     position: relative;
+}
+
+.message_top_line * {
+    pointer-events: auto;
 }
 
 .include-sender .message_top_line {
@@ -2458,12 +2463,6 @@ button.topic_edit_cancel {
 /* Reduce some of the heavy padding from Bootstrap. */
 #message_edit_form {
     margin-bottom: 10px;
-}
-#message_edit_form .edit-control-label {
-    vertical-align: top;
-    padding-top: 0px;
-    margin-right: 10px;
-    font-size: 80%;
 }
 #message_edit_form .edit-controls {
     margin-left: 0px;

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -3,7 +3,6 @@
 <form id="message_edit_form" class="form-horizontal">
     {{#if is_stream}}
     <div class="control-group no-margin">
-        <label class="edit-control-label" for="message_edit_topic">{{t "Topic" }}</label>
         <div class="controls edit-controls">
             <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" />
             <select class='message_edit_topic_propagate' style='display:none;'>
@@ -21,7 +20,6 @@
                     <path fill="#777" d="M128 768h256v64H128v-64z m320-384H128v64h320v-64z m128 192V448L384 640l192 192V704h320V576H576z m-288-64H128v64h160v-64zM128 704h160v-64H128v64z m576 64h64v128c-1 18-7 33-19 45s-27 18-45 19H64c-35 0-64-29-64-64V192c0-35 29-64 64-64h192C256 57 313 0 384 0s128 57 128 128h192c35 0 64 29 64 64v320h-64V320H64v576h640V768zM128 256h512c0-35-29-64-64-64h-64c-35 0-64-29-64-64s-29-64-64-64-64 29-64 64-29 64-64 64h-64c-35 0-64 29-64 64z" />
                 </svg>
             </button>
-            <label class="edit-control-label" for="message_edit_topic">{{t "Content" }}</label>
             <textarea class="message_edit_content" id="message_edit_content_{{message_id}}">{{content}}</textarea>
         </div>
     </div>


### PR DESCRIPTION
Removed the components from the template and cleaned up the relevant css.
New look:
![image](https://cloud.githubusercontent.com/assets/8433005/25266148/20d7908e-263e-11e7-9512-132e3e969389.png)
Fixes #4562 