### PR TITLE
css: Make avatar corners round.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1495,6 +1495,7 @@ blockquote p {
     margin-right: 11px;
     background-size: 35px 35px;
     vertical-align: top;
+    border-radius: 4px;
 }
 
 .home-error-bar {


### PR DESCRIPTION
Set a border radius of 4 pixels for user avatars displayed in the message list view.

