### PR TITLE
travis: Update .travis.yml to accompany new Travis Trusty images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # See https://zulip.readthedocs.io/en/latest/events-system.html for
 # high-level documentation on our Travis CI setup.
 dist: trusty
+group: edge
 before_install:
   - sudo apt-get install moreutils # To use 'ts' and 'mispipe' for timing logs.
 install:


### PR DESCRIPTION
See https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2 for more info.

This PR should be merged ASAP (given that tests pasts), before Wednesday, June 21st 2017 14:30 UTC.