### PR TITLE
mypy: Remove superfluous older 'type: ignore' annotations.

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -200,7 +200,7 @@ class TestProcessCountStat(AnalyticsTestCase):
         with self.assertRaises(ValueError):
             process_count_stat(stat, installation_epoch() + 65*self.MINUTE)
         with self.assertRaises(ValueError):
-            process_count_stat(stat, installation_epoch().replace(tzinfo=None) + self.HOUR)  # type: ignore # https://github.com/python/typeshed/pull/1347
+            process_count_stat(stat, installation_epoch().replace(tzinfo=None) + self.HOUR)
 
     # This tests the LoggingCountStat branch of the code in do_delete_counts_at_hour.
     # It is important that do_delete_counts_at_hour not delete any of the collected

--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -53,14 +53,13 @@ def server_is_up(server, log_file):
 def test_server_running(force=False, external_host='testserver',
                         log_file=None, dots=False, use_db=True):
     # type: (bool, str, str, bool, bool) -> Iterator[None]
+    log = sys.stdout
     if log_file:
         if os.path.exists(log_file) and os.path.getsize(log_file) < 100000:
             log = open(log_file, 'a')
             log.write('\n\n')
         else:
             log = open(log_file, 'w')
-    else:
-        log = sys.stdout  # type: ignore # BinaryIO vs. IO[str]
 
     set_up_django(external_host)
 

--- a/tools/test-tools
+++ b/tools/test-tools
@@ -29,7 +29,7 @@ if __name__ == '__main__':
 
     sys.path.insert(0, root_dir)
 
-    loader = unittest.TestLoader()  # type: ignore # https://github.com/python/typeshed/issues/372
+    loader = unittest.TestLoader()
 
     if args.coverage:
         import coverage

--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -28,7 +28,7 @@ class ParserTest(unittest.TestCase):
 
     def _assert_validate_error(self, error, fn=None, text=None, check_indent=True):
         # type: (str, Optional[str], Optional[str], bool) -> None
-        with self.assertRaisesRegex(TemplateParserException, error):  # type: ignore # See https://github.com/python/typeshed/issues/372
+        with self.assertRaisesRegex(TemplateParserException, error):
             validate(fn=fn, text=text, check_indent=check_indent)
 
     def test_is_django_block_tag(self):

--- a/zerver/lib/parallel.py
+++ b/zerver/lib/parallel.py
@@ -29,7 +29,7 @@ def run_parallel(job, data, threads=6):
             except OSError as e:
                 if e.errno != errno.EBADF:
                     raise
-            sys.stdin = open("/dev/null", "r")  # type: ignore # py2 and py3 stubs are not compatible
+            sys.stdin = open("/dev/null", "r")
             os._exit(job(item))
 
         pids[pid] = item

--- a/zerver/lib/type_debug.py
+++ b/zerver/lib/type_debug.py
@@ -90,4 +90,4 @@ def print_types_to(file_obj):
 
 def print_types(func):
     # type: (FuncT) -> FuncT
-    return print_types_to(sys.stdout)(func)  # type: ignore # https://github.com/python/mypy/issues/1551
+    return print_types_to(sys.stdout)(func)

--- a/zerver/migrations/0077_add_file_name_field_to_realm_emoji.py
+++ b/zerver/migrations/0077_add_file_name_field_to_realm_emoji.py
@@ -97,7 +97,7 @@ class LocalUploader(Uploader):
     def write_local_file(self, path, file_data):
         # type: (Text, binary_type) -> None
         self.mkdirs(path)
-        with open(path, 'wb') as f:  # type: ignore # likely mypy bug
+        with open(path, 'wb') as f:
             f.write(file_data)
 
     def upload_files(self, response, resized_image, dst_path_id):

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -79,7 +79,7 @@ class AdminZulipHandlerTest(ZulipTestCase):
             raise Exception("Testing Error!")
         except Exception:
             exc_info = sys.exc_info()
-        record = self.logger.makeRecord('name', logging.ERROR, 'function', 16, 'message', None, exc_info)  # type: ignore # https://github.com/python/typeshed/pull/1100
+        record = self.logger.makeRecord('name', logging.ERROR, 'function', 16, 'message', None, exc_info)
         handler.emit(record)
 
     def run_handler(self, record):
