### PR TITLE
Travis: Improve build performance.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ cache:
   - apt: false
   - directories:
     - $HOME/zulip-venv-cache
-    - node_modules
+    - $HOME/zulip-npm-cache
+    - $HOME/zulip-emoji-cache
     - $HOME/node
 env:
   global:

--- a/tools/travis/setup-production
+++ b/tools/travis/setup-production
@@ -34,8 +34,6 @@ if ! env TRAVIS=1 ./tools/build-release-tarball "${build_options[@]}" travis; th
 fi
 mv /tmp/tmp.*/zulip-server-travis.tar.gz ./
 
-# Remove zulip-npm-cache to ensure we install node_modules correctly
-rm -rf /home/travis/zulip-npm-cache
 
 # Shut down all services so that restarting postgres and rebuilding
 # the postgres database to match the prod installation setup will work.


### PR DESCRIPTION
In this commit we start to cache node modules properly by including `zulip-npm-cache` to directories to be cached. Also `zulip-emoji-cache` is also cached for improving build speed. Apart from this `node modules` were till now being deleted at end of production tests resulting in slow Travis builds since `NPM cache` was
rendered useless. We now no longer delete those `node modules`.