### PR TITLE
Update /devtools/ to contain URLs for error pages

### DIFF
--- a/templates/zerver/dev_tools.html
+++ b/templates/zerver/dev_tools.html
@@ -42,6 +42,26 @@
                 <td>None needed</td>
                 <td>Preview all email templates</td>
             </tr>
+            <tr>
+                <td><a href="/static/html/404.html">/static/html/404.html</a></td>
+                <td>None needed</td>
+                <td>Error 404 page served by nginx</td>
+            </tr>
+            <tr>
+                <td><a href="/static/html/5xx.html">/static/html/5xx.html</a></td>
+                <td>None needed</td>
+                <td>Error 5xx page served by nginx</td>
+            </tr>
+            <tr>
+                <td><a href="/errors/404">/errors/404</a></td>
+                <td>None needed</td>
+                <td>Error 404 page served by Django</td>
+            </tr>
+            <tr>
+                <td><a href="/errors/5xx">/errors/5xx</a></td>
+                <td>None needed</td>
+                <td>Error 5xx page served by Django</td>
+            </tr>
         </tbody>
     </table>
 </div>

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -47,6 +47,8 @@ class DocPageTest(ZulipTestCase):
                        ])
             self._test('/devlogin/', 'Normal users')
             self._test('/devtools/', 'Useful development URLs')
+            self._test('/errors/404', 'Page not found')
+            self._test('/errors/5xx', 'Internal server error')
             self._test('/emails/', 'Road Runner invited you to join Zulip')
             self._test('/register/', 'Sign up for Zulip')
 

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -38,6 +38,10 @@ urls = [
 
     # Listing of useful URLs and various tools for development
     url(r'^devtools/$', TemplateView.as_view(template_name='zerver/dev_tools.html')),
+
+    # Have easy access for error pages
+    url(r'^errors/404/$', TemplateView.as_view(template_name='404.html')),
+    url(r'^errors/5xx/$', TemplateView.as_view(template_name='500.html')),
 ]
 
 i18n_urls = [


### PR DESCRIPTION
Also modified `dev_urls.py` to serve the 400/500 templates.

Though I'm unsure if these should be added under the useful URLs like this, because four entries kind of takes up a lot of space.