### PR TITLE
Use zjquery to test pm_list.js.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -807,6 +807,10 @@ function render(template_name, args) {
     var html = '';
     html += render('sidebar_private_message_list', args);
 
+    var conversations = $(html).find('a').text().trim().split('\n');
+    assert.equal(conversations[0], 'alice,bob');
+    assert.equal(conversations[1].trim(), '(more conversations)');
+
     global.write_handlebars_output("sidebar_private_message_list", html);
 }());
 


### PR DESCRIPTION
We now stub templates.render() to see what data gets passed in
to the template, rather than using jQuery to inspect the DOM that
gets created.  This changes the nature of the test to be less about
integration with the templating layer and more about how we pass
data into the template.

To compensate, we add more assertions to the relevant test
in templates.js.