### PR TITLE
Fix Circle.CI webhook's assumption that previous build always exists

### DIFF
--- a/zerver/webhooks/circleci/view.py
+++ b/zerver/webhooks/circleci/view.py
@@ -46,7 +46,7 @@ def get_body(payload):
 def get_status(payload):
     # type: (Dict[str, Any]) -> Text
     status = payload['status']
-    if payload['previous']['status'] == FAILED_STATUS and status == FAILED_STATUS:
+    if payload['previous'] and payload['previous']['status'] == FAILED_STATUS and status == FAILED_STATUS:
         return u'is still failing'
     if status == 'success':
         return u'succeeded'


### PR DESCRIPTION
The code in the Circle.CI webhook handler assumes that a previous build exists when a status is parsed out.  Therefore, it breaks when a new branch is built that has no previous builds, leading to the following error:
```
File "./zerver/webhooks/circleci/view.py", line 27, in api_circleci_webhook
    body = get_body(payload)
  File "./zerver/webhooks/circleci/view.py", line 42, in get_body
    'status': get_status(payload)
  File "./zerver/webhooks/circleci/view.py", line 49, in get_status
    if payload['previous']['status'] == FAILED_STATUS and status == FAILED_STATUS:
TypeError: 'NoneType' object has no attribute '__getitem__'
```

The fix is very simple: just check to make sure a previous build exists before trying to get it's status.