### PR TITLE
bots: Fix unit tests not running in Vagrant.

### DIFF
--- a/contrib_bots/bots/define/test_define.py
+++ b/contrib_bots/bots/define/test_define.py
@@ -16,37 +16,25 @@ if os.path.exists(os.path.join(our_dir, '..')):
 from bots_test_lib import BotTestCase
 
 class TestDefineBot(TestCase):
-
-    # Messages to be sent to bot for testing.
-    # Eventually more test messages can be added.
-    def request_messages(self):
-        # type: None -> List[Dict[str, str]]
-        messages = []
-        message1 = {'content': "foo", 'type': "private", 'sender_email': "foo"}
-        message2 = {'content': "cat", 'type': "stream", 'display_recipient': "foo", 'subject': "foo"}
-        messages.append(message1)
-        messages.append(message2)
-        return messages
-
-    # Reply messages from the test bot.
-    # Each reply message corresponding to each request message.
-    def bot_response_messages(self):
-        # type: None -> List[str]
-        messages = []
-        message1 = "**foo**:\nDefinition not available."
-        message2 = ("**cat**:\n\n* (**noun**) a small domesticated carnivorous mammal "
+    def setUp(self):
+        # Messages to be sent to bot for testing.
+        self.request_messages = [
+            {'content': "foo", 'type': "private", 'sender_email': "foo"},
+            {'content': "cat", 'type': "stream", 'display_recipient': "foo", 'subject': "foo"},
+        ]
+        # Reply messages from the test bot.
+        self.bot_response_messages = [
+            "**foo**:\nDefinition not available.",
+            ("**cat**:\n\n* (**noun**) a small domesticated carnivorous mammal "
                     "with soft fur, a short snout, and retractile claws. It is widely "
                     "kept as a pet or for catching mice, and many breeds have been "
-                    "developed.\n&nbsp;&nbsp;their pet cat\n\n")
-        messages.append(message1)
-        messages.append(message2)
-        return messages
+                    "developed.\n&nbsp;&nbsp;their pet cat\n\n"),
+        ]
 
     def runTest(self):
         # type: None -> None
         # Edit bot_module to test different bots, the below code can be looped for all the bots.
         bot_module = os.path.join(our_dir, "define.py")
-        messages = self.request_messages()
-        bot_response = self.bot_response_messages()
         test_case = BotTestCase()
-        test_case.bot_test(messages=messages, bot_module=bot_module, bot_response=bot_response)
+        test_case.bot_test(messages=self.request_messages, bot_module=bot_module,
+            bot_response=self.bot_response_messages)

--- a/contrib_bots/bots/define/test_define.py
+++ b/contrib_bots/bots/define/test_define.py
@@ -42,7 +42,7 @@ class TestDefineBot(TestCase):
         messages.append(message2)
         return messages
 
-    def test_define(self):
+    def runTest(self):
         # type: None -> None
         # Edit bot_module to test different bots, the below code can be looped for all the bots.
         bot_module = os.path.join(our_dir, "define.py")

--- a/contrib_bots/bots_test_lib.py
+++ b/contrib_bots/bots_test_lib.py
@@ -8,14 +8,13 @@ import sys
 import unittest
 
 from mock import MagicMock, patch
-from unittest import TestCase
 
 from run import get_lib_module
 from bot_lib import StateHandler
 from contrib_bots import bot_lib
 from six.moves import zip
 
-class BotTestCase(TestCase):
+class BotTestCase():
 
     def mock_test(self, messages, message_handler, bot_response):
         # type: (List[Dict[str, str]], Function) -> None


### PR DESCRIPTION
`test-bots` would not run in Vagrant, displaying
the error 
> "ValueError: no such test method in <class
'bots_test_lib.BotTestCase'>: runTest"

This was due to
the `BotTestCase` class inheriting from the TestCase
class, even though it was not a unit test on its own.

This commit removes the inheritance of TestCase and
specifies `test_define` as the `runTest` method in
`TestDefineBot`.