### PR TITLE
Move empty_topic_placeholder() to compose_ui.js.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -107,15 +107,11 @@ exports.abort_xhr = function () {
     }
 };
 
-exports.empty_topic_placeholder = function () {
-    return i18n.t("(no topic)");
-};
-
 function create_message_object() {
     // Subjects are optional, and we provide a placeholder if one isn't given.
     var subject = compose_state.subject();
     if (subject === "") {
-        subject = compose.empty_topic_placeholder();
+        subject = compose_ui.empty_topic_placeholder();
     }
 
     var content = make_uploads_relative(compose_state.message_content());

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -6,6 +6,10 @@ exports.autosize_textarea = function () {
     $("#new_message_content").trigger("autosize.resize");
 };
 
+exports.empty_topic_placeholder = function () {
+    return i18n.t("(no topic)");
+};
+
 return exports;
 
 }());

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -170,7 +170,7 @@ exports.setup_page = function (callback) {
                 var space_string = new Handlebars.SafeString("&nbsp;");
                 var stream = (draft.stream.length > 0 ? draft.stream : space_string);
                 var draft_topic = draft.subject.length === 0 ?
-                        compose.empty_topic_placeholder() : draft.subject;
+                        compose_ui.empty_topic_placeholder() : draft.subject;
 
                 formatted = {
                     draft_id: id,

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -281,7 +281,7 @@ function edit_message(row, raw_content) {
 
     if (!is_editable) {
         row.find(".message_edit_close").focus();
-    } else if (message.type === 'stream' && message.subject === compose.empty_topic_placeholder()) {
+    } else if (message.type === 'stream' && message.subject === compose_ui.empty_topic_placeholder()) {
         message_edit_topic.val('');
         message_edit_topic.focus();
     } else if (editability === editability_types.TOPIC_ONLY) {
@@ -347,7 +347,7 @@ exports.start_topic_edit = function (recipient_row) {
     var msg_id = rows.id_for_recipient_row(recipient_row);
     var message = current_msg_list.get(msg_id);
     var topic = message.subject;
-    if (topic === compose.empty_topic_placeholder()) {
+    if (topic === compose_ui.empty_topic_placeholder()) {
         topic = '';
     }
     form.find(".inline_topic_edit").val(topic).select().focus();

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -99,7 +99,7 @@ exports.set_topic_edit_properties = function (message) {
 
     // Messages with no topics should always have an edit icon visible
     // to encourage updating them. Admins can also edit any topic.
-    if (message.subject === compose.empty_topic_placeholder()) {
+    if (message.subject === compose_ui.empty_topic_placeholder()) {
         message.always_visible_topic_edit = true;
     } else if (page_params.is_admin) {
         message.on_hover_topic_edit = true;


### PR DESCRIPTION
I'm not sure compose_ui.js is the perfect home for
empty_topic_placeholder(), but it helps us break some
dependencies.  We eventually want to re-think empty topics, so
that we really represent them as empty strings in most places,
and we only use the placedholder in the UI.