### PR TITLE
[WIP] bots: Add timed event support and a work timer bot

### DIFF
--- a/api/bots/work_timer/readme.md
+++ b/api/bots/work_timer/readme.md
@@ -1,0 +1,4 @@
+Simple Zulip bot that will respond to any query with a "beep boop".
+
+The helloworld bot is a boilerplate bot that can be used as a
+template for more sophisticated/evolved Zulip bots.

--- a/api/bots/work_timer/test_helloworld.py
+++ b/api/bots/work_timer/test_helloworld.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from six.moves import zip
+
+from bots_test_lib import BotTestCase
+
+class TestWorkTimerBot(BotTestCase):
+    bot_name = "Work Timer"
+
+    def test_bot(self):
+        #txt = "beep boop"
+        #messages = ["", "foo", "Hi, my name is abc"]
+        #self.check_expected_responses(dict(list(zip(messages, len(messages)*[txt]))))
+        pass

--- a/api/bots/work_timer/work_timer.py
+++ b/api/bots/work_timer/work_timer.py
@@ -1,0 +1,88 @@
+# See readme.md for instructions on running this code.
+from time import time
+from threading import Timer
+
+class WorkTimerHandler(object):
+    def usage(self):
+        return '''
+        This productivity bot lets you set timers to schedule work cycles.
+        Start a new timer with the following syntax:
+        work - set a work timer for the default 25 minutes
+        work on [task] - set a work timer, and specify what you're working on
+        work for [time] - set a work timer for a custom number of minutes
+        work on [task] for [time] - combines the two above
+
+        When you have a task running, you can call **status** to check how much
+        time you have left. You'll be notified when your timer runs out.
+        '''
+
+    def handle_message(self, message, bot_handler, state_handler, event_timer):
+        state = state_handler.get_state() or {}
+        req = message['content'].lower()
+        user = message['sender_email']
+        content = 'I didn\'t understand that. Say "help" for usage information.'
+        malformed = ''
+        if 'work' in req:
+            task = ''
+            task_time = 25
+            malformed = ''
+            if 'for' in req:
+                req,_,time_input = req.rpartition('for')
+                time_input = time_input.strip().split(' ')
+                if len(time_input) > 2:
+                    malformed = '**Error:** Please format as "work on [task] for [minutes]".'
+                try:
+                    task_time = int(time_input[0])
+                except ValueError:
+                    malformed = '**Error:** Invalid time specified (please use an integer).'
+            content = 'for {} minutes.'.format(task_time)
+            if 'on' in req:
+                task = req.partition('on')[2].strip()
+                content = 'on {} '.format(task) + content
+            content = 'Ok, setting a timer to work ' + content
+            if not malformed:
+                if not user in state:
+                    state[user] = {}
+                task_time *= 60
+                state[user]['time'] = time() + task_time
+                state[user]['task'] = task
+
+                task_func = self.build_task_wrapper(user, task, bot_handler)
+                event_timer.schedule(task_func, task_time)
+        elif 'status' in req:
+            if user not in state or state[user]['time'] - time() < 0:
+                content = 'You have no active timers.'
+            else:
+                mins = int(state[user]['time'] - time() + 30)/60
+                time_str = "You have about {} minutes left.".format(mins)
+                if mins == 1:
+                    time_str = "You have about 1 minute left."
+                elif mins == 0:
+                    time_str = "You have under a minute left."
+                if state[user]['task']:
+                    content = 'You\'re supposed to be working on {}. '.format(state[user]['task'])
+                else:
+                    content = 'You\'re supposed to be working. '
+                content += time_str
+        elif 'help' in req:
+            content = self.usage()
+
+        if malformed:
+            content = malformed
+        state_handler.set_state(state)
+        bot_handler.send_reply(message, content)
+
+    def build_task_wrapper(self, user, task, bot_handler):
+        return lambda: self.on_task_finish(user, task, bot_handler)
+
+    def on_task_finish(self, user, task, bot_handler):
+        message = '''Your timer has ended! You've been working on {}.
+        Give a new "work" command or take a break.'''.format(task)
+
+        bot_handler.send_message(dict(
+            type='private',
+            to=user,
+            content=message,
+        ))
+
+handler_class = WorkTimerHandler


### PR DESCRIPTION
The first commit adds a new EventTimer class to bots_api. 
I don't know what the best way to integrate such a class would be, so the current setup is perhaps temporary.

EventTimer gives sort of the JS `setTimeout` and `setInterval` functionality to bots. To run a function in 30 seconds, use `event_timer.schedule(func, 30)`. 
To run it every 30 seconds, use `event_timer.schedule(func, 30, repeat=True)`
I'd like some feedback on my implementation, and if there are more optimal ways to approach it.

And then, the bot I made to test this will let you set timers for work, in a similar vein as the Pomodoro technique. See this usage example:
![image](https://user-images.githubusercontent.com/8433005/27464444-8a4e2896-579b-11e7-88c2-d68d308a4cd6.png)

It's tagged [WIP], but at the current state the bot should be fully functional.
