### PR TITLE
Fix upload of same file twice in a row.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -34,8 +34,7 @@ function make_uploads_relative(content) {
 // This function resets an input type="file".  Pass in the
 // jquery object.
 function clear_out_file_list(jq_file_list) {
-    var clone_for_ie_sake = jq_file_list.clone(true);
-    jq_file_list.replaceWith(clone_for_ie_sake);
+    jq_file_list[0].value = '';
 
     // Hack explanation:
     // IE won't let you do this (untested, but so says StackOverflow):


### PR DESCRIPTION
Users had issues uploading the same file twice in a row. This is a fix to that issue.

ref to issue #5074

Originally, the .clone() method did not change any aspect of the file list. That means that when the user uploads the same file, there is no change in the file list (because its the same file). That means the .change() event handler does not work because it there is no change between the file in the file list, and identical one that the user is attempting to upload a second time. Therefore, I cleared an aspect of the file list so that when the user uploads the same file, it will recognize a change; now working as intended. 