### PR TITLE
uploads: Only display year uploaded if previous year.

### DIFF
--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -137,16 +137,30 @@ var timerender = require('js/timerender.js');
         twenty_four_hour_time: false,
     });
 
-    // timestamp with hour > 12
+    // timestamp with hour > 12, same year
     var timestamp = 1555091573000; // 4/12/2019 5:52:53 PM (UTC+0)
-    var expected = 'Apr 12, 2019 05:52 PM';
-    var actual = timerender.absolute_time(timestamp);
+    var today = new Date(timestamp);
+    var expected = 'Apr 12 05:52 PM';
+    var actual = timerender.absolute_time(timestamp, today);
     assert.equal(expected, actual);
 
-    // timestamp with hour < 12
+    // timestamp with hour > 12, different year
+    today.setFullYear(today.getFullYear() + 1);
+    expected = 'Apr 12, 2019 05:52 PM';
+    actual = timerender.absolute_time(timestamp, today);
+    assert.equal(expected, actual);
+
+    // timestamp with hour < 12, same year
     timestamp = 1495091573000; // 5/18/2017 7:12:53 AM (UTC+0)
+    today = new Date(timestamp);
+    expected = 'May 18 07:12 AM';
+    actual = timerender.absolute_time(timestamp, today);
+    assert.equal(expected, actual);
+
+    // timestamp with hour < 12, different year
+    today.setFullYear(today.getFullYear() + 1);
     expected = 'May 18, 2017 07:12 AM';
-    actual = timerender.absolute_time(timestamp);
+    actual = timerender.absolute_time(timestamp, today);
     assert.equal(expected, actual);
 }());
 
@@ -155,16 +169,30 @@ var timerender = require('js/timerender.js');
         twenty_four_hour_time: true,
     });
 
-    // timestamp with hour > 12
-    var timestamp = 1555091573000; // 4/12/2019 17:52:53 (UTC+0)
-    var expected = 'Apr 12, 2019 17:52';
-    var actual = timerender.absolute_time(timestamp);
+    // timestamp with hour > 12, same year
+    var timestamp = 1555091573000; // 4/12/2019 5:52:53 PM (UTC+0)
+    var today = new Date(timestamp);
+    var expected = 'Apr 12 17:52';
+    var actual = timerender.absolute_time(timestamp, today);
     assert.equal(expected, actual);
 
-    // timestamp with hour < 12
+    // timestamp with hour > 12, different year
+    today.setFullYear(today.getFullYear() + 1);
+    expected = 'Apr 12, 2019 17:52';
+    actual = timerender.absolute_time(timestamp, today);
+    assert.equal(expected, actual);
+
+    // timestamp with hour < 12, same year
     timestamp = 1495091573000; // 5/18/2017 7:12:53 AM (UTC+0)
+    today = new Date(timestamp);
+    expected = 'May 18 07:12';
+    actual = timerender.absolute_time(timestamp, today);
+    assert.equal(expected, actual);
+
+    // timestamp with hour < 12, different year
+    today.setFullYear(today.getFullYear() + 1);
     expected = 'May 18, 2017 07:12';
-    actual = timerender.absolute_time(timestamp);
+    actual = timerender.absolute_time(timestamp, today);
     assert.equal(expected, actual);
 }());
 

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -235,11 +235,20 @@ exports.absolute_time = (function () {
         return str;
     };
 
-    return function (timestamp) {
+    return function (timestamp, today) {
+        if (typeof today === 'undefined') {
+             today = new Date();
+        }
         var date = new Date(timestamp);
+        var is_older_year = (today.getFullYear() - date.getFullYear()) > 0;
         var H_24 = page_params.twenty_four_hour_time;
-
-        return MONTHS[date.getMonth()] + " " + date.getDate() + ", " + date.getFullYear() + " " + fmt_time(date, H_24);
+        var str = MONTHS[date.getMonth()] + " " + date.getDate();
+        // include year if message date is from a previous year
+        if (is_older_year) {
+            str += ", " + date.getFullYear();
+        }
+        str += " " + fmt_time(date, H_24);
+        return str;
     };
 }());
 


### PR DESCRIPTION
Modified timerender.js absolute_time() to include the year
in the returned string when the supplied timestamp is in
an older year. This included adding an optional second
argument to specify the current date to facilitate unit
tests.

Fixes #5737.

Sorry for the delay.