### PR TITLE
Make code base compliant with PEP-8 E-261.

### DIFF
--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -78,7 +78,6 @@ def check_pep8(files):
 
     # TODO: Clear up this list of violations.
     IGNORE_FILES_PEPE261 = [
-        'zerver/tests/test_subs.py',
         'zerver/tests/test_upload.py',
     ]
 

--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -78,7 +78,6 @@ def check_pep8(files):
 
     # TODO: Clear up this list of violations.
     IGNORE_FILES_PEPE261 = [
-        'zerver/tests/test_signup.py',
         'zerver/tests/test_subs.py',
         'zerver/tests/test_upload.py',
     ]

--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -78,7 +78,6 @@ def check_pep8(files):
 
     # TODO: Clear up this list of violations.
     IGNORE_FILES_PEPE261 = [
-        'zerver/tests/test_realm.py',
         'zerver/tests/test_signup.py',
         'zerver/tests/test_subs.py',
         'zerver/tests/test_upload.py',

--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -76,21 +76,9 @@ def check_pep8(files):
         'E731',
     ]
 
-    # TODO: Clear up this list of violations.
-    IGNORE_FILES_PEPE261 = []
-
-    filtered_files = [fn for fn in files if fn not in IGNORE_FILES_PEPE261]
-    filtered_files_E261 = [fn for fn in files if fn in IGNORE_FILES_PEPE261]
-
     if len(files) == 0:
         return False
-    if not len(filtered_files) == 0:
-        failed = run_pycodestyle(filtered_files, ignored_rules)
-    if not len(filtered_files_E261) == 0:
-        # Adding an extra ignore rule for these files since they still remain in
-        # violation of PEP-E261.
-        failed_ignore_e261 = run_pycodestyle(filtered_files_E261, ignored_rules + ['E261'])
-        if not failed:
-            failed = failed_ignore_e261
+
+    failed = run_pycodestyle(files, ignored_rules)
 
     return failed

