### PR TITLE
[WIP] frontend: Toggle aria-hidden for overlay container visibility.

### DIFF
--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -57,6 +57,7 @@ exports.open_overlay = function (opts) {
     open_overlay_name = opts.name;
     active_overlay = opts.overlay;
     opts.overlay.addClass('show');
+    opts.overlay.attr("aria-hidden","false");
 
     close_handler = function () {
         opts.on_close();
@@ -78,6 +79,7 @@ exports.close_overlay = function (name) {
     blueslip.debug('close overlay: ' + name);
 
     active_overlay.removeClass("show");
+    active_overlay.attr("aria-hidden","true");
 
     if (!close_handler) {
         blueslip.error("Overlay close handler for " + name + " not properly setup." );

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -54,7 +54,7 @@ var page_params = {{ page_params }};
 <div id="right-screen" class="screen"></div>
 <div id="clear-screen" class="screen"></div>
 
-<div id="settings_overlay_container" class="overlay" data-overlay="settings">
+<div id="settings_overlay_container" class="overlay" data-overlay="settings" aria-hidden="true">
   {% include "zerver/settings_overlay.html" %}
 </div>
 {% include "zerver/navbar.html" %}
@@ -141,7 +141,7 @@ var page_params = {{ page_params }};
     {% include "zerver/subscriptions.html" %}
     {% include "zerver/drafts.html" %}
 </div><!--/row-->
-    <div class="informational-overlays overlay new-style" data-overlay="informationalOverlays">
+    <div class="informational-overlays overlay new-style" data-overlay="informationalOverlays" aria-hidden="true">
         <div class="overlay-content">
             <div class="overlay-tabs">
                 <button class="button no-style exit">&times;</button>


### PR DESCRIPTION
Resolves #5024.

Right now, when none of the settings overlays are opened, the accessibility tool only reports `<a class="search_icon"` as being focusable without being visible (it is indeed visible, but the `a` has a width of `0` thus the tool is confused. not sure how to fix this without modifying the layout?)

When the overlays get the class `show`, aria-hidden also gets updated and they become visible.
However, the rest of the screen then doesn't pass the accessibility tool (should be non-focusable). The tool reports 38 errors, which include streams and so on). I am working on fixing this next.


