### PR TITLE
search: Remove in:all token.

### DIFF
--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -384,7 +384,6 @@ init();
 
     var expected = [
         "",
-        "in:all",
         "is:private",
         "is:starred",
         "is:mentioned",
@@ -400,7 +399,6 @@ init();
     function describe(q) {
         return suggestions.lookup_table[q].description;
     }
-    assert.equal(describe('in:all'), 'All messages');
     assert.equal(describe('is:private'), 'Private messages');
     assert.equal(describe('is:starred'), 'Starred messages');
     assert.equal(describe('is:mentioned'), '@-mentions');

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -345,16 +345,6 @@ function get_operator_subset_suggestions(operators) {
 function get_special_filter_suggestions(last, operators) {
     var suggestions = [
         {
-            search_string: 'in:all',
-            description: 'all messages',
-            invalid: [
-                {operator: 'in'},
-                {operator: 'stream'},
-                {operator: 'pm-with'},
-                {operator: 'is', operand: 'private'},
-            ],
-        },
-        {
             search_string: 'is:private',
             description: 'private messages',
             invalid: [


### PR DESCRIPTION
This commit removes all references to and functionality associated with `in:all`.

This search token is pretty obscure, and is indistinguishable from the home view, except for showing muted streams. It's also not really documented anywhere, and I'd assume that it's almost never used.

If anything, it kind of clutters up search suggestions and makes it a bit more confusing, so I think it's better off being removed.