### PR TITLE
Improve search suggestions

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -253,28 +253,28 @@ expect_home();
 
 // Narrow by typing in search strings or operators.
 // Test stream / recipient autocomplete in the search bar
-search_and_check('Verona', 'Narrow to stream', expect_stream,
+search_and_check('Verona', 'Stream', expect_stream,
                  'Verona - Zulip Dev - Zulip');
 
-search_and_check('Cordelia', 'Narrow to private', expect_1on1,
+search_and_check('Cordelia', 'Private', expect_1on1,
                  'private - Zulip Dev - Zulip');
 
 // Test operators
-search_and_check('stream:Verona', 'Narrow', expect_stream,
+search_and_check('stream:Verona', '', expect_stream,
                  'Verona - Zulip Dev - Zulip');
 
-search_and_check('stream:Verona subject:frontend+test', 'Narrow', expect_stream_subject,
+search_and_check('stream:Verona subject:frontend+test', '', expect_stream_subject,
                  'frontend test - Zulip Dev - Zulip');
 
-search_and_check('stream:Verona topic:frontend+test', 'Narrow', expect_stream_subject,
+search_and_check('stream:Verona topic:frontend+test', '', expect_stream_subject,
                  'frontend test - Zulip Dev - Zulip');
 
-search_and_check('subject:frontend+test', 'Narrow', expect_subject,
+search_and_check('subject:frontend+test', '', expect_subject,
                  'home - Zulip Dev - Zulip');
 
-search_silent_user('sender:emailgateway@zulip.com', 'Narrow');
+search_silent_user('sender:emailgateway@zulip.com', '');
 
-search_non_existing_user('sender:dummyuser@zulip.com', 'Narrow');
+search_non_existing_user('sender:dummyuser@zulip.com', '');
 
 // Narrow by clicking the left sidebar.
 casper.then(function () {

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -580,6 +580,9 @@ function make_sub(name, stream_id) {
     string = 'Narrow to stream devel, Exclude messages with one or more image';
     assert.equal(Filter.describe(narrow), string);
 
+    narrow = [];
+    string = 'Go to Home view';
+    assert.equal(Filter.describe(narrow), string);
 }());
 
 (function test_update_email() {

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -464,6 +464,10 @@ function make_sub(name, stream_id) {
         {operator: 'search', operand: ':stream: -:emoji: are cool'},
     ];
     _test();
+
+    string = '';
+    operators = [];
+    _test();
 }());
 
 (function test_unparse() {
@@ -489,6 +493,12 @@ function make_sub(name, stream_id) {
     ];
     string = 'near:150';
     assert.deepEqual(Filter.unparse(operators), string);
+
+    operators = [
+        {operator: '', operand: ''},
+    ];
+    string = '';
+    assert.deepEqual(Filter.unparse(operators), string);
 }());
 
 (function test_describe() {
@@ -499,85 +509,86 @@ function make_sub(name, stream_id) {
         {operator: 'stream', operand: 'devel'},
         {operator: 'is', operand: 'starred'},
     ];
-    string = 'Narrow to stream devel, Narrow to starred messages';
+    string = 'stream devel, starred messages';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'stream', operand: 'devel'},
         {operator: 'topic', operand: 'JS'},
     ];
-    string = 'Narrow to devel > JS';
+    string = 'stream devel > JS';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'is', operand: 'private'},
         {operator: 'search', operand: 'lunch'},
     ];
-    string = 'Narrow to all private messages, Search for lunch';
+    string = 'private messages, search for lunch';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'id', operand: 99},
     ];
-    string = 'Narrow to message ID 99';
+    string = 'message ID 99';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'in', operand: 'home'},
     ];
-    string = 'Narrow to messages in home';
+    string = 'messages in home';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'is', operand: 'mentioned'},
     ];
-    string = 'Narrow to mentioned messages';
+    string = '@-mentions';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'is', operand: 'alerted'},
     ];
