### PR TITLE
compose_actions.js: Allow compose to empty narrow.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -215,7 +215,7 @@ function stubbing(func_name_to_stub, test_function) {
     assert_mapping('d', 'drafts.toggle');
 
     // Next, test keys that only work on a selected message.
-    var message_view_only_keys = '@*+rRjJkKsSuvi:GM';
+    var message_view_only_keys = '@*+RjJkKsSuvi:GM';
 
     // Check that they do nothing without a selected message
     global.current_msg_list.empty = return_true;

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -61,6 +61,7 @@ function set_filter(operators) {
     assert(!narrow_state.narrowed_by_topic_reply());
     assert(!narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
+    assert(!narrow_state.narrowed_by_stream_reply());
 
     set_filter([['stream', 'Foo']]);
     assert(!narrow_state.narrowed_to_pms());
@@ -69,6 +70,7 @@ function set_filter(operators) {
     assert(!narrow_state.narrowed_by_topic_reply());
     assert(!narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
+    assert(narrow_state.narrowed_by_stream_reply());
 
     set_filter([['pm-with', 'steve@zulip.com']]);
     assert(narrow_state.narrowed_to_pms());
@@ -77,6 +79,7 @@ function set_filter(operators) {
     assert(!narrow_state.narrowed_by_topic_reply());
     assert(!narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
+    assert(!narrow_state.narrowed_by_stream_reply());
 
     set_filter([['stream', 'Foo'], ['topic', 'bar']]);
     assert(!narrow_state.narrowed_to_pms());
@@ -85,6 +88,7 @@ function set_filter(operators) {
     assert(narrow_state.narrowed_by_topic_reply());
     assert(!narrow_state.narrowed_to_search());
     assert(narrow_state.narrowed_to_topic());
+    assert(!narrow_state.narrowed_by_stream_reply());
 
     set_filter([['search', 'grail']]);
     assert(!narrow_state.narrowed_to_pms());
@@ -93,6 +97,7 @@ function set_filter(operators) {
     assert(!narrow_state.narrowed_by_topic_reply());
     assert(narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
+    assert(!narrow_state.narrowed_by_stream_reply());
 }());
 
 (function test_operators() {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -252,7 +252,21 @@ exports.respond_to_message = function (opts) {
 
     message = current_msg_list.selected_message();
 
-    if (message === undefined) {
+    if (message === undefined) { // empty narrow implementation
+        if (!narrow_state.narrowed_by_pm_reply() &&
+            !narrow_state.narrowed_by_stream_reply() &&
+            !narrow_state.narrowed_by_topic_reply()) {
+            return;
+        }
+
+        msg_type = 'stream'; // Set msg_type to stream by default
+                                 // in the case of an empty home view.
+        if (narrow_state.narrowed_by_pm_reply()) {
+            msg_type = 'private';
+        }
+
+        var new_opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
+        exports.start(new_opts.message_type, new_opts);
         return;
     }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -321,14 +321,9 @@ exports.process_enter_key = function (e) {
         return true;
     }
 
-    if (current_msg_list.empty()) {
-        return false;
-    }
-
     // If we got this far, then we're presumably in the message
-    // view and there is a "current" message, so in that case
-    // "enter" is the hotkey to respond to a message.  Note that
-    // "r" has same effect, but that is handled in process_hotkey().
+    // view, so in that case "enter" is the hotkey to respond to a message.
+    // Note that "r" has same effect, but that is handled in process_hotkey().
     compose_actions.respond_to_message({trigger: 'hotkey enter'});
     return true;
 };
@@ -589,6 +584,11 @@ exports.process_hotkey = function (e, hotkey) {
         case 'open_drafts':
             drafts.toggle();
             return true;
+        case 'reply_message': // 'r': respond to message
+            // Note that you can "enter" to respond to messages as well,
+            // but that is handled in process_enter_key().
+            compose_actions.respond_to_message({trigger: 'hotkey'});
+            return true;
     }
 
     if (current_msg_list.empty()) {
@@ -640,11 +640,6 @@ exports.process_hotkey = function (e, hotkey) {
             return do_narrow_action(narrow.by_recipient);
         case 'narrow_by_subject':
             return do_narrow_action(narrow.by_subject);
-        case 'reply_message': // 'r': respond to message
-            // Note that you can "enter" to respond to messages as well,
-            // but that is handled in process_enter_key().
-            compose_actions.respond_to_message({trigger: 'hotkey'});
-            return true;
         case 'respond_to_author': // 'R': respond to author
             compose_actions.respond_to_message({reply_type: "personal", trigger: 'hotkey pm'});
             return true;

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -153,6 +153,15 @@ exports.narrowed_by_reply = function () {
             exports.narrowed_by_topic_reply());
 };
 
+exports.narrowed_by_stream_reply = function () {
+    if (current_filter === undefined) {
+        return false;
+    }
+    var operators = current_filter.operators();
+    return (operators.length === 1 &&
+            current_filter.operands("stream").length === 1);
+};
+
 exports.narrowed_to_topic = function () {
     if (current_filter === undefined) {
         return false;


### PR DESCRIPTION
This allows r/enter hotkeys to compose to
an empty narrow (no messages).

Fixes #4500.