### PR TITLE
timerender: Make get_full_time produce a ISO 8601 date string.

### DIFF
--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -129,7 +129,7 @@ var timerender = require('js/timerender.js');
 
 (function test_get_full_time() {
     var timestamp = 1495091573; // 5/18/2017 7:12:53 AM (UTC+0)
-    var expected = '5/18/2017 7:12:53 AM (UTC+0)';
+    var expected = '2017-05-18T07:12:53Z'; // ISO 8601 date format
     var actual = timerender.get_full_time(timestamp);
     assert.equal(expected, actual);
 }());

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -202,19 +202,10 @@ exports.update_timestamps = function () {
 
 setInterval(exports.update_timestamps, 60 * 1000);
 
-// TODO: Remove the duplication with the below; it's a bit tricky
-// because the return type models are pretty different.
+// Transform a Unix timestamp into a ISO 8601 formatted date string.
+//   Example: 1978-10-31T13:37:42Z
 exports.get_full_time = function (timestamp) {
-    var time = new XDate(timestamp * 1000);
-    // Convert to number of hours ahead/behind UTC.
-    // The sign of getTimezoneOffset() is reversed wrt
-    // the conventional meaning of UTC+n / UTC-n
-    var tz_offset = -time.getTimezoneOffset() / 60;
-
-    var full_date_str = time.toLocaleDateString();
-    var full_time_str = time.toLocaleTimeString() +
-        ' (UTC' + ((tz_offset < 0) ? '' : '+') + tz_offset + ')';
-    return full_date_str + ' ' + full_time_str;
+    return new XDate(timestamp * 1000).toISOString();
 };
 
 


### PR DESCRIPTION
Having get_full_time produce a date string non-compliant with RFC2822 or ISO 8601 caused problems when showing edition timestamps on a message's edit history.

Now it returns an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date string (`1978-10-31T13:37:42Z`).