### PR TITLE
[WIP] bots: Adding a new 'poll' bot

### DIFF
--- a/api/bots/poll/poll.py
+++ b/api/bots/poll/poll.py
@@ -1,0 +1,257 @@
+# See readme.md for instructions on running this code.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from six.moves import range
+
+from collections import OrderedDict
+
+class PollHandler(object):
+    def usage(self):
+        return '''
+            This bot maintains up to one poll per user, per topic, in streams only.
+            It currently keeps a running count of the votes, as they are made, with one
+            mesage in the stream being updated to show the current status.
+            Message the bot privately, appending the stream and topic, or mention it
+            within a topic (for new, vote and end commands); if the stream or
+            topic contain spaces use a '+' where the space would be.
+            '''
+
+    def handle_message(self, message, bot_handler, state_handler):
+        help_msg = OrderedDict([
+            ('about', "gives a simple summary of this bot."),
+            ('help', "produces this help."),
+            ('commands', "a concise form of help, listing the supported commands."),
+            ('new', ("start a new poll: specify a title on the following line "
+                     "and at least two options on subsequent lines.")),
+            ('vote', ("vote in an ongoing poll: specify a poll id given in the poll message "
+                      "followed by the number of the option to vote for.")),
+            ('end', ("end your own ongoing poll.")),
+        ])
+        stream_topic_notgiven = "\nPlease specify a stream & topic if messaging the bot privately."
+        space_equivalent = "+"
+
+        sender = message["sender_email"]
+        sender_id = message["sender_id"]
+
+        # Break down the text supplied into potential input sets
+        content = message["content"]
+        lines = content.split('\n')
+        main_line = lines[0].split(' ')
+        command = main_line[0]
+        options = main_line[1:]
+        title   = ""
+        if len(lines) > 1:
+            title = lines[1]
+        vote_options = []
+        if len(lines) > 2:
+            vote_options = lines[2:]
+        vote_options = [v for v in vote_options if len(v) > 0]
+
+        # Utility function (eg. for indicating commands have been accepted)
+        def private_reply(sender, text):
+            bot_handler.send_message(dict(type='private', to=sender, content=text))
+
+        # Updates the poll text, based on the current data in the poll (may modify poll)
+        # Return True/False, depending if message was successfully posted
+        def update_poll_text(poll, stream_topic, force_end=False):
+            # Construct initial/updated poll text
+            msg = ("Poll by {} (id: {})\n{}\n"
+                   .format(poll['creator'], stream_topic[2], poll['title']))
+            for i in range(poll['n']):
+                msg += ("{}. [{}] {}\n"
+                        .format(i+1, len(poll['tallies'][i]), poll[i]))
+            if force_end:
+                msg += "**This poll has ended**\n"
+            # Set/update poll text
+            if poll['msg_id'] is None:
+                result = bot_handler.send_message(dict(type='stream',
+                                                       to=stream_topic[0],
+                                                       subject=stream_topic[1],
+                                                       content=msg))
+                if result['result'] == 'success':
+                    poll['msg_id'] = result['id']
+                    return (msg, True)
+                else:
+                    return (msg, False)
+            else:
+                result = bot_handler.update_message(dict(message_id = poll['msg_id'],
+                                                         content = msg))
+                if result['result'] == 'success':
+                    return (msg, True)
+                else:
+                    return (msg, False)  # FIXME Cannot always update a message; should poll end?
+                    # FIXME Should add handling of return value
+
+        # Quickly return for simple help response cases
+        if command == "" or command == "help":
+            txt = ("{}\n\nIt supports the following commands:\n"
+                   .format(" ".join(self.usage().split())))
+            for k, v in help_msg.items():
+                txt += "\n**{}** : {}".format(k, v)
+            private_reply(sender, txt)
+            return
+        elif command == "about":
+            private_reply(sender, " ".join(self.usage().split()))
+            return
+        elif command == "commands":
+            private_reply(sender, "Commands: " + ", ".join((k for k in help_msg)))
+            return
+
+        src_is_private = (message['type'] == 'private')
+
+        # Ensure we have some state
+        active_polls = state_handler.get_state()
+        if active_polls is None:
+            active_polls = {}
+
+        if command == "new":
+            # Check where the poll will be -> obtain stream_topic
+            stream_topic = None
+            if src_is_private:
+                if len(options) != 2:
+                    private_reply(sender, stream_topic_notgiven)
+                    return
+                else:
+                    stream = options[0].replace(space_equivalent, " ")
+                    topic = options[1].replace(space_equivalent, " ")
+                    stream_topic = (stream, topic, sender_id)
+            else:
+                stream_topic = (message['display_recipient'], message['subject'], sender_id)
+            # Check if a poll is already active with this id
+            if stream_topic in active_polls:
+                private_reply(sender, "Already have a poll with this id; end it explicitly first")
+                return
+            # Check we have at least a poll title and 2(+) options
+            if title == "" or len(vote_options) < 2:
+                private_reply(sender, "To " + help_msg['new'])
+                return
+            # Create new poll data
+            new_poll = {
+                'title': title,  # Poll title
+                'tallies': [],   # List of list of sender_id's who voted
+                'msg_id': None,  # Message id containing poll text
+                'n': len(vote_options),  # How many voting options
+                'creator': message['sender_full_name']  # Name of poll creator
+            }
+            for i, v in enumerate(vote_options):      # Set text & tallies for each vote_option
+                new_poll[i] = v
+                new_poll['tallies'].append([])
+            # Try to send initial poll message to stream/topic, and alert user of result
+            (update_msg, success) = update_poll_text(new_poll, stream_topic)
+            if success:
+                # Insert the new poll and update the state
+                active_polls[stream_topic] = new_poll
+                state_handler.set_state(active_polls)
+                # Generate private message to creator, to indicate successful creation
+                msg = ("Poll created in stream '#{}' with topic '{}':\n{}"
+                       .format(stream_topic[0], stream_topic[1], update_msg))
+            else:
+                msg = ("Could not create poll in stream '#{}' with topic '{}'"
+                       .format(stream_topic[0], stream_topic[1]))
+            private_reply(sender, msg)
+        elif command == "vote":
+            # Translate options into requested poll and vote
+            requested_poll_id = 0
+            requested_vote_option = ""
+            stream_topic = None
+            if src_is_private:
+                if len(options) != 4:
+                    private_reply(sender, "To " + help_msg['vote'] + stream_topic_notgiven)
+                    return
+                else:
+                    requested_poll_id = options[2]
+                    requested_vote_option = options[3]
+                    stream = options[0].replace(space_equivalent, " ")
+                    topic = options[1].replace(space_equivalent, " ")
+                    stream_topic = (stream, topic, requested_poll_id)
+            else:
+                if len(options) != 2:
+                    private_reply(sender, "To " + help_msg['vote'])
+                    return
+                else:
+                    requested_poll_id = options[0]
+                    requested_vote_option = options[1]
+                    stream_topic = (message['display_recipient'],
+                                    message['subject'], requested_poll_id)
+            # Validate requested_poll_id before setting stream_topic & poll
+            try:
+                requested_poll_id = int(requested_poll_id)
+            except ValueError:
+                private_reply(sender, "To " + help_msg['vote'])
+                return
+            stream_topic = (stream_topic[0], stream_topic[1], requested_poll_id)
+            if stream_topic not in active_polls:
+                private_reply(sender, "To " + help_msg['vote'])
+                return
+            poll = active_polls[stream_topic]
+            # Check if this user has voted for any option already
+            context_txt = (" in the poll on stream '#{}' (topic '{}') titled: '{}'"
+                           .format(stream_topic[0], stream_topic[1], poll['title']))
+            for i, tally in enumerate(poll['tallies']):
+                if sender_id in tally:
+                    msg = ("You have already voted{}\n(You voted for {}: {})"
+                           .format(context_txt, i+1, poll[i]))
+                    private_reply(sender, msg)
+                    return
+            # Check that vote index is within expected bounds
+            vote_index = 0
+            try:
+                vote_index = int(requested_vote_option)
+            except ValueError:
+                private_reply(sender, "Please select one number to vote for{}".format(context_txt))
+                return
+            max_vote_index = poll['n']
+            if 0 < vote_index <= max_vote_index:  # Indexed from 1
+                # Use the vote
+                poll['tallies'][vote_index-1].append(sender_id)
+                (update_msg, success) = update_poll_text(poll, stream_topic)
+                if success:
+                    state_handler.set_state(active_polls)
+                    msg = ("You just voted{}\n(You voted for {}: {})"
+                           .format(context_txt, vote_index, poll[vote_index-1]))
+                    private_reply(sender, msg)
+                else:
+                    private_reply(sender, "Could not update the poll with your vote.")
+                    # FIXME Should we end the poll automatically here?
+            else:
+                private_reply(sender,
+                              ("Please select a number to vote for, between 1-{},{}"
+                               .format(max_vote_index, context_txt)))
+            return
+        elif command == "end":
+            # Translate options into stream & topic
+            stream_topic = None
+            if src_is_private:
+                if len(options) != 2:
+                    private_reply(sender, stream_topic_notgiven)
+                    return
+                else:
+                    stream = options[0].replace(space_equivalent, " ")
+                    topic = options[1].replace(space_equivalent, " ")
+                    stream_topic = (stream, topic, sender_id)
+            else:
+                stream_topic = (message['display_recipient'], message['subject'], sender_id)
+            # End the poll if present
+            if stream_topic in active_polls:
+                (update_msg, success) = update_poll_text(active_polls[stream_topic],
+                                                         stream_topic, force_end=True)
+                private_reply(sender,
+                              (("Ending your poll in '#{}' and topic '{}', "
+                                "final results were:\n\n{}")
+                               .format(stream, topic, update_msg)))
+                if not success:
+                    private_reply(sender,
+                                  "NOTE: Your poll ended, but the poll message could not be updated.")
+                del active_polls[stream_topic]
+                state_handler.set_state(active_polls)
+            else:
+                private_reply(sender,
+                              ("You do not have a poll in '#{}' and topic '{}'"
+                               .format(stream_topic[0], stream_topic[1])))
+        else:
+            msg = "Unsupported command."
+            private_reply(sender, msg)
+
+
+handler_class = PollHandler

