### PR TITLE
frontend: Darken the static error pages text.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -1620,7 +1620,7 @@ input.new-organization-button {
 }
 
 .error_page p {
-    color: #777676;
+    color: #333333;
 }
 
 .error_page .errorcontent {


### PR DESCRIPTION
Fixes an issue mentioned in #5314.
![image](https://user-images.githubusercontent.com/13666710/27992656-de7520cc-6499-11e7-845c-1931f07bb16d.png)
