### PR TITLE
Use H, not escape, to go to the Home view.

### DIFF
--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -51,7 +51,7 @@ Try using all the navigation hotkeys:
 
 Try narrowing from the message view:
 - Hotkeys
-    - use Esc to go to home
+    - use H to go to home
     - use s to narrow to a stream (select message first
       and verify in sidebar)
     - use S to narrow to the topic (and verify in sidebar)

--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -349,7 +349,7 @@ exports.un_narrow = function () {
         // close the compose box
         common.keypress(27); // Esc
     }
-    common.keypress(27); // Esc
+    casper.page.sendEvent('keypress', "H");
 };
 
 return exports;

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -149,7 +149,7 @@ function stubbing(func_name_to_stub, test_function) {
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
     assert_unmapped('abefhlmoptxyz');
-    assert_unmapped('BEFHILNOQTUWXYZ');
+    assert_unmapped('BEFILNOQTUWXYZ');
 
     // We have to skip some checks due to the way the code is
     // currently organized for mapped keys.
@@ -207,6 +207,8 @@ function stubbing(func_name_to_stub, test_function) {
 
     assert_mapping('A', 'navigate.cycle_stream');
     assert_mapping('D', 'navigate.cycle_stream');
+
+    assert_mapping('H', 'search.clear_search');
 
     assert_mapping('c', 'compose_actions.start');
     assert_mapping('C', 'compose_actions.start');

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -90,6 +90,7 @@ var keypress_mappings = {
     67: {name: 'compose_private_message', message_view_only: true}, // 'C'
     68: {name: 'stream_cycle_forward', message_view_only: true}, // 'D'
     71: {name: 'G_end', message_view_only: true}, // 'G'
+    72: {name: 'clear_search', message_view_only: true}, // 'H'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
     75: {name: 'vim_page_up', message_view_only: true}, // 'K'
     77: {name: 'toggle_mute', message_view_only: true}, // 'M'
@@ -237,8 +238,7 @@ exports.process_escape_key = function (e) {
         return true;
     }
 
-    search.clear_search();
-    return true;
+    return false;
 };
 
 // Returns true if we handled it, false if the browser should.
@@ -537,6 +537,9 @@ exports.process_hotkey = function (e, hotkey) {
 
     // Shortcuts that don't require a message
     switch (event_name) {
+        case 'clear_search':
+            search.clear_search();
+            return true;
         case 'compose': // 'c': compose
             compose_actions.start('stream', {trigger: "compose_hotkey"});
             return true;

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -115,7 +115,7 @@
           <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
         </tr>
         <tr>
-          <td class="hotkey">Esc, Ctrl + [</td>
+          <td class="hotkey">H</td>
           <td class="definition">{% trans %}Return to home view{% endtrans %}</td>
         </tr>
       </table>


### PR DESCRIPTION
The escape key has always been a dangerous choice
for going to the home view.  People tend to hit
escape aggressively as basically a no-op key, but the
behavior of going to your Home view can be very disorienting
for folks.

The key has not only led to usability problems, but it
also complicates the codepath for dealing with Escape (already
a complicated problem), and it has led to bugs in the past.

Using H will definitely be an adjustment for some users,
but we are starting to position the interleaved view as
an advanced feature, and this is a good trial of that
concept.