### PR TITLE
Help bot: Remove triage_message() (last place in tree?)

### DIFF
--- a/contrib_bots/bots/help/help.py
+++ b/contrib_bots/bots/help/help.py
@@ -11,18 +11,6 @@ class HelpHandler(object):
             your Zulip instance.
             '''
 
-    def triage_message(self, message, client):
-        # return True if we think the message may be of interest
-        original_content = message['content']
-
-        if message['type'] != 'stream':
-            return True
-
-        if original_content.lower().strip() != 'help':
-            return False
-
-        return True
-
     def handle_message(self, message, client, state_handler):
         help_content = '''
             Info on Zulip can be found here:


### PR DESCRIPTION
@derAnfaenger indicated this function was removed in many places; this seems to be the last place in the tree to remove it.