### PR TITLE
Improve test coverage for message_list.js

### DIFF
--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -117,6 +117,20 @@ var MessageList = require('js/message_list').MessageList;
     assert.deepEqual(list.all_messages(), []);
 }());
 
+(function test_message_range() {
+    var table;
+    var filter = {};
+    var list = new MessageList(table, filter);
+
+    var messages = [{id: 30}, {id: 40}, {id: 50}, {id: 60}];
+    list.append(messages, true);
+    assert.deepEqual(list.message_range(2, 30), [{id: 30}]);
+    assert.deepEqual(list.message_range(2, 31), [{id: 30}, {id: 40}]);
+    assert.deepEqual(list.message_range(30, 40), [{id: 30}, {id: 40}]);
+    assert.deepEqual(list.message_range(31, 39), [{id: 40}]);
+    assert.deepEqual(list.message_range(31, 1000), [{id: 40}, {id: 50}, {id: 60}]);
+}());
+
 (function test_nth_most_recent_id() {
     var table;
     var filter = {};

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -44,6 +44,7 @@ var MessageList = require('js/message_list').MessageList;
 
     list.append(messages, true);
 
+    assert.equal(list.num_items(), 4);
     assert.equal(list.empty(), false);
     assert.equal(list.first().id, 50);
     assert.equal(list.last().id, 80);
@@ -65,8 +66,19 @@ var MessageList = require('js/message_list').MessageList;
     list.select_id(50);
 
     assert.equal(list.selected_id(), 50);
+    assert.equal(list.selected_idx(), 0);
 
     list.advance_past_messages([60, 80]);
+    assert.equal(list.selected_id(), 60);
+    assert.equal(list.selected_idx(), 1);
+
+    // Make sure not rerendered when reselected
+    var num_renders = 0;
+    list.rerender = function () {
+        num_renders += 1;
+    };
+    list.reselect_selected_id();
+    assert.equal(num_renders, 0);
     assert.equal(list.selected_id(), 60);
 
     var old_messages = [
@@ -99,7 +111,6 @@ var MessageList = require('js/message_list').MessageList;
 
     list.clear();
     assert.deepEqual(list.all_messages(), []);
-
 }());
 
 (function test_nth_most_recent_id() {

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -234,3 +234,41 @@ var MessageList = require('js/message_list').MessageList;
         });
     });
 }());
+
+(function test_unmuted_messages() {
+    var table;
+    var filter = {};
+
+    var list = new MessageList(table, filter);
+
+    var unmuted = [
+        {
+            id: 50,
+            stream: 'bad',
+            mentioned: true,
+        },
+        {
+            id: 60,
+            stream: 'good',
+            mentioned: false,
+        },
+    ];
+    var muted = [
+        {
+            id: 70,
+            stream: 'bad',
+            mentioned: false,
+        },
+    ];
+
+    with_overrides(function (override) {
+        override('muting.is_topic_muted', function (stream) {
+            return stream === 'bad';
+        });
+
+        // Make sure unmuted_message filters out the "muted" entry,
+        // which we mark as having a muted topic, and not mentioned.
+        var test_unmuted = list.unmuted_messages(unmuted.concat(muted));
+        assert.deepEqual(unmuted, test_unmuted);
+    });
+}());

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -272,3 +272,30 @@ var MessageList = require('js/message_list').MessageList;
         assert.deepEqual(unmuted, test_unmuted);
     });
 }());
+
+(function test_add_remove_rerender() {
+    var table;
+    var filter = {};
+
+    var list = new MessageList(table, filter);
+
+    var messages = [{id: 1}, {id: 2}, {id: 3}];
+
+    list.unmuted_messages = function (m) { return m; };
+    global.with_stub(function (stub) {
+        list.view.rerender_the_whole_thing = stub.f;
+        list.add_and_rerender(messages);
+
+        // Make sure the function has triggered a rerender
+        // and that all 3 items were added to the list.
+        assert.equal(stub.num_calls, 1);
+        assert.equal(list.num_items(), 3);
+    });
+
+    global.with_stub(function (stub) {
+        list.rerender = stub.f;
+        list.remove_and_rerender(messages);
+        assert.equal(stub.num_calls, 1);
+        assert.equal(list.num_items(), 0);
+    });
+}());

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -195,6 +195,32 @@ var MessageList = require('js/message_list').MessageList;
     assert.equal(list.get(10).content, "ok!");
 }());
 
+(function test_last_sent_by_me() {
+    var table;
+    var filter = {};
+
+    var list = new MessageList(table, filter);
+    var items = [
+            {
+                id: 1,
+                sender_id: 3,
+            },
+            {
+                id: 2,
+                sender_id: 3,
+            },
+            {
+                id: 3,
+                sender_id: 6,
+            },
+    ];
+
+    list.append(items);
+    set_global("page_params", {user_id: 3});
+    // Look for the last message where user_id == 3 (our ID)
+    assert.equal(list.get_last_message_sent_by_me().id, 2);
+}());
+
 (function test_local_echo() {
     var table;
     var filter = {};

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -182,6 +182,18 @@ var MessageList = require('js/message_list').MessageList;
     assert.equal(list.nth_most_recent_id(4), -1);
 }());
 
+(function test_change_message_id() {
+    var table;
+    var filter = {};
+
+    var list = new MessageList(table, filter);
+    list.append([{id: 10.5, content: "good job"}, {id: 20.5, content: "ok!"}]);
+    list.change_message_id(10.5, 11);
+    assert.equal(list.get(11).content, "good job");
+
+    list.change_message_id(20.5, 10);
+    assert.equal(list.get(10).content, "ok!");
+}());
 
 (function test_local_echo() {
     var table;

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -131,6 +131,45 @@ var MessageList = require('js/message_list').MessageList;
     assert.deepEqual(list.message_range(31, 1000), [{id: 40}, {id: 50}, {id: 60}]);
 }());
 
+(function test_updates() {
+    var table;
+    var filter = {};
+    var list = new MessageList(table, filter);
+    list.view.rerender_the_whole_thing = noop;
+
+    var messages = [
+        {
+            id: 1,
+            sender_id: 100,
+            sender_full_name: "tony",
+            stream_id: 32,
+            stream: "denmark",
+            small_avatar_url: "http://zulip.spork",
+        },
+        {
+            id: 2,
+            sender_id: 39,
+            sender_full_name: "jeff",
+            stream_id: 64,
+            stream: "russia",
+            small_avatar_url: "http://github.com",
+        },
+    ];
+
+    list.append(messages, true);
+    list.update_user_full_name(100, "Anthony");
+    assert.equal(list.get(1).sender_full_name, "Anthony");
+    assert.equal(list.get(2).sender_full_name, "jeff");
+
+    list.update_user_avatar(100, "http://zulip.org");
+    assert.equal(list.get(1).small_avatar_url, "http://zulip.org");
+    assert.equal(list.get(2).small_avatar_url, "http://github.com");
+
+    list.update_stream_name(64, "Finland");
+    assert.equal(list.get(2).stream, "Finland");
+    assert.equal(list.get(1).stream, "denmark");
+}());
+
 (function test_nth_most_recent_id() {
     var table;
     var filter = {};


### PR DESCRIPTION
This doesn't test anything related to view/html stuff. (but there isn't much to test there anyways)
But for everything else in `message_list.js`, there should now be 100% coverage.