### PR TITLE
P4 integration

### DIFF
--- a/api/integrations/perforce/zulip_change-commit.py
+++ b/api/integrations/perforce/zulip_change-commit.py
@@ -72,9 +72,21 @@ except ValueError:
 metadata = git_p4.p4_describe(changelist)  # type: Dict[str, str]
 
 destination = config.commit_notice_destination(changeroot, changelist)  # type: Optional[Dict[str, str]]
+
 if destination is None:
     # Don't forward the notice anywhere
     sys.exit(0)
+
+ignore_missing_stream = None
+if hasattr(config, "ZULIP_IGNORE_MISSING_STREAM"):
+    ignore_missing_stream = config.ZULIP_IGNORE_MISSING_STREAM
+
+if ignore_missing_stream:
+    # Check if the destination stream exists yet
+    stream_state = client.get_stream_id(destination["stream"])
+    if stream_state["result"] == "error":
+        # Silently discard the message
+        sys.exit(0)
 
 change = metadata["change"]
 p4web = None

--- a/api/integrations/perforce/zulip_change-commit.py
+++ b/api/integrations/perforce/zulip_change-commit.py
@@ -76,11 +76,16 @@ if destination is None:
     # Don't forward the notice anywhere
     sys.exit(0)
 
-message = "**{0}** committed revision @{1} to `{2}`.\n\n> {3}".format(
-    metadata["user"],
-    metadata["change"],
-    changeroot,
-    metadata["desc"])  # type: str
+message = """**{user}** committed revision @{change} to `{path}`.
+
+```quote
+{desc}
+```
+""".format(
+    user=metadata["user"],
+    change=metadata["change"],
+    path=changeroot,
+    desc=metadata["desc"])  # type: str
 
 message_data = {
     "type": "stream",

--- a/api/integrations/perforce/zulip_change-commit.py
+++ b/api/integrations/perforce/zulip_change-commit.py
@@ -76,6 +76,15 @@ if destination is None:
     # Don't forward the notice anywhere
     sys.exit(0)
 
+change = metadata["change"]
+p4web = None
+if hasattr(config, "P4_WEB"):
+    p4web = config.P4_WEB
+
+if p4web is not None:
+    # linkify the change number
+    change = '[{change}]({p4web}/{change}?ac=10)'.format(p4web=p4web, change=change)
+
 message = """**{user}** committed revision @{change} to `{path}`.
 
 ```quote
@@ -83,7 +92,7 @@ message = """**{user}** committed revision @{change} to `{path}`.
 ```
 """.format(
     user=metadata["user"],
-    change=metadata["change"],
+    change=change,
     path=changeroot,
     desc=metadata["desc"])  # type: str
 

--- a/api/integrations/perforce/zulip_perforce_config.py
+++ b/api/integrations/perforce/zulip_perforce_config.py
@@ -26,6 +26,10 @@ ZULIP_USER = "p4-bot@example.com"
 ZULIP_API_KEY = "0123456789abcdef0123456789abcdef"
 ZULIP_SITE = "https://zulip.example.com"
 
+# Set this to point at a p4web installation to get changelist IDs as links
+# P4_WEB = "https://p4web.example.com"
+P4_WEB = None
+
 # commit_notice_destination() lets you customize where commit notices
 # are sent to with the full power of a Python function.
 #

--- a/api/integrations/perforce/zulip_perforce_config.py
+++ b/api/integrations/perforce/zulip_perforce_config.py
@@ -26,6 +26,11 @@ ZULIP_USER = "p4-bot@example.com"
 ZULIP_API_KEY = "0123456789abcdef0123456789abcdef"
 ZULIP_SITE = "https://zulip.example.com"
 
+# Set this to True to silently drop messages if the destination stream
+# does not exist. This prevents the warnings from Zulip's Notification Bot
+# when commits are made on a branch for which no stream has been created.
+ZULIP_IGNORE_MISSING_STREAM = False
+
 # Set this to point at a p4web installation to get changelist IDs as links
 # P4_WEB = "https://p4web.example.com"
 P4_WEB = None

--- a/templates/zerver/integrations/perforce.html
+++ b/templates/zerver/integrations/perforce.html
@@ -22,6 +22,13 @@
     <li>You should also change <code>ZULIP_SITE</code> to {{ external_api_path_subdomain }}</li>
 
     <li>
+        If you have a P4Web viewer set up, you may change <code>P4_WEB</code>
+        to point at the base URL of the server. If this is configured, then
+        the changelist number of each commit will be converted to a hyperlink
+        that displays the commit details on P4Web.
+    </li>
+
+    <li>
         Edit your
         <a href="http://www.perforce.com/perforce/doc.current/manuals/p4sag/chapter.scripting.html#d0e14583">trigger table</a>
         with <code>p4 triggers</code> and add an entry something like the
@@ -40,6 +47,18 @@
         to one stream, change it now in <code>zulip_perforce_config.py</code>.
         Make sure that everyone interested in getting these post-commit Zulips
         is subscribed to the relevant streams!
+    </li>
+
+    <li>
+        By default, this hook will send a message to Zulip even if the
+        destination stream does not yet exist. Messages to nonexistent
+        streams prompt the Zulip Notification Bot to inform the bot's
+        owner by private message that they may wish to create the stream.
+        If this behaviour is undesirable, for example with a large and busy
+        Perforce server, change the <code>ZULIP_IGNORE_MISSING_STREAM</code>
+        variable in <code>zulip_perforce_config.py</code> to <code>True</code>.
+        This will change the hook's behaviour to first check whether the
+        destination stream exists and silently drop messages if it does not.
     </li>
 </ol>
 


### PR DESCRIPTION
Improvements to the perforce integration:
 * Fixed formatting of commit messages containing multiple paragraphs
 * Configurable P4_WEB url, if set: change numbers are converted to links
 * Configurable option to silently drop messages if the destination stream does not exist

The latter is useful to me, so that normal users can create streams for project branches if zulip notifications are useful to that project, rather than requiring admin intervention on the perforce server.