### PR TITLE
emoji: Fix realm emoji not appearing in settings page when reopened.

### DIFF
--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -133,6 +133,9 @@ function dispatch_normal_event(event) {
         break;
 
     case 'realm_emoji':
+        // Update `page_params.realm_emoji` so that settings page
+        // can display it properly when reopened without refresh.
+        page_params.realm_emoji = event.realm_emoji;
         emoji.update_emojis(event.realm_emoji);
         settings_emoji.populate_emoji(event.realm_emoji);
         break;


### PR DESCRIPTION
When the emoji settings page was reopened after uploading a realm emoji
without doing a page refresh, the uploaded emoji disappeared from the
emoji list. This was so because the emoji settings page uses
`page_parama.realm_emoji` to render the emojis which was not updated
when a emoji was added.

Fixes: #5130.