### PR TITLE
[wip] prod: Make `cp` copy a directory to its target, not into it.

### DIFF
--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -100,7 +100,7 @@ subprocess.check_call(['mv', os.path.join(settings.STATIC_ROOT, 'source-map'),
                       stdout=fp, stderr=fp)
 
 # Move language_options.json to the production release
-subprocess.check_call(['cp', '-a', 'static/locale',
+subprocess.check_call(['cp', '-aT', 'static/locale',
                        os.path.join(settings.STATIC_ROOT, 'locale')],
                       stdout=fp, stderr=fp)
 


### PR DESCRIPTION
This was causing `language_options.json` never to get updated by
`upgrade-zulip-from-git` after first deploy, generally causing an
install to claim less translation coverage than it actually had.

The same bug exists in several other spots in this file.  Some of
our repetitive-yet-subtly-different uses of `cp` should probably
turn into just a list of arguments to one `rsync -R` command.
Let this serve as a placeholder for me to make a comfortable
dev/test environment for myself for this kind of prod-ops script
and then go fix those in general.