### PR TITLE
Add error handling in watch_manual_resize().

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -223,7 +223,9 @@ function edit_message(row, raw_content) {
         copy_message.remove();
         var edit_id = "#message_edit_content_" + rows.id(row);
         var listeners = resize.watch_manual_resize(edit_id);
-        currently_editing_messages[rows.id(row)].listeners = listeners;
+        if (listeners) {
+            currently_editing_messages[rows.id(row)].listeners = listeners;
+        }
         composebox_typeahead.initialize_compose_typeahead(edit_id, {emoji: true, stream: true});
     }
 

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -167,8 +167,15 @@ function left_userlist_get_new_heights() {
 
 exports.watch_manual_resize = function (element) {
     return (function on_box_resize(cb) {
+        var box = document.querySelector(element);
+
+        if (!box) {
+            blueslip.error('Bad selector in watch_manual_resize: ' + element);
+            return;
+        }
+
         var meta = {
-            box: document.querySelector(element),
+            box: box,
             height: null,
             mousedown: false,
         };


### PR DESCRIPTION
We now explicitly complain if a caller passes in a bad
selector to this function and return undefined.