### PR TITLE
portico-sidebar: Fix sidebar logo to be current logo.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -840,6 +840,7 @@ a:not(.no-style):hover:before {
 @media (max-width: 1024px) {
     nav {
         padding-bottom: 110px;
+        padding-top: 30px;
     }
 
     nav .logo {
@@ -970,18 +971,22 @@ a:not(.no-style):hover:before {
     }
 
     nav ul:before {
-        content: " ";
+        content: "Zulip";
         display: block;
-        margin-top: 30px;
+        margin-top: 20px;
+        padding-top: 5px;
+        margin-left: 10px;
 
-        width: 115px;
+        width: 100px;
         height: 40px;
 
-        background-size: 100% auto;
-        background-image: url(/static/images/landing-page/bad-logo.png);
-        background-position: center;
+        font-size: 1.5rem;
+        text-align: right;
+        color: #444;
 
-        -webkit-filter: invert(0.7);
+        background-size: 40px auto;
+        background-image: url(/static/images/zulip-logo.svg);
+        background-repeat: no-repeat;
     }
 
     nav ul {
@@ -1007,7 +1012,7 @@ a:not(.no-style):hover:before {
     }
 
     nav ul li:first-of-type {
-        margin-top: 30px;
+        margin-top: 20px;
     }
 
     nav ul li {
@@ -1056,7 +1061,7 @@ a:not(.no-style):hover:before {
 
 @media (max-device-width: 450px) {
     nav {
-        padding-bottom: 90px;
+        padding-bottom: 105px;
         padding-top: 20px;
     }
 


### PR DESCRIPTION
This fixes the sidebar logo to be the current zulip logo rather
than a mockup of a potential logo that was from the redesign.