--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -78,7 +78,6 @@ def check_pep8(files):
 
     # TODO: Clear up this list of violations.
     IGNORE_FILES_PEPE261 = [
-        'zerver/tests/test_messages.py',
         'zerver/tests/test_narrow.py',
         'zerver/tests/test_realm.py',
         'zerver/tests/test_signup.py',

--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -78,7 +78,6 @@ def check_pep8(files):
 
     # TODO: Clear up this list of violations.
     IGNORE_FILES_PEPE261 = [
-        'zerver/tests/test_bugdown.py',
         'zerver/tests/test_events.py',
         'zerver/tests/test_messages.py',
         'zerver/tests/test_narrow.py',

--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -78,7 +78,6 @@ def check_pep8(files):
 
     # TODO: Clear up this list of violations.
     IGNORE_FILES_PEPE261 = [
-        'zerver/tests/test_events.py',
         'zerver/tests/test_messages.py',
         'zerver/tests/test_narrow.py',
         'zerver/tests/test_realm.py',

--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -77,9 +77,7 @@ def check_pep8(files):
     ]
 
     # TODO: Clear up this list of violations.
-    IGNORE_FILES_PEPE261 = [
-        'zerver/tests/test_upload.py',
-    ]
+    IGNORE_FILES_PEPE261 = []
 
     filtered_files = [fn for fn in files if fn not in IGNORE_FILES_PEPE261]
     filtered_files_E261 = [fn for fn in files if fn in IGNORE_FILES_PEPE261]

--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -78,7 +78,6 @@ def check_pep8(files):
 
     # TODO: Clear up this list of violations.
     IGNORE_FILES_PEPE261 = [
-        'zerver/tests/test_narrow.py',
         'zerver/tests/test_realm.py',
         'zerver/tests/test_signup.py',
         'zerver/tests/test_subs.py',

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -102,8 +102,8 @@ class FencedBlockPreprocessorTest(TestCase):
         processor = bugdown.fenced_code.FencedBlockPreprocessor(None)
 
         # Simulate code formatting.
-        processor.format_code = lambda lang, code: lang + ':' + code # type: ignore # mypy doesn't allow monkey-patching functions
-        processor.placeholder = lambda s: '**' + s.strip('\n') + '**' # type: ignore # https://github.com/python/mypy/issues/708
+        processor.format_code = lambda lang, code: lang + ':' + code  # type: ignore # mypy doesn't allow monkey-patching functions
+        processor.placeholder = lambda s: '**' + s.strip('\n') + '**'  # type: ignore # https://github.com/python/mypy/issues/708
 
         markdown = [
             '``` .py',
@@ -141,8 +141,8 @@ class FencedBlockPreprocessorTest(TestCase):
         processor = bugdown.fenced_code.FencedBlockPreprocessor(None)
 
         # Simulate code formatting.
-        processor.format_code = lambda lang, code: lang + ':' + code # type: ignore # mypy doesn't allow monkey-patching functions
-        processor.placeholder = lambda s: '**' + s.strip('\n') + '**' # type: ignore # https://github.com/python/mypy/issues/708
+        processor.format_code = lambda lang, code: lang + ':' + code  # type: ignore # mypy doesn't allow monkey-patching functions
+        processor.placeholder = lambda s: '**' + s.strip('\n') + '**'  # type: ignore # https://github.com/python/mypy/issues/708
 
         markdown = [
             '~~~ quote',
@@ -605,7 +605,7 @@ class BugdownTest(ZulipTestCase):
             directly for testing is kind of awkward
             '''
             class Instance(object):
-                realm_id = None # type: Optional[int]
+                realm_id = None  # type: Optional[int]
             instance = Instance()
             instance.realm_id = realm.id
             flush_realm_filter(sender=None, instance=instance)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1088,7 +1088,7 @@ class EventsRegisterTest(ZulipTestCase):
         # type: () -> None
         schema_checker = self.check_events_dict([
             ('type', equals('realm_filters')),
-            ('realm_filters', check_list(None)), # TODO: validate tuples in the list
+            ('realm_filters', check_list(None)),  # TODO: validate tuples in the list
         ])
         events = self.do_test(lambda: do_add_realm_filter(get_realm("zulip"), "#(?P<id>[123])",
                                                           "https://realm.com/my_realm_filter/%(id)s"))
@@ -1397,7 +1397,7 @@ class EventsRegisterTest(ZulipTestCase):
         if include_subscribers:
             subscription_fields.append(('subscribers', check_list(check_int)))  # type: ignore
         subscription_schema_checker = check_list(
-            check_dict(subscription_fields),        # TODO: Can this be converted to check_dict_only?
+            check_dict(subscription_fields),  # TODO: Can this be converted to check_dict_only?
         )
         stream_create_schema_checker = self.check_events_dict([
             ('type', equals('stream')),
@@ -1446,7 +1446,7 @@ class EventsRegisterTest(ZulipTestCase):
         ])
 
         # Subscribe to a totally new stream, so it's just Hamlet on it
-        action = lambda: self.subscribe_to_stream(self.example_email("hamlet"), "test_stream") # type: Callable
+        action = lambda: self.subscribe_to_stream(self.example_email("hamlet"), "test_stream")  # type: Callable
         events = self.do_test(action, event_types=["subscription", "realm_user"],
                               include_subscribers=include_subscribers)
         error = add_schema_checker('events[0]', events[0])

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -198,7 +198,7 @@ class TestCrossRealmPMs(ZulipTestCase):
         user2_email = 'user2@2.example.com'
         user3_email = 'user3@3.example.com'
         feedback_email = 'feedback@zulip.com'
-        support_email = 'support@3.example.com' # note: not zulip.com
+        support_email = 'support@3.example.com'  # note: not zulip.com
 
         self.create_user(random_zulip_email)
         user1 = self.create_user(user1_email)
@@ -1551,9 +1551,9 @@ class MirroredMessageUsersTest(ZulipTestCase):
     def test_invalid_sender(self):
         # type: () -> None
         user = self.example_user('hamlet')
-        recipients = [] # type: List[Text]
+        recipients = []  # type: List[Text]
         request = self.Request()
-        request.POST = dict() # no sender
+        request.POST = dict()  # no sender
 
         (valid_input, mirror_sender) = \
             create_mirrored_message_users(request, user, recipients)
@@ -1563,12 +1563,12 @@ class MirroredMessageUsersTest(ZulipTestCase):
 
     def test_invalid_client(self):
         # type: () -> None
-        client = get_client(name='banned_mirror') # Invalid!!!
+        client = get_client(name='banned_mirror')  # Invalid!!!
 
         user = self.example_user('hamlet')
         sender = user
 
-        recipients = [] # type: List[Text]
+        recipients = []  # type: List[Text]
         request = self.Request()
         request.POST = dict(
             sender=sender.email,

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -8,7 +8,7 @@ from django.test import override_settings
 from sqlalchemy.sql import (
     and_, select, column, table,
 )
-from sqlalchemy.sql import compiler # type: ignore
+from sqlalchemy.sql import compiler  # type: ignore
 
 from zerver.models import (
     Realm, Recipient, Stream, Subscription, UserProfile, Attachment,
@@ -47,7 +47,7 @@ import ujson
 
 def get_sqlalchemy_query_params(query):
     # type: (Text) -> Dict[Text, Text]
-    dialect = get_sqlalchemy_connection().dialect # type: ignore
+    dialect = get_sqlalchemy_connection().dialect  # type: ignore
     comp = compiler.SQLCompiler(dialect, query)
     return comp.params
 
@@ -416,7 +416,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def get_and_check_messages(self, modified_params):
         # type: (Dict[str, Union[str, int]]) -> Dict[str, Dict]
-        post_params = {"anchor": 1, "num_before": 1, "num_after": 1} # type: Dict[str, Union[str, int]]
+        post_params = {"anchor": 1, "num_before": 1, "num_after": 1}  # type: Dict[str, Union[str, int]]
         post_params.update(modified_params)
         payload = self.client_get("/json/messages", dict(post_params))
         self.assert_json_success(payload)
@@ -437,7 +437,7 @@ class GetOldMessagesTest(ZulipTestCase):
         hamlet_user = self.example_user('hamlet')
         othello_user = self.example_user('othello')
 
-        query_ids = {} # type: Dict[Text, int]
+        query_ids = {}  # type: Dict[Text, int]
 
         scotland_stream = get_stream('Scotland', hamlet_user.realm)
         query_ids['scotland_recipient'] = get_recipient(Recipient.STREAM, scotland_stream.id).id
@@ -646,7 +646,7 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         mit_user_profile = self.mit_user("starnine")
         email = mit_user_profile.email
-        self.login(email)        # We need to susbcribe to a stream and then send a message to
+        self.login(email)  # We need to susbcribe to a stream and then send a message to
         # it to ensure that we actually have a stream message in this
         # narrow view.
         self.subscribe_to_stream(email, "Scotland")
@@ -782,7 +782,7 @@ class GetOldMessagesTest(ZulipTestCase):
             narrow=ujson.dumps(narrow),
             anchor=0,
             num_after=10,
-        )) # type: Dict[str, Dict]
+        ))  # type: Dict[str, Dict]
         self.assertEqual(len(result['messages']), 2)
         messages = result['messages']
 
@@ -812,7 +812,7 @@ class GetOldMessagesTest(ZulipTestCase):
             narrow=ujson.dumps(multi_search_narrow),
             anchor=0,
             num_after=10,
-        )) # type: Dict[str, Dict]
+        ))  # type: Dict[str, Dict]
         self.assertEqual(len(multi_search_result['messages']), 1)
         self.assertEqual(multi_search_result['messages'][0]['match_content'], '<p><span class="highlight">discuss</span> lunch <span class="highlight">after</span> lunch</p>')
 
@@ -841,7 +841,7 @@ class GetOldMessagesTest(ZulipTestCase):
             anchor=0,
             num_after=10,
             num_before=10,
-        )) # type: Dict[str, Dict]
+        ))  # type: Dict[str, Dict]
         self.assertEqual(len(stream_search_result['messages']), 1)
         self.assertEqual(stream_search_result['messages'][0]['match_content'],
                          '<p>Public <span class="highlight">special</span> content!</p>')
@@ -885,7 +885,7 @@ class GetOldMessagesTest(ZulipTestCase):
             narrow=ujson.dumps(narrow),
             anchor=0,
             num_after=10,
-        )) # type: Dict[str, Dict]
+        ))  # type: Dict[str, Dict]
         self.assertEqual(len(result['messages']), 4)
         messages = result['messages']
 
@@ -920,7 +920,7 @@ class GetOldMessagesTest(ZulipTestCase):
             narrow=ujson.dumps(multi_search_narrow),
             anchor=0,
             num_after=10,
-        )) # type: Dict[str, Dict]
+        ))  # type: Dict[str, Dict]
         self.assertEqual(len(multi_search_result['messages']), 1)
         self.assertEqual(multi_search_result['messages'][0]['match_content'],
                          '<p><span class="highlight">Can</span> you <span class="highlight">speak</span> <a href="https://en.wikipedia.org/wiki/Japanese" target="_blank" title="https://en.wikipedia.org/wiki/Japanese">https://en.<span class="highlight">wiki</span>pedia.org/<span class="highlight">wiki</span>/Japanese</a>?</p>')
@@ -937,7 +937,7 @@ class GetOldMessagesTest(ZulipTestCase):
         narrow = [dict(operator='sender', operand=self.example_email("cordelia"))]
         result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow),
                                                   anchor=anchor, num_before=0,
-                                                  num_after=0)) # type: Dict[str, Dict]
+                                                  num_after=0))  # type: Dict[str, Dict]
         self.assertEqual(len(result['messages']), 1)
 
         narrow = [dict(operator='is', operand='mentioned')]
@@ -954,7 +954,7 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         self.login(self.example_email("hamlet"))
 
-        required_args = (("anchor", 1), ("num_before", 1), ("num_after", 1)) # type: Tuple[Tuple[Text, int], ...]
+        required_args = (("anchor", 1), ("num_before", 1), ("num_after", 1))  # type: Tuple[Tuple[Text, int], ...]
 
         for i in range(len(required_args)):
             post_params = dict(required_args[:i] + required_args[i + 1:])
@@ -993,10 +993,10 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         self.login(self.example_email("hamlet"))
 
-        other_params = [("anchor", 0), ("num_before", 0), ("num_after", 0)] # type: List[Tuple[Text, Union[int, str, bool]]]
+        other_params = [("anchor", 0), ("num_before", 0), ("num_after", 0)]  # type: List[Tuple[Text, Union[int, str, bool]]]
 
         bad_types = (False, 0, '', '{malformed json,',
-                     '{foo: 3}', '[1,2]', '[["x","y","z"]]') # type: Tuple[Union[int, str, bool], ...]
+                     '{foo: 3}', '[1,2]', '[["x","y","z"]]')  # type: Tuple[Union[int, str, bool], ...]
         for type in bad_types:
             post_params = dict(other_params + [("narrow", type)])
             result = self.client_get("/json/messages", post_params)
@@ -1030,7 +1030,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def exercise_bad_narrow_operand(self, operator, operands, error_msg):
         # type: (Text, Sequence, Text) -> None
-        other_params = [("anchor", 0), ("num_before", 0), ("num_after", 0)] # type: List
+        other_params = [("anchor", 0), ("num_before", 0), ("num_after", 0)]  # type: List
         for operand in operands:
             post_params = dict(other_params + [
                 ("narrow", ujson.dumps([[operator, operand]]))])
@@ -1044,7 +1044,7 @@ class GetOldMessagesTest(ZulipTestCase):
         returned.
         """
         self.login(self.example_email("hamlet"))
-        bad_stream_content = (0, [], ["x", "y"]) # type: Sequence
+        bad_stream_content = (0, [], ["x", "y"])  # type: Sequence
         self.exercise_bad_narrow_operand("stream", bad_stream_content,
                                          "Bad value for 'narrow'")
 
@@ -1055,7 +1055,7 @@ class GetOldMessagesTest(ZulipTestCase):
         error is returned.
         """
         self.login(self.example_email("hamlet"))
-        bad_stream_content = (0, [], ["x", "y"]) # type: Tuple[int, List[None], List[Text]]
+        bad_stream_content = (0, [], ["x", "y"])  # type: Tuple[int, List[None], List[Text]]
         self.exercise_bad_narrow_operand("pm-with", bad_stream_content,
                                          "Bad value for 'narrow'")
 
@@ -1341,7 +1341,7 @@ class GetOldMessagesTest(ZulipTestCase):
         # type: () -> None
         query_ids = self.get_query_ids()
 
-        sql_template = "SELECT anon_1.message_id, anon_1.flags, anon_1.subject, anon_1.rendered_content, anon_1.content_matches, anon_1.subject_matches \nFROM (SELECT message_id, flags, subject, rendered_content, ts_match_locs_array('zulip.english_us_search', rendered_content, plainto_tsquery('zulip.english_us_search', 'jumping')) AS content_matches, ts_match_locs_array('zulip.english_us_search', escape_html(subject), plainto_tsquery('zulip.english_us_search', 'jumping')) AS subject_matches \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (search_tsvector @@ plainto_tsquery('zulip.english_us_search', 'jumping')) AND message_id >= 0 ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC" # type: Text
+        sql_template = "SELECT anon_1.message_id, anon_1.flags, anon_1.subject, anon_1.rendered_content, anon_1.content_matches, anon_1.subject_matches \nFROM (SELECT message_id, flags, subject, rendered_content, ts_match_locs_array('zulip.english_us_search', rendered_content, plainto_tsquery('zulip.english_us_search', 'jumping')) AS content_matches, ts_match_locs_array('zulip.english_us_search', escape_html(subject), plainto_tsquery('zulip.english_us_search', 'jumping')) AS subject_matches \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (search_tsvector @@ plainto_tsquery('zulip.english_us_search', 'jumping')) AND message_id >= 0 ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC"  # type: Text
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 10,
                                               'narrow': '[["search", "jumping"]]'},
@@ -1388,7 +1388,7 @@ class GetOldMessagesTest(ZulipTestCase):
             narrow=ujson.dumps(narrow),
             anchor=0,
             num_after=10,
-        )) # type: Dict[str, Dict]
+        ))  # type: Dict[str, Dict]
         self.assertEqual(len(result['messages']), 0)
 
         narrow = [

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -233,7 +233,7 @@ class RealmAPITest(ZulipTestCase):
         # type: (str, Union[Text, int, bool]) -> Realm
         result = self.client_patch('/json/realm', {name: ujson.dumps(value)})
         self.assert_json_success(result)
-        return get_realm('zulip') # refresh data
+        return get_realm('zulip')  # refresh data
 
     def do_test_realm_update_api(self, name):
         # type: (str) -> None
@@ -244,14 +244,14 @@ class RealmAPITest(ZulipTestCase):
         assertion error.
         """
 
-        bool_tests = [False, True] # type: List[bool]
+        bool_tests = [False, True]  # type: List[bool]
         test_values = dict(
             default_language=[u'de', u'en'],
             description=[u'Realm description', u'New description'],
             message_retention_days=[10, 20],
             name=[u'Zulip', u'New Name'],
             waiting_period_threshold=[10, 20],
-        ) # type: Dict[str, Any]
+        )  # type: Dict[str, Any]
         vals = test_values.get(name)
         if Realm.property_types[name] is bool:
             vals = bool_tests

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1326,7 +1326,7 @@ class UserSignUpTest(ZulipTestCase):
         realm.save()
         with self.settings(REALMS_HAVE_SUBDOMAINS = True):
             request = HostRequestMock(host = realm.host)
-            request.session = {} # type: ignore
+            request.session = {}  # type: ignore
             email = 'user@acme.com'
             form = HomepageForm({'email': email}, realm=realm)
             self.assertIn("Your email address, {}, is not in one of the domains".format(email),
@@ -1338,7 +1338,7 @@ class UserSignUpTest(ZulipTestCase):
         realm.invite_required = True
         realm.save()
         request = HostRequestMock(host = realm.host)
-        request.session = {} # type: ignore
+        request.session = {}  # type: ignore
         email = 'user@zulip.com'
         form = HomepageForm({'email': email}, realm=realm)
         self.assertIn("Please request an invite for {} from".format(email),
@@ -1348,7 +1348,7 @@ class UserSignUpTest(ZulipTestCase):
         # type: () -> None
         with self.settings(REALMS_HAVE_SUBDOMAINS = True):
             request = HostRequestMock(host = 'acme.' + settings.EXTERNAL_HOST)
-            request.session = {} # type: ignore
+            request.session = {}  # type: ignore
             email = 'user@acme.com'
             form = HomepageForm({'email': email}, realm=None)
             self.assertIn("organization you are trying to join using {} does "

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -264,7 +264,7 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe_to_stream(email, 'private_stream')
         self.subscribe_to_stream(self.example_email("cordelia"), 'private_stream')
 
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             stream_id = get_stream('private_stream', user_profile.realm).id
             result = self.client_patch('/json/streams/%d' % (stream_id,),
@@ -319,7 +319,7 @@ class StreamAdminTest(ZulipTestCase):
                                    {'new_name': ujson.dumps('sTREAm_name1')})
         self.assert_json_success(result)
 
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             stream_id = get_stream('stream_name1', user_profile.realm).id
             result = self.client_patch('/json/streams/%d' % (stream_id,),
@@ -412,7 +412,7 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe_to_stream(email, 'stream_name1')
         do_change_is_admin(user_profile, True)
 
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             stream_id = get_stream('stream_name1', realm).id
             result = self.client_patch('/json/streams/%d' % (stream_id,),
@@ -481,7 +481,7 @@ class StreamAdminTest(ZulipTestCase):
         realm = stream.realm
         stream_id = stream.id
 
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             result = self.client_delete('/json/streams/' + str(stream_id))
         self.assert_json_success(result)
@@ -823,7 +823,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         old_subs, _ = gather_subscriptions(test_user)
         sub = old_subs[0]
         stream_id = sub['stream_id']
-        new_color = "#ffffff" # TODO: ensure that this is different from old_color
+        new_color = "#ffffff"  # TODO: ensure that this is different from old_color
         result = self.client_post(
             "/api/v1/users/me/subscriptions/properties",
             {"subscription_data": ujson.dumps([{"property": "color",
@@ -1342,7 +1342,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertNotEqual(len(self.streams), 0)  # necessary for full test coverage
         add_streams = [u"Verona2", u"Denmark5"]
         self.assertNotEqual(len(add_streams), 0)  # necessary for full test coverage
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             self.helper_check_subs_before_and_after_add(self.streams + add_streams, {},
                                                         add_streams, self.streams, self.test_email, self.streams + add_streams)
@@ -1360,7 +1360,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertNotEqual(len(self.streams), 0)
         add_streams = [u"Verona2", u"Denmark5"]
         self.assertNotEqual(len(add_streams), 0)
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         other_params = {
             'announce': 'true',
         }
@@ -1590,7 +1590,7 @@ class SubscriptionAPITest(ZulipTestCase):
         email2 = self.example_email("iago")
         realm = get_realm("zulip")
         streams_to_sub = ['multi_user_stream']
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             with queries_captured() as queries:
                 self.common_subscribe_to_streams(
@@ -1687,7 +1687,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # Now subscribe Cordelia to the stream, capturing events
         user_profile = self.example_user('cordelia')
 
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             bulk_add_subscriptions([stream], [user_profile])
 
@@ -1727,7 +1727,7 @@ class SubscriptionAPITest(ZulipTestCase):
             dict(principals=ujson.dumps(orig_emails_to_subscribe)))
 
         new_emails_to_subscribe = [self.example_email("iago"), self.example_email("cordelia")]
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             self.common_subscribe_to_streams(
                 self.test_email,
@@ -1781,7 +1781,7 @@ class SubscriptionAPITest(ZulipTestCase):
         user3 = get_user(email3, realm)
         user4 = get_user(email4, realm)
 
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             bulk_remove_subscriptions(
                 users=[user1, user2],
@@ -1834,7 +1834,7 @@ class SubscriptionAPITest(ZulipTestCase):
         for stream_name in streams:
             self.make_stream(stream_name, realm=realm)
 
-        events = [] # type: List[Dict[str, Any]]
+        events = []  # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):
             with queries_captured() as queries:
                 self.common_subscribe_to_streams(
@@ -2570,7 +2570,7 @@ class GetSubscribersTest(ZulipTestCase):
         result_dict = ujson.loads(result.content)
         self.assertIn('subscribers', result_dict)
         self.assertIsInstance(result_dict['subscribers'], list)
-        subscribers = [] # type: List[Text]
+        subscribers = []  # type: List[Text]
         for subscriber in result_dict['subscribers']:
             self.assertIsInstance(subscriber, six.string_types)
             subscribers.append(subscriber)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -54,7 +54,7 @@ def destroy_uploads():
         shutil.rmtree(settings.LOCAL_UPLOADS_DIR)
 
 class StringIO(_StringIO):
-    name = '' # https://github.com/python/typeshed/issues/598
+    name = ''  # https://github.com/python/typeshed/issues/598
 
 class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
@@ -117,7 +117,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         mock_filename.encode.assert_not_called()
 
         # Non-str filenames should be encoded.
-        mock_filename = mock.Mock(spec=None) # None is not str
+        mock_filename = mock.Mock(spec=None)  # None is not str
         mock_file.name = mock_filename
         with mock.patch('zerver.views.upload.upload_message_image_from_request'):
             result = upload_file_backend(mock_request, user_profile)
@@ -629,7 +629,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
 
     correct_files = [
         ('img.png', 'png_resized.png'),
-        ('img.jpg', None), # jpeg resizing is platform-dependent
+        ('img.jpg', None),  # jpeg resizing is platform-dependent
         ('img.gif', 'gif_resized.png'),
         ('img.tif', 'tif_resized.png')
     ]
@@ -816,7 +816,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
 
     correct_files = [
         ('img.png', 'png_resized.png'),
-        ('img.jpg', None), # jpeg resizing is platform-dependent
+        ('img.jpg', None),  # jpeg resizing is platform-dependent
         ('img.gif', 'gif_resized.png'),
         ('img.tif', 'tif_resized.png')
     ]
@@ -1044,7 +1044,7 @@ class S3Test(ZulipTestCase):
         response = self.client_get(uri)
         redirect_url = response['Location']
 
-        self.assertEqual(b"zulip!", urllib.request.urlopen(redirect_url).read().strip()) # type: ignore # six.moves.urllib.request.urlopen is not defined in typeshed
+        self.assertEqual(b"zulip!", urllib.request.urlopen(redirect_url).read().strip())  # type: ignore # six.moves.urllib.request.urlopen is not defined in typeshed
 
         self.subscribe_to_stream(self.example_email("hamlet"), "Denmark")
         body = "First message ...[zulip.txt](http://localhost:9991" + uri + ")"


### PR DESCRIPTION
This PR will track the commits which will eventually lead our code base to 100% compliance with the PEP-8 E-261. According to E-261 two spaces must be used before making an inline comment.
This contains changes which might cause merge conflicts but won't require manual intervention while rebasing. Automerge can deal with them. Also after this some 26 files are left before we can enable this check in linters.