### PR TITLE
webhooks: Use author's name to format Git push messages.

### DIFF
--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -12,7 +12,11 @@ COMMIT_OR_COMMITS = u"commit{}"
 
 PUSH_PUSHED_TEXT_WITH_URL = u"[pushed]({compare_url}) {number_of_commits} {commit_or_commits}"
 PUSH_PUSHED_TEXT_WITHOUT_URL = u"pushed {number_of_commits} {commit_or_commits}"
-PUSH_COMMITS_MESSAGE_TEMPLATE = u"""{user_name} {pushed_text} to branch {branch_name}. {committers_details}.
+PUSH_COMMITS_MESSAGE_TEMPLATE_WITH_COMMITTERS = u"""{user_name} {pushed_text} to branch {branch_name}. {committers_details}.
+
+{commits_data}
+"""
+PUSH_COMMITS_MESSAGE_TEMPLATE_WITHOUT_COMMITTERS = u"""{user_name} {pushed_text} to branch {branch_name}.
 
 {commits_data}
 """
@@ -41,15 +45,6 @@ TAG_WITHOUT_URL_TEMPLATE = u"{tag_name}"
 
 def get_push_commits_event_message(user_name, compare_url, branch_name, commits_data, is_truncated=False):
     # type: (Text, Optional[Text], Text, List[Dict[str, Any]], Optional[bool]) -> Text
-    committers_items = get_all_committers(commits_data)  # type: List[Tuple[str, int]]
-    committers_details = "{} ({})".format(*committers_items[0])
-
-    for name, number_of_commits in committers_items[1:-1]:
-        committers_details = "{}, {} ({})".format(committers_details, name, number_of_commits)
-
-    if len(committers_items) > 1:
-        committers_details = "{} and {} ({})".format(committers_details, *committers_items[-1])
-
     pushed_message_template = PUSH_PUSHED_TEXT_WITH_URL if compare_url else PUSH_PUSHED_TEXT_WITHOUT_URL
 
     pushed_text_message = pushed_message_template.format(
@@ -57,13 +52,30 @@ def get_push_commits_event_message(user_name, compare_url, branch_name, commits_
         number_of_commits=len(commits_data),
         commit_or_commits=COMMIT_OR_COMMITS.format(u's' if len(commits_data) > 1 else u''))
 
-    return PUSH_COMMITS_MESSAGE_TEMPLATE.format(
-        user_name=user_name,
-        pushed_text=pushed_text_message,
-        branch_name=branch_name,
-        committers_details=PUSH_COMMITS_MESSAGE_EXTENSION.format(committers_details),
-        commits_data=get_commits_content(commits_data, is_truncated),
-    ).rstrip()
+    committers_items = get_all_committers(commits_data)  # type: List[Tuple[str, int]]
+    if len(committers_items) == 1 and user_name == committers_items[0][0]:
+        return PUSH_COMMITS_MESSAGE_TEMPLATE_WITHOUT_COMMITTERS.format(
+            user_name=user_name,
+            pushed_text=pushed_text_message,
+            branch_name=branch_name,
+            commits_data=get_commits_content(commits_data, is_truncated),
+        ).rstrip()
+    else:
+        committers_details = "{} ({})".format(*committers_items[0])
+
+        for name, number_of_commits in committers_items[1:-1]:
+            committers_details = "{}, {} ({})".format(committers_details, name, number_of_commits)
+
+        if len(committers_items) > 1:
+            committers_details = "{} and {} ({})".format(committers_details, *committers_items[-1])
+
+        return PUSH_COMMITS_MESSAGE_TEMPLATE_WITH_COMMITTERS.format(
+            user_name=user_name,
+            pushed_text=pushed_text_message,
+            branch_name=branch_name,
+            committers_details=PUSH_COMMITS_MESSAGE_EXTENSION.format(committers_details),
+            commits_data=get_commits_content(commits_data, is_truncated),
+        ).rstrip()
 
 def get_force_push_commits_event_message(user_name, url, branch_name, head):
     # type: (Text, Text, Text, Text) -> Text

--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -12,7 +12,7 @@ COMMIT_OR_COMMITS = u"commit{}"
 
 PUSH_PUSHED_TEXT_WITH_URL = u"[pushed]({compare_url}) {number_of_commits} {commit_or_commits}"
 PUSH_PUSHED_TEXT_WITHOUT_URL = u"pushed {number_of_commits} {commit_or_commits}"
-PUSH_COMMITS_MESSAGE_TEMPLATE = u"""{user_name} {pushed_text} to branch {branch_name}. {committers_details}
+PUSH_COMMITS_MESSAGE_TEMPLATE = u"""{user_name} {pushed_text} to branch {branch_name}. {committers_details}.
 
 {commits_data}
 """
@@ -42,13 +42,13 @@ TAG_WITHOUT_URL_TEMPLATE = u"{tag_name}"
 def get_push_commits_event_message(user_name, compare_url, branch_name, commits_data, is_truncated=False):
     # type: (Text, Optional[Text], Text, List[Dict[str, Any]], Optional[bool]) -> Text
     committers_items = get_all_committers(commits_data)  # type: List[Tuple[str, int]]
-    committers_details = "{}({})".format(*committers_items[0])
+    committers_details = "{} ({})".format(*committers_items[0])
 
     for name, number_of_commits in committers_items[1:-1]:
