### PR TITLE
portico-css:  Reposition header, portico-page content, and footer.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -2,21 +2,9 @@ html {
     min-height: 500px;
 }
 
-.app-main .bg-image {
-    position: fixed;
-    top: 0px;
-    left: 0px;
-    width: 100vw;
-    height: 100vh;
-
-    background-color: hsl(0, 0%, 98%);
-
-    z-index: -1;
-}
-
 .flex {
     display: flex;
-    height: calc(100vh - 100px);
+    height: calc(100vh - 135px);
     align-items: center;
     justify-content: center;
 }
@@ -142,12 +130,12 @@ html {
     margin-bottom: 0px;
 }
 
-.header,
-.header .stripes,
-.header .darker {
-    background: #fff;
-
+.header {
     color: hsl(0, 0%, 27%);
+}
+
+.header {
+    background-color: #fff;
 }
 
 .header .top-links a,

--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -30,10 +30,6 @@ html {
     margin: 10px;
 }
 
-.footer {
-    padding: 20px 0px 10px 0px;
-}
-
 .white-box {
     position: relative;
     padding: 30px;
@@ -144,10 +140,6 @@ html {
 
 .forgot-password-container form {
     margin-bottom: 0px;
-}
-
-.header {
-    padding: 15px 0px 15px 0px;
 }
 
 .header,

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -1,3 +1,7 @@
+body {
+    background-color: #fafafa;
+}
+
 .container-fluid {
     padding: 0px;
     min-height: 100%;
@@ -29,26 +33,14 @@
 }
 
 .header {
+    position: relative;
+
     padding: 6px 0px;
     height: 29px;
-}
 
-.header .stripes,
-.header .darker {
-    position: absolute;
-    height: 100%;
-    width: 100%;
-    top: 0px;
+    background-color: #fff;
 
-    background: repeating-linear-gradient(
-      75deg,
-      hsla(0, 0%, 100%, 0.0) 0px,
-      hsla(0, 0%, 100%, 0.06) 200px
-    );
-}
-
-.header .darker {
-    background: -webkit-linear-gradient(top left, transparent , hsla(0, 0%, 0%, 0.3));
+    z-index: 2;
 }
 
 .navbar.footer .nav > li {

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -372,20 +372,28 @@ input.text-error {
     outline-color: red;
 }
 
-.header,
-.footer {
-    position: absolute;
-    z-index: 100;
-    width: 100%;
-    background-color: hsl(170, 47%, 54%);
+.portico-container {
+    position: relative;
+}
+
+.portico-wrap {
+    overflow: hidden;
+    min-height: 100vh;
 }
 
 .footer {
-    background-color: transparent;
+    position: absolute;
+    bottom: 0;
+    z-index: 100;
+    width: 100%;
 }
 
 .footer .footer-navigation {
     margin-left: 0px;
+}
+
+.header {
+    padding: 20px 0 15px;
 }
 
 .header-main .logo {
@@ -569,6 +577,7 @@ a.bottom-signup-button {
 .portico-page {
     /* height of the white portico navbar */
     min-height: calc(100% - 87px);
+    padding-bottom: 71px;
 }
 
 .signup-signature {
@@ -582,15 +591,6 @@ a.bottom-signup-button {
     padding-top: 0px;
     text-align: center;
     font-size: 16px;
-}
-
-.terms-page-container,
-.feature-page-container,
-.apps-page-container,
-.integrations-page-container,
-.portico-page-container,
-.api-page-container {
-    padding-top: 50px !important;
 }
 
 .portico-page-header {

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -9,7 +9,6 @@ $(function () {
     common.autofocus('#email');
 });
 </script>
-<div class="bg-image"></div>
 
 <div class="app register-page split-view flex full-page new-style">
     <div class="inline-block">

--- a/templates/zerver/accounts_send_confirm.html
+++ b/templates/zerver/accounts_send_confirm.html
@@ -5,7 +5,6 @@
 <div class="app portico-page">
     <div class="app-main portico-page-container center-block flex full-page account-creation new-style">
         <div class="inline-block">
-            <div class="bg-image"></div>
 
             <div class="get-started">
                 <h1>{{ _("Thanks for signing up!") }}</h1>

--- a/templates/zerver/create_realm.html
+++ b/templates/zerver/create_realm.html
@@ -12,7 +12,6 @@ $(function () {
 
 <div class="app register-page flex">
     <div class="app-main register-page-container new-style flex full-page">
-        <div class="bg-image"></div>
 
         <div class="register-form">
             <div class="lead">

--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -4,7 +4,6 @@
 {% block portico_content %}
 <div class="app login-page flex full-page">
     <div class="app-main login-page-container dev-login white-box">
-        <div class="bg-image"></div>
 
         <h4 class="login-page-header">{{ _('Click on a user to log in!') }}</h4>
         <p class="devlogin_subheader">{{ _('(Or visit the <a href="/login">normal login page</a>)') }}</p>

--- a/templates/zerver/find_my_team.html
+++ b/templates/zerver/find_my_team.html
@@ -1,7 +1,6 @@
 {% extends "zerver/portico.html" %}
 
 {% block portico_content %}
-<div class="bg-image"></div>
 
 <div class="app find-team-page flex full-page">
     <div class="inline-block new-style">

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -8,7 +8,6 @@
 
 {% block portico_content %}
 
-<div class="bg-image"></div>
 
 
 {% if password_auth_enabled %}

--- a/templates/zerver/portico.html
+++ b/templates/zerver/portico.html
@@ -11,50 +11,53 @@
 {% endblock %}
 
 {% block content %}
-<div class="header">
-    <div class="stripes"></div>
-    <div class="darker"></div>
-    <div class="header-main" id="top_navbar">
-        <div class="column-left">
-            <div>
-                {% if custom_logo_url %}
-                <a class="brand logo" href="{{ server_uri }}/"><img draggable="false" src="{{ custom_logo_url }}" class="portico-logo" alt="{{ _('Zulip') }}" content="Zulip" /></a>
-                {% else %}
-                <a class="brand logo" href="{{ server_uri }}">
-                    <svg class="brand-logo" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 40" version="1.1">
-                        <g transform="translate(-297.14285,-466.64792)">
-                            <circle cx="317.14285" cy="486.64792" r="19.030317" style="fill:#fff;stroke-width:1.93936479;stroke:transparent"></circle>
-                            <path d="m309.24286 477.14791 14.2 0 1.6 3.9-11.2 11.9 9.6 0 1.6 3.2-14.2 0-1.6-3.9 11.2-11.9-9.6 0z" style="fill:#52c2af;stroke:#52c2af"></path>
-                        </g>
-                    </svg>
-                    <span>Zulip</span>
-                </a>
-                {% endif %}
+<div class="portico-container">
+    <div class="portico-wrap">
+        <div class="header">
+            <div class="stripes"></div>
+            <div class="darker"></div>
+            <div class="header-main" id="top_navbar">
+                <div class="column-left">
+                    <div>
+                        {% if custom_logo_url %}
+                        <a class="brand logo" href="{{ server_uri }}/"><img draggable="false" src="{{ custom_logo_url }}" class="portico-logo" alt="{{ _('Zulip') }}" content="Zulip" /></a>
+                        {% else %}
+                        <a class="brand logo" href="{{ server_uri }}">
+                            <svg class="brand-logo" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 40" version="1.1">
+                                <g transform="translate(-297.14285,-466.64792)">
+                                    <circle cx="317.14285" cy="486.64792" r="19.030317" style="fill:#fff;stroke-width:1.93936479;stroke:transparent"></circle>
+                                    <path d="m309.24286 477.14791 14.2 0 1.6 3.9-11.2 11.9 9.6 0 1.6 3.2-14.2 0-1.6-3.9 11.2-11.9-9.6 0z" style="fill:#52c2af;stroke:#52c2af"></path>
+                                </g>
+                            </svg>
+                            <span>Zulip</span>
+                        </a>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="column-right top-links">
+                    {% if login_link_disabled %}
+                    {% elif not only_sso %}
+                    <a href="{{login_url}}">{{ _('Log in') }}</a>
+                    {% endif %}
+
+                    {% if register_link_disabled %}
+                    {% elif only_sso %}
+                    <a href="{{ url('login-sso') }}">{{ _('Log in') }}</a>
+                    {% else %}
+                    <a href="{{ url('register') }}">{{ _('Register') }}</a>
+                    {% endif %}
+                </div>
             </div>
         </div>
 
-        <div class="column-right top-links">
-            {% if login_link_disabled %}
-            {% elif not only_sso %}
-            <a href="{{login_url}}">{{ _('Log in') }}</a>
-            {% endif %}
-
-            {% if register_link_disabled %}
-            {% elif only_sso %}
-            <a href="{{ url('login-sso') }}">{{ _('Log in') }}</a>
-            {% else %}
-            <a href="{{ url('register') }}">{{ _('Register') }}</a>
-            {% endif %}
+        <div class="app portico-page">
+            <div class="app-main portico-page-container{% block hello_page_container %}{% endblock %}">
+                {% block portico_content %}
+                {% endblock %}
+            </div>
         </div>
     </div>
+    {% include 'zerver/footer.html' %}
 </div>
-
-<div class="app portico-page">
-    <div class="app-main portico-page-container{% block hello_page_container %}{% endblock %}">
-        {% block portico_content %}
-        {% endblock %}
-    </div>
-</div>
-
-{% include 'zerver/footer.html' %}
 {% endblock %}

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -13,7 +13,6 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
 
 {% block portico_content %}
 <div class="register-account flex full-page">
-  <div class="bg-image"></div>
   <div class="center-block new-style" style="padding: 20px 0px">
     <div class="pitch">
         {% trans %}

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -1,7 +1,6 @@
 {% extends "zerver/portico_signup.html" %}
 {% block portico_content %}
 
-<div class="bg-image"></div>
 
 <div class="flex new-style app portico-page">
     <div class="inline-block">
@@ -10,7 +9,6 @@
         </div>
 
         <div class="app-main forgot-password-container white-box new-style">
-            <div class="bg-image"></div>
 
             <p>Forgot your password? No problem, we'll send a link to reset your password to the email you signed up with.</p>
 

--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -7,7 +7,6 @@
 {% block portico_content %}
 
 <div class="password-container flex full-page new-style">
-    <div class="bg-image"></div>
 
     <!-- wrapper for flex content -->
     <div>

--- a/tools/travis/success-http-headers.txt
+++ b/tools/travis/success-http-headers.txt
@@ -22,10 +22,10 @@ Reusing existing connection to localhost:443.
   HTTP/1.1 200 OK
   Server: nginx/1.4.6 (Ubuntu)
   Content-Type: text/html; charset=utf-8
-  Content-Length: 6463
+  Content-Length: 6434
   Connection: keep-alive
   Strict-Transport-Security: max-age=15768000
-Length: 6463 (6.3K) [text/html]
+Length: 6434 (6.3K) [text/html]
 Saving to: ‘/tmp/index.html’
 
 

--- a/tools/travis/success-http-headers.txt
+++ b/tools/travis/success-http-headers.txt
@@ -22,10 +22,10 @@ Reusing existing connection to localhost:443.
   HTTP/1.1 200 OK
   Server: nginx/1.4.6 (Ubuntu)
   Content-Type: text/html; charset=utf-8
-  Content-Length: 6107
+  Content-Length: 6463
   Connection: keep-alive
   Strict-Transport-Security: max-age=15768000
-Length: 6107 (6.0K) [text/html]
+Length: 6463 (6.3K) [text/html]
 Saving to: ‘/tmp/index.html’
 
 


### PR DESCRIPTION
- Header is now positioned according to the normal flow of the page, followed immediately by content in `.portico-page`.
- Footer remains an absolute positioned element at the bottom of the document.
- Footer is 'sticky' to the bottom and does not overlap content from `.portico-page`. So the height of the page responds correctly without unnecessary scrollbars.

Also did a tiny bit of cleanup. The spacing between the header and page content on a number of pages will probably be noticeably offset by this. But there won't be any more inconsistencies with footer / header overlaps.