### PR TITLE
Provide alt text for validation check mark

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -53,7 +53,7 @@ $(function () {
                                     <input type="email" id="email" class="email" name="email" value="" required />
                                     <label for="email">Email</label>
                                     <div class="required"></div>
-                                    <img class="valid" src="/static/images/checkbox-valid.svg" />
+                                    <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
                                 </div>
 
                                 <button class="full-width" type="submit" name="">{{ _('Sign up') }}</button>

--- a/templates/zerver/create_realm.html
+++ b/templates/zerver/create_realm.html
@@ -27,7 +27,7 @@ $(function () {
                                id="email" name="email" required />
                         <label for="id_username">{{ _('Email') }}</label>
                         <div class="required"></div>
-                        <img class="valid" src="/static/images/checkbox-valid.svg" />
+                        <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
                     </div>
 
                     <button type="submit" class="new-organization-button register-button">{{ _("Create organization") }}</button>

--- a/templates/zerver/find_my_team.html
+++ b/templates/zerver/find_my_team.html
@@ -45,7 +45,7 @@
                             <input type="text" autofocus id="emails" name="emails" required />
                             <label for="id_username">{{ _('Email addresses') }}</label>
                             <div class="required"></div>
-                            <img class="valid" src="/static/images/checkbox-valid.svg" />
+                            <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
                         </div>
                         <button type="submit">{{ _('Find team') }}</button>
                     </div>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -97,14 +97,14 @@ autofocus('#id_username');
                             maxlength="72" required />
                         <label for="id_username">{{ _('Email') }}</label>
                         <div class="required"></div>
-                        <img class="valid" src="/static/images/checkbox-valid.svg" />
+                        <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
                     </div>
 
                     <div class="input-box no-validation">
                         <input id="id_password" name="password" class="required" type="password" required />
                         <label for="id_password" class="control-label">{{ _('Password') }}</label>
                         <div class="required"></div>
-                        <img class="valid" src="/static/images/checkbox-valid.svg" />
+                        <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
                     </div>
 
                     {% if form.errors %}

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -32,7 +32,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
             <input id="id_email" type='text' disabled="true" placeholder="{{ email }}" required />
             <label for="id_email" class="inline-block label-title">{{ _('Email') }}</label>
             <div class="required"></div>
-            <img class="valid" src="/static/images/checkbox-valid.svg" />
+            <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
         </div>
 
         <div class="input-box">
@@ -50,7 +50,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
             {% endif %}
             <label for="id_full_name" class="inline-block label-title">{{ _('Full name') }}</label>
             <div class="required"></div>
-            <img class="valid" src="/static/images/checkbox-valid.svg" />
+            <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
         </div>
 
         <div class="input-box full-width">
@@ -68,7 +68,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                    data-min-quality="{{password_min_quality}}" required />
             <label for="id_password" class="inline-block">{{ _('Password') }}</label>
             <div class="required"></div>
-            <img class="valid" src="/static/images/checkbox-valid.svg" />
+            <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
             {% if full_name %}
             <span class="help-inline">
               {{ _('This is used for mobile applications and other tools that require a password.') }}
@@ -99,7 +99,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                         {% endfor %}
                     {% endif %}
                 <div class="required"></div>
-                <img class="valid" src="/static/images/checkbox-valid.svg" />
+                <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
             </div>
             <label for="id_team_name" class="inline-block label-title">{{ _('Organization name') }}</label>
 
@@ -123,7 +123,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                         value="{% if form.realm_subdomain.value() %}{{ form.realm_subdomain.value() }}{% endif %}"
                         name="realm_subdomain" maxlength={{ MAX_REALM_SUBDOMAIN_LENGTH }} required />
                     <div class="required"></div>
-                    <img class="valid" src="/static/images/checkbox-valid.svg" />
+                    <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
                 </div>
                 {% if realms_have_subdomains %}
                 <div class="inline-block external-host"> .{{ external_host }}</div>

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -24,7 +24,7 @@
                                    maxlength="100" required />
                             <label for="id_email" class="">{{ _('Email') }}</label>
                             <div class="required"></div>
-                            <img class="valid" src="/static/images/checkbox-valid.svg" />
+                            <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
                             {% if form.email.errors %}
                                 {% for error in form.email.errors %}
                                 <div class="alert alert-error">{{ error }}</div>

--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -34,7 +34,7 @@
                            maxlength="100"
                            data-min-length="{{password_min_length}}"
                            data-min-quality="{{password_min_quality}}" required />
-                    <img class="valid" src="/static/images/checkbox-valid.svg" />
+                    <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
                     {% if form.new_password1.errors %}
                         {% for error in form.new_password1.errors %}
                         <div class="alert alert-error">{{ error }}</div>
@@ -53,7 +53,7 @@
                     <input id="id_new_password2" class="required" type="password" name="new_password2"
                            value="{% if form.new_password2.value() %}{{ form.new_password2.value() }}{% endif %}"
                            maxlength="100" required />
-                    <img class="valid" src="/static/images/checkbox-valid.svg" />
+                    <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
                     {% if form.new_password2.errors %}
                         {% for error in form.new_password2.errors %}
                         <div class="alert alert-error">{{ error }}</div>


### PR DESCRIPTION
The check mark which appears for valid input in assorted forms
(such as login and registration) didn't have alternative text
for better accessibility.  Added "Valid" as the alt text in all
places it's used.

Fixes #4876.