### PR TITLE
Update xkcd to use send_reply, enabling private message usage

### DIFF
--- a/contrib_bots/bots/xkcd/xkcd.py
+++ b/contrib_bots/bots/xkcd/xkcd.py
@@ -29,13 +29,7 @@ class XkcdHandler(object):
 
     def handle_message(self, message, client, state_handler):
         xkcd_bot_response = get_xkcd_bot_response(message)
-
-        client.send_message(dict(
-            type='stream',
-            to=message['display_recipient'],
-            subject=message['subject'],
-            content=xkcd_bot_response,
-        ))
+        client.send_reply(message, xkcd_bot_response)
 
 class XkcdBotCommand(object):
     LATEST = 0


### PR DESCRIPTION
Enable use in private chats, including in groups, via simplified send_reply function usage.