### PR TITLE
frontend changes for making a bot an incoming webhook 

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -112,11 +112,13 @@ exports.set_up = function () {
             $('#bot_table_error').hide();
         },
         submitHandler: function () {
+            var bot_type = $('#create_bot_type :selected').val();
             var full_name = $('#create_bot_name').val();
             var short_name = $('#create_bot_short_name').val() || $('#create_bot_short_name').text();
             var formData = new FormData();
 
             formData.append('csrfmiddlewaretoken', csrf_token);
+            formData.append('bot_type', bot_type);
             formData.append('full_name', full_name);
             formData.append('short_name', short_name);
             jQuery.each($('#bot_avatar_file_input')[0].files, function (i, file) {

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -25,6 +25,13 @@
                 <h4 class="new-bot-section-title light no-margin">{{t "Add a new bot" }}</h4>
                 <div class="new-bot-form">
                     <div class="input-group">
+                        <label for="bot_type">{{t "Bot type" }}</label>
+                        <select name="bot_type" id="create_bot_type">
+                            <option value="1">{{t "Custom bot" }}</option>
+                            <option value="2">{{t "Incoming webhook bot" }}</option>
+                        </select>
+                    </div>
+                    <div class="input-group">
                         <label for="create_bot_name">{{t "Full name" }}</label>
                         <input type="text" name="bot_name" id="create_bot_name" class="required"
                                maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -474,6 +474,32 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         result = self.client_post('/json/bots/nonexistentuser@zulip.com/api_key/regenerate')
         self.assert_json_error(result, 'No such user')
 
+    def test_add_bot_with_bot_type_default(self):
+        # type: () -> None
+        bot_email = 'hambot-bot@zulip.testserver'
+        bot_realm = get_realm('zulip')
+
+        self.login(self.example_email('hamlet'))
+        self.assert_num_bots_equal(0)
+        self.create_bot(bot_type=UserProfile.DEFAULT_BOT)
+        self.assert_num_bots_equal(1)
+
+        profile = get_user(bot_email, bot_realm)
+        self.assertEqual(profile.bot_type, UserProfile.DEFAULT_BOT)
+
+    def test_add_bot_with_bot_type_incoming_webhook(self):
+        # type: () -> None
+        bot_email = 'hambot-bot@zulip.testserver'
+        bot_realm = get_realm('zulip')
+
+        self.login(self.example_email('hamlet'))
+        self.assert_num_bots_equal(0)
+        self.create_bot(bot_type=UserProfile.INCOMING_WEBHOOK_BOT)
+        self.assert_num_bots_equal(1)
+
+        profile = get_user(bot_email, bot_realm)
+        self.assertEqual(profile.bot_type, UserProfile.INCOMING_WEBHOOK_BOT)
+
     def test_patch_bot_full_name(self):
         # type: () -> None
         self.login(self.example_email('hamlet'))

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -22,7 +22,7 @@ from zerver.lib.avatar import avatar_url, get_avatar_url
 from zerver.lib.response import json_error, json_success
 from zerver.lib.streams import access_stream_by_name
 from zerver.lib.upload import upload_avatar_image
-from zerver.lib.validator import check_bool, check_string
+from zerver.lib.validator import check_bool, check_string, check_int
 from zerver.lib.users import check_change_full_name, check_full_name
 from zerver.lib.utils import generate_random_token
 from zerver.models import UserProfile, Stream, Realm, Message, get_user_profile_by_email, \
@@ -230,11 +230,11 @@ def regenerate_bot_api_key(request, user_profile, email):
     return json_success(json_result)
 
 @has_request_variables
-def add_bot_backend(request, user_profile, full_name_raw=REQ("full_name"), short_name=REQ(),
+def add_bot_backend(request, user_profile, bot_type=REQ(validator=check_int, default=1), full_name_raw=REQ("full_name"), short_name=REQ(),
                     default_sending_stream_name=REQ('default_sending_stream', default=None),
                     default_events_register_stream_name=REQ('default_events_register_stream', default=None),
                     default_all_public_streams=REQ(validator=check_bool, default=None)):
-    # type: (HttpRequest, UserProfile, Text, Text, Optional[Text], Optional[Text], Optional[bool]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, int, Text, Text, Optional[Text], Optional[Text], Optional[bool]) -> HttpResponse
     short_name += "-bot"
     full_name = check_full_name(full_name_raw)
     email = '%s@%s' % (short_name, user_profile.realm.get_bot_domain())
@@ -269,7 +269,7 @@ def add_bot_backend(request, user_profile, full_name_raw=REQ("full_name"), short
     bot_profile = do_create_user(email=email, password='',
                                  realm=user_profile.realm, full_name=full_name,
                                  short_name=short_name, active=True,
-                                 bot_type=UserProfile.DEFAULT_BOT,
+                                 bot_type=bot_type,
                                  bot_owner=user_profile,
                                  avatar_source=avatar_source,
                                  default_sending_stream=default_sending_stream,


### PR DESCRIPTION
Add 'Type of bot' option for bots by adding dropdown in
settings->"Your bots". This dropdown has 2 options: 'Custom Bot'
and 'Incoming Webhook Bot'.
This will enable users to create and add a bot as an incoming webhook
(in addition to create/add full-featured bots).