### PR TITLE
unread: Prep client code for new server updates.

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -409,7 +409,7 @@ function initialize_stream_data() {
     stream_count.set(stream_id, 0);
     var counts = {
         stream_count: stream_count,
-        subject_count: new Dict(),
+        topic_count: new Dict(),
         mentioned_message_count: 222,
         home_unread_messages: 333,
     };
@@ -439,7 +439,7 @@ function initialize_stream_data() {
 
     var topic_count = new Dict({fold_case: true});
     topic_count.set('lunch', '555');
-    counts.subject_count.set(stream_id, topic_count);
+    counts.topic_count.set(stream_id, topic_count);
 
     stream_list.update_dom_with_unread_counts(counts);
 

--- a/frontend_tests/node_tests/topic_list.js
+++ b/frontend_tests/node_tests/topic_list.js
@@ -31,7 +31,7 @@ global.compile_template('topic_list_item');
         message_id: 400,
     });
 
-    global.unread.num_unread_for_subject = function () {
+    global.unread.num_unread_for_topic = function () {
         return 1;
     };
 

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -404,6 +404,16 @@ stream_data.get_stream_id = function () {
 }());
 
 (function test_declare_bankruptcy() {
+    var message = {
+        id: 16,
+        type: 'whatever',
+        stream_id: 1999,
+        subject: 'whatever',
+        mentioned: true,
+    };
+
+    unread.process_loaded_messages([message]);
+
     unread.declare_bankruptcy();
 
     var counts = unread.get_counts();

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -46,7 +46,7 @@ var zero_counts = {
     home_unread_messages: 0,
     mentioned_message_count: 0,
     stream_count: new Dict(),
-    subject_count: new Dict(),
+    topic_count: new Dict(),
     pm_count: new Dict(),
     unread_in_current_view: 0,
 };

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -78,7 +78,7 @@ var zero_counts = {
 (function test_changing_subjects() {
     // Summary: change the subject of a message from 'lunch'
     // to 'dinner' using update_unread_topics().
-    var count = unread.num_unread_for_subject('social', 'lunch');
+    var count = unread.num_unread_for_topic('social', 'lunch');
     assert.equal(count, 0);
 
     var stream_id = 100;
@@ -100,7 +100,7 @@ var zero_counts = {
 
     unread.process_loaded_messages([message, other_message]);
 
-    count = unread.num_unread_for_subject(stream_id, 'Lunch');
+    count = unread.num_unread_for_topic(stream_id, 'Lunch');
     assert.equal(count, 2);
     assert(unread.topic_has_any_unread(stream_id, 'lunch'));
     assert(!unread.topic_has_any_unread(wrong_stream_id, 'lunch'));
@@ -111,10 +111,10 @@ var zero_counts = {
 
     unread.update_unread_topics(message, event);
 
-    count = unread.num_unread_for_subject(stream_id, 'lUnch');
+    count = unread.num_unread_for_topic(stream_id, 'lUnch');
     assert.equal(count, 1);
 
-    count = unread.num_unread_for_subject(stream_id, 'dinner');
+    count = unread.num_unread_for_topic(stream_id, 'dinner');
     assert.equal(count, 1);
 
     event = {
@@ -123,12 +123,12 @@ var zero_counts = {
 
     unread.update_unread_topics(other_message, event);
 
-    count = unread.num_unread_for_subject(stream_id, 'lunch');
+    count = unread.num_unread_for_topic(stream_id, 'lunch');
     assert.equal(count, 0);
     assert(!unread.topic_has_any_unread(stream_id, 'lunch'));
     assert(!unread.topic_has_any_unread(wrong_stream_id, 'lunch'));
 
-    count = unread.num_unread_for_subject(stream_id, 'snack');
+    count = unread.num_unread_for_topic(stream_id, 'snack');
     assert.equal(count, 1);
     assert(unread.topic_has_any_unread(stream_id, 'snack'));
     assert(!unread.topic_has_any_unread(wrong_stream_id, 'snack'));
@@ -143,12 +143,12 @@ var zero_counts = {
     // cleanup
     message.subject = 'dinner';
     unread.process_read_message(message);
-    count = unread.num_unread_for_subject(stream_id, 'dinner');
+    count = unread.num_unread_for_topic(stream_id, 'dinner');
     assert.equal(count, 0);
 
     other_message.subject = 'snack';
     unread.process_read_message(other_message);
-    count = unread.num_unread_for_subject(stream_id, 'snack');
+    count = unread.num_unread_for_topic(stream_id, 'snack');
     assert.equal(count, 0);
 }());
 
@@ -198,13 +198,13 @@ stream_data.get_stream_id = function () {
     assert.equal(unread.num_unread_for_stream(unknown_stream_id), 0);
 }());
 
-(function test_num_unread_for_subject() {
-    // Test the num_unread_for_subject() function using many
+(function test_num_unread_for_topic() {
+    // Test the num_unread_for_topic() function using many
     // messages.
     unread.declare_bankruptcy();
 
     var stream_id = 301;
-    var count = unread.num_unread_for_subject(stream_id, 'lunch');
+    var count = unread.num_unread_for_topic(stream_id, 'lunch');
     assert.equal(count, 0);
 
     var message = {
@@ -220,7 +220,7 @@ stream_data.get_stream_id = function () {
         unread.process_loaded_messages([message]);
     }
 
-    count = unread.num_unread_for_subject(stream_id, 'lunch');
+    count = unread.num_unread_for_topic(stream_id, 'lunch');
     assert.equal(count, num_msgs);
 
     for (i = 0; i < num_msgs; i += 1) {
@@ -228,7 +228,7 @@ stream_data.get_stream_id = function () {
         unread.process_read_message(message);
     }
 
-    count = unread.num_unread_for_subject(stream_id, 'lunch');
+    count = unread.num_unread_for_topic(stream_id, 'lunch');
     assert.equal(count, 0);
 }());
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -334,8 +334,8 @@ exports.update_dom_with_unread_counts = function (counts) {
         set_stream_unread_count(stream_id, count);
     });
 
-    // counts.subject_count maps streams to hashes of topics to counts
-    counts.subject_count.each(function (subject_hash, stream_id) {
+    // counts.topic_count maps streams to hashes of topics to counts
+    counts.topic_count.each(function (subject_hash, stream_id) {
         subject_hash.each(function (count, subject) {
             topic_list.set_count(stream_id, subject, count);
         });

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -65,7 +65,7 @@ exports.build_widget = function (parent_elem, my_stream_id, active_topic, max_to
 
         _.each(topic_names, function (topic_name, idx) {
             var show_topic;
-            var num_unread = unread.num_unread_for_subject(my_stream_id, topic_name);
+            var num_unread = unread.num_unread_for_topic(my_stream_id, topic_name);
 
             if (zoomed) {
                 show_topic = true;

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -270,7 +270,7 @@ exports.num_unread_for_stream = function (stream_id) {
     return exports.unread_topic_counter.get_stream_count(stream_id);
 };
 
-exports.num_unread_for_subject = function (stream_id, subject) {
+exports.num_unread_for_topic = function (stream_id, subject) {
     return exports.unread_topic_counter.get(stream_id, subject);
 };
 

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -64,7 +64,7 @@ exports.unread_topic_counter = (function () {
         var res = {};
         res.stream_unread_messages = 0;
         res.stream_count = num_dict();  // hash by stream_id -> count
-        res.subject_count = num_dict(); // hash of hashes (stream_id, then subject -> count)
+        res.topic_count = num_dict(); // hash of hashes (stream_id, then topic -> count)
         unread_topics.each(function (_, stream_id) {
 
             // We track unread counts for streams that may be currently
@@ -77,11 +77,11 @@ exports.unread_topic_counter = (function () {
             }
 
             if (unread_topics.has(stream_id)) {
-                res.subject_count.set(stream_id, str_dict());
+                res.topic_count.set(stream_id, str_dict());
                 var stream_count = 0;
                 unread_topics.get(stream_id).each(function (msgs, topic) {
                     var topic_count = msgs.num_items();
-                    res.subject_count.get(stream_id).set(topic, topic_count);
+                    res.topic_count.get(stream_id).set(topic, topic_count);
                     if (!muting.is_topic_muted(sub.name, topic)) {
                         stream_count += topic_count;
                     }
@@ -242,11 +242,11 @@ exports.get_counts = function () {
     res.mentioned_message_count = unread_mentioned.num_items();
     res.pm_count = new Dict(); // Hash by user_ids_string -> count
 
-    // This sets stream_count, subject_count, and home_unread_messages
+    // This sets stream_count, topic_count, and home_unread_messages
     var topic_res = exports.unread_topic_counter.get_counts(res);
     res.home_unread_messages = topic_res.stream_unread_messages;
     res.stream_count = topic_res.stream_count;
-    res.subject_count = topic_res.subject_count;
+    res.topic_count = topic_res.topic_count;
 
     var pm_count = 0;
     unread_privates.each(function (obj, user_ids_string) {

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -29,33 +29,33 @@ exports.unread_topic_counter = (function () {
         unread_topics = num_dict();
     };
 
-    self.update = function (stream_id, subject, new_subject, msg_id) {
+    self.update = function (stream_id, topic, new_topic, msg_id) {
         if (unread_topics.has(stream_id) &&
-            unread_topics.get(stream_id).has(subject) &&
-            unread_topics.get(stream_id).get(subject).get(msg_id)) {
-            // Move the unread subject count to the new subject
-            unread_topics.get(stream_id).get(subject).del(msg_id);
-            if (unread_topics.get(stream_id).get(subject).num_items() === 0) {
-                unread_topics.get(stream_id).del(subject);
+            unread_topics.get(stream_id).has(topic) &&
+            unread_topics.get(stream_id).get(topic).get(msg_id)) {
+            // Move the unread topic count to the new topic
+            unread_topics.get(stream_id).get(topic).del(msg_id);
+            if (unread_topics.get(stream_id).get(topic).num_items() === 0) {
+                unread_topics.get(stream_id).del(topic);
             }
-            unread_topics.get(stream_id).setdefault(new_subject, num_dict());
-            unread_topics.get(stream_id).get(new_subject).set(msg_id, true);
+            unread_topics.get(stream_id).setdefault(new_topic, num_dict());
+            unread_topics.get(stream_id).get(new_topic).set(msg_id, true);
         }
     };
 
-    self.add = function (stream_id, subject, msg_id) {
+    self.add = function (stream_id, topic, msg_id) {
         unread_topics.setdefault(stream_id, str_dict());
-        unread_topics.get(stream_id).setdefault(subject, num_dict());
-        unread_topics.get(stream_id).get(subject).set(msg_id, true);
+        unread_topics.get(stream_id).setdefault(topic, num_dict());
+        unread_topics.get(stream_id).get(topic).set(msg_id, true);
     };
 
 
-    self.del = function (stream_id, subject, msg_id) {
+    self.del = function (stream_id, topic, msg_id) {
         var stream_dict = unread_topics.get(stream_id);
         if (stream_dict) {
-            var subject_dict = stream_dict.get(subject);
-            if (subject_dict) {
-                subject_dict.del(msg_id);
+            var topic_dict = stream_dict.get(topic);
+            if (topic_dict) {
+                topic_dict.del(msg_id);
             }
         }
     };
@@ -79,11 +79,11 @@ exports.unread_topic_counter = (function () {
             if (unread_topics.has(stream_id)) {
                 res.subject_count.set(stream_id, str_dict());
                 var stream_count = 0;
-                unread_topics.get(stream_id).each(function (msgs, subject) {
-                    var subject_count = msgs.num_items();
-                    res.subject_count.get(stream_id).set(subject, subject_count);
-                    if (!muting.is_topic_muted(sub.name, subject)) {
-                        stream_count += subject_count;
+                unread_topics.get(stream_id).each(function (msgs, topic) {
+                    var topic_count = msgs.num_items();
+                    res.subject_count.get(stream_id).set(topic, topic_count);
+                    if (!muting.is_topic_muted(sub.name, topic)) {
+                        stream_count += topic_count;
                     }
                 });
                 res.stream_count.set(stream_id, stream_count);
@@ -104,9 +104,9 @@ exports.unread_topic_counter = (function () {
             return 0;
         }
 
-        unread_topics.get(stream_id).each(function (msgs, subject) {
+        unread_topics.get(stream_id).each(function (msgs, topic) {
             var sub = stream_data.get_sub_by_id(stream_id);
-            if (sub && !muting.is_topic_muted(sub.name, subject)) {
+            if (sub && !muting.is_topic_muted(sub.name, topic)) {
                 stream_count += msgs.num_items();
             }
         });
@@ -114,11 +114,11 @@ exports.unread_topic_counter = (function () {
         return stream_count;
     };
 
-    self.get = function (stream_id, subject) {
+    self.get = function (stream_id, topic) {
         var num_unread = 0;
         if (unread_topics.has(stream_id) &&
-            unread_topics.get(stream_id).has(subject)) {
-            num_unread = unread_topics.get(stream_id).get(subject).num_items();
+            unread_topics.get(stream_id).has(topic)) {
+            num_unread = unread_topics.get(stream_id).get(topic).num_items();
         }
         return num_unread;
     };

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -218,6 +218,7 @@ exports.process_read_message = function (message) {
 exports.declare_bankruptcy = function () {
     unread_privates = new Dict();
     exports.unread_topic_counter.clear();
+    unread_mentioned = new Dict();
 };
 
 exports.num_unread_current_messages = function () {

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -286,7 +286,7 @@ exports.get_counts = function () {
     res.mentioned_message_count = unread_mentioned.num_items();
 
     // This sets stream_count, topic_count, and home_unread_messages
-    var topic_res = exports.unread_topic_counter.get_counts(res);
+    var topic_res = exports.unread_topic_counter.get_counts();
     res.home_unread_messages = topic_res.stream_unread_messages;
     res.stream_count = topic_res.stream_count;
     res.topic_count = topic_res.topic_count;


### PR DESCRIPTION
This is all code cleanup on unread.js, which should make it easier to introduce server counts.  The two main things here are subject/topic renames and consolidating the PM-based code.