### PR TITLE
message-feed: Improve scroll perf by removing scaling on emojis.

### DIFF
--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -24,16 +24,17 @@
     background-color: #eef7fa !important;
 }
 
-.message_reactions .message_reaction .emoji {
+.message_reaction div.emoji {
     display: inline-block;
     vertical-align: top;
-    top: -3px;
-    margin: 0px;
+    top: 0px;
+    margin: 1px 3px;
 
-    transform: scale(0.70);
-    transform-origin: 50% 50%;
-    -moz-transform: scale(0.70);
-    -moz-transform-origin: 50% 50%;
+    height: 17px;
+    width: 17px;
+    position: relative;
+
+    background-size: 697px 697px;
 }
 
 .message_reactions .message_reaction_count {


### PR DESCRIPTION
This removes scaling from the emojis by changing the background size to
a lower value and then allowing for the widths and heights of the
emojis to be proportionally smaller.

The transform: scale property would cause many more repaints in Chrome
and other browsers than should have been necessary which would render
messages above and below the feed light grey boxes that would
momentarily flash as blank before filling with content.