### PR TITLE
frontend: Remove old required div & css from registration pages.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -299,32 +299,6 @@ html {
     border: 2px solid hsl(0, 0%, 53%);
 }
 
-.new-style .input-box input[required] ~ .required:after {
-    /* content: "*"; */
-    position: absolute;
-    top: 25px;
-    right: 5px;
-    transform: translateY(8px);
-
-    color: hsl(0, 56%, 63%);
-    font-size: 2em;
-    font-weight: 300;
-    transition: all 0.3s ease;
-}
-
-.new-style .input-box.no-validation input[required] ~ .required:after {
-    visibility: hidden;
-}
-
-.new-style .input-box.horizontal button {
-    margin-top: 25px;
-}
-
-.new-style .input-box input[required]:valid ~ .required:after {
-    transform: translateY(0px);
-    opacity: 0;
-}
-
 .new-style .input-box label,
 .new-style .input-box input[type=text]:focus + label,
 .new-style .input-box input[type=email]:focus + label,

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -53,7 +53,6 @@ $(function () {
                                 <div class="input-box no-validate">
                                     <input type="email" id="email" class="email" name="email" value="" required />
                                     <label for="email">Email</label>
-                                    <div class="required"></div>
                                 </div>
 
                                 <button class="full-width" type="submit" name="">{{ _('Sign up') }}</button>

--- a/templates/zerver/create_realm.html
+++ b/templates/zerver/create_realm.html
@@ -25,7 +25,6 @@ $(function () {
                         <input type="text" class="email required" placeholder="{{ _("Enter your email address") }}"
                                id="email" name="email" required />
                         <label for="id_username">{{ _('Email') }}</label>
-                        <div class="required"></div>
                     </div>
 
                     <button type="submit" class="new-organization-button register-button">{{ _("Create organization") }}</button>

--- a/templates/zerver/find_my_team.html
+++ b/templates/zerver/find_my_team.html
@@ -43,7 +43,6 @@
                         <div class="inline-block relative">
                             <input type="text" autofocus id="emails" name="emails" required />
                             <label for="id_username">{{ _('Email addresses') }}</label>
-                            <div class="required"></div>
                         </div>
                         <button type="submit">{{ _('Find team') }}</button>
                     </div>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -77,13 +77,11 @@ common.autofocus('#id_username');
                             {% if email %} value="{{ email }}" {% else %} value="" {% endif %}
                             maxlength="72" required />
                         <label for="id_username">{{ _('Email') }}</label>
-                        <div class="required"></div>
                     </div>
 
                     <div class="input-box no-validation">
                         <input id="id_password" name="password" class="required" type="password" required />
                         <label for="id_password" class="control-label">{{ _('Password') }}</label>
-                        <div class="required"></div>
                     </div>
 
                     {% if form.errors %}

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -32,7 +32,6 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                     <input type='hidden' name='timezone' id='timezone'/>
                     <input id="id_email" type='text' disabled="true" placeholder="{{ email }}" required />
                     <label for="id_email" class="inline-block label-title">{{ _('Email') }}</label>
-                    <div class="required"></div>
                 </div>
 
                 <div class="input-box">
@@ -84,7 +83,6 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                             placeholder="Acme or Aκμή"
                             value="{% if form.realm_name.value() %}{{ form.realm_name.value() }}{% endif %}"
                             name="realm_name" maxlength={{ MAX_REALM_NAME_LENGTH }} required />
-                        <div class="required"></div>
                     </div>
                     <label for="id_team_name" class="inline-block label-title">{{ _('Organization name') }}</label>
                     {% if form.realm_name.errors %}
@@ -115,7 +113,6 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                             {% if realms_have_subdomains %}
                             <p class="realm_subdomain_label">.{{ external_host }}</p>
                             {% endif %}
-                            <div class="required"></div>
                             <p id="id_team_subdomain_error_client" class="error help-inline text-error"></p>
                         </div>
                         {% if form.realm_subdomain.errors %}

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -21,7 +21,6 @@
                                    value="{% if form.email.value() %}{{ form.email.value() }}{% endif %}"
                                    maxlength="100" required />
                             <label for="id_email" class="">{{ _('Email') }}</label>
-                            <div class="required"></div>
                             {% if form.email.errors %}
                                 {% for error in form.email.errors %}
                                 <div class="alert alert-error">{{ error }}</div>


### PR DESCRIPTION
Fixes #4887.

Removes class="required" divs that used to contain an asterisk
for valid/invalid input, as well as their associated css.

