### PR TITLE
bots: Add a way to mock config files.

### DIFF
--- a/api/bots/giphy/giphy.py
+++ b/api/bots/giphy/giphy.py
@@ -12,13 +12,6 @@ import re
 
 GIPHY_TRANSLATE_API = 'http://api.giphy.com/v1/gifs/translate'
 
-if not os.path.exists(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'giphy.conf')):
-    print('Giphy bot config file not found, please set it up in this bot\'s folder '
-          'with the name \'giphy.conf\'\n\nUsing format:\n\n[giphy-config]\nkey=<giphy'
-          'API key here>\n\n')
-    sys.exit(1)
-
-
 class GiphyHandler(object):
     '''
     This plugin posts a GIF in response to the keywords provided by the user.

--- a/api/bots_api/bot_lib.py
+++ b/api/bots_api/bot_lib.py
@@ -102,7 +102,7 @@ class BotHandlerApi(object):
             our_dir, '..', 'bots', bot_name, bot_name + '.conf'))
         section = section or bot_name
         config = configparser.ConfigParser()
-        config.read(conf_file_path)
+        config.readfp(open(conf_file_path))
         return dict(config.items(section))
 
 


### PR DESCRIPTION
This got bigger than I expected, due to the amount of refactoring involved:

Here's what I did to accomplish the title's claim in detail:

1. Add an `initialize(client)` function bots can implement. This will get called on the initialization of the bot, so it doesn't have to wait for a message to be sent to retrieve the `BotHandlerApi` object.

2. Add the `get_config_info` function to `BotHandlerApi`, retrieves config info in an `ini` file and stores it in a dict. Straightforward.

3. Refactor `bot_test_lib.py` to initialize `MockClass` and `message_handler` only once per test method. This saves execution time, makes the code easier in general and also enables me to easily...

4. ...mock `get_config_info` as a context manager.