### PR TITLE
[WIP] frontend: Replace scrollbars with perfectScrollbars.

### DIFF
--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -453,6 +453,8 @@ exports.initialize = function () {
     exports.build_user_sidebar();
     exports.update_huddles();
 
+    ui.set_up_scrollbar($("#user_presences"));
+
     // Let the server know we're here, but pass "false" for
     // want_redraw, since we just got all this info in page_params.
     focus_ping(false);

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -161,6 +161,7 @@ exports.activate = function (raw_operators, opts) {
     $("body").addClass("narrowed_view");
     $("#zfilt").addClass("focused_table");
     $("#zhome").removeClass("focused_table");
+    ui.update_scrollbar($(".app"));
 
     ui_util.change_tab_to('#home');
     message_list.narrowed = msg_list;

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -126,6 +126,7 @@ function make_stream_default(stream_name) {
 
 exports.set_up = function () {
     loading.make_indicator($('#admin_page_streams_loading_indicator'));
+    ui.set_up_scrollbar($("#admin-streams-list .progressive-table-wrapper"));
 
     // Populate streams table
     channel.get({

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -183,6 +183,7 @@ function populate_users(realm_people_data) {
 }
 
 exports.set_up = function () {
+    ui.set_up_scrollbar($("#admin-user-list .progressive-table-wrapper"));
     loading.make_indicator($('#admin_page_users_loading_indicator'));
     loading.make_indicator($('#admin_page_bots_loading_indicator'));
     loading.make_indicator($('#admin_page_deactivated_users_loading_indicator'));

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -184,6 +184,7 @@ function populate_users(realm_people_data) {
 
 exports.set_up = function () {
     ui.set_up_scrollbar($("#admin-user-list .progressive-table-wrapper"));
+    ui.set_up_scrollbar($("#admin-bot-list .progressive-table-wrapper"));
     loading.make_indicator($('#admin_page_users_loading_indicator'));
     loading.make_indicator($('#admin_page_bots_loading_indicator'));
     loading.make_indicator($('#admin_page_deactivated_users_loading_indicator'));

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -174,7 +174,9 @@ exports.new_stream_clicked = function (stream_name) {
 
     $(".stream-row.active").removeClass("active");
 
+
     $("#stream_settings_title, .subscriptions-container .settings, .nothing-selected").hide();
+    ui.set_up_scrollbar($("#stream-creation"));
     $("#stream-creation, #add_new_stream_title").show();
 
     if (stream_name !== '') {

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -156,6 +156,8 @@ $(function () {
         $(document.body).removeClass('window_blurred');
     });
 
+    ui.set_up_scrollbar($(".app"));
+
     $(document).on('message_selected.zulip', function (event) {
         if (current_msg_list !== event.msg_list) {
             return;

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -245,6 +245,8 @@ $(function () {
         ui.switchToFullWidth();
     }
 
+    ui.set_up_scrollbar($(".informational-overlays .modal-body"));
+
     // initialize other stuff
     reload.initialize();
     server_events.initialize();

--- a/static/styles/informational-overlays.css
+++ b/static/styles/informational-overlays.css
@@ -35,6 +35,7 @@
 .informational-overlays .overlay-modal .modal-body {
     height: 70vh;
     text-align: center;
+    position: relative;
 }
 
 .informational-overlays .overlay-modal .modal-header h3 {

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -16,6 +16,11 @@
     overflow: auto;
 }
 
+#user_presences {
+    position: relative;
+    height: 100%;
+}
+
 #user_presences:hover,
 #group-pms:hover {
     overflow-y: auto;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -570,7 +570,8 @@ input[type=checkbox].inline-block {
     overflow: auto;
 }
 
-#admin-user-list .progressive-table-wrapper {
+#admin-user-list .progressive-table-wrapper,
+#admin-streams-list .progressive-table-wrapper {
     position: relative;
     height: 100%;
 }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -570,6 +570,11 @@ input[type=checkbox].inline-block {
     overflow: auto;
 }
 
+#admin-user-list .progressive-table-wrapper {
+    position: relative;
+    height: 100%;
+}
+
 .bots_list {
     display: none;
     list-style-type: none;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -571,7 +571,8 @@ input[type=checkbox].inline-block {
 }
 
 #admin-user-list .progressive-table-wrapper,
-#admin-streams-list .progressive-table-wrapper {
+#admin-streams-list .progressive-table-wrapper,
+#admin-bot-list .progressive-table-wrapper {
     position: relative;
     height: 100%;
 }

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -731,6 +731,8 @@ form#add_new_subscription {
     overflow: auto;
     outline: none;
     -webkit-overflow-scrolling: touch;
+    height: 100%;
+    position: relative;
 }
 
 #subscription_overlay #stream-creation .modal-footer {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -179,6 +179,7 @@ p.n-margin {
     overflow-y: scroll;
     z-index: 99;
     -webkit-overflow-scrolling: touch;
+    position: relative;
 }
 
 .app-main,


### PR DESCRIPTION
Fixes #5216 .
* removed main scrollbar
* added scrollbar on the right
* fixed part of the "scrolling down then switching to a smaller page doesn't update the scroll position and you end up on an empty page".

to-do:
* for some reason, when switching between two sections that both have scrolling enabled, it does scroll down. it doesn't do that if you switch for eg, from a scrolled down `Org permissions` to `Custom emoji` (no scrollbar). i also tried setting the container's height to `100%` but that only removes the movement after switching tabs (see gif), still doesn't fully reset the scrollbar.
I'm wondering if this has to do with where the scrolling resetting happens.

![example](https://user-images.githubusercontent.com/13666710/28616242-f56fd8b4-71f3-11e7-8914-e44e10c439cc.gif)