-    string = 'Narrow to alerted messages';
+    string = 'alerted messages';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'is', operand: 'something_we_do_not_support'},
     ];
-    string = 'Narrow to (unknown operator)';
+    string = 'unknown operand';
     assert.equal(Filter.describe(narrow), string);
 
+    // this should be unreachable, but just in case
     narrow = [
         {operator: 'bogus', operand: 'foo'},
     ];
-    string = 'Narrow to (unknown operator)';
+    string = 'unknown operand';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'stream', operand: 'devel'},
         {operator: 'topic', operand: 'JS', negated: true},
     ];
-    string = 'Narrow to stream devel, Exclude topic JS';
+    string = 'stream devel, exclude topic JS';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'is', operand: 'private'},
         {operator: 'search', operand: 'lunch', negated: true},
     ];
-    string = 'Narrow to all private messages, Exclude lunch';
+    string = 'private messages, exclude lunch';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'stream', operand: 'devel'},
         {operator: 'is', operand: 'starred', negated: true},
     ];
-    string = 'Narrow to stream devel, Exclude starred messages';
+    string = 'stream devel, exclude starred messages';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'stream', operand: 'devel'},
         {operator: 'has', operand: 'image', negated: true},
     ];
-    string = 'Narrow to stream devel, Exclude messages with one or more image';
+    string = 'stream devel, exclude messages with one or more image';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [];

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -589,6 +589,32 @@ init();
         'stream:office -topic:test',
     ];
     assert.deepEqual(suggestions.strings, expected);
+
+    suggestions = search.get_suggestions('is:alerted stream:devel is:starred topic:');
+    expected = [
+        'is:alerted stream:devel is:starred topic:',
+        'is:alerted stream:devel is:starred topic:REXX',
+        'is:alerted stream:devel is:starred',
+        'is:alerted stream:devel',
+        'is:alerted',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    suggestions = search.get_suggestions('is:private stream:devel topic:');
+    expected = [
+        'is:private stream:devel topic:',
+        'is:private stream:devel',
+        'is:private',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    suggestions = search.get_suggestions('topic:REXX stream:devel topic:');
+    expected = [
+        'topic:REXX stream:devel topic:',
+        'topic:REXX stream:devel',
+        'topic:REXX',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
 }());
 
 (function test_whitespace_glitch() {

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -422,7 +422,7 @@ init();
     assert.equal(describe('is:mentioned'), '@-mentions');
     assert.equal(describe('is:alerted'), 'Alerted messages');
     assert.equal(describe('sender:bob@zulip.com'), 'Sent by me');
-    assert.equal(describe('stream:devel'), 'Narrow to stream <strong>devel</strong>');
+    assert.equal(describe('stream:devel'), 'Stream <strong>devel</strong>');
 }());
 
 (function test_sent_by_me_suggestions() {
@@ -557,7 +557,7 @@ init();
         return suggestions.lookup_table[q].description;
     }
     assert.equal(describe('te'), "Search for te");
-    assert.equal(describe('stream:office topic:team'), "Narrow to office > team");
+    assert.equal(describe('stream:office topic:team'), "Stream office > team");
 
     suggestions = search.get_suggestions('topic:staplers stream:office');
     expected = [
@@ -718,9 +718,9 @@ init();
         return suggestions.lookup_table[q].description;
     }
     assert.equal(describe('pm-with:ted@zulip.com'),
-        "Narrow to private messages with <strong>Te</strong>d Smith &lt;<strong>te</strong>d@zulip.com&gt;");
+        "Private messages with <strong>Te</strong>d Smith &lt;<strong>te</strong>d@zulip.com&gt;");
     assert.equal(describe('sender:ted@zulip.com'),
-        "Narrow to messages sent by <strong>Te</strong>d Smith &lt;<strong>te</strong>d@zulip.com&gt;");
+        "Messages sent by <strong>Te</strong>d Smith &lt;<strong>te</strong>d@zulip.com&gt;");
 
     suggestions = search.get_suggestions('Ted '); // note space
 

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -733,3 +733,41 @@ init();
     assert.deepEqual(suggestions.strings, expected);
 
 }());
