### PR TITLE
clean-repo: Revert optimization to .pyc removal.

### DIFF
--- a/tools/clean-repo
+++ b/tools/clean-repo
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# Remove .pyc files without corresponding .py files
-# to prevent loading stale code.
+# Remove .pyc files to prevent loading stale code.
 #
 # You can run it automatically on checkout:
 #
@@ -10,11 +9,5 @@ set -e
 #     chmod +x .git/hooks/post-checkout
 
 cd "$(dirname "$0")/.."
+find . -name "*.pyc" -exec rm -f {} \;
 find . -name "__pycache__" -prune -exec rm -rf {} \;
-for i in $(find . -name "*.pyc"); do
-    pyfile="${i%.pyc}.py"
-    if [ ! -e "$pyfile" ]; then
-        echo "Removing "$i" because source file ("$pyfile") doesn't exist."
-        rm "$i"
-    fi
-done


### PR DESCRIPTION
Fixes #5887.  It seems there's some sort of issue in CPython where it
can get confused into thinking a `.pyc` file that's actually stale is
up to date -- perhaps when they date from the same second, say from
the middle of a rebase.

For now, rather than dig further to fix this properly and be sure of
having really done so, just go back to wiping out all `.pyc` files.
The impact is about 1s; that's noticeable when running a short test
file on a quad-core machine (about 8s), but not so much on a more
typical dev machine or on a larger set of tests.