### PR TITLE
tests: Added ZulipTestCase.example_user() function.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -207,6 +207,21 @@ class ZulipTestCase(TestCase):
         django_client = self.client # see WRAPPER_COMMENT
         return django_client.get(url, info, **kwargs)
 
+    example_user_map = dict(
+        hamlet='hamlet@zulip.com',
+        cordelia='cordelia@zulip.com',
+        iago='iago@zulip.com',
+        prospero='prospero@zulip.com',
+        othello='othello@zulip.com',
+        AARON='AARON@zulip.com',
+        ZOE='ZOE@zulip.com',
+    )
+
+    def example_user(self, name):
+        # type: (str) -> UserProfile
+        email = self.example_user_map[name]
+        return get_user_profile_by_email(email)
+
     def login_with_return(self, email, password=None):
         # type: (Text, Optional[Text]) -> HttpResponse
         if password is None:

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -222,6 +222,10 @@ class ZulipTestCase(TestCase):
         email = self.example_user_map[name]
         return get_user_profile_by_email(email)
 
+    def notification_bot(self):
+        # type: () -> UserProfile
+        return get_user_profile_by_email('notification-bot@zulip.com')
+
     def login_with_return(self, email, password=None):
         # type: (Text, Optional[Text]) -> HttpResponse
         if password is None:

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -50,11 +50,8 @@ class AlertWordTests(ZulipTestCase):
         """
         Users start out with no alert words.
         """
-        email = "cordelia@zulip.com"
-        user = get_user_profile_by_email(email)
-
+        user = self.example_user('cordelia')
         words = user_alert_words(user)
-
         self.assertEqual(words, [])
 
     def test_add_word(self):
@@ -62,8 +59,7 @@ class AlertWordTests(ZulipTestCase):
         """
         add_user_alert_words can add multiple alert words at once.
         """
-        email = "cordelia@zulip.com"
-        user = get_user_profile_by_email(email)
+        user = self.example_user('cordelia')
 
         # Add several words, including multi-word and non-ascii words.
         add_user_alert_words(user, self.interesting_alert_word_list)
@@ -77,8 +73,7 @@ class AlertWordTests(ZulipTestCase):
         Removing alert words works via remove_user_alert_words, even
         for multi-word and non-ascii words.
         """
-        email = "cordelia@zulip.com"
-        user = get_user_profile_by_email(email)
+        user = self.example_user('cordelia')
 
         add_user_alert_words(user, self.interesting_alert_word_list)
 

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -176,7 +176,7 @@ class AlertWordTests(ZulipTestCase):
     def test_alert_flags(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile_hamlet = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile_hamlet = self.example_user('hamlet')
 
         result = self.client_put('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
         self.assert_json_success(result)

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -93,13 +93,11 @@ class AlertWordTests(ZulipTestCase):
         alert_words_in_realm. Alerts added for one user do not impact other
         users.
         """
-        email = "cordelia@zulip.com"
-        user1 = get_user_profile_by_email(email)
+        user1 = self.example_user('cordelia')
 
         add_user_alert_words(user1, self.interesting_alert_word_list)
 
-        email = "othello@zulip.com"
-        user2 = get_user_profile_by_email(email)
+        user2 = self.example_user('othello')
         add_user_alert_words(user2, ['another'])
 
         realm_words = alert_words_in_realm(user2.realm)
@@ -202,8 +200,8 @@ class AlertWordTests(ZulipTestCase):
 
     def test_update_alert_words(self):
         # type: () -> None
-        me_email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(me_email)
+        user_profile = self.example_user('hamlet')
+        me_email = user_profile.email
 
         self.login(me_email)
         result = self.client_put('/json/users/me/alert_words', {'alert_words': ujson.dumps(['ALERT'])})

--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -8,7 +8,6 @@ import ujson
 from typing import Any
 
 from zerver.lib.attachments import user_attachments
-from zerver.lib.test_helpers import get_user_profile_by_email
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import Attachment
 

--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -16,7 +16,7 @@ from zerver.models import Attachment
 class AttachmentsTests(ZulipTestCase):
     def setUp(self):
         # type: () -> None
-        user = get_user_profile_by_email("cordelia@zulip.com")
+        user = self.example_user('cordelia')
         self.attachment = Attachment.objects.create(
             file_name='test.txt', path_id='foo/bar/test.txt', owner=user)
 
@@ -25,7 +25,7 @@ class AttachmentsTests(ZulipTestCase):
         self.login("cordelia@zulip.com")
         result = self.client_get('/json/attachments')
         self.assert_json_success(result)
-        user = get_user_profile_by_email("cordelia@zulip.com")
+        user = self.example_user('cordelia')
         attachments = user_attachments(user)
         data = ujson.loads(result.content)
         self.assertEqual(data['attachments'], attachments)
@@ -36,7 +36,7 @@ class AttachmentsTests(ZulipTestCase):
         self.login("cordelia@zulip.com")
         result = self.client_delete('/json/attachments/{pk}'.format(pk=self.attachment.pk))
         self.assert_json_success(result)
-        user = get_user_profile_by_email("cordelia@zulip.com")
+        user = self.example_user('cordelia')
         attachments = user_attachments(user)
         self.assertEqual(attachments, [])
 
@@ -53,7 +53,7 @@ class AttachmentsTests(ZulipTestCase):
         self.login("iago@zulip.com")
         result = self.client_delete('/json/attachments/{pk}'.format(pk=self.attachment.pk))
         self.assert_json_error(result, 'Invalid attachment')
-        user = get_user_profile_by_email("cordelia@zulip.com")
+        user = self.example_user('cordelia')
         attachments = user_attachments(user)
         self.assertEqual(attachments, [self.attachment.to_dict()])
 

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -32,7 +32,7 @@ class TestRealmAuditLog(ZulipTestCase):
     def test_change_password(self):
         # type: () -> None
         now = timezone_now()
