### PR TITLE
Fix how we calculate fields in stream_data.js.

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -300,7 +300,7 @@ var people = global.people;
 
 (function test_admin_options() {
     function make_sub() {
-        return {
+        var sub = {
             subscribed: false,
             color: 'blue',
             name: 'stream_to_admin',
@@ -308,12 +308,14 @@ var people = global.people;
             in_home_view: false,
             invite_only: false,
         };
+        stream_data.add_sub(sub.name, sub);
+        return sub;
     }
 
     // non-admins can't do anything
     global.page_params.is_admin = false;
     var sub = make_sub();
-    stream_data.add_admin_options(sub);
+    stream_data.update_calculated_fields(sub);
     assert(!sub.is_admin);
     assert(!sub.can_make_public);
     assert(!sub.can_make_private);
@@ -326,7 +328,7 @@ var people = global.people;
 
     // admins can make public streams become private
     sub = make_sub();
-    stream_data.add_admin_options(sub);
+    stream_data.update_calculated_fields(sub);
     assert(sub.is_admin);
     assert(!sub.can_make_public);
     assert(sub.can_make_private);
@@ -336,7 +338,7 @@ var people = global.people;
     sub = make_sub();
     sub.invite_only = true;
     sub.subscribed = false;
-    stream_data.add_admin_options(sub);
+    stream_data.update_calculated_fields(sub);
     assert(sub.is_admin);
     assert(!sub.can_make_public);
     assert(!sub.can_make_private);
@@ -344,7 +346,7 @@ var people = global.people;
     sub = make_sub();
     sub.invite_only = true;
     sub.subscribed = true;
-    stream_data.add_admin_options(sub);
+    stream_data.update_calculated_fields(sub);
     assert(sub.is_admin);
     assert(sub.can_make_public);
     assert(!sub.can_make_private);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -96,6 +96,21 @@ exports.update_subscribers_count = function (sub) {
     sub.subscriber_count = count;
 };
 
+exports.render_stream_description = function (sub) {
+    if (sub.description) {
+        sub.rendered_description = marked(sub.description).replace('<p>', '').replace('</p>', '');
+    }
+};
+
+exports.update_calculated_fields = function (sub) {
+    sub.is_admin = page_params.is_admin;
+    sub.can_make_public = page_params.is_admin && sub.invite_only && sub.subscribed;
+    sub.can_make_private = page_params.is_admin && !sub.invite_only;
+    sub.preview_url = narrow.by_stream_uri(sub.name);
+    exports.render_stream_description(sub);
+    exports.update_subscribers_count(sub);
+};
+
 exports.all_subscribed_streams_are_in_home_view = function () {
     return _.every(exports.subscribed_subs(), function (sub) {
         return sub.in_home_view;
@@ -293,14 +308,6 @@ exports.receives_audible_notifications = function (stream_name) {
     return sub.audible_notifications;
 };
 
-exports.add_admin_options = function (sub) {
-    return _.extend(sub, {
-        is_admin: page_params.is_admin,
-        can_make_public: page_params.is_admin && sub.invite_only && sub.subscribed,
-        can_make_private: page_params.is_admin && !sub.invite_only,
-    });
-};
-
 exports.process_message_for_recent_topics = function process_message_for_recent_topics(
                                                 message, remove_message) {
     var current_timestamp = 0;
@@ -343,12 +350,6 @@ exports.process_message_for_recent_topics = function process_message_for_recent_
     recent_topics.set(stream, recents);
 };
 
-exports.render_stream_description = function (sub) {
-    if (sub.description) {
-        sub.rendered_description = marked(sub.description).replace('<p>', '').replace('</p>', '');
-    }
-};
-
 exports.get_streams_for_settings_page = function () {
     // Build up our list of subscribed streams from the data we already have.
     var subscribed_rows = exports.subscribed_subs();
@@ -363,16 +364,11 @@ exports.get_streams_for_settings_page = function () {
     var all_subs = unsubscribed_rows.concat(subscribed_rows);
 
     // Add in admin options and stream counts.
-    var sub_rows = [];
     _.each(all_subs, function (sub) {
-        sub = exports.add_admin_options(sub);
-        sub.preview_url = narrow.by_stream_uri(sub.name);
-        exports.update_subscribers_count(sub);
-        exports.render_stream_description(sub);
-        sub_rows.push(sub);
+        exports.update_calculated_fields(sub);
     });
 
-    return sub_rows;
+    return all_subs;
 };
 
 exports.initialize_from_page_params = function () {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -158,9 +158,7 @@ function add_email_hint(row, email_address_hint_content) {
 // this request.  These should be appended to the top of the list so
 // they are more visible.
 function add_sub_to_table(sub) {
-    sub = stream_data.add_admin_options(sub);
-    stream_data.update_subscribers_count(sub);
-    stream_data.render_stream_description(sub);
+    stream_data.update_calculated_fields(sub);
     var html = templates.render('subscription', sub);
     var settings_html = templates.render('subscription_settings', sub);
     if (stream_create.get_name() === sub.name) {


### PR DESCRIPTION
We used to have code scattered in multiple places to
calculate things like admin options, preview urls,
subscriber counts, and rendered descriptions for
streams before we rendered templates in the "Manage
Stream" code.

These are all consolidated into a new function
called stream_data.update_calculated_fields().

This is mostly code cleanup, but it also fixes a bug where
the "View Stream" button would not work for a newly created
stream.