### PR TITLE
emails: Make email sender names more descriptive

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -219,7 +219,9 @@ class ZulipPasswordResetForm(PasswordResetForm):
         if not check_subdomain(user_realm.subdomain, attempted_subdomain):
             context['attempted_realm'] = get_realm(attempted_subdomain)
 
-        send_email('zerver/emails/password_reset', to_email, context=context)
+        send_email('zerver/emails/password_reset', to_email,
+                   from_name="Zulip Account Security",
+                   from_address=FromAddress.NOREPLY, context=context)
 
     def save(self, *args, **kwargs):
         # type: (*Any, **Any) -> None

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3053,7 +3053,9 @@ def do_send_confirmation_email(invitee, referrer, body):
     """
     activation_url = Confirmation.objects.get_link_for_object(invitee, referrer.realm.host)
     context = {'referrer': referrer, 'custom_body': body, 'activate_url': activation_url}
-    send_email('zerver/emails/invitation', invitee.email, from_address=FromAddress.NOREPLY, context=context)
+    from_name = u"%s (via Zulip)" % (referrer.full_name,)
+    send_email('zerver/emails/invitation', invitee.email, from_name=from_name,
+               from_address=FromAddress.NOREPLY, context=context)
 
 def is_inactive(email):
     # type: (Text) -> None

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -640,7 +640,8 @@ def do_start_email_change_process(user_profile, new_email):
     activation_url = EmailChangeConfirmation.objects.get_link_for_object(obj, user_profile.realm.host)
     context = {'realm': user_profile.realm, 'old_email': old_email, 'new_email': new_email,
                'activate_url': activation_url}
-    send_email('zerver/emails/confirm_new_email', new_email, from_address=FromAddress.NOREPLY, context=context)
+    send_email('zerver/emails/confirm_new_email', new_email, from_name='Zulip Account Security',
+               from_address=FromAddress.NOREPLY, context=context)
 
 def compute_irc_user_fullname(email):
     # type: (NonBinaryStr) -> NonBinaryStr

--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -12,7 +12,7 @@ from django.conf import settings
 
 from zerver.lib.notifications import build_message_list, hash_util_encode, \
     one_click_unsubscribe_link
-from zerver.lib.send_email import display_email, send_future_email
+from zerver.lib.send_email import display_email, send_future_email, FromAddress
 from zerver.models import UserProfile, UserMessage, Recipient, Stream, \
     Subscription, get_active_streams
 from zerver.context_processors import common_context
@@ -209,4 +209,5 @@ def handle_digest_email(user_profile_id, cutoff):
                       new_streams_count, new_users_count):
         logger.info("Sending digest email for %s" % (user_profile.email,))
         # Send now, as a ScheduledJob
-        send_future_email('zerver/emails/digest', display_email(user_profile), context=context)
+        send_future_email('zerver/emails/digest', display_email(user_profile), from_name="Zulip Digest",
+                          from_address=FromAddress.NOREPLY, context=context)

--- a/zerver/management/commands/send_password_reset_email.py
+++ b/zerver/management/commands/send_password_reset_email.py
@@ -10,7 +10,7 @@ from django.utils.encoding import force_bytes
 
 from django.contrib.auth.tokens import default_token_generator, PasswordResetTokenGenerator
 
-from zerver.lib.send_email import send_email
+from zerver.lib.send_email import send_email, FromAddress
 from zerver.lib.management import ZulipBaseCommand
 
 class Command(ZulipBaseCommand):
@@ -61,4 +61,5 @@ class Command(ZulipBaseCommand):
             }
 
             logging.warning("Sending %s email to %s" % (email_template_name, user_profile.email,))
-            send_email('zerver/emails/password_reset', user_profile.email, context=context)
+            send_email('zerver/emails/password_reset', user_profile.email, from_name="Zulip Account Security",
+                       from_address=FromAddress.NOREPLY, context=context)

--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -7,7 +7,7 @@ from django.template import loader
 from django.utils.timezone import get_current_timezone_name as timezone_get_current_timezone_name
 from django.utils.timezone import now as timezone_now
 from typing import Any, Dict, Optional
-from zerver.lib.send_email import send_email_to_user
+from zerver.lib.send_email import send_email_to_user, FromAddress
 from zerver.models import UserProfile
 
 def get_device_browser(user_agent):
@@ -88,4 +88,6 @@ def email_on_new_login(sender, user, request, **kwargs):
         context['device_info'] = device_info
         context['user'] = user
 
-        send_email_to_user('zerver/emails/notify_new_login', user, context=context)
+        send_email_to_user('zerver/emails/notify_new_login', user,
+                           from_name='Zulip Account Security', from_address=FromAddress.NOREPLY,
+                           context=context)

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -115,7 +115,9 @@ class EmailChangeTestCase(ZulipTestCase):
             '[Zulip] Confirm your new email address for Zulip Dev'
         )
         body = email_message.body
+        from_email = email_message.from_email
         self.assertIn('We received a request to change the email', body)
+        self.assertIn('Zulip Account Security', from_email)
         self.assertIn(FromAddress.NOREPLY, email_message.from_email)
 
         activation_url = [s for s in body.split('\n') if s][4]

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -52,7 +52,8 @@ def confirm_email_change(request, confirmation_key):
                    'new_email': new_email,
                    }
         send_email('zerver/emails/notify_change_in_email', old_email,
-                   from_address=FromAddress.SUPPORT, context=context)
+                   from_name="Zulip Account Security", from_address=FromAddress.SUPPORT,
+                   context=context)
 
     ctx = {
         'confirmed': confirmed,


### PR DESCRIPTION
Makes email sender names somewhat more descriptive for invitation (includes inviting user's name a la the LinkedIn invite emails), digest (a la the Quora Digest), and account security emails.

The four commits making emails come from 'Zulip Account Security' can be squashed; I'll do that if there are no objections to the decision to use that sender name for these four (I could see the new login notifications and change in email notifications possibly wanting a different sender name).

Per the discussion at #5684, also adds some tests enforcing that these sender names and noreply email addresses are used.