### PR TITLE
Fix linter issue and ban usage of `open()` in bots.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -53,7 +53,6 @@ def build_custom_checkers(by_lang):
             for (i, line, line_newline_stripped, line_fully_stripped) in line_tups:
                 if (fn, line_fully_stripped) in exclude_list:
                     continue
-
                 try:
                     line_to_check = line_fully_stripped
                     if rule.get('strip') is not None:
@@ -142,7 +141,7 @@ def build_custom_checkers(by_lang):
                          'static/js/debug.js']),
          'description': 'console.log and similar should not be used in webapp'},
         {'pattern': 'i18n[.]t',
-         'include_only': set(['static/js/portico']),
+         'include_only': set(['static/js/portico/']),
          'description': 'i18n.t is not available in portico pages yet'},
         {'pattern': '[.]text\(["\'][a-zA-Z]',
          'description': 'Strings passed to $().text should be wrapped in i18n.t() for internationalization'},
@@ -215,7 +214,7 @@ def build_custom_checkers(by_lang):
         {'pattern': '.*%s.* % \([a-zA-Z0-9_.]*\)$',
          'description': 'Used % comprehension without a tuple'},
         {'pattern': 'django.utils.translation',
-         'include_only': set(['test']),
+         'include_only': set(['test/']),
          'description': 'Test strings should not be tagged for translationx'},
         {'pattern': 'json_success\({}\)',
          'description': 'Use json_success() to return nothing'},

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -293,7 +293,12 @@ def build_custom_checkers(by_lang):
          'exclude': set(['tools/lib/provision.py',
                          'tools/setup/setup_venvs.py',
                          'scripts/lib/setup_venv.py']),
-         'description': 'Explicit python invocations should not include a version'}
+         'description': 'Explicit python invocations should not include a version'},
+        {'pattern': '(^|\s)open\s*\(',
+         'description': 'open() should not be used in Zulip\'s bots. Use functions'
+                        ' provided by the bots framework to access the filesystem.',
+         'include_only': set(['api/bots/']),
+         'exclude': set(['api/bots/john/john.py'])},
     ]) + whitespace_rules
     bash_rules = [
         {'pattern': '#!.*sh [-xe]',


### PR DESCRIPTION
This addresses #5395.