### PR TITLE
[WIP: bots] Framework for simplified/reliable bot use/creation

### DIFF
--- a/contrib_bots/bots/generic/generic.py
+++ b/contrib_bots/bots/generic/generic.py
@@ -1,9 +1,12 @@
-class SimpleExtensibleHandler(object):
-    def __init__(self, help_text, just_mentioned=-1):
-        self._commands = {'help':'',
-                       'commands':'',
-               }
-        self._help_text = help_text
+class BotCommandRegistry(object):
+    def __init__(self, about_text, just_mentioned=-1):
+        # Note the values are empty, since they are handled elsewhere
+        self._commands = \
+            {'help'    : ('','output this help text'),
+             'commands': ('','briefly list these supported commands'),
+             'about'   : ('','tells you what this bot is intended to do'),
+            }
+        self._about_text = about_text
         self._just_mentioned = just_mentioned
       
     def usage(self):
@@ -11,31 +14,60 @@ class SimpleExtensibleHandler(object):
             This generic zulip bot is intended to be a simple extensible design
             which relies upon users simply adding in extra elements into a dict.
             '''
-    def add_command(self,cmd,text):
-        if cmd not in self._commands:
-            self._commands[cmd] = text
+    def add_command(self,cmd,text_or_function,explanation):
+        if cmd not in self._commands.keys():
+            self._commands[cmd] = (text_or_function,explanation)
+        else:
+            print("WARNING: %s command already exists, so haven't added it." % cmd)
 
     def handle_message(self, message, client, state_handler):
-        content = message['content'].strip()
+        msg = self._about_text
 
+        content = message['content']
         if len(content) == 0:
-            client.send_reply(message, self._just_mentioned)
-        elif content == 'help':
-            client.send_reply(message, self._help_text)
-        elif content == 'commands':
-            client.send_reply(message, "Commands: "+(" ".join(self._commands.keys())))
-        elif content in self._commands.keys():
-            if not isinstance(self._commands[content],str): 
-                client.send_reply(message, self._commands[content](content))
+            if self._just_mentioned != -1:
+                if not isinstance(self._just_mentioned,str):
+                    msg = self._just_mentioned()
+                else:
+                    msg = self._just_mentioned
             else:
-                client.send_reply(message, self._commands[content]) 
+                content = "help" # Default handling of just mentioning bot
+            
+        command = content.split()[0].strip()
+        args = content.split()[1:]
+
+        if command == 'help':
+            for key,value in self._commands.items(): msg += "  \n"+key+" : "+value[1]
+        elif command == 'about':
+            pass # defaults to about text
+        elif command == 'commands':
+            msg = "Commands: "+(" ".join(self._commands.keys()))
+        elif command in self._commands.keys():
+            if not isinstance(self._commands[command][0],str): 
+                msg = self._commands[command][0](args)
+            else:
+                msg = self._commands[command][0]
+        else:
+            msg = "Sorry, I don't understand that command. Please try one of the following.\n"
+            msg += "Commands: "+(" ".join(self._commands.keys()))
+
+        client.send_reply(message, msg)
 
 import time
-class DemoHandler(SimpleExtensibleHandler):
+class DemoHandler(BotCommandRegistry):
     def __init__(self):
-        SimpleExtensibleHandler.__init__(self, "help text")
-        self.add_command('about','A Generic zulip bot that you can extend using a dictionary')
-        self.add_command('dance','/me dances')
-        self.add_command('time',lambda x: time.time())
+        BotCommandRegistry.__init__(self, \
+          'A Generic zulip bot that you can extend using a dictionary',
+          'Try typing "commands" for the list of commands.'
+#          -1 # Default => just mentioning leads to help text
+          )
+
+        # This will do nothing (help command already exists)
+        self.add_command('help','help','help')
+
+        # Examples of text, function, and function which uses arguments
+        self.add_command('dance','/me dances','makes me dance!')
+        self.add_command('go',lambda x : ("I live here!" if " ".join(x)=="away" else "where?"),"where should I go?")
+        self.add_command('time',lambda x : time.time(),'time since the epoch')
 
 handler_class = DemoHandler

--- a/contrib_bots/bots/generic/generic.py
+++ b/contrib_bots/bots/generic/generic.py
@@ -6,6 +6,7 @@ class BotCommandRegistry(object):
              'commands': ('','briefly list these supported commands'),
              'about'   : ('','tells you what this bot is intended to do'),
             }
+        self._integer_command = None
         self._about_text = about_text
         self._just_mentioned = just_mentioned
       
@@ -14,11 +15,16 @@ class BotCommandRegistry(object):
             This generic zulip bot is intended to be a simple extensible design
             which relies upon users simply adding in extra elements into a dict.
             '''
-    def add_command(self,cmd,text_or_function,explanation):
+
+    def add_command(self, cmd, text_or_function, explanation):
         if cmd not in self._commands.keys():
-            self._commands[cmd] = (text_or_function,explanation)
+            self._commands[cmd] = (text_or_function, explanation)
         else:
             print("WARNING: %s command already exists, so haven't added it." % cmd)
