### PR TITLE
lint: Fix gitlint test due to non-deterministic git range.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
     - COVERALLS_SERVICE_NAME=travis-pro
     - COVERALLS_REPO_TOKEN=hnXUEBKsORKHc8xIENGs9JjktlTb2HKlG
     - BOTO_CONFIG=/tmp/nowhere
-    - UPSTREAM_MASTER=$(git ls-remote git://github.com/zulip/zulip.git refs/heads/master | cut -f 1)
 language: python
 matrix:
   include:

--- a/tools/commit-message-lint
+++ b/tools/commit-message-lint
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-# Lints all commit messages that are newer than upstream/master.
+# Lint all commit messages that are newer than upstream/master if running
+# locally or the commits in the push or PR if in TravisCI.
+
 # The rules can be found in /.gitlint
 
-# If this script is running on TravisCI, $UPSTREAM_MASTER would be set to the
-# latest HEAD in travis.yml
-if [ ! $TRAVIS ]; then
-    UPSTREAM_MASTER=upstream/master
+if [ $TRAVIS ]; then
+    range=$TRAVIS_COMMIT_RANGE
+else
+    range="upstream/master...HEAD"
 fi
 
-gitlint --commits $UPSTREAM_MASTER...HEAD
+gitlint --commits $range


### PR DESCRIPTION
This makes getting the commit SHA non time sensitive by using the range provided by TravisCI.