### PR TITLE
(wip) Make it easier to reason about message state.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,6 +56,7 @@
         "typing_events": false,
         "typing_data": false,
         "typing_status": false,
+        "sent_messages": false,
         "compose": false,
         "compose_actions": false,
         "compose_state": false,

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -284,16 +284,7 @@ people.add(bob);
     assert(reify_message_id_checked);
 }());
 
-(function test_mark_rendered_content_disparity() {
-    sent_messages.mark_rendered_content_disparity(13, true);
-    assert.deepEqual(sent_messages.send_times_data[13].data.rendered_content_disparity, true);
-}());
-
 (function test_report_as_received() {
-    var msg = {
-        id: 12,
-        sent_by_me: true,
-    };
     var set_timeout_called = false;
     global.patch_builtin('setTimeout', function (func, delay) {
         assert.equal(delay, 0);
@@ -310,14 +301,13 @@ people.add(bob);
         assert(payload.data.locally_echoed);
         assert(!payload.data.rendered_content_disparity);
     };
-    sent_messages.report_as_received(msg);
+    sent_messages.report_as_received(12);
     assert.equal(typeof(data.received), 'object');
     assert.equal(typeof(data.displayed), 'object');
     assert(set_timeout_called);
 
     delete sent_messages.send_times_data[13];
-    msg.id = 13;
-    sent_messages.report_as_received(msg);
+    sent_messages.report_as_received(13);
     data = sent_messages.get_message_state(13).data;
     assert.equal(typeof(data.received), 'object');
     assert.equal(typeof(data.displayed), 'object');
@@ -1242,27 +1232,6 @@ function test_with_mock_socket(test_params) {
         assert(!$("#undo_markdown_preview").visible());
         assert(!$("#preview_message_area").visible());
         assert($("#markdown_preview").visible());
-    }());
-
-    (function test_message_id_changed_document() {
-        sent_messages.initialize();
-        var handler = $(document).get_on_handler('message_id_changed');
-        sent_messages.send_times_data = {
-            1031: {
-                data: 'Test data!',
-            },
-        };
-        event.old_id = 1031;
-        event.new_id = 1045;
-
-        handler(event);
-
-        var send_times_data = {
-            1045: {
-                data: 'Test data!',
-            },
-        };
-        assert.deepEqual(sent_messages.send_times_data, send_times_data);
     }());
 }());
 

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -290,8 +290,11 @@ people.add(bob);
     assert.equal($("#compose-send-button").attr('disabled'), undefined);
     assert(!$("#sending-indicator").visible());
     assert.equal(_.keys(sent_messages.send_times_data).length, 1);
-    assert.equal(sent_messages.send_times_data[12].start.getTime(), new Date(test_date).getTime());
-    assert(!sent_messages.send_times_data[12].locally_echoed);
+
+    var data = sent_messages.get_message_state(12).data;
+    assert.equal(data.start.getTime(), new Date(test_date).getTime());
+    assert(!data.locally_echoed);
+
     assert(reify_message_id_checked);
     assert(server_events_triggered);
     assert(set_timeout_called);
@@ -299,7 +302,7 @@ people.add(bob);
 
 (function test_mark_rendered_content_disparity() {
     sent_messages.mark_rendered_content_disparity(13, true);
-    assert.deepEqual(sent_messages.send_times_data[13], { rendered_content_disparity: true });
+    assert.deepEqual(sent_messages.send_times_data[13].data.rendered_content_disparity, true);
 }());
 
 (function test_report_as_received() {
@@ -313,7 +316,10 @@ people.add(bob);
         func();
         set_timeout_called = true;
     });
-    sent_messages.send_times_data[12].locally_echoed = true;
+
+    var data = sent_messages.get_message_state(12).data;
+
+    data.locally_echoed = true;
     channel.post = function (payload) {
         assert.equal(payload.url, '/json/report_send_time');
         assert.equal(typeof(payload.data.time), 'string');
@@ -321,15 +327,16 @@ people.add(bob);
         assert(!payload.data.rendered_content_disparity);
     };
     sent_messages.report_as_received(msg);
-    assert.equal(typeof(sent_messages.send_times_data[12].received), 'object');
-    assert.equal(typeof(sent_messages.send_times_data[12].displayed), 'object');
+    assert.equal(typeof(data.received), 'object');
+    assert.equal(typeof(data.displayed), 'object');
     assert(set_timeout_called);
 
     delete sent_messages.send_times_data[13];
     msg.id = 13;
     sent_messages.report_as_received(msg);
