### PR TITLE
Change cursor to pointer when hovering over streams.

### DIFF
--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -20,11 +20,6 @@
     overflow-y: auto;
 }
 
-#user_presences .user_sidebar_entry:hover,
-#group-pms .group-pms-sidebar-entry:hover {
-    cursor: pointer;
-}
-
 #user_presences li {
     overflow: hidden;
     white-space: nowrap;
@@ -132,6 +127,10 @@
 
 .group-pms-sidebar-entry.group-with-count .selectable_sidebar_block {
     width: 170px;
+}
+
+.selectable_sidebar_block {
+    cursor: pointer;
 }
 
 .user_sidebar_entry .count,


### PR DESCRIPTION
Before this commit, hovering over the blank area of a stream
would not reflect its "clickability". 

This behavior is
unconsistent with other clickable lists, such as the user sidebar.

This commit changes the cursor to a pointer when hovering over a
stream and removes annoying pointer-default-pointer changes when
hovering with the mouse over multiple users in the user sidebar.

Before:
![image](https://cloud.githubusercontent.com/assets/7950151/25678422/f49a1102-3049-11e7-94f5-16cff3c00261.png)


After:
![image](https://cloud.githubusercontent.com/assets/7950151/25678334/ac3e38e8-3049-11e7-97dc-fcbcaef68ec2.png)

Apologies for the poor quality screenshots, needed a dirty workaround for capturing the mouse on windows.