### PR TITLE
Fix Twitter bot breaking layout with long words/links.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2357,6 +2357,7 @@ img.emoji {
     border: 1px solid #ddd;
     padding: .5em .75em;
     margin-bottom: 0.25em;
+    word-break: break-word;
 }
 
 .twitter-avatar {


### PR DESCRIPTION
Long words and links now get automatically broken down in the
'twitter-tweet' div; prevents a message box overflow.
Fixes #4659.
Contrary to the discussion on this with @gnprice  , I now find `word-break: break-word;` to be the most suitable option here, since it breaks too long links and words just as `break-all`, but prefers wrapping such in new lines whenever possible, whereas `break-all` doesn't bother cutting of single letters of normal length words.

Look without this commit:
![image](https://cloud.githubusercontent.com/assets/7950151/25813728/edb0dffe-341a-11e7-9442-16e184b05f8f.png)

Look with this commit:
![image](https://cloud.githubusercontent.com/assets/7950151/25813702/d940ca16-341a-11e7-9665-08669e783a6a.png)