-    assert.equal(typeof(sent_messages.send_times_data[13].received), 'object');
-    assert.equal(typeof(sent_messages.send_times_data[13].displayed), 'object');
+    data = sent_messages.get_message_state(13).data;
+    assert.equal(typeof(data.received), 'object');
+    assert.equal(typeof(data.displayed), 'object');
 }());
 
 (function test_send_message() {

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -45,6 +45,7 @@ add_dependencies({
     compose_ui: 'js/compose_ui.js',
     Handlebars: 'handlebars',
     people: 'js/people',
+    sent_messages: 'js/sent_messages',
     stream_data: 'js/stream_data',
     util: 'js/util',
 });
@@ -288,17 +289,17 @@ people.add(bob);
     assert(!$("#send-status").visible());
     assert.equal($("#compose-send-button").attr('disabled'), undefined);
     assert(!$("#sending-indicator").visible());
-    assert.equal(_.keys(compose.send_times_data).length, 1);
-    assert.equal(compose.send_times_data[12].start.getTime(), new Date(test_date).getTime());
-    assert(!compose.send_times_data[12].locally_echoed);
+    assert.equal(_.keys(sent_messages.send_times_data).length, 1);
+    assert.equal(sent_messages.send_times_data[12].start.getTime(), new Date(test_date).getTime());
+    assert(!sent_messages.send_times_data[12].locally_echoed);
     assert(reify_message_id_checked);
     assert(server_events_triggered);
     assert(set_timeout_called);
 }());
 
 (function test_mark_rendered_content_disparity() {
-    compose.mark_rendered_content_disparity(13, true);
-    assert.deepEqual(compose.send_times_data[13], { rendered_content_disparity: true });
+    sent_messages.mark_rendered_content_disparity(13, true);
+    assert.deepEqual(sent_messages.send_times_data[13], { rendered_content_disparity: true });
 }());
 
 (function test_report_as_received() {
@@ -312,23 +313,23 @@ people.add(bob);
         func();
         set_timeout_called = true;
     });
-    compose.send_times_data[12].locally_echoed = true;
+    sent_messages.send_times_data[12].locally_echoed = true;
     channel.post = function (payload) {
         assert.equal(payload.url, '/json/report_send_time');
         assert.equal(typeof(payload.data.time), 'string');
         assert(payload.data.locally_echoed);
         assert(!payload.data.rendered_content_disparity);
     };
-    compose.report_as_received(msg);
-    assert.equal(typeof(compose.send_times_data[12].received), 'object');
-    assert.equal(typeof(compose.send_times_data[12].displayed), 'object');
+    sent_messages.report_as_received(msg);
+    assert.equal(typeof(sent_messages.send_times_data[12].received), 'object');
+    assert.equal(typeof(sent_messages.send_times_data[12].displayed), 'object');
     assert(set_timeout_called);
 
-    delete compose.send_times_data[13];
+    delete sent_messages.send_times_data[13];
     msg.id = 13;
-    compose.report_as_received(msg);
-    assert.equal(typeof(compose.send_times_data[13].received), 'object');
-    assert.equal(typeof(compose.send_times_data[13].displayed), 'object');
+    sent_messages.report_as_received(msg);
+    assert.equal(typeof(sent_messages.send_times_data[13].received), 'object');
+    assert.equal(typeof(sent_messages.send_times_data[13].displayed), 'object');
 }());
 
 (function test_send_message() {
@@ -394,7 +395,7 @@ people.add(bob);
             assert.equal(typeof(message_id), 'number');
             stub_state.reify_message_id_checked += 1;
         };
-        compose.send_times_data = {};
+        sent_messages.send_times_data = {};
         // Setting message content with a host server link and we will assert
         // later that this has been converted to a relative link.
         $("#new_message_content").val('[foobar]' +
@@ -414,7 +415,7 @@ people.add(bob);
             server_events_triggered: 1,
         };
         assert.deepEqual(stub_state, state);
-        assert.equal(_.keys(compose.send_times_data).length, 1);
+        assert.equal(_.keys(sent_messages.send_times_data).length, 1);
         assert.equal($("#new_message_content").val(), '');
         assert($("#new_message_content").is_focused());
         assert(!$("#send-status").visible());
@@ -449,7 +450,7 @@ people.add(bob);
             server_events_triggered: 0,
         };
         assert.deepEqual(stub_state, state);
-        assert.equal(_.keys(compose.send_times_data).length, 1);
+        assert.equal(_.keys(sent_messages.send_times_data).length, 1);
         assert(server_error_triggered);
         assert(reload_initiate_triggered);
     }());
@@ -490,7 +491,7 @@ people.add(bob);
             server_events_triggered: 0,
         };
         assert.deepEqual(stub_state, state);
-        assert.equal(_.keys(compose.send_times_data).length, 1);
+        assert.equal(_.keys(sent_messages.send_times_data).length, 1);
         assert(server_error_triggered);
         assert(!reload_initiate_triggered);
         assert(xhr_error_msg_checked);
@@ -523,7 +524,7 @@ people.add(bob);
             server_events_triggered: 0,
         };
         assert.deepEqual(stub_state, state);
-        assert.equal(_.keys(compose.send_times_data).length, 1);
+        assert.equal(_.keys(sent_messages.send_times_data).length, 1);
         assert(server_error_triggered);
         assert(!reload_initiate_triggered);
         assert(xhr_error_msg_checked);
@@ -1249,8 +1250,9 @@ function test_with_mock_socket(test_params) {
     }());
 
     (function test_message_id_changed_document() {
+        sent_messages.initialize();
         var handler = $(document).get_on_handler('message_id_changed');
-        compose.send_times_data = {
+        sent_messages.send_times_data = {
             1031: {
                 data: 'Test data!',
             },
@@ -1265,7 +1267,7 @@ function test_with_mock_socket(test_params) {
                 data: 'Test data!',
             },
         };
-        assert.deepEqual(compose.send_times_data, send_times_data);
+        assert.deepEqual(sent_messages.send_times_data, send_times_data);
     }());
 }());
 

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -292,6 +292,10 @@ people.add(bob);
         set_timeout_called = true;
     });
 
