### PR TITLE
hotkeys: Fix glitch related to closing message edits.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -392,6 +392,10 @@ exports.end = function (row) {
     }
     condense.show_message_expander(row);
     row.find(".message_reactions").show();
+
+    // We have to blur out text fields, or else hotkeys.js
+    // thinks we are still editing.
+    row.find(".message_edit").blur();
 };
 
 exports.maybe_show_edit = function (row, id) {


### PR DESCRIPTION
If you use the escape key to close a message edit, we need
to blur out the text fields.  Otherwise, hotkeys.js thinks
we are still editing the text.  This bug would disable the
use of things like arrow keys until the user subsequently
focused another field.

We probably eventually want hotkeys.js to be smarter about
ignoring hidden fields that still have the focus, but there's
also no reason not to blur the fields here, and this is a more
local, less risky fix.