### PR TITLE
notifications: Fix the broken rendering of realm emojis in missed message emails.

### DIFF
--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -114,6 +114,11 @@ def build_message_list(user_profile, messages):
             user_profile.realm.uri + r"/static/generated/emoji/images/emoji/",
             content)
 
+        # Realm emoji should use absolute URLs when referenced in missed-message emails.
+        content = re.sub(
+            r"/user_avatars/(\d+)/emoji/",
+            user_profile.realm.uri + r"/user_avatars/\1/emoji/", content)
+
         return content
 
     def fix_plaintext_image_urls(content):


### PR DESCRIPTION
I thought it would be good to add a test for this. I had to made some modifications about which I am not sure if they are a good way of testing this. Last commit contains those changes along with test.

Fixes: #5692.