### PR TITLE
message_edit.js: Fix bug with ctrl+enter hotkey not working.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -133,7 +133,7 @@ function handle_edit_keydown(from_topic_edited_only, e) {
     var row;
     var code = e.keyCode || e.which;
 
-    if (e.target.id === "message_edit_content" && code === 13 &&
+    if ($(e.target).hasClass("message_edit_content") && code === 13 &&
         (e.metaKey || e.ctrlKey)) {
         row = $(".message_edit_content").filter(":focus").closest(".message_row");
     } else if (e.target.id === "message_edit_topic" && code === 13) {


### PR DESCRIPTION
This was a regression introduced in ba7b7a9. The ID of the edit boxes were changed in that commit, but this event listener was not updated to reflect that.

Did some more searching to confirm that there aren't any other ID disagreements like that.
Sorry about that-- I feel like that edit box PR wasn't quite ready yet. Will do more extensive testing in the future.