### PR TITLE
subs: Fix the real-time sync when adding/removing subscribers with a filter.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -23,6 +23,15 @@ function get_email_of_subscribers(subscribers) {
     return emails;
 }
 
+function rerender_subscribers_list(sub) {
+    var emails = get_email_of_subscribers(sub.subscribers);
+    var subscribers_list = list_render.get("stream_subscribers/" + sub.stream_id);
+
+    // Changing the data clears the rendered list and the list needs to be re-rendered.
+    subscribers_list.data(emails);
+    subscribers_list.render();
+}
+
 exports.collapse = function (sub) {
     // I am not sure whether this code is really correct; it was extracted
     // from subs.update_settings_for_unsubscribed() and possibly pre-dates

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -14,6 +14,15 @@ function settings_for_sub(sub) {
     return $("#subscription_overlay .subscription_settings[data-stream-id='" + id + "']");
 }
 
+function get_email_of_subscribers(subscribers) {
+    var emails = [];
+    subscribers.each(function (o, i) {
+        var email = people.get_person_from_user_id(i).email;
+        emails.push(email);
+    });
+    return emails;
+}
+
 exports.collapse = function (sub) {
     // I am not sure whether this code is really correct; it was extracted
     // from subs.update_settings_for_unsubscribed() and possibly pre-dates
@@ -153,11 +162,7 @@ function show_subscription_settings(sub_row) {
     alerts.addClass("hide");
     list.empty();
 
-    var emails = [];
-    sub.subscribers.each(function (o, i) {
-        var email = people.get_person_from_user_id(i).email;
-        emails.push(email);
-    });
+    var emails = get_email_of_subscribers(sub.subscribers);
 
     list_render(list, emails.sort(), {
         name: "stream_subscribers/" + stream_id,

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -575,18 +575,12 @@ $(function () {
 
     $(document).on('peer_subscribe.zulip', function (e, data) {
         var sub = stream_data.get_sub(data.stream_name);
-        var sub_row = settings_for_sub(sub);
-        exports.prepend_subscriber(sub_row, data.user_email);
+        rerender_subscribers_list(sub);
     });
 
     $(document).on('peer_unsubscribe.zulip', function (e, data) {
         var sub = stream_data.get_sub(data.stream_name);
-
-        var sub_row = settings_for_sub(sub);
-        var tr = sub_row.find("tr[data-subscriber-email='" +
-                              data.user_email +
-                              "']");
-        tr.remove();
+        rerender_subscribers_list(sub);
     });
 
 });


### PR DESCRIPTION
This PR fixes the updation issues related to `subscriber-list` in stream settings form. We were amending the HTML while updating the list while for a list which is being managed by `list_rendering.js` for progressive rendering, we should just update the data of list render instance and perform a re-render.

Fixes: #4812.