### PR TITLE
bots UI: Display message for empty 'Active/Inactive bots' tab.

### DIFF
--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -17,10 +17,10 @@
             <li class="add-a-new-bot-tab"><a>{{t "Add a new bot" }}</a></li>
         </ul>
 
-        <ol class="bots_list" id="active_bots_list">
+        <ol class="bots_list required-text" id="active_bots_list" data-empty="{{t 'You do not have any active bot.' }}">
         </ol>
 
-        <ol class="bots_list" id="inactive_bots_list">
+        <ol class="bots_list required-text" id="inactive_bots_list" data-empty="{{t 'You do not have any inactive bot.' }}">
         </ol>
 
         <div id="bot_table_error" class="alert alert-error hide"></div>


### PR DESCRIPTION
Add a line of text stating that there are no active or inactive bots.

This is for better understanding of the user, as blank screen that
used to appear in case of no bots being present might seem broken
to some.

Follow up task for #5733