### PR TITLE
/apps/: Fix failing tests.

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -2,9 +2,9 @@ import fuzzysearch from 'fuzzysearch';
 import blueslip from './../blueslip';
 
 const ELECTRON_APP_VERSION = "1.2.0-beta";
-const ELECTRON_APP_URL_LINUX = `https://github.com/zulip/zulip-electron/releases/download/v${ELECTRON_APP_VERSION}/Zulip-${ELECTRON_APP_VERSION}-x86_64.AppImage`;
-const ELECTRON_APP_URL_MAC = `https://github.com/zulip/zulip-electron/releases/download/v${ELECTRON_APP_VERSION}/Zulip-${ELECTRON_APP_VERSION}.dmg`;
-const ELECTRON_APP_URL_WINDOWS = `https://github.com/zulip/zulip-electron/releases/download/v${ELECTRON_APP_VERSION}/Zulip-Web-Setup-${ELECTRON_APP_VERSION}.exe`;
+const ELECTRON_APP_URL_LINUX = "https://github.com/zulip/zulip-electron/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + "-x86_64.AppImage";
+const ELECTRON_APP_URL_MAC = "https://github.com/zulip/zulip-electron/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + ".dmg";
+const ELECTRON_APP_URL_WINDOWS = "https://github.com/zulip/zulip-electron/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-Web-Setup-" + ELECTRON_APP_VERSION + ".exe";
 
 // this will either smooth scroll to an anchor where the `name`
 // is the same as the `scroll-to` reference, or to a px height


### PR DESCRIPTION
The ES6 backticks in /static/js/portico/landing-page.js were causing
the server to trip up. This was fixed by switching from JS string
interpolation to string concatenation (ES5).