### PR TITLE
Support re-rendering Markdown templates to render Jinja2 code within macros

### DIFF
--- a/templates/zerver/help/include/congrats.md
+++ b/templates/zerver/help/include/congrats.md
@@ -1,0 +1,3 @@
+**Congratulations! You're done!**
+
+Your messages may look like:

--- a/templates/zerver/help/include/create-bot-construct-url.md
+++ b/templates/zerver/help/include/create-bot-construct-url.md
@@ -1,0 +1,5 @@
+Next, on your {{ settings_html|safe }}, create a bot for this
+integration. Construct the URL for this bot using the bot API key
+and stream name:
+
+`{{ external_api_uri_subdomain }}/v1/external/

--- a/templates/zerver/help/include/create-stream.md
+++ b/templates/zerver/help/include/create-stream.md
@@ -1,0 +1,3 @@
+First, create the stream you'd like to use for notifications from
+this integration, and subscribe all interested parties to this stream.
+We recommend the name

--- a/tools/lint
+++ b/tools/lint
@@ -582,7 +582,6 @@ def build_custom_checkers(by_lang):
             "docs/migration-renumbering.md",
             "docs/readme-symlink.md",
             "README.md",
-            "zerver/webhooks/airbrake/doc.md",
             "zerver/webhooks/appfollow/doc.md",
             "zerver/webhooks/trello/doc.md",
         }

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional, Any
 
 from django.conf import settings
-from django.template import Library, loader
+from django.template import Library, loader, engines
 from django.utils.safestring import mark_safe
 from django.utils.lru_cache import lru_cache
 
@@ -82,7 +82,8 @@ def render_markdown_path(markdown_file_path, context=None):
     if context is None:
         context = {}
 
-    template = loader.get_template(markdown_file_path)
-    markdown_string = template.render(context)
+    jinja = engines['Jinja2']
+    markdown_string = jinja.env.loader.get_source(jinja.env, markdown_file_path)[0]
     html = md_engine.convert(markdown_string)
-    return mark_safe(html)
+    html_template = jinja.from_string(html)
+    return mark_safe(html_template.render(context))

--- a/zerver/webhooks/airbrake/doc.md
+++ b/zerver/webhooks/airbrake/doc.md
@@ -1,14 +1,8 @@
 Get Zulip notifications for your Airbrake bug tracker!
 
-First, create the stream you'd like to use for Airbrake notifications, and
-subscribe all interested parties to this stream. We recommend the
-name `airbrake`.
+{!create-stream.md!} `airbrake`.
 
-Next, on your {{ settings_html|safe }}, create an Airbrake bot. Construct the
-URL for the Airbrake bot using the API key and stream name:
-
-`{{ external_api_uri_subdomain }}/v1/external/airbrake?api_key=abcdefgh&stream=airbrake`
-
+{!create-bot-construct-url.md!}airbrake?api_key=abcdefgh&stream=airbrake`
 
 Now, go to your project's settings on the Airbrake site. Click
 on the `Integration` section. Choose `Webhook`, provide the above URL,
@@ -16,8 +10,6 @@ check `Enabled`, and save. Your Webhook configuration should look similar to:
 
 ![](/static/images/integrations/airbrake/001.png)
 
-**Congratulations! You're done!**
-
-Your messages may look like:
+{!congrats.md!}
 
 ![](/static/images/integrations/airbrake/002.png)

--- a/zproject/jinja2/backends.py
+++ b/zproject/jinja2/backends.py
@@ -46,6 +46,12 @@ class Jinja2(django_jinja2.Jinja2):
             six.reraise(TemplateSyntaxError, TemplateSyntaxError(exc.args),
                         sys.exc_info()[2])
 
+    def from_string(self, template_code):
+        # type: (str) -> Template
+        return Template(self.env.from_string(template_code),
+                        self.context_processors,
+                        self.debug)
+
 
 class Template(django_jinja2.Template):
         """Context processors aware Template.

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -298,6 +298,7 @@ if PRODUCTION:
 
 TEMPLATES = [
     {
+        'NAME': 'Jinja2',
         'BACKEND': 'zproject.jinja2.backends.Jinja2',
         'DIRS': [
             os.path.join(DEPLOY_ROOT, 'templates'),


### PR DESCRIPTION
@timabbott: I think I figured out a way to do this. After hours of searching and experimentation, I found the answer [here](https://docs.djangoproject.com/en/1.11/ref/templates/upgrading/#get-template-from-string). Looking forward to hearing your feedback! Thanks! :)