### PR TITLE
drafts: Fix styling issue in drafts

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -90,7 +90,7 @@
     line-height: 1;
     padding-top: 10px;
     padding-bottom: 10px;
-    padding-left: 0px;
+    margin-left: 0px;
 }
 
 .draft-row .draft-info-box .draft_controls {


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/1736001/27512436-3098f11e-595d-11e7-908c-90824486fd25.png)

After:
![image](https://user-images.githubusercontent.com/1736001/27512438-3cf9b52e-595d-11e7-87db-91cd97c45337.png)

This was introduced by this since we're using some of the message styles in drafts.
https://github.com/zulip/zulip/commit/69323d12c92d7c2ed7354f4bf276df71d3224fa1