### PR TITLE
testing: Properly exclude files for linting in Windows.

### DIFF
--- a/tools/lister.py
+++ b/tools/lister.py
@@ -66,7 +66,7 @@ def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
     # sys.argv as str, so that battle is already lost.  Settle for hoping
     # everything is UTF-8.
     repository_root = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).strip().decode('utf-8')
-    exclude_abspaths = [os.path.join(repository_root, fpath).rstrip('/') for fpath in exclude]
+    exclude_abspaths = [os.path.normpath(os.path.join(repository_root, fpath)) for fpath in exclude]
 
     cmdline = ['git', 'ls-files'] + targets
     if modified_only:


### PR DESCRIPTION
For files to be excluded in Windows, their paths have to
be normalized, so that the string matching works.