### PR TITLE
katex: Fix line height of inline math.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2057,8 +2057,12 @@ div.floating_recipient {
 }
 
 .katex-html {
-    line-height: 3em;
+    line-height: initial;
     white-space: initial;
+}
+
+.katex-display .katex-html {
+    line-height: 3em;
 }
 
 .katex-display {


### PR DESCRIPTION
24cbd6113 changed the line height of katex HTML to avoid overlapping
lines in wrapped math displays. But the change also applied to inline
math, resulting in large vertical gaps in a multi-line paragraph
containing inline math elements.