### PR TITLE
help: Rename Manage Organization snippets.

### DIFF
--- a/templates/zerver/help/change-your-organization-settings.md
+++ b/templates/zerver/help/change-your-organization-settings.md
@@ -2,8 +2,11 @@
 
 {!admin-only.md!}
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
-{!admin.md!}
+1. Click on the chevron next to the gear icon in the top-right of the screen to
+reveal a dropdown menu.
+
+2. Select [Manage organization](/#organization/organization-settings) from the
+menu.
 
 3. Click on the tabs on the left to select the settings you'd like to edit.
 

--- a/templates/zerver/help/deactivate-or-reactivate-a-user.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-user.md
@@ -14,8 +14,8 @@ with the user’s API key or any API keys of the bots the user has
 created.
 
 Instead, you should deactivate the user’s account using the Zulip
-**Manage organization** interface; this will also automatically
-deactivate any bots the user has created.
+**[organization administration interface](/help/change-your-organization-settings)**;
+this will also automatically deactivate any bots the user has created.
 
 {!go-to-the.md!} [Users](/#organization/user-list-admin)
 {!admin.md!}

--- a/templates/zerver/help/delete-a-stream.md
+++ b/templates/zerver/help/delete-a-stream.md
@@ -3,8 +3,9 @@
 {!admin-only.md!}
 
 In Zulip, most stream administration is done on the subscription page.
-However, Zulip organization administrators must use the **Manage
-organization** interface to delete streams.
+However, Zulip organization administrators must use the Zulip
+**[organization administration interface](/help/change-your-organization-settings)**
+to delete streams.
 
 {!go-to-the.md!} [Delete streams](/#organization/streams-list-admin)
 {!admin.md!}


### PR DESCRIPTION
Fixes the rest of #5678.
Grepped for `Manage` and these are the the only places in help that `Manage organization` shows up.