### PR TITLE
Add realm uri to stream links in emails

### DIFF
--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -113,6 +113,13 @@ def build_message_list(user_profile, messages):
             user_profile.realm.uri + r"/static/generated/emoji/images/emoji/",
             content)
 
+        # Stream links need to be converted from relative to absolute. They
+        # have href values in the form of "/#narrow/stream/...".
+        content = re.sub(
+            r"/#narrow/stream/",
+            user_profile.realm.uri + r"/#narrow/stream/",
+            content)
+
         return content
 
     def fix_plaintext_image_urls(content):


### PR DESCRIPTION
This is a fix for #5310.

I tested this on locally by sending a a private message to someone and waiting until the missed message html email came through in the server log.

Before the change, this was what a stream link looked like:
```
<a class="stream" data-stream-id="4" href="/#narrow/stream/Verona">#Verona</a>
```

And after the change:
```
<a class="stream" data-stream-id="4" href="http://localhost:9991/#narrow/stream/Verona">#Verona</a
```