### PR TITLE
Second pass at removing get_user_profile_from_email from tests

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -34,6 +34,7 @@ from zerver.lib.test_helpers import (
 
 from zerver.models import (
     get_stream,
+    get_user,
     get_user_profile_by_email,
     get_realm_by_email_domain,
     Client,
@@ -215,6 +216,7 @@ class ZulipTestCase(TestCase):
         prospero='prospero@zulip.com',
         othello='othello@zulip.com',
         AARON='AARON@zulip.com',
+        aaron='aaron@zulip.com',
         ZOE='ZOE@zulip.com',
     )
 
@@ -223,6 +225,23 @@ class ZulipTestCase(TestCase):
         starnine="starnine@mit.edu",
         espuser="espuser@mit.edu",
     )
+
+    # Non-registered test users
+    nonreg_user_map = dict(
+        test='test@zulip.com',
+        test1='test1@zulip.com',
+        alice='alice@zulip.com',
+        newuser='newuser@zulip.com',
+        bob='bob@zulip.com',
+        cordelia='cordelia@zulip.com',
+        newguy='newguy@zulip.com',
+        me='me@zulip.com',
+    )
+
+    def nonreg_user(self, name):
+        # type: (str) -> UserProfile
+        email = self.nonreg_user_map[name]
+        return get_user(email, get_realm_by_email_domain(email))
 
     def example_user(self, name):
         # type: (str) -> UserProfile
@@ -234,6 +253,10 @@ class ZulipTestCase(TestCase):
         email = self.mit_user_map[name]
         return get_user_profile_by_email(email)
 
+    def nonreg_email(self, name):
+        # type: (str) -> str
+        return self.nonreg_user_map[name]
+
     def example_email(self, name):
         # type: (str) -> str
         return self.example_user_map[name]
@@ -241,6 +264,11 @@ class ZulipTestCase(TestCase):
     def mit_email(self, name):
         # type: (str) -> str
         return self.mit_user_map[name]
