### PR TITLE
template_parser: Add 'with' to Django/Jinja block elements.

### DIFF
--- a/tools/lib/template_parser.py
+++ b/tools/lib/template_parser.py
@@ -289,6 +289,7 @@ def is_django_block_tag(tag):
         'blocktrans',
         'trans',
         'raw',
+        'with',
     ]
 
 def get_handlebars_tag(text, i):

--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -77,6 +77,15 @@ class ParserTest(unittest.TestCase):
             '''
         validate(text=my_html)
 
+        my_html = '''
+            {% block "content" %}
+                {% with className="class" %}
+                {% include 'foobar' %}
+                {% endwith %}
+            {% endblock %}
+            '''
+        validate(text=my_html)
+
     def test_validate_no_start_tag(self):
         # type: () -> None
         my_html = '''


### PR DESCRIPTION
Fixes #5863.