### PR TITLE
bots: De-duplicate removing at-mention pattern for calling bots.

### DIFF
--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -470,47 +470,12 @@ class EmbeddedBotWorker(QueueProcessingWorker):
         # type: () -> StateHandler
         return StateHandler()
 
-    def remove_leading_pattern(self, pattern, content):
-        # type: (str, str) -> Optional[str]
-        """
-        This function attempts to match and remove the pattern from the
-        beginning of the content.  The return value is the removal result if
-        there is a match, or None if there is not a match.
-        """
-        leading_pattern = re.compile(r'^' + pattern)
-        match = leading_pattern.match(content)
-        if match:
-            return content[len(match.group()):]
-        else:
-            return None
-
-    # TODO: Consolidate this with the code in bot_lib.py
-    def remove_leading_mention_if_necessary(self, message, user_profile):
-        # type: (Dict[str, Any], UserProfile) -> None
-        """
-        If the embedded bot is the leading @mention, then this function removes
-        the leading @mention from the message content (note that spaces after
-        the @mention also get stripped).  Otherwise, it leaves the message
-        unchanged.
-        """
-        mention_patterns = [
-            r'@({0})'.format(user_profile.full_name),
-            r'@(\*\*{0}\*\*)'.format(user_profile.full_name),
-        ]
-        content = message['content']
-        for pattern in mention_patterns:
-            content_without_mention = self.remove_leading_pattern(pattern, content)
-            if content_without_mention:
-                message['content'] = content_without_mention.lstrip()
-                return
-
     def consume(self, event):
         # type: (Mapping[str, Any]) -> None
         user_profile_id = event['user_profile_id']
         user_profile = get_user_profile_by_id(user_profile_id)
 
         message = cast(Dict[str, Any], event['message'])
-        self.remove_leading_mention_if_necessary(message, user_profile)
 
         # TODO: Do we actually want to allow multiple Services per bot user?
         services = get_bot_services(user_profile_id)


### PR DESCRIPTION
Similar code appeared at two places (the code is meant to remove the
leading @-mention before passing the remainder of the message to the
bot handler)—both 'zerver/worker/queue_processors.py' and
'api/bots_api/bot_lib.py'.

Remove function from the queue_processors.py file and let the entire message
be processed (includes removing of @-mention) at bot_lib.py.