### PR TITLE
frontend: increases contrast of sidebar captions

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -18,7 +18,7 @@
 #streams_filter_icon,
 #join_unsub_stream {
     float: right;
-    color: hsl(0, 0%, 80%);
+    color: hsl(0, 0%, 54%);
     font-size: 13px;
     margin-top: 3px;
     margin-left: 10px;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -473,7 +473,7 @@ a:hover code {
 
 .sidebar-title {
     font-size: 1em;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 43%);
     font-weight: normal;
     display: inline;
 }


### PR DESCRIPTION
fixes #5316.
this is what it looks like normally:
![screen shot 2017-06-09 at 15 53 47](https://user-images.githubusercontent.com/13666710/26981041-e53a4f98-4d2b-11e7-93f2-9b87ebeb5ffa.png)

this is what it looks like with this PR:
![screen shot 2017-06-09 at 15 49 05](https://user-images.githubusercontent.com/13666710/26981001-b6094d1e-4d2b-11e7-916c-58aef13e5371.png)

i feel like this is a small enough change to not affect visual priority, but still makes them more readable.

(going darker would give this result:)
![screen shot 2017-06-09 at 15 55 53](https://user-images.githubusercontent.com/13666710/26981166-2c875b48-4d2c-11e7-8427-ceda911f91d9.png)

