### PR TITLE
Differentiate commonality between composition and reaction.

### DIFF
--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -182,6 +182,10 @@ exports.register_click_handlers = function () {
     });
 };
 
+exports.is_composition = function (emoji) {
+    return emoji.classList.contains('composition');
+};
+
 return exports;
 
 }());

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -245,7 +245,11 @@ exports.process_enter_key = function (e) {
     }
 
     if (emoji_picker.reactions_popped()) {
-        reactions.toggle_reaction(current_msg_list.selected_id());
+        if (emoji_picker.is_composition(e.target)) {
+            e.target.click();
+        } else {
+            reactions.toggle_reaction(current_msg_list.selected_id());
+        }
         return true;
     }
 

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -116,7 +116,11 @@ function maybe_select_emoji(e) {
         e.preventDefault();
         var first_emoji = get_emoji_at_index(0);
         if (first_emoji) {
-            exports.toggle_reaction(current_msg_list.selected_id(), first_emoji.title);
+            if (emoji_picker.is_composition(first_emoji)) {
+                first_emoji.click();
+            } else {
+                exports.toggle_reaction(current_msg_list.selected_id(), first_emoji.title);
+            }
         }
     }
 }
@@ -326,6 +330,10 @@ exports.get_message_reactions = function (message) {
         return reaction;
     });
     return reactions;
+};
+
+exports.is_reaction = function (emoji) {
+    return emoji.classList.contains('reaction');
 };
 
 $(function () {


### PR DESCRIPTION
Since, we have emoji-picker for both composition and reaction. There are few cases where an action has to carried out differently on composition and on reaction. So, there needs to be a check before carrying out the respective actions.
One such case was selecting the emoji using hotkey enter. It would by default, add it as reaction even when we want it to be added to the compose box. In case of empty narrow topic this would lead to error.
Other case invovles pressing the enter after entering the search string. It would by default add reaction to the message selected even if it was a composition.
So, I have added a check before evaluating such situations.
Fixes #4736