### PR TITLE
Fix textarea resize for editing messages.

### DIFF
--- a/frontend_tests/casper_tests/08-edit.js
+++ b/frontend_tests/casper_tests/08-edit.js
@@ -94,8 +94,8 @@ casper.then(function () {
     casper.test.assertNotVisible('form.message_edit_form', 'Message edit box not visible');
 
     common.keypress(37);
-    casper.waitUntilVisible("#message_edit_content", function () {
-        var fieldVal = common.get_form_field_value('#message_edit_content');
+    casper.waitUntilVisible(".message_edit_content", function () {
+        var fieldVal = common.get_form_field_value('.message_edit_content');
         casper.test.assertEquals(fieldVal, "test edited pm", "Opened editing last own message");
         casper.click('.message_edit_cancel');
     });

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -598,35 +598,7 @@ exports.validate = function () {
 };
 
 $(function () {
-    (function on_compose_resize(cb) {
-        var meta = {
-            compose_box: document.querySelector("#new_message_content"),
-            height: null,
-            mousedown: false,
-        };
-
-        meta.compose_box.addEventListener("mousedown", function () {
-            meta.mousedown = true;
-            meta.height = meta.compose_box.clientHeight;
-        });
-
-        // If the user resizes the compose box manually, we use the
-        // callback to stop autosize from adjusting the compose box height.
-        document.body.addEventListener("mouseup", function () {
-            if (meta.mousedown === true) {
-                meta.mousedown = false;
-                if (meta.height !== meta.compose_box.clientHeight) {
-                    meta.height = meta.compose_box.clientHeight;
-                    cb.call(meta.compose_box, meta.height);
-                }
-            }
-        });
-    }(function (height) {
-        // This callback disables autosize on the compose box.  It
-        // will be re-enabled when the compose box is next opened.
-        $("#new_message_content").trigger("autosize.destroy")
-            .height(height + "px");
-    }));
+    resize.watch_manual_resize("#new_message_content");
 
     // Run a feature test and decide whether to display
     // the "Attach files" button

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -220,6 +220,7 @@ function edit_message(row, raw_content) {
         initClipboard(copy_message[0]);
     } else if (editability === editability_types.FULL) {
         copy_message.remove();
+        resize.watch_manual_resize("#message_edit_content");
         composebox_typeahead.initialize_compose_typeahead("#message_edit_content", {emoji: true, stream: true});
     }
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -183,6 +183,7 @@ function edit_message(row, raw_content) {
     var form = $(templates.render(
         'message_edit_form',
         {is_stream: (message.type === 'stream'),
+         message_id: message.id,
          is_editable: is_editable,
          has_been_editable: (editability !== editability_types.NO),
          topic: message.subject,
@@ -220,9 +221,10 @@ function edit_message(row, raw_content) {
         initClipboard(copy_message[0]);
     } else if (editability === editability_types.FULL) {
         copy_message.remove();
-        var listeners = resize.watch_manual_resize("#message_edit_content");
+        var edit_id = "#message_edit_content_" + rows.id(row);
+        var listeners = resize.watch_manual_resize(edit_id);
         currently_editing_messages[rows.id(row)].listeners = listeners;
-        composebox_typeahead.initialize_compose_typeahead("#message_edit_content", {emoji: true, stream: true});
+        composebox_typeahead.initialize_compose_typeahead(edit_id, {emoji: true, stream: true});
     }
 
     // Add tooltip
@@ -364,7 +366,7 @@ exports.end = function (row) {
 
         // Clean up resize event listeners
         var listeners = currently_editing_messages[message.id].listeners;
-        var edit_box = document.querySelector("#message_edit_content");
+        var edit_box = document.querySelector("#message_edit_content_" + message.id);
         edit_box.removeEventListener("mousedown", listeners[0]);
         document.body.removeEventListener("mouseup", listeners[1]);
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -220,7 +220,8 @@ function edit_message(row, raw_content) {
         initClipboard(copy_message[0]);
     } else if (editability === editability_types.FULL) {
         copy_message.remove();
-        resize.watch_manual_resize("#message_edit_content");
+        var listeners = resize.watch_manual_resize("#message_edit_content");
+        currently_editing_messages[rows.id(row)].listeners = listeners;
         composebox_typeahead.initialize_compose_typeahead("#message_edit_content", {emoji: true, stream: true});
     }
 
@@ -360,6 +361,13 @@ exports.end = function (row) {
         currently_editing_messages[message.id] !== undefined) {
         var scroll_by = currently_editing_messages[message.id].scrolled_by;
         message_viewport.scrollTop(message_viewport.scrollTop() - scroll_by);
+
+        // Clean up resize event listeners
+        var listeners = currently_editing_messages[message.id].listeners;
+        var edit_box = document.querySelector("#message_edit_content");
+        edit_box.removeEventListener("mousedown", listeners[0]);
+        document.body.removeEventListener("mouseup", listeners[1]);
+
         delete currently_editing_messages[message.id];
         current_msg_list.hide_edit_message(row);
     }

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -165,6 +165,38 @@ function left_userlist_get_new_heights() {
     return res;
 }
 
+exports.watch_manual_resize = function (element) {
+    (function on_box_resize(cb) {
+        var meta = {
+            box: document.querySelector(element),
+            height: null,
+            mousedown: false,
+        };
+
+        meta.box.addEventListener("mousedown", function () {
+            meta.mousedown = true;
+            meta.height = meta.box.clientHeight;
+        });
+
+        // If the user resizes the textarea manually, we use the
+        // callback to stop autosize from adjusting the height.
+        document.body.addEventListener("mouseup", function () {
+            if (meta.mousedown === true) {
+                meta.mousedown = false;
+                if (meta.height !== meta.box.clientHeight) {
+                    meta.height = meta.box.clientHeight;
+                    cb.call(meta.box, meta.height);
+                }
+            }
+        });
+    }(function (height) {
+        // This callback disables autosize on the textarea.  It
+        // will be re-enabled when this component is next opened.
+        $(element).trigger("autosize.destroy")
+            .height(height + "px");
+    }));
+};
+
 exports.resize_bottom_whitespace = function (h) {
     if (page_params.autoscroll_forever) {
         $("#bottom_whitespace").height($("#compose-container")[0].offsetHeight);

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -166,21 +166,22 @@ function left_userlist_get_new_heights() {
 }
 
 exports.watch_manual_resize = function (element) {
-    (function on_box_resize(cb) {
+    return (function on_box_resize(cb) {
         var meta = {
             box: document.querySelector(element),
             height: null,
             mousedown: false,
         };
 
-        meta.box.addEventListener("mousedown", function () {
+        var box_handler = function () {
             meta.mousedown = true;
             meta.height = meta.box.clientHeight;
-        });
+        };
+        meta.box.addEventListener("mousedown", box_handler);
 
         // If the user resizes the textarea manually, we use the
         // callback to stop autosize from adjusting the height.
-        document.body.addEventListener("mouseup", function () {
+        var body_handler = function () {
             if (meta.mousedown === true) {
                 meta.mousedown = false;
                 if (meta.height !== meta.box.clientHeight) {
@@ -188,7 +189,10 @@ exports.watch_manual_resize = function (element) {
                     cb.call(meta.box, meta.height);
                 }
             }
-        });
+        };
+        document.body.addEventListener("mouseup", body_handler);
+
+        return [box_handler, body_handler];
     }(function (height) {
         // This callback disables autosize on the textarea.  It
         // will be re-enabled when this component is next opened.

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -214,11 +214,11 @@ $(function () {
 
     $('.copy_message[data-toggle="tooltip"]').tooltip();
 
-    $("body").on("mouseover", "#message_edit_content", function () {
+    $("body").on("mouseover", ".message_edit_content", function () {
         $(this).closest(".message_row").find(".copy_message").show();
     });
 
-    $("body").on("mouseout", "#message_edit_content", function () {
+    $("body").on("mouseout", ".message_edit_content", function () {
         $(this).closest(".message_row").find(".copy_message").hide();
     });
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1293,6 +1293,7 @@ div.focused_table {
 
 .message_edit_content {
     line-height: 18px;
+    resize: vertical!important;
 }
 
 .message_edit_countdown_timer {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1294,6 +1294,7 @@ div.focused_table {
 .message_edit_content {
     line-height: 18px;
     resize: vertical!important;
+    max-height: 24em;
 }
 
 .message_edit_countdown_timer {

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -16,13 +16,13 @@
     {{/if}}
     <div class="control-group no-margin">
         <div class="controls edit-controls">
-            <button class="btn pull-right copy_message" data-toggle="tooltip" title="{{t "Copy and close" }}" data-clipboard-target="#message_edit_content">
+            <button class="btn pull-right copy_message" data-toggle="tooltip" title="{{t "Copy and close" }}" data-clipboard-target="#message_edit_content_{{message_id}}">
                 <svg height="20" width="18" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg" id="clipboard_image">
                     <path fill="#777" d="M128 768h256v64H128v-64z m320-384H128v64h320v-64z m128 192V448L384 640l192 192V704h320V576H576z m-288-64H128v64h160v-64zM128 704h160v-64H128v64z m576 64h64v128c-1 18-7 33-19 45s-27 18-45 19H64c-35 0-64-29-64-64V192c0-35 29-64 64-64h192C256 57 313 0 384 0s128 57 128 128h192c35 0 64 29 64 64v320h-64V320H64v576h640V768zM128 256h512c0-35-29-64-64-64h-64c-35 0-64-29-64-64s-29-64-64-64-64 29-64 64-29 64-64 64h-64c-35 0-64 29-64 64z" />
                 </svg>
             </button>
             <label class="edit-control-label" for="message_edit_topic">{{t "Content" }}</label>
-            <textarea class="message_edit_content" id="message_edit_content">{{content}}</textarea>
+            <textarea class="message_edit_content" id="message_edit_content_{{message_id}}">{{content}}</textarea>
         </div>
     </div>
     <div class="control-group action-buttons">


### PR DESCRIPTION
Fixes #4573

The message edit textfield has JS attached to it to be autoresized. So as a result, if the user tries to manually resize it, autosize would take over and prevent the user from actually resizing. The way the main compose box gets around this is by listening for textarea resize events, and if the user tries to resize, disable autosize.

With some refactoring, I moved the compose box's resize code into `resize.js`, and made it a function that could be applied to any textarea. So the function `resize.watch_manual_resize` applies listeners to a provided textarea that destroys autosize when the user tries to manually resize.

I do have a slight concern with this, and might need some further refinement. Every time a new edit dialog is opened, a event listener gets added to `document.body`, and doesn't get cleaned up once the edit is closed. Maybe I'll add code to delete the listener when the edit box is closed if the effect is non-negligible.