### PR TITLE
travis: Increase cache building timeout to 500s.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
   - unset GEM_PATH
   - mispipe "./tools/travis/$TEST_SUITE" ts
 cache:
+  - timeout: 500
   - apt: false
   - directories:
     - $HOME/zulip-venv-cache


### PR DESCRIPTION
In this commit we basically increase the timeout period for building cache in Travis CI. 