### PR TITLE
Refactor left sidebar topic cursor css.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -66,7 +66,6 @@
 
 #stream_filters li ul.topic-list li {
     padding-left: 29px;
-    padding-top: 1px;
 }
 
 #stream-filters-container {
@@ -386,6 +385,8 @@ li.expanded_private_message a {
 .topic-box {
     display: block;
     margin-right: 38px;
+    padding-top: 1px;
+    cursor: pointer;
 }
 
 .pm-box {


### PR DESCRIPTION
This commit addresses to issues with the left sidebar: The cursor flickering when hovering over topics, and
the cursor not becoming a pointer when resting just right of a topic's name (in a clickable area).
This commit is related to #4675.