### PR TITLE
travis: Fix the order of running the test suites in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,6 @@ matrix:
   include:
     - python: "3.4"
       env: TEST_SUITE=static-analysis
-    - python: "3.4"
-      env: TEST_SUITE=production
-    - python: "2.7"
-      env: TEST_SUITE=production
     - python: "2.7"
       env: TEST_SUITE=frontend
     - python: "3.4"
@@ -60,6 +56,10 @@ matrix:
       env: TEST_SUITE=backend
     - python: "3.4"
       env: TEST_SUITE=backend
+    - python: "2.7"
+      env: TEST_SUITE=production
+    - python: "3.4"
+      env: TEST_SUITE=production
 sudo: required
 services:
 - docker


### PR DESCRIPTION
This commit fixes the order in which we run the test suites in Travis
CI. Most of the PRs include changes only to backend/frontend and it is
fairly rare for them to break production test suite. Since travis runs
atmost four jobs at a time, most of the time developers need to wait for
the production suite to get completed so that the backend test suite can
start which has a fairly large chances of being broken. Now, we run the
production test suite in last.
Discussion on chat.zulip.org: https://chat.zulip.org/#narrow/stream/backend/subject/Order.20of.20running.20test.20suites/near/235687