### PR TITLE
name_restrictions: Update with new competitors and portico pages

### DIFF
--- a/zerver/lib/name_restrictions.py
+++ b/zerver/lib/name_restrictions.py
@@ -19,21 +19,21 @@ def is_disposable_domain(domain):
 ZULIP_RESERVED_SUBDOMAINS = frozenset([
     # zulip terms
     'stream', 'channel', 'topic', 'thread', 'installation', 'organization', 'realm',
-    'team', 'subdomain', 'activity', 'octopus', 'acme',
+    'team', 'subdomain', 'activity', 'octopus', 'acme', 'push',
     # machines
     'zulipdev', 'localhost', 'staging', 'prod', 'production', 'testing', 'nagios', 'nginx',
     # website pages
     'server', 'client', 'features', 'integration', 'bot', 'blog', 'history', 'story',
-    'stories', 'testimonial', 'compare',
+    'stories', 'testimonial', 'compare', 'for', 'vs',
     # competitor pages
     'slack', 'mattermost', 'rocketchat', 'irc', 'twitter', 'zephyr', 'flowdock', 'spark',
-    'skype', 'microsoft',
+    'skype', 'microsoft', 'twist', 'ryver', 'matrix', 'discord', 'email', 'usenet',
     # zulip names
     'zulip', 'tulip', 'humbug',
     # platforms
     'plan9', 'electron', 'linux', 'mac', 'windows', 'cli', 'ubuntu', 'android', 'ios',
     # floss
-    'contribute', 'floss', 'foss', 'free', 'opensource', 'open', 'code',
+    'contribute', 'floss', 'foss', 'free', 'opensource', 'open', 'code', 'license',
     # intership programs
     'intern', 'outreachy', 'gsoc', 'gci', 'externship',
     # tech blogs


### PR DESCRIPTION
Since we've added the `/for/` portico pages and there are new competitors like Twist, this file probably needs updating.