### PR TITLE
Indent topics in the left sidebar.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -203,6 +203,10 @@ li.hidden-filter {
     margin-right: 15px;
 }
 
+.topic-box {
+    padding-left: 5px;
+}
+
 .topic-name {
     display: block;
     line-height: 1.3em;


### PR DESCRIPTION
While demoing Zulip at PyCon, I learned that it is hard to
distinguish topics from streams in our left sidebar.
Indenting them by a few pixel seems to make it more clear
that topics belong to a stream.