### PR TITLE
settings_notifications.js: Refactor and save setting on change.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -255,20 +255,12 @@ exports.set_stream_property = function (sub, property, value) {
     });
 };
 
-function set_notification_setting_for_all_streams(notification_type, new_setting) {
+exports.set_notification_setting_for_all_streams = function (notification_type, new_setting) {
     _.each(stream_data.subscribed_subs(), function (sub) {
         if (sub[notification_type] !== new_setting) {
             exports.set_stream_property(sub, notification_type, new_setting);
         }
     });
-}
-
-exports.set_all_stream_desktop_notifications_to = function (new_setting) {
-    set_notification_setting_for_all_streams("desktop_notifications", new_setting);
-};
-
-exports.set_all_stream_audible_notifications_to = function (new_setting) {
-    set_notification_setting_for_all_streams("audible_notifications", new_setting);
 };
 
 function redraw_privacy_related_stuff(sub_row, sub) {

--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -151,16 +151,6 @@
             $("#digest_container").hide();
             --}}
         </div>
-
-        <div class="input-group no-border">
-            <div class="controls notification-submission">
-                <button type="submit" id="change_notification_settings"
-                    name="change_notification_settings"
-                    class="button white rounded sea-green">
-                    {{t 'Save changes' }}
-                </button>
-            </div>
-        </div>
     </form>
 
 </div>


### PR DESCRIPTION
I'm refactoring user notification settings and thought I'd also work on having them save automatically, similarly to user display settings. I had a few questions/ran into a few issues that I tried to solve for:

- `update_subscription_properties_backend` in zerver/views/streams.py wasn't converting the strings 'true' and 'false' (from JS) to Python booleans, thus the changes to streams.py. I wasn't sure the correct way to do this piece.
- I wasn't clear on what `maybe_bulk_update_stream_notification_settings` was doing in settings_notifications.js. I removed it and in manually testing, things seem to still be working, but I might be missing a piece.
- Is there a preferred way to make a modal or a status div that sticks to the visible part of the settings container? (Currently, if someone is scrolled to the bottom of the container, the notification that something has been changed isn't in view). 