### PR TITLE
Change unexpected error with proper results

### DIFF
--- a/static/yaml/zulip.yaml
+++ b/static/yaml/zulip.yaml
@@ -502,11 +502,10 @@ definitions:
   ErrorModel:
     type: object
     required:
-      - code
-      - message
+      - msg
+      - result
     properties:
-      code:
-        type: integer
-        format: int32
-      message:
+      msg:
+        type: string
+      result:
         type: string


### PR DESCRIPTION
The error message under Unexpected errors was not the format we received for any errors. WE changed it to be msg and result to fit with the results we got when for JSON errors.