### PR TITLE
upgrade: Fix str/bytes type error.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -96,7 +96,7 @@ if not args.skip_migrations:
     migrations_output = subprocess.check_output(["./manage.py", "showmigrations"],
                                                 preexec_fn=su_to_zulip)
     for ln in migrations_output.split(b"\n"):
-        if ln.strip().startswith("[ ]"):
+        if ln.strip().startswith(b"[ ]"):
             migrations_needed = True
 
 # Now we start shutting down services; we start with


### PR DESCRIPTION
With this fix, upgrading the zulipchat.com staging environment to run on Python 3 works smoothly.