### PR TITLE
Refactor email addresses to change sender names

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -14,7 +14,7 @@ from jinja2 import Markup as mark_safe
 from zerver.lib.actions import do_change_password, is_inactive, user_email_is_unique
 from zerver.lib.name_restrictions import is_reserved_subdomain, is_disposable_domain
 from zerver.lib.request import JsonableError
-from zerver.lib.send_email import send_email
+from zerver.lib.send_email import send_email, FromAddress
 from zerver.lib.users import check_full_name
 from zerver.lib.utils import get_subdomain, check_subdomain
 from zerver.models import Realm, get_user_profile_by_email, UserProfile, \
@@ -219,8 +219,8 @@ class ZulipPasswordResetForm(PasswordResetForm):
         if not check_subdomain(user_realm.subdomain, attempted_subdomain):
             context['attempted_realm'] = get_realm(attempted_subdomain)
 
-        send_email('zerver/emails/password_reset', to_email, from_email=from_email,
-                   context=context)
+        send_email('zerver/emails/password_reset', to_email,
+                   from_address=FromAddress.NOREPLY, context=context)
 
     def save(self, *args, **kwargs):
         # type: (*Any, **Any) -> None

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -29,7 +29,7 @@ from zerver.lib.message import (
 )
 from zerver.lib.realm_icon import realm_icon_url
 from zerver.lib.retention import move_message_to_archive
-from zerver.lib.send_email import send_email
+from zerver.lib.send_email import send_email, FromAddress
 from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, \
     RealmDomain, \
     Subscription, Recipient, Message, Attachment, UserMessage, RealmAuditLog, \
@@ -99,6 +99,7 @@ import platform
 import logging
 import itertools
 from collections import defaultdict
+
 
 # This will be used to type annotate parameters in a function if the function
 # works on both str and unicode in python 2 but in python 3 it only works on str.
@@ -638,8 +639,7 @@ def do_start_email_change_process(user_profile, new_email):
     activation_url = EmailChangeConfirmation.objects.get_link_for_object(obj, host=user_profile.realm.host)
     context = {'realm': user_profile.realm, 'old_email': old_email, 'new_email': new_email,
                'activate_url': activation_url}
-    send_email('zerver/emails/confirm_new_email', new_email, from_email=settings.ZULIP_ADMINISTRATOR,
-               context=context)
+    send_email('zerver/emails/confirm_new_email', new_email, from_address=FromAddress.SUPPORT, context=context)
 
 def compute_irc_user_fullname(email):
     # type: (NonBinaryStr) -> NonBinaryStr
