### PR TITLE
deliver_email: When disabled, sleep forever rather than exit.

### DIFF
--- a/docs/email.md
+++ b/docs/email.md
@@ -23,7 +23,7 @@ with only a few things you need to know to get started.
   are several other functions in `zerver.lib.send_email`, but all of them
   eventually call the `send_email` function. The most interesting one is
   `send_future_email`. The `ScheduledEmail` entries are eventually processed
-  by a cron job that runs `zerver/management/commands/deliver_email.py`.
+  by a supervisor job that runs `zerver/management/commands/deliver_email.py`.
 * A good way to find a bunch of example email pathways is to `git grep` for
   `zerver/emails` in the `zerver/` directory.
 

--- a/zerver/management/commands/deliver_email.py
+++ b/zerver/management/commands/deliver_email.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-"""
+"""\
 Deliver email messages that have been queued by various things
 (at this time invitation reminders and day1/day2 followup emails).
 
-This management command is run via supervisor. Do not run on multiple machines,
-as you may encounter multiple sends in a specific race condition.
+This management command is run via supervisor.  Do not run on multiple
+machines, as you may encounter multiple sends in a specific race
+condition.  (Alternatively, you can set `EMAIL_DELIVERER_DISABLED=True`
+on all but one machine to make the command have no effect.)
 """
 
 from __future__ import absolute_import
@@ -48,13 +50,10 @@ Usage: ./manage.py deliver_email
 
     def handle(self, *args, **options):
         # type: (*Any, **Any) -> None
-        # TODO: this only acquires a lock on the system, not on the DB:
-        # be careful not to run this on multiple systems.
 
-        # In the meantime, we have an option to prevent this job from
-        # running on >1 machine
         if settings.EMAIL_DELIVERER_DISABLED:
-            return
+            while True:
+                time.sleep(10*9)
 
         with lockfile("/tmp/zulip_email_deliver.lockfile"):
             while True:


### PR DESCRIPTION
This makes supervisor see the service as cheerfully running
and let it alone, rather than constantly retry starting it.
Because the crash/restart loop means repeatedly spending a
couple of seconds loading Django and the app, separated by
brief periods while supervisor notices the crash and acts
on it, it was actually consuming about 30-50% CPU on the
zulipchat.com staging server.