### PR TITLE
msg edit history: Fix messages and timestamps visual overlap

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1354,6 +1354,11 @@ div.focused_table {
     max-width: 100%;
 }
 
+#message-edit-history .message_top_line {
+    /* consistent with .recipient_row_date */
+    height: 17px;
+}
+
 #message-edit-history .message_author {
     position: relative;
 }


### PR DESCRIPTION
Fixes #4638

The timestamp row's height is pegged to be consistent with `.recipient_row_date`.

Before:
![before](https://cloud.githubusercontent.com/assets/85198/25508429/f305d23c-2b7f-11e7-9d2d-9d7e3a949314.png)

After:
![message-edit-history](https://cloud.githubusercontent.com/assets/395821/26022735/9cdfcf8a-37d6-11e7-8464-1881781ee3c2.png)
