### PR TITLE
tools/linter_lib: Clean unused imports told by F401.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 import os
 import re
-import sys
 import traceback
 
 from .printer import print_err, colors

--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import subprocess
-import sys
 
 from .printer import print_err, colors
 

--- a/tools/linter_lib/pyflakes.py
+++ b/tools/linter_lib/pyflakes.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import subprocess
-import sys
 
 from .printer import print_err, colors
 


### PR DESCRIPTION
The '  # NOQA' comment is added so that the unused imports check (F401)
can still be run while still having the Mypy type check.