### PR TITLE
Parse Timestamps in Messages: Core Implementation

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1126,6 +1126,7 @@ run_test('begins_typeahead', () => {
         stream: true,
         syntax: true,
         topic: true,
+        timestamp: true,
     }}};
 
     function get_values(input, rest) {
@@ -1301,6 +1302,15 @@ run_test('begins_typeahead', () => {
     assert_typeahead_equals("#**Sweden>more ice", sweden_topics_to_show);
     sweden_topics_to_show.push('totally new topic');
     assert_typeahead_equals("#**Sweden>totally new topic", sweden_topics_to_show);
+
+    // time_jump
+    assert_typeahead_equals("!tim", false);
+    assert_typeahead_equals("!timerandom", false);
+    assert_typeahead_equals("!time", ['translated: Pick a date/time']);
+    assert_typeahead_equals("!time(", ['translated: Pick a date/time']);
+    assert_typeahead_equals("!time(something", ['translated: Pick a date/time']);
+    assert_typeahead_equals("!time(something)", ['translated: Pick a date/time']);
+    assert_typeahead_equals("!time(something) ", false); // Already completed a topic.
 
     // Following tests place the cursor before the second string
     assert_typeahead_equals("#test", "ing", false);

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -3,6 +3,7 @@ set_global('page_params', {
     twenty_four_hour_time: true,
 });
 set_global('XDate', zrequire('XDate', 'xdate'));
+set_global('moment', zrequire('moment', 'moment-timezone'));
 zrequire('timerender');
 
 run_test('render_now_returns_today', () => {
@@ -288,4 +289,84 @@ run_test('set_full_datetime', () => {
     time_str = timerender.stringify_time(time);
     expected = '1:55 PM';
     assert.equal(expected, time_str);
+});
+
+run_test('render_markdown_timestamp', () => {
+    let target;
+    let current;
+
+    // ------ SET 1 ------
+
+    page_params.twenty_four_hour_time = false;
+    moment.tz.setDefault("UTC");
+
+    // Render all time details precisely (generic case).
+    target = moment(1549979707000); // Tuesday 2019-02-12T13:55:07+00:00
+    current = moment(1549958107000); // Tuesday 2019-02-12T07:55:07+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Tue, Feb 12, 1:55:07 PM');
+
+    // Ignore seconds.
+    target = moment(1549979700000); // Tuesday 2019-02-12T13:55:00+00:00
+    current = moment(1549958107000); // Tuesday 2019-02-12T07:55:07+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Tue, Feb 12, 1:55 PM');
+
+    // Ignore minutes and seconds
+    target = moment(1531486800000); // Friday 2018-07-13T13:00:00+00:00
+    current = moment(1531909397313); // Wednesday 2018-07-18T10:23:17+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Fri, Jul 13, 1 PM');
+
+    // Render year if different from current year.
+    target = moment(1531486800000); // Friday 2018-07-13T13:00:00+00:00
+    current = moment(1549958107000); // Tuesday 2019-02-12T07:55:07+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Fri, Jul 13 2018, 1 PM');
+
+    // ------ SET 2 ------
+
+    page_params.twenty_four_hour_time = true;
+    moment.tz.setDefault("UTC");
+
+    // Render all time details precisely (generic case).
+    target = moment(1549979707000); // Tuesday 2019-02-12T13:55:07+00:00
+    current = moment(1549958107000); // Tuesday 2019-02-12T07:55:07+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Tue, Feb 12, 13:55:07');
+
+    // Ignore seconds.
+    target = moment(1549979700000); // Tuesday 2019-02-12T13:55:00+00:00
+    current = moment(1549958107000); // Tuesday 2019-02-12T07:55:07+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Tue, Feb 12, 13:55');
+
+    // Ignore minutes and seconds
+    target = moment(1531486800000); // Friday 2018-07-13T13:00:00+00:00
+    current = moment(1531909397313); // Wednesday 2018-07-18T10:23:17+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Fri, Jul 13, 13:00');
+
+    // Render year if different from current year.
+    target = moment(1531486800000); // Friday 2018-07-13T13:00:00+00:00
+    current = moment(1549958107000); // Tuesday 2019-02-12T07:55:07+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Fri, Jul 13 2018, 13:00');
+
+    // ------ SET 3 ------
+
+    page_params.twenty_four_hour_time = false;
+    moment.tz.setDefault('Asia/Kolkata');  // UTC Offset: +05:30
+
+    // Render all time details precisely (generic case).
+    target = moment(1549979707000); // Tuesday 2019-02-12T13:55:07+00:00
+    current = moment(1549958107000); // Tuesday 2019-02-12T07:55:07+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Tue, Feb 12, 7:25:07 PM');
+
+    // Ignore seconds.
+    target = moment(1549979700000); // Tuesday 2019-02-12T13:55:00+00:00
+    current = moment(1549958107000); // Tuesday 2019-02-12T07:55:07+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Tue, Feb 12, 7:25 PM');
+
+    // Ignore minutes and seconds
+    target = moment(1531488600000); // Friday 22018-07-13T13:30:00+00:00
+    current = moment(1531909397313); // Wednesday 2018-07-18T10:23:17+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Fri, Jul 13, 7 PM');
+
+    // Render year if different from current year.
+    target = moment(1531486800000); // Friday 2018-07-13T13:00:00+00:00
+    current = moment(1549958107000); // Tuesday 2019-02-12T07:55:07+00:00
+    assert.equal(timerender.render_markdown_timestamp(target, current).text, 'Fri, Jul 13 2018, 6:30 PM');
 });

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -168,6 +168,10 @@ page_params.starred_messages = [];
 page_params.presences = [];
 
 $('#tab_bar').append = () => {};
+$('#tab_bar').empty = () => {};  // We need this to be noop to not clear the find_results.
+const timestamp_stub = $.create('timestamp_stub');
+timestamp_stub.each = () => {};
+$('#tab_bar').set_find_results('span.timestamp', timestamp_stub);
 upload.setup_upload = () => {};
 
 server_events.home_view_loaded = () => true;

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -2,6 +2,7 @@ const pygments_data = require("../generated/pygments_data.json");
 const typeahead = require("../shared/js/typeahead");
 const autosize = require('autosize');
 const settings_data = require("./settings_data");
+const confirmDatePlugin = require("flatpickr/dist/plugins/confirmDate/confirmDate.js");
 
 //************************************
 // AN IMPORTANT NOTE ABOUT TYPEAHEADS
@@ -328,6 +329,11 @@ exports.tokenize_compose_str = function (s) {
             // maybe topic_list; let's let the stream_topic_regex decide later.
             return '>topic_list';
         }
+    }
+
+    const timestamp_index = s.indexOf('!time');
+    if (timestamp_index >= 0) {
+        return s.slice(timestamp_index);
     }
 
     return '';
@@ -733,6 +739,14 @@ exports.get_candidates = function (query) {
             }
         }
     }
+    if (this.options.completions.timestamp) {
+        const time_jump_regex = /!time(\(([^\)]*?\)?))?$/;
+        if (time_jump_regex.test(split[0])) {
+            this.completing = 'time_jump';
+            return ['Pick a date/time'];
+
+        }
+    }
     return false;
 };
 
