### PR TITLE
webpack: Migrate `stats.js` and `signup.js` bundles to webpack static asset pipeline.

### DIFF
--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -7,7 +7,7 @@
 {% block content %}
 <div class="app portico-page">
 
-{{ minified_js('stats')|safe }}
+{{ render_bundle('stats') }}
 {% stylesheet 'stats' %}
 
 <div class="page-content">

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -3,7 +3,7 @@
 
 {% block customhead %}
     {{ super() }}
-    {{ minified_js('signup')|safe }}
+    {{ render_bundle('signup') }}
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/portico_signup.html
+++ b/templates/zerver/portico_signup.html
@@ -4,5 +4,5 @@
 
 {% block customhead %}
 {{ super() }}
-{{ minified_js('signup')|safe }}
+{{ render_bundle('signup') }}
 {% endblock %}

--- a/tools/travis/success-http-headers.txt
+++ b/tools/travis/success-http-headers.txt
@@ -22,10 +22,10 @@ Reusing existing connection to localhost:443.
   HTTP/1.1 200 OK
   Server: nginx/1.4.6 (Ubuntu)
   Content-Type: text/html; charset=utf-8
-  Content-Length: 6187
+  Content-Length: 6205
   Connection: keep-alive
   Strict-Transport-Security: max-age=15768000
-Length: 6187 (6.0K) [text/html]
+Length: 6205 (6.1K) [text/html]
 Saving to: ‘/tmp/index.html’
 
 

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -3,6 +3,10 @@
     "api": "./static/js/portico/api.js",
     "katex": ["./node_modules/katex/dist/katex.min.js"],
     "landing-page": "./static/js/portico/landing-page.js",
+    "signup": [
+               "./static/js/portico/signup.js",
+               "./node_modules/jquery-validation/dist/jquery.validate.min.js"
+              ],
     "stats": [
               "./static/js/stats/stats.js",
               "./node_modules/plotly.js/dist/plotly-basic.min.js"

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -3,6 +3,10 @@
     "api": "./static/js/portico/api.js",
     "katex": ["./node_modules/katex/dist/katex.min.js"],
     "landing-page": "./static/js/portico/landing-page.js",
+    "stats": [
+              "./static/js/stats/stats.js",
+              "./node_modules/plotly.js/dist/plotly-basic.min.js"
+             ],
     "translations": "./static/js/translations.js",
     "zxcvbn": "./node_modules/zxcvbn/dist/zxcvbn.js"
 }

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -822,13 +822,6 @@ JS_SPECS = {
         ],
         'output_filename': 'min/common.js'
     },
-    'signup': {
-        'source_filenames': [
-            'js/portico/signup.js',
-            'node_modules/jquery-validation/dist/jquery.validate.js',
-        ],
-        'output_filename': 'min/signup.js'
-    },
     'app': {
         'source_filenames': [
             'third/bootstrap-notify/js/bootstrap-notify.js',

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -984,15 +984,6 @@ JS_SPECS = {
         ],
         'output_filename': 'min/app.js'
     },
-    'stats': {
-        'source_filenames': [
-            'js/stats/stats.js',
-        ],
-        'minifed_source_filenames': [
-            'node_modules/plotly.js/dist/plotly-basic.min.js',
-        ],
-        'output_filename': 'min/stats.js'
-    },
     # We also want to minify sockjs separately for the sockjs iframe transport
     'sockjs': {
         'source_filenames': ['third/sockjs/sockjs-0.3.4.js'],


### PR DESCRIPTION
A part of series of PRs for issue: #5377.