### PR TITLE
bots: Remove githook-post-receive link.

### DIFF
--- a/bots/githook-post-receive
+++ b/bots/githook-post-receive
@@ -1,1 +1,0 @@
-../api/integrations/git/post-receive


### PR DESCRIPTION
Based on commits cdedb8593 and 58a8934a8 it seems to be unused.