+
+    def add_int_handler(self, text_or_function, explanation):
+        self._integer_command = (text_or_function, explanation)
+        self._commands["<id>"] = ('', explanation)
 
     def handle_message(self, message, client, state_handler):
         msg = self._about_text
@@ -26,7 +32,7 @@ class BotCommandRegistry(object):
         content = message['content']
         if len(content) == 0:
             if self._just_mentioned != -1:
-                if not isinstance(self._just_mentioned,str):
+                if not isinstance(self._just_mentioned, str):
                     msg = self._just_mentioned()
                 else:
                     msg = self._just_mentioned
@@ -37,22 +43,27 @@ class BotCommandRegistry(object):
         command = content.split()[0].strip()
         args = content.split()[1:]
 
-        if command == 'about':
+        if self._integer_command is not None and command.isdigit():
+            msg = self._integer_command[0](command,args)
+        elif command == 'about':
             pass # defaults to about text
         elif command == 'help':
-            for key,value in self._commands.items(): msg += "  \n"+key+" : "+value[1]
+            for key, value in self._commands.items(): msg += "\n* " + key + " : " + value[1]
         elif command == 'commands':
-            msg = "Commands: "+(" ".join(self._commands.keys()))
+            msg = "Commands: " + (" ".join(self._commands.keys()))
+        elif command == '<id>' and self._integer_command is not None:
+            msg = "This command is not intended to be used explicitly, but is a placeholder for a number; please check the help."
         elif command in self._commands.keys():
-            if not isinstance(self._commands[command][0],str): 
+            if not isinstance(self._commands[command][0], str): 
                 msg = self._commands[command][0](args)
             else:
                 msg = self._commands[command][0]
         else:
             msg = "Sorry, I don't understand that command. Please try one of the following.\n"
-            msg += "Commands: "+(" ".join(self._commands.keys()))
+            msg += "Commands: " + (" ".join(self._commands.keys()))
 
         client.send_reply(message, msg)
+
 
 import time
 class DemoHandler(BotCommandRegistry):
@@ -70,5 +81,118 @@ class DemoHandler(BotCommandRegistry):
         self.add_command('dance','/me dances','makes me dance!')
         self.add_command('go',lambda x : ("I live here!" if " ".join(x)=="away" else "where?"),"where should I go?")
         self.add_command('time',lambda x : time.time(),'time since the epoch')
+p
 
-handler_class = DemoHandler
+from random import randint
+
+import logging
+import requests
+
+XKCD_TEMPLATE_URL = 'https://xkcd.com/%s/info.0.json'
+LATEST_XKCD_URL = 'https://xkcd.com/info.0.json'
+
+class XkcdHandler(BotCommandRegistry):
+    '''
+    This plugin provides several commands that can be used for fetch a comic
+    strip from https://xkcd.com. The bot looks for messages starting with
+    "@mention-bot" and responds with a message with the comic based on provided
+    commands.
+    '''
+
+    def __init__(self):
+        BotCommandRegistry.__init__(self, \
+          'This bot provides several commands for fetching a comic strip from https://xkcd.com', # about text
+          'Try typing "commands" for the list of commands.'             # if just mentioned
+          )
+
+        self.add_command('latest', lambda x:get_xkcd_bot_response('latest'),\
+                         'fetch the latest comic strip from xkcd')
+        self.add_command('random', lambda x:get_xkcd_bot_response('random'),\
+                         'fetch a random comic strip from xkcd')
+        self.add_int_handler(lambda x,y:get_xkcd_bot_response(x),\
+                         'fetch a comic strip based on the supplied id')
+
+    def usage(self):
+        return '''
+            This plugin allows users to fetch a comic strip provided by
+            https://xkcd.com. Users should preface the command with "@mention-bot".
+
+            There are several commands to use this bot:
+            - @mention-bot help -> To show all commands the bot supports.
+            - @mention-bot latest -> To fetch the latest comic strip from xkcd.
+            - @mention-bot random -> To fetch a random comic strip from xkcd.
+            - @mention-bot <comic_id> -> To fetch a comic strip based on
+            `<comic_id>`, e.g `@mention-bot 1234`.
+            '''
+
+class XkcdBotCommand(object):
+    LATEST = 0
+    RANDOM = 1
+    COMIC_ID = 2
+
+class XkcdNotFoundError(Exception):
+    pass
+
+class XkcdServerError(Exception):
+    pass
+
+def get_xkcd_bot_response(command): # v2
+    try:
+        if command == 'latest':
+            fetched = fetch_xkcd_query(XkcdBotCommand.LATEST)
+        elif command == 'random':
+            fetched = fetch_xkcd_query(XkcdBotCommand.RANDOM)
+        elif command.isdigit():
+            fetched = fetch_xkcd_query(XkcdBotCommand.COMIC_ID, command)
+        else:
+            logging.exception('Unsupported command')
+            return 'Unsupported command'
+    except (requests.exceptions.ConnectionError, XkcdServerError):
+        logging.exception('Connection error occurred when trying to connect to xkcd server')
+        return 'Sorry, I cannot process your request right now, please try again later!'
+    except XkcdNotFoundError:
+        logging.exception('XKCD server responded 404 when trying to fetch comic with id %s'
+                          % (command))
+        return 'Sorry, there is likely no xkcd comic strip with id: #%s' % (command,)
+    else:
+        return ("#%s: **%s**\n[%s](%s)" % (fetched['num'],
+                                           fetched['title'],
+                                           fetched['alt'],
+                                           fetched['img']))
+
+def fetch_xkcd_query(mode, comic_id=None):
+    try:
+        if mode == XkcdBotCommand.LATEST:  # Fetch the latest comic strip.
+            url = LATEST_XKCD_URL
+
+        elif mode == XkcdBotCommand.RANDOM:  # Fetch a random comic strip.
+            latest = requests.get(LATEST_XKCD_URL)
+
+            if latest.status_code != 200:
+                raise XkcdServerError()
+
+            latest_id = latest.json()['num']
+            random_id = randint(1, latest_id)
+            url = XKCD_TEMPLATE_URL % (str(random_id))
+
+        elif mode == XkcdBotCommand.COMIC_ID:  # Fetch specific comic strip by id number.
+            if comic_id is None:
+                raise Exception('Missing comic_id argument')
+            url = XKCD_TEMPLATE_URL % (comic_id)
+
+        fetched = requests.get(url)
+
+        if fetched.status_code == 404:
+            raise XkcdNotFoundError()
+        elif fetched.status_code != 200:
+            raise XkcdServerError()
+
+        xkcd_json = fetched.json()
+    except requests.exceptions.ConnectionError as e:
+        logging.warning(e)
+        raise
+
+    return xkcd_json
+
+handler_class = XkcdHandler
+#handler_class = DemoHandler

