### PR TITLE
message-edit: Trigger mouseleave on row when hiding message_edit div.

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -485,6 +485,7 @@ exports.MessageList.prototype = {
     hide_edit_message: function MessageList_hide_edit_message(row) {
         row.find(".message_content, .status-message").show();
         row.find(".message_edit").hide();
+        row.trigger("mouseleave");
     },
 
     show_edit_topic: function MessageList_show_edit_topic(recipient_row, form) {


### PR DESCRIPTION
For the pencil icon to appear, `message_unhover` has to be called before `message_hover` (both in *ui_init.js*). This happens when the `mouseleave` event is triggered on a row. But, when clicking the save button and the edit box is hidden, the `mouseleave` event is not triggered and hence `message_unhover` not called.

Fixes: #4287.