### PR TITLE
org settings: Make Organization description read-only for non-admins.

### DIFF
--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -24,7 +24,7 @@
     <div class="input-group admin-realm">
       <label for="realm_description">{{t "Your organization's description" }}</label>
       <textarea id="id_realm_description" name="realm_description" class="admin-realm-description"
-        maxlength="1000">{{ realm_description }}
+        maxlength="1000" {{#unless is_admin}}disabled="disabled"{{/unless}}>{{ realm_description }}
       </textarea>
     </div>
     <div class="input-group admin-restricted-to-domain">


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/15116870/26026913/84f8fddc-37b9-11e7-96d1-53e1c00dc7eb.png)

After:
![after](https://cloud.githubusercontent.com/assets/15116870/26026914/87ecd856-37b9-11e7-876d-816c6fc696ed.png)
