### PR TITLE
bugdown: Remove shortname mention syntax.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1041,8 +1041,6 @@ class UserMentionPattern(markdown.inlinepatterns.Pattern):
             return (True, None)
 
         user = db_data['full_names'].get(name.lower(), None)
-        if user is None:
-            user = db_data['short_names'].get(name.lower(), None)
 
         return (False, user)
 

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -716,20 +716,6 @@ class BugdownTest(ZulipTestCase):
                          '@King Hamlet</span></p>' % (self.example_email("hamlet"), user_id))
         self.assertEqual(msg.mentions_user_ids, set([user_profile.id]))
 
-    def test_mention_shortname(self):
-        # type: () -> None
-        sender_user_profile = self.example_user('othello')
-        user_profile = self.example_user('hamlet')
-        msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
-        user_id = user_profile.id
-
-        content = "@**hamlet**"
-        self.assertEqual(render_markdown(msg, content),
-                         '<p><span class="user-mention" '
-                         'data-user-email="%s" data-user-id="%s">'
-                         '@King Hamlet</span></p>' % (self.example_email("hamlet"), user_id))
-        self.assertEqual(msg.mentions_user_ids, set([user_profile.id]))
-
     def test_mention_multiple(self):
         # type: () -> None
         sender_user_profile = self.example_user('othello')
@@ -737,7 +723,7 @@ class BugdownTest(ZulipTestCase):
         cordelia = self.example_user('cordelia')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
 
-        content = "@**King Hamlet** and @**cordelia**, check this out"
+        content = "@**King Hamlet** and @**Cordelia Lear**, check this out"
         self.assertEqual(render_markdown(msg, content),
                          '<p>'
                          '<span class="user-mention" '

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -63,8 +63,8 @@ class TestMissedMessages(ZulipTestCase):
         for i in range(0, 11):
             self.send_message(self.example_email('othello'), "Denmark", Recipient.STREAM, str(i))
         self.send_message(self.example_email('othello'), "Denmark", Recipient.STREAM, '11', subject='test2')
-        msg_id = self.send_message(self.example_email('othello'), "denmark", Recipient.STREAM, '@**hamlet**')
-        body = 'Denmark > test Othello, the Moor of Venice 1 2 3 4 5 6 7 8 9 10 @**hamlet**'
+        msg_id = self.send_message(self.example_email('othello'), "denmark", Recipient.STREAM, '@**King Hamlet**')
+        body = 'Denmark > test Othello, the Moor of Venice 1 2 3 4 5 6 7 8 9 10 @**King Hamlet**'
         subject = 'Othello, the Moor of Venice mentioned you in Zulip Dev'
         self._test_cases(tokens, msg_id, body, subject, send_as_user)
 
@@ -76,8 +76,8 @@ class TestMissedMessages(ZulipTestCase):
 
         for i in range(0, 3):
             self.send_message(self.example_email('cordelia'), "Denmark", Recipient.STREAM, str(i))
-        msg_id = self.send_message(self.example_email('othello'), "Denmark", Recipient.STREAM, '@**hamlet**')
-        body = 'Denmark > test Cordelia Lear 0 1 2 Othello, the Moor of Venice @**hamlet**'
+        msg_id = self.send_message(self.example_email('othello'), "Denmark", Recipient.STREAM, '@**King Hamlet**')
+        body = 'Denmark > test Cordelia Lear 0 1 2 Othello, the Moor of Venice @**King Hamlet**'
         subject = 'Othello, the Moor of Venice mentioned you in Zulip Dev'
         self._test_cases(tokens, msg_id, body, subject, send_as_user)
 
@@ -178,7 +178,7 @@ class TestMissedMessages(ZulipTestCase):
         mock_random_token.side_effect = tokens
 
         msg_id = self.send_message(self.example_email('othello'), "denmark", Recipient.STREAM,
-                                   '@**hamlet** to be deleted')
+                                   '@**King Hamlet** to be deleted')
 
         hamlet = self.example_user('hamlet')
         email = self.example_email('othello')


### PR DESCRIPTION
We used shortnames for mentioning users before we had autocomplete feature. Since we now have autocomplete typeahead, this syntax is no more useful and just causes problems so it is better to remove it.

Fixes: #4189.