### PR TITLE
emails: Customize sender and reply-to for missed message emails

### DIFF
--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -6,6 +6,7 @@ from confirmation.models import Confirmation, create_confirmation_link
 from django.conf import settings
 from django.template import loader
 from django.utils.timezone import now as timezone_now
+from django.core.mail.message import sanitize_address
 from zerver.decorator import statsd_increment
 from zerver.lib.send_email import send_future_email, \
     send_email_from_dict, FromAddress
@@ -337,12 +338,17 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile, missed_messages, m
     if reply_to_address == FromAddress.NOREPLY:
         reply_to_name = ""
 
+    try:
+        reply_to_email = sanitize_address((reply_to_name, reply_to_address), 'ascii')
+    except UnicodeError:
+        reply_to_email = sanitize_address((reply_to_name, reply_to_address), 'utf-8')
+
     email_dict = {
         'template_prefix': 'zerver/emails/missed_message',
         'to_user_id': user_profile.id,
         'from_name': from_name,
         'from_address': from_address,
-        'reply_to_email': formataddr((reply_to_name, reply_to_address)),
+        'reply_to_email': reply_to_email,
         'context': context}
     queue_json_publish("missedmessage_email_senders", email_dict, send_email_from_dict)
 

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -320,7 +320,8 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile, missed_messages, m
         'realm_str': user_profile.realm.name,
     })
 
-    from_name, from_address = None, None
+    from_name = "Zulip Missed Messages"  # type: Text
+    from_address = FromAddress.NOREPLY
     if len(senders) == 1 and settings.SEND_MISSED_MESSAGE_EMAILS_AS_USER:
         # If this setting is enabled, you can reply to the Zulip
         # missed message emails directly back to the original sender.

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
+from django.core.mail.message import sanitize_address
 from django.template import loader
 from django.utils.timezone import now as timezone_now
 from zerver.models import UserProfile, ScheduledEmail, get_user_profile_by_id, \
@@ -43,7 +44,10 @@ def build_email(template_prefix, to_user_id=None, to_email=None, from_name=None,
         from_name = "Zulip"
     if from_address is None:
         from_address = FromAddress.NOREPLY
-    from_email = formataddr((from_name, from_address))
+    try:
+        from_email = sanitize_address((from_name, from_address), "ascii")
+    except UnicodeError:
+        from_email = sanitize_address((from_name, from_address), "utf-8")
     reply_to = None
     if reply_to_email is not None:
         reply_to = [reply_to_email]

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -48,7 +48,7 @@ class TestMissedMessages(ZulipTestCase):
         else:
             reply_to_emails = ["noreply@zulip.example.com"]
         msg = mail.outbox[0]
-        from_email = formataddr(("Zulip", FromAddress.NOREPLY))
+        from_email = formataddr(("Zulip Missed Messages", FromAddress.NOREPLY))
         self.assertEqual(len(mail.outbox), 1)
         if send_as_user:
             from_email = '"%s" <%s>' % (othello.full_name, othello.email)


### PR DESCRIPTION
For missed-message emails, changes the sender to "Zulip Missed Messages."  In the case that an email gateway is set up such that replying to missed-message emails sends a zulip to the appropriate stream/huddle/person, makes the reply-to field of the email address contain the name of the stream/huddle/person.  For example "#Denmark <mm859109432@example.com>" or "Cordelia Lear, Iago, and 2 others <mm859109432@example.com>".

Fixes #5652.