### PR TITLE
update-prod-static: Redirect update-authors-json stderr to log file.

### DIFF
--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -104,6 +104,6 @@ if os.environ.get("TRAVIS"):
     authors_cmd.append("--use-fixture")
 if args.authors_not_required:
     authors_cmd.append("--not-required")
-subprocess.check_call(authors_cmd, stdout=fp)
+subprocess.check_call(authors_cmd, stdout=fp, stderr=fp)
 
 fp.close()


### PR DESCRIPTION
(I didn't actually encounter an issue involving update-authors-json stderr output, but it should be consistent with the other commands.)