### PR TITLE
[WIP] Restore draft, if available, when narrowing 

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -136,7 +136,8 @@ exports.restore_draft = function (draft_id) {
         }
     } else {
         if (draft.private_message_recipient !== "") {
-            narrow.activate([{operator: "pm-with", operand: draft.private_message_recipient}],
+            var recipients = draft.private_message_recipient.replace(/\s/g, '');
+            narrow.activate([{operator: "pm-with", operand: recipients}],
                              {select_first_unread: true, trigger: "restore draft"});
         }
     }

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -246,6 +246,7 @@ exports.activate = function (raw_operators, opts) {
     search.update_button_visibility();
 
     compose_actions.on_narrow();
+    drafts.restore_on_narrow(operators);
 
     var current_filter = narrow_state.get_current_filter();
     $(document).trigger($.Event('narrow_activated.zulip', {msg_list: message_list.narrowed,


### PR DESCRIPTION
With this functionality, if you type a draft of a message, then leave and do other things, then come back to that narrow, your draft should pop back up. (As a part of #5591)

More specifically, when you narrow, this code checks to see if any drafts match the current narrow, and if so, open the most recent one.

I'd like feedback on this to figure out what direction to take on it before I keep going and add tests. I think the current functionality is too aggressive on opening drafts, so I'm trying to figure out what the best way is to handle it. 

(Also the first commit fixes a bug that occurs when you restore a draft in a group PM -- when it auto-narrows to the group, the narrow query was kind of malformed)