### PR TITLE
frontend: Make table headers fixed.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -194,6 +194,11 @@ td .button {
     background-color: inherit;
     color: inherit;
     border-top: 1px solid hsl(0, 0%, 86%) !important;
+    border-bottom: 1px solid hsl(0, 0%, 86%) !important;
+}
+
+#admin-user-list .table tr:first-of-type td {
+    border-top: none;
 }
 
 .settings-section input[type=text].search {

--- a/static/templates/settings/bot-list-admin.handlebars
+++ b/static/templates/settings/bot-list-admin.handlebars
@@ -1,17 +1,19 @@
 <div id="admin-user-list" class="settings-section" data-name="bot-list-admin">
     <input type="text" class="search" placeholder="{{t 'Filter bots' }}" />
     <div class="clear-float"></div>
+    <table class="table table-condensed table-striped wrapped-table">
+        <thead>
+            <th class="wrapped-cell">{{t "Name" }}</th>
+            <th>{{t "Email" }}</th>
+            <th>{{t "Owner" }}</th>
+            <th>{{t "Bot type" }}</th>
+            {{#if is_admin}}
+            <th class="actions">{{t "Actions" }}</th>
+            {{/if}}
+        </thead>
+    </table>
     <div class="progressive-table-wrapper">
         <table class="table table-condensed table-striped wrapped-table">
-            <thead>
-                <th class="wrapped-cell">{{t "Name" }}</th>
-                <th>{{t "Email" }}</th>
-                <th>{{t "Owner" }}</th>
-                <th>{{t "Bot type" }}</th>
-                {{#if is_admin}}
-                <th class="actions">{{t "Actions" }}</th>
-                {{/if}}
-            </thead>
             <tbody id="admin_bots_table" class="admin_bot_table required-text thick"
                    data-empty="{{ t 'No bots match your current filter.' }}"></tbody>
         </table>


### PR DESCRIPTION
Fixes #4746.
This simple solution is to separate the header & body of the table into two separate tables, with the header outside of the scrollable wrapper. I am not sure if we want to do this in terms of keeping the table in one piece? 

Another way this could be done would be to add a div inside each header cell and add a bunch of css to both hide the `th` while making the `th div` fixed. This is more complex, so I wanted feedback on whether the current fix is acceptable.

Current behaviour:
![image](https://user-images.githubusercontent.com/13666710/27793008-91fd39d8-5ffc-11e7-8820-704696116a3c.png)
![image](https://user-images.githubusercontent.com/13666710/27793016-a0903b76-5ffc-11e7-9899-451b0e6426d5.png)
 