### PR TITLE
Send avatar URL with the realm URL in gcm push notifications

### DIFF
--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -10,6 +10,7 @@ from zerver.lib.avatar_hash import gravatar_hash, user_avatar_path, \
     user_avatar_path_from_ids
 from zerver.lib.upload import upload_backend, MEDIUM_AVATAR_SIZE
 from zerver.models import get_user_profile_by_email
+from six.moves import urllib
 
 def avatar_url(user_profile, medium=False):
     # type: (UserProfile, bool) -> Text
@@ -59,3 +60,12 @@ def _get_unversioned_avatar_url(avatar_source, email=None, realm_id=None,
         return u"https://secure.gravatar.com/avatar/%s?d=identicon%s" % (hash_key, gravitar_query_suffix)
     else:
         return settings.DEFAULT_AVATAR_URI+'?x=x'
+
+def absolute_avatar_url(user_profile):
+    # type: (UserProfile, Message) -> Text
+
+    # URLs for uploaded avatars are of the form
+    # "/user_avatars/*".
+    # Make them full paths containing the realm URL.
+    # Or return the URL of avatar from other site
+    return urllib.parse.urljoin(user_profile.realm.uri, avatar_url(user_profile))

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -9,7 +9,7 @@ from zerver.models import PushDeviceToken, Message, Recipient, UserProfile, \
     UserMessage, get_display_recipient, receives_offline_notifications, \
     receives_online_notifications
 from zerver.models import get_user_profile_by_id
-from zerver.lib.avatar import avatar_url
+from zerver.lib.avatar import absolute_avatar_url
 from zerver.lib.request import JsonableError
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
 from zerver.decorator import statsd_increment
@@ -331,7 +331,7 @@ def get_gcm_payload(user_profile, message):
         'content_truncated': content_truncated,
         'sender_email': message.sender.email,
         'sender_full_name': message.sender.full_name,
-        'sender_avatar_url': avatar_url(message.sender),
+        'sender_avatar_url': absolute_avatar_url(message.sender),
     }
 
     if message.recipient.type == Recipient.STREAM:

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -564,7 +564,7 @@ class TestGetGCMPayload(PushNotificationTest):
             "content_truncated": True,
             "sender_email": self.example_email("hamlet"),
             "sender_full_name": "King Hamlet",
-            "sender_avatar_url": apn.avatar_url(message.sender),
+            "sender_avatar_url": apn.absolute_avatar_url(message.sender),
             "recipient_type": "stream",
             "stream": apn.get_display_recipient(message.recipient),
             "topic": message.subject,
@@ -586,7 +586,7 @@ class TestGetGCMPayload(PushNotificationTest):
             "content_truncated": False,
             "sender_email": self.example_email("hamlet"),
             "sender_full_name": "King Hamlet",
-            "sender_avatar_url": apn.avatar_url(message.sender),
+            "sender_avatar_url": apn.absolute_avatar_url(message.sender),
             "recipient_type": "private",
         }
         self.assertDictEqual(payload, expected)


### PR DESCRIPTION
Required for https://github.com/zulip/zulip-mobile/pull/637

Also will not break the current push notifications for the android native app
The code is mostly from here, https://github.com/zulip/zulip/blob/master/zerver/lib/notifications.py#L92