### PR TITLE
testing: Make test_hit_ratelimits deterministic.

### DIFF
--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -105,8 +105,10 @@ class RateLimitTests(ZulipTestCase):
         user = get_user_profile_by_email(email)
         clear_user_history(user)
 
+        start_time = time.time()
         for i in range(6):
-            result = self.send_api_message(email, "some stuff %s" % (i,))
+            with mock.patch('time.time', return_value=(start_time + i * 0.1)):
+                result = self.send_api_message(email, "some stuff %s" % (i,))
 
         self.assertEqual(result.status_code, 429)
         json = ujson.loads(result.content)
@@ -114,11 +116,12 @@ class RateLimitTests(ZulipTestCase):
         self.assertIn("API usage exceeded rate limit, try again in", json.get("msg"))
         self.assertTrue('Retry-After' in result)
         self.assertIn(result['Retry-After'], json.get("msg"))
+        self.assertEqual(result['Retry-After'], '0.5')
 
         # We actually wait a second here, rather than force-clearing our history,
         # to make sure the rate-limiting code automatically forgives a user
         # after some time has passed.
-        with mock.patch('time.time', return_value=(time.time() + 1)):
+        with mock.patch('time.time', return_value=(start_time + 1.0)):
             result = self.send_api_message(email, "Good message")
 
             self.assert_json_success(result)


### PR DESCRIPTION
On slower systems or virtual environments, when you are running
tests in parallel mode, sometimes the time taken to send messages
in this test exceeds 1 second which resets the limit.