### PR TITLE
Cleanup rabbitmq queues when doing dev db rebuild.

### DIFF
--- a/docs/queuing.md
+++ b/docs/queuing.md
@@ -67,10 +67,10 @@ You can publish events to a RabbitMQ queue using the
 ### Clearing a RabbitMQ queue
 
 If you need to clear a queue (delete all the events in it), run
-`./manage.py purge_queue <queue_name>`, for example:
+`./manage.py purge_queue --queue-name <queue_name>`, for example:
 
 ```
-./manage.py purge_queue user_activity
+./manage.py purge_queue --queue-name user_activity
 ```
 
 You can also use the amqp tools directly.  Install `amqp-tools` from

--- a/tools/do-destroy-rebuild-database
+++ b/tools/do-destroy-rebuild-database
@@ -15,6 +15,7 @@ EOF
 
 sh "$(dirname "$0")/../scripts/setup/flush-memcached"
 
+./manage.py purge_queue --all
 ./manage.py migrate --noinput
 migration_status "var/migration_status_dev"
 ./manage.py createcachetable third_party_api_results

--- a/zerver/management/commands/purge_queue.py
+++ b/zerver/management/commands/purge_queue.py
@@ -5,19 +5,30 @@ from argparse import ArgumentParser
 from django.core.management.base import BaseCommand
 from django.core.management import CommandError
 from zerver.lib.queue import SimpleQueueClient
+from zerver.worker.queue_processors import get_active_worker_queues
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
-        parser.add_argument('queue_name', metavar='<queue name>', type=str,
-                            help="queue to purge")
+        parser.add_argument('--queue-name', dest="queue_name", type=str,
+                            default=False, help="queue to purge")
+        parser.add_argument('--all', dest="all", action="store_true",
+                            default=False, help="purge all queues")
 
     help = "Discards all messages from the given queue"
 
     def handle(self, *args, **options):
         # type: (*Any, **str) -> None
-        queue_name = options['queue_name']
-        queue = SimpleQueueClient()
-        queue.ensure_queue(queue_name, lambda: None)
-        queue.channel.queue_purge(queue_name)
+        def purge_queue(queue_name):
+            # type: (str) -> None
+            queue = SimpleQueueClient()
+            queue.ensure_queue(queue_name, lambda: None)
+            queue.channel.queue_purge(queue_name)
+
+        if options['all']:
+            for queue_name in get_active_worker_queues():
+                purge_queue(queue_name)
+        else:
+            queue_name = options['queue_name']
+            purge_queue(queue_name)
         print("Done")


### PR DESCRIPTION
- [ ] This is still pending for A/B testing since I can't reproduce the issue yet. I need help.

note: `purge_queue` wraps `pika` which wraps `rabbitmq`.

(maybe) Fixes #1335