@@ -3052,8 +3052,7 @@ def do_send_confirmation_email(invitee, referrer, body):
     """
     activation_url = Confirmation.objects.get_link_for_object(invitee, host=referrer.realm.host)
     context = {'referrer': referrer, 'custom_body': body, 'activate_url': activation_url}
-    send_email('zerver/emails/invitation', invitee.email, from_email=settings.ZULIP_ADMINISTRATOR,
-               context=context)
+    send_email('zerver/emails/invitation', invitee.email, from_address=FromAddress.SUPPORT, context=context)
 
 def is_inactive(email):
     # type: (Text) -> None

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -17,6 +17,7 @@ from zerver.lib.redis_utils import get_redis_client
 from zerver.lib.upload import upload_message_image
 from zerver.lib.utils import generate_random_token
 from zerver.lib.str_utils import force_text
+from zerver.lib.send_email import FromAddress
 from zerver.models import Stream, Recipient, \
     get_user_profile_by_id, get_display_recipient, get_recipient, \
     Message, Realm, UserProfile, get_system_bot
@@ -105,7 +106,7 @@ def create_missed_message_address(user_profile, message):
     if settings.EMAIL_GATEWAY_PATTERN == '':
         logging.warning("EMAIL_GATEWAY_PATTERN is an empty string, using "
                         "NOREPLY_EMAIL_ADDRESS in the 'from' field.")
-        return settings.NOREPLY_EMAIL_ADDRESS
+        return "Zulip <%s>" % (FromAddress.NOREPLY,)
 
     if message.recipient.type == Recipient.PERSONAL:
         # We need to reply to the sender so look up their personal recipient_id

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -8,7 +8,7 @@ from django.template import loader
 from django.utils.timezone import now as timezone_now
 from zerver.decorator import statsd_increment
 from zerver.lib.send_email import send_future_email, display_email, \
-    send_email_from_dict
+    send_email_from_dict, FromAddress
 from zerver.lib.queue import queue_json_publish
 from zerver.models import (
     Recipient,
@@ -309,7 +309,7 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile, missed_messages, m
         'realm_str': user_profile.realm.name,
     })
 
-    from_email = None
+    from_name, from_address = None, None
 
     if len(senders) == 1 and settings.SEND_MISSED_MESSAGE_EMAILS_AS_USER:
         # If this setting is enabled, you can reply to the Zulip
@@ -318,7 +318,7 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile, missed_messages, m
         # record for the domain, or there will be spam/deliverability
         # problems.
         sender = senders[0]
-        from_email = '"%s" <%s>' % (sender.full_name, sender.email)
+        from_name, from_address = (sender.full_name, sender.email)
         context.update({
             'reply_warning': False,
             'reply_to_zulip': False,
@@ -327,7 +327,8 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile, missed_messages, m
     email_dict = {
         'template_prefix': 'zerver/emails/missed_message',
         'to_email': display_email(user_profile),
-        'from_email': from_email,
+        'from_name': from_name,
+        'from_address': from_address,
         'reply_to_email': address,
         'context': context}
     queue_json_publish("missedmessage_email_senders", email_dict, send_email_from_dict)
@@ -395,10 +396,11 @@ def enqueue_welcome_emails(email, name):
     from zerver.context_processors import common_context
     if settings.WELCOME_EMAIL_SENDER is not None:
         # line break to avoid triggering lint rule
-        from_email = '%(name)s <%(email)s>' % \
-                     settings.WELCOME_EMAIL_SENDER
+        from_name = settings.WELCOME_EMAIL_SENDER['name']
+        from_address = settings.WELCOME_EMAIL_SENDER['email']
     else:
-        from_email = settings.ZULIP_ADMINISTRATOR
+        from_name = None
+        from_address = FromAddress.SUPPORT
 
     user_profile = get_user_profile_by_email(email)
     unsubscribe_link = one_click_unsubscribe_link(user_profile, "welcome")
@@ -407,11 +409,11 @@ def enqueue_welcome_emails(email, name):
         'unsubscribe_link': unsubscribe_link
     })
     send_future_email(
-        "zerver/emails/followup_day1", '%s <%s>' % (name, email),
-        from_email=from_email, context=context, delay=datetime.timedelta(hours=1))
+        "zerver/emails/followup_day1", '%s <%s>' % (name, email), from_name=from_name,
+        from_address=from_address, context=context, delay=datetime.timedelta(hours=1))
     send_future_email(
-        "zerver/emails/followup_day2", '%s <%s>' % (name, email),
-        from_email=from_email, context=context, delay=datetime.timedelta(days=1))
+        "zerver/emails/followup_day2", '%s <%s>' % (name, email), from_name=from_name,
+        from_address=from_address, context=context, delay=datetime.timedelta(days=1))
 
 def convert_html_to_markdown(html):
     # type: (Text) -> Text

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -5,10 +5,14 @@ from django.utils.timezone import now as timezone_now
 from zerver.models import UserProfile, ScheduledJob
 
 import datetime
-from email.utils import parseaddr
+from email.utils import parseaddr, formataddr
 import ujson
 
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Text
+
+class FromAddress(object):
+    SUPPORT = parseaddr(settings.ZULIP_ADMINISTRATOR)[1]
+    NOREPLY = parseaddr(settings.NOREPLY_EMAIL_ADDRESS)[1]
 
 def display_email(user):
     # type: (UserProfile) -> Text
@@ -17,8 +21,8 @@ def display_email(user):
     return user.email
 
 # Intended only for test code
-def build_email(template_prefix, to_email, from_email=None, reply_to_email=None, context={}):
-    # type: (str, Text, Optional[Text], Optional[Text], Dict[str, Any]) -> EmailMultiAlternatives
+def build_email(template_prefix, to_email, from_name=None, from_address=None, reply_to_email=None, context={}):
+    # type: (str, Text, Optional[Text], Optional[Text], Optional[Text], Dict[str, Any]) -> EmailMultiAlternatives
     context.update({
         'support_email': settings.ZULIP_ADMINISTRATOR,
         'verbose_support_offers': settings.VERBOSE_SUPPORT_OFFERS,
@@ -28,8 +32,15 @@ def build_email(template_prefix, to_email, from_email=None, reply_to_email=None,
     message = loader.render_to_string(template_prefix + '.txt',
                                       context=context, using='Jinja2_plaintext')
     html_message = loader.render_to_string(template_prefix + '.html', context)
-    if from_email is None:
-        from_email = settings.NOREPLY_EMAIL_ADDRESS
+
+    # We set these as checks for None rather than as defaults for the keyword arguments
+    # because sometimes the from_name and from_address to be passed into send_email are
+    # possibly modified from their default values in conditional blocks.
+    if from_name is None:
+        from_name = "Zulip"
+    if from_address is None:
+        from_address = FromAddress.NOREPLY
+    from_email = formataddr((from_name, from_address))
     reply_to = None
     if reply_to_email is not None:
         reply_to = [reply_to_email]
@@ -39,15 +50,16 @@ def build_email(template_prefix, to_email, from_email=None, reply_to_email=None,
         mail.attach_alternative(html_message, 'text/html')
     return mail
 
-def send_email(template_prefix, to_email, from_email=None, reply_to_email=None, context={}):
-    # type: (str, Text, Optional[Text], Optional[Text], Dict[str, Any]) -> bool
-    mail = build_email(template_prefix, to_email, from_email=from_email,
-                       reply_to_email=reply_to_email, context=context)
+def send_email(template_prefix, to_email, from_name=None, from_address=None, reply_to_email=None, context={}):
+    # type: (str, Text, Optional[Text], Optional[Text], Optional[Text], Dict[str, Any]) -> bool
+    mail = build_email(template_prefix, to_email, from_name=from_name,
+                       from_address=from_address, reply_to_email=reply_to_email, context=context)
     return mail.send() > 0
 
-def send_email_to_user(template_prefix, user, from_email=None, context={}):
-    # type: (str, UserProfile, Optional[Text], Dict[str, Text]) -> bool
-    return send_email(template_prefix, display_email(user), from_email=from_email, context=context)
+def send_email_to_user(template_prefix, user, from_name=None, from_address=None, context={}):
+    # type: (str, UserProfile, Optional[Text], Optional[Text], Dict[str, Text]) -> bool
+    return send_email(template_prefix, display_email(user), from_name=from_name,
+                      from_address=from_address, context=context)
 
 # Returns None instead of bool so that the type signature matches the third
 # argument of zerver.lib.queue.queue_json_publish
@@ -55,11 +67,11 @@ def send_email_from_dict(email_dict):
     # type: (Mapping[str, Any]) -> None
     send_email(**dict(email_dict))
 
-def send_future_email(template_prefix, to_email, from_email=None, context={},
+def send_future_email(template_prefix, to_email, from_name=None, from_address=None, context={},
                       delay=datetime.timedelta(0)):
-    # type: (str, Text, Optional[Text], Dict[str, Any], datetime.timedelta) -> None
-    email_fields = {'template_prefix': template_prefix, 'to_email': to_email, 'from_email': from_email,
-                    'context': context}
+    # type: (str, Text, Optional[Text], Optional[Text], Dict[str, Any], datetime.timedelta) -> None
+    email_fields = {'template_prefix': template_prefix, 'to_email': to_email, 'from_name': from_name,
+                    'from_address': from_address, 'context': context}
     ScheduledJob.objects.create(type=ScheduledJob.EMAIL, filter_string=parseaddr(to_email)[1],
                                 data=ujson.dumps(email_fields),
                                 scheduled_timestamp=timezone_now() + delay)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -31,7 +31,7 @@ from zerver.lib.email_mirror import (
 )
 
 from zerver.lib.digest import handle_digest_email
-
+from zerver.lib.send_email import FromAddress
 from zerver.lib.notifications import (
     handle_missedmessage_emails,
 )
@@ -253,7 +253,7 @@ class TestEmptyGatewaySetting(ZulipTestCase):
         usermessage = most_recent_usermessage(user_profile)
         with self.settings(EMAIL_GATEWAY_PATTERN=''):
             mm_address = create_missed_message_address(user_profile, usermessage.message)
-            self.assertEqual(mm_address, settings.NOREPLY_EMAIL_ADDRESS)
+            self.assertEqual(mm_address, "Zulip <%s>" % (FromAddress.NOREPLY,))
 
     def test_encode_email_addr(self):
         # type: () -> None

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -17,6 +17,7 @@ from zerver.lib.notifications import handle_missedmessage_emails
 from zerver.lib.actions import render_incoming_message, do_update_message
 from zerver.lib.message import access_message
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.send_email import FromAddress
 from zerver.models import (
     Recipient,
     UserMessage,
@@ -43,8 +44,7 @@ class TestMissedMessages(ZulipTestCase):
         else:
             reply_to_addresses = ["Zulip <noreply@example.com>"]
         msg = mail.outbox[0]
-        sender = settings.NOREPLY_EMAIL_ADDRESS
-        from_email = sender
+        from_email = "Zulip <noreply@example.com>"
         self.assertEqual(len(mail.outbox), 1)
         if send_as_user:
             from_email = '"%s" <%s>' % (othello.full_name, othello.email)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -36,7 +36,7 @@ from zerver.lib.actions import (
     get_stream,
     do_create_realm,
 )
-from zerver.lib.send_email import display_email, send_email, send_future_email
+from zerver.lib.send_email import display_email, send_email, send_future_email, FromAddress
 from zerver.lib.initial_password import initial_password
 from zerver.lib.actions import (
     do_deactivate_realm,
@@ -743,7 +743,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         with self.settings(EMAIL_BACKEND='django.core.mail.backends.console.EmailBackend'):
             send_future_email(
                 "zerver/emails/invitation_reminder", data["email"],
-                from_email=settings.ZULIP_ADMINISTRATOR, context=context)
+                from_address=FromAddress.SUPPORT, context=context)
         email_jobs_to_deliver = ScheduledJob.objects.filter(
             type=ScheduledJob.EMAIL,
             scheduled_timestamp__lte=timezone_now())

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -16,7 +16,7 @@ from zerver.models import UserProfile, Realm, PreregistrationUser, \
     name_changes_disabled, email_to_username, \
     completely_open, get_unique_open_realm, email_allowed_for_realm, \
     get_realm, get_realm_by_email_domain, get_system_bot
-from zerver.lib.send_email import send_email, send_email_to_user
+from zerver.lib.send_email import send_email, send_email_to_user, FromAddress
 from zerver.lib.events import do_events_register
 from zerver.lib.actions import do_change_password, do_change_full_name, do_change_is_admin, \
     do_activate_user, do_create_user, do_create_realm, set_default_streams, \
@@ -313,7 +313,7 @@ def send_registration_completion_email(email, request, realm_creation=False):
     """
     prereg_user = create_preregistration_user(email, request, realm_creation)
     activation_url = Confirmation.objects.get_link_for_object(prereg_user, host=request.get_host())
