### PR TITLE
Add support for "is:unread" search token

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -2,6 +2,7 @@ add_dependencies({
     people: 'js/people.js',
     stream_data: 'js/stream_data.js',
     util: 'js/util.js',
+    unread: 'js/unread.js',
 });
 
 set_global('page_params', {});
@@ -255,6 +256,10 @@ function make_sub(name, stream_id) {
     predicate = get_predicate([['is', 'starred']]);
     assert(predicate({starred: true}));
     assert(!predicate({starred: false}));
+
+    predicate = get_predicate([['is', 'unread']]);
+    assert(predicate({flags: ''}));
+    assert(!predicate({flags: 'read'}));
 
     predicate = get_predicate([['is', 'alerted']]);
     assert(predicate({alerted: true}));

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -518,6 +518,13 @@ function make_sub(name, stream_id) {
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
+        {operator: 'stream', operand: 'river'},
+        {operator: 'is', operand: 'unread'},
+    ];
+    string = 'stream river, unread messages';
+    assert.equal(Filter.describe(narrow), string);
+
+    narrow = [
         {operator: 'stream', operand: 'devel'},
         {operator: 'topic', operand: 'JS'},
     ];

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -122,6 +122,11 @@ function set_filter(operators) {
     assert.equal(hide_id,'.empty_feed_notice');
     assert.equal(show_id, '#empty_narrow_all_private_message');
 
+    set_filter([['is', 'unread']]);
+    narrow.show_empty_narrow_message();
+    assert.equal(hide_id,'.empty_feed_notice');
+    assert.equal(show_id, '#no_unread_narrow_message');
+
     set_filter([['pm-with', ['alice@example.com', 'Yo']]]);
     narrow.show_empty_narrow_message();
     assert.equal(hide_id,'.empty_feed_notice');

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -179,11 +179,12 @@ global.stream_data.populate_stream_topics_for_tests({});
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    query = 'from:ted';
+    query = 'is:unread from:ted';
     suggestions = search.get_suggestions(query);
     expected = [
-        "from:ted",
-        "from:ted@zulip.com",
+        "is:unread from:ted",
+        "is:unread from:ted@zulip.com",
+        "is:unread",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -388,6 +389,7 @@ init();
         "is:starred",
         "is:mentioned",
         "is:alerted",
+        "is:unread",
         "sender:bob@zulip.com",
         "stream:devel",
         "stream:office",
@@ -403,6 +405,7 @@ init();
     assert.equal(describe('is:starred'), 'Starred messages');
     assert.equal(describe('is:mentioned'), '@-mentions');
     assert.equal(describe('is:alerted'), 'Alerted messages');
+    assert.equal(describe('is:unread'), 'Unread messages');
     assert.equal(describe('sender:bob@zulip.com'), 'Sent by me');
     assert.equal(describe('stream:devel'), 'Stream <strong>devel</strong>');
 }());

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -493,6 +493,8 @@ Filter.describe = function (operators) {
                 return verb + '@-mentions';
             } else if (operand === 'alerted') {
                 return verb + 'alerted messages';
+            } else if (operand === 'unread') {
+                return verb + 'unread messages';
             }
         } else {
             var prefix_for_operator = Filter.operator_to_prefix(canonicalized_operator,

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -55,6 +55,8 @@ function message_matches_search_term(message, operator, operand) {
             return message.mentioned;
         } else if (operand === 'alerted') {
             return message.alerted;
+        } else if (operand === 'unread') {
+            return unread.message_unread(message);
         }
         return true; // is:whatever returns true
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -478,6 +478,9 @@ function pick_empty_narrow_banner() {
         } else if (first_operand === "private") {
             // You have no private messages.
             return $("#empty_narrow_all_private_message");
+        } else if (first_operand === "unread") {
+            // You have no unread messages.
+            return $("#no_unread_narrow_message");
         }
     } else if ((first_operator === "stream") && !stream_data.is_subscribed(first_operand)) {
         // You are narrowed to a stream to which you aren't subscribed.

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -390,6 +390,13 @@ function get_special_filter_suggestions(last, operators) {
                 {operator: 'is', operand: 'alerted'},
             ],
         },
+        {
+            search_string: 'is:unread',
+            description: 'unread messages',
+            invalid: [
+                {operator: 'is', operand: 'unread'},
+            ],
+        },
     ];
 
     var last_string = Filter.unparse([last]).toLowerCase();

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -72,6 +72,8 @@ you.
 that you've received.
 * `is:starred` - This operator narrows the view to show all messages that you've
 starred.
+* `is:unread` - This operator narrows the view to show all messages that you
+haven't read.
 * `has:link` - This operator narrows the view to show all messages that contain
 any links.
 * `has:image` - This operator narrows the view to show all messages that contain