@@ -752,6 +766,8 @@ exports.content_highlighter = function (item) {
     } else if (this.completing === 'topic_jump') {
         return typeahead_helper.render_typeahead_item({ primary: item });
     } else if (this.completing === 'topic_list') {
+        return typeahead_helper.render_typeahead_item({ primary: item });
+    } else if (this.completing === 'time_jump') {
         return typeahead_helper.render_typeahead_item({ primary: item });
     }
 };
@@ -841,6 +857,38 @@ exports.content_typeahead_selected = function (item, event) {
         // with the topic and the final **.
         const start = beginning.length - this.token.length;
         beginning = beginning.substring(0, start) + item + '** ';
+    } else if (this.completing === 'time_jump') {
+        const flatpickr_input = $("<input id='#timestamp_flatpickr'>");
+        const instance = flatpickr_input.flatpickr({
+            enableTime: true,
+            clickOpens: false,
+            defaultDate: moment().format(),
+            plugins: [new confirmDatePlugin({})], // eslint-disable-line new-cap, no-undef
+            positionElement: this.$element[0],
+            dateFormat: 'Z',
+            formatDate: (date) => {
+                const dt = moment(date);
+                return dt.local().format();
+            },
+        });
+        const container = $($(instance.innerContainer).parent());
+        container.on('click', '.flatpickr-calendar', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+        });
+
+        container.on('click', '.flatpickr-confirm', () => {
+            const datestr = flatpickr_input.val();
+            beginning = beginning.substring(0, beginning.lastIndexOf('!time')) +  `!time(${datestr}) `;
+            textbox.val(beginning + rest);
+            textbox.caret(beginning.length, beginning.length);
+            compose_ui.autosize_textarea();
+            instance.close();
+            instance.destroy();
+        });
+        instance.open();
+        container.find('.flatpickr-monthDropdown-months').focus();
+        return beginning + rest;
     }
 
     // Keep the cursor after the newly inserted text, as Bootstrap will call textbox.change() to
