### PR TITLE
templates: Support parametric Markdown macros for webhooks docs.

### DIFF
--- a/templates/zerver/help/include/create-bot-construct-url.md
+++ b/templates/zerver/help/include/create-bot-construct-url.md
@@ -1,5 +1,5 @@
-Next, on your {{ settings_html|safe }}, create a bot for this
-integration. Construct the URL for this bot using the bot API key
-and stream name:
+Next, on your {{ settings_html|safe }}, create a bot for
+{{ integration_display_name }}. Construct the URL for the
+{{ integration_display_name }} bot using the bot API key and stream name:
 
-`{{ external_api_uri_subdomain }}/v1/external/
+{!webhook-url.md!}

--- a/templates/zerver/help/include/create-stream.md
+++ b/templates/zerver/help/include/create-stream.md
@@ -1,3 +1,4 @@
-First, create the stream you'd like to use for notifications from
-this integration, and subscribe all interested parties to this stream.
-We recommend the name
+First, create the stream you'd like to use for
+{{ integration_display_name }} notifications, and subscribe all
+interested parties to this stream. We recommend the
+name `{{ integration_name }}`.

--- a/templates/zerver/help/include/webhook-url.md
+++ b/templates/zerver/help/include/webhook-url.md
@@ -1,0 +1,1 @@
+`{{ external_api_uri_subdomain }}{{ integration_url }}?api_key=abcdefgh&stream={{ integration_name }}`

--- a/tools/lint
+++ b/tools/lint
@@ -584,7 +584,6 @@ def build_custom_checkers(by_lang):
             "docs/migration-renumbering.md",
             "docs/readme-symlink.md",
             "README.md",
-            "zerver/webhooks/appfollow/doc.md",
             "zerver/webhooks/trello/doc.md",
         }
         for fn in by_lang['md']:

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -82,6 +82,13 @@ def render_markdown_path(markdown_file_path, context=None):
     if context is None:
         context = {}
 
+    if markdown_file_path.endswith('doc.md'):
+        integration_dir = markdown_file_path.split('/')[0]
+        integration = context['integrations_dict'][integration_dir]
+        context['integration_name'] = integration.name
+        context['integration_display_name'] = integration.display_name
+        context['integration_url'] = integration.url[3:]
+
     jinja = engines['Jinja2']
     markdown_string = jinja.env.loader.get_source(jinja.env, markdown_file_path)[0]
     html = md_engine.convert(markdown_string)

--- a/zerver/webhooks/airbrake/doc.md
+++ b/zerver/webhooks/airbrake/doc.md
@@ -1,8 +1,8 @@
 Get Zulip notifications for your Airbrake bug tracker!
 
-{!create-stream.md!} `airbrake`.
+{!create-stream.md!}
 
-{!create-bot-construct-url.md!}airbrake?api_key=abcdefgh&stream=airbrake`
+{!create-bot-construct-url.md!}
 
 Now, go to your project's settings on the Airbrake site. Click
 on the `Integration` section. Choose `Webhook`, provide the above URL,

--- a/zerver/webhooks/appfollow/doc.md
+++ b/zerver/webhooks/appfollow/doc.md
@@ -1,11 +1,9 @@
 Receive user reviews from your tracked apps on AppFolllow in Zulip
 using the Zulip AppFollow plugin!
 
-First, create the stream you'd like to use for AppFollow notifications, and
-subscribe all interested parties to this stream. We recommend the
-name `appfollow`.
+{!create-stream.md!}
 
-Next, on your {{ settings_html|safe }}, create an AppFollow bot.
+{!create-bot-construct-url.md!}
 
 Then, log into your account on [appfollow.io](http://appfollow.io), and:
 
@@ -13,9 +11,7 @@ Then, log into your account on [appfollow.io](http://appfollow.io), and:
    Click on **Integrations** and then go to the **Others** tab.
    ![](/static/images/integrations/appfollow/001.png)
 
-2. In the Webhook URL field, enter the following URL, replacing the bot API key
-   and Zulip stream with the appropriate information.
-   `{{ external_api_uri_subdomain }}/v1/external/appfollow?api_key=test_api_key&stream=appfollow`
+2. In the Webhook URL field, enter the URL created above.
 
 3. **Save changes** – all done!
 

--- a/zerver/webhooks/trello/doc.md
+++ b/zerver/webhooks/trello/doc.md
@@ -2,14 +2,9 @@ This webhook integration for Trello is the recommended way to
 integrate with Trello, and should support all the features of
 the [legacy Trello cron-based integration](#trello-plugin).
 
-First, create the stream you'd like to use for Trello notifications,
-and subscribe all interested parties to this stream. We recommend the
-name `trello`.
+{!create-stream.md!}
 
-Your webhook URL is:
-`{{ external_api_uri_subdomain }}/v1/external/trello?api_key=abcdefgh&stream=trello`
-where `api_key` is the API key of your Zulip bot,
-and `stream` is the stream name you want the notifications sent to.
+{!create-bot-construct-url.md!}
 
 Trello doesn't support creating webhooks on their website; you
 have to do it using their API.  So before you create a webhook,


### PR DESCRIPTION
@timabbott: This is what I came up with. I feel like there is a better way to do this. The problem is, the `context` dictionary passed in when a person visits `/integrations` or `/integations#webhook_name` contains an `OrderedDict` that contains key/value pairs for all integrations names and their respective objects, but there is no value in the `context` that points to the current webhook documentation the visitor is viewing. Is there maybe a better and more elegant way? :)