### PR TITLE
Remove style to show text in portico-page-container.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -593,10 +593,6 @@ a.bottom-signup-button {
     padding-top: 50px !important;
 }
 
-.portico-page-container {
-    padding-top: 0px !important;
-}
-
 .portico-page-header {
     font-weight: 300;
     font-size: 35px;


### PR DESCRIPTION
Fixes #5368, #5371.

Just a quick fix.