### PR TITLE
notifications: Fix relative stream links in missed message emails.

### DIFF
--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -68,6 +68,15 @@ def bulk_create_streams(realm, stream_dict):
                     invite_only=options["invite_only"]
                 )
             )
+    # Sort streams by name before creating them so that we can have a
+    # reliable ordering of `stream_id` across different python versions.
+    # This is required for test fixtures which contain `stream_id`. Prior
+    # to python 3.3 hashes were not randomized but after a security fix
+    # hash randomization was enabled in python 3.3 which made iteration
+    # of dictionaries and sets completely unpredictable. Here the order
+    # of elements while iterating `stream_dict` will be completely random
+    # for python 3.3 and later versions.
+    streams_to_create.sort(key=lambda x: x.name)
     Stream.objects.bulk_create(streams_to_create)
 
     recipients_to_create = []  # type: List[Recipient]

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -119,6 +119,13 @@ def build_message_list(user_profile, messages):
             r"/user_avatars/(\d+)/emoji/",
             user_profile.realm.uri + r"/user_avatars/\1/emoji/", content)
 
+        # Stream links need to be converted from relative to absolute. They
+        # have href values in the form of "/#narrow/stream/...".
+        content = re.sub(
+            r"/#narrow/stream/",
+            user_profile.realm.uri + r"/#narrow/stream/",
+            content)
+
         return content
 
     def fix_plaintext_image_urls(content):

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -349,3 +349,16 @@ class TestMissedMessages(ZulipTestCase):
         body = '<img alt=":test_emoji:" height="20px" src="http://testserver/user_avatars/1/emoji/test_emoji.png" title=":test_emoji:">'
         subject = 'Othello, the Moor of Venice sent you a message'
         self._test_cases(tokens, msg_id, body, subject, send_as_user=False, verify_html_body=True)
+
+    @patch('zerver.lib.email_mirror.generate_random_token')
+    def test_stream_link_in_missed_message(self, mock_random_token):
+        # type: (MagicMock) -> None
+        tokens = self._get_tokens()
+        mock_random_token.side_effect = tokens
+
+        msg_id = self.send_message(self.example_email('othello'), self.example_email('hamlet'),
+                                   Recipient.PERSONAL,
+                                   'Come and join us in #**Verona**.')
+        body = '<a class="stream" data-stream-id="5" href="http://testserver/#narrow/stream/Verona">#Verona</a'
+        subject = 'Othello, the Moor of Venice sent you a message'
+        self._test_cases(tokens, msg_id, body, subject, send_as_user=False, verify_html_body=True)


### PR DESCRIPTION
@timabbott I saw your comment in #5321  regarding whether using `stream_narrow_url()` would be the right way to do this or not? It will not be since we only encode stream name in `stream_narrow_url()` and since here we are replacing content in rendered content which already has the encoded stream name. So not using the `stream_narrow_url()` will be the right choice here.

Replaces: #5321.
Fixes: #5310.