### PR TITLE
frontend: Fix elements that are not visible should not be focusable.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1891,6 +1891,9 @@ nav a .no-style {
 #searchbox a.search_icon {
     color: hsl(0, 0%, 80%);
     text-decoration: none;
+    display: block;
+    width: 1px;
+    height: 1px;
 }
 
 #searchbox a.search_icon:hover {


### PR DESCRIPTION
Fixes #5534. 
Fixed the first bulletpoint. 
Working on the second one right now -- there's interesting behaviour in that some `message_label_clickable narrows_by_subject` and `message_label_clickable narrows_by_subject` are actually visible but the audit tool still fires off for them: 
![image](https://user-images.githubusercontent.com/13666710/27595840-b01521e8-5b55-11e7-8672-92cd3d6090f4.png)
as well as firing off for messages at the very top and the very bottom:
![image](https://user-images.githubusercontent.com/13666710/27595888-d277729a-5b55-11e7-9ca7-55491f0e604c.png)

EDIT: having the compose box half-open also causes the audit tool to not pass.
![image](https://user-images.githubusercontent.com/13666710/27596014-36ab8e04-5b56-11e7-8b8b-42ec28a97b55.png)


