### PR TITLE
requirements cleanup: remove redundant lib list

### DIFF
--- a/requirements/py2_common.txt
+++ b/requirements/py2_common.txt
@@ -1,5 +1,3 @@
--r common.txt
-
 # Used for Hesiod lookups, etc.
 pydns==2.3.6
 

--- a/requirements/py3_common.txt
+++ b/requirements/py3_common.txt
@@ -1,5 +1,3 @@
--r common.txt
-
 # Used for Hesiod lookups, etc.
 py3dns==3.1.0
 


### PR DESCRIPTION
The line `-r common.txt` can be found in dev.txt and prod.txt

This should speed up the build process by 2-3s, in addition to the speed
up from not having to prepare a python2 venv.