### PR TITLE
bookend: Remove .sea-green class for Unsubscribe state.

### DIFF
--- a/static/templates/bookend.handlebars
+++ b/static/templates/bookend.handlebars
@@ -5,7 +5,7 @@
     <span>{{bookend_content}}</span>
     {{#if trailing}}
     <div class="sub_button_row new-style">
-        <button class="button white sea-green rounded stream_sub_unsub_button {{#unless subscribed}}unsubscribed{{/unless}}" type="button" name="subscription">
+        <button class="button white rounded stream_sub_unsub_button {{#unless subscribed}}sea-green{{/unless}}" type="button" name="subscription">
             {{#if subscribed}}
             {{t 'Unsubscribe' }}
             {{else}}


### PR DESCRIPTION
Quick fix for removing the `.sea-green` class for the Unsubscribe button; it should be normally colored while it's Unsubscribe, and colored green when it's Subscribe.

Pinging @timabbott (hopefully to get it in before 1.6 is released)

Followup to #5222 