### PR TITLE
refactoring: timerender.js render_now() returns an object

### DIFF
--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -1,0 +1,141 @@
+var jsdom = require("jsdom");
+var window = jsdom.jsdom().defaultView;
+global.$ = require('jquery')(window);
+
+add_dependencies({
+    i18n: 'i18next',
+    XDate: 'node_modules/xdate/src/xdate.js',
+});
+
+var timerender = require('js/timerender.js');
+
+(function test_render_now_returns_today() {
+    var today = new XDate(1555091573000); // Friday 4/12/2019 5:52:53 PM (UTC+0)
+    var expected = {
+        time_str: i18n.t('Today'),
+        formal_time_str: 'Friday, April 12, 2019',
+        needs_update: true,
+    };
+    var actual = timerender.render_now(today, today);
+    assert.equal(expected.time_str, actual.time_str);
+    assert.equal(expected.formal_time_str, actual.formal_time_str);
+    assert.equal(expected.needs_update, actual.needs_update);
+}());
+
+(function test_render_now_returns_yesterday() {
+    var today = new XDate(1555091573000); // Friday 4/12/2019 5:52:53 PM (UTC+0)
+    var yesterday = today.clone().addDays(-1);
+    var expected = {
+        time_str: i18n.t('Yesterday'),
+        formal_time_str: 'Thursday, April 11, 2019',
+        needs_update: true,
+    };
+    var actual = timerender.render_now(yesterday, today);
+    assert.equal(expected.time_str, actual.time_str);
+    assert.equal(expected.formal_time_str, actual.formal_time_str);
+    assert.equal(expected.needs_update, actual.needs_update);
+}());
+
+(function test_render_now_returns_year() {
+    var today = new XDate(1555091573000); // Friday 4/12/2019 5:52:53 PM (UTC+0)
+    var year_ago = today.clone().addYears(-1);
+    var expected = {
+        time_str: 'Apr 12, 2018',
+        formal_time_str: 'Thursday, April 12, 2018',
+        needs_update: false,
+    };
+    var actual = timerender.render_now(year_ago, today);
+    assert.equal(expected.time_str, actual.time_str);
+    assert.equal(expected.formal_time_str, actual.formal_time_str);
+    assert.equal(expected.needs_update, actual.needs_update);
+}());
+
+(function test_render_now_returns_month_and_day() {
+    var today = new XDate(1555091573000); // Friday 4/12/2019 5:52:53 PM (UTC+0)
+    var three_months_ago = today.clone().addMonths(-3, true);
+    var expected = {
+        time_str: 'Jan 12',
+        formal_time_str: 'Saturday, January 12, 2019',
+        needs_update: false,
+    };
+    var actual = timerender.render_now(three_months_ago, today);
+    assert.equal(expected.time_str, actual.time_str);
+    assert.equal(expected.formal_time_str, actual.formal_time_str);
+    assert.equal(expected.needs_update, actual.needs_update);
+}());
+
+(function test_render_date_renders_time_html() {
+    var today = new XDate(1555091573000); // Friday 4/12/2019 5:52:53 PM (UTC+0)
+    var message_time  = today.clone();
+    var expected_html = 'Today';
+    var actual = timerender.render_date(message_time, undefined, today);
+    assert.equal(expected_html, actual.html());
+}());
+
+(function test_render_date_renders_time_above_html() {
+    var today = new XDate(1555091573000); // Friday 4/12/2019 5:52:53 PM (UTC+0)
+    var message_time = today.clone();
+    var message_time_above = today.clone().addDays(-1);
+    var expected = $('<div></div>');
+    expected.append('<i class="date-direction icon-vector-caret-up"></i>');
+    expected.append('Yesterday');
+    expected.append('<hr class="date-line">');
+    expected.append('<i class="date-direction icon-vector-caret-down"></i>');
+    expected.append('Today');
+    var actual = timerender.render_date(message_time, message_time_above, today);
+    assert.equal(expected.html(), actual.html());
+}());
+
+(function test_get_full_time() {
+    var timestamp = 1495091573; // 5/18/2017 7:12:53 AM (UTC+0)
+    var expected = '5/18/2017 7:12:53 AM (UTC+0)';
+    var actual = timerender.get_full_time(timestamp);
+    assert.equal(expected, actual);
+}());
+
+(function test_absolute_time_12_hour() {
+    set_global('page_params', {
+        twenty_four_hour_time: false,
+    });
+
+    // timestamp with hour > 12
+    var timestamp = 1555091573000; // 4/12/2019 5:52:53 PM (UTC+0)
+    var expected = 'Apr 12, 05:52 PM';
+    var actual = timerender.absolute_time(timestamp);
+    assert.equal(expected, actual);
+
+    // timestamp with hour < 12
+    timestamp = 1495091573000; // 5/18/2017 7:12:53 AM (UTC+0)
+    expected = 'May 18, 07:12 AM';
+    actual = timerender.absolute_time(timestamp);
+    assert.equal(expected, actual);
+}());
+
+(function test_absolute_time_24_hour() {
+    set_global('page_params', {
+        twenty_four_hour_time: true,
+    });
+
+    // timestamp with hour > 12
+    var timestamp = 1555091573000; // 4/12/2019 17:52:53 (UTC+0)
+    var expected = 'Apr 12, 17:52';
+    var actual = timerender.absolute_time(timestamp);
+    assert.equal(expected, actual);
+
+    // timestamp with hour < 12
+    timestamp = 1495091573000; // 5/18/2017 7:12:53 AM (UTC+0)
+    expected = 'May 18, 07:12';
+    actual = timerender.absolute_time(timestamp);
+    assert.equal(expected, actual);
+}());
+
+(function test_set_full_datetime() {
+    var message = {
+        timestamp: 1495091573, // 5/18/2017 7:12:53 AM (UTC+0)
+    };
+    var time_element = $('<span/>');
+    var expected = '5/18/2017 7:12:53 AM (UTC+0)';
+    timerender.set_full_datetime(message, time_element);
+    var actual = time_element.attr('title');
+    assert.equal(expected, actual);
+}());

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -65,18 +65,19 @@ function same_recipient(a, b) {
 
 function add_display_time(group, message_container, prev) {
     var time = new XDate(message_container.msg.timestamp * 1000);
+    var today = new XDate();
 
     if (prev !== undefined) {
         var prev_time = new XDate(prev.msg.timestamp * 1000);
         if (time.toDateString() !== prev_time.toDateString()) {
             // NB: show_date is HTML, inserted into the document without escaping.
-            group.show_date = (timerender.render_date(time, prev_time))[0].outerHTML;
+            group.show_date = (timerender.render_date(time, prev_time, today))[0].outerHTML;
             group.show_date_separator = true;
         }
     } else {
         // Show the date in the recipient bar, but not a date separator bar.
         group.show_date_separator = false;
-        group.show_date = (timerender.render_date(time))[0].outerHTML;
+        group.show_date = (timerender.render_date(time, undefined, today))[0].outerHTML;
     }
 
     if (message_container.timestr === undefined) {
@@ -116,7 +117,8 @@ function populate_group_from_message_container(group, message_container) {
     group.subject_links = message_container.msg.subject_links;
 
     var time = new XDate(message_container.msg.timestamp * 1000);
-    var date_element = timerender.render_date(time)[0];
+    var today = new XDate();
+    var date_element = timerender.render_date(time, undefined, today)[0];
 
     group.date = date_element.outerHTML;
 }
@@ -132,8 +134,9 @@ MessageListView.prototype = {
         if (message_container.msg.last_edit_timestamp !== undefined) {
             // Add or update the last_edit_timestr
             var last_edit_time = new XDate(message_container.msg.last_edit_timestamp * 1000);
+            var today = new XDate();
             message_container.last_edit_timestr =
-                (timerender.render_date(last_edit_time))[0].textContent
+                (timerender.render_date(last_edit_time, undefined, today))[0].textContent
                 + " at " + stringify_time(last_edit_time);
         }
     },

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -130,12 +130,14 @@ function populate_users(realm_people_data) {
         name: "users_table_list",
         modifier: function (item) {
             var activity_rendered;
+            var today = new XDate();
             if (people.is_current_user(item.email)) {
-                activity_rendered = timerender.render_date(new XDate());
+                activity_rendered = timerender.render_date(today, undefined, today);
             } else if (presence.presence_info[item.user_id]) {
                 // XDate takes number of milliseconds since UTC epoch.
                 var last_active = presence.presence_info[item.user_id].last_active * 1000;
-                activity_rendered = timerender.render_date(new XDate(last_active));
+                var last_active_date = new XDate(last_active);
+                activity_rendered = timerender.render_date(last_active_date, undefined, today);
             } else {
                 activity_rendered = $("<span></span>").text(i18n.t("Unknown"));
             }

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -16,8 +16,8 @@ var set_to_start_of_day = function (time) {
 //      needs_update:    a boolean for if it will need to be updated when the
 //                       day changes
 // }
-exports.render_now = function (time) {
-    var start_of_today = set_to_start_of_day(new XDate());
+exports.render_now = function (time, today) {
+    var start_of_today = set_to_start_of_day(today || new XDate());
     var start_of_other_day = set_to_start_of_day(time.clone());
 
     var time_str = '';
@@ -102,13 +102,13 @@ function render_date_span(elem, rendered_time, rendered_time_above) {
 // (What's actually spliced into the message template is the contents
 // of this DOM node as HTML, so effectively a copy of the node. That's
 // okay since to update the time later we look up the node by its id.)
-exports.render_date = function (time, time_above) {
+exports.render_date = function (time, time_above, today) {
     var id = "timerender" + next_timerender_id;
     next_timerender_id += 1;
-    var rendered_time = exports.render_now(time);
+    var rendered_time = exports.render_now(time, today);
     var node = $("<span />").attr('id', id);
     if (time_above !== undefined) {
-        var rendered_time_above = exports.render_now(time_above);
+        var rendered_time_above = exports.render_now(time_above, today);
         node = render_date_span(node, rendered_time, rendered_time_above);
     } else {
         node = render_date_span(node, rendered_time);

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -35,15 +35,18 @@ exports.render_now = function (time, today) {
     // constants.
     var days_old = Math.round(start_of_other_day.diffDays(start_of_today));
 
+    var is_older_year =
+        (start_of_today.getFullYear() - start_of_other_day.getFullYear()) > 0;
+
     if (days_old === 0) {
         time_str = i18n.t("Today");
         needs_update = true;
     } else if (days_old === 1) {
         time_str = i18n.t("Yesterday");
         needs_update = true;
-    } else if (days_old >= 365) {
+    } else if (is_older_year) {
         // For long running servers, searching backlog can get ambiguous
-        // without a year stamp. Only show year if message is over a year old.
+        // without a year stamp. Only show year if message is from an older year
         time_str = time.toString("MMM\xa0dd,\xa0yyyy");
         needs_update = false;
     } else {

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -8,16 +8,23 @@ var set_to_start_of_day = function (time) {
     return time.setMilliseconds(0).setSeconds(0).setMinutes(0).setHours(0);
 };
 
-// Given an XDate object 'time', return a three-element list containing
-//   - a string for the current human-formatted version
-//   - a string for the current formally formatted version
-//         e.g. "Monday, April 15, 2017"
-//   - a boolean for if it will need to be updated when the day changes
+// Given an XDate object 'time', returns an object:
+// {
+//      time_str:        a string for the current human-formatted version
+//      formal_time_str: a string for the current formally formatted version
+//                          e.g. "Monday, April 15, 2017"
+//      needs_update:    a boolean for if it will need to be updated when the
+//                       day changes
+// }
 exports.render_now = function (time) {
     var start_of_today = set_to_start_of_day(new XDate());
     var start_of_other_day = set_to_start_of_day(time.clone());
 
+    var time_str = '';
+    var needs_update = false;
     // render formal time to be used as title attr tooltip
+    // "\xa0" is U+00A0 NO-BREAK SPACE.
+    // Can't use &nbsp; as that represents the literal string "&nbsp;".
     var formal_time_str = time.toString('dddd,\xa0MMMM\xa0d,\xa0yyyy');
 
     // How many days old is 'time'? 0 = today, 1 = yesterday, 7 = a
@@ -29,20 +36,27 @@ exports.render_now = function (time) {
     var days_old = Math.round(start_of_other_day.diffDays(start_of_today));
 
     if (days_old === 0) {
-        return [i18n.t("Today"), formal_time_str, true];
+        time_str = i18n.t("Today");
+        needs_update = true;
     } else if (days_old === 1) {
-        return [i18n.t("Yesterday"), formal_time_str, true];
+        time_str = i18n.t("Yesterday");
+        needs_update = true;
     } else if (days_old >= 365) {
         // For long running servers, searching backlog can get ambiguous
         // without a year stamp. Only show year if message is over a year old.
-        return [time.toString("MMM\xa0dd,\xa0yyyy"), formal_time_str, false];
+        time_str = time.toString("MMM\xa0dd,\xa0yyyy");
+        needs_update = false;
+    } else {
+        // For now, if we get a message from tomorrow, we don't bother
+        // rewriting the timestamp when it gets to be tomorrow.
+        time_str = time.toString("MMM\xa0dd");
+        needs_update = false;
     }
-    // For now, if we get a message from tomorrow, we don't bother
-    // rewriting the timestamp when it gets to be tomorrow.
-
-    // "\xa0" is U+00A0 NO-BREAK SPACE.
-    // Can't use &nbsp; as that represents the literal string "&nbsp;".
-    return [time.toString("MMM\xa0dd"), formal_time_str, false];
+    return {
+        time_str: time_str,
+        formal_time_str: formal_time_str,
+        needs_update: needs_update,
+    };
 };
 
 // List of the dates that need to be updated when the day changes.
@@ -69,14 +83,14 @@ function maybe_add_update_list_entry(needs_update, id, time, time_above) {
     }
 }
 
-function render_date_span(elem, time_str, time_above_str, time_formal_str) {
+function render_date_span(elem, rendered_time, rendered_time_above) {
     elem.text("");
-    if (time_above_str !== undefined) {
+    if (rendered_time_above !== undefined) {
         return elem.append('<i class="date-direction icon-vector-caret-up"></i>' +
-                           time_above_str).append($('<hr class="date-line">')).append('<i class="date-direction icon-vector-caret-down"></i>'
-                           + time_str);
+                           rendered_time_above.time_str).append($('<hr class="date-line">')).append('<i class="date-direction icon-vector-caret-down"></i>'
+                           + rendered_time.time_str);
     }
-    return elem.append(time_str).attr('title', time_formal_str);
+    return elem.append(rendered_time.time_str).attr('title', rendered_time.formal_time_str);
 }
 
 // Given an XDate object 'time', return a DOM node that initially
@@ -95,11 +109,11 @@ exports.render_date = function (time, time_above) {
     var node = $("<span />").attr('id', id);
     if (time_above !== undefined) {
         var rendered_time_above = exports.render_now(time_above);
-        node = render_date_span(node, rendered_time[0], rendered_time_above[0], rendered_time[1]);
+        node = render_date_span(node, rendered_time, rendered_time_above);
     } else {
-        node = render_date_span(node, rendered_time[0], undefined, rendered_time[1]);
+        node = render_date_span(node, rendered_time);
     }
-    maybe_add_update_list_entry(rendered_time[2], id, time, time_above);
+    maybe_add_update_list_entry(rendered_time.needs_update, id, time, time_above);
     return node;
 };
 
@@ -124,12 +138,11 @@ exports.update_timestamps = function () {
                 if (elem.length === 3) {
                     time_above = elem[2];
                     var rendered_time_above = exports.render_now(time_above);
-                    render_date_span($(element), rendered_time[0], rendered_time_above[0],
-                        rendered_time[1]);
+                    render_date_span($(element), rendered_time, rendered_time_above);
                 } else {
-                    render_date_span($(element), rendered_time[0], undefined, rendered_time[1]);
+                    render_date_span($(element), rendered_time);
                 }
-                maybe_add_update_list_entry(rendered_time[2], id, time, time_above);
+                maybe_add_update_list_entry(rendered_time.needs_update, id, time, time_above);
             }
         });
 


### PR DESCRIPTION
The render_now() function in timerender.js will now return
an object instead of an array, which is then passed to the
functions render_date_span() and update_timestamps().
This should increase readability and extensibility.

Fixes #4820.