+    sent_messages.track_message({
+        client_message_id: 12,
+    });
+
     var data = sent_messages.get_message_state(12).data;
 
     data.locally_echoed = true;
@@ -307,6 +311,11 @@ people.add(bob);
     assert(set_timeout_called);
 
     delete sent_messages.send_times_data[13];
+    sent_messages.track_message({
+        client_message_id: 13,
+    });
+
+
     sent_messages.report_as_received(13);
     data = sent_messages.get_message_state(13).data;
     assert.equal(typeof(data.received), 'object');
@@ -431,7 +440,6 @@ people.add(bob);
             server_events_triggered: 0,
         };
         assert.deepEqual(stub_state, state);
-        assert.equal(_.keys(sent_messages.send_times_data).length, 1);
         assert(server_error_triggered);
         assert(reload_initiate_triggered);
     }());
@@ -472,7 +480,6 @@ people.add(bob);
             server_events_triggered: 0,
         };
         assert.deepEqual(stub_state, state);
-        assert.equal(_.keys(sent_messages.send_times_data).length, 1);
         assert(server_error_triggered);
         assert(!reload_initiate_triggered);
         assert(xhr_error_msg_checked);
@@ -505,7 +512,6 @@ people.add(bob);
             server_events_triggered: 0,
         };
         assert.deepEqual(stub_state, state);
-        assert.equal(_.keys(sent_messages.send_times_data).length, 1);
         assert(server_error_triggered);
         assert(!reload_initiate_triggered);
         assert(xhr_error_msg_checked);
@@ -774,6 +780,7 @@ function test_with_mock_socket(test_params) {
         error_func_checked = true;
     };
 
