### PR TITLE
settings: Nest PM content in desktop messages setting in Enable desktop notification setting.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -844,6 +844,21 @@ function render(template_name, args) {
         assert.equal($(html).find("#" + checkbox).is(":checked"), false);
     });
 
+    // Check if enable_desktop_notifications setting disables subsetting too.
+    var parent_elem = $('#pm_content_in_desktop_notifications_label').wrap("<div></div>");
+
+    $('#enable_desktop_notifications').prop('checked', false).triggerHandler('change');
+    $('#enable_desktop_notifications').change(function () {
+        assert(parent_elem.hasClass('control-label-disabled'));
+        assert.equal($('#pm_content_in_desktop_notifications').attr('disabled'), 'disabled');
+    });
+
+    $('#enable_desktop_notifications').prop('checked', true).triggerHandler('change');
+    $('#enable_desktop_notifications').change(function () {
+        assert(!parent_elem.hasClass('control-label-disabled'));
+        assert.equal($('#pm_content_in_desktop_notifications').attr('disabled'), undefined);
+    });
+
 }());
 
 (function sidebar_private_message_list() {

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -74,6 +74,16 @@ exports.set_up = function () {
             }
         });
     });
+
+    $("#enable_desktop_notifications").change(function () {
+        if (this.checked) {
+            $("#pm_content_in_desktop_notifications").removeAttr("disabled");
+            $("#pm_content_in_desktop_notifications_label").parent().removeClass("control-label-disabled");
+        } else {
+            $("#pm_content_in_desktop_notifications").attr("disabled", true);
+            $("#pm_content_in_desktop_notifications_label").parent().addClass("control-label-disabled");
+        }
+    });
 };
 
 function _update_page() {

--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -60,16 +60,17 @@
                 </label>
             </div>
 
-            <div class="input-group">
+            <div class="input-group disableable {{#unless page_params.enable_desktop_notifications}}control-label-disabled{{/unless}}">
                 <label class="checkbox">
                     <input type="checkbox" name="pm_content_in_desktop_notifications"
                               id="pm_content_in_desktop_notifications"
+                           {{#unless page_params.enable_desktop_notifications}}disabled="disabled"{{/unless}}
                            {{#if page_params.pm_content_in_desktop_notifications}}
                            checked="checked"
                            {{/if}} />
                     <span></span>
                 </label>
-                <label for="pm_content_in_desktop_notifications" class="inline-block">
+                <label for="pm_content_in_desktop_notifications" id="pm_content_in_desktop_notifications_label" class="inline-block">
                     {{t "Include content of private messages in desktop notifications" }}
                 </label>
             </div>


### PR DESCRIPTION
As a fix to #5781, this PR moves the "Include content of private messages in desktop notifications" setting to be a subset of the "Desktop notifications" setting under the **Private messages and @-mentions** section. The subsetting is now automatically disabled (frontend, visually) when the "Desktop notifications" setting is disabled.

![screenshot at jul 20 22-20-05](https://user-images.githubusercontent.com/15116870/28450056-a4699b7a-6d99-11e7-8c16-e76c40a991d8.png)
