### PR TITLE
middleware: Use a proper error code on CSRF failure.

### DIFF
--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -192,7 +192,7 @@ function test_with_mock_ajax(test_params) {
     test_with_mock_ajax({
         xhr: {
             status: 403,
-            responseText: '{"msg": "CSRF Error: whatever"}',
+            responseText: '{"msg": "CSRF Fehler: etwas", "code": "CSRF_FAILED"}',
         },
 
         run_code: function () {

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -30,7 +30,7 @@ function call(args, idempotent) {
 
         if (xhr.status === 403) {
             try {
-                if (JSON.parse(xhr.responseText).msg.indexOf("CSRF Error:") !== -1) {
+                if (JSON.parse(xhr.responseText).code === 'CSRF_FAILED') {
                     reload.initiate({immediate: true,
                                      save_pointer: true,
                                      save_narrow: true,

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -36,6 +36,7 @@ class ErrorCode(AbstractEnum):
     BAD_NARROW = ()
     UNAUTHORIZED_PRINCIPAL = ()
     BAD_EVENT_QUEUE_ID = ()
+    CSRF_FAILED = ()
 
 class JsonableError(Exception):
     '''A standardized error format we can turn into a nice JSON HTTP response.


### PR DESCRIPTION
This allows us to reliably parse the error in code, rather than
attempt to parse the error text.  Because the error text gets
translated into the user's language, this error-handling path
wasn't functioning at all for users using Zulip in any of the
seven non-English languages for which we had a translation for
this string.

Together with 709c3b50f which fixed a similar issue in a
different error-handling path, this fixes #5598.