+    sent_messages.send_times_data = {};
     sent_messages.reset_id_state();
 
     test_with_mock_socket({

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -379,10 +379,11 @@ people.add(bob);
               reply_to: 'alice@example.com',
               private_message_recipient: 'alice@example.com',
               to_user_ids: '31',
+              client_message_id: 1,
               local_id: 1,
             };
             assert.equal(payload.url, '/json/messages');
-            assert.equal(_.keys(payload.data).length, 11);
+            assert.equal(_.keys(payload.data).length, 12);
             assert.deepEqual(payload.data, single_msg);
             payload.data.id = stub_state.local_id_counter;
             payload.success(payload.data);
@@ -803,6 +804,7 @@ function test_with_mock_socket(test_params) {
             assert.equal(send_args.request, request);
             assert.deepEqual(send_args.request, {
                 foo: 'bar',
+                client_message_id: undefined,
                 socket_user_agent: 'unittest_transmit_message',
             });
 

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -255,6 +255,8 @@ people.add(bob);
 }());
 
 (function test_send_message_success() {
+    sent_messages.reset_id_state();
+
     blueslip.error = noop;
     blueslip.log = noop;
     $("#new_message_content").val('foobarfoobar');
@@ -801,6 +803,8 @@ function test_with_mock_socket(test_params) {
         error_func_checked = true;
     };
 
+    sent_messages.reset_id_state();
+
     test_with_mock_socket({
         run_code: function () {
             compose.transmit_message(request, success, error);
@@ -812,7 +816,7 @@ function test_with_mock_socket(test_params) {
             assert.equal(send_args.request, request);
             assert.deepEqual(send_args.request, {
                 foo: 'bar',
-                client_message_id: undefined,
+                client_message_id: 1,
                 socket_user_agent: 'unittest_transmit_message',
             });
 

--- a/frontend_tests/node_tests/sent_messages.js
+++ b/frontend_tests/node_tests/sent_messages.js
@@ -1,0 +1,34 @@
+var sent_messages = require('js/sent_messages.js');
+
+(function test_ids() {
+    sent_messages.reset_id_state();
+
+    var client_message_id = sent_messages.get_new_client_message_id({
+        local_id: 42,
+    });
+
+    assert.equal(client_message_id, 1);
+
+    var local_id = sent_messages.get_local_id({
+        client_message_id: 1,
+    });
+
+    assert.equal(local_id, 42);
+
+
+    client_message_id = sent_messages.get_new_client_message_id({});
+
+    assert.equal(client_message_id, 2);
+
+    local_id = sent_messages.get_local_id({
+        client_message_id: 2,
+    });
+
+    assert.equal(local_id, undefined);
+
+    local_id = sent_messages.get_local_id({
+        client_message_id: undefined,
+    });
+    assert.equal(local_id, undefined);
+
+}());

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -53,6 +53,10 @@ server_events.home_view_loaded();
         flags: [],
     };
 
+    set_global('sent_messages', {
+        get_local_id: function () { return 9999; },
+    });
+
     var inserted;
     set_global('message_events', {
         insert_new_messages: function (messages) {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -239,9 +239,6 @@ exports.transmit_message = function (request, on_success, error) {
 
         // Once everything is done, get ready to report times to the server.
         message_state.process_success();
-
-        // TODO: rework the timers
-        sent_messages.set_timer_for_restarting_event_loop(client_message_id);
     }
 
     if (page_params.use_websockets) {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -302,6 +302,13 @@ exports.send_message_success = function (local_id, message_id, start_time, local
 };
 
 exports.transmit_message = function (request, success, error) {
+    // Give the server our local_id as client_message_id.  We
+    // will eventually decouple these concepts, so that local_id
+    // is only an interim value for a message id, whereas
+    // client_message_id will be a key used to track the message through
+    // its lifecycle of being posted/received/acked/sent/displayed.
+    request.client_message_id = request.local_id;
+
     delete exports.send_times_data[request.id];
     if (page_params.use_websockets) {
         send_message_socket(request, success, error);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -222,12 +222,9 @@ exports.send_message_success = function (local_id, message_id, start_time, local
 };
 
 exports.transmit_message = function (request, success, error) {
-    // Give the server our local_id as client_message_id.  We
-    // will eventually decouple these concepts, so that local_id
-    // is only an interim value for a message id, whereas
-    // client_message_id will be a key used to track the message through
-    // its lifecycle of being posted/received/acked/sent/displayed.
-    request.client_message_id = request.local_id;
+    request.client_message_id = sent_messages.get_new_client_message_id({
+        local_id: request.local_id,
+    });
 
     sent_messages.clear(request.id);
 

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -173,11 +173,14 @@ exports.process_from_server = function process_from_server(messages) {
             if (client_message.content !== message.content) {
                 client_message.content = message.content;
                 updated = true;
-                sent_messages.mark_rendered_content_disparity(message.id, true);
+                sent_messages.mark_rendered_content_disparity({
+                    client_message_id: message.client_message_id,
+                    changed: true,
+                });
             }
             msgs_to_rerender.push(client_message);
             locally_processed_ids.push(client_message.id);
-            sent_messages.report_as_received(client_message);
+            sent_messages.report_as_received(message.client_message_id);
             delete waiting_for_ack[client_message.id];
             return false;
         }

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -171,11 +171,11 @@ exports.process_from_server = function process_from_server(messages) {
             if (client_message.content !== message.content) {
                 client_message.content = message.content;
                 updated = true;
-                compose.mark_rendered_content_disparity(message.id, true);
+                sent_messages.mark_rendered_content_disparity(message.id, true);
             }
             msgs_to_rerender.push(client_message);
             locally_processed_ids.push(client_message.id);
-            compose.report_as_received(client_message);
+            sent_messages.report_as_received(client_message);
             delete waiting_for_ack[client_message.id];
             return false;
         }

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -13,14 +13,16 @@ function resend_message(message, row) {
     // Always re-set queue_id if we've gotten a new one
     // since the time when the message object was initially created
     message.queue_id = page_params.queue_id;
-    var start_time = new Date();
     compose.transmit_message(message, function success(data) {
         retry_spinner.toggleClass('rotating', false);
 
         var message_id = data.id;
 
         retry_spinner.toggleClass('rotating', false);
-        compose.send_message_success(message.local_id, message_id, start_time, true);
+
+        var locally_echoed = true;
+
+        compose.send_message_success(message.local_id, message_id, locally_echoed);
 
         // Resend succeeded, so mark as no longer failed
         message_store.get(message_id).failed_request = false;

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -23,7 +23,7 @@ exports.add_messages = function add_messages(messages, msg_list, opts) {
     if (msg_list === home_msg_list && opts.messages_are_new) {
         _.each(messages, function (message) {
             if (message.local_id === undefined) {
-                sent_messages.report_as_received(message);
+                sent_messages.report_as_received(message.client_message_id);
             }
         });
     }

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -23,7 +23,7 @@ exports.add_messages = function add_messages(messages, msg_list, opts) {
     if (msg_list === home_msg_list && opts.messages_are_new) {
         _.each(messages, function (message) {
             if (message.local_id === undefined) {
-                compose.report_as_received(message);
+                sent_messages.report_as_received(message);
             }
         });
     }

--- a/static/js/sent_messages.js
+++ b/static/js/sent_messages.js
@@ -5,6 +5,28 @@ var exports = {};
 exports.send_times_log = [];
 exports.send_times_data = {};
 
+exports.reset_id_state = function () {
+    exports.local_id_dict = new Dict();
+    exports.next_client_message_id = 0;
+};
+
+exports.get_new_client_message_id = function (opts) {
+    exports.next_client_message_id += 1;
+    var client_message_id = exports.next_client_message_id;
+    exports.local_id_dict.set(client_message_id, opts.local_id);
+    return client_message_id;
+};
+
+exports.get_local_id = function (opts) {
+    var client_message_id = opts.client_message_id;
+
+    if (client_message_id === undefined) {
+        return undefined;
+    }
+
+    return exports.local_id_dict.get(client_message_id);
+};
+
 function report_send_time(send_time, receive_time, display_time, locally_echoed, rendered_changed) {
     var data = {time: send_time.toString(),
                 received: receive_time.toString(),
@@ -150,6 +172,8 @@ exports.initialize = function () {
             delete exports.send_times_data[event.old_id];
         }
     });
+
+    exports.reset_id_state();
 };
 
 return exports;

--- a/static/js/sent_messages.js
+++ b/static/js/sent_messages.js
@@ -1,0 +1,112 @@
+var sent_messages = (function () {
+
+var exports = {};
+
+exports.send_times_log = [];
+exports.send_times_data = {};
+
+function report_send_time(send_time, receive_time, display_time, locally_echoed, rendered_changed) {
+    var data = {time: send_time.toString(),
+                received: receive_time.toString(),
+                displayed: display_time.toString(),
+                locally_echoed: locally_echoed};
+    if (locally_echoed) {
+        data.rendered_content_disparity = rendered_changed;
+    }
+    channel.post({
+        url: '/json/report_send_time',
+        data: data,
+    });
+}
+
+function maybe_report_send_times(message_id) {
+    var data = exports.send_times_data[message_id];
+    if (data.send_finished === undefined || data.received === undefined ||
+        data.displayed === undefined) {
+        // We report the data once we have both the send and receive times
+        return;
+    }
+    report_send_time(data.send_finished - data.start,
+                     data.received - data.start,
+                     data.displayed - data.start,
+                     data.locally_echoed,
+                     data.rendered_content_disparity || false);
+}
+
+function mark_end_to_end_receive_time(message_id) {
+    if (exports.send_times_data[message_id] === undefined) {
+        exports.send_times_data[message_id] = {};
+    }
+    exports.send_times_data[message_id].received = new Date();
+    maybe_report_send_times(message_id);
+}
+
+function mark_end_to_end_display_time(message_id) {
+    exports.send_times_data[message_id].displayed = new Date();
+    maybe_report_send_times(message_id);
+}
+
+exports.mark_rendered_content_disparity = function (message_id, changed) {
+    if (exports.send_times_data[message_id] === undefined) {
+        exports.send_times_data[message_id] = {};
+    }
+    exports.send_times_data[message_id].rendered_content_disparity = changed;
+};
+
+exports.report_as_received = function report_as_received(message) {
+    if (message.sent_by_me) {
+        mark_end_to_end_receive_time(message.id);
+        setTimeout(function () {
+            mark_end_to_end_display_time(message.id);
+        }, 0);
+    }
+};
+
+exports.process_success = function (message_id, start_time, locally_echoed) {
+    var send_finished = new Date();
+    var send_time = (send_finished - start_time);
+    if (feature_flags.log_send_times) {
+        blueslip.log("send time: " + send_time);
+    }
+    if (feature_flags.collect_send_times) {
+        exports.send_times_log.push(send_time);
+    }
+    if (exports.send_times_data[message_id] === undefined) {
+        exports.send_times_data[message_id] = {};
+    }
+    exports.send_times_data[message_id].start = start_time;
+    exports.send_times_data[message_id].send_finished = send_finished;
+    exports.send_times_data[message_id].locally_echoed  = locally_echoed;
+    maybe_report_send_times(message_id);
+};
+
+exports.set_timer_for_restarting_event_loop = function (message_id) {
+    setTimeout(function () {
+        if (exports.send_times_data[message_id].received === undefined) {
+            blueslip.log("Restarting get_events due to delayed receipt of sent message " + message_id);
+            server_events.restart_get_events();
+        }
+    }, 5000);
+};
+
+exports.clear = function (message_id) {
+    delete exports.send_times_data[message_id];
+};
+
+exports.initialize = function () {
+    $(document).on('message_id_changed', function (event) {
+        if (exports.send_times_data[event.old_id] !== undefined) {
+            var value = exports.send_times_data[event.old_id];
+            delete exports.send_times_data[event.old_id];
+            exports.send_times_data[event.new_id] =
+                _.extend({}, exports.send_times_data[event.old_id], value);
+        }
+    });
+};
+
+return exports;
+
+}());
+if (typeof module !== 'undefined') {
+    module.exports = sent_messages;
+}

--- a/static/js/sent_messages.js
+++ b/static/js/sent_messages.js
@@ -19,38 +19,87 @@ function report_send_time(send_time, receive_time, display_time, locally_echoed,
     });
 }
 
-function maybe_report_send_times(message_id) {
-    var data = exports.send_times_data[message_id];
-    if (data.send_finished === undefined || data.received === undefined ||
-        data.displayed === undefined) {
-        // We report the data once we have both the send and receive times
-        return;
+exports.message_state = function () {
+    var self = {};
+    self.data = {};
+
+    // TODO: Fix quirk that we don't know the start time sometime
+    //       when we start recording message state.
+    self.data.start = undefined;
+    self.data.received = undefined;
+    self.data.displayed = undefined;
+    self.data.send_finished = undefined;
+    self.data.locally_echoed = false;
+    self.data.rendered_content_disparity = false;
+
+    self.maybe_report_send_times = function () {
+        if (!self.ready()) {
+            return;
+        }
+        var data = self.data;
+        report_send_time(data.send_finished - data.start,
+                         data.received - data.start,
+                         data.displayed - data.start,
+                         data.locally_echoed,
+                         data.rendered_content_disparity || false);
+    };
+
+    self.mark_received = function () {
+        self.data.received = new Date();
+        self.maybe_report_send_times();
+    };
+
+    self.mark_displayed = function () {
+        self.data.displayed = new Date();
+        self.maybe_report_send_times();
+    };
+
+    self.mark_disparity = function (changed) {
+        self.data.rendered_content_disparity = changed;
+    };
+
+    self.process_success = function (opts) {
+        self.data.start = opts.start;
+        self.data.send_finished = opts.send_finished;
+        self.data.locally_echoed = opts.locally_echoed;
+        self.maybe_report_send_times();
+    };
+
+    self.was_received = function () {
+        return self.data.received !== undefined;
+    };
+
+    self.ready = function () {
+        return (self.data.send_finished !== undefined) &&
+               (self.data.received !== undefined) &&
+               (self.data.displayed !== undefined);
+    };
+
+    return self;
+};
+
+exports.get_message_state = function (message_id) {
+    if (exports.send_times_data[message_id] === undefined) {
+        exports.send_times_data[message_id] = exports.message_state();
     }
-    report_send_time(data.send_finished - data.start,
-                     data.received - data.start,
-                     data.displayed - data.start,
-                     data.locally_echoed,
-                     data.rendered_content_disparity || false);
-}
+
+    return exports.send_times_data[message_id];
+};
+
 
 function mark_end_to_end_receive_time(message_id) {
-    if (exports.send_times_data[message_id] === undefined) {
-        exports.send_times_data[message_id] = {};
-    }
-    exports.send_times_data[message_id].received = new Date();
-    maybe_report_send_times(message_id);
+    var state = exports.get_message_state(message_id);
+    state.mark_received();
 }
 
 function mark_end_to_end_display_time(message_id) {
-    exports.send_times_data[message_id].displayed = new Date();
-    maybe_report_send_times(message_id);
+    var state = exports.get_message_state(message_id);
+    state.mark_displayed();
 }
 
 exports.mark_rendered_content_disparity = function (message_id, changed) {
-    if (exports.send_times_data[message_id] === undefined) {
-        exports.send_times_data[message_id] = {};
-    }
-    exports.send_times_data[message_id].rendered_content_disparity = changed;
+    var state = exports.get_message_state(message_id);
+    state.mark_disparity(changed);
 };
 
 exports.report_as_received = function report_as_received(message) {
@@ -71,18 +120,18 @@ exports.process_success = function (message_id, start_time, locally_echoed) {
     if (feature_flags.collect_send_times) {
         exports.send_times_log.push(send_time);
     }
-    if (exports.send_times_data[message_id] === undefined) {
-        exports.send_times_data[message_id] = {};
-    }
-    exports.send_times_data[message_id].start = start_time;
-    exports.send_times_data[message_id].send_finished = send_finished;
-    exports.send_times_data[message_id].locally_echoed  = locally_echoed;
-    maybe_report_send_times(message_id);
+
+    var state = exports.get_message_state(message_id);
+    state.process_success({
+        start: start_time,
+        send_finished: send_finished,
+        locally_echoed: locally_echoed,
+    });
 };
 
 exports.set_timer_for_restarting_event_loop = function (message_id) {
     setTimeout(function () {
-        if (exports.send_times_data[message_id].received === undefined) {
+        if (!exports.send_times_data[message_id].was_received()) {
             blueslip.log("Restarting get_events due to delayed receipt of sent message " + message_id);
             server_events.restart_get_events();
         }
@@ -97,9 +146,8 @@ exports.initialize = function () {
     $(document).on('message_id_changed', function (event) {
         if (exports.send_times_data[event.old_id] !== undefined) {
             var value = exports.send_times_data[event.old_id];
+            exports.send_times_data[event.new_id] = value;
             delete exports.send_times_data[event.old_id];
-            exports.send_times_data[event.new_id] =
-                _.extend({}, exports.send_times_data[event.old_id], value);
         }
     });
 };

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -69,11 +69,12 @@ function get_events_success(events) {
             var msg = event.message;
             msg.flags = event.flags;
 
-            // We will eventually decouple msg.local_id from event.client_message_id,
-            // but for now they are the same value.
-            if (event.client_message_id !== undefined) {
-                msg.local_id = event.client_message_id;
-            }
+            // The server echos client_message_id to us, and then we
+            // map it back to our local_id that was used for rendering.
+            msg.local_id = sent_messages.get_local_id({
+                client_message_id: event.client_message_id,
+            });
+
             messages.push(msg);
             break;
 

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -74,6 +74,7 @@ function get_events_success(events) {
             msg.local_id = sent_messages.get_local_id({
                 client_message_id: event.client_message_id,
             });
+            msg.client_message_id = event.client_message_id;
 
             messages.push(msg);
             break;

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -68,8 +68,11 @@ function get_events_success(events) {
         case 'message':
             var msg = event.message;
             msg.flags = event.flags;
-            if (event.local_message_id !== undefined) {
-                msg.local_id = event.local_message_id;
+
+            // We will eventually decouple msg.local_id from event.client_message_id,
+            // but for now they are the same value.
+            if (event.client_message_id !== undefined) {
+                msg.local_id = event.client_message_id;
             }
             messages.push(msg);
             break;

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -266,6 +266,7 @@ $(function () {
     pm_list.initialize();
     stream_list.initialize();
     drafts.initialize();
+    sent_messages.initialize();
     compose.initialize();
 });
 

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -47,6 +47,7 @@ enforce_fully_covered = {
     'static/js/recent_senders.js',
     'static/js/rtl.js',
     'static/js/search_suggestion.js',
+    'static/js/sent_messages.js',
     'static/js/stream_events.js',
     'static/js/stream_sort.js',
     'static/js/topic_generator.js',

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -47,7 +47,6 @@ enforce_fully_covered = {
     'static/js/recent_senders.js',
     'static/js/rtl.js',
     'static/js/search_suggestion.js',
-    'static/js/sent_messages.js',
     'static/js/stream_events.js',
     'static/js/stream_sort.js',
     'static/js/topic_generator.js',

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -752,7 +752,7 @@ def do_send_messages(messages_maybe_none):
     for message in messages:
         message['rendered_content'] = message.get('rendered_content', None)
         message['stream'] = message.get('stream', None)
-        message['local_id'] = message.get('local_id', None)
+        message['client_message_id'] = message.get('client_message_id', None)
         message['sender_queue_id'] = message.get('sender_queue_id', None)
         message['realm'] = message.get('realm', message['message'].sender.realm)
 
@@ -898,8 +898,8 @@ def do_send_messages(messages_maybe_none):
                 event['stream_name'] = message['stream'].name
             if message['stream'].invite_only:
                 event['invite_only'] = True
-        if message['local_id'] is not None:
-            event['local_id'] = message['local_id']
+        if message['client_message_id'] is not None:
+            event['client_message_id'] = message['client_message_id']
         if message['sender_queue_id'] is not None:
             event['sender_queue_id'] = message['sender_queue_id']
         send_event(event, users)
@@ -1181,12 +1181,12 @@ def extract_recipients(s):
 # Returns the id of the sent message.  Has same argspec as check_message.
 def check_send_message(sender, client, message_type_name, message_to,
                        subject_name, message_content, realm=None, forged=False,
-                       forged_timestamp=None, forwarder_user_profile=None, local_id=None,
+                       forged_timestamp=None, forwarder_user_profile=None, client_message_id=None,
                        sender_queue_id=None):
     # type: (UserProfile, Client, Text, Sequence[Text], Optional[Text], Text, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[Text], Optional[Text]) -> int
     message = check_message(sender, client, message_type_name, message_to,
                             subject_name, message_content, realm, forged, forged_timestamp,
-                            forwarder_user_profile, local_id, sender_queue_id)
+                            forwarder_user_profile, client_message_id, sender_queue_id)
     return do_send_messages([message])[0]
 
 def check_stream_name(stream_name):
@@ -1251,7 +1251,7 @@ def send_pm_if_empty_stream(sender, stream, stream_name, realm):
 # Returns message ready for sending with do_send_message on success or the error message (string) on error.
 def check_message(sender, client, message_type_name, message_to,
                   subject_name, message_content_raw, realm=None, forged=False,
-                  forged_timestamp=None, forwarder_user_profile=None, local_id=None,
+                  forged_timestamp=None, forwarder_user_profile=None, client_message_id=None,
                   sender_queue_id=None):
     # type: (UserProfile, Client, Text, Sequence[Text], Optional[Text], Text, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[Text], Optional[Text]) -> Dict[str, Any]
     stream = None
@@ -1346,7 +1346,7 @@ def check_message(sender, client, message_type_name, message_to,
         if id is not None:
             return {'message': id}
 
-    return {'message': message, 'stream': stream, 'local_id': local_id,
+    return {'message': message, 'stream': stream, 'client_message_id': client_message_id,
             'sender_queue_id': sender_queue_id, 'realm': realm}
 
 def _internal_prep_message(realm, sender, recipient_type_name, parsed_recipients,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -272,8 +272,9 @@ class GetEventsTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assert_length(events, 0)
 
-        local_id = 10.01
-        self.send_message(email, recipient_email, Recipient.PERSONAL, "hello", local_id=local_id, sender_queue_id=queue_id)
+        client_message_id = 'opaque-id-1'
+        self.send_message(email, recipient_email, Recipient.PERSONAL,
+                          "hello", client_message_id=client_message_id, sender_queue_id=queue_id)
 
         result = self.tornado_call(get_events_backend, user_profile,
                                    {"queue_id": queue_id,
@@ -286,14 +287,14 @@ class GetEventsTest(ZulipTestCase):
         self.assert_length(events, 1)
         self.assertEqual(events[0]["type"], "message")
         self.assertEqual(events[0]["message"]["sender_email"], email)
-        self.assertEqual(events[0]["local_message_id"], local_id)
+        self.assertEqual(events[0]["client_message_id"], client_message_id)
         self.assertEqual(events[0]["message"]["display_recipient"][0]["is_mirror_dummy"], False)
         self.assertEqual(events[0]["message"]["display_recipient"][1]["is_mirror_dummy"], False)
 
         last_event_id = events[0]["id"]
-        local_id += 0.01
+        client_message_id = 'opaque-id-2'
 
-        self.send_message(email, recipient_email, Recipient.PERSONAL, "hello", local_id=local_id, sender_queue_id=queue_id)
+        self.send_message(email, recipient_email, Recipient.PERSONAL, "hello", client_message_id=client_message_id, sender_queue_id=queue_id)
 
         result = self.tornado_call(get_events_backend, user_profile,
                                    {"queue_id": queue_id,
@@ -306,7 +307,7 @@ class GetEventsTest(ZulipTestCase):
         self.assert_length(events, 1)
         self.assertEqual(events[0]["type"], "message")
         self.assertEqual(events[0]["message"]["sender_email"], email)
-        self.assertEqual(events[0]["local_message_id"], local_id)
+        self.assertEqual(events[0]["client_message_id"], client_message_id)
 
         # Test that the received message in the receiver's event queue
         # exists and does not contain a local id
@@ -321,10 +322,10 @@ class GetEventsTest(ZulipTestCase):
         self.assertEqual(len(recipient_events), 2)
         self.assertEqual(recipient_events[0]["type"], "message")
         self.assertEqual(recipient_events[0]["message"]["sender_email"], email)
-        self.assertTrue("local_message_id" not in recipient_events[0])
+        self.assertTrue("client_message_id" not in recipient_events[0])
         self.assertEqual(recipient_events[1]["type"], "message")
         self.assertEqual(recipient_events[1]["message"]["sender_email"], email)
-        self.assertTrue("local_message_id" not in recipient_events[1])
+        self.assertTrue("client_message_id" not in recipient_events[1])
 
     def test_get_events_narrow(self):
         # type: () -> None

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -356,7 +356,7 @@ class TornadoTestCase(WebSocketBaseTestCase):
                 "queue_id": queue_events_data['response']['queue_id'],
                 "to": ujson.dumps([self.example_email('othello')]),
                 "reply_to": self.example_email('hamlet'),
-                "local_id": -1
+                "client_message_id": 'id-42',
             }
         }
         user_message_str = ujson.dumps(user_message)
@@ -391,7 +391,7 @@ class TornadoTestCase(WebSocketBaseTestCase):
                 "queue_id": queue_events_data['response']['queue_id'],
                 "to": ujson.dumps(["Denmark"]),
                 "reply_to": self.example_email('hamlet'),
-                "local_id": -1
+                "client_message_id": 'id-99',
             }
         }
         user_message_str = ujson.dumps(user_message)

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -762,9 +762,9 @@ def process_message_event(event_template, users):
             user_event.update(extra_data)
 
         if is_sender:
-            local_message_id = event_template.get('local_id', None)
-            if local_message_id is not None:
-                user_event["local_message_id"] = local_message_id
+            client_message_id = event_template.get('client_message_id', None)
+            if client_message_id is not None:
+                user_event["client_message_id"] = client_message_id
 
         if not client.accepts_event(user_event):
             continue

--- a/zerver/tornado/socket.py
+++ b/zerver/tornado/socket.py
@@ -262,7 +262,7 @@ def fake_message_sender(event):
         msg_id = check_send_message(sender, client, req['type'],
                                     extract_recipients(req['to']),
                                     req['subject'], req['content'],
-                                    local_id=req.get('local_id', None),
+                                    client_message_id=req.get('client_message_id', None),
                                     sender_queue_id=req.get('queue_id', None))
         resp = {"result": "success", "msg": "", "id": msg_id}
     except JsonableError as e:

--- a/zerver/tornado/websocket_client.py
+++ b/zerver/tornado/websocket_client.py
@@ -118,7 +118,7 @@ class WebsocketClient(object):
                 "queue_id": self.events_data['queue_id'],
                 "to": ujson.dumps([private_message_recepient]),
                 "reply_to": self.user_profile.email,
-                "local_id": -1
+                "client_message_id": -1,
             }
         }
         self.ws.write_message(ujson.dumps([ujson.dumps(user_message)]))

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -923,7 +923,7 @@ def send_message_backend(request, user_profile,
                          subject_name = REQ('subject', lambda x: x.strip(), None),
                          message_content = REQ('content'),
                          realm_str = REQ('realm_str', default=None),
-                         local_id = REQ(default=None),
+                         client_message_id = REQ(default=None),
                          queue_id = REQ(default=None)):
     # type: (HttpRequest, UserProfile, Text, List[Text], bool, Optional[Text], Text, Optional[Text], Optional[Text], Optional[Text]) -> HttpResponse
     client = request.client
@@ -979,7 +979,7 @@ def send_message_backend(request, user_profile,
                              subject_name, message_content, forged=forged,
                              forged_timestamp = request.POST.get('time'),
                              forwarder_user_profile=user_profile, realm=realm,
-                             local_id=local_id, sender_queue_id=queue_id)
+                             client_message_id=client_message_id, sender_queue_id=queue_id)
     return json_success({"id": ret})
 
 def fill_edit_history_entries(message_history, message):

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -870,6 +870,7 @@ JS_SPECS = {
             'js/markdown.js',
             'js/echo.js',
             'js/socket.js',
+            'js/sent_messages.js',
             'js/compose_state.js',
             'js/compose_actions.js',
             'js/compose.js',


### PR DESCRIPTION
In order to address timeout situations better, it's useful to have some kind of state machine that addresses various complexities:

- Some messages have local_id, some don't.
- There's a race between having messages acked on the send and arriving on the event loop.
- The event loop may die.
- The server may just be down.
- The post may time out.

We already had a hidden state machine for posting send times to the server.  This PR attempts to clarify that code.

It extracts a per-message message_state object.  Ideally we can attach the timeout logic to that object, so that things like success() callbacks can query the object to see if the message has been abandoned due to a timeout.  Also, that timer could be used to trigger things like restarting the event loop and/or send us blueslip errors/warnings.

There's currently a timer inside of the success() handler for sending a message, but, as I mentioned to @timabbott on chat, that seems like a coding mistake, and it happens too late.  (You want the timer before the success callback, since the whole point of a timeout is you don't get called back.)

Splitting out the message_state object also gives us some more flexibility on how we find the state objects, and I'll try to explain that over chat.