### PR TITLE
bots-ui: Add 'copy zuliprc' button to bots' cards.

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -445,14 +445,42 @@ exports.set_up = function () {
         });
     });
 
-    $("#active_bots_list").on("click", "a.download_bot_zuliprc", function () {
+    $("#active_bots_list").on("click", "button.open_get_zuliprc_modal", function (e) {
+        e.stopPropagation();
         var bot_info = $(this).closest(".bot-information-box");
         var email = bot_info.find(".email .value").text();
         var api_key = bot_info.find(".api_key .api-key-value-and-button .value").text();
+        var zuliprc_text = exports.generate_zuliprc_content($.trim(email), $.trim(api_key));
+        $('#zuliprc_textarea').text(zuliprc_text);
+        $('#get_zuliprc_modal').modal('show');
+    });
 
-        $(this).attr("href", exports.generate_zuliprc_uri(
-            $.trim(email), $.trim(api_key)
-        ));
+    $("#active_bots_list").on("click", "button#download_bot_zuliprc", function () {
+        var bot_info = $(this).closest(".bot-information-box");
+        var email = bot_info.find(".email .value").text();
+        var api_key = bot_info.find(".api_key .api-key-value-and-button .value").text();
+        var zuliprc_uri = exports.generate_zuliprc_uri($.trim(email), $.trim(api_key));
+        var anchor = document.createElement('a');
+        document.body.appendChild(anchor);
+        anchor.download = "zuliprc";
+        anchor.id = "download_bot_zuliprc_anchor";
+        anchor.href = zuliprc_uri;
+        anchor.click();
+        anchor.parentNode.removeChild(anchor);
+    });
+
+    $("#active_bots_list").on("click", "button#copy_bot_zuliprc", function () {
+        var bot_info = $(this).closest(".bot-information-box");
+        var email = bot_info.find(".email .value").text();
+        var api_key = bot_info.find(".api_key .api-key-value-and-button .value").text();
+        var data = exports.generate_zuliprc_content($.trim(email), $.trim(api_key));
+        // Generates a disposable text area and deletes it after done copying.
+        var element = document.createElement('textarea');
+        element.append(document.createTextNode(data));
+        document.body.append(element);
+        element.select();
+        document.execCommand('copy');
+        element.parentNode.removeChild(element);
     });
 
     $("#bots_lists_navbar .add-a-new-bot-tab").click(function (e) {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2786,3 +2786,8 @@ div.message_content table.tictactoe {
 td.tictactoe {
     width: 15px;
 }
+
+#zuliprc_textarea {
+    width: calc(100% - 15px);
+    height: 100px;
+}

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -8,9 +8,22 @@
                 <button type="submit" class="btn open_edit_bot_form" data-sidebar-form="edit-bot" title="{{t 'Edit bot' }}" data-email="{{email}}">
                     <i class="icon-vector-pencil blue"></i>
                 </button>
-                <a type="submit" download="{{zuliprc}}" class="btn download_bot_zuliprc" title="{{t 'Download zuliprc' }}" data-email="{{email}}">
+                <button class="btn open_get_zuliprc_modal" title="{{t 'Get zuliprc' }}" data-email="{{email}}">
                     <i class="icon-vector-download-alt sea-green"></i>
-                </a>
+                </button>
+                <div id="get_zuliprc_modal" class="modal hide" tabindex="-1" role="dialog" aria-hidden="true">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                        <h3 id="get_zuliprc_modal_label">{{t "Get zuliprc for" }} {{name}}</h3>
+                    </div>
+                    <div class="modal-body">
+                        <textarea id="zuliprc_textarea"></textarea>
+                    </div>
+                    <div class="modal-footer">
+                        <button id='copy_bot_zuliprc' class="button rounded" data-dismiss="modal" aria-hidden="true">{{t "Copy" }}</button>
+                        <button id='download_bot_zuliprc' class="button rounded" data-dismiss="modal" aria-hidden="true">{{t "Download" }}</button>
+                    </div>
+                </div>
                 <button type="submit" class="btn delete_bot" title="{{t 'Delete bot' }}" data-user-id="{{user_id}}">
                     <i class="icon-vector-trash danger-red"></i>
                 </button>


### PR DESCRIPTION
Since browsers do not allow direct access to clipboard for
security reasons, we use a workaround that involves creating
a new **visible** textarea element with our text and calling
`document.execCommand('copy')` to copy its text. After we
have copied the text, we remove the element from the DOM.

Because of the nature of the method, we cannot reliably test
this code using casper; browsers allow reading the clipboard
only as a reaction to a user event like click.