### PR TITLE
Fix webpack-dev-server urls for external resources

### DIFF
--- a/tools/webpack.dev.config.js
+++ b/tools/webpack.dev.config.js
@@ -1,9 +1,9 @@
 var config = require('./webpack.config.js');
 var BundleTracker = require('webpack-bundle-tracker');
 
-config.entry.translations.push('webpack-dev-server/client?http://0.0.0.0:9991/socket.io');
+config.entry.translations.push('webpack-dev-server/client?/socket.io');
 config.devtool = 'eval';
-config.output.publicPath = 'http://0.0.0.0:9991/webpack/';
+config.output.publicPath = '/webpack/';
 config.plugins.push(new BundleTracker({filename: 'static/webpack-bundles/webpack-stats-dev.json'}));
 
 config.devServer = {


### PR DESCRIPTION
@timabbott I think this is actually a bug, but I can't replicate the issue #5118 so I don't know if this fixes it.