### PR TITLE
Eliminate get_user_profile in remaining management commands

### DIFF
--- a/zerver/management/commands/generate_invite_links.py
+++ b/zerver/management/commands/generate_invite_links.py
@@ -4,62 +4,53 @@ from __future__ import print_function
 from typing import Any
 
 from argparse import ArgumentParser
-from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
 from confirmation.models import Confirmation
-from zerver.models import UserProfile, PreregistrationUser, \
-    get_user_profile_by_email, get_realm, email_allowed_for_realm
+from zerver.lib.management import ZulipBaseCommand
+from zerver.models import PreregistrationUser, email_allowed_for_realm
 
-class Command(BaseCommand):
+class Command(ZulipBaseCommand):
     help = "Generate activation links for users and print them to stdout."
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None
-        parser.add_argument('--realm',
-                            dest='string_id',
-                            type=str,
-                            help='The realm in which to generate the invites (use for open realms).')
         parser.add_argument('--force',
                             dest='force',
                             action="store_true",
                             default=False,
                             help='Override that the domain is restricted to external users.')
         parser.add_argument('emails', metavar='<email>', type=str, nargs='*',
-                            help='email of user to generate an activation link for')
+                            help='email of users to generate an activation link for')
+        self.add_realm_args(parser, True)
 
     def handle(self, *args, **options):
         # type: (*Any, **Any) -> None
         duplicates = False
+        realm = self.get_realm(options)
+
+        if not options['emails']:
+            self.print_help("./manage.py", "generate_invite_links")
+            exit(1)
+
         for email in options['emails']:
             try:
-                get_user_profile_by_email(email)
+                self.get_user(email, realm)
                 print(email + ": There is already a user registered with that address.")
                 duplicates = True
                 continue
-            except UserProfile.DoesNotExist:
+            except CommandError:
                 pass
 
         if duplicates:
             return
 
-        realm = None
-        string_id = options["string_id"]
-        if string_id:
-            realm = get_realm(string_id)
-        if not realm:
-            print("The realm %s doesn't exist yet, please create it first." % (string_id,))
-            print("Don't forget default streams!")
-            exit(1)
-
         for email in options['emails']:
-            if realm:
-                if not email_allowed_for_realm(email, realm) and not options["force"]:
-                    print("You've asked to add an external user (%s) to a closed realm (%s)." % (
-                        email, string_id))
-                    print("Are you sure? To do this, pass --force.")
-                    exit(1)
-                else:
-                    prereg_user = PreregistrationUser(email=email, realm=realm)
+            if not email_allowed_for_realm(email, realm) and not options["force"]:
+                print("You've asked to add an external user '%s' to a closed realm '%s'." % (
+                    email, realm.string_id))
+                print("Are you sure? To do this, pass --force.")
+                exit(1)
             else:
-                prereg_user = PreregistrationUser(email=email)
-            prereg_user.save()
-            print(email + ": " + Confirmation.objects.get_link_for_object(prereg_user, realm.host))
+                prereg_user = PreregistrationUser(email=email, realm=realm)
+                prereg_user.save()
+                print(email + ": " + Confirmation.objects.get_link_for_object(prereg_user, realm.host))


### PR DESCRIPTION
I have made realm argument in generate_invite_links compulsory so have made some extra refactoring. 
