### PR TITLE
message_feed: Remove unnecessary "user-select: none".

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1961,12 +1961,6 @@ div.floating_recipient {
 #bottom_whitespace {
     display: block;
     height: 300px;
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
 }
 
 .loading_indicator_spinner {


### PR DESCRIPTION
There is a "user-select: none" (cross-browser) that was put on
the #bottom_whitespace div, but the div doesn't actually have any
content that can be selected, and it also makes it difficult to
deselect selected text because when clicked over it will save the
current selection.