### PR TITLE
hotkeys: Disable enter hotkey while Streams menu is open.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -269,6 +269,10 @@ exports.process_enter_key = function (e) {
         return false;
     }
 
+    if (exports.is_subs) {
+        return false;
+    }
+
     if (exports.processing_text()) {
         if (activity.searching()) {
             activity.blur_search();


### PR DESCRIPTION
Prevents compose box from opening and potentially sending a message.
Fixes #2412