### PR TITLE
[WIP] emoji_picker: Change emoji picker to category-based and improve the search and navigation.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -608,6 +608,7 @@ with_overrides(function (override) {
     global.with_stub(function (stub) {
         override('emoji.update_emojis', stub.f);
         override('settings_emoji.populate_emoji', noop);
+        override('emoji_picker.generate_emoji_picker_data', noop);
         dispatch(event);
         var args = stub.get_args('realm_emoji');
         assert_same(args.realm_emoji, event.realm_emoji);

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -570,14 +570,39 @@ function render(template_name, args) {
     assert.equal(li.text(), 'The email will be forwarded to this stream');
 }());
 
+(function emoji_popover() {
+    var args = {
+        class: "emoji-info-popover",
+        categories: [
+            { name: "Test category 1", icon: "test-icon-1" },
+            { name: "Test category 2", icon: "test-icon-2" },
+        ],
+    };
+    var html = render('emoji_popover', args);
+    var categories = $(html).find(".emoji-popover-tab-item");
+    assert.equal(categories.length, 2);
+    var category_1 = $(html).find(".emoji-popover-tab-item[data-tab-name = 'Test category 1']");
+    assert(category_1.hasClass("active"));
+    global.write_handlebars_output("emoji_popover", html);
+}());
+
 (function emoji_popover_content() {
     var args = {
         search: 'Search',
         message_id: 1,
-        emojis: [{
-            name: '100',
-            css_class: '100',
-        }],
+        emoji_categories: [
+            {
+                name: 'Test',
+                emojis: [
+                    {
+                        has_reacted: false,
+                        is_realm_emoji: false,
+                        name: '100',
+                        css_class: '100',
+                    },
+                ],
+            },
+        ],
     };
 
     var html = '<div style="height: 250px">';
@@ -587,6 +612,33 @@ function render(template_name, args) {
     var emoji_key = $(html).find(".emoji-100").attr('title');
     assert.equal(emoji_key, ':100:');
     global.write_handlebars_output("emoji_popover_content", html);
+}());
+
+(function emoji_popover_search_results() {
+    var args = {
+        message_id: 1,
+        search_results: [
+            {
+                has_reacted: false,
+                is_realm_emoji: false,
+                name: 'test-1',
+                css_class: 'test-1',
+            },
+            {
+                has_reacted: true,
+                is_realm_emoji: false,
+                name: 'test-2',
+                css_class: 'test-2',
+            },
+        ],
+    };
+    var html = "<div>";
+    html += render("emoji_popover_search_results", args);
+    html += "</div>";
+    global.write_handlebars_output("emoji_popover_search_results", html);
+    var used_emoji = $(html).find(".emoji-test-2").parent();
+    assert(used_emoji.hasClass("reaction"));
+    assert(used_emoji.hasClass("reacted"));
 }());
 
 (function group_pms() {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -654,7 +654,7 @@ $(function () {
         }
 
         // Dismiss popovers if the user has clicked outside them
-        if ($('.popover-inner').has(e.target).length === 0) {
+        if ($('.popover-inner, .emoji-info-popover').has(e.target).length === 0) {
             popovers.hide_all();
         }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -354,6 +354,10 @@ exports.process_tab_key = function () {
         return true;
     }
 
+    if (emoji_picker.reactions_popped()) {
+        return emoji_picker.navigate('tab');
+    }
+
     return false;
 };
 
@@ -381,6 +385,11 @@ exports.process_shift_tab_key = function () {
         focused_message_edit_save.closest(".message_edit_form")
                                  .find(".message_edit_content").focus();
         return true;
+    }
+
+    // Shift-tabbing from emoji catalog/search results takes you back to search textbox.
+    if (emoji_picker.reactions_popped()) {
+        return emoji_picker.navigate('shift_tab');
     }
 
     return false;
@@ -445,7 +454,7 @@ exports.process_hotkey = function (e, hotkey) {
     }
 
     if (emoji_picker.reactions_popped()) {
-        return emoji_picker.navigate(e, event_name);
+        return emoji_picker.navigate(event_name);
     }
 
     if (hotspots.is_open()) {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -120,6 +120,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         page_params.realm_emoji = event.realm_emoji;
         emoji.update_emojis(event.realm_emoji);
         settings_emoji.populate_emoji(event.realm_emoji);
+        emoji_picker.generate_emoji_picker_data(emoji.active_realm_emojis);
         break;
 
     case 'realm_filters':

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -118,39 +118,78 @@
     color: hsl(200, 100%, 40%);
 }
 
+.emoji-info-popover {
+    padding: 0;
+    height: 326px;
+}
+
+.emoji-info-popover .popover-content {
+    padding: 0;
+}
+
+.emoji-info-popover.bottom .arrow {
+    border-bottom-color: #eee;
+}
+
+.emoji-info-popover.top .arrow {
+    border-top-color: #eee;
+}
+
 .emoji-popover {
-    display: inline-block;
-    width: 240px;
+    display: block;
+    width: 250px;
 }
 
 .emoji-popover-top {
-    padding-bottom: 0;
+    position: relative;
+
+    padding: 8px 10px;
+    margin-bottom: 0px;
+
+    background-color: #eee;
+
+    border-radius: 5px 5px 0px 0px;
 }
 
 .emoji-popover-top .icon-vector-search {
-    display: inline-block;
-    vertical-align: top;
-    padding: 8px;
+    position: absolute;
     color: hsl(0, 0%, 73%);
-    cursor: pointer;
+    top: 15px;
+    left: 17px;
+    z-index: 3;
 }
 
-.emoji-popover-filter {
-    width: calc(100% - 48px);
+.emoji-popover-top .emoji-popover-filter {
     margin: auto;
-    padding-left: 3em;
+    padding-left: 22px;
+    width: calc(100% - 22px - 8px);
 }
 
-.emoji-popover-emoji-map {
-    margin: 0;
-    padding: 0.5em 0;
+.emoji-popover-emoji-map,
+.emoji-search-results-container {
+    padding: 0px;
     position: relative;
     overflow: hidden;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
-    align-content: flex-start;
-    height: 16.5em;
+    display: block;
+    height: 250px;
+    width: 247px;
+    margin-left: 3px;
+}
+
+.emoji-search-results-container {
+    height: 283px;
+}
+
+.emoji-popover-results-heading {
+    font-weight: 600;
+    padding: 5px 3px 3px 5px;
+    font-size: 17px;
+}
+
+.emoji-popover-subheading {
+    font-weight: 600;
+    color: #333;
+    padding: 5px 3px;
 }
 
 .emoji-popover-emoji {
@@ -179,4 +218,28 @@
     color: hsl(0, 0%, 20%);
     margin: 0px 1px 0px 0px;
     line-height: 1em;
+}
+
+.emoji-popover-category-tabs {
+    background-color: #eee;
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+    width: 100%;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.emoji-popover-category-tabs .emoji-popover-tab-item {
+    display: inline-block;
+    padding-top: 8px;
+    width: 25px;
+    height: 25px;
+    text-align: center;
+    color: #515151;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+.emoji-popover-category-tabs .emoji-popover-tab-item.active {
+    background: #cecece;
 }

--- a/static/templates/emoji_popover.handlebars
+++ b/static/templates/emoji_popover.handlebars
@@ -1,0 +1,11 @@
+<div class="popover {{class}}">
+    <div class="arrow"></div>
+    <div class="popover-content">
+        <div></div>
+    </div>
+    <div class="emoji-popover-category-tabs">
+        {{#each categories}}
+        <span class="emoji-popover-tab-item {{#if @first}} active {{/if}}" data-tab-name='{{name}}' title='{{name}}'><i class="fa {{icon}}"></i></span>
+        {{/each}}
+    </div>
+</div>

--- a/static/templates/emoji_popover_content.handlebars
+++ b/static/templates/emoji_popover_content.handlebars
@@ -1,31 +1,20 @@
 <div class="emoji-popover">
-    <div class="emoji-popover-top">
+    <div class="emoji-popover-top input-append">
         <input class="emoji-popover-filter" type="text" autofocus placeholder={{t 'Search' }} />
         <i class="icon-vector-search"></i>
     </div>
-    {{#if message_id}} {{! message_id -> message reaction, no message_id -> message composition }}
     <div class="emoji-popover-emoji-map" data-message-id="{{message_id}}">
-        {{#each emojis}}
-        <div class="emoji-popover-emoji {{#if has_reacted}} reacted {{/if}} reaction" title={{name}} tabindex="0">
-            {{#if is_realm_emoji}}
-            <img src="{{url}}" class="emoji" title= ":{{name}}:" />
-            {{else}}
-            <div class="emoji emoji-{{css_class}}" title= ":{{name}}:" />
-            {{/if}}
+        {{#each emoji_categories }}
+        <div class="emoji-popover-subheading" data-section="{{name}}">{{name}}</div>
+        <div class="emoji-collection" data-section="{{name}}">
+            {{#each this.emojis }}
+            {{ partial "emoji_popover_emoji" "type" "emoji_picker_emoji" "section" @../index "index" @index "message_id" ../../message_id "emoji_dict" this}}
+            {{/each}}
         </div>
         {{/each}}
     </div>
-    {{else}}
-    <div class="emoji-popover-emoji-map">
-        {{#each emojis}}
-        <div class="emoji-popover-emoji composition" title={{name}} tabindex="0">
-            {{#if is_realm_emoji}}
-            <img src="{{url}}" class="emoji" title= ":{{name}}:" />
-            {{else}}
-            <div class="emoji emoji-{{css_class}}" title= ":{{name}}:" />
-            {{/if}}
-        </div>
-        {{/each}}
+    <div class="emoji-search-results-container" data-message-id="{{message_id}}">
+        <div class="emoji-popover-results-heading">{{t "Search results" }}</div>
+        <div class="emoji-search-results"></div>
     </div>
-    {{/if}}
 </div>

--- a/static/templates/emoji_popover_emoji.handlebars
+++ b/static/templates/emoji_popover_emoji.handlebars
@@ -1,0 +1,9 @@
+{{#with emoji_dict}}
+<div class="emoji-popover-emoji {{# if ../message_id }}{{#if has_reacted}} reacted {{/if}} reaction {{else}} composition {{/if}}" title={{name}} tabindex="0" data-emoji-id="{{../type}}_{{../section}}_{{../index}}">
+    {{#if is_realm_emoji}}
+    <img src="{{url}}" class="emoji" title= ":{{name}}:" />
+    {{else}}
+    <div class="emoji emoji-{{css_class}}" title= ":{{name}}:"></div>
+    {{/if}}
+</div>
+{{/with}}

--- a/static/templates/emoji_popover_search_results.handlebars
+++ b/static/templates/emoji_popover_search_results.handlebars
@@ -1,0 +1,3 @@
+{{#each search_results}}
+{{ partial "emoji_popover_emoji" "type" "emoji_search_result" "section" "0" "index" @index "message_id" ../message_id "emoji_dict" this }}
+{{/each}}


### PR DESCRIPTION
This PR replaces PR #5299.
This PR is an effort to make our emoji picker more organized and user-friendly by introducing categorization. A part of this PR was done at PyCon after which I took it up for polishing it. I thought it to be an easy task but I was certainly wrong :smile_cat:. I had initially planned to fix some bugs as mentioned in PR #5299 but I ended up re-doing almost all of the things. Major things I have changed:
* Made rendering emoji picker more efficient by generating the data needed once and then caching it for further use.
* Reworked the navigation system.
* Improved the search.
* Made code easier to read/follow and deleted some dead code.

One change that is not so easy to spot is that now emoji picker supports overlap feature, i.e., if someone uploads a realm emoji called `:tada:`, it will replace the :tada: for everyone.(discussed here: https://chat.zulip.org/#narrow/stream/development.20help/subject/suggestions.20for.20field.20name/near/190097).

Things yet to be done:
* Adding comments.
* Fixing tests.
* Small tweaks and further code cleanup.