### PR TITLE
drafts: Narrow when restoring draft

### DIFF
--- a/frontend_tests/casper_tests/14-drafts.js
+++ b/frontend_tests/casper_tests/14-drafts.js
@@ -101,6 +101,7 @@ casper.then(function () {
             subject: 'tests',
             content: 'Test Stream Message',
         }, "Stream message box filled with draft content");
+        casper.test.assertSelectorHasText('title', 'tests - Zulip Dev - Zulip', 'Narrowed to topic');
     });
 });
 
@@ -137,6 +138,7 @@ casper.then(function () {
             recipient: 'cordelia@zulip.com, hamlet@zulip.com',
             content: 'Test Private Message',
         }, "Private message box filled with draft content");
+        casper.test.assertSelectorHasText('title', 'private - Zulip Dev - Zulip', 'Narrowed to huddle');
     });
 });
 
@@ -175,6 +177,8 @@ casper.then(function () {
 
 casper.then(function () {
     casper.test.info('Finished reloading; now opening drafts again');
+    // Reloading into a narrow opens compose box automatically
+    casper.click("#compose_close");
     casper.waitUntilVisible('.drafts-link', function () {
         casper.click('.drafts-link');
     });

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -128,6 +128,19 @@ exports.restore_draft = function (draft_id) {
                               draft_copy);
     }
 
+    if (draft.type === "stream") {
+        if (draft.stream !== "") {
+            narrow.activate([{operator: "stream", operand: draft.stream},
+                             {operator: "topic", operand: draft.subject}],
+                             {select_first_unread: true, trigger: "restore draft"});
+        }
+    } else {
+        if (draft.private_message_recipient !== "") {
+            narrow.activate([{operator: "pm-with", operand: draft.private_message_recipient}],
+                             {select_first_unread: true, trigger: "restore draft"});
+        }
+    }
+
     overlays.close_overlay("drafts");
     compose_fade.clear_compose();
     if (draft.type === "stream" && draft.stream === "") {


### PR DESCRIPTION
If a draft has a stream/private message recipient, then we re-narrow to that on restoring. But if the stream/recipient is empty, we choose not to do anything as this seems better than just restoring to home or to all private messages.