### PR TITLE
search: Add support for quoting inputs with spaces.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -506,6 +506,13 @@ function make_sub(name, stream_id) {
     string = '';
     operators = [];
     _test();
+
+    string = 'stream: separated topic: "with space"';
+    operators = [
+        {operator: 'stream', operand: 'separated'},
+        {operator: 'topic', operand: 'with space'},
+    ];
+    _test();
 }());
 
 (function test_unparse() {

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -442,6 +442,26 @@ function make_sub(name, stream_id) {
     ];
     _test();
 
+    string = 'stream:"with quoted space" topic:and separate';
+    operators = [
+        {operator: 'stream', operand: 'with quoted space'},
+        {operator: 'topic', operand: 'and'},
+        {operator: 'search', operand: 'separate'},
+    ];
+    _test();
+
+    string = 'stream:"unclosed quote';
+    operators = [
+        {operator: 'stream', operand: 'unclosed quote'},
+    ];
+    _test();
+
+    string = 'stream:""';
+    operators = [
+        {operator: 'stream', operand: ''},
+    ];
+    _test();
+
     string = 'https://www.google.com';
     operators = [
         {operator: 'search', operand: 'https://www.google.com'},

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -467,7 +467,6 @@ init();
     assert.equal(describe('is:alerted'), 'Alerted messages');
     assert.equal(describe('is:unread'), 'Unread messages');
     assert.equal(describe('sender:bob@zulip.com'), 'Sent by me');
-    assert.equal(describe('stream:devel'), 'Stream <strong>devel</strong>');
 }());
 
 (function test_sent_by_me_suggestions() {

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -865,3 +865,42 @@ init();
     ];
     assert.deepEqual(suggestions.strings, expected);
 }());
+
+(function test_queries_with_spaces() {
+    global.stream_data.subscribed_streams = function () {
+        return ['office', 'dev help'];
+    };
+
+    global.narrow_state.stream = function () {
+        return;
+    };
+
+    global.stream_data.populate_stream_topics_for_tests({});
+
+    // test allowing spaces with quotes surrounding operand
+    var query = 'stream:"dev he"';
+    var suggestions = search.get_suggestions(query);
+    var expected = [
+        "stream:dev+he",
+        "stream:dev+help",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    // test mismatched quote
+    query = 'stream:"dev h';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "stream:dev+h",
+        "stream:dev+help",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    // test extra space after operator still works
+    query = 'stream: offi';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "stream:offi",
+        "stream:office",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+}());

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -212,14 +212,16 @@ Filter.canonicalize_term = function (opts) {
 function encodeOperand(operand) {
     return operand.replace(/%/g,  '%25')
                   .replace(/\+/g, '%2B')
-                  .replace(/ /g,  '+');
+                  .replace(/ /g,  '+')
+                  .replace(/"/g,  '%22');
 }
 
 function decodeOperand(encoded, operator) {
+    encoded = encoded.replace(/"/g, '');
     if (operator !== 'pm-with' && operator !== 'sender' && operator !== 'from') {
         encoded = encoded.replace(/\+/g, ' ');
     }
-    return util.robust_uri_decode(encoded);
+    return util.robust_uri_decode(encoded).trim();
 }
 
 // Parse a string into a list of operators (see below).
@@ -231,7 +233,9 @@ Filter.parse = function (str) {
     var operand;
     var term;
 
-    var matches = str.match(/"[^"]+"|\S+/g);
+    // Match all operands that either have no spaces, or are surrounded by
+    // quotes, preceded by an optional operator that may have a space after it.
+    var matches = str.match(/([^\s:]+: ?)?("[^"]+"?|\S+)/g);
     if (matches === null) {
         return operators;
     }

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -97,7 +97,7 @@ function get_stream_suggestions(last, operators) {
 
     var objs = _.map(streams, function (stream) {
         var prefix = 'stream';
-        var highlighted_stream = typeahead_helper.highlight_query_in_phrase(query, stream);
+        var highlighted_stream = typeahead_helper.highlight_with_escaping(query, stream);
         var description = prefix + ' ' + highlighted_stream;
         var term = {
             operator: 'stream',


### PR DESCRIPTION
This enhancement was actually not too involved (once I learned regex).
Basically, the regex matcher will now accept `operand:"foo bar"` as one token, and then in `Filter.parse`, the quotations get removed to put it in the canonical form. Hence, no backend changes needed to be made to accommodate this.

**Additionally** this regex change allows a space after the operator `:` so that `pm-with: me@example.com` will be correctly parsed. (as there is no situation that makes sense to leave an empty operand)

(Note from this screenshot, that if you have one unclosed quote, it just considers the whole remainder of the query as the operand, which I think is what we want)

![recording 3](https://user-images.githubusercontent.com/8433005/27504824-dcd8352e-585f-11e7-8942-b41b939ff90e.gif)

