### PR TITLE
Create /devtools to list useful development URLs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -55,6 +55,7 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@echo "View pages at http://127.0.0.1:9991/docs/index.html"
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -1628,3 +1628,12 @@ input.new-organization-button {
     font-size: .85rem;
     color: #AAA;
 }
+
+#devtools-wrapper {
+    text-align: right;
+}
+
+#devtools-page {
+    max-width: 800px;
+    margin: 0 auto;
+}

--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -36,6 +36,9 @@
                 </div>
             </div>
         </form>
+        <div id="devtools-wrapper">
+            <a id="devtools-link" href="/devtools">Zulip developer tools</a>
+        </div>
     </div>
 </div>
 

--- a/templates/zerver/dev_tools.html
+++ b/templates/zerver/dev_tools.html
@@ -1,0 +1,49 @@
+{% extends "zerver/portico.html" %}
+
+{# Login page. #}
+{% block portico_content %}
+<div id="devtools-page">
+    <h2>Useful development URLs</h2>
+    <p>
+        Below is a list of useful tools and data sets available only in the Zulip
+        development environment that are often useful when contributing to Zulip.
+        Most of these require you to run a command to build/generate the relevant
+        content. This table specifies which command to use to update the data served
+        by each page (since several of these, like test coverage, require a special
+        command to be run to generate the data). Make sure your development server is still running
+        when you visit these!
+    </p>
+    <table class="table table-striped table-rounded table-bordered">
+        <thead>
+            <tr>
+                <th>URL</th>
+                <th>Command</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><a href="/coverage/index.html">/coverage/index.html</a></td>
+                <td><code>./tools/test-backend --coverage</code></td>
+                <td>View backend coverage report</td>
+            </tr>
+            <tr>
+                <td><a href="/node-coverage/index.html">/node-coverage/index.html</a></td>
+                <td><code>./tools/test-js-with-node --coverage</code></td>
+                <td>View node coverage report</td>
+            </tr>
+            <tr>
+                <td><a href="/docs/index.html">/docs/index.html</a></td>
+                <td><code>./tools/build-docs</code></td>
+                <td>View Zulip documentation</td>
+            </tr>
+            <tr>
+                <td><a href="/emails">/emails</a></td>
+                <td>None needed</td>
+                <td>Preview all email templates</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+{% endblock %}

--- a/tools/build-docs
+++ b/tools/build-docs
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")"/../docs
+rm -rf _build
+make html

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -421,6 +421,7 @@ def write_instrumentation_reports(full_suite):
 
         if full_suite:
             print('INFO: URL coverage report is in %s' % (fn,))
+            print('INFO: View report at http://127.0.0.1:9991/coverage/index.html')
             print('INFO: Try running: ./tools/create-test-api-docs')
 
         if full_suite and len(untested_patterns):  # nocoverage -- test suite error handling

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -46,6 +46,7 @@ class DocPageTest(ZulipTestCase):
                            "https://my.pingdom.com/reports/integration/settings",
                        ])
             self._test('/devlogin/', 'Normal users')
+            self._test('/devtools/', 'Useful development URLs')
             self._test('/emails/', 'Road Runner invited you to join Zulip')
             self._test('/register/', 'Sign up for Zulip')
 

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import url
 from django.conf import settings
+from django.views.generic import TemplateView
 import os.path
 from django.views.static import serve
 import zerver.views.registration
@@ -34,6 +35,9 @@ urls = [
 
     # Page for testing email templates
     url(r'^emails/$', zerver.views.test_emails.email_page),
+
+    # Listing of useful URLs and various tools for development
+    url(r'^devtools/$', TemplateView.as_view(template_name='zerver/dev_tools.html')),
 ]
 
 i18n_urls = [


### PR DESCRIPTION
Added a link to this page on `/devlogin`.
Additionally, updated the tools themselves to output the URL of the output.

The page may overlap with the header, but this will be resolved upon merging #5376.