-        committers_details = "{}, {}({})".format(committers_details, name, number_of_commits)
+        committers_details = "{}, {} ({})".format(committers_details, name, number_of_commits)
 
     if len(committers_items) > 1:
-        committers_details = "{} and {}({})".format(committers_details, *committers_items[-1])
+        committers_details = "{} and {} ({})".format(committers_details, *committers_items[-1])
 
     pushed_message_template = PUSH_PUSHED_TEXT_WITH_URL if compare_url else PUSH_PUSHED_TEXT_WITHOUT_URL
 

--- a/zerver/webhooks/beanstalk/tests.py
+++ b/zerver/webhooks/beanstalk/tests.py
@@ -12,7 +12,7 @@ class BeanstalkHookTests(WebhookTestCase):
     def test_git_single(self):
         # type: () -> None
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master. Commits by Leo Franchi(1)
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master. Commits by Leo Franchi (1).
 
 * add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
         self.send_and_test_stream_message('git_singlecommit', expected_subject, expected_message,
@@ -23,7 +23,7 @@ class BeanstalkHookTests(WebhookTestCase):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master. Commits by Leo Franchi(1)
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master. Commits by Leo Franchi (1).
 
 * add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
         self.send_and_test_stream_message('git_singlecommit', expected_subject, expected_message,
@@ -33,7 +33,7 @@ class BeanstalkHookTests(WebhookTestCase):
     def test_git_multiple_committers(self):
         # type: () -> None
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi(2) and Tomasz Kolek(1)
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi (2) and Tomasz Kolek (1).
 
 * Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
@@ -46,7 +46,7 @@ class BeanstalkHookTests(WebhookTestCase):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi(2) and Tomasz Kolek(1)
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi (2) and Tomasz Kolek (1).
 
 * Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
@@ -58,7 +58,7 @@ class BeanstalkHookTests(WebhookTestCase):
     def test_git_multiple(self):
         # type: () -> None
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi(3)
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi (3).
 
 * Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
@@ -71,7 +71,7 @@ class BeanstalkHookTests(WebhookTestCase):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi(3)
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi (3).
 
 * Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
@@ -84,7 +84,7 @@ class BeanstalkHookTests(WebhookTestCase):
         # type: () -> None
         commits_info = "* add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))\n"
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master. Commits by Leo Franchi(50)
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master. Commits by Leo Franchi (50).
 
 {}[and {} more commit(s)]""".format((commits_info * COMMITS_LIMIT), 50 - COMMITS_LIMIT)
         self.send_and_test_stream_message('git_morethanlimitcommits', expected_subject, expected_message,
@@ -96,7 +96,7 @@ class BeanstalkHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(branches='master,development')
         commits_info = "* add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))\n"
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master. Commits by Leo Franchi(50)
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master. Commits by Leo Franchi (50).
 
 {}[and {} more commit(s)]""".format((commits_info * COMMITS_LIMIT), 50 - COMMITS_LIMIT)
         self.send_and_test_stream_message('git_morethanlimitcommits', expected_subject, expected_message,

--- a/zerver/webhooks/beanstalk/tests.py
+++ b/zerver/webhooks/beanstalk/tests.py
@@ -12,7 +12,7 @@ class BeanstalkHookTests(WebhookTestCase):
     def test_git_single(self):
         # type: () -> None
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master. Commits by Leo Franchi (1).
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master.
 
 * add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
         self.send_and_test_stream_message('git_singlecommit', expected_subject, expected_message,
@@ -23,7 +23,7 @@ class BeanstalkHookTests(WebhookTestCase):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master. Commits by Leo Franchi (1).
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master.
 
 * add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
         self.send_and_test_stream_message('git_singlecommit', expected_subject, expected_message,
@@ -58,7 +58,7 @@ class BeanstalkHookTests(WebhookTestCase):
     def test_git_multiple(self):
         # type: () -> None
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi (3).
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master.
 
 * Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
@@ -71,7 +71,7 @@ class BeanstalkHookTests(WebhookTestCase):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi (3).
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master.
 
 * Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
@@ -84,7 +84,7 @@ class BeanstalkHookTests(WebhookTestCase):
         # type: () -> None
         commits_info = "* add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))\n"
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master. Commits by Leo Franchi (50).
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master.
 
 {}[and {} more commit(s)]""".format((commits_info * COMMITS_LIMIT), 50 - COMMITS_LIMIT)
         self.send_and_test_stream_message('git_morethanlimitcommits', expected_subject, expected_message,
@@ -96,7 +96,7 @@ class BeanstalkHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(branches='master,development')
         commits_info = "* add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))\n"
         expected_subject = "work-test / master"
-        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master. Commits by Leo Franchi (50).
+        expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master.
 
 {}[and {} more commit(s)]""".format((commits_info * COMMITS_LIMIT), 50 - COMMITS_LIMIT)
         self.send_and_test_stream_message('git_morethanlimitcommits', expected_subject, expected_message,

--- a/zerver/webhooks/beanstalk/view.py
+++ b/zerver/webhooks/beanstalk/view.py
@@ -57,7 +57,7 @@ def api_beanstalk_webhook(request, user_profile,
             return json_success()
         # To get a linkable url,
         for commit in payload['commits']:
-            commit['committer'] = {'username': commit['author']['name']}
+            commit['author'] = {'username': commit['author']['name']}
 
         subject, content = build_message_from_gitlog(user_profile, payload['repository']['name'],
                                                      payload['ref'], payload['commits'],

--- a/zerver/webhooks/bitbucket/tests.py
+++ b/zerver/webhooks/bitbucket/tests.py
@@ -16,7 +16,7 @@ class BitbucketHookTests(WebhookTestCase):
         fixture_name = 'push'
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))'
-        expected_message = u"kolaszek pushed 1 commit to branch master. Commits by kolaszek (1).\n\n{}".format(commit_info)
+        expected_message = u"kolaszek pushed 1 commit to branch master.\n\n{}".format(commit_info)
         self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
 
     def test_bitbucket_on_push_event_filtered_by_branches(self):
@@ -25,7 +25,7 @@ class BitbucketHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name),
                                           branches='master,development')
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))'
-        expected_message = u"kolaszek pushed 1 commit to branch master. Commits by kolaszek (1).\n\n{}".format(commit_info)
+        expected_message = u"kolaszek pushed 1 commit to branch master.\n\n{}".format(commit_info)
         self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
 
     def test_bitbucket_on_push_commits_above_limit_event(self):
@@ -33,7 +33,7 @@ class BitbucketHookTests(WebhookTestCase):
         fixture_name = 'push_commits_above_limit'
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n'
-        expected_message = u"kolaszek pushed 50 commits to branch master. Commits by kolaszek (50).\n\n{}[and 30 more commit(s)]".format(commit_info * 20)
+        expected_message = u"kolaszek pushed 50 commits to branch master.\n\n{}[and 30 more commit(s)]".format(commit_info * 20)
         self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
 
     def test_bitbucket_on_push_commits_above_limit_event_filtered_by_branches(self):
@@ -42,7 +42,7 @@ class BitbucketHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name),
                                           branches='master,development')
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n'
-        expected_message = u"kolaszek pushed 50 commits to branch master. Commits by kolaszek (50).\n\n{}[and 30 more commit(s)]".format(commit_info * 20)
+        expected_message = u"kolaszek pushed 50 commits to branch master.\n\n{}[and 30 more commit(s)]".format(commit_info * 20)
         self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
 
     def test_bitbucket_on_force_push_event(self):

