### PR TITLE
repository: Update information with Codecov migration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   # Disable Travis CI's built-in NVM installation
   - mispipe "mv ~/.nvm ~/.travis-nvm-disabled" ts
 
-  # Install coveralls, the library for the code coverage reporting tool we use
+  # Install codecov, the library for the code coverage reporting tool we use
   - mispipe "pip install codecov" ts
 
   # This is the main setup job for the test suite

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ missed-message emails, desktop apps, and much more.
 Further information on the Zulip project and its features can be found
 at <https://www.zulip.org>.
 
-[![Build Status](https://travis-ci.org/zulip/zulip.svg?branch=master)](https://travis-ci.org/zulip/zulip) [![Coverage Status](https://coveralls.io/repos/github/zulip/zulip/badge.svg?branch=master)](https://coveralls.io/github/zulip/zulip?branch=master) [![docs](https://readthedocs.org/projects/zulip/badge/?version=latest)](http://zulip.readthedocs.io/en/latest/) [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org) [![Twitter](https://img.shields.io/badge/twitter-@zuliposs-blue.svg?style=flat)](http://twitter.com/zuliposs)
+[![Build Status](https://travis-ci.org/zulip/zulip.svg?branch=master)](https://travis-ci.org/zulip/zulip) [![Coverage Status](https://img.shields.io/codecov/c/github/zulip/zulip.svg)](https://codecov.io/gh/zulip/zulip) [![docs](https://readthedocs.org/projects/zulip/badge/?version=latest)](http://zulip.readthedocs.io/en/latest/) [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org) [![Twitter](https://img.shields.io/badge/twitter-@zuliposs-blue.svg?style=flat)](http://twitter.com/zuliposs)
 
 ## Community
 

--- a/docs/code-reviewing.md
+++ b/docs/code-reviewing.md
@@ -18,8 +18,7 @@ participating in code review.
   commit](https://travis-ci.org/zulip/zulip/builds/144300899), at
   least one of which failed, and go to [one of the failing
   tests](https://travis-ci.org/zulip/zulip/jobs/144300901) to see the
-  error.) Since Coveralls's data on changes isn't always accurate, one
-  should look at the test coverage situation directly.
+  error.)
 
 * *Technical design.* There are a lot of considerations here:
   security, migration paths/backwards compatibility, cost of new

--- a/docs/mypy.md
+++ b/docs/mypy.md
@@ -73,7 +73,7 @@ So `{1: 'a', 2: 'b', 3: 'c'}` will be printed as `{int: str, ...}`.
 Zulip is hoping to reach 100% of the codebase annotated with mypy
 static types, and then enforce that it stays that way.  Our current
 coverage is shown in
-[Coveralls](https://coveralls.io/github/zulip/zulip).
+[Codecov](https://codecov.io/gh/zulip/zulip).
 
 ## Installing mypy
 

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -120,7 +120,7 @@ if args.quick:
 if python_files:
     rc = subprocess.call([mypy_command] + extra_args + python_files)
     if args.linecoverage_report:
-        # Move the coverage report to where coveralls will look for it.
+        # Move the coverage report to where codecov will look for it.
         try:
             os.rename('var/linecoverage-report/coverage.txt', 'var/.coverage')
         except OSError:


### PR DESCRIPTION
Followup to #5458; updates repository information with Codecov coverage info (instead of Coveralls)