### PR TITLE
Correctly associate bot name field label

### DIFF
--- a/templates/zerver/settings_sidebar.html
+++ b/templates/zerver/settings_sidebar.html
@@ -15,7 +15,7 @@
                 <div class="edit-bot-form-box">
                     <div class="">
                         <label for="edit_bot_name">{{ _("Full name") }}</label>
-                        <input type="text" name="bot_name" class="edit_bot_name required" maxlength=50 />
+                        <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" maxlength=50 />
                         <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
                     </div>
                     <div class="edit-bot-owner">


### PR DESCRIPTION
The label element for the bot name editing field was trying to use
a "for" attribute to link it to the input field, but the field had
no ID for it to associate with.  Added the ID value which it
was trying to use.

Fixes #4999.