### PR TITLE
Change from and noreply emails to use EXTERNAL_HOST domain.

### DIFF
--- a/docs/prod-email.md
+++ b/docs/prod-email.md
@@ -51,10 +51,10 @@ later setup a real SMTP provider!
 To configure outgoing SMTP, you will need to complete the following steps:
 
 1. Fill out the outgoing email sending configuration block in
-`/etc/zulip/settings.py`, including `EMAIL_HOST`, `EMAIL_HOST_USER`,
-and `NOREPLY_EMAIL_ADDRESS`.  You may also need
-to set `EMAIL_PORT` if your provider doesn't use the standard
-SMTP submission port (587).
+`/etc/zulip/settings.py`, including `EMAIL_HOST`, `EMAIL_HOST_USER`, and
+`NOREPLY_EMAIL_ADDRESS`. You may also need to set `EMAIL_PORT` if your provider
+doesn't use the standard SMTP submission port (587). You may also want to update
+`NOREPLY_EMAIL_ADDRESS` from its default value.
 
 2. Put the SMTP password for `EMAIL_HOST_USER` in
 `/etc/zulip/zulip-secrets.conf` as `email_password = yourPassword`.

--- a/docs/prod-install.md
+++ b/docs/prod-install.md
@@ -78,14 +78,14 @@ These settings include:
   maintaining this installation and who will get support and error
   emails.
 
-- `EMAIL_*` and `NOREPLY_EMAIL_ADDRESS`:
+- `EMAIL_*`:
   credentials for an outgoing SMTP server so Zulip can send emails
   when needed (don't forget to set `email_password` in the
   `zulip-secrets.conf` file!).  We highly recommend reading our
   [production email docs](prod-email.html) and following the test
   procedure discussed there to make sure you've setup outgoing email
   correctly, since outgoing email is the most common configuration
-  problem.
+  problem. You may also want to update `NOREPLY_EMAIL_ADDRESS`
 
 - If desired, you can also configure additional
   [authentication backends](prod-authentication-methods.html) while

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -41,7 +41,7 @@ class TestMissedMessages(ZulipTestCase):
         if settings.EMAIL_GATEWAY_PATTERN != "":
             reply_to_addresses = [settings.EMAIL_GATEWAY_PATTERN % (u'mm' + t) for t in tokens]
         else:
-            reply_to_addresses = ["Zulip <noreply@example.com>"]
+            reply_to_addresses = ["Zulip <noreply@zulip.example.com>"]
         msg = mail.outbox[0]
         sender = settings.NOREPLY_EMAIL_ADDRESS
         from_email = sender

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -76,8 +76,8 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 # The noreply address to be used as the sender for certain generated emails.
 # Messages sent to this address could contain sensitive user data and should
-# not be delivered anywhere.
-NOREPLY_EMAIL_ADDRESS = "Zulip <noreply@example.com>"
+# not be delivered anywhere. (e.g. "Zulip <noreply@example.com>")
+NOREPLY_EMAIL_ADDRESS = "Zulip <noreply@" + EXTERNAL_HOST.split(":")[0] + ">"
 
 
 ## OPTIONAL SETTINGS

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -236,7 +236,6 @@ REQUIRED_SETTINGS = [("EXTERNAL_HOST", "zulip.example.com"),
                      # case, it seems worth having in this list
                      ("SECRET_KEY", ""),
                      ("AUTHENTICATION_BACKENDS", ()),
-                     ("NOREPLY_EMAIL_ADDRESS", "Zulip <noreply@example.com>"),
                      ]
 
 if ADMINS == "":


### PR DESCRIPTION
This should simplify initial configuration of required settings to saner defaults.