### PR TITLE
emails: Mark variables in non-HTML emails as HTML-safe.

### DIFF
--- a/templates/zerver/emails/confirm_new_email.subject
+++ b/templates/zerver/emails/confirm_new_email.subject
@@ -1,1 +1,1 @@
-[Zulip] Confirm your new email address for {{ realm.name }}
+[Zulip] Confirm your new email address for {{ realm.name|safe }}

--- a/templates/zerver/emails/digest.txt
+++ b/templates/zerver/emails/digest.txt
@@ -1,7 +1,7 @@
 {#
 Mail sent to a user who hasn't logged in for 24 hours.
 #}
-
+{% autoescape off %}
 Hello {{ name }},
 
 A lot has happened on Zulip while you've been away! Visit
@@ -59,3 +59,4 @@ Manage email preferences:
 Unsubscribe from digest emails:
 
 {{ unsubscribe_link }}
+{% endautoescape %}

--- a/templates/zerver/emails/find_team.txt
+++ b/templates/zerver/emails/find_team.txt
@@ -1,6 +1,6 @@
-Hi {{ user_profile.full_name }},
+Hi {{ user_profile.full_name|safe }},
 
-You can log in to your Zulip organization, {{ user_profile.realm.name }},
+You can log in to your Zulip organization, {{ user_profile.realm.name|safe }},
 at the following link:
     {{ user_profile.realm.uri }}
 

--- a/templates/zerver/emails/invitation.subject
+++ b/templates/zerver/emails/invitation.subject
@@ -1,1 +1,1 @@
-{{referrer.full_name}} invited you to join Zulip
+{{ referrer.full_name|safe }} invited you to join Zulip

--- a/templates/zerver/emails/invitation.txt
+++ b/templates/zerver/emails/invitation.txt
@@ -1,8 +1,8 @@
 Hi there,
 
-{{ referrer.full_name }} ({{ referrer.email }}) wants you to join them on Zulip -- the group communication tool you've always wished you had at work.
+{{ referrer.full_name|safe }} ({{ referrer.email }}) wants you to join them on Zulip -- the group communication tool you've always wished you had at work.
 {% if custom_body %}
-Message from {{ referrer.full_name }}: {{ custom_body }}
+Message from {{ referrer.full_name|safe }}: {{ custom_body|safe }}
 {% endif %}
 To get started, visit the link below:
     <{{ activate_url }}>

--- a/templates/zerver/emails/invitation_mit.subject
+++ b/templates/zerver/emails/invitation_mit.subject
@@ -1,1 +1,1 @@
-{{referrer.full_name}} invited you to join Zulip
+{{ referrer.full_name|safe }} invited you to join Zulip

--- a/templates/zerver/emails/invitation_mit.txt
+++ b/templates/zerver/emails/invitation_mit.txt
@@ -1,8 +1,8 @@
 Hi there,
 
-{{ referrer.full_name }} ({{ referrer.email }}) wants you to join them on Zulip, an awesome web-based Zephyr client with desktop apps for Mac, Linux, and Windows, as well as native mobile apps.
+{{ referrer.full_name|safe }} ({{ referrer.email }}) wants you to join them on Zulip, an awesome web-based Zephyr client with desktop apps for Mac, Linux, and Windows, as well as native mobile apps.
 
-{% if custom_body %}Message from {{ referrer.full_name }}: {{ custom_body }}
+{% if custom_body %}Message from {{ referrer.full_name|safe }}: {{ custom_body|safe }}
 {% endif %}
 To get started, visit the link below:
     <{{ activate_url }}>

--- a/templates/zerver/emails/invitation_reminder.subject
+++ b/templates/zerver/emails/invitation_reminder.subject
@@ -1,1 +1,1 @@
-Reminder: {{ referrer_name }} invited you to join Zulip{% if referrer_realm_name %} for {{ referrer_realm_name }}{% endif %}
+Reminder: {{ referrer_name|safe }} invited you to join Zulip{% if referrer_realm_name %} for {{ referrer_realm_name|safe }}{% endif %}

--- a/templates/zerver/emails/invitation_reminder.txt
+++ b/templates/zerver/emails/invitation_reminder.txt
@@ -1,6 +1,6 @@
 Hi again,
 
-This is a friendly reminder that {{ referrer_name }} ({{ referrer_email }}) wants you to join them on Zulip, a workplace chat tool that actually makes you more productive.
+This is a friendly reminder that {{ referrer_name|safe }} ({{ referrer_email }}) wants you to join them on Zulip, a workplace chat tool that actually makes you more productive.
 
 To get started, visit the link below:
     <{{ activate_url }}>

--- a/templates/zerver/emails/missed_message.subject
+++ b/templates/zerver/emails/missed_message.subject
@@ -1,4 +1,4 @@
-{% if group_pm %} Group PMs with {{ huddle_display_name }} in {{ realm_str }}
-{% elif at_mention %} {{ sender_str }} mentioned you in {{ realm_str }}
-{% elif private_message %} {{ sender_str }} sent you a message in {{ realm_str }}
+{% if group_pm %} Group PMs with {{ huddle_display_name|safe }} in {{ realm_str|safe }}
+{% elif at_mention %} {{ sender_str|safe }} mentioned you in {{ realm_str|safe }}
+{% elif private_message %} {{ sender_str|safe }} sent you a message in {{ realm_str|safe }}
 {% endif %}

--- a/templates/zerver/emails/missed_message.txt
+++ b/templates/zerver/emails/missed_message.txt
@@ -2,6 +2,7 @@
 Mail sent to user when she was not logged in and received a PM or @-mention
 #}
 
+{% autoescape off %}
 Hello {{ name }},
 
 While you were away you received {{ message_count }} new message{{ messages|pluralize }}{% if mention %} in which you were mentioned{% endif %}!
@@ -38,3 +39,4 @@ Manage email preferences:
 Unsubscribe from missed message emails:
 
 {{ unsubscribe_link }}
+{% endautoescape %}

--- a/templates/zerver/emails/notify_change_in_email.subject
+++ b/templates/zerver/emails/notify_change_in_email.subject
@@ -1,1 +1,1 @@
-[Zulip] Email address changed for {{ realm.name }}
+[Zulip] Email address changed for {{ realm.name|safe }}

--- a/templates/zerver/emails/notify_new_login.txt
+++ b/templates/zerver/emails/notify_new_login.txt
@@ -1,5 +1,6 @@
 {# Informs user of a new login to their account #}
 
+{% autoescape off %}
 Hello, {{ user.full_name | title }}.
 
 This is a notification that a new login to your Zulip account has just occurred.
@@ -17,3 +18,4 @@ If you recognize this login activity, you can archive this notice.
 
 Thanks,
 Zulip Account Security
+{% endautoescape %}


### PR DESCRIPTION
Make sure 's, &s, and other characters are not HTML-escaped in subject
lines and plain-text emails.
    
Hack so that this isn't blocking the release of Zulip 1.6. A more robust way
to do this would be to have two different template Engines, one that renders
HTML, and one that doesn't.

--
Manual testing: did some spot checking, but did not check all of them.
