### PR TITLE
realm: add required topic setting on org level.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -49,6 +49,7 @@ function _setup_page() {
         is_admin: page_params.is_admin,
         realm_icon_source: page_params.realm_icon_source,
         realm_icon_url: page_params.realm_icon_url,
+        realm_mandatory_topics: page_params.realm_mandatory_topics,
     };
 
     var admin_tab = templates.render('admin_tab', options);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -99,6 +99,8 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             page_params.realm_icon_url = event.data.icon_url;
             page_params.realm_icon_source = event.data.icon_source;
             realm_icon.rerender();
+        } else if (event.op === 'update' && event.property === 'mandatory_topics') {
+            page_params.realm_mandatory_topics = event.value;
         }
 
         break;

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -246,6 +246,11 @@ function _set_up() {
                 checked_msg: i18n.t("New user e-mails now restricted to certain domains!"),
                 unchecked_msg: i18n.t("New users may have arbitrary e-mails!"),
             },
+            mandatory_topics: {
+                type: 'bool',
+                checked_msg: i18n.t("Topics are required in messages to streams"),
+                unchecked_msg: i18n.t("Topics are not required in messages to streams"),
+            },
         },
     };
 

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -12,6 +12,7 @@
         <div class="alert" id="admin-realm-message-editing-status"></div>
         <div class="alert" id="admin-realm-name-changes-disabled-status"></div>
         <div class="alert" id="admin-realm-email-changes-disabled-status"></div>
+        <div class="alert" id="admin-realm-mandatory-topics-status"></div>
 
         <div class="m-10 inline-block organization-permissions-parent">
             <div class="input-group admin-restricted-to-domain">
@@ -167,6 +168,18 @@
                   value="{{ realm_message_retention_days }}"/>
             </div>
             {{/if}}
+
+            <div class="input-group">
+                <label class="checkbox">
+                    <input type="checkbox" id="id_realm_mandatory_topics" name="realm_mandatory_topics"
+                           {{#if realm_mandatory_topics}}checked="checked"{{/if}} />
+                    <span></span>
+                </label>
+                <label for="id_realm_mandatory_topics" id="id_realm_mandatory_topics_label" class="inline-block"
+                    title="{{t 'If checked, topics are required.'}}">
+                    {{t "Require topics in messages to streams" }}
+                </label>
+            </div>
 
             {{#if is_admin }}
             <div class="input-group organization-submission">

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -156,6 +156,7 @@ class Realm(ModelReprMixin, models.Model):
         invite_by_admins_only=bool,
         inline_image_preview=bool,
         inline_url_embed_preview=bool,
+        mandatory_topics=bool,
         message_retention_days=(int, type(None)),
         name=Text,
         name_changes_disabled=bool,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -856,6 +856,7 @@ class EventsRegisterTest(ZulipTestCase):
             invite_by_admins_only=bool_tests,
             inline_image_preview=bool_tests,
             inline_url_embed_preview=bool_tests,
+            mandatory_topics=bool_tests,
             message_retention_days=[10, 20],
             name=[u'Zulip', u'New Name'],
             name_changes_disabled=bool_tests,

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -255,6 +255,7 @@ class RealmAPITest(ZulipTestCase):
             invite_by_admins_only=bool_tests,
             inline_image_preview=bool_tests,
             inline_url_embed_preview=bool_tests,
+            mandatory_topics=bool_tests,
             message_retention_days=[10, 20],
             name=[u'Zulip', u'New Name'],
             name_changes_disabled=bool_tests,

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -33,13 +33,14 @@ def update_realm(request, user_profile, name=REQ(validator=check_string, default
                  create_stream_by_admins_only=REQ(validator=check_bool, default=None),
                  add_emoji_by_admins_only=REQ(validator=check_bool, default=None),
                  allow_message_editing=REQ(validator=check_bool, default=None),
+                 mandatory_topics=REQ(validator=check_bool, default=None),
                  message_content_edit_limit_seconds=REQ(converter=to_non_negative_int, default=None),
                  default_language=REQ(validator=check_string, default=None),
                  waiting_period_threshold=REQ(converter=to_non_negative_int, default=None),
                  authentication_methods=REQ(validator=check_dict([]), default=None),
                  notifications_stream_id=REQ(validator=check_int, default=None),
                  message_retention_days=REQ(converter=to_not_negative_int_or_none, default=None)):
-    # type: (HttpRequest, UserProfile, Optional[str], Optional[str], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[int], Optional[str], Optional[int], Optional[dict], Optional[int], Optional[int]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, Optional[str], Optional[str], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[bool], Optional[int], Optional[str], Optional[int], Optional[dict], Optional[int], Optional[int]) -> HttpResponse
     realm = user_profile.realm
 
     # Additional validation/error checking beyond types go here, so


### PR DESCRIPTION
Lets organizations require users to specify a topic the discussion

- Fixes: #5164