### PR TITLE
Add a patter to the fenced extension for recognising font awesome icons. 

### DIFF
--- a/templates/zerver/help/add-a-bot-or-integration.md
+++ b/templates/zerver/help/add-a-bot-or-integration.md
@@ -19,8 +19,8 @@ the creation of your bot.
 
 4. You now have access to your bot's API key and API
 configuration file (`.zuliprc`) which you will need for integrations that you would like
-to use with this bot. You can click on the download
-(<i class="icon-vector-download-alt"></i>) icon to download your `.zuliprc` file.
+to use with this bot. You can click on the download !icon(download) icon to download your
+`.zuliprc` file.
 
 ## Add an integration
 

--- a/zerver/lib/bugdown/zulip_help_markdown.py
+++ b/zerver/lib/bugdown/zulip_help_markdown.py
@@ -1,0 +1,64 @@
+from __future__ import absolute_import
+import re
+import os
+import markdown
+import six
+from typing import Any, Dict, Iterable, List, MutableSequence, Optional, Tuple, Union, Text
+from typing.re import Match
+from xml.etree.cElementTree import Element
+from zerver.lib.cache import cache
+
+class HelpMarkdownExtension(markdown.Extension):
+
+    def extendMarkdown(self, md, md_globals):
+        # type: (markdown.Markdown, Dict[str, Any]) -> None
+        """ Add HelpMarkdownExtension to the Markdown instance. """
+        md.registerExtension(self)
+        md.inlinePatterns.add('icon',
+                              Icon(r'!icon\((?P<icon_name>.*?)\)'),
+                              '>backtick')
+
+@cache
+def get_fa_icons():
+    # type: () -> List[str]
+    allowed_fa_icons = []  # type: List[str]
+    ZERVER_LIB_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    ZULIP_PATH = os.path.dirname(os.path.dirname(ZERVER_LIB_PATH))
+    FA_CSS_FILE = os.path.join(ZULIP_PATH, 'static', 'third', 'thirdparty-fonts.css')
+    with open(FA_CSS_FILE) as f:
+        content = f.read()
+        icons = re.findall('fa-(\S*):before', content)
+        allowed_fa_icons = allowed_fa_icons + icons
+    return allowed_fa_icons
+
+class Icon(markdown.inlinepatterns.Pattern):
+    def handleMatch(self, match):
+        # type: (Match[Text]) -> Optional[Element]
+        allowed_fa_icons = get_fa_icons()
+        icon_data = match.group('icon_name')
+        icon_data = icon_data.strip().lower().split(',')
+        icon_name = icon_data[0].strip()
+        if len(icon_data) > 1:
+            icon_param = icon_data[1].strip()
+        else:
+            icon_param = ''
+        if icon_name in allowed_fa_icons:
+            if icon_param == '':
+                wrap_icon = markdown.util.etree.Element('span')
+                wrap_icon.set('aria-hidden', 'true')
+                wrap_icon.text = u'('
+                icon = markdown.util.etree.SubElement(wrap_icon, 'i')
+                icon.set('class', 'fa fa-%s' % (icon_name))
+                icon.tail = u')'
+                return wrap_icon
+            elif icon_param == 'hidden' or icon_param == 'no-bracket':
+                icon = markdown.util.etree.Element('i')
+                icon.set('class', 'fa fa-%s' % (icon_name))
+                if icon_param == 'hidden':
+                    icon.set('aria-hidden', 'true')
+                return icon
+        return None
+
+def makeExtension(*args, **kwargs):
+    # type: (*Any, **Union[bool, None, Text]) -> HelpMarkdownExtension
+    return HelpMarkdownExtension(*args, **kwargs)

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -9,6 +9,7 @@ from django.utils.lru_cache import lru_cache
 from zerver.lib.utils import force_text
 from typing import List
 import zerver.lib.bugdown.fenced_code
+import zerver.lib.bugdown.zulip_help_markdown
 
 import markdown
 import markdown.extensions.admonition
@@ -75,6 +76,7 @@ def render_markdown_path(markdown_file_path, context=None):
                 guess_lang=False
             ),
             zerver.lib.bugdown.fenced_code.makeExtension(),
+            zerver.lib.bugdown.zulip_help_markdown.makeExtension(),
             markdown_include.include.makeExtension(base_path='templates/zerver/help/include/'),
         ]
     md_engine = markdown.Markdown(extensions=md_extensions)


### PR DESCRIPTION
In this PR we are going to implement the macro kind of a method to ease out the font awesome migration in help docs. This is in reference to this [comment](https://github.com/zulip/zulip/pull/5289#issuecomment-307227695).
What we have basically done now is that:
* We have added a class `Icon` to `fenced_code.py` which is responsible for handling the `!icon(icon_name,params)` syntax in markdown.

With this we can just add `!icon('cog','hidden')` anywhere fenced_code is used to obtain a `cog` icon with aria-hidden attrib. Also there is another param supported which is `!icon('cog','bracket')` which will return a `cog` icon wrapped inside brackets(using `<span>`) and the `<span>` having the `aria-hidden: true` label set.
Check out PR #5289 for the previous discussion trail.
This PR also has a help doc ported for giving the reviewer a taste of how the new pattern will be used.
One unintended effect of this is that we can use same syntax in compose box as well while writing messages.
I can migrate all the help docs to use this is once this gets approved as the right way to go about this.
@timabbott @eeshangarg @hackerkid @sinwar 