### PR TITLE
Fix the broken rendering of flag emojis in emoji picker and in reactions.

### DIFF
--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -8,8 +8,10 @@ add_dependencies({
 var reactions = require("js/reactions.js");
 
 set_global('emoji', {
-    emoji_name_to_css_class: function (name) {
-        return name + '-css'; // only to make testing easy
+    emojis_name_to_css_class: {
+        frown: 'frown-css',
+        octopus: 'octopus-css',
+        smile: 'smile-css',
     },
     realm_emojis: {},
 });

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -30,10 +30,6 @@ _.each(emoji_codes.codepoints, function (value) {
                                  emoji_url: "/static/generated/emoji/images/emoji/unicode/" + value + ".png"});
 });
 
-exports.emoji_name_to_css_class = function (emoji_name) {
-    return emoji_codes.name_to_codepoint[emoji_name];
-};
-
 exports.update_emojis = function update_emojis(realm_emojis) {
     // exports.realm_emojis is emptied before adding the realm-specific emoji to it.
     // This makes sure that in case of deletion, the deleted realm_emojis don't
@@ -52,7 +48,7 @@ exports.update_emojis = function update_emojis(realm_emojis) {
     exports.emojis_by_name = {};
     exports.emojis_name_to_css_class = {};
     _.each(default_emojis, function (emoji) {
-        var css_class = exports.emoji_name_to_css_class(emoji.emoji_name);
+        var css_class = emoji_codes.name_to_codepoint[emoji.emoji_name];
         exports.emojis_name_to_css_class[emoji.emoji_name] = css_class;
         exports.emojis_by_name[emoji.emoji_name] = emoji.emoji_url;
     });

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -56,6 +56,12 @@ exports.update_emojis = function update_emojis(realm_emojis) {
         exports.emojis_name_to_css_class[emoji.emoji_name] = css_class;
         exports.emojis_by_name[emoji.emoji_name] = emoji.emoji_url;
     });
+    // Code for patching CSS classes for flag emojis so that they render
+    // properly in emoji picker. Remove after migration to iamcal dataset
+    // is complete.
+    _.each(emoji_codes.patched_css_classes, function (css_class, name) {
+        exports.emojis_name_to_css_class[name] = css_class;
+    });
     exports.emojis_by_unicode = {};
     _.each(default_unicode_emojis, function (emoji) {
         exports.emojis_by_unicode[emoji.emoji_name] = emoji.emoji_url;

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -69,7 +69,7 @@ function generate_emoji_picker_content(id) {
             emojis[emoji_name] = {
                 name: emoji_name,
                 has_reacted: true,
-                css_class: emoji.emoji_name_to_css_class(emoji_name),
+                css_class: emoji.emojis_name_to_css_class[emoji_name],
                 is_realm_emoji: emojis[emoji_name].is_realm_emoji,
                 url: emojis[emoji_name].url,
             };
@@ -83,7 +83,7 @@ function generate_emoji_picker_content(id) {
 
         return {
             name: emoji_name,
-            css_class: emoji.emoji_name_to_css_class(emoji_name),
+            css_class: emoji.emojis_name_to_css_class[emoji_name],
             has_reacted: false,
             is_realm_emoji: false,
         };

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -238,7 +238,7 @@ function generate_title(emoji_name, user_ids) {
 }
 
 exports.add_reaction = function (event) {
-    event.emoji_name_css_class = emoji.emoji_name_to_css_class(event.emoji_name);
+    event.emoji_name_css_class = emoji.emojis_name_to_css_class[event.emoji_name];
     event.user.id = event.user.user_id;
     var message = message_store.get(event.message_id);
     if (message === undefined) {
@@ -343,7 +343,7 @@ exports.get_message_reactions = function (message) {
         var user_ids = item[1];
         var reaction = {
             emoji_name: emoji_name,
-            emoji_name_css_class: emoji.emoji_name_to_css_class(emoji_name),
+            emoji_name_css_class: emoji.emojis_name_to_css_class[emoji_name],
             count: user_ids.length,
             title: generate_title(emoji_name, user_ids),
             emoji_alt_code: page_params.emoji_alt_code,

--- a/tools/setup/emoji/build_emoji
+++ b/tools/setup/emoji/build_emoji
@@ -47,6 +47,8 @@ exports.name_to_codepoint = %(name_to_codepoint)s;
 
 exports.emoji_catalog = %(emoji_catalog)s;
 
+exports.patched_css_classes = %(patched_css_classes)s;
+
 return exports;
 }());
 if (typeof module !== 'undefined') {
@@ -294,11 +296,20 @@ def dump_emojis(cache_path):
     up_index = names.index('thumbs_up')
     names[down_index], names[up_index] = ('thumbs_up', 'thumbs_down')
 
+    # Patch CSS classes of flag emojis.
+    patched_css_classes = {}
+    for emoji in emoji_data:
+        if emoji['category'] == 'Flags':
+            for name in emoji['short_names']:
+                if name in emoji_map:
+                    patched_css_classes[str(name)] = str(emoji['unified'].lower())
+
     emoji_codes_file.write(EMOJI_CODES_FILE_TEMPLATE % {
         'names': names,
         'codepoints': sorted([str(code_point) for code_point in set(emoji_map.values())]),
         'name_to_codepoint': {str(key): str(emoji_map[key]) for key in emoji_map},
-        'emoji_catalog': emoji_catalog
+        'emoji_catalog': emoji_catalog,
+        'patched_css_classes': patched_css_classes
     })
     emoji_codes_file.close()
 


### PR DESCRIPTION
Fix the rendering of flag emojis in emoji picker and in the reactions by patching the css classes. There is still a difference between the image rendered for flag emojis in emoji picker and messages. This will be fixed only when the migration to iamcal dataset is complete. However, since we have switched to using sprite sheets for rendering reactions, the image rendered for flag emojis is same in emoji picker and reactions.
The last commit is a follow up to PR #3923.