### PR TITLE
replaced @zulip references

### DIFF
--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -15,33 +15,34 @@ from zerver.models import Attachment
 class AttachmentsTests(ZulipTestCase):
     def setUp(self):
         # type: () -> None
-        user = self.example_user('cordelia')
+        user_profile = self.example_user('cordelia')
         self.attachment = Attachment.objects.create(
-            file_name='test.txt', path_id='foo/bar/test.txt', owner=user)
+            file_name='test.txt', path_id='foo/bar/test.txt', owner=user_profile)
 
     def test_list_by_user(self):
         # type: () -> None
-        self.login("cordelia@zulip.com")
+        user_profile = self.example_user('cordelia')
+        self.login(user_profile.email)
         result = self.client_get('/json/attachments')
         self.assert_json_success(result)
-        user = self.example_user('cordelia')
-        attachments = user_attachments(user)
+        attachments = user_attachments(user_profile)
         data = ujson.loads(result.content)
         self.assertEqual(data['attachments'], attachments)
 
     @mock.patch('zerver.lib.attachments.delete_message_image')
     def test_remove_attachment(self, ignored):
         # type: (Any) -> None
-        self.login("cordelia@zulip.com")
+        user_profile = self.example_user('cordelia')
+        self.login(user_profile.email)
         result = self.client_delete('/json/attachments/{pk}'.format(pk=self.attachment.pk))
         self.assert_json_success(result)
-        user = self.example_user('cordelia')
-        attachments = user_attachments(user)
+        attachments = user_attachments(user_profile)
         self.assertEqual(attachments, [])
 
     def test_list_another_user(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        user_profile = self.example_user('iago')
+        self.login(user_profile.email)
         result = self.client_get('/json/attachments')
         self.assert_json_success(result)
         data = ujson.loads(result.content)
@@ -49,11 +50,12 @@ class AttachmentsTests(ZulipTestCase):
 
     def test_remove_another_user(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        user_profile = self.example_user('iago')
+        self.login(user_profile.email)
         result = self.client_delete('/json/attachments/{pk}'.format(pk=self.attachment.pk))
         self.assert_json_error(result, 'Invalid attachment')
-        user = self.example_user('cordelia')
-        attachments = user_attachments(user)
+        user_profile_to_remove = self.example_user('cordelia')
+        attachments = user_attachments(user_profile_to_remove)
         self.assertEqual(attachments, [self.attachment.to_dict()])
 
     def test_list_unauthenticated(self):

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import subprocess
 
 from django.http import HttpResponse
-from django.test import TestCase
 
 from zerver.lib.test_helpers import (
     most_recent_message,
@@ -88,8 +87,8 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
         # build dummy messages for stream
         # test valid incoming stream message is processed properly
-        self.login("hamlet@zulip.com")
         user_profile = self.example_user('hamlet')
+        self.login(user_profile.email)
         self.subscribe_to_stream(user_profile.email, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -98,9 +97,9 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
         incoming_valid_message = MIMEText('TestStreamEmailMessages Body') # type: Any # https://github.com/python/typeshed/issues/275
 
         incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
-        incoming_valid_message['From'] = "hamlet@zulip.com"
+        incoming_valid_message['From'] = self.example_email('hamlet')
         incoming_valid_message['To'] = stream_to_address
-        incoming_valid_message['Reply-to'] = "othello@zulip.com"
+        incoming_valid_message['Reply-to'] = self.example_email('othello')
 
         process_message(incoming_valid_message)
 
@@ -117,22 +116,22 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
 
         # build dummy messages for stream
         # test message with empty body is not sent
-        self.login("hamlet@zulip.com")
         user_profile = self.example_user('hamlet')
+        self.login(user_profile.email)
         self.subscribe_to_stream(user_profile.email, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
         stream_to_address = encode_email_address(stream)
         headers = {}
-        headers['Reply-To'] = 'othello@zulip.com'
+        headers['Reply-To'] = self.example_email('othello')
 
         # empty body
         incoming_valid_message = MIMEText('') # type: Any # https://github.com/python/typeshed/issues/275
 
         incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
-        incoming_valid_message['From'] = "hamlet@zulip.com"
+        incoming_valid_message['From'] = self.example_email('hamlet')
         incoming_valid_message['To'] = stream_to_address
-        incoming_valid_message['Reply-to'] = "othello@zulip.com"
+        incoming_valid_message['Reply-to'] = self.example_email('othello')
 
         exception_message = ""
         debug_info = {} # type: Dict[str, Any]
@@ -156,11 +155,12 @@ class TestMissedPersonalMessageEmailMessages(ZulipTestCase):
         # build dummy messages for missed messages email reply
         # have Hamlet send Othello a PM. Othello will reply via email
         # Hamlet will receive the message.
-        self.login("hamlet@zulip.com")
+        email = self.example_email('hamlet')
+        self.login(email)
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": "test_receive_missed_message_email_messages",
                                                      "client": "test suite",
-                                                     "to": "othello@zulip.com"})
+                                                     "to": self.example_email('othello')})
         self.assert_json_success(result)
 
         user_profile = self.example_user('othello')
@@ -173,9 +173,9 @@ class TestMissedPersonalMessageEmailMessages(ZulipTestCase):
         incoming_valid_message = MIMEText('TestMissedMessageEmailMessages Body') # type: Any # https://github.com/python/typeshed/issues/275
 
         incoming_valid_message['Subject'] = 'TestMissedMessageEmailMessages Subject'
-        incoming_valid_message['From'] = "othello@zulip.com"
+        incoming_valid_message['From'] = self.example_email('othello')
         incoming_valid_message['To'] = mm_address
-        incoming_valid_message['Reply-to'] = "othello@zulip.com"
+        incoming_valid_message['Reply-to'] = self.example_email('othello')
 
         process_message(incoming_valid_message)
 
@@ -196,12 +196,13 @@ class TestMissedHuddleMessageEmailMessages(ZulipTestCase):
         # build dummy messages for missed messages email reply
         # have Othello send Iago and Cordelia a PM. Cordelia will reply via email
         # Iago and Othello will receive the message.
-        self.login("othello@zulip.com")
+        email = self.example_email('othello')
+        self.login(email)
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": "test_receive_missed_message_email_messages",
                                                      "client": "test suite",
-                                                     "to": ujson.dumps(["cordelia@zulip.com",
-                                                                        "iago@zulip.com"])})
+                                                     "to": ujson.dumps([self.example_email('cordelia'),
+                                                                        self.example_email('iago')])})
         self.assert_json_success(result)
 
         user_profile = self.example_user('cordelia')
