### PR TITLE
Clarify GitHub/Google auth for dev env.

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -108,6 +108,47 @@ maximize convenience of testing all of Zulip's features; they should
 be enabled by default in production if we expect most Zulip sites to
 want those settings.
 
+#### Testing Google & GitHub authentication
+
+In order to set up Google or GitHub authentication in the development
+environment, you'll have to go through the steps detailed in
+`prod_settings_template.py` with some changes. Here is the full
+procedure:
+
+##### Google
+
+* Visit https://console.developers.google.com, click on Credentials on
+the left sidebar and create a Oauth2 client ID that allows redirects
+to `https://localhost:9991/accounts/login/google/done/`.
+
+* Go to the Library (left sidebar), then under "Social APIs" click on
+"Google+ API" and click the button to enable the API.
+
+* Uncomment `'zproject.backends.GoogleMobileOauth2Backend'` in
+`AUTHENTICATION_BACKENDS` in `dev_settings.py`.
+
+* Uncomment `GOOGLE_OAUTH2_CLIENT_ID` in `prod_settings_template.py` &
+assign it the Client ID you got from Google.
+
+* Put the Client Secret you got from Google as
+`google_oauth2_client_secret` in `dev-secrets.conf`.
+
+##### GitHub
+
+* Register an OAuth2 application with GitHub at one of
+https://github.com/settings/developers or
+https://github.com/organizations/ORGNAME/settings/developers.
+Specify `http://localhost:9991/complete/github/` as the callback URL.
+
+* Uncomment `'zproject.backends.GitHubAuthBackend'` in
+`AUTHENTICATION_BACKENDS` in `dev_settings.py`.
+
+* Uncomment `SOCIAL_AUTH_GITHUB_KEY` in `prod_settings_template.py` &
+assign it the Client ID you got from GitHub.
+
+* Put the Client Secret you got from GitHub as
+`social_auth_github_secret` in `dev-secrets.conf`.
+
 #### Testing non-default settings
 
 You can write tests for settings using e.g. `with

--- a/templates/zerver/dev_tools.html
+++ b/templates/zerver/dev_tools.html
@@ -59,6 +59,7 @@
             </tr>
         </tbody>
     </table>
+    <p>You can find docs on testing Google &amp; GitHub authentication over <a href="http://zulip.readthedocs.io/en/latest/settings.html#testing-google-github-authentication">here</a>.</p>
 </div>
 
 {% endblock %}

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -118,6 +118,25 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from scripts.lib.zulip_tools import WARNING, ENDC
 from django.conf import settings
 
+if 'zproject.backends.GoogleMobileOauth2Backend' in settings.AUTHENTICATION_BACKENDS:
+    if not (settings.GOOGLE_OAUTH2_CLIENT_ID and
+            settings.GOOGLE_OAUTH2_CLIENT_SECRET):
+        print('\n'.join([
+            WARNING,
+            "You are using the Google auth backend. Please make sure of the following:",
+            "- You have updated GOOGLE_OAUTH2_CLIENT_ID and"
+            " GOOGLE_OAUTH2_CLIENT_SECRET settings.",
+            "- You have setup an Oauth2 client ID that allows redirects, ",
+            "  e.g. https://zulip.example.com/accounts/login/google/done/.",
+            "- You have enabled the Google+ API.",
+            "  You can create OAuth2 apps from",
+            "  https://console.developers.google.com.",
+            "  -----",
+            "  http://zulip.readthedocs.io/en/latest/settings.html#testing-google-github-authentication ",
+            "  for more information on how to set up.",
+            ENDC]))
+        sys.exit(1)
+
 if 'zproject.backends.GitHubAuthBackend' in settings.AUTHENTICATION_BACKENDS:
     if not (settings.SOCIAL_AUTH_GITHUB_KEY and
             settings.SOCIAL_AUTH_GITHUB_SECRET):
@@ -130,6 +149,9 @@ if 'zproject.backends.GitHubAuthBackend' in settings.AUTHENTICATION_BACKENDS:
             "  as the callback URL in the OAuth application in GitHub.",
             "  You can create OAuth apps from ",
             "  https://github.com/settings/developers.",
+            "  -----",
+            "  http://zulip.readthedocs.io/en/latest/settings.html#testing-google-github-authentication ",
+            "  for more information on how to set up.",
             ENDC]))
         sys.exit(1)
 

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -101,12 +101,11 @@ AUTHENTICATION_BACKENDS = (
 
 # To enable Google authentication, you need to do the following:
 #
-# (1) Visit https://console.developers.google.com, setup an
-# Oauth2 client ID that allows redirects to
+# (1) Visit https://console.developers.google.com, click on Credentials on
+# the left sidebar and create a Oauth2 client ID
 # e.g. https://zulip.example.com/accounts/login/google/done/.
 #
-# (2) Then click into the APIs and Auth section (in the sidebar on the
-# left side of the page), APIs, then under "Social APIs" click on
+# (2) Go to the Library (left sidebar), then under "Social APIs" click on
 # "Google+ API" and click the button to enable the API.
 #
 # (3) put your client secret as "google_oauth2_client_secret" in
@@ -117,8 +116,8 @@ AUTHENTICATION_BACKENDS = (
 # To enable GitHub authentication, you will need to need to do the following:
 #
 # (1) Register an OAuth2 application with GitHub at one of:
-#   https://github.com/settings/applications
-#   https://github.com/organizations/ORGNAME/settings/applications
+#   https://github.com/settings/developers
+#   https://github.com/organizations/ORGNAME/settings/developers
 # Specify e.g. https://zulip.example.com/complete/github/ as the callback URL.
 #
 # (2) Put your "Client ID" as SOCIAL_AUTH_GITHUB_KEY below and your


### PR DESCRIPTION
To-do:
- [x] fix test for google auth (second commit)
- [x] update comments in `prod_settings_template.py` to be clearer & in line with the latest github/google interfaces.
- [x] Port into [readthedocs](http://zulip.readthedocs.io/en/latest/settings.html)?