### PR TITLE
User .on('load') instead of .load().

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -36,7 +36,7 @@ var list_of_popovers = [];
 function load_medium_avatar(user_email) {
     var sender_avatar_medium = new Image();
     sender_avatar_medium.src= "avatar/" + user_email + "/medium";
-    $(sender_avatar_medium).load(function () {
+    $(sender_avatar_medium).on("load", function () {
         $(".popover-avatar").css("background-image","url("+$(this).attr("src")+")");
     });
 }


### PR DESCRIPTION
.load is deprecated since jQuery 1.8. We are currently on jQuery 3.2.1.