--- a/zerver/webhooks/bitbucket/tests.py
+++ b/zerver/webhooks/bitbucket/tests.py
@@ -16,7 +16,7 @@ class BitbucketHookTests(WebhookTestCase):
         fixture_name = 'push'
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))'
-        expected_message = u"kolaszek pushed 1 commit to branch master. Commits by kolaszek(1)\n\n{}".format(commit_info)
+        expected_message = u"kolaszek pushed 1 commit to branch master. Commits by kolaszek (1).\n\n{}".format(commit_info)
         self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
 
     def test_bitbucket_on_push_event_filtered_by_branches(self):
@@ -25,7 +25,7 @@ class BitbucketHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name),
                                           branches='master,development')
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))'
-        expected_message = u"kolaszek pushed 1 commit to branch master. Commits by kolaszek(1)\n\n{}".format(commit_info)
+        expected_message = u"kolaszek pushed 1 commit to branch master. Commits by kolaszek (1).\n\n{}".format(commit_info)
         self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
 
     def test_bitbucket_on_push_commits_above_limit_event(self):
@@ -33,7 +33,7 @@ class BitbucketHookTests(WebhookTestCase):
         fixture_name = 'push_commits_above_limit'
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n'
-        expected_message = u"kolaszek pushed 50 commits to branch master. Commits by kolaszek(50)\n\n{}[and 30 more commit(s)]".format(commit_info * 20)
+        expected_message = u"kolaszek pushed 50 commits to branch master. Commits by kolaszek (50).\n\n{}[and 30 more commit(s)]".format(commit_info * 20)
         self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
 
     def test_bitbucket_on_push_commits_above_limit_event_filtered_by_branches(self):
@@ -42,7 +42,7 @@ class BitbucketHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name),
                                           branches='master,development')
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n'
-        expected_message = u"kolaszek pushed 50 commits to branch master. Commits by kolaszek(50)\n\n{}[and 30 more commit(s)]".format(commit_info * 20)
+        expected_message = u"kolaszek pushed 50 commits to branch master. Commits by kolaszek (50).\n\n{}[and 30 more commit(s)]".format(commit_info * 20)
         self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
 
     def test_bitbucket_on_force_push_event(self):

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -16,46 +16,46 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_push_event(self):
         # type: () -> None
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))'
-        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz(1)\n\n{}".format(commit_info)
+        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz (1).\n\n{}".format(commit_info)
         self.send_and_test_stream_message('v2_push', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers(self):
         # type: () -> None
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Benjamin(2) and Tomasz(1)\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*2)
+        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Benjamin (2) and Tomasz (1).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*2)
         self.send_and_test_stream_message('v2_push_multiple_committers', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers_with_others(self):
         # type: () -> None
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz(4), James(3), Brendon(2) and others(1)\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*9)
+        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz (4), James (3), Brendon (2) and others (1).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*9)
         self.send_and_test_stream_message('v2_push_multiple_committers_with_others', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Benjamin(2) and Tomasz(1)\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*2)
+        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Benjamin (2) and Tomasz (1).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*2)
         self.send_and_test_stream_message('v2_push_multiple_committers', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers_with_others_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz(4), James(3), Brendon(2) and others(1)\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*9)
+        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz (4), James (3), Brendon (2) and others (1).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*9)
         self.send_and_test_stream_message('v2_push_multiple_committers_with_others', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_event_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))'
