### PR TITLE
message_edit: Avoid always fetching raw content.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -320,8 +320,20 @@ function start_edit_maintaining_scroll(row, content) {
     }
 }
 
+function start_edit_with_content(row, content, edit_box_open_callback) {
+    start_edit_maintaining_scroll(row, content);
+    if (edit_box_open_callback) {
+        edit_box_open_callback();
+    }
+}
+
 exports.start = function (row, edit_box_open_callback) {
     var message = current_msg_list.get(rows.id(row));
+    if (message.raw_content) {
+        start_edit_with_content(row, message.raw_content, edit_box_open_callback);
+        return;
+    }
+
     var msg_list = current_msg_list;
     channel.get({
         url: '/json/messages/' + message.id,
@@ -329,10 +341,7 @@ exports.start = function (row, edit_box_open_callback) {
         success: function (data) {
             if (current_msg_list === msg_list) {
                 message.raw_content = data.raw_content;
-                start_edit_maintaining_scroll(row, data.raw_content);
-                if (edit_box_open_callback) {
-                    edit_box_open_callback();
-                }
+                start_edit_with_content(row, data.raw_content, edit_box_open_callback);
             }
         },
     });

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -214,6 +214,7 @@ exports.update_messages = function update_messages(events) {
                 msg.edit_history = [];
             }
             msg.edit_history = [edit_history_entry].concat(msg.edit_history);
+            delete msg.raw_content;
             message_content_edited = true;
         }
 


### PR DESCRIPTION
Altered `message_edit.start` to check for `message.raw_content` before retrieving the same from the backend. `message.raw_content` is being set for messages in `insert_local_message`.

Fixes: #4404