### PR TITLE
Use POST instead of PUT in endpoints which are not idempotent

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -310,7 +310,7 @@ function test_upload_realm_icon(upload_realm_icon) {
     ];
 
     var posted;
-    channel.put = function (req) {
+    channel.post = function (req) {
         posted = true;
         assert.equal(req.url, '/json/realm/icon');
         assert.equal(req.data.csrfmiddlewaretoken, 'token-stub');

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -209,7 +209,7 @@ exports.set_up = function () {
         var spinner = $("#upload_avatar_spinner").expectOne();
         loading.make_indicator(spinner, {text: 'Uploading avatar.'});
 
-        channel.put({
+        channel.post({
             url: '/json/users/me/avatar',
             data: form_data,
             cache: false,

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -91,7 +91,7 @@ exports.set_up = function () {
         $.each($('#emoji_file_input')[0].files, function (i, file) {
             formData.append('file-' + i, file);
         });
-        channel.put({
+        channel.post({
             url: "/json/realm/emoji/" + encodeURIComponent(emoji.name),
             data: formData,
             cache: false,

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -634,7 +634,7 @@ function _set_up() {
         var spinner = $("#upload_icon_spinner").expectOne();
         loading.make_indicator(spinner, {text: i18n.t("Uploading icon.")});
 
-        channel.put({
+        channel.post({
             url: '/json/realm/icon',
             data: form_data,
             cache: false,

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -154,21 +154,6 @@ class ZulipTestCase(TestCase):
         return django_client.put(url, encoded, **kwargs)
 
     @instrument_url
-    def client_put_multipart(self, url, info={}, **kwargs):
-        # type: (Text, Dict[str, Any], **Any) -> HttpResponse
-        """
-        Use this for put requests that have file uploads or
-        that need some sort of multi-part content.  In the future
-        Django's test client may become a bit more flexible,
-        so we can hopefully eliminate this.  (When you post
-        with the Django test client, it deals with MULTIPART_CONTENT
-        automatically, but not put.)
-        """
-        encoded = encode_multipart(BOUNDARY, info)
-        django_client = self.client  # see WRAPPER_COMMENT
-        return django_client.put(url, encoded, content_type=MULTIPART_CONTENT, **kwargs)
-
-    @instrument_url
     def client_delete(self, url, info={}, **kwargs):
         # type: (Text, Dict[str, Any], **Any) -> HttpResponse
         encoded = urllib.parse.urlencode(info)

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -50,7 +50,7 @@ class ReactionEmojiTest(ZulipTestCase):
         self.login(email)
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
-            result = self.client_put_multipart('/json/realm/emoji/my_emoji', info=emoji_data)
+            result = self.client_post('/json/realm/emoji/my_emoji', info=emoji_data)
         self.assert_json_success(result)
         emoji = RealmEmoji.objects.get(name="my_emoji")
         emoji.deactivated = True
@@ -119,8 +119,8 @@ class ReactionEmojiTest(ZulipTestCase):
         emoji_name = 'my_emoji'
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
-            result = self.client_put_multipart('/json/realm/emoji/my_emoji', info=emoji_data,
-                                               **self.api_auth(sender))
+            result = self.client_post('/json/realm/emoji/my_emoji', info=emoji_data,
+                                      **self.api_auth(sender))
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
 

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -53,7 +53,7 @@ class RealmEmojiTest(ZulipTestCase):
         self.login(email)
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
-            result = self.client_put_multipart('/json/realm/emoji/my_emoji', info=emoji_data)
+            result = self.client_post('/json/realm/emoji/my_emoji', info=emoji_data)
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
         emoji = RealmEmoji.objects.get(name="my_emoji")
@@ -79,7 +79,7 @@ class RealmEmojiTest(ZulipTestCase):
         self.login(email)
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
-            result = self.client_put_multipart('/json/realm/emoji/my_em*oji', info=emoji_data)
+            result = self.client_post('/json/realm/emoji/my_em*oji', info=emoji_data)
         self.assert_json_error(result, 'Invalid characters in emoji name')
 
     def test_upload_uppercase_exception(self):
@@ -88,7 +88,7 @@ class RealmEmojiTest(ZulipTestCase):
         self.login(email)
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
-            result = self.client_put_multipart('/json/realm/emoji/my_EMoji', info=emoji_data)
+            result = self.client_post('/json/realm/emoji/my_EMoji', info=emoji_data)
         self.assert_json_error(result, 'Invalid characters in emoji name')
 
     def test_upload_admins_only(self):
@@ -100,7 +100,7 @@ class RealmEmojiTest(ZulipTestCase):
         realm.save()
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
-            result = self.client_put_multipart('/json/realm/emoji/my_emoji', info=emoji_data)
+            result = self.client_post('/json/realm/emoji/my_emoji', info=emoji_data)
         self.assert_json_error(result, 'Must be a realm administrator')
 
     def test_delete(self):
@@ -169,7 +169,7 @@ class RealmEmojiTest(ZulipTestCase):
         email = self.example_email('iago')
         self.login(email)
         with get_test_image_file('img.png') as fp1, get_test_image_file('img.png') as fp2:
-            result = self.client_put_multipart('/json/realm/emoji/my_emoji', {'f1': fp1, 'f2': fp2})
+            result = self.client_post('/json/realm/emoji/my_emoji', {'f1': fp1, 'f2': fp2})
         self.assert_json_error(result, 'You must upload exactly one file.')
 
     def test_emoji_upload_file_size_error(self):
@@ -178,7 +178,7 @@ class RealmEmojiTest(ZulipTestCase):
         self.login(email)
         with get_test_image_file('img.png') as fp:
             with self.settings(MAX_EMOJI_FILE_SIZE=0):
-                result = self.client_put_multipart('/json/realm/emoji/my_emoji', {'file': fp})
+                result = self.client_post('/json/realm/emoji/my_emoji', {'file': fp})
         self.assert_json_error(result, 'Uploaded file is larger than the allowed limit of 0 MB')
 
     def test_upload_already_existed_emoji(self):
@@ -187,8 +187,8 @@ class RealmEmojiTest(ZulipTestCase):
         self.login(email)
         with get_test_image_file('img.png') as fp1:
             emoji_data = {'f1': fp1}
-            self.client_put_multipart('/json/realm/emoji/my_emoji', info=emoji_data)
+            self.client_post('/json/realm/emoji/my_emoji', info=emoji_data)
         with get_test_image_file('img.png') as fp1:
                 emoji_data = {'f1': fp1}
-                result = self.client_put_multipart('/json/realm/emoji/my_emoji', info=emoji_data)
+                result = self.client_post('/json/realm/emoji/my_emoji', info=emoji_data)
         self.assert_json_error(result, 'Realm emoji with this Realm and Name already exists.')

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -614,7 +614,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
         self.login(self.example_email("hamlet"))
         with get_test_image_file('img.png') as fp1, \
                 get_test_image_file('img.png') as fp2:
-            result = self.client_put_multipart("/json/users/me/avatar", {'f1': fp1, 'f2': fp2})
+            result = self.client_post("/json/users/me/avatar", {'f1': fp1, 'f2': fp2})
         self.assert_json_error(result, "You must upload exactly one avatar.")
 
     def test_no_file_upload_failure(self):
@@ -624,7 +624,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
         """
         self.login(self.example_email("hamlet"))
 
-        result = self.client_put_multipart("/json/users/me/avatar")
+        result = self.client_post("/json/users/me/avatar")
         self.assert_json_error(result, "You must upload exactly one avatar.")
 
     correct_files = [
@@ -705,7 +705,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
             # with self.subTest(fname=fname):
             self.login(self.example_email("hamlet"))
             with get_test_image_file(fname) as fp:
-                result = self.client_put_multipart("/json/users/me/avatar", {'file': fp})
+                result = self.client_post("/json/users/me/avatar", {'file': fp})
 
             self.assert_json_success(result)
             json = ujson.loads(result.content)
@@ -744,7 +744,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
             # with self.subTest(fname=fname):
             self.login(self.example_email("hamlet"))
             with get_test_image_file(fname) as fp:
-                result = self.client_put_multipart("/json/users/me/avatar", {'file': fp})
+                result = self.client_post("/json/users/me/avatar", {'file': fp})
 
             self.assert_json_error(result, "Could not decode image; did you upload an image file?")
             user_profile = self.example_user('hamlet')
@@ -776,7 +776,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
         self.login(self.example_email("hamlet"))
         with get_test_image_file(self.correct_files[0][0]) as fp:
             with self.settings(MAX_AVATAR_FILE_SIZE=0):
-                result = self.client_put_multipart("/json/users/me/avatar", {'file': fp})
+                result = self.client_post("/json/users/me/avatar", {'file': fp})
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MB")
 
     def test_get_avatar_url_with_user_profile_lookup(self):

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -801,7 +801,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
         self.login(self.example_email("iago"))
         with get_test_image_file('img.png') as fp1, \
                 get_test_image_file('img.png') as fp2:
-            result = self.client_put_multipart("/json/realm/icon", {'f1': fp1, 'f2': fp2})
+            result = self.client_post("/json/realm/icon", {'f1': fp1, 'f2': fp2})
         self.assert_json_error(result, "You must upload exactly one icon.")
 
     def test_no_file_upload_failure(self):
@@ -811,7 +811,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
         """
         self.login(self.example_email("iago"))
 
-        result = self.client_put_multipart("/json/realm/icon")
+        result = self.client_post("/json/realm/icon")
         self.assert_json_error(result, "You must upload exactly one icon.")
 
     correct_files = [
@@ -826,7 +826,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
         # type: () -> None
         self.login(self.example_email("hamlet"))
         with get_test_image_file(self.correct_files[0][0]) as fp:
-            result = self.client_put_multipart("/json/realm/icon", {'file': fp})
+            result = self.client_post("/json/realm/icon", {'file': fp})
         self.assert_json_error(result, 'Must be a realm administrator')
 
     def test_get_gravatar_icon(self):
@@ -867,7 +867,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
             # with self.subTest(fname=fname):
             self.login(self.example_email("iago"))
             with get_test_image_file(fname) as fp:
-                result = self.client_put_multipart("/json/realm/icon", {'file': fp})
+                result = self.client_post("/json/realm/icon", {'file': fp})
             realm = get_realm('zulip')
             self.assert_json_success(result)
             json = ujson.loads(result.content)
@@ -890,7 +890,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
             # with self.subTest(fname=fname):
             self.login(self.example_email("iago"))
             with get_test_image_file(fname) as fp:
-                result = self.client_put_multipart("/json/realm/icon", {'file': fp})
+                result = self.client_post("/json/realm/icon", {'file': fp})
 
             self.assert_json_error(result, "Could not decode image; did you upload an image file?")
 
@@ -920,7 +920,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
         icon_version = realm.icon_version
         self.assertEqual(icon_version, 1)
         with get_test_image_file(self.correct_files[0][0]) as fp:
-            self.client_put_multipart("/json/realm/icon", {'file': fp})
+            self.client_post("/json/realm/icon", {'file': fp})
         realm = get_realm('zulip')
         self.assertEqual(realm.icon_version, icon_version + 1)
 
@@ -929,7 +929,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
         self.login(self.example_email("iago"))
         with get_test_image_file(self.correct_files[0][0]) as fp:
             with self.settings(MAX_ICON_FILE_SIZE=0):
-                result = self.client_put_multipart("/json/realm/icon", {'file': fp})
+                result = self.client_post("/json/realm/icon", {'file': fp})
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MB")
 
     def tearDown(self):

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -196,7 +196,7 @@ v1_api_and_json_patterns = [
 
     # realm/icon -> zerver.views.realm_icon
     url(r'^realm/icon$', rest_dispatch,
-        {'PUT': 'zerver.views.realm_icon.upload_icon',
+        {'POST': 'zerver.views.realm_icon.upload_icon',
          'DELETE': 'zerver.views.realm_icon.delete_icon_backend',
          'GET': 'zerver.views.realm_icon.get_icon_backend'}),
 

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -313,7 +313,7 @@ v1_api_and_json_patterns = [
     url(r'^users/me/enter-sends$', rest_dispatch,
         {'POST': 'zerver.views.user_settings.change_enter_sends'}),
     url(r'^users/me/avatar$', rest_dispatch,
-        {'PUT': 'zerver.views.user_settings.set_avatar_backend',
+        {'POST': 'zerver.views.user_settings.set_avatar_backend',
          'DELETE': 'zerver.views.user_settings.delete_avatar_backend'}),
 
     # users/me/hotspots -> zerver.views.hotspots

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -191,7 +191,7 @@ v1_api_and_json_patterns = [
     url(r'^realm/emoji$', rest_dispatch,
         {'GET': 'zerver.views.realm_emoji.list_emoji'}),
     url(r'^realm/emoji/(?P<emoji_name>.*)$', rest_dispatch,
-        {'PUT': 'zerver.views.realm_emoji.upload_emoji',
+        {'POST': 'zerver.views.realm_emoji.upload_emoji',
          'DELETE': 'zerver.views.realm_emoji.delete_emoji'}),
 
     # realm/icon -> zerver.views.realm_icon


### PR DESCRIPTION
PUT was used instead of POST in the following 3 non idempotent endpoints. They have been changed to POST.

* zerver.views.user_settings.set_avatar_backend
* zerver.views.realm_emoji.upload_emoji
* zerver.views.realm_icon.upload_icon

Solves 3/4 problems mentioned in #5676.

