### PR TITLE
Increase node test coverage for activity.js and emoji.js

### DIFF
--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -1,0 +1,29 @@
+set_global('$', global.make_zjquery());
+set_global('page_params', {});
+set_global('upload_widget', {});
+
+add_dependencies({
+    emoji_codes: 'generated/emoji/emoji_codes.js',
+});
+
+var emoji = require('js/emoji.js');
+
+(function test_build_emoji_upload_widget() {
+    var build_widget_stub = false;
+    upload_widget.build_widget = function (
+        get_file_input,
+        file_name_field,
+        input_error,
+        clear_button,
+        upload_button
+    ) {
+        assert.deepEqual(get_file_input(), $('#emoji_file_input'));
+        assert.deepEqual(file_name_field, $('#emoji-file-name'));
+        assert.deepEqual(input_error, $('#emoji_file_input_error'));
+        assert.deepEqual(clear_button, $('#emoji_image_clear_button'));
+        assert.deepEqual(upload_button, $('#emoji_upload_button'));
+        build_widget_stub = true;
+    };
+    emoji.build_emoji_upload_widget();
+    assert(build_widget_stub);
+}());

--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -27,3 +27,16 @@ var emoji = require('js/emoji.js');
     emoji.build_emoji_upload_widget();
     assert(build_widget_stub);
 }());
+
+(function test_initialize() {
+    var image_stub = false;
+    class Image {
+        set src(data) {
+            assert.equal(data, '/static/generated/emoji/sheet_google_32.png');
+            image_stub = true;
+        }
+    }
+    set_global('Image', Image);
+    emoji.initialize();
+    assert(image_stub);
+}());

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -30,6 +30,7 @@ enforce_fully_covered = {
     'static/js/compose_state.js',
     'static/js/compose_ui.js',
     'static/js/dict.js',
+    'static/js/emoji.js',
     'static/js/filter.js',
     'static/js/fenced_code.js',
     'static/js/hash_util.js',

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -22,6 +22,7 @@ USAGE = '''
     '''
 
 enforce_fully_covered = {
+    'static/js/activity.js',
     'static/js/alert_words.js',
     'static/js/bot_data.js',
     'static/js/colorspace.js',


### PR DESCRIPTION
This PR contains commits to increase node coverage for `activity.js` and `emoji.js`. I did the `activity.js` in one commit so part with me there. But have been careful since then to have file split up in commits.