### PR TITLE
nginx: Add Access-Control-Allow-Origin header for all response codes.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -57,7 +57,7 @@ location / {
 }
 
 location /api/ {
-    add_header Access-Control-Allow-Origin *;
+    add_header Access-Control-Allow-Origin * always;
     add_header Access-Control-Allow-Headers Authorization;
     add_header Access-Control-Allow-Methods 'GET, POST, DELETE, PUT, PATCH, HEAD';
 


### PR DESCRIPTION
This makes API error responses accessible inside a browser.