+
+(function test_contains_suggestions() {
+    var query = 'has:';
+    var suggestions = search.get_suggestions(query);
+    var expected = [
+        'has:',
+        'has:link',
+        'has:image',
+        'has:attachment',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'has:im';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'has:im',
+        'has:image',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'att';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'att',
+        'has:attachment',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'stream:Denmark is:alerted has:lin';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'stream:Denmark is:alerted has:lin',
+        'stream:Denmark is:alerted has:link',
+        'stream:Denmark is:alerted',
+        'stream:Denmark',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+}());

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -417,6 +417,33 @@ init();
         "sender:bob@zulip.com",
     ];
     assert.deepEqual(suggestions.strings, expected);
+
+    query = 'stream:Denmark topic:Denmark1 sent';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "stream:Denmark topic:Denmark1 sent",
+        "stream:Denmark topic:Denmark1 sender:bob@zulip.com",
+        "stream:Denmark topic:Denmark1",
+        "stream:Denmark",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'is:starred sender:m';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "is:starred sender:m",
+        "is:starred sender:bob@zulip.com",
+        "is:starred",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'sender:alice@zulip.com sender:';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "sender:alice@zulip.com sender:",
+        "sender:alice@zulip.com",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
 }());
 
 (function test_topic_suggestions() {

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -119,7 +119,8 @@ global.stream_data.populate_stream_topics_for_tests({});
     expected = [
         "is:private al",
         "is:private is:alerted",
-        "pm-with:alice@zulip.com",
+        "is:private pm-with:alice@zulip.com",
+        "is:private sender:alice@zulip.com",
         "is:private",
     ];
     assert.deepEqual(suggestions.strings, expected);
@@ -172,7 +173,7 @@ global.stream_data.populate_stream_topics_for_tests({});
     suggestions = search.get_suggestions(query);
     expected = [
         "-sender:te",
-        "is:private -sender:ted@zulip.com",
+        "-sender:ted@zulip.com",
         "is:private",
     ];
     assert.deepEqual(suggestions.strings, expected);
@@ -210,6 +211,46 @@ global.stream_data.populate_stream_topics_for_tests({});
     expected = [
         "pm-with:ted@zulip.com near:3",
         "pm-with:ted@zulip.com",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    // Make sure suggestions still work if preceding tokens
+    query = 'is:alerted sender:ted@zulip.com';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "is:alerted sender:ted@zulip.com",
+        "is:alerted is:private",
+        "is:alerted",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'is:starred has:link is:private al';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "is:starred has:link is:private al",
+        "is:starred has:link is:private is:alerted",
+        "is:starred has:link is:private pm-with:alice@zulip.com",
+        "is:starred has:link is:private sender:alice@zulip.com",
+        "is:starred has:link is:private",
+        "is:starred has:link",
+        "is:starred",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    // Make sure it handles past context correctly
+    query = 'stream:Denmark pm-with:';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'stream:Denmark pm-with:',
+        'stream:Denmark',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'sender:ted@zulip.com sender:';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'sender:ted@zulip.com sender:',
+        'sender:ted@zulip.com',
     ];
     assert.deepEqual(suggestions.strings, expected);
 }());
@@ -318,6 +359,27 @@ global.stream_data.populate_stream_topics_for_tests({});
     expected = [
         "-pm-with:bob@zulip.com,red",
         "is:private",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    // Test multiple operators
+    query = 'is:starred has:link pm-with:bob@zulip.com,Smit';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "is:starred has:link pm-with:bob@zulip.com,Smit",
+        "is:starred has:link pm-with:bob@zulip.com,ted@zulip.com",
+        "is:starred has:link is:private",
+        "is:starred has:link",
+        "is:starred",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'stream:Denmark has:link pm-with:bob@zulip.com,Smit';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "stream:Denmark has:link pm-with:bob@zulip.com,Smit",
+        "stream:Denmark has:link",
+        "stream:Denmark",
     ];
     assert.deepEqual(suggestions.strings, expected);
 }());
