### PR TITLE
linter: Fix bug resulting in <pre> being indented cyclically.

### DIFF
--- a/tools/check-templates
+++ b/tools/check-templates
@@ -150,7 +150,7 @@ def check_html_templates(templates, all_dups):
         'templates/zerver/markdown_help.html',
         'templates/zerver/navbar.html',
         'templates/zerver/register.html',
-        'templates/zerver/test_emails.html',
+
         'zerver/webhooks/deskdotcom/doc.html',
         'zerver/webhooks/librato/doc.html',
         'zerver/webhooks/splunk/doc.html',

--- a/tools/tests/test_pretty_print.py
+++ b/tools/tests/test_pretty_print.py
@@ -362,6 +362,36 @@ GOOD_HTML13 = """
     <div>{{this.count}}</div>
 </div>
 """
+
+BAD_HTML14 = """
+<div>
+  {{#if this.code}}
+    <pre>Here goes some cool code.</pre>
+  {{else}}
+    <div>
+    content of first div
+    <div>
+    content of second div.
+    </div>
+    </div>
+  {{/if}}
+</div>
+"""
+
+GOOD_HTML14 = """
+<div>
+    {{#if this.code}}
+    <pre>Here goes some cool code.</pre>
+    {{else}}
+    <div>
+        content of first div
+        <div>
+            content of second div.
+        </div>
+    </div>
+    {{/if}}
+</div>
+"""
 class TestPrettyPrinter(unittest.TestCase):
     def compare(self, a, b):
         # type: (str, str) -> None
@@ -384,3 +414,4 @@ class TestPrettyPrinter(unittest.TestCase):
         self.compare(pretty_print_html(BAD_HTML11), GOOD_HTML11)
         self.compare(pretty_print_html(BAD_HTML12), GOOD_HTML12)
         self.compare(pretty_print_html(BAD_HTML13), GOOD_HTML13)
+        self.compare(pretty_print_html(BAD_HTML14), GOOD_HTML14)


### PR DESCRIPTION
In this commit we fix the bug resulting in cyclic loop of desire of indentation before `<pre>` tags when nested inside Django or handlebar templates in a specific situation.
What is the specific situation?
The situation is somewhat like this. We start a template tag and continue adding stuff. This is the place our `<pre>` tags is added. After adding these we add a html block tag with actual block body. Now since we would need to indent the body of template tag, earlier we were indenting `<pre>` as well but actually don't want to change indentation of `<pre>` tags at all because of rendered formatting issues. Since we didn't left `<pre>` tag alone else where in code and indenting it here resulted in a cyclic indentation requirement.