### PR TITLE
Use the singular 'they' pronoun where appropriate

### DIFF
--- a/docs/bots-guide.md
+++ b/docs/bots-guide.md
@@ -137,7 +137,7 @@ You need:
 It is a simple python flask server which can be used to interact with bots through making use of
 outgoing webhook services. It makes it really convenient for users to run multiple bots. Traditionally,
 a person would be required to download zuliprc of each bot and run each of them separately. With Zulip Bot
-server, he or she would be able to download a single configuration file for all bots i.e. `flaskbotrc` and
+server, they would be able to download a single configuration file for all bots i.e. `flaskbotrc` and
 start the server which would enable interacting with all the bots.
 
 It's location is `api/zulip/bot_server.py`.

--- a/docs/custom-apps.md
+++ b/docs/custom-apps.md
@@ -16,7 +16,7 @@ with the following goals in mind:
 - Simple custom apps should be simple to write and deploy.
 - Custom app authors should be able to easily distribute their work.
 - Zulip should provide deployment support for mature, general-purpose bots,
-ideally either within organizations (a Zulip admin can vet her own
+ideally either within organizations (a Zulip admin can vet their own
 custom apps and easily deploy them across upgrade cycles)
 or across organizations (custom apps get distributed with the Zulip
 tarball).

--- a/docs/german.md
+++ b/docs/german.md
@@ -278,7 +278,7 @@ This translation is unambiguous.
 
 Transifex has two different translations for "Narrow to" -
 "Schränke auf ... ein." and "Begrenze auf ... ." Both sound a bit strange to a
-German speaker, since he would expect grammatically correct sentences when
+German speaker, since they would expect grammatically correct sentences when
 using the imperative (e.g. "Schränke diesen Stream ein auf ... .") Since this
 would be too long for many labels, the infinitive "begrenzen auf" is preferable.
 "einschränken auf" sounds equally good, but Transifex shows more use cases for

--- a/docs/git-guide.md
+++ b/docs/git-guide.md
@@ -203,7 +203,7 @@ current state of the index and advancing HEAD to point at the new
 A fast-forward is a special type of merge where you have a revision
 and you are "merging" another branch's changes that happen to be a
 descendant of what you have. In such these cases, you do not make a
-new mergecommit but instead just update to his revision. This will
+new mergecommit but instead just update to their revision. This will
 happen frequently on a remote-tracking branch of a remote
 repository.
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -402,7 +402,7 @@ exports.deactivate = function () {
         // stream from the home view since leaving it the old selected id might
         // no longer be there
         // Additionally, we pass empty_ok as the user may have removed **all** streams
-        // from her home view
+        // from their home view
         if (unread.messages_read_in_narrow) {
             // We read some unread messages in a narrow. Instead of going back to
             // where we were before the narrow, go to our first unread message (or
@@ -418,7 +418,7 @@ exports.deactivate = function () {
             // to go back to exactly where we were before narrowing.
             if (preserve_pre_narrowing_screen_position) {
                 // We scroll the user back to exactly the offset from the selected
-                // message that he was at the time that he narrowed.
+                // message that they were at the time that they narrowed.
                 // TODO: Make this correctly handle the case of resizing while narrowed.
                 select_opts.target_scroll_offset = current_msg_list.pre_narrow_offset;
             }

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -539,7 +539,7 @@ function get_message_header(message) {
 exports.possibly_notify_new_messages_outside_viewport = function (messages, local_id) {
     _.each(messages, function (message) {
         // A warning should only be displayed when the message was sent by the user and
-        // this is the tab he sent it in.
+        // this is the tab they sent it in.
         if (!people.is_current_user(message.sender_email) ||
             local_id === undefined) {
             return;

--- a/templates/zerver/emails/missed_message.html
+++ b/templates/zerver/emails/missed_message.html
@@ -1,5 +1,5 @@
 {#
-Mail sent to user when she was not logged in and received a PM or @-mention
+Mail sent to user when they were not logged in and received a PM or @-mention
 #}
 
 Hello {{ name }},

--- a/templates/zerver/emails/missed_message.txt
+++ b/templates/zerver/emails/missed_message.txt
@@ -1,5 +1,5 @@
 {#
-Mail sent to user when she was not logged in and received a PM or @-mention
+Mail sent to user when they were not logged in and received a PM or @-mention
 #}
 
 Hello {{ name }},

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -652,7 +652,7 @@ def rate_limit_user(request, user, domain):
     request._ratelimit_applied_limits = True
     request._ratelimit_secs_to_freedom = time
     request._ratelimit_over_limit = ratelimited
-    # Abort this request if the user is over her rate limits
+    # Abort this request if the user is over their rate limits
     if ratelimited:
         statsd.incr("ratelimiter.limited.%s.%s" % (type(user), user.id))
         raise RateLimited()

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -168,7 +168,7 @@ class MessageDict(object):
             display_type = "private"
             if len(display_recipient) == 1:
                 # add the sender in if this isn't a message between
-                # someone and his self, preserving ordering
+                # someone and themself, preserving ordering
                 recip = {'email': sender_email,
                          'full_name': sender_full_name,
                          'short_name': sender_short_name,

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -88,7 +88,7 @@ def filter_stream_authorization(user_profile, streams):
 
     unauthorized_streams = []  # type: List[Stream]
     for stream in streams:
-        # The user is authorized for his own streams
+        # The user is authorized for their own streams
         if stream.id in streams_subscribed:
             continue
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -620,7 +620,7 @@ class UserProfile(ModelReprMixin, AbstractBaseUser, PermissionsMixin):
 
     # Hours to wait before sending another email to a user
     EMAIL_REMINDER_WAITPERIOD = 24
-    # Minutes to wait before warning a bot owner that her bot sent a message
+    # Minutes to wait before warning a bot owner that their bot sent a message
     # to a nonexistent stream
     BOT_OWNER_STREAM_ALERT_WAITPERIOD = 1
 

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -714,8 +714,8 @@ def process_message_event(event_template, users):
             if sender_queue_id is not None and client.event_queue.id == sender_queue_id:
                 send_to_clients[client.event_queue.id]['is_sender'] = True
 
-        # If the recipient was offline and the message was a single or group PM to him
-        # or she was @-notified potentially notify more immediately
+        # If the recipient was offline and the message was a single or group PM to them
+        # or they were @-notified potentially notify more immediately
         received_pm = message_type == "private" and user_profile_id != sender_id
         mentioned = 'mentioned' in flags
         idle = receiver_is_idle(user_profile_id, realm_presences)

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -104,7 +104,7 @@ def json_change_settings(request, user_profile,
         do_change_password(user_profile, new_password)
         # In Django 1.10, password changes invalidates sessions, see
         # https://docs.djangoproject.com/en/1.10/topics/auth/default/#session-invalidation-on-password-change
-        # for details. To avoid this logging the user out of his own
+        # for details. To avoid this logging the user out of their own
         # session (which would provide a confusing UX at best), we
         # update the session hash here.
         update_session_auth_hash(request, user_profile)


### PR DESCRIPTION
Grepped for `he`, `she`, `his` and `hers` and replaced it with `they`/`theirs` where appropriate, while also checking the grammar for the remainder of the sentence. Most of these affect docs/comments, but it's still nice to have them changed for when other devs look at them.
* Didn't change the example texts, or THIRDPARTY doc. 
* Didn't change where the gender of the person was known

Let me know if I should squash all of these?