### PR TITLE
Update some things mentioning "api/integrations" to reflect the repo split.

### DIFF
--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -120,15 +120,13 @@ Django context (i.e. with database access).
 
 ### API and Bots
 
-* `api/` Zulip's Python API bindings (released separately).
+* See the [Zulip API repository](https://github.com/zulip/python-zulip-api).
+  Zulip's Python API bindings, a number of Zulip integrations and
+  bots, and a framework for running and testing Zulip bots, used to be
+  developed in the main Zulip server repo but are now in their own repo.
 
-* `api/examples/` API examples.
-
-* `api/integrations/` Integrations distributed as part of the Zulip API bundle.
-
-* `api/bots/` Bots distributed as part of the Zulip API bundle.
-
-* `api/bots_api/` Framework for running and testing bots in `api/bots/`.
+* `templates/zerver/integrations/` (within `templates/zerver/`, above).
+  Documentation for these integrations.
 
 -------------------------------------------------------------------------
 

--- a/docs/prod-maintain-secure-upgrade.md
+++ b/docs/prod-maintain-secure-upgrade.md
@@ -416,9 +416,13 @@ the `knight` management command:
 
 If you need to manage the IRC, Jabber, or Zephyr mirrors, you will
 need to create API super users.  To do this, use `./manage.py knight`
-with the `--permission=api_super_user` argument.  See
-`api/integrations/irc-mirror.py` and
-`api/integrations/jabber_mirror.py` for further detail on these.
+with the `--permission=api_super_user` argument.  See the respective
+integration scripts for these mirrors (under
+[`zulip/integrations/`][integrations-source] in the [Zulip Python API
+repo][python-api-repo]) for further detail on these.
+
+[integrations-source]: https://github.com/zulip/python-zulip-api/tree/master/zulip/integrations
+[python-api-repo]: https://github.com/zulip/python-zulip-api
 
 #### Exporting users and realms with manage.py export
 


### PR DESCRIPTION
After this, there are still some left -- most of them in our Zephyr mirroring, and then a few others:
```
$ git grep -l api/integrations
docs/THIRDPARTY
puppet/zulip_ops/files/cron.d/zephyr-mirror
puppet/zulip_ops/files/munin-plugins/humbug_send_receive
puppet/zulip_ops/files/nagios3/commands.cfg
puppet/zulip_ops/files/nagios3/zuliprc
puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_zephyr_mirror
puppet/zulip_ops/files/supervisor/conf.d/zmirror.conf
puppet/zulip_ops/manifests/nagios.pp
templates/zerver/help/import-users-and-channels-from-slack.md
templates/zerver/integrations/codebase.md
zerver/tests/test_zephyr.py
zerver/views/zephyr.py
```
