### PR TITLE
modals: Make error reports more specific.

### DIFF
--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -59,12 +59,17 @@ exports.open_overlay = function (opts) {
 };
 
 exports.close_modal = function (name) {
-    if ((name !== open_modal_name) || !close_handler) {
-        blueslip.error("Modal close handler for " + name + " not properly setup." );
+    if (name !== open_modal_name) {
+        blueslip.error("Trying to close " + name + " when " + open_modal_name + " is open." );
         return;
     }
 
     active_overlay.removeClass("show");
+
+    if (!close_handler) {
+        blueslip.error("Modal close handler for " + name + " not properly setup." );
+        return;
+    }
 
     close_handler();
 };


### PR DESCRIPTION
We now give a more specific error message when something goes
wrong in closing a modal.