### PR TITLE
sidebars: Reduce font-size and use better font colour.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -147,11 +147,11 @@ li.hidden-filter {
 }
 
 .left-sidebar li a {
-    color: #555;
+    color: rgba(51, 51, 51, 0.95);
 }
 
 .left-sidebar li {
-    font-size: 1.05em;
+    font-size: 1em;
     padding-top: 2px;
     padding-bottom: 2px;
 }

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -1,6 +1,6 @@
 .right-sidebar {
     -webkit-font-smoothing: antialiased;
-    color: #555;
+    color: rgba(51, 51, 51, 0.95);
 }
 
 #group-pms li:hover,


### PR DESCRIPTION
We reduce the font-size of the text in left-sidebar and start to use
font-colour which provides with better readability.

Before:
![image](https://cloud.githubusercontent.com/assets/17237412/25563149/3bdc6842-2db3-11e7-8339-b37b659ac756.png)
![image](https://cloud.githubusercontent.com/assets/17237412/25563150/429a2480-2db3-11e7-836a-4ee711e7a193.png)

After:
![image](https://cloud.githubusercontent.com/assets/17237412/25563144/14cbab00-2db3-11e7-9945-8cc520a2e673.png)
![image](https://cloud.githubusercontent.com/assets/17237412/25563146/1db0a9c8-2db3-11e7-9226-058a094df7f8.png)