@@ -105,7 +105,7 @@ class AdminZulipHandlerTest(ZulipTestCase):
 
             global captured_request
             global captured_exc_info
-            record = self.logger.makeRecord('name', logging.ERROR, 'function', 15,  # type: ignore # https://github.com/python/typeshed/pull/1100
+            record = self.logger.makeRecord('name', logging.ERROR, 'function', 15,
                                             'message\nmoremesssage\nmore', None,
                                             None)
             record.request = captured_request  # type: ignore # this field is dynamically added
@@ -130,7 +130,7 @@ class AdminZulipHandlerTest(ZulipTestCase):
 
             global captured_request
             global captured_exc_info
-            record = self.logger.makeRecord('name', logging.ERROR, 'function', 15, 'message', None, captured_exc_info)  # type: ignore # https://github.com/python/typeshed/pull/1100
+            record = self.logger.makeRecord('name', logging.ERROR, 'function', 15, 'message', None, captured_exc_info)
             record.request = captured_request  # type: ignore # this field is dynamically added
 
             report = self.run_handler(record)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1037,7 +1037,7 @@ class S3Test(ZulipTestCase):
         response = self.client_get(uri)
         redirect_url = response['Location']
 
-        self.assertEqual(b"zulip!", urllib.request.urlopen(redirect_url).read().strip())  # type: ignore # six.moves.urllib.request.urlopen is not defined in typeshed
+        self.assertEqual(b"zulip!", urllib.request.urlopen(redirect_url).read().strip())
 
         self.subscribe_to_stream(self.example_email("hamlet"), "Denmark")
         body = "First message ...[zulip.txt](http://localhost:9991" + uri + ")"

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -2,7 +2,8 @@
 # high-level documentation on how this system works.
 from __future__ import absolute_import
 from typing import cast, AbstractSet, Any, Callable, Dict, List, \
-    Mapping, MutableMapping, Optional, Iterable, Sequence, Set, Text, Union
+    Mapping, MutableMapping, Optional, Iterable, Sequence, Set, Text, Union, \
+    Deque
 
 from django.utils.translation import ugettext as _
 from django.conf import settings
@@ -233,7 +234,7 @@ def compute_full_event_type(event):
 class EventQueue(object):
     def __init__(self, id):
         # type: (str) -> None
-        self.queue = deque()  # type: ignore # type signature should Deque[Dict[str, Any]] but we need https://github.com/python/mypy/pull/2845 to be merged
+        self.queue = deque()  # type: Deque[Dict[str, Any]]
         self.next_event_id = 0  # type: int
         self.id = id  # type: str
         self.virtual_events = {}  # type: Dict[str, Dict[str, Any]]
@@ -472,7 +473,7 @@ def setup_event_queue():
         load_event_queues()
         atexit.register(dump_event_queues)
         # Make sure we dump event queues even if we exit via signal
-        signal.signal(signal.SIGTERM, lambda signum, stack: sys.exit(1))  # type: ignore # https://github.com/python/mypy/issues/2955
+        signal.signal(signal.SIGTERM, lambda signum, stack: sys.exit(1))
         tornado.autoreload.add_reload_hook(dump_event_queues)  # type: ignore # TODO: Fix missing tornado.autoreload stub
 
     try:

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -212,7 +212,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
                 response = None
 
                 # Apply request middleware
-                for middleware_method in self._request_middleware:  # type: ignore # Should be List[Callable[[WSGIRequest], Any]] https://github.com/JukkaL/mypy/issues/1174
+                for middleware_method in self._request_middleware:
                     response = middleware_method(request)
                     if response:
                         break

--- a/zerver/tornado/ioloop_logging.py
+++ b/zerver/tornado/ioloop_logging.py
@@ -21,7 +21,7 @@ except Exception:
     # There isn't a good way to get at what the underlying poll implementation
     # will be without actually constructing an IOLoop, so we just assume it will
     # be epoll.
-    orig_poll_impl = select.epoll  # type: ignore # There is no stub for select.epoll on python 3
+    orig_poll_impl = select.epoll
 
     class InstrumentedPollIOLoop(PollIOLoop):
         def initialize(self, **kwargs):  # type: ignore # TODO investigate likely buggy monkey patching here


### PR DESCRIPTION
These changes pass my current mypy version locally.