### PR TITLE
bots: Allow empty bot queries.

### DIFF
--- a/contrib_bots/bot_lib.py
+++ b/contrib_bots/bot_lib.py
@@ -88,7 +88,7 @@ def run_message_handler_for_bot(lib_module, quiet, config_file):
         if start_with_mention is None:
            return None
         query_without_mention = message['content'][len(start_with_mention.group()):]
-        return query_without_mention
+        return query_without_mention.lstrip()
 
     def is_private(message, client):
         # bot will not reply if the sender name is the same as the bot name

--- a/contrib_bots/bot_lib.py
+++ b/contrib_bots/bot_lib.py
@@ -78,28 +78,13 @@ def run_message_handler_for_bot(lib_module, quiet, config_file):
     if not quiet:
         print(message_handler.usage())
 
-    def extract_message_if_mentioned(message, client):
-        bot_mention = r'^@(\*\*{0}\*\*\s|{0}\s)(?=.*)'.format(client.full_name)
+    def extract_message(message, client):
+        bot_mention = r'^@(\*\*{0}\*\*)'.format(client.full_name)
         start_with_mention = re.compile(bot_mention).match(message['content'])
-        if start_with_mention:
-            query = message['content'][len(start_with_mention.group()):]
-            return query
-        else:
-            bot_response = 'Please mention me first, then type the query.'
-            if message['type'] == 'private':
-                client.send_message(dict(
-                    type='private',
-                    to=message['sender_email'],
-                    content=bot_response,
-                ))
-            else:
-                client.send_message(dict(
-                    type='stream',
-                    to=message['display_recipient'],
-                    subject=message['subject'],
-                    content=bot_response,
-                ))
-            return None
+        if start_with_mention is None:
+           return None
+        query_without_mention = message['content'][len(start_with_mention.group()):]
+        return query_without_mention
 
     def is_private(message, client):
         # bot will not reply if the sender name is the same as the bot name
@@ -116,7 +101,7 @@ def run_message_handler_for_bot(lib_module, quiet, config_file):
 
         # Strip at-mention botname from the message
         if is_mentioned:
-            message['content'] = extract_message_if_mentioned(message=message, client=restricted_client)
+            message['content'] = extract_message(message=message, client=restricted_client)
             if message['content'] is None:
                 return
 


### PR DESCRIPTION
This commit allows bots to be adressed with empty queries,
that is, by just @-mentioning them. @-mentioning is now the
only way to adress a bot.

@robot-dreams 