-        user = get_user_profile_by_email("hamlet@zulip.com")
+        user = self.example_user('hamlet')
         password = 'test1'
         do_change_password(user, password)
         self.assertEqual(RealmAuditLog.objects.filter(event_type='user_change_password',
@@ -42,7 +42,7 @@ class TestRealmAuditLog(ZulipTestCase):
     def test_change_email(self):
         # type: () -> None
         now = timezone_now()
-        user = get_user_profile_by_email("hamlet@zulip.com")
+        user = self.example_user('hamlet')
         email = 'test@example.com'
         do_change_user_email(user, email)
         self.assertEqual(RealmAuditLog.objects.filter(event_type='user_email_changed',
@@ -52,7 +52,7 @@ class TestRealmAuditLog(ZulipTestCase):
     def test_change_avatar_source(self):
         # type: () -> None
         now = timezone_now()
-        user = get_user_profile_by_email("hamlet@zulip.com")
+        user = self.example_user('hamlet')
         avatar_source = u'G'
         do_change_avatar_fields(user, avatar_source)
         self.assertEqual(RealmAuditLog.objects.filter(event_type='user_change_avatar_source',
@@ -62,9 +62,9 @@ class TestRealmAuditLog(ZulipTestCase):
     def test_change_bot_owner(self):
         # type: () -> None
         now = timezone_now()
-        admin = get_user_profile_by_email('iago@zulip.com')
+        admin = self.example_user('iago')
         bot = get_user_profile_by_email("notification-bot@zulip.com")
-        bot_owner = get_user_profile_by_email("hamlet@zulip.com")
+        bot_owner = self.example_user('hamlet')
         do_change_bot_owner(bot, bot_owner, admin)
         self.assertEqual(RealmAuditLog.objects.filter(event_type='bot_owner_changed',
                                                       event_time__gte=now).count(), 1)
@@ -73,7 +73,7 @@ class TestRealmAuditLog(ZulipTestCase):
     def test_regenerate_api_key(self):
         # type: () -> None
         now = timezone_now()
-        user = get_user_profile_by_email("hamlet@zulip.com")
+        user = self.example_user('hamlet')
         do_regenerate_api_key(user, user)
         self.assertEqual(RealmAuditLog.objects.filter(event_type='user_api_key_changed',
                                                       event_time__gte=now).count(), 1)

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -6,7 +6,7 @@ from zerver.lib.actions import do_create_user, do_deactivate_user, \
     do_change_user_email, do_change_avatar_fields, do_change_bot_owner, \
     do_regenerate_api_key
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import RealmAuditLog, get_realm, get_user_profile_by_email
+from zerver.models import RealmAuditLog, get_realm
 
 from datetime import timedelta
 from django.contrib.auth.password_validation import validate_password

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -63,7 +63,7 @@ class TestRealmAuditLog(ZulipTestCase):
         # type: () -> None
         now = timezone_now()
         admin = self.example_user('iago')
-        bot = get_user_profile_by_email("notification-bot@zulip.com")
+        bot = self.notification_bot()
         bot_owner = self.example_user('hamlet')
         do_change_bot_owner(bot, bot_owner, admin)
         self.assertEqual(RealmAuditLog.objects.filter(event_type='bot_owner_changed',

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -226,11 +226,11 @@ class AuthBackendTest(ZulipTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.GoogleMobileOauth2Backend',))
     def test_google_backend(self):
         # type: () -> None
-        email = "hamlet@zulip.com"
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         backend = GoogleMobileOauth2Backend()
         payload = dict(email_verified=True,
                        email=email)
-        user_profile = get_user_profile_by_email(email)
         self.setup_subdomain(user_profile)
 
         with mock.patch('apiclient.sample_tools.client.verify_id_token', return_value=payload):
@@ -273,9 +273,9 @@ class AuthBackendTest(ZulipTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_ldap_backend(self):
         # type: () -> None
-        email = "hamlet@zulip.com"
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         password = "test_password"
-        user_profile = get_user_profile_by_email(email)
         self.setup_subdomain(user_profile)
 
         username = self.get_username()
@@ -1364,8 +1364,8 @@ class FetchAuthBackends(ZulipTestCase):
 class TestDevAuthBackend(ZulipTestCase):
     def test_login_success(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         data = {'direct_email': email}
         result = self.client_post('/accounts/login/local/', data)
         self.assertEqual(result.status_code, 302)
@@ -1373,8 +1373,8 @@ class TestDevAuthBackend(ZulipTestCase):
 
     def test_login_with_subdomain(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         data = {'direct_email': email}
         with self.settings(REALMS_HAVE_SUBDOMAINS=True):
             result = self.client_post('/accounts/login/local/', data)
@@ -1401,8 +1401,8 @@ class TestDevAuthBackend(ZulipTestCase):
 class TestZulipRemoteUserBackend(ZulipTestCase):
     def test_login_success(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
             result = self.client_post('/accounts/login/sso/', REMOTE_USER=email)
             self.assertEqual(result.status_code, 302)
@@ -1416,8 +1416,7 @@ class TestZulipRemoteUserBackend(ZulipTestCase):
     def test_login_success_with_sso_append_domain(self):
         # type: () -> None
         username = 'hamlet'
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',),
                            SSO_APPEND_DOMAIN='zulip.com'):
             result = self.client_post('/accounts/login/sso/', REMOTE_USER=username)
@@ -1478,8 +1477,8 @@ class TestZulipRemoteUserBackend(ZulipTestCase):
 
     def test_login_success_under_subdomains(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         with mock.patch('zerver.views.auth.get_subdomain', return_value='zulip'):
             with self.settings(
                     REALMS_HAVE_SUBDOMAINS=True,
@@ -1612,8 +1611,7 @@ class TestJWTLogin(ZulipTestCase):
 class TestLDAP(ZulipTestCase):
     def setUp(self):
         # type: () -> None
-        email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
         self.setup_subdomain(user_profile)
 
         ldap_patcher = mock.patch('django_auth_ldap.config.ldap.initialize')

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -411,11 +411,11 @@ class SocialAuthMixinTest(ZulipTestCase):
 class GitHubAuthBackendTest(ZulipTestCase):
     def setUp(self):
         # type: () -> None
-        self.email = 'hamlet@zulip.com'
+        self.user_profile = self.example_user('hamlet')
+        self.email = self.user_profile.email
         self.name = 'Hamlet'
         self.backend = GitHubAuthBackend()
         self.backend.strategy = DjangoStrategy(storage=BaseDjangoStorage())
-        self.user_profile = get_user_profile_by_email(self.email)
         self.user_profile.backend = self.backend
 
         rf = RequestFactory()
@@ -1057,8 +1057,8 @@ class GoogleLoginTest(GoogleOAuthTest):
 class FetchAPIKeyTest(ZulipTestCase):
     def setUp(self):
         # type: () -> None
-        self.email = "hamlet@zulip.com"
-        self.user_profile = get_user_profile_by_email(self.email)
+        self.user_profile = self.example_user('hamlet')
+        self.email = self.user_profile.email
 
     def test_success(self):
         # type: () -> None
@@ -1172,8 +1172,8 @@ class FetchAPIKeyTest(ZulipTestCase):
 class DevFetchAPIKeyTest(ZulipTestCase):
     def setUp(self):
         # type: () -> None
-        self.email = "hamlet@zulip.com"
-        self.user_profile = get_user_profile_by_email(self.email)
+        self.user_profile = self.example_user('hamlet')
+        self.email = self.user_profile.email
 
     def test_success(self):
         # type: () -> None

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -381,8 +381,9 @@ class AuthBackendTest(ZulipTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.GitHubAuthBackend',))
     def test_github_backend(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        self.setup_subdomain(get_user_profile_by_email(email))
+        user = self.example_user('hamlet')
+        email = user.email
+        self.setup_subdomain(user)
         good_kwargs = dict(response=dict(email=email), return_data=dict(),
                            realm_subdomain='acme')
         self.verify_backend(GitHubAuthBackend(),

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -781,7 +781,7 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         self.assertEqual(query_params["realm"], ['http://zulip.testserver'])
         self.assertEqual(query_params["email"], ['hamlet@zulip.com'])
         encrypted_api_key = query_params["otp_encrypted_api_key"][0]
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").api_key,
+        self.assertEqual(self.example_user('hamlet').api_key,
                          otp_decrypt_api_key(encrypted_api_key, mobile_flow_otp))
 
     def test_log_into_subdomain(self):
@@ -794,7 +794,7 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         with mock.patch('zerver.views.auth.get_subdomain', return_value='zulip'):
             result = self.client_get('/accounts/login/subdomain/')
             self.assertEqual(result.status_code, 302)
-            user_profile = get_user_profile_by_email('hamlet@zulip.com')
+            user_profile = self.example_user('hamlet')
             self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
 
             # If authenticate_remote_user detects a subdomain mismatch, then
@@ -910,7 +910,7 @@ class GoogleLoginTest(GoogleOAuthTest):
         account_response = ResponseMock(200, account_data)
         self.google_oauth2_test(token_response, account_response)
 
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
 
     def test_google_oauth2_registration(self):
@@ -1001,7 +1001,7 @@ class GoogleLoginTest(GoogleOAuthTest):
         account_response = ResponseMock(200, account_data)
         self.google_oauth2_test(token_response, account_response)
 
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
 
     def test_google_oauth2_account_response_no_email(self):

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -224,7 +224,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_add_bot_with_default_sending_stream_private_allowed(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         stream = get_stream("Denmark", user_profile.realm)
         self.subscribe_to_stream(user_profile.email, stream.name)
         do_change_stream_invite_only(stream, True)
@@ -262,7 +262,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_add_bot_with_default_sending_stream_private_denied(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         stream = get_stream("Denmark", user_profile.realm)
         self.unsubscribe_from_stream("hamlet@zulip.com", "Denmark")
         do_change_stream_invite_only(stream, True)
@@ -289,7 +289,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_add_bot_with_default_events_register_stream_private_allowed(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         stream = self.subscribe_to_stream(user_profile.email, 'Denmark')
         do_change_stream_invite_only(stream, True)
 
@@ -326,7 +326,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_add_bot_with_default_events_register_stream_private_denied(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         stream = get_stream("Denmark", user_profile.realm)
         self.unsubscribe_from_stream("hamlet@zulip.com", "Denmark")
         do_change_stream_invite_only(stream, True)
@@ -597,7 +597,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_patch_bot_to_stream_private_allowed(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         stream = self.subscribe_to_stream(user_profile.email, "Denmark")
         do_change_stream_invite_only(stream, True)
 
@@ -623,7 +623,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_patch_bot_to_stream_private_denied(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         stream = get_stream("Denmark", user_profile.realm)
         self.unsubscribe_from_stream("hamlet@zulip.com", "Denmark")
         do_change_stream_invite_only(stream, True)
@@ -680,7 +680,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_patch_bot_events_register_stream_allowed(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         stream = self.subscribe_to_stream(user_profile.email, "Denmark")
         do_change_stream_invite_only(stream, True)
 
@@ -705,7 +705,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_patch_bot_events_register_stream_denied(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         stream = get_stream("Denmark", user_profile.realm)
         self.unsubscribe_from_stream("hamlet@zulip.com", "Denmark")
         do_change_stream_invite_only(stream, True)

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -163,7 +163,7 @@ def bugdown_convert(text):
     # type: (Text) -> Text
     return bugdown.convert(text, message_realm=get_realm('zulip'))
 
-class BugdownTest(TestCase):
+class BugdownTest(ZulipTestCase):
     def load_bugdown_tests(self):
         # type: () -> Tuple[Dict[Text, Any], List[List[Text]]]
         test_fixtures = {}
@@ -236,7 +236,7 @@ class BugdownTest(TestCase):
         without_preview = '<p><a href="http://cdn.wallpapersafari.com/13/6/16eVjx.jpeg" target="_blank" title="http://cdn.wallpapersafari.com/13/6/16eVjx.jpeg">http://cdn.wallpapersafari.com/13/6/16eVjx.jpeg</a></p>'
         content = 'http://cdn.wallpapersafari.com/13/6/16eVjx.jpeg'
 
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
         converted = render_markdown(msg, content)
         self.assertEqual(converted, with_preview)
@@ -245,7 +245,7 @@ class BugdownTest(TestCase):
         setattr(realm, 'inline_image_preview', False)
         realm.save()
 
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
         converted = render_markdown(msg, content)
         self.assertEqual(converted, without_preview)
@@ -256,7 +256,7 @@ class BugdownTest(TestCase):
         content = 'http://imaging.nikon.com/lineup/dslr/df/img/sample/img_01.jpg\nhttp://imaging.nikon.com/lineup/dslr/df/img/sample/img_02.jpg\nhttp://imaging.nikon.com/lineup/dslr/df/img/sample/img_03.jpg'
         expected = '<p><a href="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_01.jpg" target="_blank" title="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_01.jpg">http://imaging.nikon.com/lineup/dslr/df/img/sample/img_01.jpg</a><br>\n<a href="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_02.jpg" target="_blank" title="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_02.jpg">http://imaging.nikon.com/lineup/dslr/df/img/sample/img_02.jpg</a><br>\n<a href="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_03.jpg" target="_blank" title="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_03.jpg">http://imaging.nikon.com/lineup/dslr/df/img/sample/img_03.jpg</a></p>\n<div class="message_inline_image"><a href="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_01.jpg" target="_blank" title="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_01.jpg"><img src="https://external-content.zulipcdn.net/1081f3eb3d307ff5b578c1f5ce9d4cef8f8953c4/687474703a2f2f696d6167696e672e6e696b6f6e2e636f6d2f6c696e6575702f64736c722f64662f696d672f73616d706c652f696d675f30312e6a7067"></a></div><div class="message_inline_image"><a href="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_02.jpg" target="_blank" title="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_02.jpg"><img src="https://external-content.zulipcdn.net/8a2da7577389c522fab18ba2e6d6947b85458074/687474703a2f2f696d6167696e672e6e696b6f6e2e636f6d2f6c696e6575702f64736c722f64662f696d672f73616d706c652f696d675f30322e6a7067"></a></div><div class="message_inline_image"><a href="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_03.jpg" target="_blank" title="http://imaging.nikon.com/lineup/dslr/df/img/sample/img_03.jpg"><img src="https://external-content.zulipcdn.net/9c389273b239846aa6e07e109216773934e52828/687474703a2f2f696d6167696e672e6e696b6f6e2e636f6d2f6c696e6575702f64736c722f64662f696d672f73616d706c652f696d675f30332e6a7067"></a></div>'
 
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
         converted = render_markdown(msg, content)
         self.assertEqual(converted, expected)
@@ -276,7 +276,7 @@ class BugdownTest(TestCase):
 
         settings.INLINE_IMAGE_PREVIEW = True
 
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         bugdown.current_message = copy.deepcopy(Message(sender=sender_user_profile, sending_client=get_client("test")))
         realm = bugdown.current_message.get_realm()
 
@@ -290,7 +290,7 @@ class BugdownTest(TestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=False)
     def test_url_embed_preview_enabled_for_realm(self):
         # type: () -> None
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         message = copy.deepcopy(Message(sender=sender_user_profile, sending_client=get_client("test")))
         realm = message.get_realm()
 
@@ -488,7 +488,7 @@ class BugdownTest(TestCase):
         check_add_realm_emoji(realm, "test", 'test.png')
 
         # Needs to mock an actual message because that's how bugdown obtains the realm
-        msg = Message(sender=get_user_profile_by_email("hamlet@zulip.com"))
+        msg = Message(sender=self.example_user('hamlet'))
         converted = bugdown.convert(":test:", message_realm=realm, message=msg)
         self.assertEqual(converted, '<p>%s</p>' % (emoji_img(':test:', 'test.png', realm.id)))
 
@@ -519,7 +519,7 @@ class BugdownTest(TestCase):
             '<RealmFilter(zulip): #(?P<id>[0-9]{2,8})'
             ' https://trac.zulip.net/ticket/%(id)s>')
 
-        msg = Message(sender=get_user_profile_by_email("othello@zulip.com"),
+        msg = Message(sender=self.example_user('othello'),
                       subject="#444")
 
         flush_per_request_caches()
@@ -533,7 +533,7 @@ class BugdownTest(TestCase):
 
         RealmFilter(realm=realm, pattern=r'#(?P<id>[a-zA-Z]+-[0-9]+)',
                     url_format_string=r'https://trac.zulip.net/ticket/%(id)s').save()
-        msg = Message(sender=get_user_profile_by_email('hamlet@zulip.com'))
+        msg = Message(sender=self.example_user('hamlet'))
 
         content = '#ZUL-123 was fixed and code was deployed to production, also #zul-321 was deployed to staging'
         converted = bugdown.convert(content, message_realm=realm, message=msg)
@@ -602,14 +602,14 @@ class BugdownTest(TestCase):
         realm = get_realm('zulip')
         RealmFilter(realm=realm, pattern=r"#(?P<id>[0-9]{2,8})",
                     url_format_string=r"https://trac.zulip.net/ticket/%(id)s").save()
-        boring_msg = Message(sender=get_user_profile_by_email("othello@zulip.com"),
+        boring_msg = Message(sender=self.example_user('othello'),
                              subject=u"no match here")
         converted_boring_subject = bugdown.subject_links(realm.id, boring_msg.subject)
         self.assertEqual(converted_boring_subject, [])
 
     def test_is_status_message(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email("othello@zulip.com")
+        user_profile = self.example_user('othello')
         msg = Message(sender=user_profile, sending_client=get_client("test"))
 
         content = '/me makes a list\n* one\n* two'
@@ -630,7 +630,7 @@ class BugdownTest(TestCase):
 
     def test_alert_words(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email("othello@zulip.com")
+        user_profile = self.example_user('othello')
         do_set_alert_words(user_profile, ["ALERTWORD", "scaryword"])
         msg = Message(sender=user_profile, sending_client=get_client("test"))
         realm_alert_words = alert_words_in_realm(user_profile.realm)
@@ -653,7 +653,7 @@ class BugdownTest(TestCase):
 
     def test_mention_wildcard(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email("othello@zulip.com")
+        user_profile = self.example_user('othello')
         msg = Message(sender=user_profile, sending_client=get_client("test"))
 
         content = "@all test"
@@ -665,7 +665,7 @@ class BugdownTest(TestCase):
 
     def test_mention_everyone(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email("othello@zulip.com")
+        user_profile = self.example_user('othello')
         msg = Message(sender=user_profile, sending_client=get_client("test"))
 
         content = "@everyone test"
@@ -675,8 +675,8 @@ class BugdownTest(TestCase):
 
     def test_mention_single(self):
         # type: () -> None
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        sender_user_profile = self.example_user('othello')
+        user_profile = self.example_user('hamlet')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
         user_id = user_profile.id
 
@@ -690,8 +690,8 @@ class BugdownTest(TestCase):
 
     def test_mention_shortname(self):
         # type: () -> None
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        sender_user_profile = self.example_user('othello')
+        user_profile = self.example_user('hamlet')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
         user_id = user_profile.id
 
@@ -704,9 +704,9 @@ class BugdownTest(TestCase):
 
     def test_mention_multiple(self):
         # type: () -> None
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
-        hamlet = get_user_profile_by_email("hamlet@zulip.com")
-        cordelia = get_user_profile_by_email("cordelia@zulip.com")
+        sender_user_profile = self.example_user('othello')
+        hamlet = self.example_user('hamlet')
+        cordelia = self.example_user('cordelia')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
 
         content = "@**King Hamlet** and @**cordelia**, check this out"
@@ -723,7 +723,7 @@ class BugdownTest(TestCase):
 
     def test_mention_invalid(self):
         # type: () -> None
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
 
         content = "Hey @**Nonexistent User**"
@@ -734,7 +734,7 @@ class BugdownTest(TestCase):
     def test_stream_single(self):
         # type: () -> None
         denmark = get_stream('Denmark', get_realm('zulip'))
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
         content = "#**Denmark**"
         self.assertEqual(
@@ -745,7 +745,7 @@ class BugdownTest(TestCase):
 
     def test_stream_multiple(self):
         # type: () -> None
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
         realm = get_realm('zulip')
         denmark = get_stream('Denmark', realm)
@@ -765,7 +765,7 @@ class BugdownTest(TestCase):
         # type: () -> None
         realm = get_realm('zulip')
         case_sens = Stream.objects.create(name='CaseSens', realm=realm)
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
         content = "#**CaseSens**"
         self.assertEqual(
@@ -781,7 +781,7 @@ class BugdownTest(TestCase):
         test."""
         realm = get_realm('zulip')
         Stream.objects.create(name='CaseSens', realm=realm)
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
         content = "#**casesens**"
         self.assertEqual(
@@ -792,7 +792,7 @@ class BugdownTest(TestCase):
         # type: () -> None
         realm = get_realm('zulip')
         uni = Stream.objects.create(name=u'привет', realm=realm)
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
         content = u"#**привет**"
         self.assertEqual(
@@ -804,7 +804,7 @@ class BugdownTest(TestCase):
 
     def test_stream_invalid(self):
         # type: () -> None
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
 
         content = "There #**Nonexistentstream**"
@@ -948,7 +948,7 @@ class BugdownApiTests(ZulipTestCase):
         )
         self.assert_json_success(result)
         data = ujson.loads(result.content)
-        user_id = get_user_profile_by_email('hamlet@zulip.com').id
+        user_id = self.example_user('hamlet').id
         self.assertEqual(data['rendered'],
                          u'<p>This mentions <a class="stream" data-stream-id="%s" href="/#narrow/stream/Denmark">#Denmark</a> and <span class="user-mention" data-user-email="%s" data-user-id="%s">@King Hamlet</span>.</p>' % (get_stream("Denmark", get_realm("zulip")).id, 'hamlet@zulip.com', user_id))
 
@@ -973,10 +973,10 @@ class BugdownErrorTests(ZulipTestCase):
 class BugdownAvatarTestCase(ZulipTestCase):
     def test_avatar_with_id(self):
         # type: () -> None
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         message = Message(sender=sender_user_profile, sending_client=get_client("test"))
 
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         msg = '!avatar({0})'.format(user_profile.email)
         converted = bugdown.convert(msg, message=message)
         values = {'email': user_profile.email, 'id': user_profile.id}
@@ -986,7 +986,7 @@ class BugdownAvatarTestCase(ZulipTestCase):
 
     def test_avatar_of_unregistered_user(self):
         # type: () -> None
-        sender_user_profile = get_user_profile_by_email("othello@zulip.com")
+        sender_user_profile = self.example_user('othello')
         message = Message(sender=sender_user_profile, sending_client=get_client("test"))
 
         email = 'fakeuser@example.com'

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -248,7 +248,7 @@ class CustomProfileDataTest(ZulipTestCase):
 
     def test_delete(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email('iago@zulip.com')
+        user_profile = self.example_user('iago')
         realm = user_profile.realm
         field = try_add_realm_custom_profile_field(
             realm,

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -588,9 +588,9 @@ class DeactivatedRealmTest(ZulipTestCase):
 
         """
         realm = get_realm("zulip")
-        email = "hamlet@zulip.com"
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         test_password = "abcd1234"
-        user_profile = get_user_profile_by_email(email)
         user_profile.set_password(test_password)
 
         self.login(email)
@@ -630,8 +630,8 @@ class LoginRequiredTest(ZulipTestCase):
         """
         Verifies the zulip_login_required decorator blocks deactivated users.
         """
-        email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
 
         # Verify fails if logged-out
         result = self.client_get('/accounts/accept_terms/')
@@ -684,8 +684,8 @@ class InactiveUserTest(ZulipTestCase):
         rest_dispatch rejects requests from deactivated users, both /json and api
 
         """
-        email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
         do_deactivate_user(user_profile)
 
@@ -720,8 +720,8 @@ class InactiveUserTest(ZulipTestCase):
         authenticated_json_view views fail with a deactivated user
 
         """
-        email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         test_password = "abcd1234"
         user_profile.set_password(test_password)
         user_profile.save()
@@ -738,8 +738,7 @@ class InactiveUserTest(ZulipTestCase):
         logging in fails with an inactive user
 
         """
-        email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
         do_deactivate_user(user_profile)
 
         result = self.login_with_return("hamlet@zulip.com")
@@ -751,8 +750,8 @@ class InactiveUserTest(ZulipTestCase):
         Deactivated users can't use webhooks
 
         """
-        email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         do_deactivate_user(user_profile)
 
         api_key = self.get_api_key(email)

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -102,7 +102,7 @@ class EmailChangeTestCase(ZulipTestCase):
 
     def test_start_email_change_process(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
         do_start_email_change_process(user_profile, 'hamlet-new@zulip.com')
         self.assertEqual(EmailChangeStatus.objects.count(), 1)
 

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -58,10 +58,10 @@ class EmailChangeTestCase(ZulipTestCase):
 
     def test_confirm_email_change_when_time_exceeded(self):
         # type: () -> None
-        old_email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        old_email = user_profile.email
         new_email = 'hamlet-new@zulip.com'
         self.login('hamlet@zulip.com')
-        user_profile = get_user_profile_by_email(old_email)
         obj = EmailChangeStatus.objects.create(new_email=new_email,
                                                old_email=old_email,
                                                user_profile=user_profile,
@@ -77,10 +77,10 @@ class EmailChangeTestCase(ZulipTestCase):
 
     def test_confirm_email_change(self):
         # type: () -> None
-        old_email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        old_email = user_profile.email
         new_email = 'hamlet-new@zulip.com'
         self.login('hamlet@zulip.com')
-        user_profile = get_user_profile_by_email(old_email)
         obj = EmailChangeStatus.objects.create(new_email=new_email,
                                                old_email=old_email,
                                                user_profile=user_profile,

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -133,9 +133,9 @@ class EmailChangeTestCase(ZulipTestCase):
     def test_unauthorized_email_change(self):
         # type: () -> None
         data = {'email': 'hamlet-new@zulip.com'}
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         do_set_realm_property(user_profile.realm, 'email_changes_disabled', True)
         url = '/json/settings/change'
         result = self.client_post(url, data)
@@ -147,7 +147,8 @@ class EmailChangeTestCase(ZulipTestCase):
     def test_unauthorized_email_change_from_email_confirmation_link(self):
         # type: () -> None
         data = {'email': 'hamlet-new@zulip.com'}
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
         url = '/json/settings/change'
         self.assertEqual(len(mail.outbox), 0)
@@ -162,7 +163,6 @@ class EmailChangeTestCase(ZulipTestCase):
         body = email_message.body
         self.assertIn('We received a request to change the email', body)
 
-        user_profile = get_user_profile_by_email(email)
         do_set_realm_property(user_profile.realm, 'email_changes_disabled', True)
 
         activation_url = [s for s in body.split('\n') if s][4]

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -16,8 +16,10 @@ from zerver.lib.test_classes import (
 )
 
 from zerver.models import (
-    get_display_recipient, get_stream, get_user_profile_by_email,
-    Recipient, get_realm,
+    get_display_recipient,
+    get_realm,
+    get_stream,
+    Recipient
 )
 
 from zerver.lib.actions import (

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -87,7 +87,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
         # build dummy messages for stream
         # test valid incoming stream message is processed properly
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         self.subscribe_to_stream(user_profile.email, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -116,7 +116,7 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         # build dummy messages for stream
         # test message with empty body is not sent
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         self.subscribe_to_stream(user_profile.email, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -161,7 +161,7 @@ class TestMissedPersonalMessageEmailMessages(ZulipTestCase):
                                                      "to": "othello@zulip.com"})
         self.assert_json_success(result)
 
-        user_profile = get_user_profile_by_email("othello@zulip.com")
+        user_profile = self.example_user('othello')
         usermessage = most_recent_usermessage(user_profile)
 
         # we don't want to send actual emails but we do need to create and store the
@@ -179,11 +179,11 @@ class TestMissedPersonalMessageEmailMessages(ZulipTestCase):
 
         # self.login("hamlet@zulip.com")
         # confirm that Hamlet got the message
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         message = most_recent_message(user_profile)
 
         self.assertEqual(message.content, "TestMissedMessageEmailMessages Body")
-        self.assertEqual(message.sender, get_user_profile_by_email("othello@zulip.com"))
+        self.assertEqual(message.sender, self.example_user('othello'))
         self.assertEqual(message.recipient.id, user_profile.id)
         self.assertEqual(message.recipient.type, Recipient.PERSONAL)
 
@@ -202,7 +202,7 @@ class TestMissedHuddleMessageEmailMessages(ZulipTestCase):
                                                                         "iago@zulip.com"])})
         self.assert_json_success(result)
 
-        user_profile = get_user_profile_by_email("cordelia@zulip.com")
+        user_profile = self.example_user('cordelia')
         usermessage = most_recent_usermessage(user_profile)
 
         # we don't want to send actual emails but we do need to create and store the
@@ -219,19 +219,19 @@ class TestMissedHuddleMessageEmailMessages(ZulipTestCase):
         process_message(incoming_valid_message)
 
         # Confirm Iago received the message.
-        user_profile = get_user_profile_by_email("iago@zulip.com")
+        user_profile = self.example_user('iago')
         message = most_recent_message(user_profile)
 
         self.assertEqual(message.content, "TestMissedHuddleMessageEmailMessages Body")
-        self.assertEqual(message.sender, get_user_profile_by_email("cordelia@zulip.com"))
+        self.assertEqual(message.sender, self.example_user('cordelia'))
         self.assertEqual(message.recipient.type, Recipient.HUDDLE)
 
         # Confirm Othello received the message.
-        user_profile = get_user_profile_by_email("othello@zulip.com")
+        user_profile = self.example_user('othello')
         message = most_recent_message(user_profile)
 
         self.assertEqual(message.content, "TestMissedHuddleMessageEmailMessages Body")
-        self.assertEqual(message.sender, get_user_profile_by_email("cordelia@zulip.com"))
+        self.assertEqual(message.sender, self.example_user('cordelia'))
         self.assertEqual(message.recipient.type, Recipient.HUDDLE)
 
 class TestMissedMessageAddressWithEmptyGateway(ZulipTestCase):
@@ -245,7 +245,7 @@ class TestMissedMessageAddressWithEmptyGateway(ZulipTestCase):
                                                                         "iago@zulip.com"])})
         self.assert_json_success(result)
 
-        user_profile = get_user_profile_by_email("cordelia@zulip.com")
+        user_profile = self.example_user('cordelia')
         usermessage = most_recent_usermessage(user_profile)
         with self.settings(EMAIL_GATEWAY_PATTERN=''):
             mm_address = create_missed_message_address(user_profile, usermessage.message)
@@ -268,7 +268,7 @@ class TestDigestEmailMessages(ZulipTestCase):
                                                      "to": "othello@zulip.com"})
         self.assert_json_success(result)
 
-        user_profile = get_user_profile_by_email("othello@zulip.com")
+        user_profile = self.example_user('othello')
         cutoff = time.mktime(datetime.datetime(year=2016, month=1, day=1).timetuple())
 
         handle_digest_email(user_profile.id, cutoff)
@@ -282,7 +282,7 @@ class TestReplyExtraction(ZulipTestCase):
         # build dummy messages for stream
         # test valid incoming stream message is processed properly
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         self.subscribe_to_stream(user_profile.email, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -313,7 +313,7 @@ class TestReplyExtraction(ZulipTestCase):
         # build dummy messages for stream
         # test valid incoming stream message is processed properly
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         self.subscribe_to_stream(user_profile.email, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -420,7 +420,7 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
             })
         self.assert_json_success(result)
 
-        user_profile = get_user_profile_by_email("cordelia@zulip.com")
+        user_profile = self.example_user('cordelia')
         user_message = most_recent_usermessage(user_profile)
         return create_missed_message_address(user_profile, user_message.message)
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -195,7 +195,7 @@ class EventsEndpointTest(ZulipTestCase):
                     event=dict(
                         type='other'
                     ),
-                    users=[get_user_profile_by_email('hamlet@zulip.com').id],
+                    users=[self.example_user('hamlet').id],
                 ),
             ),
         )
@@ -348,7 +348,7 @@ class GetEventsTest(ZulipTestCase):
         self.assertEqual(events[0]["message"]["display_recipient"], "Denmark")
 
 class EventsRegisterTest(ZulipTestCase):
-    user_profile = get_user_profile_by_email("hamlet@zulip.com")
+    user_profile = get_user_profile_by_email('hamlet@zulip.com')
     maxDiff = None # type: Optional[int]
 
     def create_bot(self, email):
@@ -534,7 +534,7 @@ class EventsRegisterTest(ZulipTestCase):
         ])
 
         message = self.send_message("cordelia@zulip.com", "hamlet@zulip.com", Recipient.PERSONAL, "hello")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         events = self.do_test(
             lambda: do_update_message_flags(user_profile, 'add', 'starred',
                                             [message], False, None, None),
@@ -1351,8 +1351,8 @@ class EventsRegisterTest(ZulipTestCase):
                 ('owner_id', check_int),
             ])),
         ])
-        self.user_profile = get_user_profile_by_email('iago@zulip.com')
-        owner = get_user_profile_by_email('hamlet@zulip.com')
+        self.user_profile = self.example_user('iago')
+        owner = self.example_user('hamlet')
         bot = self.create_bot('test-bot@zulip.com')
         action = lambda: do_change_bot_owner(bot, owner, self.user_profile)
         events = self.do_test(action)
@@ -1561,7 +1561,7 @@ class EventsRegisterTest(ZulipTestCase):
 
         # Now remove the first user, to test the normal unsubscribe flow
         action = lambda: bulk_remove_subscriptions(
-            [get_user_profile_by_email("othello@zulip.com")],
+            [self.example_user('othello')],
             [stream])
         events = self.do_test(action,
                               include_subscribers=include_subscribers,
@@ -1572,7 +1572,7 @@ class EventsRegisterTest(ZulipTestCase):
 
         # Now remove the second user, to test the 'vacate' event flow
         action = lambda: bulk_remove_subscriptions(
-            [get_user_profile_by_email("hamlet@zulip.com")],
+            [self.example_user('hamlet')],
             [stream])
         events = self.do_test(action,
                               include_subscribers=include_subscribers,
@@ -1596,7 +1596,7 @@ class EventsRegisterTest(ZulipTestCase):
 
         # Subscribe to a totally new invite-only stream, so it's just Hamlet on it
         stream = self.make_stream("private", get_realm("zulip"), invite_only=True)
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         action = lambda: bulk_add_subscriptions([stream], [user_profile])
         events = self.do_test(action, include_subscribers=include_subscribers,
                               num_events=2)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -220,8 +220,8 @@ class GetEventsTest(ZulipTestCase):
         # type: () -> None
         user_profile = self.example_user('hamlet')
         email = user_profile.email
-        recipient_email = "othello@zulip.com"
-        recipient_user_profile = get_user_profile_by_email(recipient_email)
+        recipient_user_profile = self.example_user('othello')
+        recipient_email = recipient_user_profile.email
         self.login(email)
 
         result = self.tornado_call(get_events_backend, user_profile,
@@ -1769,11 +1769,11 @@ class EventQueueTest(TestCase):
                            'type': 'unknown',
                            "timestamp": "1"}])
 
-class TestEventsRegisterAllPublicStreamsDefaults(TestCase):
+class TestEventsRegisterAllPublicStreamsDefaults(ZulipTestCase):
     def setUp(self):
         # type: () -> None
-        self.email = 'hamlet@zulip.com'
-        self.user_profile = get_user_profile_by_email(self.email)
+        self.user_profile = self.example_user('hamlet')
+        self.email = self.user_profile.email
 
     def test_use_passed_all_public_true_default_false(self):
         # type: () -> None
@@ -1817,11 +1817,11 @@ class TestEventsRegisterAllPublicStreamsDefaults(TestCase):
         result = _default_all_public_streams(self.user_profile, None)
         self.assertFalse(result)
 
-class TestEventsRegisterNarrowDefaults(TestCase):
+class TestEventsRegisterNarrowDefaults(ZulipTestCase):
     def setUp(self):
         # type: () -> None
-        self.email = 'hamlet@zulip.com'
-        self.user_profile = get_user_profile_by_email(self.email)
+        self.user_profile = self.example_user('hamlet')
+        self.email = self.user_profile.email
         self.stream = get_stream('Verona', self.user_profile.realm)
 
     def test_use_passed_narrow_no_default(self):

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1614,7 +1614,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
         self.assert_length(result['realm_bots'], 0)
 
         # additionally the API key for a random bot is not present in the data
-        api_key = get_user_profile_by_email('notification-bot@zulip.com').api_key
+        api_key = self.notification_bot().api_key
         self.assertNotIn(api_key, str(result))
 
     # Admin users have access to all bots in the realm_bots field

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -218,9 +218,9 @@ class GetEventsTest(ZulipTestCase):
 
     def test_get_events(self):
         # type: () -> None
-        email = "hamlet@zulip.com"
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         recipient_email = "othello@zulip.com"
-        user_profile = get_user_profile_by_email(email)
         recipient_user_profile = get_user_profile_by_email(recipient_email)
         self.login(email)
 
@@ -308,8 +308,8 @@ class GetEventsTest(ZulipTestCase):
 
     def test_get_events_narrow(self):
         # type: () -> None
-        email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
 
         result = self.tornado_call(get_events_backend, user_profile,
@@ -1608,8 +1608,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
     # Non-admin users don't have access to all bots
     def test_realm_bots_non_admin(self):
         # type: () -> None
-        email = 'cordelia@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('cordelia')
         self.assertFalse(user_profile.is_realm_admin)
         result = fetch_initial_state_data(user_profile, None, "")
         self.assert_length(result['realm_bots'], 0)
@@ -1621,8 +1620,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
     # Admin users have access to all bots in the realm_bots field
     def test_realm_bots_admin(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
         do_change_is_admin(user_profile, True)
         self.assertTrue(user_profile.is_realm_admin)
         result = fetch_initial_state_data(user_profile, None, "")

--- a/zerver/tests/test_export.py
+++ b/zerver/tests/test_export.py
@@ -36,7 +36,6 @@ from zerver.lib.test_classes import (
 from zerver.lib.test_runner import slow
 
 from zerver.models import (
-    get_user_profile_by_email,
     Message,
     Realm,
     Recipient,

--- a/zerver/tests/test_export.py
+++ b/zerver/tests/test_export.py
@@ -60,8 +60,8 @@ class QueryUtilTest(ZulipTestCase):
         # type: () -> None
         self._create_messages()
 
-        cordelia = get_user_profile_by_email('cordelia@zulip.com')
-        hamlet = get_user_profile_by_email('hamlet@zulip.com')
+        cordelia = self.example_user('cordelia')
+        hamlet = self.example_user('hamlet')
 
         def get_queries():
             # type: () -> List[Any]
@@ -177,7 +177,7 @@ class QueryUtilTest(ZulipTestCase):
         self.assertEqual(actual_msg.sender_id, expected_msg.sender_id)
 
 
-class ExportTest(TestCase):
+class ExportTest(ZulipTestCase):
 
     def setUp(self):
         # type: () -> None
@@ -289,8 +289,8 @@ class ExportTest(TestCase):
         # TODO, extract get_set/find_by_id, so we can split this test up
 
         # Now, restrict users
-        cordelia = get_user_profile_by_email('cordelia@zulip.com')
-        hamlet = get_user_profile_by_email('hamlet@zulip.com')
+        cordelia = self.example_user('cordelia')
+        hamlet = self.example_user('hamlet')
         user_ids = set([cordelia.id, hamlet.id])
 
         full_data = self._export_realm(realm, exportable_user_ids=user_ids)

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -78,8 +78,8 @@ class RateLimitTests(ZulipTestCase):
 
     def test_headers(self):
         # type: () -> None
-        email = "hamlet@zulip.com"
-        user = get_user_profile_by_email(email)
+        user = self.example_user('hamlet')
+        email = user.email
         clear_user_history(user)
 
         result = self.send_api_message(email, "some stuff")
@@ -89,8 +89,8 @@ class RateLimitTests(ZulipTestCase):
 
     def test_ratelimit_decrease(self):
         # type: () -> None
-        email = "hamlet@zulip.com"
-        user = get_user_profile_by_email(email)
+        user = self.example_user('hamlet')
+        email = user.email
         clear_user_history(user)
         result = self.send_api_message(email, "some stuff")
         limit = int(result['X-RateLimit-Remaining'])
@@ -101,8 +101,8 @@ class RateLimitTests(ZulipTestCase):
 
     def test_hit_ratelimits(self):
         # type: () -> None
-        email = "cordelia@zulip.com"
-        user = get_user_profile_by_email(email)
+        user = self.example_user('cordelia')
+        email = user.email
         clear_user_history(user)
 
         start_time = time.time()

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -17,7 +17,6 @@ from zerver.lib.actions import compute_mit_user_fullname
 from zerver.lib.test_classes import (
     ZulipTestCase,
 )
-from zerver.models import get_user_profile_by_email
 
 import DNS
 import mock

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -221,11 +221,11 @@ class HomeTest(ZulipTestCase):
 
     def test_terms_of_service(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        user = self.example_user('hamlet')
+        email = user.email
         self.login(email)
 
         for user_tos_version in [None, '1.1', '2.0.3.4']:
-            user = get_user_profile_by_email(email)
             user.tos_version = user_tos_version
             user.save()
 
@@ -240,10 +240,10 @@ class HomeTest(ZulipTestCase):
 
     def test_terms_of_service_first_time_template(self):
         # type: () -> None
-        email = "hamlet@zulip.com"
+        user = self.example_user('hamlet')
+        email = user.email
         self.login(email)
 
-        user = get_user_profile_by_email(email)
         user.tos_version = None
         user.save()
 
@@ -279,8 +279,8 @@ class HomeTest(ZulipTestCase):
 
     def test_bad_pointer(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         user_profile.pointer = 999999
         user_profile.save()
 
@@ -359,8 +359,8 @@ class HomeTest(ZulipTestCase):
 
     def test_invites_by_admins_only(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
 
         realm = user_profile.realm
         realm.invite_by_admins_only = True

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -326,6 +326,9 @@ class HomeTest(ZulipTestCase):
         cross_bots = page_params['cross_realm_bots']
         self.assertEqual(len(cross_bots), 2)
         cross_bots.sort(key=lambda d: d['email'])
+
+        notification_bot = self.notification_bot()
+
         self.assertEqual(cross_bots, [
             dict(
                 user_id=get_user_profile_by_email('feedback@zulip.com').id,
@@ -335,9 +338,9 @@ class HomeTest(ZulipTestCase):
                 is_bot=True
             ),
             dict(
-                user_id=get_user_profile_by_email('notification-bot@zulip.com').id,
+                user_id=notification_bot.id,
                 is_admin=False,
-                email='notification-bot@zulip.com',
+                email=notification_bot.email,
                 full_name='Notification Bot',
                 is_bot=True
             ),

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -60,11 +60,11 @@ class TopicHistoryTest(ZulipTestCase):
     def test_topics_history(self):
         # type: () -> None
         # verified: int(UserMessage.flags.read) == 1
-        email = 'iago@zulip.com'
+        user_profile = self.example_user('iago')
+        email = user_profile.email
         stream_name = 'Verona'
         self.login(email)
 
-        user_profile = get_user_profile_by_email(email)
         stream = get_stream(stream_name, user_profile.realm)
         recipient = get_recipient(Recipient.STREAM, stream.id)
 
@@ -504,8 +504,8 @@ class StreamMessagesTest(ZulipTestCase):
     def test_stream_message_mirroring(self):
         # type: () -> None
         from zerver.lib.actions import do_change_is_admin
-        email = "iago@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('iago')
+        email = user_profile.email
 
         do_change_is_admin(user_profile, True, 'api_super_user')
         result = self.client_post("/api/v1/messages", {"type": "stream",
@@ -772,8 +772,8 @@ class MessagePOSTTest(ZulipTestCase):
         Sending messages without a to field should be sent to the default
         stream for the user_profile.
         """
-        email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         user_profile.default_sending_stream = get_stream('Verona', user_profile.realm)
         user_profile.save()
         result = self.client_post("/api/v1/messages", {"type": "stream",

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -446,8 +446,7 @@ class StreamMessagesTest(ZulipTestCase):
         for email in recipient_list:
             self.subscribe_to_stream(email, "Denmark")
 
-        sender_email = 'hamlet@zulip.com'
-        sender = get_user_profile_by_email(sender_email)
+        sender = self.example_user('hamlet')
         message_type_name = "stream"
         sending_client = make_client(name="test suite")
         stream = 'Denmark'
@@ -1829,8 +1828,8 @@ class AttachmentTest(ZulipTestCase):
         # type: () -> None
 
         # Create dummy DB entry
-        sender_email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(sender_email)
+        user_profile = self.example_user('hamlet')
+        sender_email = user_profile.email
         sample_size = 10
         dummy_files = [
             ('zulip.txt', '1/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt', sample_size),

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -71,7 +71,7 @@ class TopicHistoryTest(ZulipTestCase):
         def create_test_message(topic, read, starred=False):
             # type: (str, bool, bool) -> None
 
-            hamlet = get_user_profile_by_email('hamlet@zulip.com')
+            hamlet = self.example_user('hamlet')
             message = Message.objects.create(
                 sender=hamlet,
                 recipient=recipient,
@@ -469,7 +469,7 @@ class StreamMessagesTest(ZulipTestCase):
 
     def test_stream_message_dict(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email("iago@zulip.com")
+        user_profile = self.example_user('iago')
         self.subscribe_to_stream(user_profile.email, "Denmark")
         self.send_message("hamlet@zulip.com", "Denmark", Recipient.STREAM,
                           content="whatever", subject="my topic")
@@ -483,7 +483,7 @@ class StreamMessagesTest(ZulipTestCase):
 
     def test_stream_message_unicode(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email("iago@zulip.com")
+        user_profile = self.example_user('iago')
         self.subscribe_to_stream(user_profile.email, "Denmark")
         self.send_message("hamlet@zulip.com", "Denmark", Recipient.STREAM,
                           content="whatever", subject="my topic")
@@ -494,7 +494,7 @@ class StreamMessagesTest(ZulipTestCase):
 
     def test_message_mentions(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email("iago@zulip.com")
+        user_profile = self.example_user('iago')
         self.subscribe_to_stream(user_profile.email, "Denmark")
         self.send_message("hamlet@zulip.com", "Denmark", Recipient.STREAM,
                           content="test @**Iago** rules")
@@ -560,8 +560,8 @@ class MessageDictTest(ZulipTestCase):
     @slow('builds lots of messages')
     def test_bulk_message_fetching(self):
         # type: () -> None
-        sender = get_user_profile_by_email('othello@zulip.com')
-        receiver = get_user_profile_by_email('hamlet@zulip.com')
+        sender = self.example_user('othello')
+        receiver = self.example_user('hamlet')
         pm_recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
         stream_name = u'Çiğdem'
         stream = self.make_stream(stream_name)
@@ -606,8 +606,8 @@ class MessageDictTest(ZulipTestCase):
 
     def test_applying_markdown(self):
         # type: () -> None
-        sender = get_user_profile_by_email('othello@zulip.com')
-        receiver = get_user_profile_by_email('hamlet@zulip.com')
+        sender = self.example_user('othello')
+        receiver = self.example_user('hamlet')
         recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
         sending_client = make_client(name="test suite")
         message = Message(
@@ -637,8 +637,8 @@ class MessageDictTest(ZulipTestCase):
         # type: (Any) -> None
         # pretend the converter returned an invalid message without raising an exception
         convert_mock.return_value = None
-        sender = get_user_profile_by_email('othello@zulip.com')
-        receiver = get_user_profile_by_email('hamlet@zulip.com')
+        sender = self.example_user('othello')
+        receiver = self.example_user('hamlet')
         recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
         sending_client = make_client(name="test suite")
         message = Message(
@@ -662,8 +662,8 @@ class MessageDictTest(ZulipTestCase):
 
     def test_reaction(self):
         # type: () -> None
-        sender = get_user_profile_by_email('othello@zulip.com')
-        receiver = get_user_profile_by_email('hamlet@zulip.com')
+        sender = self.example_user('othello')
+        receiver = self.example_user('hamlet')
         recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
         sending_client = make_client(name="test suite")
         message = Message(
@@ -697,8 +697,8 @@ class MessageDictTest(ZulipTestCase):
 class SewMessageAndReactionTest(ZulipTestCase):
     def test_sew_messages_and_reaction(self):
         # type: () -> None
-        sender = get_user_profile_by_email('othello@zulip.com')
-        receiver = get_user_profile_by_email('hamlet@zulip.com')
+        sender = self.example_user('othello')
+        receiver = self.example_user('hamlet')
         pm_recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
         stream_name = u'Çiğdem'
         stream = self.make_stream(stream_name)
@@ -1246,7 +1246,7 @@ class EditMessageTest(ZulipTestCase):
         """This test verifies the accuracy of construction of Zulip's edit
         history data structures."""
         self.login("hamlet@zulip.com")
-        hamlet = get_user_profile_by_email("hamlet@zulip.com")
+        hamlet = self.example_user('hamlet')
         msg_id = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
                                    subject="subject 1", content="content 1")
         result = self.client_patch("/json/messages/" + str(msg_id), {
@@ -1302,7 +1302,7 @@ class EditMessageTest(ZulipTestCase):
         self.assert_json_success(result)
         history = ujson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0]['prev_subject'], 'subject 3')
-        self.assertEqual(history[0]['user_id'], get_user_profile_by_email("iago@zulip.com").id)
+        self.assertEqual(history[0]['user_id'], self.example_user('iago').id)
 
         history = ujson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0]['prev_subject'], 'subject 3')
@@ -1480,13 +1480,13 @@ class EditMessageTest(ZulipTestCase):
         self.check_message(id5, subject="edited")
         self.check_message(id6, subject="topic3")
 
-class MirroredMessageUsersTest(TestCase):
+class MirroredMessageUsersTest(ZulipTestCase):
     class Request(object):
         pass
 
     def test_invalid_sender(self):
         # type: () -> None
-        user = get_user_profile_by_email('hamlet@zulip.com')
+        user = self.example_user('hamlet')
         recipients = [] # type: List[Text]
         request = self.Request()
         request.POST = dict() # no sender
@@ -1501,7 +1501,7 @@ class MirroredMessageUsersTest(TestCase):
         # type: () -> None
         client = get_client(name='banned_mirror') # Invalid!!!
 
-        user = get_user_profile_by_email('hamlet@zulip.com')
+        user = self.example_user('hamlet')
         sender = user
 
         recipients = [] # type: List[Text]
@@ -1603,7 +1603,7 @@ class MirroredMessageUsersTest(TestCase):
         # type: () -> None
         client = get_client(name='irc_mirror')
 
-        sender = get_user_profile_by_email('hamlet@zulip.com')
+        sender = self.example_user('hamlet')
         user = sender
 
         recipients = ['alice@zulip.com', 'bob@irc.zulip.com', 'cordelia@zulip.com']
@@ -1633,7 +1633,7 @@ class MirroredMessageUsersTest(TestCase):
         # type: () -> None
         client = get_client(name='jabber_mirror')
 
-        sender = get_user_profile_by_email('hamlet@zulip.com')
+        sender = self.example_user('hamlet')
         user = sender
 
         recipients = ['alice@zulip.com', 'bob@zulip.com', 'cordelia@zulip.com']
@@ -1886,7 +1886,7 @@ class LogDictTest(ZulipTestCase):
 class CheckMessageTest(ZulipTestCase):
     def test_basic_check_message_call(self):
         # type: () -> None
-        sender = get_user_profile_by_email('othello@zulip.com')
+        sender = self.example_user('othello')
         client = make_client(name="test suite")
         stream_name = u'España y Francia'
         self.make_stream(stream_name)
@@ -1903,7 +1903,7 @@ class CheckMessageTest(ZulipTestCase):
         # type: () -> None
         """We send a PM to a bot's owner if their bot sends a message to
         an unsubscribed stream"""
-        parent = get_user_profile_by_email('othello@zulip.com')
+        parent = self.example_user('othello')
         bot = do_create_user(
             email='othello-bot@zulip.com',
             password='',

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -48,9 +48,9 @@ class MutedTopicsTests(ZulipTestCase):
 
     def test_remove_muted_topic(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        self.user_profile = self.example_user('hamlet')
+        email = self.user_profile.email
         self.login(email)
-        self.user_profile = get_user_profile_by_email(email)
 
         do_set_muted_topics(self.user_profile, [[u'Verona', u'Verona3']])
         url = '/api/v1/users/me/subscriptions/muted_topics'
@@ -63,9 +63,9 @@ class MutedTopicsTests(ZulipTestCase):
 
     def test_muted_topic_add_invalid(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        self.user_profile = self.example_user('hamlet')
+        email = self.user_profile.email
         self.login(email)
-        self.user_profile = get_user_profile_by_email(email)
 
         do_set_muted_topics(self.user_profile, [[u'Verona', u'Verona3']])
         url = '/api/v1/users/me/subscriptions/muted_topics'
@@ -75,9 +75,9 @@ class MutedTopicsTests(ZulipTestCase):
 
     def test_muted_topic_remove_invalid(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        self.user_profile = self.example_user('hamlet')
+        email = self.user_profile.email
         self.login(email)
-        self.user_profile = get_user_profile_by_email(email)
 
         do_set_muted_topics(self.user_profile, [[u'Denmark', u'Denmark3']])
         url = '/api/v1/users/me/subscriptions/muted_topics'

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -72,7 +72,7 @@ class NarrowBuilderTest(ZulipTestCase):
     def setUp(self):
         # type: () -> None
         self.realm = get_realm('zulip')
-        self.user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        self.user_profile = self.example_user('hamlet')
         self.builder = NarrowBuilder(self.user_profile, column('id'))
         self.raw_query = select([column("id")], None, table("zerver_message"))
 
@@ -420,8 +420,8 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def get_query_ids(self):
         # type: () -> Dict[Text, int]
-        hamlet_user = get_user_profile_by_email('hamlet@zulip.com')
-        othello_user = get_user_profile_by_email('othello@zulip.com')
+        hamlet_user = self.example_user('hamlet')
+        othello_user = self.example_user('othello')
 
         query_ids = {} # type: Dict[Text, int]
 
@@ -543,7 +543,7 @@ class GetOldMessagesTest(ZulipTestCase):
         # narrow view.
         self.subscribe_to_stream("hamlet@zulip.com", 'Scotland')
         self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM)
-        messages = get_user_messages(get_user_profile_by_email("hamlet@zulip.com"))
+        messages = get_user_messages(self.example_user('hamlet'))
         stream_messages = [msg for msg in messages if msg.recipient.type == Recipient.STREAM]
         stream_name = get_display_recipient(stream_messages[0].recipient)
         stream_id = stream_messages[0].recipient.id
@@ -1066,7 +1066,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def common_check_get_messages_query(self, query_params, expected):
         # type: (Dict[str, object], Text) -> None
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         request = POSTRequestMock(query_params, user_profile)
         with queries_captured() as queries:
             get_messages_backend(request, user_profile)
@@ -1080,7 +1080,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def test_use_first_unread_anchor_with_some_unread_messages(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
 
         # Have Othello send messages to Hamlet that he hasn't read.
         self.send_message("othello@zulip.com", "Scotland", Recipient.STREAM)
@@ -1117,7 +1117,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def test_use_first_unread_anchor_with_no_unread_messages(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
 
         query_params = dict(
             use_first_unread_anchor='true',
@@ -1155,7 +1155,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
         realm = get_realm('zulip')
         self.make_stream('web stuff')
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         user_profile.muted_topics = ujson.dumps([['Scotland', 'golf'], ['web stuff', 'css'], ['bogus', 'bogus']])
         user_profile.save()
 
@@ -1192,7 +1192,7 @@ class GetOldMessagesTest(ZulipTestCase):
         # type: () -> None
         realm = get_realm('zulip')
         self.make_stream('web stuff')
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
 
         # Test the do-nothing case first.
         user_profile.muted_topics = ujson.dumps([['irrelevant_stream', 'irrelevant_topic']])

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -31,8 +31,8 @@ class TestMissedMessages(ZulipTestCase):
 
     def _test_cases(self, tokens, msg_id, body, send_as_user):
         # type: (List[str], int, str, bool) -> None
-        othello = get_user_profile_by_email('othello@zulip.com')
-        hamlet = get_user_profile_by_email('hamlet@zulip.com')
+        othello = self.example_user('othello')
+        hamlet = self.example_user('hamlet')
         handle_missedmessage_emails(hamlet.id, [{'message_id': msg_id}])
         if settings.EMAIL_GATEWAY_PATTERN != "":
             reply_to_addresses = [settings.EMAIL_GATEWAY_PATTERN % (u'mm' + t) for t in tokens]
@@ -122,7 +122,7 @@ class TestMissedMessages(ZulipTestCase):
         msg_id = self.send_message("othello@zulip.com", "denmark", Recipient.STREAM,
                                    '@**hamlet** to be deleted')
 
-        hamlet = get_user_profile_by_email('hamlet@zulip.com')
+        hamlet = self.example_user('hamlet')
         self.login("othello@zulip.com")
         result = self.client_patch('/json/messages/' + str(msg_id),
                                    {'message_id': msg_id, 'content': ' '})
@@ -139,7 +139,7 @@ class TestMissedMessages(ZulipTestCase):
         msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com", Recipient.PERSONAL,
                                    'Extremely personal message! to be deleted!')
 
-        hamlet = get_user_profile_by_email('hamlet@zulip.com')
+        hamlet = self.example_user('hamlet')
         self.login("othello@zulip.com")
         result = self.client_patch('/json/messages/' + str(msg_id),
                                    {'message_id': msg_id, 'content': ' '})
@@ -156,8 +156,8 @@ class TestMissedMessages(ZulipTestCase):
         msg_id = self.send_message("othello@zulip.com", ["hamlet@zulip.com", "iago@zulip.com"],
                                    Recipient.PERSONAL, 'Group personal message!')
 
-        hamlet = get_user_profile_by_email('hamlet@zulip.com')
-        iago = get_user_profile_by_email('iago@zulip.com')
+        hamlet = self.example_user('hamlet')
+        iago = self.example_user('iago')
         self.login("othello@zulip.com")
         result = self.client_patch('/json/messages/' + str(msg_id),
                                    {'message_id': msg_id, 'content': ' '})

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -17,7 +17,11 @@ from zerver.lib.notifications import handle_missedmessage_emails
 from zerver.lib.actions import render_incoming_message, do_update_message
 from zerver.lib.message import access_message
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import get_user_profile_by_email, Recipient, UserMessage, UserProfile
+from zerver.models import (
+    Recipient,
+    UserMessage,
+    UserProfile,
+)
 
 class TestMissedMessages(ZulipTestCase):
     def normalize_string(self, s):

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -233,7 +233,7 @@ class SingleUserPresenceTests(ZulipTestCase):
         result = self.client_get("/json/users/cordelia@zulip.com/presence")
         self.assert_json_error(result, "No presence data for cordelia@zulip.com")
 
-        do_deactivate_user(get_user_profile_by_email("cordelia@zulip.com"))
+        do_deactivate_user(self.example_user('cordelia'))
         result = self.client_get("/json/users/cordelia@zulip.com/presence")
         self.assert_json_error(result, "No such user")
 

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -65,8 +65,8 @@ class UserPresenceModelTests(ZulipTestCase):
         # type: () -> None
         UserPresence.objects.all().delete()
 
-        email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         presence_dct = UserPresence.get_status_dict_by_realm(user_profile.realm_id)
         self.assertEqual(len(presence_dct), 0)
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -149,8 +149,8 @@ class PushBouncerNotificationTest(ZulipTestCase):
         push notification bouncer flow
         """
         mock.side_effect = self.bounce_request
-        email = "cordelia@zulip.com"
-        user = get_user_profile_by_email(email)
+        user = self.example_user('cordelia')
+        email = user.email
         self.login(email)
         server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
 
@@ -295,8 +295,8 @@ class ResponseListenerTest(PushNotificationTest):
 class TestPushApi(ZulipTestCase):
     def test_push_api(self):
         # type: () -> None
-        email = "cordelia@zulip.com"
-        user = get_user_profile_by_email(email)
+        user = self.example_user('cordelia')
+        email = user.email
         self.login(email)
 
         endpoints = [

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -215,14 +215,13 @@ class PushBouncerNotificationTest(ZulipTestCase):
         # Auth on this user
         return self.api_auth(self.server_uuid)
 
-class PushNotificationTest(TestCase):
+class PushNotificationTest(ZulipTestCase):
     def setUp(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        self.user_profile = self.example_user('hamlet')
         apn.connection = apn.get_connection('fake-cert', 'fake-key')
         self.redis_client = apn.redis_client = MockRedis()  # type: ignore
         apn.dbx_connection = apn.get_connection('fake-cert', 'fake-key')
-        self.user_profile = get_user_profile_by_email(email)
         self.tokens = [u'aaaa', u'bbbb']
         for token in self.tokens:
             PushDeviceToken.objects.create(
@@ -560,8 +559,7 @@ class GCMFailureTest(GCMTest):
 class TestReceivesNotificationsFunctions(ZulipTestCase):
     def setUp(self):
         # type: () -> None
-        email = "cordelia@zulip.com"
-        self.user = get_user_profile_by_email(email)
+        self.user = self.example_user('cordelia')
 
     def test_receivers_online_notifications_when_user_is_a_bot(self):
         # type: () -> None

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -14,8 +14,10 @@ from django.conf import settings
 from django.http import HttpResponse
 
 from zerver.models import PushDeviceToken, UserProfile, Message
-from zerver.models import get_user_profile_by_email, receives_online_notifications, \
-    receives_offline_notifications
+from zerver.models import (
+    receives_offline_notifications,
+    receives_online_notifications,
+)
 from zerver.lib import push_notifications as apn
 from zerver.lib.response import json_success
 from zerver.lib.test_classes import (

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -16,7 +16,7 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import get_client, get_user_profile_by_email, UserActivity
 from zerver.worker import queue_processors
 
-class WorkerTest(TestCase):
+class WorkerTest(ZulipTestCase):
     class FakeClient(object):
         def __init__(self):
             # type: () -> None
@@ -66,7 +66,7 @@ class WorkerTest(TestCase):
         # type: () -> None
         fake_client = self.FakeClient()
 
-        user = get_user_profile_by_email('hamlet@zulip.com')
+        user = self.example_user('hamlet')
         UserActivity.objects.filter(
             user_profile = user.id,
             client = get_client('ios')

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, List, Mapping, Tuple
 
 from zerver.lib.test_helpers import simulated_queue_client
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import get_client, get_user_profile_by_email, UserActivity
+from zerver.models import get_client, UserActivity
 from zerver.worker import queue_processors
 
 class WorkerTest(ZulipTestCase):

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -73,8 +73,8 @@ class ReactionEmojiTest(ZulipTestCase):
         self.subscribe_to_stream("cordelia@zulip.com", stream_name, realm=realm)
         message_id = self.send_message("cordelia@zulip.com", stream_name, Recipient.STREAM)
 
-        sender = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(sender)
+        user_profile = self.example_user('hamlet')
+        sender = user_profile.email
 
         # Verify that hamlet did not receive the message.
         self.assertFalse(UserMessage.objects.filter(user_profile=user_profile,

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -106,9 +106,9 @@ class RealmTest(ZulipTestCase):
         # type: () -> None
         new_name = 'Mice will play while the cat is away'
 
-        email = 'othello@zulip.com'
+        user_profile = self.example_user('othello')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         do_change_is_admin(user_profile, False)
 
         req = dict(name=ujson.dumps(new_name))
@@ -118,9 +118,9 @@ class RealmTest(ZulipTestCase):
     def test_unauthorized_name_change(self):
         # type: () -> None
         data = {'full_name': 'Sir Hamlet'}
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         do_set_realm_property(user_profile.realm, 'name_changes_disabled', True)
         url = '/json/settings/change'
         result = self.client_post(url, data)
@@ -171,9 +171,9 @@ class RealmAPITest(ZulipTestCase):
 
     def setUp(self):
         # type: () -> None
-        email = 'cordelia@zulip.com'
+        user_profile = self.example_user('cordelia')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         do_change_is_admin(user_profile, True)
 
     def set_up_db(self, attr, value):

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -29,7 +29,7 @@ class RealmTest(ZulipTestCase):
         """The main complicated thing about setting realm names is fighting the
         cache, and we start by populating the cache for Hamlet, and we end
         by checking the cache to ensure that the new value is there."""
-        get_user_profile_by_email('hamlet@zulip.com')
+        self.example_user('hamlet')
         realm = get_realm('zulip')
         new_name = u'Zed You Elle Eye Pea'
         do_set_realm_property(realm, 'name', new_name)
@@ -135,10 +135,10 @@ class RealmTest(ZulipTestCase):
         Hamlet, and we end by checking the cache to ensure that his
         realm appears to be deactivated.  You can make this test fail
         by disabling cache.flush_realm()."""
-        get_user_profile_by_email('hamlet@zulip.com')
+        self.example_user('hamlet')
         realm = get_realm('zulip')
         do_deactivate_realm(realm)
-        user = get_user_profile_by_email('hamlet@zulip.com')
+        user = self.example_user('hamlet')
         self.assertTrue(user.realm.deactivated)
 
     def test_change_realm_default_language(self):

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -85,9 +85,9 @@ class ChangeSettingsTest(ZulipTestCase):
 
     def test_illegal_name_changes(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        user = self.example_user('hamlet')
+        email = user.email
         self.login(email)
-        user = get_user_profile_by_email(email)
         full_name = user.full_name
 
         with self.settings(NAME_CHANGES_DISABLED=True):
@@ -265,9 +265,9 @@ class ChangeSettingsTest(ZulipTestCase):
 class UserChangesTest(ZulipTestCase):
     def test_update_api_key(self):
         # type: () -> None
-        email = "hamlet@zulip.com"
+        user = self.example_user('hamlet')
+        email = user.email
         self.login(email)
-        user = get_user_profile_by_email(email)
         old_api_key = user.api_key
         result = self.client_post('/json/users/me/api_key/regenerate')
         self.assert_json_success(result)

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -23,19 +23,19 @@ class ChangeSettingsTest(ZulipTestCase):
     def check_for_toggle_param(self, pattern, param):
         # type: (str, str) -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         json_result = self.client_post(pattern,
                                        {param: ujson.dumps(True)})
         self.assert_json_success(json_result)
         # refetch user_profile object to correctly handle caching
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         self.assertEqual(getattr(user_profile, param), True)
 
         json_result = self.client_post(pattern,
                                        {param: ujson.dumps(False)})
         self.assert_json_success(json_result)
         # refetch user_profile object to correctly handle caching
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         self.assertEqual(getattr(user_profile, param), False)
 
     # TODO: requires method consolidation, right now, there's no alternative
@@ -43,19 +43,19 @@ class ChangeSettingsTest(ZulipTestCase):
     def check_for_toggle_param_patch(self, pattern, param):
         # type: (str, str) -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         json_result = self.client_patch(pattern,
                                         {param: ujson.dumps(True)})
         self.assert_json_success(json_result)
         # refetch user_profile object to correctly handle caching
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         self.assertEqual(getattr(user_profile, param), True)
 
         json_result = self.client_patch(pattern,
                                         {param: ujson.dumps(False)})
         self.assert_json_success(json_result)
         # refetch user_profile object to correctly handle caching
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         self.assertEqual(getattr(user_profile, param), False)
 
     def test_successful_change_settings(self):
@@ -76,11 +76,11 @@ class ChangeSettingsTest(ZulipTestCase):
         self.assert_json_success(json_result)
         result = ujson.loads(json_result.content)
         self.check_well_formed_change_settings_response(result)
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").
+        self.assertEqual(self.example_user('hamlet').
                          full_name, "Foo Bar")
         self.logout()
         self.login("hamlet@zulip.com", "foobar1")
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
 
     def test_illegal_name_changes(self):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1336,8 +1336,8 @@ class SubscriptionAPITest(ZulipTestCase):
 
         msg = self.get_second_to_last_message()
         self.assertEqual(msg.recipient.type, Recipient.PERSONAL)
-        self.assertEqual(msg.sender_id,
-                         get_user_profile_by_email('notification-bot@zulip.com').id)
+        self.assertEqual(msg.sender_id, self.notification_bot().id)
+
         expected_msg = "Hi there!  %s just created a new stream #**%s**." % (invitee_full_name, invite_streams[0])
         self.assertEqual(msg.content, expected_msg)
 
@@ -1372,8 +1372,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         msg = self.get_second_to_last_message()
         self.assertEqual(msg.recipient.type, Recipient.STREAM)
-        self.assertEqual(msg.sender_id,
-                         get_user_profile_by_email('notification-bot@zulip.com').id)
+        self.assertEqual(msg.sender_id, self.notification_bot().id)
         expected_msg = "%s just created a new stream #**%s**." % (invitee_full_name, invite_streams[0])
         self.assertEqual(msg.content, expected_msg)
 
@@ -1410,8 +1409,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         msg = self.get_second_to_last_message()
         self.assertEqual(msg.recipient.type, Recipient.STREAM)
-        self.assertEqual(msg.sender_id,
-                         get_user_profile_by_email('notification-bot@zulip.com').id)
+        self.assertEqual(msg.sender_id, self.notification_bot().id)
         stream_id = Stream.objects.latest('id').id
         expected_rendered_msg = '<p>%s just created a new stream <a class="stream" data-stream-id="%d" href="/#narrow/stream/%s">#%s</a>.</p>' % (
             user.full_name, stream_id, invite_streams[0], invite_streams[0])
@@ -1442,8 +1440,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assert_json_success(result)
 
         msg = self.get_second_to_last_message()
-        self.assertEqual(msg.sender_id,
-                         get_user_profile_by_email('notification-bot@zulip.com').id)
+        self.assertEqual(msg.sender_id, self.notification_bot().id)
         expected_msg = "%s just created a new stream #**%s**." % (invitee_full_name, invite_streams[0])
         self.assertEqual(msg.content, expected_msg)
 
@@ -1535,8 +1532,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # verify that the user was sent a message informing them about the subscription
         msg = self.get_second_to_last_message()
         self.assertEqual(msg.recipient.type, msg.recipient.PERSONAL)
-        self.assertEqual(msg.sender_id,
-                         get_user_profile_by_email("notification-bot@zulip.com").id)
+        self.assertEqual(msg.sender_id, self.notification_bot().id)
         expected_msg = ("Hi there!  We thought you'd like to know that %s just "
                         "subscribed you to the %sstream #**%s**."
                         % (self.user_profile.full_name,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -143,9 +143,9 @@ class RecipientTest(ZulipTestCase):
 class StreamAdminTest(ZulipTestCase):
     def test_make_stream_public(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         self.make_stream('private_stream', invite_only=True)
 
         do_change_is_admin(user_profile, True)
@@ -173,9 +173,9 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_make_stream_private(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         realm = user_profile.realm
         self.make_stream('public_stream', realm=realm)
 
@@ -192,9 +192,9 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_deactivate_stream_backend(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         stream = self.make_stream('new_stream')
         self.subscribe_to_stream(user_profile.email, stream.name)
         do_change_is_admin(user_profile, True)
@@ -219,9 +219,9 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_deactivate_stream_backend_requires_existing_stream(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         self.make_stream('new_stream')
         do_change_is_admin(user_profile, True)
 
@@ -230,8 +230,8 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_deactivate_stream_backend_requires_realm_admin(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
         self.subscribe_to_stream(email, 'new_stream')
 
@@ -241,10 +241,10 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_private_stream_live_updates(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
 
-        user_profile = get_user_profile_by_email(email)
         do_change_is_admin(user_profile, True)
 
         self.make_stream('private_stream', invite_only=True)
@@ -284,9 +284,9 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_rename_stream(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         realm = user_profile.realm
         stream = self.subscribe_to_stream(email, 'stream_name1')
         do_change_is_admin(user_profile, True)
@@ -380,8 +380,8 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_rename_stream_requires_realm_admin(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
         self.make_stream('stream_name1')
 
@@ -392,9 +392,9 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_change_stream_description(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         realm = user_profile.realm
         self.subscribe_to_stream(email, 'stream_name1')
         do_change_is_admin(user_profile, True)
@@ -428,9 +428,9 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_change_stream_description_requires_realm_admin(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
 
         self.subscribe_to_stream(email, 'stream_name1')
         do_change_is_admin(user_profile, False)
@@ -446,9 +446,9 @@ class StreamAdminTest(ZulipTestCase):
         """
         Create a stream for deletion by an administrator.
         """
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         stream = self.make_stream(stream_name, invite_only=invite_only)
 
         # For testing deleting streams you aren't on.
@@ -548,9 +548,9 @@ class StreamAdminTest(ZulipTestCase):
         # type: (bool, bool, bool, bool) -> HttpResponse
 
         # Set up the main user, who is in most cases an admin.
-        email = "hamlet@zulip.com"
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
-        user_profile = get_user_profile_by_email(email)
         if is_admin:
             do_change_is_admin(user_profile, True)
 
@@ -635,8 +635,8 @@ class StreamAdminTest(ZulipTestCase):
         the number of days since the user had joined is less than waiting period
         threshold, non admin users shouldn't be able to create new streams.
         """
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
         do_set_realm_property(user_profile.realm, 'create_stream_by_admins_only', True)
 
@@ -653,8 +653,8 @@ class StreamAdminTest(ZulipTestCase):
         Non admin users with account age greater or equal to waiting period
         threshold should be able to create new streams.
         """
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
         do_change_is_admin(user_profile, False)
 
@@ -1651,8 +1651,7 @@ class SubscriptionAPITest(ZulipTestCase):
         bulk_add_subscriptions([stream], [existing_user_profile])
 
         # Now subscribe Cordelia to the stream, capturing events
-        email = 'cordelia@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('cordelia')
 
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
@@ -2229,7 +2228,8 @@ class InviteOnlyStreamTest(ZulipTestCase):
     def test_inviteonly(self):
         # type: () -> None
         # Creating an invite-only stream is allowed
-        email = 'hamlet@zulip.com'
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         stream_name = "Saxony"
 
         result = self.common_subscribe_to_streams(email, [stream_name], invite_only=True)
@@ -2240,13 +2240,15 @@ class InviteOnlyStreamTest(ZulipTestCase):
         self.assertEqual(json["already_subscribed"], {})
 
         # Subscribing oneself to an invite-only stream is not allowed
-        email = "othello@zulip.com"
+        user_profile = self.example_user('othello')
+        email = user_profile.email
         self.login(email)
         result = self.common_subscribe_to_streams(email, [stream_name])
         self.assert_json_error(result, 'Unable to access stream (Saxony).')
 
         # authorization_errors_fatal=False works
-        email = "othello@zulip.com"
+        user_profile = self.example_user('othello')
+        email = user_profile.email
         self.login(email)
         result = self.common_subscribe_to_streams(email, [stream_name],
                                                   extra_post_data={'authorization_errors_fatal': ujson.dumps(False)})
@@ -2257,8 +2259,8 @@ class InviteOnlyStreamTest(ZulipTestCase):
         self.assertEqual(json["already_subscribed"], {})
 
         # Inviting another user to an invite-only stream is allowed
-        email = 'hamlet@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
         self.login(email)
         result = self.common_subscribe_to_streams(
             email, [stream_name],

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -800,10 +800,11 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         A POST request to /json/subscriptions/property with stream_name and
         color data sets the stream color, and for that stream only.
         """
-        test_email = "hamlet@zulip.com"
+        test_user = self.example_user('hamlet')
+        test_email = test_user.email
         self.login(test_email)
 
-        old_subs, _ = gather_subscriptions(get_user_profile_by_email(test_email))
+        old_subs, _ = gather_subscriptions(test_user)
         sub = old_subs[0]
         stream_name = sub['name']
         new_color = "#ffffff" # TODO: ensure that this is different from old_color
@@ -871,9 +872,10 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         Called by invalid request method. No other request method other than
         'post' is allowed in this case.
         """
-        test_email = "hamlet@zulip.com"
+        test_user = self.example_user('hamlet')
+        test_email = test_user.email
         self.login(test_email)
-        subs = gather_subscriptions(get_user_profile_by_email(test_email))[0]
+        subs = gather_subscriptions(test_user)[0]
 
         result = self.client_get(
             "/json/subscriptions/property",
@@ -887,9 +889,10 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         """
         Updating the color property requires a color.
         """
-        test_email = "hamlet@zulip.com"
+        test_user = self.example_user('hamlet')
+        test_email = test_user.email
         self.login(test_email)
-        subs = gather_subscriptions(get_user_profile_by_email(test_email))[0]
+        subs = gather_subscriptions(test_user)[0]
         result = self.client_post(
             "/json/subscriptions/property",
             {"subscription_data": ujson.dumps([{"property": "color",
@@ -930,9 +933,10 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         """
         Trying to set a property incorrectly returns a JSON error.
         """
-        test_email = "hamlet@zulip.com"
+        test_user = self.example_user('hamlet')
+        test_email = test_user.email
         self.login(test_email)
-        subs = gather_subscriptions(get_user_profile_by_email(test_email))[0]
+        subs = gather_subscriptions(test_user)[0]
 
         property_name = "in_home_view"
         result = self.client_post(
@@ -993,9 +997,10 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         """
         Trying to set an invalid property returns a JSON error.
         """
-        test_email = "hamlet@zulip.com"
+        test_user = self.example_user('hamlet')
+        test_email = test_user.email
         self.login(test_email)
-        subs = gather_subscriptions(get_user_profile_by_email(test_email))[0]
+        subs = gather_subscriptions(test_user)[0]
         result = self.client_post(
             "/json/subscriptions/property",
             {"subscription_data": ujson.dumps([{"property": "bad",

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -260,8 +260,8 @@ class StreamAdminTest(ZulipTestCase):
         # Should be just a description change event
         self.assert_length(events, 1)
 
-        cordelia = get_user_profile_by_email('cordelia@zulip.com')
-        prospero = get_user_profile_by_email('prospero@zulip.com')
+        cordelia = self.example_user('cordelia')
+        prospero = self.example_user('prospero')
 
         notified_user_ids = set(events[-1]['users'])
         self.assertIn(user_profile.id, notified_user_ids)
@@ -332,7 +332,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertEqual(notified_user_ids, set(active_user_ids(realm)))
         self.assertIn(user_profile.id,
                       notified_user_ids)
-        self.assertIn(get_user_profile_by_email('prospero@zulip.com').id,
+        self.assertIn(self.example_user('prospero').id,
                       notified_user_ids)
 
         # Test case to handle unicode stream name change
@@ -421,7 +421,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertEqual(notified_user_ids, set(active_user_ids(realm)))
         self.assertIn(user_profile.id,
                       notified_user_ids)
-        self.assertIn(get_user_profile_by_email('prospero@zulip.com').id,
+        self.assertIn(self.example_user('prospero').id,
                       notified_user_ids)
 
         self.assertEqual('Test description', stream.description)
@@ -780,7 +780,7 @@ class DefaultStreamTest(ZulipTestCase):
     def test_api_calls(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
         do_change_is_admin(user_profile, True)
         stream_name = 'stream ADDED via api'
         (stream, _) = create_stream_if_needed(user_profile.realm, stream_name)
@@ -1166,7 +1166,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         here with a simple scenario to avoid false positives related to
         subscription complications.
         '''
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
         user_profile.full_name = 'Hamlet'
         user_profile.save()
 
@@ -1183,7 +1183,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         with self.assertRaises(JsonableError):
             compose_views(None, user_profile, [(method1, {}), (method2, {})])
 
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
         self.assertEqual(user_profile.full_name, 'Hamlet')
 
 class SubscriptionAPITest(ZulipTestCase):
@@ -1386,7 +1386,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         invite_streams = ["cross_stream"]
 
-        user = get_user_profile_by_email("AARON@zulip.com")
+        user = self.example_user('AARON')
         user.realm = realm
         user.save()
 

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -10,7 +10,6 @@ from django.test import override_settings
 from django.template import Template, Context
 from django.template.loader import get_template
 
-from zerver.models import get_user_profile_by_email
 from zerver.lib.test_helpers import get_all_templates
 from zerver.lib.test_classes import (
     ZulipTestCase,

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -164,8 +164,8 @@ class TemplateTestCase(ZulipTestCase):
             context.
 
         """
-        email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
 
         context = dict(
             article="zerver/help/index.md",

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -28,8 +28,8 @@ def fix_params(raw_params):
 class TutorialTests(ZulipTestCase):
     def test_send_message(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user = get_user_profile_by_email(email)
+        user = self.example_user('hamlet')
+        email = user.email
         self.login(email)
 
         welcome_bot = get_user_profile_by_email("welcome-bot@zulip.com")

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -122,9 +122,10 @@ class TypingStartedNotificationTest(ZulipTestCase):
         Sending typing notification to yourself
         is successful.
         """
-        email = 'hamlet@zulip.com'
+        user = self.example_user('hamlet')
+        email = user.email
         expected_recipient_emails = set([email])
-        expected_recipient_ids = set([get_user_profile_by_email(email).id])
+        expected_recipient_ids = set([user.id])
         events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             result = self.client_post('/api/v1/typing', {'to': email,
@@ -183,9 +184,10 @@ class StoppedTypingNotificationTest(ZulipTestCase):
         Sending stopped typing notification to yourself
         is successful.
         """
-        email = 'hamlet@zulip.com'
+        user = self.example_user('hamlet')
+        email = user.email
         expected_recipient_emails = set([email])
-        expected_recipient_ids = set([get_user_profile_by_email(email).id])
+        expected_recipient_ids = set([user.id])
 
         events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -22,11 +22,11 @@ class PointerTest(ZulipTestCase):
         the pointer we store for your UserProfile.
         """
         self.login("hamlet@zulip.com")
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").pointer, -1)
+        self.assertEqual(self.example_user('hamlet').pointer, -1)
         msg_id = self.send_message("othello@zulip.com", "Verona", Recipient.STREAM)
         result = self.client_post("/json/users/me/pointer", {"pointer": msg_id})
         self.assert_json_success(result)
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").pointer, msg_id)
+        self.assertEqual(self.example_user('hamlet').pointer, msg_id)
 
     def test_api_update_pointer(self):
         # type: () -> None
@@ -48,10 +48,10 @@ class PointerTest(ZulipTestCase):
         returns a 400 and error message.
         """
         self.login("hamlet@zulip.com")
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").pointer, -1)
+        self.assertEqual(self.example_user('hamlet').pointer, -1)
         result = self.client_post("/json/users/me/pointer", {"foo": 1})
         self.assert_json_error(result, "Missing 'pointer' argument")
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").pointer, -1)
+        self.assertEqual(self.example_user('hamlet').pointer, -1)
 
     def test_invalid_pointer(self):
         # type: () -> None
@@ -60,10 +60,10 @@ class PointerTest(ZulipTestCase):
         message.
         """
         self.login("hamlet@zulip.com")
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").pointer, -1)
+        self.assertEqual(self.example_user('hamlet').pointer, -1)
         result = self.client_post("/json/users/me/pointer", {"pointer": "foo"})
         self.assert_json_error(result, "Bad value for 'pointer': foo")
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").pointer, -1)
+        self.assertEqual(self.example_user('hamlet').pointer, -1)
 
     def test_pointer_out_of_range(self):
         # type: () -> None
@@ -72,10 +72,10 @@ class PointerTest(ZulipTestCase):
         and error message.
         """
         self.login("hamlet@zulip.com")
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").pointer, -1)
+        self.assertEqual(self.example_user('hamlet').pointer, -1)
         result = self.client_post("/json/users/me/pointer", {"pointer": -2})
         self.assert_json_error(result, "Bad value for 'pointer': -2")
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").pointer, -1)
+        self.assertEqual(self.example_user('hamlet').pointer, -1)
 
     def test_use_first_unread_anchor_interaction_with_pointer(self):
         # type: () -> None
@@ -86,7 +86,7 @@ class PointerTest(ZulipTestCase):
         """
         self.login("hamlet@zulip.com")
         # Ensure the pointer is not set (-1)
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").pointer, -1)
+        self.assertEqual(self.example_user('hamlet').pointer, -1)
         # Mark all existing messages as read
         result = self.client_post("/json/messages/flags", {"messages": ujson.dumps([]),
                                                            "op": "add",
@@ -115,7 +115,7 @@ class PointerTest(ZulipTestCase):
         # Verify the message is marked as read
         user_message = UserMessage.objects.get(
             message_id=old_message_id,
-            user_profile=get_user_profile_by_email("hamlet@zulip.com"))
+            user_profile=self.example_user('hamlet'))
         self.assertTrue(user_message.flags.read)
 
         # Let's set this old message to be unread
@@ -127,7 +127,7 @@ class PointerTest(ZulipTestCase):
         # Verify it's now marked as unread
         user_message = UserMessage.objects.get(
             message_id=old_message_id,
-            user_profile=get_user_profile_by_email("hamlet@zulip.com"))
+            user_profile=self.example_user('hamlet'))
         self.assert_json_success(result)
         self.assertFalse(user_message.flags.read)
 
@@ -142,13 +142,13 @@ class PointerTest(ZulipTestCase):
         result = self.client_post("/json/users/me/pointer",
                                   {"pointer": next_old_message_id})
         self.assert_json_success(result)
-        self.assertEqual(get_user_profile_by_email("hamlet@zulip.com").pointer,
+        self.assertEqual(self.example_user('hamlet').pointer,
                          next_old_message_id)
 
         # Verify that moving the pointer didn't mark our message as read.
         user_message = UserMessage.objects.get(
             message_id=old_message_id,
-            user_profile=get_user_profile_by_email("hamlet@zulip.com"))
+            user_profile=self.example_user('hamlet'))
         self.assertFalse(user_message.flags.read)
 
         # Now if we call get_messages with use_first_unread_anchor=True,
@@ -236,7 +236,7 @@ class UnreadCountTests(ZulipTestCase):
     def test_mark_all_in_stream_read(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         self.subscribe_to_stream(user_profile.email, "test_stream", user_profile.realm)
         self.subscribe_to_stream("cordelia@zulip.com", "test_stream", user_profile.realm)
 
@@ -288,7 +288,7 @@ class UnreadCountTests(ZulipTestCase):
     def test_mark_all_in_stream_topic_read(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        user_profile = get_user_profile_by_email("hamlet@zulip.com")
+        user_profile = self.example_user('hamlet')
         self.subscribe_to_stream(user_profile.email, "test_stream", user_profile.realm)
 
         message_id = self.send_message("hamlet@zulip.com", "test_stream", Recipient.STREAM, "hello", "test_topic")

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -33,8 +33,9 @@ class PointerTest(ZulipTestCase):
         """
         Same as above, but for the API view
         """
-        email = "hamlet@zulip.com"
-        self.assertEqual(get_user_profile_by_email(email).pointer, -1)
+        user = self.example_user('hamlet')
+        email = user.email
+        self.assertEqual(user.pointer, -1)
         msg_id = self.send_message("othello@zulip.com", "Verona", Recipient.STREAM)
         result = self.client_post("/api/v1/users/me/pointer", {"pointer": msg_id},
                                   **self.api_auth(email))

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -96,7 +96,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         and does so in a way that preserves 100% test coverage for Python 3.
         """
 
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
 
         mock_file = mock.Mock()
         mock_file._get_size = mock.Mock(return_value=1024)
@@ -638,7 +638,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
     def test_get_gravatar_avatar(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        cordelia = get_user_profile_by_email('cordelia@zulip.com')
+        cordelia = self.example_user('cordelia')
 
         cordelia.avatar_source = UserProfile.AVATAR_FROM_GRAVATAR
         cordelia.save()
@@ -655,7 +655,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
     def test_get_user_avatar(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        cordelia = get_user_profile_by_email('cordelia@zulip.com')
+        cordelia = self.example_user('cordelia')
 
         cordelia.avatar_source = UserProfile.AVATAR_FROM_USER
         cordelia.save()
@@ -670,7 +670,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
     def test_get_user_avatar_medium(self):
         # type: () -> None
         self.login("hamlet@zulip.com")
-        cordelia = get_user_profile_by_email('cordelia@zulip.com')
+        cordelia = self.example_user('cordelia')
 
         cordelia.avatar_source = UserProfile.AVATAR_FROM_USER
         cordelia.save()
@@ -720,7 +720,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
                 self.assertEqual(Image.open(io.BytesIO(data)).size, (100, 100))
 
             # Verify that the medium-size avatar was created
-            user_profile = get_user_profile_by_email('hamlet@zulip.com')
+            user_profile = self.example_user('hamlet')
             medium_avatar_disk_path = avatar_disk_path(user_profile, medium=True)
             self.assertTrue(os.path.exists(medium_avatar_disk_path))
 
@@ -747,7 +747,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
                 result = self.client_put_multipart("/json/users/me/avatar", {'file': fp})
 
             self.assert_json_error(result, "Could not decode image; did you upload an image file?")
-            user_profile = get_user_profile_by_email("hamlet@zulip.com")
+            user_profile = self.example_user('hamlet')
             self.assertEqual(user_profile.avatar_version, 1)
 
     def test_delete_avatar(self):
@@ -756,12 +756,12 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
         A DELETE request to /json/users/me/avatar should delete the user avatar and return gravatar URL
         """
         self.login("hamlet@zulip.com")
-        hamlet = get_user_profile_by_email("hamlet@zulip.com")
+        hamlet = self.example_user('hamlet')
         hamlet.avatar_source = UserProfile.AVATAR_FROM_USER
         hamlet.save()
 
         result = self.client_delete("/json/users/me/avatar")
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
 
         self.assert_json_success(result)
         json = ujson.loads(result.content)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -933,8 +933,7 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
 
     def test_file_upload_local(self):
         # type: () -> None
-        sender_email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(sender_email)
+        user_profile = self.example_user('hamlet')
         uri = upload_message_image(u'dummy.txt', len(b'zulip!'), u'text/plain', b'zulip!', user_profile)
 
         base = '/user_uploads/'
@@ -985,8 +984,7 @@ class S3Test(ZulipTestCase):
         conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
         bucket = conn.create_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
 
-        sender_email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(sender_email)
+        user_profile = self.example_user('hamlet')
         uri = upload_message_image(u'dummy.txt', len(b'zulip!'), u'text/plain', b'zulip!', user_profile)
 
         base = '/user_uploads/'
@@ -1009,8 +1007,7 @@ class S3Test(ZulipTestCase):
         conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
         conn.create_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
 
-        sender_email = "hamlet@zulip.com"
-        user_profile = get_user_profile_by_email(sender_email)
+        user_profile = self.example_user('hamlet')
         uri = upload_message_image(u'dummy.txt', len(b'zulip!'), u'text/plain', b'zulip!', user_profile)
 
         path_id = re.sub('/user_uploads/', '', uri)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -173,9 +173,9 @@ class AdminCreateUserTest(ZulipTestCase):
         # conditions, and it also does a basic test of the success
         # path.
 
-        admin_email = 'hamlet@zulip.com'
+        admin = self.example_user('hamlet')
+        admin_email = admin.email
         self.login(admin_email)
-        admin = get_user_profile_by_email(admin_email)
         do_change_is_admin(admin, True)
 
         result = self.client_post("/json/users", dict())

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -51,7 +51,7 @@ def find_dict(lst, k, v):
 class PermissionTest(ZulipTestCase):
     def test_get_admin_users(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
         do_change_is_admin(user_profile, False)
         admin_users = user_profile.realm.get_admin_users()
         self.assertFalse(user_profile in admin_users)
@@ -62,7 +62,7 @@ class PermissionTest(ZulipTestCase):
     def test_updating_non_existent_user(self):
         # type: () -> None
         self.login('hamlet@zulip.com')
-        admin = get_user_profile_by_email('hamlet@zulip.com')
+        admin = self.example_user('hamlet')
         do_change_is_admin(admin, True)
 
         result = self.client_patch('/json/users/nonexistentuser@zulip.com', {})
@@ -71,8 +71,8 @@ class PermissionTest(ZulipTestCase):
     def test_admin_api(self):
         # type: () -> None
         self.login('hamlet@zulip.com')
-        admin = get_user_profile_by_email('hamlet@zulip.com')
-        user = get_user_profile_by_email('othello@zulip.com')
+        admin = self.example_user('hamlet')
+        user = self.example_user('othello')
         realm = admin.realm
         do_change_is_admin(admin, True)
 
@@ -138,7 +138,7 @@ class PermissionTest(ZulipTestCase):
         req = dict(full_name=ujson.dumps(new_name))
         result = self.client_patch('/json/users/hamlet@zulip.com', req)
         self.assertTrue(result.status_code == 200)
-        hamlet = get_user_profile_by_email('hamlet@zulip.com')
+        hamlet = self.example_user('hamlet')
         self.assertEqual(hamlet.full_name, new_name)
 
     def test_non_admin_cannot_change_full_name(self):
@@ -238,11 +238,11 @@ class AdminCreateUserTest(ZulipTestCase):
         self.assert_json_error(result,
                                "Email 'romeo@zulip.net' already in use")
 
-class UserProfileTest(TestCase):
+class UserProfileTest(ZulipTestCase):
     def test_get_emails_from_user_ids(self):
         # type: () -> None
-        hamlet = get_user_profile_by_email('hamlet@zulip.com')
-        othello = get_user_profile_by_email('othello@zulip.com')
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
         dct = get_emails_from_user_ids([hamlet.id, othello.id])
         self.assertEqual(dct[hamlet.id], 'hamlet@zulip.com')
         self.assertEqual(dct[othello.id], 'othello@zulip.com')
@@ -250,7 +250,7 @@ class UserProfileTest(TestCase):
 class ActivateTest(ZulipTestCase):
     def test_basics(self):
         # type: () -> None
-        user = get_user_profile_by_email('hamlet@zulip.com')
+        user = self.example_user('hamlet')
         do_deactivate_user(user)
         self.assertFalse(user.is_active)
         do_reactivate_user(user)
@@ -258,21 +258,21 @@ class ActivateTest(ZulipTestCase):
 
     def test_api(self):
         # type: () -> None
-        admin = get_user_profile_by_email('othello@zulip.com')
+        admin = self.example_user('othello')
         do_change_is_admin(admin, True)
         self.login('othello@zulip.com')
 
-        user = get_user_profile_by_email('hamlet@zulip.com')
+        user = self.example_user('hamlet')
         self.assertTrue(user.is_active)
 
         result = self.client_delete('/json/users/hamlet@zulip.com')
         self.assert_json_success(result)
-        user = get_user_profile_by_email('hamlet@zulip.com')
+        user = self.example_user('hamlet')
         self.assertFalse(user.is_active)
 
         result = self.client_post('/json/users/hamlet@zulip.com/reactivate')
         self.assert_json_success(result)
-        user = get_user_profile_by_email('hamlet@zulip.com')
+        user = self.example_user('hamlet')
         self.assertTrue(user.is_active)
 
     def test_api_me_user(self):
@@ -294,7 +294,7 @@ class ActivateTest(ZulipTestCase):
 
     def test_api_with_nonexistent_user(self):
         # type: () -> None
-        admin = get_user_profile_by_email('othello@zulip.com')
+        admin = self.example_user('othello')
         do_change_is_admin(admin, True)
         self.login('othello@zulip.com')
 
@@ -318,7 +318,7 @@ class ActivateTest(ZulipTestCase):
 
     def test_api_with_insufficient_permissions(self):
         # type: () -> None
-        non_admin = get_user_profile_by_email('othello@zulip.com')
+        non_admin = self.example_user('othello')
         do_change_is_admin(non_admin, False)
         self.login('othello@zulip.com')
 
@@ -370,7 +370,7 @@ class GetProfileTest(ZulipTestCase):
         # type: () -> None
         with queries_captured() as queries:
             with simulated_empty_cache() as cache_queries:
-                user_profile = get_user_profile_by_email('hamlet@zulip.com')
+                user_profile = self.example_user('hamlet')
 
         self.assert_length(queries, 1)
         self.assert_length(cache_queries, 1)
@@ -426,7 +426,7 @@ class GetProfileTest(ZulipTestCase):
 
     def test_get_all_profiles_avatar_urls(self):
         # type: () -> None
-        user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        user_profile = self.example_user('hamlet')
         result = self.client_get("/api/v1/users", **self.api_auth('hamlet@zulip.com'))
         self.assert_json_success(result)
         json = ujson.loads(result.content)


### PR DESCRIPTION
The example_user() function is specifically designed for
AARON, hamlet, cordelia, and friends, and it allows a concise
way of using their built-in user profiles. Eventually, the
widespread use of example_user() should help us with refactorings
such as moving the tests users out of the "zulip.com" realm
and deprecating get_user_profile_by_email.