### PR TITLE
css: Fix KaTeX summation alignment and line wrapping.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2058,8 +2058,12 @@ div.floating_recipient {
 }
 
 .katex-html {
-    line-height: initial;
+    line-height: 3em;
     white-space: initial;
+}
+
+.katex-display {
+    margin: 0em 0;
 }
 
 .tex-error {


### PR DESCRIPTION
Here's what this short change does:
Before:
![image](https://cloud.githubusercontent.com/assets/8433005/26140182/3e1cf0b6-3aa3-11e7-8a29-d8eb49b7f0c0.png)

After:
![image](https://cloud.githubusercontent.com/assets/8433005/26140351/45e22572-3aa4-11e7-99f9-efa9a3b9678a.png)

I turned off `line-height: initial` which seems to mess with summation bounds. I added a pretty large fixed line-height which prevents line-wrapped lines from overlapping. Finally, got rid of the top/bottom margins of `katex-display` to compensate for this big line height.