### PR TITLE
Virtual_fs bot: Add readme.md, work with empty messages & private chats

### DIFF
--- a/contrib_bots/bots/virtual_fs/readme.md
+++ b/contrib_bots/bots/virtual_fs/readme.md
@@ -1,0 +1,41 @@
+# Virtual fs bot
+
+This bot allows users to store information in a virtual file system, for a given stream or private chat.
+
+## Usage
+
+Run this bot as described in [here](http://zulip.readthedocs.io/en/latest/bots-guide.html#how-to-deploy-a-bot).
+
+Use this bot with any of the following commands:
+
+`@fs mkdir` : create a directory
+`@fs ls` : list a directory
+`@fs cd` : change directory
+`@fs pwd` : show current path
+`@fs write` : write text
+`@fs read` : read text
+`@fs rm` : remove a file
+`@fs rmdir` : remove a directory
+
+where `fs` may be the name of the bot you registered in the zulip system.
+
+### Usage examples
+
+`@fs ls` - Initially shows nothing (with a warning)
+`@fs pwd` - Show which directory we are in: we start in /
+`@fs mkdir foo` - Make directory foo
+`@fs ls` - Show that foo is now created
+`@fs cd foo` - Change into foo (and do a pwd, automatically)
+`@fs write test hello world` - Write "hello world" to the file 'test'
+`@fs read test` - Check the text was written
+`@fs ls` - Show that the new file exists
+`@fs rm test` - Remove that file
+`@fs cd /` - Change back to root directory
+`@fs rmdir foo` - Remove foo
+
+## Notes
+
+* In a stream, the bot must be mentioned; in a private chat the bot will assume
+  every message is a command and so does not require this, though doing so will still work.
+
+* Use commands like `@fs help write` for more details on a command.

--- a/contrib_bots/bots/virtual_fs/virtual_fs.py
+++ b/contrib_bots/bots/virtual_fs/virtual_fs.py
@@ -9,7 +9,7 @@ class VirtualFsHandler(object):
 
     def handle_message(self, message, client, state_handler):
         command = message['content']
-        stream = message['display_recipient']
+        if command == "": return
         topic = message['subject']
         sender = message['sender_email']
 
@@ -17,23 +17,22 @@ class VirtualFsHandler(object):
         if state is None:
             state = {}
 
-        if stream not in state:
-            state[stream] = fs_new()
-        fs = state[stream]
+        recipient = message['display_recipient']
+        if isinstance(recipient, list): # If not a stream, then hash on list of emails
+            recipient = " ".join([x['email'] for x in recipient])
+
+        if recipient not in state:
+            state[recipient] = fs_new()
+        fs = state[recipient]
         if sender not in fs['user_paths']:
             fs['user_paths'][sender] = '/'
         fs, msg = fs_command(fs, sender, command)
         prependix = '{}:\n'.format(sender)
         msg = prependix + msg
-        state[stream] = fs
+        state[recipient] = fs
         state_handler.set_state(state)
 
-        client.send_message(dict(
-            type='stream',
-            to=stream,
-            subject=topic,
-            content=msg,
-        ))
+        client.send_reply(message, msg)
 
 
 def get_help():


### PR DESCRIPTION
- Add suitable help text to new readme.md file.
- Add test for empty message to avoid crash in case of simple mention of bot name
- Use new send_reply function to simplify send_message logic & enable private chats
- Hash on list of emails in private chats to allow application to private chats