### PR TITLE
people.js: Ignore diacritics in search bar.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -213,11 +213,23 @@ initialize();
         user_id: 304,
         full_name: 'Linus Torvalds',
     };
+    var noah = {
+        email: 'emnoa@example.com',
+        user_id: 305,
+        full_name: 'Nöôáàh Ëmerson',
+    };
+    var plain_noah = {
+        email: 'otheremnoa@example.com',
+        user_id: 306,
+        full_name: 'Nooaah Emerson',
+    };
 
     people.add_in_realm(charles);
     people.add_in_realm(maria);
     people.add_in_realm(ashton);
     people.add_in_realm(linus);
+    people.add_in_realm(noah);
+    people.add_in_realm(plain_noah);
 
     var search_term = 'a';
     var users = people.get_rest_of_realm();
@@ -238,6 +250,18 @@ initialize();
     assert.equal(filtered_people.num_items(), 2);
     assert(filtered_people.has(charles.user_id));
     assert(filtered_people.has(maria.user_id));
+
+    // Test filtering of names with diacritics
+    // This should match Nöôáàh by ignoring diacritics, and also match Nooaah
+    filtered_people = people.filter_people_by_search_terms(users, ['noOa']);
+    assert.equal(filtered_people.num_items(), 2);
+    assert(filtered_people.has(noah.user_id));
+    assert(filtered_people.has(plain_noah.user_id));
+
+    // This should match ëmerson, but not emerson
+    filtered_people = people.filter_people_by_search_terms(users, ['ëm']);
+    assert.equal(filtered_people.num_items(), 1);
+    assert(filtered_people.has(noah.user_id));
 
     // Test filtering with undefined user
     var foo = {
@@ -609,4 +633,3 @@ initialize();
     assert.equal(global.page_params.realm_users, undefined);
     assert.equal(global.page_params.cross_realm_bots, undefined);
 }());
-

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -505,6 +505,23 @@ exports.incr_recipient_count = function (user_id) {
     pm_recipient_count_dict.set(user_id, old_count + 1);
 };
 
+// Diacritic removal from:
+// https://stackoverflow.com/questions/18236208/perform-a-find-match-with-javascript-ignoring-special-language-characters-acce
+function remove_diacritics(s) {
+    if (/^[a-z]+$/.test(s)) {
+        return s;
+    }
+
+    return s
+            .replace(/[áàãâä]/g,"a")
+            .replace(/[éèëê]/g,"e")
+            .replace(/[íìïî]/g,"i")
+            .replace(/[óòöôõ]/g,"o")
+            .replace(/[úùüû]/g, "u")
+            .replace(/[ç]/g, "c")
+            .replace(/[ñ]/g, "n");
+}
+
 exports.filter_people_by_search_terms = function (users, search_terms) {
         var filtered_users = new Dict();
 
@@ -519,7 +536,12 @@ exports.filter_people_by_search_terms = function (users, search_terms) {
                     return true;
                 }
                 return _.all(termlets, function (termlet) {
+                    var is_ascii = /^[a-z]+$/.test(termlet);
                     return _.any(names, function (name) {
+                        if (is_ascii) {
+                            // Only ignore diacritics if the query is plain ascii
+                            name = remove_diacritics(name);
+                        }
                         if (name.indexOf(termlet) === 0) {
                             return true;
                         }


### PR DESCRIPTION
Fixes #5315

When searching for users, we replace all characters with diacritics with the base ASCII character. This is not exhaustive enough to cover all cases, but is a simple solution that probably covers most situations. But there's a lot of string replacements (could look into a faster method if desirable), so I'm hoping we don't lose performance.

This is done so that searching "zulip" will match both "zulip, zùlip", but searching "zùlip" will only match "zùlip"