+
+    def get_email(self, name):
+        # type: (str) -> str
+        email = '{name}@zulip.com'.format(name=name)
+        return email
 
     def notification_bot(self):
         # type: () -> UserProfile

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -33,6 +33,7 @@ from zerver.lib.actions import (
 from zerver.models import (
     get_recipient,
     get_stream,
+    get_user,
     get_user_profile_by_email,
     Client,
     Message,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -11,7 +11,7 @@ from django.test import TestCase
 from django.utils.timezone import now as timezone_now
 
 from zerver.models import (
-    get_client, get_realm, get_recipient, get_stream, get_user_profile_by_email,
+    get_client, get_realm, get_recipient, get_stream, get_user,
     Message, RealmDomain, Recipient, UserMessage, UserPresence, UserProfile,
     Realm,
 )
@@ -340,7 +340,9 @@ class GetEventsTest(ZulipTestCase):
         self.assertEqual(events[0]["message"]["display_recipient"], "Denmark")
 
 class EventsRegisterTest(ZulipTestCase):
+
     def setUp(self):
+        # type: () -> None
         super(EventsRegisterTest, self).setUp()
         self.user_profile = self.example_user('hamlet')
         self.maxDiff = None # type: Optional[int]
@@ -1506,8 +1508,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
 
     def test_max_message_id_with_no_history(self):
         # type: () -> None
-        email = 'aaron@zulip.com'
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('aaron')
         # Delete all historical messages for this user
         UserMessage.objects.filter(user_profile=user_profile).delete()
         result = fetch_initial_state_data(user_profile, None, "")

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -8,13 +8,13 @@ from mock import patch
 from typing import Any, Dict
 
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import get_user_profile_by_email
+from zerver.models import get_realm, get_user
 from zerver.lib.actions import do_set_muted_topics
 
 class MutedTopicsTests(ZulipTestCase):
     def test_json_set(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        email = self.get_email('hamlet')
         self.login(email)
 
         url = '/api/v1/users/me/subscriptions/muted_topics'
@@ -22,7 +22,7 @@ class MutedTopicsTests(ZulipTestCase):
         result = self.client_post(url, data, **self.api_auth(email))
         self.assert_json_success(result)
 
-        user = get_user_profile_by_email(email)
+        user = self.example_user('hamlet')
         self.assertEqual(ujson.loads(user.muted_topics), [["stream", "topic"]])
 
         url = '/api/v1/users/me/subscriptions/muted_topics'
@@ -30,12 +30,12 @@ class MutedTopicsTests(ZulipTestCase):
         result = self.client_post(url, data, **self.api_auth(email))
         self.assert_json_success(result)
 
-        user = get_user_profile_by_email(email)
+        user = self.example_user('hamlet')
         self.assertEqual(ujson.loads(user.muted_topics), [["stream2", "topic2"]])
 
     def test_add_muted_topic(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        email = self.example_email('hamlet')
         self.login(email)
 
         url = '/api/v1/users/me/subscriptions/muted_topics'
@@ -43,7 +43,7 @@ class MutedTopicsTests(ZulipTestCase):
         result = self.client_patch(url, data, **self.api_auth(email))
         self.assert_json_success(result)
 
-        user = get_user_profile_by_email(email)
+        user = self.example_user('hamlet')
         self.assertIn([u'Verona', u'Verona3'], ujson.loads(user.muted_topics))
 
     def test_remove_muted_topic(self):
@@ -58,7 +58,7 @@ class MutedTopicsTests(ZulipTestCase):
         result = self.client_patch(url, data, **self.api_auth(email))
 
         self.assert_json_success(result)
-        user = get_user_profile_by_email(email)
+        user = self.example_user('hamlet')
         self.assertNotIn([[u'Verona', u'Verona3']], ujson.loads(user.muted_topics))
 
     def test_muted_topic_add_invalid(self):

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql import compiler # type: ignore
 
 from zerver.models import (
     Realm, Recipient, Stream, Subscription, UserProfile, Attachment,
-    get_display_recipient, get_recipient, get_realm, get_stream, get_user_profile_by_email,
+    get_display_recipient, get_recipient, get_realm, get_stream, get_user,
     Reaction
 )
 from zerver.lib.message import (
@@ -481,7 +481,7 @@ class GetOldMessagesTest(ZulipTestCase):
         A request for old messages with a narrow by pm-with only returns
         conversations with that user.
         """
-        me = 'hamlet@zulip.com'
+        me = self.example_email('hamlet')
 
         def dr_emails(dr):
             # type: (Union[Text, List[Dict[str, Any]]]) -> Text
@@ -492,7 +492,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.send_message(me,
                           ['iago@zulip.com', 'cordelia@zulip.com'],
                           Recipient.HUDDLE)
-        personals = [m for m in get_user_messages(get_user_profile_by_email(me))
+        personals = [m for m in get_user_messages(self.example_user('hamlet'))
                      if m.recipient.type == Recipient.PERSONAL or
                      m.recipient.type == Recipient.HUDDLE]
         for personal in personals:
@@ -535,7 +535,7 @@ class GetOldMessagesTest(ZulipTestCase):
         A request for old messages with a narrow by stream only returns
         messages for that stream.
         """
-        self.login("hamlet@zulip.com")
+        self.login(self.example_email('hamlet'))
         # We need to subscribe to a stream and then send a message to
         # it to ensure that we actually have a stream message in this
         # narrow view.
@@ -576,7 +576,7 @@ class GetOldMessagesTest(ZulipTestCase):
         result = self.get_and_check_messages(dict(num_after=2,
                                                   narrow=ujson.dumps(narrow)))
 
-        messages = get_user_messages(get_user_profile_by_email(self.mit_user("starnine").email))
+        messages = get_user_messages(self.mit_user("starnine"))
         stream_messages = [msg for msg in messages if msg.recipient.type == Recipient.STREAM]
 
         self.assertEqual(len(result["messages"]), 2)

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -8,7 +8,7 @@ from six import string_types
 from zerver.lib.test_helpers import tornado_redirected_to_list, get_display_recipient, \
     get_test_image_file
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import get_realm, get_user_profile_by_email, Recipient, UserMessage
+from zerver.models import get_realm, Recipient, UserMessage
 
 class ReactionEmojiTest(ZulipTestCase):
     def test_missing_emoji(self):
@@ -216,25 +216,24 @@ class ReactionEventTest(ZulipTestCase):
         Recipients of the message receive the reaction event
         and event contains relevant data
         """
-        pm_sender = 'hamlet@zulip.com'
-        pm_recipient = 'othello@zulip.com'
+        pm_sender = self.example_user('hamlet')
+        pm_recipient = self.example_user('othello')
         reaction_sender = pm_recipient
 
         result = self.client_post("/api/v1/messages", {"type": "private",
                                                        "content": "Test message",
-                                                       "to": pm_recipient},
-                                  **self.api_auth(pm_sender))
+                                                       "to": pm_recipient.email},
+                                  **self.api_auth(pm_sender.email))
         self.assert_json_success(result)
         content = ujson.loads(result.content)
         pm_id = content['id']
 
-        expected_recipient_emails = set([pm_sender, pm_recipient])
-        expected_recipient_ids = set([get_user_profile_by_email(email).id for email in expected_recipient_emails])
+        expected_recipient_ids = set([pm_sender.id, pm_recipient.id])
 
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             result = self.client_put('/api/v1/messages/%s/emoji_reactions/smile' % (pm_id,),
-                                     **self.api_auth(reaction_sender))
+                                     **self.api_auth(reaction_sender.email))
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -242,7 +241,7 @@ class ReactionEventTest(ZulipTestCase):
         event_user_ids = set(events[0]['users'])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event['user']['email'], reaction_sender)
+        self.assertEqual(event['user']['email'], reaction_sender.email)
         self.assertEqual(event['type'], 'reaction')
         self.assertEqual(event['op'], 'add')
         self.assertEqual(event['emoji_name'], 'smile')
@@ -254,29 +253,28 @@ class ReactionEventTest(ZulipTestCase):
         Recipients of the message receive the reaction event
         and event contains relevant data
         """
-        pm_sender = 'hamlet@zulip.com'
-        pm_recipient = 'othello@zulip.com'
+        pm_sender = self.example_user('hamlet')
+        pm_recipient = self.example_user('othello')
         reaction_sender = pm_recipient
 
         result = self.client_post("/api/v1/messages", {"type": "private",
                                                        "content": "Test message",
-                                                       "to": pm_recipient},
-                                  **self.api_auth(pm_sender))
+                                                       "to": pm_recipient.email},
+                                  **self.api_auth(pm_sender.email))
         self.assert_json_success(result)
         content = ujson.loads(result.content)
         pm_id = content['id']
 
-        expected_recipient_emails = set([pm_sender, pm_recipient])
-        expected_recipient_ids = set([get_user_profile_by_email(email).id for email in expected_recipient_emails])
+        expected_recipient_ids = set([pm_sender.id, pm_recipient.id])
 
         add = self.client_put('/api/v1/messages/%s/emoji_reactions/smile' % (pm_id,),
-                              **self.api_auth(reaction_sender))
+                              **self.api_auth(reaction_sender.email))
         self.assert_json_success(add)
 
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             result = self.client_delete('/api/v1/messages/%s/emoji_reactions/smile' % (pm_id,),
-                                        **self.api_auth(reaction_sender))
+                                        **self.api_auth(reaction_sender.email))
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -284,7 +282,7 @@ class ReactionEventTest(ZulipTestCase):
         event_user_ids = set(events[0]['users'])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event['user']['email'], reaction_sender)
