### PR TITLE
testing: Change AvatarTest to UploadAvatarTest.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -236,7 +236,7 @@ if __name__ == "__main__":
             classname = suite.rsplit('.', 1)[0]
             rewrite_arguments(classname)
         elif suite[0].isupper():
-            rewrite_arguments(suite)
+            rewrite_arguments('class %s(' % (suite,))
 
     for suite in args:
         if suite.startswith('test'):


### PR DESCRIPTION
AvatarTest conflicts with BugdownAvatarTestCase. It seems that a test class name
cannot contain another test class's name. If it does then running the tests
by giving the class name fails.

Fixes #4983

@timabbott 