### PR TITLE
apps: Move all documentation of client apps upstream.

### DIFF
--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -139,20 +139,11 @@ sudo apt-get install zulip-desktop
                         <div class="platform">
                             <h2>Other Platforms</h2>
                             <div class="instructions">
-                                {% if only_sso %}
-                                  <p>{% trans %}We provide a <a href="https://zulip.org/dist/apps/sso/linux/zulip-desktop_latest.bin.tar.gz" download>binary tarball</a> of the Zulip application, built for 64-bit systems.{% endtrans %}
-                                  </p>
-                                  <a href="https://zulip.org/dist/apps/sso/linux/zulip-desktop_latest.bin.tar.gz" download>
-                                      <img src="/static/images/landing-page/tar.gz.svg" alt="{{ _('Download') }}" />
-                                  </a>
-                                {% else %}
-                                  <p>{% trans %}We provide a <a href="https://zulip.org/dist/apps/linux/zulip-desktop_latest.bin.tar.gz" download>binary tarball</a> of the Zulip application, built for 64-bit systems.{% endtrans %}
-                                  </p>
-                                  <a href="https://zulip.org/dist/apps/linux/zulip-desktop_latest.bin.tar.gz" download>
-                                      <img src="/static/images/landing-page/tar.gz.svg" alt="{{ _('Download') }}" />
-                                  </a>
-                                {% endif %}
-                            </div>
+                                <p>{% trans %}We provide a <a href="https://zulip.org/dist/apps/linux/zulip-desktop_latest.bin.tar.gz" download>binary tarball</a> of the Zulip application, built for 64-bit systems.{% endtrans %}
+                                </p>
+                                <a href="https://zulip.org/dist/apps/linux/zulip-desktop_latest.bin.tar.gz" download>
+                                    <img src="/static/images/landing-page/tar.gz.svg" alt="{{ _('Download') }}" />
+                                </a>
                         </div>
                     </div>
                 </div>

--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -288,7 +288,7 @@
                     </div>
                     <div class="block">
                         <h4>{% trans %}Mobile apps{% endtrans %}</h4>
-                        <p>{% trans %}Check Zulip on the go with native <a href="/apps">iOS and
+                        <p>{% trans %}Check Zulip on the go with native <a href="{{ apps_page_url }}">iOS and
                         Android apps</a>.{% endtrans %}</p>
                     </div>
                 </div>
@@ -301,7 +301,7 @@
                     <div class="block">
                         <h4>{% trans %}Desktop apps{% endtrans %}</h4>
                         <p>{% trans %}Prefer Zulip in its own window and rich, OS-level notifications?