-        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz(1)\n\n{}".format(commit_info)
+        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz (1).\n\n{}".format(commit_info)
         self.send_and_test_stream_message('v2_push', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_above_limit_event(self):
         # type: () -> None
         commit_info = '* a ([6f161a7](https://bitbucket.org/kolaszek/repository-name/commits/6f161a7bced94430ac8947d87dbf45c6deee3fb0))\n'
-        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branches/compare/6f161a7bced94430ac8947d87dbf45c6deee3fb0..1221f2fda6f1e3654b09f1f3a08390e4cb25bb48) 5 commits to branch master. Commits by Tomasz(5)\n\n{}[and more commit(s)]".format(
+        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branches/compare/6f161a7bced94430ac8947d87dbf45c6deee3fb0..1221f2fda6f1e3654b09f1f3a08390e4cb25bb48) 5 commits to branch master. Commits by Tomasz (5).\n\n{}[and more commit(s)]".format(
             (commit_info * 5),
         )
         self.send_and_test_stream_message('v2_push_commits_above_limit', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
@@ -64,7 +64,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = '* a ([6f161a7](https://bitbucket.org/kolaszek/repository-name/commits/6f161a7bced94430ac8947d87dbf45c6deee3fb0))\n'
-        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branches/compare/6f161a7bced94430ac8947d87dbf45c6deee3fb0..1221f2fda6f1e3654b09f1f3a08390e4cb25bb48) 5 commits to branch master. Commits by Tomasz(5)\n\n{}[and more commit(s)]".format(
+        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branches/compare/6f161a7bced94430ac8947d87dbf45c6deee3fb0..1221f2fda6f1e3654b09f1f3a08390e4cb25bb48) 5 commits to branch master. Commits by Tomasz (5).\n\n{}[and more commit(s)]".format(
             (commit_info * 5),
         )
         self.send_and_test_stream_message('v2_push_commits_above_limit', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
@@ -224,7 +224,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         }
         self.send_and_test_stream_message('v2_more_than_one_push_event', **kwargs)
         msg = self.get_second_to_last_message()
-        self.do_test_message(msg, 'kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz(1)\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))')
+        self.do_test_message(msg, 'kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz (1).\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))')
         self.do_test_subject(msg, self.EXPECTED_SUBJECT_BRANCH_EVENTS)
         msg = self.get_last_message()
         self.do_test_message(msg, 'kolaszek pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a)')
@@ -238,7 +238,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         }
         self.send_and_test_stream_message('v2_more_than_one_push_event', **kwargs)
         msg = self.get_second_to_last_message()
-        self.do_test_message(msg, 'kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz(1)\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))')
+        self.do_test_message(msg, 'kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz (1).\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))')
         self.do_test_subject(msg, self.EXPECTED_SUBJECT_BRANCH_EVENTS)
         msg = self.get_last_message()
         self.do_test_message(msg, 'kolaszek pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a)')

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -16,40 +16,40 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_push_event(self):
         # type: () -> None
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))'
-        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz (1).\n\n{}".format(commit_info)
+        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n{}".format(commit_info)
         self.send_and_test_stream_message('v2_push', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers(self):
         # type: () -> None
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Benjamin (2) and Tomasz (1).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*2)
+        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by zbenjamin (2) and kolaszek (1).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*2)
         self.send_and_test_stream_message('v2_push_multiple_committers', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers_with_others(self):
         # type: () -> None
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz (4), James (3), Brendon (2) and others (1).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*9)
+        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by james (3), Brendon (2), Tomasz (2) and others (3).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*9)
         self.send_and_test_stream_message('v2_push_multiple_committers_with_others', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Benjamin (2) and Tomasz (1).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*2)
+        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by zbenjamin (2) and kolaszek (1).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*2)
         self.send_and_test_stream_message('v2_push_multiple_committers', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers_with_others_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz (4), James (3), Brendon (2) and others (1).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*9)
+        expected_message = u"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by james (3), Brendon (2), Tomasz (2) and others (3).\n\n{}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))""".format(commit_info*9)
         self.send_and_test_stream_message('v2_push_multiple_committers_with_others', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_event_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = u'* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))'
-        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz (1).\n\n{}".format(commit_info)
+        expected_message = u"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n{}".format(commit_info)
         self.send_and_test_stream_message('v2_push', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_above_limit_event(self):
@@ -224,7 +224,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         }
         self.send_and_test_stream_message('v2_more_than_one_push_event', **kwargs)
         msg = self.get_second_to_last_message()
-        self.do_test_message(msg, 'kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz (1).\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))')
+        self.do_test_message(msg, 'kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))')
         self.do_test_subject(msg, self.EXPECTED_SUBJECT_BRANCH_EVENTS)
         msg = self.get_last_message()
         self.do_test_message(msg, 'kolaszek pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a)')
@@ -238,7 +238,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         }
         self.send_and_test_stream_message('v2_more_than_one_push_event', **kwargs)
         msg = self.get_second_to_last_message()
-        self.do_test_message(msg, 'kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master. Commits by Tomasz (1).\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))')
+        self.do_test_message(msg, 'kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))')
         self.do_test_subject(msg, self.EXPECTED_SUBJECT_BRANCH_EVENTS)
         msg = self.get_last_message()
         self.do_test_message(msg, 'kolaszek pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a)')

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -170,10 +170,16 @@ def get_force_push_body(payload, change):
         change['new']['target']['hash']
     )
 
