### PR TITLE
bots: Corrected weird behavior of followup bot for empty messages

### DIFF
--- a/contrib_bots/bots/followup/followup.py
+++ b/contrib_bots/bots/followup/followup.py
@@ -23,18 +23,22 @@ class FollowupHandler(object):
             '''
 
     def handle_message(self, message, client, state_handler):
-        bot_response = self.get_bot_followup_response(message)
-        client.send_message(dict(
-            type='stream',
-            to='followup',
-            subject=message['sender_email'],
-            content=bot_response,
-        ))
+        if message['content'] == '':
+            bot_response = "Please specify the message you want to send to followup stream after @mention-bot"
+            client.send_reply(message, bot_response)
+        else:
+            bot_response = self.get_bot_followup_response(message)
+            client.send_message(dict(
+                type='stream',
+                to='followup',
+                subject=message['sender_email'],
+                content=bot_response,
+            ))
 
     def get_bot_followup_response(self, message):
         original_content = message['content']
         original_sender = message['sender_email']
-        temp_content = 'from %s:' % (original_sender,)
+        temp_content = 'from %s: ' % (original_sender,)
         new_content = temp_content + original_content
 
         return new_content


### PR DESCRIPTION
Before it send empty message to followup stream, now it sends help message back to the user/stream who send original one