### PR TITLE
Adapt EC2 Puppet handling if address_of an interface is None? (mypy)

### DIFF
--- a/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
+++ b/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
@@ -65,11 +65,14 @@ def address_of(device_id):
         return None
 
 def guess_gateway(device_id):
-    # type: (int) -> str
+    # type: (int) -> Optional[str]
     # This will not work if the default gateway isn't n.n.n.1.
-    address = address_of(device_id).split('.')
-    address[3] = '1'
-    return '.'.join(address)
+    address = address_of(device_id)
+    if address is None:
+        return None
+    gateway = address.split('.')
+    gateway[3] = '1'
+    return '.'.join(gateway)
 
 log = logging.getLogger('configure-cloud-interfaces')
 log.setLevel(logging.DEBUG)

--- a/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
+++ b/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
@@ -105,7 +105,9 @@ for device in macs.values():
         # HACK: It appears on Xenial device_number in the data set is 0 but in reality it is 3
         device_number += 3
 
-    if address_of(device_number) is None:
+    address = address_of(device_number)
+
+    if address is None:
         # If the device was not autoconfigured, do so now.
         log.info("Device ens%i not configured, starting dhcpd" % (device_number,))
         subprocess.check_call(['/sbin/dhcpcd', 'ens%i' % device_number])
@@ -127,7 +129,7 @@ for device in macs.values():
             ['/sbin/iptables', '-t', 'mangle', '-A', 'OUTPUT', '-m', 'conntrack', '--ctorigdst',
              address, '-j', 'MARK', '--set-mark', dev_num])
 
-    to_configure.remove(address_of(device_number))
+    to_configure.remove(address)
 
     for (count, ip) in enumerate(to_configure):
         # Configure the IP via a virtual interface

--- a/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
+++ b/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
@@ -110,16 +110,22 @@ for device in macs.values():
         log.info("Device ens%i not configured, starting dhcpd" % (device_number,))
         subprocess.check_call(['/sbin/dhcpcd', 'ens%i' % device_number])
 
+        dev_num = str(device_number)
+        address = address_of(device_number)
+        gateway = guess_gateway(device_number)
+        assert(address is not None)
+        assert(gateway is not None)
+
         # Horrible hack to route return packets on the correct interface
         # See http://unix.stackexchange.com/a/4421/933
         subprocess.check_call(
-            ['/sbin/ip', 'rule', 'add', 'fwmark', str(device_number), 'table', str(device_number)])
+            ['/sbin/ip', 'rule', 'add', 'fwmark', dev_num, 'table', dev_num])
         subprocess.check_call(
-            ['/sbin/ip', 'route', 'add', '0.0.0.0/0', 'table', str(device_number), 'dev',
-             'ens%i' % device_number, 'via', guess_gateway(device_number)])
+            ['/sbin/ip', 'route', 'add', '0.0.0.0/0', 'table', dev_num, 'dev',
+             'ens%i' % device_number, 'via', gateway])
         subprocess.check_call(
             ['/sbin/iptables', '-t', 'mangle', '-A', 'OUTPUT', '-m', 'conntrack', '--ctorigdst',
-             address_of(device_number), '-j', 'MARK', '--set-mark', str(device_number)])
+             address, '-j', 'MARK', '--set-mark', dev_num])
 
     to_configure.remove(address_of(device_number))
 


### PR DESCRIPTION
Currently, address_of may return None, and is annotated as such.

In the first commit I've amended guess_gateway such that it may also return None, if the address is None. (It might be simpler if guess_gateway had an address (rather than device) as parameter, but that's a side issue) 

Both functions are subsequently used explicitly in a block where the address is explicitly None (line 139 in the patched file). Since I'm not entirely familiar with what the code is trying to solve, I'm unsure if the "Horrible hack" section should be outside of that block and so might work in some cases, or if the dhcpd line (if it succeeds) should assign an address? The second commit assumes the latter and pre-assigns the result of these functions and asserts that they are not None, which is the simplest resolution I can imagine if dhcpd successfully gives an IP address.

Thoughts?

(mypy also complains regarding the to_configure.remove line below the block, since there is no guarantee at that position that the passed-in parameter from address_of is not None, so the above could be adjusted to resolve this too)