--- a/templates/zerver/home.html
+++ b/templates/zerver/home.html
@@ -74,6 +74,9 @@
       <div id="empty_star_narrow_message" class="empty_feed_notice">
         <h4>{{ _("You haven't starred anything yet!") }}</h4>
       </div>
+      <div id="no_unread_narrow_message" class="empty_feed_notice">
+        <h4>{{ _("You have no unread messages!") }}</h4>
+      </div>
       <div id="empty_narrow_all_mentioned" class="empty_feed_notice">
         <h4>{{ _("You haven't been mentioned yet!") }}</h4>
       </div>

--- a/templates/zerver/search_operators.html
+++ b/templates/zerver/search_operators.html
@@ -53,6 +53,10 @@
                 <td class="definition">{{ _('Narrow to starred messages.') }}</td>
             </tr>
             <tr>
+                <td class="operator">is:unread</td>
+                <td class="definition">{{ _('Narrow to unread messages.') }}</td>
+            </tr>
+            <tr>
                 <td class="operator">has:link</td>
                 <td class="definition">{{ _('Narrow to messages containing links.') }}</td>
             </tr>

--- a/zerver/fixtures/narrow.json
+++ b/zerver/fixtures/narrow.json
@@ -227,5 +227,27 @@
                 "mentioned"
             ]
         ]
+    },
+    {
+        "accept_events":[
+            {
+                "message":null,
+                "flags": [],
+            }
+        ],
+        "reject_events":[
+            {
+                "message":null,
+                "flags":[
+                    "read"
+                ]
+            }
+        ],
+        "narrow":[
+            [
+                "is",
+                "unread"
+            ]
+        ]
     }
 ]

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -43,6 +43,9 @@ def build_narrow_filter(narrow):
             elif operator == "is" and operand in ["starred"]:
                 if operand not in flags:
                     return False
+            elif operator == "is" and operand == "unread":
+                if "read" in flags:
+                    return False
             elif operator == "is" and operand in ["alerted", "mentioned"]:
                 if "mentioned" not in flags:
                     return False

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -112,6 +112,16 @@ class NarrowBuilderTest(ZulipTestCase):
             term = dict(operator='is', operand=operand)
             self._do_add_term_test(term, 'WHERE (flags & :flags_1) != :param_1')
 
+    def test_add_term_using_is_operator_and_unread_operand(self):
+        # type: () -> None
+        term = dict(operator='is', operand='unread')
+        self._do_add_term_test(term, 'WHERE (flags & :flags_1) = :param_1')
+
+    def test_add_term_using_is_operator_and_unread_operand_and_negated(self):  # NEGATED
+        # type: () -> None
+        term = dict(operator='is', operand='unread', negated=True)
+        self._do_add_term_test(term, 'WHERE (flags & :flags_1) != :param_1')
+
     def test_add_term_using_is_operator_non_private_operand_and_negated(self):  # NEGATED
         # type: () -> None
         for operand in ['starred', 'mentioned', 'alerted']:
@@ -335,7 +345,7 @@ class BuildNarrowFilterTest(TestCase):
         fixtures_path = os.path.join(os.path.dirname(__file__),
                                      '../fixtures/narrow.json')
         scenarios = ujson.loads(open(fixtures_path, 'r').read())
-        self.assertTrue(len(scenarios) == 8)
+        self.assertTrue(len(scenarios) == 9)
         for scenario in scenarios:
             narrow = scenario['narrow']
             accept_events = scenario['accept_events']
@@ -372,6 +382,12 @@ class IncludeHistoryTest(ZulipTestCase):
         # History doesn't apply to PMs.
         narrow = [
             dict(operator='is', operand='private'),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, realm))
+
+        # History doesn't apply to unread messages.
+        narrow = [
+            dict(operator='is', operand='unread'),
         ]
         self.assertFalse(ok_to_include_history(narrow, realm))
 

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -133,6 +133,9 @@ class NarrowBuilder(object):
         elif operand == 'starred':
             cond = column("flags").op("&")(UserMessage.flags.starred.mask) != 0
             return query.where(maybe_negate(cond))
+        elif operand == 'unread':
+            cond = column("flags").op("&")(UserMessage.flags.read.mask) == 0
+            return query.where(maybe_negate(cond))
         elif operand == 'mentioned' or operand == 'alerted':
             cond = column("flags").op("&")(UserMessage.flags.mentioned.mask) != 0
             return query.where(maybe_negate(cond))


### PR DESCRIPTION
As proposed in #1423, you can now type is:unread in the search bar, and this narrows to all messages that haven't been read at the time the search was made.

Relevant tests were added, and updated the user reference/documentation.

(Note that the PR doesn't reflect this, but I moved the commit ordering around to put 83e5bfb first, which I think makes sense)