### PR TITLE
scripts/upgrade-zulip-from-git: Don't cache the repo URL, only the contents

### DIFF
--- a/scripts/upgrade-zulip-from-git
+++ b/scripts/upgrade-zulip-from-git
@@ -46,7 +46,6 @@ get_deployment_lock(error_rerun_script)
 try:
     deploy_path = make_deploy_path()
     if not os.path.exists(LOCAL_GIT_CACHE_DIR):
-        os.chdir('/srv/')
         logging.info("Cloning the repository")
         subprocess.check_call(["git", "clone", "-q", git_url, "--mirror", LOCAL_GIT_CACHE_DIR],
                               stdout=open('/dev/null', 'w'))
@@ -54,6 +53,7 @@ try:
 
     logging.info("Fetching the latest commits")
     os.chdir(LOCAL_GIT_CACHE_DIR)
+    subprocess.check_call(["git", "remote", "set-url", "origin", git_url], preexec_fn=su_to_zulip)
     subprocess.check_call(["git", "fetch", "-q"], preexec_fn=su_to_zulip)
 
     subprocess.check_call(["git", "clone", "-q", "-b", refname, LOCAL_GIT_CACHE_DIR, deploy_path],


### PR DESCRIPTION
We document the `deployment.git_repo_url` setting in `/etc/zulip/zulip.conf`
to control where this script fetches from, and don't say that it's
only read on the first such upgrade and cached thereafter.  The documented
behavior seems like the right behavior.  So use the currently configured
URL every time, by writing it anew into the config of our cache repo.

---

@timabbott, probably best for you to review when you're back. (There's no rush to land this.)

I haven't yet tested this change at all. Do we have any tools or infrastructure for a "dev prod" environment in which to test this kind of change? If not, making a crude one (and over time a less-crude one) probably goes on my agenda.
