### PR TITLE
Fix bugs when exiting message popover menus.

### DIFF
--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -107,7 +107,6 @@ function generate_emoji_picker_content(id) {
 exports.toggle_emoji_popover = function (element, id) {
     var last_popover_elem = current_message_emoji_popover_elem;
     popovers.hide_all();
-    $(element).closest('.message_row').toggleClass('has_popover has_emoji_popover');
     if (last_popover_elem !== undefined
         && last_popover_elem.get()[0] === element) {
         // We want it to be the case that a user can dismiss a popover
@@ -115,6 +114,7 @@ exports.toggle_emoji_popover = function (element, id) {
         return;
     }
 
+    $(element).closest('.message_row').toggleClass('has_popover has_emoji_popover');
     var elt = $(element);
     if (id !== undefined) {
         current_msg_list.select_id(id);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -125,7 +125,6 @@ function show_message_info_popover(element, id) {
 exports.toggle_actions_popover = function (element, id) {
     var last_popover_elem = current_actions_popover_elem;
     popovers.hide_all();
-    $(element).closest('.message_row').toggleClass('has_popover has_actions_popover');
     if (last_popover_elem !== undefined
         && last_popover_elem.get()[0] === element) {
         // We want it to be the case that a user can dismiss a popover
@@ -133,6 +132,7 @@ exports.toggle_actions_popover = function (element, id) {
         return;
     }
 
+    $(element).closest('.message_row').toggleClass('has_popover has_actions_popover');
     current_msg_list.select_id(id);
     var elt = $(element);
     if (elt.data('popover') === undefined) {
@@ -251,6 +251,7 @@ exports.actions_popped = function () {
 
 exports.hide_actions_popover = function () {
     if (popovers.actions_popped()) {
+        $('.has_popover').removeClass('has_popover has_actions_popover');
         current_actions_popover_elem.popover("destroy");
         current_actions_popover_elem = undefined;
     }

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -544,6 +544,12 @@ exports.register_click_handlers = function () {
         row.find(".alert-copied").css("display", "block");
         row.find(".alert-copied").delay(1000).fadeOut(300);
 
+        setTimeout(function () {
+            // The Cliboard library works by focusing to a hidden textarea.
+            // We unfocus this so keyboard shortcuts, etc., will work again.
+            $(":focus").blur();
+        }, 0);
+
         e.stopPropagation();
         e.preventDefault();
     });


### PR DESCRIPTION
This fixes the following bugs with the popover menu icons on a message:

First, when you click on the chevron to activate the message actions popover, and then click on the chevron again, the popover closes, but the chevron is still there, even though it should disappear. (This is #4329)
The same bug applied for the emoji popover, though I don't think we had an issue open for this.

Also, when you clicked on any of the options in the message actions popover, the chevron still persisted until you clicked somewhere else. That was actually caused by a slightly different problem.

Finally, when you clicked on the "copy link to conversation" option, the keyboard shortcuts stopped working (#5374). This happened because the Clipboard library changes focus to some hidden textarea as their strategy for copying text. (the solution I had is to just un-focus this textarea after copying)