--- a/api/bots/poll/readme.md
+++ b/api/bots/poll/readme.md
@@ -1,0 +1,154 @@
+# Poll bot
+
+The poll bot maintains up to one poll per user, per topic, in streams only.
+It currently keeps a running count of the votes, as they are made, with one
+message in the stream being updated to show the current status.
+
+## Usage
+
+The bot can be messaged:
+
+* privately; the stream and topic must be mentioned explicitly in some commands
+(as in `[<stream> <topic>]` below), and a '+' must be used in place of any
+spaces in the stream or topic names.
+
+* in a stream/topic; the poll location is then implied to be in that stream and
+topic. The bot must be mentioned in this case, eg. each of the commands must
+be preceded with `@botname`, where botname is the bot user running this code.  
+
+The bot has the following commands, the success or failure of each being
+reported privately to the user attempting them:
+
+* **commands**:
+This command simply provides a concise listing of the available bot commands,
+which should give a list of the following.
+
+* **about**:
+This command explains what the bot is for.
+
+* **help**:
+This command provides a more detailed help listing than just the commands.
+
+* **new**:
+This command adds a new poll in the specified stream/topic, for the user.
+The format of this command is:
+```
+new [<stream> <topic>]
+<poll title>
+<option 1>
+<option 2>
+  ...
+```
+This produces a message in the stream/topic with the new poll details.
+It will fail if the user already has a poll in the stream/topic, in which
+case a different stream/topic can be used, or the current poll ended with
+the **end** command. A poll must have a title/question, and at least 2 options.
+
+* **vote**:
+This command allows any user to vote on a currently running poll, started
+with **new**.
+The format of this command is:
+```
+vote [<stream> <topic>] <poll id> <option number>
+```
+where `<poll id>` is the id of an active poll, as given in the main poll message
+output after the **new** command has been made.
+This currently attempts to update (edit) the poll message to indicate the vote.
+
+* **end**:
+This command allows a user to end a currently running poll.
+The format of this command is:
+```
+end [<stream> <topic>]  
+```
+The bot will attempt to update (edit) the poll message to indicate the poll has
+closed.
+This will fail if there is no active poll running in the specified topic for
+the user.
+
+### Example usage
+
+#### In a particular stream & topic
+
+```
+@pollbot commands
+```
+
+```
+@pollbot about
+```
+
+```
+@pollbot help
+```
+
+```
+@pollbot new
+How do you like the new poll bot service?
+Beyond measure!
+It's ok.
+It's terrible.
+```
+
+```
+@pollbot vote 2406 1
+```
+
+```
+@pollbot end
+```
+
+#### From a private message with the pollbot
+
+```
+commands
+```
+
+```
+about
+```
+
+```
+help
+```
+
+```
+new bot+testing testing+here
+How do you like the new poll bot service?
+Beyond measure!
+It's ok.
+It's terrible.
+```
+
+```
+vote bot+testing testing+here 2406 1
+```
+
+```
+@pollbot end
+```
+
+
+## Outstanding Bugs, Limitations & Issues
+
+### Larger issues
+
+* Polls can be explicitly ended, but also end if the bot is terminated or (if
+implemented) if the message cannot be updated. This could occur if the server
+is configured to not allow message editing, or only for a finite time (eg. 1
+hour), which the bot currently has no way of querying. The current state for each
+poll is stored within the bot, but also within the poll messages, which could
+allow for restarting/continuing polls if they could be queried.
+* The help text could be improved?
+
+### Potential areas to develop
+
+* Support changing of votes? (optionally)
+* Show votes only at the end of a vote? (optionally)
+* Support different vote schemes (eg. voting preferences for each option)
+* Support external vote engines?
+
+### Design decisions
+
+* Polls are limited to one per user per topic per stream (thought to be sufficient).
+* Polls are only in streams (this is an intentional initial design).

