### PR TITLE
portico: Add initial why zulip page.

### DIFF
--- a/templates/zerver/why-zulip.html
+++ b/templates/zerver/why-zulip.html
@@ -1,0 +1,34 @@
+{% extends "zerver/portico.html" %}
+
+{% block title %}
+<title>The best group chat</title>
+{% endblock %}
+
+{% block customhead %}
+{{ super() }}
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% stylesheet 'portico' %}
+{% stylesheet 'landing-page' %}
+{{ render_bundle('landing-page') }}
+
+{% endblock %}
+
+{% block portico_content %}
+
+{% include 'zerver/landing_nav.html' %}
+
+<div class="portico-landing apps">
+    <div class="main">
+        <div class="padded-content headline">
+            <h1 class="center">{% trans %}Why Zulip?{% endtrans %}</h1>
+        </div>
+        <div class="padded-content">
+            <div class="inner-content">
+                {{ 'zerver/why-zulip.md'|render_markdown_path }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/templates/zerver/why-zulip.md
+++ b/templates/zerver/why-zulip.md
@@ -1,0 +1,35 @@
+Zulip is not just a “better Slack”, in the same way that iPods were not just
+“better CD players”. Zulip’s topic-based threading changes what is possible
+in chat. If you haven’t seen Zulip in action, log on to our developers’
+server at <https://chat.zulip.org>, or check out our short screencast
+(coming soon) on topics and threading.
+
+## Asynchronous matters
+
+Zulip’s threading model allows for long-running conversations to co-exist
+with real time chat. This allows remote team members, part-time contractors,
+internal clients, and others who aren’t going to be on your chat full-time
+to participate effectively.
+
+## Usability matters
+
+Email is clunky for real-time communication. A thread with even 100 messages
+feels cluttered and slow, whereas real-time chat conversations (on any
+platform) regularly exceed that. Typing notifications, emoji reactions,
+keyboard shortcuts, and blazingly fast clients make Zulip a daily
+pleasure. Usability is important; if people don’t like a communications
+tool, they just won't use it.
+
+## Zulip changes the way you operate
+
+The Zulip project currently has over 30 full-time engineers, working from 10
+different countries. Outside of one-on-one conversations, Zulip doesn’t have
+a single phone or video-based meeting. Zulip also has 0 internal mailing
+lists, and 0 internal email discussions.
+
+Threaded conversations mean that all stakeholders can see and respond to
+every message, just like in meetings and email. But unlike meetings, Zulip
+conversations don’t require coordinating busy schedules, or hour long
+commitments from folks that just need a 5 minute update. And unlike email, a
+lively discussion of 300 Zulip messages is just as easy to digest and
+respond to as an in-person conversation.

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -37,6 +37,7 @@ class DocPageTest(ZulipTestCase):
         self._test('/apps/', 'Appsolutely')
         self._test('/features/', 'Talk about multiple topics at once')
         self._test('/hello/', 'productive group chat')
+        self._test('/why-zulip/', 'all stakeholders can see and')
         self._test('/for/open-source/', 'for open source projects')
         self._test('/integrations/',
                    'Over 60 native integrations.',

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -151,6 +151,7 @@ i18n_urls = [
     url(r'^hello/$', TemplateView.as_view(template_name='zerver/hello.html'), name='landing-page'),
     url(r'^new-user/$', RedirectView.as_view(url='/hello', permanent=True)),
     url(r'^features/$', TemplateView.as_view(template_name='zerver/features.html')),
+    url(r'^why-zulip/$', TemplateView.as_view(template_name='zerver/why-zulip.html')),
     url(r'^for/open-source/$', TemplateView.as_view(template_name='zerver/for-open-source.html')),
     url(r'^find_my_team/$', zerver.views.registration.find_my_team, name='zerver.views.registration.find_my_team'),
     url(r'^authors/$', zerver.views.users.authors_view, name='zerver.views.users.authors_view'),


### PR DESCRIPTION
Follow-up is writing the "Read more about how we’ve made Zulip work for you" pieces, screencast of threading and topics, and possibly a page with comparisons to other products. 
