### PR TITLE
css: Replace all RGB colors with HSL colors

### DIFF
--- a/static/styles/activity.css
+++ b/static/styles/activity.css
@@ -9,19 +9,19 @@
 }
 
 .table-striped tr.recently_active td {
-    background-color: #afa;
+    background-color: hsl(120, 97%, 83%);
 }
 
 .table-striped tr.recently_active:nth-child(odd) td {
-    background-color: #9e9;
+    background-color: hsl(120, 70%, 76%);
 }
 
 .table-striped tr.long_inactive td {
-    background-color: #faa;
+    background-color: hsl(0, 97%, 83%);
 }
 
 .table-striped tr.long_inactive:nth-child(odd) td {
-    background-color: #e99;
+    background-color: hsl(0, 70%, 76%);
 }
 
 td.number {
@@ -41,10 +41,10 @@ tr.admin td:first-child {
 
 .good {
     font-weight: bold;
-    color: #0a0;
+    color: hsl(120, 100%, 33%);
 }
 
 .bad {
     font-weight: bold;
-    color: #c00;
+    color: hsl(0, 100%, 39%);
 }

--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -29,7 +29,7 @@
 }
 
 .box-shadow {
-    box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
+    box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);
 }
 
 .bg-white {
@@ -56,7 +56,7 @@
     background-color: #fff;
     color: inherit;
     outline: none;
-    border: 1px solid #CCC;
+    border: 1px solid hsl(0, 0%, 80%);
     border-radius: 2px;
 
     box-shadow: none;
@@ -81,11 +81,11 @@
 }
 
 .new-style .button.green {
-    background-color: #64ad89;
+    background-color: hsl(150, 31%, 53%);
 }
 
 .new-style .button.grey {
-    background-color: #aaa;
+    background-color: hsl(0, 0%, 66%);
 }
 
 .new-style .button.standalone {
@@ -104,59 +104,59 @@
 }
 
 .new-style .button.sea-green {
-    color: #5bb792;
-    border-color: #addcc9;
+    color: hsl(156, 39%, 54%);
+    border-color: hsl(156, 39%, 77%);
 }
 
 .new-style .button.btn-warning {
-    color: #de9b40;
-    border-color: #ffdfb1;
+    color: hsl(35, 70%, 56%);
+    border-color: hsl(35, 98%, 84%);
 }
 
 .new-style .button.btn-danger {
-    color: #e6898d;
-    border-color: #ecbdba;
+    color: hsl(357, 64%, 72%);
+    border-color: hsl(4, 56%, 82%);
 }
 
 /* -- button states -- */
 .new-style .button:hover {
-    border-color: #999;
+    border-color: hsl(0, 0%, 60%);
 }
 
 .new-style .button:active {
-    border-color: #999;
+    border-color: hsl(0, 0%, 60%);
     color: inherit;
-    background-color: #f4f4f4;
+    background-color: hsl(0, 0%, 95%);
 }
 
 .new-style .button.sea-green:hover {
-    border-color: #6ab094;
+    border-color: hsl(156, 30%, 55%);
 }
 
 .new-style .button.sea-green:active {
-    border-color: #6ab094;
-    color: #3e9f78;
-    background-color: #f2f9f6;
+    border-color: hsl(156, 30%, 55%);
+    color: hsl(156, 44%, 43%);
+    background-color: hsl(154, 33%, 96%);
 }
 
 .new-style .button.btn-danger:hover {
-    border-color: #d48d8a;
+    border-color: hsl(2, 46%, 68%);
 }
 
 .new-style .button.btn-danger:active {
-    color: #d56d72;
-    border-color: #d48d8a;
-    background-color: #fff7f6;
+    color: hsl(357, 55%, 63%);
+    border-color: hsl(2, 46%, 68%);
+    background-color: hsl(7, 82%, 98%);
 }
 
 .new-style .button.btn-warning:hover {
-    border-color: #debb8a;
+    border-color: hsl(35, 55%, 70%);
 }
 
 .new-style .button.btn-warning:active {
-    color: #bb7613;
-    border-color: #debb8a;
-    background-color: #faf5ef;
+    color: hsl(35, 82%, 40%);
+    border-color: hsl(35, 55%, 70%);
+    background-color: hsl(33, 48%, 96%);
 }
 
 
@@ -164,14 +164,14 @@
     cursor: not-allowed;
     -moz-filter: saturate(0);
     filter: saturate(0);
-    background-color: #eee;
-    color: #888181;
+    background-color: hsl(0, 0%, 93%);
+    color: hsl(0, 3%, 52%);
 }
 
 .new-style .button[disabled="disabled"]:hover {
-    background-color: #eee;
-    color: #5bb792;
-    border-color: #addcc9;
+    background-color: hsl(0, 0%, 93%);
+    color: hsl(156, 39%, 54%);
+    border-color: hsl(156, 39%, 77%);
 }
 
 /* -- tab switcher -- */
@@ -214,7 +214,7 @@
 }
 
 .new-style .tab-switcher .ind-tab:not(.selected) {
-    border: 1px solid #ccc;
+    border: 1px solid hsl(0, 0%, 80%);
 }
 
 .new-style .tab-switcher .ind-tab.first {
@@ -232,16 +232,16 @@
 
 .new-style .tab-switcher .ind-tab.selected {
     position: relative;
-    background: #888;
+    background: hsl(0, 0%, 53%);
     color: #fff;
-    border: 1px solid #777;
+    border: 1px solid hsl(0, 0%, 46%);
     z-index: 2;
 }
 
 .new-style .tab-switcher .ind-tab.disabled {
     pointer-events: none;
-    color: #CCC;
-    border-color: #DDD;
+    color: hsl(0, 0%, 80%);
+    border-color: hsl(0, 0%, 86%);
 }
 
 .new-style label.checkbox {
@@ -269,8 +269,8 @@
     line-height: 0.8;
     font-size: 1.3rem;
     text-align: center;
-    border: 2px solid #ccc;
-    color: #ccc;
+    border: 2px solid hsl(0, 0%, 80%);
+    color: hsl(0, 0%, 80%);
 
     border-radius: 4px;
     -webkit-filter: grayscale(1) brightness(0.7);
@@ -310,7 +310,7 @@
     overflow: auto;
     -webkit-overflow-scrolling: touch;
 
-    background-color: rgba(32,32,32,0.8);
+    background-color: hsla(0, 0%, 13%, 0.8);
     z-index: 105;
 
     pointer-events: none;
@@ -349,7 +349,7 @@
 }
 
 .clear_search_button:hover {
-    color: #000;
+    color: hsl(0, 0%, 0%);
 }
 
 .clear_search_button[disabled] {
@@ -367,7 +367,7 @@
     text-align: center;
     padding-top: 8px;
     padding-left: 4px;
-    color: #ccc;
+    color: hsl(0, 0%, 80%);
     text-shadow: none;
     outline: none !important;
     box-shadow: none;

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -1,6 +1,6 @@
 .compose-content {
     background-color: #fff;
-    border-top: 1px solid #eee;
+    border-top: 1px solid hsl(0, 0%, 93%);
     -webkit-transition: background-color 200ms linear;
     -moz-transition: background-color 200ms linear;
     -o-transition: background-color 200ms linear;
@@ -55,7 +55,7 @@
 }
 
 .compose_table .message_header_colorblock.message_header_private_message {
-    background: #444;
+    background: hsl(0, 0%, 27%);
 }
 
 .compose_table .right_part {
@@ -84,7 +84,7 @@
     padding-top: 0px;
     padding-bottom: 0px;
     width: 4em;
-    background: #444444;
+    background: hsl(0, 0%, 27%);
     color: #ffffff;
 }
 
@@ -115,7 +115,7 @@
 
 .compose_table .message_header {
     background: none;
-    background-color: #ececec;
+    background-color: hsl(0, 0%, 92%);
     border: none;
     border-radius: 0px;
     box-shadow: none !important;
@@ -181,8 +181,8 @@ table.compose_table {
     margin-right: 250px;
     position: relative;
 
-    border-left: 1px solid #eee;
-    border-right: 1px solid #eee;
+    border-left: 1px solid hsl(0, 0%, 93%);
+    border-right: 1px solid hsl(0, 0%, 93%);
 }
 
 #compose_close {
@@ -249,8 +249,8 @@ table.compose_table {
 }
 
 #out-of-view-notification {
-    background: #9bff8b;
-    background: rgba(163,211,147,0.95);
+    background: hsl(112, 98%, 77%);
+    background: hsla(105, 42%, 70%, 0.95);
     border-bottom: 1px solid #ffffff;
     border-right: 1px solid #ffffff;
     border-left: 1px solid #ffffff;
@@ -258,7 +258,7 @@ table.compose_table {
     font-weight: 400;
     font-size: 12px;
     display: inline-block;
-    box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.5);
+    box-shadow: 0px 0px 1px 0px hsla(0, 0%, 0%, 0.5);
     position: relative;
     top: -8px;
     width: 100%;
@@ -300,7 +300,7 @@ textarea.new_message_textarea {
 textarea.new_message_textarea,
 #subject.recipient_box,
 #stream.recipient_box {
-    border: 1px solid #ddd;
+    border: 1px solid hsl(0, 0%, 86%);
     box-shadow: none;
     -webkit-box-shadow: none;
     transition: border 0.2s ease;
@@ -309,7 +309,7 @@ textarea.new_message_textarea,
 textarea.new_message_textarea:focus,
 #subject.recipient_box:focus,
 #stream.recipient_box:focus {
-    border: 1px solid #AAA;
+    border: 1px solid hsl(0, 0%, 66%);
 }
 
 #stream.recipient_box:focus {
@@ -353,7 +353,7 @@ input.recipient_box {
 }
 
 #send_controls .compose_checkbox_label {
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     margin-right: 2px;
 }
 
@@ -368,13 +368,13 @@ input.recipient_box {
     padding-bottom: 2px;
     margin-right: 7px;
     font-weight: 600;
-    border: 1px solid #21af97;
-    background-color: #52c2af;
+    border: 1px solid hsl(170, 68%, 41%);
+    background-color: hsl(170, 47%, 54%);
     color: #fff;
 }
 
 #compose-send-button:focus {
-    box-shadow: 0px 0px 10px #52c2af, 0px 0px 5px #52c2af;
+    box-shadow: 0px 0px 10px hsl(170, 47%, 54%), 0px 0px 5px hsl(170, 47%, 54%);
 }
 
 #stream-message,
@@ -401,7 +401,7 @@ input.recipient_box {
 
 #compose a.message-control-button {
     display: block;
-    color: #777;
+    color: hsl(0, 0%, 46%);
     text-decoration: none;
     font-size: 14px;
     width: 14px;
@@ -413,7 +413,7 @@ input.recipient_box {
 }
 
 #compose a.message-control-button:hover {
-    color: #000;
+    color: hsl(0, 0%, 0%);
 }
 
 .drag {
@@ -446,9 +446,9 @@ input.recipient_box {
 
     margin-top: 5px;
 
-    border: 1px solid #aaa;
+    border: 1px solid hsl(0, 0%, 66%);
     border-radius: 4px;
-    background-color: #fafafa;
+    background-color: hsl(0, 0%, 98%);
     cursor: not-allowed;
 }
 
@@ -457,7 +457,7 @@ a#undo_markdown_preview {
     text-decoration: none;
     position: relative;
     font-size: 16px;
-    color: #777;
+    color: hsl(0, 0%, 46%);
 }
 
 #markdown_preview_spinner {

--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -18,7 +18,7 @@
     padding-top: 4px;
     text-align: center;
     text-transform: uppercase;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 .drafts-header h1 {
@@ -31,7 +31,7 @@
     position: absolute;
     top: 10px;
     right: 10px;
-    color: #AAA;
+    color: hsl(0, 0%, 66%);
     cursor: pointer;
 }
 
@@ -56,7 +56,7 @@
     margin-top: calc(45vh - 30px - 1.5em);
     text-align: center;
     font-size: 1.5em;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
 }
