### PR TITLE
Ensure help bot replies in private chat, including 3+ users

### DIFF
--- a/contrib_bots/bots/help/help.py
+++ b/contrib_bots/bots/help/help.py
@@ -29,11 +29,6 @@ class HelpHandler(object):
             https://github.com/zulip/zulip
             '''.strip()
 
-        client.send_message(dict(
-            type='stream',
-            to=message['display_recipient'],
-            subject=message['subject'],
-            content=help_content,
-        ))
+        client.send_reply(message, help_content)
 
 handler_class = HelpHandler


### PR DESCRIPTION
I noticed the bot didn't reply in private, like the tictactoe bot.

After discussion, this could probably be integrated into the core lib to ensure all bots have this functionality.