### PR TITLE
CSS: Change color and styling of @-mentions.

### DIFF
--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -16,7 +16,7 @@
 
 .private-message .message_reactions .message_reaction {
     /* Use the PM color background, since white-on-yellow looks bad. */
-    background-color: #feffe0;
+    background-color: #f0f4f5;
 }
 
 .message_reactions .reacted {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -615,7 +615,7 @@ td.pointer {
 }
 
 .private-message .alert-copied {
-    background-color: #feffe0;
+    background-color: #f0f4f5;
 }
 
 .include-sender .alert-copied {
@@ -988,7 +988,7 @@ td.pointer {
 
 .private-message .messagebox,
 .message_header_private_message .message-header-contents {
-    background-color: #feffe0;
+    background-color: #f0f4f5;
 }
 
 .floating_recipient .message-header-contents {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -996,7 +996,7 @@ td.pointer {
 }
 
 .mention .messagebox-content {
-    background-color: #ffe4e0;
+    background-color: hsl(40, 80%, 88%);
 }
 
 .messagebox .message_top_line {
@@ -2525,24 +2525,18 @@ img.emoji {
 }
 
 .user-mention {
-    background-color: #eee;
-    border-radius: 3px;
+    border-radius: 4px;
     padding: 0 0.2em;
-    box-shadow: 0px 0px 0px 1px #ccc;
+    box-shadow: 0 0 0 1px #ccc;
     margin-right: 2px;
-    white-space: nowrap;
-    background-image: -moz-linear-gradient(top, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0) 100%);
-    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(0,0,0,0.1)), color-stop(100%,rgba(0,0,0,0)));
-    background-image: -webkit-linear-gradient(top, rgba(0,0,0,0.1) 0%,rgba(0,0,0,0) 100%);
-    background-image: -o-linear-gradient(top, rgba(0,0,0,0.1) 0%,rgba(0,0,0,0) 100%);
-    background-image: -ms-linear-gradient(top, rgba(0,0,0,0.1) 0%,rgba(0,0,0,0) 100%);
-    background-image: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%,rgba(0,0,0,0) 100%);
-    display: inline-block;
     margin-bottom: 1px;
+    white-space: nowrap;
+    display: inline-block;
+    color: hsl(120, 100%, 18%);
 }
 
 .user-mention-me {
-    background-color: #c9fcc1;
+    box-shadow: 0 0 0 1px #888;
 }
 
 .alert-word {

--- a/templates/zerver/emails/digest.html
+++ b/templates/zerver/emails/digest.html
@@ -11,9 +11,9 @@ Hello {{ name }},
 <p>You have some missed private messages. Here are some of them:</p>
 <div id='private-messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
     {% for recipient_block in unread_pms %}
-        <div class='recipient_block' style="background-color: #feffe0;border: 1px solid black;margin-bottom: 4px;">
+        <div class='recipient_block' style="background-color: #f0f4f5;border: 1px solid black;margin-bottom: 4px;">
             <div class='recipient_header' style="color: #ffffff;background-color: #444444;border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
-            <div class='message_content' style="background-color: #feffe0;margin-left: 1px;margin-right: 2px;">
+            <div class='message_content' style="background-color: #f0f4f5;margin-left: 1px;margin-right: 2px;">
             {% for sender_block in recipient_block.senders %}
                 {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
                 {% for message_block in sender_block.content %}

--- a/templates/zerver/emails/missed_message.html
+++ b/templates/zerver/emails/missed_message.html
@@ -10,9 +10,9 @@ Hello {{ name }},
 
 <div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
     {% for recipient_block in messages %}
-    <div class='recipient_block' style="{% if not recipient_block.header.stream_message %}background-color: #feffe0;{% endif %}border: 1px solid black;margin-bottom: 4px;">
+    <div class='recipient_block' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}border: 1px solid black;margin-bottom: 4px;">
         <div class='recipient_header' style="{% if recipient_block.header.stream_message %}background-color: #9ecaff;{% else %}color: #ffffff;background-color: #444444;{% endif %}border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
-        <div class='message_content' style="{% if not recipient_block.header.stream_message %}background-color: #feffe0;{% endif %}margin-left: 1px;margin-right: 2px;">
+        <div class='message_content' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}margin-left: 1px;margin-right: 2px;">
             {% for sender_block in recipient_block.senders %}
                 {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
                 {% for message_block in sender_block.content %}


### PR DESCRIPTION
The original hope here was to get rid of the colored background entirely, and I have my best attempt at something that does that at https://github.com/rishig/zulip/tree/pm-colors-exploration-1. The main issue is that Zulip (at least chat.zulip.org) is busy enough with emoji, emoji reactions, blue links, pasted images, code blocks, etc that in order for a highlighted (or bubbled, or whatever) name to stand out it has to grab visual attention in a way that is then too ugly for the @-mentions narrow.

There might be other ways of indicating an @-mention other than {something localized to the name, background color}. I did not explore that.

In terms of choice of background color -- the color chosen is not really in-line with our green-blue ocean theme, but it also needs to look distinct from the PM background color. I tried to choose a color that was as bland as possible, while still being sufficiently different from white and the PM color. 

For the green text color - I wanted something that wasn't the blue link color, but sort of similar. It's not as saturated as the blue link color; that's easy to change if we think the non-you-@-mentions should have more (or less) prominence than they do in this PR. 

For the box-shadow - it would be nice to avoid it (and use a highlight, like slack), to make them not look like our buttons. Without at least some box-shadow though it's hard to make multiple @-mentions in a row look good, which I think is a common-enough case. Slack uses usernames without spaces, which solves this problem for them.

If people like this, some followups are:
    * Pick an emoji-reactions background color that works with this color
    * Fix the existing bug where the background-color here has higher z-index than the edge of the message box
    * Figure out how to make an at-message in a PM look good.
    * Change color of code blocks (transparent? grey?) to make them work with @-mention background and PM-background.

I could also imagine tweaks to the colors. A less intense background color might be `hsl(47, 70%, 96%)`. 