### PR TITLE
Common base template for HTML emails

### DIFF
--- a/templates/zerver/emails/confirm_new_email.html
+++ b/templates/zerver/emails/confirm_new_email.html
@@ -1,42 +1,26 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html lang="en">
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Zulip</title>
-  </head>
-  <body>
-    <table width="80%" style="align:center; max-width:800px" align="center">
-      <tr>
-        <td style="font-size:16px; font-family:Helvetica;">
-          <p>Hi!
-          </p>
+{% extends "zerver/emails/email_base.html" %}
 
-          <p>
-          We received a request to change the email address for the Zulip
-          account on {{ realm.uri }} from {{ old_email }} to {{ new_email }}.
-          If you would like to confirm this change, please click this link:
-          <br />
-          <a href="{{ activate_url }}" style="color:#08c">{{ activate_url }}</a>
-          </p>
+{% block content %}
+<p>Hi!</p>
+<p>
+We received a request to change the email address for the Zulip
+account on {{ realm.uri }} from {{ old_email }} to {{ new_email }}.
+If you would like to confirm this change, please click this link:
+<br />
+<a href="{{ activate_url }}" style="color:#08c">{{ activate_url }}</a>
+</p>
+<p>
+{% if verbose_support_offers %}
+Feel free to give us a shout at
+<a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>
+if you have any questions or you did not request this change.
+{% else %}
+If you did not request this change, please contact the administrator
+of this Zulip server at
+<a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>.
+{% endif %}
+</p>
 
-          <p>
-          {% if verbose_support_offers %}
-          Feel free to give us a shout at
-          <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>
-          if you have any questions or you did not request this change.
-          {% else %}
-          If you did not request this change, please contact the administrator
-          of this Zulip server at
-          <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>.
-          {% endif %}
-          </p>
-
-          <p>
-          Cheers,<br />
-          The Zulip Team
-          </p>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>
+<p>Cheers,<br />
+The Zulip Team</p>
+{% endblock %}

--- a/templates/zerver/emails/confirm_registration.html
+++ b/templates/zerver/emails/confirm_registration.html
@@ -1,36 +1,25 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html lang="en">
-<head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>Zulip</title>
-</head>
-<body>
-<table width="80%" style="align:center; max-width:800px" align="center">
-    <tr>
-        <td style="font-size:16px; font-family:Helvetica;">
-            <p>Hello there.
-            </p>
-            <p>
-                You recently signed up for Zulip. Awesome!
-            </p>
-            <p>
-                To complete signup, visit this link below:
-                <br />
-                <a href="{{ activate_url }}" style="color:#08c">{{ activate_url }}</a>
-            </p>
-            <p>
-            {% if verbose_support_offers %}
-                Feel free to give us a shout at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>, if you have any questions.
-            {% else %}
-                If you are having issues, please contact your Zulip administrator at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>.
-            {% endif %}
-            </p>
-            <p>
-                Cheers,<br />
-                The Zulip Team
-            </p>
-        </td>
-    </tr>
-</table>
-</body>
-</html>
+{% extends "zerver/emails/email_base.html" %}
+
+{% block header %} almost there! {% endblock %}
+{% block content %}
+<p>Hello there.
+</p>
+<p>
+    You recently signed up for Zulip. Awesome!
+</p>
+<p>
+    To complete signup, visit this link below:
+    <br />
+    <a href="{{ activate_url }}" style="color:#08c">{{ activate_url }}</a>
+</p>
+<p>
+{% if verbose_support_offers %}
+    Feel free to give us a shout at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>, if you have any questions.
+{% else %}
+    If you are having issues, please contact your Zulip administrator at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>.
+{% endif %}
+</p>
+
+<p>Cheers,<br />
+The Zulip Team</p>
+{% endblock %}

