### PR TITLE
docs: Update the path of Supervisor config file.

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -154,8 +154,8 @@ We use [supervisord](http://supervisord.org/) to start server processes,
 restart them automatically if they crash, and direct logging.
 
 The config file is
-`zulip/puppet/zulip/files/supervisor/conf.d/zulip.conf`. This is where
-Tornado and Django are set up, as well as a number of background
+`zulip/puppet/zulip/templates/supervisor/zulip.conf.template.erb`. This
+is where Tornado and Django are set up, as well as a number of background
 processes that process event queues. We use event queues for the kinds
 of tasks that are best run in the background because they are
 expensive (in terms of performance) and don't have to be synchronous


### PR DESCRIPTION
zulip.conf was changed to template file but the update was missed out in the doc.
See https://github.com/zulip/zulip/commit/ae09d55e460e18c66d88ba3c1d41baaa9eaab014