### PR TITLE
emoji-reactions: Fix reactions to not break inline-block display.

### DIFF
--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -97,7 +97,7 @@ var reaction_show_list = []; // local reaction_show_list
 exports.render_reaction_show_list = function () {
     var reaction_list = $(".emoji-popover-emoji");
     reaction_show_list = reaction_list.filter(function () {
-        return this.style.display === "block" || this.style.display === "";
+        return this.style.display === "inline-block" || this.style.display === "";
     }).toArray();
 };
 
@@ -106,14 +106,15 @@ function filter_emojis() {
     var search_term = elt.val().trim().toLowerCase();
     var reaction_list = $(".emoji-popover-emoji");
     if (search_term !== '') {
-        reaction_list.filter(function () {
-            return this.title.indexOf(search_term) === -1;
-        }).css("display", "none");
-        reaction_list.filter(function () {
-            return this.title.indexOf(search_term) !== -1;
-        }).css("display", "block");
+        reaction_list.each(function () {
+            if (this.title.indexOf(search_term) === -1) {
+                this.classList.add("hide");
+            } else {
+                this.classList.remove("hide");
+            }
+        });
     } else {
-        reaction_list.css("display", "block");
+        reaction_list.removeClass("hide");
     }
     exports.render_reaction_show_list();
 }

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -151,12 +151,15 @@
 }
 
 .emoji-popover-emoji {
-    float: left;
-    margin: 0.1em;
-    padding: 0.3em;
+    display: inline-block;
+    margin: 0;
+    padding: 6px;
     cursor: pointer;
-    border: 1px solid white;
     border-radius: 0.5em;
+}
+
+.emoji-popover-emoji.hide {
+    display: none;
 }
 
 .emoji-popover .reacted {


### PR DESCRIPTION
This fixes the reactions to not break a new line by changing them from
a weird combination of “float: left” and “display: block” (inlined), to
just “display: inline-block”.

Fixes: #4818.