### PR TITLE
frontend: Fix more ARIA audit tool issues.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -197,7 +197,8 @@ td .button {
     border-bottom: 1px solid hsl(0, 0%, 86%) !important;
 }
 
-#admin-user-list .table tr:first-of-type td {
+#admin-user-list .table tr:first-of-type td,
+#admin-bot-list .table tr:first-of-type td {
     border-top: none;
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2267,7 +2267,7 @@ button.topic_edit_cancel {
     max-height: 300px;
 }
 
-#invite-user .custom_invite_body {
+#invite-user #custom_invite_body {
     margin-top: 10px;
 }
 

--- a/static/templates/admin_streams_list.handlebars
+++ b/static/templates/admin_streams_list.handlebars
@@ -5,7 +5,7 @@
         <span class="stream_name">{{name}}</span>
     </td>
     <td>
-        <button class="button small btn-danger deactivate btn-danger">
+        <button class="button small btn-danger deactivate btn-danger" aria-label="{{t 'Deactivate stream' }}">
             <i class="icon-vector-trash" aria-hidden="true"></i>
         </button>
     </td>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -120,7 +120,7 @@
         <div id="deactivate_self_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_self_modal_label" aria-hidden="true">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-                <h3 id="deactivation_user_modal_label">{{t "Deactivate your account" }} </h3>
