### PR TITLE
bug_down: Fix modal_link.

### DIFF
--- a/zerver/fixtures/bugdown-data.json
+++ b/zerver/fixtures/bugdown-data.json
@@ -387,7 +387,7 @@
     {
       "name": "modal_link",
       "input": "!modal_link(#settings, Settings page)",
-      "expected_output": "<p><a data-toggle=\"modal\" href=\"#settings\" title=\"#settings\">Settings page</a></p>",
+      "expected_output": "<p><a href=\"#settings\" title=\"#settings\">Settings page</a></p>",
       "bugdown_matches_marked": false
     },
     {

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -793,7 +793,6 @@ class ModalLink(markdown.inlinepatterns.Pattern):
         a_tag = markdown.util.etree.Element("a")
         a_tag.set("href", relative_url)
         a_tag.set("title", relative_url)
-        a_tag.set("data-toggle", "modal")
         a_tag.text = text
 
         return a_tag

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -884,7 +884,7 @@ class BugdownTest(ZulipTestCase):
         self.assertEqual(
             converted,
             '<p>'
-            '<a data-toggle="modal" href="#settings" title="#settings">Settings page</a>'
+            '<a href="#settings" title="#settings">Settings page</a>'
             '</p>'
         )
 


### PR DESCRIPTION
The `data-toggle` property prevents modals from launching. This still doesn't work for the overlays that doesn't use the hashchange system, see #5206.