### PR TITLE
settings: Remove intermediate hash change.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -87,7 +87,7 @@ exports.launch_page = function (tab) {
     var $active_tab = $("#settings_overlay_container li[data-section='" + tab + "']");
 
     if ($active_tab.hasClass("admin")) {
-        $(".sidebar .ind-tab[data-tab-key='organization']").click();
+        components.toggle.lookup("settings-toggle").goto("organization", { dont_switch_tab: true });
     }
 
     overlays.open_settings();

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -728,15 +728,19 @@ $(function () {
                 { label: i18n.t("Settings"), key: "settings" },
                 { label: i18n.t("Organization"), key: "organization" },
             ],
-            callback: function (name, key) {
+            callback: function (name, key, payload) {
                 $(".sidebar li").hide();
 
                 if (key === "organization") {
                     $("li.admin").show();
-                    $("li[data-section='organization-settings']").click();
+                    if (!payload.dont_switch_tab) {
+                        $("li[data-section='organization-settings']").click();
+                    }
                 } else {
                     $("li:not(.admin)").show();
-                    $("li[data-section='your-account']").click();
+                    if (!payload.dont_switch_tab) {
+                        $("li[data-section='your-account']").click();
+                    }
                 }
             },
         }).get();

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -55,7 +55,7 @@ exports.toggle = (function () {
 
                     if (meta.last_value !== opts.values[id].label) {
                         meta.last_value = opts.values[id].label;
-                        opts.callback(meta.last_value, opts.values[id].key);
+                        opts.callback(meta.last_value, opts.values[id].key, {});
                     }
                 }
             });
@@ -79,7 +79,12 @@ exports.toggle = (function () {
             },
             // go through the process of finding the correct tab for a given name,
             // and when found, select that one and provide the proper callback.
-            goto: function (name) {
+            // supply a payload of data; since this is a custom event, we'll pass
+            // the data through to the callback.
+            goto: function (name, payload) {
+                // there are cases in which you would want to set this tab, but
+                // not to run the content inside the callback because it doesn't
+                // need to be initialized.
                 var value = _.find(opts.values, function (o) {
                     return o.label === name || o.key === name;
                 });
@@ -90,7 +95,7 @@ exports.toggle = (function () {
                     meta.$ind_tab.removeClass("selected");
                     meta.$ind_tab.filter("[data-tab-id='" + idx + "']").addClass("selected");
 
-                    opts.callback(value.label, value.key);
+                    opts.callback(value.label, value.key, payload || {});
 
                     meta.last_value = idx;
                 }

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -112,7 +112,7 @@ exports.launch_page = function (tab) {
     var $active_tab = $("#settings_overlay_container li[data-section='" + tab + "']");
 
     if (!$active_tab.hasClass("admin")) {
-        $(".sidebar .ind-tab[data-tab-key='settings']").click();
+        components.toggle.lookup("settings-toggle").goto("settings", { dont_switch_tab: true });
     }
 
     overlays.open_settings();


### PR DESCRIPTION
This removes an unecessary intermediate hash change when opening
up the settings page automatically on page load.

Fixes: #3634.