### PR TITLE
Move the webpack stats files to var/ and deploy root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ npm-debug.log
 *.mo
 var/*
 .vscode/
+/webpack-stats-production.json
 tools/conf.ini
 tools/custom_provision
 api/bots/john/assets/var/database.db

--- a/tools/build-release-tarball
+++ b/tools/build-release-tarball
@@ -119,7 +119,7 @@ find prod-static/serve/generated/emoji/images/emoji/ -regex '.*\.[0-9a-f]+\.png'
 
 cd "$TMPDIR"
 
-tar --append -f "$TARBALL" "$prefix/prod-static" "$prefix/build_id" "$prefix/version" "$prefix/staticfiles.json"
+tar --append -f "$TARBALL" "$prefix/prod-static" "$prefix/build_id" "$prefix/version" "$prefix/staticfiles.json" "$prefix/webpack-stats-production.json"
 
 rm -rf "$prefix"
 

--- a/tools/webpack
+++ b/tools/webpack
@@ -49,7 +49,7 @@ def run_test():
         "status": "done",
         "chunks": entries
     }
-    directory = os.path.join(STATIC_PATH, 'webpack-bundles')
+    directory = 'var'
     if not os.path.exists(directory):
         os.makedirs(directory)
     with open(os.path.join(directory, 'webpack-stats-test.json'), 'w') as outfile:

--- a/tools/webpack.dev.config.js
+++ b/tools/webpack.dev.config.js
@@ -13,7 +13,7 @@ config.entry.common.push('./static/js/debug.js');
 
 config.devtool = 'eval';
 config.output.publicPath = '/webpack/';
-config.plugins.push(new BundleTracker({filename: 'static/webpack-bundles/webpack-stats-dev.json'}));
+config.plugins.push(new BundleTracker({filename: 'var/webpack-stats-dev.json'}));
 // Hot Reload of code in development
 config.plugins.push(new webpack.HotModuleReplacementPlugin());
 // Better logging from console for hot reload

--- a/tools/webpack.production.config.js
+++ b/tools/webpack.production.config.js
@@ -3,6 +3,6 @@ var BundleTracker = require('webpack-bundle-tracker');
 
 config.devtool = 'source-map';
 config.output.filename = '[name]-[hash].js';
-config.plugins.push(new BundleTracker({filename: 'static/webpack-bundles/webpack-stats-production.json'}));
+config.plugins.push(new BundleTracker({filename: 'webpack-stats-production.json'}));
 
 module.exports = config;

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -969,12 +969,14 @@ JS_SPECS = {
 }
 
 app_srcs = JS_SPECS['app']['source_filenames']
-
-WEBPACK_STATS_FILE = 'webpack-stats-dev.json' if DEVELOPMENT else 'webpack-stats-production.json'
+if DEVELOPMENT:
+    WEBPACK_STATS_FILE = os.path.join('var', 'webpack-stats-dev.json')
+else:
+    WEBPACK_STATS_FILE = 'webpack-stats-production.json'
 WEBPACK_LOADER = {
     'DEFAULT': {
         'BUNDLE_DIR_NAME': 'webpack-bundles/',
-        'STATS_FILE': os.path.join(STATIC_ROOT, 'webpack-bundles', WEBPACK_STATS_FILE),
+        'STATS_FILE': os.path.join(DEPLOY_ROOT, WEBPACK_STATS_FILE),
     }
 }
 

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -98,8 +98,8 @@ CACHES['database'] = {
 if CASPER_TESTS:
     WEBPACK_FILE = 'webpack-stats-production.json'
 else:
-    WEBPACK_FILE = 'webpack-stats-test.json'
-WEBPACK_LOADER['DEFAULT']['STATS_FILE'] = os.path.join(STATIC_ROOT, 'webpack-bundles', WEBPACK_FILE)
+    WEBPACK_FILE = os.path.join('var', 'webpack-stats-test.json')
+WEBPACK_LOADER['DEFAULT']['STATS_FILE'] = os.path.join(DEPLOY_ROOT, WEBPACK_FILE)
 
 if CASPER_TESTS:
     # Don't auto-restart Tornado server during casper tests


### PR DESCRIPTION
static/ serves static files which get copied around per deploy. Since
the webpack stats files need a consistent name and change per deploy,
they can't live in static/