### PR TITLE
Update create-production-venv

### DIFF
--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -32,5 +32,5 @@ cached_venv_path = setup_virtualenv(
     virtualenv_args=['-p', 'python{}'.format(python_version)])
 
 current_venv_path = os.path.join(args.deploy_path, 'zulip-current-venv')
-run(['ln', '-s', venv_name, current_venv_path])
+run(['ln', '-nsf', venv_name, current_venv_path])
 # Now the virtualenv has been activated


### PR DESCRIPTION
The install script was failing on 2nd+ attempts if the first attempt was interrupted. This failure happened because zulip-venv already existed at `current_venv_path`. Changing the `ln` command's flags from `-s` to `-nsf` should make this part of the script idempotent.