### PR TITLE
frontend: Change inaccurate aria-hidden assignments on buttons.

### DIFF
--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -119,7 +119,7 @@ $(function () {
 
         // if the target is not the .overlay element, search up the node tree
         // until it is found.
-        if ($target.is(".exit, .exit-sign, .overlay-content")) {
+        if ($target.is(".exit, .exit-sign, .overlay-content, .exit span")) {
             $target = $target.closest("[data-overlay]");
         } else if (!$target.is(".overlay")) {
             // not a valid click target then.

--- a/static/templates/default_language_modal.handlebars
+++ b/static/templates/default_language_modal.handlebars
@@ -1,7 +1,7 @@
 <div id="default_language_modal" class="modal hide" tabindex="-1" role="dialog"
     aria-labelledby="default_language_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
         <h3 id="default_language_modal_label">{{t "Select default language" }}</h3>
     </div>
     <div class="modal-body">
@@ -43,6 +43,6 @@
         </div>
     </div>
     <div class="modal-footer">
-        <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">{{t "Close" }}</button>
+        <button class="btn btn-primary" data-dismiss="modal">{{t "Close" }}</button>
     </div>
 </div>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -13,7 +13,7 @@
             <div id="change_email_modal" class="modal hide" tabindex="-1" role="dialog"
                 aria-labelledby="change_email_modal_label" aria-hidden="true">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
                     <h3 id="change_email_modal_label">{{t "Change email" }}</h3>
                 </div>
                 <div class="modal-body">
@@ -23,8 +23,8 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button id='change_email_button' class="btn btn-success" data-dismiss="modal" aria-hidden="true">{{t "Change" }}</button>
-                    <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">{{t "Close" }}</button>
+                    <button id='change_email_button' class="btn btn-success" data-dismiss="modal">{{t "Change" }}</button>
+                    <button class="btn btn-primary" data-dismiss="modal">{{t "Close" }}</button>
                 </div>
             </div>
         </form>
@@ -50,7 +50,7 @@
                     {{#if page_params.realm_password_auth_enabled}}
                     <div class="input-group" id="pw_change_link">
                         <label for="change_password_button" class="inline-block title">{{t "Password" }}</label>
-                        <button class="change_password_button button rounded inline-block input-size" data-dismiss="modal" aria-hidden="true">{{t "Change password" }}</button>
+                        <button class="change_password_button button rounded inline-block input-size" data-dismiss="modal">{{t "Change password" }}</button>
                     </div>
 
                     <div id="pw_change_controls">
@@ -119,7 +119,7 @@
 
         <div id="deactivate_self_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_self_modal_label" aria-hidden="true">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
                 <h3 id="deactivation_self_modal_label">{{t "Deactivate your account" }} </h3>
             </div>
             <div class="modal-body">
@@ -127,7 +127,7 @@
                 <p>{{t "Note that any bots that you maintain will be disabled." }}</p>
             </div>
             <div class="modal-footer">
-                <button class="button" data-dismiss="modal" aria-hidden="true">{{t "Cancel" }}</button>
+                <button class="button" data-dismiss="modal">{{t "Cancel" }}</button>
                 <button class="button btn-danger" id="do_deactivate_self_button">{{t "Deactivate now" }}</button>
 
             </div>

--- a/static/templates/settings/deactivation-stream-modal.handlebars
+++ b/static/templates/settings/deactivation-stream-modal.handlebars
@@ -1,13 +1,13 @@
 <div id="deactivation_stream_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_stream_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
         <h3 id="deactivation_stream_modal_label">{{t "Delete stream" }} <span class="stream_name"></span></h3>
     </div>
     <div class="modal-body">
         <p>{{t "Deleting this stream will immediately unsubscribe everyone, and the stream's content will not be recoverable." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
     </div>
     <div class="modal-footer">
-        <button class="button rounded" data-dismiss="modal" aria-hidden="true">{{t "Cancel" }}</button>
+        <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
         <button class="button rounded btn-danger" id="do_deactivate_stream_button">{{t "Yes, delete this stream" }}</button>
     </div>
 </div>

--- a/static/templates/settings/deactivation-user-modal.handlebars
+++ b/static/templates/settings/deactivation-user-modal.handlebars
@@ -1,6 +1,6 @@
 <div id="deactivation_user_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_user_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
         <h3 id="deactivation_user_modal_label">{{t "Deactivate" }} <span class="email"></span></h3>
     </div>
     <div class="modal-body">
@@ -8,7 +8,7 @@
         <p>{{t "Their password will be cleared from our systems, and any bots they maintain will be disabled." }}</p>
     </div>
     <div class="modal-footer">
-        <button class="button rounded" data-dismiss="modal" aria-hidden="true">{{t "Cancel" }}</button>
+        <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
         <button class="button rounded btn-danger" id="do_deactivate_user_button">{{t "Deactivate now" }}</button>
     </div>
 </div>

--- a/static/templates/settings/realm-domains-modal.handlebars
+++ b/static/templates/settings/realm-domains-modal.handlebars
@@ -1,6 +1,6 @@
 <div id="realm_domains_modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="realm_domains_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
         <h3 id="realm_domains_modal_label">{{t "Allowed domains" }}</h3>
     </div>
     <div class="modal-body">

--- a/static/templates/subscription_creation_form.handlebars
+++ b/static/templates/subscription_creation_form.handlebars
@@ -56,7 +56,7 @@
             </section>
         </div>
         <div class="modal-footer">
-            <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">{{t "Cancel" }}</button>
+            <button class="btn btn-default" data-dismiss="modal">{{t "Cancel" }}</button>
             <button class="btn btn-primary" type="submit">{{t "Create" }}</button>
         </div>
     </form>

--- a/static/templates/subscription_invites_warning_modal.handlebars
+++ b/static/templates/subscription_invites_warning_modal.handlebars
@@ -1,14 +1,14 @@
 <div id='invites-warning-overlay' class='overlay new-style show' style='z-index:1000;'>
     <div class="modal" id="invites-warning-modal" tabindex="-1" role="dialog" aria-labelledby="invites-warning-label" aria-hidden="true">
         <div class="modal-header">
-            <button type="button" class="close close-invites-warning-modal" aria-hidden="true">×</button>
+            <button type="button" class="close close-invites-warning-modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
             <h3 id="invites-warning-label">{{t "Large number of subscribers" }}</h3>
         </div>
         <div class="modal-body">
             <p>{{#tr this}}Are you sure you want to create stream '__stream_name__' and subscribe __count__ users to it?{{/tr}}</p>
         </div>
         <div class="modal-footer">
-            <button class="btn btn-default close-invites-warning-modal" aria-hidden="true">{{t "Go back" }}</button>
+            <button class="btn btn-default close-invites-warning-modal">{{t "Go back" }}</button>
             <button class="btn btn-warning confirm-invites-warning-modal">{{#tr this}}Yes, subscribe __count__ users!{{/tr}}</button>
         </div>
     </div>

--- a/static/templates/subscription_stream_privacy_modal.handlebars
+++ b/static/templates/subscription_stream_privacy_modal.handlebars
@@ -1,6 +1,6 @@
 <div id="stream_privacy_modal" class="modal" tabindex="-1" role="dialog" aria-labelledby="stream_privacy_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close close-privacy-modal" aria-hidden="true">×</button>
+        <button type="button" class="close close-privacy-modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
         <h3 id="stream_privacy_modal_label">{{t "Change stream privacy" }} <span class="email"></span></h3>
     </div>
     <div class="modal-body">
@@ -20,7 +20,7 @@
         {{/if}}
     </div>
     <div class="modal-footer">
-        <button class="btn btn-default close-privacy-modal" aria-hidden="true">{{t "Cancel" }}</button>
+        <button class="btn btn-default close-privacy-modal">{{t "Cancel" }}</button>
         <button class="btn{{#if is_private}} btn-primary{{else}} btn-danger{{/if}}" id="change-stream-privacy-button"
             tabindex="-1" data-stream-id="{{stream_id}}">
             {{#if is_private}}

--- a/templates/zerver/bankruptcy.html
+++ b/templates/zerver/bankruptcy.html
@@ -2,7 +2,7 @@
     aria-labelledby="bankruptcy-label" aria-hidden="true">
 
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">×</span></button>
         <h3 id="bankruptcy-label">{{ _('Welcome back') }}</h3>
     </div>
 
@@ -10,8 +10,8 @@
 
     <div class="modal-footer">
         <button id="yes-bankrupt" class="bankruptcy_button btn btn-primary"
-                aria-hidden="true">{{ _('Yes, please!') }}</button>
+                >{{ _('Yes, please!') }}</button>
         <button id="no-bankrupt" class="bankruptcy_button btn btn-default"
-                data-dismiss="modal" aria-hidden="true">{{ _("No, I'll catch up.") }}</button>
+                data-dismiss="modal">{{ _("No, I'll catch up.") }}</button>
     </div>
 </div>

--- a/templates/zerver/delete_message.html
+++ b/templates/zerver/delete_message.html
@@ -1,6 +1,6 @@
 <div id="delete_message_modal" class="modal hide fade new-style" tabindex="-1" role="dialog" aria-labelledby="delete_message_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">×</span></button>
         <h3 id="delete_message_modal_label">{{ _("Delete message") }} </h3>
     </div>
     <div class="modal-body">
@@ -10,7 +10,7 @@
         <div id="delete-message-error"></div>
     </div>
     <div class="modal-footer">
-        <button class="button rounded" data-dismiss="modal" aria-hidden="true">{{ _("Cancel") }}</button>
+        <button class="button rounded" data-dismiss="modal">{{ _("Cancel") }}</button>
         <button class="button rounded btn-danger" id="do_delete_message_button">{{ _("Yes, delete this message") }}</button>
     </div>
 </div>

--- a/templates/zerver/invite_user.html
+++ b/templates/zerver/invite_user.html
@@ -2,7 +2,7 @@
     aria-labelledby="invite-user-label" aria-hidden="true">
     <div class="overlay-content">
         <div class="modal-header">
-            <button type="button" class="exit" aria-hidden="true">×</button>
+            <button type="button" class="exit" aria-label="{{ _('Close') }}"><span aria-hidden="true">×</span></button>
             <h3 id="invite-user-label">{% trans %}Invite users to Zulip{% endtrans %}</h3>
         </div>
         <form id="invite_user_form" class="form-horizontal"
@@ -35,7 +35,7 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn btn-default exit" data-dismiss="modal" aria-hidden="true">{{ _('Cancel') }}</button>
+                <button class="btn btn-default exit" data-dismiss="modal">{{ _('Cancel') }}</button>
                 <button id="submit-invitation" class="btn btn-primary"
                 data-loading-text="{{ _('Inviting...') }}" type="submit">{{ _('Invite') }}</button>
             </div>

--- a/templates/zerver/lightbox_overlay.html
+++ b/templates/zerver/lightbox_overlay.html
@@ -4,7 +4,7 @@
             <div class="title"></div>
             <div class="user"></div>
         </div>
-        <div class="exit">x</div>
+        <div class="exit" aria-label="{{ _('Close') }}"><span aria-hidden="true">x</span></div>
         <div class="image-actions">
             <a class="button small open icon" target="_blank">
                 <span class="text">Open</span>

--- a/templates/zerver/message_history.html
+++ b/templates/zerver/message_history.html
@@ -1,7 +1,7 @@
 <div class="modal hide" id="message-edit-history" tabindex="-1" role="dialog"
     aria-labelledby="message-history-label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">×</span></button>
         <h3 id="message-history-label">{{ _('Message edit history') }}</h3>
     </div>
     <div class="modal-body">
@@ -9,6 +9,6 @@
         <div class="controls" id="message-history"></div>
     </div>
     <div class="modal-footer">
-        <button class="btn btn-default" id="message-history-cancel" data-dismiss="modal" aria-hidden="true">{{ _("Close") }}</button>
+        <button class="btn btn-default" id="message-history-cancel" data-dismiss="modal">{{ _("Close") }}</button>
     </div>
 </div>


### PR DESCRIPTION
This either removes aria-hidden=true assignments from buttons with text, or adds a span to only hide the 'x' symbol rather than the button for closing buttons.

As documented in [this answer](https://stackoverflow.com/questions/21199141/bootstrap-modal-close-button-aria-hidden-true/23987054#23987054), the correct way of dealing with 'x' being used as a cross for closing is to wrap it in a span and hide it, without hiding the actual button.
```
<button type="button" class="close" data-dismiss="modal" aria-label="Close">
<span aria-hidden="true">&times;</span>
</button>
```