### PR TITLE
bots: Add dependencies management.

### DIFF
--- a/api/bots/.gitignore
+++ b/api/bots/.gitignore
@@ -1,0 +1,1 @@
+bot_dependencies

--- a/api/bots/thesaurus/requirements.txt
+++ b/api/bots/thesaurus/requirements.txt
@@ -1,0 +1,1 @@
+PyDictionary

--- a/api/bots/thesaurus/thesaurus.py
+++ b/api/bots/thesaurus/thesaurus.py
@@ -2,11 +2,7 @@
 from __future__ import print_function
 import sys
 import logging
-try:
-    from PyDictionary import PyDictionary as Dictionary
-except ImportError:
-    logging.error("Dependency Missing!")
-    sys.exit(0)
+from PyDictionary import PyDictionary as Dictionary
 
 #Uses Python's Dictionary module
 #  pip install PyDictionary

--- a/api/bots_api/provision.py
+++ b/api/bots_api/provision.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+import pip
+
+def provision_bot(path_to_bot, force):
+    # type: (str, bool) -> None
+    req_path = os.path.join(path_to_bot, 'requirements.txt')
+    install_path = os.path.join(path_to_bot, 'bot_dependencies')
+    if os.path.isfile(req_path):
+        print('Installing dependencies...')
+        if not os.path.isdir(install_path):
+            os.makedirs(install_path)
+        # pip install -r $BASEDIR/requirements.txt -t $BASEDIR/bot_dependencies --quiet
+        rcode = pip.main(['install', '-r', req_path, '-t', install_path, '--quiet'])
+        if not rcode == 0:
+            print('Error. Check output of `pip install` above for details.')
+            if not force:
+                print('Use --force to try running anyway.')
+                sys.exit(rcode)  # Use pip's exit code
+        else:
+            print('Installed.')
+        sys.path.insert(0, install_path)
+
+def dir_join(dir1, dir2):
+    # type: (str, str) -> str
+    return os.path.abspath(os.path.join(dir1, dir2))
+
+def run():
+    # type: () -> None
+    usage = '''
+        Installs dependencies of bots in api/bots directory. Add a
+        reuirements.txt file in a bot's folder before provisioning.
+
+        To provision all bots, use:
+        ./provision.py
+
+        To provision specific bots, use:
+        ./provision.py [names of bots]
+        Example: ./provision.py helloworld xkcd wikipedia
+
+        '''
+
+    bots_dir = dir_join(os.path.dirname(os.path.abspath(__file__)), '../bots')
+    available_bots = [b for b in os.listdir(bots_dir) if os.path.isdir(dir_join(bots_dir, b))]
+
+    parser = argparse.ArgumentParser(usage=usage)
+    parser.add_argument('bots_to_provision',
+                        metavar='bots',
+                        nargs='*',
+                        default=available_bots,
+                        help='specific bots to provision (default is all)')
+    parser.add_argument('--force',
+                        default=False,
+                        action="store_true",
+                        help='Continue installation despite pip errors.')
+    options = parser.parse_args()
+    for bot in options.bots_to_provision:
+        provision_bot(os.path.join(dir_join(bots_dir, bot)), options.force)
+
+if __name__ == '__main__':
+    run()

--- a/api/bots_api/test-bots
+++ b/api/bots_api/test-bots
@@ -53,6 +53,8 @@ if __name__ == '__main__':
 
     suites = []
     for bot_to_test in args.bots_to_test:
+        dep_path = os.path.join(bots_test_dir, bot_to_test, 'bot_dependencies')
+        sys.path.insert(0, dep_path)
         try:
             suites.append(loader.discover(start_dir = dir_join(bots_test_dir, bot_to_test),
                                           top_level_dir = root_dir))


### PR DESCRIPTION
1. Since `pip.main()` doesn't throw any exceptions and we get regular `pip` return codes, there is just a simple `rcode == 0` check.
2. Also, once installed, pip won't install again, so this would run each time a bot is run without much overhead.
3. Also, in case a person is offline, I added a `--force` option.

Perhaps the --force option could also lift restrictions on the path we run the bots from?