### PR TITLE
compose: Distinguish get_message_type() from composing().

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -67,7 +67,7 @@ people.add(bob);
         };
     };
 
-    global.compose_state.composing = function () {
+    global.compose_state.get_message_type = function () {
         return 'stream';
     };
 
@@ -81,7 +81,7 @@ people.add(bob);
     assert.equal(message.subject, 'lunch');
     assert.equal(message.content, 'burrito');
 
-    global.compose_state.composing = function () {
+    global.compose_state.get_message_type = function () {
         return 'private';
     };
     message = compose.create_message_object();

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -99,8 +99,11 @@ var draft_2 = {
 
 (function test_snapshot_message() {
     function stub_draft(draft) {
-        global.compose_state.composing = function () {
+        global.compose_state.get_message_type = function () {
             return draft.type;
+        };
+        global.compose_state.composing = function () {
+            return !!draft.type;
         };
         global.compose_state.message_content = function () {
             return draft.content;

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -126,7 +126,7 @@ function create_message_object() {
 
     // Changes here must also be kept in sync with echo.try_deliver_locally
     var message = {
-        type: compose_state.composing(),
+        type: compose_state.get_message_type(),
         content: content,
         sender_id: page_params.user_id,
         queue_id: page_params.event_queue_id,
@@ -591,7 +591,7 @@ exports.validate = function () {
         return false;
     }
 
-    if (compose_state.composing() === 'private') {
+    if (compose_state.get_message_type() === 'private') {
         return validate_private_message();
     }
     return validate_stream_message();

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -169,7 +169,7 @@ function fill_in_opts_from_current_narrowed_view(msg_type, opts) {
 }
 
 function same_recipient_as_before(msg_type, opts) {
-    return (compose_state.composing() === msg_type) &&
+    return (compose_state.get_message_type() === msg_type) &&
             ((msg_type === "stream" &&
               opts.stream === compose_state.stream_name() &&
               opts.subject === compose_state.subject()) ||

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -13,14 +13,9 @@ exports.get_message_type = function () {
 };
 
 exports.composing = function () {
-    // For legacy reasons, this is the same as get_message_type.
-    // Most callers use this in a boolean context, but there are
-    // some stragglers that inspect the string value.
-    //
-    // TODO: Fix callers who care about stream/private to use
-    //       get_message_type(), and then convert this to return
-    //       `!!message_type` or something like that.
-    return message_type;
+    // This is very similar to get_message_type(), but it returns
+    // a boolean.
+    return !!message_type;
 };
 
 function get_or_set(fieldname, keep_leading_whitespace) {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -72,7 +72,7 @@ exports.snapshot_message = function () {
 
     // Save what we can.
     var message = {
-        type: compose_state.composing(),
+        type: compose_state.get_message_type(),
         content: compose_state.message_content(),
     };
     if (message.type === "private") {

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -22,16 +22,17 @@ function preserve_state(send_after_reload, save_pointer, save_narrow, save_compo
     url += "+csrf_token=" + encodeURIComponent(csrf_token);
 
     if (save_compose) {
-        if (compose_state.composing() === 'stream') {
+        var msg_type = compose_state.get_message_type();
+        if (msg_type === 'stream') {
             url += "+msg_type=stream";
             url += "+stream=" + encodeURIComponent(compose_state.stream_name());
             url += "+subject=" + encodeURIComponent(compose_state.subject());
-        } else if (compose_state.composing() === 'private') {
+        } else if (msg_type === 'private') {
             url += "+msg_type=private";
             url += "+recipient=" + encodeURIComponent(compose_state.recipient());
         }
 
-        if (compose_state.composing()) {
+        if (msg_type) {
             url += "+msg=" + encodeURIComponent(compose_state.message_content());
         }
     }

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -39,7 +39,7 @@ function is_valid_conversation(recipient) {
         return false;
     }
 
-    if (compose_state.composing() !== 'private') {
+    if (compose_state.get_message_type() !== 'private') {
         // We only use typing indicators in PMs for now.
         // There was originally some support for having
         // typing indicators related to stream conversations,


### PR DESCRIPTION
We now only call compose_state.composing() in a boolean context,
where we simply care whether or not the compose box is open.  The
function now also returns true/false.

Callers who need to know the actual message type (e.g. "stream" or
"private") now call compose_state.get_message_type().