### PR TITLE
frontend: Add header to static/404.html + 5xx.html.

### DIFF
--- a/static/html/5xx.html
+++ b/static/html/5xx.html
@@ -18,6 +18,23 @@
         <!-- TODO: Make nginx 5xx error page customizable -->
         <!-- This is tricky because it's not served by Django, -->
         <!-- so we can't use variables -->
+<div class="header" style="background-color: #c9e9e0;">
+    <div class="header-main" id="top_navbar">
+        <div class="column-left">
+            <div>
+                <a class="brand logo" href="https://zulipchat.com/">
+                    <svg class="brand-logo" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 40" version="1.1">
+                        <g transform="translate(-297.14285,-466.64792)">
+                            <circle cx="317.14285" cy="486.64792" r="19.030317" style="fill:hsl(156, 100%, 24%)!important;stroke-width:1.93936479;stroke:transparent"></circle>
+                            <path d="m309.24286 477.14791 14.2 0 1.6 3.9-11.2 11.9 9.6 0 1.6 3.2-14.2 0-1.6-3.9 11.2-11.9-9.6 0z" style="fill:#52c2af;stroke:#52c2af"></path>
+                        </g>
+                    </svg>
+                    <span style="color: hsl(156, 100%, 24%);">Zulip</span>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
 <div class="container">
 
 <div class="row-fluid">


### PR DESCRIPTION
Follow-up on #5314:
> Figure out how we want to make clear that Zulip is the product with the error. Probably we want a basic version of the landing_nav.html content at the top to at least show the logo.

Should the image possibly link to something?

![image](https://user-images.githubusercontent.com/13666710/28017728-cbcd7f46-657a-11e7-952c-be1cfe099f53.png)

