### PR TITLE
server_events_dispatch: Deduplicate realm and user_display code

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -32,6 +32,21 @@ set_global('markdown', {
     set_realm_filters: noop,
 });
 
+set_global('notifications', {
+    redraw_title: noop,
+});
+
+set_global('settings_emoji', {
+    update_custom_emoji_ui: noop,
+});
+
+set_global('settings_org', {
+    reset_realm_default_language: noop,
+    toggle_email_change_display: noop,
+    toggle_name_change_display: noop,
+    update_message_retention_days: noop,
+});
+
 // page_params is highly coupled to dispatching now
 set_global('page_params', {test_suite: false});
 var page_params = global.page_params;

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -45,6 +45,7 @@ set_global('settings_org', {
     toggle_email_change_display: noop,
     toggle_name_change_display: noop,
     update_message_retention_days: noop,
+    update_realm_description: noop,
 });
 
 // page_params is highly coupled to dispatching now

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -525,7 +525,8 @@ function test_change_allow_subdomains(change_allow_subdomains) {
     assert(email_toggled);
     assert(email_tooltip_toggled);
 
-    settings_org.update_realm_description('realm description');
+    page_params.realm_description = 'realm description';
+    settings_org.update_realm_description();
     assert.equal($('#id_realm_description').val(), 'realm description');
 
     page_params.message_retention_days = 42;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -54,7 +54,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             allow_edit_history: noop,
             create_stream_by_admins_only: noop,
             default_language: settings_org.reset_realm_default_language,
-            description: noop,
+            description: settings_org.update_realm_description,
             email_changes_disabled: settings_org.toggle_email_change_display,
             inline_image_preview: noop,
             inline_url_embed_preview: noop,
@@ -71,9 +71,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         if (event.op === 'update' && _.has(realm_settings, event.property)) {
             page_params['realm_' + event.property] = event.value;
             realm_settings[event.property]();
-            } if (event.property === 'description') {
-                settings_org.update_realm_description(event.value);
-            } else if (event.property === 'create_stream_by_admins_only') {
+            if (event.property === 'create_stream_by_admins_only') {
                 if (!page_params.is_admin) {
                     page_params.can_create_streams = (!page_params.
                                                         realm_create_stream_by_admins_only);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -65,12 +65,12 @@ exports.toggle_email_change_display = function () {
     $(".change_email_tooltip").toggle();
 };
 
-exports.update_realm_description = function (description) {
+exports.update_realm_description = function () {
     if (!meta.loaded) {
         return;
     }
 
-    $('#id_realm_description').val(description);
+    $('#id_realm_description').val(page_params.realm_description);
 };
 
 exports.update_message_retention_days = function () {


### PR DESCRIPTION
Deduplicate code updating page_params for realm settings and user display settings.

I'm wondering if this is the right direction, and if we'd want to pursue further automating the part that rerenders the UI after a setting is changed -- perhaps by standardizing the names of the functions that update the UI and calling those after a given setting is updated, or creating an object that maps setting names to the functions that should be called after page_params are updated?

Addresses issue #5696.