### PR TITLE
bookend: Hide re-subscribe button for private streams.

### DIFF
--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -294,9 +294,10 @@ var MessageList = require('js/message_list').MessageList;
         global.with_stub(function (stub) {
             list.view.render_trailing_bookend = stub.f;
             list.update_trailing_bookend();
-            var bookend = stub.get_args('content', 'subscribed');
+            var bookend = stub.get_args('content', 'subscribed', 'show_button');
             assert.equal(bookend.content, expected);
             assert.equal(bookend.subscribed, true);
+            assert.equal(bookend.show_button, true);
         });
 
         expected = "You unsubscribed from stream IceCream";
@@ -305,12 +306,36 @@ var MessageList = require('js/message_list').MessageList;
             return false;
         });
 
+        override("stream_data.get_sub", function () {
+            return {invite_only: false};
+        });
+
         global.with_stub(function (stub) {
             list.view.render_trailing_bookend = stub.f;
             list.update_trailing_bookend();
-            var bookend = stub.get_args('content', 'subscribed');
+            var bookend = stub.get_args('content', 'subscribed', 'show_button');
             assert.equal(bookend.content, expected);
             assert.equal(bookend.subscribed, false);
+            assert.equal(bookend.show_button, true);
+        });
+
+        // Test when the stream is privates (invite only)
+        expected = "You unsubscribed from stream IceCream";
+        override("stream_data.is_subscribed", function () {
+            return false;
+        });
+
+        override("stream_data.get_sub", function () {
+            return {invite_only: true};
+        });
+
+        global.with_stub(function (stub) {
+            list.view.render_trailing_bookend = stub.f;
+            list.update_trailing_bookend();
+            var bookend = stub.get_args('content', 'subscribed', 'show_button');
+            assert.equal(bookend.content, expected);
+            assert.equal(bookend.subscribed, false);
+            assert.equal(bookend.show_button, false);
         });
 
         expected = "You are not subscribed to stream IceCream";
@@ -319,9 +344,10 @@ var MessageList = require('js/message_list').MessageList;
         global.with_stub(function (stub) {
             list.view.render_trailing_bookend = stub.f;
             list.update_trailing_bookend();
-            var bookend = stub.get_args('content', 'subscribed');
+            var bookend = stub.get_args('content', 'subscribed', 'show_button');
             assert.equal(bookend.content, expected);
             assert.equal(bookend.subscribed, false);
+            assert.equal(bookend.show_button, true);
         });
     });
 }());

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -384,18 +384,22 @@ exports.MessageList.prototype = {
             return;
         }
         var trailing_bookend_content;
+        var show_button = true;
         var subscribed = stream_data.is_subscribed(stream);
         if (subscribed) {
             trailing_bookend_content = this.subscribed_bookend_content(stream);
         } else {
             if (!this.last_message_historical) {
                 trailing_bookend_content = this.unsubscribed_bookend_content(stream);
+
+                // For invite only streams, hide the resubscribe button
+                show_button = !stream_data.get_sub(stream).invite_only;
             } else {
                 trailing_bookend_content = this.not_subscribed_bookend_content(stream);
             }
         }
         if (trailing_bookend_content !== undefined) {
-            this.view.render_trailing_bookend(trailing_bookend_content, subscribed);
+            this.view.render_trailing_bookend(trailing_bookend_content, subscribed, show_button);
         }
     },
 

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -934,10 +934,10 @@ MessageListView.prototype = {
     },
 
     render_trailing_bookend: function MessageListView_render_trailing_bookend(
-                                trailing_bookend_content, subscribed) {
+                                trailing_bookend_content, subscribed, show_button) {
         var rendered_trailing_bookend = $(templates.render('bookend', {
             bookend_content: trailing_bookend_content,
-            trailing: true,
+            trailing: show_button,
             subscribed: subscribed,
         }));
         rows.get_table(this.table_name).append(rendered_trailing_bookend);


### PR DESCRIPTION
As mentioned in #5181, when you unsubscribe from a private stream, in the narrow there's still the button to subscribe back to the stream. However, this just throws error 400s, since you have to be re-invited.

This commit removes that button for private streams and adds some tests.