### PR TITLE
Send welcome messages as part of /create_realm flow.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2380,6 +2380,29 @@ def do_set_user_display_setting(user_profile, setting_name, setting_value):
         send_event(dict(type='realm_user', op='update', person=payload),
                    active_user_ids(user_profile.realm))
 
+def create_streams_with_welcome_messages(realm, stream_dict):
+    # type: (Realm, Dict[Text, Dict[Text, Any]]) -> None
+
+    # Generally, we call this method as part of creating a realm,
+    # and we seed our default streams with a welcome message (but
+    # not the announce stream, which gets seeded elsewhere).
+    messages = []
+
+    for name, options in stream_dict.items():
+        stream, created = create_stream_if_needed(
+            realm,
+            name,
+            invite_only = options["invite_only"],
+            stream_description = options["description"],
+        )
+
+        if created:
+            message = prep_stream_welcome_message(stream)
+            messages.append(message)
+
+    if messages:
+        do_send_messages(messages)
+
 def set_default_streams(realm, stream_dict):
     # type: (Realm, Dict[Text, Dict[Text, Any]]) -> None
     DefaultStream.objects.filter(realm=realm).delete()

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -22,8 +22,8 @@ from zerver.views.registration import confirmation_key, \
     redirect_and_log_into_subdomain, send_registration_completion_email
 from zerver.models import (
     get_realm, get_prereg_user_by_email, get_user_profile_by_email,
-    get_unique_open_realm, completely_open,
-    PreregistrationUser, Realm, RealmDomain, Recipient,
+    get_unique_open_realm, completely_open, get_recipient,
+    PreregistrationUser, Realm, RealmDomain, Recipient, Message,
     Referral, ScheduledJob, UserProfile, UserMessage,
     Stream, Subscription, ScheduledJob, flush_per_request_caches
 )
@@ -912,6 +912,14 @@ class RealmCreationTest(ZulipTestCase):
             self.assertEqual(realm.invite_required, True)
 
             self.assertTrue(result["Location"].endswith("/"))
+
+            # Check welcome messages
+            for stream_name in ['general', 'social', 'zulip']:
+                stream = get_stream(stream_name, realm)
+                recipient = get_recipient(Recipient.STREAM, stream.id)
+                messages = Message.objects.filter(recipient=recipient)
+                self.assertEqual(len(messages), 1)
+                self.assertIn('Welcome to', messages[0].content)
 
     def test_create_realm_existing_email(self):
         # type: () -> None

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -20,7 +20,7 @@ from zerver.lib.send_email import send_email_to_user
 from zerver.lib.events import do_events_register
 from zerver.lib.actions import do_change_password, do_change_full_name, do_change_is_admin, \
     do_activate_user, do_create_user, do_create_realm, set_default_streams, \
-    user_email_is_unique, \
+    user_email_is_unique, create_streams_with_welcome_messages, \
     compute_mit_user_fullname
 from zerver.forms import RegistrationForm, HomepageForm, RealmCreationForm, \
     CreateUserForm, FindMyTeamForm
@@ -192,7 +192,10 @@ def accounts_register(request):
             org_type = int(form.cleaned_data['realm_org_type'])
             realm = do_create_realm(string_id, realm_name, org_type=org_type)[0]
 
-            set_default_streams(realm, settings.DEFAULT_NEW_REALM_STREAMS)
+            stream_info = settings.DEFAULT_NEW_REALM_STREAMS
+
+            create_streams_with_welcome_messages(realm, stream_info)
+            set_default_streams(realm, stream_info)
 
         full_name = form.cleaned_data['full_name']
         short_name = email_to_username(email)


### PR DESCRIPTION
We now pre-populate the streams in DEFAULT_NEW_REALM_STREAMS
(social/general/zulip, unless somebody changes settings.py) with
welcome messages.  This makes the streams appear to be active
right away, and it also gives the Zulip realm less of a
blank-slate feeling when you create it.

This change only affects the normal web-based create-realm flow.
It doesn't impact the management commands for creating realms
or setting default streams.