### PR TITLE
Add aggregated info to real-time sync race for presence.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2344,7 +2344,7 @@ def send_presence_changed(user_profile, presence):
     presence_dict = presence.to_dict()
     event = dict(type="presence", email=user_profile.email,
                  server_timestamp=time.time(),
-                 presence={presence_dict['client']: presence.to_dict()})
+                 presence={presence_dict['client']: presence_dict})
     send_event(event, active_user_ids(user_profile.realm))
 
 def consolidate_client(client):

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -29,7 +29,7 @@ from zerver.lib.actions import validate_user_access_to_subscribers_helper, \
     gather_subscriptions_helper, get_realm_domains, \
     get_status_dict, streams_to_dicts_sorted
 from zerver.tornado.event_queue import request_event_queue, get_user_events
-from zerver.models import Client, Message, Realm, UserProfile, \
+from zerver.models import Client, Message, Realm, UserPresence, UserProfile, \
     get_user_profile_by_email, get_user_profile_by_id, \
     get_active_user_dicts_in_realm, realm_filters_for_realm, \
     get_owned_bot_dicts, custom_profile_fields_for_realm
@@ -349,7 +349,7 @@ def apply_event(state, event, user_profile, include_subscribers):
                         user_id in sub['subscribers']):
                     sub['subscribers'].remove(user_id)
     elif event['type'] == "presence":
-        state['presences'][event['email']] = event['presence']
+        state['presences'] = UserPresence.get_status_dict_by_user(user_profile)
     elif event['type'] == "update_message":
         # The client will get the updated message directly
         pass

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1567,8 +1567,8 @@ class UserPresence(models.Model):
         return user_statuses
 
     @staticmethod
-    def to_presence_dict(client_name, status, dt, push_enabled=None,
-                         has_push_devices=None, is_mirror_dummy=None):
+    def to_presence_dict(client_name, status, dt, push_enabled=False,
+                         has_push_devices=False, is_mirror_dummy=None):
         # type: (Text, int, datetime.datetime, Optional[bool], Optional[bool], Optional[bool]) -> Dict[str, Any]
         presence_val = UserPresence.status_to_string(status)
 


### PR DESCRIPTION
- Add aggregated info to real-time updated presence status.
- Update `presence events` test case with adding aggregated
  information to presence event.

Fixes #4282