### PR TITLE
Various improvements/bugfixes to search_suggestions.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -578,14 +578,14 @@ function make_sub(name, stream_id) {
     narrow = [
         {operator: 'is', operand: 'something_we_do_not_support'},
     ];
-    string = 'unknown operand';
+    string = 'something_we_do_not_support messages';
     assert.equal(Filter.describe(narrow), string);
 
     // this should be unreachable, but just in case
     narrow = [
         {operator: 'bogus', operand: 'foo'},
     ];
-    string = 'unknown operand';
+    string = 'unknown operator';
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -704,7 +704,7 @@ init();
     assert.equal(describe('pm-with:ted@zulip.com'),
         "Private messages with <strong>Te</strong>d Smith &lt;<strong>te</strong>d@zulip.com&gt;");
     assert.equal(describe('sender:ted@zulip.com'),
-        "Messages sent by <strong>Te</strong>d Smith &lt;<strong>te</strong>d@zulip.com&gt;");
+        "Sent by <strong>Te</strong>d Smith &lt;<strong>te</strong>d@zulip.com&gt;");
 
     suggestions = search.get_suggestions('Ted '); // note space
 

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -430,6 +430,7 @@ init();
     var expected = [
         "sender",
         "sender:bob@zulip.com",
+        "sender:",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -438,6 +439,7 @@ init();
     expected = [
         "from",
         "from:bob@zulip.com",
+        "from:",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -756,6 +758,44 @@ init();
     expected = [
         'stream:Denmark is:alerted has:lin',
         'stream:Denmark is:alerted has:link',
+        'stream:Denmark is:alerted',
+        'stream:Denmark',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+}());
+
+(function test_operator_suggestions() {
+    // Completed operator should return nothing
+    var query = 'stream:';
+    var suggestions = search.get_suggestions(query);
+    var expected = [
+        'stream:',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'st';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'st',
+        'is:starred',
+        'stream:',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = '-s';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        '-s',
+        '-stream:',
+        '-sender:',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'stream:Denmark is:alerted -f';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'stream:Denmark is:alerted -f',
+        'stream:Denmark is:alerted -from:',
         'stream:Denmark is:alerted',
         'stream:Denmark',
     ];

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -443,7 +443,7 @@ Filter.operator_to_prefix = function (operator, negated) {
 
     case 'from':
     case 'sender':
-        return verb + 'messages sent by';
+        return verb + 'sent by';
 
     case 'pm-with':
         return verb + 'private messages with';

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -496,14 +496,14 @@ Filter.describe = function (operators) {
             } else if (operand === 'unread') {
                 return verb + 'unread messages';
             }
-        } else {
-            var prefix_for_operator = Filter.operator_to_prefix(canonicalized_operator,
-                                                                elem.negated);
-            if (prefix_for_operator !== '') {
-                return prefix_for_operator + ' ' + operand;
-            }
+            return operand + ' messages';
         }
-        return "unknown operand";
+        var prefix_for_operator = Filter.operator_to_prefix(canonicalized_operator,
+                                                            elem.negated);
+        if (prefix_for_operator !== '') {
+            return prefix_for_operator + ' ' + operand;
+        }
+        return "unknown operator";
     });
     return parts.concat(more_parts).join(', ');
 };

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -469,6 +469,30 @@ function get_containing_suggestions(last) {
         });
 }
 
+function get_operator_suggestions(last) {
+        if (!(last.operator === 'search')) {
+            return [];
+        }
+
+        var negated = false;
+        if (last.operand.indexOf("-") === 0) {
+            negated = true;
+            last.operand = last.operand.slice(1);
+        }
+
+        var choices = ['stream', 'topic', 'pm-with', 'sender', 'near', 'has', 'from'];
+        choices = _.filter(choices, function (choice) {
+            return phrase_match(choice, last.operand);
+        });
+
+        return _.map(choices, function (choice) {
+            var op = [{operator: choice, operand: '', negated: negated}];
+            var search_string = Filter.unparse(op);
+            var description = Filter.describe(op);
+            return {description: description, search_string: search_string};
+        });
+}
+
 function attach_suggestions(result, base, suggestions) {
     _.each(suggestions, function (suggestion) {
         if (base.description.length > 0) {
@@ -535,6 +559,9 @@ exports.get_suggestions = function (query) {
     attach_suggestions(result, base, suggestions);
 
     suggestions = get_topic_suggestions(last, base_operators);
+    attach_suggestions(result, base, suggestions);
+
+    suggestions = get_operator_suggestions(last);
     attach_suggestions(result, base, suggestions);
 
     suggestions = get_containing_suggestions(last);


### PR DESCRIPTION
~1. Got rid of `is:private` being suggested for all `sender` and `pm-with` searches.~ Merged
2. Removed the ugly "unknown operand" message from `is:` searches.
3. Added support for autocompleting operator names, so `str` completes to `stream:`.
~4. Negated `-has` previously broke autocomplete, but this was fixed.~ Merged
5. Changed "Messages sent by..." to "Sent by..."