### PR TITLE
frontend: Redesign templates/ error pages.

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -2,11 +2,20 @@
 
 {% block portico_content %}
 
-<br/>
-<p class="lead">404: Page not found.</p>
+<div class="error_page" style="padding-bottom: 60px;">
+    <div class="container">
+        <div class="row-fluid">
+            <img src="/static/images/400art.svg" alt=""/>
+            <div class="errorbox">
+                <div class="errorcontent">
+                    <h1 class="lead">Page not found (404)</h1>
+                    <p>We know this is stressful, but we still love you.</p>
+                    <p>If you'd like, you can <a href="mailto:{{ support_email }}?Subject=404%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20404%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
+                </div>
 
-<p>We know this is stressful, but we still love you.</p>
-
-<p>If you'd like, you can <a href="mailto:{{ support_email }}?Subject=404%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20404%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
+            </div>
+        </div>
+    </div>
+</div>
 
 {% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -7,11 +7,21 @@
 
 {% block portico_content %}
 
-<br/>
-<p class="lead">Internal server error.</p>
+<div class="error_page" style="padding-bottom: 60px;">
+    <div class="container">
+        <div class="row-fluid">
+            <img src="/static/images/500art.svg" alt=""/>
+            <div class="errorbox">
+                <div class="errorcontent">
+                    <h1 class="lead">Internal server error</h1>
+                    <p>This Zulip server is currently experiencing some technical difficulties. Sorry about that!</p>
+                    <p>The page will reload automatically soon after service is restored.</p>
+                    <p>If you'd like, you can <a href="mailto:{{ support_email }}?Subject=500%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20500%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
+                </div>
 
-<p>Well oops. This one's probably our fault. Sorry about that!</p>
-
-<p>If you'd like, you can <a href="mailto:{{ support_email }}?Subject=500%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20500%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
+            </div>
+        </div>
+    </div>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
* the left/right margins are due to the container in `portico.html`. 
* The current text is a mix of the new `static/` text and the `templates/` text:
```
# static/5xx
Internal server error
This Zulip server is currently experiencing some technical difficulties. Sorry about that!
The page will reload automatically soon after service is restored.

# templates/500
Internal server error.
Well oops. This one's probably our fault. Sorry about that!
If you'd like, you can [drop us a line] to let us know what happened.

# this PR:
Internal server error.
This Zulip server is currently experiencing some technical difficulties. Sorry about that!
The page will reload automatically soon after service is restored.
If you'd like, you can [drop us a line] to let us know what happened.

# static/404
Page not found (404)
We can't find the page you're looking for.

# templates/404
404: Page not found.
We know this is stressful, but we still love you.
If you'd like, you can [drop us a line] to let us know what happened.

# this PR:
Page not found (404)
We know this is stressful, but we still love you.
If you'd like, you can [drop us a line] to let us know what happened.
```

![image](https://user-images.githubusercontent.com/13666710/28112844-c52539f0-66fa-11e7-87a2-3f7391406302.png)
![image](https://user-images.githubusercontent.com/13666710/28113224-02c45bc8-66fc-11e7-9131-24221b043e6e.png)

