### PR TITLE
Only render one stream at a time for editing.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -880,6 +880,36 @@ function render(template_name, args) {
 }());
 
 
+(function subscription_settings() {
+    var sub = {
+        name: 'devel',
+        subscribed: true,
+        notifications: true,
+        is_admin: true,
+        render_subscribers: true,
+        color: 'purple',
+        invite_only: true,
+        can_make_public: true,
+        can_make_private: true, /* not logical, but that's ok */
+        email_address: 'xxxxxxxxxxxxxxx@zulip.com',
+        stream_id: 888,
+        in_home_view: true,
+    };
+
+    var html = '';
+    html += render('subscription_settings', sub);
+
+    global.write_handlebars_output("subscription_settings", html);
+
+    var div = $(html).find(".subscription-type");
+    assert(div.text().indexOf('invite-only stream') > 0);
+
+    var anchor = $(html).find(".change-stream-privacy:first");
+    assert.equal(anchor.data("is-private"), true);
+    assert.equal(anchor.text(), "[Change]");
+}());
+
+
 (function subscription_stream_privacy_modal() {
     var args = {
         stream_id: 999,
@@ -932,13 +962,6 @@ function render(template_name, args) {
 
     var span = $(html).find(".stream-name:first");
     assert.equal(span.text(), 'devel');
-
-    var div = $(html).find(".subscription-type");
-    assert(div.text().indexOf('invite-only stream') > 0);
-
-    var anchor = $(html).find(".change-stream-privacy:first");
-    assert.equal(anchor.data("is-private"), true);
-    assert.equal(anchor.text(), "[Change]");
 }());
 
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -273,7 +273,7 @@ function redraw_privacy_related_stuff(sub_row, sub) {
     var stream_settings = settings_for_sub(sub);
     var html;
 
-    sub = stream_data.add_admin_options(sub);
+    stream_data.update_calculated_fields(sub);
 
     html = templates.render('subscription_setting_icon', sub);
     sub_row.find('.icon').expectOne().replaceWith($(html));

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -209,15 +209,17 @@ function show_subscription_settings(sub_row) {
 exports.show_settings_for = function (node) {
     var stream_id = get_stream_id(node);
     var sub = stream_data.get_sub_by_id(stream_id);
+
+    stream_data.update_calculated_fields(sub);
+    var html = templates.render('subscription_settings', sub);
+    $('.subscriptions .right .settings').html(html);
+
     var sub_settings = settings_for_sub(sub);
 
-    var sub_row = $(".subscription_settings[data-stream-id='" + stream_id + "']");
-    $(".subscription_settings[data-stream].show").removeClass("show");
-
-    $("#subscription_overlay .subscription_settings.show").removeClass("show");
+    $(".nothing-selected").hide();
     sub_settings.addClass("show");
 
-    show_subscription_settings(sub_row);
+    show_subscription_settings(sub_settings);
 };
 
 function stream_home_view_clicked(e) {

--- a/static/templates/subscription_table_body.handlebars
+++ b/static/templates/subscription_table_body.handlebars
@@ -36,9 +36,7 @@
                     {{t 'Nothing selected.' }}
                 </div>
                 <div class="settings">
-                    {{#each subscriptions}}
-                    {{ partial "subscription_settings" }}
-                    {{/each}}
+                    {{!-- edit stream here --}}
                 </div>
                 {{ partial "subscription_creation_form" }}
             </div>


### PR DESCRIPTION
We used to render the subscriptions_settings template for every
stream when you loaded "Manage Streams," which can be very slow
for a big realm.  Now we only render the right pane on demand.