### PR TITLE
Fix aria-hidden assignments in modals.

### DIFF
--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -9,12 +9,14 @@ exports.set_up = function () {
     $("#emojiset_select").val(page_params.emojiset);
 
     $("#default_language_modal [data-dismiss]").click(function () {
+      $('#default_language_modal').attr('aria-hidden', true);
       $("#default_language_modal").fadeOut(300);
     });
 
     $("#default_language_modal .language").click(function (e) {
         e.preventDefault();
         e.stopPropagation();
+        $('#default_language_modal').show().attr('aria-hidden', true);
         $('#default_language_modal').fadeOut(300);
 
         var data = {};

--- a/static/templates/subscription_creation_form.handlebars
+++ b/static/templates/subscription_creation_form.handlebars
@@ -1,5 +1,5 @@
 <div class="hide" id="stream-creation" tabindex="-1" role="dialog"
-    aria-label="{{t 'Stream creation' }}" aria-hidden="true">
+    aria-label="{{t 'Stream creation' }}">
     <form id="stream_creation_form" class="form-inline">
         <div class="stream-creation-body">
             <section class="block">

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -1,5 +1,5 @@
 <div class="overlay-modal" id="keyboard-shortcuts" tabindex="-1" role="dialog"
-     aria-label="{{ _('Keyboard shortcuts') }}" aria-hidden="true">
+     aria-label="{{ _('Keyboard shortcuts') }}">
   <div class="modal-body" tabindex="0">
     <div>
       <table class="hotkeys_table table table-striped table-bordered table-condensed">

--- a/templates/zerver/markdown_help.html
+++ b/templates/zerver/markdown_help.html
@@ -1,5 +1,5 @@
 <div class="overlay-modal hide" id="markdown-help" tabindex="-1" role="dialog"
-    aria-label="{{ _('Message formatting') }}" aria-hidden="true">
+    aria-label="{{ _('Message formatting') }}">
     <div class="modal-body" tabindex="0">
         <div id="markdown-instructions">
             <table class="table table-striped table-condensed table-rounded table-bordered help-table">

--- a/templates/zerver/search_operators.html
+++ b/templates/zerver/search_operators.html
@@ -1,5 +1,5 @@
 <div class="overlay-modal hide" id="search-operators" tabindex="-1" role="dialog"
-    aria-label="{{ _('Search operators') }}" aria-hidden="true">
+    aria-label="{{ _('Search operators') }}">
     <div class="modal-body" tabindex="0">
         <table class="table table-striped table-condensed table-rounded table-bordered help-table">
             <thead>


### PR DESCRIPTION
Fixes #6024.

* The `overlay-modal`s and `stream-creation` have their `display` toggled to hidden when they get opened/closed; i assume it's safe to just remove `aria-hidden="true" for them as content that is not displayed won't get read by the screenreader ([mostly](https://stackoverflow.com/questions/1755656/displaynone-vs-visibilityhidden-vs-text-indent9999-how-screen-reader-behave-w)), and we certainly do not want them to be always set to `aria-hidden="true"`.

* Added a couple of lines of code that would make the `#default_language_modal` aria behaviour work. 

* Not sure what should be done about the formatting & question mark for message editing? 