### PR TITLE
webpack: Migrate translations.js to use ES2015 syntax.

### DIFF
--- a/static/js/translations.js
+++ b/static/js/translations.js
@@ -1,56 +1,55 @@
 // commonjs code goes here
 
-(function () {
-    var i18n = window.i18n = require('i18next');
-    var XHR = require('i18next-xhr-backend');
-    var lngDetector = require('i18next-browser-languagedetector');
-    var Cache = require('i18next-localstorage-cache');
+import i18next from 'i18next';
+import XHR from 'i18next-xhr-backend';
+import LngDetector from 'i18next-browser-languagedetector';
+import Cache from 'i18next-localstorage-cache';
 
-    var backendOptions = {
-        loadPath: '/static/locale/__lng__/translations.json',
-    };
-    var callbacks = [];
-    var initialized = false;
+window.i18n = i18next;
 
-    var detectionOptions = {
-        order: ['htmlTag'],
-        htmlTag: document.documentElement,
-    };
+var backendOptions = {
+    loadPath: '/static/locale/__lng__/translations.json',
+};
+var callbacks = [];
+var initialized = false;
 
-    var cacheOptions = {
-        enabled: true,
-        prefix: 'i18next:' + page_params.server_generation + ':',
-        expirationTime: 2*7*24*60*60*1000,  // 2 weeks
-    };
+var detectionOptions = {
+    order: ['htmlTag'],
+    htmlTag: document.documentElement,
+};
 
-    i18n.use(XHR)
-        .use(lngDetector)
-        .use(Cache)
-        .init({
-            nsSeparator: false,
-            keySeparator: false,
-            interpolation: {
-                prefix: "__",
-                suffix: "__",
-            },
-            backend: backendOptions,
-            detection: detectionOptions,
-            cache: cacheOptions,
-            fallbackLng: 'en',
-        }, function () {
-            var i;
-            initialized = true;
-            for (i=0; i<callbacks.length; i += 1) {
-                callbacks[i]();
-            }
-        });
+var cacheOptions = {
+    enabled: true,
+    prefix: 'i18next:' + page_params.server_generation + ':',
+    expirationTime: 2*7*24*60*60*1000,  // 2 weeks
+};
 
-    i18n.ensure_i18n = function (callback) {
-        if (initialized) {
-            callback();
-        } else {
-            callbacks.push(callback);
+i18next.use(XHR)
+    .use(LngDetector)
+    .use(Cache)
+    .init({
+        nsSeparator: false,
+        keySeparator: false,
+        interpolation: {
+            prefix: "__",
+            suffix: "__",
+        },
+        backend: backendOptions,
+        detection: detectionOptions,
+        cache: cacheOptions,
+        fallbackLng: 'en',
+    }, function () {
+        var i;
+        initialized = true;
+        for (i=0; i<callbacks.length; i += 1) {
+            callbacks[i]();
         }
-    };
+    });
 
-}());
+i18next.ensure_i18n = function (callback) {
+    if (initialized) {
+        callback();
+    } else {
+        callbacks.push(callback);
+    }
+};


### PR DESCRIPTION
- Changed all the require statements to import statements.
- Removed IIFE wrapper

A part of the PR #5377.
@pweaver 