### PR TITLE
settings: Add a USE_ERROR_FILES setting.

### DIFF
--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -162,6 +162,12 @@ FEEDBACK_EMAIL = ZULIP_ADMINISTRATOR
 # Controls whether or not error reports (tracebacks) are emailed to the
 # server administrators.
 #ERROR_REPORTING = True
+
+# Controls whether errors get reported to files.  For some configurations
+# the console already gets redirected to container logging mechanisms,
+# and files become a nuisance if you don't rotate them.
+#USE_ERROR_FILES = True
+
 # For frontend (JavaScript) tracebacks
 #BROWSER_ERROR_REPORTING = False
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -128,6 +128,7 @@ DEFAULT_SETTINGS = {'TWITTER_CONSUMER_KEY': '',
                     'MAX_ICON_FILE_SIZE': 5,
                     'MAX_EMOJI_FILE_SIZE': 5,
                     'ERROR_REPORTING': True,
+                    'USE_ERROR_FILES': True,
                     'BROWSER_ERROR_REPORTING': False,
                     'STAGING_ERROR_NOTIFICATIONS': False,
                     'EVENT_LOGS_ENABLED': False,
@@ -1034,7 +1035,8 @@ LOGGING_NOT_DISABLED = True
 
 DEFAULT_ZULIP_HANDLERS = (
     (['zulip_admins'] if ERROR_REPORTING else []) +
-    ['console', 'file', 'errors_file']
+    ['console', 'file'] +
+    (['errors_file'] if USE_ERROR_FILES else [])
 )
 
 LOGGING = {


### PR DESCRIPTION
We got feedback that some admins redirect their consoles to
container logging mechanisms, so files are unnecessary for them.