### PR TITLE
katek: Make tex errors gray.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2066,7 +2066,7 @@ div.floating_recipient {
 }
 
 .tex-error {
-    color: red;
+    color: gray;
 }
 
 .hotkeys_table {


### PR DESCRIPTION
Red is too visually loud for a medium where tex errors are not fatal
(readers will be still able to understand the tex source).