### PR TITLE
subs: Fix the traceback when an user subscribes/unsubscribes.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -28,8 +28,12 @@ function rerender_subscribers_list(sub) {
     var subscribers_list = list_render.get("stream_subscribers/" + sub.stream_id);
 
     // Changing the data clears the rendered list and the list needs to be re-rendered.
-    subscribers_list.data(emails);
-    subscribers_list.render();
+    // Perform re-rendering only when the stream settings form of the corresponding
+    // stream is open.
+    if (subscribers_list) {
+        subscribers_list.data(emails);
+        subscribers_list.render();
+    }
 }
 
 exports.collapse = function (sub) {


### PR DESCRIPTION
On receiving a `peer_add`/`peer_remove` event we were performing a
subscribers list re-rendering even when the stream settings form was
not open which was causing a traceback. This commit fixes this behavior
by first checking if the corresponding stream settings form is open and
performs a re-rendering only when it is open.