### PR TITLE
Fix webpack-dev-server to not inline serve bad sockjs url

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -379,8 +379,8 @@ class Application(web.Application):
             (r"/json/events.*", TornadoHandler),
             (r"/api/v1/events.*", TornadoHandler),
             (r"/webpack.*", WebPackHandler),
+            (r"/sockjs-node.*", WebPackHandler),
             (r"/sockjs.*", TornadoHandler),
-            (r"/socket.io.*", WebPackHandler),
             (r"/.*", DjangoHandler)
         ]
         super(Application, self).__init__(handlers, enable_logging=enable_logging)

--- a/tools/webpack.dev.config.js
+++ b/tools/webpack.dev.config.js
@@ -1,13 +1,14 @@
 var config = require('./webpack.config.js');
 var BundleTracker = require('webpack-bundle-tracker');
 
-config.entry.translations.push('webpack-dev-server/client?/socket.io');
+config.entry.translations.unshift('webpack-dev-server/client?sockjs-node');
 config.devtool = 'eval';
 config.output.publicPath = '/webpack/';
 config.plugins.push(new BundleTracker({filename: 'static/webpack-bundles/webpack-stats-dev.json'}));
 
 config.devServer = {
     port: 9994,
+    inline: false,
     stats: "errors-only",
     watchOptions: {
         aggregateTimeout: 300,


### PR DESCRIPTION
Failed to sleep, this fixes half of #5118