### PR TITLE
message-feed: Fix message drag uncaught errors.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -22,8 +22,17 @@ $(function () {
             end: function (e) {
                 var end = { x: e.offsetX, y: e.offsetY };
 
-                // get the linear difference between two coordinates on the screen.
-                var dist = Math.sqrt(Math.pow(end.x - start.x, 2) + Math.pow(end.y - start.y, 2));
+                var dist;
+                if (start) {
+                    // get the linear difference between two coordinates on the screen.
+                    dist = Math.sqrt(Math.pow(end.x - start.x, 2) + Math.pow(end.y - start.y, 2));
+                } else {
+                    // this usually happens if someone started dragging from outside of
+                    // a message and finishes their drag inside the message. Ideally,
+                    // this should not select a message, so we throw Infinity which
+                    // will filter this as a drag, rather than a click.
+                    dist = Infinity;
+                }
 
                 this.val = dist;
                 this.time = new Date().getTime() - time;


### PR DESCRIPTION
There is a mechanism to prevent a user from "clicking" on a message
if they drag over it, to allow people to copy message contents without
triggering the compose box to open.

In the case that a user would start dragging from outside a message
and finish dragging within a message, data on where the cursor started
at is missing.

This is fixed by checking if start data exists and if it doesn't, we
just throw a drag distance of Infinity which will tell the program to
not count the action as a "click" on the message. This now does not
have an uncaught error because it instead validates "start" as existing
before attempting to access its properties.