### PR TITLE
casper: Fix flake in drafts tests

### DIFF
--- a/frontend_tests/casper_tests/14-drafts.js
+++ b/frontend_tests/casper_tests/14-drafts.js
@@ -48,7 +48,6 @@ casper.then(function () {
     casper.click('body');
     casper.page.sendEvent('keypress', "c");
     casper.waitUntilVisible('#stream-message', function () {
-        casper.test.info('Creating Private Message Draft');
         casper.fill('form#send_message_form', {
             stream: 'all',
             subject: 'tests',
@@ -195,7 +194,10 @@ casper.then(function () {
     casper.click("#drafts_table .message_row.private-message .restore-draft");
     waitWhileDraftsVisible(function () {
         casper.test.assertVisible('#private-message');
-        casper.click('#compose-send-button');
+        casper.click("#enter_sends");
+        casper.waitUntilVisible('#compose-send-button', function () {
+            casper.click('#compose-send-button');
+        });
     });
 });
 


### PR DESCRIPTION
On some developer machines (me and @hackerkid), casper was having trouble clicking on a hidden button. Added a step to make sure the button was visible before being clicked on.

Thread: https://chat.zulip.org/#narrow/stream/test.20suites/subject/casper/near/236580