--- a/templates/zerver/emails/digest.html
+++ b/templates/zerver/emails/digest.html
@@ -1,6 +1,10 @@
+{% extends "zerver/emails/email_base.html" %}
+
 {#
 Mail sent to a user who hasn't logged in for 24 hours.
 #}
+
+{% block content %}
 
 Hello {{ name }},
 
@@ -94,6 +98,7 @@ Here are some of the hot conversations that have happened while you've been gone
 The Zulip Team</p>
 
 <p>
-  <a href="{{ realm_uri }}/#settings">Manage email preferences</a> |
-  <a href="{{ unsubscribe_link }}">Unsubscribe from digest emails</a>
+    <a href="{{ realm_uri }}/#settings">Manage email preferences</a> |
+    <a href="{{ unsubscribe_link }}">Unsubscribe from digest emails</a>
 </p>
+{% endblock %}

--- a/templates/zerver/emails/email_base.html
+++ b/templates/zerver/emails/email_base.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+<head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <title>Zulip</title>
+        <style>
+        h3 {
+            font-family: Arial;
+            font-size: 30px;
+            margin: 5px 0px;
+            color: #555;
+        }
+        </style>
+</head>
+<body>
+<table width="80%" style="align:center; max-width:800px" align="center">
+    <tr>
+        <td>
+            <h3>{% block header %}{% endblock %}</h3>
+        </td>
+    </tr>
+    <tr>
+        <td style="font-size:16px; font-family:Helvetica;">
+            {% block content %}{% endblock %}
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/templates/zerver/emails/find_team.html
+++ b/templates/zerver/emails/find_team.html
@@ -1,10 +1,6 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html lang="en">
-<head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>Zulip</title>
-</head>
-<body>
+{% extends "zerver/emails/email_base.html" %}
+
+{% block content %}
 <p>Hi {{ user_profile.full_name }},</p>
 
 <p>You can log in to your Zulip organization, {{ user_profile.realm.name }},
@@ -25,7 +21,6 @@ at the following link:</p>
   this email.</p>
 
 {% endif %}
-<p>Thanks for using Zulip!</p>
 
-</body>
-</html>
+<p>Thanks for using Zulip!</p>
+{% endblock %}

--- a/templates/zerver/emails/followup_day1.html
+++ b/templates/zerver/emails/followup_day1.html
@@ -1,20 +1,8 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html lang="en">
-<head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>Zulip</title>
-</head>
-<body>
-<table width="80%" style="align:center; max-width:800px" align="center">
-<tr><td>
-      <a href="{{ realm_uri }}/"><img style="max-height:75px; height:75px;"  height="75px" alt="{{ _('Zulip') }}" title="Zulip" src="{{ realm_uri }}/static/images/landing-page/zulip-header.png" /></a>
+{% extends "zerver/emails/email_base.html" %}
 
-<h3 style="font-family:Arial; font-size:30px; margin: 5px 0px; color:#555">we love our users</h3>
-</td></tr>
-
-<tr><td style="font-size:16px; font-family:Helvetica;">
+{% block header %} we love our users {% endblock %}
+{% block content %}
 <p>Hi there!</p>
-
 <p>Welcome to Zulip.</p>
 
 <p><a href="{{ server_uri }}/hello" style="color:#08c">{{ server_uri }}/hello</a> has a nice overview of what we're up to, but here are a few tips that'll help you get the most out of it:</p>
@@ -38,15 +26,9 @@
 {% endif %}
 
 <p>Thanks,<br />Zulip</p>
-</td></tr>
-
-</table>
 
 <p>
-  <a href="{{ realm_uri }}/#settings">Manage email preferences</a> |
-  <a href="{{ unsubscribe_link }}">Unsubscribe from welcome emails</a> <small>(but there's only one more and aren't you a little curious?)</small>
+    <a href="{{ realm_uri }}/#settings">Manage email preferences</a> |
+    <a href="{{ unsubscribe_link }}">Unsubscribe from digest emails</a>
 </p>
-
-</body>
-
-</html>
+{% endblock %}

--- a/templates/zerver/emails/followup_day2.html
+++ b/templates/zerver/emails/followup_day2.html
@@ -1,18 +1,7 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html lang="en">
-<head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>Zulip</title>
-</head>
-<body>
-<table width="80%" style="align:center; max-width:800px" align="center">
-<tr><td>
-    <a href="{{ realm_uri }}/"><img style="max-height:75px; height:75px;"  height="75px" alt="{{ _('Zulip') }}" title="Zulip" src="{{ realm_uri }}/static/images/landing-page/zulip-header.png" /></a>
+{% extends "zerver/emails/email_base.html" %}
 
-<h3 style="font-family:Arial; font-size:30px; margin: 5px 0px; color:#555">one last thing</h3>
-</td></tr>
-
-<tr><td style="font-size:16px; font-family:Helvetica;">
+{% block header %} one last thing {% endblock %}
+{% block content %}
 <p>Hey,</p>
 
 <p>I wanted to share one last thing with you: a few tips about topics, since mastering topics is a key part of being a Zulip power user.</p>
@@ -29,15 +18,9 @@
 <p><a href="{{ realm_uri }}">Take it for a spin now.</a></p>
 
 <p>Thanks,<br />Zulip</p>
-</td></tr>
-
-</table>
 
 <p>
-  <a href="{{ realm_uri }}/#settings">Manage email preferences</a> |
-  <a href="{{ unsubscribe_link }}">Unsubscribe from welcome emails</a>
+    <a href="{{ realm_uri }}/#settings">Manage email preferences</a> |
+    <a href="{{ unsubscribe_link }}">Unsubscribe from welcome emails</a>
 </p>
-
-</body>
-
-</html>
+{% endblock %}

--- a/templates/zerver/emails/invitation.html
+++ b/templates/zerver/emails/invitation.html
@@ -1,39 +1,29 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html lang="en">
-<head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>Zulip</title>
-</head>
-<body>
-<table width="80%" style="align:center; max-width:800px" align="center">
-    <tr>
-        <td style="font-size:16px; font-family:Helvetica;">
-            <p>Hi there,
-            </p>
-            <p>
-                {{ referrer.full_name }} ({{ referrer.email }}) wants you to join them on Zulip -- the group communication tool you've always wished you had at work.
-            </p>
-            {% if custom_body %}
-            <p>Message from {{ referrer.full_name }}: {{ custom_body }}</p>
-            {% endif %}
-            <p>
-                To get started, visit the link below:
-                <br />
-                <a href="{{ activate_url }}" style="color:#08c">{{ activate_url }}</a>
-            </p>
-            <p>
-            {% if verbose_support_offers %}
-                Feel free to give us a shout at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>, if you have any questions.
-            {% else %}
-                If you are having issues, please contact your Zulip administrator at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>.
-            {% endif %}
-            </p>
-            <p>
-                Cheers,<br />
-                The Zulip Team
-            </p>
-        </td>
-    </tr>
-</table>
-</body>
-</html>
+{% extends "zerver/emails/email_base.html" %}
+
+{% block header %} you've got mail! {% endblock %}
+{% block content %}
+<p>Hi there,
+</p>
+<p>
+    {{ referrer.full_name }} ({{ referrer.email }}) wants you to join them on Zulip -- the group communication tool you've always wished you had at work.
+</p>
+{% if custom_body %}
+<p>Message from {{ referrer.full_name }}: {{ custom_body }}</p>
+{% endif %}
+<p>
+    To get started, visit the link below:
+    <br />
+    <a href="{{ activate_url }}" style="color:#08c">{{ activate_url }}</a>
+</p>
+<p>
+{% if verbose_support_offers %}
+    Feel free to give us a shout at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>, if you have any questions.
+{% else %}
+    If you are having issues, please contact your Zulip administrator at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>.
+{% endif %}
+</p>
+
+<p>Cheers,<br />
+The Zulip Team</p>
+{% endblock %}
+

--- a/templates/zerver/emails/invitation_reminder.html
+++ b/templates/zerver/emails/invitation_reminder.html
@@ -1,46 +1,25 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html lang="en">
-<head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>Zulip</title>
-</head>
-<body>
-<table width="80%" style="align:center; max-width:800px" align="center">
-    <tr>
-        <td>
-            <a href="{{ server_uri }}/hello">
-              <img style="max-height:75px; height:75px;"  height="75px" alt="{{ _('Zulip') }}" title="Zulip" src="{{ server_uri }}/static/images/landing-page/zulip-header.png" />
-            </a>
-            <h3 style="font-family:Arial; font-size:30px; margin: 5px 0px; color:#555">
-                you're busy: we get you
-            </h3>
-        </td>
-    </tr>
-    <tr>
-        <td style="font-size:16px; font-family:Helvetica;">
-            <p>Hi again,
-            </p>
-            <p>
-                This is a friendly reminder that {{ referrer_name }} (<a href="mailto:{{ referrer_email }}" style="color:#08c">{{ referrer_email }}</a>) wants you to join them on Zulip, a workplace chat tool that actually makes you more productive.
-            </p>
-            <p>
-                To get started, visit the link below:
-                <br />
-                <a href="{{ activate_url }}" style="color:#08c">{{ activate_url }}</a>
-            </p>
-            <p>
-            {% if verbose_support_offers %}
-                We're here for you at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>, if you have any questions.
-            {% else %}
-                If you are having issues, please contact your Zulip administrator at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>.
-            {% endif %}
-            </p>
-            <p>
-                Cheers,<br />
-                The Zulip Team
-            </p>
-        </td>
-    </tr>
-</table>
-</body>
-</html>
+{% extends "zerver/emails/email_base.html" %}
+
+{% block header %} you're busy: we get you {% endblock %}
+{% block content %}
+<p>Hi again,
+</p>
+<p>
+    This is a friendly reminder that {{ referrer_name }} (<a href="mailto:{{ referrer_email }}" style="color:#08c">{{ referrer_email }}</a>) wants you to join them on Zulip, a workplace chat tool that actually makes you more productive.
+</p>
+<p>
+    To get started, visit the link below:
+    <br />
+    <a href="{{ activate_url }}" style="color:#08c">{{ activate_url }}</a>
+</p>
+<p>
+{% if verbose_support_offers %}
+    We're here for you at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>, if you have any questions.
+{% else %}
+    If you are having issues, please contact your Zulip administrator at <a href="mailto:{{ support_email }}" style="color:#08c">{{ support_email }}</a>.
+{% endif %}
+</p>
+
+<p>Cheers,<br />
+The Zulip Team</p>
+{% endblock %}

--- a/templates/zerver/emails/missed_message.html
+++ b/templates/zerver/emails/missed_message.html
@@ -1,47 +1,54 @@
+{% extends "zerver/emails/email_base.html" %}
+
 {#
 Mail sent to user when she was not logged in and received a PM or @-mention
 #}
 
-Hello {{ name }},
+{% block content %}
 
-<p>
-    While you were away you received {{ message_count }} new message{{ message_count|pluralize }}{% if mention %} in which you were mentioned{% endif %}!
-</p>
+    Hello {{ name }},
 
-<div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
-    {% for recipient_block in messages %}
-    <div class='recipient_block' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}border: 1px solid black;margin-bottom: 4px;">
-        <div class='recipient_header' style="{% if recipient_block.header.stream_message %}background-color: #9ecaff;{% else %}color: #ffffff;background-color: #444444;{% endif %}border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
-        <div class='message_content' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}margin-left: 1px;margin-right: 2px;">
-            {% for sender_block in recipient_block.senders %}
-                {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
-                {% for message_block in sender_block.content %}
-                <div class='message_content_block' style="padding-left: 6px;font-weight: normal;">
-                    {{ message_block.html|safe }}
-                </div>
+    <p>
+        While you were away you received {{ message_count }} new message{{ message_count|pluralize }}{% if mention %} in which you were mentioned{% endif %}!
+    </p>
+
+    <div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
+        {% for recipient_block in messages %}
+        <div class='recipient_block' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}border: 1px solid black;margin-bottom: 4px;">
+            <div class='recipient_header' style="{% if recipient_block.header.stream_message %}background-color: #9ecaff;{% else %}color: #ffffff;background-color: #444444;{% endif %}border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
+            <div class='message_content' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}margin-left: 1px;margin-right: 2px;">
+                {% for sender_block in recipient_block.senders %}
+                    {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
+                    {% for message_block in sender_block.content %}
+                    <div class='message_content_block' style="padding-left: 6px;font-weight: normal;">
+                        {{ message_block.html|safe }}
+                    </div>
+                    {% endfor %}
                 {% endfor %}
-            {% endfor %}
+            </div>
         </div>
+        {% endfor %}
     </div>
-    {% endfor %}
-</div>
 
 
-<p>
-    <a href="{{ realm_uri }}">Click here to log in to Zulip and view your new messages.</a>
-    {% if reply_to_zulip  %}
-    Or just reply to this email.
+    <p>
+        <a href="{{ realm_uri }}">Click here to log in to Zulip and view your new messages.</a>
+        {% if reply_to_zulip  %}
+        Or just reply to this email.
+        {% endif %}
+    </p>
+
+    {% if reply_warning %}
+    <p>Please do not reply to this automated message. To respond to the missed messages you have received, please log on to Zulip and send your replies there.</p>
     {% endif %}
-</p>
 
-{% if reply_warning %}
-<p>Please do not reply to this automated message. To respond to the missed messages you have received, please log on to Zulip and send your replies there.</p>
-{% endif %}
+    <p>Cheers,<br />
+    The Zulip Team</p>
 
-<p>
-    Cheers,
-    <br></br>
-    The Zulip Team
-</p>
+    <p>
+        <a href="{{ realm_uri }}/#settings">Manage email preferences</a> |
+        <a href="{{ unsubscribe_link }}">Unsubscribe from digest emails</a>
+    </p>
+{% endblock %}
 
-<p><a href="{{ realm_uri }}/#settings">Manage email preferences</a> | <a href="{{ unsubscribe_link }}">Unsubscribe from missed message emails</a></p>
+

--- a/templates/zerver/emails/notify_new_login.html
+++ b/templates/zerver/emails/notify_new_login.html
@@ -1,34 +1,20 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html lang="en">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <title>Zulip</title>
-    </head>
-    <body>
-        <table width="80%" style="align:center; max-width:800px" align="center">
-            <tr>
-                <td>
-                    <a href="{{ realm_uri }}"><img style="max-height:75px; height:75px;"  height="75px" alt="{{ _('Zulip') }}" title="Zulip" src="{{ realm_uri }}/static/images/landing-page/zulip-header.png" /></a>
-                    <h3 style="font-family:Arial; font-size:30px; margin: 5px 0px; color:#555">New login to Zulip</h3>
-                </td>
-            </tr>
-            <tr>
-                <td style="font-size:16px; font-family:Helvetica;">
-                    <p><b>Hello, {{ user.full_name | title }}.</b></p>
-                    <p>This is a notification that a new login to your Zulip account has just occurred.</p>
-                    <p><b>Login details:</b></p>
-                    <blockquote>
-                        <p>Server: {{ realm_uri }}</p>
-                        <p>Account: {{ user.email }}</p>
-                        <p>Time: {{ device_info.login_time }}</p>
-                        <p>Device: {{ device_info.device_browser if device_info.device_browser else 'An unknown browser' }} on {{ device_info.device_os if device_info.device_os else 'an unknown operating system' }}.</p>
-                        <p>IP Address: {{ device_info.device_ip }}</p>
-                    </blockquote>
-                    <p><b>If you do not recognize this login activity or think your account may have been compromised, contact Zulip Support at {{ zulip_support }}.</b></p>
-                    <p>If you recognize this login activity, you can archive this notice.</p>
-                    <p>Thanks,<br />Zulip Account Security</p>
-                </td>
-            </tr>
-        </table>
-    </body>
-</html>
+{% extends "zerver/emails/email_base.html" %}
+
+{% block header %} New login to zulip {% endblock %}
+{% block content %}
+<p><b>Hello, {{ user.full_name | title }}.</b></p>
+<p>This is a notification that a new login to your Zulip account has just occurred.</p>
+<p><b>Login details:</b></p>
+<blockquote>
+    <p>Server: {{ realm_uri }}</p>
+    <p>Account: {{ user.email }}</p>
+    <p>Time: {{ device_info.login_time }}</p>
+    <p>Device: {{ device_info.device_browser if device_info.device_browser else 'An unknown browser' }} on {{ device_info.device_os if device_info.device_os else 'an unknown operating system' }}.</p>
+    <p>IP Address: {{ device_info.device_ip }}</p>
+</blockquote>
+<p><b>If you do not recognize this login activity or think your account may have been compromised, contact Zulip Support at {{ zulip_support }}.</b></p>
+<p>If you recognize this login activity, you can archive this notice.</p>
+
+<p>Thanks,<br />Zulip Account Security</p>
+{% endblock %}
+


### PR DESCRIPTION
fixes #5114. 

a few things I am uncertain about:

- right now, every email that has a defined `header` block has a copy of the whole h3 tag, plus the inside text. i wasn't sure how to make it so when `header` is defined, the h3 wrapper would be added and thus the actual email would only have to define the inside text (it works right now, but it would just look nicer!)
- is there a general loader that can be used for populating variables like `realm_uri` so the template generates properly? i've included my simple loader for Jinja at `templates/zerver/emails/tester.py` for comparison. Also unsure on what file path is used in the official loader, which would affect the `{% extends "base.html" %}` path working.
- i made it so all emails have manage preferences/unsubscribe at their bottom.

