### PR TITLE
stats: Fix sort order bug in messages sent by client.

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -117,11 +117,9 @@ def get_chart_data(request, user_profile, chart_name=REQ(),
 
 def sort_by_totals(value_arrays):
     # type: (Dict[str, List[int]]) -> List[str]
-    totals = []
-    for label, values in value_arrays.items():
-        totals.append((label, sum(values)))
-    totals.sort(key=lambda label_total: "%s:%s" % (label_total[1], label_total[0]), reverse=True)
-    return [label for label, total in totals]
+    totals = [(sum(values), label) for label, values in value_arrays.items()]
+    totals.sort(reverse=True)
+    return [label for total, label in totals]
 
 # For any given user, we want to show a fixed set of clients in the chart,
 # regardless of the time aggregation or whether we're looking at realm or

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -395,13 +395,12 @@ function populate_messages_sent_by_client(data) {
     };
 
     // sort labels so that values are descending in the default view
-    var realm_cumulative = compute_summary_chart_data(data.realm, data.end_times.length,
-                                                      data.display_order.slice(0, 12));
+    var realm_month = compute_summary_chart_data(data.realm, 30, data.display_order.slice(0, 12));
     var label_values = [];
-    for (var i=0; i<realm_cumulative.values.length; i+=1) {
+    for (var i=0; i<realm_month.values.length; i+=1) {
         label_values.push({
-            label: realm_cumulative.labels[i],
-            value: realm_cumulative.labels[i] === "Other" ? -1 : realm_cumulative.values[i],
+            label: realm_month.labels[i],
+            value: realm_month.labels[i] === "Other" ? -1 : realm_month.values[i],
         });
     }
     label_values.sort(function (a, b) { return b.value - a.value; });


### PR DESCRIPTION
As semi-related followup we might want to change the names of ZulipElectron and others via `analytics.views.client_label_map`.