-                          Enjoy <a href="/apps">Zulip on your desktop</a>.{% endtrans %}</p>
+                          Enjoy <a href="{{ apps_page_url }}">Zulip on your desktop</a>.{% endtrans %}</p>
                     </div>
                 </div>
             </div>

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -314,28 +314,28 @@ html {
             <div class="platform-icons">
                 <div class="group">
                     <h2>Web</h2>
-                    <a href="/apps/">
+                    <a href="{{ apps_page_url }}">
                         <i class="icon-vector-desktop platform-icon"></i>
                     </a>
                 </div>
                 <div class="group">
                     <h2>Desktop</h2>
-                    <a class="no-style" href="/apps/#mac">
+                    <a class="no-style" href="{{ apps_page_url }}#mac">
                         <i class="icon-vector-apple platform-icon"></i>
                     </a>
-                    <a class="no-style" href="/apps/#windows">
+                    <a class="no-style" href="{{ apps_page_url }}#windows">
                         <i class="icon-vector-windows platform-icon"></i>
                     </a>
-                    <a class="no-style" href="/apps/#linux">
+                    <a class="no-style" href="{{ apps_page_url }}#linux">
                         <i class="icon-vector-linux platform-icon"></i>
                     </a>
                 </div>
                 <div class="group">
                     <h2>Mobile</h2>
-                    <a class="no-style" href="/apps/#ios">
+                    <a class="no-style" href="{{ apps_page_url }}#ios">
                         <i class="icon-vector-mobile-phone platform-icon"></i>
                     </a>
-                    <a class="no-style" href="/apps/#android">
+                    <a class="no-style" href="{{ apps_page_url }}#android">
                         <i class="icon-vector-android platform-icon"></i>
                     </a>
                 </div>

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -21,7 +21,7 @@
                 <a class="no-style" href="/features/">Features</a>
             </li>
             <li on-page="apps">
-                <a class="no-style" href="/apps/">Apps</a>
+                <a class="no-style" href="{{ apps_page_url }}">Apps</a>
             </li>
             <li on-page="integrations">
                 <a class="no-style" href="/integrations/">Integrations</a>

--- a/templates/zerver/landing_nav_blue.html
+++ b/templates/zerver/landing_nav_blue.html
@@ -17,7 +17,7 @@
                 <a class="no-style" href="/features/">Features</a>
             </li>
             <li on-page="apps">
-                <a class="no-style" href="/apps/">Apps</a>
+                <a class="no-style" href="{{ apps_page_url }}">Apps</a>
             </li>
             <li on-page="integrations">
                 <a class="no-style" href="/integrations/">Integrations</a>

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -88,7 +88,7 @@
                   </li>
                   <li class="divider" role="presentation"></li>
                   <li title="{{ _('Desktop & mobile apps') }}" role="presentation">
-                    <a href="/apps" target="_blank" role="menuitem">
+                    <a href="{{ apps_page_url }}" target="_blank" role="menuitem">
                       <i class="icon-vector-desktop"></i> {{ _('Desktop & mobile apps') }}
                     </a>
                   </li>

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -77,6 +77,10 @@ def zulip_default_context(request):
         about_link_disabled = True
         find_team_link_disabled = False
 
+    apps_page_url = 'https://zulipchat.com/apps/'
+    if settings.ZILENCER_ENABLED:
+        apps_page_url = '/apps/'
+
     return {
         'realms_have_subdomains': settings.REALMS_HAVE_SUBDOMAINS,
         'custom_logo_url': settings.CUSTOM_LOGO_URL,
@@ -100,6 +104,7 @@ def zulip_default_context(request):
         'server_uri': settings.SERVER_URI,
         'api_site_required': settings.EXTERNAL_API_PATH != "api.zulip.com",
         'email_gateway_example': settings.EMAIL_GATEWAY_EXAMPLE,
+        'apps_page_url': apps_page_url,
         'open_realm_creation': settings.OPEN_REALM_CREATION,
         'password_auth_enabled': password_auth_enabled(realm),
         'dev_auth_enabled': dev_auth_enabled(realm),

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -395,6 +395,23 @@ class HomeTest(ZulipTestCase):
         path = urllib.parse.urlparse(result['Location']).path
         self.assertEqual(path, "/")
 
+    def test_apps_view(self):
+        # type: () -> None
+        result = self.client_get('/apps')
+        self.assertEqual(result.status_code, 301)
+        self.assertTrue(result['Location'].endswith('/apps/'))
+
+        with self.settings(ZILENCER_ENABLED=False):
+            result = self.client_get('/apps/')
+        self.assertEqual(result.status_code, 301)
+        self.assertTrue(result['Location'] == 'https://zulipchat.com/apps/')
+
+        with self.settings(ZILENCER_ENABLED=True):
+            result = self.client_get('/apps/')
+        self.assertEqual(result.status_code, 200)
+        html = result.content.decode('utf-8')
+        self.assertIn('Appsolutely', html)
+
     def test_generate_204(self):
         # type: () -> None
         email = self.example_email("hamlet")

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -265,6 +265,12 @@ def desktop_home(request):
     # type: (HttpRequest) -> HttpResponse
     return HttpResponseRedirect(reverse('zerver.views.home.home'))
 
+def apps_view(request):
+    # type: (HttpRequest) -> HttpResponse
+    if settings.ZILENCER_ENABLED:
+        return render(request, 'zerver/apps.html')
+    return HttpResponseRedirect('https://zulipchat.com/apps/', status=301)
+
 def is_buggy_ua(agent):
     # type: (str) -> bool
     """Discrimiate CSS served to clients based on User Agent

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -141,7 +141,7 @@ i18n_urls = [
     url(r'^api/endpoints/$', zerver.views.integrations.api_endpoint_docs, name='zerver.views.integrations.api_endpoint_docs'),
     url(r'^integrations/$', IntegrationView.as_view()),
     url(r'^about/$', TemplateView.as_view(template_name='zerver/about.html')),
-    url(r'^apps/$', TemplateView.as_view(template_name='zerver/apps.html')),
+    url(r'^apps/$', zerver.views.home.apps_view, name='zerver.views.home.apps_view'),
 
     url(r'^robots\.txt$', RedirectView.as_view(url='/static/robots.txt', permanent=True)),
 


### PR DESCRIPTION
The /apps page describes software the user will get from upstream for their own devices, independent of what's on the server they're using.  So it should live in a place maintained together with that other software, rather than be distributed and versioned with the server.

Fixes #5234.
