### PR TITLE
Embedded bots: Fix minor errors to make embedded bots/service run.

### DIFF
--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -501,5 +501,5 @@ class EmbeddedBotWorker(QueueProcessingWorker):
         for service in services:
             self.get_bot_handler(service).handle_message(
                 message=message,
-                client=self.get_bot_api_client(user_profile),
+                bot_handler=self.get_bot_api_client(user_profile),
                 state_handler=self.get_state_handler())


### PR DESCRIPTION
Splitting bot_lib.py file into 2 files led to unnecessary
redirection of the code workflow. For an embedded bot/service to
send a reply, it was being redirected 3 times.

First, the code flow comes to "EmbeddedBotHandler" class to send
reply, then it goes to the common function in "zulip_bots/lib.py",
then it would come back to "EmbeddedBotHandler". Later on, if we
create an abstract class, from where the bot work flow would
directly hit and then from there it is classified into
EmbeddedBotHandler or ExternalBotHandler and accordingly it would
get redirected.

Now, first the bot flow goes to its handler class External or
Embedded (where we pass that this is External or Embedded bot as
parameter) and then goes to a common point and then comes back to
the same class.