### PR TITLE
components: Make button component styles sensible.

### DIFF
--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -46,18 +46,20 @@
 
 /* -- base button styling -- */
 .new-style .button {
-    padding: 8px 15px;
+    padding: 7px 14px;
     margin: 0;
     min-width: 130px;
 
     font-weight: 400;
     text-align: center;
 
-    background-color: #478fca;
-    color: #FFF;
+    background-color: #fff;
+    color: inherit;
     outline: none;
-    border: none;
+    border: 1px solid #CCC;
     border-radius: 2px;
+
+    box-shadow: none;
 
     cursor: pointer;
     transition: all 0.2s ease;
@@ -86,14 +88,6 @@
     background-color: #aaa;
 }
 
-.new-style .button.white {
-    padding: 7px 14px;
-    background-color: #fff;
-    color: inherit;
-    border: 1px solid #CCC;
-    box-shadow: none;
-}
-
 .new-style .button.standalone {
     margin-top: 10px;
 }
@@ -109,82 +103,69 @@
     min-width: inherit;
 }
 
-/* -- button states -- */
-.new-style .button:hover {
-    -webkit-filter: brightness(1.1);
-    -moz-filter: brightness(1.1);
-    filter: brightness(1.1);
-}
-
-.new-style .button.white:hover {
-    border-color: #888;
-    background-color: #e4e4e4;
-}
-
-.new-style .button:active {
-    -webkit-filter: brightness(0.94);
-    -moz-filter: brightness(0.94);
-    filter: brightness(0.94);
-}
-
-.new-style .button[disabled="disabled"] {
-    cursor: not-allowed;
-    -webkit-filter: saturate(0);
-    -moz-filter: saturate(0);
-    filter: saturate(0);
-    background-color: #eee;
-    color: #888181;
-}
-
 .new-style .button.sea-green {
     color: #5bb792;
     border-color: #addcc9;
 }
 
 .new-style .button.btn-warning {
-    color: #f1a02e;
+    color: #de9b40;
     border-color: #ffdfb1;
 }
 
 .new-style .button.btn-danger {
     color: #e6898d;
-    border-color: #f5d0ce;
+    border-color: #ecbdba;
 }
 
