### PR TITLE
Feature/webpack2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "plotly.js": "1.19.2",
     "string.prototype.codepointat": "0.2.0",
     "underscore": "1.8.3",
-    "webpack": "1.12.5",
+    "webpack": "2.5.1",
     "winchan": "0.2.0",
     "xdate": "0.8.0",
     "zxcvbn": "4.4.1"
@@ -35,7 +35,7 @@
     "nwmatcher": "1.3.6",
     "phantomjs-prebuilt": "2.1.14",
     "svgo": "0.7.2",
-    "webpack-dev-server": "1.12.1",
+    "webpack-dev-server": "2.4.1",
     "xmlhttprequest": "1.5.0"
   },
   "scripts": {

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 module.exports = {
     entry: [
         'webpack-dev-server/client?http://0.0.0.0:9991/socket.io',
@@ -6,7 +8,7 @@ module.exports = {
     devtool: 'eval',
     output: {
         publicPath: 'http://0.0.0.0:9991/webpack/',
-        path: './static/js',
+        path: path.resolve(__dirname, '/static/js'),
         filename: 'bundle.js',
     },
     devServer: {

--- a/tools/webpack.production.config.js
+++ b/tools/webpack.production.config.js
@@ -1,7 +1,9 @@
+var path = require('path');
+
 module.exports = {
     entry: './static/js/src/main.js',
     output: {
-        path: './static/js',
+        path: path.resolve(__dirname, '../static/js'),
         filename: 'bundle.js',
     },
 };


### PR DESCRIPTION
Minor changes to use newer version of webpack.
Build process is still using Django Pipeline

Experienced some npm caching problems with esprima and istanbul, that's why added esprima original to dependencies.
Still investigating that problem.