### PR TITLE
Move add new default stream box to top.

### DIFF
--- a/static/templates/settings/default-streams-list-admin.handlebars
+++ b/static/templates/settings/default-streams-list-admin.handlebars
@@ -12,6 +12,18 @@
       <p>{{#tr this}}Configure the default streams new users are subscribed to when joining your organization.{{/tr}}</p>
     </div>
 
+    {{#if is_admin}}
+      <form class="form-horizontal default-stream-form">
+        <div class="add-new-default-stream-box grey-bg">
+          <div class="new-default-stream-section-title">{{t "Add new default stream" }}</div>
+          <div class="control-group" id="default_stream_inputs">
+            <label for="default_stream_name" class="control-label">{{t "Stream name" }}</label>
+            <input class="create_default_stream" type="text" placeholder="{{t "Stream name" }}" name="stream_name" autocomplete="off"></input>
+          </div>
+        </div>
+      </form>
+    {{/if}}
+
     <div class="progressive-table-wrapper">
         <table class="table table-condensed table-striped">
             <thead>
@@ -25,15 +37,4 @@
     </div>
 
     <div id="admin_page_default_streams_loading_indicator"></div>
-    {{#if is_admin}}
-      <form class="form-horizontal default-stream-form">
-        <div class="add-new-default-stream-box grey-bg">
-          <div class="new-default-stream-section-title">{{t "Add new default stream" }}</div>
-          <div class="control-group" id="default_stream_inputs">
-            <label for="default_stream_name" class="control-label">{{t "Stream name" }}</label>
-            <input class="create_default_stream" type="text" placeholder="{{t "Stream name" }}" name="stream_name" autocomplete="off"></input>
-          </div>
-        </div>
-      </form>
-    {{/if}}
 </div>


### PR DESCRIPTION
The reason why I moved this box to top is that it is quite difficult to add new default streams once we have a decent number of default streams. The stream select drop down goes to the bottom of the screen. 

**Before**
![screenshot from 2017-05-10 22 14 26](https://cloud.githubusercontent.com/assets/7190633/25913632/0f0d45b0-35d9-11e7-80fa-5e7c1959a557.png)

**Now**
![screenshot from 2017-05-10 22 15 12](https://cloud.githubusercontent.com/assets/7190633/25913660/23ecdf04-35d9-11e7-9441-50464387c444.png)

This should also fix #4734