### PR TITLE
Fix bug in pep8 linter.

### DIFF
--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -109,7 +109,8 @@ def check_pep8(files):
     if not len(filtered_files_E261) == 0:
         # Adding an extra ignore rule for these files since they still remain in
         # violation of PEP-E261.
+        failed_ignore_e261 = run_pycodestyle(filtered_files_E261, ignored_rules + ['E261'])
         if not failed:
-            failed = run_pycodestyle(filtered_files_E261, ignored_rules + ['E261'])
+            failed = failed_ignore_e261
 
     return failed


### PR DESCRIPTION
In this commit we fix the bug introduced by 24b1efc which was to fix the bug in pep8 linter (pep8 linter does not report false and exit when we got linting issues). 
Sorry for the inconvenience @timabbott.  