### PR TITLE
Encrypt bot: switch to use send_reply

### DIFF
--- a/contrib_bots/bots/encrypt/encrypt.py
+++ b/contrib_bots/bots/encrypt/encrypt.py
@@ -30,20 +30,7 @@ class EncryptHandler(object):
 
     def handle_message(self, message, client, state_handler):
         bot_response = self.get_bot_encrypt_response(message)
-
-        if message['type'] == 'private':
-            client.send_message(dict(
-                type='private',
-                to=message['sender_email'],
-                content=bot_response,
-            ))
-        else:
-            client.send_message(dict(
-                type='stream',
-                to=message['display_recipient'],
-                subject=message['subject'],
-                content=bot_response,
-            ))
+        client.send_reply(message, bot_response)
 
     def get_bot_encrypt_response(self, message):
         original_content = message['content']


### PR DESCRIPTION
Small change to use new send_reply function, simplifying bot code & improving private chat response (with 3+ members).