### PR TITLE
frontend: Add a new tab for "Add a new bot" in '#settings/your-bots'.

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -46,10 +46,16 @@ function render_bots() {
         });
     });
 
-    if ($("#bots_lists_navbar .active-bots-tab").hasClass("active")) {
+    if ($("#bots_lists_navbar .add-a-new-bot-tab").hasClass("active")) {
+        $("#add-a-new-bot-form").show();
+        $("#active_bots_list").hide();
+        $("#inactive_bots_list").hide();
+    } else if ($("#bots_lists_navbar .active-bots-tab").hasClass("active")) {
+        $("#add-a-new-bot-form").hide();
         $("#active_bots_list").show();
         $("#inactive_bots_list").hide();
     } else {
+        $("#add-a-new-bot-form").hide();
         $("#active_bots_list").hide();
         $("#inactive_bots_list").show();
     }
@@ -331,12 +337,26 @@ exports.set_up = function () {
         ));
     });
 
+    $("#bots_lists_navbar .add-a-new-bot-tab").click(function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        $("#bots_lists_navbar .add-a-new-bot-tab").addClass("active");
+        $("#bots_lists_navbar .active-bots-tab").removeClass("active");
+        $("#bots_lists_navbar .inactive-bots-tab").removeClass("active");
+        $("#add-a-new-bot-form").show();
+        $("#active_bots_list").hide();
+        $("#inactive_bots_list").hide();
+    });
+
     $("#bots_lists_navbar .active-bots-tab").click(function (e) {
         e.preventDefault();
         e.stopPropagation();
 
+        $("#bots_lists_navbar .add-a-new-bot-tab").removeClass("active");
         $("#bots_lists_navbar .active-bots-tab").addClass("active");
         $("#bots_lists_navbar .inactive-bots-tab").removeClass("active");
+        $("#add-a-new-bot-form").hide();
         $("#active_bots_list").show();
         $("#inactive_bots_list").hide();
     });
@@ -345,8 +365,10 @@ exports.set_up = function () {
         e.preventDefault();
         e.stopPropagation();
 
+        $("#bots_lists_navbar .add-a-new-bot-tab").removeClass("active");
         $("#bots_lists_navbar .active-bots-tab").removeClass("active");
         $("#bots_lists_navbar .inactive-bots-tab").addClass("active");
+        $("#add-a-new-bot-form").hide();
         $("#active_bots_list").hide();
         $("#inactive_bots_list").show();
     });

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -29,58 +29,56 @@
         <div id="bot_table_error" class="alert alert-error hide"></div>
 
         <div id="add-a-new-bot-form">
-            <div class="add-new-bot-box grey-bg">
-                <form id="create_bot_form" class="form-horizontal no-padding">
-                    <h4 class="new-bot-section-title light no-margin">{{t "Add a new bot" }}</h4>
-                    <div class="new-bot-form">
-                        <div class="input-group">
-                            <label for="bot_type">
-                                {{t "Bot type" }}
-                                <i class="icon-vector-question-sign bot_type_tooltip" data-toggle="tooltip"
-                                 title='{{t "Incoming webhooks can only send messages." }}'></i>
-                            </label>
-                            <select name="bot_type" id="create_bot_type">
-                                <option value="1">{{t "Generic bot" }}</option>
-                                <option value="2">{{t "Incoming webhook" }}</option>
-                                <option value="3">{{t "Outgoing webhook" }}</option>
-                            </select>
-                        </div>
-                        <div class="input-group">
-                            <label for="create_bot_name">{{t "Full name" }}</label>
-                            <input type="text" name="bot_name" id="create_bot_name" class="required"
-                                   maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />
-                            <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
-                        </div>
-                        <div class="input-group">
-                            <label for="bot_short_name">{{t "Username" }}</label>
-                            <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part"
-                                   placeholder="cookie" value="" />
-                            -bot@{{ page_params.realm_bot_domain }}
-                            <div>
-                                <label for="create_bot_short_name" generated="true" class="text-error"></label>
-                            </div>
-                        </div>
-                        <div class="input-group" id="payload_url_inputbox">
-                            <label for="create_payload_url">{{t "Outgoing webhook service base URL" }}</label>
-                            <input type="text" name="payload_url" id="create_payload_url"
-                                maxlength=100 placeholder="https://hostname.example.com/bots/followup" value="" />
-                            <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
-                        </div>
-                        <div class="input-group">
-                            <div id="bot_avatar_file"></div>
-                            <input type="file" name="bot_avatar_file_input" class="notvisible" id="bot_avatar_file_input" value="{{t 'Upload avatar' }}" />
-                            <button class="button white rounded small btn-danger display-none" id="bot_avatar_clear_button">{{t "Clear avatar" }}</button>
-                            <button class="button white rounded" id="bot_avatar_upload_button">{{t "Customize avatar" }}</button> ({{t "Optional" }})
-                        </div>
-                        <p>
-                            <div id="bot_avatar_file_input_error" class="text-error"></div>
-                        </p>
-                        <button type="submit" class="button white rounded sea-green" id="create_bot_button">
-                            {{t 'Create bot' }}
-                        </button>
+            <form id="create_bot_form" class="form-horizontal no-padding">
+                <h4 class="new-bot-section-title light no-margin">{{t "Add a new bot" }}</h4>
+                <div class="new-bot-form">
+                    <div class="input-group">
+                        <label for="bot_type">
+                            {{t "Bot type" }}
+                            <i class="icon-vector-question-sign bot_type_tooltip" data-toggle="tooltip"
+                             title='{{t "Incoming webhooks can only send messages." }}'></i>
+                        </label>
+                        <select name="bot_type" id="create_bot_type">
+                            <option value="1">{{t "Generic bot" }}</option>
+                            <option value="2">{{t "Incoming webhook" }}</option>
+                            <option value="3">{{t "Outgoing webhook" }}</option>
+                        </select>
                     </div>
