### PR TITLE
bots: Move mock http conversations to fixtures.

### DIFF
--- a/api/bots/giphy/fixtures/test_1_request.json
+++ b/api/bots/giphy/fixtures/test_1_request.json
@@ -1,0 +1,7 @@
+{
+    "api_url": "http://api.giphy.com/v1/gifs/translate",
+    "params": {
+        "s": "Hello",
+        "api_key": "12345678"
+    }
+}

--- a/api/bots/giphy/fixtures/test_1_response.json
+++ b/api/bots/giphy/fixtures/test_1_response.json
@@ -1,0 +1,12 @@
+{
+    "meta": {
+        "status": 200
+    },
+    "data": {
+        "images": {
+            "original": {
+                "url": "https://media4.giphy.com/media/3o6ZtpxSZbQRRnwCKQ/giphy.gif"
+            }
+        }
+    }
+}

--- a/api/bots/giphy/test_giphy.py
+++ b/api/bots/giphy/test_giphy.py
@@ -13,48 +13,18 @@ sys.path.insert(0, os.path.normpath(os.path.join(our_dir)))
 if os.path.exists(os.path.join(our_dir, '..')):
     sys.path.insert(0, '..')
 from bots_test_lib import BotTestCase
-from bots.giphy import giphy
-
-def get_http_response_json(gif_url):
-    response_json = {
-        'meta': {
-            'status': 200
-        },
-        'data': {
-            'images': {
-                'original': {
-                    'url': gif_url
-                }
-            }
-        }
-    }
-    return response_json
-
-def get_bot_response(gif_url):
-    return ('[Click to enlarge](%s)'
-            '[](/static/images/interactive-bot/giphy/powered-by-giphy.png)'
-            % (gif_url))
-
-def get_http_request(keyword):
-    return {
-        'api_url': giphy.GIPHY_TRANSLATE_API,
-        'params': {
-            's': keyword,
-            'api_key': giphy.get_giphy_api_key_from_config()
-        }
-    }
 
 class TestGiphyBot(BotTestCase):
     bot_name = "giphy"
 
     def test_bot(self):
-        # This message calls `send_reply` function of BotHandlerApi
-        keyword = "Hello"
-        gif_url = "https://media4.giphy.com/media/3o6ZtpxSZbQRRnwCKQ/giphy.gif"
-        with self.mock_http_conversation(get_http_request(keyword),
-                                         get_http_response_json(gif_url)):
+        bot_response = '[Click to enlarge]' \
+                       '(https://media4.giphy.com/media/3o6ZtpxSZbQRRnwCKQ/giphy.gif)' \
+                       '[](/static/images/interactive-bot/giphy/powered-by-giphy.png)'
+        # This message calls the `send_reply` function of BotHandlerApi
+        with self.mock_http_conversation('test_1'):
             self.assert_bot_response(
-                message = {'content': keyword},
-                response = {'content': get_bot_response(gif_url)},
+                message = {'content': 'Hello'},
+                response = {'content': bot_response},
                 expected_method='send_reply'
             )


### PR DESCRIPTION
```.py
with open(http_request_path, 'r') as http_request_file, \
        open(http_response_path, 'r') as http_response_file:
```
will make the linter complain about wrong indentation of the second `open` statement - yet this is a recommended way to write such a statement, as in http://legacy.python.org/dev/peps/pep-0008/#maximum-line-length.

I would add a linter exception here, waiting for feedback :)