### PR TITLE
local echo: Simplify code related to mix notifications.

### DIFF
--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -2,7 +2,7 @@ var message_events = (function () {
 
 var exports = {};
 
-function maybe_add_narrowed_messages(messages, msg_list, messages_are_new, local_id) {
+function maybe_add_narrowed_messages(messages, msg_list, messages_are_new) {
     var ids = [];
     _.each(messages, function (elem) {
         ids.push(elem.id);
@@ -39,7 +39,6 @@ function maybe_add_narrowed_messages(messages, msg_list, messages_are_new, local
                 {messages_are_new: messages_are_new}
             );
             unread_ops.process_visible();
-            notifications.possibly_notify_new_messages_outside_viewport(new_messages, local_id);
             notifications.notify_messages_outside_current_search(elsewhere_messages);
         },
         error: function () {
@@ -48,7 +47,7 @@ function maybe_add_narrowed_messages(messages, msg_list, messages_are_new, local
                 if (msg_list === current_msg_list) {
                     // Don't actually try again if we unnarrowed
                     // while waiting
-                    maybe_add_narrowed_messages(messages, msg_list, messages_are_new, local_id);
+                    maybe_add_narrowed_messages(messages, msg_list, messages_are_new);
                 }
             }, 5000);
         }});
@@ -69,7 +68,7 @@ exports.insert_new_messages = function insert_new_messages(messages, local_id) {
             notifications.possibly_notify_new_messages_outside_viewport(messages, local_id);
         } else {
             // if we cannot apply locally, we have to wait for this callback to happen to notify
-            maybe_add_narrowed_messages(messages, message_list.narrowed, true, local_id);
+            maybe_add_narrowed_messages(messages, message_list.narrowed, true);
         }
     } else {
         notifications.possibly_notify_new_messages_outside_viewport(messages, local_id);

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -65,13 +65,15 @@ exports.insert_new_messages = function insert_new_messages(messages, local_id) {
     if (narrow_state.active()) {
         if (narrow_state.filter().can_apply_locally()) {
             message_util.add_messages(messages, message_list.narrowed, {messages_are_new: true});
-            notifications.possibly_notify_new_messages_outside_viewport(messages, local_id);
         } else {
             // if we cannot apply locally, we have to wait for this callback to happen to notify
             maybe_add_narrowed_messages(messages, message_list.narrowed, true);
         }
-    } else {
-        notifications.possibly_notify_new_messages_outside_viewport(messages, local_id);
+    }
+
+
+    if (local_id) {
+        notifications.notify_local_mixes(messages);
     }
 
     activity.process_loaded_messages(messages);

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -78,7 +78,14 @@ exports.insert_new_messages = function insert_new_messages(messages, local_id) {
 
     activity.process_loaded_messages(messages);
     message_util.do_unread_count_updates(messages);
+    exports.maybe_advance_to_recently_sent_message(messages);
+    unread_ops.process_visible();
+    notifications.received_messages(messages);
+    stream_list.update_streams_sidebar();
+    pm_list.update_private_messages();
+};
 
+exports.maybe_advance_to_recently_sent_message = function (messages) {
     if (narrow_state.narrowed_by_reply()) {
         // If you send a message when narrowed to a recipient, move the
         // pointer to it.
@@ -101,11 +108,6 @@ exports.insert_new_messages = function insert_new_messages(messages, local_id) {
             }
         }
     }
-
-    unread_ops.process_visible();
-    notifications.received_messages(messages);
-    stream_list.update_streams_sidebar();
-    pm_list.update_private_messages();
 };
 
 exports.update_messages = function update_messages(events) {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -537,11 +537,16 @@ function get_message_header(message) {
 }
 
 exports.possibly_notify_new_messages_outside_viewport = function (messages, local_id) {
+    // A warning should only be displayed when the message was sent by the user and
+    // this is the tab they sent it in.
+
+    if (local_id === undefined) {
+        return;
+    }
+
     _.each(messages, function (message) {
-        // A warning should only be displayed when the message was sent by the user and
-        // this is the tab they sent it in.
-        if (!people.is_current_user(message.sender_email) ||
-            local_id === undefined) {
+        if (!people.is_my_user_id(message.sender_id)) {
+            blueslip.warn('We did not expect messages sent by others to get here');
             return;
         }
         // queue up offscreen because of narrowed, or (secondarily) offscreen

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -536,13 +536,18 @@ function get_message_header(message) {
     return "PM with " + message.display_reply_to;
 }
 
-exports.possibly_notify_new_messages_outside_viewport = function (messages, local_id) {
-    // A warning should only be displayed when the message was sent by the user and
-    // this is the tab they sent it in.
+exports.notify_local_mixes = function (messages) {
+    /*
+        This code should only be called when we are locally echoing
+        messages.  It notifies users that their messages aren't
+        actually in the view that they composed to.
 
-    if (local_id === undefined) {
-        return;
-    }
+        This code is called after we insert messages into our
+        message list widgets.  All of the conditions here are
+        checkable locally, so we may want to execute this code
+        earlier in the codepath at some point and possibly punt
+        on local rendering.
+    */
 
     _.each(messages, function (message) {
         if (!people.is_my_user_id(message.sender_id)) {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -536,6 +536,28 @@ function get_message_header(message) {
     return "PM with " + message.display_reply_to;
 }
 
+exports.get_local_notify_mix_reason = function (message) {
+    var row = current_msg_list.get_row(message.id);
+    if (row.length > 0) {
+        // If our message is in the current message list, we do
+        // not have a mix, so we are happy.
+        return;
+    }
+
+    if (message.type === "stream" && muting.is_topic_muted(message.stream, message.subject)) {
+        return "Sent! Your message was sent to a topic you have muted.";
+    }
+
+    if (message.type === "stream" && !stream_data.in_home_view(message.stream_id)) {
+        return "Sent! Your message was sent to a stream you have muted.";
+    }
+
+    // offscreen because it is outside narrow
+    // we can only look for these on non-search (can_apply_locally) messages
+    // see also: exports.notify_messages_outside_current_search
+    return "Sent! Your message is outside your current narrow.";
+};
+
 exports.notify_local_mixes = function (messages) {
     /*
         This code should only be called when we are locally echoing
@@ -554,33 +576,19 @@ exports.notify_local_mixes = function (messages) {
             blueslip.warn('We did not expect messages sent by others to get here');
             return;
         }
-        // queue up offscreen because of narrowed, or (secondarily) offscreen
-        // because it doesn't fit in the currently visible viewport
 
-        var note;
-        var link_class;
-        var link_msg_id = message.id;
-        var link_text;
+        var reason = exports.get_local_notify_mix_reason(message);
 
-        var row = current_msg_list.get_row(message.id);
-        if (row.length === 0) {
-            if (message.type === "stream" && muting.is_topic_muted(message.stream, message.subject)) {
-                note = "Sent! Your message was sent to a topic you have muted.";
-            } else if (message.type === "stream" && !stream_data.in_home_view(message.stream_id)) {
-                note = "Sent! Your message was sent to a stream you have muted.";
-            } else {
-                // offscreen because it is outside narrow
-                // we can only look for these on non-search (can_apply_locally) messages
-                // see also: exports.notify_messages_outside_current_search
-                note = "Sent! Your message is outside your current narrow.";
-            }
-            link_class = "compose_notification_narrow_by_subject";
-            link_text = "Narrow to " + get_message_header(message);
-        } else {
-            // return with _.each is like continue for normal for loops.
+        if (!reason) {
+            // This is more than normal, just continue on.
             return;
         }
-        exports.notify_above_composebox(note, link_class, link_msg_id, link_text);
+
+        var link_msg_id = message.id;
+        var link_class = "compose_notification_narrow_by_subject";
+        var link_text = "Narrow to " + get_message_header(message);
+
+        exports.notify_above_composebox(reason, link_class, link_msg_id, link_text);
     });
 };
 


### PR DESCRIPTION
Most of the cleanup effort here is designed to avoid passing around a `local_id` parameter in a bunch of different places.

There's also some general tidying of code.