### PR TITLE
lightbox: update help text for `v` shortcut.

### DIFF
--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -88,8 +88,9 @@ Zulip keyboard shortcuts are divided into four categories:
 
 * **Edit your last message**: `⇽` — This shortcut opens the last editable
   message that the user sent in the current view (if any) in the compose box.
-* **Show images in message**: `v` — This shortcut opens any images or videos
-  (if any) embedded in a message in the lightbox viewer.
+* **Show images in thread**: `v` — This shortcut opens any images or videos
+  (if any) embedded in a message or previous messages within the thread
+  using the lightbox viewer.
 * **Edit selected message**: `i` then `Enter` (`Return` on Mac) —
   This shortcut allows the user to edit the selected message (outlined
   in blue) if the user authored the selected message. If the selected

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -131,7 +131,7 @@
         </tr>
         <tr>
           <td class="hotkey">v</td>
-          <td class="definition">{% trans %}Show images in message{% endtrans %}</td>
+          <td class="definition">{% trans %}Show images in thread{% endtrans %}</td>
         </tr>
         <tr id="edit-message-hotkey-help">
           <td class="hotkey">i then Enter</td>


### PR DESCRIPTION
New behavior of the `v` shortcut updated in documentation.

Follow up to #4869