### PR TITLE
typeahead: Alter style for user emails.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -342,8 +342,7 @@ exports.content_highlighter = function (item) {
     if (this.completing === 'emoji') {
         return "<img class='emoji' src='" + item.emoji_url + "' /> " + item.emoji_name;
     } else if (this.completing === 'mention') {
-        var item_formatted = typeahead_helper.render_person(item);
-        return typeahead_helper.highlight_with_escaping(this.token, item_formatted);
+        return typeahead_helper.render_person(this.token, item);
     } else if (this.completing === 'stream') {
         return typeahead_helper.render_stream(this.token, item);
     } else if (this.completing === 'syntax') {
@@ -502,8 +501,7 @@ exports.initialize = function () {
         fixed: true,
         highlighter: function (item) {
             var query = get_last_recipient_in_pm(this.query);
-            var item_formatted = typeahead_helper.render_person(item);
-            return typeahead_helper.highlight_with_escaping(query, item_formatted);
+            return typeahead_helper.render_person(query, item);
         },
         matcher: function (item) {
             var current_recipient = get_last_recipient_in_pm(this.query);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -183,8 +183,7 @@ function show_subscription_settings(sub_row) {
         source: people.get_realm_persons, // This is a function.
         items: 5,
         highlighter: function (item) {
-            var item_formatted = typeahead_helper.render_person(item);
-            return typeahead_helper.highlight_with_escaping(this.query, item_formatted);
+            return typeahead_helper.render_person(this.query, item);
         },
         matcher: function (item) {
             var query = $.trim(this.query.toLowerCase());

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -69,11 +69,15 @@ exports.highlight_query_in_phrase = function (query, phrase) {
     return result;
 };
 
-exports.render_person = function (person) {
+exports.render_person = function (token, person) {
     if (person.special_item_text) {
         return person.special_item_text;
     }
-    return person.full_name + " <" + person.email + ">";
+
+    var full_name = exports.highlight_with_escaping(token, person.full_name);
+    var email = exports.highlight_with_escaping(token, person.email);
+
+    return full_name + " <" + email + ">";
 };
 
 exports.render_stream = function (token, stream) {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -69,6 +69,10 @@ exports.highlight_query_in_phrase = function (query, phrase) {
     return result;
 };
 
+function render_secondary(item) {
+    return '&nbsp;&nbsp;<small class = "autocomplete_secondary">' + item + '</small>';
+}
+
 exports.render_person = function (token, person) {
     if (person.special_item_text) {
         return person.special_item_text;
@@ -77,7 +81,7 @@ exports.render_person = function (token, person) {
     var full_name = exports.highlight_with_escaping(token, person.full_name);
     var email = exports.highlight_with_escaping(token, person.email);
 
-    return full_name + " <" + email + ">";
+    return full_name + render_secondary(email);
 };
 
 exports.render_stream = function (token, stream) {
@@ -92,7 +96,7 @@ exports.render_stream = function (token, stream) {
 
     var name = exports.highlight_with_escaping(token, stream.name);
 
-    return name + '&nbsp;&nbsp;<small class = "autocomplete_secondary">' + desc + '</small>';
+    return name + render_secondary(desc);
 };
 
 function split_by_subscribers(people, current_stream) {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -26,7 +26,11 @@
 }
 
 .autocomplete_secondary {
-    opacity: 0.6;
+    opacity: 0.8;
+}
+
+.active .autocomplete_secondary {
+    opacity: 1;
 }
 
 #compose_buttons {


### PR DESCRIPTION
Altered the style for emails in the @-mention typeahead to match the style used for stream description in `#**stream**`. This also affects typeaheads for PM recipients and adding new users in stream settings. [relavant topic on Zulip](https://chat.zulip.org/#narrow/stream/design/subject/users.20typeahead/near/215743).

Here's an image depicting the changes:
![comb](https://cloud.githubusercontent.com/assets/19967087/26711491/36a2e7cc-477e-11e7-9281-aef8faabadb3.png)