@@ -433,6 +495,7 @@ init();
     expected = [
         "is:starred sender:m",
         "is:starred sender:bob@zulip.com",
+        "is:starred is:private",
         "is:starred",
     ];
     assert.deepEqual(suggestions.strings, expected);

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -118,6 +118,7 @@ global.stream_data.populate_stream_topics_for_tests({});
     suggestions = search.get_suggestions(query);
     expected = [
         "is:private al",
+        "is:private is:alerted",
         "pm-with:alice@zulip.com",
         "is:private",
     ];

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -200,8 +200,6 @@ Filter.canonicalize_term = function (opts) {
     };
 };
 
-
-
 /* We use a variant of URI encoding which looks reasonably
    nice and still handles unambiguously cases such as
    spaces in operands.
@@ -419,10 +417,10 @@ Filter.operator_to_prefix = function (operator, negated) {
     var verb;
 
     if (operator === 'search') {
-        return negated ? 'Exclude' : 'Search for';
+        return negated ? 'exclude' : 'search for';
     }
 
-    verb = negated ? 'Exclude ' : 'Narrow to ';
+    verb = negated ? 'exclude ' : '';
 
     switch (operator) {
     case 'stream':
@@ -474,7 +472,7 @@ Filter.describe = function (operators) {
         if (is(operators[0], 'stream') && is(operators[1], 'topic')) {
             var stream = operators[0].operand;
             var topic = operators[1].operand;
-            var part = 'Narrow to ' + stream + ' > ' + topic;
+            var part = "stream " + stream + ' > ' + topic;
             parts = [part];
             operators = operators.slice(2);
         }
@@ -484,13 +482,13 @@ Filter.describe = function (operators) {
         var operand = elem.operand;
         var canonicalized_operator = Filter.canonicalize_operator(elem.operator);
         if (canonicalized_operator ==='is') {
-            var verb = elem.negated ? 'Exclude ' : 'Narrow to ';
+            var verb = elem.negated ? 'exclude ' : '';
             if (operand === 'private') {
-                return verb + 'all private messages';
+                return verb + 'private messages';
             } else if (operand === 'starred') {
                 return verb + 'starred messages';
             } else if (operand === 'mentioned') {
-                return verb + 'mentioned messages';
+                return verb + '@-mentions';
             } else if (operand === 'alerted') {
                 return verb + 'alerted messages';
             }
@@ -501,7 +499,7 @@ Filter.describe = function (operators) {
                 return prefix_for_operator + ' ' + operand;
             }
         }
-        return 'Narrow to (unknown operator)';
+        return "unknown operand";
     });
     return parts.concat(more_parts).join(', ');
 };

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -293,6 +293,9 @@ Filter.unparse = function (operators) {
             return elem.operand;
         }
         var sign = elem.negated ? '-' : '';
+        if (elem.operator === '') {
+            return elem.operand;
+        }
         return sign + elem.operator + ':' + encodeOperand(elem.operand.toString());
     });
     return parts.join(' ');

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -453,6 +453,24 @@ function get_sent_by_me_suggestions(last, operators) {
     return [];
 }
 
+function get_containing_suggestions(last) {
+        if (!(last.operator === 'search' || last.operator === 'has')) {
+            return [];
+        }
+
+        var choices = ['link', 'image', 'attachment'];
+        choices = _.filter(choices, function (choice) {
+            return phrase_match(choice, last.operand);
+        });
+
+        return _.map(choices, function (choice) {
+            var op = [{operator: 'has', operand: choice, negated: false}];
+            var search_string = Filter.unparse(op);
+            var description = Filter.describe(op);
+            return {description: description, search_string: search_string};
+        });
+}
+
 function attach_suggestions(result, base, suggestions) {
     _.each(suggestions, function (suggestion) {
         if (base.description.length > 0) {
@@ -519,6 +537,9 @@ exports.get_suggestions = function (query) {
     attach_suggestions(result, base, suggestions);
 
     suggestions = get_topic_suggestions(last, base_operators);
+    attach_suggestions(result, base, suggestions);
+
+    suggestions = get_containing_suggestions(last);
     attach_suggestions(result, base, suggestions);
 
     suggestions = get_operator_subset_suggestions(operators);

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -69,7 +69,7 @@ function get_stream_suggestions(last, operators) {
     streams = typeahead_helper.sorter(query, streams);
 
     var objs = _.map(streams, function (stream) {
-        var prefix = 'Narrow to stream';
+        var prefix = 'stream';
         var highlighted_stream = typeahead_helper.highlight_query_in_phrase(query, stream);
         var description = prefix + ' ' + highlighted_stream;
         var term = {
@@ -359,7 +359,7 @@ function get_special_filter_suggestions(last, operators) {
     var suggestions = [
         {
             search_string: 'in:all',
-            description: 'All messages',
+            description: 'all messages',
             invalid: [
                 {operator: 'in'},
                 {operator: 'stream'},
@@ -369,7 +369,7 @@ function get_special_filter_suggestions(last, operators) {
         },
         {
             search_string: 'is:private',
-            description: 'Private messages',
+            description: 'private messages',
             invalid: [
                 {operator: 'is', operand: 'private'},
                 {operator: 'stream'},
@@ -380,7 +380,7 @@ function get_special_filter_suggestions(last, operators) {
         },
         {
             search_string: 'is:starred',
-            description: 'Starred messages',
+            description: 'starred messages',
             invalid: [
                 {operator: 'is', operand: 'starred'},
             ],
@@ -394,7 +394,7 @@ function get_special_filter_suggestions(last, operators) {
         },
         {
             search_string: 'is:alerted',
-            description: 'Alerted messages',
+            description: 'alerted messages',
             invalid: [
                 {operator: 'is', operand: 'alerted'},
             ],
@@ -424,7 +424,7 @@ function get_sent_by_me_suggestions(last, operators) {
     var last_string = Filter.unparse([last]).toLowerCase();
     var sender_query = 'sender:' + people.my_current_email();
     var from_query = 'from:' + people.my_current_email();
-    var description = 'Sent by me';
+    var description = 'sent by me';
     var invalid = [
         {operator: 'sender'},
         {operator: 'from'},
@@ -544,6 +544,11 @@ exports.get_suggestions = function (query) {
 
     suggestions = get_operator_subset_suggestions(operators);
     result = result.concat(suggestions);
+
+    _.each(result, function (sug) {
+        var first = sug.description.charAt(0).toUpperCase();
+        sug.description = first + sug.description.slice(1);
+    });
 
     // Typeahead expects us to give it strings, not objects, so we maintain our own hash
     // back to our objects, and we also filter duplicates here.

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -463,29 +463,29 @@ function get_special_filter_suggestions(last, operators) {
     return suggestions;
 }
 
-function get_sent_by_me_suggestions(query, operators) {
-    if (operators.length >= 2) {
-        return [];
-    }
-
+function get_sent_by_me_suggestions(last, operators) {
+    var last_string = Filter.unparse([last]).toLowerCase();
     var sender_query = 'sender:' + people.my_current_email();
     var from_query = 'from:' + people.my_current_email();
     var description = 'Sent by me';
+    var invalid = [
+        {operator: 'sender'},
+        {operator: 'from'},
+    ];
 
-    query = query.toLowerCase();
-
-    if (query === sender_query || query === from_query) {
+    if (match_criteria(operators, invalid)) {
         return [];
-    } else if (query === '' ||
-        sender_query.indexOf(query) === 0 ||
-        description.toLowerCase().indexOf(query) === 0) {
+    }
+
+    if (last.operator === '' || sender_query.indexOf(last_string) === 0 ||
+        'sender:me'.indexOf(last_string) === 0 || last_string === 'sent') {
         return [
             {
                 search_string: sender_query,
                 description: description,
             },
         ];
-    } else if (from_query.indexOf(query) === 0) {
+    } else if (from_query.indexOf(last_string) === 0 || 'sender:me'.indexOf(last_string) === 0) {
         return [
             {
                 search_string: from_query,
@@ -541,8 +541,8 @@ exports.get_suggestions = function (query) {
     suggestions = get_special_filter_suggestions(last, base_operators);
     attach_suggestions(result, base, suggestions);
 
-    suggestions = get_sent_by_me_suggestions(query, operators);
-    result = result.concat(suggestions);
+    suggestions = get_sent_by_me_suggestions(last, base_operators);
+    attach_suggestions(result, base, suggestions);
 
     suggestions = get_stream_suggestions(operators);
     result = result.concat(suggestions);

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -44,24 +44,22 @@ function match_criteria(operators, criteria) {
     });
 }
 
-function get_stream_suggestions(operators) {
-    var query;
-
-    switch (operators.length) {
-    case 0:
-        query = '';
-        break;
-    case 1:
-        var operator = operators[0].operator;
-        query = operators[0].operand;
-        if (!(operator === 'stream' || operator === 'search')) {
-            return [];
-        }
-        break;
-    default:
+function get_stream_suggestions(last, operators) {
+    if (!(last.operator === 'stream' || last.operator === 'search'
+        || last.operator === '')) {
         return [];
     }
 
+    var invalid = [
+        {operator: 'stream'},
+        {operator: 'is', operand: 'private'},
+        {operator: 'pm-with'},
+    ];
+    if (match_criteria(operators, invalid)) {
+        return [];
+    }
+
+    var query = last.operand;
     var streams = stream_data.subscribed_streams();
 
     streams = _.filter(streams, function (stream) {
@@ -501,8 +499,8 @@ exports.get_suggestions = function (query) {
     suggestions = get_sent_by_me_suggestions(last, base_operators);
     attach_suggestions(result, base, suggestions);
 
-    suggestions = get_stream_suggestions(operators);
-    result = result.concat(suggestions);
+    suggestions = get_stream_suggestions(last, base_operators);
+    attach_suggestions(result, base, suggestions);
 
     var persons = people.get_all_persons();
 


### PR DESCRIPTION
Major update of the search typeahead system to support multiple tokens. Examples:
![image](https://cloud.githubusercontent.com/assets/8433005/26757379/940a238a-4887-11e7-8a42-2ba303de09f6.png)
![image](https://cloud.githubusercontent.com/assets/8433005/26757399/f7832baa-4887-11e7-991a-0b4bd4b0ffb0.png)

Generally, the structure is changed so that each helper method takes in the last token of the search bar (the one currently being typed), and all the previous operators as context. 

Each helper has an array, `invalid`, that specifies previous operators that would make a suggestion invalid. For example, it is invalid to suggest `stream` if the previous operators contains `pm-with`.

Then, each helper method returns a suggestion based on the last term, and then this is appended to the search string of all the previous operators, via `attach_suggestions`.

A few things I should address:
- ~This probably fails all of the current `search_suggestions` tests~ All tests now passing! ~Now need to add new ones for the added features.~ Done.
- ~Negation of operators doesn't really work with typeahead. It is currently supported to autocomplete `-topic`, but `-sender` no longer works, which is a regression. Not sure if negating any other operators is worth supporting in typeahead.~ Done.
- ~There has never been support for autocompleting `has:link/image/attachment`. I might add a new helper function to do so.~ Done.
- ~Note that a keyword search only works with typeahead if it's the last operator. The way `Filter.describe` kind of breaks when a keyword is sandwiched between other terms, but I don't really think this is case worth worrying about.~ Ignoring.
- ~I don't like the way Filter describes some things. I feel like it gets kind of verbose by saying "Narrow to..." for every step. Also there are some weird cases, where like `is:` gets described as "Narrow to: (unknown operator)"~ Done.

