### PR TITLE
Fix flakes in backend tests

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -340,8 +340,10 @@ class GetEventsTest(ZulipTestCase):
         self.assertEqual(events[0]["message"]["display_recipient"], "Denmark")
 
 class EventsRegisterTest(ZulipTestCase):
-    user_profile = get_user_profile_by_email('hamlet@zulip.com')
-    maxDiff = None # type: Optional[int]
+    def setUp(self):
+        super(EventsRegisterTest, self).setUp()
+        self.user_profile = get_user_profile_by_email('hamlet@zulip.com')
+        self.maxDiff = None # type: Optional[int]
 
     def create_bot(self, email):
         # type: (str) -> UserProfile

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -6,6 +6,7 @@ from typing import Any
 import django
 import mock
 from django.test import TestCase
+from django.utils import translation
 from django.conf import settings
 from django.http import HttpResponse
 from six.moves.http_cookies import SimpleCookie
@@ -21,6 +22,10 @@ class TranslationTestCase(ZulipTestCase):
     Tranlations strings should change with locale. URLs should be locale
     aware.
     """
+
+    def tearDown(self):
+        # type: () -> None
+        translation.activate(settings.LANGUAGE_CODE)
 
     # e.g. self.client_post(url) if method is "post"
     def fetch(self, method, url, expected_status, **kwargs):
@@ -74,6 +79,10 @@ class TranslationTestCase(ZulipTestCase):
 
 
 class JsonTranslationTestCase(ZulipTestCase):
+    def tearDown(self):
+        # type: () -> None
+        translation.activate(settings.LANGUAGE_CODE)
+
     @mock.patch('zerver.lib.request._')
     def test_json_error(self, mock_gettext):
         # type: (Any) -> None


### PR DESCRIPTION
Class variables are shared between all instances and as a result changes
made by one instance are leaked to other instances.