### PR TITLE
documentation: Make li element clickable

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -134,6 +134,7 @@ body {
 
 .help .sidebar li a {
     color: inherit;
+    display: block;
 }
 
 .app.help .hamburger {


### PR DESCRIPTION
documentation: Make the whole 'li' element clickable of left sidebar links in /help/ page, instead of just the link part.

Fixes: #5797.