### PR TITLE
composebox_typeahead: Fix stream typeahead highlighting.

### DIFF
--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -7,6 +7,7 @@ add_dependencies({
     people: 'js/people.js',
     typeahead_helper: 'js/typeahead_helper.js',
     util: 'js/util.js',
+    Handlebars: 'handlebars',
 });
 
 var popular = {num_items: function () {
@@ -137,4 +138,24 @@ _.each(matches, function (person) {
         'b_bot@example.com',
     ]);
 
+}());
+
+(function test_highlight_with_escaping() {
+    var item = "Denmark";
+    var query = "Den";
+    var expected = "<strong>Den</strong>mark";
+    var result = th.highlight_with_escaping(query, item);
+    assert.equal(result, expected);
+
+    item = "w3IrD_naMe";
+    query = "w3IrD_naMe";
+    expected = "<strong>w3IrD_naMe</strong>";
+    result = th.highlight_with_escaping(query, item);
+    assert.equal(result, expected);
+
+    item = "development help";
+    query = "development h";
+    expected = "<strong>development h</strong>elp";
+    result = th.highlight_with_escaping(query, item);
+    assert.equal(result, expected);
 }());

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -468,7 +468,7 @@ exports.initialize = function () {
         fixed: true,
         highlighter: function (item) {
             var query = this.query;
-            return typeahead_helper.highlight_query_in_phrase(query, item);
+            return typeahead_helper.highlight_with_escaping(query, item);
         },
         matcher: function (item) {
             // The matcher for "stream" is strictly prefix-based,


### PR DESCRIPTION
Changed the highlighting method used by the stream input field.
The one now in use supports spaces in the input.
Fixes #5211