### PR TITLE
docs: Prod overview page, and tweaks

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@ Contents:
    :maxdepth: 2
    :caption: Zulip in production
 
+   Production overview <prod>
    prod-requirements
    Installing a production server <prod-install>
    prod-troubleshooting

--- a/docs/prod-customize.md
+++ b/docs/prod-customize.md
@@ -1,16 +1,27 @@
 # Customize Zulip
 
 Once you've got Zulip setup, you'll likely want to configure it the
-way you like.  Most configuration can be done by a realm administrator
-on the web (see
-[the documentation for realm administrators][realm-admin-docs]); this
-page discusses those additional configuration items that can be done
-by a system administrator.
+way you like.
+
+## Making changes
+
+Most configuration can be done by a realm administrator, on the web.
+For those settings, see [the documentation for realm
+administrators][realm-admin-docs].
 
 [realm-admin-docs]: https://zulipchat.com/help/getting-your-organization-started-with-zulip
 
+This page discusses additional configuration that a system
+administrator can do.  To change any of the following settings, edit
+the `/etc/zulip/settings.py` file on your Zulip server, and then
+restart the server with the following command:
+```
+su zulip -c /home/zulip/deployments/current/scripts/restart-server
+```
 
-## Authentication Backends
+## Specific settings
+
+### Authentication Backends
 
 `AUTHENTICATION_BACKENDS` is a list of enabled authentication mechanisms. By
 default the email backend is enabled.
@@ -21,7 +32,7 @@ that backend as documented in the `settings.py` file. See
 the [section on Authentication](prod-authentication-methods.html) for more detail on the available
 authentication backends and how to configure them.
 
-## Mobile and desktop apps
+### Mobile and desktop apps
 
 The Zulip apps expect to be talking to to servers with a properly
 signed SSL certificate, in most cases and will not accept a
@@ -43,7 +54,7 @@ By the end of summer 2017, all of the Zulip apps will have full
 support for multiple accounts, potentially on different Zulip servers,
 with a convenient UI for switching between them.
 
-## Terms of service and Privacy policy
+### Terms of service and Privacy policy
 
 Zulip allows you to configure your server's Terms of Service and
 Privacy Policy pages (`/terms` and `/privacy`, respectively).  You can
@@ -53,7 +64,7 @@ support for included HTML).  A good approach is to use paths like
 `/etc/zulip/terms.md`, so that it's easy to back up your policy
 configuration along with your other Zulip server configuration.
 
-## Miscellaneous server settings
+### Miscellaneous server settings
 
 Zulip has dozens of settings documented in the comments in
 `/etc/zulip/settings.py`; you can review

--- a/docs/prod-requirements.md
+++ b/docs/prod-requirements.md
@@ -66,15 +66,16 @@ Zulip in production. 64-bit is recommended.
 You should already have a domain name available for your Zulip
 production instance. In order to generate valid SSL certificates with Let's
 Encrypt, and to enable other services such as Google Authentication, you'll
-need to update the domains A record to point to your production server.
+need to update the domain's A record to point to your production server.
 
 ## Credentials needed
 
 #### SSL Certificate
 
-* SSL Certificate for the host you're putting this on (e.g. zulip.example.com).
-  The installation instructions contain documentation for how to get an SSL
-  certificate for free using [LetsEncrypt](https://letsencrypt.org/).
+* An SSL certificate for the host you're putting this on (e.g.,
+  zulip.example.com).  If you don't have an SSL solution already, read
+  about [getting an SSL certificate for free](ssl-certificates.html) using
+  Let's Encrypt.
 
 #### Outgoing email
 

--- a/docs/prod.md
+++ b/docs/prod.md
@@ -1,0 +1,45 @@
+# Zulip in production
+
+To play around with Zulip and see what it looks like, you can [install
+a dev
+environment](readme-symlink.html#installing-the-zulip-development-environment)
+or check out the [Zulip development community server](chat-zulip-org.html).
+
+If you like what you see, you can set up Zulip for your team by
+installing a production Zulip server.  These pages will walk you
+through how.
+
+## Requirements
+
+You'll [need a few things](prod-requirements.html) to run a production
+Zulip server.  Key requirements include:
+* a dedicated server or VM, running Ubuntu, with at least 2GB of RAM
+  (or 4GB for a large site);
+* a valid DNS name and SSL certificates;
+* a way to send outgoing email.
+
+See [the requirements page](prod-requirements.html) for more details,
+including free options [for SSL](ssl-certificates.html) and [for
+outgoing email](prod-email.html#free-outgoing-smtp) if you don't have
+those already.
+
+## Install
+
+Follow [the install instructions](prod-install.html).  You'll download
+the built release tarball, run the Zulip install script, and configure
+a handful of required settings; then create your Zulip organization
+through your new server's web interface.
+
+## Running
+
+You now have a running Zulip install!
+
+* Read [our advice on helping your community](realm-admin-docs) make
+  the most of Zulip.
+
+* [Customize Zulip](prod-customize.html) to your needs.
+
+* Read about Zulip's support for backups, monitoring, and
+  other [important production considerations](prod-maintain-secure-upgrade.html).
+
+[realm-admin-docs]: https://zulipchat.com/help/getting-your-organization-started-with-zulip

--- a/docs/ssl-certificates.md
+++ b/docs/ssl-certificates.md
@@ -42,7 +42,7 @@ renew with this command:
 
 If you aren't able to use Let's Encrypt, you can generate a
 self-signed ssl certificate.  We recommend getting a real certificate
-using LetsEncrypt over this approach because your browser (and some of
+using Let's Encrypt over this approach because your browser (and some of
 the Zulip clients) will complain when connecting to your server that
 the certificate isn't signed.
 


### PR DESCRIPTION
This gives us a page that can serve as a good drop-in replacement for https://zulip.org/server.html .
