### PR TITLE
Add unread_msgs to the initial state data

### DIFF
--- a/docs/unread_messages.md
+++ b/docs/unread_messages.md
@@ -1,0 +1,32 @@
+# Unread message synchronization
+
+In general displaying unread counts for all streams and topics may require
+downloading an unbounded number of messages. Consider a user who has a muted
+stream or topic and has not read the backlog in a month; to have an accurate
+unread count we would need to load all messages this user has received in the
+past month. This is inefficient for web clients and even more for mobile
+devices.
+
+We work around this by including a list of unread message ids in the initial
+state grouped by recipient and subject. This data is included in the
+`unread_msgs` key if both update_message_flags and message are required in the
+register call.
+
+```
+[
+    [
+        {
+            'display_recipient': 'general',
+            'recipient_id': 54,
+            'subject': 'lunch',
+        },
+        [400, 823]
+    ]
+]
+```
+
+Three event types are required to correctly maintain the `unread_msgs`. New
+messages can be created without the unread flag by the `message` event type.
+The unread flag can be added and removed by the `update_message_flags` event,
+and the subject of unread messages can be updated by the `update_message` event
+type.

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -140,6 +140,7 @@ class HomeTest(ZulipTestCase):
             "timezone",
             "twenty_four_hour_time",
             "unread_count",
+            "unread_msgs",
             "unsubscribed",
             "use_websockets",
             "user_id",


### PR DESCRIPTION
We are adding a new list of unread message ids grouped by
display_recipient to the queue registration call this will allow clients to show accurate unread badges
without needing to load an unbound number of historic messages.