### PR TITLE
eslint: Remove `no-new` rule.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -241,7 +241,6 @@
         "no-multi-str": 2,
         "no-native-reassign": 2,
         "no-nested-ternary": 0,
-        "no-new": 2,
         "no-new-func": "error",
         "no-new-object": 2,
         "no-new-wrappers": 2,

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -16,10 +16,6 @@ var editability_types = {
 };
 exports.editability_types = editability_types;
 
-function initClipboard(elem) {
-    return new Clipboard(elem);
-}
-
 function get_editability(message, edit_limit_seconds_buffer) {
     edit_limit_seconds_buffer = edit_limit_seconds_buffer || 0;
     if (!(message && message.sent_by_me)) {
@@ -210,7 +206,7 @@ function edit_message(row, raw_content) {
     if (editability === editability_types.NO) {
         message_edit_content.prop("readonly", "readonly");
         message_edit_topic.prop("readonly", "readonly");
-        initClipboard(copy_message[0]);
+        new Clipboard(copy_message[0]);
     } else if (editability === editability_types.NO_LONGER) {
         // You can currently only reach this state in non-streams. If that
         // changes (e.g. if we stop allowing topics to be modified forever
@@ -218,12 +214,12 @@ function edit_message(row, raw_content) {
         // row.find('input.message_edit_topic') as well.
         message_edit_content.prop("readonly", "readonly");
         message_edit_countdown_timer.text(i18n.t("View source"));
-        initClipboard(copy_message[0]);
+        new Clipboard(copy_message[0]);
     } else if (editability === editability_types.TOPIC_ONLY) {
         message_edit_content.prop("readonly", "readonly");
         // Hint why you can edit the topic but not the message content
         message_edit_countdown_timer.text(i18n.t("Topic editing only"));
-        initClipboard(copy_message[0]);
+        new Clipboard(copy_message[0]);
     } else if (editability === editability_types.FULL) {
         copy_message.remove();
         var edit_id = "#message_edit_content_" + rows.id(row);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -546,10 +546,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    function initClipboard(selector) {
-        return new Clipboard(selector);
-    }
-    initClipboard('.copy_link');
+    new Clipboard('.copy_link');
 
     $('body').on('click', '.copy_link', function (e) {
         popovers.hide_actions_popover();


### PR DESCRIPTION
This removes the `no-new` rule which is relatively detrimental to
code cleanliness in our codebase because third-party libraries may
utilize data structures that don't fly well with our linting rules.

This also fixes abstractions that were created due to the limitations
and impositions of this lint rule.