@@ -870,7 +918,8 @@ exports.compose_content_matcher = function (completing, token) {
     return function () {
         switch (completing) {
         case 'topic_jump':
-            // topic_jump doesn't actually have a typeahead popover, so we return quickly here.
+        case 'time_jump':
+            // these don't actually have a typeahead popover, so we return quickly here.
             return true;
         }
     };
@@ -887,6 +936,7 @@ exports.sort_results = function (completing, matches, token) {
     case 'syntax':
         return typeahead_helper.sort_languages(matches, token);
     case 'topic_jump':
+    case 'time_jump':
         // topic_jump doesn't actually have a typeahead popover, so we return quickly here.
         return matches;
     case 'topic_list':
@@ -942,6 +992,7 @@ exports.initialize_compose_typeahead = function (selector) {
         stream: true,
         syntax: true,
         topic: true,
+        timestamp: true,
     };
 
     $(selector).typeahead({

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -743,7 +743,7 @@ exports.get_candidates = function (query) {
         const time_jump_regex = /!time(\(([^\)]*?\)?))?$/;
         if (time_jump_regex.test(split[0])) {
             this.completing = 'time_jump';
-            return ['Pick a date/time'];
+            return [i18n.t('Pick a date/time')];
 
         }
     }
@@ -859,10 +859,22 @@ exports.content_typeahead_selected = function (item, event) {
         beginning = beginning.substring(0, start) + item + '** ';
     } else if (this.completing === 'time_jump') {
         const flatpickr_input = $("<input id='#timestamp_flatpickr'>");
+        let timeobject;
+        let timestring = beginning.substring(beginning.lastIndexOf('!time'));
+        if (timestring.startsWith('!time(') && timestring.endsWith(')')) {
+            timestring = timestring.substring(6, timestring.length - 1);
+            moment.suppressDeprecationWarnings = true;
+            try {
+                timeobject = moment(timestring).toDate();
+            } catch {
+                // do nothing. We'll just default to showing current date for the edit.
+            }
+        }
+
         const instance = flatpickr_input.flatpickr({
             enableTime: true,
             clickOpens: false,
-            defaultDate: moment().format(),
+            defaultDate: timeobject || moment().format(),
             plugins: [new confirmDatePlugin({})], // eslint-disable-line new-cap, no-undef
             positionElement: this.$element[0],
             dateFormat: 'Z',

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -619,6 +619,21 @@ MessageListView.prototype = {
             }
         });
 
+        content.find('span.timestamp').each(function (index, elem) {
+            // Populate each timestamp span with mentioned time
+            // in user's local timezone.
+            const timestamp = moment.unix($(this).attr('value'));
+            if (timestamp.isValid() && $(this).attr('value') !== null) {
+                const text = $(this).text();
+                const rendered_time = timerender.render_markdown_timestamp(timestamp,
+                                                                           null, text);
+                $(this).text(rendered_time.text);
+                $(this).attr('title', rendered_time.title);
+            } else {
+                elem.classList.remove('timestamp');
+                elem.setAttribute('title', 'Could not parse timestamp.');
+            }
+        });
         // Display emoji (including realm emoji) as text if
         // page_params.emojiset is 'text'.
         if (page_params.emojiset === 'text') {

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -620,19 +620,7 @@ MessageListView.prototype = {
         });
 
         content.find('span.timestamp').each(function (index, elem) {
-            // Populate each timestamp span with mentioned time
-            // in user's local timezone.
-            const timestamp = moment.unix($(this).attr('value'));
-            if (timestamp.isValid() && $(this).attr('value') !== null) {
-                const text = $(this).text();
-                const rendered_time = timerender.render_markdown_timestamp(timestamp,
-                                                                           null, text);
-                $(this).text(rendered_time.text);
-                $(this).attr('title', rendered_time.title);
-            } else {
-                elem.classList.remove('timestamp');
-                elem.setAttribute('title', 'Could not parse timestamp.');
-            }
+            timerender.replace_markdown_timestamp(elem);
         });
         // Display emoji (including realm emoji) as text if
         // page_params.emojiset is 'text'.

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -60,6 +60,9 @@ function display_tab_bar(tab_bar_data) {
         exports.colorize_tab_bar();
     }
     tab_bar.removeClass('notdisplayed');
+    tab_bar.find('span.timestamp').each(function (index, elem) {
+        timerender.replace_markdown_timestamp(elem);
+    });
 }
 
 function build_tab_bar(filter) {

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -167,10 +167,6 @@ exports.render_date = function (time, time_above, today) {
 // Renders the timestamp returned by the !time() markdown syntax.
 exports.render_markdown_timestamp = function (time, now, text) {
     now = now || moment();
-    if (page_params.timezone) {
-        now = now.tz(page_params.timezone);
-        time = time.tz(page_params.timezone);
-    }
     let timestring = time.format('ddd, MMM D');
     if (now.year() !== time.year()) {
         timestring += time.format(' YYYY');

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -164,6 +164,40 @@ exports.render_date = function (time, time_above, today) {
     return node;
 };
 
+// Renders the timestamp returned by the !time() markdown syntax.
+exports.render_markdown_timestamp = function (time, now, text) {
+    now = now || moment();
+    if (page_params.timezone) {
+        now = now.tz(page_params.timezone);
+        time = time.tz(page_params.timezone);
+    }
+    let timestring = time.format('ddd, MMM D');
+    if (now.year() !== time.year()) {
+        timestring += time.format(' YYYY');
+    }
+    timestring += ',';
+    const military_time = page_params.twenty_four_hour_time;
+    if (military_time) {
+        timestring += time.format(' HH');
+    } else {
+        timestring += time.format(' h');
+    }
+    if (military_time || time.minutes() !== 0 || time.seconds() !== 0) {
+        timestring += time.format(':mm');
+    }
+    if (time.seconds() !== 0) {
+        timestring += time.format(":ss");
+    }
+    if (!military_time) {
+        timestring += time.format(" A");
+    }
+    const titlestring = "This time is in your timezone. Original text was '" + text + "'.";
+    return {
+        text: timestring,
+        title: titlestring,
+    };
+};
+
 // This isn't expected to be called externally except manually for
 // testing purposes.
 exports.update_timestamps = function () {

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -197,8 +197,8 @@ exports.render_markdown_timestamp = function (time, now, text) {
 exports.replace_markdown_timestamp = (elem) => {
     // Populate each timestamp span with mentioned time
     // in user's local timezone.
-    const timestamp = moment.unix($(elem).attr('value'));
-    if (timestamp.isValid() && $(elem).attr('value') !== null) {
+    const timestamp = moment.unix($(elem).attr('data-timestamp'));
+    if (timestamp.isValid() && $(elem).attr('data-timestamp') !== null) {
         const text = $(elem).text();
         const rendered_time = exports.render_markdown_timestamp(timestamp, null, text);
         $(elem).text(rendered_time.text);

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -194,6 +194,21 @@ exports.render_markdown_timestamp = function (time, now, text) {
     };
 };
 
+exports.replace_markdown_timestamp = (elem) => {
+    // Populate each timestamp span with mentioned time
+    // in user's local timezone.
+    const timestamp = moment.unix($(elem).attr('value'));
+    if (timestamp.isValid() && $(elem).attr('value') !== null) {
+        const text = $(elem).text();
+        const rendered_time = exports.render_markdown_timestamp(timestamp, null, text);
+        $(elem).text(rendered_time.text);
+        $(elem).attr('title', rendered_time.title);
+    } else {
+        elem.classList.remove('timestamp');
+        elem.setAttribute('title', 'Could not parse timestamp.');
+    }
+};
+
 // This isn't expected to be called externally except manually for
 // testing purposes.
 exports.update_timestamps = function () {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -477,6 +477,11 @@ on a dark background, and don't change the dark labels dark either. */
         }
     }
 
+    .timestamp {
+        background: hsla(0, 0%, 0%, 0.2);
+        box-shadow: 0px 0px 0px 1px hsla(0, 0%, 0%, 0.4);
+    }
+
     .tip {
         color: inherit;
         background-color: hsla(46, 28%, 38%, 0.27);

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -141,6 +141,19 @@
         vertical-align: text-bottom;
     }
 
+    /* Timestamps */
+    .timestamp {
+        background: hsl(0, 0%, 93%);
+        border-radius: 3px;
+        padding: 0 0.2em;
+        box-shadow: 0px 0px 0px 1px hsl(0, 0%, 80%);
+        white-space: nowrap;
+        margin-left: 2px;
+        margin-right: 2px;
+        display: inline-block;
+        margin-bottom: 1px;
+    }
+
     /* Highlighting for message edit history */
     .highlight_text_inserted {
         color: hsl(122, 72%, 30%);


### PR DESCRIPTION
Code needs cleaning up as well as decisions regarding the display format.

Example: `!timestamp(Jun 6 2017 4:48 PM)` should render as `<span class="timestamp" value="1496767680">Tuesday, June 6th 2017, 10:18:00 pm (Timezone: UTC+05:30)</span>`.

Question: What should we do with timestamps that are incorrect or not parsable?
Currently, I've done it so that no error messages are displayed and the original text is kept intact.

Since right now the syntax only picks up timestamps in UTC, I'm looking for ways to add support for timezones using `dateutil.parser`.

Some sample runs:
![image](https://cloud.githubusercontent.com/assets/8033238/26827131/7d107856-4ad9-11e7-8a42-efa4bed96801.png)
