### PR TITLE
frontend: make notification header consistent

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -471,7 +471,7 @@ input[type=checkbox].inline-block {
     margin-right: 8px;
 }
 #notification-settings .notification-reminder {
-    text-align: center;
+    text-align: left;
 }
 
 .control-label-disabled {

--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -1,6 +1,6 @@
 <div id="notification-settings" class="settings-section" data-name="notifications">
     <form class="notification-settings-form">
-        <div class="notification-reminder w-70 padded-container center-block">{{#tr this }}You'll receive notifications when a message arrives and Zulip isn't in focus or the message is offscreen.{{/tr}}</div>
+        <div class="notification-reminder vertical-padding">{{#tr this }}You'll receive notifications when a message arrives and Zulip isn't in focus or the message is offscreen.{{/tr}}</div>
         <div class="alert" id="notify-settings-status"></div>
 
         <h4>{{t "Stream messages" }}</h4>


### PR DESCRIPTION
fixes #5172. 

Looks like this for me: 
![screen shot 2017-06-05 at 16 53 30](https://cloud.githubusercontent.com/assets/13666710/26791692/c9e5b6a2-4a0f-11e7-8020-b7506fd46cfa.png)

Do we want to emphasise it more somehow?
