### PR TITLE
navbar: Add link to /stats from the gear menu.

### DIFF
--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -102,6 +102,12 @@
                       <i class="icon-vector-sitemap"></i> {{ _('API documentation') }}
                     </a>
                   </li>
+                  <li title="{{ _('Statistics') }}" role="presentation">
+                    <a href="/stats" target="_blank" role="menuitem">
+                      <i class="icon-vector-bar-chart"></i>
+                      <span>{{ _('Statistics') }}</span>
+                    </a>
+                  </li>
                   <li class="divider" role="presentation"></li>
                   {% if enable_feedback %}
                   <li title="{{ _('Feedback') }}" role="presentation">


### PR DESCRIPTION
This adds a link to the Zulip statistics UI, making it easy for users
to discover.  We'd been waiting on doing this until the visual design
of that page was satisfactory, which it is now.

Fixes #5774.