### PR TITLE
test_subs: Remove left out occurrence class variable realm.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1363,9 +1363,9 @@ class SubscriptionAPITest(ZulipTestCase):
         other_params = {
             'announce': 'true',
         }
-        notifications_stream = get_stream(self.streams[0], self.realm)
-        self.realm.notifications_stream = notifications_stream
-        self.realm.save()
+        notifications_stream = get_stream(self.streams[0], self.test_realm)
+        self.test_realm.notifications_stream = notifications_stream
+        self.test_realm.save()
 
         # Delete the UserProfile from the cache so the realm change will be
         # picked up

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -388,10 +388,10 @@ class GetProfileTest(ZulipTestCase):
         self.assertIn("pointer", json)
 
     def test_cache_behavior(self):
+        # type: () -> None
         """Tests whether fetching a user object the normal way, with
         `get_user`, makes 1 cache query and 1 database query.
         """
-        # type: () -> None
         realm = get_realm("zulip")
         email = self.example_email("hamlet")
         with queries_captured() as queries:


### PR DESCRIPTION
This also fixes the regression introduced in 6e133cc.
@timabbott Please take a look.