### PR TITLE
Fix registration email field label association

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -51,7 +51,7 @@ $(function () {
 
                                 <div class="input-box no-validate">
                                     <input type="email" id="email" class="email" name="email" value="" required />
-                                    <label>Email</label>
+                                    <label for="email">Email</label>
                                     <div class="required"></div>
                                     <img class="valid" src="/static/images/checkbox-valid.svg" />
                                 </div>


### PR DESCRIPTION
The label element for the registration form's email field was
missing a "for" attribute to link it to the input field.  Added
the missing attribute.

Fixes #4896.