-    send_email('zerver/emails/confirm_registration', email, from_email=settings.ZULIP_ADMINISTRATOR,
+    send_email('zerver/emails/confirm_registration', email, from_address=FromAddress.SUPPORT,
                context={'activate_url': activation_url})
     if settings.DEVELOPMENT and realm_creation:
         request.session['confirmation_key'] = {'confirmation_key': activation_url.split('/')[-1]}

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -17,7 +17,7 @@ from zerver.lib.actions import do_change_password, \
     do_regenerate_api_key, do_change_avatar_fields, do_set_user_display_setting, \
     validate_email, do_change_user_email, do_start_email_change_process
 from zerver.lib.avatar import avatar_url
-from zerver.lib.send_email import send_email, display_email
+from zerver.lib.send_email import send_email, display_email, FromAddress
 from zerver.lib.i18n import get_available_language_codes
 from zerver.lib.response import json_success, json_error
 from zerver.lib.upload import upload_avatar_image
@@ -52,7 +52,7 @@ def confirm_email_change(request, confirmation_key):
                    'new_email': new_email,
                    }
         send_email('zerver/emails/notify_change_in_email', old_email,
-                   from_email=settings.ZULIP_ADMINISTRATOR, context=context)
+                   from_address=FromAddress.SUPPORT, context=context)
 
     ctx = {
         'confirmed': confirmed,

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -27,7 +27,7 @@ from zerver.lib.actions import do_send_confirmation_email, \
     render_incoming_message, do_update_embedded_data
 from zerver.lib.url_preview import preview as url_preview
 from zerver.lib.digest import handle_digest_email
-from zerver.lib.send_email import send_future_email, send_email_from_dict
+from zerver.lib.send_email import send_future_email, send_email_from_dict, FromAddress
 from zerver.lib.email_mirror import process_message as mirror_email
 from zerver.decorator import JsonableError
 from zerver.tornado.socket import req_redis_key
@@ -180,7 +180,7 @@ class ConfirmationEmailWorker(QueueProcessingWorker):
         send_future_email(
             "zerver/emails/invitation_reminder",
             data["email"],
-            from_email=settings.ZULIP_ADMINISTRATOR,
+            from_address=FromAddress.SUPPORT,
             context=context,
             delay=datetime.timedelta(days=2))
 

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -40,6 +40,8 @@ ALLOWED_HOSTS = [EXTERNAL_HOST.split(":")[0]]
 # appear on 404 pages, is used as the sender's address for many automated
 # emails, and is advertised as a support address. An email address like
 # support@example.com is totally reasonable, as is admin@example.com.
+# Do not put a display name; e.g. 'support@example.com', not
+# 'Zulip Support <support@example.com>'.
 ZULIP_ADMINISTRATOR = 'zulip-admin@example.com'
 
 # Configure the outgoing SMTP server below. You will need working
@@ -76,8 +78,9 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 # The noreply address to be used as the sender for certain generated emails.
 # Messages sent to this address could contain sensitive user data and should
-# not be delivered anywhere.
-NOREPLY_EMAIL_ADDRESS = "Zulip <noreply@example.com>"
+# not be delivered anywhere. Do not put a display name;
+# e.g. 'noreply@example.com', not 'Zulip <noreply@example.com>'.
+NOREPLY_EMAIL_ADDRESS = 'noreply@example.com'
 
 
 ## OPTIONAL SETTINGS

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -236,7 +236,7 @@ REQUIRED_SETTINGS = [("EXTERNAL_HOST", "zulip.example.com"),
                      # case, it seems worth having in this list
                      ("SECRET_KEY", ""),
                      ("AUTHENTICATION_BACKENDS", ()),
-                     ("NOREPLY_EMAIL_ADDRESS", "Zulip <noreply@example.com>"),
+                     ("NOREPLY_EMAIL_ADDRESS", "noreply@example.com"),
                      ]
 
 if ADMINS == "":


### PR DESCRIPTION
To enable different senders to show up in people's email inboxes for different types of messages (e.g. 'Zulip  Account Security' for new login notifications but 'Zulip Digest' for digest emails), break up the `settings.NOREPLY_EMAIL_ADDRESS` and `settings.DEFAULT_FROM_EMAIl` fields from the form `Zulip <noreply@example.com>` to just contain the email address, then add in more helpful email sender names when the emails are generated/sent.

Fixes the rest of #4553 (making the missed message emails come from 'Zulip Missed Messages').