### PR TITLE
docs: Emphasise Travis CI setup in dev env setup docs.

### DIFF
--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -584,7 +584,9 @@ Next, read the following to learn more about developing for Zulip:
 
 * [Git & GitHub Guide][rtd-git-guide]
 * [Using the Development Environment][rtd-using-dev-env]
-* [Testing][rtd-testing]
+* [Testing][rtd-testing] (and [Configuring Travis CI][travis-ci] to
+test your fork, so you don't need to create a pull request to get
+your code tested)
 
 ### Troubleshooting & Common Errors
 
@@ -1054,3 +1056,4 @@ for the IP address that means any IP address can connect to your development ser
 [git-bash]: https://git-for-windows.github.io/
 [bash-admin-setup]: https://superuser.com/questions/1002262/run-applications-as-administrator-by-default-in-windows-10
 [set-up-git]: git-guide.html#set-up-git
+[travis-ci]: git-guide.html#step-3-configure-travis-ci-continuous-integration

--- a/docs/dev-overview.md
+++ b/docs/dev-overview.md
@@ -76,7 +76,7 @@ Once you've installed the Zulip development environment, you'll want
 to read these documents to learn how to use it:
 
 * [Using the Development Environment][using-dev-env]
-* [Testing][testing]
+* [Testing][testing] (and [Configuring Travis CI][travis-ci])
 
 And if you've setup the Zulip development environment on a remote
 machine, take a look at our tips for
@@ -92,3 +92,4 @@ machine, take a look at our tips for
 [configure-proxy]: dev-env-first-time-contributors.html#specifying-a-proxy
 [using-dev-env]: using-dev-environment.html
 [testing]: testing.html
+[travis-ci]: git-guide.html#step-3-configure-travis-ci-continuous-integration

--- a/docs/git-guide.md
+++ b/docs/git-guide.md
@@ -1344,6 +1344,10 @@ $ ls -l .git/hooks
 pre-commit -> ../../tools/pre-commit
 ```
 
+### Set up Travis CI integration
+
+You might also wish to [configure your fork for use with Travis CI][self-travisci].
+
 ### Reset to pull request
 
 `tools/reset-to-pull-request` is a short-cut for [checking out a pull request


### PR DESCRIPTION
Fixes #5266. 

Felt like `Next Steps` was the best location for this, as it doesn't detract from the core content.