### PR TITLE
build_emoji: Update `get_success_stamp()` function.

### DIFF
--- a/tools/setup/emoji/build_emoji
+++ b/tools/setup/emoji/build_emoji
@@ -196,6 +196,14 @@ def get_success_stamp():
         with open(filename, 'rb') as reader:
             sha.update(reader.read())
 
+    # Take into account the version of `emoji-datasource` package while generating success stamp.
+    PACKAGE_FILE_PATH = os.path.join(ZULIP_PATH, 'package.json')
+    with open(PACKAGE_FILE_PATH, 'r') as fp:
+        parsed_package_file = ujson.load(fp)
+        dependency_data = parsed_package_file['dependencies']
+        emoji_datasource_version = dependency_data['emoji-datasource'].encode('utf-8')
+    sha.update(emoji_datasource_version)
+
     return os.path.join(EMOJI_CACHE_PATH, sha.hexdigest(), 'emoji', '.success-stamp')
 
 def dump_emojis(cache_path):


### PR DESCRIPTION
Updates `get_success_stamp()` function to use the `emoji-datasource`
package's version while calculating success stamp so that an emoji
cache rebuild gets triggered automatically if the version is changed.