### PR TITLE
Fix focus issues on login and registration pages.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -224,6 +224,10 @@ html {
     margin-top: 20px;
 }
 
+.new-style button:focus {
+    outline: 3px solid hsl(213, 81%, 79%);
+}
+
 .new-style button.full-width {
     width: 100%;
 }

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -74,20 +74,17 @@ $(function () {
 
                         {% if google_auth_enabled %}
                         <div class="register-google">
-                            <a href="{{ url('zerver.views.auth.start_google_oauth2') }}">
+                            <form class="form-inline" action="{{ url('zerver.views.auth.start_google_oauth2') }}" method="get">
                                 <button class="login-google-button full-width">{{ _('Sign up with Google') }}</button>
-                            </a>
+                            </form>
                         </div>
                         {% endif %}
 
                         {% if github_auth_enabled %}
                         <div class="login-github">
-                            <a href="{{ url('signup-social', args=('github',)) }}"
-                                class="github-wrapper">
-                                <button class="login-github-button github">
-                                    <span>{{ _('Sign up with GitHub') }}</span>
-                                </button>
-                            </a>
+                            <form class="form-inline github-wrapper" action="{{ url('signup-social', args=('github',)) }}" method="get">
+                                <button class="login-github-button github">{{ _('Sign up with GitHub') }}</button>
+                            </form>
                         </div>
                         {% endif %}
                     {% endif %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -119,19 +119,17 @@ common.autofocus('#id_username');
 
                 {% if google_auth_enabled %}
                 <div class="login-google">
-                    <a href="{{ url('zerver.views.auth.start_google_oauth2') }}">
-                        <button class="login-google-button">{{ _('Sign in with Google') }}</button>
-                    </a>
+                    <form class="form-inline" action="{{ url('zerver.views.auth.start_google_oauth2') }}" method="get">
+                        <button class="login-google-button full-width">{{ _('Sign in with Google') }}</button>
+                    </form>
                 </div>
                 {% endif %}
 
                 {% if github_auth_enabled %}
-                <div class="login-github">
-                    <a href="{{ url('login-social', args=('github',)) }}" class="github-wrapper">
-                        <button class="login-github-button github">
-                            <span>{{ _('Sign in with GitHub') }}</span>
-                        </button>
-                    </a>
+                 <div class="login-github">
+                    <form class="form-inline github-wrapper" action="{{ url('login-social', args=('github',)) }}" method="get">
+                        <button class="login-github-button github">{{ _('Sign in with GitHub') }}</button>
+                    </form>
                 </div>
                 {% endif %}
 


### PR DESCRIPTION
Fixes #4894.
* This is what the focus on the sign up/sign in button looks like:

![image](https://user-images.githubusercontent.com/13666710/28466098-20356534-6e23-11e7-821e-54a64899fc7f.png)

* Those buttons were contained in an anchor element. This [isn't valid HTML5](https://stackoverflow.com/questions/6393827/can-i-nest-a-button-element-inside-an-a-using-html5) and causes the buttons to be focused on twice when using tab-based navigation. Replacing the anchor with a form element fixes this issue.