### PR TITLE
Patch filedrop/spectrum for jQuery 3 compatibility.

### DIFF
--- a/static/third/jquery-filedrop/jquery.filedrop.js
+++ b/static/third/jquery-filedrop/jquery.filedrop.js
@@ -51,8 +51,6 @@
  */
 ;(function($) {
 
-  jQuery.event.props.push("dataTransfer");
-
   var default_opts = {
       fallback_id: '',
       url: '',
@@ -113,6 +111,11 @@
     });
 
     function drop(e) {
+      if (!e.originalEvent.dataTransfer) {
+        return;
+      }
+
+      files = e.originalEvent.dataTransfer.files;
 
       function has_type(dom_stringlist, type) {
         var j;
@@ -124,19 +127,18 @@
         return false;
       }
 
-      if (e.dataTransfer.files.length === 0) {
+      if (files.length === 0) {
         var i;
         for (i = 0; i < opts.raw_droppable.length; i++) {
           var type = opts.raw_droppable[i];
-          if (has_type(e.dataTransfer.types, type)) {
-            opts.rawDrop(e.dataTransfer.getData(type));
+          if (has_type(e.originalEvent.dataTransfer.types, type)) {
+            opts.rawDrop(e.originalEvent.dataTransfer.getData(type));
             return false;
           }
         }
       }
 
       if( opts.drop.call(this, e) === false ) return false;
-      files = e.dataTransfer.files;
       if (files === null || files === undefined || files.length === 0) {
         opts.error(errors[0]);
         return false;

--- a/static/third/spectrum/spectrum.js
+++ b/static/third/spectrum/spectrum.js
@@ -231,7 +231,7 @@
                 }
             }
 
-            offsetElement.bind("click.spectrum touchstart.spectrum", function (e) {
+            offsetElement.on("click.spectrum touchstart.spectrum", function (e) {
                 toggle();
 
                 e.stopPropagation();
@@ -246,18 +246,18 @@
 
             // Handle user typed input
             textInput.change(setFromTextInput);
-            textInput.bind("paste", function () {
+            textInput.on("paste", function () {
                 setTimeout(setFromTextInput, 1);
             });
             textInput.keydown(function (e) { if (e.keyCode == 13) { setFromTextInput(); } });
 
-            cancelButton.bind("click.spectrum", function (e) {
+            cancelButton.on("click.spectrum", function (e) {
                 e.stopPropagation();
                 e.preventDefault();
                 hide("cancel");
             });
 
-            chooseButton.bind("click.spectrum", function (e) {
+            chooseButton.on("click.spectrum", function (e) {
                 e.stopPropagation();
                 e.preventDefault();
 
@@ -321,8 +321,8 @@
             }
 
             var paletteEvent = IE ? "mousedown.spectrum" : "click.spectrum touchstart.spectrum";
-            paletteContainer.delegate(".sp-thumb-el", paletteEvent, palletElementClick);
-            initialColorContainer.delegate(".sp-thumb-el::nth-child(1)", paletteEvent, { ignore: true }, palletElementClick);
+            paletteContainer.on(paletteEvent, ".sp-thumb-el", palletElementClick);
+            initialColorContainer.on(paletteEvent, ".sp-thumb-el:nth-child(1)", { ignore: true }, palletElementClick);
         }
         function addColorToSelectionPalette(color) {
             if (showSelectionPalette) {
@@ -414,8 +414,8 @@
             hideAll();
             visible = true;
 
-            $(doc).bind("click.spectrum", hide);
-            $(window).bind("resize.spectrum", resize);
+            $(doc).on("click.spectrum", hide);
+            $(window).on("resize.spectrum", resize);
             replacer.addClass("sp-active");
             container.show();
 
@@ -440,8 +440,8 @@
             if (!visible || flat) { return; }
             visible = false;
 
-            $(doc).unbind("click.spectrum", hide);
-            $(window).unbind("resize.spectrum", resize);
+            $(doc).off("click.spectrum", hide);
+            $(window).off("resize.spectrum", resize);
 
             replacer.removeClass("sp-active");
             container.hide();
@@ -634,7 +634,7 @@
 
         function destroy() {
             boundElement.show();
-            offsetElement.unbind("click.spectrum touchstart.spectrum");
+            offsetElement.off("click.spectrum touchstart.spectrum");
             container.remove();
             replacer.remove();
             spectrums[spect.id] = null;
@@ -779,7 +779,7 @@
                     maxWidth = $(element).width();
                     offset = $(element).offset();
 
-                    $(doc).bind(duringDragEvents);
+                    $(doc).on(duringDragEvents);
                     $(doc.body).addClass("sp-dragging");
 
                     if (!hasTouch) {
@@ -792,14 +792,13 @@
         }
         function stop() {
             if (dragging) {
-                $(doc).unbind(duringDragEvents);
+                $(doc).off(duringDragEvents);
                 $(doc.body).removeClass("sp-dragging");
                 onstop.apply(element, arguments);
             }
             dragging = false;
         }
-
-        $(element).bind(hasTouch ? "touchstart" : "mousedown", start);
+        $(element).on(hasTouch ? "touchstart" : "mousedown", start);
     }
 
     function throttle(func, wait, debounce) {


### PR DESCRIPTION
Since we've already had several modifications to filedrop for our system, instead of updating to the latest version, I figured it would make more sense to just update compatibility manually (largely by comparing with the diff of the latest version of filedrop).

For spectrum, we have a couple little modifications, and the latest version of spectrum changes around the structure of the code quite a bit, but still basically accomplishes the same thing. So again, I went with the approach of just manually updating.
And I'm not sure if this should be handled in this PR, but check out this note about spectrum behavior: https://chat.zulip.org/#narrow/stream/frontend/subject/change.20stream.20color/near/241809

Refer to #5627 for discussion.