### PR TITLE
tests: Bring all the top-level test scripts into alignment on what to test.

### DIFF
--- a/tools/test-all
+++ b/tools/test-all
@@ -36,9 +36,14 @@ run ./tools/clean-repo
 
 # travis/static-analysis
 run ./tools/run-mypy
+# Not running check-py3 because it demands a clean Git worktree.
+# run ./tools/check-py3
 
 # travis/backend
 run ./tools/lint --pep8 $FORCEARG
+run python manage.py makemessages --locale en
+run python -W ignore tools/check-capitalization --no-generate
+run python -W ignore tools/check-frontend-i18n --no-generate
 run ./tools/test-tools
 run ./tools/test-backend $FORCEARG
 run ./tools/test-migrations
@@ -48,7 +53,8 @@ run ./tools/test-migrations
 # run ./tools/test-documentation
 run ./tools/test-help-documentation.py $FORCEARG
 run ./tools/test-api
-
+# Not running run-dev tests locally; we never have
+# run ./tools/test-run-dev
 # Not running queue worker reload tests since it's low-churn code
 # run ./tools/test-queue-worker-reload
 

--- a/tools/test-all
+++ b/tools/test-all
@@ -30,22 +30,30 @@ function run {
     fi
 }
 
+# prep
 run ./tools/check-provision $FORCEARG
 run ./tools/clean-repo
-run ./tools/test-tools
-run ./tools/lint --pep8 $FORCEARG
-run ./tools/test-migrations
-run ./tools/test-js-with-node
+
+# travis/static-analysis
 run ./tools/run-mypy
+
+# travis/backend
+run ./tools/lint --pep8 $FORCEARG
+run ./tools/test-tools
 run ./tools/test-backend $FORCEARG
-run ./tools/test-js-with-casper $FORCEARG
+run ./tools/test-migrations
 # Not running SVG optimizing since it's low-churn
 # run ./tools/optimize-svg
-# Not running queue worker reload tests since it's low-churn code
-# run ./tools/test-queue-worker-reload
 # Not running documentation tests since it takes 20s and only tests documentation
 # run ./tools/test-documentation
 run ./tools/test-help-documentation.py $FORCEARG
 run ./tools/test-api
+
+# Not running queue worker reload tests since it's low-churn code
+# run ./tools/test-queue-worker-reload
+
+# travis/frontend
+run ./tools/test-js-with-node
+run ./tools/test-js-with-casper $FORCEARG
 
 printf '\n\e[32mAll OK!\e[0m\n'

--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -13,14 +13,15 @@ set -x
 ./tools/test-tools
 ./tools/test-backend --coverage
 ./tools/test-migrations
-# test-run-dev temporarily disabled due to weird Travis CI issues.
-#./tools/test-run-dev
 ./tools/optimize-svg
 ./tools/test-documentation
 ./tools/test-help-documentation.py
 ./tools/test-api
+
+# Some test suites disabled in CI for being flaky
+#./tools/test-run-dev
+#./tools/test-queue-worker-reload
+
 python manage.py makemessages --locale en
 python -W ignore tools/check-capitalization --no-generate
 python -W ignore tools/check-frontend-i18n --no-generate
-# Some test suites disabled in CI for being flaky
-#./tools/test-queue-worker-reload

--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -1,8 +1,4 @@
 #!/bin/bash
-# This script is very similar to tools/test-all (what one runs
-# locally).  Possibly they should be merged, though it's worth noting,
-# they are intentionally different (basically some slow stuff is not
-# worth running in `test-all`).
 
 source tools/travis/activate-venv
 
@@ -10,6 +6,10 @@ set -e
 set -x
 
 ./tools/lint --pep8 # Include the slow and thus non-default pep8 linter check
+python manage.py makemessages --locale en
+python -W ignore tools/check-capitalization --no-generate
+python -W ignore tools/check-frontend-i18n --no-generate
+
 ./tools/test-tools
 ./tools/test-backend --coverage
 ./tools/test-migrations
@@ -17,11 +17,9 @@ set -x
 ./tools/test-documentation
 ./tools/test-help-documentation.py
 ./tools/test-api
+#./tools/test-run-dev  # Disabled in CI because flaky.
+#./tools/test-queue-worker-reload  # Disabled in CI because flaky.
 
-# Some test suites disabled in CI for being flaky
-#./tools/test-run-dev
-#./tools/test-queue-worker-reload
-
-python manage.py makemessages --locale en
-python -W ignore tools/check-capitalization --no-generate
-python -W ignore tools/check-frontend-i18n --no-generate
+# NB: Everything here should be in `tools/test-all`.  If there's a
+# reason not to run it there, it should be there as a comment
+# explaining why.

--- a/tools/travis/frontend
+++ b/tools/travis/frontend
@@ -7,3 +7,7 @@ set -x
 
 ./tools/test-js-with-node --coverage
 ./tools/test-js-with-casper
+
+# NB: Everything here should be in `tools/test-all`.  If there's a
+# reason not to run it there, it should be there as a comment
+# explaining why.

--- a/tools/travis/static-analysis
+++ b/tools/travis/static-analysis
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-retcode=0
+set -e
 set -x
+
+retcode=0
 ./tools/run-mypy --py2 --linecoverage-report || retcode=1
 ./tools/run-mypy --py3 || retcode=1
 set +x
-
 if [ "$retcode" == "0" ]; then
     echo "The mypy static type checker for python detected no errors!"
 else
@@ -16,5 +17,10 @@ else
     echo "on mypy, how Zulip is using mypy, and how to debug common issues."
     exit "$retcode"
 fi
+set -x
 
 tools/check-py3
+
+# NB: Everything here should be in `tools/test-all`.  If there's a
+# reason not to run it there, it should be there as a comment
+# explaining why.


### PR DESCRIPTION
Notably, this adds our checks on translated message strings to `tools/test-all`, so that they don't cause surprise failures in CI after a branch is pushed (like they did in #5877).

See commits for details.
