### PR TITLE
[WIP] jinja2 whitespace stripping and email testing

### DIFF
--- a/zerver/views/test_emails.py
+++ b/zerver/views/test_emails.py
@@ -48,6 +48,7 @@ def email_page(request):
         },
         'referrer_name': 'Road Runner',
         'referrer_email': 'runner@acme.com',
+        'referrer_realm_name': 'Acme Corporation',
         'realm_uri': realm.uri,
         'server_uri': settings.SERVER_URI,
         'old_email': 'old_address@acme.com',

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -335,6 +335,8 @@ non_html_template_engine_settings.update({
 })
 non_html_template_engine_settings['OPTIONS'].update({
     'autoescape': False,
+    'trim_blocks': True,
+    'lstrip_blocks': True,
 })
 
 # The order here is important; get_template and related/parent functions try


### PR DESCRIPTION
fixes #5274.

The only places I found control blocks not being on their own line was in `digest.txt` & `missed_message.txt` (both of them will be redone so i left them as-is), and `invitation_reminder.subject` -- i didn't find it to cause problems as it's all in one line.

the second commit adds a test value so `invitation_reminder.subject` triggers the `{% if referrer_realm_name %}` block.