### PR TITLE
emails: Make emails with a confirmation link come from the NOREPLY address

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -640,7 +640,7 @@ def do_start_email_change_process(user_profile, new_email):
     activation_url = EmailChangeConfirmation.objects.get_link_for_object(obj, host=user_profile.realm.host)
     context = {'realm': user_profile.realm, 'old_email': old_email, 'new_email': new_email,
                'activate_url': activation_url}
-    send_email('zerver/emails/confirm_new_email', new_email, from_address=FromAddress.SUPPORT, context=context)
+    send_email('zerver/emails/confirm_new_email', new_email, from_address=FromAddress.NOREPLY, context=context)
 
 def compute_irc_user_fullname(email):
     # type: (NonBinaryStr) -> NonBinaryStr
@@ -3053,7 +3053,7 @@ def do_send_confirmation_email(invitee, referrer, body):
     """
     activation_url = Confirmation.objects.get_link_for_object(invitee, host=referrer.realm.host)
     context = {'referrer': referrer, 'custom_body': body, 'activate_url': activation_url}
-    send_email('zerver/emails/invitation', invitee.email, from_address=FromAddress.SUPPORT, context=context)
+    send_email('zerver/emails/invitation', invitee.email, from_address=FromAddress.NOREPLY, context=context)
 
 def is_inactive(email):
     # type: (Text) -> None

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -17,6 +17,7 @@ from zerver.lib.actions import do_start_email_change_process, do_set_realm_prope
 from zerver.lib.test_classes import (
     ZulipTestCase,
 )
+from zerver.lib.send_email import FromAddress
 from zerver.models import get_user, EmailChangeStatus, Realm, get_realm
 
 
@@ -124,6 +125,7 @@ class EmailChangeTestCase(ZulipTestCase):
         )
         body = email_message.body
         self.assertIn('We received a request to change the email', body)
+        self.assertIn(FromAddress.NOREPLY, email_message.from_email)
 
         activation_url = [s for s in body.split('\n') if s][4]
         response = self.client_get(activation_url)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -313,7 +313,7 @@ def send_registration_completion_email(email, request, realm_creation=False):
     """
     prereg_user = create_preregistration_user(email, request, realm_creation)
     activation_url = Confirmation.objects.get_link_for_object(prereg_user, host=request.get_host())
-    send_email('zerver/emails/confirm_registration', email, from_address=FromAddress.SUPPORT,
+    send_email('zerver/emails/confirm_registration', email, from_address=FromAddress.NOREPLY,
                context={'activate_url': activation_url})
     if settings.DEVELOPMENT and realm_creation:
         request.session['confirmation_key'] = {'confirmation_key': activation_url.split('/')[-1]}

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -180,7 +180,7 @@ class ConfirmationEmailWorker(QueueProcessingWorker):
         send_future_email(
             "zerver/emails/invitation_reminder",
             data["email"],
-            from_address=FromAddress.SUPPORT,
+            from_address=FromAddress.NOREPLY,
             context=context,
             delay=datetime.timedelta(days=2))
 


### PR DESCRIPTION
Prevents users from sending a confirmation link specific to their account to their Zulip administrator if they reply to the invitation, invitation reminder, account confirmation, or new email confirmation emails.