### PR TITLE
formatting help: Add documentation for TeX math.

### DIFF
--- a/templates/zerver/markdown_help.html
+++ b/templates/zerver/markdown_help.html
@@ -104,6 +104,20 @@ Quoted block
                     <td><blockquote><p>Quoted block</p></blockquote></td>
                     </tr>
                     <tr>
+                        <td>Some inline math $$e^{i \pi } + 1 = 0$$</td>
+                        <td>
+                            Some inline math <span class="katex"><span class="katex-mathml"><math><semantics><mrow><msup><mi>e</mi><mrow><mi>i</mi><mi>π</mi></mrow></msup><mo>+</mo><mn>1</mn><mo>=</mo><mn>0</mn></mrow><annotation encoding="application/x-tex">e^{i \pi } + 1 = 0</annotation></semantics></math></span><span aria-hidden="true" class="katex-html"><span class="strut" style="height:0.824664em;"></span><span class="strut bottom" style="height:0.907994em;vertical-align:-0.08333em;"></span><span class="base textstyle uncramped"><span class="mord"><span class="mord mathit">e</span><span class="msupsub"><span class="vlist"><span style="top:-0.363em;margin-right:0.05em;"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;">&#8203;</span></span><span class="reset-textstyle scriptstyle uncramped mtight"><span class="mord scriptstyle uncramped mtight"><span class="mord mathit mtight">i</span><span class="mord mathit mtight" style="margin-right:0.03588em;">π</span></span></span></span><span class="baseline-fix"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;">&#8203;</span></span>&#8203;</span></span></span></span><span class="mbin">+</span><span class="mord mathrm">1</span><span class="mrel">=</span><span class="mord mathrm">0</span></span></span></span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="preserve_spaces">```math
+\int_{0}^{1} f(x) dx
+```</td>
+                        <td>
+                            <span class="katex-display"><span class="katex"><span class="katex-mathml"><math><semantics><mrow><msubsup><mo>∫</mo><mrow><mn>0</mn></mrow><mrow><mn>1</mn></mrow></msubsup><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo><mi>d</mi><mi>x</mi></mrow><annotation encoding="application/x-tex">\int_{0}^{1} f(x) dx</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height:1.4251079999999998em;"></span><span class="strut bottom" style="height:2.337358em;vertical-align:-0.91225em;"></span><span class="base displaystyle textstyle uncramped"><span class="mop"><span class="mop op-symbol large-op" style="margin-right:0.44445em;top:-0.0011249999999999316em;">∫</span><span class="msupsub"><span class="vlist"><span style="top:0.91225em;margin-left:-0.44445em;margin-right:0.05em;"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;">&#8203;</span></span><span class="reset-textstyle scriptstyle cramped mtight"><span class="mord scriptstyle cramped mtight"><span class="mord mathrm mtight">0</span></span></span></span><span style="top:-0.9739999999999999em;margin-right:0.05em;"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;">&#8203;</span></span><span class="reset-textstyle scriptstyle uncramped mtight"><span class="mord scriptstyle uncramped mtight"><span class="mord mathrm mtight">1</span></span></span></span><span class="baseline-fix"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;">&#8203;</span></span>&#8203;</span></span></span></span><span class="mord mathit" style="margin-right:0.10764em;">f</span><span class="mopen">(</span><span class="mord mathit">x</span><span class="mclose">)</span><span class="mord mathit">d</span><span class="mord mathit">x</span></span></span></span></span>
+                        </td>
+                    </tr>
+                    <tr>
                         <td colspan="2">{% trans %}You can also make <a target="_blank"
                             href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#wiki-tables">tables</a>
                             with this <a target="_blank"

--- a/templates/zerver/markdown_help.html
+++ b/templates/zerver/markdown_help.html
@@ -98,7 +98,7 @@ def zulip():
 
                     </tr>
                     <tr>
-                    <td class="preserve_spaces">``` quote
+                    <td class="preserve_spaces">```quote
 Quoted block
 ```</td>
                     <td><blockquote><p>Quoted block</p></blockquote></td>


### PR DESCRIPTION
This adds to the formatting help a couple of references about the TeX math support that was included in #3330.

The code produced by KaTeX could be easily prettyfied, but that would noticeably increase the length of the file and I considered that wasn't worth it.

I tried to keep the examples mathematically simple yet rich enough to show the power of TeX.  
Let me know if you have any suggestions on how can we modify/replace them :)