### PR TITLE
integrations page revisions

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -189,6 +189,15 @@ function integration_search() {
     var update_integrations = _.debounce(function () {
         integrations.forEach(function (integration) {
             var $integration = $(integration).find('.integration-lozenge');
+            var $integration_category = $integration.find('.integration-category');
+
+            if (current_category !== 'All') {
+                $integration_category.css('display', 'none');
+                $integration.addClass('without-category');
+            } else {
+                $integration_category.css('display', '');
+                $integration.removeClass('without-category');
+            }
 
             var display =
                 fuzzysearch(current_query, $integration.data('name').toLowerCase()) &&

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -1,4 +1,5 @@
 import fuzzysearch from 'fuzzysearch';
+import blueslip from './../blueslip';
 
 // this will either smooth scroll to an anchor where the `name`
 // is the same as the `scroll-to` reference, or to a px height
@@ -80,6 +81,18 @@ var integration_events = function () {
     var show_integration = function (hash) {
         // the version of the hash without the leading "#".
         var _hash = hash.replace(/^#/, "");
+        var integration_name = _hash;
+
+        $.get({
+            url: '/integrations/doc/' + integration_name,
+            dataType: 'html',
+            success: function (doc) {
+                $('#' + integration_name + '.integration-instructions .help-content').html(doc);
+            },
+            error: function (err) {
+                blueslip.error("Integration documentation for '" + integration_name + "' not found.", err);
+            },
+        });
 
         // clear out the integrations instructions that may exist in the instruction
         // block from a previous hash.

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -45,13 +45,37 @@ var integration_events = function () {
             }
         );
 
+    function adjust_font_sizing() {
+        $('.integration-lozenge').toArray().forEach(function (integration) {
+            var $integration_name = $(integration).find('.integration-name');
+            var $integration_category = $(integration).find('.integration-category');
+
+            // if the text has wrapped to two lines, decrease font-size
+            if ($integration_name.height() > 30) {
+                $integration_name.css('font-size', '1em');
+                if ($integration_name.height() > 30) {
+                     $integration_name.css('font-size', '.95em');
+                }
+            }
+
+            if ($integration_category.height() > 30) {
+                $integration_category.css('font-size', '.8em');
+                if ($integration_category.height() > 30) {
+                    $integration_category.css('font-size', '.75em');
+                }
+            }
+        });
+    }
+
+    adjust_font_sizing();
+    $(window).resize(adjust_font_sizing);
+
     var $lozenge_icon;
     var currentblock;
     var instructionbox = $("#integration-instruction-block");
     var hashes = $('.integration-instructions').map(function () {
         return this.id || null;
     }).get();
-
 
     var show_integration = function (hash) {
         // the version of the hash without the leading "#".
@@ -112,6 +136,8 @@ var integration_events = function () {
             $(".integration-categories-dropdown").removeClass('hide');
             $(".integrations .catalog").removeClass('hide');
         }
+
+        adjust_font_sizing();
     }
 
     window.onhashchange = update_hash;

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -199,15 +199,17 @@ function integration_search() {
                 $integration.removeClass('without-category');
             }
 
-            var display =
-                fuzzysearch(current_query, $integration.data('name').toLowerCase()) &&
-                ($integration.data('categories').indexOf(current_category) !== -1 ||
-                 current_category === 'All');
+            if (!$integration.hasClass('integration-create-your-own')) {
+                var display =
+                    fuzzysearch(current_query, $integration.data('name').toLowerCase()) &&
+                    ($integration.data('categories').indexOf(current_category) !== -1 ||
+                     current_category === 'All');
 
-            if (display) {
-                $integration.css('display', 'inline-block');
-            } else {
-                $integration.css('display', 'none');
+                if (display) {
+                    $integration.css('display', 'inline-block');
+                } else {
+                    $integration.css('display', 'none');
+                }
             }
         });
     }, 50);

--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -2141,7 +2141,7 @@ a:not(.no-style):hover:before {
     }
 
     #integration-instruction-block .integration-lozenge {
-        display: none;
+        display: none !important;
     }
 
     #integration-list-link {

--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -1811,10 +1811,19 @@ a:not(.no-style):hover:before {
     height: 60px;
 }
 
+.portico-landing.integrations .integration-lozenge .icon-vector-plus {
+    font-size: 59px;
+}
+
 .portico-landing.integrations .integration-lozenge .integration-name {
     font-size: 1.2em;
     font-weight: 400;
     margin: 10px 4px 0 4px;
+}
+
+.portico-landing.integrations .integration-lozenge .integration-name.create-your-own {
+    margin-top: 27px;
+    font-size: 1.1em !important;
 }
 
 .portico-landing.integrations .integration-lozenge .integration-name.with-secondary {
@@ -2114,6 +2123,10 @@ a:not(.no-style):hover:before {
     .portico-landing.integrations .integration-lozenge .integration-logo {
         margin: 34px auto 15px;
         height: 45px;
+    }
+
+    .portico-landing.integrations .integration-lozenge .icon-vector-plus {
+        font-size: 45px;
     }
 
     .portico-landing.integrations .integration-lozenge .integration-name {

--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -1798,6 +1798,10 @@ a:not(.no-style):hover:before {
     transition: all 0.3s ease;
 }
 
+.portico-landing.integrations .integration-lozenge.without-category {
+    height: 180px;
+}
+
 .portico-landing.integrations .integration-lozenge:hover {
     border: 1px solid hsl(170, 47%, 53%);
 }
@@ -2103,6 +2107,10 @@ a:not(.no-style):hover:before {
         height: 180px;
     }
 
+    .portico-landing.integrations .integration-lozenge.without-category {
+        height: 160px;
+    }
+
     .portico-landing.integrations .integration-lozenge .integration-logo {
         margin: 34px auto 15px;
         height: 45px;
@@ -2402,6 +2410,10 @@ a:not(.no-style):hover:before {
     .portico-landing.integrations .integration-lozenge {
         width: 108px;
         height: 160px;
+    }
+
+    .portico-landing.integrations .integration-lozenge.without-category {
+        height: 140px;
     }
 
     .portico-landing.integrations .integration-lozenge .integration-logo {

--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -1734,7 +1734,7 @@ a:not(.no-style):hover:before {
 .portico-landing.integrations .catalog {
     margin-top: 20px;
     padding: 0 30px;
-    min-height: 1000px;
+    min-height: 500px;
 }
 
 .portico-landing.integrations .integration-categories-sidebar {

--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -1810,7 +1810,7 @@ a:not(.no-style):hover:before {
 .portico-landing.integrations .integration-lozenge .integration-name {
     font-size: 1.2em;
     font-weight: 400;
-    margin-bottom: 0;
+    margin: 10px 4px 0 4px;
 }
 
 .portico-landing.integrations .integration-lozenge .integration-name.with-secondary {

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -96,6 +96,14 @@
                             </a>
                             {% endif %}
                         {% endfor %}
+                        <a href="http://zulip.readthedocs.io/en/latest/integration-guide.html" class="no-style">
+                            <div class="integration-lozenge integration-create-your-own">
+                                <div class="integration-logo">
+                                    <i class="icon-vector-plus"></i>
+                                </div>
+                                <h3 class="integration-name create-your-own">{% trans %}Create your own!{% endtrans %}</h3>
+                            </div>
+                        </a>
                     </div>
                 </div>
 

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -21,99 +21,99 @@
         <div class="padded-content">
             <div class="inner-content">
 
-        <div id="integration-main-text">
-            <header>
-                <h1 class="portico-page-heading">
-                    {% trans %}Over 60 native integrations.{% endtrans %}
-                </h1>
-            </header>
-            <h2 class="portico-page-subheading">
-                {% trans %}
-                    And hundreds more through
-                    <a href="#hubot">Hubot</a>,
-                    <a href="#zapier">Zapier</a>,
-                    and
-                    <a href="#ifttt">IFTTT</a>.
-                {% endtrans %}
-            </h2>
-        </div>
-
-        <div id="integration-search">
-            <div class="searchbar">
-                <div class="searchbar-reset">
-                    <i class="icon-vector-search" aria-hidden="true"></i>
-                    <input type="text" placeholder="{{ _('Search integrations') }}"/>
+                <div id="integration-main-text">
+                    <header>
+                        <h1 class="portico-page-heading">
+                            {% trans %}Over 60 native integrations.{% endtrans %}
+                        </h1>
+                    </header>
+                    <h2 class="portico-page-subheading">
+                        {% trans %}
+                        And hundreds more through
+                        <a href="#hubot">Hubot</a>,
+                        <a href="#zapier">Zapier</a>,
+                        and
+                        <a href="#ifttt">IFTTT</a>.
+                        {% endtrans %}
+                    </h2>
                 </div>
-            </div>
-        </div>
 
-    <div id="integration-instruction-block" class="integration-instruction-block">
-       <a href="#!" id="integration-list-link"><i class="icon-vector-circle-arrow-left"></i><span>Back to list</span></a>
-    </div>
-    <div class="clear-float"></div>
-
-    <div class="integration-categories-dropdown">
-        <div class="dropdown-toggle">
-            <h3>{% trans %}View all categories{% endtrans %}</h3>
-            <i class="icon-vector-angle-right" aria-hidden="true"></i>
-        </div>
-        <div class="dropdown-list">
-            <h4 class="integration-category selected" data-category="All">All</h4>
-            {% for category in categories_dict.values() %}
-                <h4 class="integration-category" data-category="{{ category }}">{{ category }}</h4>
-            {% endfor %}
-        </div>
-    </div>
-
-    <div class="catalog">
-        <div class="integration-categories-sidebar">
-            <h3>{% trans %}Categories{% endtrans %}</h3>
-            <h4 data-category="All" class="integration-category selected">{% trans %}All{% endtrans %}</h4>
-            {% for category in categories_dict.values() %}
-                <h4 data-category="{{ category }}" class="integration-category">{{ category }}</h4>
-            {% endfor %}
-        </div>
-
-        <div class="integration-lozenges">
-            {% for integration in integrations_dict.values() %}
-                {% if integration.is_enabled() %}
-                    <a href="#{{ integration.name }}" class="no-style">
-                        <div class="integration-lozenge integration-{{ integration.name }}"
-                            data-categories="{{ integration.categories }}"
-                            data-name="{{ integration.display_name }}">
-                            <img class="integration-logo" src="/{{ integration.logo }}"
-                                 alt="{{ integration.display_name }} logo"/>
-                            {% if integration.secondary_line_text %}
-                            <h3 class="integration-name with-secondary">{{ integration.display_name }}</h3>
-                            <h4 class="integration-secondary-line-text">
-                                {{ integration.secondary_line_text }}
-                            </h4>
-                            {% else %}
-                            <h3 class="integration-name">{{ integration.display_name }}</h3>
-                            {% endif %}
-                            <h4 class="integration-category">{{ integration.categories[0] }}</h4>
+                <div id="integration-search">
+                    <div class="searchbar">
+                        <div class="searchbar-reset">
+                            <i class="icon-vector-search" aria-hidden="true"></i>
+                            <input type="text" placeholder="{{ _('Search integrations') }}"/>
                         </div>
-                    </a>
-                {% endif %}
-            {% endfor %}
-        </div>
-    </div>
+                    </div>
+                </div>
 
-<div id="integration-instructions-group">
-    {% for integration in integrations_dict.values() %}
-        {% if integration.is_enabled() %}
-            <div id={{ integration.name }} class="integration-instructions">
-                {{ integration.help_content }}
-                <p style="font-size:11px; font-style:italic;">
-                    Logos are trademarks of their respective owners.
-                    None of the integrations on this page are created by,
-                    affiliated with, or supported by the companies
-                    represented by the logos.
-                </p>
-            </div>
-        {% endif %}
-    {% endfor %}
-</div>
+                <div id="integration-instruction-block" class="integration-instruction-block">
+                    <a href="#!" id="integration-list-link"><i class="icon-vector-circle-arrow-left"></i><span>Back to list</span></a>
+                </div>
+                <div class="clear-float"></div>
+
+                <div class="integration-categories-dropdown">
+                    <div class="dropdown-toggle">
+                        <h3>{% trans %}View all categories{% endtrans %}</h3>
+                        <i class="icon-vector-angle-right" aria-hidden="true"></i>
+                    </div>
+                    <div class="dropdown-list">
+                        <h4 class="integration-category selected" data-category="All">All</h4>
+                        {% for category in categories_dict.values() %}
+                        <h4 class="integration-category" data-category="{{ category }}">{{ category }}</h4>
+                        {% endfor %}
+                    </div>
+                </div>
+
+                <div class="catalog">
+                    <div class="integration-categories-sidebar">
+                        <h3>{% trans %}Categories{% endtrans %}</h3>
+                        <h4 data-category="All" class="integration-category selected">{% trans %}All{% endtrans %}</h4>
+                        {% for category in categories_dict.values() %}
+                        <h4 data-category="{{ category }}" class="integration-category">{{ category }}</h4>
+                        {% endfor %}
+                    </div>
+
+                    <div class="integration-lozenges">
+                        {% for integration in integrations_dict.values() %}
+                            {% if integration.is_enabled() %}
+                            <a href="#{{ integration.name }}" class="no-style">
+                                <div class="integration-lozenge integration-{{ integration.name }}"
+                                    data-categories="{{ integration.categories }}"
+                                    data-name="{{ integration.display_name }}">
+                                    <img class="integration-logo" src="/{{ integration.logo }}"
+                                         alt="{{ integration.display_name }} logo"/>
+                                    {% if integration.secondary_line_text %}
+                                    <h3 class="integration-name with-secondary">{{ integration.display_name }}</h3>
+                                    <h4 class="integration-secondary-line-text">
+                                        {{ integration.secondary_line_text }}
+                                    </h4>
+                                    {% else %}
+                                    <h3 class="integration-name">{{ integration.display_name }}</h3>
+                                    {% endif %}
+                                    <h4 class="integration-category">{{ integration.categories[0] }}</h4>
+                                </div>
+                            </a>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                </div>
+
+                <div id="integration-instructions-group">
+                    {% for integration in integrations_dict.values() %}
+                        {% if integration.is_enabled() %}
+                        <div id={{ integration.name }} class="integration-instructions">
+                            {{ integration.help_content }}
+                            <p style="font-size:11px; font-style:italic;">
+                                Logos are trademarks of their respective owners.
+                                None of the integrations on this page are created by,
+                                affiliated with, or supported by the companies
+                                represented by the logos.
+                            </p>
+                        </div>
+                        {% endif %}
+                    {% endfor %}
+                </div>
 
             </div> <!-- .inner-content -->
         </div> <!-- .padded-content -->

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -111,7 +111,7 @@
                     {% for integration in integrations_dict.values() %}
                         {% if integration.is_enabled() %}
                         <div id={{ integration.name }} class="integration-instructions">
-                            {{ integration.help_content }}
+                            <div class="help-content"></div>
                             <p style="font-size:11px; font-style:italic;">
                                 Logos are trademarks of their respective owners.
                                 None of the integrations on this page are created by,

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -68,7 +68,7 @@
     <div class="catalog">
         <div class="integration-categories-sidebar">
             <h3>{% trans %}Categories{% endtrans %}</h3>
-            <h4 data-category="All" class="integration-category selected">All</h4>
+            <h4 data-category="All" class="integration-category selected">{% trans %}All{% endtrans %}</h4>
             {% for category in categories_dict.values() %}
                 <h4 data-category="{{ category }}" class="integration-category">{{ category }}</h4>
             {% endfor %}

--- a/tools/check-templates
+++ b/tools/check-templates
@@ -130,7 +130,6 @@ def check_html_templates(templates, all_dups):
         'templates/zerver/hello.html',
         'templates/zerver/home.html',
         'templates/zerver/index.html',
-        'templates/zerver/integrations/index.html',
         'templates/zerver/keyboard_shortcuts.html',
         'templates/zerver/login.html',
         'templates/zerver/markdown_help.html',

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -93,12 +93,6 @@ class Integration(object):
         # type: (Dict[Any, Any]) -> None
         self.doc_context = context
 
-    @property
-    def help_content(self):
-        # type: () -> Text
-        doc_context = self.doc_context or {}
-        return render_markdown_path(self.doc, doc_context)
-
 class EmailIntegration(Integration):
     def is_enabled(self):
         # type: () -> bool

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -46,12 +46,16 @@ class DocPageTest(ZulipTestCase):
                        'Zapier',
                        'IFTTT'
                    ])
+        self._test('/integrations/doc/travis', 'Your Travis CI notifications may look like:')
         self._test('/devlogin/', 'Normal users')
         self._test('/devtools/', 'Useful development URLs')
         self._test('/errors/404/', 'Page not found')
         self._test('/errors/5xx/', 'Internal server error')
         self._test('/emails/', 'Road Runner invited you to join Zulip')
         self._test('/register/', 'Sign up for Zulip')
+
+        result = self.client_get('/integrations/doc/nonexistent_integration', follow=True)
+        self.assertEqual(result.status_code, 404)
 
         result = self.client_get('/new-user/')
         self.assertEqual(result.status_code, 301)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -140,6 +140,8 @@ i18n_urls = [
     url(r'^api/$', APIView.as_view(template_name='zerver/api.html')),
     url(r'^api/endpoints/$', zerver.views.integrations.api_endpoint_docs, name='zerver.views.integrations.api_endpoint_docs'),
     url(r'^integrations/$', IntegrationView.as_view()),
+    url(r'^integrations/doc/(?P<integration_name>[^/]*)$', zerver.views.integrations.integration_doc,
+        name="zerver.views.integrations.integration_doc"),
     url(r'^about/$', TemplateView.as_view(template_name='zerver/about.html')),
     url(r'^apps/$', zerver.views.home.apps_view, name='zerver.views.home.apps_view'),
 


### PR DESCRIPTION
A list of issues, from https://github.com/zulip/zulip/pull/5280#issuecomment-313537358:

- [x] page is really slow to load if you do a shift-reload, as noted [here](https://chat.zulip.org/#narrow/stream/design/topic/.2Fintegrations.20page)
- [x] We probably don't need to show the categories in the cards when you're filtered to a given category?
- [x] It'd be nice if "Continuous integration" fit, though we should keep in mind with i18n that we still need things to look OK if it goes to 2 lines.
- [x] We should add a "create your own integration!" card with some sort of cute logo (maybe a gear or +?) pointing to http://zulip.readthedocs.io/en/latest/integration-guide.html
- [x] The extra space at the bottom looks a bit odd when you click a category.
- [x] Let's make sure "All" internationalizes properly.
- [x] this doesn't look good: 
![image](https://user-images.githubusercontent.com/12771126/28041526-ae61a42e-657e-11e7-8b0a-d6652bb4738e.png)
- [x] Fix the individual integrations on mobile:
![image](https://user-images.githubusercontent.com/2746074/27935521-60f19d0a-6260-11e7-93b9-d079851de796.png)
