### PR TITLE
subscriptions: Confirm inviting 100+ users to a new stream.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -884,6 +884,14 @@ function render(template_name, args) {
     assert.equal($(html).find(".stream-privacy").children("*").attr("class"), "hashtag");
 }());
 
+(function subscription_invites_warning_modal() {
+    var html = render('subscription_invites_warning_modal');
+
+    global.write_handlebars_output("subscription_invites_warning_modal", html);
+
+    var button = $(html).find(".close-invites-warning-modal").last();
+    assert.equal(button.text(), 'Oops! Let me change it');
+}());
 
 (function subscription_settings() {
     var sub = {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -1013,3 +1013,7 @@ form#add_new_subscription {
         -webkit-overflow-scrolling: touch;
     }
 }
+
+#stream-creation #invites-warning-modal .modal-footer {
+    position: static;
+}

--- a/static/templates/subscription_invites_warning_modal.handlebars
+++ b/static/templates/subscription_invites_warning_modal.handlebars
@@ -1,0 +1,15 @@
+<div id='invites-warning-overlay' class='overlay new-style show' style='z-index:1000;'>
+    <div class="modal" id="invites-warning-modal" tabindex="-1" role="dialog" aria-labelledby="invites-warning-label" aria-hidden="true">
+        <div class="modal-header">
+            <button type="button" class="close close-invites-warning-modal" aria-hidden="true">×</button>
+            <h3 id="invites-warning-label">{{t "Confirm invites" }}</h3>
+        </div>
+        <div class="modal-body">
+            <p>{{t 'You are going to invite a large numbers of users! Are you sure?' }}</p>
+        </div>
+        <div class="modal-footer">
+            <button class="btn btn-default close-invites-warning-modal" aria-hidden="true">{{t "Oops! Let me change it" }}</button>
+            <button class="btn btn-warning confirm-invites-warning-modal"></button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Our current workflow for creating a new stream allows the user to
invite as many other users as they like but since there can be
mistakes in doing so, we now open a modal with a warning if the
number of invites are more than 100 just to confirm that user indeed
wanted to do this.

Fixes: #1663.