### PR TITLE
[WIP] Add a service worker fallback for web notifications

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -39,24 +39,27 @@ if (window.webkitNotifications) {
                 return notification_object;
             } catch (e) {
                 if (e.name == 'TypeError') {
-                    // We are probably on Chrome Android where non-persistent notifications are not supported.
-                    // Details: https://github.com/whatwg/notifications/issues/26
-                    // Use a service worker to send the notification instead.
-                    if ('serviceWorker' in navigator) {
-                        return navigator.serviceWorker.register('/static/js/sw.js').then(function(registration) {
-							return registration.showNotification(title, {
-								icon: icon,
-							  	body: content,
-							  	tag: tag
-							});
-                        });
-                    }
+                    return service_worker_notification(icon, title, content, tag);
                 }
             }
         },
     };
 }
 
+function service_worker_notification() {
+    // we are probably on chrome android where non-persistent notifications are not supported.
+    // details: https://github.com/whatwg/notifications/issues/26
+    // use a service worker to send the notification instead.
+    if ('serviceworker' in navigator) {
+        return navigator.serviceworker.register('/static/js/sw.js').then(function(registration) {
+            return registration.shownotification(title, {
+                icon: icon,
+                body: content,
+                tag: tag
+            });
+        });
+    }
+}
 
 function browser_desktop_notifications_on() {
     return (notifications_api &&

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -38,7 +38,7 @@ if (window.webkitNotifications) {
                 notification_object.cancel = function () { notification_object.close(); };
                 return notification_object;
             } catch (e) {
-                if (e.name == 'TypeError') {
+                if (e.name === 'TypeError') {
                     return service_worker_notification(icon, title, content, tag);
                 }
             }
@@ -46,16 +46,16 @@ if (window.webkitNotifications) {
     };
 }
 
-function service_worker_notification() {
+function service_worker_notification(icon, title, content, tag) {
     // we are probably on chrome android where non-persistent notifications are not supported.
     // details: https://github.com/whatwg/notifications/issues/26
     // use a service worker to send the notification instead.
     if ('serviceworker' in navigator) {
-        return navigator.serviceworker.register('/static/js/sw.js').then(function(registration) {
+        return navigator.serviceworker.register('/static/js/sw.js').then(function (registration) {
             return registration.shownotification(title, {
                 icon: icon,
                 body: content,
-                tag: tag
+                tag: tag,
             });
         });
     }

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -370,13 +370,15 @@ function process_notification(notification) {
             message_id: message.id,
         };
         notification_object = notice_memory[key].obj;
-        notification_object.onclick = function () {
-            notification_object.cancel();
-            if (feature_flags.clicking_notification_causes_narrow) {
-                narrow.by_subject(message.id, {trigger: 'notification'});
-            }
-            window.focus();
-        };
+        if ('onclick' in notification_object) {
+            notification_object.onclick = function () {
+                notification_object.cancel();
+                if (feature_flags.clicking_notification_causes_narrow) {
+                    narrow.by_subject(message.id, {trigger: 'notification'});
+                }
+                window.focus();
+            };
+        }
         notification_object.onclose = function () {
             delete notice_memory[key];
         };

--- a/static/js/sw.js
+++ b/static/js/sw.js
@@ -1,17 +1,18 @@
-self.addEventListener('notificationclick', function(event) {
+self.addEventListener('notificationclick', function (event) {
     var clickedNotification = event.notification;
     clickedNotification.close();
 
-    // This looks to see if the current is already open and  
-    // focuses if it is  
+    // This looks to see if the current is already open and
+    // focuses if it is
     event.waitUntil(
-        clients.matchAll({  
+        /* eslint-disable no-undef */
+        clients.matchAll({
             includeUncontrolled: true,
-            type: "window"
+            type: "window",
         })
-        .then(function(clientList) {  
-            for (var i = 0; i < clientList.length; i++) {  
-                var client = clientList[i];  
+        .then(function (clientList) {  
+            for (var i = 0; i < clientList.length; i++) {
+                var client = clientList[i];
                 if ('focus' in client) {
                     // Do something as the result of the notification click
                     // TODO: how to get access feature_flags and narrow variables here?
@@ -22,8 +23,9 @@ self.addEventListener('notificationclick', function(event) {
                 }
             }  
             if (clients.openWindow) {
-                return clients.openWindow('/');  
+                return clients.openWindow('/');
             }
         })
+        /* eslint-enable no-undef */
     );
 });

--- a/static/js/sw.js
+++ b/static/js/sw.js
@@ -11,7 +11,7 @@ self.addEventListener('notificationclick', function (event) {
             type: "window",
         })
         .then(function (clientList) {  
-            for (var i = 0; i < clientList.length; i++) {
+            for (var i = 0; i < clientList.length; i + 1) {
                 var client = clientList[i];
                 if ('focus' in client) {
                     // Do something as the result of the notification click
@@ -21,7 +21,7 @@ self.addEventListener('notificationclick', function (event) {
                     // }
                     return client.focus();
                 }
-            }  
+            }
             if (clients.openWindow) {
                 return clients.openWindow('/');
             }

--- a/static/js/sw.js
+++ b/static/js/sw.js
@@ -1,0 +1,29 @@
+self.addEventListener('notificationclick', function(event) {
+    var clickedNotification = event.notification;
+    clickedNotification.close();
+
+	// This looks to see if the current is already open and  
+	// focuses if it is  
+	event.waitUntil(
+		clients.matchAll({  
+            includeUncontrolled: true,
+		    type: "window"
+		})
+		.then(function(clientList) {  
+			for (var i = 0; i < clientList.length; i++) {  
+				var client = clientList[i];  
+				if ('focus' in client) {
+                    // Do something as the result of the notification click
+                    // TODO: how to get access feature_flags and narrow variables here?
+                    // if (feature_flags.clicking_notification_causes_narrow) {
+                        // narrow.by_subject(message.id, {trigger: 'notification'});
+                    // }
+				    return client.focus();
+                }
+			}  
+            if (clients.openWindow) {
+                return clients.openWindow('/');  
+            }
+		})
+	);
+});

--- a/static/js/sw.js
+++ b/static/js/sw.js
@@ -2,28 +2,28 @@ self.addEventListener('notificationclick', function(event) {
     var clickedNotification = event.notification;
     clickedNotification.close();
 
-	// This looks to see if the current is already open and  
-	// focuses if it is  
-	event.waitUntil(
-		clients.matchAll({  
+    // This looks to see if the current is already open and  
+    // focuses if it is  
+    event.waitUntil(
+        clients.matchAll({  
             includeUncontrolled: true,
-		    type: "window"
-		})
-		.then(function(clientList) {  
-			for (var i = 0; i < clientList.length; i++) {  
-				var client = clientList[i];  
-				if ('focus' in client) {
+            type: "window"
+        })
+        .then(function(clientList) {  
+            for (var i = 0; i < clientList.length; i++) {  
+                var client = clientList[i];  
+                if ('focus' in client) {
                     // Do something as the result of the notification click
                     // TODO: how to get access feature_flags and narrow variables here?
                     // if (feature_flags.clicking_notification_causes_narrow) {
                         // narrow.by_subject(message.id, {trigger: 'notification'});
                     // }
-				    return client.focus();
+                    return client.focus();
                 }
-			}  
+            }  
             if (clients.openWindow) {
                 return clients.openWindow('/');  
             }
-		})
-	);
+        })
+    );
 });


### PR DESCRIPTION
This is an attempt at fixing #213.

It's still a bit of a work-in-progress, I'm curious to know what others think needs to be done before this is merge-able.

This code checks to see if the old Notification API is supported, and if not attempts to create a service worker instead, which will be created as long as the Zulip tab in Chrome was not killed for memory. The service worker will then create a notification in the background. Even though it's not super reliable because the tab can be killed and notifications will not be sent, I believe it's better than the current state of the code which throws an exception and doesn't send any notifications ever.

What I think still needs to be done:

* clicking_notification_causes_narrow
* use Push API so that notifications can be sent even if the Zulip tab is not loaded
* I haven't tested that the clients.openWindow works as expected
* remove second `new Notification()` in `process_notification`
* will it be an issue that https is required for it to work?
* needs tests