-                </form>
-            </div>
+                    <div class="input-group">
+                        <label for="create_bot_name">{{t "Full name" }}</label>
+                        <input type="text" name="bot_name" id="create_bot_name" class="required"
+                               maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />
+                        <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
+                    </div>
+                    <div class="input-group">
+                        <label for="bot_short_name">{{t "Username" }}</label>
+                        <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part"
+                               placeholder="cookie" value="" />
+                        -bot@{{ page_params.realm_bot_domain }}
+                        <div>
+                            <label for="create_bot_short_name" generated="true" class="text-error"></label>
+                        </div>
+                    </div>
+                    <div class="input-group" id="payload_url_inputbox">
+                        <label for="create_payload_url">{{t "Outgoing webhook service base URL" }}</label>
+                        <input type="text" name="payload_url" id="create_payload_url"
+                            maxlength=100 placeholder="https://hostname.example.com/bots/followup" value="" />
+                        <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
+                    </div>
+                    <div class="input-group">
+                        <div id="bot_avatar_file"></div>
+                        <input type="file" name="bot_avatar_file_input" class="notvisible" id="bot_avatar_file_input" value="{{t 'Upload avatar' }}" />
+                        <button class="button white rounded small btn-danger display-none" id="bot_avatar_clear_button">{{t "Clear avatar" }}</button>
+                        <button class="button white rounded" id="bot_avatar_upload_button">{{t "Customize avatar" }}</button> ({{t "Optional" }})
+                    </div>
+                    <p>
+                        <div id="bot_avatar_file_input_error" class="text-error"></div>
+                    </p>
+                    <button type="submit" class="button white rounded sea-green" id="create_bot_button">
+                        {{t 'Create bot' }}
+                    </button>
+                </div>
+            </form>
         </div>
 
     </div>

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -15,7 +15,8 @@
         </div>
 
         <ul class="nav nav-tabs nav-justified" id="bots_lists_navbar">
-            <li class="active active-bots-tab"><a>{{t "Active bots" }}</a></li>
+            <li class="active add-a-new-bot-tab"><a>{{t "Add a new bot" }}</a></li>
+            <li class="active-bots-tab"><a>{{t "Active bots" }}</a></li>
             <li class="inactive-bots-tab"><a>{{t "Inactive bots" }}</a></li>
         </ul>
 
@@ -27,57 +28,59 @@
 
         <div id="bot_table_error" class="alert alert-error hide"></div>
 
