### PR TITLE
Updated click_handlers.js, fix text format bug

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -601,7 +601,7 @@ $(function () {
         // Unfocus our compose area if we click out of it. Don't let exits out
         // of overlays or selecting text (for copy+paste) trigger cancelling.
         if (compose_state.composing() && !$(e.target).is("a") &&
-            ($(e.target).closest(".modal").length === 0) &&
+            ($(e.target).closest(".overlay").length === 0) &&
             window.getSelection().toString() === "" &&
             ($(e.target).closest('.popover-content').length === 0)) {
             compose_actions.cancel();


### PR DESCRIPTION
The message doesn't get deleted automatically if we click anywhere while formatting its text style!
Fixes issue: #5886 