### PR TITLE
stream_list: Use more direct code in build_stream_list.

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -86,16 +86,9 @@ set_global('topic_list', {});
         assert.equal(social_value.text(), '42');
     }());
 
-    function set_getter(elem, stub_value) {
-        elem.get = function (idx) {
-            assert.equal(idx, 0);
-            return stub_value;
-        };
-    }
-
-    set_getter($('<hr class="stream-split">'), 'split');
-    set_getter($('<devel sidebar row>'), 'devel-sidebar');
-    set_getter($('<social sidebar row>'), 'social-sidebar');
+    var split = '<hr class="stream-split">';
+    var devel_sidebar = $('<devel sidebar row>');
+    var social_sidebar = $('<social sidebar row>');
 
     var appended_elems;
     $('#stream_filters').append = function (elems) {
@@ -105,9 +98,9 @@ set_global('topic_list', {});
     stream_list.build_stream_list();
 
     var expected_elems = [
-        'split',
-        'devel-sidebar',
-        'social-sidebar',
+        split,
+        devel_sidebar,
+        social_sidebar,
     ];
 
     assert.deepEqual(appended_elems, expected_elems);
@@ -333,16 +326,18 @@ function initialize_stream_data() {
 
     stream_list.build_stream_list();
 
+    var split = '<hr class="stream-split">';
     var expected_elems = [
-        '<devel sidebar row html>',
-        '<Rome sidebar row html>',
-        '<test sidebar row html>',
-        'split',
-        '<announce sidebar row html>',
-        '<Denmark sidebar row html>',
-        'split',
-        '<cars sidebar row html>',
+        $('<devel sidebar row html>'),
+        $('<Rome sidebar row html>'),
+        $('<test sidebar row html>'),
+        split,
+        $('<announce sidebar row html>'),
+        $('<Denmark sidebar row html>'),
+        split,
+        $('<cars sidebar row html>'),
     ];
+
     assert.deepEqual(appended_elems, expected_elems);
 
     var streams = global.stream_sort.get_streams();

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -108,7 +108,7 @@ exports.build_stream_list = function () {
         var sub = stream_data.get_sub(stream);
         var sidebar_row = exports.stream_sidebar.get_row(sub.stream_id);
         sidebar_row.update_whether_active();
-        elems.push(sidebar_row.get_li().get(0));
+        elems.push(sidebar_row.get_li());
     }
 
     parent.empty();
@@ -116,13 +116,13 @@ exports.build_stream_list = function () {
     _.each(stream_groups.pinned_streams, add_sidebar_li);
 
     if (stream_groups.pinned_streams.length > 0) {
-        elems.push($('<hr class="stream-split">').get(0));
+        elems.push('<hr class="stream-split">');
     }
 
     _.each(stream_groups.normal_streams, add_sidebar_li);
 
     if (stream_groups.dormant_streams.length > 0) {
-        elems.push($('<hr class="stream-split">').get(0));
+        elems.push('<hr class="stream-split">');
     }
 
     _.each(stream_groups.dormant_streams, add_sidebar_li);


### PR DESCRIPTION
We eliminate `.get(0)` calls in buld_stream_list.

The easy case is that we stop building jQuery objects
for the splitters only to pull out the DOM immediately.

The more subtle case is that we also don't do `.get(0)` calls
to get DOM out of our individual list items.  By passing
in full jQuery objects to `append()`, we should prevent ourself
from orphaning the old objects, which may in the future have
things like tooltip logic attached to them.