### PR TITLE
Tools update

### DIFF
--- a/tools/clean-branches
+++ b/tools/clean-branches
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
+# usage: clean-branches
 # Deletes any local branches which are ancestors of origin/master,
 # and also any branches in origin which are ancestors of
 # origin/master and are named like $USER-*.
 
+# usage: clean-branches --reviews
+# Deletes all the above mentioned branches as well as branches
+# created by the scripts like `fetch-rebase-pull-request`. Be careful
+# as this would also remove other branches woth names like review-*
+
+review=0
+if [ $# -ne 0 ] && [ "$1" == "--reviews" ]; then
+    review=1
+fi
 push_args=()
 
 function is_merged {
@@ -16,6 +26,14 @@ function clean_ref {
     case "$ref" in
         */master | */HEAD)
             return
+            ;;
+
+        refs/heads/review-*)
+            if [ $review -ne 0 ]; then
+                echo -n "Deleting local branch $(echo "$ref" | sed 's!^refs/heads/!!')"
+                echo " (was $(git rev-parse --short "$ref"))"
+                git update-ref -d "$ref"
+            fi
             ;;
 
         refs/heads/*)

--- a/tools/fetch-pull-request
+++ b/tools/fetch-pull-request
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+set -x
+
+if ! git diff-index --quiet HEAD; then
+    set +x
+    echo "There are uncommitted changes:"
+    git status --short
+    echo "Doing nothing to avoid losing your work."
+    exit 1
+fi
+request_id="$1"
+remote=${2:-"upstream"}
+git fetch "$remote" "pull/$request_id/head"
+git checkout -B "review-original-${request_id}"
+git reset --hard FETCH_HEAD


### PR DESCRIPTION
1. Add a `fetch-pull-request` script which won't rebase the PR like `fetch-rebase-pull-request` does so that a reviewer can view the PR as it appeared to the author. This would allow for reviewing PRs faster that might need tweaking because of recent changes in `upstream/master`.
2. At the same time I noticed that `clean-branches` did not clean branches created by scripts like above so added a commit to allow that by using `clean-branches --reviews`. However, this has a chance to unintentionally delete actual branches named like `review-*` so this would need more tweaking.