### PR TITLE
Restructure production Docker scripts in #450.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ zulip.kdev4
 # (Ideally this section is empty.)
 zthumbor/thumbor_local_settings.py
 .transifexrc
+docker-compose*.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,19 @@ matrix:
     - python: "3.4"
       env: TEST_SUITE=production
     # Other suites moved to CircleCI -- see .circleci/.
+    - python: "3.5"
+      env: TEST_SUITE=backend
+    - python: "3.4"
+      before_install:
+        - docker-compose --verbose up -d
+        - docker-compose ps
+          #- nc -v localhost 443
+          #- docker exec zulip_zulip_1 nc -v localhost 443
+          #- docker exec zulip_zulip_1 wget -qO- https://localhost
+        - docker exec zulip_zulip_1 ps aux
+        - curl --insecure -v http://localhost:443
+        - docker-compose down
+        - docker-compose rm -sf
 sudo: required
 addons:
   artifacts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM quay.io/sameersbn/ubuntu:14.04.20170608
+MAINTAINER Alexander Trost <galexrt@googlemail.com>
+
+ENV ZULIP_VERSION="1.7.0" DATA_DIR="/data"
+
+RUN apt-get -q update && \
+    apt-get -q dist-upgrade -y && \
+    mkdir -p "$DATA_DIR" /root/zulip && \
+    wget -q "https://www.zulip.org/dist/releases/zulip-server-$ZULIP_VERSION.tar.gz" -O /tmp/zulip-server.tar.gz && \
+    tar xfz /tmp/zulip-server.tar.gz -C /root/zulip --strip-components=1 && \
+    rm -rf /tmp/zulip-server.tar.gz && \
+    export PUPPET_CLASSES="zulip::dockervoyager" DEPLOYMENT_TYPE="dockervoyager" \
+        ADDITIONAL_PACKAGES="python-dev python-six" has_nginx="0" has_appserver="0" && \
+    /root/zulip/scripts/setup/install && \
+    apt-get -qq autoremove --purge -y && \
+    apt-get -qq clean && \
+    rm -rf /root/zulip/puppet/ /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY docker-entrypoint.sh /sbin/entrypoint.sh
+COPY scripts/lib/docker-functions.sh /opt/docker-functions.sh
+
+VOLUME ["$DATA_DIR"]
+EXPOSE 80 443
+
+ENTRYPOINT ["/sbin/entrypoint.sh"]
+CMD ["app:run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,3 +52,4 @@ zulip:
     ZULIP_USER_DOMAIN: "example.com"
   volumes:
     - "/opt/docker/zulip/zulip:/data:rw"
+  tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+database:
+  image: "quay.io/galexrt/zulip-postgresql-tsearchextras:latest"
+  environment:
+    DB_NAME: zulip
+    DB_USER: zulip
+    DB_PASS: zulip
+  volumes:
+    - "/opt/docker/zulip/postgresql:/var/lib/postgresql:rw"
+memcached:
+  image: "quay.io/sameersbn/memcached:latest"
+  restart: always
+rabbitmq:
+  image: "rabbitmq:3.5.5"
+  hostname: zulip-rabbit
+  restart: always
+  environment:
+      RABBITMQ_DEFAULT_USER: "zulip"
+      RABBITMQ_DEFAULT_PASS: "zulip"
+redis:
+  image: "quay.io/sameersbn/redis:latest"
+  volumes:
+    - "/opt/docker/zulip/redis:/var/lib/redis:rw"
+zulip:
+  image: "quay.io/galexrt/docker-zulip:latest"
+  ports:
+    - "8080:80"
+    - "8443:443"
+  links:
+    - database
+    - memcached
+    - rabbitmq
+    - redis
+  environment:
+    DB_HOST: "database"
+    DB_USER: "zulip"
+    DB_PASS: "zulip"
+    SETTING_MEMCACHED_LOCATION: "memcached:11211"
+    SETTING_RABBITMQ_HOST: "rabbitmq"
+    SETTING_REDIS_HOST: "redis"
+    SECRETS_email_password: "123456789"
+    SECRETS_rabbitmq_password: "zulip"
+    ZULIP_AUTH_BACKENDS: "EmailAuthBackend"
+    SETTING_EXTERNAL_HOST: "example.com"
+    SETTING_ZULIP_ADMINISTRATOR: "admin@example.com"
+    SETTING_ADMIN_DOMAIN: "example.com"
+    SETTING_NOREPLY_EMAIL_ADDRESS: "noreply@example.com"
+    SETTING_DEFAULT_FROM_EMAIL: "Zulip <noreply@example.com>"
+    SETTING_EMAIL_HOST: "smtp.example.com"
+    SETTING_EMAIL_HOST_USER: "noreply@example.com"
+    ZULIP_USER_EMAIL: "example@example.com"
+    ZULIP_USER_PASS: "zulip"
+    ZULIP_USER_DOMAIN: "example.com"
+  volumes:
+    - "/opt/docker/zulip/zulip:/data:rw"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+if [ "$DEBUG" = "true" ] || [ "$DEBUG" = "True" ]; then
+    set -x
+    set -o functrace
+fi
+set -e
+
+if [ -f /opt/docker-functions.sh ]; then
+    source /opt/docker-functions.sh
+elif [ -f ./docker-functions.sh ]; then
+    source /opt/docker-functions.sh
+else
+    echo "docker-functions.sh not found in /opt nor current work directory."
+    exit 1
+fi
+
+# BEGIN app functions
+app_run() {
+    run_initial_configuration
+    bootstrap_environment
+    echo "=== Begin Run Phase ==="
+    echo "Starting Zulip using supervisor with \"/etc/supervisor/supervisord.conf\" config ..."
+    echo ""
+    exec supervisord -n -c "/etc/supervisor/supervisord.conf"
+}
+app_managepy() {
+    COMMAND="$1"
+    shift 1
+    if [ -z "$COMMAND" ]; then
+        echo "No command given for manage.py. Defaulting to \"shell\"."
+        COMMAND="shell"
+    fi
+    echo "Running manage.py ..."
+    set +e
+    exec su zulip -c "/home/zulip/deployments/current/manage.py $COMMAND $*"
+}
+app_backup() {
+    echo "Starting backup process ..."
+    if [ -d "/tmp/backup-$(date "%D-%H-%M-%S")" ]; then
+        echo "Temporary backup folder for \"$(date "%D-%H-%M-%S")\" already exists. Aborting."
+        echo "Backup process failed. Exiting."
+        exit 1
+    fi
+    local BACKUP_FOLDER
+    BACKUP_FOLDER="/tmp/backup-$(date "%D-%H-%M-%S")"
+    mkdir -p "$BACKUP_FOLDER"
+    wait_for_database
+    pg_dump -h "$DB_HOST" -p "$DB_HOST_PORT" -U "$DB_USER" "$DB_NAME" > "$BACKUP_FOLDER/database-postgres.sql"
+    tar -zcvf "$DATA_DIR/backups/backup-$(date "%D-%H-%M-%S").tar.gz" "$BACKUP_FOLDER/"
+    rm -r "${BACKUP_FOLDER:?}/"
+    echo "Backup process succeeded."
+    exit 0
+}
+app_restore() {
+    echo "Starting restore process ..."
+    if [ "$(ls -A "$DATA_DIR/backups/")" ]; then
+        echo "No backups to restore found in \"$DATA_DIR/backups/\"."
+        echo "Restore process failed. Exiting."
+        exit 1
+    fi
+    while true; do
+        ls "$DATA_DIR/backups/" | awk '{print "|-> " $1}'
+        echo "Please enter backup filename (full filename with extension): "
+        read BACKUP_FILE
+        if [ -z "$BACKUP_FILE" ]; then
+            echo "Empty filename given. Please try again."
+            echo ""
+            continue
+        fi
+        if [ ! -e "$DATA_DIR/backups/$BACKUP_FILE" ]; then
+            echo "File \"$BACKUP_FILE\" not found. Please try again."
+            echo ""
+        fi
+        break
+    done
+    echo "File \"$BACKUP_FILE\" found."
+    echo ""
+    echo "==============================================================="
+    echo "!! WARNING !! Your current data will be deleted!"
+    echo "!! WARNING !! YOU HAVE BEEN WARNED! You can abort with \"CTRL+C\"."
+    echo "!! WARNING !! Waiting 10 seconds before continuing ..."
+    echo "==============================================================="
+    echo ""
+    local TIMEOUT=11
+    while true; do
+        TIMEOUT=$(expr $TIMEOUT - 1)
+        if [[ $TIMEOUT -eq 0 ]]; then
+            break
+        fi
+        echo "$TIMEOUT"
+        sleep 1
+    done
+    echo "!! WARNING !! Starting restore process ... !! WARNING !!"
+    wait_for_database
+    tar -zxvf "$DATA_DIR/backups/$BACKUP_FILE" -C /tmp
+    psql -h "$DB_HOST" -p "$DB_HOST_PORT" -U "$DB_USER" "$DB_NAME" < "/tmp/$(basename "$BACKUP_FILE" | cut -d. -f1)/database-postgres.sql"
+    rm -r "/tmp/$(basename  | cut -d. -f1)/"
+    echo "Restore process succeeded. Exiting."
+    exit 0
+}
+app_certs() {
+    configure_certs
+}
+app_help() {
+    echo "Available commands:"
+    echo "> app:help     - Show this help menu and exit"
+    echo "> app:version  - Container Zulip server version"
+    echo "> app:managepy - Run Zulip's manage.py script (defaults to \"shell\")"
+    echo "> app:backup   - Create backups of Zulip instances"
+    echo "> app:restore  - Restore backups of Zulip instances"
+    echo "> app:certs    - Create self-signed certificates"
+    echo "> app:run      - Run the Zulip server"
+    echo "> [COMMAND]    - Run given command with arguments in shell"
+}
+app_version() {
+    echo "This container contains:"
+    echo "> Zulip server $ZULIP_VERSION"
+    echo "> Checksum: $ZULIP_CHECKSUM"
+    exit 0
+}
+# END app functions
+
+case "$1" in
+    app:run)
+        app_run
+    ;;
+    app:managepy)
+        shift 1
+        app_managepy "$@"
+    ;;
+    app:backup)
+        app_backup
+    ;;
+    app:restore)
+        app_restore
+    ;;
+    app:certs)
+        app_certs
+    ;;
+    app:help)
+        app_help
+    ;;
+    app:version)
+        app_version
+    ;;
+    *)
+        if [[ -x $1 ]]; then
+            $1
+        else
+            COMMAND="$1"
+            if [[ -n $(which $COMMAND) ]] ; then
+                shift 1
+                exec "$(which $COMMAND)" "$@"
+            else
+                app_help
+            fi
+        fi
+    ;;
+esac

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -34,7 +34,8 @@ recommended)**:
 * On **other Linux** distributions, you'll need to follow slightly different
   instructions to **[install manually][install-generic]**.
 * On **macOS and Linux** (Ubuntu recommended), you can install **[using
-  Docker][install-docker]**, though support for this remains experimental.
+  Docker][dev-setup-non-vagrant.html#using-docker-experimental]**, though
+  support for this remains experimental.
 
 Unfortunately, the only supported method to install on Windows is the [Vagrant
 method][install-vagrant].

--- a/docs/install-docker-production.md
+++ b/docs/install-docker-production.md
@@ -1,0 +1,67 @@
+Using Docker in production (experimental)
+---------------------------
+
+To install `docker-compose`, see the official Docker docs https://docs.docker.com/compose/install/.
+
+Download the repo or clone it and enter it:
+```
+git clone https://github.com/zulip/zulip.git
+```
+
+Use `docker-compose up` to start Zulip in the container.
+Stop the containers using `docker-compose stop` or `Ctrl+C`. Modify the config files to your needs.
+The config files are located in your data volume/directory, by default it is `/opt/docker/zulip/zulip`.
+After setting all required config options, start Zulip again with `docker-compose up`.
+
+**Please note: If you change the database configuration, change it in the Zulip
+configuration too and in the `docker-compose.yml`.**
+
+If you have modified the config aka `docker-compose.yml` file correctly, you
+should now have a working Zulip running on port 80/http, 443/https.
+
+Configuration
+=============
+
+Every configuration option can be added as a environment variable.
+The environment variable has to begin with `SETTING_setting_name`.
+
+Please refer to the official Zulip documentation on how to configure Zulip.
+
+Creating or Adding your Certificates
+====================================
+
+If you already have Certificates, rename your key to `zulip.key` and your
+certificate to `zulip.combined-chain.crt` and put them into your certs folder
+in the data volume path on the host system.
+
+You can generate your self-signed SSL certificates
+by using the following guide [our SSL certificate documentation](ssl-certificates.html),
+but you don't have to as a certificate is generated automatically by the image on start up if none is given.
+
+Congratulations! You have now added your SSL certificate to be used in the Docker image.
+
+Running in the background
+=========================
+
+Add the `-d` argument to your `docker-compose up`, like this `docker-compose -d up`.
+
+Persistent Data Volume
+======================
+
+The default data volume location of the Zulip container on the host system is `/opt/docker/zulip/zulip`.
+The default data volume location of the PostgreSQL server on the host system is `/opt/docker/zulip/postgresql`.
+The default data volume location of the Redis server on the host system is `/opt/docker/zulip/redis`.
+To change it modify the path(s) in the `docker-compose.yml`.
+
+**NOTE** To keep your data safe. Don't delete the data on the host system.
+A deletion of the data on the host system is a direct deletion of the data.
+
+Backups
+=======
+The Docker image has an in-built automatic backup mechanism.
+By default a backup will be created every day at 3:30am (`30 3 * * *`).
+The backups are stored in `/data/backups` directory. For example on your host
+(when using the default volume paths), the path to the backups would be `/opt/docker/zulip/zulip/backups`.
+
+To manually trigger a backup. Exec into the Zulip container and run `entrypoint.sh app:backup`.
+This will automatically create a backup in your backups directory.


### PR DESCRIPTION
This PR contains the entirety of #450, freshly restructured. There is a remaining catch-22 problem (fixable actually, see https://github.com/rht/zulip/commit/0b6ad2f28802770bdc520105470c651600a36646) that the production Dockerfile requires the tarball to contain the Puppet files in the first commit of this PR.

(cc: @galexrt)