### PR TITLE
Start using requirements file for pip/setuptools/wheels in venv setup.

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,0 +1,4 @@
+# Dependancies for setting up pip to install our requirements.txt file.
+setuptools==36.0.1
+pip==9.0.1
+wheel==0.29.0

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -37,8 +37,8 @@ VENV_DEPENDENCIES = [
 
 def install_venv_deps(requirements_file):
     # type: (str) -> None
-    run(["pip", "install", "-U", "setuptools==36.0.1"])
-    run(["pip", "install", "--upgrade", "pip", "wheel"])
+    pip_requirements = os.path.join(ZULIP_PATH, "requirements", "pip.txt")
+    run(["pip", "install", "-U", "--requirement", pip_requirements])
     run(["pip", "install", "--no-deps", "--requirement", requirements_file])
 
 def get_index_filename(venv_path):


### PR DESCRIPTION
Basically we are adding this requirements file to better manage the requirements for `pip` which is used to install our `requirements.txt` file. This way we have versions pinned which are easy to change and lookout for in the future.
Fixes: #5158.