### PR TITLE
tornado: Close queue connection on reload.

### DIFF
--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -9,7 +9,6 @@ import ujson
 import random
 import time
 import threading
-import atexit
 from collections import defaultdict
 
 from zerver.lib.utils import statsd
@@ -290,12 +289,6 @@ def get_queue_client():
             queue_client = SimpleQueueClient()
 
     return queue_client
-
-def setup_tornado_rabbitmq():
-    # type: () -> None
-    # When tornado is shut down, disconnect cleanly from rabbitmq
-    if settings.USING_RABBITMQ:
-        atexit.register(lambda: queue_client.close())
 
 # We using a simple lock to prevent multiple RabbitMQ messages being
 # sent to the SimpleQueueClient at the same time; this is a workaround

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -17,8 +17,8 @@ from tornado.log import app_log
 from typing import Callable
 
 from zerver.lib.debug import interactive_debug_listen
-from zerver.lib.queue import setup_tornado_rabbitmq
-from zerver.tornado.application import create_tornado_application
+from zerver.tornado.application import create_tornado_application, \
+    setup_tornado_rabbitmq
 from zerver.tornado.event_queue import add_client_gc_hook, \
     missedmessage_hook, process_notification, setup_event_queue
 from zerver.tornado.socket import respond_send_message

--- a/zerver/tornado/application.py
+++ b/zerver/tornado/application.py
@@ -17,6 +17,7 @@ def setup_tornado_rabbitmq():
     if settings.USING_RABBITMQ:
         queue_client = get_queue_client()
         atexit.register(lambda: queue_client.close())
+        tornado.autoreload.add_reload_hook(lambda: queue_client.close())  # type: ignore # TODO: Fix missing tornado.autoreload stub
 
 def create_tornado_application():
     # type: () -> tornado.web.Application

--- a/zerver/tornado/application.py
+++ b/zerver/tornado/application.py
@@ -1,12 +1,22 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import atexit
+
 from django.conf import settings
 
 from zerver.tornado.handlers import AsyncDjangoHandler
 from zerver.tornado.socket import get_sockjs_router
+from zerver.lib.queue import get_queue_client
 
 import tornado.web
+
+def setup_tornado_rabbitmq():
+    # type: () -> None
+    # When tornado is shut down, disconnect cleanly from rabbitmq
+    if settings.USING_RABBITMQ:
+        queue_client = get_queue_client()
+        atexit.register(lambda: queue_client.close())
 
 def create_tornado_application():
     # type: () -> tornado.web.Application


### PR DESCRIPTION
Tornado reloads the app whenever there is a change in code. Due to this,
new connection is created to the client which also results in a new
channel. To avoid creating two channels for the queue in the RabbitMQ
broker we should close the old channel. Otherwise messages sent to the
queue will be distributed among these two channels in a round robin
scheme and we will end up losing one message since one of the channels
doesn't have an active consumer.

This commit closes the connection to the queue whenever Tornado reloads
the application using add_reload_hook().

Fixes #5824

@showell, @timabbott 