### PR TITLE
settings: improves public/private stream descriptions

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -576,6 +576,11 @@ form#add_new_subscription {
     font-weight: 600;
 }
 
+.stream-creation-info {
+    font-style: italic;
+    margin-bottom: 20px;
+}
+
 .stream-creation-body section.block {
     margin-bottom: 20px;
 }
@@ -589,6 +594,10 @@ form#add_new_subscription {
 .stream-creation-body #make-invite-only label span.icon-vector-lock {
     margin-left: 15px;
     margin-right: 11px;
+}
+
+.stream-creation-body #make-invite-only .radio {
+    margin-bottom: 10px;
 }
 
 #announce-new-stream {

--- a/static/templates/subscription_creation_form.handlebars
+++ b/static/templates/subscription_creation_form.handlebars
@@ -19,15 +19,24 @@
                 <div class="create-stream-title">
                     {{t "Stream accessibility" }}
                 </div>
+                <div class="stream-creation-info">
+                    {{#tr this}}
+                    For more information on public/private streams, check out our <a href="http://zulip.readthedocs.io/en/latest/security-model.html?highlight=private%20stream#messages-and-history">docs</a>.
+                    {{/tr}}
+                </div>
                 <label class="radio">
                     <input type="radio" name="privacy" value="public" checked />
                     <span class="fa fa-globe" aria-hidden="true"></span>
-                    {{t "Anyone can join" }}
+                    {{#tr this}}
+                    <b>Public:</b> anyone can join; anyone can view complete message history without joining
+                    {{/tr}}
                 </label><br />
                 <label class="radio">
                     <input type="radio" name="privacy" value="invite-only" />
                     <span class="fa fa-lock" aria-hidden="true"></span>
-                    {{t "People must be invited" }}
+                    {{#tr this}}
+                    <b>Private:</b> must be invited by a member; new members can only see messages sent after they join; hidden from non-administrator users
+                    {{/tr}}
                 </label>
                 <div id="announce-new-stream">
                     <label class="checkbox">


### PR DESCRIPTION
resolves #5305.

* changed phrasing
* added a link below the header pointing to further info
* increased margin between the two radios & checkbox below, as the increase in text made it less readable

It now looks like this:
![screen shot 2017-06-10 at 16 04 22](https://user-images.githubusercontent.com/13666710/27003868-c7aff678-4df6-11e7-9d70-b7f1bb89b0d2.png)

Concerns: 
* "hidden from non-administrator users" might lead people to assume that administrators have full access to the stream, while it's actually just that they are able to see the existence of the stream, if i understood correctly from the docs? Not sure if this is important to rephrase.
* this makes the old translations obsolete. what is the workflow for this-- removing the deprecated translations & letting the translation stream know about it?

@timabbott would appreciate feedback on this!