### PR TITLE
Fix manual build instructions for Debian Jessie

### DIFF
--- a/docs/dev-setup-non-vagrant.md
+++ b/docs/dev-setup-non-vagrant.md
@@ -51,6 +51,8 @@ Install the following non-Python dependencies:
  * rabbitmq-server
  * libldap2-dev
  * python-dev
+ * python3-dev
+ * python-virtualenv
  * redis-server — rate limiting
  * tsearch-extras — better text search
  * libfreetype6-dev — needed before you pip install Pillow to properly generate emoji PNGs
@@ -66,16 +68,18 @@ https://github.com/zulip/zulip.git`
 sudo apt-get install closure-compiler libfreetype6-dev libffi-dev \
     memcached rabbitmq-server libldap2-dev redis-server \
     postgresql-server-dev-all libmemcached-dev python-dev \
-    hunspell-en-us nodejs nodejs-legacy npm git yui-compressor \
-    puppet gettext postgresql
+    python3-dev python-virtualenv hunspell-en-us nodejs \
+    nodejs-legacy npm git yui-compressor puppet gettext postgresql
 
-# Next, install PGroonga from its PPA
+# If using Ubuntu, install PGroonga from its PPA
 sudo add-apt-repository -ys ppa:groonga/ppa
 sudo apt-get update
 # On 14.04
 sudo apt-get install postgresql-9.3-pgroonga
 # On 16.04
 sudo apt-get install postgresql-9.5-pgroonga
+
+# If using Debian, follow the instructions here: http://pgroonga.github.io/install/debian.html
 
 # Next, install Zulip's tsearch-extras postgresql extension
 # If on 14.04 or 16.04, you can use the Zulip PPA for tsearch-extras:

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -214,10 +214,6 @@ def main(options):
     # create linecoverage directory`var/node-coverage`
     run(["mkdir", "-p", NODE_TEST_COVERAGE_DIR_PATH])
 
-    if not os.path.isdir(EMOJI_CACHE_PATH):
-        run(["sudo", "mkdir", EMOJI_CACHE_PATH])
-    run(["sudo", "chown", "%s:%s" % (user_id, user_id), EMOJI_CACHE_PATH])
-    run(["tools/setup/emoji/download-emoji-data"])
     run(["tools/setup/emoji/build_emoji"])
     run(["tools/setup/build_pygments_data.py"])
     run(["scripts/setup/generate_secrets.py", "--development"])

--- a/tools/setup/emoji/build_emoji
+++ b/tools/setup/emoji/build_emoji
@@ -82,7 +82,12 @@ EMOJI_POS_INFO_TEMPLATE = """\
 }
 """
 
-# change directory
+# Make and enter emoji directory
+user_id = os.getuid()
+if not os.path.isdir(EMOJI_CACHE_PATH):
+    run(["sudo", "mkdir", EMOJI_CACHE_PATH])
+run(["sudo", "chown", "%s:%s" % (user_id, user_id), EMOJI_CACHE_PATH])
+run(["tools/setup/emoji/download-emoji-data"])
 os.chdir(EMOJI_SCRIPT_DIR_PATH)
 
 if 'TRAVIS' in os.environ:


### PR DESCRIPTION
These commits fix the following issues I ran into while manually installing Zulip on Debian Jessie:
 - Libraries not being available via PPA
 - Incomplete dependency list
 - Problems with creating the emoji cache