### PR TITLE
mypy: Add comment for future use of Deque.

### DIFF
--- a/tools/renumber-migrations
+++ b/tools/renumber-migrations
@@ -61,8 +61,8 @@ def resolve_conflicts(conflicts, files_list):
 if __name__ == '__main__':
 
     while True:
-        conflicts = []  # type: list[str]
-        stack = []  # type: list[str]
+        conflicts = []  # type: List[str]
+        stack = []  # type: List[str]
         files_list = [os.path.basename(path) for path in glob.glob("zerver/migrations/????_*.py")]
         file_index = [file[0:4] for file in files_list]
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -407,7 +407,7 @@ class RealmEmoji(ModelReprMixin, models.Model):
         return u"<RealmEmoji(%s): %s %s>" % (self.realm.string_id, self.name, self.file_name)
 
 def get_realm_emoji_uncached(realm):
-    # type: (Realm) -> Dict[Text, Optional[Dict[str, Iterable[Text]]]]
+    # type: (Realm) -> Dict[Text, Dict[str, Any]]
     d = {}
     from zerver.lib.emoji import get_emoji_url
     for row in RealmEmoji.objects.filter(realm=realm).select_related('author'):

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -232,7 +232,7 @@ def compute_full_event_type(event):
 class EventQueue(object):
     def __init__(self, id):
         # type: (str) -> None
-        self.queue = deque() # type: deque[Dict[str, Any]]
+        self.queue = deque() # type: ignore # type signature should Deque[Dict[str, Any]] but we need https://github.com/python/mypy/pull/2845 to be merged
         self.next_event_id = 0 # type: int
         self.id = id # type: str
         self.virtual_events = {} # type: Dict[str, Dict[str, Any]]


### PR DESCRIPTION
In the future, the type annotation should use Deque in order to be
compatible with the latest mypy version. 
See: https://github.com/python/mypy/pull/2845