### PR TITLE
hotkeys: Include .editable-section in processing_text().

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -150,7 +150,7 @@ exports.get_keypress_hotkey = function (e) {
 };
 
 exports.processing_text = function () {
-    var selector = 'input:focus,select:focus,textarea:focus,#compose-send-button:focus';
+    var selector = 'input:focus,select:focus,textarea:focus,#compose-send-button:focus,.editable-section:focus';
     return $(selector).length > 0;
 };
 


### PR DESCRIPTION
Prevents accidental hotkey triggering while span.editable-section is focused. Fixes #5232