### PR TITLE
api-docs: Fix line break in API keys section.

### DIFF
--- a/templates/zerver/api.html
+++ b/templates/zerver/api.html
@@ -193,8 +193,8 @@ Sample steps to do:
     <p>Create a bot:</p>
     <img class="screenshot" src="/static/images/api/create-bot.png" />
 
-    <p>Look for the bot's email and API key:
-    <img class="screenshot" src="/static/images/api/bot-key.png" /></p>
+    <p>Look for the bot's email and API key:</p>
+    <img class="screenshot" src="/static/images/api/bot-key.png" />
 
     <p>If you prefer to send messages as your own user, you can also find your API key on your <a href="/#settings" target="_blank">settings page</a>.</p>
     <p>When using our python bindings, you may either specify the user


### PR DESCRIPTION
See https://zulipchat.com/api/#api_keys. The two images with "Your bots" are not laid out the same way.