### PR TITLE
Bot testing: Support testing return values & multiple responses

### DIFF
--- a/api/bots/followup/test_followup.py
+++ b/api/bots/followup/test_followup.py
@@ -9,23 +9,34 @@ class TestFollowUpBot(BotTestCase):
     bot_name = "followup"
 
     def test_bot(self):
-        expected_send_reply = {
-            "": 'Please specify the message you want to send to followup stream after @mention-bot'
-        }
-        self.check_expected_responses(expected_send_reply, expected_method='send_reply')
-
-        expected_send_message = {
-            "foo": {
+        messages = [  # Template for message inputs to test, absent of message content
+            {
                 'type': 'stream',
-                'to': 'followup',
-                'subject': 'foo_sender@zulip.com',
-                'content': 'from foo_sender@zulip.com: foo',
+                'display_recipient': 'some stream',
+                'subject': 'some subject',
+                'sender_email': 'foo_sender@zulip.com',
             },
-            "I have completed my task": {
-                'type': 'stream',
-                'to': 'followup',
-                'subject': 'foo_sender@zulip.com',
-                'content': 'from foo_sender@zulip.com: I have completed my task',
+            {
+                'type': 'private',
+                'sender_email': 'foo_sender@zulip.com',
             },
+        ]
+        stream_response = {  # Template for the stream response, absent of response content
+            'type': 'stream',
+            'to': 'followup',  # Always outputs to followup
+            'subject': 'foo_sender@zulip.com',
         }
-        self.check_expected_responses(expected_send_message, expected_method='send_message')
+        expected_send_reply = [
+            ("", 'Please specify the message you want to send to followup stream after @mention-bot')
+        ]
+        expected_send_message = [
+            ("foo", 'from foo_sender@zulip.com: foo'),
+            ("I have completed my task", 'from foo_sender@zulip.com: I have completed my task'),
+        ]
+        for m in messages:
+            for sr in expected_send_reply:
+                self.assert_bot_response(dict(m, content=sr[0]),
+                                         (sr[1], 'send_reply'))
+            for sm in expected_send_message:
+                self.assert_bot_response(dict(m, content=sm[0]),
+                                         (dict(stream_response, content=sm[1]), 'send_message'))


### PR DESCRIPTION
This takes ideas originally in #5502, splitting out the additional features into this PR to allow discussion of these separate from any helper function changes (`check_expected_responses`).

This PR adds support for testing:
* messages which result in multiple responses from a bot;
* messages/responses which depend upon the return value of `send_*` functions.

API comments:
* function signature for `assert_bot_response` changes, with `response` and `expected_method` replaced by `response_list` and `result`; instead of a single response and method, `response_list` is a nested list of them. `result` is the default return value of the `send_*` functions, with a default success value, and can be overridden by use of a third entry in each element of `response_list`.
* `check_expected_responses` identical, but adjusted to use new `assert_bot_response` (does not support new features)

Generally the error reporting should be an improvement, ie. a failure outputs the message, etc. causing the problem.

`test_followup.py` is updated to demonstrate the new call signatures (and also not using `check_expected_responses` @showell ). I have a simple bot which would test multiple responses, and pollbot would test that and return values.

To do/discuss:
* FIXME: This concerns that multiple calls to `send_*` must match the return value order, but any_order would make testing simpler, and is applicable if the return values are all identical?
* If the list-of-lists approach is too loosely specified, a list of namedtuples may be an option?
* Other bot tests need updating (beyond just followup), though those calling `check_expected_responses` appear to still pass.
* Would message/response templates in the bot testing or even bot lib be useful? These libraries are there to make bot writing easier, so referring to the API docs shouldn't be necessary?
* Maybe result -> default_result renaming?
* MyPy types could be improved?
* Expand check_expected_responses to support these features, or drop it? (later PR?)