### PR TITLE
Show detailed message why password is weak to user.

### DIFF
--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -32,18 +32,6 @@ var common = require("js/common.js");
         return self;
     }());
 
-    password = 'plain';
-    accepted = common.password_quality(password, bar);
-    assert(!accepted);
-    assert.equal(bar.w, '10.654507557627486%');
-    assert.equal(bar.added_class, 'bar-danger');
-
-    password = 'z!X4@S_&';
-    accepted = common.password_quality(password, bar);
-    assert(accepted);
-    assert.equal(bar.w, '47.679074269445294%');
-    assert.equal(bar.added_class, 'bar-success');
-
     function password_field(min_length, min_quality) {
         var self = {};
 

--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -2,11 +2,14 @@ add_dependencies({
     zxcvbn: 'node_modules/zxcvbn/dist/zxcvbn.js',
 });
 
+set_global('i18n', global.stub_i18n);
+
 var common = require("js/common.js");
 
 (function test_basics() {
     var accepted;
     var password;
+    var warning;
 
     var bar = (function () {
         var self = {};
@@ -60,21 +63,28 @@ var common = require("js/common.js");
     assert(!accepted);
     assert.equal(bar.w, '39.7%');
     assert.equal(bar.added_class, 'bar-danger');
-
+    warning = common.password_warning(password, password_field(10));
+    assert.equal(warning, 'translated: Password should be at least 10 characters long');
 
     password = 'foo';
     accepted = common.password_quality(password, bar, password_field(2, 0.001));
     assert(accepted);
     assert.equal(bar.w, '10.390277164940581%');
     assert.equal(bar.added_class, 'bar-success');
+    warning = common.password_warning(password, password_field(2));
+    assert.equal(warning, 'translated: Password is too weak');
 
     password = 'aaaaaaaa';
     accepted = common.password_quality(password, bar, password_field(6, 1000));
     assert(!accepted);
     assert.equal(bar.added_class, 'bar-danger');
+    warning = common.password_warning(password, password_field(6));
+    assert.equal(warning, 'Repeats like "aaa" are easy to guess');
 
     delete global.zxcvbn;
     password = 'aaaaaaaa';
     accepted = common.password_quality(password, bar, password_field(6, 1000));
     assert(accepted === undefined);
+    warning = common.password_warning(password, password_field(6));
+    assert(warning === undefined);
 }());

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -62,6 +62,23 @@ exports.password_quality = function (password, bar, password_field) {
     return acceptable;
 };
 
+exports.password_warning = function (password, password_field) {
+    if (typeof zxcvbn === 'undefined') {
+        return undefined;
+    }
+
+    var min_length = 6;
+
+    if (password_field) {
+        min_length = password_field.data('minLength') || min_length;
+    }
+
+    if (password.length < min_length) {
+        return i18n.t('Password should be at least __length__ characters long', {length: min_length});
+    }
+    return zxcvbn(password).feedback.warning || i18n.t("Password is too weak");
+};
+
 return exports;
 
 }());

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -24,13 +24,8 @@ exports.password_quality = function (password, bar, password_field) {
         return undefined;
     }
 
-    var min_length = 6;
-    var min_quality = 0;
-
-    if (password_field) {
-        min_length = password_field.data('minLength') || min_length;
-        min_quality = password_field.data('minQuality') || min_quality;
-    }
+    var min_length = password_field.data('minLength');
+    var min_quality = password_field.data('minQuality');
 
     // Consider the password acceptable if it's at least 6 characters.
     var acceptable = password.length >= min_length;
@@ -67,11 +62,7 @@ exports.password_warning = function (password, password_field) {
         return undefined;
     }
 
-    var min_length = 6;
-
-    if (password_field) {
-        min_length = password_field.data('minLength') || min_length;
-    }
+    var min_length = password_field.data('minLength');
 
     if (password.length < min_length) {
         return i18n.t('Password should be at least __length__ characters long', {length: min_length});

--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -1,10 +1,13 @@
 $(function () {
     // NB: this file is included on multiple pages.  In each context,
     // some of the jQuery selectors below will return empty lists.
+    var password_field = $('#id_password, #id_new_password1');
 
     $.validator.addMethod('password_strength', function (value) {
-        return common.password_quality(value, undefined, $('#id_password, #id_new_password1'));
-    }, "Password is too weak.");
+        return common.password_quality(value, undefined, password_field);
+    }, function () {
+        return common.password_warning(password_field.val(), password_field);
+    });
 
     function highlight(class_to_add) {
         // Set a class on the enclosing control group.
@@ -35,7 +38,7 @@ $(function () {
         unhighlight: highlight('success'),
     });
 
-    $('#id_password, #id_new_password1').on('change keyup', function () {
+    password_field.on('change keyup', function () {
         // Update the password strength bar even if we aren't validating
         // the field yet.
         common.password_quality($(this).val(), $('#pw_strength .bar'), $(this));

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -64,7 +64,8 @@
 
                         <div class="input-group">
                             <label for="new_password" class="inline-block title">{{t "New password" }}</label>
-                            <input type="password" autocomplete="off" name="new_password" id="new_password" class="w-200 inline-block" value="" />
+                            <input type="password" autocomplete="off" name="new_password" id="new_password" class="w-200 inline-block" value=""
+                             data-min-length="{{ page_params.password_min_length }}" data-min-quality="{{ page_params.password_min_quality }}" />
                             <div class="warning">
                                 <div class="progress inline-block" id="pw_strength">
                                     <div class="bar bar-danger fade" style="width: 10%;"></div>

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -9,6 +9,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
 {% block customhead %}
 {{ super() }}
 {{ render_bundle('zxcvbn') }}
+{{ render_bundle('translations') }}
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -67,8 +67,6 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                    data-min-length="{{password_min_length}}"
                    data-min-quality="{{password_min_quality}}" required />
             <label for="id_password" class="inline-block">{{ _('Password') }}</label>
-            <div class="required"></div>
-            <img class="valid" src="/static/images/checkbox-valid.svg" alt="{{ _('Valid') }}" />
             {% if full_name %}
             <span class="help-inline">
               {{ _('This is used for mobile applications and other tools that require a password.') }}

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -89,6 +89,8 @@ class HomeTest(ZulipTestCase):
             "narrow_stream",
             "needs_tutorial",
             "never_subscribed",
+            "password_min_length",
+            "password_min_quality",
             "pm_content_in_desktop_notifications",
             "pointer",
             "poll_timeout",

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -198,6 +198,8 @@ def home_real(request):
         save_stacktraces      = settings.SAVE_FRONTEND_STACKTRACES,
         server_inline_image_preview = settings.INLINE_IMAGE_PREVIEW,
         server_inline_url_embed_preview = settings.INLINE_URL_EMBED_PREVIEW,
+        password_min_length = settings.PASSWORD_MIN_LENGTH,
+        password_min_quality = settings.PASSWORD_MIN_ZXCVBN_QUALITY,
 
         # Misc. extra data.
         have_initial_messages = user_has_messages,


### PR DESCRIPTION
The goal of the PR is to show why the password is not valid to the user rather than showing `Password is too weak.` message. Here are some screenshots
![screenshot from 2017-06-21 18 10 52](https://user-images.githubusercontent.com/7190633/27384606-198a2270-56ad-11e7-9424-c7dd5d83384d.png)
![screenshot from 2017-06-21 18 03 15](https://user-images.githubusercontent.com/7190633/27384619-2984e156-56ad-11e7-87dc-3c608cadad20.png)

There are two factors used for determining whether a password is valid. 
* Password length
* Password quality

The password length should be greater than `settings.PASSWORD_MIN_LENGTH` and quality should be greater than `settings.PASSWORD_MIN_ZXCVBN_QUALITY`. 

Choosing a value for Password quality is kind of a tedious task for server admins who don't have much time to research on what number it should be. This is how we caluclate the password quality

```js
 var quality = Math.min(1,Math.log(1 + result.crack_times_seconds.
                                          offline_slow_hashing_1e4_per_second) / 22);

 ```

Instead of using this I propose to use the result.score(Integer from 0-4 provided by `zxcvbn's` for determining the password strength, Also pointed out by @rht). 

  0 # too guessable: risky password. (guesses < 10^3)

  1 # very guessable: protection from throttled online attacks. (guesses < 10^6)

  2 # somewhat guessable: protection from unthrottled online attacks. (guesses < 10^8)

  3 # safely unguessable: moderate protection from offline slow-hash scenario. (guesses < 10^10)

  4 # very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)

The admins can choose one of them and we can keep maybe 2 or 3 as the default. I have not implemented this part in the PR. What do you folks think?
Addresses #5052

@rishig @showell @gnprice  @adnrs96

For seeing error messages other than length you can set `PASSWORD_MIN_ZXCVBN_QUALITY = 0.5`(or some similar value other than 0) in dev_settings.