--- a/contrib_bots/bots/generic/generic.py
+++ b/contrib_bots/bots/generic/generic.py
@@ -30,16 +30,17 @@ class BotCommandRegistry(object):
                     msg = self._just_mentioned()
                 else:
                     msg = self._just_mentioned
+                content = "about" # Use pass-through below
             else:
                 content = "help" # Default handling of just mentioning bot
             
         command = content.split()[0].strip()
         args = content.split()[1:]
 
-        if command == 'help':
-            for key,value in self._commands.items(): msg += "  \n"+key+" : "+value[1]
-        elif command == 'about':
+        if command == 'about':
             pass # defaults to about text
+        elif command == 'help':
+            for key,value in self._commands.items(): msg += "  \n"+key+" : "+value[1]
         elif command == 'commands':
             msg = "Commands: "+(" ".join(self._commands.keys()))
         elif command in self._commands.keys():

--- a/contrib_bots/bots/generic/generic.py
+++ b/contrib_bots/bots/generic/generic.py
@@ -1,0 +1,41 @@
+class SimpleExtensibleHandler(object):
+    def __init__(self, help_text, just_mentioned=-1):
+        self._commands = {'help':'',
+                       'commands':'',
+               }
+        self._help_text = help_text
+        self._just_mentioned = just_mentioned
+      
+    def usage(self):
+        return '''
+            This generic zulip bot is intended to be a simple extensible design
+            which relies upon users simply adding in extra elements into a dict.
+            '''
+    def add_command(self,cmd,text):
+        if cmd not in self._commands:
+            self._commands[cmd] = text
+
+    def handle_message(self, message, client, state_handler):
+        content = message['content'].strip()
+
+        if len(content) == 0:
+            client.send_reply(message, self._just_mentioned)
+        elif content == 'help':
+            client.send_reply(message, self._help_text)
+        elif content == 'commands':
+            client.send_reply(message, "Commands: "+(" ".join(self._commands.keys())))
+        elif content in self._commands.keys():
+            if not isinstance(self._commands[content],str): 
+                client.send_reply(message, self._commands[content](content))
+            else:
+                client.send_reply(message, self._commands[content]) 
+
+import time
+class DemoHandler(SimpleExtensibleHandler):
+    def __init__(self):
+        SimpleExtensibleHandler.__init__(self, "help text")
+        self.add_command('about','A Generic zulip bot that you can extend using a dictionary')
+        self.add_command('dance','/me dances')
+        self.add_command('time',lambda x: time.time())
+
+handler_class = DemoHandler


### PR DESCRIPTION
Rather than explicitly writing a handle_message function and handling each command, this framework involves registering commands and their associated text/function, which are then returned upon being used by someone interacting with it. It's very similar in style to libraries which parse command line arguments, perhaps like getopt or later versions?

There are two demos, one simple and showing basic features, another a port of the xkcd bot (which required adding handling an 'int' as a 'command') - which one is run involves specifying the handler at the end of the file.

At this point I'm mainly seeking feedback; I'm sure it doesn't really belong as a separate bot, but I'm not sure if it is appropriate to be in the core bot code?