@@ -66,7 +66,7 @@
 }
 
 .draft-row.active {
-    background-color: #eee;
+    background-color: hsl(0, 0%, 93%);
 }
 
 .draft-row > div {
@@ -76,9 +76,9 @@
 
 .draft-row .draft-info-box {
     width: 100%;
-    background: #f1f1f1;
-    border-bottom: 1px solid #e2e2e2;
-    border-top: 1px solid #e2e2e2;
+    background: hsl(0, 0%, 94%);
+    border-bottom: 1px solid hsl(0, 0%, 88%);
+    border-top: 1px solid hsl(0, 0%, 88%);
     margin-bottom: 10px;
 }
 
@@ -104,7 +104,7 @@
 .draft_controls .restore-draft {
     cursor: pointer;
     margin-right: 5px;
-    color: #52c2af;
+    color: hsl(170, 47%, 54%);
     opacity: 0.7;
 }
 
@@ -115,7 +115,7 @@
 .draft_controls .delete-draft {
     cursor: pointer;
     margin-left: 5px;
-    color: #cc5a60;
+    color: hsl(357, 52%, 57%);
     opacity: 0.7;
 }
 

--- a/static/styles/informational-overlays.css
+++ b/static/styles/informational-overlays.css
@@ -13,7 +13,7 @@
 
 .informational-overlays .overlay-tabs {
     padding: 10px 0px;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid hsl(0, 0%, 93%);
 }
 
 .informational-overlays .overlay-tabs .tab-switcher {
@@ -23,7 +23,7 @@
 .informational-overlays .overlay-tabs .exit {
     float: right;
     font-size: 1.5rem;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     font-weight: 600;
     margin: 1px 15px;
 }

--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -7,19 +7,19 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;
-    background-color: #eaeaea;
-    color: #444;
+    background-color: hsl(0, 0%, 91%);
+    color: hsl(0, 0%, 27%);
     line-height: normal;
 
     max-width: 100vw;
 }
 
 *::-moz-selection {
-    background-color: rgba(240, 155, 66, 0.3);
+    background-color: hsla(31, 84%, 60%, 0.3);
 }
 
 *::selection {
-    background-color: rgba(240, 155, 66, 0.3);
+    background-color: hsla(31, 84%, 60%, 0.3);
 }
 
 .center {
@@ -33,23 +33,23 @@ button {
     font-family: inherit;
     font-size: 0.7em;
     background-color: #fff;
-    color: #444;
+    color: hsl(0, 0%, 27%);
 
     border-radius: 4px;
-    border: 1px solid #ccc;
+    border: 1px solid hsl(0, 0%, 80%);
     outline: none;
 }
 
 button:active {
-    background-color: #fafafa;
-    border: 1px solid #bbb;
+    background-color: hsl(0, 0%, 98%);
+    border: 1px solid hsl(0, 0%, 73%);
 }
 
 button.green {
     color: #fff;
-    background-color: #4fc0ad;
+    background-color: hsl(170, 47%, 53%);
 
-    border: 1px solid #3ca08d;
+    border: 1px solid hsl(169, 45%, 43%);
 }
 
 button.button.grey-transparent {
@@ -68,12 +68,12 @@ button.button.grey-transparent {
 }
 
 button.button.grey-transparent:hover {
-    background-color: rgba(255,255,255,0.2);
+    background-color: hsla(0, 0%, 100%, 0.2);
 }
 
 button.button.grey-transparent:active {
     background-color: #fff;
-    color: #666;
+    color: hsl(0, 0%, 40%);
 }
 
 /* -- navbar styling -- */
@@ -81,9 +81,9 @@ button.button.grey-transparent:active {
 nav {
     position: relative;
 
-    background-color: #348576;
-    background: -webkit-linear-gradient(to bottom, black , #68d2c0);
-    background: linear-gradient(-145deg, #2e6f63 , #68d2c0);
+    background-color: hsl(169, 44%, 36%);
+    background: -webkit-linear-gradient(to bottom, black, hsl(170, 54%, 61%));
+    background: linear-gradient(-145deg, hsl(169, 41%, 31%), hsl(170, 54%, 61%));
     padding: 50px 100px 130px 100px;
 
     color: #fff;
@@ -120,19 +120,19 @@ nav .faded-light {
 nav .stripes {
     background: repeating-linear-gradient(
       75deg,
-      rgba(255,255,255,0) 0px,
-      rgba(255,255,255,0.05) 200px
+      hsla(0, 0%, 100%, 0.0) 0px,
+      hsla(0, 0%, 100%, 0.05) 200px
     );
 }
 
 nav .faded {
-    background: -webkit-linear-gradient(top bottom, transparent , rgba(0,0,0,0.1));
-    background: linear-gradient(0deg, transparent , rgba(0,0,0,0.1));
+    background: -webkit-linear-gradient(top bottom, transparent , hsla(0, 0%, 0%, 0.1));
+    background: linear-gradient(0deg, transparent , hsla(0, 0%, 0%, 0.1));
 }
 
 nav .faded-light {
-    background: -webkit-linear-gradient(top top, transparent , rgba(104, 210, 192, 0.8));
-    background: linear-gradient(180deg, transparent , rgba(104, 210, 192, 0.8));
+    background: -webkit-linear-gradient(top top, transparent , hsla(170, 54%, 61%, 0.8));
+    background: linear-gradient(180deg, transparent , hsla(170, 54%, 61%, 0.8));
 }
 
 nav .logo {
@@ -204,7 +204,7 @@ nav ul li.active::after {
 }
 
 nav.dark-blue {
-    background: rgb(32, 39, 51);
+    background: hsl(218, 23%, 16%);
 }
 
 /* -- main panel styling -- */
@@ -251,7 +251,7 @@ p {
 a,
 a:hover,
 a:visited {
-    color: #4fc0ad;
+    color: hsl(170, 47%, 53%);
 }
 
 a.no-style:hover {
@@ -301,7 +301,7 @@ a:not(.no-style):before {
     height: 1px;
     width: 0%;
 
-    background-color: #4fc0ad;
+    background-color: hsl(170, 47%, 53%);
     transition: all 0.5s ease;
 }
 
@@ -334,15 +334,15 @@ a:not(.no-style):hover:before {
 }
 
 .box-shadow {
-    box-shadow: 0px 0px 80px rgba(0,0,0,0.12);
+    box-shadow: 0px 0px 80px hsla(0, 0%, 0%, 0.12);
 }
 
 .grey {
-    color: #999;
+    color: hsl(0, 0%, 60%);
 }
 
 .dark-grey {
-    color: #666;
+    color: hsl(0, 0%, 40%);
 }
 
 .bold {
@@ -401,7 +401,7 @@ a:not(.no-style):hover:before {
 }
 
 .feature-block i:before {
-    background: -webkit-linear-gradient(65deg, #2e6f63, #68d2c0);
+    background: -webkit-linear-gradient(65deg, hsl(169, 41%, 31%), hsl(170, 54%, 61%));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 }
@@ -410,7 +410,7 @@ a:not(.no-style):hover:before {
     font-size: 1em;
     font-weight: 400;
     text-transform: uppercase;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     margin-left: 15px;
 }
 
@@ -423,15 +423,15 @@ a:not(.no-style):hover:before {
 /* -- hello page -- */
 .portico-landing.hello {
     background-color: #fff;
-    color: #414e67;
+    color: hsl(219, 23%, 33%);
 }
 
 .portico-landing.hello .hero {
     position: relative;
     padding: 100px 50px 320px 50px;
 
-    background-color: #262d3a;
-    color: #bac0cc;
+    background-color: hsl(219, 21%, 19%);
+    color: hsl(220, 15%, 76%);
 
     overflow: hidden;
 }
@@ -467,18 +467,18 @@ a:not(.no-style):hover:before {
 }
 
 .portico-landing.hello .hero .waves .wave.dark-blue {
-    background-color: #141d2e;
+    background-color: hsl(219, 39%, 13%);
 }
 
 .portico-landing.hello .hero .waves .wave.light-blue {
-    background-color: rgba(220, 71, 71, 0.9);
+    background-color: hsla(0, 67%, 57%, 0.9);
 
     animation-duration: 18s;
 
 }
 
 .portico-landing.hello .hero .waves .wave.light-green {
-    background-color: rgba(129, 241, 255, 0.75);
+    background-color: hsla(187, 98%, 75%, 0.75);
 
     animation-name: wavesBackward;
     animation-duration: 21s;
@@ -535,28 +535,28 @@ a:not(.no-style):hover:before {
 .portico-landing.hello .hero header button {
     padding: 8px 15px;
 
-    background-color: #52c2af;
+    background-color: hsl(170, 47%, 54%);
     border: none;
 
     font-size: 1em;
     font-weight: 600;
     color: #fff;
 
-    box-shadow: 0px 1px 2px rgba(0,0,0,0.2);
+    box-shadow: 0px 1px 2px hsla(0, 0%, 0%, 0.2);
 
     transition: all 0.2s ease;
 }
 
 .portico-landing.hello .hero header button:hover {
-    background-color: #3fcdb6;
+    background-color: hsl(170, 58%, 52%);
 
-    box-shadow: 0px 2px 5px rgba(0,0,0,0.18);
+    box-shadow: 0px 2px 5px hsla(0, 0%, 0%, 0.18);
 }
 
 .portico-landing.hello .hero header button:active {
-    background-color: #44a796;
+    background-color: hsl(170, 42%, 46%);
 
-    box-shadow: 0px 1px 1px rgba(0,0,0,0.18);
+    box-shadow: 0px 1px 1px hsla(0, 0%, 0%, 0.18);
 }
 
 .portico-landing.hello .hero header .download-button {
@@ -594,7 +594,7 @@ a:not(.no-style):hover:before {
 
 /* -- compare css -- */
 .compare {
-    background-color: #3e6157;
+    background-color: hsl(163, 22%, 31%);
     color: #fff;
 }
 
@@ -614,7 +614,7 @@ a:not(.no-style):hover:before {
 
     font-weight: 400;
 
-    color: rgba(255,255,255,0.8);
+    color: hsla(0, 0%, 100%, 0.8);
 }
 
 .compare table thead th:last-of-type {
@@ -631,7 +631,7 @@ a:not(.no-style):hover:before {
 }
 
 .compare thead {
-    border-bottom: 5px solid rgba(0,0,0,0.1);
+    border-bottom: 5px solid hsla(0, 0%, 0%, 0.1);
 }
 
 .compare thead th {
@@ -647,7 +647,7 @@ a:not(.no-style):hover:before {
 }
 
 .compare tbody tr {
-    border-bottom: 1px solid rgb(56, 88, 79);
+    border-bottom: 1px solid hsl(163, 22%, 28%);
 }
 
 .compare tbody tr td {
@@ -698,7 +698,7 @@ a:not(.no-style):hover:before {
 
     line-height: 1.2;
 
-    color: rgba(255,255,255,0.8);
+    color: hsla(0, 0%, 100%, 0.8);
 }
 
 .screen .line {
@@ -706,7 +706,7 @@ a:not(.no-style):hover:before {
     height: 6px;
     margin: 8px 0px;
 
-    background-color: #eee;
+    background-color: hsl(0, 0%, 93%);
     border-radius: 3px;
 }
 
@@ -722,7 +722,7 @@ a:not(.no-style):hover:before {
 }
 
 .screen .line.darker {
-    background-color: #bbb;
+    background-color: hsl(0, 0%, 73%);
 }
 
 .screen .line.nano {
@@ -745,19 +745,19 @@ a:not(.no-style):hover:before {
 }
 
 .screen .line.red {
-    background-color: rgb(222, 172, 180);
+    background-color: hsl(350, 42%, 77%);
 }
 
 .screen .line.blue {
-    background-color: rgb(172, 211, 222);
+    background-color: hsl(193, 42%, 77%);
 }
 
 .screen .line.green {
-    background-color: rgb(173, 222, 172);
+    background-color: hsl(119, 42%, 77%);
 }
 
 .screen .line.orange {
-    background-color: rgb(222, 197, 172);
+    background-color: hsl(30, 42%, 77%);
 }
 
 .screen .top .avatar {
@@ -766,7 +766,7 @@ a:not(.no-style):hover:before {
 
     width: 20px;
     height: 20px;
-    background-color: #bbb;
+    background-color: hsl(0, 0%, 73%);
     border-radius: 4px;
 }
 
@@ -777,11 +777,11 @@ a:not(.no-style):hover:before {
     width: 50px;
     margin-top: 0px;
 
-    background-color: #bbb;
+    background-color: hsl(0, 0%, 73%);
 }
 
 .screen .navbar {
-    background-color: #52c2af;
+    background-color: hsl(170, 47%, 54%);
     padding: 10px;
 }
 
@@ -812,7 +812,7 @@ a:not(.no-style):hover:before {
     background-color: #fff;
     border-radius: 4px;
 
-    box-shadow: 0px 0px 15px rgba(0,0,0,0.01);
+    box-shadow: 0px 0px 15px hsla(0, 0%, 0%, 0.01);
 }
 
 .portico-landing.hello .screen.hero-screen {
@@ -836,7 +836,7 @@ a:not(.no-style):hover:before {
     transform: translateY(-12px) translateX(3px);
     -webkit-transform: translateY(-12px) translateX(3px);
     -moz-transform: translateY(-12px) translateX(3px);
-    border: 5px solid #000;
+    border: 5px solid hsl(0, 0%, 0%);
 }
 
 .portico-landing.hello .screen {
@@ -844,15 +844,15 @@ a:not(.no-style):hover:before {
     margin: -300px auto 0px auto;
 
     width: 600px;
-    background-color: #fafafa;
+    background-color: hsl(0, 0%, 98%);
     height: 350px;
 
     padding: 10px 30px 10px 30px;
 
     border-radius: 12px;
-    box-shadow: 0px 0px 50px rgba(0,0,0,0.2);
+    box-shadow: 0px 0px 50px hsla(0, 0%, 0%, 0.2);
 
-    background-color: #444;
+    background-color: hsl(0, 0%, 27%);
 
     z-index: 1;
 }
@@ -867,7 +867,7 @@ a:not(.no-style):hover:before {
     height: 10px;
 
     border-radius: 5px;
-    background-color: #222;
+    background-color: hsl(0, 0%, 13%);
 }
 
 .portico-landing.hello .screen::after {
@@ -880,7 +880,7 @@ a:not(.no-style):hover:before {
     height: 25px;
 
     border-radius: 13px;
-    background-color: #bbb;
+    background-color: hsl(0, 0%, 73%);
 }
 
 .portico-landing.hello .screen .main-page {
@@ -890,10 +890,10 @@ a:not(.no-style):hover:before {
     width: calc(100% - 30px);
     margin: 10px;
 
-    border: 5px solid #222;
+    border: 5px solid hsl(0, 0%, 13%);
     border-radius: 4px;
 
-    background-color: #fafafa;
+    background-color: hsl(0, 0%, 98%);
 }
 
 .portico-landing.hello .features {
@@ -917,8 +917,8 @@ a:not(.no-style):hover:before {
 }
 
 .portico-landing.hello .testimonials {
-    color: #bac0cc;
-    background-color: #262d3a;
+    color: hsl(220, 15%, 76%);
+    background-color: hsl(219, 21%, 19%);
 }
 
 .portico-landing.hello .testimonials .text-header .text-content {
@@ -953,7 +953,7 @@ a:not(.no-style):hover:before {
     margin-top: 5px;
     margin-bottom: 30px;
 
-    color: #797f8c;
+    color: hsl(221, 8%, 51%);
     font-weight: 400;
 }
 
@@ -971,7 +971,7 @@ a:not(.no-style):hover:before {
     width: 60%;
     margin: 0 auto;
     border: none;
-    border-bottom: 1px solid #555;
+    border-bottom: 1px solid hsl(0, 0%, 33%);
 }
 
 .portico-landing.hello .testimonials .company-container {
@@ -1001,7 +1001,7 @@ a:not(.no-style):hover:before {
     height: 60px;
     width: calc(20% - 44px);
 
-    background-color: #aaa;
+    background-color: hsl(0, 0%, 66%);
     background-size: contain;
     background-position: center;
     background-repeat: no-repeat;
@@ -1056,9 +1056,9 @@ a:not(.no-style):hover:before {
 .portico-landing.hello .apps {
     padding: 80px;
 
-    background: #50C9C3;
-    background: -webkit-linear-gradient(145deg, #25b197, #4bb4cc);
-    background: linear-gradient(145deg, #4bb4cc, #25b197);
+    background: hsl(177, 52%, 55%);
+    background: -webkit-linear-gradient(145deg, hsl(169, 65%, 42%), hsl(191, 55%, 54%));
+    background: linear-gradient(145deg, hsl(191, 56%, 55%), hsl(169, 65%, 42%));
 
     color: #fff;
 }
@@ -1147,13 +1147,13 @@ a:not(.no-style):hover:before {
     padding: 0 4px;
     transition: all 0.3s ease;
     margin-top: 10px;
-    color: #414e67;
+    color: hsl(219, 23%, 33%);
 }
 
 .portico-landing.hello .integrations .integration-icons .group:hover {
-    -webkit-box-shadow: 1px 5px 20px 5px rgba(0,0,0,0.08);
-    -moz-box-shadow: 1px 5px 20px 5px rgba(0,0,0,0.08);
-    box-shadow: 1px 5px 20px 5px rgba(0,0,0,0.08);
+    -webkit-box-shadow: 1px 5px 20px 5px hsla(0, 0%, 0%, 0.08);
+    -moz-box-shadow: 1px 5px 20px 5px hsla(0, 0%, 0%, 0.08);
+    box-shadow: 1px 5px 20px 5px hsla(0, 0%, 0%, 0.08);
 }
 
 .portico-landing.hello .integrations .integration-logo {
@@ -1179,7 +1179,7 @@ a:not(.no-style):hover:before {
     padding: 125px 100px 20px 100px;
     margin-top: 0px;
 
-    background-color: rgb(32, 39, 51);
+    background-color: hsl(218, 23%, 16%);
 }
 
 .portico-landing.hello .call-to-action-bottom button {
@@ -1188,9 +1188,9 @@ a:not(.no-style):hover:before {
     padding: 12px 25px 10px 25px;
 
     font-size: 1.2rem;
-    color: #bac0cc;
+    color: hsl(220, 15%, 76%);
 
-    border: 1px solid #bac0cc;
+    border: 1px solid hsl(220, 15%, 76%);
     background: transparent;
 
     transition: all 0.2s ease;
@@ -1199,7 +1199,7 @@ a:not(.no-style):hover:before {
 .portico-landing.hello .call-to-action-bottom button:hover {
     border-color: #fff;
     background: #fff;
-    color: #414e67;
+    color: hsl(219, 23%, 33%);
 }
 
 .portico-landing.hello .call-to-action-bottom h1 {
@@ -1221,7 +1221,7 @@ a:not(.no-style):hover:before {
 }
 
 .footer.hello li a {
-    color: #bac0cc;
+    color: hsl(220, 15%, 76%);
 }
 
 .footer.hello li a:hover {
@@ -1245,7 +1245,7 @@ a:not(.no-style):hover:before {
 .portico-landing.apps .main .headline h3 {
     font-weight: 400;
     font-size: 1em;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 .portico-landing.apps .main ul.sidebar {
@@ -1254,7 +1254,7 @@ a:not(.no-style):hover:before {
     margin: 0 -4px 0 0;
     list-style: none;
     font-weight: 500;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 .portico-landing.apps .main ul.sidebar li {
@@ -1274,7 +1274,7 @@ a:not(.no-style):hover:before {
 }
 
 .portico-landing.apps .main ul.sidebar li.active {
-    color: #444;
+    color: hsl(0, 0%, 27%);
     font-weight: 600;
 
     transform: translateX(-10px);
@@ -1301,7 +1301,7 @@ a:not(.no-style):hover:before {
     vertical-align: top;
     height: 500px;
     width: calc(100% - 155px);
-    background-color: #888;
+    background-color: hsl(0, 0%, 53%);
 }
 
 .portico-landing.apps .main .details-container .details-box {
@@ -1324,80 +1324,80 @@ a:not(.no-style):hover:before {
 }
 
 .portico-landing.apps .main .details-container .details-box[data-name="android"] {
-    color: #ebfaf4;
+    color: hsl(156, 56%, 95%);
 
-    background: -webkit-radial-gradient(top right, ellipse cover, #b7f7bf 0%, #17849c 100%);
-    background: radial-gradient(ellipse farthest corner at 0px 0px, #b7f7bf 0%, #17849c 100%);
+    background: -webkit-radial-gradient(top right, ellipse cover, hsl(128, 78%, 84%) 0%, hsl(191, 74%, 35%) 100%);
+    background: radial-gradient(ellipse farthest corner at 0px 0px, hsl(128, 78%, 84%) 0%, hsl(191, 74%, 35%) 100%);
 }
 
 .portico-landing.apps .main .details-container .details-box[data-name="ios"] {
-    color: #ecf4f9;
+    color: hsl(203, 48%, 95%);
 
-    background: -webkit-radial-gradient(top right, ellipse cover, #ffdfb0 0%, #1381ab 100%);
-    background: radial-gradient(ellipse farthest corner at 0px 0px, #ffdfb0 0%, #1381ab 100%);
+    background: -webkit-radial-gradient(top right, ellipse cover, hsl(36, 98%, 84%) 0%, hsl(197, 80%, 37%) 100%);
+    background: radial-gradient(ellipse farthest corner at 0px 0px, hsl(36, 98%, 84%) 0%, hsl(197, 80%, 37%) 100%);
 }
 
 .portico-landing.apps .main .details-container .details-box[data-name="windows"] {
-    color: #eeeeee;
+    color: hsl(0, 0%, 93%);
 
-    background: -webkit-radial-gradient(top right, ellipse cover, #a7c6ea 0%, #052c67 100%);
-    background: radial-gradient(ellipse farthest corner at 0px 0px, #a7c6ea 0%, #052c67 100%);
+    background: -webkit-radial-gradient(top right, ellipse cover, hsl(212, 60%, 78%) 0%, hsl(216, 91%, 21%) 100%);
+    background: radial-gradient(ellipse farthest corner at 0px 0px, hsl(212, 60%, 78%) 0%, hsl(216, 91%, 21%) 100%);
 }
 
 .portico-landing.apps .main .details-container .details-box[data-name="mac"] {
-    color: #ffe8ec;
+    color: hsl(350, 92%, 95%);
 
-    background: -webkit-radial-gradient(top right, ellipse cover, #ffebb3 0%, #90163e 100%);
-    background: radial-gradient(ellipse farthest corner at 0px 0px, #ffebb3 0%, #90163e 100%);
+    background: -webkit-radial-gradient(top right, ellipse cover, hsl(44, 97%, 85%) 0%, hsl(340, 73%, 32%) 100%);
+    background: radial-gradient(ellipse farthest corner at 0px 0px, hsl(44, 97%, 85%) 0%, hsl(340, 73%, 32%) 100%);
 }
 
 .portico-landing.apps .main .details-container .details-box[data-name="linux"] {
-    color: #ffece5;
+    color: hsl(16, 93%, 95%);
 
-    background: -webkit-radial-gradient(top right, ellipse cover, #ffb89e 0%, #d01f0d 100%);
-    background: radial-gradient(ellipse farthest corner at 0px 0px, #ffb89e 0%, #d01f0d 100%);
+    background: -webkit-radial-gradient(top right, ellipse cover, hsl(16, 98%, 81%) 0%, hsl(6, 88%, 43%) 100%);
+    background: radial-gradient(ellipse farthest corner at 0px 0px, hsl(16, 98%, 81%) 0%, hsl(6, 88%, 43%) 100%);
 }
 
 .portico-landing.apps .main .details-container .details-box[data-name="snipe"] {
-    color: #ffe8ec;
+    color: hsl(350, 92%, 95%);
 
-    background: -webkit-radial-gradient(top right, ellipse cover, #ffc6bc 0%, #1b0e8a 100%);
-    background: radial-gradient(ellipse farthest corner at 0px 0px, #ffc6bc 0%, #1b0e8a 100%);
+    background: -webkit-radial-gradient(top right, ellipse cover, hsl(9, 97%, 87%) 0%, hsl(246, 82%, 30%) 100%);
+    background: radial-gradient(ellipse farthest corner at 0px 0px, hsl(9, 97%, 87%) 0%, hsl(246, 82%, 30%) 100%);
 }
 
 .portico-landing.apps .main .details-container .details-box[data-name="plan9"] {
-    color: #ffe8ec;
+    color: hsl(350, 92%, 95%);
 
-    background: -webkit-radial-gradient(top right, ellipse cover, #ffc6bc 0%, #8a0e17 100%);
-    background: radial-gradient(ellipse farthest corner at 0px 0px, #ffc6bc 0%, #8a0e17 100%);
+    background: -webkit-radial-gradient(top right, ellipse cover, hsl(9, 97%, 87%) 0%, hsl(356, 82%, 30%) 100%);
+    background: radial-gradient(ellipse farthest corner at 0px 0px, hsl(9, 97%, 87%) 0%, hsl(356, 82%, 30%) 100%);
 }
 
 .portico-landing.apps .main ul.sidebar li[data-name="android"].active {
-    color: #179c92;
+    color: hsl(175, 74%, 35%);
 }
 
 .portico-landing.apps .main ul.sidebar li[data-name="ios"].active {
-    color: #56b0d2;
+    color: hsl(196, 57%, 58%);
 }
 
 .portico-landing.apps .main ul.sidebar li[data-name="windows"].active {
-    color: #1e55a9;
+    color: hsl(216, 70%, 39%);
 }
 
 .portico-landing.apps .main ul.sidebar li[data-name="mac"].active {
-    color: #c73e6b;
+    color: hsl(340, 55%, 51%);
 }
 
 .portico-landing.apps .main ul.sidebar li[data-name="linux"].active {
-    color: #d01f0d;
+    color: hsl(6, 88%, 43%);
 }
 
 .portico-landing.apps .main ul.sidebar li[data-name="snipe"].active {
-    color: #1b0e8a;
+    color: hsl(246, 82%, 30%);
 }
 
 .portico-landing.apps .main ul.sidebar li[data-name="plan9"].active {
-    color: #8a0e17;
+    color: hsl(356, 82%, 30%);
 }
 
 .portico-landing.apps .main .details-container .platform.description {
@@ -1453,15 +1453,15 @@ a:not(.no-style):hover:before {
 }
 
 .portico-landing.apps .details-box[data-name="mac"] button.grey-transparent:active {
-    color: #bd323c;
+    color: hsl(356, 58%, 47%);
 }
 
 .portico-landing.apps .details-box[data-name="ios"] button.grey-transparent:active {
-    color: #6b96b5;
+    color: hsl(205, 33%, 56%);
 }
 
 .portico-landing.apps .details-box[data-name="windows"] button.grey-transparent:active {
-    color: #2d5187;
+    color: hsl(216, 50%, 35%);
 }
 
 .portico-landing.apps .main .details-box > .image {
@@ -1471,7 +1471,7 @@ a:not(.no-style):hover:before {
     width: 100%;
     padding: 35px 0px;
     height: calc(100% - 70px);
-    background-color: rgba(255,255,255,0.1);
+    background-color: hsla(0, 0%, 100%, 0.1);
 }
 
 .portico-landing.apps .main .details-container h1 {
@@ -1495,10 +1495,10 @@ a:not(.no-style):hover:before {
     max-width: 400px;
     border: none;
     padding: 15px;
-    box-shadow: 0px 0px 30px rgba(255,255,255,0.3);
+    box-shadow: 0px 0px 30px hsla(0, 0%, 100%, 0.3);
     text-align: left;
-    background-color: #ffece5;
-    color: #b5776f;
+    background-color: hsl(16, 93%, 95%);
+    color: hsl(7, 32%, 57%);
 }
 
 .portico-landing.apps .main .details-container .instructions {
@@ -1512,7 +1512,7 @@ a:not(.no-style):hover:before {
 }
 
 .portico-landing.apps .main .details-container .instructions a:not(.no-style):before {
-    background-color: rgba(255,255,255,0.5);
+    background-color: hsla(0, 0%, 100%, 0.5);
     width: 50%;
     left: 25%;
 }
@@ -1555,7 +1555,7 @@ a:not(.no-style):hover:before {
 
     -webkit-transform: translateY(-50px);
 
-    background: linear-gradient(90deg, #444 0%, #555 8%, #555 92%, #444 100%);
+    background: linear-gradient(90deg, hsl(0, 0%, 27%) 0%, hsl(0, 0%, 33%) 8%, hsl(0, 0%, 33%) 92%, hsl(0, 0%, 27%) 100%);
 }
 
 .portico-landing.hello .apps .screen .center-page {
@@ -1572,14 +1572,14 @@ a:not(.no-style):hover:before {
 
     width: 40px;
     height: 5px;
-    background-color: #ccc;
+    background-color: hsl(0, 0%, 80%);
 }
 
 .portico-landing.hello .apps .screen.ios::after {
     top: auto;
     bottom: 7px;
     left: calc(50% - 12.5px);
-    background-color: #ccc;
+    background-color: hsl(0, 0%, 80%);
 }
 
 .portico-landing.hello .apps .screen.android::before {
@@ -1590,25 +1590,25 @@ a:not(.no-style):hover:before {
     top: auto;
     bottom: 10px;
     left: calc(50% - 17.5px);
-    background-color: #ccc;
+    background-color: hsl(0, 0%, 80%);
 
     border-radius: 8px;
-    background-color: #222;
+    background-color: hsl(0, 0%, 13%);
     width: 35px;
     height: 20px;
 }
 
 .portico-landing.hello .apps .screen.ios .main-page {
-    border-color: #ddd;
+    border-color: hsl(0, 0%, 86%);
 }
 
 .portico-landing.hello .apps .screen.android .main-page {
-    border-color: #222;
+    border-color: hsl(0, 0%, 13%);
 }
 
 /* -- integrations page css -- */
 .portico-landing.integrations {
-    color: #444;
+    color: hsl(0, 0%, 27%);
     font-weight: normal;
 }
 
@@ -1677,8 +1677,8 @@ a:not(.no-style):hover:before {
 }
 
 .portico-landing.integrations .integration-lozenge:hover {
-    box-shadow: 0px 0px 40px rgba(0,0,0,0.1);
-    background: #fefefe;
+    box-shadow: 0px 0px 40px hsla(0, 0%, 0%, 0.1);
+    background: hsl(0, 0%, 99%);
 }
 
 .portico-landing.integrations .integration-lozenge img {
@@ -1692,7 +1692,7 @@ a:not(.no-style):hover:before {
 .portico-landing.integrations .integration-lozenge .integration-label {
     font-weight: 600;
     font-size: 20px;
-    color: #666;
+    color: hsl(0, 0%, 40%);
 }
 
 /* -- media queries -- */
@@ -2005,7 +2005,7 @@ a:not(.no-style):hover:before {
 
         font-size: 1.5rem;
         text-align: right;
-        color: #444;
+        color: hsl(0, 0%, 27%);
 
         background-size: 40px auto;
         background-image: url(/static/images/zulip-logo.svg);
@@ -2025,7 +2025,7 @@ a:not(.no-style):hover:before {
         transform: translate(-350px, 0px);
 
 
-        box-shadow: 0px 0px 80px rgba(0,0,0,0.12);
+        box-shadow: 0px 0px 80px hsla(0, 0%, 0%, 0.12);
 
         transition: all 0.5s ease;
     }
@@ -2059,7 +2059,7 @@ a:not(.no-style):hover:before {
 
     nav ul li,
     nav ul li a {
-        color: #444 !important;
+        color: hsl(0, 0%, 27%) !important;
     }
 
     nav ul li.active:after {

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -18,7 +18,7 @@
 #streams_filter_icon,
 #join_unsub_stream {
     float: right;
-    color: #ccc;
+    color: hsl(0, 0%, 80%);
     font-size: 13px;
     margin-top: 3px;
     margin-left: 10px;
@@ -27,7 +27,7 @@
 #streams_inline_cog:hover,
 #streams_filter_icon:hover,
 #join_unsub_stream:hover {
-    color: #555;
+    color: hsl(0, 0%, 33%);
 }
 
 #streams_header #join_unsub_stream {
@@ -91,11 +91,11 @@
 
 #global_filters li:hover,
 #stream_filters li:hover {
-    background-color: #e2e8dd;
+    background-color: hsl(93, 19%, 88%);
 }
 
 #stream_filters li.active-sub-filter:hover {
-    background-color: #ccd6cc;
+    background-color: hsl(120, 11%, 82%);
 }
 
 ul.filters {
@@ -104,7 +104,7 @@ ul.filters {
 }
 
 ul.filters a {
-    color: #333;
+    color: hsl(0, 0%, 20%);
 }
 
 ul.filters hr {
@@ -115,7 +115,7 @@ ul.filters hr {
 li.active-filter,
 li.active-sub-filter {
     font-weight: 600 !important;
-    background: #ddedf6;
+    background: hsl(202, 56%, 91%);
     position: relative;
 }
 
@@ -125,7 +125,7 @@ li.active-sub-filter {
 }
 
 .left-sidebar .sidebar-title:hover {
-    color: #555;
+    color: hsl(0, 0%, 33%);
 }
 
 li.hidden-filter {
@@ -181,7 +181,7 @@ li.hidden-filter {
     float: right;
     margin-top: 3px;
     line-height: 12px;
-    background: #80837f;
+    background: hsl(105, 2%, 50%);
     padding: 2px 4px 1px 4px;
     border-radius: 0px;
     color: #ffffff;
@@ -220,7 +220,7 @@ li.hidden-filter {
     line-height: 1em;
     top: 4px;
     padding: 2px 4px 1px 4px;
-    background: #a6ada4;
+    background: hsl(107, 5%, 66%);
     color: #ffffff;
     border-radius: 1px;
     font-size: 12px;
@@ -257,13 +257,13 @@ ul.filters .arrow {
 ul.filters li:hover .arrow {
     display: inline;
     cursor: pointer;
-    color: #888;
+    color: hsl(0, 0%, 53%);
 }
 
 ul.filters li .arrow:hover {
     display: inline;
     cursor: pointer;
-    color: #000;
+    color: hsl(0, 0%, 0%);
 }
 
 ul.filters .topic-sidebar-arrow {
@@ -275,13 +275,13 @@ ul.filters .topic-sidebar-arrow {
 li.topic-list-item:hover .topic-sidebar-arrow {
     display: inline !important;
     cursor: pointer;
-    color: #888;
+    color: hsl(0, 0%, 53%);
 }
 
 li.topic-list-item .topic-sidebar-arrow:hover {
     display: inline;
     cursor: pointer;
-    color: #000;
+    color: hsl(0, 0%, 0%);
 }
 
 ul.filters li.muted_topic,
@@ -377,7 +377,7 @@ li.expanded_private_message a {
 }
 
 .show-all-streams a {
-    color: #333;
+    color: hsl(0, 0%, 20%);
 }
 
 .all-streams-padding {
@@ -412,7 +412,7 @@ li.expanded_private_message a {
 
 #topics_header,
 #sharethelove-header {
-    border-top: 1px solid #e2e2e2;
+    border-top: 1px solid hsl(0, 0%, 88%);
     margin-top: 5px;
     margin-right: 10px;
 }

--- a/static/styles/lightbox.css
+++ b/static/styles/lightbox.css
@@ -1,5 +1,5 @@
 #lightbox_overlay {
-    background-color: #19203a;
+    background-color: hsl(227, 40%, 16%);
 
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -25,15 +25,15 @@
 
     background-color: #FFF;
     background-image:
-      -moz-linear-gradient(45deg, #CCC 25%, transparent 25%),
-      -moz-linear-gradient(-45deg, #CCC 25%, transparent 25%),
-      -moz-linear-gradient(45deg, transparent 75%, #000 75%),
-      -moz-linear-gradient(-45deg, transparent 75%, #000 75%);
+      -moz-linear-gradient(45deg, hsl(0, 0%, 80%) 25%, transparent 25%),
+      -moz-linear-gradient(-45deg, hsl(0, 0%, 80%) 25%, transparent 25%),
+      -moz-linear-gradient(45deg, transparent 75%, hsl(0, 0%, 0%) 75%),
+      -moz-linear-gradient(-45deg, transparent 75%, hsl(0, 0%, 0%) 75%);
     background-image:
-      -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.25, #CCC), color-stop(.25, transparent)),
-      -webkit-gradient(linear, 0 0, 100% 100%, color-stop(.25, #CCC), color-stop(.25, transparent)),
-      -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.75, transparent), color-stop(.75, #CCC)),
-      -webkit-gradient(linear, 0 0, 100% 100%, color-stop(.75, transparent), color-stop(.75, #CCC));
+      -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.25, hsl(0, 0%, 80%)), color-stop(.25, transparent)),
+      -webkit-gradient(linear, 0 0, 100% 100%, color-stop(.25, hsl(0, 0%, 80%)), color-stop(.25, transparent)),
+      -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.75, transparent), color-stop(.75, hsl(0, 0%, 80%))),
+      -webkit-gradient(linear, 0 0, 100% 100%, color-stop(.75, transparent), color-stop(.75, hsl(0, 0%, 80%)));
 
     -moz-background-size: 20px 20px;
     background-size: 20px 20px;
@@ -45,7 +45,7 @@
 #lightbox_overlay .exit {
     float: right;
 
-    color: rgba(255,255,255,0.8);
+    color: hsla(0, 0%, 100%, 0.8);
     font-size: 2rem;
     font-weight: 200;
     margin: 24px 20px 0px 0px;
@@ -198,7 +198,7 @@
     height: 50px;
     margin: 0px 2px;
 
-    background-color: rgba(240, 240, 240, 0.2);
+    background-color: hsla(0, 0%, 94%, 0.2);
     opacity: 0.5;
 
     background-size: cover;
@@ -214,7 +214,7 @@
     font-size: 0.8rem;
     min-width: inherit;
     padding: 4px 10px;
-    border: 1px solid rgba(255,255,255,0.6);
+    border: 1px solid hsla(0, 0%, 100%, 0.6);
     background-color: transparent;
     color: #fff;
     border-radius: 4px;
@@ -222,7 +222,7 @@
 
 .image-actions .button:hover {
     background-color: #fff;
-    color: #19203a;
+    color: hsl(227, 40%, 16%);
 }
 
 .image-actions a.button {

--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -32,9 +32,9 @@
     }
 
     .column-right.expanded .right-sidebar {
-        background: rgba(255,255,255,1);
-        box-shadow: 0px -2px 3px 0px rgba(0,0,0,0.1);
-        border-left: 1px solid #dddddd;
+        background: hsla(0, 0%, 100%, 1.0);
+        box-shadow: 0px -2px 3px 0px hsla(0, 0%, 0%, 0.1);
+        border-left: 1px solid hsl(0, 0%, 86%);
         margin-top: 40px;
         padding-top: 10px;
         height: 100%;
@@ -74,9 +74,9 @@
 
     .nav .dropdown-menu {
         min-width: 180px;
-        -webkit-box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.2);
-        -moz-box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.2);
-        box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.2);
+        -webkit-box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
+        -moz-box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
+        box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
     }
 
     .nav .dropdown-menu:after {
@@ -117,9 +117,9 @@
     }
 
     .column-left.expanded .left-sidebar {
-        background: rgba(255,255,255,1);
-        box-shadow: 0px 2px 3px 0px rgba(0,0,0,0.1);
-        border-right: 1px solid #dddddd;
+        background: hsla(0, 0%, 100%, 1.0);
+        box-shadow: 0px 2px 3px 0px hsla(0, 0%, 0%, 0.1);
+        border-right: 1px solid hsl(0, 0%, 86%);
         margin-top: 40px;
         padding-top: 10px;
         height: 100%;

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -113,7 +113,7 @@ ul.actions_popover i {
         width: 100vw;
         height: 100vh;
 
-        background-color: rgba(0,0,0,0.7);
+        background-color: hsla(0, 0%, 0%, 0.7);
         border-radius: 0px;
         border: none;
 

--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -9,7 +9,7 @@ html {
     width: 100vw;
     height: 100vh;
 
-    background-color: #fafafa;
+    background-color: hsl(0, 0%, 98%);
 
     z-index: -1;
 }
@@ -40,7 +40,7 @@ html {
     min-width: 0px;
 
     background-color: #fff;
-    box-shadow: 0px 0px 100px rgba(0,0,0,0.2);
+    box-shadow: 0px 0px 100px hsla(0, 0%, 0%, 0.2);
 }
 
 .find-team-page-container #find_my_team i {
@@ -155,16 +155,16 @@ html {
 .header .darker {
     background: #fff;
 
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 .header .top-links a,
 .header .header-main .logo span {
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 .header .header-main .logo .brand-logo circle {
-    fill: #444 !important;
+    fill: hsl(0, 0%, 27%) !important;
 }
 
 .header .header-main .logo .brand-logo path {
@@ -262,7 +262,7 @@ html {
     background-color: transparent;
 
     border: none;
-    color: rgb(190, 88, 88);
+    color: hsl(0, 44%, 54%);
 
 }
 
@@ -281,7 +281,7 @@ html {
 
     width: 280px;
 
-    border: 2px solid #ddd;
+    border: 2px solid hsl(0, 0%, 86%);
     box-shadow: none;
     border-radius: 0px;
 
@@ -305,7 +305,7 @@ html {
     transform: translateY(35px) translateX(-50%);
     font-size: 1.2rem;
     font-weight: 500;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 
     pointer-events: none;
 }
@@ -314,13 +314,13 @@ html {
 .new-style .input-box input[type=email]:focus:invalid,
 .new-style .input-box input[type=password]:focus:invalid {
     box-shadow: none;
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 .new-style .input-box input[type=text]:focus,
 .new-style .input-box input[type=email]:focus,
 .new-style .input-box input[type=password]:focus {
-    border: 2px solid #888;
+    border: 2px solid hsl(0, 0%, 53%);
 }
 
 .new-style .input-box input[required] ~ .required:after {
@@ -330,7 +330,7 @@ html {
     right: 5px;
     transform: translateY(8px);
 
-    color: #d66a6a;
+    color: hsl(0, 56%, 63%);
     font-size: 2em;
     font-weight: 300;
     transition: all 0.3s ease;
@@ -378,14 +378,14 @@ html {
 
     font-size: 1rem;
     font-weight: 600;
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 .new-style .input-box p.text-error {
     display: block;
     padding: 0px;
 
-    color: #d26666;
+    color: hsl(0, 54%, 61%);
     font-size: 0.7em;
     font-weight: 600;
     height: 0;
@@ -398,7 +398,7 @@ html {
     display: block;
 
     top: 66px;
-    color: #d26666;
+    color: hsl(0, 54%, 61%);
     font-size: 0.7em;
     font-weight: 600;
     padding-left: 0px;
@@ -407,7 +407,7 @@ html {
 .new-style .get-started {
     font-size: 2.5rem;
     text-align: center;
-    color: #666;
+    color: hsl(0, 0%, 40%);
 }
 
 .new-style button {
@@ -422,7 +422,7 @@ html {
     box-sizing: border-box;
     outline: none;
     color: #fff;
-    background-color: #313e4e;
+    background-color: hsl(213, 23%, 25%);
 
     border: none;
 
@@ -430,11 +430,11 @@ html {
 }
 
 .new-style button:hover {
-    background-color: #354c69;
+    background-color: hsl(213, 33%, 31%);
 }
 
 .new-style button:active {
-    background-color: #1d2734;
+    background-color: hsl(214, 28%, 16%);
 }
 
 /* -- /accounts/register/ page -- */
@@ -444,7 +444,7 @@ html {
 
 .portico-page .pitch p {
     font-weight: 400;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 .register-account .pitch {
@@ -453,8 +453,8 @@ html {
 }
 
 .login-page-container input[type=submit] {
-    color: #aaa;
-    border: 2px solid #ddd;
+    color: hsl(0, 0%, 66%);
+    border: 2px solid hsl(0, 0%, 86%);
     border-radius: 0px;
     background: transparent;
 
@@ -462,18 +462,18 @@ html {
 }
 
 .login-page-container input[type=submit]:hover {
-    border-color: #888;
-    color: #444;
+    border-color: hsl(0, 0%, 53%);
+    color: hsl(0, 0%, 27%);
 }
 
 .login-page-container input[type=submit].btn-admin {
-    border-color: #54b8a7;
-    color: #54b8a7;
+    border-color: hsl(170, 41%, 52%);
+    color: hsl(170, 41%, 52%);
 }
 
 .login-page-container input[type=submit].btn-admin:hover {
-    color: #60daaa;
-    border-color: #60daaa;
+    color: hsl(156, 62%, 61%);
+    border-color: hsl(156, 62%, 61%);
 }
 
 .split-view .org-header {
@@ -520,7 +520,7 @@ html {
 
 .split-view .info-box .organization-path {
     font-weight: 500;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     margin-top: 10px;
 }
 
@@ -532,7 +532,7 @@ html {
     width: 328px;
     display: block;
     margin: 0 auto;
-    color: #bbb;
+    color: hsl(0, 0%, 73%);
     font-weight: 600;
     text-align: center;
     text-transform: uppercase;
@@ -547,7 +547,7 @@ html {
     width: calc(149px);
     top: -3px;
 
-    border-bottom: 2px solid #ddd;
+    border-bottom: 2px solid hsl(0, 0%, 86%);
 
 }
 
@@ -581,20 +581,20 @@ button.login-github-button {
 button.login-google-button,
 button.login-github-button {
     background-color: #fff;
-    box-shadow: 0px 1px 3px rgba(0,0,0,0.3), 0px 0px 5px rgba(0,0,0,0.1);
-    color: #888;
+    box-shadow: 0px 1px 3px hsla(0, 0%, 0%, 0.3), 0px 0px 5px hsla(0, 0%, 0%, 0.1);
+    color: hsl(0, 0%, 53%);
 }
 
 button.login-google-button:hover,
 button.login-github-button:hover {
-    background-color: #fafafa;
-    box-shadow: 1px 2px 5px rgba(0,0,0,0.2);
+    background-color: hsl(0, 0%, 98%);
+    box-shadow: 1px 2px 5px hsla(0, 0%, 0%, 0.2);
 }
 
 button.login-google-button:active,
 button.login-github-button:active {
-    background-color: #eee;
-    box-shadow: 0px 1px 1px rgba(0,0,0,0.3);
+    background-color: hsl(0, 0%, 93%);
+    box-shadow: 0px 1px 1px hsla(0, 0%, 0%, 0.3);
 }
 
 button.login-google-button {
@@ -607,7 +607,7 @@ button.login-google-button {
 
     font-family: "FontAwesome";
     font-size: 2rem;
-    color: #333;
+    color: hsl(0, 0%, 20%);
     transform: translateX(15px) translateY(13px);
 }
 
@@ -617,7 +617,7 @@ button.login-google-button {
 }
 
 .split-view .actions a {
-    color: #54b8a7;
+    color: hsl(170, 41%, 52%);
     text-decoration: none;
     font-weight: 600;
     font-size: 0.8em;
@@ -628,7 +628,7 @@ button.login-google-button {
 }
 
 .split-view .actions a:hover {
-    color: #60daaa;
+    color: hsl(156, 62%, 61%);
 }
 
 #registration .input-box {
@@ -660,7 +660,7 @@ button.login-google-button {
     font-weight: 400;
     font-size: 1.2rem;
 
-    background-color: #ddd;
+    background-color: hsl(0, 0%, 86%);
 }
 
 #registration .center-block .pitch {
@@ -688,13 +688,13 @@ button.login-google-button {
 
 .split-view .left-side {
     width: 500px;
-    border-right: 1px solid #eee;
+    border-right: 1px solid hsl(0, 0%, 93%);
     position: relative;
     left: -1px;
 }
 
 .split-view .left-side + .right-side {
-    border-left: 1px solid #eee;
+    border-left: 1px solid hsl(0, 0%, 93%);
     /* this is to make sure the borders of the left and right side overlap
        each other. */
     padding-left: 15px;

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -42,13 +42,13 @@
 
     background: repeating-linear-gradient(
       75deg,
-      rgba(255,255,255,0) 0px,
-      rgba(255,255,255,0.06) 200px
+      hsla(0, 0%, 100%, 0.0) 0px,
+      hsla(0, 0%, 100%, 0.06) 200px
     );
 }
 
 .header .darker {
-    background: -webkit-linear-gradient(top left, transparent , rgba(0,0,0,0.3));
+    background: -webkit-linear-gradient(top left, transparent , hsla(0, 0%, 0%, 0.3));
 }
 
 .navbar.footer .nav > li {
@@ -121,7 +121,7 @@ body {
     vertical-align: top;
     padding: 3px 6.5px 3px 7.5px;
     margin-right: 5px;
-    background-color: #52c2af;
+    background-color: hsl(170, 47%, 54%);
     color: white;
     border-radius: 100%;
     font-size: 0.9em;
@@ -185,11 +185,11 @@ body {
     font-weight: 500;
     line-height: 1.2;
 
-    color: #444;
+    color: hsl(0, 0%, 27%);
 
-    border: 1px solid #ddd;
+    border: 1px solid hsl(0, 0%, 86%);
     border-radius: 4px;
-    background-color: #FAFAFA;
+    background-color: hsl(0, 0%, 98%);
 }
 
 .display-none {
@@ -206,7 +206,7 @@ body {
 }
 
 .help-inline.text-error {
-    color: #b94a48;
+    color: hsl(1, 44%, 50%);
 }
 
 a.title {
@@ -349,11 +349,11 @@ img.screenshot {
 }
 
 .shaded-background {
-    background-color: #ededed;
+    background-color: hsl(0, 0%, 93%);
 }
 
 .darker-background {
-    background-color: #474747;
+    background-color: hsl(0, 0%, 28%);
     color: white;
 }
 
@@ -377,7 +377,7 @@ input.text-error {
     position: absolute;
     z-index: 100;
     width: 100%;
-    background-color: #52c2af;
+    background-color: hsl(170, 47%, 54%);
 }
 
 .footer {
@@ -425,7 +425,7 @@ input.text-error {
 }
 
 .main-headline {
-    background-color: #bad2fa;
+    background-color: hsl(218, 84%, 85%);
     background: url("/static/images/landing-page/gg.jpg");
     background-position: center;
     background-size: cover;
@@ -448,7 +448,7 @@ input.text-error {
 
 .feature-block i {
     float: left;
-    color: #7e98ad;
+    color: hsl(207, 22%, 58%);
 }
 
 .feature-block p {
@@ -461,7 +461,7 @@ input.text-error {
 }
 
 .feature-line.dark {
-    background: #ddedf6;
+    background: hsl(202, 56%, 91%);
     color: black;
 }
 
@@ -554,7 +554,7 @@ a.bottom-signup-button {
 
 .feature-image.shadow {
     border-radius: 6px;
-    box-shadow: 0px 0px 4px rgba(0,0,0,0.4);
+    box-shadow: 0px 0px 4px hsla(0, 0%, 0%, 0.4);
 }
 
 .login-page,
@@ -607,7 +607,7 @@ a.bottom-signup-button {
 
 .portico-page-header a,
 .portico-page-header a:hover {
-    color: #000;
+    color: hsl(0, 0%, 0%);
     text-decoration: none;
     display: inline-block;
 }
@@ -640,8 +640,8 @@ a.bottom-signup-button {
 }
 
 .authors_row td:hover {
-    color: #00796B;
-    box-shadow: 0px 0px 30px #B2DFDB;
+    color: hsl(173, 100%, 24%);
+    box-shadow: 0px 0px 30px hsl(175, 41%, 78%);
 }
 
 .authors_row .avatar {
@@ -670,7 +670,7 @@ a.bottom-signup-button {
 
 .integration-lozenge {
     width: 125px;
-    background: #ededed;
+    background: hsl(0, 0%, 93%);
     border-radius: 10px;
     margin: 15px 5px 0px 5px;
     display: inline-block;
@@ -688,7 +688,7 @@ a.bottom-signup-button {
 
 .integration-lozenge-static:hover {
     box-shadow: none;
-    background: #ededed;
+    background: hsl(0, 0%, 93%);
 }
 
 .integration-lozenge .integration-link:hover {
@@ -714,7 +714,7 @@ a.bottom-signup-button {
     font-weight: 500;
     text-align: center;
     padding-bottom: 5px;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 .integration-instructions {
@@ -833,16 +833,16 @@ a.bottom-signup-button {
 
 .btn-user {
     background-color: #ffffff;
-    border-color: #55bdaa;
+    border-color: hsl(169, 44%, 54%);
     border-style: solid;
-    color: #3f9486;
+    color: hsl(170, 40%, 41%);
 }
 
 .btn-admin {
     background-color: #ffffff;
-    border-color: #00a9f4;
+    border-color: hsl(198, 100%, 48%);
     border-style: solid;
-    color: #2196f3;
+    color: hsl(207, 89%, 54%);
 }
 
 .feature-page-header {
@@ -1006,14 +1006,14 @@ input.new-organization-button {
 .footer-navigation li a {
     display: inline-block;
     vertical-align: middle;
-    color: #888;
+    color: hsl(0, 0%, 53%);
     font-size: 0.9em;
     font-weight: 400;
     cursor: pointer;
 }
 
 .footer-navigation li:hover a {
-    color: #444;
+    color: hsl(0, 0%, 27%);
     text-decoration: none;
 }
 
@@ -1050,8 +1050,8 @@ input.new-organization-button {
 
 .top-links a:hover {
     text-decoration: none;
-    background-color: rgba(255,255,255,1);
-    color: #339a89;
+    background-color: hsla(0, 0%, 100%, 1.0);
+    color: hsl(170, 50%, 40%);
 }
 
 .centered-button {
@@ -1061,7 +1061,7 @@ input.new-organization-button {
 .button-muted {
     display: block;
     font-size: 12px;
-    color: #ddd;
+    color: hsl(0, 0%, 86%);
 }
 
 /* -- password reset container -- */
@@ -1193,15 +1193,15 @@ input.new-organization-button {
     font-weight: 400;
     font-size: 1rem;
     line-height: 1.5;
-    color: #666;
+    color: hsl(0, 0%, 40%);
 
     -webkit-font-smoothing: antialiased;
-    outline: 10000px solid rgba(240,240,240,0.5);
-    box-shadow: 0px 0px 30px rgba(0,0,0,0.2);
+    outline: 10000px solid hsla(0, 0%, 94%, 0.5);
+    box-shadow: 0px 0px 30px hsla(0, 0%, 0%, 0.2);
 }
 
 .markdown a {
-    color: #399993;
+    color: hsl(176, 46%, 41%);
     font-weight: 600;
 }
 
@@ -1238,7 +1238,7 @@ input.new-organization-button {
 
 .markdown img {
     vertical-align: top;
-    box-shadow: 0px 0px 40px rgba(0,0,0,0.1);
+    box-shadow: 0px 0px 40px hsla(0, 0%, 0%, 0.1);
 }
 
 .markdown img.inline {
@@ -1250,16 +1250,16 @@ input.new-organization-button {
 .markdown .tip {
     position: relative;
     display: block;
-    background-color: #f5f7f9;
-    border: 1px solid #eee;
+    background-color: hsl(210, 22%, 96%);
+    border: 1px solid hsl(0, 0%, 93%);
     border-radius: 4px;
     padding: 10px;
     margin-bottom: 10px;
 }
 
 .markdown .tip {
-    background-color: #fbf7ea;
-    border: 1px solid #e0ddd0;
+    background-color: hsl(46, 63%, 95%);
+    border: 1px solid hsl(49, 20%, 84%);
 }
 
 .markdown .warn p,
@@ -1292,21 +1292,21 @@ input.new-organization-button {
 }
 
 .markdown .indicator.grey {
-    border: 1px solid #CCC;
+    border: 1px solid hsl(0, 0%, 80%);
 }
 
 .markdown .indicator.orange {
-    border: 1px solid #ec7e18;
-    background: linear-gradient(to bottom,rgba(255,255,255,0) 50%,rgba(236,126,24,1) 50%);
+    border: 1px solid hsl(29, 84%, 51%);
+    background: linear-gradient(to bottom,hsla(0, 0%, 100%, 0.0) 50%,hsla(29, 84%, 51%, 1.0) 50%);
 }
 
 .markdown .indicator.green {
-    border: 1px solid #44c21d;
-    background-color: rgba(68,194,29,0.3);
+    border: 1px solid hsl(106, 74%, 44%);
+    background-color: hsla(106, 74%, 44%, 0.3);
 }
 
 .markdown .indicator.green.solid {
-    background-color: #44c21d;
+    background-color: hsl(106, 74%, 44%);
 }
 
 /* make sure that it doesn't wrap and disappear around the line.. odd bug. */
@@ -1543,7 +1543,7 @@ input.new-organization-button {
 
 .input-group.grid {
     padding: 10px 0px;
-    border-bottom: 1px solid #DDD;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 label.label-title {
@@ -1575,7 +1575,7 @@ input.new-organization-button {
 
     font-weight: 400;
 
-    background-color: #478fca;
+    background-color: hsl(207, 55%, 53%);
     color: #FFF;
     outline: none;
     border: none;
@@ -1599,7 +1599,7 @@ input.new-organization-button {
 }
 
 .button-new.sea-green {
-    background-color: #24cac2;
+    background-color: hsl(177, 70%, 46%);
     color: #fff;
 }
 
@@ -1622,7 +1622,7 @@ input.new-organization-button {
 
 .documentation-footer {
     font-size: .85rem;
-    color: #AAA;
+    color: hsl(0, 0%, 66%);
 }
 
 #devtools-wrapper {

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -10,21 +10,21 @@
     height: 19px;
     cursor: pointer;
     background-color: #ffffff;
-    border: 1px solid #c7dfe6;
+    border: 1px solid hsl(194, 37%, 84%);
     border-radius: 4px;
 }
 
 .private-message .message_reactions .message_reaction {
-    background-color: #f0f4f5;
+    background-color: hsl(192, 19%, 95%);
 }
 
 .message_reactions .message_reaction.reacted {
-    background-color: #eef7fa;
+    background-color: hsl(195, 50%, 95%);
 }
 
 .private-message .message_reactions .message_reaction.reacted {
-    background-color: #e4f2f7;
-    border-color: #96c3d0;
+    background-color: hsl(196, 51%, 93%);
+    border-color: hsl(193, 38%, 70%);
 }
 
 .message_reaction .emoji {
@@ -44,7 +44,7 @@
     font-size: 0.8em;
     display: inline-block;
     vertical-align: top;
-    color: #0088CC;
+    color: hsl(200, 100%, 40%);
     margin: 0px 1px 0px 0px;
     line-height: 1em;
 }
@@ -56,7 +56,7 @@
 .message_reactions i {
     font-size: 1.3em;
     float: left;
-    color: #555;
+    color: hsl(0, 0%, 33%);
 }
 
 .message_reactions .reaction_button:not(:only-child) {
@@ -66,8 +66,8 @@
 .message_reactions:hover .message_reaction + .reaction_button {
     visibility: visible;
     pointer-events: all;
-    background-color: #fafafa;
-    color: #bbb;
+    background-color: hsl(0, 0%, 98%);
+    color: hsl(0, 0%, 73%);
 }
 
 .message_reactions .reaction_button i {
@@ -76,11 +76,11 @@
 }
 
 .message_reactions .reaction_button:hover i {
-    color: #0088CC;
+    color: hsl(200, 100%, 40%);
 }
 
 .message_reactions .message_reaction:hover {
-    border: 1px solid #0088CC;
+    border: 1px solid hsl(200, 100%, 40%);
 }
 
 .message_reactions .reaction_button:only-child {
@@ -95,27 +95,27 @@
     height: 14px;
     border-radius: 4px;
     padding-left: 0.3em;
-    border: 1px solid #bbb;
+    border: 1px solid hsl(0, 0%, 73%);
     padding-right: 0.3em;
     float: left;
 }
 
 .message_reactions .reaction_button:hover {
-    border: 1px solid #0088CC;
-    background-color: #eef7fa;
+    border: 1px solid hsl(200, 100%, 40%);
+    background-color: hsl(195, 50%, 95%);
     cursor: pointer;
     opacity: 1.0;
-    color: #0088CC;
+    color: hsl(200, 100%, 40%);
 }
 
 .message_reactions .reaction_button .message_reaction_count {
     font-size: 1.1em;
-    color: #555;
+    color: hsl(0, 0%, 33%);
     margin-left: 3px;
 }
 
 .message_reactions .reaction_button:hover .message_reaction_count {
-    color: #0088CC;
+    color: hsl(200, 100%, 40%);
 }
 
 .emoji-popover {
@@ -131,7 +131,7 @@
     display: inline-block;
     vertical-align: top;
     padding: 8px;
-    color: #bbb;
+    color: hsl(0, 0%, 73%);
     cursor: pointer;
 }
 
@@ -166,8 +166,8 @@
 }
 
 .emoji-popover .reacted {
-    background-color: #eef7fa;
-    border-color: #add8e6;
+    background-color: hsl(195, 50%, 95%);
+    border-color: hsl(195, 52%, 79%);
 }
 
 .emoji_alt_code {
@@ -176,7 +176,7 @@
     font-size: 0.8em;
     display: inline-block;
     vertical-align: top;
-    color: #333;
+    color: hsl(0, 0%, 20%);
     margin: 0px 1px 0px 0px;
     line-height: 1em;
 }

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -1,12 +1,12 @@
 .right-sidebar {
     -webkit-font-smoothing: antialiased;
-    color: #555;
+    color: hsl(0, 0%, 33%);
     font-size: 0.89rem;
 }
 
 #group-pms li:hover,
 #user_presences li:hover {
-    background-color: #e2e8dd;
+    background-color: hsl(93, 19%, 88%);
 }
 
 #user_presences,
@@ -57,20 +57,20 @@
 
 .user_active .user-status-indicator,
 .group-pm-status-indicator {
-    background-color: #44C21D;
-    border-color: #44C21D;
+    background-color: hsl(106, 74%, 44%);
+    border-color: hsl(106, 74%, 44%);
 }
 
 .user_idle .user-status-indicator {
-    border-color: #EC7E18;
-    background-color: #EC7E18;
+    border-color: hsl(29, 84%, 51%);
+    background-color: hsl(29, 84%, 51%);
 
-    background: -moz-linear-gradient(top,  rgba(255,255,255,0) 50%, rgba(236,126,24,1) 50%); /* FF3.6+ */
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(50%,rgba(255,255,255,0)), color-stop(50%,rgba(236,126,24,1))); /* Chrome,Safari4+ */
-    background: -webkit-linear-gradient(top,  rgba(255,255,255,0) 50%,rgba(236,126,24,1) 50%); /* Chrome10+,Safari5.1+ */
-    background: -o-linear-gradient(top,  rgba(255,255,255,0) 50%,rgba(236,126,24,1) 50%); /* Opera 11.10+ */
-    background: -ms-linear-gradient(top,  rgba(255,255,255,0) 50%,rgba(236,126,24,1) 50%); /* IE10+ */
-    background: linear-gradient(to bottom,  rgba(255,255,255,0) 50%,rgba(236,126,24,1) 50%); /* W3C */
+    background: -moz-linear-gradient(top,  hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* FF3.6+ */
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(50%,hsla(0, 0%, 100%, 0.0)), color-stop(50%,hsla(29, 84%, 51%, 1.0))); /* Chrome,Safari4+ */
+    background: -webkit-linear-gradient(top,  hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* Chrome10+,Safari5.1+ */
+    background: -o-linear-gradient(top,  hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* Opera 11.10+ */
+    background: -ms-linear-gradient(top,  hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* IE10+ */
+    background: linear-gradient(to bottom,  hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* W3C */
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#ec7e18',GradientType=0 ); /* IE6-9 */
 }
 
@@ -144,7 +144,7 @@
     right: 25px;
     top: 4px;
     padding: 2px 4px 1px 4px;
-    background: #80837f;
+    background: hsl(105, 2%, 50%);
     border-radius: 0px;
     color: #ffffff;
     font-size: 12px;
@@ -171,13 +171,13 @@
     right: 0px;
     text-align: center;
     vertical-align: middle;
-    border-left: 2px solid #afbfca;
+    border-left: 2px solid hsl(204, 20%, 74%);
 }
 
 #userlist-toggle-button {
     text-decoration: none;
-    background-color: #e4e4e4;
-    color: #858585;
+    background-color: hsl(0, 0%, 89%);
+    color: hsl(0, 0%, 52%);
     display: block;
     width: 40px;
     height: 19px;
@@ -205,7 +205,7 @@
 #feedback_section {
     text-align: left;
     padding-bottom: 15px;
-    border-bottom: 1px solid #e2e2e2;
+    border-bottom: 1px solid hsl(0, 0%, 88%);
     margin-right: 10px;
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -97,7 +97,7 @@ label {
     vertical-align: top;
 
     border-radius: 4px;
-    box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
+    box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);
 }
 
 .admin-realm-description {
@@ -134,7 +134,7 @@ label {
 }
 
 .table tbody {
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 .table-condensed td {
@@ -193,7 +193,7 @@ td .button {
 .settings-section .table-striped thead th {
     background-color: inherit;
     color: inherit;
-    border-top: 1px solid #dddddd !important;
+    border-top: 1px solid hsl(0, 0%, 86%) !important;
 }
 
 .settings-section input[type=text].search {
@@ -220,14 +220,14 @@ td .button {
 .settings-section .tip {
     position: relative;
     display: block;
-    background-color: #fbf7ea;
-    border: 1px solid #e0ddd0;
+    background-color: hsl(46, 63%, 95%);
+    border: 1px solid hsl(49, 20%, 84%);
     border-radius: 4px;
     padding: 10px;
     margin: 10px 0px;
     font-size: 1rem;
     line-height: 1.5;
-    color: #666;
+    color: hsl(0, 0%, 40%);
 }
 
 .settings-section .tip::before {
@@ -243,7 +243,7 @@ td .button {
     display: inline-block;
     padding: 5px;
     background-color: #FFF;
-    border: 1px solid #CCC;
+    border: 1px solid hsl(0, 0%, 80%);
     border-radius: 3px;
     transition: box-shadow 0.3s ease;
     min-width: 208px;
@@ -251,7 +251,7 @@ td .button {
 
 .dynamic-input:hover {
     outline: none;
-    box-shadow: 0px 0px 4px rgba(56,177,232,1);
+    box-shadow: 0px 0px 4px hsla(199, 79%, 56%, 1.0);
 }
 
 .dynamic-input div,
@@ -270,12 +270,12 @@ td .button {
 
 .dynamic-input div:empty::after {
     content: "username";
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 .dynamic-input.bot_user_name div:empty::after {
     content: "bot_user_name";
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 .button,
@@ -307,7 +307,7 @@ input[type=checkbox] + .inline-block {
 #user-settings-avatar,
 #realm-icon-section {
     border-radius: 5px;
-    box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
+    box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);
 }
 
 input[type=checkbox].inline-block {
@@ -315,7 +315,7 @@ input[type=checkbox].inline-block {
 }
 
 #attachments_list .attachment-item {
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid hsl(0, 0%, 93%);
 }
 
 #attachments_list .attachment-item .list-container {
@@ -328,7 +328,7 @@ input[type=checkbox].inline-block {
     margin-top: 10px;
     margin-right: 5px;
     font-size: 1.2em;
-    color: #e29595;
+    color: hsl(0, 56%, 73%);
 }
 
 #attachments_list .attachment-item .list-container .file-icon {
@@ -341,8 +341,8 @@ input[type=checkbox].inline-block {
     font-weight: 600;
     color: #fff;
 
-    background: -webkit-linear-gradient(-45deg, #43C6AC , #70e6ce);
-    background: linear-gradient(-45deg, #43C6AC , #70e6ce);
+    background: -webkit-linear-gradient(-45deg, hsl(168, 53%, 52%), hsl(168, 69%, 67%));
+    background: linear-gradient(-45deg, hsl(168, 53%, 52%), hsl(168, 69%, 67%));
 
     box-sizing: border-box;
     border-radius: 4px;
@@ -378,7 +378,7 @@ input[type=checkbox].inline-block {
     border-radius: 4px;
     overflow: hidden;
 
-    border: 1px solid #aaa;
+    border: 1px solid hsl(0, 0%, 66%);
 
     transition: all 0.2s ease;
 }
@@ -390,20 +390,20 @@ input[type=checkbox].inline-block {
 
 #attachments_list .attachment-messages .ind-message .message-id {
     padding: 2px 4px 1px 4px;
-    background-color: #aaa;
+    background-color: hsl(0, 0%, 66%);
     color: #fff;
 }
 
 #attachments_list .attachment-messages .ind-message:hover {
-    border: 1px solid #888;
+    border: 1px solid hsl(0, 0%, 53%);
 }
 
 #attachments_list .attachment-messages .ind-message:hover .message-id {
-    background-color: #888;
+    background-color: hsl(0, 0%, 53%);
 }
 
 #attachments_list .attachment-messages .ind-message {
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     text-decoration: none;
 }
 
@@ -418,17 +418,17 @@ input[type=checkbox].inline-block {
 }
 
 .grey-bg {
-    background: #e3e3e3;
+    background: hsl(0, 0%, 89%);
     padding: 10px;
     width: 90%;
     margin: 15px auto;
-    box-shadow: 0px 0px 2px rgba(0,0,0,0.5);
+    box-shadow: 0px 0px 2px hsla(0, 0%, 0%, 0.5);
     position: relative;
     font-size: 14px;
 }
 
 .green-bg {
-    background-color: #cbe3cb;
+    background-color: hsl(120, 29%, 84%);
 }
 
 .new-default-stream-section-title {
@@ -497,7 +497,7 @@ input[type=checkbox].inline-block {
 }
 
 .control-label-disabled {
-    color: #d3d3d3;
+    color: hsl(0, 0%, 82%);
 }
 
 .disableable {
@@ -582,12 +582,12 @@ input[type=checkbox].inline-block {
 .bots_list .regenerate_bot_api_key {
     position: relative;
     margin-left: 5px;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     transition: all 0.3s ease;
 }
 
 .bots_list .regenerate_bot_api_key:hover {
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 .bots_list .edit-bot-buttons {
@@ -603,15 +603,15 @@ input[type=checkbox].inline-block {
 }
 
 .bots_list .edit-bot-buttons .sea-green {
-    color: #24cac2;
+    color: hsl(177, 70%, 46%);
 }
 
 .bots_list .edit-bot-buttons .blue {
-    color: #3ba4e6;
+    color: hsl(203, 77%, 56%);
 }
 
 .bots_list .edit-bot-buttons .danger-red {
-    color: #e29595;
+    color: hsl(0, 56%, 73%);
 }
 
 .bots_list .bot-information-box {
@@ -622,7 +622,7 @@ input[type=checkbox].inline-block {
     margin: 5px;
 
     background-color: #fff;
-    border: 1px solid #ddd;
+    border: 1px solid hsl(0, 0%, 86%);
     border-radius: 4px;
     box-sizing: border-box;
 
@@ -635,7 +635,7 @@ input[type=checkbox].inline-block {
     width: 50px;
     border-radius: 4px;
     vertical-align: top;
-    box-shadow: 0px 0px 4px rgba(0,0,0,0.1);
+    box-shadow: 0px 0px 4px hsla(0, 0%, 0%, 0.1);
 }
 
 .bots_list .email {
@@ -668,7 +668,7 @@ input[type=checkbox].inline-block {
     font-weight: 300;
     text-transform: uppercase;
     font-weight: 600;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 .edit_bot h3 {
@@ -677,7 +677,7 @@ input[type=checkbox].inline-block {
 }
 
 #bots_lists_navbar .active a {
-    background-color: #FAFAFA;
+    background-color: hsl(0, 0%, 98%);
 }
 
 #inactive_bots_list .bot_info .reactivate_bot {
@@ -693,7 +693,7 @@ input[type=checkbox].inline-block {
 .edit_bot_form label {
     text-transform: uppercase;
     font-weight: 600;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     margin-top: 5px;
 }
 
@@ -779,7 +779,7 @@ input[type=checkbox].inline-block {
 
 #user-settings-avatar {
     border-radius: 5px;
-    box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
+    box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);
     width: 200px;
     height: 200px;
 
@@ -792,7 +792,7 @@ input[type=checkbox].inline-block {
 
 #realm-settings-icon {
     border-radius: 5px;
-    box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
+    box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);
     width: 100px;
     height: 100px;
 }
@@ -824,13 +824,13 @@ input[type=checkbox].inline-block {
     min-height: 550px;
     overflow-y: auto;
     border-top-left-radius: 4px;
-    border-right: 1px solid #eee;
+    border-right: 1px solid hsl(0, 0%, 93%);
 }
 
 #settings_page .sidebar .tab-container {
     background-color: #fff;
     padding: 6px;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 #settings_page .sidebar .settings-list {
@@ -850,17 +850,17 @@ input[type=checkbox].inline-block {
 #settings_page .content-wrapper .settings-header {
     width: 100%;
     height: 43px;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 #settings_page .content-wrapper .settings-header h1 .section {
     font-weight: 400;
-    color: #666;
+    color: hsl(0, 0%, 40%);
 }
 
 #settings_page .settings-header.mobile {
     display: none;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 .settings-header.mobile .icon-vector-chevron-left {
@@ -879,7 +879,7 @@ input[type=checkbox].inline-block {
     overflow-y: auto;
     overflow-x: hidden;
 
-    background-color: #fafafa;
+    background-color: hsl(0, 0%, 98%);
 }
 
 #settings_page .table-striped thead th {
@@ -901,7 +901,7 @@ input[type=checkbox].inline-block {
     height: calc(100% - 45px);
 
     background-color: #fff;
-    border-left: 1px solid #ddd;
+    border-left: 1px solid hsl(0, 0%, 86%);
 
     pointer-events: none;
     transition: all 0.3s ease;
@@ -932,9 +932,9 @@ input[type=checkbox].inline-block {
 }
 
 #settings_page .form-sidebar .title {
-    background-color: #fafafa;
+    background-color: hsl(0, 0%, 98%);
     padding: 10px 20px;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 #settings_page .form-sidebar .title h1 {
@@ -959,8 +959,8 @@ input[type=checkbox].inline-block {
     text-align: center;
     text-transform: uppercase;
 
-    background-color: #edefef;
-    border-bottom: 1px solid #DDD;
+    background-color: hsl(180, 6%, 93%);
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 #settings_page .settings-header {
@@ -980,7 +980,7 @@ input[type=checkbox].inline-block {
     position: absolute;
     top: 10px;
     right: 10px;
-    color: #AAA;
+    color: hsl(0, 0%, 66%);
     cursor: pointer;
 }
 
@@ -1000,8 +1000,8 @@ input[type=checkbox].inline-block {
 }
 
 #deactivate_self_modal {
-    box-shadow: 0px 0px 75px rgba(0,0,0,0.5);
-    outline: 10000px solid rgba(0,0,0,0.3);
+    box-shadow: 0px 0px 75px hsla(0, 0%, 0%, 0.5);
+    outline: 10000px solid hsla(0, 0%, 0%, 0.3);
     border: none;
     border-radius: 0px;
 }
@@ -1022,19 +1022,19 @@ input[type=text]#settings_search {
     width: calc(100% - 10px - 2px);
     margin: 0px;
 
-    color: #555;
+    color: hsl(0, 0%, 33%);
     font-size: 0.9rem;
     padding: 3px 5px;
     outline: none;
-    border: 1px solid #DDD;
+    border: 1px solid hsl(0, 0%, 86%);
     border-radius: 4px;
 }
 
 input[type=text]:focus#settings_search {
     box-shadow: none;
-    border: 1px solid #BBB;
+    border: 1px solid hsl(0, 0%, 73%);
 
-    border-bottom: 1px solid #DDD;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 input[type=text]#settings_search {
@@ -1053,7 +1053,7 @@ input[type=text]#settings_search {
     outline: none;
     cursor: pointer;
     transition: all 0.2s ease;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid hsl(0, 0%, 93%);
 }
 
 #settings_page .sidebar li.no-border {
@@ -1061,7 +1061,7 @@ input[type=text]#settings_search {
 }
 
 #settings_page .sidebar li.active {
-    background-color: #eee;
+    background-color: hsl(0, 0%, 93%);
 }
 
 #settings_page .sidebar li.active {
@@ -1085,7 +1085,7 @@ input[type=text]#settings_search {
     margin: 10px 10px;
 
     font-size: 1.4em;
-    color: #888;
+    color: hsl(0, 0%, 53%);
 
     background-size: cover;
     background-repeat: no-repeat;
@@ -1202,7 +1202,7 @@ thead .actions {
     display: block;
 
     font-style: italic;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 /* This is a hack; essentially the issue is that if the ::after element is on

--- a/static/styles/stats.css
+++ b/static/styles/stats.css
@@ -101,7 +101,7 @@ svg {
 }
 
 .button:hover {
-    background: #D8D8D8 !important;
+    background: hsl(0, 0%, 84%) !important;
 }
 
 .pie-button {
@@ -114,7 +114,7 @@ svg {
 }
 
 .pie-button:hover {
-    background: #D8D8D8 !important;
+    background: hsl(0, 0%, 84%) !important;
 }
 
 #button_container {
@@ -128,94 +128,94 @@ svg {
     font-size: 14px;
     margin-left: 40px;
     margin-top: 0px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
 }
 
 #daily_button {
     padding: 0px 5px 0px 5px;
     font-size: 14px;
     margin-top: 0px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
 }
 
 #weekly_button {
     padding: 0px 5px 0px 5px;
     font-size: 14px;
     margin-top: 0px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
 }
 
 #cumulative_button {
     padding: 0px 5px 0px 5px;
     font-size: 14px;
     margin-top: 0px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
 }
 
 #messages_by_client_realm_button {
     font-size: 14px;
-    background: #D8D8D8;
+    background: hsl(0, 0%, 84%);
 }
 
 #messages_by_client_user_button {
     font-size: 14px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
 }
 
 #messages_by_client_cumulative_button {
     font-size: 14px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
 }
 
 #messages_by_client_last_year_button {
     font-size: 14px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
 }
 
 #messages_by_client_last_month_button {
     font-size: 14px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
 }
 
 #messages_by_client_last_week_button {
     font-size: 14px;
     margin-left: 50px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
 }
 
 #messages_by_type_realm_button {
     font-size: 14px;
     margin-bottom: 100px;
-    background: #D8D8D8;
+    background: hsl(0, 0%, 84%);
 }
 
 #messages_by_type_user_button {
     font-size: 14px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
     margin-bottom: 100px;
 }
 
 #messages_by_type_cumulative_button {
     font-size: 14px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
     vertical-align: top;
 }
 
 #messages_by_type_last_year_button {
     font-size: 14px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
     vertical-align: top;
 }
 
 #messages_by_type_last_month_button {
     font-size: 14px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
     vertical-align: top;
 }
 
 #messages_by_type_last_week_button {
     font-size: 14px;
-    background: #F0F0F0;
+    background: hsl(0, 0%, 94%);
     vertical-align: top;
     margin-left: 50px;
 }
@@ -271,7 +271,7 @@ svg {
 
 .last-update {
     display: none;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     padding: 50px 0px;
     font-weight: bolder;
     font-size: 16px;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -129,8 +129,8 @@
     font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
     padding: 5px;
     font-size: 0.9em;
-    background-color: #EEE;
-    border: 1px solid #DDD;
+    background-color: hsl(0, 0%, 93%);
+    border: 1px solid hsl(0, 0%, 86%);
     border-radius: 4px;
 }
 
@@ -144,13 +144,13 @@
 .sp-preview {
     width: 20px;
     border: none;
-    box-shadow: 0px 0px 1px rgba(0,0,0,1);
+    box-shadow: 0px 0px 1px hsla(0, 0%, 0%, 1.0);
 }
 
 .sp-replacer {
     margin-right: 12px;
     border: none;
-    box-shadow: 0px 0px 2px rgba(0,0,0,0.8);
+    box-shadow: 0px 0px 2px hsla(0, 0%, 0%, 0.8);
 }
 
 .stream-email .email-address {
@@ -166,12 +166,12 @@
 }
 
 .muted-sub {
-    color: #A3A3A3;
+    color: hsl(0, 0%, 64%);
 }
 
 .mute-note {
     font-size: 90%;
-    font-color: #525252;
+    font-color: hsl(0, 0%, 32%);
 }
 
 .hide-mute-note {
@@ -191,16 +191,16 @@
     display: none;
     float: right;
     padding: 3px 10px;
-    border: 1px solid #ccc;
+    border: 1px solid hsl(0, 0%, 80%);
     margin: 9px 10px 0px 0px;
-    color: #333;
+    color: hsl(0, 0%, 20%);
 }
 
 .preview-stream:hover {
-    color: #333;
+    color: hsl(0, 0%, 20%);
     text-decoration: none;
-    background-color: #ebebeb;
-    border: 1px solid #adadad;
+    background-color: hsl(0, 0%, 92%);
+    border: 1px solid hsl(0, 0%, 68%);
 }
 
 .stream-row .btn.sub_unsub_button {
@@ -218,9 +218,9 @@
 }
 
 #create_or_filter_stream_row td {
-    background-color: #f3f3f3;
-    border-color: #BBB;
-    border-bottom: 1px solid #BBB;
+    background-color: hsl(0, 0%, 95%);
+    border-color: hsl(0, 0%, 73%);
+    border-bottom: 1px solid hsl(0, 0%, 73%);
 }
 
 #create_or_filter_stream_row input[type="text"] {
@@ -243,7 +243,7 @@ form#add_new_subscription {
     font-size: 2.2em;
     font-weight: 300;
     line-height: 1;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 
     display: inline-block;
     transition: all 0.2s ease;
@@ -252,7 +252,7 @@ form#add_new_subscription {
 }
 
 #create_stream_button:hover {
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 #create_stream_description {
@@ -262,7 +262,7 @@ form#add_new_subscription {
 #stream_name_error {
     display: none;
     margin-left: 2px;
-    color: #FF0000;
+    color: hsl(0, 100%, 50%);
 }
 
 .sub_settings_title {
@@ -282,7 +282,7 @@ form#add_new_subscription {
 
 .subscriber-list-box {
     text-align: center;
-    border: 1px solid #ddd;
+    border: 1px solid hsl(0, 0%, 86%);
     border-radius: 4px;
 }
 
@@ -300,7 +300,7 @@ form#add_new_subscription {
 }
 
 .subscriber-list tr {
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid hsl(0, 0%, 93%);
 }
 
 .subscriber-list tr:last-of-type {
@@ -333,7 +333,7 @@ form#add_new_subscription {
     display: block;
 
     text-align: center;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 .subscriber-list:empty {
@@ -406,8 +406,8 @@ form#add_new_subscription {
     left: 0;
     width: 100vw;
     height: 100vh;
-    background-color: rgba(20,20,20,0.7);
-    color: #444;
+    background-color: hsla(0, 0%, 8%, 0.7);
+    color: hsl(0, 0%, 27%);
 }
 
 .subscriptions-container {
@@ -427,7 +427,7 @@ form#add_new_subscription {
     text-align: center;
     text-transform: uppercase;
     font-weight: 700;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 .subscriptions-header .fa-chevron-left {
@@ -439,7 +439,7 @@ form#add_new_subscription {
     position: relative;
     transform: translate(-50px, 0px);
     opacity: 0;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 
     float: left;
     padding: 5px 10px;
@@ -466,7 +466,7 @@ form#add_new_subscription {
     position: absolute;
     top: 10px;
     right: 10px;
-    color: #AAA;
+    color: hsl(0, 0%, 66%);
     cursor: pointer;
 }
 
@@ -498,25 +498,25 @@ form#add_new_subscription {
     margin-top: calc(45vh - 30px - 1em);
     text-align: center;
     font-size: 1em;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
 }
 
 .subscriptions-container .left {
-    border-right: 1px solid #ddd;
+    border-right: 1px solid hsl(0, 0%, 86%);
 }
 
 .subscriptions-container .left .search-container {
     padding: 6px 8px;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 .subscriptions-container .right .display-type {
     padding: 6px;
     text-align: center;
     font-weight: 600;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
 .subscriptions-container .display-type.preview:after {
@@ -534,15 +534,15 @@ form#add_new_subscription {
     margin: 9px 0px;
     font-weight: 400;
     font-weight: 600;
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 .subscriptions-container .right #preview_iframe {
     width: 100%;
     height: calc(100% - 45px);
     border: none;
-    background-color: #FAFAFA;
-    box-shadow: inset 0px 0px 50px rgba(0,0,0,0.5);
+    background-color: hsl(0, 0%, 98%);
+    box-shadow: inset 0px 0px 50px hsla(0, 0%, 0%, 0.5);
     background-image: url(../images/preview-loading.png);
     background-size: 150px auto;
     background-position: center center;
@@ -550,11 +550,11 @@ form#add_new_subscription {
 }
 
 .subscriptions-container input[type=text].small {
-    border: 1px solid #ccc;
+    border: 1px solid hsl(0, 0%, 80%);
     border-radius: 4px;
     padding: 3px;
     outline: none;
-    color: #444;
+    color: hsl(0, 0%, 27%);
     text-align: center;
 }
 
@@ -614,12 +614,12 @@ form#add_new_subscription {
 
 .stream-row {
     padding: 15px 10px 14px 10px;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid hsl(0, 0%, 93%);
     cursor: pointer;
 }
 
 .stream-row.active {
-    background-color: #eee;
+    background-color: hsl(0, 0%, 93%);
 }
 
 .stream-row > div {
@@ -645,11 +645,11 @@ form#add_new_subscription {
 
 .stream-row:hover .check:not(.checked) svg,
 .stream-row.active:hover .check:not(.checked) svg {
-    fill: #ddd;
+    fill: hsl(0, 0%, 86%);
 }
 
 .stream-row .checked svg {
-    fill: #52c2af;
+    fill: hsl(170, 47%, 54%);
 }
 
 .stream-row .icon {
@@ -691,7 +691,7 @@ form#add_new_subscription {
 .stream-row .sub-info-box .top-bar .message-count,
 .stream-row .sub-info-box .top-bar .subscriber-count {
     float: right;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 .stream-row .sub-info-box .top-bar .subscriber-count {
@@ -714,7 +714,7 @@ form#add_new_subscription {
 .stream-row .sub-info-box .description:empty:after {
     content: attr(data-no-description);
     font-style: italic;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 #subscription_overlay #stream-creation {
@@ -737,7 +737,7 @@ form#add_new_subscription {
 .stream-row .settings-dropdown-trigger {
     float: right;
     margin-left: 10px;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 .add-user-label {
@@ -769,12 +769,12 @@ form#add_new_subscription {
 }
 
 #subscription_overlay .stream-header .subscribe-button.unsubscribed {
-    color: #5bb792;
-    border-color: #addcc9;
+    color: hsl(156, 39%, 54%);
+    border-color: hsl(156, 39%, 77%);
 }
 
 #subscription_overlay .stream-header .subscribe-button.unsubscribed:active {
-    background-color: rgba(91,183,146,0.2);
+    background-color: hsla(156, 39%, 54%, 0.2);
 }
 
 #subscription_overlay .stream-header .large-icon {
@@ -807,7 +807,7 @@ form#add_new_subscription {
 
 .editable-section[contenteditable=true] {
     display: inline-block;
-    color: #52c2af;
+    color: hsl(170, 47%, 54%);
 }
 
 .editable-section[contenteditable=true]:focus {
@@ -818,7 +818,7 @@ form#add_new_subscription {
     position: relative;
     top: -1px;
     margin-left: 5px;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     cursor: pointer;
     font-size: 1.4rem;
     font-weight: 300;
@@ -839,14 +839,14 @@ form#add_new_subscription {
 }
 
 #subscription_overlay .editable:hover {
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 #subscription_overlay .checkmark {
     display: none;
     margin-left: 5px;
     font-size: 0.9rem;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 
     cursor: pointer;
 }
@@ -858,7 +858,7 @@ form#add_new_subscription {
 #subscription_overlay .subscription-type {
     margin-bottom: 10px;
     font-size: 0.9em;
-    color: #888;
+    color: hsl(0, 0%, 53%);
 }
 
 #subscription_overlay .subscription-type .subscription-type-text {
@@ -867,7 +867,7 @@ form#add_new_subscription {
 
 #subscription_overlay .subscription-type b {
     font-weight: 600;
-    color: #666;
+    color: hsl(0, 0%, 40%);
 }
 
 #subscription_overlay .stream-header .large-icon.hash::after {
@@ -900,13 +900,13 @@ form#add_new_subscription {
 #subscription_overlay .subscription_settings ul {
     margin: 0px;
     padding: 10px;
-    background-color: #EEE;
-    border: 1px solid #DDD;
+    background-color: hsl(0, 0%, 93%);
+    border: 1px solid hsl(0, 0%, 86%);
     border-radius: 4px;
 }
 
 #subscription_overlay .subscription_settings ul li {
-    border-bottom: 1px solid #DDD;
+    border-bottom: 1px solid hsl(0, 0%, 86%);
     padding: 5px 0px;
 }
 
@@ -990,7 +990,7 @@ form#add_new_subscription {
         left: 101%;
 
         top: 45px;
-        border-top: 1px solid #ddd;
+        border-top: 1px solid hsl(0, 0%, 86%);
         background-color: #fff;
         border-top: none;
 

--- a/static/styles/typing_notifications.css
+++ b/static/styles/typing_notifications.css
@@ -2,7 +2,7 @@
     display: none;
     margin-left: 10px;
     font-style: italic;
-    color: #888;
+    color: hsl(0, 0%, 53%);
 }
 
 #typing_notification_list {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -97,9 +97,9 @@ p.n-margin {
     left: calc(50vw - 220px);
     padding: 15px;
 
-    background-color: #FAFAFA;
+    background-color: hsl(0, 0%, 98%);
     border-radius: 5px;
-    box-shadow: 0px 0px 30px rgba(0,0,0,0.25);
+    box-shadow: 0px 0px 30px hsla(0, 0%, 0%, 0.25);
     z-index: 110;
 
     animation-name: pulse;
@@ -121,13 +121,13 @@ p.n-margin {
 
 @keyframes pulse {
     0% {
-        box-shadow: 0px 0px 30px rgba(0,0,0,0.35);
+        box-shadow: 0px 0px 30px hsla(0, 0%, 0%, 0.35);
     }
     50% {
-        box-shadow: 0px 0px 30px rgba(0,0,0,0.15);
+        box-shadow: 0px 0px 30px hsla(0, 0%, 0%, 0.15);
     }
     100% {
-        box-shadow: 0px 0px 30px rgba(0,0,0,0.35);
+        box-shadow: 0px 0px 30px hsla(0, 0%, 0%, 0.35);
     }
 }
 
@@ -145,14 +145,14 @@ p.n-margin {
 
 #unmute_muted_topic_notification .btn {
     background-color: transparent;
-    border: 1px solid #444;
+    border: 1px solid hsl(0, 0%, 27%);
     outline: none;
     transition: all 0.2s ease;
 }
 
 #unmute_muted_topic_notification .btn:hover {
-    background-color: #444;
-    color: #FAFAFA;
+    background-color: hsl(0, 0%, 27%);
+    color: hsl(0, 0%, 98%);
 }
 
 #unmute_muted_topic_notification .exit-me {
@@ -167,7 +167,7 @@ p.n-margin {
     z-index: 102; /* Needs to be higher than .alert-bar-container */
     width: 100%;
     background: #ffffff;
-    border-bottom: 1px solid #dadada;
+    border-bottom: 1px solid hsl(0, 0%, 85%);
     height: 40px;
 }
 
@@ -416,18 +416,18 @@ pre {
 pre::-webkit-scrollbar {
     height: 8px;
 
-    background-color: rgba(0,0,0,0.05);
+    background-color: hsla(0, 0%, 0%, 0.05);
 }
 
 pre::-webkit-scrollbar-thumb {
-    background-color: rgba(0,0,0,0.3);
+    background-color: hsla(0, 0%, 0%, 0.3);
     border-radius: 20px;
 
     transition: all 0.2s ease;
 }
 
 pre::-webkit-scrollbar-thumb:hover {
-    background-color: rgb(0,0,0,0.6);
+    background-color: hsla(0, 0%, 0%, 0.6);
 }
 
 pre code {
@@ -438,13 +438,13 @@ pre code {
 /* Style inline code inside a link
    to look more like a normal link */
 a code {
-    color: #08C;
-    border-color: #08C;
+    color: hsl(200, 100%, 40%);
+    border-color: hsl(200, 100%, 40%);
 }
 
 a:hover code {
-    color: #005580;
-    border-color: #005580;
+    color: hsl(200, 100%, 25%);
+    border-color: hsl(200, 100%, 25%);
 }
 
 .preserve_spaces {
@@ -473,14 +473,14 @@ a:hover code {
 
 .sidebar-title {
     font-size: 1em;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
     font-weight: normal;
     display: inline;
 }
 
 #message_edit_tooltip {
     float: right;
-    color: #000;
+    color: hsl(0, 0%, 0%);
     font-size: 13px;
     margin-top: 3px;
     margin-left: 6px;
@@ -504,7 +504,7 @@ a:hover code {
 }
 
 .message_header_stream a.message_label_clickable {
-    color: #333;
+    color: hsl(0, 0%, 20%);
 }
 
 li.actual-dropdown-menu i {
@@ -558,7 +558,7 @@ td.pointer {
 
 .message_edit_notice {
     font-size: 10px;
-    color: #a1a1a1;
+    color: hsl(0, 0%, 63%);
     font-weight: 300;
     line-height: 0px;
     text-align: right;
@@ -583,7 +583,7 @@ td.pointer {
 .message_time {
     display: block;
     font-size: 12px;
-    color: #b1b1b1;
+    color: hsl(0, 0%, 69%);
     vertical-align: middle;
     padding: 1px;
     font-weight: 400;
@@ -604,7 +604,7 @@ td.pointer {
     position: absolute;
     right: -110px;
     font-size: 14px;
-    color: #52c2af;
+    color: hsl(170, 47%, 54%);
     background-color: white;
     z-index: 999;
     padding-left: 20px;
@@ -614,7 +614,7 @@ td.pointer {
 }
 
 .private-message .alert-copied {
-    background-color: #f0f4f5;
+    background-color: hsl(192, 19%, 95%);
 }
 
 .include-sender .alert-copied {
@@ -675,14 +675,14 @@ td.pointer {
 }
 
 .message_list .recipient_row {
-    background: #f1f1f1;
-    border-bottom: 1px solid #e2e2e2;
-    border-top: 1px solid #e2e2e2;
+    background: hsl(0, 0%, 94%);
+    border-bottom: 1px solid hsl(0, 0%, 88%);
+    border-top: 1px solid hsl(0, 0%, 88%);
     margin-bottom: 10px;
 }
 
 .floating_recipient .recipient_row {
-    border-top: 1px solid #e2e2e2;
+    border-top: 1px solid hsl(0, 0%, 88%);
 }
 
 .stream_label {
@@ -691,11 +691,11 @@ td.pointer {
     font-weight: normal;
     height: 17px;
     line-height: 17px;
-    border-top-color: rgba(0, 0, 0, 0);
-    border-right-color: rgba(0, 0, 0, 0);
-    border-bottom-color: rgba(0, 0, 0, 0);
-    background-color: #e2e2e2;
-    border-left-color: #e2e2e2;
+    border-top-color: hsla(0, 0%, 0%, 0.0);
+    border-right-color: hsla(0, 0%, 0%, 0.0);
+    border-bottom-color: hsla(0, 0%, 0%, 0.0);
+    background-color: hsl(0, 0%, 88%);
+    border-left-color: hsl(0, 0%, 88%);
     border-width: 0px;
     position: relative;
     text-decoration: none;
@@ -742,7 +742,7 @@ td.pointer {
     margin-top: -14px;
     border-style: solid;
     border-width: 14px 0 14px 6px;
-    border-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0) rgba(0, 0, 0, 0) #ffffff;
+    border-color: hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) #ffffff;
     z-index: 1;
     -moz-transform: scale(.9999);
 }
@@ -760,7 +760,7 @@ td.pointer {
     right: 0;
     top: 0;
 
-    color: #888;
+    color: hsl(0, 0%, 53%);
     font-size: 12px;
     font-weight: 600;
     padding: 3px 11px 2px 10px;
@@ -802,7 +802,9 @@ td.pointer {
 
 .summary_row.last_message .message_header {
     border-bottom-right-radius: 3px;
-    box-shadow: inset 0px 2px 1px -2px #333, inset -2px 0px 1px -2px #333, inset 0px -2px 1px -2px #333;
+    box-shadow: inset 0px 2px 1px -2px hsl(0, 0%, 20%),
+        inset -2px 0px 1px -2px hsl(0, 0%, 20%),
+        inset 0px -2px 1px -2px hsl(0, 0%, 20%);
 }
 
 .summary_row.last_message .summary_colorblock {
@@ -825,12 +827,12 @@ td.pointer {
 
 .message_header_colorblock {
     border-radius: 3px 0px 0px 0px;
-    /* box-shadow: 0px 2px 3px #ccc; */
-    box-shadow: inset 0px 2px 1px -2px #333, inset 2px 0px 1px -2px #333 !important;
+    /* box-shadow: 0px 2px 3px hsl(0, 0%, 80%); */
+    box-shadow: inset 0px 2px 1px -2px hsl(0, 0%, 20%), inset 2px 0px 1px -2px hsl(0, 0%, 20%) !important;
 }
 
 .summary_row_private_message .summary_colorblock {
-    background: #000;
+    background: hsl(0, 0%, 0%);
 }
 
 .messages-expand,
@@ -959,16 +961,16 @@ td.pointer {
     height: 3px;
     background-color: #fff;
     border-radius: 0px 0px 3px 0px;
-    /* box-shadow: 0px 2px 2px -1px #ccc; */
-    border: 1px solid #c1dbd5;
+    /* box-shadow: 0px 2px 2px -1px hsl(0, 0%, 80%); */
+    border: 1px solid hsl(166, 26%, 80%);
     border-top: none;
     border-left: none;
 }
 
 .messagebox-bottom-colorblock {
     border-radius: 0px 0px 0px 3px;
-    /* box-shadow: 0px 2px 2px -1px #ccc; */
-    border: 1px solid #c1dbd5;
+    /* box-shadow: 0px 2px 2px -1px hsl(0, 0%, 80%); */
+    border: 1px solid hsl(166, 26%, 80%);
     border-top: none;
     border-right: none;
 }
@@ -979,14 +981,14 @@ td.pointer {
 }
 
 .message_header_private_message .message_label_clickable {
-    background-color: #444444;
+    background-color: hsl(0, 0%, 27%);
     display: inline-block;
     padding: 3px 4px 2px 4px;
     font-weight: normal;
     font-size: 14px;
     height: 17px;
     line-height: 17px;
-    border-left-color: #444;
+    border-left-color: hsl(0, 0%, 27%);
 }
 
 /* Base color backgrounds for messageboxes,
@@ -999,15 +1001,15 @@ td.pointer {
 
 .private-message .messagebox,
 .message_header_private_message .message-header-contents {
-    background-color: #f0f4f5;
+    background-color: hsl(192, 19%, 95%);
 }
 
 .message-header-contents {
-    border-right: 1px solid #e2e2e2;
+    border-right: 1px solid hsl(0, 0%, 88%);
 }
 
 .mention .messagebox-content {
-    background-color: #ffe4e0;
+    background-color: hsl(8, 94%, 94%);
 }
 
 .messagebox .message_top_line {
@@ -1034,7 +1036,7 @@ td.pointer {
 }
 
 .unread-marker-fill {
-    background: #2b8213;
+    background: hsl(107, 74%, 29%);
     width: 3px;
     height: 100%;
     box-shadow: inset 0px -1px 0px 0px #ffffff;
@@ -1071,11 +1073,11 @@ td.pointer {
 }
 
 .selected_message .messagebox-content {
-    box-shadow: inset 0px 0px 0px 2px #4577bc,
-                     -1px -1px 0px 0px #4577bc,
-                      1px 1px 0px 0px #4577bc,
-                     -1px 1px 0px 0px #4577bc,
-                      1px -1px 0px 0px #4577bc;
+    box-shadow: inset 0px 0px 0px 2px hsl(215, 47%, 50%),
+                     -1px -1px 0px 0px hsl(215, 47%, 50%),
+                      1px 1px 0px 0px hsl(215, 47%, 50%),
+                     -1px 1px 0px 0px hsl(215, 47%, 50%),
+                      1px -1px 0px 0px hsl(215, 47%, 50%);
 }
 
 .message_sender {
@@ -1085,7 +1087,7 @@ td.pointer {
 }
 
 .sender_name {
-    color: #333;
+    color: hsl(0, 0%, 20%);
     display: inline-block;
     font-weight: 700;
     vertical-align: top;
@@ -1117,11 +1119,11 @@ td.pointer {
 
 .sender_name_hovered .sender_name,
 .sender_name_hovered .sender_name-in-status {
-    color: #0088CC;
+    color: hsl(200, 100%, 40%);
 }
 
 .sender_name_hovered .inline_profile_picture {
-    border-color: #0088CC;
+    border-color: hsl(200, 100%, 40%);
 }
 
 .message_sender .bot-icon {
@@ -1139,7 +1141,7 @@ td.pointer {
 }
 
 .actions_hover:hover {
-    color: #0088CC;
+    color: hsl(200, 100%, 40%);
 }
 
 .message_failed,
@@ -1157,7 +1159,7 @@ td.pointer {
 
 a.message_label_clickable:hover {
     cursor: pointer;
-    color: #08C;
+    color: hsl(200, 100%, 40%);
 }
 
 .on_hover_topic_edit {
@@ -1187,22 +1189,22 @@ a.message_label_clickable:hover {
     width: 12px;
     display: inline-block;
     position: relative;
-    color: #bbb;
+    color: hsl(0, 0%, 73%);
 }
 
 .edit_content:hover {
     cursor: pointer;
-    color: #0088CC;
+    color: hsl(200, 100%, 40%);
 }
 
 .reactions_hover {
     display: inline-block;
     position: relative;
-    color: #bbb;
+    color: hsl(0, 0%, 73%);
 }
 
 .reactions_hover:hover {
-    color: #0088CC;
+    color: hsl(200, 100%, 40%);
 }
 
 .message_hovered .reactions_hover,
@@ -1225,7 +1227,7 @@ a.dark_background:hover,
 }
 
 .dark_background a.message_label_clickable:hover {
-    color: #3BF;
+    color: hsl(200, 99%, 60%);
 }
 
 .message_top_line {
@@ -1255,7 +1257,7 @@ a.dark_background:hover,
 
 .actions_hovered .message_time,
 .actions_hovered .info {
-    color: #0088CC;
+    color: hsl(200, 100%, 40%);
     cursor: pointer;
 }
 
@@ -1263,7 +1265,7 @@ a.dark_background:hover,
     display: inline-block;
     position: relative;
     font-size: 15px;
-    color: #bbb;
+    color: hsl(0, 0%, 73%);
 }
 
 .actions_hovered .actions_link {
@@ -1279,8 +1281,8 @@ div.message_table {
 
 .message_row {
     position: relative;
-    border-left: 1px solid #e2e2e2;
-    border-right: 1px solid #e2e2e2;
+    border-left: 1px solid hsl(0, 0%, 88%);
+    border-right: 1px solid hsl(0, 0%, 88%);
 }
 
 .message_row.selected_message {
@@ -1316,12 +1318,12 @@ div.focused_table {
 .message_edit_countdown_timer {
     text-align: right;
     display: inline;
-    color: #a1a1a1;
+    color: hsl(0, 0%, 63%);
 }
 
 .message_edit_tooltip {
     display: inline;
-    color: #a1a1a1;
+    color: hsl(0, 0%, 63%);
 }
 
 .message-edit-timer-control-group {
@@ -1349,7 +1351,7 @@ div.focused_table {
     font-size: 14px;
 
     border-radius: 0px;
-    border: 1px solid #afbfca;
+    border: 1px solid hsl(204, 20%, 74%);
     box-shadow: none;
 }
 
@@ -1393,7 +1395,7 @@ div.focused_table {
 .message_length_controller {
     display: none;
     text-align: center;
-    color: #0088CC;
+    color: hsl(200, 100%, 40%);
 
     /* to match .message_content */
     margin-left: 5px;
@@ -1413,7 +1415,7 @@ div.message_content table {
 }
 
 div.message_content thead {
-    background-color: #EFEFEF;
+    background-color: hsl(0, 0%, 93%);
 }
 
 div.message_content div {
@@ -1422,13 +1424,13 @@ div.message_content div {
 }
 
 div.message_content div {
-    border: 1px solid #cccccc;
+    border: 1px solid hsl(0, 0%, 80%);
     padding: 4px;
     text-align: left;
 }
 
 div.message_content div {
-    border: 1px solid #cccccc;
+    border: 1px solid hsl(0, 0%, 80%);
     padding: 4px;
 }
 
@@ -1467,7 +1469,7 @@ blockquote p {
 .messagebox blockquote {
     padding-left: 5px;
     margin-left: 10px;
-    border-left-color: #ddd;
+    border-left-color: hsl(0, 0%, 86%);
 }
 
 .bookend {
@@ -1550,7 +1552,7 @@ blockquote p {
     display: inline-block;
     position: relative;
     font-weight: 300;
-    background-color: #f9f9f9;
+    background-color: hsl(0, 0%, 97%);
     margin: 0px;
     padding: 0px;
     text-overflow: ellipsis;
@@ -1558,11 +1560,11 @@ blockquote p {
 }
 
 #tab_list li.inactive {
-    border-top-color: rgba(0, 0, 0, 0);
-    border-right-color: rgba(0, 0, 0, 0);
-    border-bottom-color: rgba(0, 0, 0, 0);
-    background-color: #e2e2e2;
-    border-left-color: #e2e2e2;
+    border-top-color: hsla(0, 0%, 0%, 0.0);
+    border-right-color: hsla(0, 0%, 0%, 0.0);
+    border-bottom-color: hsla(0, 0%, 0%, 0.0);
+    background-color: hsl(0, 0%, 88%);
+    border-left-color: hsl(0, 0%, 88%);
     border-width: 0px;
 }
 
@@ -1597,7 +1599,7 @@ blockquote p {
     margin-top: -28px;
     border-style: solid;
     border-width: 28px 0 28px 14px;
-    border-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0) rgba(0, 0, 0, 0) #ffffff;
+    border-color: hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) #ffffff;
     z-index: 1;
     -moz-transform: scale(.9999);
 }
@@ -1618,7 +1620,7 @@ blockquote p {
 #tab_list li.active {
     padding-left: 17px;
     padding-right: 10px;
-    background-color: #e2e2e2;
+    background-color: hsl(0, 0%, 88%);
     max-width: 120px;
     white-space: nowrap;
     overflow: hidden;
@@ -1630,18 +1632,18 @@ blockquote p {
 }
 
 #tab_list li.private_message {
-    border-top-color: rgba(0, 0, 0, 0);
-    border-right-color: rgba(0, 0, 0, 0);
-    border-bottom-color: rgba(0, 0, 0, 0);
-    background-color: #111111;
-    border-left-color: #111111;
+    border-top-color: hsla(0, 0%, 0%, 0.0);
+    border-right-color: hsla(0, 0%, 0%, 0.0);
+    border-bottom-color: hsla(0, 0%, 0%, 0.0);
+    background-color: hsl(0, 0%, 7%);
+    border-left-color: hsl(0, 0%, 7%);
     color: #ffffff;
     border-width: 0px;
 }
 
 #tab_list .root {
-    border-color: #e2e2e2;
-    background-color: #e2e2e2;
+    border-color: hsl(0, 0%, 88%);
+    background-color: hsl(0, 0%, 88%);
     margin: 0px;
 }
 
@@ -1652,13 +1654,13 @@ blockquote p {
 }
 
 #tab_list li.root a {
-    color: #858585;
+    color: hsl(0, 0%, 52%);
     padding-right: 2px;
 }
 
 
 #tab_list .root a:hover {
-    color: #000000;
+    color: hsl(0, 0%, 0%);
 }
 
 #tab_bar_underpadding {
@@ -1688,15 +1690,15 @@ blockquote p {
     left: 0px;
     text-align: center;
     vertical-align: middle;
-    border-right: 2px solid #afbfca;
+    border-right: 2px solid hsl(204, 20%, 74%);
 }
 
 #streamlist-toggle-button {
     text-decoration: none;
-    color: #858585;
+    color: hsl(0, 0%, 52%);
     display: block;
     position: relative;
-    background-color: #e4e4e4;
+    background-color: hsl(0, 0%, 89%);
     width: 40px;
     height: 19px;
     padding-top: 12px;
@@ -1710,11 +1712,11 @@ blockquote p {
     height: 12px;
     min-width: 12px;
     line-height: 12px;
-    background: #670000;
+    background: hsl(0, 100%, 20%);
     top: 4px;
     right: 4px;
-    border: 1px solid #eee;
-    box-shadow: 0px 0px 1px rgba(0,0,0,0.2);
+    border: 1px solid hsl(0, 0%, 93%);
+    box-shadow: 0px 0px 1px hsla(0, 0%, 0%, 0.2);
     border-radius: 12px;
     padding: 1px 1px 1px 1px;
     font-size: 9px;
@@ -1728,9 +1730,9 @@ blockquote p {
     right: 0px;
     top: 30px;
     min-width: 180px;
-    -webkit-box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.2);
-    -moz-box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.2);
-    box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.2);
+    -webkit-box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
+    -moz-box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
+    box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
 }
 
 .nav .dropdown-menu:after {
@@ -1741,7 +1743,7 @@ blockquote p {
     right: 10px;
     display: inline-block;
     border-right: 7px solid transparent;
-    border-bottom: 7px solid #aaa;
+    border-bottom: 7px solid hsl(0, 0%, 66%);
     border-left: 7px solid transparent;
     content: '';
     z-index: 10;
@@ -1750,7 +1752,7 @@ blockquote p {
 #navbar-buttons ul.nav .dropdown-toggle,
 #navbar-buttons ul.nav li.active .dropdown-toggle {
     font-size: 20px;
-    color: #858585;
+    color: hsl(0, 0%, 52%);
     text-shadow: none;
     padding-left: 0px !important;
     background-color: inherit;
@@ -1765,12 +1767,12 @@ blockquote p {
 
 #navbar-buttons ul.nav .dropdown-toggle,
 #navbar-buttons ul.nav li.active .dropdown-toggle:hover {
-    color: #111111;
+    color: hsl(0, 0%, 7%);
 }
 
 #navbar-buttons ul.nav li.dropdown.open .dropdown-toggle {
     background: none;
-    color: #111111;
+    color: hsl(0, 0%, 7%);
     text-shadow: none;
 }
 
@@ -1818,7 +1820,7 @@ nav .column-left .company-name {
     margin-left: 8px;
     font-size: 1.2rem;
     font-weight: 600;
-    color: #52c2af;
+    color: hsl(170, 47%, 54%);
     letter-spacing: 0.1em;
     cursor: pointer;
 }
@@ -1832,7 +1834,7 @@ nav a .no-style {
     width: auto;
     float: none;
     overflow: hidden;
-    border-right: 1px solid #dadada;
+    border-right: 1px solid hsl(0, 0%, 85%);
     height: 40px;
 }
 
@@ -1841,11 +1843,11 @@ nav a .no-style {
     font-size: 18px;
     height: 40px;
     padding: 0px;
-    color: #222;
-    box-shadow: inset 2px 0px 0px 0px #afbfca;
+    color: hsl(0, 0%, 13%);
+    box-shadow: inset 2px 0px 0px 0px hsl(204, 20%, 74%);
     padding-left: 35px;
     padding-right: 20px;
-    background: rgb(255,255,255); /* Old browsers */
+    background: hsl(0, 0%, 100%); /* Old browsers */
     border: none;
     border-radius: 0px;
     font-family: 'Humbug';
@@ -1855,7 +1857,7 @@ nav a .no-style {
 
 
 #search_query:focus {
-    box-shadow: inset 0px 0px 0px 2px #afbfca;
+    box-shadow: inset 0px 0px 0px 2px hsl(204, 20%, 74%);
 }
 
 #searchbox .search_button,
@@ -1869,7 +1871,7 @@ nav a .no-style {
     height: 30px;
     text-align: center;
     padding: 4px;
-    color: #ccc;
+    color: hsl(0, 0%, 80%);
     font-size: 18px;
     box-shadow: none;
     -webkit-box-shadow: none;
@@ -1879,7 +1881,7 @@ nav a .no-style {
 }
 
 #searchbox .search_button:hover {
-    color: #000;
+    color: hsl(0, 0%, 0%);
 }
 
 #searchbox .search_button[disabled] {
@@ -1887,28 +1889,28 @@ nav a .no-style {
 }
 
 #searchbox a.search_icon {
-    color: #ccc;
+    color: hsl(0, 0%, 80%);
     text-decoration: none;
 }
 
 #searchbox a.search_icon:hover {
-    color: #000;
+    color: hsl(0, 0%, 0%);
     text-decoration: none;
 }
 
 .highlight {
-    background-color: #FCEA81;
+    background-color: hsl(51, 94%, 74%);
 }
 
 .highlight_text_inserted {
-    color: #158318;
-    background-color: #E9FBE9;
+    color: hsl(122, 72%, 30%);
+    background-color: hsl(120, 64%, 95%);
 }
 
 .highlight_text_deleted {
-    color: #BBBBBB;
+    color: hsl(0, 0%, 73%);
     text-decoration: line-through;
-    background-color: #FEDFDB;
+    background-color: hsl(7, 90%, 92%);
 }
 
 #search_arrows {
@@ -1938,7 +1940,7 @@ div.floating_recipient {
 }
 
 .message-header-contents {
-    background: #e2e2e2;
+    background: hsl(0, 0%, 88%);
 }
 
 .recipient_row.sticky {
@@ -2148,7 +2150,7 @@ div.floating_recipient {
 }
 
 .table-striped thead th {
-    background-color: #444;
+    background-color: hsl(0, 0%, 27%);
     color: white;
 }
 
@@ -2199,7 +2201,7 @@ div.floating_recipient {
 }
 
 button.primary {
-    background-color: #89a0b3;
+    background-color: hsl(207, 21%, 62%);
     padding: 2px;
     color: #fff;
     border: none;
@@ -2207,7 +2209,7 @@ button.primary {
 }
 
 button.primary:hover {
-    background-color: #91aabe;
+    background-color: hsl(207, 25%, 65%);
 }
 
 button.primary:focus {
@@ -2246,7 +2248,7 @@ button.topic_edit_cancel {
 
 #invite-user .modal-header {
     padding: 7px 15px;
-    border-color: #ddd;
+    border-color: hsl(0, 0%, 86%);
 }
 
 #invite-user .modal-header .exit {
@@ -2257,7 +2259,7 @@ button.topic_edit_cancel {
     position: absolute;
     top: 6px;
     right: 5px;
-    color: #aaa;
+    color: hsl(0, 0%, 66%);
 }
 
 #invitee_emails {
@@ -2361,7 +2363,7 @@ img.emoji {
 }
 
 .twitter-tweet {
-    border: 1px solid #ddd;
+    border: 1px solid hsl(0, 0%, 86%);
     padding: .5em .75em;
     margin-bottom: 0.25em;
     word-break: break-word;
@@ -2377,7 +2379,7 @@ img.emoji {
 .star {
     display: inline-block;
     font-size: 14px;
-    color: #2c8211;
+    color: hsl(106, 77%, 29%);
 }
 
 .star:not(.empty-star) {
@@ -2386,17 +2388,17 @@ img.emoji {
 }
 
 .empty-star {
-    color: #bbb;
+    color: hsl(0, 0%, 73%);
 }
 
 .empty-star:hover {
     cursor: pointer;
-    color: #565656;
+    color: hsl(0, 0%, 34%);
 }
 
 .star:hover {
     cursor: pointer;
-    color: #0d7245;
+    color: hsl(153, 80%, 25%);
 }
 
 /* FIXME: Combine this rule with the one in portico.css somehow? */
@@ -2430,7 +2432,7 @@ img.emoji {
     display: inline-block;
     vertical-align: middle;
     width: 33%;
-    border-top: 1px solid #e2e2e2;
+    border-top: 1px solid hsl(0, 0%, 88%);
     border-bottom: 1px solid #fff;
     margin: 0px 5px 0px 5px;
 }
@@ -2443,7 +2445,7 @@ img.emoji {
     overflow: hidden;
     text-transform: uppercase;
     font-size: 0.8em;
-    color: #bbb;
+    color: hsl(0, 0%, 73%);
     text-shadow: 1px 1px 0px #fff;
 }
 
@@ -2462,7 +2464,7 @@ img.emoji {
     vertical-align: middle;
     width: 50%;
     height: 0px;
-    border-top: 1px solid #e2e2e2;
+    border-top: 1px solid hsl(0, 0%, 88%);
     border-bottom: 1px solid #fff;
 }
 
@@ -2509,7 +2511,7 @@ img.emoji {
 
 #message_edit_form a.message-control-button {
     display: inline;
-    color: #777;
+    color: hsl(0, 0%, 46%);
     text-decoration: none;
     font-size: 12px;
     width: 12px;
@@ -2528,7 +2530,7 @@ img.emoji {
     display: inline-block;
     margin: 0 0 0 0;
     height: 22px;
-    background: #e2e2e2;
+    background: hsl(0, 0%, 88%);
     padding-left: 20px;
     padding-right: 3px;
     line-height: 22px;
@@ -2543,28 +2545,28 @@ img.emoji {
 }
 
 .user-mention {
-    background-color: #eee;
+    background-color: hsl(0, 0%, 93%);
     border-radius: 3px;
     padding: 0 0.2em;
-    box-shadow: 0px 0px 0px 1px #ccc;
+    box-shadow: 0px 0px 0px 1px hsl(0, 0%, 80%);
     margin-right: 2px;
     white-space: nowrap;
-    background-image: -moz-linear-gradient(top, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0) 100%);
-    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(0,0,0,0.1)), color-stop(100%,rgba(0,0,0,0)));
-    background-image: -webkit-linear-gradient(top, rgba(0,0,0,0.1) 0%,rgba(0,0,0,0) 100%);
-    background-image: -o-linear-gradient(top, rgba(0,0,0,0.1) 0%,rgba(0,0,0,0) 100%);
-    background-image: -ms-linear-gradient(top, rgba(0,0,0,0.1) 0%,rgba(0,0,0,0) 100%);
-    background-image: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%,rgba(0,0,0,0) 100%);
+    background-image: -moz-linear-gradient(top, hsla(0, 0%, 0%, 0.1) 0%, hsla(0, 0%, 0%, 0.0) 100%);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,hsla(0, 0%, 0%, 0.1)), color-stop(100%,hsla(0, 0%, 0%, 0.0)));
+    background-image: -webkit-linear-gradient(top, hsla(0, 0%, 0%, 0.1) 0%, hsla(0, 0%, 0%, 0.0) 100%);
+    background-image: -o-linear-gradient(top, hsla(0, 0%, 0%, 0.1) 0%, hsla(0, 0%, 0%, 0.0) 100%);
+    background-image: -ms-linear-gradient(top, hsla(0, 0%, 0%, 0.1) 0%, hsla(0, 0%, 0%, 0.0) 100%);
+    background-image: linear-gradient(to bottom, hsla(0, 0%, 0%, 0.1) 0%, hsla(0, 0%, 0%, 0.0) 100%);
     display: inline-block;
     margin-bottom: 1px;
 }
 
 .user-mention-me {
-    background-color: #c9fcc1;
+    background-color: hsl(112, 88%, 87%);
 }
 
 .alert-word {
-    background-color: #c9fcc1;
+    background-color: hsl(112, 88%, 87%);
 }
 
 #organization h1,
@@ -2591,7 +2593,7 @@ img.emoji {
     position: absolute;
     left: 0;
     top: 0;
-    background: #000;
+    background: hsl(0, 0%, 0%);
     z-index: 20000;
 }
 
@@ -2626,7 +2628,7 @@ img.emoji {
     position: relative;
     margin: 5px 0px;
     border: none;
-    border-left: 3px solid #eee;
+    border-left: 3px solid hsl(0, 0%, 93%);
     height: 70px;
     padding: 5px;
     z-index: 1;


### PR DESCRIPTION
All RGB hex codes, rgb() colors, or rgba() colors, were replaced with hsl() or hsla() by a script.

I spent quite a while trying to manually verify the changes and handle edge cases, so hopefully everything is in order. (If you're wondering why the number of additions is slightly more than deletions, it's because I split up one line that got particularly huge with the inserted hsla colors.)

This resolves #4603