### PR TITLE
Dev/Prod environment setup: default to python3

### DIFF
--- a/docs/dev-setup-non-vagrant.md
+++ b/docs/dev-setup-non-vagrant.md
@@ -295,24 +295,18 @@ Make sure you have followed the steps specific for your platform:
 For managing Zulip's python dependencies, we recommend using
 [virtualenvs](https://virtualenv.pypa.io/en/stable/).
 
-You must create two virtualenvs. One for Python 2 and one for Python 3.
-You must also install appropriate python packages in them.
+You must create a Python 3 virtualenv.  You must also install appropriate
+python packages in it.
 
-You should either install the virtualenvs in `/srv`, or put symlinks to
-them in `/srv`.  If you don't do that, some scripts might not work correctly.
+You should either install the virtualenv in `/srv`, or put symlinks to them in
+`/srv`.  If you don't do that, some scripts might not work correctly.
 
-You can run `tools/setup/setup_venvs.py` to do this.  This script will create two
-virtualenvs - /srv/zulip-venv and /srv/zulip-py3-venv.
+You can run `python3 tools/setup/setup_venvs.py`.  This script will create a
+virtualenv /srv/zulip-py3-venv.
 
 If you want to do it manually, here are the steps:
 
 ```
-sudo virtualenv /srv/zulip-venv -p python2 # Create a python2 virtualenv
-sudo chown -R `whoami`:`whoami` /srv/zulip-venv
-source /srv/zulip-venv/bin/activate # Activate python2 virtualenv
-pip install --upgrade pip # upgrade pip itself because older versions have known issues
-pip install --no-deps -r requirements/py2_dev.txt # install python packages required for development
-
 sudo virtualenv /srv/zulip-py3-venv -p python3 # Create a python3 virtualenv
 sudo chown -R `whoami`:`whoami` /srv/zulip-py3-venv
 source /srv/zulip-py3-venv/bin/activate # Activate python3 virtualenv

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -14,6 +14,9 @@ DEPLOYMENT_TYPE="${DEPLOYMENT_TYPE:-voyager}"
 # Docker.  Use e.g. zulip::app_frontend for a Zulip frontend server.
 PUPPET_CLASSES="${PUPPET_CLASSES:-zulip::voyager}"
 VIRTUALENV_NEEDED="${VIRTUALENV_NEEDED:-yes}"
+# Python version to use; default to python3.
+# To use Python 2, set this env var to python2
+PYTHON="${PYTHON:python3}"
 
 # Check for at least ~1.9GB of RAM before starting installation;
 # otherwise users will find out about insufficient RAM via weird
@@ -41,7 +44,7 @@ apt-get install -y puppet git python python3 python-six python3-six crudini $ADD
 
 # Create and activate a virtualenv
 if [ "$VIRTUALENV_NEEDED" = "yes" ]; then
-    "$ZULIP_PATH"/scripts/lib/create-production-venv "$ZULIP_PATH"
+    $PYTHON "$ZULIP_PATH"/scripts/lib/create-production-venv "$ZULIP_PATH"
 fi
 
 "$ZULIP_PATH"/scripts/lib/install-node

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -53,6 +53,14 @@ if not os.path.exists((os.path.join(deploy_path, "zproject/prod_settings"))):
     subprocess.check_call(["ln", "-nsf", "/etc/zulip/settings.py",
                            os.path.join(deploy_path, "zproject/prod_settings.py")])
 
+# Ensure the hashbang on the scripts to be python3 when upgrading from git.
+# This is not run when upgrading from tarball because a tarball might already
+# have the hashbang patched.
+if args.from_git:
+    sed_cmd = ["sed", "-i", "-e", "1 s|#!/usr/bin/env python|#!/usr/bin/env python3|g",
+               "{}", ";"]
+    subprocess.check_call(["find", deploy_path, "-type", "f", '-exec'] + sed_cmd)
+
 # Now we should have an environment setup where we can run our tools;
 # first, creating the production venv.
 subprocess.check_call([os.path.join(deploy_path, "scripts", "lib", "create-production-venv"),

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -35,6 +35,9 @@ parser.add_argument("--skip-migrations", dest="skip_migrations", action='store_t
                     help="Skip doing migrations.")
 parser.add_argument("--from-git", dest="from_git", action='store_true',
                     help="Upgrading from git, so run update-prod-static.")
+parser.add_argument("--py2", dest="py2", action='store_true',
+                    help="Ensure the Python 2 is being used instead of the"
+                         "default Python 3.")
 args = parser.parse_args()
 
 deploy_path = args.deploy_path
@@ -56,7 +59,7 @@ if not os.path.exists((os.path.join(deploy_path, "zproject/prod_settings"))):
 # Ensure the hashbang on the scripts to be python3 when upgrading from git.
 # This is not run when upgrading from tarball because a tarball might already
 # have the hashbang patched.
-if args.from_git:
+if args.from_git and not args.py2:
     sed_cmd = ["sed", "-i", "-e", "1 s|#!/usr/bin/env python|#!/usr/bin/env python3|g",
                "{}", ";"]
     subprocess.check_call(["find", deploy_path, "-type", "f", '-exec'] + sed_cmd)

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -313,6 +313,7 @@ def build_custom_checkers(by_lang):
         {'pattern': 'python[23]',
          'exclude': set(['tools/lib/provision.py',
                          'tools/setup/setup_venvs.py',
+                         'scripts/lib/upgrade-zulip-stage-2',
                          'scripts/lib/setup_venv.py']),
          'description': 'Explicit python invocations should not include a version'},
         {'pattern': '(^|\s)open\s*\(',

--- a/tools/provision
+++ b/tools/provision
@@ -10,6 +10,14 @@ if [ "$EUID" -eq 0 ]; then
     exit 1
 fi
 
+if [ "$TRAVIS" = true ]; then
+    PYTHON=python
+else
+    # Default to Python 3 if the env is not Travis
+    # To use Python 2, set this env var to python2
+    PYTHON=python3
+fi
+
 #Make the script independent of the location from where it is
 #executed
 PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
@@ -23,7 +31,7 @@ echo "PROVISIONING STARTING." >> $LOG_PATH
 # PYTHONUNBUFFERED is important to ensure that tracebacks don't get
 # lost far above where they should be in the output.
 export PYTHONUNBUFFERED=1
-python "$PROVISION_PATH" $@ 2>&1 | tee -a "$LOG_PATH"
+$PYTHON "$PROVISION_PATH" $@ 2>&1 | tee -a "$LOG_PATH"
 failed=${PIPESTATUS[0]}
 
 if [ $failed = 1 ]; then

--- a/tools/travis/production-helper
+++ b/tools/travis/production-helper
@@ -36,7 +36,7 @@ service rabbitmq-server stop
 rm -rf /var/lib/rabbitmq/mnesia/
 
 # Install Zulip
-env TRAVIS=1 /root/zulip/scripts/setup/install
+env TRAVIS=1 PYTHON=" " /root/zulip/scripts/setup/install
 
 cat >>/etc/zulip/settings.py <<EOF
 # Travis CI override settings above


### PR DESCRIPTION
From the line in tools/provision it should trickle to the rest of the
scripts. This works since almost all the python scripts have been linted
to be generic.

Proof that the setup is python3 only: with this commit, within the
vagrant container env, /srv/zulip-venv is no longer present and
`./tools/run-dev.py` runs just fine.

Fix #256