### PR TITLE
Add support for special characters in language names for code blocks.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -87,6 +87,15 @@ var social = {
 stream_data.add_sub('Denmark', denmark);
 stream_data.add_sub('social', social);
 
+// Check the default behavior of fenced code blocks
+// works properly before markdown is initialized.
+(function test_fenced_block_defaults() {
+    var input = '\n```\nfenced code\n```\n\nand then after\n';
+    var expected = '\n\n<div class="codehilite"><pre><span></span>fenced code\n</pre></div>\n\n\n\nand then after\n\n';
+    var output = fenced_code.process_fenced_code(input);
+    assert.equal(output, expected);
+}());
+
 var markdown = require('js/markdown.js');
 
 markdown.initialize();
@@ -181,6 +190,10 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
          expected: '<div class="codehilite"><pre><span></span>    fenced code trailing whitespace\n</pre></div>\n\n\n<p>and then after</p>'},
         {input: '* a\n* list \n* here',
          expected: '<ul>\n<li>a</li>\n<li>list </li>\n<li>here</li>\n</ul>'},
+        {input: '\n```c#\nfenced code special\n```\n\nand then after\n',
+         expected: '<div class="codehilite"><pre><span></span>fenced code special\n</pre></div>\n\n\n<p>and then after</p>'},
+        {input: '\n```vb.net\nfenced code dot\n```\n\nand then after\n',
+         expected: '<div class="codehilite"><pre><span></span>fenced code dot\n</pre></div>\n\n\n<p>and then after</p>'},
         {input: 'Some text first\n* a\n* list \n* here\n\nand then after',
          expected: '<p>Some text first</p>\n<ul>\n<li>a</li>\n<li>list </li>\n<li>here</li>\n</ul>\n<p>and then after</p>'},
         {input: '1. an\n2. ordered \n3. list',

--- a/static/js/fenced_code.js
+++ b/static/js/fenced_code.js
@@ -9,13 +9,13 @@ var exports = {};
 // auto-completing code blocks missing a trailing close.
 
 // See backend fenced_code.py:71 for associated regexp
-var fencestr = "^(~{3,}|`{3,})"          + // Opening Fence
-               "[ ]*"                    + // Spaces
-               "("                       +
-                   "\\{?\\.?"            +
-                   "([a-zA-Z0-9_+-]*)"   + // Language
-                   "\\}?"                +
-               "[ ]*"                    + // Spaces
+var fencestr = "^(~{3,}|`{3,})"            + // Opening Fence
+               "[ ]*"                      + // Spaces
+               "("                         +
+                   "\\{?\\.?"              +
+                   "([a-zA-Z0-9_+-./#]*)"  + // Language
+                   "\\}?"                  +
+               "[ ]*"                      + // Spaces
                ")$";
 var fence_re = new RegExp(fencestr);
 

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -29,6 +29,7 @@ enforce_fully_covered = {
     'static/js/compose_ui.js',
     'static/js/dict.js',
     'static/js/filter.js',
+    'static/js/fenced_code.js',
     'static/js/hash_util.js',
     'static/js/muting.js',
     'static/js/people.js',

--- a/zerver/lib/bugdown/fenced_code.py
+++ b/zerver/lib/bugdown/fenced_code.py
@@ -98,7 +98,7 @@ FENCE_RE = re.compile(u"""
     (
         \\{?\\.?
         (?P<lang>
-            [a-zA-Z0-9_+-]*
+            [a-zA-Z0-9_+-./#]*
         ) # "py" or "javascript"
         \\}?
     ) # language, like ".py" or "{javascript}"

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -110,10 +110,13 @@ class FencedBlockPreprocessorTest(TestCase):
             'hello()',
             '```',
             '',
-            '``` .py',
+            '```vb.net',
             'goodbye()',
             '```',
             '',
+            '```c#',
+            'weirdchar()',
+            '```',
             ''
         ]
         expected = [
@@ -122,8 +125,11 @@ class FencedBlockPreprocessorTest(TestCase):
             '',
             '',
             '',
-            '**py:goodbye()**',
+            '**vb.net:goodbye()**',
             '',
+            '',
+            '',
+            '**c#:weirdchar()**',
             '',
             ''
         ]


### PR DESCRIPTION
Resolves #5412 
Also, in the process of adding tests for this, added a few extras and got `fenced_code.js` to 100% line coverage.