### PR TITLE
refactor to get_user in zerver/mgmt/commands/

### DIFF
--- a/zerver/management/commands/add_users_to_streams.py
+++ b/zerver/management/commands/add_users_to_streams.py
@@ -8,7 +8,7 @@ from typing import Any
 from django.core.management.base import BaseCommand, CommandParser
 
 from zerver.lib.actions import create_stream_if_needed, bulk_add_subscriptions
-from zerver.models import UserProfile, get_realm, get_user_profile_by_email
+from zerver.models import UserProfile, get_realm, get_user_for_mgmt
 
 class Command(BaseCommand):
     help = """Add some or all users in a realm to a set of streams."""
@@ -56,7 +56,10 @@ class Command(BaseCommand):
             emails = set([email.strip() for email in options["users"].split(",")])
             user_profiles = []
             for email in emails:
-                user_profiles.append(get_user_profile_by_email(email))
+                try:
+                    user_profiles.append(get_user_for_mgmt(email, realm))
+                except UserProfile.DoesNotExist:
+                    print("e-mail %s doesn't exist in this realm, skipping" % (email,))
 
         for stream_name in set(stream_names):
             for user_profile in user_profiles:

--- a/zerver/management/commands/bankrupt_users.py
+++ b/zerver/management/commands/bankrupt_users.py
@@ -7,21 +7,28 @@ from argparse import ArgumentParser
 from django.core.management.base import BaseCommand
 
 from zerver.lib.actions import do_update_message_flags
-from zerver.models import UserProfile, Message, get_user_profile_by_email
+from zerver.models import UserProfile, Message, get_realm, get_user_for_mgmt
 
 class Command(BaseCommand):
     help = """Bankrupt one or many users."""
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
+        parser.add_argument(
+            '-r', '--realm', nargs='?', default=None,
+            dest='string_id',
+            type=str,
+            help='The name of the realm in which you are bankrupting users.')
+
         parser.add_argument('emails', metavar='<email>', type=str, nargs='+',
-                            help='email address to bankrupt')
+                            help='email address(es) to bankrupt')
 
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
+        realm = get_realm(options["string_id"])
         for email in options['emails']:
             try:
-                user_profile = get_user_profile_by_email(email)
+                user_profile = get_user_for_mgmt(email, realm)
             except UserProfile.DoesNotExist:
                 print("e-mail %s doesn't exist in the system, skipping" % (email,))
                 continue

--- a/zerver/management/commands/bulk_change_user_name.py
+++ b/zerver/management/commands/bulk_change_user_name.py
@@ -7,25 +7,32 @@ from argparse import ArgumentParser
 from django.core.management.base import BaseCommand
 
 from zerver.lib.actions import do_change_full_name
-from zerver.models import UserProfile, get_user_profile_by_email
+from zerver.models import UserProfile, get_realm, get_user_for_mgmt
 
 class Command(BaseCommand):
     help = """Change the names for many users."""
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
+        parser.add_argument(
+            '-r', '--realm', nargs='?', default=None,
+            dest='string_id',
+            type=str,
+            help='The name of the realm in which you are bulk changing user names.')
+
         parser.add_argument('data_file', metavar='<data file>', type=str,
                             help="file containing rows of the form <email>,<desired name>")
 
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
         data_file = options['data_file']
+        realm = get_realm(options["string_id"])
         with open(data_file, "r") as f:
             for line in f:
                 email, new_name = line.strip().split(",", 1)
 
                 try:
-                    user_profile = get_user_profile_by_email(email)
+                    user_profile = get_user_for_mgmt(email, realm)
                     old_name = user_profile.full_name
                     print("%s: %s -> %s" % (email, old_name, new_name))
                     do_change_full_name(user_profile, new_name)

--- a/zerver/management/commands/change_user_email.py
+++ b/zerver/management/commands/change_user_email.py
@@ -8,13 +8,19 @@ from django.core.management.base import BaseCommand
 from typing import Any
 
 from zerver.lib.actions import do_change_user_email
