### PR TITLE
Add URL for viewing node coverage data on dev server.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -132,6 +132,8 @@ if options.coverage and ret == 0:
     print()
 
 if ret == 0:
+    if options.coverage:
+        print("View coverage reports at http://127.0.0.1:9991/node-coverage/index.html")
     print("Test(s) passed. SUCCESS!")
 else:
     print("FAIL - Test(s) failed")

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -396,6 +396,7 @@ def write_instrumentation_reports(full_suite):
             # static content URLs, since the content they point to may
             # or may not exist.
             'coverage/(?P<path>.*)',
+            'node-coverage/(?P<path>.*)',
             'docs/(?P<path>.*)',
         ])
 

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -19,6 +19,10 @@ urls = [
         serve, {'document_root':
                 os.path.join(settings.DEPLOY_ROOT, 'var/coverage'),
                 'show_indexes': True}),
+    url(r'^node-coverage/(?P<path>.*)$',
+        serve, {'document_root':
+                os.path.join(settings.DEPLOY_ROOT, 'var/node-coverage/lcov-report'),
+                'show_indexes': True}),
     url(r'^docs/(?P<path>.*)$',
         serve, {'document_root':
                 os.path.join(settings.DEPLOY_ROOT, 'docs/_build/html')}),


### PR DESCRIPTION
Running test-js-with-node --coverage now provides a URL
to view the output data on the web.

Fixes #5177.