### PR TITLE
Remove Highlighting from typeaheads.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1056,6 +1056,23 @@ function render(template_name, args) {
     });
 }());
 
+(function typeahead_list_item() {
+    var args = {
+        primary: 'primary-text',
+        secondary: 'secondary-text',
+        img_src: 'https://zulip.org',
+        has_image: true,
+        has_secondary: true,
+    };
+
+    var html = '<div>' + render('typeahead_list_item', args) + '</div>';
+    global.write_handlebars_output('typeahead_list_item', html);
+
+    assert.equal($(html).find('.emoji').attr('src'), 'https://zulip.org');
+    assert.equal($(html).find('strong').text().trim(), 'primary-text');
+    assert.equal($(html).find('small').text().trim(), 'secondary-text');
+}());
+
 (function typing_notifications() {
     var args = {
         users: [{

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -44,10 +44,6 @@ function get_last_recipient_in_pm(query_string) {
     return recipients[recipients.length-1];
 }
 
-function composebox_typeahead_highlighter(item) {
-    return typeahead_helper.highlight_with_escaping(this.query, item);
-}
-
 function query_matches_language(query, lang) {
     query = query.toLowerCase();
     return lang.indexOf(query) !== -1;
@@ -340,13 +336,16 @@ exports.compose_content_begins_typeahead = function (query) {
 
 exports.content_highlighter = function (item) {
     if (this.completing === 'emoji') {
-        return "<img class='emoji' src='" + item.emoji_url + "' /> " + item.emoji_name;
+        return typeahead_helper.render_typeahead_item({
+            primary: item.emoji_name,
+            img_src: item.emoji_url,
+        });
     } else if (this.completing === 'mention') {
-        return typeahead_helper.render_person(this.token, item);
+        return typeahead_helper.render_person(item);
     } else if (this.completing === 'stream') {
-        return typeahead_helper.render_stream(this.token, item);
+        return typeahead_helper.render_stream(item);
     } else if (this.completing === 'syntax') {
-        return typeahead_helper.highlight_with_escaping(this.token, item);
+        return typeahead_helper.render_typeahead_item({ primary: item });
     }
 };
 
@@ -466,8 +465,7 @@ exports.initialize = function () {
         items: 3,
         fixed: true,
         highlighter: function (item) {
-            var query = this.query;
-            return typeahead_helper.highlight_with_escaping(query, item);
+            return typeahead_helper.render_typeahead_item({ primary: item });
         },
         matcher: function (item) {
             // The matcher for "stream" is strictly prefix-based,
@@ -484,7 +482,9 @@ exports.initialize = function () {
         },
         items: 3,
         fixed: true,
-        highlighter: composebox_typeahead_highlighter,
+        highlighter: function (item) {
+            return typeahead_helper.render_typeahead_item({ primary: item });
+        },
         sorter: function (items) {
             var sorted = typeahead_helper.sorter(this.query, items, function (x) {return x;});
             if (sorted.length > 0 && sorted.indexOf(this.query) === -1) {
@@ -500,8 +500,7 @@ exports.initialize = function () {
         dropup: true,
         fixed: true,
         highlighter: function (item) {
-            var query = get_last_recipient_in_pm(this.query);
-            return typeahead_helper.render_person(query, item);
+            return typeahead_helper.render_person(item);
         },
         matcher: function (item) {
             var current_recipient = get_last_recipient_in_pm(this.query);

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -174,7 +174,9 @@ exports.on_load_success = function (streams_data) {
         source: function () {
             return get_non_default_streams_names(all_streams);
         },
-        highlight: true,
+        highlighter: function (item) {
+            return typeahead_helper.render_typeahead_item({ primary: item });
+        },
         updater: function (stream_name) {
             make_stream_default(stream_name);
         },

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -183,7 +183,7 @@ function show_subscription_settings(sub_row) {
         source: people.get_realm_persons, // This is a function.
         items: 5,
         highlighter: function (item) {
-            return typeahead_helper.render_person(this.query, item);
+            return typeahead_helper.render_person(item);
         },
         matcher: function (item) {
             var query = $.trim(this.query.toLowerCase());

--- a/static/templates/typeahead_list_item.handlebars
+++ b/static/templates/typeahead_list_item.handlebars
@@ -1,0 +1,13 @@
+{{#if has_image}}
+<img class="emoji" src="{{ img_src }}" />
+&nbsp;&nbsp;
+{{/if}}
+<strong>
+    {{ primary }}
+</strong>
+{{#if has_secondary}}
+&nbsp;&nbsp;
+<small class="autocomplete_secondary">
+    {{ secondary }}
+</small>
+{{/if}}


### PR DESCRIPTION
Added a common template `typeahead_list_item.handlebars` which is used by all the typeaheads. Eliminated calls to `highlight_with_escaping` from typeaheads. Further improvements to the look of the typeaheads can easily be done by modifying the template.

This is a follow-up for #5170.