-.new-style .button.btn-danger:hover {
-    background-color: rgba(245, 179, 179, 0.05);
-    color: #d1686c;
-    border: 1px solid #e2a7a5;
+/* -- button states -- */
+.new-style .button:hover {
+    border-color: #999;
 }
 
-.new-style .button.btn-warning:hover {
-    background-color: rgba(238, 162, 54, 0.05);
-    color: #ff9600;
-    border: 1px solid #eea236;
+.new-style .button:active {
+    border-color: #999;
+    color: inherit;
+    background-color: #f4f4f4;
 }
 
 .new-style .button.sea-green:hover {
-    background-color: rgba(91,183,146,0.05);
-    border: 1px solid #52c2af;
-    color: #1daf93;
+    border-color: #6ab094;
 }
 
 .new-style .button.sea-green:active {
-    color: #1daf93;
-    background-color: rgba(91, 183, 146, 0.2);
-    border: 1px solid #52c2af;
+    border-color: #6ab094;
+    color: #3e9f78;
+    background-color: #f2f9f6;
+}
+
+.new-style .button.btn-danger:hover {
+    border-color: #d48d8a;
 }
 
 .new-style .button.btn-danger:active {
-    color: #d1686c;
-    background-color: rgba(245, 179, 179, 0.2);
-    border: 1px solid #e2a7a5;
+    color: #d56d72;
+    border-color: #d48d8a;
+    background-color: #fff7f6;
+}
+
+.new-style .button.btn-warning:hover {
+    border-color: #debb8a;
 }
 
 .new-style .button.btn-warning:active {
-    color: #eea236;
-    background-color: rgba(238, 162, 54, 0.2);
-    border: 1px solid #eea236;
+    color: #bb7613;
+    border-color: #debb8a;
+    background-color: #faf5ef;
+}
+
+
+.new-style .button[disabled="disabled"] {
+    cursor: not-allowed;
+    -moz-filter: saturate(0);
+    filter: saturate(0);
+    background-color: #eee;
+    color: #888181;
 }
 
 .new-style .button[disabled="disabled"]:hover {

--- a/static/templates/admin_default_streams_list.handlebars
+++ b/static/templates/admin_default_streams_list.handlebars
@@ -6,7 +6,7 @@
     </td>
     {{#if ../can_modify}}
     <td>
-        <button class="button white rounded remove-default-stream btn-danger">
+        <button class="button rounded remove-default-stream btn-danger">
             {{t "Remove from default" }}
         </button>
     </td>

--- a/static/templates/admin_emoji_list.handlebars
+++ b/static/templates/admin_emoji_list.handlebars
@@ -14,7 +14,7 @@
         {{/if}}
     </td>
     <td>
-        <button class="button white rounded small delete btn-danger" {{#unless can_admin_emoji}}disabled="disabled"{{/unless}} data-emoji-name="{{name}}">
+        <button class="button rounded small delete btn-danger" {{#unless can_admin_emoji}}disabled="disabled"{{/unless}} data-emoji-name="{{name}}">
             <i class="icon-vector-trash" aria-hidden="true"></i>
         </button>
     </td>

--- a/static/templates/admin_filter_list.handlebars
+++ b/static/templates/admin_filter_list.handlebars
@@ -8,7 +8,7 @@
     </td>
     {{#if ../can_modify}}
     <td>
-        <button class="button white small delete btn-danger" data-filter-id="{{id}}">
+        <button class="button small delete btn-danger" data-filter-id="{{id}}">
             <i class="icon-vector-trash" aria-hidden="true"></i>
         </button>
     </td>

--- a/static/templates/admin_streams_list.handlebars
+++ b/static/templates/admin_streams_list.handlebars
@@ -5,7 +5,7 @@
         <span class="stream_name">{{name}}</span>
     </td>
     <td>
-        <button class="button white small btn-danger deactivate btn-danger">
+        <button class="button small btn-danger deactivate btn-danger">
             <i class="icon-vector-trash" aria-hidden="true"></i>
         </button>
     </td>

--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -18,11 +18,11 @@
     <td>
         <span class="user-status-settings">
             {{#if is_active}}
-            <button class="button white rounded small deactivate btn-danger">
+            <button class="button rounded small deactivate btn-danger">
                 {{t "Deactivate" }}
             </button>
             {{else}}
-            <button class="button white rounded small reactivate btn-warning">
+            <button class="button rounded small reactivate btn-warning">
                 {{t "Reactivate" }}
             </button>
             {{/if}}
@@ -30,17 +30,17 @@
         <span class="user-admin-settings">
             {{#if is_active_human}}
                 {{#if is_admin}}
-                <button class="button white rounded small remove-admin btn-danger">
+                <button class="button rounded small remove-admin btn-danger">
                     {{t "Remove admin" }}
                 </button>
                 {{else}}
-                <button class="button white rounded small make-admin btn-warning">
+                <button class="button rounded small make-admin btn-warning">
                     {{t "Make admin" }}
                 </button>
                 {{/if}}
             {{/if}}
         </span>
-        <button class="button white rounded small btn-warning open-user-form{{#unless is_active}} display-none{{/unless}}" title="{{t 'Edit user' }}" data-user-id="{{user_id}}">
+        <button class="button rounded small btn-warning open-user-form{{#unless is_active}} display-none{{/unless}}" title="{{t 'Edit user' }}" data-user-id="{{user_id}}">
             <i class="icon-vector-pencil"></i>
         </button>
         <div class='admin-user-status'>
@@ -62,10 +62,10 @@
             </div>
             {{/if}}
             <div class="input-group">
-                <button type="button" class="button white rounded sea-green submit_name_changes">
+                <button type="button" class="button rounded sea-green submit_name_changes">
                     {{t 'Save changes' }}
                 </button>
-                <button type="button" class="button white rounded btn-danger reset_edit_user">{{t 'Cancel' }}</button>
+                <button type="button" class="button rounded btn-danger reset_edit_user">{{t 'Cancel' }}</button>
             </div>
         </form>
     </td>

--- a/static/templates/alert_word_settings_item.handlebars
+++ b/static/templates/alert_word_settings_item.handlebars
@@ -17,7 +17,7 @@
                         </button>
                         <span>{{t "Alert words can't be empty!"}}</span>
                     </div>
-                    <button class="button white rounded sea-green add-alert-word" id="create_alert_word_button" type="button">
+                    <button class="button rounded sea-green add-alert-word" id="create_alert_word_button" type="button">
                         {{t 'Add alert word'}}
                     </button>
                 </div>
@@ -30,7 +30,7 @@
             <span class="value">{{word}}</span>
         </div>
         <div class="edit-alert-word-buttons">
-            <button type="submit" class="button small white btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
+            <button type="submit" class="button small btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
                 <i class="icon-vector-trash"></i>
             </button>
         </div>

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -36,7 +36,7 @@
         </div>
         <div id="bot_delete_error{{id_suffix}}" class="alert alert-error hide"></div>
         {{else}}
-        <button class="button white round btn-warning reactivate_bot" title="{{t 'Reactivate bot' }}" data-email="{{email}}">{{t "Reactivate bot" }}</button>
+        <button class="button round btn-warning reactivate_bot" title="{{t 'Reactivate bot' }}" data-email="{{email}}">{{t "Reactivate bot" }}</button>
         {{/if}}
     </div>
 </li>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -50,7 +50,7 @@
                     {{#if page_params.realm_password_auth_enabled}}
                     <div class="input-group" id="pw_change_link">
                         <label for="change_password_button" class="inline-block title">{{t "Password" }}</label>
-                        <button class="change_password_button button white rounded inline-block input-size" data-dismiss="modal" aria-hidden="true">{{t "Change password" }}</button>
+                        <button class="change_password_button button rounded inline-block input-size" data-dismiss="modal" aria-hidden="true">{{t "Change password" }}</button>
                     </div>
 
                     <div id="pw_change_controls">
@@ -81,13 +81,13 @@
 
                     <div class="input-group no-border">
                         <label for="" class="inline-block"></label>
-                        <button type="submit" class="button white rounded w-200 sea-green input-size" name="change_settings">
+                        <button type="submit" class="button rounded w-200 sea-green input-size" name="change_settings">
                             {{t 'Save changes'}}
                         </button>
                     </div>
                     <div class="input-group">
                         <label for="" class="inline-block"></label>
-                        <button type="submit" class="button white rounded w-200 btn-danger input-size" id="user_deactivate_account_button">
+                        <button type="submit" class="button rounded w-200 btn-danger input-size" id="user_deactivate_account_button">
                             {{t 'Deactivate account' }}
                         </button>
                     </div>
@@ -104,10 +104,10 @@
                     <div id="upload_avatar_spinner"></div>
                 </div>
                 <div class="inline-block avatar-controls">
-                    <button class="button white rounded sea-green w-200 block" id="user_avatar_upload_button">
+                    <button class="button rounded sea-green w-200 block" id="user_avatar_upload_button">
                         {{t 'Upload new avatar' }}
                     </button>
-                    <button class="button white rounded btn-danger w-200 m-t-20 block" id="user_avatar_delete_button">
+                    <button class="button rounded btn-danger w-200 m-t-20 block" id="user_avatar_delete_button">
                         {{t 'Delete avatar' }}
                     </button>
                 </div>
@@ -126,7 +126,7 @@
                 <p>{{t "Note that any bots that you maintain will be disabled." }}</p>
             </div>
             <div class="modal-footer">
-                <button class="button white" data-dismiss="modal" aria-hidden="true">{{t "Cancel" }}</button>
+                <button class="button" data-dismiss="modal" aria-hidden="true">{{t "Cancel" }}</button>
                 <button class="button btn-danger" id="do_deactivate_self_button">{{t "Deactivate now" }}</button>
 
             </div>

--- a/static/templates/settings/auth-methods-settings-admin.handlebars
+++ b/static/templates/settings/auth-methods-settings-admin.handlebars
@@ -14,7 +14,7 @@
         {{#if is_admin}}
         <div class="input-group">
             <div class="organization-submission">
-                <button type="submit" class="button white rounded sea-green">
+                <button type="submit" class="button rounded sea-green">
                     {{t 'Save changes'}}
                 </button>
             </div>

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -53,13 +53,13 @@
                     <div class="input-group">
                         <div id="bot_avatar_file"></div>
                         <input type="file" name="bot_avatar_file_input" class="notvisible" id="bot_avatar_file_input" value="{{t 'Upload avatar' }}" />
-                        <button class="button white rounded small btn-danger display-none" id="bot_avatar_clear_button">{{t "Clear avatar" }}</button>
-                        <button class="button white rounded" id="bot_avatar_upload_button">{{t "Customize avatar" }}</button> ({{t "Optional" }})
+                        <button class="button rounded small btn-danger display-none" id="bot_avatar_clear_button">{{t "Clear avatar" }}</button>
+                        <button class="button rounded" id="bot_avatar_upload_button">{{t "Customize avatar" }}</button> ({{t "Optional" }})
                     </div>
                     <p>
                         <div id="bot_avatar_file_input_error" class="text-error"></div>
                     </p>
-                    <button type="submit" class="button white rounded sea-green" id="create_bot_button">
+                    <button type="submit" class="button rounded sea-green" id="create_bot_button">
                         {{t 'Create bot' }}
                     </button>
                 </div>
@@ -78,7 +78,7 @@
                     messages, you should use your personal API key.
                     {{/tr}}
                 </p>
-                <button class="button white rounded" id="api_key_button">{{t "Show/change your API key" }}</button>
+                <button class="button rounded" id="api_key_button">{{t "Show/change your API key" }}</button>
             </div>
         </div>
         <div id="get_api_key_box" class="side-padded-container">

--- a/static/templates/settings/deactivation-stream-modal.handlebars
+++ b/static/templates/settings/deactivation-stream-modal.handlebars
@@ -7,7 +7,7 @@
         <p>{{t "Deleting this stream will immediately unsubscribe everyone, and the stream's content will not be recoverable." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
     </div>
     <div class="modal-footer">
-        <button class="button white rounded" data-dismiss="modal" aria-hidden="true">{{t "Cancel" }}</button>
-        <button class="button white rounded btn-danger" id="do_deactivate_stream_button">{{t "Yes, delete this stream" }}</button>
+        <button class="button rounded" data-dismiss="modal" aria-hidden="true">{{t "Cancel" }}</button>
+        <button class="button rounded btn-danger" id="do_deactivate_stream_button">{{t "Yes, delete this stream" }}</button>
     </div>
 </div>

--- a/static/templates/settings/deactivation-user-modal.handlebars
+++ b/static/templates/settings/deactivation-user-modal.handlebars
@@ -8,7 +8,7 @@
         <p>{{t "Their password will be cleared from our systems, and any bots they maintain will be disabled." }}</p>
     </div>
     <div class="modal-footer">
-        <button class="button white rounded" data-dismiss="modal" aria-hidden="true">{{t "Cancel" }}</button>
-        <button class="button white rounded btn-danger" id="do_deactivate_user_button">{{t "Deactivate now" }}</button>
+        <button class="button rounded" data-dismiss="modal" aria-hidden="true">{{t "Cancel" }}</button>
+        <button class="button rounded btn-danger" id="do_deactivate_user_button">{{t "Deactivate now" }}</button>
     </div>
 </div>

--- a/static/templates/settings/default-streams-list-admin.handlebars
+++ b/static/templates/settings/default-streams-list-admin.handlebars
@@ -17,7 +17,7 @@
             </div>
             <div class="control-group">
                 <div class="controls">
-                    <button type="submit" id="do_submit_stream" class="button white rounded sea-green">{{t "Add stream" }}</button>
+                    <button type="submit" id="do_submit_stream" class="button rounded sea-green">{{t "Add stream" }}</button>
                 </div>
             </div>
         </div>

--- a/static/templates/settings/emoji-settings-admin.handlebars
+++ b/static/templates/settings/emoji-settings-admin.handlebars
@@ -30,10 +30,10 @@
                     <input type="file" name="emoji_file_input" class="notvisible"
                  id="emoji_file_input" value="{{t 'Upload emoji' }}"/>
                     <button class="btn btn-default display-none" id="emoji_image_clear_button">{{t "Clear emoji image" }}</button>
-                    <button class="button white" id="emoji_upload_button">{{t "Upload emoji" }}</button>
+                    <button class="button" id="emoji_upload_button">{{t "Upload emoji" }}</button>
                     <p id="emoji_file_input_error" class="text-error"></p>
                 </div>
-                <button type="submit" class="button white rounded sea-green">
+                <button type="submit" class="button rounded sea-green">
                     {{t 'Add emoji' }}
                 </button>
             </div>

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -170,7 +170,7 @@
 
             {{#if is_admin }}
             <div class="input-group organization-submission">
-                <button type="submit" class="button white rounded sea-green">
+                <button type="submit" class="button rounded sea-green">
                     {{t 'Save changes' }}
                 </button>
             </div>

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -35,7 +35,7 @@
             </div>
             {{#if is_admin }}
             <div class="input-group organization-submission">
-                <button type="submit" class="button white rounded sea-green">
+                <button type="submit" class="button rounded sea-green">
                     {{t 'Save changes' }}
                 </button>
             </div>
@@ -53,9 +53,9 @@
                 <div id="upload_icon_spinner"></div>
             </div>
             <div class="inline-block avatar-controls">
-                <button class="button white rounded sea-green w-200 block input-size"
+                <button class="button rounded sea-green w-200 block input-size"
                         id="realm_icon_upload_button">{{t 'Upload new icon' }}</button>
-                <button class="button white rounded btn-danger w-200 m-t-10 block input-size"
+                <button class="button rounded btn-danger w-200 m-t-10 block input-size"
                         id="realm_icon_delete_button">{{t 'Delete icon' }}</button>
             </div>
         </div>

--- a/static/templates/settings/realm-filter-settings-admin.handlebars
+++ b/static/templates/settings/realm-filter-settings-admin.handlebars
@@ -51,7 +51,7 @@
                 </div>
                 <div class="control-group">
                     <div class="controls">
-                        <button type="submit" class="button white rounded sea-green">
+                        <button type="submit" class="button rounded sea-green">
                             {{t 'Add filter' }}
                         </button>
                     </div>

--- a/static/templates/settings/ui-settings.handlebars
+++ b/static/templates/settings/ui-settings.handlebars
@@ -31,7 +31,7 @@
         </div>
         <div class="input-group no-border">
             <div class="ui-submission">
-                <input type="submit" name="change_settings" value="{{t 'Save changes' }}" class="button white rounded sea-green" />
+                <input type="submit" name="change_settings" value="{{t 'Save changes' }}" class="button rounded sea-green" />
             </div>
         </div>
     </form>

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -16,9 +16,9 @@
                 <span class="checkmark" data-finish-editing=".stream-name-editable">✓</span>
                 {{/if}}
             </div>
-            <button class="button small white rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button">
+            <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button">
                 {{#if subscribed }}{{#tr oneself }}Unsubscribe{{/tr}}{{else}}{{#tr oneself }}Subscribe{{/tr}}{{/if}}</button>
-            <a href="{{preview_url}}" class="button small white rounded" id="preview-stream-button" role="button">{{t "View stream"}}</a>
+            <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button">{{t "View stream"}}</a>
         </div>
         <div class="stream-description" data-no-description="{{t 'No description.' }}">
             <span class="stream-description-editable editable-section">{{{rendered_description}}}</span>

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -6,13 +6,13 @@
           <div id="compose_buttons">
             <span class="new_message_button">
               <a class="drafts-link no-style" href="#drafts">
-                <button type="button" class="button white small rounded compose_drafts_button">
+                <button type="button" class="button small rounded compose_drafts_button">
                   <span>{{ _('Drafts') }}</span>
                 </button>
               </a>
             </span>
             <span class="new_message_button">
-              <button type="button" class="button white small rounded compose_stream_button"
+              <button type="button" class="button small rounded compose_stream_button"
                       id="left_bar_compose_stream_button_big"
                       title="{{ _('New topic') }} (c)">
                 <span class="compose_stream_button_label">{{ _('New topic') }}</span>
@@ -20,7 +20,7 @@
             </span>
             {% if not embedded %}
             <span class="new_message_button">
-              <button type="button" class="button white small rounded compose_private_button"
+              <button type="button" class="button small rounded compose_private_button"
                       id="left_bar_compose_private_button_big"
                       title="{{ _('New private message') }} (C)">
                 <span class="compose_private_button_label">{{ _('New private message') }}</span>
@@ -100,7 +100,7 @@
                   <div id="send_controls" class="new-style">
                     <label id="enter-sends-label" class="compose_checkbox_label" for="enter_sends">{{ _('Press Enter to send') }}&nbsp;</label>
                     <input type="checkbox" id="enter_sends" name="enter_sends" value="enter_sends" />
-                    <button type="submit" id="compose-send-button" class="button small white send_message" tabindex="150">{{ _('Send') }}</button>
+                    <button type="submit" id="compose-send-button" class="button small send_message" tabindex="150">{{ _('Send') }}</button>
                   </div>
                 </div>
               </td>

--- a/templates/zerver/delete_message.html
+++ b/templates/zerver/delete_message.html
@@ -10,7 +10,7 @@
         <div id="delete-message-error"></div>
     </div>
     <div class="modal-footer">
-        <button class="button white rounded" data-dismiss="modal" aria-hidden="true">{{ _("Cancel") }}</button>
-        <button class="button white rounded btn-danger" id="do_delete_message_button">{{ _("Yes, delete this message") }}</button>
+        <button class="button rounded" data-dismiss="modal" aria-hidden="true">{{ _("Cancel") }}</button>
+        <button class="button rounded btn-danger" id="do_delete_message_button">{{ _("Yes, delete this message") }}</button>
     </div>
 </div>


### PR DESCRIPTION
This removes the old base button style which was a blue button and
kills the unnecessary .white class which was essentially just acting as
the new button base.

This then removes all references throughout the settings/subscriptions
pages to those button styles.

This also fixes the strange button styles that changed the :hover and
:active opacity to 0.05 which led to unpredictable results on various
backgrounds.