### PR TITLE
user-profile: Break long emails into multiple lines.

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -68,8 +68,19 @@ ul.actions_popover i {
 }
 
 .user_popover {
+    width: 240px;
     top: 100px!important;
+
     margin: -14px;
+    padding: 0;
+}
+
+.user_popover .popover-title {
+    padding: 0;
+}
+
+.user_popover .popover_info li {
+    word-wrap: break-word;
 }
 
 .popover-avatar .popover-inner {
@@ -89,14 +100,6 @@ ul.actions_popover i {
 }
 
 .message-info-popover .popover-title {
-    padding: 0;
-}
-
-.user_popover {
-    padding: 0;
-}
-
-.user_popover .popover-title {
     padding: 0;
 }
 


### PR DESCRIPTION
Before the user profile bounding box width was not set so it
would overflow the 240px and there would be grey space next to
the avatar. Now the width is always maintained and long text
is cut into multiple lines.

Fixes: #5938.