### PR TITLE
Fix overlapping chevron-left icon in stream subscription modal.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -659,7 +659,7 @@ $(function () {
         $(".subscriptions-header").addClass("slide-left");
     });
 
-    $("#subscriptions_table").on("click", ".icon-vector-chevron-left", function () {
+    $("#subscriptions_table").on("click", ".fa-chevron-left", function () {
         $(".right").removeClass("show");
         $(".subscriptions-header").removeClass("slide-left");
     });

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -430,7 +430,7 @@ form#add_new_subscription {
     border-bottom: 1px solid #ddd;
 }
 
-.subscriptions-header .icon-vector-chevron-left,
+.subscriptions-header .fa-chevron-left,
 #settings_overlay_container .settings-header.mobile .icon-vector-chevron-left {
     position: relative;
     transform: translate(-50px, 0px);
@@ -445,7 +445,7 @@ form#add_new_subscription {
     transition: all 0.3s ease;
 }
 
-.subscriptions-header.slide-left .icon-vector-chevron-left,
+.subscriptions-header.slide-left .fa-chevron-left,
 #settings_overlay_container .settings-header.mobile.slide-left .icon-vector-chevron-left {
     transform: translate(-0px, 0px);
     opacity: 1;
@@ -955,7 +955,7 @@ form#add_new_subscription {
         position: relative;
     }
 
-    .subscriptions-header .icon-vector-chevron-left {
+    .subscriptions-header .fa-chevron-left {
         display: block;
     }
 


### PR DESCRIPTION
This basically fixes the issue introduced in commit 293abb which was supposed to migrate the subscription_table_body.handlebars file to use more recent version of font-awesome. This should be able do this without causing new merge conflicts to any of the open PR's. If it causes a merge conflict to a PR then it is either fixable by just doing a rebase or the PR already has dense merge conflict to resolve that mostly stuff would be required to looked at carefully again.