### PR TITLE
Disallow handlebars within {{#tr}}{{/tr}}.

### DIFF
--- a/docs/translating.md
+++ b/docs/translating.md
@@ -326,6 +326,16 @@ The rules for plurals are same as for JavaScript files. You just have
 to declare the appropriate keys in the resource file and then include
 the `count` in the context.
 
+Note: Make sure that you don't use handlebars within the block of text
+enclosed by `{{#tr}}{{/tr}}`. The reason is that in most templating
+languages, handlebars are used as variable placeholders. Due to this,
+translatable the string becomes different when the correct value of the
+variable is substituted. The translatable strings are captured by a
+preprocessor and doesn't substitude variables with values. We also have
+a linter, tools/check-frontend-i18n, to disallow such patterns, so the
+Travis build will not pass if the linter finds this pattern.
+
+
 ## Transifex config
 
 The config file that maps the resources from Zulip to Transifex is

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -90,6 +90,7 @@ function _setup_page() {
         zuliprc: 'zuliprc',
         flaskbotrc: 'flaskbotrc',
         timezones: moment.tz.names(),
+        server_uri: page_params.server_uri,
     });
 
     $(".settings-box").html(settings_tab);

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -3,7 +3,7 @@
         <p class="bot-settings-note padded-container">
             {{#tr this}}
             Looking for our <a href="/integrations" target="_blank">Integrations</a>
-            or <a href="{{ server_uri }}/api" target="_blank">API</a> documentation?
+            or <a href="__server_uri__/api" target="_blank">API</a> documentation?
             {{/tr}}
         </p>
 

--- a/tools/check-frontend-i18n
+++ b/tools/check-frontend-i18n
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import print_function
+
+from typing import List, Text
+# check for the venv
+from lib import sanity_check
+sanity_check.check_venv(__file__)
+
+import json
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from scripts.lib.zulip_tools import WARNING, FAIL, ENDC
+
+def find_handlebars(translatable_strings):
+    # type: (List[Text]) -> List[Text]
+    errored = []
+    for string in translatable_strings:
+        if '{{' in string:
+            errored.append(string)
+    return errored
+
+if __name__ == '__main__':
+    with open('static/locale/en/translations.json') as f:
+        data = json.load(f)
+
+    found = find_handlebars(list(data.keys()))
+    if found:
+        print(WARNING + "Translation strings contain handlebars:" + ENDC)
+        print('\n'.join(found))
+
+        print(WARNING +
+              "See http://zulip.readthedocs.io/en/latest/translating.html#frontend-translations "
+              "on how you can insert variables in the frontend translatable "
+              "strings." +
+              ENDC)
+        print(FAIL + "Failed!" + ENDC)
+        sys.exit(1)
+    else:
+        sys.exit(0)

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -385,12 +385,6 @@ def build_custom_checkers(by_lang):
          'description': "Period should be part of the translatable string."},
         {'pattern': "{{/tr}}[\.\?!]",
          'description': "Period should be part of the translatable string."},
-        {'pattern': "{{#tr.*}}.*{{.*{{/tr}}",
-         'exclude_line': set([
-             ('static/templates/subscription_settings.handlebars',
-              '{{#if subscribed }}{{#tr oneself }}Unsubscribe{{/tr}}{{else}}{{#tr oneself }}Subscribe{{/tr}}{{/if}}</button>'),
-         ]),
-         'description': "Translated messages should not contain handlebars."},
     ]
     jinja2_rules = html_rules + [
         {'pattern': "{% endtrans %}[\.\?!]",

--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -20,5 +20,6 @@ set -x
 ./tools/test-help-documentation.py
 ./tools/test-api
 python -W ignore tools/check-capitalization
+python -W ignore tools/check-frontend-i18n
 # Some test suites disabled in CI for being flaky
 #./tools/test-queue-worker-reload


### PR DESCRIPTION
This commit adds a new linter which runs from tools/travis/backend.
It runs over the translations.json file and checks if any of the
translatable string contains handlebars in it.

Fixes #5544