### PR TITLE
Add preheader content to some emails

### DIFF
--- a/templates/zerver/emails/digest.html
+++ b/templates/zerver/emails/digest.html
@@ -2,6 +2,45 @@
 Mail sent to a user who hasn't logged in for 24 hours.
 #}
 
+{% extends "zerver/emails/email_missed_message_base.html" %}
+
+{% block preheader %}
+    {% if unread_pms %}
+        {% for recipient_block in unread_pms %}
+            {% for sender_block in recipient_block.senders %}
+                {% if sender_block.sender %}{{ sender_block.sender }}{% endif %}
+                {% for message_block in sender_block.content %}
+                {{ message_block.html|safe }}
+                {% endfor %}
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
+
+    {% if hot_conversations %}
+        {% for convo in hot_conversations %}
+            {% for recipient_block in convo.first_few_messages %}
+                {{ recipient_block.header.html|safe }}
+                {% for sender_block in recipient_block.senders %}
+                    {% if sender_block.sender %}{{ sender_block.sender }}{% endif %}
+                    {% for message_block in sender_block.content %}
+                    {{ message_block.html|safe }}
+                    {% endfor %}
+                {% endfor %}
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
+
+    {% if new_streams.html %}
+        {% if new_stream_count and new_stream_count > 1 %}A new stream was{% else %}Some new streams were{% endif %} created:
+        {{ new_streams.html|display_list(4)|safe }}.
+    {% endif %}
+
+    {% if new_users %}
+        {% if new_streams.html or unread_pms or hot_conversations %}And finally, please{% else %}Please{% endif %} welcome {{ new_users|display_list(4) }} to Zulip!
+    {% endif %}
+{% endblock %}
+
+{% block content %}
 Hello {{ name }},
 
 <p>A lot has happened on Zulip while you've been away! <a href="{{ realm_uri }}">Visit Zulip</a> to catch up.</p>
@@ -92,8 +131,11 @@ Hello {{ name }},
 
 <p>Cheers,<br />
 The Zulip Team</p>
+{% endblock %}
 
+{% block manage_preferences %}
 <p>
     <a href="{{ realm_uri }}/#settings">Manage email preferences</a> |
     <a href="{{ unsubscribe_link }}">Unsubscribe from digest emails</a>
 </p>
+{% endblock %}

--- a/templates/zerver/emails/digest.html
+++ b/templates/zerver/emails/digest.html
@@ -41,96 +41,96 @@ Mail sent to a user who hasn't logged in for 24 hours.
 {% endblock %}
 
 {% block content %}
-Hello {{ name }},
+    Hello {{ name }},
 
-<p>A lot has happened on Zulip while you've been away! <a href="{{ realm_uri }}">Visit Zulip</a> to catch up.</p>
+    <p>A lot has happened on Zulip while you've been away! <a href="{{ realm_uri }}">Visit Zulip</a> to catch up.</p>
 
