### PR TITLE
landing-page: Remove navbar content max width.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -244,6 +244,7 @@ nav .hamburger {
 }
 
 nav .content {
+    margin: 0 5px 0 10px;
     position: relative;
     z-index: 2;
 }

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -13,15 +13,6 @@ body {
     margin: 0 auto -56px;
 }
 
-/* This is a hack so that our main content
-   remains centered in the middle 1440px or so
-   on wide monitors, but that our little color
-   bars can extend to the edges of the screen */
-.content {
-    max-width: 1440px;
-    margin: 0px auto;
-}
-
 .navbar {
     margin-bottom: 0px;
 }


### PR DESCRIPTION
Zulip's logo and navigation options stay aligned with the page content on screens larger than 1440px.

Addresses #5693.

@timabbott 