### PR TITLE
Avoid some cache calls.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -700,8 +700,10 @@ def render_incoming_message(message, content, message_users, realm):
 def get_recipient_user_profiles(recipient, sender_id):
     # type: (Recipient, int) -> List[UserProfile]
     if recipient.type == Recipient.PERSONAL:
-        recipients = list(set([get_user_profile_by_id(recipient.type_id),
-                               get_user_profile_by_id(sender_id)]))
+        # The sender and recipient may be the same id, so
+        # de-duplicate using a set.
+        user_ids = list({recipient.type_id, sender_id})
+        recipients = [get_user_profile_by_id(user_id) for user_id in user_ids]
         # For personals, you send out either 1 or 2 copies, for
         # personals to yourself or to someone else, respectively.
         assert((len(recipients) == 1) or (len(recipients) == 2))

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -107,7 +107,7 @@ def response_listener(error_response):
     errmsg = ERROR_CODES[code]
     data = redis_client.hgetall(key)
     token = data['token']
-    user = get_user_profile_by_id(int(data['user_id']))
+    user_id = int(data['user_id'])
     b64_token = hex_to_b64(token)
 
     logging.warn("APNS: Failed to deliver APNS notification to %s, reason: %s" % (b64_token, errmsg))
@@ -115,7 +115,7 @@ def response_listener(error_response):
         # Invalid Token, remove from our database
         logging.warn("APNS: Removing token from database due to above failure")
         try:
-            PushDeviceToken.objects.get(user=user, token=b64_token).delete()
+            PushDeviceToken.objects.get(user_id=user_id, token=b64_token).delete()
             return  # No need to check RemotePushDeviceToken
         except PushDeviceToken.DoesNotExist:
             pass
@@ -124,7 +124,7 @@ def response_listener(error_response):
             # Trying to delete from both models is a bit inefficient than
             # deleting from only one model but this method is very simple.
             try:
-                RemotePushDeviceToken.objects.get(user_id=user.id,
+                RemotePushDeviceToken.objects.get(user_id=user_id,
                                                   token=b64_token).delete()
             except RemotePushDeviceToken.DoesNotExist:
                 pass

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1507,7 +1507,7 @@ def get_huddle_backend(huddle_hash, id_list):
             recipient = Recipient.objects.create(type_id=huddle.id,
                                                  type=Recipient.HUDDLE)
             subs_to_create = [Subscription(recipient=recipient,
-                                           user_profile=get_user_profile_by_id(user_profile_id))
+                                           user_profile_id=user_profile_id)
                               for user_profile_id in id_list]
             Subscription.objects.bulk_create(subs_to_create)
         return huddle


### PR DESCRIPTION
These are pretty low-risk changes that remove some unneeded calls to one of our user caches.  I also cleaned up a test in passing.

The motivation behind this PR was to find cases where we call get_user_profile_by_id() with a bunch of ids on a single request, in hopes we could batch lookups.  I added some temporary instrumentation to the function, but didn't really find any egregious repeat callers, except for `delete_all_deactivated_user_sessions`, but that function would have been difficult to re-structure.