### PR TITLE
Add short descriptions of topic lifetime to help docs

### DIFF
--- a/templates/zerver/help/about-streams-and-topics.md
+++ b/templates/zerver/help/about-streams-and-topics.md
@@ -64,3 +64,9 @@ threaded together, allowing for better reception for users.
 Users can easily [change the topics](/help/change-the-topic-of-a-message) of
 the messages that they sent if they sent the message to the wrong topic or
 if some messages in a topic have gone off-topic.
+
+5 topics per stream are displayed by default, unless the user has more topics
+with unread messages.  Older topics aren't displayed unless the user has
+unread messages in them, this generally works well, as older topics organically
+drop off the sidebar as their messages become less recent.  A method to view
+and search old topics may be added in future development.

--- a/templates/zerver/help/about-streams-and-topics.md
+++ b/templates/zerver/help/about-streams-and-topics.md
@@ -64,9 +64,3 @@ threaded together, allowing for better reception for users.
 Users can easily [change the topics](/help/change-the-topic-of-a-message) of
 the messages that they sent if they sent the message to the wrong topic or
 if some messages in a topic have gone off-topic.
-
-5 topics per stream are displayed by default, unless the user has more topics
-with unread messages.  Older topics aren't displayed unless the user has
-unread messages in them, this generally works well, as older topics organically
-drop off the sidebar as their messages become less recent.  A method to view
-and search old topics may be added in future development.

--- a/templates/zerver/help/getting-your-organization-started-with-zulip.md
+++ b/templates/zerver/help/getting-your-organization-started-with-zulip.md
@@ -70,6 +70,9 @@ effectively.
 - Topics really shine for asynchronous communication.
 - When starting a new conversation, use a new topic, just like you
   would when starting an email thread.
+- 5 topics per stream are displayed initially, unless you have more
+  with unread messages, in which case all topics with unread messages
+  are listed.
 
 ## Familiarize yourself with Zulip’s featureset
 


### PR DESCRIPTION
I think my added description should cover most users' questions about how long topics last.  Happy to add/remove/edit though, just let me know.

See discussion here [chat.zulip.org:general/topic lifetimes](https://chat.zulip.org/#narrow/stream/general/subject/topic.20lifetimes).

```
Steve Howell: We start by displaying up to 5 topics per stream, unless you have 6+ topics with unread counts, in which case we show all the topics with unread counts that we know about on the client. When you hit "more topics", we show all the topics that we know about on the client. And on the client, the list of known topics is exactly the set of unique topics from known messages on the client.

Steve Howell: The current limiting factor basically comes down to us limiting the number of recent messages we load.
```
Once a method of searching, linking to, and viewing old topics gets added to the UI, we should update these docs to reflect that.