### PR TITLE
mypy: PySvn Client.Log returns a dictionary -> many types.

### DIFF
--- a/api/integrations/svn/post-commit
+++ b/api/integrations/svn/post-commit
@@ -57,7 +57,7 @@ path, rev = sys.argv[1:]  # type: Tuple[Text, Text]
 # since its a local path, prepend "file://"
 path = "file://" + path
 
-entry = svn.log(path, revision_end=pysvn.Revision(pysvn.opt_revision_kind.number, rev))[0]  # type: Dict[Text, Union[Text, pysvn.Revision, List[Dict[Text, pysvn.Revision]]]]
+entry = svn.log(path, revision_end=pysvn.Revision(pysvn.opt_revision_kind.number, rev))[0]  # type: Dict[Text, Any] 
 message = "**{0}** committed revision r{1} to `{2}`.\n\n> {3}".format(
     entry['author'],
     rev,


### PR DESCRIPTION
Fixes these errors:
api/integrations/svn/post-commit:65: error: Invalid index type "str" for "Union[str, Any, List[Dict[str, Any]]]"; expected type "Union[int, slice]"
api/integrations/svn/post-commit:65: error: No overload variant of "__getitem__" of "list" matches argument types [builtins.str]

See http://pysvn.stage.tigris.org/docs/pysvn_prog_ref.html#pysvn_client (search for pysvn.Client.log) for more info.