### PR TITLE
Outgoing webhook UI changes to "Add new bot" and "Edit bot" form.

### DIFF
--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -15,6 +15,8 @@ set_global('document', null);
 var page_params = {
     realm_bots: [{email: 'bot0@zulip.com', full_name: 'Bot 0'}],
     is_admin: false,
+    realm_services: [{email: 'testbot@zulip.com', base_url: 'http://example.domain.com',
+        interface:1, name: 'test'}],
 };
 set_global('page_params', page_params);
 
@@ -36,6 +38,8 @@ var bot_data = require('js/bot_data.js');
 bot_data.initialize();
 // Our startup logic should have added Bot 0 from page_params.
 assert.equal(bot_data.get('bot0@zulip.com').full_name, 'Bot 0');
+assert.equal(bot_data.get_service('testbot@zulip.com').base_url, 'http://example.domain.com');
+assert.equal(bot_data.get_service('testbot@zulip.com').name, 'test');
 
 (function () {
     var test_bot = {
@@ -44,6 +48,38 @@ assert.equal(bot_data.get('bot0@zulip.com').full_name, 'Bot 0');
         full_name: 'Bot 1',
         extra: 'Not in data',
     };
+
+    var test_service_1 = {
+        base_url: 'http://example.domain1.com',
+        interface: 1,
+        name: 'test1',
+        token: 'abcd',
+        email: 'bot1@zulip.com',
+    };
+
+    var test_service_2 = {
+        base_url: 'http://example.domain2.com',
+        interface: 1,
+        name: 'test2',
+        token: 'abcd',
+        email: 'bot1@zulip.com',
+    };
+
+    (function test_add_service() {
+        bot_data.add_service(test_service_1);
+
+        var service = bot_data.get_service('bot1@zulip.com');
+        assert.equal('http://example.domain1.com', service.base_url);
+        assert.equal('test1', service.name);
+    }());
+
+    (function test_update_service() {
+        bot_data.update_service('bot1@zulip.com', test_service_2);
+
+        var service = bot_data.get_service('bot1@zulip.com');
+        assert.equal('http://example.domain2.com', service.base_url);
+        assert.equal('test2', service.name);
+    }());
 
     (function test_add() {
         bot_data.add(test_bot);

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -30,6 +30,12 @@ var bot_data = (function () {
         send_change_event();
     };
 
+    exports.add_services = function bot_data__add_services(services) {
+        _.each(services, function (service) {
+            exports.add_service(service);
+        });
+    };
+
     exports.add_service = function bot_data__add_service(service) {
         var clean_service = _.pick(service, services_fields);
         services[service.email] = clean_service;
@@ -78,9 +84,7 @@ var bot_data = (function () {
         _.each(page_params.realm_bots, function (bot) {
             exports.add(bot);
         });
-        _.each(page_params.realm_services, function (service) {
-            exports.add_service(service);
-        });
+        exports.add_services(page_params.realm_services);
     };
 
     return exports;

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -6,6 +6,9 @@ var bot_data = (function () {
                       'default_events_register_stream', 'default_sending_stream',
                       'email', 'full_name', 'is_active', 'owner', 'bot_type'];
 
+    var services = {};
+    var services_fields = ['base_url', 'interface', 'name'];
+
     var send_change_event = _.debounce(function () {
         $(document).trigger('zulip.bot_data_changed');
     }, 50);
@@ -27,6 +30,12 @@ var bot_data = (function () {
         send_change_event();
     };
 
+    exports.add_service = function bot_data__add_service(service) {
+        var clean_service = _.pick(service, services_fields);
+        services[service.email] = clean_service;
+        send_change_event();
+    };
+
     exports.deactivate = function bot_data__deactivate(email) {
         bots[email].is_active = false;
         send_change_event();
@@ -36,6 +45,12 @@ var bot_data = (function () {
         var bot = bots[email];
         _.extend(bot, _.pick(bot_update, bot_fields));
         set_can_admin(bot);
+        send_change_event();
+    };
+
+    exports.update_service = function bot_data__update_service(email, service_update) {
+        var service = services[email];
+        _.extend(service, _.pick(service_update, services_fields));
         send_change_event();
     };
 
@@ -55,9 +70,16 @@ var bot_data = (function () {
         return bots[email];
     };
 
+    exports.get_service = function bot_data__get_service(email) {
+        return services[email];
+    };
+
     exports.initialize = function () {
         _.each(page_params.realm_bots, function (bot) {
             exports.add(bot);
+        });
+        _.each(page_params.realm_services, function (service) {
+            exports.add_service(service);
         });
     };
 

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -98,6 +98,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
     case 'realm_bot':
         if (event.op === 'add') {
             bot_data.add(event.bot);
+            bot_data.add_services(event.service);
             settings_users.update_user_data(event.bot.user_id, event.bot);
         } else if (event.op === 'remove') {
             bot_data.deactivate(event.bot.email);
@@ -108,6 +109,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 event.bot.owner = people.get_person_from_user_id(event.bot.owner_id).email;
             }
             bot_data.update(event.bot.email, event.bot);
+            bot_data.update_service(event.bot.email, event.service);
             settings_users.update_user_data(event.bot.user_id, event.bot);
         }
         break;

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -123,6 +123,8 @@ exports.set_up = function () {
     var OUTGOING_WEBHOOK_BOT_TYPE = '3';
     var GENERIC_BOT_TYPE = '1';
 
+    var GENERIC_INTERFACE = '1';
+
     $('#create_bot_form').validate({
         errorClass: 'text-error',
         success: function () {
@@ -133,6 +135,7 @@ exports.set_up = function () {
             var full_name = $('#create_bot_name').val();
             var short_name = $('#create_bot_short_name').val() || $('#create_bot_short_name').text();
             var payload_url = $('#create_payload_url').val();
+            var interface_type = $('#create_interface_type').val();
             var formData = new FormData();
 
             formData.append('csrfmiddlewaretoken', csrf_token);
@@ -143,6 +146,7 @@ exports.set_up = function () {
             // If the selected bot_type is Outgoing webhook
             if (bot_type === OUTGOING_WEBHOOK_BOT_TYPE) {
                 formData.append('payload_url', JSON.stringify(payload_url));
+                formData.append('interface_type', interface_type);
             }
             jQuery.each($('#bot_avatar_file_input')[0].files, function (i, file) {
                 formData.append('file-'+i, file);
@@ -162,6 +166,7 @@ exports.set_up = function () {
                     $('#payload_url_inputbox').hide();
                     $('#create_bot_type').val(GENERIC_BOT_TYPE);
                     $('#create_bot_button').show();
+                    $('#create_interface_type').val(GENERIC_INTERFACE);
                     create_avatar_widget.clear();
                     $("#bots_lists_navbar .add-a-new-bot-tab").removeClass("active");
                     $("#bots_lists_navbar .active-bots-tab").addClass("active");

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -1,7 +1,7 @@
 var settings_bots = (function () {
 
 var exports = {};
-
+var OUTGOING_WEBHOOK = "Outgoing webhook";
 function add_bot_row(info) {
     info.id_suffix = _.uniqueId('_bot_');
     var row = $(templates.render('bot_avatar_row', info));
@@ -26,7 +26,7 @@ exports.type_id_to_string = function (type_id) {
     } else if (type_id === 2) {
         return i18n.t("Incoming webhook");
     } else if (type_id === 3) {
-        return i18n.t("Outgoing webhook");
+        return i18n.t(OUTGOING_WEBHOOK);
     }
 };
 
@@ -253,12 +253,22 @@ exports.set_up = function () {
         var old_full_name = bot_info.find(".name").text();
         var old_owner = bot_data.get(bot_info.find(".email .value").text()).owner;
         var bot_email = bot_info.find(".email .value").text();
+        var bot_type = bot_info.find(".type .value").text();
 
         $("#settings_page .edit_bot .edit_bot_name").val(old_full_name);
         $("#settings_page .edit_bot .select-form").text("").append(owner_select);
         $("#settings_page .edit_bot .edit-bot-owner select").val(old_owner);
         $("#settings_page .edit_bot_form").attr("data-email", bot_email);
         $(".edit_bot_email").text(bot_email);
+
+        if (bot_type === OUTGOING_WEBHOOK) {
+            var service = bot_data.get_service(bot_email);
+            $("#settings_page .edit_bot #service_data").show();
+            $("#settings_page .edit_bot #edit_service_base_url").val(service.base_url);
+            $("#settings_page .edit_bot #edit_service_interface").val(service.interface);
+        } else {
+            $("#settings_page .edit_bot #service_data").hide();
+        }
 
         avatar_widget.clear();
 
@@ -295,6 +305,13 @@ exports.set_up = function () {
                 formData.append('csrfmiddlewaretoken', csrf_token);
                 formData.append('full_name', full_name);
                 formData.append('bot_owner', bot_owner);
+                if (bot_type === OUTGOING_WEBHOOK) {
+                    var service_payload_url = $("#settings_page .edit_bot #edit_service_base_url").val();
+                    var service_interface = $("#settings_page .edit_bot #edit_service_interface :selected").val();
+                    formData.append('service_payload_url', JSON.stringify(service_payload_url));
+                    formData.append('service_interface', service_interface);
+                }
+
                 jQuery.each(file_input[0].files, function (i, file) {
                     formData.append('file-'+i, file);
                 });

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -55,11 +55,21 @@
                             <label for="create_bot_short_name" generated="true" class="text-error"></label>
                         </div>
                     </div>
-                    <div class="input-group" id="payload_url_inputbox">
-                        <label for="create_payload_url">{{t "Outgoing webhook service base URL" }}</label>
-                        <input type="text" name="payload_url" id="create_payload_url"
-                            maxlength=100 placeholder="https://hostname.example.com/bots/followup" value="" />
-                        <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
+                    <div id="payload_url_inputbox">
+                        <div class="input-group">
+                            <label for="create_payload_url">{{t "Base URL" }}</label>
+                            <input type="text" name="payload_url" id="create_payload_url"
+                                maxlength=100 placeholder="https://hostname.example.com/bots/followup" value="" />
+                            <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
+                        </div>
+                        <div class="input-group">
+                            <label for="interface_type">{{t "Interface" }}</label>
+                            <select name="interface_type" id="create_interface_type">
+                                <option value="1">{{t "Generic" }}</option>
+                                <option value="2">{{t "Slack's outgoing webhooks" }}</option>
+                            </select>
+                            <div><label for="create_interface_type" generated="true" class="text-error"></label></div>
+                        </div>
                     </div>
                     <div class="input-group">
                         <div id="bot_avatar_file"></div>

--- a/templates/zerver/settings_sidebar.html
+++ b/templates/zerver/settings_sidebar.html
@@ -22,6 +22,20 @@
                         <label for="bot_owner_select">{{ _("Owner") }}</label>
                         <div class="select-form"></div>
                     </div>
+                    <div id="service_data">
+                        <div class="">
+                            <label for="edit_service_base_url">{{ _("Base URL") }}</label>
+                            <input id="edit_service_base_url" type="text" name="service_payload_url" class="edit_service_base_url required" maxlength=50 />
+                            <div><label for="edit_service_base_url" generated="true" class="text-error"></label></div>
+                        </div>
+                        <div class="">
+                            <label for="edit_service_interface">{{ _("Interface") }}</label>
+                            <select id="edit_service_interface" name="service_interface" default="1">
+                                <option value="1">{{ _("Generic") }}</option>
+                                <option value="2">{{ _("Slack's outgoing webhooks") }}</option>
+                            </select>
+                        </div>
+                    </div>
                     <div class="avatar-section">
                         <label for="bot_avatar_file_input">Avatar</label>
                         <input type="file" name="bot_avatar_file_input" class="notvisible edit_bot_avatar_file_input" value="{{ _('Upload avatar') }}" />

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -48,7 +48,7 @@ from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, 
     Reaction, EmailChangeStatus, CustomProfileField, \
     custom_profile_fields_for_realm, \
     CustomProfileFieldValue, validate_attachment_request, get_system_bot, \
-    get_display_recipient_by_id
+    get_display_recipient_by_id, get_service_dicts_for_bots, get_bot_services
 
 from zerver.lib.alert_words import alert_words_in_realm
 from zerver.lib.avatar import avatar_url
@@ -397,14 +397,17 @@ def notify_created_bot(user_profile):
                default_all_public_streams=user_profile.default_all_public_streams,
                avatar_url=avatar_url(user_profile),
                )
-
+    if user_profile.bot_type == UserProfile.OUTGOING_WEBHOOK_BOT:
+        services = get_service_dicts_for_bots(user_profile)
+    else:
+        services = []
     # Set the owner key only when the bot has an owner.
     # The default bots don't have an owner. So don't
     # set the owner key while reactivating them.
     if user_profile.bot_owner is not None:
         bot['owner'] = user_profile.bot_owner.email
 
-    event = dict(type="realm_bot", op="add", bot=bot)
+    event = dict(type="realm_bot", op="add", bot=bot, service=services)
     send_event(event, bot_owner_userids(user_profile))
 
 def do_create_user(email, password, realm, full_name, short_name,
@@ -3487,3 +3490,23 @@ def do_update_user_custom_profile_data(user_profile, data):
             update_or_create(user_profile=user_profile,
                              field_id=field['id'],
                              defaults={'value': field['value']})
+
+def do_update_outgoing_webhook_service(bot_profile, service_interface, service_payload_url):
+    # type: (UserProfile, int, Text) -> None
+    # TODO: First service is chosen because currently one bot can have one service. Update it if multiple services
+    # are supported.
+    service = get_bot_services(bot_profile.id)[0]
+    service.base_url = service_payload_url
+    service.interface = service_interface
+    service.save()
+    send_event(dict(type='realm_bot',
+                    op='update',
+                    bot=dict(email=bot_profile.email,
+                             user_id=bot_profile.id,
+                             owner_id=bot_profile.bot_owner.id,
+                             ),
+                    service=dict(email=bot_profile.email,
+                                 name=service.name,
+                                 base_url=service.base_url,
+                                 interface=service.interface)),
+               bot_owner_userids(bot_profile))

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -38,7 +38,7 @@ from zerver.tornado.event_queue import request_event_queue, get_user_events
 from zerver.models import Client, Message, Realm, UserPresence, UserProfile, \
     get_user_profile_by_id, \
     get_active_user_dicts_in_realm, realm_filters_for_realm, get_user,\
-    get_owned_bot_dicts, custom_profile_fields_for_realm, get_realm_domains
+    get_owned_bot_dicts, custom_profile_fields_for_realm, get_realm_domains, get_service_dicts_for_users
 from zproject.backends import password_auth_enabled
 from version import ZULIP_VERSION
 
@@ -149,6 +149,7 @@ def fetch_initial_state_data(user_profile, event_types, queue_id,
 
     if want('realm_bot'):
         state['realm_bots'] = get_owned_bot_dicts(user_profile)
+        state['realm_services'] = get_service_dicts_for_users(user_profile)
 
     if want('subscription'):
         subscriptions, unsubscribed, never_subscribed = gather_subscriptions_helper(
@@ -269,14 +270,17 @@ def apply_event(state, event, user_profile, include_subscribers):
                             user_profile.email == person['email']):
                         if p['is_admin'] and not person['is_admin']:
                             state['realm_bots'] = []
+                            state['realm_services'] = []
                         if not p['is_admin'] and person['is_admin']:
                             state['realm_bots'] = get_owned_bot_dicts(user_profile)
+                            state['realm_services'] = get_service_dicts_for_users(user_profile)
 
                     # Now update the person
                     p.update(person)
     elif event['type'] == 'realm_bot':
         if event['op'] == 'add':
             state['realm_bots'].append(event['bot'])
+            state['realm_services'].extend(event['service'])
 
         if event['op'] == 'remove':
             email = event['bot']['email']
@@ -291,6 +295,10 @@ def apply_event(state, event, user_profile, include_subscribers):
                         bot['owner'] = get_user_profile_by_id(event['bot']['owner_id']).email
                     else:
                         bot.update(event['bot'])
+            if 'service' in event:
+                for service in state['realm_services']:
+                    if service['email'] == event['service']['email']:
+                        service.update(event['service'])
 
     elif event['type'] == 'stream':
         if event['op'] == 'create':

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext as _
 
 from zerver.lib.actions import do_change_full_name
 from zerver.lib.request import JsonableError
-from zerver.models import UserProfile
+from zerver.models import UserProfile, Service
 
 def check_full_name(full_name_raw):
     # type: (Text) -> Text
@@ -39,3 +39,8 @@ def check_valid_bot_type(bot_type):
     # type: (int) -> None
     if bot_type not in UserProfile.ALLOWED_BOT_TYPES:
         raise JsonableError(_('Invalid bot type'))
+
+def check_valid_interface_type(interface_type):
+    # type: (int) -> None
+    if interface_type not in Service.ALLOWED_INTERFACE_TYPES:
+        raise JsonableError(_('Invalid interface type'))

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1854,3 +1854,23 @@ def get_bot_services(user_profile_id):
 def get_service_profile(user_profile_id, service_name):
     # type: (str, str) -> Service
     return Service.objects.get(user_profile__id=user_profile_id, name=service_name)
+
+def get_service_dicts_for_bots(user_profile):
+    # type: (UserProfile) -> List[Dict[str, Any]]
+    services = get_bot_services(user_profile.id)
+    service_dicts = ([{'email': user_profile.email,
+                       'name': service.name,
+                       'base_url': service.base_url,
+                       'interface': service.interface,
+                       }
+                      for service in services])
+    return service_dicts
+
+def get_service_dicts_for_users(user_profile):
+    # type: (UserProfile) -> List[Dict[str, Any]]
+
+    bots = UserProfile.objects.filter(realm=user_profile.realm, is_bot=True, bot_owner=user_profile)
+    service_dicts = []
+    for bot in bots:
+        service_dicts.extend(get_service_dicts_for_bots(bot))
+    return service_dicts

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -64,6 +64,7 @@ from zerver.lib.actions import (
     do_update_message,
     do_update_message_flags,
     do_update_muted_topic,
+    do_update_outgoing_webhook_service,
     do_update_pointer,
     do_update_user_presence,
     log_event,
@@ -80,13 +81,14 @@ from zerver.lib.test_classes import (
 )
 from zerver.lib.validator import (
     check_bool, check_dict, check_dict_only, check_float, check_int, check_list, check_string,
-    equals, check_none_or, Validator
+    equals, check_none_or, Validator, check_url
 )
 
 from zerver.views.events_register import _default_all_public_streams, _default_narrow
 
 from zerver.tornado.event_queue import allocate_client_descriptor, EventQueue
 from zerver.tornado.views import get_events_backend
+from zerver.views.users import add_outgoing_webhook_service
 
 from collections import OrderedDict
 import mock
@@ -1222,6 +1224,12 @@ class EventsRegisterTest(ZulipTestCase):
                 ('avatar_url', check_string),
                 ('owner', check_string),
             ])),
+            ('service', check_list(check_dict_only([
+                ('name', check_string),
+                ('base_url', check_url),
+                ('interface', check_int),
+                ('email', check_string)
+            ]))),
         ])
         action = lambda: self.create_bot('test-bot@zulip.com')
         events = self.do_test(action, num_events=2)
@@ -1327,6 +1335,33 @@ class EventsRegisterTest(ZulipTestCase):
         error = change_bot_owner_checker('events[0]', events[0])
         self.assert_on_error(error)
 
+    def test_do_update_outgoing_webhook_service(self):
+        # type: () -> None
+        update_outgoing_webhook_service_checker = self.check_events_dict([
+            ('type', equals('realm_bot')),
+            ('op', equals('update')),
+            ('bot', check_dict_only([
+                ('email', check_string),
+                ('user_id', check_int),
+                ('owner_id', check_int),
+            ])),
+            ('service', check_dict_only([
+                ('name', check_string),
+                ('base_url', check_url),
+                ('interface', check_int),
+                ('email', check_string)
+            ])),
+        ])
+        self.user_profile = self.example_user('iago')
+        bot = do_create_user('test-bot@zulip.com', '123', get_realm('zulip'), 'Test Bot', 'test',
+                             bot_type=UserProfile.OUTGOING_WEBHOOK_BOT, bot_owner=self.user_profile)
+        add_outgoing_webhook_service(user_profile=bot, name="test", base_url="http://hostname.domain1.com",
+                                     interface=1, token="abced")
+        action = lambda: do_update_outgoing_webhook_service(bot, 1, 'http://hostname.domain2.com')
+        events = self.do_test(action)
+        error = update_outgoing_webhook_service_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
     def test_do_deactivate_user(self):
         # type: () -> None
         bot_deactivate_checker = self.check_events_dict([
@@ -1362,6 +1397,12 @@ class EventsRegisterTest(ZulipTestCase):
                 ('avatar_url', check_string),
                 ('owner', check_none_or(check_string)),
             ])),
+            ('service', check_list(check_dict_only([
+                ('name', check_string),
+                ('base_url', check_url),
+                ('interface', check_int),
+                ('email', check_string)
+            ]))),
         ])
         bot = self.create_bot('foo-bot@zulip.com')
         do_deactivate_user(bot)

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -127,6 +127,7 @@ class HomeTest(ZulipTestCase):
             "realm_password_auth_enabled",
             "realm_presence_disabled",
             "realm_restricted_to_domain",
+            "realm_services",
             "realm_show_digest_email",
             "realm_uri",
             "realm_users",


### PR DESCRIPTION
interface_type select menu will be used to choose the interface for outgoing webhooks. It will be displayed only when the selected bot type is OUTGOING WEBHOOK type. The default value is GENERIC interface type (value=1).