### PR TITLE
search_suggestion: Prioritize known huddles.

### DIFF
--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -303,6 +303,14 @@ global.stream_data.populate_stream_topics_for_tests({});
     ];
     assert.deepEqual(suggestions.strings, expected);
 
+    // Do not suggest "bob@zulip.com" (the name of the current user)
+    query = 'pm-with:ted@zulip.com,bo';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "pm-with:ted@zulip.com,bo",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
     // No superfluous suggestions should be generated.
     query = 'pm-with:bob@zulip.com,red';
     suggestions = search.get_suggestions(query);

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -113,7 +113,7 @@ function get_group_suggestions(all_persons, last, operators) {
 
     // We don't suggest a person if their email is already present in the
     // operand (not including the last part).
-    var parts = all_but_last_part.split(',');
+    var parts = all_but_last_part.split(',').concat(people.my_current_email());
     var persons = _.filter(all_persons, function (person) {
         if (_.contains(parts, person.email)) {
             return false;


### PR DESCRIPTION
In `search_suggestions`, a new `compare_by_huddle` function was introduced. Its purpose is to rank people higher if the huddle they create is one that has already been recently seen. The second order sort is by number of PMs to each person, and third order sort is alphabetic.
(and so the behavior was changed to now work correctly in the example given in #5612)