### PR TITLE
docs: Fix typos in git-guide.md.

### DIFF
--- a/docs/git-guide.md
+++ b/docs/git-guide.md
@@ -1065,7 +1065,7 @@ working on a feature or bugfix. In order for Git to merge your changes and the
 changes that have occurred on zulip/upstream since you first started your work,
 it must perform a three-way merge and create a merge commit.
 
-Merge commits aren't bad, however, Zulip don't use them. Instead Zulip uses a
+Merge commits aren't bad, however, Zulip doesn't use them. Instead Zulip uses a
 forked-repo, rebase-oriented workflow.
 
 A merge commit is usually created when you've run `git pull` or `git merge`.
@@ -1125,9 +1125,9 @@ keep any changes that are in your working directory or that you have committed,
 use `git reset --merge <commit>` instead.
 
 You can also use the relative reflog `HEAD@{1}` instead of the commit hash,
-just keep in mind this changes as you run git commands.
+just keep in mind that this changes as you run git commands.
 
-Now when I look at the git reflog, I see the tip of my branch is pointing to my
+Now when you look at the output of `git reflog`, you should see that the tip of your branch points to your
 last commit `13bea0e` before the merge:
 
 ```


### PR DESCRIPTION
Fixes minor grammatical errors as well as shifts the text to be in second person form (one sentence was in first person).

There exist similar first-person/second-person mixing in the document. Should they be updated to be consistent? Example:

> One situation in which `git rebase` will fail and require **you** to intervene is
when your change, which git will try to re-apply on top of new commits from
which ever branch you are rebasing on top of, is to code that has been changed
by those new commits.
> 
> For example, while I'm working on a file, another contributor makes a change to
that file, submits a pull request and has their code merged into master.
Usually this is not a problem, but in this case the other contributor made a
change to a part of the file I also want to change. When **I** try to bring my
branch up to date with `git fetch` and then `git rebase upstream/master`, I see
the following: