### PR TITLE
Factor out send_reply functionality into bot_lib

### DIFF
--- a/contrib_bots/bot_lib.py
+++ b/contrib_bots/bot_lib.py
@@ -56,6 +56,21 @@ class BotHandlerApi(object):
                           ' its own messages?')
             sys.exit(1)
 
+    def send_reply(self, message, response):
+        if message['type'] == 'private':
+            self.send_message(dict(
+                type='private',
+                to=[x['email'] for x in message['display_recipient'] if self.email != x['email']],
+                content=response,
+            ))
+        else:
+            self.send_message(dict(
+                type='stream',
+                to=message['display_recipient'],
+                subject=message['subject'],
+                content=response,
+            ))
+
 def run_message_handler_for_bot(lib_module, quiet, config_file):
     # Make sure you set up your ~/.zuliprc
     client = Client(config_file=config_file)

--- a/contrib_bots/bots/wikipedia/wikipedia.py
+++ b/contrib_bots/bots/wikipedia/wikipedia.py
@@ -28,19 +28,7 @@ class WikipediaHandler(object):
 
     def handle_message(self, message, client, state_handler):
         bot_response = self.get_bot_wiki_response(message, client)
-        if message['type'] == 'private':
-            client.send_message(dict(
-                type='private',
-                to=[x['email'] for x in message['display_recipient'] if client.email != x['email']],
-                content=bot_response,
-            ))
-        else:
-            client.send_message(dict(
-                type='stream',
-                to=message['display_recipient'],
-                subject=message['subject'],
-                content=bot_response,
-            ))
+        client.send_reply(message, bot_response)
 
     def get_bot_wiki_response(self, message, client):
         query = message['content']


### PR DESCRIPTION
Initial work to add a send_reply(message,response) to BotHandlerApi, which greatly simplifies the general use-case.

Hopefully as per the suggestion in #4917.

Currently the old API for specifically responding to streams or in private is unchanged, to allow responding only to a stream or in private. As discussed with @robot-dreams, this new function could be extended with eg. options (defaulting to current behaviour) to respond to just stream and/or private, or separate utility functions, but this seems like a good first step before looking through the other bots to use this new function.