### PR TITLE
product-pages: Better detect matching URL on product page JS.

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -16,6 +16,13 @@ var ScrollTo = function () {
     });
 };
 
+var detectPath = function (pathname) {
+    var match = (pathname || window.location.pathname).match(/(\/\w+)?\/(.+)\//);
+    if (match !== null) {
+        return match[2];
+    }
+};
+
 // these are events that are only to run on the integrations page.
 // check if the page location is integrations.
 var integration_events = function () {
@@ -199,7 +206,7 @@ var events = function () {
             window.location.hash = $(this).data("name");
         });
 
-        if (window.location.pathname === "/apps/") {
+        if (detectPath() === "apps") {
             var hash = function () {
                 return window.location.hash.replace(/^#/, "");
             };
@@ -212,11 +219,11 @@ var events = function () {
         }
     }());
 
-    if (/\/integrations\/*/.test(window.location.pathname)) {
+    if (detectPath() === "integrations") {
         integration_events();
     }
 
-    if (/\/hello\/*/.test(window.location.pathname)) {
+    if (detectPath() === "hello") {
         hello_events();
     }
 };


### PR DESCRIPTION
The product page JS detects the page to run small bundle functions
but does not work correctly with language prefixes in the pathname,
such as /es/apps, so this properly detects that.

Fixes: #5635.