### PR TITLE
alert_words: Don't muck up rendered HTML content while munging.

### DIFF
--- a/frontend_tests/node_tests/alert_words.js
+++ b/frontend_tests/node_tests/alert_words.js
@@ -3,7 +3,7 @@ add_dependencies({
 });
 
 set_global('page_params', {
-    alert_words: ['alertone', 'alerttwo', 'alertthree', 'al*rt.*s', '.+'],
+    alert_words: ['alertone', 'alerttwo', 'alertthree', 'al*rt.*s', '.+', 'emoji'],
 });
 
 set_global('feature_flags', {
@@ -41,7 +41,9 @@ var question_word_message = { sender_email: 'another@zulip.com', content: '<p>st
 
 var alert_domain_message = { sender_email: 'another@zulip.com', content: '<p>now with link <a href="http://www.alerttwo.us/foo/bar" target="_blank" title="http://www.alerttwo.us/foo/bar">www.alerttwo.us/foo/bar</a></p>',
                      alerted: true };
-
+// This test ensure we are not mucking up rendered HTML content.
+var message_with_emoji = { sender_email: 'another@zulip.com', content: '<p>I <img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/unicode/2764.png" title="heart"> emoji!</p>',
+                           alerted: true };
 
 (function test_notifications() {
     assert(!alert_words.notifies(regular_message));
@@ -52,6 +54,7 @@ var alert_domain_message = { sender_email: 'another@zulip.com', content: '<p>now
     assert(alert_words.notifies(multialert_message));
     assert(alert_words.notifies(unsafe_word_message));
     assert(alert_words.notifies(alert_domain_message));
+    assert(alert_words.notifies(message_with_emoji));
 }());
 
 (function test_munging() {
@@ -82,4 +85,7 @@ var alert_domain_message = { sender_email: 'another@zulip.com', content: '<p>now
 
     alert_words.process_message(alert_domain_message);
     assert.equal(alert_domain_message.content, '<p>now with link <a href="http://www.alerttwo.us/foo/bar" target="_blank" title="http://www.alerttwo.us/foo/bar">www.<span class=\'alert-word\'>alerttwo</span>.us/foo/bar</a></p>');
+
+    alert_words.process_message(message_with_emoji);
+    assert.equal(message_with_emoji.content, '<p>I <img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/unicode/2764.png" title="heart"> <span class=\'alert-word\'>emoji</span>!</p>');
 }());


### PR DESCRIPTION
Prior to this we were also performing highlighting inside HTML tags
which was wrong and causing weird behavior. Like, for example, if
someone added `emoji` as an alert word then any message containing
both emoji and alert word was rendered with a jumbo emoji.

Fixes: #4357.