### PR TITLE
[WIP] help: Update links to point to organization permissions.

### DIFF
--- a/templates/zerver/help/allow-anyone-to-join-without-an-invitation.md
+++ b/templates/zerver/help/allow-anyone-to-join-without-an-invitation.md
@@ -11,7 +11,7 @@ members to those with email invitations.
 
 ## Limiting new membership to users invited by organization members
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 4. Locate the **E-mail invitation required** checkbox.

--- a/templates/zerver/help/allow-image-link-previews.md
+++ b/templates/zerver/help/allow-image-link-previews.md
@@ -1,0 +1,15 @@
+# Allow image/link previews
+
+{!admin-only.md!}
+
+By default, when a user uploads or links to an image or links to a website, a
+preview of the content will be showed. You can choose to disable previews of
+images and links separately.
+
+{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
+{!admin.md!}
+
+2. Select the **Show previews of uploaded and linked images** or the **Show
+previews of linked websites** checkbox.
+
+{!save-changes.md!} organization settings.

--- a/templates/zerver/help/index.md
+++ b/templates/zerver/help/index.md
@@ -128,6 +128,8 @@ is known as an **organization**.
 * [Allow anyone to join without an invitation](/help/allow-anyone-to-join-without-an-invitation)
 * [Only allow admins to invite new users](/help/only-allow-admins-to-invite-new-users)
 * [Only allow admins to create new streams](/help/only-allow-admins-to-create-new-streams-feature)
+* [Only allow admins to add emoji](/help/only-allow-admins-to-add-emoji)
+* [Allow image/link previews](/help/allow-image-link-previews)
 * [Prevent users from changing their name](/help/prevent-users-from-changing-their-name)
 * [Prevent users from changing their email address](/help/prevent-users-from-changing-their-email-address)
 * [Restrict editing of old messages and topics](/help/restrict-editing-of-old-messages-and-topics)

--- a/templates/zerver/help/only-allow-admins-to-add-emoji.md
+++ b/templates/zerver/help/only-allow-admins-to-add-emoji.md
@@ -1,0 +1,14 @@
+# Only allow admins to add emoji
+
+{!admin-only.md!}
+
+By default, any user in your Zulip organization can add custom emoji to the
+organization. You can change your organization's settings to only allow
+administrators to add new emoji.
+
+{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
+{!admin.md!}
+
+2. Select the **Only admins may add emoji** checkbox.
+
+{!save-changes.md!} organization settings.

--- a/templates/zerver/help/only-allow-admins-to-create-new-streams-feature.md
+++ b/templates/zerver/help/only-allow-admins-to-create-new-streams-feature.md
@@ -5,7 +5,7 @@
 By default, any user can create new streams. You can enable a setting that
 only allows administrators to create new streams in the organization.
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 2. Select the **Only admins may create streams** checkbox.

--- a/templates/zerver/help/only-allow-admins-to-invite-new-users.md
+++ b/templates/zerver/help/only-allow-admins-to-invite-new-users.md
@@ -6,7 +6,7 @@ By default, any user in your Zulip organization can invite new users. You
 can change your organization's settings to only allow administrators to
 invite new users.
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 2. Select the **E-mail invitation required** and **Only admins may invite**

--- a/templates/zerver/help/prevent-users-from-changing-their-email-address.md
+++ b/templates/zerver/help/prevent-users-from-changing-their-email-address.md
@@ -11,7 +11,7 @@ solution where a user's account is managed elsewhere, you can enable a
 setting that prevents them from changing their own email address via
 the Zulip UI.
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 2. Select the **Prevent users from changing their email address** checkbox.

--- a/templates/zerver/help/prevent-users-from-changing-their-name.md
+++ b/templates/zerver/help/prevent-users-from-changing-their-name.md
@@ -6,7 +6,7 @@ By default, any user can change their name by going through the
 steps given [here](/help/change-your-name), but administrators can enable a
 setting that prevents them from changing their own names via the Zulip UI.
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 2. Select the **Prevent users from changing their name** checkbox.

--- a/templates/zerver/help/restrict-editing-of-old-messages-and-topics.md
+++ b/templates/zerver/help/restrict-editing-of-old-messages-and-topics.md
@@ -6,7 +6,7 @@ You can easily change the time limit that your organization's users have to
 change their messages after sending them. Alternatively, you can choose to
 disable message editing for your organization users.
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 4. Locate the **Users can edit old messages**

--- a/templates/zerver/help/restrict-user-email-addresses-to-certain-domains.md
+++ b/templates/zerver/help/restrict-user-email-addresses-to-certain-domains.md
@@ -7,7 +7,7 @@ who are not in their organization. The administrator can accomplish this by
 restricting users to have email addresses only from the organization's
 domains.
 
-{!go-to-the.md!} [Organization settings](/#organization/)
+{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 2. Restricting user email addresses to certain domains can be enabled or disabled


### PR DESCRIPTION
Fixes #5678.

* Regarding `/help/change-your-organization-settings`, I am not sure whether to edit it to emphasise the `Organization Permissions` section, or whether to add a separate doc altogether for it, in the same format as the one for `Organization Settings`?

* I grouped the `Show previews of uploaded and linked images ` and `Show previews of linked websites` settings into one doc as they are so similar. 