### PR TITLE
Fix "copy link to conversation" for private messages

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -310,6 +310,19 @@ function make_sub(name, stream_id) {
     }));
     assert(!predicate({type: 'stream'}));
 
+    predicate = get_predicate([['pm-with', 'Joe@example.com,steve@foo.com']]);
+    assert(predicate({
+        type: 'private',
+        display_recipient: [{user_id: joe.user_id}, {user_id: steve.user_id}],
+    }));
+
+    // Make sure your own email is ignored
+    predicate = get_predicate([['pm-with', 'Joe@example.com,steve@foo.com,me@example.com']]);
+    assert(predicate({
+        type: 'private',
+        display_recipient: [{user_id: joe.user_id}, {user_id: steve.user_id}],
+    }));
+
     predicate = get_predicate([['pm-with', 'nobody@example.com']]);
     assert(!predicate({
         type: 'private',

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -564,8 +564,14 @@ exports.by_conversation_and_time_uri = function (message, is_absolute_url) {
             "/subject/" + hash_util.encodeHashComponent(message.subject) +
             "/near/" + hash_util.encodeHashComponent(message.id);
     }
+
+    // Include your own email in this URI if it's not there already
+    var all_emails = message.reply_to;
+    if (all_emails.indexOf(people.my_current_email()) === -1) {
+        all_emails += "," + people.my_current_email();
+    }
     return absolute_url + "#narrow/pm-with/" +
-        hash_util.encodeHashComponent(message.reply_to) +
+        hash_util.encodeHashComponent(all_emails) +
         "/near/" + hash_util.encodeHashComponent(message.id);
 };
 

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -372,6 +372,11 @@ exports.pm_with_operand_ids = function (operand) {
         return people_dict.get(email);
     });
 
+    // If your email is included in a PM group with other people, just ignore it
+    if (persons.length > 1) {
+        persons = _.without(persons, people_by_user_id_dict.get(my_user_id));
+    }
+
     if (!_.all(persons)) {
         return;
     }

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -261,7 +261,8 @@ class NarrowBuilder(object):
         if ',' in operand:
             # Huddle
             try:
-                emails = [e.strip() for e in operand.split(',')]
+                # Ignore our own email if it is in this list
+                emails = [e.strip() for e in operand.split(',') if e.strip() != self.user_profile.email]
                 recipient = recipient_for_emails(emails, False,
                                                  self.user_profile, self.user_profile)
             except ValidationError:


### PR DESCRIPTION
Previously, for all private messages, the copy link button was fairly useless, because you couldn't share this link with others, or it won't work. This is because it only has the other participants' name, but excludes your own name.

This PR adds your own email address to the returned link, in both single-person PMs and group PMs. 
To accommodate this, the message filtering for PMs was changed such that it ignores all instances of your own name (unless you are in a PM with yourself). 

So additionally, if you had a group message with Bob and Jeff, you could now also type
`pm-with:me@example.com,bob@zulip.org,jeff@zulip.org`
into the search bar, and the filtering treats this as equivalent to `pm-with:bob@zulip.org,jeff@zulip.org` 
(node test was added for this filtering equivalence)

Fixes #2360