### PR TITLE
travis: Add 'ts' to all Travis CI builds for timestamping logs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,27 @@
 # See https://zulip.readthedocs.io/en/latest/events-system.html for
 # high-level documentation on our Travis CI setup.
 dist: trusty
+before_install:
+  - sudo apt-get install moreutils # To use 'ts' and 'mispipe' for timing logs.
 install:
   # Disable Travis CI's built-in NVM installation
-  - mv ~/.nvm ~/.travis-nvm-disabled
+  - mispipe "mv ~/.nvm ~/.travis-nvm-disabled" ts
 
   # Install coveralls, the library for the code coverage reporting tool we use
-  - pip install coveralls
+  - mispipe "pip install coveralls" ts
 
   # This is the main setup job for the test suite
-  - tools/travis/setup-$TEST_SUITE
+  - mispipe "tools/travis/setup-$TEST_SUITE" ts
 
   # Clean any virtualenvs that are not in use to avoid our cache
   # becoming huge.  TODO: Add similar cleanup code for the other caches.
-  - tools/clean-venv-cache --travis
+  - mispipe "tools/clean-venv-cache --travis" ts
 script:
   # We unset GEM_PATH here as a hack to work around Travis CI having
   # broken running their system puppet with Ruby.  See
   # https://travis-ci.org/zulip/zulip/jobs/240120991 for an example traceback.
   - unset GEM_PATH
-  - ./tools/travis/$TEST_SUITE
+  - mispipe "./tools/travis/$TEST_SUITE" ts
 cache:
   - apt: false
   - directories:

--- a/tools/lint
+++ b/tools/lint
@@ -180,7 +180,7 @@ def run():
 
         failed = run_parallel(lint_functions)
 
-    sys.exit(1 if failed else 0)
+    sys.exit(1)
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
In this PR we start to time stamp our travis logs by default while taking care that tests don't pass unconditionally.
Fixes: #5264.