### PR TITLE
Improve tests for help, define, helloworld, wikipedia & xkcd bots

### DIFF
--- a/contrib_bots/bots/define/test_define.py
+++ b/contrib_bots/bots/define/test_define.py
@@ -16,14 +16,17 @@ class TestDefineBot(BotTestCase):
     bot_name = "define"
 
     def test_bot(self):
-        self.assert_bot_output(
-            {'content': "foo", 'type': "private", 'sender_email': "foo"},
-            "**foo**:\nDefinition not available."
-        )
-        self.assert_bot_output(
-            {'content': "cat", 'type': "stream", 'display_recipient': "foo", 'subject': "foo"},
+        expected = { "":    'Please enter a word to define.',
+                     "foo": "**foo**:\nDefinition not available.",
+                     "cat": 
             ("**cat**:\n\n* (**noun**) a small domesticated carnivorous mammal "
              "with soft fur, a short snout, and retractile claws. It is widely "
              "kept as a pet or for catching mice, and many breeds have been "
              "developed.\n&nbsp;&nbsp;their pet cat\n\n"),
-        )
+                   }
+        for m, r in expected.items():
+            self.assert_bot_output(
+                {'content': m, 'type': "private", 'sender_email': "foo"}, r)
+            self.assert_bot_output(
+                {'content': m, 'type': "stream", 'display_recipient': "foo", 
+                 'subject': "foo"}, r)

--- a/contrib_bots/bots/helloworld/test_helloworld.py
+++ b/contrib_bots/bots/helloworld/test_helloworld.py
@@ -16,15 +16,11 @@ class TestHelloWorldBot(BotTestCase):
     bot_name = "helloworld"
 
     def test_bot(self):
-        self.assert_bot_output(
-            {'content': "foo", 'type': "private", 'sender_email': "foo"},
-            "beep boop"
-        )
-        self.assert_bot_output(
-            {'content': "Hi, my name is abc", 'type': "stream", 'display_recipient': "foo", 'subject': "foo"},
-            "beep boop"
-        )
-        self.assert_bot_output(
-            {'content': "", 'type': "stream", 'display_recipient': "foo", 'subject': "foo"},
-            "beep boop"
-        )
+        txt = "beep boop"
+        messages = ["", "foo", "Hi, my name is abc"]
+        for m in messages:
+            self.assert_bot_output(
+                {'content': m, 'type': "private", 'sender_email': "foo"}, txt)
+            self.assert_bot_output(
+                {'content': m, 'type': "stream", 'display_recipient': "foo", 
+                 'subject': "foo"}, txt)

--- a/contrib_bots/bots/help/test_help.py
+++ b/contrib_bots/bots/help/test_help.py
@@ -16,15 +16,11 @@ class TestHelpBot(BotTestCase):
     bot_name = "help"
 
     def test_bot(self):
-        self.assert_bot_output(
-            {'content': "help", 'type': "private", 'sender_email': "foo"},
-            "Info on Zulip can be found here:\nhttps://github.com/zulip/zulip"
-        )
-        self.assert_bot_output(
-            {'content': "Hi, my name is abc", 'type': "stream", 'display_recipient': "foo", 'subject': "foo"},
-            "Info on Zulip can be found here:\nhttps://github.com/zulip/zulip"
-        )
-        self.assert_bot_output(
-            {'content': "", 'type': "stream", 'display_recipient': "foo", 'subject': "foo"},
-            "Info on Zulip can be found here:\nhttps://github.com/zulip/zulip"
-        )
+        txt = "Info on Zulip can be found here:\nhttps://github.com/zulip/zulip"
+        messages = ["", "help", "Hi, my name is abc"]
+        for m in messages:
+            self.assert_bot_output(
+                {'content': m, 'type': "private", 'sender_email': "foo"}, txt)
+            self.assert_bot_output(
+                {'content': m, 'type': "stream", 'display_recipient': "foo", 
+                 'subject': "foo"}, txt)

--- a/contrib_bots/bots/wikipedia/test_wikipedia.py
+++ b/contrib_bots/bots/wikipedia/test_wikipedia.py
@@ -16,19 +16,20 @@ class TestWikipediaBot(BotTestCase):
     bot_name = "wikipedia"
 
     def test_bot(self):
-        self.assert_bot_output(
-            {'content': "foo", 'type': "private", 'sender_email': "foo"},
-            'For search term "foo", https://en.wikipedia.org/wiki/Foobar'
-        )
-        self.assert_bot_output(
-            {'content': "", 'type': "stream", 'display_recipient': "foo", 'subject': "foo"},
-            'Please enter your message after @mention-bot'
-        )
-        self.assert_bot_output(
-            {'content': "sssssss kkkkk", 'type': "stream", 'display_recipient': "foo", 'subject': "foo"},
-            'I am sorry. The search term you provided is not found :slightly_frowning_face:'
-        )
-        self.assert_bot_output(
-            {'content': "123", 'type': "stream", 'display_recipient': "foo", 'subject': "foo"},
-            'For search term "123", https://en.wikipedia.org/wiki/123'
-        )
+        expected = { 
+            "":       'Please enter your message after @mention-bot',
+            "sssssss kkkkk": 
+                      ('I am sorry. The search term you provided is not found :slightly_frowning_face:'),
+            "foo":    ('For search term "foo", '
+                       'https://en.wikipedia.org/wiki/Foobar'),
+            "123":    ('For search term "123", '
+                       'https://en.wikipedia.org/wiki/123'),
+            "laugh":  ('For search term "laugh", '
+                       'https://en.wikipedia.org/wiki/Laughter'),
+                   }
+        for m, r in expected.items():
+            self.assert_bot_output(
+                {'content': m, 'type': "private", 'sender_email': "foo"}, r)
+            self.assert_bot_output(
+                {'content': m, 'type': "stream", 'display_recipient': "foo", 
+                 'subject': "foo"}, r)

--- a/contrib_bots/bots/xkcd/test_xkcd.py
+++ b/contrib_bots/bots/xkcd/test_xkcd.py
@@ -43,4 +43,5 @@ class TestXkcdBot(BotTestCase):
             self.assert_bot_output(
                 {'content': m, 'type': "private", 'sender_email': "foo"}, r)
             self.assert_bot_output(
-                {'content': m, 'type': "stream", 'sender_email': "foo"}, r)
+                {'content': m, 'type': "stream", 'display_recipient': "foo", 
+                 'subject': "foo"}, r)


### PR DESCRIPTION
This is mostly just a rebase of my previous test additions after a recent merge by @abhijeetkaur, with the additional tweak of the stream message arguments.

This commit:
* converts code to always check both private and stream messages
* simplifies input(s)/output(s) into literals/arrays/dicts
* incorporates the previous test cases

This seems more concise and legible; I would appreciate any comments.