-{% if unread_pms %}
-<h2>Missed private messages</h2>
-<p>You have some missed private messages. Here are some of them:</p>
-<div id='private-messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
-    {% for recipient_block in unread_pms %}
-    <div class='recipient_block' style="background-color: #f0f4f5;border: 1px solid black;margin-bottom: 4px;">
-        <div class='recipient_header' style="color: #ffffff;background-color: #444444;border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
-        <div class='message_content' style="background-color: #f0f4f5;margin-left: 1px;margin-right: 2px;">
-            {% for sender_block in recipient_block.senders %}
-                {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
-                {% for message_block in sender_block.content %}
-                <div class='message_content_block' style="padding-left: 6px;font-weight: normal;">
-                    {{ message_block.html|safe }}
-                </div>
+    {% if unread_pms %}
+    <h2>Missed private messages</h2>
+    <p>You have some missed private messages. Here are some of them:</p>
+    <div id='private-messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
+        {% for recipient_block in unread_pms %}
+        <div class='recipient_block' style="background-color: #f0f4f5;border: 1px solid black;margin-bottom: 4px;">
+            <div class='recipient_header' style="color: #ffffff;background-color: #444444;border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
+            <div class='message_content' style="background-color: #f0f4f5;margin-left: 1px;margin-right: 2px;">
+                {% for sender_block in recipient_block.senders %}
+                    {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
+                    {% for message_block in sender_block.content %}
+                    <div class='message_content_block' style="padding-left: 6px;font-weight: normal;">
+                        {{ message_block.html|safe }}
+                    </div>
+                    {% endfor %}
                 {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+
+        {% if remaining_unread_pms_count > 0 %}<p>+ {{ remaining_unread_pms_count }} more new private message{{ remaining_unread_pms_count|pluralize }}</p>{% endif %}
+        <p><a href="{{ realm_uri }}/#narrow/is/private">Catch up on the rest of your PMs.</a></p>
+    </div>
+    {% endif %}
+
+
+    {% if hot_conversations %}
+        <br />
+        <h2>Hot conversations</h2>
+        <p>
+            Here are some of the hot conversations that have happened while you've been gone:
+        </p>
+
+        {% for convo in hot_conversations %}
+        <div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
+            {% for recipient_block in convo.first_few_messages %}
+                <div class='recipient_block' style="border: 1px solid black;margin-bottom: 4px;">
+                    <div class='recipient_header' style="background-color: #9ecaff;border-bottom: 1px solid black;font-weight: bold;padding: 2px">{{ recipient_block.header.html|safe }}</div>
+                    <div class='message_content' style="margin-left: 1px;margin-right: 2px;">
+                        {% for sender_block in recipient_block.senders %}
+                            {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
+                            {% for message_block in sender_block.content %}
+                            <div class='message_content_block' style="padding-left: 6px;font-weight: normal;">
+                                {{ message_block.html|safe }}
+                            </div>
+                            {% endfor %}
+                        {% endfor %}
+                    </div>
+                </div>
+                {% if convo.count > 0 %}<p>+ {{ convo.count }} more message{{ convo.count|pluralize }} by {{ convo.participants|display_list(4) }}.</p>{% endif %}
             {% endfor %}
         </div>
-    </div>
-    {% endfor %}
-
-    {% if remaining_unread_pms_count > 0 %}<p>+ {{ remaining_unread_pms_count }} more new private message{{ remaining_unread_pms_count|pluralize }}</p>{% endif %}
-    <p><a href="{{ realm_uri }}/#narrow/is/private">Catch up on the rest of your PMs.</a></p>
-</div>
-{% endif %}
-
-
-{% if hot_conversations %}
-    <br />
-    <h2>Hot conversations</h2>
-    <p>
-        Here are some of the hot conversations that have happened while you've been gone:
-    </p>
-
-    {% for convo in hot_conversations %}
-    <div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
-        {% for recipient_block in convo.first_few_messages %}
-            <div class='recipient_block' style="border: 1px solid black;margin-bottom: 4px;">
-                <div class='recipient_header' style="background-color: #9ecaff;border-bottom: 1px solid black;font-weight: bold;padding: 2px">{{ recipient_block.header.html|safe }}</div>
-                <div class='message_content' style="margin-left: 1px;margin-right: 2px;">
-                    {% for sender_block in recipient_block.senders %}
-                        {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
-                        {% for message_block in sender_block.content %}
-                        <div class='message_content_block' style="padding-left: 6px;font-weight: normal;">
-                            {{ message_block.html|safe }}
-                        </div>
-                        {% endfor %}
-                    {% endfor %}
-                </div>
-            </div>
-            {% if convo.count > 0 %}<p>+ {{ convo.count }} more message{{ convo.count|pluralize }} by {{ convo.participants|display_list(4) }}.</p>{% endif %}
         {% endfor %}
-    </div>
-    {% endfor %}
-    <p><a href="{{ realm_uri }}">Catch up on the rest of these conversations.</a></p>
+        <p><a href="{{ realm_uri }}">Catch up on the rest of these conversations.</a></p>
 
-{% endif %}
+    {% endif %}
 
-{% if new_users and new_streams.html %}
-<br />
-<h2>Group updates</h2>
-{% elif new_users %}
-<br />
-<h2>New users</h2>
-{% elif new_streams.html %}
-<br />
-<h2>New streams</h2>
-{% endif %}
+    {% if new_users and new_streams.html %}
+    <br />
+    <h2>Group updates</h2>
+    {% elif new_users %}
+    <br />
+    <h2>New users</h2>
+    {% elif new_streams.html %}
+    <br />
+    <h2>New streams</h2>
+    {% endif %}
 
-{% if new_streams.html %}
-<p>{% if new_stream_count and new_stream_count > 1 %}A new stream was{% else %}Some new streams were{% endif %} created:</p>
+    {% if new_streams.html %}
+    <p>{% if new_stream_count and new_stream_count > 1 %}A new stream was{% else %}Some new streams were{% endif %} created:</p>
 
-<p>{{ new_streams.html|display_list(4)|safe }}.</p>
+    <p>{{ new_streams.html|display_list(4)|safe }}.</p>
 
-<p>Click on {% if new_stream_count and new_stream_count > 1 %}a{% else %}the{% endif %} name to check out some of the traffic, or visit your <a href="{{ realm_uri }}/#streams">Streams page</a> to subscribe.</p>
-{% endif %}
+    <p>Click on {% if new_stream_count and new_stream_count > 1 %}a{% else %}the{% endif %} name to check out some of the traffic, or visit your <a href="{{ realm_uri }}/#streams">Streams page</a> to subscribe.</p>
+    {% endif %}
 
-{% if new_users %}
-<p>{% if new_streams.html or unread_pms or hot_conversations %}And finally, please{% else %}Please{% endif %} welcome {{ new_users|display_list(4) }} to Zulip!</p>
-{% endif %}
+    {% if new_users %}
+    <p>{% if new_streams.html or unread_pms or hot_conversations %}And finally, please{% else %}Please{% endif %} welcome {{ new_users|display_list(4) }} to Zulip!</p>
+    {% endif %}
 
-<br />
+    <br />
 
-<p><a href="{{ realm_uri }}">Click here to log in to Zulip and catch up.</a></p>
+    <p><a href="{{ realm_uri }}">Click here to log in to Zulip and catch up.</a></p>
 
-<p>Cheers,<br />
-The Zulip Team</p>
+    <p>Cheers,<br />
+    The Zulip Team</p>
 {% endblock %}
 
 {% block manage_preferences %}

--- a/templates/zerver/emails/email_base.html
+++ b/templates/zerver/emails/email_base.html
@@ -5,6 +5,21 @@
         <title>Zulip</title>
     </head>
     <body>
+        <td style="display:none !important;
+            visibility:hidden;
+            color:transparent;
+            mso-hide:all;
+            font-size:1px;
+            color:#ffffff;
+            line-height:1px;
+            max-height:0px;
+            height:0px;
+            max-width:0px;
+            width:0px;
+            opacity:0;
+            overflow:hidden;">
+            {% block preheader %}{% endblock %}
+        </td>
         <table width="80%" style="align:center; max-width:800px" align="center">
             <tr>
                 <td style="font-size:16px; font-family:Helvetica;">

--- a/templates/zerver/emails/email_missed_message_base.html
+++ b/templates/zerver/emails/email_missed_message_base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <title>Zulip</title>
+    </head>
+    <body>
+        <td style="display:none !important;
+            visibility:hidden;
+            color:transparent;
+            mso-hide:all;
+            font-size:1px;
+            color:#ffffff;
+            line-height:1px;
+            max-height:0px;
+            height:0px;
+            max-width:0px;
+            width:0px;
+            opacity:0;
+            overflow:hidden;">
+            {% block preheader %}{% endblock %}
+        </td>
+        <table width="80%" style="align:center; max-width:800px" align="center">
+            <tr>
+                <td style="font-size:16px; font-family:Helvetica;">
+                    {% block content %}{% endblock %}
+                </td>
+            </tr>
+        </table>
+        {% block manage_preferences %}{% endblock %}
+    </body>
+</html>

--- a/templates/zerver/emails/missed_message.html
+++ b/templates/zerver/emails/missed_message.html
@@ -18,47 +18,47 @@ Mail sent to user when she was not logged in and received a PM or @-mention
 {% endblock %}
 
 {% block content %}
-Hello {{ name }},
+    Hello {{ name }},
 
-<p>
-    While you were away you received {{ message_count }} new message{{ message_count|pluralize }}{% if mention %} in which you were mentioned{% endif %}!
-</p>
+    <p>
+        While you were away you received {{ message_count }} new message{{ message_count|pluralize }}{% if mention %} in which you were mentioned{% endif %}!
+    </p>
 
-<div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
-    {% for recipient_block in messages %}
-    <div class='recipient_block' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}border: 1px solid black;margin-bottom: 4px;">
-        <div class='recipient_header' style="{% if recipient_block.header.stream_message %}background-color: #9ecaff;{% else %}color: #ffffff;background-color: #444444;{% endif %}border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
-        <div class='message_content' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}margin-left: 1px;margin-right: 2px;">
-            {% for sender_block in recipient_block.senders %}
-                {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
-                {% for message_block in sender_block.content %}
-                <div class='message_content_block' style="padding-left: 6px;font-weight: normal;">
-                    {{ message_block.html|safe }}
-                </div>
+    <div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
+        {% for recipient_block in messages %}
+        <div class='recipient_block' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}border: 1px solid black;margin-bottom: 4px;">
+            <div class='recipient_header' style="{% if recipient_block.header.stream_message %}background-color: #9ecaff;{% else %}color: #ffffff;background-color: #444444;{% endif %}border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
+            <div class='message_content' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}margin-left: 1px;margin-right: 2px;">
+                {% for sender_block in recipient_block.senders %}
+                    {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
+                    {% for message_block in sender_block.content %}
+                    <div class='message_content_block' style="padding-left: 6px;font-weight: normal;">
+                        {{ message_block.html|safe }}
+                    </div>
+                    {% endfor %}
                 {% endfor %}
-            {% endfor %}
+            </div>
         </div>
+        {% endfor %}
     </div>
-    {% endfor %}
-</div>
 
 
-<p>
-    <a href="{{ realm_uri }}">Click here to log in to Zulip and view your new messages.</a>
-    {% if reply_to_zulip  %}
-    Or just reply to this email.
+    <p>
+        <a href="{{ realm_uri }}">Click here to log in to Zulip and view your new messages.</a>
+        {% if reply_to_zulip  %}
+        Or just reply to this email.
+        {% endif %}
+    </p>
+
+    {% if reply_warning %}
+    <p>Please do not reply to this automated message. To respond to the missed messages you have received, please log on to Zulip and send your replies there.</p>
     {% endif %}
-</p>
 
-{% if reply_warning %}
-<p>Please do not reply to this automated message. To respond to the missed messages you have received, please log on to Zulip and send your replies there.</p>
-{% endif %}
-
-<p>
-    Cheers,
-    <br></br>
-    The Zulip Team
-</p>
+    <p>
+        Cheers,
+        <br></br>
+        The Zulip Team
+    </p>
 {% endblock %}
 
 {% block manage_preferences %}

--- a/templates/zerver/emails/missed_message.html
+++ b/templates/zerver/emails/missed_message.html
@@ -2,6 +2,22 @@
 Mail sent to user when she was not logged in and received a PM or @-mention
 #}
 
+{% extends "zerver/emails/email_missed_message_base.html" %}
+
+{% block preheader %}
+    While you were away you received {{ message_count }} new message{{ message_count|pluralize }}{% if mention %} in which you were mentioned{% endif %}!
+    {% for recipient_block in messages %}
+        {{ recipient_block.header.html|safe }}
+        {% for sender_block in recipient_block.senders %}
+            {% if sender_block.sender %}{{ sender_block.sender }}{% endif %}
+            {% for message_block in sender_block.content %}
+            {{ message_block.html|safe }}
+            {% endfor %}
+        {% endfor %}
+    {% endfor %}
+{% endblock %}
+
+{% block content %}
 Hello {{ name }},
 
 <p>
@@ -43,5 +59,8 @@ Hello {{ name }},
     <br></br>
     The Zulip Team
 </p>
+{% endblock %}
 
+{% block manage_preferences %}
 <p><a href="{{ realm_uri }}/#settings">Manage email preferences</a> | <a href="{{ unsubscribe_link }}">Unsubscribe from missed message emails</a></p>
+{% endblock %}


### PR DESCRIPTION
Adds an (invisible) preheader block to the `email_base.html` template and include content in the preheader for the digest and missed message emails.  The goal is that some of the interesting content a user might have missed appears in the inbox preview of the messages.