### PR TITLE
bots: Refactor and simplify bot_test_lib.py.

### DIFF
--- a/api/bots/giphy/test_giphy.py
+++ b/api/bots/giphy/test_giphy.py
@@ -51,11 +51,10 @@ class TestGiphyBot(BotTestCase):
         # This message calls `send_reply` function of BotHandlerApi
         keyword = "Hello"
         gif_url = "https://media4.giphy.com/media/3o6ZtpxSZbQRRnwCKQ/giphy.gif"
-        expectations = {
-            keyword: get_bot_response(gif_url)
-        }
-        self.check_expected_responses(
-            expectations=expectations,
+        self.assert_bot_response(
+            message = {'content': keyword},
+            response = {'content': get_bot_response(gif_url)},
+            expected_method='send_reply',
             http_request=get_http_request(keyword),
             http_response=get_http_response_json(gif_url)
         )


### PR DESCRIPTION
#### First commit
This commit integrates the mock_test function in
check_expected_responses and makes this function usable
for simple tests only by not allowing mock http conversations.

assert_bot_response() is now used for single message-response pairs,
resolving potential issues with multiple messages and a single http
request-response pair.

The giphy bot test file is updated accordingly.

#### The rest
If this does not get merged right away, I'll continue adding some commits on top of this PR, since they will rely on these changes.