--- a/api/bots/poll/test_poll.py
+++ b/api/bots/poll/test_poll.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from collections import OrderedDict
+
+from bots_test_lib import BotTestCase
+
+class TestPollBot(BotTestCase):
+    bot_name = "poll"
+
+    def test_bot(self):
+
+        test_email  = "sender@realm.com"
+        test_stream = "test stream"
+        test_topic  = "test topic"
+
+        private_msg_template = dict(type='private', to=test_email)
+        poll_msg_template = dict(type='stream', to=test_stream, subject=test_topic)
+
+        # Simple commands
+        # These are accepted anywhere, but private messages are sent to the sender
+
+        about_multiline = '''
+        This bot maintains up to one poll per user, per topic, in streams only.
+        It currently keeps a running count of the votes, as they are made, with one
+        mesage in the stream being updated to show the current status.
+        Message the bot privately, appending the stream and topic, or mention it
+        within a topic (for new, vote and end commands); if the stream or topic contain spaces use a
+        '+' where the space would be.
+        '''
+
+        about_txt = " ".join(about_multiline.split())
+        commands_txt = "Commands: about, help, commands, new, vote, end"
+        extended_commands_multiline = '''\n\nIt supports the following commands:\n\n**about** : gives a simple summary of this bot.\n**help** : produces this help.\n**commands** : a concise form of help, listing the supported commands.\n**new** : start a new poll: specify a title on the following line and at least two options on subsequent lines.\n**vote** : vote in an ongoing poll: specify a poll id given in the poll message followed by the number of the option to vote for.\n**end** : end your own ongoing poll.'''
+        help_txt = about_txt + extended_commands_multiline
+        simple_map = OrderedDict([
+            ("", help_txt),
+            ("about", about_txt),
+            ("help", help_txt),
+            ("commands", commands_txt),
+        ])
+        expected_simple = OrderedDict([(k, dict(private_msg_template, content=v))
+                                       for k, v in simple_map.items()])
+        self.check_expected_responses(expected_simple, expected_method='send_message',
+                                      email=test_email, type='all')
+
+        # Complex commands
+
+        error_msg = {
+            'new': ("To start a new poll: specify a title on the following line "
+                    "and at least two options on subsequent lines."),
+            'vote': ("To vote in an ongoing poll: specify a poll id given in the "
+                     "poll message followed by the number of the option to vote for."),
+            'end': ("You do not have a poll in '#test stream' and topic 'test topic'"),
+        }
+        poll_lines = ["Please select from one of the following options:",
+                      "Something great", "Something not so great", "This is bad"]
+        private_msg = "\nPlease specify a stream & topic if messaging the bot privately."
+
+        ## First do tests for cases that don't generate a poll and should fail with just
+        ## a private error message
+
+        def test_fails(src_location):
+            s = t = ""  # These need to be specified if src_location is private
+            recipient = test_stream
+            if src_location == 'private':
+                (s, t) = (" "+test_stream.replace(" ", "+"), " "+test_topic.replace(" ", "+"))
+                recipient = test_email
+            st = (src_location == 'stream')
+            # Note that if stream & topic are "" then some of these entries are overwritten
+            expected_ = OrderedDict([
+                ('new', error_msg['new'] if st else private_msg),
+                ('new' + s, error_msg['new'] if st else private_msg),
+                ('new' + s + t + t, error_msg['new'] if st else private_msg),
+                ('new' + s + t + "\n", error_msg['new']),
+                ('new' + s + t + "\n" + poll_lines[0], error_msg['new']),
+                ('new' + s + t + "\n" + poll_lines[0] + "\n", error_msg['new']),
+                ('new' + s + t + "\n" + poll_lines[0] + "\n" + poll_lines[1], error_msg['new']),
+                ('new' + s + t + "\n" + poll_lines[0] + "\n" + poll_lines[1] + "\n", error_msg['new']),
+                ('vote', error_msg['vote'] if st else error_msg['vote']+private_msg),
+                ('vote' + s, error_msg['vote'] if st else error_msg['vote']+private_msg),
+                ('vote' + s + t + t, error_msg['vote'] if st else error_msg['vote']+private_msg),
+                ('vote' + s + t + " 5", error_msg['vote'] if st else error_msg['vote']+private_msg),
+                ('vote' + s + t + " 5" + " 1", error_msg['vote']),  # no poll, so fails
+                ('end', error_msg['end'] if st else private_msg),
+                ('end' + s, error_msg['end'] if st else private_msg),
+                ('end' + s + t, error_msg['end']),  # no poll, so fails
+            ])
+            # Convert table above into expectation dict with templated messages
+            expected = OrderedDict([(k, dict(private_msg_template, content=v))
+                                    for k, v in expected_.items()])
+            self.check_expected_responses(expected, expected_method='send_message',
+                                          email=test_email, type=src_location,
+                                          recipient=recipient, subject='test topic')
+
+        # Test messages from within a stream/topic
+        test_fails('stream')
+        # Test messages sent privately
+        test_fails('private')
+
+        ## Now test the stateful poll generation, voting and poll ending
+        ## This depends on functional
+        ## - dual-posting support (poll-bot may update the poll message and
+        ##   always sends a private message stating what has happened)
+        ## - message update support
+        ## FIXME Both of these are currently lacking in the test framework
+
+        poll_message = "Poll created in stream '#test stream' with topic 'test topic':\nPoll by Foo Bar (id: 0)\nPlease select from one of the following options:\n1. [0] Something great\n2. [0] Something not so great\n3. [0] This is bad\n"
+
+        def test_polls(src_location):
+            s = t = ""  # These need to be specified if src_location is private
+            recipient = test_stream
+            if src_location == 'private':
+                (s, t) = (" "+test_stream.replace(" ", "+"), " "+test_topic.replace(" ", "+"))
+                recipient = test_email
+            st = (src_location == 'stream')
+            expected_ = OrderedDict([
+                ('new' + s + t + "\n" + "\n".join(poll_lines), poll_message),
+            ])
+            # Convert table above into expectation dict with templated messages
+            expected = OrderedDict([(k, dict(private_msg_template, content=v))
+                                    for k, v in expected_.items()])
+            self.check_expected_responses(expected, expected_method='send_message',
+                                          email=test_email, type=src_location,
+                                          recipient=recipient, subject=test_topic)
+
+            expected_ = OrderedDict([
+                ('new' + s + t + "\n" + "\n".join(poll_lines), poll_message),
+            ])
+            # Convert table above into expectation dict with templated messages
+            expected = OrderedDict([(k, dict(poll_msg_template, content=v))
+                                    for k, v in expected_.items()])
+            self.check_expected_responses(expected, expected_method='send_message',
+                                          email=test_email, type=src_location,
+                                          recipient=recipient, subject=test_topic)
+
+#        if 1: print("Testing poll usage from a stream")
+#        test_polls('stream')
+#        if 1: print("Testing poll usage from a private message")
+#        test_polls('private')


### PR DESCRIPTION
This is a fairly complete initial implementation of a bot to support polls within streams. It should work against current master, and can often be found running as **Shiny test bot** in #bot testing/neiljp.

I have noted the main design aspects and limitations in the usage text for now; the main limitation I see is currently the parsing of stream and topic names with spaces - if this worked properly, then polls could be started/controlled entirely by private messages, which seems much simpler. This is supported as-is, but spaces in names will confuse it.

Most recently, I added support for one poll per user per topic, rather than just one per topic; this seems sufficient for most cases, though I'm currently seeding the 'id' of the poll with just the user (creator) id.

Reviews and comments gratefully accepted.