+def get_commit_author_name(commit):
+    # type: (Dict[str, Any]) -> Text
+    if commit.get('author').get('user'):
+        return commit.get('author').get('user').get('username')
+    return commit.get('author').get('raw').split()[0]
+
 def get_normal_push_body(payload, change):
     # type: (Dict[str, Any], Dict[str, Any]) -> Text
     commits_data = [{
-        'name': commit.get('author').get('raw').split()[0],
+        'name': get_commit_author_name(commit),
         'sha': commit.get('hash'),
         'url': commit.get('links').get('html').get('href'),
         'message': commit.get('message'),

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -12,7 +12,7 @@ class GithubV1HookTests(WebhookTestCase):
     SEND_STREAM = False
     BRANCHES = None # type: Optional[Text]
 
-    push_content = u"""zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 3 commits to branch master. Commits by zbenjamin (3).
+    push_content = u"""zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 3 commits to branch master.
 
 * Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))
 * Baz needs to be longer ([06ebe5f](https://github.com/zbenjamin/zulip-test/commit/06ebe5f472a32f6f31fd2a665f0c7442b69cce72))
@@ -78,7 +78,7 @@ class GithubV1HookTests(WebhookTestCase):
     def test_push_multiple_commits(self):
         # type: () -> None
         commit_info = "* Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))\n"
-        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 50 commits to branch master. Commits by zbenjamin (50).\n\n{}[and {} more commit(s)]".format(
+        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 50 commits to branch master.\n\n{}[and {} more commit(s)]".format(
             commit_info * COMMITS_LIMIT,
             50 - COMMITS_LIMIT,
         )
@@ -152,7 +152,7 @@ class GithubV2HookTests(WebhookTestCase):
     SEND_STREAM = False
     BRANCHES = None # type: Optional[Text]
 
-    push_content = """zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 3 commits to branch master. Commits by zbenjamin (3).
+    push_content = """zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 3 commits to branch master.
 
 * Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))
 * Baz needs to be longer ([06ebe5f](https://github.com/zbenjamin/zulip-test/commit/06ebe5f472a32f6f31fd2a665f0c7442b69cce72))
@@ -214,7 +214,7 @@ class GithubV2HookTests(WebhookTestCase):
     def test_push_multiple_commits(self):
         # type: () -> None
         commit_info = "* Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))\n"
-        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 50 commits to branch master. Commits by zbenjamin (50).\n\n{}[and {} more commit(s)]".format(
+        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 50 commits to branch master.\n\n{}[and {} more commit(s)]".format(
             commit_info * COMMITS_LIMIT,
             50 - COMMITS_LIMIT,
         )

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -12,7 +12,7 @@ class GithubV1HookTests(WebhookTestCase):
     SEND_STREAM = False
     BRANCHES = None # type: Optional[Text]
 
-    push_content = u"""zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 3 commits to branch master. Commits by zbenjamin(3)
+    push_content = u"""zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 3 commits to branch master. Commits by zbenjamin (3).
 
 * Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))
 * Baz needs to be longer ([06ebe5f](https://github.com/zbenjamin/zulip-test/commit/06ebe5f472a32f6f31fd2a665f0c7442b69cce72))
@@ -78,7 +78,7 @@ class GithubV1HookTests(WebhookTestCase):
     def test_push_multiple_commits(self):
         # type: () -> None
         commit_info = "* Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))\n"
-        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 50 commits to branch master. Commits by zbenjamin(50)\n\n{}[and {} more commit(s)]".format(
+        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 50 commits to branch master. Commits by zbenjamin (50).\n\n{}[and {} more commit(s)]".format(
             commit_info * COMMITS_LIMIT,
             50 - COMMITS_LIMIT,
         )
@@ -152,7 +152,7 @@ class GithubV2HookTests(WebhookTestCase):
     SEND_STREAM = False
     BRANCHES = None # type: Optional[Text]
 
-    push_content = """zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 3 commits to branch master. Commits by zbenjamin(3)
+    push_content = """zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 3 commits to branch master. Commits by zbenjamin (3).
 
 * Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))
 * Baz needs to be longer ([06ebe5f](https://github.com/zbenjamin/zulip-test/commit/06ebe5f472a32f6f31fd2a665f0c7442b69cce72))
@@ -214,7 +214,7 @@ class GithubV2HookTests(WebhookTestCase):
     def test_push_multiple_commits(self):
         # type: () -> None
         commit_info = "* Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))\n"
-        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 50 commits to branch master. Commits by zbenjamin(50)\n\n{}[and {} more commit(s)]".format(
+        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 50 commits to branch master. Commits by zbenjamin (50).\n\n{}[and {} more commit(s)]".format(
             commit_info * COMMITS_LIMIT,
             50 - COMMITS_LIMIT,
         )
@@ -223,13 +223,13 @@ class GithubV2HookTests(WebhookTestCase):
     def test_push_multiple_committers(self):
         # type: () -> None
         commit_info = "* Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))\n"
-        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 6 commits to branch master. Commits by tomasz(3), baxthehacker(2) and zbenjamin(1)\n\n{}* Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))".format(commit_info * 5)
+        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 6 commits to branch master. Commits by tomasz (3), baxthehacker (2) and zbenjamin (1).\n\n{}* Add baz ([48c329a](https://github.com/zbenjamin/zulip-test/commit/48c329a0b68a9a379ff195ee3f1c1f4ab0b2a89e))".format(commit_info * 5)
         self.basic_test('push_multiple_committers', 'commits', 'zulip-test / master', expected_subject)
 
     def test_push_multiple_committers_with_others(self):
         # type: () -> None
         commit_info = "* Final edit to baz, I swear ([b954491](https://github.com/zbenjamin/zulip-test/commit/b95449196980507f08209bdfdc4f1d611689b7a8))\n"
-        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 10 commits to branch master. Commits by baxthehacker(4), James(3), Tomasz(2) and others(1)\n\n{}* Final edit to baz, I swear ([b954491](https://github.com/zbenjamin/zulip-test/commit/b95449196980507f08209bdfdc4f1d611689b7a8))".format(commit_info * 9)
+        expected_subject = "zbenjamin [pushed](https://github.com/zbenjamin/zulip-test/compare/4f9adc4777d5...b95449196980) 10 commits to branch master. Commits by baxthehacker (4), James (3), Tomasz (2) and others (1).\n\n{}* Final edit to baz, I swear ([b954491](https://github.com/zbenjamin/zulip-test/commit/b95449196980507f08209bdfdc4f1d611689b7a8))".format(commit_info * 9)
         self.basic_test('push_multiple_committers_with_others', 'commits', 'zulip-test / master', expected_subject)
 
     def test_legacy_hook(self):

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -300,7 +300,7 @@ def _transform_commits_list_to_common_format(commits):
     new_commits_list = []
     for commit in commits:
         new_commits_list.append({
-            'name': commit.get('committer').get('username'),
+            'name': commit.get('author').get('username'),
             'sha': commit.get('id'),
             'url': commit.get('url'),
             'message': commit.get('message'),

--- a/zerver/webhooks/github_webhook/tests.py
+++ b/zerver/webhooks/github_webhook/tests.py
@@ -25,26 +25,26 @@ class GithubWebhookTest(WebhookTestCase):
 
     def test_push_1_commit(self):
         # type: () -> None
-        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes. Commits by baxterthehacker(1)\n\n* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
+        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes. Commits by baxterthehacker (1).\n\n* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
         self.send_and_test_stream_message('push_1_commit', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
 
     def test_push_1_commit_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url('master,changes')
-        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes. Commits by baxterthehacker(1)\n\n* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
+        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes. Commits by baxterthehacker (1).\n\n* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
         self.send_and_test_stream_message('push_1_commit', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
 
     def test_push_multiple_comitters(self):
         # type: () -> None
         commits_info = u'* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n'
-        expected_message = u"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 6 commits to branch changes. Commits by Tomasz(3), Ben(2) and baxterthehacker(1)\n\n{}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))""".format(commits_info * 5)
+        expected_message = u"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 6 commits to branch changes. Commits by Tomasz (3), Ben (2) and baxterthehacker (1).\n\n{}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))""".format(commits_info * 5)
 
         self.send_and_test_stream_message('push_multiple_committers', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
 
     def test_push_multiple_comitters_with_others(self):
         # type: () -> None
         commits_info = u'* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n'
-        expected_message = u"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 10 commits to branch changes. Commits by Tomasz(4), Ben(3), James(2) and others(1)\n\n{}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))""".format(commits_info * 9)
+        expected_message = u"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 10 commits to branch changes. Commits by Tomasz (4), Ben (3), James (2) and others (1).\n\n{}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))""".format(commits_info * 9)
 
         self.send_and_test_stream_message('push_multiple_committers_with_others', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
 
@@ -52,7 +52,7 @@ class GithubWebhookTest(WebhookTestCase):
         # type: () -> None
         self.url = self.build_webhook_url('master,changes')
         commits_info = u'* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n'
-        expected_message = u"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 6 commits to branch changes. Commits by Tomasz(3), Ben(2) and baxterthehacker(1)\n\n{}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))""".format(commits_info * 5)
+        expected_message = u"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 6 commits to branch changes. Commits by Tomasz (3), Ben (2) and baxterthehacker (1).\n\n{}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))""".format(commits_info * 5)
 
         self.send_and_test_stream_message('push_multiple_committers', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
 
@@ -60,14 +60,14 @@ class GithubWebhookTest(WebhookTestCase):
         # type: () -> None
         self.url = self.build_webhook_url('master,changes')
         commits_info = u'* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n'
-        expected_message = u"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 10 commits to branch changes. Commits by Tomasz(4), Ben(3), James(2) and others(1)\n\n{}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))""".format(commits_info * 9)
+        expected_message = u"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 10 commits to branch changes. Commits by Tomasz (4), Ben (3), James (2) and others (1).\n\n{}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))""".format(commits_info * 9)
 
         self.send_and_test_stream_message('push_multiple_committers_with_others', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
 
     def test_push_50_commits(self):
         # type: () -> None
         commit_info = "* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
-        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes. Commits by baxterthehacker(50)\n\n{}[and 30 more commit(s)]".format(
+        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes. Commits by baxterthehacker (50).\n\n{}[and 30 more commit(s)]".format(
             commit_info * COMMITS_LIMIT
         )
         self.send_and_test_stream_message('push_50_commits', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
@@ -76,7 +76,7 @@ class GithubWebhookTest(WebhookTestCase):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,changes')
         commit_info = "* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
-        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes. Commits by baxterthehacker(50)\n\n{}[and 30 more commit(s)]".format(
+        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes. Commits by baxterthehacker (50).\n\n{}[and 30 more commit(s)]".format(
             commit_info * COMMITS_LIMIT
         )
         self.send_and_test_stream_message('push_50_commits', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')

--- a/zerver/webhooks/github_webhook/tests.py
+++ b/zerver/webhooks/github_webhook/tests.py
@@ -25,13 +25,13 @@ class GithubWebhookTest(WebhookTestCase):
 
     def test_push_1_commit(self):
         # type: () -> None
-        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes. Commits by baxterthehacker (1).\n\n* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
+        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes.\n\n* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
         self.send_and_test_stream_message('push_1_commit', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
 
     def test_push_1_commit_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url('master,changes')
-        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes. Commits by baxterthehacker (1).\n\n* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
+        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes.\n\n* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
         self.send_and_test_stream_message('push_1_commit', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
 
     def test_push_multiple_comitters(self):
@@ -67,7 +67,7 @@ class GithubWebhookTest(WebhookTestCase):
     def test_push_50_commits(self):
         # type: () -> None
         commit_info = "* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
-        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes. Commits by baxterthehacker (50).\n\n{}[and 30 more commit(s)]".format(
+        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes.\n\n{}[and 30 more commit(s)]".format(
             commit_info * COMMITS_LIMIT
         )
         self.send_and_test_stream_message('push_50_commits', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
@@ -76,7 +76,7 @@ class GithubWebhookTest(WebhookTestCase):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,changes')
         commit_info = "* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
-        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes. Commits by baxterthehacker (50).\n\n{}[and 30 more commit(s)]".format(
+        expected_message = u"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes.\n\n{}[and 30 more commit(s)]".format(
             commit_info * COMMITS_LIMIT
         )
         self.send_and_test_stream_message('push_50_commits', self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')

--- a/zerver/webhooks/github_webhook/view.py
+++ b/zerver/webhooks/github_webhook/view.py
@@ -180,7 +180,7 @@ def get_push_tags_body(payload):
 def get_push_commits_body(payload):
     # type: (Dict[str, Any]) -> Text
     commits_data = [{
-        'name': commit['committer']['username'],
+        'name': commit['author']['username'],
         'sha': commit['id'],
         'url': commit['url'],
         'message': commit['message']

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -13,34 +13,34 @@ class GitlabHookTests(WebhookTestCase):
     def test_push_event_message(self):
         # type: () -> None
         expected_subject = u"my-awesome-project / tomek"
-        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek. Commits by Tomasz Kolek(2)\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek. Commits by Tomasz Kolek (2).\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.send_and_test_stream_message('push', expected_subject, expected_message, HTTP_X_GITLAB_EVENT="Push Hook")
 
     def test_push_event_message_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,tomek')
         expected_subject = u"my-awesome-project / tomek"
-        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek. Commits by Tomasz Kolek(2)\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek. Commits by Tomasz Kolek (2).\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.send_and_test_stream_message('push', expected_subject, expected_message, HTTP_X_GITLAB_EVENT="Push Hook")
 
     def test_push_multiple_committers(self):
         # type: () -> None
         expected_subject = u"my-awesome-project / tomek"
-        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek. Commits by Ben(1) and Tomasz Kolek(1)\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek. Commits by Ben (1) and Tomasz Kolek (1).\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.send_and_test_stream_message('push_multiple_committers', expected_subject, expected_message, HTTP_X_GITLAB_EVENT="Push Hook")
 
     def test_push_multiple_committers_with_others(self):
         # type: () -> None
         expected_subject = u"my-awesome-project / tomek"
         commit_info = u"* b ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))\n"
-        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 7 commits to branch tomek. Commits by Ben(3), baxterthehacker(2), James(1) and others(1)\n\n{}* b ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))".format(commit_info * 6)
+        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 7 commits to branch tomek. Commits by Ben (3), baxterthehacker (2), James (1) and others (1).\n\n{}* b ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))".format(commit_info * 6)
         self.send_and_test_stream_message('push_multiple_committers_with_others', expected_subject, expected_message, HTTP_X_GITLAB_EVENT="Push Hook")
 
     def test_push_commits_more_than_limit_event_message(self):
         # type: () -> None
         expected_subject = u"my-awesome-project / tomek"
         commits_info = u'* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n'
-        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 50 commits to branch tomek. Commits by Tomasz Kolek(50)\n\n{}[and {} more commit(s)]".format(
+        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 50 commits to branch tomek. Commits by Tomasz Kolek (50).\n\n{}[and {} more commit(s)]".format(
             commits_info * COMMITS_LIMIT,
             50 - COMMITS_LIMIT,
         )
@@ -51,7 +51,7 @@ class GitlabHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(branches='master,tomek')
         expected_subject = u"my-awesome-project / tomek"
         commits_info = u'* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n'
-        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 50 commits to branch tomek. Commits by Tomasz Kolek(50)\n\n{}[and {} more commit(s)]".format(
+        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 50 commits to branch tomek. Commits by Tomasz Kolek (50).\n\n{}[and {} more commit(s)]".format(
             commits_info * COMMITS_LIMIT,
             50 - COMMITS_LIMIT,
         )

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -13,14 +13,14 @@ class GitlabHookTests(WebhookTestCase):
     def test_push_event_message(self):
         # type: () -> None
         expected_subject = u"my-awesome-project / tomek"
-        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek. Commits by Tomasz Kolek (2).\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.send_and_test_stream_message('push', expected_subject, expected_message, HTTP_X_GITLAB_EVENT="Push Hook")
 
     def test_push_event_message_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,tomek')
         expected_subject = u"my-awesome-project / tomek"
-        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek. Commits by Tomasz Kolek (2).\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.send_and_test_stream_message('push', expected_subject, expected_message, HTTP_X_GITLAB_EVENT="Push Hook")
 
     def test_push_multiple_committers(self):
@@ -40,7 +40,7 @@ class GitlabHookTests(WebhookTestCase):
         # type: () -> None
         expected_subject = u"my-awesome-project / tomek"
         commits_info = u'* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n'
-        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 50 commits to branch tomek. Commits by Tomasz Kolek (50).\n\n{}[and {} more commit(s)]".format(
+        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 50 commits to branch tomek.\n\n{}[and {} more commit(s)]".format(
             commits_info * COMMITS_LIMIT,
             50 - COMMITS_LIMIT,
         )
@@ -51,7 +51,7 @@ class GitlabHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(branches='master,tomek')
         expected_subject = u"my-awesome-project / tomek"
         commits_info = u'* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n'
-        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 50 commits to branch tomek. Commits by Tomasz Kolek (50).\n\n{}[and {} more commit(s)]".format(
+        expected_message = u"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 50 commits to branch tomek.\n\n{}[and {} more commit(s)]".format(
             commits_info * COMMITS_LIMIT,
             50 - COMMITS_LIMIT,
         )

--- a/zerver/webhooks/gogs/tests.py
+++ b/zerver/webhooks/gogs/tests.py
@@ -14,7 +14,7 @@ class GogsHookTests(WebhookTestCase):
     def test_push(self):
         # type: () -> None
         expected_subject = u"try-git / master"
-        expected_message = u"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 1 commit to branch master. Commits by John(1)
+        expected_message = u"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 1 commit to branch master. Commits by John (1).
 
 * Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))"""
         self.send_and_test_stream_message('push', expected_subject, expected_message, HTTP_X_GOGS_EVENT='push')
@@ -23,7 +23,7 @@ class GogsHookTests(WebhookTestCase):
         # type: () -> None
         commit_info = u'* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n'
         expected_subject = u"try-git / master"
-        expected_message = u"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 2 commits to branch master. Commits by Benjamin(1) and John(1)\n\n{}* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))""".format(commit_info)
+        expected_message = u"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 2 commits to branch master. Commits by Benjamin (1) and John (1).\n\n{}* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))""".format(commit_info)
         self.send_and_test_stream_message('push_commits_multiple_committers', expected_subject, expected_message, HTTP_X_GOGS_EVENT='push')
 
     def test_push_multiple_committers_filtered_by_branches(self):
@@ -31,14 +31,14 @@ class GogsHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = u'* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n'
         expected_subject = u"try-git / master"
-        expected_message = u"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 2 commits to branch master. Commits by Benjamin(1) and John(1)\n\n{}* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))""".format(commit_info)
+        expected_message = u"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 2 commits to branch master. Commits by Benjamin (1) and John (1).\n\n{}* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))""".format(commit_info)
         self.send_and_test_stream_message('push_commits_multiple_committers', expected_subject, expected_message, HTTP_X_GOGS_EVENT='push')
 
     def test_push_filtered_by_branches(self):
         # type: () -> None
         self.url = self.build_webhook_url(branches='master,development')
         expected_subject = u"try-git / master"
-        expected_message = u"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 1 commit to branch master. Commits by John(1)
+        expected_message = u"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 1 commit to branch master. Commits by John (1).
 
 * Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))"""
         self.send_and_test_stream_message('push', expected_subject, expected_message, HTTP_X_GOGS_EVENT='push')
@@ -47,7 +47,7 @@ class GogsHookTests(WebhookTestCase):
         # type: () -> None
         expected_subject = u"try-git / master"
         commits_info = "* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n"
-        expected_message = u"john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 30 commits to branch master. Commits by John(30)\n\n{}[and {} more commit(s)]".format(
+        expected_message = u"john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 30 commits to branch master. Commits by John (30).\n\n{}[and {} more commit(s)]".format(
             commits_info * COMMITS_LIMIT,
             30 - COMMITS_LIMIT
         )
@@ -58,7 +58,7 @@ class GogsHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(branches='master,development')
         expected_subject = u"try-git / master"
         commits_info = "* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n"
-        expected_message = u"john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 30 commits to branch master. Commits by John(30)\n\n{}[and {} more commit(s)]".format(
+        expected_message = u"john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 30 commits to branch master. Commits by John (30).\n\n{}[and {} more commit(s)]".format(
             commits_info * COMMITS_LIMIT,
             30 - COMMITS_LIMIT
         )

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -18,7 +18,8 @@ def format_push_event(payload):
 
     for commit in payload['commits']:
         commit['sha'] = commit['id']
-        commit['name'] = commit['author']['name'].split()[0]
+        commit['name'] = (commit['author']['username'] or
+                          commit['author']['name'].split()[0])
 
     data = {
         'user_name': payload['sender']['username'],


### PR DESCRIPTION
This PR solves some of the problems that were discussed in the `#commits` stream a while ago. @timabbott : I recall you telling me that there were 4 things wrong in total, could you please tell me what else there was? :) I'll push further related commits to this branch.

Looking forward to hearing your feedback! Thanks!

This PR is follow-up to #4006 and #3968. 