-from zerver.models import UserProfile, get_user_for_mgmt
+from zerver.models import UserProfile, get_user_for_mgmt, get_realm
 
 class Command(BaseCommand):
     help = """Change the email address for a user."""
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
+        parser.add_argument(
+            '-r', '--realm', nargs='?', default=None,
+            dest='string_id',
+            type=str,
+            help='The name of the realm in which you are changing user emails.')
+
         parser.add_argument('old_email', metavar='<old email>', type=str,
                             help='email address to change')
         parser.add_argument('new_email', metavar='<new email>', type=str,
@@ -24,8 +30,9 @@ class Command(BaseCommand):
         # type: (*Any, **str) -> None
         old_email = options['old_email']
         new_email = options['new_email']
+        realm = get_realm(options["string_id"])
         try:
-            user_profile = get_user_for_mgmt(old_email)
+            user_profile = get_user_for_mgmt(old_email, realm)
         except UserProfile.DoesNotExist:
             print("Old e-mail doesn't exist in the system.")
             sys.exit(1)

--- a/zerver/management/commands/deactivate_user.py
+++ b/zerver/management/commands/deactivate_user.py
@@ -10,24 +10,39 @@ from django.core.management.base import BaseCommand
 
 from zerver.lib.actions import do_deactivate_user
 from zerver.lib.sessions import user_sessions
-from zerver.models import get_user_profile_by_email, UserProfile
+from zerver.models import get_realm, get_user_for_mgmt, UserProfile
+
+import sys
 
 class Command(BaseCommand):
     help = "Deactivate a user, including forcibly logging them out."
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
+        parser.add_argument(
+            '-r', '--realm', nargs='?', default=None,
+            dest='string_id',
+            type=str,
+            help='The name of the realm in which you are deactivating a user.')
+
         parser.add_argument('-f', '--for-real',
                             dest='for_real',
                             action='store_true',
                             default=False,
                             help="Actually deactivate the user. Default is a dry run.")
+
         parser.add_argument('email', metavar='<email>', type=str,
                             help='email of user to deactivate')
 
     def handle(self, *args, **options):
         # type: (*Any, **Any) -> None
-        user_profile = get_user_profile_by_email(options['email'])
+        email = options['email']
+        realm = get_realm(options["string_id"])
+        try:
+            user_profile = get_user_for_mgmt(email, realm)
+        except UserProfile.DoesNotExist:
+            print("e-mail %s doesn't exist in the system, skipping" % (email,))
+            sys.exit(1)
 
         print("Deactivating %s (%s) - %s" % (user_profile.full_name,
                                              user_profile.email,

--- a/zerver/management/commands/export_single_user.py
+++ b/zerver/management/commands/export_single_user.py
@@ -12,9 +12,10 @@ import shutil
 import subprocess
 import tempfile
 import ujson
+import sys
 
 from zerver.lib.export import do_export_user
-from zerver.models import UserProfile, get_user_profile_by_email
+from zerver.models import UserProfile, get_realm, get_user_for_mgmt
 
 class Command(BaseCommand):
     help = """Exports message data from a Zulip user
@@ -27,8 +28,15 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
+        parser.add_argument(
+            '-r', '--realm', nargs='?', default=None,
+            dest='string_id',
+            type=str,
+            help='The name of the realm from which you are exporting a single user.')
+
         parser.add_argument('email', metavar='<email>', type=str,
                             help="email of user to export")
+
         parser.add_argument('--output',
                             dest='output_dir',
                             action="store",
@@ -37,10 +45,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # type: (*Any, **Any) -> None
+        email = options['email']
+        realm = get_realm(options["string_id"])
         try:
-            user_profile = get_user_profile_by_email(options["email"])
+            user_profile = get_user_for_mgmt(email, realm)
         except UserProfile.DoesNotExist:
-            raise CommandError("No such user.")
+            print("e-mail %s doesn't exist in the system, skipping" % (email,))
+            sys.exit(1)
 
         output_dir = options["output_dir"]
         if output_dir is None:

--- a/zerver/management/commands/rate_limit.py
+++ b/zerver/management/commands/rate_limit.py
@@ -4,17 +4,24 @@ from __future__ import print_function
 from typing import Any
 
 from argparse import ArgumentParser
-from zerver.models import UserProfile, get_user_profile_by_email
+from zerver.models import UserProfile, get_user_for_mgmt, get_realm
 from zerver.lib.rate_limiter import block_user, unblock_user
 
 from django.core.management.base import BaseCommand
 from optparse import make_option
+
+import sys
 
 class Command(BaseCommand):
     help = """Manually block or unblock a user from accessing the API"""
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
+        parser.add_argument('-r', '--realm',
+                            nargs='?', default=None,
+                            dest='string_id',
+                            type=str,
+                            help='The name of the realm in which you are limiting rate.')
         parser.add_argument('-e', '--email',
                             dest='email',
                             help="Email account of user.")
@@ -35,8 +42,8 @@ class Command(BaseCommand):
                             action='store_true',
                             default=False,
                             help="Whether or not to also block all bots for this user.")
-        parser.add_argument('operation', metavar='<operation>', type=str, choices=['block', 'unblock'],
-                            help="operation to perform (block or unblock)")
+        parser.add_argument('operation', metavar='<operation>', type=str,
+                            choices=['block', 'unblock'], help="operation to perform (block or unblock)")
 
     def handle(self, *args, **options):
         # type: (*Any, **Any) -> None
@@ -45,8 +52,14 @@ class Command(BaseCommand):
             print("Please enter either an email or API key to manage")
             exit(1)
 
-        if options['email']:
-            user_profile = get_user_profile_by_email(options['email'])
+        email = options['email']
+        realm = get_realm(options["string_id"])
+        if email:
+            try:
+                user_profile = get_user_for_mgmt(email, realm)
+            except UserProfile.DoesNotExist:
+                print("Could not find specified user for email %s" % (email,))
+                sys.exit(1)
         else:
             try:
                 user_profile = UserProfile.objects.get(api_key=options['api_key'])


### PR DESCRIPTION
Replaced all instances of get_user_profile_by_email with get_user in zerver/management/commands/ directory.
Passes ./tools/test-all (i.e., passes backend, linter, mypy, etc.)
[>>>DEPRECATED PER ADDITION OF `get_user_for_mgmt` FUNCTION>>>] Only change I'm not confident in is removing a section in turn_off_digests.py -- the prior logic checked for realm and then pulled all user profiles for that realm, now assumes realm is given for all commands so that get_user functions. If this isn't true, may need to go back through all of these changes and add logic for cases where options['string_id'] == None (i.e., realm is not given as part of the options parameter).