### PR TITLE
user_popover: Handle the case when user presence is unknown.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -113,6 +113,7 @@ presence.presence_info = presence_info;
     assert.equal(presence.get_status(page_params.user_id), "active");
     assert.equal(presence.get_status(alice.user_id), "inactive");
     assert.equal(presence.get_status(fred.user_id), "active");
+    assert.equal(presence.get_status(zoe.user_id), "unknown");
 }());
 
 (function test_sort_users() {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -42,14 +42,15 @@ function load_medium_avatar(user_email) {
 }
 
 function user_last_seen_time_status(user_id) {
-    if (presence.get_status(user_id) === "active") {
+    var status = presence.get_status(user_id);
+    if (status === "active") {
         return i18n.t("Active now");
     }
-
-    if (people.get_person_from_user_id(user_id).is_bot) {
-        return i18n.t("Bot");
+    if (status === "unknown") {
+        // We are not using this anywhere right now as the user presence indicator
+        // is hidden for this case
+        return i18n.t("Unknown");
     }
-
     return timerender.last_seen_status_from_date(presence.last_active_date(user_id).clone());
 }
 

--- a/static/js/presence.js
+++ b/static/js/presence.js
@@ -36,7 +36,10 @@ exports.get_status = function (user_id) {
     if (user_id === page_params.user_id) {
         return "active";
     }
-    return exports.presence_info[user_id].status;
+    if (user_id in exports.presence_info) {
+        return exports.presence_info[user_id].status;
+    }
+    return "unknown";
 };
 
 exports.get_mobile = function (user_id) {

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -79,6 +79,10 @@
     border-color: gray;
 }
 
+.user_unknown .user-status-indicator {
+    display: none;
+}
+
 #user_presences a,
 #group-pms a {
     color: inherit;


### PR DESCRIPTION
For bots and users who have not logged in for a long time the presence information is not known. Right now the popup fails to open for these users. This PR fixes the issue and make the presence indicator hidden for the users.
![screenshot from 2017-06-19 22 45 16](https://user-images.githubusercontent.com/7190633/27297077-08650e32-5541-11e7-8814-4e142962ac1a.png)
Actually we can do better.
* Show the bot icon for bots instead of hiding the status indicator
* Show user have not been seen in a long time for the users.

But right now we can't differentiate the users and bots easily. The value of `is_bot` attribute for bots like `welcome-bot`and `Zulip New User Bot` are false in page_params(in Realms other than zulip). Once we fix this issue we can work on this section.
