### PR TITLE
sign-in: Show proper error for deactivated user.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -257,6 +257,12 @@ Please contact %s to reactivate this group.""" % (
                 settings.ZULIP_ADMINISTRATOR)
             raise ValidationError(mark_safe(error_msg))
 
+        if not user_profile.is_active:
+            error_msg = (u"Sorry for the trouble, but your account has been "
+                         u"deactivated. Please contact %s to reactivate "
+                         u"it.") % (settings.ZULIP_ADMINISTRATOR,)
+            raise ValidationError(mark_safe(error_msg))
+
         if not check_subdomain(get_subdomain(self.request), user_profile.realm.subdomain):
             logging.warning("User %s attempted to password login to wrong subdomain %s" %
                             (user_profile.email, get_subdomain(self.request)))

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -755,7 +755,9 @@ class InactiveUserTest(ZulipTestCase):
         do_deactivate_user(user_profile)
 
         result = self.login_with_return(self.example_email("hamlet"))
-        self.assert_in_response("Please enter a correct email and password", result)
+        self.assert_in_response(
+            "Sorry for the trouble, but your account has been deactivated",
+            result)
 
     def test_webhook_deactivated_user(self):
         # type: () -> None


### PR DESCRIPTION
Show a clear error message when a user tries to sign in with
a deactivated account.

Fixes #4757