### PR TITLE
bots: tests: Move http mock to separate function.

### DIFF
--- a/api/bots/giphy/test_giphy.py
+++ b/api/bots/giphy/test_giphy.py
@@ -51,10 +51,10 @@ class TestGiphyBot(BotTestCase):
         # This message calls `send_reply` function of BotHandlerApi
         keyword = "Hello"
         gif_url = "https://media4.giphy.com/media/3o6ZtpxSZbQRRnwCKQ/giphy.gif"
-        self.assert_bot_response(
-            message = {'content': keyword},
-            response = {'content': get_bot_response(gif_url)},
-            expected_method='send_reply',
-            http_request=get_http_request(keyword),
-            http_response=get_http_response_json(gif_url)
-        )
+        with self.mock_http_conversation(get_http_request(keyword),
+                                         get_http_response_json(gif_url)):
+            self.assert_bot_response(
+                message = {'content': keyword},
+                response = {'content': get_bot_response(gif_url)},
+                expected_method='send_reply'
+            )


### PR DESCRIPTION
This commit decouples the http mock conversation feature from assert_bot_response(), and moves it
to the wrapper function mock_http_conversation(). This allows a modular design with more wrappers
that could be added for assert_bot_response().