### PR TITLE
help: Add Getting started with Zulip.

### DIFF
--- a/templates/zerver/help/getting-started-with-zulip.md
+++ b/templates/zerver/help/getting-started-with-zulip.md
@@ -1,0 +1,58 @@
+# Getting started with Zulip
+
+Welcome to Zulip! Like any new tool, mastering Zulip will take some time,
+but once you get the hang of it, you'll never want to use another chat
+service again.
+
+Zulip is designed around a few key ideas:
+
+- You spend far more time reading communications than writing them.  So
+  Zulip is primarily designed to optimize consuming messages; either reading
+  them, or making an informed decision not to read them.
+- Messages in Zulip are organized into streams and topics.  Streams are
+  similar to chatrooms, IRC channels, and email lists in that they determine
+  who receives the message.  Each conversation in a stream also has a topic,
+  which plays the role of the subject line of an email (though topics are
+  usually shorter, e.g. "logo" or "logo design", not "feedback on the new
+  logo design?") in that it organizes messages into threads.
+- Zulip keeps careful track of which messages and threads you've read, and
+  always places you exactly where you left off.
+
+## Basic workflows
+
+A few basic workflows are useful when getting oriented.
+
+### For reading
+
+- Use the left sidebar (or the `n` key) to review messages thread-by-thread.
+- Use the down arrow key (`↓`) to move the cursor to the next message.
+- Use the End key to mark all messages in the current view as read (could be
+  a thread, stream, or anything else).
+
+### For writing
+
+- When starting a new conversation, remember to start a new topic. Don't
+  overthink it; the first 2-3 words that come to your mind are probably
+  fine. Using topics may take some attention at the beginning, but after a
+  few days of using Zulip it will feel like second nature.
+- It is totally normal to have 5 conversations happening in a stream at the
+  same time; each on its own topic. So don't worry about interrupting; each
+  conversation has its own space.
+- If you see a conversation where the last message was sent a few hours (or
+  days!) ago, feel free to reply anyway. It'll be easy for everyone to see
+  your reply in context, regardless of anything else that has happened on
+  the stream in the meantime.
+
+## Next steps
+
+Once you've figured out the basics, you'll probably want to:
+
+- [Add an avatar](/#settings/your-account)
+- [Get the mobile and desktop apps](/apps)
+- [Configure your notifications](/#settings/notifications) to work the way
+  you do.
+- [Browse the streams](/#streams/all) in your organization and join those of
+  interest.
+- Master Zulip's [keyboard shortcuts](/help/keyboard-shortcuts). Anything
+  you can do with the mouse, you can do even faster from the keyboard. Start
+  with `n`, `↓`, `c`, and `Enter` (`Return`), and use `?` for help.

--- a/templates/zerver/help/index.md
+++ b/templates/zerver/help/index.md
@@ -12,3 +12,10 @@ downloaded [here](https://zulipchat.com/apps/).
 
 One Zulip account, associated with a particular company, project, or team,
 is known as an **organization**.
+
+## Getting started
+
+The following two guides are a good place to start.
+
+* [Getting started with Zulip](/help/getting-started-with-zulip)
+* [Getting your organization started with Zulip](/help/getting-your-organization-started-with-zulip)

--- a/templates/zerver/help/sidebar.md
+++ b/templates/zerver/help/sidebar.md
@@ -1,5 +1,6 @@
 ## Guides
 
+* [Getting started with Zulip](/help/getting-started-with-zulip)
 * [Getting your organization started with Zulip](/help/getting-your-organization-started-with-zulip)
 
 ## Account Basics

--- a/templates/zerver/help/sidebar.md
+++ b/templates/zerver/help/sidebar.md
@@ -1,3 +1,7 @@
+## Guides
+
+* [Getting your organization started with Zulip](/help/getting-your-organization-started-with-zulip)
+
 ## Account Basics
 * [Change your name](/help/change-your-name)
 * [Change your email address](/help/change-your-email-address)
@@ -102,10 +106,6 @@
 <!-- Connect to Zulip over IRC/etc (not implemented?) -->
 * [The Zulip browser window](/help/the-zulip-browser-window)
 * [Zulip glossary](/help/zulip-glossary)
-
-## Guides
-
-* [Getting your organization started with Zulip](/help/getting-your-organization-started-with-zulip)
 
 ## Organization Settings
 

--- a/templates/zerver/help/sidebar.md
+++ b/templates/zerver/help/sidebar.md
@@ -103,7 +103,7 @@
 * [The Zulip browser window](/help/the-zulip-browser-window)
 * [Zulip glossary](/help/zulip-glossary)
 
-## Administration
+## Guides
 
 * [Getting your organization started with Zulip](/help/getting-your-organization-started-with-zulip)
 


### PR DESCRIPTION
The section on "Writing" could I'm sure be improved, but I think we can just take another pass once we have a better argument or video for topics somewhere. 

Also, can't figure out why "Guides" is not at the top of the sidebar after these changes. (It still appears halfway down the list for me)