### PR TITLE
bugdown: Add domain-name to relative image-url in open graph data.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -163,6 +163,12 @@ def add_embed(root, link, extracted_data):
 
     img_link = extracted_data.get('image')
     if img_link:
+        parsed_img_link = urllib.parse.urlparse(img_link)
+        # Append domain where relative img_link url is given
+        if not parsed_img_link.netloc:
+            parsed_url = urllib.parse.urlparse(link)
+            domain = '{url.scheme}://{url.netloc}/'.format(url=parsed_url)
+            img_link = urllib.parse.urljoin(domain, img_link)
         img = markdown.util.etree.SubElement(container, "a")
         img.set("style", "background-image: url(" + img_link + ")")
         img.set("href", link)


### PR DESCRIPTION
fixes #4608

Need advice on whether this needs testing, and if yes, how. Since it requires querying external services that might change their behavior someday, I'm confused what to do.

![image](https://cloud.githubusercontent.com/assets/8033238/25686090/6618b34e-3089-11e7-995e-c0c79d544d85.png)
