### PR TITLE
Make the realm icon an img element

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -492,8 +492,6 @@ html {
 
     width: 100px;
     height: 100px;
-
-    background-size: 100% auto;
 }
 
 .split-view .org-header .info-box {

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -21,7 +21,7 @@ $(function () {
                 {% if realm_name %}
                 <div class="left-side">
                     <div class="org-header">
-                        <div class="avatar" style="background-image: url('{{ realm_icon }}')"></div>
+                        <img class="avatar" src="{{ realm_icon }}" alt="" />
                         <div class="info-box">
                             <div class="organization-name">{{ realm_name }}</div>
                             <div class="organization-path">{{ realm_uri }}</div>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -60,7 +60,7 @@ autofocus('#id_username');
             {% if realm_name %}
             <div class="left-side">
                 <div class="org-header">
-                    <div class="avatar" style="background-image: url('{{ realm_icon }}')"></div>
+                    <img class="avatar" src="{{ realm_icon }}" alt="" />
                     <div class="info-box">
                         <div class="organization-name">{{ realm_name }}</div>
                         <div class="organization-path">{{ realm_uri }}</div>


### PR DESCRIPTION
The realm avatar icon on the login and registration pages was
being set as a background image, which could vanish in high
contrast mode in many browsers.  Converted it to an img tag and
verified that it is still styled correctly.  I think the empty
alt attribute (to remove it from the audio description) is
appropriate in this context, since the realm name and description
are already provided immediately afterwards in the page content.

Fixes #4889.