### PR TITLE
Add test coverage for 'stream_sort.js'.

### DIFF
--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -1,0 +1,65 @@
+var assert = require('assert');
+
+add_dependencies({
+    stream_data: 'js/stream_data.js',
+    util: 'js/util.js',
+});
+
+var stream_sort = require('js/stream_sort.js');
+var stream_data = require('js/stream_data.js');
+var with_overrides = global.with_overrides;
+
+stream_data.add_sub('scalene', {
+    subscribed: true,
+    name: 'scalene',
+    stream_id: 1,
+    pin_to_top: true,
+});
+stream_data.add_sub('tortoise', {
+    subscribed: true,
+    name: 'tortoise',
+    stream_id: 2,
+    pin_to_top: false,
+});
+stream_data.add_sub('pneumonia', {
+    subscribed: true,
+    name: 'pneumonia',
+    stream_id: 3,
+    pin_to_top: false,
+});
+stream_data.add_sub('clarinet', {
+    subscribed: true,
+    name: 'clarinet',
+    stream_id: 4,
+    pin_to_top: false,
+});
+stream_data.add_sub('weaving', {
+    subscribed: false,
+    name: 'weaving',
+    stream_id: 5,
+    pin_to_top: false,
+});
+
+with_overrides(function (override) {
+    override('stream_data.is_active', function (sub) {
+        return (sub.name !== "pneumonia");
+    });
+
+    // Test sorting into categories/alphabetized
+    var sorted = stream_sort.sort_groups("");
+    assert.deepEqual(sorted.pinned_streams, ['scalene']);
+    assert.deepEqual(sorted.normal_streams, ['clarinet', 'tortoise']);
+    assert.deepEqual(sorted.dormant_streams, ['pneumonia']);
+
+    // Test filtering
+    sorted = stream_sort.sort_groups("s");
+    assert.deepEqual(sorted.pinned_streams, ['scalene']);
+    assert.deepEqual(sorted.normal_streams, []);
+    assert.deepEqual(sorted.dormant_streams, []);
+
+    // Test searching entire word, case-insensitive
+    sorted = stream_sort.sort_groups("PnEuMoNiA");
+    assert.deepEqual(sorted.pinned_streams, []);
+    assert.deepEqual(sorted.normal_streams, []);
+    assert.deepEqual(sorted.dormant_streams, ['pneumonia']);
+});


### PR DESCRIPTION
Added new file to test stream sort. Specifically,
it tests the `sort_group` function's ability to put
streams into the corect pinned/normal/dormant category,
filter them based on keyword, and sort alphabetically.