### PR TITLE
travis: Run different suites first, then try Python 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,19 +46,23 @@ language: python
 # against both Python versions).
 matrix:
   include:
+    # Travis will actually run the jobs in the order they're listed here;
+    # that doesn't seem to be documented, but it's what we see empirically.
+    # We only get 4 jobs running at a time, so we try to make the first few
+    # the most likely to break.
     - python: "3.4"
       env: TEST_SUITE=static-analysis
-    - python: "2.7"
-      env: TEST_SUITE=frontend
     - python: "3.4"
       env: TEST_SUITE=frontend
-    - python: "2.7"
-      env: TEST_SUITE=backend
     - python: "3.4"
       env: TEST_SUITE=backend
-    - python: "2.7"
+    - python: "3.4"
       env: TEST_SUITE=production
-    - python: "3.4"
+    - python: "2.7"
+      env: TEST_SUITE=frontend
+    - python: "2.7"
+      env: TEST_SUITE=backend
+    - python: "2.7"
       env: TEST_SUITE=production
 sudo: required
 services:


### PR DESCRIPTION
Also add a comment explaining why the order in this file matters;
it's not obvious that it should, so it's otherwise tempting
to reorder them to optimize only for readability.

---
@HarshitOnGitHub, thanks for raising this question! After #5539 I realized that it's natural for someone to reorder the tests in the file without realizing why it matters, so a comment would be helpful.

Also that caused me to think a bit more about the order -- and I'd rather squeeze one of the production tests in as one of the first 4, at the expense of one of the frontend tests. It might be less likely to break than frontend, but I think it's much more likely than frontend breaking on 2.7 and not on 3.4.
