### PR TITLE
streams-modal: Fix styling around stream accessibility option.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -584,13 +584,13 @@ form#add_new_subscription {
     margin-bottom: 20px;
 }
 
-.stream-creation-body #make-invite-only label span.icon-vector-globe {
+.stream-creation-body #make-invite-only label span.fa-globe {
     margin-left: 14px;
     margin-right: 10px;
 }
 
 
-.stream-creation-body #make-invite-only label span.icon-vector-lock {
+.stream-creation-body #make-invite-only label span.fa-lock {
     margin-left: 15px;
     margin-right: 11px;
 }
@@ -599,7 +599,7 @@ form#add_new_subscription {
     margin-top: 5px;
 }
 
-.stream-creation-body #announce-new-stream div[class^="icon"] {
+.stream-creation-body #announce-new-stream div[class^="fa"] {
     margin-left: 3px;
     margin-right: 8px;
 }


### PR DESCRIPTION
This fixes the faulty spacing around the various icons in stream accessibility option under the create new stream modal. This regression was introduced in 7e71bf.
I have gone through all the font-awesome migrations merged till now and found that this is another place where I missed upon correctly establishing the fact that the icons migrated where ok.
Sorry for the inconvenience.

PS: I have now learnt that cases where we use `<div>` or `<span>` to display icons instead of `<i>` are the potentially areas where we might end up disturbing the behaviour.  