### PR TITLE
Fix: Change .on => .bind.

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -371,7 +371,7 @@ var events = function () {
             $(".portico-landing").removeClass("show");
             setTimeout(function () {
                 window.location.href = $(this).attr("href");
-            }.on(this), 500);
+            }.bind(this), 500);
         }
     });
 


### PR DESCRIPTION
This changes a typo where a function was attempting to execute the
scope of the parent's "this" by using `function () {}.on()`, rather
than using the `Function.prototype.bind` built-in.

The links previously would not have worked on any of the product pages.