### PR TITLE
settings/bots: Fix broken tooltip.

### DIFF
--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -28,7 +28,7 @@
                         <label for="bot_type">
                             {{t "Bot type" }}
                             <i class="icon-vector-question-sign bot_type_tooltip" data-toggle="tooltip"
-                             title={{t "Incoming webhooks can only send messages." }}></i>
+                             title='{{t "Incoming webhooks can only send messages." }}'></i>
                         </label>
                         <select name="bot_type" id="create_bot_type">
                             <option value="1">{{t "Generic bot" }}</option>


### PR DESCRIPTION
This fixes the broken tooltip in bots section of settings area:
![anim](https://user-images.githubusercontent.com/16687990/26896386-1dfa33ac-4be2-11e7-96b9-4cba4d550d17.gif)
