### PR TITLE
lightbox: Remove the unwanted scrollbar from the image list.

### DIFF
--- a/static/styles/lightbox.css
+++ b/static/styles/lightbox.css
@@ -187,7 +187,7 @@
     font-size: 0px;
 
     max-width: 40vw;
-    overflow-x: auto;
+    overflow: hidden;
     white-space: nowrap;
 }
 


### PR DESCRIPTION
Fix: Appearance of scrollbar in image list of image overlay when many images are uploaded or the screen is zoomed in.
Overflow was set as `auto` , which lead to the appearance of scrollbar when many images uploaded or screen is zoomed in, so  changed it to `hidden` in lightbox.css
Fixes: #5277.