### PR TITLE
Enable search of non-displayed users in right sidebar typeahead.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -670,3 +670,23 @@ $('.user-list-filter').is = function (sel) {
   assert(!activity.new_user_input);
   assert(!activity.has_focus);
 }());
+
+(function test_row_modifier() {
+    var fred_info = {
+            name: 'Fred Flintstone',
+            href: '#narrow/pm-with/2-fred',
+            user_id: fred.user_id,
+            num_unread: 0,
+            type: 'active',
+            type_desc: 'is active',
+            mobile: undefined,
+        };
+    var template_data;
+
+    global.templates.render = function (template_name, data) {
+        assert.equal(template_name, "user_presence_row");
+        template_data = data;
+    };
+    activity.row_modifier(fred_info.user_id);
+    assert(template_data, fred_info);
+}());

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -174,7 +174,7 @@ people.initialize_current_user(me.user_id);
     );
 
     assert(!presence.presence_info[bot.user_id]);
-
+    assert.deepEqual(presence.get_mobile(bot.user_id), false);
     // Make it seem like realm has a lot of people
     var get_realm_count = people.get_realm_count;
     people.get_realm_count = function () { return 1000; };

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -319,6 +319,20 @@ exports.insert_user_into_list = function (user_id) {
     var elt = get_pm_list_item(user_id);
     compose_fade.update_one_user_row(elt);
 };
+ 
+function row_modifier(user_id) {
+    var person_data = info_for(user_id);
+    var row = templates.render('user_presence_row', person_data);
+    return row;
+};
+exports._row_modifier = row_modifier;
+
+exports.create_filter_function = function () {
+    return function () {
+        return true;
+    };
+};
+
 
 exports.build_user_sidebar = function () {
     if (page_params.realm_presence_disabled) {
@@ -327,16 +341,22 @@ exports.build_user_sidebar = function () {
 
     var user_ids = filter_and_sort(presence.get_user_ids());
 
-    var user_info = _.map(user_ids, info_for);
-    var html = templates.render('user_presence_rows', {users: user_info});
-    $('#user_presences').html(html);
+    var filter_function = exports.create_filter_function();
+    var table = $('#user_presences');
+    list_render(table, user_ids, {
+        name: "users_list",
+        modifier: row_modifier,
+        filter: {
+            element: $(".user-list-filter"),
+            callback: filter_function,
+        },
+    }).init();
 
     // Update user fading, if necessary.
     compose_fade.update_faded_users();
 
     resize.resize_page_components();
 
-    return user_info; // for testing
 };
 
 function actually_update_users_for_search() {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -510,6 +510,10 @@ exports.get_all_persons = function () {
     return people_by_user_id_dict.values();
 };
 
+exports.get_all_persons_ids = function () {
+    return people_by_user_id_dict.keys();
+};
+
 exports.get_realm_persons = function () {
     return realm_people_dict.values();
 };

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -47,8 +47,6 @@ function user_last_seen_time_status(user_id) {
         return i18n.t("Active now");
     }
     if (status === "unknown") {
-        // We are not using this anywhere right now as the user presence indicator
-        // is hidden for this case
         return i18n.t("Unknown");
     }
     if (page_params.realm_is_zephyr_mirror_realm) {

--- a/static/js/presence.js
+++ b/static/js/presence.js
@@ -43,7 +43,11 @@ exports.get_status = function (user_id) {
 };
 
 exports.get_mobile = function (user_id) {
-    return exports.presence_info[user_id].mobile;
+
+    if (user_id in exports.presence_info) {
+        return exports.presence_info[user_id].mobile;
+    }
+    return false;
 };
 
 exports.get_user_ids = function () {

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -81,7 +81,8 @@
 }
 
 .user_unknown .user-status-indicator {
-    display: none;
+    background-color: none;
+    border-color: gray;
 }
 
 #user_presences a,

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -14,6 +14,7 @@
     list-style-position: inside; /* Draw the bullets inside our box */
     margin-left: 0;
     overflow: auto;
+    max-height: 100%;
 }
 
 #user_presences:hover,


### PR DESCRIPTION
Users were previously unable to search for non-displayed users in right
sidebar search. This enables that search pulling in a complete people
list from the people module.

Fixes: #5775