### PR TITLE
Add exception for link with search term

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -57,7 +57,7 @@ $(function () {
     function is_clickable_message_element(target) {
         return target.is("a") || target.is("img.message_inline_image") || target.is("img.twitter-avatar") ||
             target.is("div.message_length_controller") || target.is("textarea") || target.is("input") ||
-            target.is("i.edit_content_button");
+            target.is("i.edit_content_button") || target.parent().is("a");
     }
 
     $("#main_div").on("click", ".messagebox", function (e) {


### PR DESCRIPTION
Link that is a search term opens compose box,
add this exception to the is_clickable_message_element.

Fixes: #4651.