### PR TITLE
frontend: main UI content not in background images

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1495,7 +1495,6 @@ blockquote p {
     width: 35px;
     height: 35px;
     margin-right: 11px;
-    background-size: 35px 35px;
     vertical-align: top;
     border-radius: 4px;
 }
@@ -1806,10 +1805,7 @@ nav .column-left .nav-logo {
     margin-top: 8px;
     width: 25px;
     height: 25px;
-    background-image: url(../images/logo/zulip-icon-128x128.png);
-    background-size: 100% 100%;
-    background-repeat: no-repeat;
-    background-position: center center;
+
 }
 
 nav .column-left .company-name {
@@ -2696,4 +2692,13 @@ img.emoji {
         max-width: 100%;
         margin-top: 10px;
     }
+}
+
+.no-drag {
+    user-drag: none;
+    user-select: none;
+    -moz-user-select: none;
+    -webkit-user-drag: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
 }

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -9,8 +9,9 @@
                     <span class="message_sender{{^status_message}} sender_info_hover{{/status_message}}">
                         {{#include_sender}}
                             {{! See ../js/notifications.js for another user of avatar_url. }}
-                            <div class="u-{{msg/sender_id}} inline_profile_picture{{#status_message}} sender_info_hover{{/status_message}}"
-                                 style="background-image: url('{{small_avatar_url}}');"/>
+                            <div class="u-{{msg/sender_id}} inline_profile_picture{{#status_message}} sender_info_hover{{/status_message}}">
+                                <img src="{{small_avatar_url}}" alt="{{msg/sender_id}}" class="no-drag"/>
+                            </div>
                             {{#if status_message}}
                                 <span class="sender-status">
                                     <span class="sender_name-in-status sender_info_hover">{{msg/sender_full_name}}</span>

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -2,7 +2,7 @@
 <nav class="header-main rightside-userlist" id="top_navbar">
   <div class="column-left">
       <a class="no-style brand" href="#">
-          <div class="nav-logo"></div>
+          <img src="/static/images/logo/zulip-icon-128x128.png" class="nav-logo no-drag"/>
           <div class="company-name">
               zulip
           </div>


### PR DESCRIPTION
Fixes #5004.

The upper left logo is an image, not a background-image; same for inline profile pictures, which have the user's ID as an alt tag.

I can't really think of any other graphics in the main UI that would need to be altered (apart from emojis but this has been deferred). Let me know if I missed anything! 