@@ -214,9 +215,9 @@ class TestMissedHuddleMessageEmailMessages(ZulipTestCase):
         incoming_valid_message = MIMEText('TestMissedHuddleMessageEmailMessages Body') # type: Any # https://github.com/python/typeshed/issues/275
 
         incoming_valid_message['Subject'] = 'TestMissedHuddleMessageEmailMessages Subject'
-        incoming_valid_message['From'] = "cordelia@zulip.com"
+        incoming_valid_message['From'] = self.example_email('cordelia')
         incoming_valid_message['To'] = mm_address
-        incoming_valid_message['Reply-to'] = "cordelia@zulip.com"
+        incoming_valid_message['Reply-to'] = self.example_email('cordelia')
 
         process_message(incoming_valid_message)
 
@@ -239,12 +240,13 @@ class TestMissedHuddleMessageEmailMessages(ZulipTestCase):
 class TestMissedMessageAddressWithEmptyGateway(ZulipTestCase):
     def test_address_with_empty_gateway(self):
         # type: () -> None
-        self.login("othello@zulip.com")
+        email = self.example_email('othello')
+        self.login(email)
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": "test_receive_missed_message_email_messages",
                                                      "client": "test suite",
-                                                     "to": ujson.dumps(["cordelia@zulip.com",
-                                                                        "iago@zulip.com"])})
+                                                     "to": ujson.dumps([self.example_email('cordelia'),
+                                                                        self.example_email('iago')])})
         self.assert_json_success(result)
 
         user_profile = self.example_user('cordelia')
@@ -263,11 +265,12 @@ class TestDigestEmailMessages(ZulipTestCase):
         # build dummy messages for missed messages email reply
         # have Hamlet send Othello a PM. Othello will reply via email
         # Hamlet will receive the message.
-        self.login("hamlet@zulip.com")
+        email = self.example_email('hamlet')
+        self.login(email)
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": "test_receive_missed_message_email_messages",
                                                      "client": "test suite",
-                                                     "to": "othello@zulip.com"})
+                                                     "to": self.example_email('othello')})
         self.assert_json_success(result)
 
         user_profile = self.example_user('othello')
@@ -275,7 +278,7 @@ class TestDigestEmailMessages(ZulipTestCase):
 
         handle_digest_email(user_profile.id, cutoff)
         self.assertEqual(mock_send_future_email.call_count, 1)
-        self.assertEqual(mock_send_future_email.call_args[0][1], u'othello@zulip.com')
+        self.assertEqual(mock_send_future_email.call_args[0][1], self.example_email('othello'))
 
 class TestReplyExtraction(ZulipTestCase):
     def test_reply_is_extracted_from_plain(self):
@@ -283,7 +286,8 @@ class TestReplyExtraction(ZulipTestCase):
 
         # build dummy messages for stream
         # test valid incoming stream message is processed properly
