### PR TITLE
message_store.js to 100% line coverage.

### DIFF
--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -5,10 +5,28 @@ add_dependencies({
 });
 
 var noop = function () {};
+var with_overrides = global.with_overrides;
 var people = global.people;
 
 set_global('alert_words', {
     process_message: noop,
+});
+
+set_global('stream_data' , {
+    process_message_for_recent_topics: noop,
+});
+
+set_global('recent_senders', {
+    process_message_for_senders: noop,
+});
+
+set_global('page_params', {
+    realm_allow_message_editing: true,
+    is_admin: true,
+});
+
+set_global('blueslip', {
+    error: noop,
 });
 
 var me = {
@@ -67,6 +85,7 @@ var message_store = require('js/message_store.js');
         type: 'private',
         display_recipient: [me, bob, cindy],
         flags: ['has_alert_word'],
+        id: 2067,
     };
     message_store.add_message_metadata(message);
 
@@ -76,4 +95,81 @@ var message_store = require('js/message_store.js');
     assert.equal(message.display_reply_to, 'Bob, Cindy');
     assert.equal(message.alerted, true);
     assert.equal(message.is_me_message, false);
+
+    var retrieved_message = message_store.get(2067);
+    assert.equal(retrieved_message, message);
+
+    // access cached previous message, and test match subject/content
+    message = {
+        id: 2067,
+        match_subject: "subject foo",
+        match_content: "bar content",
+    };
+    message = message_store.add_message_metadata(message);
+
+    assert.equal(message.reply_to, 'bob@example.com,cindy@example.com');
+    assert.equal(message.to_user_ids, '103,104');
+    assert.equal(message.display_reply_to, 'Bob, Cindy');
+    assert.equal(message.match_subject, 'subject foo');
+    assert.equal(message.match_content, 'bar content');
+
+    message = {
+        sender_email: 'me@example.com',
+        sender_id: me.user_id,
+        type: 'stream',
+        display_recipient: [me, cindy],
+        stream: 'Zoolippy',
+        topic: 'cool thing',
+        subject: 'the_subject',
+        id: 2068,
+    };
+
+    // test stream properties
+    with_overrides(function (override) {
+        override('compose.empty_topic_placeholder', function () {
+            return 'the_subject';
+        });
+        global.with_stub(function (stub) {
+            set_global('composebox_typeahead', {add_topic: stub.f});
+            message_store.add_message_metadata(message);
+            var typeahead_added = stub.get_args('stream', 'subject');
+            assert.deepEqual(typeahead_added.stream, [me, cindy]);
+            assert.equal(message.subject, typeahead_added.subject);
+        });
+
+        assert.equal(message.always_visible_topic_edit, true);
+        assert.equal(message.on_hover_topic_edit, false);
+        assert.deepEqual(message.stream, [me, cindy]);
+        assert.equal(message.reply_to, 'me@example.com');
+        assert.deepEqual(message.flags, []);
+        assert.equal(message.alerted, false);
+
+        override('compose.empty_topic_placeholder', function () {
+            return 'not_the_subject';
+        });
+
+        message = {
+            sender_id: me.user_id,
+            type: 'stream',
+            id: 2069,
+            display_recipient: [me],
+            sender_email: 'me@example.org',
+        };
+        message_store.add_message_metadata(message);
+
+        assert.equal(message.always_visible_topic_edit, false);
+        assert.equal(message.on_hover_topic_edit, true);
+    });
+
+    page_params.realm_allow_message_editing = false;
+    message = {
+        sender_id: me.user_id,
+        type: 'stream',
+        id: 2070,
+        display_recipient: [me],
+        sender_email: 'me@example.org',
+    };
+    message_store.add_message_metadata(message);
+    assert.equal(message.always_visible_topic_edit, false);
+    assert.equal(message.on_hover_topic_edit, false);
 }());

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -8,6 +8,9 @@ var noop = function () {};
 var with_overrides = global.with_overrides;
 var people = global.people;
 
+set_global('$', global.make_zjquery());
+set_global('document', '');
+
 set_global('alert_words', {
     process_message: noop,
 });
@@ -25,9 +28,7 @@ set_global('page_params', {
     is_admin: true,
 });
 
-set_global('blueslip', {
-    error: noop,
-});
+set_global('blueslip', {});
 
 var me = {
     email: 'me@example.com',
@@ -59,8 +60,6 @@ people.add_in_realm(bob);
 people.add_in_realm(cindy);
 
 global.people.initialize_current_user(me.user_id);
-
-global.util.execute_early = noop;
 
 var message_store = require('js/message_store.js');
 
@@ -180,11 +179,22 @@ var message_store = require('js/message_store.js');
         type: 'private',
         display_recipient: [{user_id: 92714}],
     };
+
+    var blueslip_errors = 0;
+    blueslip.error = function () {
+        blueslip_errors += 1;
+    };
+
+    // Expect each to throw two blueslip errors
+    // One from message_store.js, one from person.js
     var emails = message_store.get_pm_emails(message);
     assert.equal(emails, '?');
+    assert.equal(blueslip_errors, 2);
 
+    blueslip_errors = 0;
     var names = message_store.get_pm_full_names(message);
     assert.equal(names, '?');
+    assert.equal(blueslip_errors, 2);
 
     message = {
         type: 'stream',
@@ -213,4 +223,49 @@ var message_store = require('js/message_store.js');
         var warn = stub.get_args("message");
         assert.equal(warn.message, "Unknown reply_to in message: ");
     });
+}());
+
+(function test_message_id_change() {
+    var message = {
+        sender_email: 'me@example.com',
+        sender_id: me.user_id,
+        type: 'private',
+        display_recipient: [me, bob, cindy],
+        flags: ['has_alert_word'],
+        id: 401,
+    };
+    message_store.add_message_metadata(message);
+
+    set_global('pointer', {
+        furthest_read: 401,
+    });
+
+    set_global('message_list', {});
+    set_global('home_msg_list', {});
+
+    var id_change_event = {
+        name: 'message_id_changed',
+        data: {
+            old_id: 401,
+            new_id: 402,
+        },
+    };
+
+    global.with_stub(function (stub) {
+        home_msg_list.change_message_id = stub.f;
+        $(document).trigger(id_change_event);
+        var msg_id = stub.get_args('old', 'new');
+        assert.equal(msg_id.old, 401);
+        assert.equal(msg_id.new, 402);
+    });
+
+    home_msg_list.view = {};
+    global.with_stub(function (stub) {
+        home_msg_list.view.change_message_id = stub.f;
+        $(document).trigger(id_change_event);
+        var msg_id = stub.get_args('old', 'new');
+        assert.equal(msg_id.old, 401);
+        assert.equal(msg_id.new, 402);
+    });
+
 }());

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -176,10 +176,6 @@ exports.add_message_metadata = function (message) {
     return message;
 };
 
-exports.clear = function clear() {
-    this.stored_messages = {};
-};
-
 util.execute_early(function () {
     $(document).on('message_id_changed', function (event) {
         var old_id = event.old_id;

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -32,6 +32,7 @@ enforce_fully_covered = {
     'static/js/fenced_code.js',
     'static/js/hash_util.js',
     'static/js/markdown.js',
+    'static/js/message_store.js',
     'static/js/muting.js',
     'static/js/people.js',
     'static/js/pm_conversations.js',


### PR DESCRIPTION
In addition to the tests, I fixed a bug in `message_store.clear()` that caused it to basically do nothing. (Though I don't think we actually use this function anywhere)