-        <div class="add-new-bot-box grey-bg">
-            <form id="create_bot_form" class="form-horizontal no-padding">
-                <h4 class="new-bot-section-title light no-margin">{{t "Add a new bot" }}</h4>
-                <div class="new-bot-form">
-                    <div class="input-group">
-                        <label for="bot_type">
-                            {{t "Bot type" }}
-                            <i class="icon-vector-question-sign bot_type_tooltip" data-toggle="tooltip"
-                             title='{{t "Incoming webhooks can only send messages." }}'></i>
-                        </label>
-                        <select name="bot_type" id="create_bot_type">
-                            <option value="1">{{t "Generic bot" }}</option>
-                            <option value="2">{{t "Incoming webhook" }}</option>
-                            <option value="3">{{t "Outgoing webhook" }}</option>
-                        </select>
-                    </div>
-                    <div class="input-group">
-                        <label for="create_bot_name">{{t "Full name" }}</label>
-                        <input type="text" name="bot_name" id="create_bot_name" class="required"
-                               maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />
-                        <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
-                    </div>
-                    <div class="input-group">
-                        <label for="bot_short_name">{{t "Username" }}</label>
-                        <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part"
-                               placeholder="cookie" value="" />
-                        -bot@{{ page_params.realm_bot_domain }}
-                        <div>
-                            <label for="create_bot_short_name" generated="true" class="text-error"></label>
+        <div id="add-a-new-bot-form">
+            <div class="add-new-bot-box grey-bg">
+                <form id="create_bot_form" class="form-horizontal no-padding">
+                    <h4 class="new-bot-section-title light no-margin">{{t "Add a new bot" }}</h4>
+                    <div class="new-bot-form">
+                        <div class="input-group">
+                            <label for="bot_type">
+                                {{t "Bot type" }}
+                                <i class="icon-vector-question-sign bot_type_tooltip" data-toggle="tooltip"
+                                 title='{{t "Incoming webhooks can only send messages." }}'></i>
+                            </label>
+                            <select name="bot_type" id="create_bot_type">
+                                <option value="1">{{t "Generic bot" }}</option>
+                                <option value="2">{{t "Incoming webhook" }}</option>
+                                <option value="3">{{t "Outgoing webhook" }}</option>
+                            </select>
                         </div>
+                        <div class="input-group">
+                            <label for="create_bot_name">{{t "Full name" }}</label>
+                            <input type="text" name="bot_name" id="create_bot_name" class="required"
+                                   maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />
+                            <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
+                        </div>
+                        <div class="input-group">
+                            <label for="bot_short_name">{{t "Username" }}</label>
+                            <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part"
+                                   placeholder="cookie" value="" />
+                            -bot@{{ page_params.realm_bot_domain }}
+                            <div>
+                                <label for="create_bot_short_name" generated="true" class="text-error"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="payload_url_inputbox">
+                            <label for="create_payload_url">{{t "Outgoing webhook service base URL" }}</label>
+                            <input type="text" name="payload_url" id="create_payload_url"
+                                maxlength=100 placeholder="https://hostname.example.com/bots/followup" value="" />
+                            <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
+                        </div>
+                        <div class="input-group">
+                            <div id="bot_avatar_file"></div>
+                            <input type="file" name="bot_avatar_file_input" class="notvisible" id="bot_avatar_file_input" value="{{t 'Upload avatar' }}" />
+                            <button class="button white rounded small btn-danger display-none" id="bot_avatar_clear_button">{{t "Clear avatar" }}</button>
+                            <button class="button white rounded" id="bot_avatar_upload_button">{{t "Customize avatar" }}</button> ({{t "Optional" }})
+                        </div>
+                        <p>
+                            <div id="bot_avatar_file_input_error" class="text-error"></div>
+                        </p>
+                        <button type="submit" class="button white rounded sea-green" id="create_bot_button">
+                            {{t 'Create bot' }}
+                        </button>
                     </div>
-                    <div class="input-group" id="payload_url_inputbox">
-                        <label for="create_payload_url">{{t "Outgoing webhook service base URL" }}</label>
-                        <input type="text" name="payload_url" id="create_payload_url"
-                            maxlength=100 placeholder="https://hostname.example.com/bots/followup" value="" />
-                        <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
-                    </div>
-                    <div class="input-group">
-                        <div id="bot_avatar_file"></div>
-                        <input type="file" name="bot_avatar_file_input" class="notvisible" id="bot_avatar_file_input" value="{{t 'Upload avatar' }}" />
-                        <button class="button rounded small btn-danger display-none" id="bot_avatar_clear_button">{{t "Clear avatar" }}</button>
-                        <button class="button rounded" id="bot_avatar_upload_button">{{t "Customize avatar" }}</button> ({{t "Optional" }})
-                    </div>
-                    <p>
-                        <div id="bot_avatar_file_input_error" class="text-error"></div>
-                    </p>
-                    <button type="submit" class="button rounded sea-green" id="create_bot_button">
-                        {{t 'Create bot' }}
-                    </button>
-                </div>
-            </form>
+                </form>
+            </div>
         </div>
 
     </div>

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -30,7 +30,6 @@
 
         <div id="add-a-new-bot-form">
             <form id="create_bot_form" class="form-horizontal no-padding">
-                <h4 class="new-bot-section-title light no-margin">{{t "Add a new bot" }}</h4>
                 <div class="new-bot-form">
                     <div class="input-group">
                         <label for="bot_type">


### PR DESCRIPTION
"Add a new bot" UI used to be common in "Active bots" and
"Inactive bots". "Add a new bot" UI was below the list of all
active/inactive bots.

If the count of active or inactive bots is more than four,
then the user has to scroll down the entire list of bots to
"Add a new bot".