### PR TITLE
emoji-reactions-filter: set the cursor at the end on focus

### DIFF
--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -150,7 +150,9 @@ exports.reaction_navigate = function (e, event_name) {
         }
     } else if (event_name === 'up_arrow') {
         if (selected_emoji && selected_index < 6) { // move up into reaction filter
-            $('.emoji-popover-filter').focus();
+            // cursor always goes to the end of the search String.
+            $('.emoji-popover-filter').focus().caret(Infinity);
+            return true;
         }
     }
 


### PR DESCRIPTION
When we use the arrow keys to navigate through the emoji-reactions-picker and when the emoji reactions filter gets focused, the cursor is set to the end of search text.
Fixes #4604