+                <h3 id="deactivation_self_modal_label">{{t "Deactivate your account" }} </h3>
             </div>
             <div class="modal-body">
                 <p>{{#tr this}}By deactivating your account, you will be logged out immediately.{{/tr}}</p>

--- a/static/templates/settings/auth-methods-settings-admin.handlebars
+++ b/static/templates/settings/auth-methods-settings-admin.handlebars
@@ -1,4 +1,4 @@
-<div id="organization-settings" class="settings-section" data-name="auth-methods">
+<div id="admin-auth-settings" class="settings-section" data-name="auth-methods">
     <form class="form-horizontal admin-realm-form org-authentications-form">
         <div class="alert" id="admin-realm-authentication-methods-status"></div>
         <div class="admin-table-wrapper">

--- a/static/templates/settings/bot-list-admin.handlebars
+++ b/static/templates/settings/bot-list-admin.handlebars
@@ -1,4 +1,4 @@
-<div id="admin-user-list" class="settings-section" data-name="bot-list-admin">
+<div id="admin-bot-list" class="settings-section" data-name="bot-list-admin">
     <input type="text" class="search" placeholder="{{t 'Filter bots' }}" />
     <div class="clear-float"></div>
     <table class="table table-condensed table-striped wrapped-table">

--- a/static/templates/settings/default-streams-list-admin.handlebars
+++ b/static/templates/settings/default-streams-list-admin.handlebars
@@ -9,7 +9,7 @@
             <div class="new-default-stream-section-title">{{t "Add new default stream" }}</div>
             <div class="control-group" id="default_stream_inputs">
                 <label for="default_stream_name" class="control-label">{{t "Stream name" }}</label>
-                <input class="create_default_stream" type="text" placeholder="{{t "Stream name" }}" name="stream_name" autocomplete="off"></input>
+                <input class="create_default_stream" type="text" placeholder="{{t "Stream name" }}" name="stream_name" autocomplete="off" aria-label="{{t "Stream name" }}"></input>
                 <div class="alert" id="admin-default-stream-status"></div>
             </div>
             <div class="control-group">
@@ -21,7 +21,7 @@
     </form>
     {{/if}}
 
-    <input type="text" class="search" placeholder="{{t 'Filter streams' }}" />
+    <input type="text" class="search" placeholder="{{t 'Filter streams' }}" aria-label="{{t 'Filter streams' }}"/>
     <div class="clear-float"></div>
 
     <div class="progressive-table-wrapper">

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -35,7 +35,7 @@
                            {{#if realm_invite_required}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_invite_required" id="realm_restricted_to_domains_label" class="inline-block"
+                <label for="id_realm_invite_required" id="realm_restricted_to_invites_label" class="inline-block"
                     title="{{t 'If checked, users must be invited in order to join your organization.' }}">
                     {{t "E-mail invitation required" }}
                 </label>

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -143,7 +143,7 @@
             </div>
 
             <div class="input-group disableable {{#unless realm_allow_message_editing}}control-label-disabled{{/unless}}">
-                <label for="realm_message_content_edit_limit_minutes"
+                <label for="id_realm_message_content_edit_limit_minutes"
                     id="id_realm_message_content_edit_limit_minutes_label"
                     title="{{t 'If non-zero, users can edit their message for this many minutes after it is sent. If zero, users can edit all their past messages.' }}">
                     {{t 'Message edit limit in minutes (0 for no limit)' }}

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -10,7 +10,7 @@
 
         <div class="m-10 inline-block organization-settings-parent">
             <div class="input-group admin-realm">
-                <label for="realm_name">{{t "Your organization's name" }}</label>
+                <label for="id_realm_name">{{t "Your organization's name" }}</label>
                 <input type="text" id="id_realm_name" name="realm_name" class="admin-realm-name"
                        value="{{ realm_name }}" />
             </div>
@@ -28,7 +28,7 @@
                 </select>
             </div>
             <div class="input-group">
-                <label for="realm_waiting_period_threshold">{{t "Waiting period for stream creation (in days)" }}</label>
+                <label for="id_realm_waiting_period_threshold">{{t "Waiting period for stream creation (in days)" }}</label>
                 <input type="text" id="id_realm_waiting_period_threshold"
                      name="realm_waiting_period_threshold"
                      class="admin-realm-message-content-edit-limit-minutes"

--- a/static/templates/settings/streams-list-admin.handlebars
+++ b/static/templates/settings/streams-list-admin.handlebars
@@ -3,7 +3,7 @@
         {{#tr this}}Most stream administration is done on the <a href="/#streams">Streams page</a>.{{/tr}}
     </div>
 
-    <input type="text" class="search" placeholder="{{t 'Filter streams' }}" />
+    <input type="text" class="search" placeholder="{{t 'Filter streams' }}" aria-label="{{t 'Filter streams' }}"/>
     <div class="clear-float"></div>
 
     <div class="progressive-table-wrapper">

--- a/static/templates/settings/user-list-admin.handlebars
+++ b/static/templates/settings/user-list-admin.handlebars
@@ -1,5 +1,5 @@
 <div id="admin-user-list" class="settings-section" data-name="user-list-admin">
-    <input type="text" class="search" placeholder="{{t 'Filter users' }}" />
+    <input type="text" class="search" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
     <div class="clear-float"></div>
 
     <table class="table table-condensed table-striped wrapped-table">

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -56,11 +56,11 @@
                   </span>
                   <input type="text" class="recipient_box" name="stream" id="stream"
                          maxlength="30"
-                         value="" placeholder="{{ _('Stream') }}" autocomplete="off" tabindex="0"/>
+                         value="" placeholder="{{ _('Stream') }}" autocomplete="off" tabindex="0" aria-label="{{ _('Stream') }}"/>
                   <i class="icon-vector-narrow icon-vector-small"></i>
                   <input type="text" class="recipient_box" name="subject" id="subject"
                          maxlength="60"
-                         value="" placeholder="{{ _('Topic') }}" autocomplete="off" tabindex="0"/>
+                         value="" placeholder="{{ _('Topic') }}" autocomplete="off" tabindex="0" aria-label="{{ _('Topic') }}"/>
               </td>
             </tr>
             <tr id="private-message">
@@ -78,7 +78,7 @@
             <tr>
               <td class="messagebox" colspan="2">
                 <textarea class="new_message_textarea" name="content" id="new_message_content"
-                          value="" placeholder="{{ _('Compose your message here...') }}" tabindex="0" maxlength="10000"></textarea>
+                          value="" placeholder="{{ _('Compose your message here...') }}" tabindex="0" maxlength="10000" aria-label="{{ _('Compose your message here...') }}"></textarea>
                 <div class="scrolling_list" id="preview_message_area" style="display:none;">
                   <div id="markdown_preview_spinner"></div>
                   <div id="preview_content"></div>

--- a/templates/zerver/invite_user.html
+++ b/templates/zerver/invite_user.html
@@ -17,9 +17,9 @@
                             placeholder="{{ _('One or more email addresses...') }}">
                         </textarea>
                     </div>
-                    <label class="control-label" for="custom_body">{{ _('Custom invitation message (if you want to add one)') }}</label>
+                    <label class="control-label" for="custom_invite_body">{{ _('Custom invitation message (if you want to add one)') }}</label>
                     <div class="controls">
-                        <textarea rows="2" class="custom_invite_body"
+                        <textarea rows="2" id="custom_invite_body"
                             name="custom_body"
                             placeholder="{{ _('Custom message') }}">
                         </textarea>

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -24,7 +24,7 @@
                 <input class="search-query input-block-level" id="search_query" type="text" placeholder="{{ _('Search') }}"
                        autocomplete="off" aria-label="{{ _('Search') }}"/>
                 {# Start the button off disabled since there is no active search #}
-                <button class="btn search_button" type="button" id="search_exit" disabled="disabled"><i class="icon-vector-remove"></i></button>
+                <button class="btn search_button" type="button" id="search_exit" disabled="disabled" aria-label="{{ _('Exit search') }}"><i class="icon-vector-remove"></i></button>
               </div>
             </form>
           </div>{# /searchbox #}


### PR DESCRIPTION
Fixes some `Controls and media elements should have labels` and `An element's ID must be unique in the DOM` issues thrown by Chrome Accessibility Tools. 

The `class="autosizejs"` textarea gets marked with the "should have label" error -- i am not sure if this can be fixed as it seems to be a third-party generated area? 