### PR TITLE
Tidying: Combine multiple 'import typing' lines onto one line.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -44,7 +44,6 @@ from zerver.lib.str_utils import force_str, force_text
 from zerver.lib.tex import render_tex
 import six
 from six.moves import range, html_parser
-from typing import Text
 
 if six.PY3:
     import html

--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -2,9 +2,8 @@
 import os
 import re
 import hashlib
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Text
 from importlib import import_module
-from typing import Text
 from six.moves import cStringIO as StringIO
 
 from django.db import connections, DEFAULT_DB_ALIAS

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from contextlib import contextmanager
 from typing import (cast, Any, Callable, Dict, Generator, Iterable, Iterator, List, Mapping,
-                    Optional, Set, Sized, Tuple, Union, IO)
+                    Optional, Set, Sized, Tuple, Union, IO, Text)
 
 from django.core import signing
 from django.core.urlresolvers import LocaleRegexURLResolver
@@ -58,7 +58,6 @@ import ujson
 import unittest
 from six.moves import urllib
 from six import binary_type
-from typing import Text
 from zerver.lib.str_utils import NonBinaryStr
 
 from contextlib import contextmanager

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Any
+from typing import Dict, Optional, Any, List
 from os.path import basename, splitext
 
 from django.conf import settings
@@ -7,7 +7,6 @@ from django.utils.safestring import mark_safe
 from django.utils.lru_cache import lru_cache
 
 from zerver.lib.utils import force_text
-from typing import List
 import zerver.lib.bugdown.fenced_code
 
 import markdown

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -60,11 +60,10 @@ from collections import defaultdict
 import re
 import ujson
 
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Text
 
 from six.moves import urllib
 from six.moves import range
-from typing import Any, Text
 import os
 
 class RedirectAndLogIntoSubdomainTestCase(ZulipTestCase):

--- a/zerver/views/alert_words.py
+++ b/zerver/views/alert_words.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.http import HttpResponse, HttpRequest
 
-from typing import List
+from typing import List, Text
 from zerver.models import UserProfile
 
 from zerver.decorator import has_request_variables, REQ
@@ -11,8 +11,6 @@ from zerver.lib.validator import check_list, check_string
 
 from zerver.lib.actions import do_add_alert_words, do_remove_alert_words, do_set_alert_words
 from zerver.lib.alert_words import user_alert_words
-
-from typing import Text
 
 def list_alert_words(request, user_profile):
     # type: (HttpRequest, UserProfile) -> HttpResponse

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 from django.http import HttpRequest, HttpResponse
-from typing import Text
-from typing import Iterable, Optional, Sequence
+from typing import Iterable, Optional, Sequence, Text
 
 from zerver.lib.events import do_events_register
 from zerver.lib.request import REQ, has_request_variables

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Text
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
@@ -12,8 +12,6 @@ from zerver.lib.unminify import SourceMap
 from zerver.lib.utils import statsd, statsd_key
 from zerver.lib.validator import check_bool, check_dict
 from zerver.models import UserProfile
-
-from typing import Optional, Text
 
 import subprocess
 import os

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from typing import Any, Optional, Tuple, List, Set, Iterable, Mapping, Callable, Dict
+from typing import Any, Optional, Tuple, List, Set, Iterable, Mapping, Callable, Dict, Text
 
 from django.utils.translation import ugettext as _
 from django.conf import settings
@@ -33,7 +33,6 @@ import ujson
 from six.moves import urllib
 
 import six
-from typing import Text
 
 class PrincipalError(JsonableError):
     def __init__(self, principal, status_code=403):

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
-from typing import Optional, Any
-from typing import Dict, Text
+from typing import Optional, Any, Dict, Text
 
 from django.utils.translation import ugettext as _
 from django.conf import settings

--- a/zerver/webhooks/gosquared/view.py
+++ b/zerver/webhooks/gosquared/view.py
@@ -7,8 +7,7 @@ from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_vi
 from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
-from typing import Text
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Text
 
 BODY_TEMPLATE = '[{website_name}]({website_url}) has {user_num} visitors online.'
 

--- a/zerver/webhooks/papertrail/view.py
+++ b/zerver/webhooks/papertrail/view.py
@@ -8,8 +8,7 @@ from zerver.lib.validator import check_dict, check_string
 from zerver.models import UserProfile
 
 from django.http import HttpRequest, HttpResponse
-from typing import Text
-from typing import Dict, Any, Iterable, Optional
+from typing import Dict, Any, Iterable, Optional, Text
 
 @api_key_only_webhook_view('Papertrail')
 @has_request_variables


### PR DESCRIPTION
I noticed a number of files had multiple import lines for types, presumably as mypy support was added incrementally. This PR simply combines multiple small lines into one.