### PR TITLE
Add cache cleaning tool for our npm and emoji caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,16 @@ install:
   - mispipe "tools/travis/setup-$TEST_SUITE" ts
 
   # Clean any virtualenvs that are not in use to avoid our cache
-  # becoming huge.  TODO: Add similar cleanup code for the other caches.
+  # becoming huge.
   - mispipe "tools/clean-venv-cache --travis" ts
 
   # Clean any npm cache which was generated but not required anymore to avoid
   # our cache becoming huge.
   - mispipe "tools/clean-npm-cache --travis" ts
+
+  # Clean any emoji cache which was generated but not required anymore to avoid
+  # our cache becoming huge.
+  - mispipe "tools/clean-emoji-cache --travis" ts
 script:
   # We unset GEM_PATH here as a hack to work around Travis CI having
   # broken running their system puppet with Ruby.  See

--- a/tools/clean-emoji-cache
+++ b/tools/clean-emoji-cache
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import print_function
+import os
+import subprocess
+import sys
+
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+EMOJI_CACHE_SYMLINK = os.path.join(ZULIP_PATH, 'static', 'generated', 'emoji')
+EMOJI_CACHE_PATH = "/srv/zulip-emoji-cache"
+if "--travis" in sys.argv:
+    EMOJI_CACHE_PATH = os.path.join(os.environ["HOME"], "zulip-emoji-cache")
+
+curr_emoji_cache_dir = os.path.dirname(os.path.realpath(EMOJI_CACHE_SYMLINK))
+
+for cache_dir_base in os.listdir(EMOJI_CACHE_PATH):
+    emoji_cache_dir = os.path.join(EMOJI_CACHE_PATH, cache_dir_base)
+    if emoji_cache_dir not in curr_emoji_cache_dir:
+        print("Cleaning unused emoji cache dir %s" % (emoji_cache_dir,))
+        subprocess.check_call(["sudo", "rm", "-rf", emoji_cache_dir])
+    else:
+        print("Keeping used emoji cache dir %s" % (emoji_cache_dir,))


### PR DESCRIPTION
In this PR we intend to add new cache cleaning tools for our npm and emoji caches. Also start using them in travis to keep cache size in check and hence avoid huge build times and timeout problems with storing cache.
Fixes: #5243.