### PR TITLE
settings: Use perfectScrollbar on settings sidebar.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -47,6 +47,12 @@ $("body").ready(function () {
 
 
 function _setup_page() {
+    $(".sidebar.left").perfectScrollbar({
+        suppressScrollX: true,
+        useKeyboard: false,
+        wheelSpeed: 0.5,
+    });
+
     // only run once -- if the map has not already been initialized.
     if (!map_initialized) {
         map = {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -835,7 +835,6 @@ input[type=checkbox].inline-block {
 
 #settings_page .sidebar .settings-list {
     position: relative;
-    z-index: 3;
 }
 
 #settings_page .content-wrapper {


### PR DESCRIPTION
Use perfectScrollbar on settings sidebar, since the default scrollbar
makes settings menu breaks when not enough vertical space available.

Also delete the z-index on `.settings-list` since it makes the
perfectScrollbar covered.

Fixes #5216

![peek 2017-06-14 18-29](https://user-images.githubusercontent.com/20320125/27130236-aebd3400-512f-11e7-8c62-34cd13eb9885.gif)
