### PR TITLE
message-feed: Remove underline from external link icon.

### DIFF
--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -41,7 +41,7 @@
 
                 {{! exterior links (e.g. to a trac ticket) }}
                 {{#each subject_links}}
-                <a href="{{this}}" target="_blank">
+                <a href="{{this}}" target="_blank" class="no-underline">
                     <i class="icon-vector-external-link-sign"></i>
                 </a>
                 {{/each}}


### PR DESCRIPTION
Currently when hovering over the external link icon an underline
appears. This commit removes that underline.