### PR TITLE
/register/: Hide sign up on invite-only realms.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -60,6 +60,25 @@ html {
     font-weight: 600;
 }
 
+.register-page-container.closed-realm .right-side {
+    display: none;
+}
+
+.register-page-container.closed-realm .left-side {
+    border-right: none;
+}
+
+.register-page-container .invite-required {
+    display: none;
+}
+
+.register-page-container.closed-realm .invite-required {
+    display: block;
+
+    color: #aaa;
+    font-weight: normal;
+}
+
 .new-style .inline-block {
     text-align: left;
 }

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -15,8 +15,8 @@ $(function () {
         <div class="lead">
             <h1 class="get-started">{{ _("Sign up for Zulip") }}</h1>
         </div>
-        <div class="app-main register-page-container white-box">
-            <div class="register-form new-style">
+        <div class="app-main register-page-container white-box {% if not realm_open %}closed-realm{% endif %}">
+            <div class="register-form new-style {% if realm_open %}closed-realm{% endif %}">
                 {% if realm_name %}
                 <div class="left-side">
                     <div class="org-header">
@@ -29,8 +29,14 @@ $(function () {
                     <div class="description">
                         {{ realm_description|safe }}
                     </div>
+
+                    <div class="invite-required">
+                        <hr>
+                        <i class="fa fa-lock"></i> This organization requires invitation to join.
+                    </div>
                 </div>
                 {% endif %}
+
                 <div class="right-side">
                     {% if no_auth_enabled %}
                         <div class="alert">

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -62,16 +62,19 @@ def zulip_default_context(request):
         realm_icon = get_realm_icon_url(realm)
         realm_description_raw = realm.description or "The coolest place in the universe."
         realm_description = convert(realm_description_raw, message_realm=realm)
+        realm_open = not realm.invite_required and not realm.restricted_to_domain
     else:
         realm_uri = settings.SERVER_URI
         realm_name = None
         realm_icon = None
         realm_description = None
+        realm_open = None
 
     register_link_disabled = settings.REGISTER_LINK_DISABLED
     login_link_disabled = settings.LOGIN_LINK_DISABLED
     about_link_disabled = settings.ABOUT_LINK_DISABLED
     find_team_link_disabled = settings.FIND_TEAM_LINK_DISABLED
+
     if settings.SUBDOMAINS_HOMEPAGE and get_subdomain(request) == "":
         register_link_disabled = True
         login_link_disabled = True
@@ -96,6 +99,7 @@ def zulip_default_context(request):
         'external_api_uri': settings.EXTERNAL_API_URI,
         'external_host': settings.EXTERNAL_HOST,
         'external_uri_scheme': settings.EXTERNAL_URI_SCHEME,
+        'realm_open': realm_open,
         'realm_uri': realm_uri,
         'realm_name': realm_name,
         'realm_icon': realm_icon,


### PR DESCRIPTION
This hides the right-hand sign up form for realms that are
invite-only, and shows some text that states the realm is invite-only.