### PR TITLE
lightbox: On .player-container direct click, hide lightbox.

### DIFF
--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -235,6 +235,12 @@ $(function () {
         $("#lightbox_overlay .lightbox-canvas-trigger").click();
         e.preventDefault();
     });
+
+    $("#lightbox_overlay .player-container").on("click", function () {
+        if ($(this).is(".player-container")) {
+            overlays.close_active();
+        }
+    });
 });
 
 return exports;


### PR DESCRIPTION
When a user clicks on the `.player-container` node and the click
target is actually that (and not the YT video iFrame within), then
hide the lightbox – they likely mean to exit out of the lightbox.