### PR TITLE
Add mobile auth redirect to custom URI scheme (zulip://)

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -25,6 +25,7 @@ IGNORED_PHRASES = [
     r"Kerberos",
     r"Mac",
     r"MiB",
+    r"OTP",
     r"Pivotal",
     r'REMOTE_USER',
     r'Slack',

--- a/zerver/lib/mobile_auth_otp.py
+++ b/zerver/lib/mobile_auth_otp.py
@@ -1,0 +1,56 @@
+# Simple one-time-pad library, to be used for encrypting Zulip API
+# keys when sending them to the mobile apps via new standard mobile
+# authentication flow.  This encryption is used to protect against
+# credential-stealing attacks where a malicious app registers the
+# zulip:// URL on a device, which might otherwise allow it to hijack a
+# user's API key.
+#
+# The decryption logic here isn't actually used by the flow; we just
+# have it here as part of testing the overall library.
+from __future__ import absolute_import
+
+import binascii
+from six.moves import zip
+from zerver.lib.str_utils import force_str
+from zerver.models import UserProfile
+
+def xor_hex_strings(bytes_a, bytes_b):
+    # type: (str, str) -> str
+    """Given two hex strings of equal length, return a hex string with
+    the bitwise xor of the two hex strings."""
+    assert len(bytes_a) == len(bytes_b)
+    return ''.join(["%x" % (int(x, 16) ^ int(y, 16))
+                    for x, y in zip(bytes_a, bytes_b)])
+
+def ascii_to_hex(input_string):
+    # type: (str) -> str
+    """Given an ascii string, encode it as a hex string"""
+    return "".join([hex(ord(c))[2:].zfill(2) for c in input_string])
+
+def hex_to_ascii(input_string):
+    # type: (str) -> str
+    """Given a hex array, decode it back to a string"""
+    return force_str(binascii.unhexlify(input_string))
+
+def otp_encrypt_api_key(user_profile, otp):
+    # type: (UserProfile, str) -> str
+    assert len(otp) == UserProfile.API_KEY_LENGTH * 2
+    hex_encoded_api_key = ascii_to_hex(force_str(user_profile.api_key))
+    assert len(hex_encoded_api_key) == UserProfile.API_KEY_LENGTH * 2
+    return xor_hex_strings(hex_encoded_api_key, otp)
+
+def otp_decrypt_api_key(otp_encrypted_api_key, otp):
+    # type: (str, str) -> str
+    assert len(otp) == UserProfile.API_KEY_LENGTH * 2
+    assert len(otp_encrypted_api_key) == UserProfile.API_KEY_LENGTH * 2
+    hex_encoded_api_key = xor_hex_strings(otp_encrypted_api_key, otp)
+    return hex_to_ascii(hex_encoded_api_key)
+
+def is_valid_otp(otp):
+    # type: (str) -> bool
+    try:
+        assert len(otp) == UserProfile.API_KEY_LENGTH * 2
+        [int(c, 16) for c in otp]
+        return True
+    except Exception:
+        return False

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -534,6 +534,7 @@ class UserProfile(ModelReprMixin, AbstractBaseUser, PermissionsMixin):
 
     USERNAME_FIELD = 'email'
     MAX_NAME_LENGTH = 100
+    API_KEY_LENGTH = 32
     NAME_INVALID_CHARS = ['*', '`', '>', '"', '@']
 
     # Our custom site-specific fields
@@ -543,7 +544,7 @@ class UserProfile(ModelReprMixin, AbstractBaseUser, PermissionsMixin):
     pointer = models.IntegerField() # type: int
     last_pointer_updater = models.CharField(max_length=64) # type: Text
     realm = models.ForeignKey(Realm) # type: Realm
-    api_key = models.CharField(max_length=32) # type: Text
+    api_key = models.CharField(max_length=API_KEY_LENGTH) # type: Text
     tos_version = models.CharField(null=True, max_length=10) # type: Text
 
     ### Notifications settings. ###

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -663,8 +663,11 @@ class GoogleOAuthTest(ZulipTestCase):
     def google_oauth2_test(self, token_response, account_response, subdomain=None):
         # type: (ResponseMock, ResponseMock, Optional[str]) -> HttpResponse
         url = "/accounts/login/google/send/"
+        params = {}
         if subdomain is not None:
-            url += "?subdomain=" + subdomain
+            params['subdomain'] = subdomain
+        if len(params) > 0:
+            url += "?%s" % (urllib.parse.urlencode(params))
 
         result = self.client_get(url)
         self.assertEqual(result.status_code, 302)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1178,7 +1178,7 @@ class FetchAuthBackends(ZulipTestCase):
         self.assert_json_success(result)
         data = ujson.loads(result.content)
         self.assertEqual(set(data.keys()),
-                         {'msg', 'password', 'google', 'dev', 'result', 'zulip_version'})
+                         {'msg', 'password', 'github', 'google', 'dev', 'result', 'zulip_version'})
         for backend in set(data.keys()) - {'msg', 'result', 'zulip_version'}:
             self.assertTrue(isinstance(data[backend], bool))
 
@@ -1192,6 +1192,7 @@ class FetchAuthBackends(ZulipTestCase):
             self.assertEqual(data, {
                 'msg': '',
                 'password': False,
+                'github': False,
                 'google': True,
                 'dev': True,
                 'result': 'success',
@@ -1207,6 +1208,7 @@ class FetchAuthBackends(ZulipTestCase):
                 self.assertEqual(data, {
                     'msg': '',
                     'password': False,
+                    'github': False,
                     'google': True,
                     'dev': True,
                     'result': 'success',
@@ -1229,6 +1231,7 @@ class FetchAuthBackends(ZulipTestCase):
                 self.assertEqual(data, {
                     'msg': '',
                     'password': False,
+                    'github': False,
                     'google': False,
                     'dev': True,
                     'result': 'success',
@@ -1249,6 +1252,7 @@ class FetchAuthBackends(ZulipTestCase):
                 self.assertEqual(data, {
                     'msg': '',
                     'password': False,
+                    'github': False,
                     'google': False,
                     'dev': True,
                     'result': 'success',

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -202,7 +202,7 @@ def send_oauth_request_to_google(request):
     # Now compute the CSRF hash with the other parameters as an input
     csrf_state += ":%s" % (google_oauth2_csrf(request, csrf_state),)
 
-    prams = {
+    params = {
         'response_type': 'code',
         'client_id': settings.GOOGLE_OAUTH2_CLIENT_ID,
         'redirect_uri': ''.join((
@@ -213,7 +213,7 @@ def send_oauth_request_to_google(request):
         'scope': 'profile email',
         'state': csrf_state,
     }
-    return redirect(google_uri + urllib.parse.urlencode(prams))
+    return redirect(google_uri + urllib.parse.urlencode(params))
 
 def finish_google_oauth2(request):
     # type: (HttpRequest) -> HttpResponse

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -29,8 +29,8 @@ from zerver.lib.validator import validate_login_email
 from zerver.models import PreregistrationUser, UserProfile, remote_user_to_email, Realm
 from zerver.views.registration import create_preregistration_user, get_realm_from_request, \
     redirect_and_log_into_subdomain
-from zproject.backends import password_auth_enabled, dev_auth_enabled, google_auth_enabled, \
-    ldap_auth_enabled
+from zproject.backends import password_auth_enabled, dev_auth_enabled, \
+    github_auth_enabled, google_auth_enabled, ldap_auth_enabled
 from version import ZULIP_VERSION
 
 import hashlib
@@ -510,6 +510,7 @@ def api_get_auth_backends(request):
         realm = None
     return json_success({"password": password_auth_enabled(realm),
                          "dev": dev_auth_enabled(realm),
+                         "github": github_auth_enabled(realm),
                          "google": google_auth_enabled(realm),
                          "zulip_version": ZULIP_VERSION,
                          })


### PR DESCRIPTION
This is a cleaned-up version of #4168.

Changes include:
* Fixed various minor bugs
* Added full test coverage of the new code path
* Added a one-time pad XORed with the api key.  See `zerver/lib/mobile_auth_otp.py` for the implementation; we'll need to modify the mobile-side implementation to securely generate the OTP and use the correct decryption algorithm.

Note that while this approach should work for all all auth methods (including e.g. REMOTE_USER auth), at present it only supports Google auth.  

@neerajwahi @borisyankov FYI.
