### PR TITLE
Hitting enter while in preview mode will not try to send empty messages

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -540,6 +540,8 @@ people.add(bob);
 }());
 
 (function test_enter_with_preview_open() {
+    // Test sending a message with content.
+    $("#new_message_content").val('message me');
     $("#new_message_content").hide();
     $("#undo_markdown_preview").show();
     $("#preview_message_area").show();
@@ -560,6 +562,17 @@ people.add(bob);
     $("#new_message_content").blur();
     compose.enter_with_preview_open();
     assert($("#new_message_content").is_focused());
+
+    // Test sending a message without content.
+    $("#new_message_content").val('');
+    $("#preview_message_area").show();
+    $("#enter_sends").prop("checked", true);
+    page_params.enter_sends = true;
+
+    compose.enter_with_preview_open();
+
+    assert($("#enter_sends").prop("checked"));
+    assert.equal($("#error-msg").html(), i18n.t('You have nothing to send!'));
 }());
 
 (function test_finish() {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -360,8 +360,8 @@ exports.send_message = function send_message(request) {
 exports.enter_with_preview_open = function () {
     exports.clear_preview_area();
     if (page_params.enter_sends) {
-        // If enter_sends is enabled, we just send the message
-        exports.send_message();
+        // If enter_sends is enabled, we attempt to send the message
+        exports.finish();
     } else {
         // Otherwise, we return to the compose box and focus it
         $("#new_message_content").focus();


### PR DESCRIPTION
When enter is hit in preview mode a validation check is performed using validate() in the compose.js file. There is also finish() which seems also calls validate() and gets me a similar result. I'm trying to figure out which is appropriate to use. 

Tests have not been written. I am working on testing. I have to quickly get re-familiarized with writing the js tests.

Fixes #5574
