### PR TITLE
docs: Emphasise running Git BASH as admin under Win10.

### DIFF
--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -190,10 +190,15 @@ sudo apt-get install build-essential git ruby lxc redir
 If you do, make sure to **install default required packages** along with
 **git**, **curl**, **openssh**, and **rsync** binaries.)
 
-After installing, you must run **Git BASH as an administrator**.
-
 Also, you must have hardware virtualization enabled (VT-X or AMD-V) in your
 computer's BIOS.
+
+#### Running Git BASH as an administrator
+
+It is important that you **always run Git BASH with administrator privileges**
+when working on Zulip code, as not doing so will cause errors in the development
+environment (such as symlink creation). You might wish to configure your Git
+BASH shortcut to always run with these privileges enabled (see this [guide][bash-admin-setup] for how to set this up).
 
 ##### Enable native symlinks
 
@@ -996,3 +1001,4 @@ for the IP address that means any IP address can connect to your development ser
 [rtd-using-dev-env]: using-dev-environment.html
 [rtd-dev-remote]: dev-remote.html
 [git-bash]: https://git-for-windows.github.io/
+[bash-admin-setup]: https://superuser.com/questions/1002262/run-applications-as-administrator-by-default-in-windows-10

--- a/docs/git-guide.md
+++ b/docs/git-guide.md
@@ -62,6 +62,9 @@ can skip this section. Otherwise, read on!
 If you're not already using Git, you might need to [install][gitbook-install]
 and [configure][gitbook-setup] it.
 
+**If you are using Windows 10, make sure you [are running Git BASH as an
+administrator][git-bash-admin] at all times.**
+
 You'll also need a GitHub account, which you can sign up for
 [here][github-join]. We also recommend you create an ssh key if you don't
 already have one and [add it to your GitHub account][github-help-add-ssh-key].
@@ -1459,6 +1462,7 @@ Deleting local branch review-original-5156 (was 5a1e982)
 [zulip-rtd-dev-first-time]: dev-env-first-time-contributors.html
 [zulip-rtd-zulipbot-usage]: zulipbot-usage.html
 [gitgui-tower]: https://www.git-tower.com/
+[git-bash-admin]: dev-end-first-time-contributors.html#running-git-bash-as-an-administrator
 [gitgui-fork]: https://git-fork.com/
 [gitgui-gitxdev]: https://rowanj.github.io/gitx/
 [gitgui-ghdesktop]: https://desktop.github.com/


### PR DESCRIPTION
Adds a subsection `Running Git BASH as an administrator` and links to it from the git guide.