### PR TITLE
test: Fix test_i18n.test_json_error().

### DIFF
--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -86,16 +86,17 @@ class JsonTranslationTestCase(ZulipTestCase):
     @mock.patch('zerver.lib.request._')
     def test_json_error(self, mock_gettext):
         # type: (Any) -> None
-        dummy_value = "Some other language '%s'"
+        dummy_value = "this arg is bad: '%s' (translated to German)"
         mock_gettext.return_value = dummy_value
 
         email = self.example_email('hamlet')
         self.login(email)
-        result = self.client_post("/json/refer_friend",
+        result = self.client_post("/json/invite_users",
                                   HTTP_ACCEPT_LANGUAGE='de')
 
+        expected_error = u"this arg is bad: 'invitee_emails' (translated to German)"
         self.assert_json_error_contains(result,
-                                        dummy_value % 'email',
+                                        expected_error,
                                         status_code=400)
 
     @mock.patch('zerver.views.auth._')


### PR DESCRIPTION
The refer_friend endpoint is about to be deprecated, so we
test with invite_users instead, and I tried to make the
dummy value returned by the mocked gettext function a little
more clear.