### PR TITLE
zerver/decorator: Set request.client in api_key_only_webhook_view.

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -1,0 +1,19 @@
+# Clients in Zulip
+
+`zerver.models.Client` is Zulip's analogue of UserAgent.
+
+## Analytics
+A `Client` is used to sort messages into client categories such as
+`ZulipElectron` on the `/stats`
+[page](https://chat.zulip.org/stats). For more information see,
+[Analytics](analytics.html).
+
+## Webhook Integrations
+Auth decorators for incoming webhooks defined in `zerver/decorators.py`
+(such as `api_key_only_webhook_view`) set the `request.client`
+attribute on `request` (Django
+[HttpRequest](https://docs.djangoproject.com/en/1.8/ref/request-response/#django.http.HttpRequest))
+objects. `request.client` is then passed to `check_send_message`.
+`check_send_message` accepts a `Client` as a positional argument and is
+used to validate and send a public (stream) message. For more information,
+see [the webhook walkthrough](webhook-walkthrough.html).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,3 +136,4 @@ Contents:
    release-checklist
    README
    user-docs
+   client

--- a/docs/webhook-walkthrough.md
+++ b/docs/webhook-walkthrough.md
@@ -72,11 +72,11 @@ from typing import Dict, Any, Iterable, Optional, Text
 
 @api_key_only_webhook_view('HelloWorld')
 @has_request_variables
-def api_helloworld_webhook(request, user_profile, client,
+def api_helloworld_webhook(request, user_profile,
                            payload=REQ(argument_type='body'),
                            stream=REQ(default='test'),
                            topic=REQ(default='Hello World')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Iterable[Dict[str, Any]]], Text, Optional[Text]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Iterable[Dict[str, Any]]], Text, Optional[Text]) -> HttpResponse
 
   # construct the body of the message
   body = 'Hello! I am happy to be here! :smile:'
@@ -90,7 +90,8 @@ def api_helloworld_webhook(request, user_profile, client,
       return json_error(_("Missing key {} in JSON").format(str(e)))
 
   # send the message
-  check_send_message(user_profile, client, 'stream', [stream], topic, body)
+  check_send_message(user_profile, request.client, 'stream',
+                     [stream], topic, body)
 
   # return json result
   return json_success()
@@ -104,10 +105,11 @@ access request variables with `REQ()`. You can find more about `REQ` and request
 variables in [Writing views](writing-views.html#request-variables).
 
 You must pass the name of your webhook to the `api_key_only_webhook_view`
-decorator so your webhook can access the `user_profile` and `client` fields
-from the request. Here we have used `HelloWorld`. To be consistent with Zulip code
-style, use the name of the product you are integrating in camel case, spelled
-as the product spells its own name (except always first letter upper-case).
+decorator so your webhook can access the `user_profile` and `request.client`
+(Zulip's analogue of UserAgent) fields from the request. Here we have used
+`HelloWorld`. To be consistent with Zulip code style, use the name of the
+product you are integrating in camel case, spelled as the product spells
+its own name (except always first letter upper-case).
 
 The `api_key_only_webhook_view` decorator indicates that the 3rd party service will
 send the authorization as an API key in the query parameters. If your service uses
@@ -119,9 +121,8 @@ You should name your webhook function as such `api_webhookname_webhook` where
 
 At minimum, the webhook function must accept `request` (Django
 [HttpRequest](https://docs.djangoproject.com/en/1.8/ref/request-response/#django.http.HttpRequest)
-object), `user_profile` (Zulip's user object), and `client` (Zulip's analogue
-of UserAgent). You may also want to define additional parameters using the
-`REQ` object.
+object), and `user_profile` (Zulip's user object). You may also want to
+define additional parameters using the `REQ` object.
 
 In the example above, we have defined `payload` which is populated
 from the body of the http request, `stream` with a default of `test`

--- a/docs/writing-views.md
+++ b/docs/writing-views.md
@@ -355,15 +355,15 @@ target server for the webhook, and an API key.
 
 If the webhook does not have an option to provide a bot email, use the
 `api_key_only_webhook_view` decorator, to fill in the `user_profile` and
-`client` fields of a request:
+`request.client` fields of a request:
 
 ``` py
 @api_key_only_webhook_view('PagerDuty')
 @has_request_variables
-def api_pagerduty_webhook(request, user_profile, client,
+def api_pagerduty_webhook(request, user_profile,
                           payload=REQ(argument_type='body'),
                           stream=REQ(default='pagerduty'),
                           topic=REQ(default=None)):
 ```
-The `client` will be the result of `get_client("ZulipPagerDutyWebhook")`
-in this example.
+`request.client` will be the result of `get_client("ZulipPagerDutyWebhook")`
+in this example and it will be passed to `check_send_message`.

--- a/docs/writing-views.md
+++ b/docs/writing-views.md
@@ -366,4 +366,5 @@ def api_pagerduty_webhook(request, user_profile,
                           topic=REQ(default=None)):
 ```
 `request.client` will be the result of `get_client("ZulipPagerDutyWebhook")`
-in this example and it will be passed to `check_send_message`.
+in this example and it will be passed to `check_send_message`. For more
+information, see [Clients in Zulip](client.html).

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -245,7 +245,7 @@ def api_key_only_webhook_view(client_name):
             process_client(request, user_profile, client_name=webhook_client_name)
             if settings.RATE_LIMITING:
                 rate_limit_user(request, user_profile, domain='all')
-            return view_func(request, user_profile, request.client, *args, **kwargs)
+            return view_func(request, user_profile, *args, **kwargs)
         return _wrapped_func_arguments
     return _wrapped_view_func
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -208,8 +208,8 @@ class DecoratorTestCase(TestCase):
     def test_api_key_only_webhook_view(self):
         # type: () -> None
         @api_key_only_webhook_view('ClientName')
-        def my_webhook(request, user_profile, client):
-            # type: (HttpRequest, UserProfile, Client) -> Text
+        def my_webhook(request, user_profile):
+            # type: (HttpRequest, UserProfile) -> Text
             return user_profile.email
 
         class Request(HostRequestMock):

--- a/zerver/webhooks/airbrake/view.py
+++ b/zerver/webhooks/airbrake/view.py
@@ -6,23 +6,24 @@ from django.utils.translation import ugettext as _
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 AIRBRAKE_SUBJECT_TEMPLATE = '{project_name}'
 AIRBRAKE_MESSAGE_TEMPLATE = '[{error_class}]({error_url}): "{error_message}" occurred.'
 
 @api_key_only_webhook_view('Airbrake')
 @has_request_variables
-def api_airbrake_webhook(request, user_profile, client, payload=REQ(argument_type='body'),
+def api_airbrake_webhook(request, user_profile,
+                         payload=REQ(argument_type='body'),
                          stream=REQ(default='airbrake')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
     try:
         subject = get_subject(payload)
         body = get_body(payload)
     except KeyError as e:
         return json_error(_("Missing key {} in JSON").format(str(e)))
 
-    check_send_message(user_profile, client, 'stream', [stream], subject, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()
 
 def get_subject(payload):

--- a/zerver/webhooks/appfollow/view.py
+++ b/zerver/webhooks/appfollow/view.py
@@ -8,22 +8,22 @@ from django.utils.translation import ugettext as _
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 from typing import Dict, Any, Text
 
 @api_key_only_webhook_view("AppFollow")
 @has_request_variables
-def api_appfollow_webhook(request, user_profile, client, stream=REQ(default="appfollow"),
+def api_appfollow_webhook(request, user_profile, stream=REQ(default="appfollow"),
                           payload=REQ(argument_type="body")):
-    # type: (HttpRequest, UserProfile, Client, Text, Dict[str, Any]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Text, Dict[str, Any]) -> HttpResponse
     try:
         message = payload["text"]
     except KeyError:
         return json_error(_("Missing 'text' argument in JSON"))
     app_name = re.search('\A(.+)', message).group(0)
 
-    check_send_message(user_profile, client, "stream", [stream], app_name, convert_markdown(message))
+    check_send_message(user_profile, request.client, "stream", [stream], app_name, convert_markdown(message))
     return json_success()
 
 def convert_markdown(text):

--- a/zerver/webhooks/basecamp/view.py
+++ b/zerver/webhooks/basecamp/view.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 from .support_event import SUPPORT_EVENTS
 
@@ -21,9 +21,9 @@ TODO_TEMPLATE = "{user_name} {verb} the todo task [{title}]({url})"
 
 @api_key_only_webhook_view('Basecamp')
 @has_request_variables
-def api_basecamp_webhook(request, user_profile, client, payload=REQ(argument_type='body'),
+def api_basecamp_webhook(request, user_profile, payload=REQ(argument_type='body'),
                          stream=REQ(default='basecamp')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
     event = get_event_type(payload)
 
     if event not in SUPPORT_EVENTS:
@@ -49,7 +49,7 @@ def api_basecamp_webhook(request, user_profile, client, payload=REQ(argument_typ
         logging.warning("Basecamp handling of {} event is not implemented".format(event))
         return json_success()
 
-    check_send_message(user_profile, client, 'stream', [stream], subject, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()
 
 def get_project_name(payload):

--- a/zerver/webhooks/circleci/view.py
+++ b/zerver/webhooks/circleci/view.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Text
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 import ujson
 
@@ -19,14 +19,14 @@ FAILED_STATUS = 'failed'
 
 @api_key_only_webhook_view('CircleCI')
 @has_request_variables
-def api_circleci_webhook(request, user_profile, client, payload=REQ(argument_type='body'),
+def api_circleci_webhook(request, user_profile, payload=REQ(argument_type='body'),
                          stream=REQ(default='circleci')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
     payload = payload['payload']
     subject = get_subject(payload)
     body = get_body(payload)
 
-    check_send_message(user_profile, client, 'stream', [stream], subject, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()
 
 def get_subject(payload):

--- a/zerver/webhooks/codeship/view.py
+++ b/zerver/webhooks/codeship/view.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 import ujson
 
@@ -26,9 +26,9 @@ CODESHIP_STATUS_MAPPER = {
 
 @api_key_only_webhook_view('Codeship')
 @has_request_variables
-def api_codeship_webhook(request, user_profile, client, payload=REQ(argument_type='body'),
+def api_codeship_webhook(request, user_profile, payload=REQ(argument_type='body'),
                          stream=REQ(default='codeship')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], str) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], str) -> HttpResponse
     try:
         payload = payload['build']
         subject = get_subject_for_http_request(payload)
@@ -36,7 +36,7 @@ def api_codeship_webhook(request, user_profile, client, payload=REQ(argument_typ
     except KeyError as e:
         return json_error(_("Missing key {} in JSON").format(str(e)))
 
-    check_send_message(user_profile, client, 'stream', [stream], subject, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()
 
 

--- a/zerver/webhooks/crashlytics/view.py
+++ b/zerver/webhooks/crashlytics/view.py
@@ -4,7 +4,7 @@ from django.utils.translation import ugettext as _
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 from django.http import HttpRequest, HttpResponse
 from typing import Any, Dict, Text
 
@@ -19,9 +19,9 @@ VERIFICATION_EVENT = 'verification'
 
 @api_key_only_webhook_view('Crashlytics')
 @has_request_variables
-def api_crashlytics_webhook(request, user_profile, client, payload=REQ(argument_type='body'),
+def api_crashlytics_webhook(request, user_profile, payload=REQ(argument_type='body'),
                             stream=REQ(default='crashlytics')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
     try:
         event = payload['event']
         if event == VERIFICATION_EVENT:
@@ -40,6 +40,6 @@ def api_crashlytics_webhook(request, user_profile, client, payload=REQ(argument_
     except KeyError as e:
         return json_error(_("Missing key {} in JSON".format(str(e))))
 
-    check_send_message(user_profile, client, 'stream', [stream],
+    check_send_message(user_profile, request.client, 'stream', [stream],
                        subject, body)
     return json_success()

--- a/zerver/webhooks/delighted/view.py
+++ b/zerver/webhooks/delighted/view.py
@@ -4,7 +4,7 @@ from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
 from six import text_type
@@ -19,11 +19,11 @@ def body_template(score):
 
 @api_key_only_webhook_view("Delighted")
 @has_request_variables
-def api_delighted_webhook(request, user_profile, client,
+def api_delighted_webhook(request, user_profile,
                           payload=REQ(argument_type='body'),
                           stream=REQ(default='delighted'),
                           topic=REQ(default='Survey Response')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Dict[str, Any]], text_type, text_type) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Dict[str, Any]], text_type, text_type) -> HttpResponse
     try:
         person = payload['event_data']['person']
         selected_payload = {'email': person['email']}
@@ -35,6 +35,6 @@ def api_delighted_webhook(request, user_profile, client,
     BODY_TEMPLATE = body_template(selected_payload['score'])
     body = BODY_TEMPLATE.format(**selected_payload)
 
-    check_send_message(user_profile, client, 'stream', [stream],
+    check_send_message(user_profile, request.client, 'stream', [stream],
                        topic, body)
     return json_success()

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -7,7 +7,7 @@ from zerver.lib.webhooks.git import get_push_commits_event_message, EMPTY_SHA,\
     get_remove_branch_event_message, get_pull_request_event_message,\
     get_issue_event_message, SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE,\
     get_commits_comment_action_message, get_push_tag_event_message
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
 from typing import Dict, Any, Iterable, Optional, Text
@@ -279,16 +279,16 @@ EVENT_FUNCTION_MAPPER = {
 
 @api_key_only_webhook_view("Gitlab")
 @has_request_variables
-def api_gitlab_webhook(request, user_profile, client,
+def api_gitlab_webhook(request, user_profile,
                        stream=REQ(default='gitlab'),
                        payload=REQ(argument_type='body'),
                        branches=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Client, Text, Dict[str, Any], Optional[Text]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Text, Dict[str, Any], Optional[Text]) -> HttpResponse
     event = get_event(request, payload, branches)
     if event is not None:
         body = get_body_based_on_event(event)(payload)
         subject = get_subject_based_on_event(event, payload)
-        check_send_message(user_profile, client, 'stream', [stream], subject, body)
+        check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()
 
 def get_body_based_on_event(event):

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext as _
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 from zerver.lib.webhooks.git import get_push_commits_event_message, \
     get_pull_request_event_message, get_create_branch_event_message, \
     SUBJECT_WITH_BRANCH_TEMPLATE, SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE
@@ -63,11 +63,11 @@ def format_pull_request_event(payload):
 
 @api_key_only_webhook_view('Gogs')
 @has_request_variables
-def api_gogs_webhook(request, user_profile, client,
+def api_gogs_webhook(request, user_profile,
                      payload=REQ(argument_type='body'),
                      stream=REQ(default='commits'),
                      branches=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text, Optional[Text]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Optional[Text]) -> HttpResponse
 
     repo = payload['repository']['name']
     event = request.META['HTTP_X_GOGS_EVENT']
@@ -101,5 +101,5 @@ def api_gogs_webhook(request, user_profile, client,
     except KeyError as e:
         return json_error(_('Missing key {} in JSON').format(str(e)))
 
-    check_send_message(user_profile, client, 'stream', [stream], topic, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
     return json_success()

--- a/zerver/webhooks/gosquared/view.py
+++ b/zerver/webhooks/gosquared/view.py
@@ -4,7 +4,7 @@ from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
 from typing import Text
@@ -14,11 +14,11 @@ BODY_TEMPLATE = '[{website_name}]({website_url}) has {user_num} visitors online.
 
 @api_key_only_webhook_view('GoSquared')
 @has_request_variables
-def api_gosquared_webhook(request, user_profile, client,
+def api_gosquared_webhook(request, user_profile,
                           payload=REQ(argument_type='body'),
                           stream=REQ(default='gosquared'),
                           topic=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Dict[str, Any]], Text, Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Dict[str, Any]], Text, Text) -> HttpResponse
     try:
         domain_name = payload['siteDetails']['domain']
         user_num = payload['concurrents']
@@ -32,6 +32,6 @@ def api_gosquared_webhook(request, user_profile, client,
     if topic is None:
         topic = 'GoSquared - {website_name}'.format(website_name=domain_name)
 
-    check_send_message(user_profile, client, 'stream', [stream],
+    check_send_message(user_profile, request.client, 'stream', [stream],
                        topic, body)
     return json_success()

--- a/zerver/webhooks/greenhouse/view.py
+++ b/zerver/webhooks/greenhouse/view.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 import ujson
 
@@ -36,10 +36,10 @@ def message_creator(action, application):
 
 @api_key_only_webhook_view('Greenhouse')
 @has_request_variables
-def api_greenhouse_webhook(request, user_profile, client,
+def api_greenhouse_webhook(request, user_profile,
                            payload=REQ(argument_type='body'),
                            stream=REQ(default='greenhouse'), topic=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], str, str) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], str, str) -> HttpResponse
     try:
         if payload['action'] == 'update_candidate':
             candidate = payload['payload']['candidate']
@@ -60,5 +60,5 @@ def api_greenhouse_webhook(request, user_profile, client,
     except KeyError as e:
         return json_error(_("Missing key {} in JSON").format(str(e)))
 
-    check_send_message(user_profile, client, 'stream', [stream], topic, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
     return json_success()

--- a/zerver/webhooks/hellosign/view.py
+++ b/zerver/webhooks/hellosign/view.py
@@ -4,7 +4,7 @@ from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
 from six import text_type
@@ -45,11 +45,11 @@ def ready_payload(signatories, payload):
 
 @api_key_only_webhook_view('HelloSign')
 @has_request_variables
-def api_hellosign_webhook(request, user_profile, client,
+def api_hellosign_webhook(request, user_profile,
                           payload=REQ(argument_type='body'),
                           stream=REQ(default='hellosign'),
                           topic=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Dict[str, Any]], text_type, text_type) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Dict[str, Any]], text_type, text_type) -> HttpResponse
     try:
         model_payload = ready_payload(payload['signature_request']['signatures'],
                                       payload)
@@ -58,6 +58,6 @@ def api_hellosign_webhook(request, user_profile, client,
 
     body = format_body(payload['signature_request']['signatures'], model_payload)
     topic = model_payload['contract_title']
-    check_send_message(user_profile, client, 'stream', [stream],
+    check_send_message(user_profile, request.client, 'stream', [stream],
                        topic, body)
     return json_success()

--- a/zerver/webhooks/helloworld/view.py
+++ b/zerver/webhooks/helloworld/view.py
@@ -5,17 +5,17 @@ from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 from zerver.lib.validator import check_dict, check_string
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
 from typing import Dict, Any, Iterable, Optional, Text
 
 @api_key_only_webhook_view('HelloWorld')
 @has_request_variables
-def api_helloworld_webhook(request, user_profile, client,
+def api_helloworld_webhook(request, user_profile,
                            payload=REQ(argument_type='body'), stream=REQ(default='test'),
                            topic=REQ(default='Hello World')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Iterable[Dict[str, Any]]], Text, Optional[Text]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Iterable[Dict[str, Any]]], Text, Optional[Text]) -> HttpResponse
 
     # construct the body of the message
     body = 'Hello! I am happy to be here! :smile:'
@@ -29,6 +29,6 @@ def api_helloworld_webhook(request, user_profile, client,
         return json_error(_("Missing key {} in JSON").format(str(e)))
 
     # send the message
-    check_send_message(user_profile, client, 'stream', [stream], topic, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
 
     return json_success()

--- a/zerver/webhooks/heroku/view.py
+++ b/zerver/webhooks/heroku/view.py
@@ -7,16 +7,16 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 
 @api_key_only_webhook_view("Heroku")
 @has_request_variables
-def api_heroku_webhook(request, user_profile, client, stream=REQ(default="heroku"),
+def api_heroku_webhook(request, user_profile, stream=REQ(default="heroku"),
                        head=REQ(), app=REQ(), user=REQ(), url=REQ(), git_log=REQ()):
-    # type: (HttpRequest, UserProfile, Client, Text, Text, Text, Text, Text, Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Text, Text, Text, Text, Text, Text) -> HttpResponse
     template = "{} deployed version {} of [{}]({})\n> {}"
     content = template.format(user, head, app, url, git_log)
 
-    check_send_message(user_profile, client, "stream", [stream], app, content)
+    check_send_message(user_profile, request.client, "stream", [stream], app, content)
     return json_success()

--- a/zerver/webhooks/homeassistant/view.py
+++ b/zerver/webhooks/homeassistant/view.py
@@ -5,17 +5,17 @@ from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 from zerver.lib.validator import check_dict, check_string
 
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
 from typing import Dict, Any, Iterable, Optional, Text
 
 @api_key_only_webhook_view('HomeAssistant')
 @has_request_variables
-def api_homeassistant_webhook(request, user_profile, client,
+def api_homeassistant_webhook(request, user_profile,
                               payload=REQ(argument_type='body'),
                               stream=REQ(default="homeassistant")):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, str], Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, str], Text) -> HttpResponse
 
     # construct the body of the message
     try:
@@ -30,7 +30,7 @@ def api_homeassistant_webhook(request, user_profile, client,
         topic = "homeassistant"
 
     # send the message
-    check_send_message(user_profile, client, 'stream', [stream], topic, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
 
     # return json result
     return json_success()

--- a/zerver/webhooks/ifttt/view.py
+++ b/zerver/webhooks/ifttt/view.py
@@ -5,20 +5,20 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 
 @api_key_only_webhook_view('IFTTT')
 @has_request_variables
-def api_iftt_app_webhook(request, user_profile, client,
+def api_iftt_app_webhook(request, user_profile,
                          payload=REQ(argument_type='body'),
                          stream=REQ(default='ifttt')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], str) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], str) -> HttpResponse
     subject = payload.get('subject')
     content = payload.get('content')
     if subject is None:
         return json_error(_("Subject can't be empty"))
     if content is None:
         return json_error(_("Content can't be empty"))
-    check_send_message(user_profile, client, "stream", [stream], subject, content)
+    check_send_message(user_profile, request.client, "stream", [stream], subject, content)
     return json_success()

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 
-from zerver.models import Client, UserProfile, get_user_profile_by_email, Realm
+from zerver.models import UserProfile, get_user_profile_by_email, Realm
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import api_key_only_webhook_view, has_request_variables, REQ
@@ -239,10 +239,10 @@ def handle_deleted_issue_event(payload):
 
 @api_key_only_webhook_view("JIRA")
 @has_request_variables
-def api_jira_webhook(request, user_profile, client,
+def api_jira_webhook(request, user_profile,
                      payload=REQ(argument_type='body'),
                      stream=REQ(default='jira')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
 
     event = get_event_type(payload)
     if event == 'jira:issue_created':
@@ -267,5 +267,5 @@ def api_jira_webhook(request, user_profile, client,
                 logging.warning("Got JIRA event type we don't support: {}".format(event))
             return json_success()
 
-    check_send_message(user_profile, client, "stream", [stream], subject, content)
+    check_send_message(user_profile, request.client, "stream", [stream], subject, content)
     return json_success()

--- a/zerver/webhooks/librato/view.py
+++ b/zerver/webhooks/librato/view.py
@@ -11,7 +11,7 @@ from django.http import HttpRequest, HttpResponse
 from zerver.decorator import api_key_only_webhook_view, REQ, has_request_variables
 from zerver.lib.response import json_success, json_error
 from zerver.lib.actions import check_send_message
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 import ujson
 
@@ -160,9 +160,9 @@ class LibratoWebhookHandler(LibratoWebhookParser):
 
 @api_key_only_webhook_view('Librato')
 @has_request_variables
-def api_librato_webhook(request, user_profile, client, payload=REQ(converter=ujson.loads, default={}),
+def api_librato_webhook(request, user_profile, payload=REQ(converter=ujson.loads, default={}),
                         stream=REQ(default='librato'), topic=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text, Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Text) -> HttpResponse
     try:
         attachments = ujson.loads(request.body).get('attachments', [])
     except ValueError:
@@ -181,5 +181,5 @@ def api_librato_webhook(request, user_profile, client, payload=REQ(converter=ujs
     except Exception as e:
         return json_error(_(str(e)))
 
-    check_send_message(user_profile, client, "stream", [stream], topic, content)
+    check_send_message(user_profile, request.client, "stream", [stream], topic, content)
     return json_success()

--- a/zerver/webhooks/mention/view.py
+++ b/zerver/webhooks/mention/view.py
@@ -5,18 +5,18 @@ from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 from zerver.lib.validator import check_dict, check_string
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
 from typing import Dict, Any, Iterable, Optional, Text
 
 @api_key_only_webhook_view('Mention')
 @has_request_variables
-def api_mention_webhook(request, user_profile, client,
+def api_mention_webhook(request, user_profile,
                         payload=REQ(argument_type='body'),
                         stream=REQ(default='mention'),
                         topic=REQ(default='news')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Iterable[Dict[str, Any]]], Text, Optional[Text]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Iterable[Dict[str, Any]]], Text, Optional[Text]) -> HttpResponse
 
     try:
         title = payload["title"]
@@ -29,6 +29,6 @@ def api_mention_webhook(request, user_profile, client,
     body = '**[%s](%s)**:\n%s' % (title, source_url, description)
 
     # send the message
-    check_send_message(user_profile, client, 'stream', [stream], topic, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
 
     return json_success()

--- a/zerver/webhooks/newrelic/view.py
+++ b/zerver/webhooks/newrelic/view.py
@@ -9,15 +9,15 @@ from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.lib.validator import check_dict
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Stream, Client
+from zerver.models import UserProfile, Stream
 
 
 @api_key_only_webhook_view("NewRelic")
 @has_request_variables
-def api_newrelic_webhook(request, user_profile, client, stream=REQ(),
+def api_newrelic_webhook(request, user_profile, stream=REQ(),
                          alert=REQ(validator=check_dict([]), default=None),
                          deployment=REQ(validator=check_dict([]), default=None)):
-    # type: (HttpRequest, UserProfile, Client, Optional[Stream], Optional[Dict[str, Any]], Optional[Dict[str, Any]]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Optional[Stream], Optional[Dict[str, Any]], Optional[Dict[str, Any]]) -> HttpResponse
     if alert:
         # Use the message as the subject because it stays the same for
         # "opened", "acknowledged", and "closed" messages that should be
@@ -33,6 +33,6 @@ def api_newrelic_webhook(request, user_profile, client, stream=REQ(),
     else:
         return json_error(_("Unknown webhook request"))
 
-    check_send_message(user_profile, client, "stream",
+    check_send_message(user_profile, request.client, "stream",
                        [stream], subject, content)
     return json_success()

--- a/zerver/webhooks/pagerduty/view.py
+++ b/zerver/webhooks/pagerduty/view.py
@@ -109,20 +109,20 @@ def send_formated_pagerduty(user_profile, client, stream, message_type, format_d
 
 @api_key_only_webhook_view('PagerDuty')
 @has_request_variables
-def api_pagerduty_webhook(request, user_profile, client, payload=REQ(argument_type='body'),
+def api_pagerduty_webhook(request, user_profile, payload=REQ(argument_type='body'),
                           stream=REQ(default='pagerduty'), topic=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Iterable[Dict[str, Any]]], Text, Optional[Text]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Iterable[Dict[str, Any]]], Text, Optional[Text]) -> HttpResponse
     for message in payload['messages']:
         message_type = message['type']
 
         if message_type not in PAGER_DUTY_EVENT_NAMES:
-            send_raw_pagerduty_json(user_profile, client, stream, message, topic)
+            send_raw_pagerduty_json(user_profile, request.client, stream, message, topic)
 
         try:
             format_dict = build_pagerduty_formatdict(message)
         except Exception:
-            send_raw_pagerduty_json(user_profile, client, stream, message, topic)
+            send_raw_pagerduty_json(user_profile, request.client, stream, message, topic)
         else:
-            send_formated_pagerduty(user_profile, client, stream, message_type, format_dict, topic)
+            send_formated_pagerduty(user_profile, request.client, stream, message_type, format_dict, topic)
 
     return json_success()

--- a/zerver/webhooks/papertrail/view.py
+++ b/zerver/webhooks/papertrail/view.py
@@ -5,7 +5,7 @@ from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 from zerver.lib.validator import check_dict, check_string
 
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
 from typing import Text
@@ -13,11 +13,11 @@ from typing import Dict, Any, Iterable, Optional
 
 @api_key_only_webhook_view('Papertrail')
 @has_request_variables
-def api_papertrail_webhook(request, user_profile, client,
+def api_papertrail_webhook(request, user_profile,
                            payload=REQ(argument_type='body'),
                            stream=REQ(default='papertrail'),
                            topic=REQ(default='logs')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text, Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Text) -> HttpResponse
 
     # construct the message of the message
     try:
@@ -41,7 +41,7 @@ def api_papertrail_webhook(request, user_profile, client,
         return json_error(_("Missing key {} in JSON").format(str(e)))
 
     # send the message
-    check_send_message(user_profile, client, 'stream', [stream], topic, post)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, post)
 
     # return json result
     return json_success()

--- a/zerver/webhooks/pingdom/view.py
+++ b/zerver/webhooks/pingdom/view.py
@@ -8,7 +8,7 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 import ujson
 
@@ -34,9 +34,9 @@ SUPPORTED_CHECK_TYPES = (
 
 @api_key_only_webhook_view('Pingdom')
 @has_request_variables
-def api_pingdom_webhook(request, user_profile, client, payload=REQ(argument_type='body'),
+def api_pingdom_webhook(request, user_profile, payload=REQ(argument_type='body'),
                         stream=REQ(default='pingdom')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
     check_type = get_check_type(payload)
 
     if check_type in SUPPORTED_CHECK_TYPES:
@@ -45,7 +45,7 @@ def api_pingdom_webhook(request, user_profile, client, payload=REQ(argument_type
     else:
         return json_error(_('Unsupported check_type: {check_type}').format(check_type=check_type))
 
-    check_send_message(user_profile, client, 'stream', [stream], subject, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()
 
 

--- a/zerver/webhooks/pivotal/view.py
+++ b/zerver/webhooks/pivotal/view.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext as _
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import api_key_only_webhook_view, REQ, has_request_variables
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 from defusedxml.ElementTree import fromstring as xml_fromstring
 
@@ -162,8 +162,8 @@ def api_pivotal_webhook_v5(request, user_profile, stream):
 
 @api_key_only_webhook_view("Pivotal")
 @has_request_variables
-def api_pivotal_webhook(request, user_profile, client, stream=REQ()):
-    # type: (HttpRequest, UserProfile, Client, Text) -> HttpResponse
+def api_pivotal_webhook(request, user_profile, stream=REQ()):
+    # type: (HttpRequest, UserProfile, Text) -> HttpResponse
     subject = content = None
     try:
         subject, content = api_pivotal_webhook_v3(request, user_profile, stream)
@@ -179,6 +179,6 @@ def api_pivotal_webhook(request, user_profile, client, stream=REQ()):
     if subject is None or content is None:
         return json_error(_("Unable to handle Pivotal payload"))
 
-    check_send_message(user_profile, client, "stream",
+    check_send_message(user_profile, request.client, "stream",
                        [stream], subject, content)
     return json_success()

--- a/zerver/webhooks/semaphore/view.py
+++ b/zerver/webhooks/semaphore/view.py
@@ -8,7 +8,7 @@ from zerver.models import get_client, get_user_profile_by_email
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 import ujson
 
 from typing import Any, Dict
@@ -16,10 +16,10 @@ from typing import Any, Dict
 
 @api_key_only_webhook_view('Semaphore')
 @has_request_variables
-def api_semaphore_webhook(request, user_profile, client,
+def api_semaphore_webhook(request, user_profile,
                           payload=REQ(argument_type='body'),
                           stream=REQ(default='builds')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], str) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], str) -> HttpResponse
 
     # semaphore only gives the last commit, even if there were multiple commits
     # since the last build
@@ -62,6 +62,6 @@ def api_semaphore_webhook(request, user_profile, client,
                                                commit_url, message)
     subject = u"%s/%s" % (project_name, branch_name)
 
-    check_send_message(user_profile, client, "stream",
+    check_send_message(user_profile, request.client, "stream",
                        [stream], subject, content)
     return json_success()

--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -1,7 +1,7 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
 from django.http import HttpRequest, HttpResponse
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -9,13 +9,13 @@ from typing import Any, Dict
 
 @api_key_only_webhook_view('Sentry')
 @has_request_variables
-def api_sentry_webhook(request, user_profile, client,
+def api_sentry_webhook(request, user_profile,
                        payload=REQ(argument_type='body'),
                        stream=REQ(default='sentry')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], str) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], str) -> HttpResponse
     subject = "{}".format(payload.get('project_name'))
     body = "New {} [issue]({}): {}.".format(payload.get('level').upper(),
                                             payload.get('url'),
                                             payload.get('message'))
-    check_send_message(user_profile, client, 'stream', [stream], subject, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -6,20 +6,20 @@ from zerver.lib.actions import check_send_message, create_stream_if_needed
 from zerver.lib.response import json_success, json_error
 from zerver.lib.validator import check_string, check_int
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 ZULIP_MESSAGE_TEMPLATE = "**{message_sender}**: `{text}`"
 VALID_OPTIONS = {'SHOULD_NOT_BE_MAPPED': '0', 'SHOULD_BE_MAPPED': '1'}
 
 @api_key_only_webhook_view('Slack')
 @has_request_variables
-def api_slack_webhook(request, user_profile, client,
+def api_slack_webhook(request, user_profile,
                       user_name=REQ(),
                       text=REQ(),
                       channel_name=REQ(),
                       stream=REQ(default='slack'),
                       channels_map_to_topics=REQ(default='1')):
-    # type: (HttpRequest, UserProfile, Client, str, str, str, str, str) -> HttpResponse
+    # type: (HttpRequest, UserProfile, str, str, str, str, str) -> HttpResponse
 
     if channels_map_to_topics not in list(VALID_OPTIONS.values()):
         return json_error(_('Error: channels_map_to_topics parameter other than 0 or 1'))
@@ -31,5 +31,5 @@ def api_slack_webhook(request, user_profile, client,
         subject = _("Message from Slack")
 
     content = ZULIP_MESSAGE_TEMPLATE.format(message_sender=user_name, text=text)
-    check_send_message(user_profile, client, "stream", [stream], subject, content)
+    check_send_message(user_profile, request.client, "stream", [stream], subject, content)
     return json_success()

--- a/zerver/webhooks/solano/view.py
+++ b/zerver/webhooks/solano/view.py
@@ -14,14 +14,14 @@ from typing import Any, Dict
 
 @api_key_only_webhook_view('SolanoLabs')
 @has_request_variables
-def api_solano_webhook(request, user_profile, client,
+def api_solano_webhook(request, user_profile,
                        stream=REQ(default='solano labs'),
                        topic=REQ(default='build update'),
                        payload=REQ(argument_type='body')):
-    # type: (HttpRequest, UserProfile, Client, str, str, Dict[str, Any]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, str, str, Dict[str, Any]) -> HttpResponse
     event = payload.get('event')
     if event == 'test':
-        return handle_test_event(user_profile, client, stream, topic)
+        return handle_test_event(user_profile, request.client, stream, topic)
     try:
         try:
             author = payload['committers'][0]
@@ -65,7 +65,7 @@ def api_solano_webhook(request, user_profile, client,
 
     body = template.format(author, commit_id, commit_url, status, emoji, build_log)
 
-    check_send_message(user_profile, client, 'stream', [stream], topic, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
     return json_success()
 
 def handle_test_event(user_profile, client, stream, topic):

--- a/zerver/webhooks/splunk/view.py
+++ b/zerver/webhooks/splunk/view.py
@@ -5,17 +5,17 @@ from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 from zerver.lib.validator import check_dict, check_string
-from zerver.models import Client, UserProfile, MAX_SUBJECT_LENGTH
+from zerver.models import UserProfile, MAX_SUBJECT_LENGTH
 
 from django.http import HttpRequest, HttpResponse
 from typing import Dict, Any, Iterable, Optional, Text
 
 @api_key_only_webhook_view('Splunk')
 @has_request_variables
-def api_splunk_webhook(request, user_profile, client,
+def api_splunk_webhook(request, user_profile,
                        payload=REQ(argument_type='body'), stream=REQ(default='splunk'),
                        topic=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text, Optional[Text]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Optional[Text]) -> HttpResponse
 
     # use default values if expected data is not provided
     search_name = payload.get('search_name', 'Missing search_name')
@@ -39,6 +39,6 @@ def api_splunk_webhook(request, user_profile, client,
                                  host = host, source = source, raw = raw)
 
     # send the message
-    check_send_message(user_profile, client, 'stream', [stream], topic, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
 
     return json_success()

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -4,7 +4,7 @@ from django.utils.translation import ugettext as _
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import Client, UserProfile
+from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
 from typing import Dict, Any, Optional, Text
@@ -14,10 +14,10 @@ import time
 
 @api_key_only_webhook_view('Stripe')
 @has_request_variables
-def api_stripe_webhook(request, user_profile, client,
+def api_stripe_webhook(request, user_profile,
                        payload=REQ(argument_type='body'), stream=REQ(default='test'),
                        topic=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text, Optional[Text]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Optional[Text]) -> HttpResponse
     body = None
     event_type = payload["type"]
     try:
@@ -163,7 +163,7 @@ def api_stripe_webhook(request, user_profile, client,
     if body is None:
         return json_error(_("We don't support {} event".format(event_type)))
 
-    check_send_message(user_profile, client, 'stream', [stream], topic, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
 
     return json_success()
 

--- a/zerver/webhooks/taiga/view.py
+++ b/zerver/webhooks/taiga/view.py
@@ -27,7 +27,7 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 import ujson
 from six.moves import range
@@ -35,9 +35,9 @@ from six.moves import range
 
 @api_key_only_webhook_view('Taiga')
 @has_request_variables
-def api_taiga_webhook(request, user_profile, client, message=REQ(argument_type='body'),
+def api_taiga_webhook(request, user_profile, message=REQ(argument_type='body'),
                       stream=REQ(default='taiga'), topic=REQ(default='General')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], Text, Text) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Text) -> HttpResponse
     parsed_events = parse_message(message)
 
     content_lines = []
@@ -45,7 +45,7 @@ def api_taiga_webhook(request, user_profile, client, message=REQ(argument_type='
         content_lines.append(generate_content(event) + '\n')
     content = "".join(sorted(content_lines))
 
-    check_send_message(user_profile, client, 'stream', [stream], topic, content)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, content)
 
     return json_success()
 

--- a/zerver/webhooks/teamcity/view.py
+++ b/zerver/webhooks/teamcity/view.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
 from typing import Any, Dict, List, Optional
 
-from zerver.models import Client, UserProfile, Realm
+from zerver.models import UserProfile, Realm
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -39,9 +39,9 @@ def get_teamcity_property_value(property_list, name):
 
 @api_key_only_webhook_view('Teamcity')
 @has_request_variables
-def api_teamcity_webhook(request, user_profile, client, payload=REQ(argument_type='body'),
+def api_teamcity_webhook(request, user_profile, payload=REQ(argument_type='body'),
                          stream=REQ(default='teamcity')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], str) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], str) -> HttpResponse
     message = payload['build']
 
     build_name = message['buildFullName']
@@ -94,8 +94,8 @@ def api_teamcity_webhook(request, user_profile, client, payload=REQ(argument_typ
             return json_success()
 
         body = "Your personal build of " + body
-        check_send_message(user_profile, client, 'private', [teamcity_user.email], topic, body)
+        check_send_message(user_profile, request.client, 'private', [teamcity_user.email], topic, body)
         return json_success()
 
-    check_send_message(user_profile, client, 'stream', [stream], topic, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
     return json_success()

--- a/zerver/webhooks/transifex/view.py
+++ b/zerver/webhooks/transifex/view.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from django.utils.translation import ugettext as _
 from django.http import HttpRequest, HttpResponse
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -10,12 +10,12 @@ from typing import Optional
 
 @api_key_only_webhook_view('Transifex')
 @has_request_variables
-def api_transifex_webhook(request, user_profile, client,
+def api_transifex_webhook(request, user_profile,
                           project=REQ(), resource=REQ(),
                           language=REQ(), translated=REQ(default=None),
                           reviewed=REQ(default=None),
                           stream=REQ(default='transifex')):
-    # type: (HttpRequest, UserProfile, Client, str, str, str, Optional[int], Optional[int], str) -> HttpResponse
+    # type: (HttpRequest, UserProfile, str, str, str, Optional[int], Optional[int], str) -> HttpResponse
     subject = "{} in {}".format(project, language)
     if translated:
         body = "Resource {} fully translated.".format(resource)
@@ -23,5 +23,5 @@ def api_transifex_webhook(request, user_profile, client,
         body = "Resource {} fully reviewed.".format(resource)
     else:
         return json_error(_("Transifex wrong request"))
-    check_send_message(user_profile, client, 'stream', [stream], subject, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/webhooks/travis/view.py
+++ b/zerver/webhooks/travis/view.py
@@ -7,7 +7,7 @@ from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_vi
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
 from zerver.lib.validator import check_dict, check_string, check_bool
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 from typing import Dict
 
 import ujson
@@ -23,7 +23,7 @@ MESSAGE_TEMPLATE = (
 
 @api_key_only_webhook_view('Travis')
 @has_request_variables
-def api_travis_webhook(request, user_profile, client,
+def api_travis_webhook(request, user_profile,
                        stream=REQ(default='travis'),
                        topic=REQ(default=None),
                        ignore_pull_requests=REQ(validator=check_bool, default=True),
@@ -32,7 +32,7 @@ def api_travis_webhook(request, user_profile, client,
                            ('status_message', check_string),
                            ('compare_url', check_string),
                        ]))):
-    # type: (HttpRequest, UserProfile, Client, str, str, str, Dict[str, str]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, str, str, str, Dict[str, str]) -> HttpResponse
 
     message_status = message['status_message']
     if ignore_pull_requests and message['type'] == 'pull_request':
@@ -53,5 +53,5 @@ def api_travis_webhook(request, user_profile, client,
         message['build_url']
     )
 
-    check_send_message(user_profile, client, 'stream', [stream], topic, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
     return json_success()

--- a/zerver/webhooks/trello/__init__.py
+++ b/zerver/webhooks/trello/__init__.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
 from zerver.decorator import return_success_on_head_request
 from zerver.lib.response import json_success, json_error
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 
 from .view.card_actions import SUPPORTED_CARD_ACTIONS, process_card_action
@@ -17,8 +17,8 @@ from .view.exceptions import UnsupportedAction
 @api_key_only_webhook_view('Trello')
 @return_success_on_head_request
 @has_request_variables
-def api_trello_webhook(request, user_profile, client, payload=REQ(argument_type='body'), stream=REQ(default='trello')):
-    # type: (HttpRequest, UserProfile, Client, Mapping[str, Any], Text) -> HttpResponse
+def api_trello_webhook(request, user_profile, payload=REQ(argument_type='body'), stream=REQ(default='trello')):
+    # type: (HttpRequest, UserProfile, Mapping[str, Any], Text) -> HttpResponse
     payload = ujson.loads(request.body)
     action_type = payload.get('action').get('type')
     try:
@@ -26,7 +26,7 @@ def api_trello_webhook(request, user_profile, client, payload=REQ(argument_type=
     except UnsupportedAction:
         return json_error(_('Unsupported action_type: {action_type}'.format(action_type=action_type)))
 
-    check_send_message(user_profile, client, 'stream', [stream], subject, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()
 
 def get_subject_and_body(payload, action_type):

--- a/zerver/webhooks/trello/view/__init__.py
+++ b/zerver/webhooks/trello/view/__init__.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
 from zerver.decorator import return_success_on_head_request
 from zerver.lib.response import json_success, json_error
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 
 from .card_actions import SUPPORTED_CARD_ACTIONS, process_card_action
@@ -17,8 +17,8 @@ from .exceptions import UnsupportedAction
 @api_key_only_webhook_view('Trello')
 @return_success_on_head_request
 @has_request_variables
-def api_trello_webhook(request, user_profile, client, payload=REQ(argument_type='body'), stream=REQ(default='trello')):
-    # type: (HttpRequest, UserProfile, Client, Mapping[str, Any], Text) -> HttpResponse
+def api_trello_webhook(request, user_profile, payload=REQ(argument_type='body'), stream=REQ(default='trello')):
+    # type: (HttpRequest, UserProfile, Mapping[str, Any], Text) -> HttpResponse
     payload = ujson.loads(request.body)
     action_type = payload.get('action').get('type')
     try:
@@ -26,7 +26,7 @@ def api_trello_webhook(request, user_profile, client, payload=REQ(argument_type=
     except UnsupportedAction:
         return json_error(_('Unsupported action_type: {action_type}'.format(action_type=action_type)))
 
-    check_send_message(user_profile, client, 'stream', [stream], subject, body)
+    check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()
 
 def get_subject_and_body(payload, action_type):

--- a/zerver/webhooks/updown/view.py
+++ b/zerver/webhooks/updown/view.py
@@ -68,12 +68,12 @@ def get_body_for_down_event(event):
 
 @api_key_only_webhook_view('Updown')
 @has_request_variables
-def api_updown_webhook(request, user_profile, client,
+def api_updown_webhook(request, user_profile,
                        payload=REQ(argument_type='body'),
                        stream=REQ(default='updown')):
-    # type: (HttpRequest, UserProfile, Client, List[Dict[str, Any]], str) -> HttpResponse
+    # type: (HttpRequest, UserProfile, List[Dict[str, Any]], str) -> HttpResponse
     for event in payload:
-        send_message_for_event(event, user_profile, client, stream)
+        send_message_for_event(event, user_profile, request.client, stream)
     return json_success()
 
 EVENT_TYPE_BODY_MAPPER = {

--- a/zerver/webhooks/wordpress/view.py
+++ b/zerver/webhooks/wordpress/view.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from django.utils.translation import ugettext as _
 from django.http import HttpRequest, HttpResponse
-from zerver.models import Client, get_client, UserProfile
+from zerver.models import get_client, UserProfile
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -15,7 +15,7 @@ WP_LOGIN_TEMPLATE = 'User {name} logged in.'
 
 @api_key_only_webhook_view("Wordpress")
 @has_request_variables
-def api_wordpress_webhook(request, user_profile, client,
+def api_wordpress_webhook(request, user_profile,
                           stream=REQ(default="wordpress"),
                           topic=REQ(default="WordPress Notification"),
                           hook=REQ(default="WordPress Action"),
@@ -25,7 +25,7 @@ def api_wordpress_webhook(request, user_profile, client,
                           display_name=REQ(default="New User Name"),
                           user_email=REQ(default="New User Email"),
                           user_login=REQ(default="Logged in User")):
-    # type: (HttpRequest, UserProfile, Client, text_type, text_type, text_type, text_type, text_type, text_type, text_type, text_type, text_type) -> HttpResponse
+    # type: (HttpRequest, UserProfile, text_type, text_type, text_type, text_type, text_type, text_type, text_type, text_type, text_type) -> HttpResponse
 
     # remove trailing whitespace (issue for some test fixtures)
     hook = hook.rstrip()

--- a/zerver/webhooks/yo/view.py
+++ b/zerver/webhooks/yo/view.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 from django.http import HttpRequest, HttpResponse
 from typing import Optional
 
@@ -11,11 +11,11 @@ import ujson
 
 @api_key_only_webhook_view('Yo')
 @has_request_variables
-def api_yo_app_webhook(request, user_profile, client, email=REQ(default=None),
+def api_yo_app_webhook(request, user_profile, email=REQ(default=None),
                        username=REQ(default='Yo Bot'), topic=REQ(default=None),
                        user_ip=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Client, Optional[str], str, Optional[str], Optional[str]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Optional[str], str, Optional[str], Optional[str]) -> HttpResponse
 
     body = ('Yo from %s') % (username,)
-    check_send_message(user_profile, client, 'private', [email], topic, body)
+    check_send_message(user_profile, request.client, 'private', [email], topic, body)
     return json_success()

--- a/zerver/webhooks/zapier/view.py
+++ b/zerver/webhooks/zapier/view.py
@@ -5,20 +5,20 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
-from zerver.models import UserProfile, Client
+from zerver.models import UserProfile
 
 
 @api_key_only_webhook_view('Zapier')
 @has_request_variables
-def api_zapier_webhook(request, user_profile, client,
+def api_zapier_webhook(request, user_profile,
                        payload=REQ(argument_type='body'),
                        stream=REQ(default='zapier')):
-    # type: (HttpRequest, UserProfile, Client, Dict[str, Any], str) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Dict[str, Any], str) -> HttpResponse
     subject = payload.get('subject')
     content = payload.get('content')
     if subject is None:
         return json_error(_("Subject can't be empty"))
     if content is None:
         return json_error(_("Content can't be empty"))
-    check_send_message(user_profile, client, "stream", [stream], subject, content)
+    check_send_message(user_profile, request.client, "stream", [stream], subject, content)
     return json_success()


### PR DESCRIPTION
Previously, api_key_only_webhook_view passed 3 positional arguments
(request, user_profile, and client) into a function. However, most
of our other auth decorators only pass 2 positional arguments. For
the sake of consistency, we now make api_key_only_webhook_view set
request.client and pass only request and user_profile as positional
arguments.