### PR TITLE
[WIP] Make initial messages in initial streams on realm creation customizable.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2353,7 +2353,11 @@ def create_streams_with_welcome_messages(realm, stream_dict):
         )
 
         if created:
-            message = prep_stream_welcome_message(stream)
+            default_welcome_message = options.get('welcome_message')
+            if default_welcome_message is None:
+                message = prep_stream_welcome_message(stream)
+            else:
+                message = default_welcome_message
             messages.append(message)
 
     if messages:

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -204,10 +204,12 @@ def accounts_register(request):
             org_type = int(form.cleaned_data['realm_org_type'])
             realm = do_create_realm(string_id, realm_name, org_type=org_type)[0]
 
+            # Eventually, picking the names, descriptions, and welcome messages will be
+            # done in the realm creation UI, and this data will be coming from a form.
             stream_info = {
-                "social": {"description": "For socializing", "invite_only": False},
-                "general": {"description": "For general stuff", "invite_only": False},
-                "zulip": {"description": "For zulip stuff", "invite_only": False}
+                "social": {"description": "For socializing", "invite_only": False, "welcome_message": None},
+                "general": {"description": "For general stuff", "invite_only": False, "welcome_message": None},
+                "zulip": {"description": "For zulip stuff", "invite_only": False, "welcome_message": None}
             }  # type: Dict[Text, Dict[Text, Any]]
 
             create_streams_with_welcome_messages(realm, stream_info)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -204,7 +204,11 @@ def accounts_register(request):
             org_type = int(form.cleaned_data['realm_org_type'])
             realm = do_create_realm(string_id, realm_name, org_type=org_type)[0]
 
-            stream_info = settings.DEFAULT_NEW_REALM_STREAMS
+            stream_info = {
+                "social": {"description": "For socializing", "invite_only": False},
+                "general": {"description": "For general stuff", "invite_only": False},
+                "zulip": {"description": "For zulip stuff", "invite_only": False}
+            }  # type: Dict[Text, Dict[Text, Any]]
 
             create_streams_with_welcome_messages(realm, stream_info)
             set_default_streams(realm, stream_info)

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -197,11 +197,6 @@ DEFAULT_SETTINGS = {'TWITTER_CONSUMER_KEY': '',
                     # analytics into part of the main server, rather
                     # than a separate app.
                     'EXTRA_INSTALLED_APPS': ['analytics'],
-                    'DEFAULT_NEW_REALM_STREAMS': {
-                        "social": {"description": "For socializing", "invite_only": False},
-                        "general": {"description": "For general stuff", "invite_only": False},
-                        "zulip": {"description": "For zulip stuff", "invite_only": False}
-                    },
                     'REALM_CREATION_LINK_VALIDITY_DAYS': 7,
                     'TERMS_OF_SERVICE': None,
                     'PRIVACY_POLICY': None,


### PR DESCRIPTION
This is initial work on making the hello messages in the streams created on realm creation customizable.  This places settings in settings.py and a Realm-level constant in models.py to allow the initial messages in the default initial streams and the default notifications stream to be customized.  We will likely eventually want a more interactive way to set these values during the realm creation process.  See the discussion at #5343 

actions.py: modify logic to create streams with welcome messages
settings.py: add custom_welcome_message setting to default streams
models.py: make default notification stream welcome message customizable