### PR TITLE
casper: Fix the waiting condition.

### DIFF
--- a/frontend_tests/casper_tests/15-delete-message.js
+++ b/frontend_tests/casper_tests/15-delete-message.js
@@ -29,13 +29,15 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitWhileVisible(last_message_id, function () {
-        var msgs_after_deleting = casper.evaluate(function () {
-            return $('#zhome .message_row').length;
-        });
-        casper.test.assertEquals(msgs_qty - 1, msgs_after_deleting);
-        casper.test.assertDoesntExist(last_message_id);
+    casper.waitFor(function check_length() {
+        return casper.evaluate(function (expected_length) {
+            return $('#zhome .message_row').length === expected_length;
+        }, msgs_qty - 1);
     });
+});
+
+casper.then(function () {
+    casper.test.assertDoesntExist(last_message_id);
 });
 
 casper.run(function () {


### PR DESCRIPTION
We now specifically wait for the length to decrease by one. This seems
like a more deterministic condition to wait on.

Previously we were waiting till the id of the deleted message remained
visible; intuitively, this should have worked but it seems that there
is some race condition that was causing the test to fail sporadically.

@timabbott 