+        self.assertEqual(event['user']['email'], reaction_sender.email)
         self.assertEqual(event['type'], 'reaction')
         self.assertEqual(event['op'], 'remove')
         self.assertEqual(event['emoji_name'], 'smile')

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -15,13 +15,12 @@ from zerver.lib.actions import (
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import tornado_redirected_to_list
-from zerver.models import get_realm, get_user_profile_by_email, Realm
+from zerver.models import get_realm, Realm, UserProfile
 
 
 class RealmTest(ZulipTestCase):
-    def assert_user_profile_cache_gets_new_name(self, email, new_realm_name):
-        # type: (Text, Text) -> None
-        user_profile = get_user_profile_by_email(email)
+    def assert_user_profile_cache_gets_new_name(self, user_profile, new_realm_name):
+        # type: (UserProfile, Text) -> None
         self.assertEqual(user_profile.realm.name, new_realm_name)
 
     def test_do_set_realm_name_caching(self):
@@ -34,7 +33,7 @@ class RealmTest(ZulipTestCase):
         new_name = u'Zed You Elle Eye Pea'
         do_set_realm_property(realm, 'name', new_name)
         self.assertEqual(get_realm(realm.string_id).name, new_name)
-        self.assert_user_profile_cache_gets_new_name('hamlet@zulip.com', new_name)
+        self.assert_user_profile_cache_gets_new_name(self.example_user('hamlet'), new_name)
 
     def test_update_realm_name_events(self):
         # type: () -> None

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -11,7 +11,7 @@ from zerver.lib.actions import do_change_is_admin, \
 from zerver.lib.domains import validate_domain
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import email_allowed_for_realm, get_realm, \
-    get_realm_by_email_domain, get_user_profile_by_email, \
+    get_realm_by_email_domain, \
     GetRealmByDomainException, RealmDomain
 
 import ujson

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -10,7 +10,7 @@ from typing import Any, Dict
 from zerver.lib.initial_password import initial_password
 from zerver.lib.sessions import get_session_dict_user
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import get_user_profile_by_email
+from zerver.models import get_realm, get_user
 
 class ChangeSettingsTest(ZulipTestCase):
 
@@ -99,7 +99,7 @@ class ChangeSettingsTest(ZulipTestCase):
         # give them the courtesy of an error reason.
         self.assert_json_success(json_result)
 
-        user = get_user_profile_by_email(email)
+        user = self.example_user('hamlet')
         self.assertEqual(user.full_name, full_name)
 
         # Now try a too-long name
@@ -203,13 +203,13 @@ class ChangeSettingsTest(ZulipTestCase):
         """
         Test changing the default language of the user.
         """
-        email = "hamlet@zulip.com"
+        email = self.example_email('hamlet')
         self.login(email)
         german = "de"
         data = dict(default_language=ujson.dumps(german))
         result = self.client_patch("/json/settings/display", data)
         self.assert_json_success(result)
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
         self.assertEqual(user_profile.default_language, german)
 
         # Test to make sure invalid languages are not accepted
@@ -218,7 +218,7 @@ class ChangeSettingsTest(ZulipTestCase):
         data = dict(default_language=ujson.dumps(invalid_lang))
         result = self.client_patch("/json/settings/display", data)
         self.assert_json_error(result, "Invalid language '%s'" % (invalid_lang,))
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
         self.assertNotEqual(user_profile.default_language, invalid_lang)
 
     def test_change_timezone(self):
@@ -226,13 +226,13 @@ class ChangeSettingsTest(ZulipTestCase):
         """
         Test changing the timezone of the user.
         """
-        email = "hamlet@zulip.com"
+        email = self.example_email('hamlet')
         self.login(email)
         usa_pacific = 'US/Pacific'
         data = dict(timezone=ujson.dumps(usa_pacific))
         result = self.client_patch("/json/settings/display", data)
         self.assert_json_success(result)
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
         self.assertEqual(user_profile.timezone, usa_pacific)
 
         # Test to make sure invalid timezones are not accepted
@@ -241,7 +241,7 @@ class ChangeSettingsTest(ZulipTestCase):
         data = dict(timezone=ujson.dumps(invalid_timezone))
         result = self.client_patch("/json/settings/display", data)
         self.assert_json_error(result, "Invalid timezone '%s'" % (invalid_timezone,))
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
         self.assertNotEqual(user_profile.timezone, invalid_timezone)
 
     def test_change_emojiset(self):
@@ -249,13 +249,13 @@ class ChangeSettingsTest(ZulipTestCase):
         """
         Test changing the emojiset.
         """
-        email = "hamlet@zulip.com"
+        email = self.example_email('hamlet')
         self.login(email)
         emojiset = 'apple'
         data = dict(emojiset=ujson.dumps(emojiset))
         result = self.client_patch("/json/settings/display", data)
         self.assert_json_success(result)
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
         self.assertEqual(user_profile.emojiset, emojiset)
 
         # Test to make sure invalid emojisets are not accepted
@@ -264,7 +264,7 @@ class ChangeSettingsTest(ZulipTestCase):
         data = dict(emojiset=ujson.dumps(invalid_emojiset))
         result = self.client_patch("/json/settings/display", data)
         self.assert_json_error(result, "Invalid emojiset '%s'" % (invalid_emojiset,))
-        user_profile = get_user_profile_by_email(email)
+        user_profile = self.example_user('hamlet')
         self.assertNotEqual(user_profile.emojiset, invalid_emojiset)
 
 class UserChangesTest(ZulipTestCase):
@@ -278,5 +278,5 @@ class UserChangesTest(ZulipTestCase):
         self.assert_json_success(result)
         new_api_key = ujson.loads(result.content)['api_key']
         self.assertNotEqual(old_api_key, new_api_key)
-        user = get_user_profile_by_email(email)
+        user = self.example_user('hamlet')
         self.assertEqual(new_api_key, user.api_key)

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -4,8 +4,9 @@ from __future__ import print_function
 
 from typing import Any, Dict
 
+from django.conf import settings
+
 from zerver.lib.test_helpers import (
-    get_user_profile_by_email,
     most_recent_message,
 )
 
@@ -14,7 +15,8 @@ from zerver.lib.test_classes import (
 )
 
 from zerver.models import (
-    UserProfile,
+    get_system_bot,
+    UserProfile
 )
 
 import ujson
@@ -32,7 +34,7 @@ class TutorialTests(ZulipTestCase):
         email = user.email
         self.login(email)
 
-        welcome_bot = get_user_profile_by_email("welcome-bot@zulip.com")
+        welcome_bot = get_system_bot(settings.WELCOME_BOT)
 
         raw_params = dict(
             type='stream',
@@ -69,7 +71,7 @@ class TutorialTests(ZulipTestCase):
 
     def test_tutorial_status(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        email = self.example_email('hamlet')
         self.login(email)
 
         cases = [
@@ -81,5 +83,5 @@ class TutorialTests(ZulipTestCase):
             params = fix_params(raw_params)
             result = self.client_post('/json/tutorial_status', params)
             self.assert_json_success(result)
-            user = get_user_profile_by_email(email)
+            user = self.example_user('hamlet')
             self.assertEqual(user.tutorial_status, expected_db_status)

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -9,7 +9,7 @@ from zerver.lib.test_helpers import tornado_redirected_to_list, get_display_reci
 from zerver.lib.test_classes import (
     ZulipTestCase,
 )
-from zerver.models import get_user_profile_by_email
+from zerver.models import get_realm, get_user
 
 class TypingNotificationOperatorTest(ZulipTestCase):
     def test_missing_parameter(self):
@@ -61,16 +61,17 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
         """
         Sending typing notification to a single recipient is successful
         """
-        sender = 'hamlet@zulip.com'
-        recipient = 'othello@zulip.com'
-        expected_recipient_emails = set([sender, recipient])
-        expected_recipient_ids = set([get_user_profile_by_email(email).id for email in expected_recipient_emails])
+        sender = self.example_user('hamlet')
+        recipient = self.example_user('othello')
+        expected_recipients = set([sender, recipient])
+        expected_recipient_emails = set([user.email for user in expected_recipients])
+        expected_recipient_ids = set([user.id for user in expected_recipients])
 
         events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_post('/api/v1/typing', {'to': recipient,
+            result = self.client_post('/api/v1/typing', {'to': recipient.email,
                                                          'op': 'start'},
-                                      **self.api_auth(sender))
+                                      **self.api_auth(sender.email))
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -81,7 +82,7 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
 
         self.assertEqual(expected_recipient_ids, event_recipient_user_ids)
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event['sender']['email'], sender)
+        self.assertEqual(event['sender']['email'], sender.email)
         self.assertEqual(event_recipient_emails, expected_recipient_emails)
         self.assertEqual(event['type'], 'typing')
         self.assertEqual(event['op'], 'start')
@@ -91,15 +92,16 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
         """
         Sending typing notification to a single recipient is successful
         """
-        sender = 'hamlet@zulip.com'
-        recipient = ['othello@zulip.com', 'cordelia@zulip.com']
-        expected_recipient_emails = set(recipient) | set([sender])
-        expected_recipient_ids = set([get_user_profile_by_email(email).id for email in expected_recipient_emails])
+        sender = self.example_user('hamlet')
+        recipient = [self.example_user('othello'), self.example_user('cordelia')]
+        expected_recipients = set(recipient) | set([sender])
+        expected_recipient_emails = set([user.email for user in expected_recipients])
+        expected_recipient_ids = set([user.id for user in expected_recipients])
         events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_post('/api/v1/typing', {'to': ujson.dumps(recipient),
+            result = self.client_post('/api/v1/typing', {'to': ujson.dumps([user.email for user in recipient]),
                                                          'op': 'start'},
-                                      **self.api_auth(sender))
+                                      **self.api_auth(sender.email))
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -110,7 +112,7 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
 
         self.assertEqual(expected_recipient_ids, event_recipient_user_ids)
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event['sender']['email'], sender)
+        self.assertEqual(event['sender']['email'], sender.email)
         self.assertEqual(event_recipient_emails, expected_recipient_emails)
         self.assertEqual(event['type'], 'typing')
         self.assertEqual(event['op'], 'start')
@@ -152,16 +154,17 @@ class TypingStartedNotificationTest(ZulipTestCase):
         Sending typing notification to another user
         is successful.
         """
-        sender = 'hamlet@zulip.com'
-        recipient = 'othello@zulip.com'
-        expected_recipient_emails = set([sender, recipient])
-        expected_recipient_ids = set([get_user_profile_by_email(email).id for email in expected_recipient_emails])
+        sender = self.example_user('hamlet')
+        recipient = self.example_user('othello')
+        expected_recipients = set([sender, recipient])
+        expected_recipient_emails = set([user.email for user in expected_recipients])
+        expected_recipient_ids = set([user.id for user in expected_recipients])
 
         events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_post('/api/v1/typing', {'to': recipient,
+            result = self.client_post('/api/v1/typing', {'to': recipient.email,
                                                          'op': 'start'},
-                                      **self.api_auth(sender))
+                                      **self.api_auth(sender.email))
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -173,7 +176,7 @@ class TypingStartedNotificationTest(ZulipTestCase):
         self.assertEqual(expected_recipient_ids, event_recipient_user_ids)
         self.assertEqual(expected_recipient_ids, event_user_ids)
         self.assertEqual(event_recipient_emails, expected_recipient_emails)
-        self.assertEqual(event['sender']['email'], sender)
+        self.assertEqual(event['sender']['email'], sender.email)
         self.assertEqual(event['type'], 'typing')
         self.assertEqual(event['op'], 'start')
 
@@ -215,16 +218,17 @@ class StoppedTypingNotificationTest(ZulipTestCase):
         Sending stopped typing notification to another user
         is successful.
         """
-        sender = 'hamlet@zulip.com'
-        recipient = 'othello@zulip.com'
-        expected_recipient_emails = set([sender, recipient])
-        expected_recipient_ids = set([get_user_profile_by_email(email).id for email in expected_recipient_emails])
+        sender = self.example_user('hamlet')
+        recipient = self.example_user('othello')
+        expected_recipients = set([sender, recipient])
+        expected_recipient_emails = set([user.email for user in expected_recipients])
+        expected_recipient_ids = set([user.id for user in expected_recipients])
 
         events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_post('/api/v1/typing', {'to': recipient,
+            result = self.client_post('/api/v1/typing', {'to': recipient.email,
                                                          'op': 'stop'},
-                                      **self.api_auth(sender))
+                                      **self.api_auth(sender.email))
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -236,6 +240,6 @@ class StoppedTypingNotificationTest(ZulipTestCase):
         self.assertEqual(expected_recipient_ids, event_recipient_user_ids)
         self.assertEqual(expected_recipient_ids, event_user_ids)
         self.assertEqual(event_recipient_emails, expected_recipient_emails)
-        self.assertEqual(event['sender']['email'], sender)
+        self.assertEqual(event['sender']['email'], sender.email)
         self.assertEqual(event['type'], 'typing')
         self.assertEqual(event['op'], 'stop')

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -18,7 +18,7 @@ from zerver.lib.upload import sanitize_name, S3UploadBackend, \
     upload_message_image, delete_message_image, LocalUploadBackend, \
     ZulipUploadBackend
 import zerver.lib.upload
-from zerver.models import Attachment, Recipient, get_user_profile_by_email, \
+from zerver.models import Attachment, Recipient, get_user, \
     get_old_unclaimed_attachments, Message, UserProfile, Stream, Realm, \
     RealmDomain, get_realm
 from zerver.lib.actions import do_delete_old_unclaimed_attachments
@@ -462,10 +462,10 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
     def test_cross_realm_file_access(self):
         # type: () -> None
 
-        def create_user(email):
+        def create_user(email, realm_id):
             # type: (Text) -> UserProfile
             self.register(email, 'test')
-            return get_user_profile_by_email(email)
+            return get_user(email, get_realm(realm_id))
 
         user1_email = 'user1@uploadtest.example.com'
         user2_email = 'test-og-bot@zulip.com'
@@ -485,9 +485,9 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         deployment = Deployment.objects.filter()[0]
         deployment.realms.add(r1)
 
-        create_user(user1_email)
-        create_user(user2_email)
-        create_user(user3_email)
+        create_user(user1_email, 'uploadtest.example.com')
+        create_user(user2_email, 'zulip')
+        create_user(user3_email, 'uploadtest.example.com')
 
         # Send a message from @zulip.com -> @uploadtest.example.com
         self.login(user2_email, 'test')


### PR DESCRIPTION
Verified that the following are clean: 
- tools/test-backend
- tools/run-mypy
- tools/lint