### PR TITLE
floating_recipient_bar improvements and fix date <span> id duplication

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -648,7 +648,7 @@ function render(template_name, args) {
             is_stream: true,
             message_ids: [1, 2],
             message_containers: messages,
-            show_date: '"<span id="timerender82">Jan&nbsp;07</span>"',
+            show_date: '"<span class="timerender82">Jan&nbsp;07</span>"',
             show_date_separator: true,
             subject: 'two messages',
             match_subject: '<span class="highlight">two</span> messages',

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -99,7 +99,7 @@ var timerender = require('js/timerender.js');
     var actual = timerender.render_date(message_time, undefined, today);
     assert.equal(expected_html, actual.html());
     assert.equal(attrs.get('title'), 'Friday, April 12, 2019');
-    assert.equal(attrs.get('id'), 'timerender0');
+    assert.equal(attrs.get('class'), 'timerender0');
 }());
 
 (function test_render_date_renders_time_above_html() {

--- a/static/js/floating_recipient_bar.js
+++ b/static/js/floating_recipient_bar.js
@@ -46,6 +46,12 @@ exports.hide = function () {
 };
 
 exports.update = function () {
+    // .temp-show-date might be forcing the display of a recipient_row_date if
+    // the floating_recipient_bar is just beginning to overlap the
+    // top-most recipient_bar. remove all instances of .temp-show-date and
+    // re-apply it if we continue to detect overlap
+    $('.recipient_row_date').removeClass('temp-show-date');
+
     var floating_recipient_bar = $("#floating_recipient_bar");
     var floating_recipient_bar_top = floating_recipient_bar.offset().top;
     var floating_recipient_bar_bottom =
@@ -88,6 +94,9 @@ exports.update = function () {
     var header_height = $(current_label).find('.message_header').outerHeight();
     if (floating_recipient_bar_bottom <=
         (current_label.offset().top + header_height)) {
+        // hide floating_recipient_bar and use .temp-show-date to force display
+        // of the recipient_row_date belonging to the current recipient_bar
+        $('.recipient_row_date', current_label).addClass('temp-show-date');
         exports.hide();
         return;
     }

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -76,13 +76,9 @@ $(function () {
 
 // time_above is an optional argument, to support dates that look like:
 // --- ▲ Yesterday ▲ ------ ▼ Today ▼ ---
-function maybe_add_update_list_entry(needs_update, id, time, time_above) {
-    if (needs_update) {
-        if (time_above !== undefined) {
-            update_list.push([id, time, time_above]);
-        } else {
-            update_list.push([id, time]);
-        }
+function maybe_add_update_list_entry(entry) {
+    if (entry.needs_update) {
+        update_list.push(entry);
     }
 }
 
@@ -123,7 +119,12 @@ exports.render_date = function (time, time_above, today) {
     } else {
         node = render_date_span(node, rendered_time);
     }
-    maybe_add_update_list_entry(rendered_time.needs_update, className, time, time_above);
+    maybe_add_update_list_entry({
+      needs_update: rendered_time.needs_update,
+      className: className,
+      time: time,
+      time_above: time_above,
+    });
     return node;
 };
 
@@ -136,26 +137,28 @@ exports.update_timestamps = function () {
         update_list = [];
 
         _.each(to_process, function (entry) {
-            var className = entry[0];
+            var className = entry.className;
             var elements = $('.' + className);
             // The element might not exist any more (because it
             // was in the zfilt table, or because we added
             // messages above it and re-collapsed).
             if (elements !== null) {
                 _.each(elements, function (element) {
-                  blueslip.log(element);
-                    var time = entry[1];
-                    var time_above;
+                    var time = entry.time;
+                    var time_above = entry.time_above;
                     var rendered_time = exports.render_now(time);
-                    if (entry.length === 3) {
-                        time_above = entry[2];
+                    if (time_above) {
                         var rendered_time_above = exports.render_now(time_above);
                         render_date_span($(element), rendered_time, rendered_time_above);
                     } else {
                         render_date_span($(element), rendered_time);
                     }
-                    maybe_add_update_list_entry(
-                      rendered_time.needs_update, className, time, time_above);
+                    maybe_add_update_list_entry({
+                        needs_update: rendered_time.needs_update,
+                        className: className,
+                        time: time,
+                        time_above: time_above,
+                    });
                 });
             }
         });

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -113,50 +113,54 @@ function render_date_span(elem, rendered_time, rendered_time_above) {
 // of this DOM node as HTML, so effectively a copy of the node. That's
 // okay since to update the time later we look up the node by its id.)
 exports.render_date = function (time, time_above, today) {
-    var id = "timerender" + next_timerender_id;
+    var className = "timerender" + next_timerender_id;
     next_timerender_id += 1;
     var rendered_time = exports.render_now(time, today);
-    var node = $("<span />").attr('id', id);
+    var node = $("<span />").attr('class', className);
     if (time_above !== undefined) {
         var rendered_time_above = exports.render_now(time_above, today);
         node = render_date_span(node, rendered_time, rendered_time_above);
     } else {
         node = render_date_span(node, rendered_time);
     }
-    maybe_add_update_list_entry(rendered_time.needs_update, id, time, time_above);
+    maybe_add_update_list_entry(rendered_time.needs_update, className, time, time_above);
     return node;
 };
 
 // This isn't expected to be called externally except manually for
 // testing purposes.
 exports.update_timestamps = function () {
-    var time = new XDate();
-    if (time >= next_update) {
+    var now = new XDate();
+    if (now >= next_update) {
         var to_process = update_list;
         update_list = [];
 
-        _.each(to_process, function (elem) {
-            var id = elem[0];
-            var element = document.getElementById(id);
+        _.each(to_process, function (entry) {
+            var className = entry[0];
+            var elements = $('.' + className);
             // The element might not exist any more (because it
             // was in the zfilt table, or because we added
             // messages above it and re-collapsed).
-            if (element !== null) {
-                var time = elem[1];
-                var time_above;
-                var rendered_time = exports.render_now(time);
-                if (elem.length === 3) {
-                    time_above = elem[2];
-                    var rendered_time_above = exports.render_now(time_above);
-                    render_date_span($(element), rendered_time, rendered_time_above);
-                } else {
-                    render_date_span($(element), rendered_time);
-                }
-                maybe_add_update_list_entry(rendered_time.needs_update, id, time, time_above);
+            if (elements !== null) {
+                _.each(elements, function (element) {
+                  blueslip.log(element);
+                    var time = entry[1];
+                    var time_above;
+                    var rendered_time = exports.render_now(time);
+                    if (entry.length === 3) {
+                        time_above = entry[2];
+                        var rendered_time_above = exports.render_now(time_above);
+                        render_date_span($(element), rendered_time, rendered_time_above);
+                    } else {
+                        render_date_span($(element), rendered_time);
+                    }
+                    maybe_add_update_list_entry(
+                      rendered_time.needs_update, className, time, time_above);
+                });
             }
         });
 
-        next_update = set_to_start_of_day(time.clone().addDays(1));
+        next_update = set_to_start_of_day(now.clone().addDays(1));
     }
 };
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -772,6 +772,14 @@ td.pointer {
     display: none;
 }
 
+/*
+   used to override .hide-date when floating_recipient_bar just begins to
+   overlap the top-most recipient_bar
+*/
+.recipient_row_date.temp-show-date {
+    display: block !important;
+}
+
 .floating_recipient .recipient_row_date.hide-date {
     display: block;
 }

--- a/static/templates/message_edit_history.handlebars
+++ b/static/templates/message_edit_history.handlebars
@@ -1,6 +1,6 @@
 {{! Client-side Mustache template for viewing message edit history.}}
 
-<div class="date_row"><span id="timerender2">{{t 'Earliest' }}</span></div>
+<div class="date_row"><span class="timerender2">{{t 'Earliest' }}</span></div>
 {{#each edited_messages}}
 <div class="">
     <div class="messagebox-border">


### PR DESCRIPTION
Force display of the top-most recipient_bar's recipient_row_date
when the floating_recipient_bar is just about to overlap and
becomes hidden while user is scrolling.

Fixes #4844

WIP while also working to fix #4997 and #5128.