### PR TITLE
composebox_typeahead: Fix the autcomplete behavior while editing message

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -353,6 +353,7 @@ exports.content_typeahead_selected = function (item) {
     var pieces = exports.split_at_cursor(this.query, this.$element);
     var beginning = pieces[0];
     var rest = pieces[1];
+    var textbox = this.$element;
 
     if (this.completing === 'emoji') {
         // leading and trailing spaces are required for emoji, except if it begins a message.
@@ -378,7 +379,7 @@ exports.content_typeahead_selected = function (item) {
     // Keep the cursor after the newly inserted text, as Bootstrap will call textbox.change() to
     // overwrite the text in the textbox.
     setTimeout(function () {
-        $('#new_message_content').caret(beginning.length, beginning.length);
+        textbox.caret(beginning.length, beginning.length);
         // Also, trigger autosize to check if compose box needs to be resized.
         compose_ui.autosize_textarea();
     }, 0);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -357,7 +357,9 @@ exports.content_typeahead_selected = function (item) {
 
     if (this.completing === 'emoji') {
         // leading and trailing spaces are required for emoji, except if it begins a message.
-        if (beginning.lastIndexOf(":") === 0 || beginning.charAt(beginning.lastIndexOf(":") - 1) === " ") {
+        if (beginning.lastIndexOf(":") === 0 ||
+            beginning.charAt(beginning.lastIndexOf(":") - 1) === " " ||
+            beginning.charAt(beginning.lastIndexOf(":") - 1) === "\n") {
             beginning = beginning.replace(/:\S+$/, "") + ":" + item.emoji_name + ": ";
         } else {
             beginning = beginning.replace(/:\S+$/, "") + " :" + item.emoji_name + ": ";


### PR DESCRIPTION
On editing a multi-line message inserting an emoji or stream name,
the autocomplete was incorrectly sending the cursor to the the end
of the message.

Fixes: #5515.