### PR TITLE
Bot testing: Add state testing & use in tictactoe bot

### DIFF
--- a/api/bots/tictactoe/test_tictactoe.py
+++ b/api/bots/tictactoe/test_tictactoe.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from bots_test_lib import BotTestCase
+from bot_lib import StateHandler
+
+class TestTictactoeBot(BotTestCase):
+    bot_name = "tictactoe"
+
+    def test_bot(self):
+        messages = [  # Template for message inputs to test, absent of message content
+            {
+                'type': 'stream',
+                'display_recipient': 'some stream',
+                'subject': 'some subject',
+                'sender_email': 'foo_sender@zulip.com',
+            },
+            {
+                'type': 'private',
+                'sender_email': 'foo_sender@zulip.com',
+            },
+        ]
+        private_response = {
+            'type': 'private',
+            'to': 'foo_sender@zulip.com',
+            'subject': 'foo_sender@zulip.com',  # FIXME Requiring this in bot is a bug?
+        }
+
+        help_txt = "*Help for Tic-Tac-Toe bot* \nThe bot responds to messages starting with @mention-bot.\n**@mention-bot new** will start a new game (but not if you're already in the middle of a game). You must type this first to start playing!\n**@mention-bot help** will return this help function.\n**@mention-bot quit** will quit from the current game.\n**@mention-bot <coordinate>** will make a move at the given coordinate.\nCoordinates are entered in a (row, column) format. Numbering is from top to bottom and left to right. \nHere are the coordinates of each position. (Parentheses and spaces are optional). \n(1, 1)  (1, 2)  (1, 3) \n(2, 1)  (2, 2)  (2, 3) \n(3, 1) (3, 2) (3, 3) \n"
+        didnt_understand_txt = "Hmm, I didn't understand your input. Type **@tictactoe help** or **@ttt help** to see valid inputs."
+        new_game_txt = "Welcome to tic-tac-toe! You'll be x's and I'll be o's. Your move first!\nCoordinates are entered in a (row, column) format. Numbering is from top to bottom and left to right.\nHere are the coordinates of each position. (Parentheses and spaces are optional.) \n(1, 1)  (1, 2)  (1, 3) \n(2, 1)  (2, 2)  (2, 3) \n(3, 1) (3, 2) (3, 3) \n Your move would be one of these. To make a move, type @mention-bot followed by a space and the coordinate."
+
+        expected_send_message = [
+            ("", didnt_understand_txt),
+            ("help", help_txt),
+            ("quit", didnt_understand_txt),  # Quit not understood when no game
+            ("new", new_game_txt),
+            ("quit", "You've successfully quit the game."),  # If have state
+            ("quit", didnt_understand_txt),  # Quit not understood when no game
+        ]
+        for m in messages:
+            state = StateHandler()
+            for (mesg, resp) in expected_send_message:
+                self.assert_bot_response(dict(m, content=mesg),
+                                         dict(private_response, content=resp),
+                                         'send_message', state)

--- a/api/bots_api/bots_test_lib.py
+++ b/api/bots_api/bots_test_lib.py
@@ -80,10 +80,12 @@ class BotTestCase(TestCase):
                            'sender_full_name': sender_full_name}
                 self.assert_bot_response(message=message, response=response, expected_method=expected_method)
 
-    def call_request(self, message, expected_method, response):
-        # type: (Dict[str, Any], str, Dict[str, Any]) -> None
+    def call_request(self, message, expected_method, response, state_handler):
+        # type: (Dict[str, Any], str, Dict[str, Any], Optional[StateHandler]) -> None
+        if state_handler is None:
+            state_handler = StateHandler()
         # Send message to the concerned bot
-        self.message_handler.handle_message(message, self.MockClass(), StateHandler())
+        self.message_handler.handle_message(message, self.MockClass(), state_handler)
 
         # Check if the bot is sending a message via `send_message` function.
         # Where response is a dictionary here.
@@ -131,8 +133,8 @@ class BotTestCase(TestCase):
                 else:
                     mock_get.assert_called_with(http_request['api_url'], params=params)
 
-    def assert_bot_response(self, message, response, expected_method):
-        # type: (Dict[str, Any], Dict[str, Any], str) -> None
+    def assert_bot_response(self, message, response, expected_method, state_handler = None):
+        # type: (Dict[str, Any], Dict[str, Any], str, Optional[StateHandler]) -> None
         # Strictly speaking, this function is not needed anymore,
         # kept for now for legacy reasons.
-        self.call_request(message, expected_method, response)
+        self.call_request(message, expected_method, response, state_handler)


### PR DESCRIPTION
This PR:
* Extends `assert_bot_response` with a `state_handler` parameter; if the parameter is `None` (the default) then it constructs a `StateHandler()` anew on each call, as previously. If not, then the passed-in `StateHandler` is used to update state, and can be passed in on subsequent calls.
* Adds preliminary tests for the tictactoe bot, which since it uses state could not previously be fully tested.