### PR TITLE
Fix the i18n stubbed version in zjsunit for cases where it is cleanup on namespace cleanup

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1,4 +1,5 @@
 set_global('$', global.make_zjquery());
+set_global('i18n', global.stub_i18n);
 
 set_global('page_params', {
     use_websockets: false,
@@ -10,7 +11,6 @@ set_global('document', {
 });
 set_global('channel', {});
 
-var i18n = global.i18n;
 var noop = function () {};
 
 add_dependencies({

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -109,7 +109,7 @@ people.add(bob);
     assert(!$("#sending-indicator").visible());
     assert(!$("#compose-send-button").is_focused());
     assert.equal($("#compose-send-button").attr('disabled'), undefined);
-    assert.equal($('#error-msg').html(), 'You have nothing to send!');
+    assert.equal($('#error-msg').html(), i18n.t('You have nothing to send!'));
 
     $("#new_message_content").val('foobarfoobar');
     var zephyr_checked = false;
@@ -122,13 +122,13 @@ people.add(bob);
     };
     assert(!compose.validate());
     assert(zephyr_checked);
-    assert.equal($('#error-msg').html(), 'You need to be running Zephyr mirroring in order to send messages!');
+    assert.equal($('#error-msg').html(), i18n.t('You need to be running Zephyr mirroring in order to send messages!'));
 
     compose_state.set_message_type('private');
     compose_state.recipient('');
     $("#private_message_recipient").select(noop);
     assert(!compose.validate());
-    assert.equal($('#error-msg').html(), 'Please specify at least one recipient');
+    assert.equal($('#error-msg').html(), i18n.t('Please specify at least one recipient'));
 
     compose_state.recipient('foo@zulip.com');
     global.page_params.realm_is_zephyr_mirror_realm = true;
@@ -150,14 +150,14 @@ people.add(bob);
     compose_state.stream_name('');
     $("#stream").select(noop);
     assert(!compose.validate());
-    assert.equal($('#error-msg').html(), 'Please specify a stream');
+    assert.equal($('#error-msg').html(), i18n.t('Please specify a stream'));
 
     compose_state.stream_name('Denmark');
     global.page_params.realm_mandatory_topics = true;
     compose_state.subject('');
     $("#subject").select(noop);
     assert(!compose.validate());
-    assert.equal($('#error-msg').html(), 'Please specify a topic');
+    assert.equal($('#error-msg').html(), i18n.t('Please specify a topic'));
 }());
 
 (function test_set_focused_recipient() {

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -1,4 +1,5 @@
 set_global('$', global.make_zjquery());
+set_global('i18n', global.stub_i18n);
 
 add_dependencies({
     stream_data: 'js/stream_data',
@@ -7,11 +8,6 @@ add_dependencies({
 var settings_org = require('js/settings_org.js');
 
 var noop = function () {};
-
-set_global('i18n', {
-    ensure_i18n: function (f) { f(); },
-    t: function (s) { return 'translated: ' + s; },
-});
 
 set_global('loading', {
     make_indicator: noop,
@@ -419,7 +415,7 @@ function test_change_allow_subdomains(change_allow_subdomains) {
 
     success_callback();
     assert.equal(info.text(),
-                 'translated: Update successful: Subdomains allowed for __domain__');
+                 'translated: Update successful: Subdomains allowed for example.com');
     assert(info.hasClass('text-success'));
 
     var xhr = {
@@ -435,7 +431,7 @@ function test_change_allow_subdomains(change_allow_subdomains) {
     change_allow_subdomains.apply('elem-stub', [ev]);
     success_callback();
     assert.equal(info.text(),
-                 'translated: Update successful: Subdomains no longer allowed for __domain__');
+                 'translated: Update successful: Subdomains no longer allowed for example.com');
 }
 
 (function test_set_up() {

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -1,7 +1,5 @@
 set_global('$', global.make_zjquery());
-set_global('i18n', {
-    t: function (str) { return 'translated: ' + str; },
-});
+set_global('i18n', global.stub_i18n);
 
 add_dependencies({
     XDate: 'node_modules/xdate/src/xdate.js',

--- a/frontend_tests/zjsunit/i18n.js
+++ b/frontend_tests/zjsunit/i18n.js
@@ -5,7 +5,7 @@ i18n.t = function (str, context) {
     // of key value pairs and string will be having substitution for keywords
     // like these "__keyword__".
     if (context === undefined) {
-        return str;
+        return 'translated: ' + str;
     }
     var keyword_regex = /__(\w)+__/g;
     var keys_in_str = str.match(keyword_regex);

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -43,7 +43,7 @@ global.append_test_output = output.append_test_output;
 global.make_zjquery = require('./zjquery.js').make_zjquery;
 
 // Set up fake translation
-global.i18n = require('./i18n.js');
+global.stub_i18n = require('./i18n.js');
 
 var noop = function () {};
 


### PR DESCRIPTION
In this PR we fix the issue which is as below
i18n error out as not being defined, though we recently added a minimal lib version of it for tests in global scope.
What is happening is that once the module is put in global scope by doing, `global.i18n = require(./i18n.js')` from inside of `index.js` in `zjsunit`, this module should stick around for every test run. What happens is that if a module with same name is added using add_dependency from inside of any test file, this module comes under the namespace. Now at every test run, at end `index.js` performs a namespace cleanup leading to i18n being lost. This is what happens at end of `i18n.js`(Test file inside node tests) resulting in stubbed version of i18n no longer available in any of the further test files.

Also added some commits to fix another issue with stubbed version of i18n and made current tests use the stub version instead of individual stubbing. 