### PR TITLE
markdown.js: Move markdown.js test to bugdown-data.json.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -240,8 +240,6 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
           expected: '<p>T<br>\n<span class="user-mention" data-user-id="101">@Cordelia Lear</span></p>'},
         {input: 'This is a realm filter `hello` with text after it',
          expected: '<p>This is a realm filter <code>hello</code> with text after it</p>'},
-        {input: '```quote\n# line 1\n# line 2\n```',
-         expected: '<blockquote>\n<p># line 1<br>\n# line 2</p>\n</blockquote>'},
     ];
 
     // We remove one of the unicode emoji we put as input in one of the test

--- a/zerver/fixtures/bugdown-data.json
+++ b/zerver/fixtures/bugdown-data.json
@@ -55,6 +55,12 @@
       "bugdown_matches_marked": false
     },
     {
+      "name": "fenced_quote_with_hashtag",
+      "input": "```quote\n# line 1\n# line 2\n```",
+      "expected_output": "<blockquote>\n<p># line 1<br>\n# line 2</p>\n</blockquote>",
+      "bugdown_matches_marked": true
+    },
+    {
       "name": "dangerous_block",
       "input": "xxxxxx xxxxx xxxxxxxx xxxx. x xxxx xxxxxxxxxx:\n\n```\"xxxx xxxx\\xxxxx\\xxxxxx\"```\n\nxxx xxxx xxxxx:```xx.xxxxxxx(x'^xxxx$', xx.xxxxxxxxx)```\n\nxxxxxxx'x xxxx xxxxxxxxxx ```'xxxx'```, xxxxx xxxxxxxxx xxxxx ^ xxx $ xxxxxx xxxxx xxxxxxxxxxxx xxx xxxx xx x xxxx xx xxxx xx xxx xxxxx xxxxxx?",
       "expected_output": "<p>xxxxxx xxxxx xxxxxxxx xxxx. x xxxx xxxxxxxxxx:</p>\n<p><code>\"xxxx xxxx\\xxxxx\\xxxxxx\"</code></p>\n<p>xxx xxxx xxxxx:<code>xx.xxxxxxx(x'^xxxx$', xx.xxxxxxxxx)</code></p>\n<p>xxxxxxx'x xxxx xxxxxxxxxx <code>'xxxx'</code>, xxxxx xxxxxxxxx xxxxx ^ xxx $ xxxxxx xxxxx xxxxxxxxxxxx xxx xxxx xx x xxxx xx xxxx xx xxx xxxxx xxxxxx?</p>",


### PR DESCRIPTION
There are no usermention and stream name tests in `bugdown-data.json`. So, only moving this single test from node to bugdown-data.json.