### PR TITLE
lightbox: Fix incorrectly displayed avatar image.

### DIFF
--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -140,14 +140,14 @@ exports.open = function (image, options) {
 
 exports.show_from_selected_message = function () {
     var $message = $(".selected_message");
-    var $image = $message.find("img");
+    var $image = $message.find(".message_content img");
 
     while ($image.length === 0) {
         $message = $message.prev();
         if ($message.length === 0) {
             break;
         }
-        $image = $message.find("img");
+        $image = $message.find(".message_content img");
     }
 
     if ($image.length !== 0) {


### PR DESCRIPTION
The lightbox "v" shortcut should not show a user's avatar,
so this limits the scope of images it can choose to ones inside
of the `.message_content` div.