### PR TITLE
api.html: Recommend pip install for installing API bindings.

### DIFF
--- a/templates/zerver/api.html
+++ b/templates/zerver/api.html
@@ -9,23 +9,12 @@
 
     <p><strong>Don't want to make it yourself?</strong> Zulip <a href="/integrations">already integrates with lots of services</a>.</p>
 
-    <br/>
-    <div class="centered-button">
-       <a href="https://www.zulip.org/dist/api/python-zulip_0.2.5.tar.gz" class="btn btn-large btn-primary"><i class="icon-vector-download"></i> Download Python bindings and examples<span class="button-muted">Version 0.2.5</span></a>
-    </div>
-
-
     <p>&nbsp;</p>
 
     <h3>Installation instructions</h3>
     <h4>Python</h4>
-    <p>This package uses <tt>distutils</tt>, so you can just run <code>python setup.py install</code> after downloading.</p>
-    <p>If you have <tt>setuptools</tt> installed on your system then the application's dependencies will be downloaded and installed automatically from <a href="https://pypi.python.org/">PyPI</a>. Otherwise, you'll need to make sure you have these Python libraries installed:</p>
-    <ul>
-      <li><tt>simplejson</tt></li>
-      <li><tt>requests</tt> (0.12.1 or later)</li>
-    </ul>
-    <p>&nbsp;</p>
+    <p>Install it with <a href="https://pypi.python.org/pypi/zulip/0.3.0">pip</a>:</p>
+    <pre><code>pip install zulip</code></pre>
     <h4>JavaScript</h4>
     <p>Install it with <a href="https://www.npmjs.com/package/zulip-js">npm</a>:</p>
     <pre><code>npm install zulip-js</code></pre>


### PR DESCRIPTION
We have an updated [PyPI package](https://pypi.python.org/pypi/zulip/0.3.0) now for our API bindings, so we
now recommend `pip install` rather than providing a download link
to the package. :)