### PR TITLE
util: Delete execute_early

### DIFF
--- a/frontend_tests/casper_tests/00-realm-creation.js
+++ b/frontend_tests/casper_tests/00-realm-creation.js
@@ -75,7 +75,7 @@ casper.then(function () {
 
 casper.then(function () {
     // The user is logged in to the newly created realm
-    this.test.assertTitle('home - ' + organization_name + ' - Zulip');
+    this.test.assertTitle('(1) home - ' + organization_name + ' - Zulip');
 });
 
 common.then_log_out();

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -62,6 +62,7 @@ people.add_in_realm(cindy);
 global.people.initialize_current_user(me.user_id);
 
 var message_store = require('js/message_store.js');
+message_store.initialize();
 
 (function test_insert_recent_private_message() {
     message_store.insert_recent_private_message('1', 1001);

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -103,26 +103,6 @@ var _ = global._;
     assert(!util.same_recipient(undefined, undefined));
 }());
 
-(function test_execute_early() {
-    var doc = $(document);
-    doc.one = function (event_name, f) {
-        assert.equal(event_name, 'phantom_page_loaded');
-        f();
-    };
-
-    var called = false;
-    var func = function () { called = true; };
-
-    global.page_params.test_suite = true;
-    util.execute_early(func);
-    assert(called);
-
-    called = false;
-    global.page_params.test_suite = false;
-    util.execute_early(func);
-    assert(called);
-}());
-
 (function test_robust_uri_decode() {
     assert.equal(util.robust_uri_decode('xxx%3Ayyy'), 'xxx:yyy');
     assert.equal(util.robust_uri_decode('xxx%3'), 'xxx');

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -156,7 +156,7 @@ exports.load_more_messages = function load_more_messages(msg_list) {
     });
 };
 
-util.execute_early(function () {
+exports.initialize = function () {
     // get the initial message list
     function load_more(messages) {
 
@@ -213,7 +213,7 @@ util.execute_early(function () {
     } else {
         server_events.home_view_loaded();
     }
-});
+};
 
 
 return exports;

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -176,7 +176,7 @@ exports.add_message_metadata = function (message) {
     return message;
 };
 
-util.execute_early(function () {
+exports.initialize = function () {
     $(document).on('message_id_changed', function (event) {
         var old_id = event.old_id;
         var new_id = event.new_id;
@@ -204,7 +204,7 @@ util.execute_early(function () {
             }
         });
     });
-});
+};
 
 return exports;
 

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -261,7 +261,7 @@ exports.check_for_unsuspend = function () {
 };
 setInterval(exports.check_for_unsuspend, 5000);
 
-util.execute_early(function () {
+exports.initialize = function () {
     $(document).on('unsuspend', function () {
         // Immediately poll for new events on unsuspend
         blueslip.log("Restarting get_events due to unsuspend");
@@ -269,7 +269,7 @@ util.execute_early(function () {
         exports.restart_get_events({dont_block: true});
     });
     get_events();
-});
+};
 
 exports.cleanup_event_queue = function cleanup_event_queue() {
     // Submit a request to the server to cleanup our event queue

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -245,6 +245,7 @@ $(function () {
     reload.initialize();
     people.initialize();
     bot_data.initialize(); // Must happen after people.initialize()
+    message_fetch.initialize();
     markdown.initialize();
     composebox_typeahead.initialize();
     search.initialize();

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -246,6 +246,7 @@ $(function () {
     people.initialize();
     bot_data.initialize(); // Must happen after people.initialize()
     message_fetch.initialize();
+    message_store.initialize();
     markdown.initialize();
     composebox_typeahead.initialize();
     search.initialize();

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -243,6 +243,7 @@ $(function () {
 
     // initialize other stuff
     reload.initialize();
+    server_events.initialize();
     people.initialize();
     bot_data.initialize(); // Must happen after people.initialize()
     message_fetch.initialize();

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -197,14 +197,6 @@ exports.CachedValue.prototype = {
     },
 };
 
-exports.execute_early = function (func) {
-    if (page_params.test_suite) {
-        $(document).one('phantom_page_loaded', func);
-    } else {
-        $(func);
-    }
-};
-
 exports.is_all_or_everyone_mentioned = function (message_content) {
     var all_everyone_re = /(^|\s)(@\*{2}(all|everyone)\*{2})|(@(all|everyone))($|\s)/;
     return all_everyone_re.test(message_content);


### PR DESCRIPTION
This is a part of the jQuery 3.2.1 update, in #5627.

This PR proposes that we delete `util.execute_early`, which is essentially a wrapper for the `$(...)` document ready event. Especially in jQuery 3, where these functions all run asynchronously, you may run into undesirable timings when multiple of these try to run concurrently. (for example, if you try to run `master` with jQuery 3, we try to fetch messages before loading users, which breaks page loading). 

Instead, this PR moves all of these to be synchronized in a well-defined order in `ui_init.js`. 
Note that one casper test was changed -- in the tests, when you register, the page is now marked as having 1 unread message, probably some default message. This doesn't seem like incorrect behavior, so I just changed the test.
