### PR TITLE
user setting: Update page_params when user uploads Avatar in setting.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -168,7 +168,11 @@ exports.set_up = function () {
             contentType: false,
             success: function (data) {
                 loading.destroy_indicator($("#upload_avatar_spinner"));
-                $("#user-settings-avatar").expectOne().attr("src", data.avatar_url);
+                if (page_params.avatar_url_medium) {
+                    page_params.avatar_url_medium = data.avatar_url;
+                } else {
+                    page_params.avatar_url = data.avatar_url;
+                }
                 $("#user_avatar_delete_button").show();
             },
         });


### PR DESCRIPTION
The original implementation only modifies image url of
setting page is reopen. The new implementation instead updates
page_params with the latest url to avatar.

Manual testing to upload Avatar is done on local developer server.

Fixes: #4591.