### PR TITLE
preview.py: Fix error raised on uploading file with unicode filename.

### DIFF
--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -8,6 +8,7 @@ import requests
 from zerver.lib.cache import cache_with_key, get_cache_with_key
 from zerver.lib.url_preview.oembed import get_oembed_data
 from zerver.lib.url_preview.parsers import OpenGraphParser, GenericParser
+from django.utils.encoding import smart_text
 
 
 CACHE_NAME = "database"
@@ -22,7 +23,7 @@ link_regex = re.compile(
 
 def is_link(url):
     # type: (Text) -> Match[Text]
-    return link_regex.match(str(url))
+    return link_regex.match(smart_text(url))
 
 
 def cache_key_func(url):

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -306,3 +306,4 @@ class PreviewTestCase(ZulipTestCase):
         # type: () -> None
         with self.settings(INLINE_URL_EMBED_PREVIEW=True, TEST_SUITE=False, CACHES=TEST_CACHES):
             self.assertIsNone(get_link_embed_data('com.notvalidlink'))
+            self.assertIsNone(get_link_embed_data(u'μένει.com.notvalidlink'))


### PR DESCRIPTION
In this commit we fix the error raised in console due to uploading a file with unicode chars in filename and then trying to preview it. Basically we used `str` function to convert from unicode to string somewhere which should be `.encode('utf-8')`.
Error which was raised before fix:
![image](https://user-images.githubusercontent.com/17237412/27204330-247e2fb4-5248-11e7-989e-59b8663510bd.png)