-        self.login("hamlet@zulip.com")
+        email = self.example_email('hamlet')
+        self.login(email)
         user_profile = self.example_user('hamlet')
         self.subscribe_to_stream(user_profile.email, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
@@ -298,9 +302,9 @@ class TestReplyExtraction(ZulipTestCase):
         incoming_valid_message = MIMEText(text) # type: Any # https://github.com/python/typeshed/issues/275
 
         incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
-        incoming_valid_message['From'] = "hamlet@zulip.com"
+        incoming_valid_message['From'] = self.example_email('hamlet')
         incoming_valid_message['To'] = stream_to_address
-        incoming_valid_message['Reply-to'] = "othello@zulip.com"
+        incoming_valid_message['Reply-to'] = self.example_email('othello')
 
         process_message(incoming_valid_message)
 
@@ -314,7 +318,8 @@ class TestReplyExtraction(ZulipTestCase):
 
         # build dummy messages for stream
         # test valid incoming stream message is processed properly
-        self.login("hamlet@zulip.com")
+        email = self.example_email('hamlet')
+        self.login(email)
         user_profile = self.example_user('hamlet')
         self.subscribe_to_stream(user_profile.email, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
@@ -342,9 +347,9 @@ class TestReplyExtraction(ZulipTestCase):
         incoming_valid_message = MIMEText(html, 'html') # type: Any # https://github.com/python/typeshed/issues/275
 
         incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
-        incoming_valid_message['From'] = "hamlet@zulip.com"
+        incoming_valid_message['From'] = self.example_email('hamlet')
         incoming_valid_message['To'] = stream_to_address
-        incoming_valid_message['Reply-to'] = "othello@zulip.com"
+        incoming_valid_message['Reply-to'] = self.example_email('othello')
 
         process_message(incoming_valid_message)
 
@@ -356,14 +361,14 @@ class TestReplyExtraction(ZulipTestCase):
 MAILS_DIR = os.path.join(dirname(dirname(abspath(__file__))), "fixtures", "email")
 
 
-class TestScriptMTA(TestCase):
+class TestScriptMTA(ZulipTestCase):
 
     def test_success(self):
         # type: () -> None
         script = os.path.join(os.path.dirname(__file__),
                               '../../scripts/lib/email-mirror-postfix')
 
-        sender = "hamlet@zulip.com"
+        sender = self.example_email('hamlet')
         stream = get_stream("Denmark", get_realm("zulip"))
         stream_to_address = encode_email_address(stream)
 
@@ -383,7 +388,7 @@ class TestScriptMTA(TestCase):
         script = os.path.join(os.path.dirname(__file__),
                               '../../scripts/lib/email-mirror-postfix')
 
-        sender = "hamlet@zulip.com"
+        sender = self.example_email('hamlet')
         stream = get_stream("Denmark", get_realm("zulip"))
         stream_to_address = encode_email_address(stream)
         template_path = os.path.join(MAILS_DIR, "simple.txt")
@@ -411,14 +416,15 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
 
     def send_private_message(self):
         # type: () -> Text
-        self.login("othello@zulip.com")
+        email = self.example_email('othello')
+        self.login(email)
         result = self.client_post(
             "/json/messages",
             {
                 "type": "private",
                 "content": "test_receive_missed_message_email_messages",
                 "client": "test suite",
-                "to": ujson.dumps(["cordelia@zulip.com", "iago@zulip.com"])
+                "to": ujson.dumps([self.example_email('cordelia'), self.example_email('iago')])
             })
         self.assert_json_success(result)
 
@@ -454,7 +460,7 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
         # type: () -> None
         stream = get_stream("Denmark", get_realm("zulip"))
         stream_to_address = encode_email_address(stream)
-        result = self.send_offline_message(stream_to_address, "hamlet@zulip.com")
+        result = self.send_offline_message(stream_to_address, self.example_email('hamlet'))
         self.assert_json_success(result)
 
     def test_error_to_stream_with_wrong_address(self):
@@ -463,7 +469,7 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
         stream_to_address = encode_email_address(stream)
         stream_to_address = stream_to_address.replace("Denmark", "Wrong_stream")
 
-        result = self.send_offline_message(stream_to_address, "hamlet@zulip.com")
+        result = self.send_offline_message(stream_to_address, self.example_email('hamlet'))
         self.assert_json_error(
             result,
             "5.1.1 Bad destination mailbox address: "
@@ -472,14 +478,14 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
     def test_success_to_private(self):
         # type: () -> None
         mm_address = self.send_private_message()
-        result = self.send_offline_message(mm_address, "cordelia@zulip.com")
+        result = self.send_offline_message(mm_address, self.example_email('cordelia'))
         self.assert_json_success(result)
 
     def test_using_mm_address_twice(self):
         # type: () -> None
         mm_address = self.send_private_message()
-        self.send_offline_message(mm_address, "cordelia@zulip.com")
-        result = self.send_offline_message(mm_address, "cordelia@zulip.com")
+        self.send_offline_message(mm_address, self.example_email('cordelia'))
+        result = self.send_offline_message(mm_address, self.example_email('cordelia'))
         self.assert_json_error(
             result,
             "5.1.1 Bad destination mailbox address: Bad or expired missed message address.")
@@ -488,7 +494,7 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
         # type: () -> None
         self.send_private_message()
         mm_address = 'mm' + ('x' * 32) + '@testserver'
-        result = self.send_offline_message(mm_address, "cordelia@zulip.com")
+        result = self.send_offline_message(mm_address, self.example_email('cordelia'))
         self.assert_json_error(
             result,
             "5.1.1 Bad destination mailbox address: Bad or expired missed message address.")

--- a/zerver/tests/test_export.py
+++ b/zerver/tests/test_export.py
@@ -50,9 +50,9 @@ def rm_tree(path):
 class QueryUtilTest(ZulipTestCase):
     def _create_messages(self):
         # type: () -> None
-        for email in ['cordelia@zulip.com', 'hamlet@zulip.com', 'iago@zulip.com']:
+        for email in [self.example_email('cordelia'), self.example_email('hamlet'), self.example_email('iago')]:
             for _ in range(5):
-                self.send_message(email, 'othello@zulip.com', Recipient.PERSONAL)
+                self.send_message(email, self.example_email('othello'), Recipient.PERSONAL)
 
     @slow('creates lots of data')
     def test_query_chunker(self):
@@ -266,7 +266,7 @@ class ExportTest(ZulipTestCase):
                 if r['id'] == db_id][0]
 
         exported_user_emails = get_set('zerver_userprofile', 'email')
-        self.assertIn('cordelia@zulip.com', exported_user_emails)
+        self.assertIn(self.example_email('cordelia'), exported_user_emails)
         self.assertIn('default-bot@zulip.com', exported_user_emails)
         self.assertIn('emailgateway@zulip.com', exported_user_emails)
 
@@ -295,11 +295,11 @@ class ExportTest(ZulipTestCase):
         full_data = self._export_realm(realm, exportable_user_ids=user_ids)
         data = full_data['realm']
         exported_user_emails = get_set('zerver_userprofile', 'email')
-        self.assertIn('cordelia@zulip.com', exported_user_emails)
-        self.assertIn('hamlet@zulip.com', exported_user_emails)
+        self.assertIn(self.example_email('cordelia'), exported_user_emails)
+        self.assertIn(self.example_email('hamlet'), exported_user_emails)
         self.assertNotIn('default-bot@zulip.com', exported_user_emails)
-        self.assertNotIn('iago@zulip.com', exported_user_emails)
+        self.assertNotIn(self.example_email('iago'), exported_user_emails)
 
         dummy_user_emails = get_set('zerver_userprofile_mirrordummy', 'email')
-        self.assertIn('iago@zulip.com', dummy_user_emails)
-        self.assertNotIn('cordelia@zulip.com', dummy_user_emails)
+        self.assertIn(self.example_email('iago'), dummy_user_emails)
+        self.assertNotIn(self.example_email('cordelia'), dummy_user_emails)

--- a/zerver/tests/test_hotspots.py
+++ b/zerver/tests/test_hotspots.py
@@ -15,19 +15,19 @@ import ujson
 class TestGetNextHotspots(ZulipTestCase):
     def test_first_hotspot(self):
         # type: () -> None
-        user = UserProfile.objects.get(email='hamlet@zulip.com')
+        user = self.example_user('hamlet')
         self.assertEqual(get_next_hotspots(user), ['welcome'])
 
     def test_some_done_some_not(self):
         # type: () -> None
-        user = UserProfile.objects.get(email='hamlet@zulip.com')
+        user = self.example_user('hamlet')
         do_mark_hotspot_as_read(user, 'welcome')
         do_mark_hotspot_as_read(user, 'topics')
         self.assertEqual(get_next_hotspots(user), ['streams'])
 
     def test_all_done(self):
         # type: () -> None
-        user = UserProfile.objects.get(email='hamlet@zulip.com')
+        user = self.example_user('hamlet')
         for hotspot in ALL_HOTSPOTS:
             do_mark_hotspot_as_read(user, hotspot)
         self.assertEqual(get_next_hotspots(user), [])
@@ -35,16 +35,15 @@ class TestGetNextHotspots(ZulipTestCase):
 class TestHotspots(ZulipTestCase):
     def test_do_mark_hotspot_as_read(self):
         # type: () -> None
-        user = UserProfile.objects.get(email='hamlet@zulip.com')
+        user = self.example_user('hamlet')
         do_mark_hotspot_as_read(user, 'streams')
         self.assertEqual(list(UserHotspot.objects.filter(user=user)
                               .values_list('hotspot', flat=True)), ['streams'])
 
     def test_hotspots_url_endpoint(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
-        user = UserProfile.objects.get(email=email)
-        self.login(email)
+        user = self.example_user('hamlet')
+        self.login(user.email)
         result = self.client_post('/json/users/me/hotspots',
                                   {'hotspot': ujson.dumps('welcome')})
         self.assert_json_success(result)

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -80,7 +80,8 @@ class JsonTranslationTestCase(ZulipTestCase):
         dummy_value = "Some other language '%s'"
         mock_gettext.return_value = dummy_value
 
-        self.login("hamlet@zulip.com")
+        email = self.example_email('hamlet')
+        self.login(email)
         result = self.client_post("/json/refer_friend",
                                   HTTP_ACCEPT_LANGUAGE='de')
 
@@ -94,7 +95,8 @@ class JsonTranslationTestCase(ZulipTestCase):
         dummy_value = "Some other language"
         mock_gettext.return_value = dummy_value
 
-        self.login("hamlet@zulip.com")
+        email = self.example_email('hamlet')
+        self.login(email)
         result = self.client_get("/de/accounts/login/jwt/")
 
         self.assert_json_error_contains(result,

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -95,7 +95,8 @@ class AdminZulipHandlerTest(ZulipTestCase):
         # type: () -> None
         """A request with with no stack where report.getMessage() has newlines
         in it is handled properly"""
-        self.login("hamlet@zulip.com")
+        email = self.example_email('hamlet')
+        self.login(email)
         with patch("zerver.decorator.rate_limit") as rate_limit_patch:
             rate_limit_patch.side_effect = capture_and_throw
             result = self.client_get("/json/users")
@@ -119,7 +120,8 @@ class AdminZulipHandlerTest(ZulipTestCase):
     def test_request(self):
         # type: () -> None
         """A normal request is handled properly"""
-        self.login("hamlet@zulip.com")
+        email = self.example_email('hamlet')
+        self.login(email)
         with patch("zerver.decorator.rate_limit") as rate_limit_patch:
             rate_limit_patch.side_effect = capture_and_throw
             result = self.client_get("/json/users")

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -21,7 +21,8 @@ class SendLoginEmailTest(ZulipTestCase):
         # type: () -> None
         with self.settings(SEND_LOGIN_EMAILS=True):
             self.assertTrue(settings.SEND_LOGIN_EMAILS)
-            self.login("hamlet@zulip.com")
+            email = self.example_email('hamlet')
+            self.login(email)
 
             # email is sent and correct subject
             self.assertEqual(len(mail.outbox), 1)
@@ -30,7 +31,8 @@ class SendLoginEmailTest(ZulipTestCase):
     def test_dont_send_login_emails_if_send_login_emails_is_false(self):
         # type: () -> None
         self.assertFalse(settings.SEND_LOGIN_EMAILS)
-        self.login("hamlet@zulip.com")
+        email = self.example_email('hamlet')
+        self.login(email)
 
         self.assertEqual(len(mail.outbox), 0)
 

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -61,9 +61,9 @@ class TestMissedMessages(ZulipTestCase):
         mock_random_token.side_effect = tokens
 
         for i in range(0, 11):
-            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, str(i))
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '11', subject='test2')
-        msg_id = self.send_message("othello@zulip.com", "denmark", Recipient.STREAM, '@**hamlet**')
+            self.send_message(self.example_email('othello'), "Denmark", Recipient.STREAM, str(i))
+        self.send_message(self.example_email('othello'), "Denmark", Recipient.STREAM, '11', subject='test2')
+        msg_id = self.send_message(self.example_email('othello'), "denmark", Recipient.STREAM, '@**hamlet**')
         body = 'Denmark > test Othello, the Moor of Venice 1 2 3 4 5 6 7 8 9 10 @**hamlet**'
         subject = 'Othello, the Moor of Venice mentioned you in Zulip Dev'
         self._test_cases(tokens, msg_id, body, subject, send_as_user)
@@ -75,8 +75,8 @@ class TestMissedMessages(ZulipTestCase):
         mock_random_token.side_effect = tokens
 
         for i in range(0, 3):
-            self.send_message("cordelia@zulip.com", "Denmark", Recipient.STREAM, str(i))
-        msg_id = self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '@**hamlet**')
+            self.send_message(self.example_email('cordelia'), "Denmark", Recipient.STREAM, str(i))
+        msg_id = self.send_message(self.example_email('othello'), "Denmark", Recipient.STREAM, '@**hamlet**')
         body = 'Denmark > test Cordelia Lear 0 1 2 Othello, the Moor of Venice @**hamlet**'
         subject = 'Othello, the Moor of Venice mentioned you in Zulip Dev'
         self._test_cases(tokens, msg_id, body, subject, send_as_user)
@@ -87,7 +87,7 @@ class TestMissedMessages(ZulipTestCase):
         tokens = self._get_tokens()
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
+        msg_id = self.send_message(self.example_email('othello'), self.example_email('hamlet'),
                                    Recipient.PERSONAL,
                                    'Extremely personal message!')
         body = 'You and Othello, the Moor of Venice Extremely personal message!'
@@ -100,7 +100,7 @@ class TestMissedMessages(ZulipTestCase):
         tokens = self._get_tokens()
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
+        msg_id = self.send_message(self.example_email('othello'), self.example_email('hamlet'),
                                    Recipient.PERSONAL,
                                    'Extremely personal message!')
         body = 'Or just reply to this email.'
@@ -113,7 +113,7 @@ class TestMissedMessages(ZulipTestCase):
         tokens = self._get_tokens()
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
+        msg_id = self.send_message(self.example_email('othello'), self.example_email('hamlet'),
                                    Recipient.PERSONAL,
                                    'Extremely personal message!')
         body = 'Please do not reply to this automated message.'
@@ -126,8 +126,8 @@ class TestMissedMessages(ZulipTestCase):
         tokens = self._get_tokens()
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com",
-                                   ["hamlet@zulip.com", "iago@zulip.com"],
+        msg_id = self.send_message(self.example_email('othello'),
+                                   [self.example_email('hamlet'), self.example_email('iago')],
                                    Recipient.HUDDLE,
                                    'Group personal message!')
 
@@ -142,8 +142,8 @@ class TestMissedMessages(ZulipTestCase):
         tokens = self._get_tokens()
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com",
-                                   ["hamlet@zulip.com", "iago@zulip.com", "cordelia@zulip.com"],
+        msg_id = self.send_message(self.example_email('othello'),
+                                   [self.example_email('hamlet'), self.example_email('iago'), self.example_email('cordelia')],
                                    Recipient.HUDDLE,
                                    'Group personal message!')
 
@@ -158,8 +158,9 @@ class TestMissedMessages(ZulipTestCase):
         tokens = self._get_tokens()
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com",
-                                   ["hamlet@zulip.com", "iago@zulip.com", "cordelia@zulip.com", "prospero@zulip.com"],
+        msg_id = self.send_message(self.example_email('othello'),
+                                   [self.example_email('hamlet'), self.example_email('iago'), \
+                                    self.example_email('cordelia'), self.example_email('prospero')],
                                    Recipient.HUDDLE,
                                    'Group personal message!')
 
@@ -174,11 +175,12 @@ class TestMissedMessages(ZulipTestCase):
         tokens = self._get_tokens()
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com", "denmark", Recipient.STREAM,
+        msg_id = self.send_message(self.example_email('othello'), "denmark", Recipient.STREAM,
                                    '@**hamlet** to be deleted')
 
         hamlet = self.example_user('hamlet')
-        self.login("othello@zulip.com")
+        email = self.example_email('othello')
+        self.login(email)
         result = self.client_patch('/json/messages/' + str(msg_id),
                                    {'message_id': msg_id, 'content': ' '})
         self.assert_json_success(result)
@@ -191,11 +193,12 @@ class TestMissedMessages(ZulipTestCase):
         tokens = self._get_tokens()
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com", Recipient.PERSONAL,
+        msg_id = self.send_message(self.example_email('othello'), self.example_email('hamlet'), Recipient.PERSONAL,
                                    'Extremely personal message! to be deleted!')
 
         hamlet = self.example_user('hamlet')
-        self.login("othello@zulip.com")
+        email = self.example_email('othello')
+        self.login(email)
         result = self.client_patch('/json/messages/' + str(msg_id),
                                    {'message_id': msg_id, 'content': ' '})
         self.assert_json_success(result)
@@ -208,12 +211,13 @@ class TestMissedMessages(ZulipTestCase):
         tokens = self._get_tokens()
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com", ["hamlet@zulip.com", "iago@zulip.com"],
+        msg_id = self.send_message(self.example_email('othello'), [self.example_email('hamlet'), self.example_email('iago')],
                                    Recipient.PERSONAL, 'Group personal message!')
 
         hamlet = self.example_user('hamlet')
         iago = self.example_user('iago')
-        self.login("othello@zulip.com")
+        email = self.example_email('othello')
+        self.login(email)
         result = self.client_patch('/json/messages/' + str(msg_id),
                                    {'message_id': msg_id, 'content': ' '})
         self.assert_json_success(result)

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -40,17 +40,17 @@ class WorkerTest(ZulipTestCase):
             dict(
                 message=u'\xf3test',
                 time=time.time(),
-                rcpt_to='hamlet@zulip.com',
+                rcpt_to=self.example_email('hamlet'),
             ),
             dict(
                 message='\xf3test',
                 time=time.time(),
-                rcpt_to='hamlet@zulip.com',
+                rcpt_to=self.example_email('hamlet'),
             ),
             dict(
                 message='test',
                 time=time.time(),
-                rcpt_to='hamlet@zulip.com',
+                rcpt_to=self.example_email('hamlet'),
             ),
         ]
         for element in data:

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -11,7 +11,8 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_list(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         realm = get_realm('zulip')
         check_add_realm_emoji(realm, "my_emoji", "my_emoji")
         result = self.client_get("/json/realm/emoji")
@@ -22,7 +23,8 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_list_no_author(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         realm = get_realm('zulip')
         RealmEmoji.objects.create(realm=realm, name='my_emojy', file_name='my_emojy')
         result = self.client_get("/json/realm/emoji")
@@ -33,7 +35,8 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_list_admins_only(self):
         # type: () -> None
-        self.login('othello@zulip.com')
+        email = self.example_email('othello')
+        self.login(email)
         realm = get_realm('zulip')
         realm.add_emoji_by_admins_only = True
         realm.save()
@@ -46,7 +49,7 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_upload(self):
         # type: () -> None
-        email = "iago@zulip.com"
+        email = self.example_email('iago')
         self.login(email)
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
@@ -72,7 +75,8 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_upload_exception(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
             result = self.client_put_multipart('/json/realm/emoji/my_em*oji', info=emoji_data)
@@ -80,7 +84,8 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_upload_uppercase_exception(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
             result = self.client_put_multipart('/json/realm/emoji/my_EMoji', info=emoji_data)
@@ -88,7 +93,8 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_upload_admins_only(self):
         # type: () -> None
-        self.login('othello@zulip.com')
+        email = self.example_email('othello')
+        self.login(email)
         realm = get_realm('zulip')
         realm.add_emoji_by_admins_only = True
         realm.save()
@@ -99,7 +105,8 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_delete(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         realm = get_realm('zulip')
         check_add_realm_emoji(realm, "my_emoji", "my_emoji.png")
         result = self.client_delete("/json/realm/emoji/my_emoji")
@@ -112,7 +119,8 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_delete_admins_only(self):
         # type: () -> None
-        self.login('othello@zulip.com')
+        email = self.example_email('othello')
+        self.login(email)
         realm = get_realm('zulip')
         realm.add_emoji_by_admins_only = True
         realm.save()
@@ -122,20 +130,23 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_delete_exception(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         result = self.client_delete("/json/realm/emoji/invalid_emoji")
         self.assert_json_error(result, "Emoji 'invalid_emoji' does not exist")
 
     def test_multiple_upload(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         with get_test_image_file('img.png') as fp1, get_test_image_file('img.png') as fp2:
             result = self.client_put_multipart('/json/realm/emoji/my_emoji', {'f1': fp1, 'f2': fp2})
         self.assert_json_error(result, 'You must upload exactly one file.')
 
     def test_emoji_upload_file_size_error(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         with get_test_image_file('img.png') as fp:
             with self.settings(MAX_EMOJI_FILE_SIZE=0):
                 result = self.client_put_multipart('/json/realm/emoji/my_emoji', {'file': fp})
@@ -143,7 +154,8 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_upload_already_existed_emoji(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
             self.client_put_multipart('/json/realm/emoji/my_emoji', info=emoji_data)

--- a/zerver/tests/test_realm_filters.py
+++ b/zerver/tests/test_realm_filters.py
@@ -11,7 +11,8 @@ class RealmFilterTest(ZulipTestCase):
 
     def test_list(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         realm = get_realm('zulip')
         do_add_realm_filter(
             realm,
@@ -25,7 +26,8 @@ class RealmFilterTest(ZulipTestCase):
 
     def test_create(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         data = {"pattern": "", "url_format_string": "https://realm.com/my_realm_filter/%(id)s"}
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_error(result, 'This field cannot be blank.')
@@ -54,7 +56,8 @@ class RealmFilterTest(ZulipTestCase):
 
     def test_not_realm_admin(self):
         # type: () -> None
-        self.login("hamlet@zulip.com")
+        email = self.example_email('hamlet')
+        self.login(email)
         result = self.client_post("/json/realm/filters")
         self.assert_json_error(result, 'Must be a realm administrator')
         result = self.client_delete("/json/realm/filters/15")
@@ -62,7 +65,8 @@ class RealmFilterTest(ZulipTestCase):
 
     def test_delete(self):
         # type: () -> None
-        self.login("iago@zulip.com")
+        email = self.example_email('iago')
+        self.login(email)
         realm = get_realm('zulip')
         filter_id = do_add_realm_filter(
             realm,

--- a/zerver/tests/test_report.py
+++ b/zerver/tests/test_report.py
@@ -39,7 +39,7 @@ class StatsMock(object):
 class TestReport(ZulipTestCase):
     def test_send_time(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        email = self.example_email('hamlet')
         self.login(email)
 
         params = dict(
@@ -66,7 +66,7 @@ class TestReport(ZulipTestCase):
 
     def test_narrow_time(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        email = self.example_email('hamlet')
         self.login(email)
 
         params = dict(
@@ -89,7 +89,7 @@ class TestReport(ZulipTestCase):
 
     def test_unnarrow_time(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        email = self.example_email('hamlet')
         self.login(email)
 
         params = dict(
@@ -111,7 +111,7 @@ class TestReport(ZulipTestCase):
     @override_settings(BROWSER_ERROR_REPORTING=True)
     def test_report_error(self):
         # type: () -> None
-        email = 'hamlet@zulip.com'
+        email = self.example_email('hamlet')
         self.login(email)
 
         params = fix_params(dict(

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -182,7 +182,7 @@ class TornadoTestCase(WebSocketBaseTestCase):
     @gen_test
     def test_tornado_connect(self):
         # type: () -> Generator[str, Any, None]
-        user_profile = UserProfile.objects.filter(email='hamlet@zulip.com').first()
+        user_profile = self.example_user('hamlet')
         cookies = self._get_cookies(user_profile)
         cookie_header = self.get_cookie_header(cookies)
         ws = yield self.ws_connect('/sockjs/366/v8nw22qe/websocket', cookie_header=cookie_header)
@@ -193,7 +193,7 @@ class TornadoTestCase(WebSocketBaseTestCase):
     @gen_test
     def test_tornado_auth(self):
         # type: () -> Generator[str, TornadoTestCase, None]
-        user_profile = UserProfile.objects.filter(email='hamlet@zulip.com').first()
+        user_profile = self.example_user('hamlet')
         cookies = self._get_cookies(user_profile)
         cookie_header = self.get_cookie_header(cookies)
         ws = yield self.ws_connect('/sockjs/366/v8nw22qe/websocket', cookie_header=cookie_header)
@@ -227,7 +227,7 @@ class TornadoTestCase(WebSocketBaseTestCase):
     @gen_test
     def test_sending_private_message(self):
         # type: () -> Generator[str, Any, None]
-        user_profile = UserProfile.objects.filter(email='hamlet@zulip.com').first()
+        user_profile = self.example_user('hamlet')
         cookies = self._get_cookies(user_profile)
         cookie_header = self.get_cookie_header(cookies)
         queue_events_data = self._get_queue_events_data(user_profile.email)
@@ -243,12 +243,12 @@ class TornadoTestCase(WebSocketBaseTestCase):
                 "type": "private",
                 "subject": "(no topic)",
                 "stream": "",
-                "private_message_recipient": "othello@zulip.com",
+                "private_message_recipient": self.example_email('othello'),
                 "content": "hello",
                 "sender_id": user_profile.id,
                 "queue_id": queue_events_data['response']['queue_id'],
-                "to": ujson.dumps(["othello@zulip.com"]),
-                "reply_to": "hamlet@zulip.com",
+                "to": ujson.dumps([self.example_email('othello')]),
+                "reply_to": self.example_email('hamlet'),
                 "local_id": -1
             }
         }
@@ -262,7 +262,7 @@ class TornadoTestCase(WebSocketBaseTestCase):
     @gen_test
     def test_sending_stream_message(self):
         # type: () -> Generator[str, Any, None]
-        user_profile = UserProfile.objects.filter(email='hamlet@zulip.com').first()
+        user_profile = self.example_user('hamlet')
         cookies = self._get_cookies(user_profile)
         cookie_header = self.get_cookie_header(cookies)
         queue_events_data = self._get_queue_events_data(user_profile.email)
@@ -283,7 +283,7 @@ class TornadoTestCase(WebSocketBaseTestCase):
                 "sender_id": user_profile.id,
                 "queue_id": queue_events_data['response']['queue_id'],
                 "to": ujson.dumps(["Denmark"]),
-                "reply_to": "hamlet@zulip.com",
+                "reply_to": self.example_email('hamlet'),
                 "local_id": -1
             }
         }


### PR DESCRIPTION
Replaced <NAME>@zulip.com references with self.example_email(<NAME>) or self.example_user(<NAME>) where appropriate.