### PR TITLE
settings_org: Split out separate forms for orgs settings/permissions/auth

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -24,10 +24,14 @@ casper.then(function () {
     casper.click("li[data-section='organization-permissions']");
 });
 
+function submit_permissions_change() {
+    casper.click('form.org-permissions-form button.button');
+}
+
 // Test setting limiting stream creation to administrators
 casper.then(function () {
     casper.click('#id_realm_create_stream_by_admins_only + span');
-    casper.click('form.admin-realm-form button.button');
+    submit_permissions_change();
 });
 
 casper.then(function () {
@@ -58,7 +62,7 @@ casper.waitUntilVisible('#id_realm_create_stream_by_admins_only + span', functio
     // Deactivate setting
 
     casper.click('#id_realm_create_stream_by_admins_only + span');
-    casper.click('form.admin-realm-form button.button');
+    submit_permissions_change();
 });
 
 casper.then(function () {
@@ -236,6 +240,10 @@ casper.then(function () {
     });
 });
 
+function submit_org_settings_change() {
+    casper.click('form.org-settings-form button.button');
+}
+
 casper.then(function () {
     casper.click("li[data-section='organization-settings']");
     casper.waitUntilVisible('#id_realm_default_language', function () {
@@ -243,7 +251,7 @@ casper.then(function () {
         casper.evaluate(function () {
             $('#id_realm_default_language').val('de').change();
         });
-        casper.click('form.admin-realm-form button.button');
+        submit_org_settings_change();
     });
 });
 
@@ -254,12 +262,16 @@ casper.then(function () {
     });
 });
 
+function submit_org_authentication_change() {
+    casper.click('form.org-authentications-form button.button');
+}
+
 // Test authentication methods setting
 casper.then(function () {
     casper.click("li[data-section='auth-methods']");
     casper.waitUntilVisible(".method_row[data-method='Email'] input[type='checkbox'] + span", function () {
         casper.click(".method_row[data-method='Email'] input[type='checkbox'] + span");
-        casper.click('form.admin-realm-form button.button');
+        submit_org_authentication_change();
     });
 });
 
@@ -294,7 +306,7 @@ casper.then(function () {
 // Deactivate setting--default is checked
 casper.then(function () {
     casper.click(".method_row[data-method='Email'] input[type='checkbox'] + span");
-    casper.click('form.admin-realm-form button.button');
+    submit_org_authentication_change();
     casper.waitUntilVisible('#admin-realm-authentication-methods-status', function () {
         casper.test.assertSelectorHasText('#admin-realm-authentication-methods-status', 'Authentication methods saved!');
         casper.test.assertEval(function () {

--- a/frontend_tests/casper_tests/12-toggle-message-editing.js
+++ b/frontend_tests/casper_tests/12-toggle-message-editing.js
@@ -91,7 +91,7 @@ casper.then(function () {
 // deactivate "allow message editing"
 casper.waitUntilVisible('input[type="checkbox"][id="id_realm_allow_message_editing"] + span', function () {
     casper.click('input[type="checkbox"][id="id_realm_allow_message_editing"] + span');
-    casper.click('form.admin-realm-form button.button');
+    casper.click('form.org-permissions-form button.button');
 });
 
 casper.then(function () {
@@ -153,7 +153,7 @@ casper.then(function () {
 });
 casper.waitUntilVisible('input[type="checkbox"][id="id_realm_allow_message_editing"] + span', function () {
     casper.click('input[type="checkbox"][id="id_realm_allow_message_editing"] + span');
-    casper.click('form.admin-realm-form button.button');
+    casper.click('form.org-permissions-form button.button');
     casper.waitUntilVisible('#admin-realm-message-editing-status', function () {
         casper.test.assertSelectorHasText('#admin-realm-message-editing-status', 'Users can now edit topics for all their messages, and the content of messages which are less than 10 minutes old.');
         casper.test.assertEval(function () {
@@ -213,7 +213,7 @@ casper.waitUntilVisible('input[type="checkbox"][id="id_realm_allow_message_editi
         $('input[type="text"][id="id_realm_message_content_edit_limit_minutes"]').val('4');
     });
     casper.click('input[type="checkbox"][id="id_realm_allow_message_editing"] + span');
-    casper.click('form.admin-realm-form button.button');
+    casper.click('form.org-permissions-form button.button');
 });
 
 casper.then(function () {
@@ -232,7 +232,7 @@ casper.then(function () {
     // allow message editing again, and check that the old edit limit is still there
     casper.waitUntilVisible('input[type="checkbox"][id="id_realm_allow_message_editing"] + span', function () {
         casper.click('input[type="checkbox"][id="id_realm_allow_message_editing"] + span');
-        casper.click('form.admin-realm-form button.button');
+        casper.click('form.org-permissions-form button.button');
     });
 });
 
@@ -254,7 +254,7 @@ casper.then(function () {
         casper.evaluate(function () {
             $('input[type="text"][id="id_realm_message_content_edit_limit_minutes"]').val('0');
         });
-        casper.click('form.admin-realm-form button.button');
+        casper.click('form.org-permissions-form button.button');
     });
 });
 
@@ -277,7 +277,7 @@ casper.then(function () {
             $('input[type="text"][id="id_realm_message_content_edit_limit_minutes"]').val('moo');
         });
         casper.click('input[type="checkbox"][id="id_realm_allow_message_editing"] + span');
-        casper.click('form.admin-realm-form button.button');
+        casper.click('form.org-permissions-form button.button');
     });
 });
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -120,6 +120,21 @@ function _set_up() {
 
     // create property_types object
     var property_types = {
+        settings: {
+            name: {
+                type: 'Text',
+                msg: i18n.t("Name changed!"),
+            },
+            description: {
+                type: 'Text',
+                msg: i18n.t("Description changed!"),
+            },
+            default_language: {
+                type: 'Text',
+                msg: i18n.t("Default language changed!"),
+            },
+        },
+        permissions: {
             add_emoji_by_admins_only: {
                 type: 'bool',
                 checked_msg: i18n.t("Only administrators may now add new emoji!"),
@@ -129,14 +144,6 @@ function _set_up() {
                 type: 'bool',
                 checked_msg: i18n.t("Only administrators may now create new streams!"),
                 unchecked_msg: i18n.t("Any user may now create new streams!"),
-            },
-            default_language: {
-                type: 'Text',
-                msg: i18n.t("Default language changed!"),
-            },
-            description: {
-                type: 'Text',
-                msg: i18n.t("Description changed!"),
             },
             email_changes_disabled: {
                 type: 'bool',
@@ -163,10 +170,6 @@ function _set_up() {
                 checked_msg: i18n.t("Previews for linked websites will be shown!"),
                 unchecked_msg: i18n.t("Previews for linked websites will not be shown!"),
             },
-            name: {
-                type: 'Text',
-                msg: i18n.t("Name changed!"),
-            },
             name_changes_disabled: {
                 type: 'bool',
                 checked_msg: i18n.t("Users cannot change their name!"),
@@ -177,7 +180,29 @@ function _set_up() {
                 checked_msg: i18n.t("New user e-mails now restricted to certain domains!"),
                 unchecked_msg: i18n.t("New users may have arbitrary e-mails!"),
             },
-        };
+        },
+    };
+
+    function process_response_data(response_data, setting) {
+        for (var key in response_data) {
+                if (response_data.hasOwnProperty(key)) {
+                    if (key in property_types[setting] && response_data[key] !== undefined) {
+                        if (property_types[setting][key].type === 'bool') {
+                            if (response_data[key]) {
+                                ui_report.success(property_types[setting][key].checked_msg,
+                                    property_type_status_element(key));
+                            } else {
+                                ui_report.success(property_types[setting][key].unchecked_msg,
+                                    property_type_status_element(key));
+                            }
+                        } else if (property_types[setting][key].type === 'Text') {
+                            ui_report.success(property_types[setting][key].msg,
+                               property_type_status_element(key));
+                        }
+                    }
+                }
+            }
+        }
 
     $("#id_realm_invite_required").change(function () {
         if (this.checked) {
@@ -199,35 +224,80 @@ function _set_up() {
         }
     });
 
-    $(".organization").on("submit", "form.admin-realm-form", function (e) {
-        // TODO: We actually have three forms named admin-realm-form.  We really
-        //       should break out three separate forms.
-
-        for (var k1 in property_types) {
-            if (property_types.hasOwnProperty(k1)) {
+    $(".organization").on("submit", "form.org-settings-form", function (e) {
+        for (var k1 in property_types.settings) {
+            if (property_types.settings.hasOwnProperty(k1)) {
                 property_type_status_element(k1).hide();
             }
         }
-
         var name_status = $("#admin-realm-name-status").expectOne();
-        var authentication_methods_status = $("#admin-realm-authentication-methods-status").expectOne();
-        var message_editing_status = $("#admin-realm-message-editing-status").expectOne();
         var waiting_period_threshold_status = $("#admin-realm-waiting-period-threshold-status").expectOne();
         name_status.hide();
-        authentication_methods_status.hide();
-        message_editing_status.hide();
         waiting_period_threshold_status.hide();
 
         e.preventDefault();
         e.stopPropagation();
+
+        var url = "/json/realm";
+        var data = {
+            waiting_period_threshold: JSON.stringify(parseInt($("#id_realm_waiting_period_threshold").val(), 10)),
+        };
+        for (var k2 in property_types.settings) {
+            if (property_types.settings.hasOwnProperty(k2)) {
+                if (property_types.settings[k2].type === 'bool') {
+                    data[k2] = JSON.stringify($('#id_realm_'+k2).prop('checked'));
+                } else if (property_types.settings[k2].type === 'Text') {
+                    data[k2] = JSON.stringify($('#id_realm_'+k2).val().trim());
+                }
+            }
+        }
+
+        channel.patch({
+            url: url,
+            data: data,
+
+            success: function (response_data) {
+                process_response_data(response_data, 'settings');
+                if (response_data.waiting_period_threshold !== undefined) {
+                    if (response_data.waiting_period_threshold >= 0) {
+                        ui_report.success(i18n.t("Waiting period threshold changed!"), waiting_period_threshold_status);
+                    }
+                }
+                // Check if no changes made
+                var no_changes_made = true;
+                for (var key in response_data) {
+                    if (['msg', 'result'].indexOf(key) < 0) {
+                        no_changes_made = false;
+                    }
+                }
+                if (no_changes_made) {
+                    ui_report.success(i18n.t("No changes to save!"), name_status);
+                }
+            },
+            error: function (xhr) {
+                ui_report.error(i18n.t("Failed"), xhr, name_status);
+            },
+        });
+    });
+
+    $(".organization").on("submit", "form.org-permissions-form", function (e) {
+        for (var k1 in property_types.permissions) {
+            if (property_types.permissions.hasOwnProperty(k1)) {
+                property_type_status_element(k1).hide();
+            }
+        }
+        var restricted_to_domain_status = $("#admin-realm-restricted-to-domain-status").expectOne();
+        var message_editing_status = $("#admin-realm-message-editing-status").expectOne();
+        restricted_to_domain_status.hide();
+        message_editing_status.hide();
+
+        e.preventDefault();
+        e.stopPropagation();
+
         var new_allow_message_editing = $("#id_realm_allow_message_editing").prop("checked");
         var new_message_content_edit_limit_minutes = $("#id_realm_message_content_edit_limit_minutes").val();
         var new_message_retention_days = $("#id_realm_message_retention_days").val();
-        var new_waiting_period_threshold = $("#id_realm_waiting_period_threshold").val();
-        var new_auth_methods = {};
-        _.each($("#admin_auth_methods_table").find('tr.method_row'), function (method_row) {
-            new_auth_methods[$(method_row).data('method')] = $(method_row).find('input').prop('checked');
-        });
+
         // If allow_message_editing is unchecked, message_content_edit_limit_minutes
         // is irrelevant.  Hence if allow_message_editing is unchecked, and
         // message_content_edit_limit_minutes is poorly formed, we set the latter to
@@ -247,50 +317,25 @@ function _set_up() {
 
         var url = "/json/realm";
         var data = {
-            authentication_methods: JSON.stringify(new_auth_methods),
             allow_message_editing: JSON.stringify(new_allow_message_editing),
             message_content_edit_limit_seconds:
                 JSON.stringify(parseInt(new_message_content_edit_limit_minutes, 10) * 60),
             message_retention_days: new_message_retention_days !== "" ? JSON.stringify(parseInt(new_message_retention_days, 10)) : null,
-            waiting_period_threshold: JSON.stringify(parseInt(new_waiting_period_threshold, 10)),
         };
-        for (var k2 in property_types) {
-            if (property_types.hasOwnProperty(k2)) {
-                if (property_types[k2].type === 'bool') {
+        for (var k2 in property_types.permissions) {
+            if (property_types.permissions.hasOwnProperty(k2)) {
+                if (property_types.permissions[k2].type === 'bool') {
                     data[k2] = JSON.stringify($('#id_realm_'+k2).prop('checked'));
-                } else if (property_types[k2].type === 'Text') {
+                } else if (property_types.permissions[k2].type === 'Text') {
                     data[k2] = JSON.stringify($('#id_realm_'+k2).val());
                 }
             }
         }
-
         channel.patch({
             url: url,
             data: data,
             success: function (response_data) {
-                for (var k3 in response_data) {
-                    if (response_data.hasOwnProperty(k3)) {
-                        if (k3 in property_types && response_data[k3] !== undefined) {
-                            if (property_types[k3].type === 'bool') {
-                                if (response_data[k3]) {
-                                    ui_report.success(property_types[k3].checked_msg,
-                                        property_type_status_element(k3));
-                                } else {
-                                    ui_report.success(property_types[k3].unchecked_msg,
-                                        property_type_status_element(k3));
-                                }
-                            } else if (property_types[k3].type === 'Text') {
-                                ui_report.success(property_types[k3].msg,
-                                   property_type_status_element(k3));
-                            }
-                        }
-                    }
-                }
-                if (response_data.authentication_methods !== undefined) {
-                    if (response_data.authentication_methods) {
-                        ui_report.success(i18n.t("Authentication methods saved!"), authentication_methods_status);
-                    }
-                }
+                process_response_data(response_data, 'permissions');
                 if (response_data.allow_message_editing !== undefined) {
                     // We expect message_content_edit_limit_seconds was sent in the
                     // response as well
@@ -313,9 +358,47 @@ function _set_up() {
                     // in this function, so update the field just in case
                     $("#id_realm_message_content_edit_limit_minutes").val(data_message_content_edit_limit_minutes);
                 }
-                if (response_data.waiting_period_threshold !== undefined) {
-                    if (response_data.waiting_period_threshold >= 0) {
-                        ui_report.success(i18n.t("Waiting period threshold changed!"), waiting_period_threshold_status);
+                // Check if no changes made
+                var no_changes_made = true;
+                for (var key in response_data) {
+                    if (['msg', 'result'].indexOf(key) < 0) {
+                        no_changes_made = false;
+                    }
+                }
+                if (no_changes_made) {
+                    ui_report.success(i18n.t("No changes to save!"), restricted_to_domain_status);
+                }
+            },
+            error: function (xhr) {
+                ui_report.error(i18n.t("Failed"), xhr, restricted_to_domain_status);
+            },
+        });
+    });
+    $(".organization").on("submit", "form.org-authentications-form", function (e) {
+        var authentication_methods_status = $("#admin-realm-authentication-methods-status").expectOne();
+
+        var new_auth_methods = {};
+        _.each($("#admin_auth_methods_table").find('tr.method_row'), function (method_row) {
+            new_auth_methods[$(method_row).data('method')] = $(method_row).find('input').prop('checked');
+        });
+
+        authentication_methods_status.hide();
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        var url = "/json/realm";
+        var data = {
+            authentication_methods: JSON.stringify(new_auth_methods),
+        };
+
+        channel.patch({
+            url: url,
+            data: data,
+            success: function (response_data) {
+                if (response_data.authentication_methods !== undefined) {
+                    if (response_data.authentication_methods) {
+                        ui_report.success(i18n.t("Authentication methods saved!"), authentication_methods_status);
                     }
                 }
                 // Check if no changes made
@@ -326,16 +409,11 @@ function _set_up() {
                     }
                 }
                 if (no_changes_made) {
-                    ui_report.success(i18n.t("No changes to save!"), name_status);
+                    ui_report.success(i18n.t("No changes to save!"), authentication_methods_status);
                 }
             },
             error: function (xhr) {
-                var reason = $.parseJSON(xhr.responseText).reason;
-                if (reason === "no authentication") {
-                    ui_report.error(i18n.t("Failed"), xhr, authentication_methods_status);
-                } else {
-                    ui_report.error(i18n.t("Failed"), xhr, name_status);
-                }
+                ui_report.error(i18n.t("Failed"), xhr, authentication_methods_status);
             },
         });
     });

--- a/static/templates/settings/auth-methods-settings-admin.handlebars
+++ b/static/templates/settings/auth-methods-settings-admin.handlebars
@@ -1,5 +1,5 @@
 <div id="organization-settings" class="settings-section" data-name="auth-methods">
-    <form class="form-horizontal admin-realm-form">
+    <form class="form-horizontal admin-realm-form org-authentications-form">
         <div class="alert" id="admin-realm-authentication-methods-status"></div>
         <div class="admin-table-wrapper">
             <p>{{#tr this}}Configure the authentication methods for your organization.{{/tr}}</p>

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -1,5 +1,5 @@
 <div id="organization-permissions" data-name="organization-permissions" class="settings-section">
-    <form class="form-horizontal admin-realm-form">
+    <form class="form-horizontal admin-realm-form org-permissions-form">
         <h3 class="light">{{t "Organization permissions" }}</h3>
 
         <div class="alert" id="admin-realm-restricted-to-domain-status"></div>

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -1,5 +1,5 @@
 <div id="organization-settings" data-name="organization-settings" class="settings-section">
-    <form class="form-horizontal admin-realm-form">
+    <form class="form-horizontal admin-realm-form org-settings-form">
         <h3 class="light">{{t "Organization settings" }}</h3>
 
         <div class="alert" id="admin-realm-name-status"></div>


### PR DESCRIPTION
Fix merge conflicts in settings_org.js from PR #4850 and apply the changes to separate out forms for organization settings, permissions and authentication methods. 

Also updates casper tests to fit the new organization settings templates.