### PR TITLE
auth.py: Add warning for misconfigured github/google auth.

### DIFF
--- a/templates/zerver/config_error.html
+++ b/templates/zerver/config_error.html
@@ -1,0 +1,41 @@
+{% extends "zerver/portico.html" %}
+
+{% block customhead %}
+{{ super() }}
+<meta http-equiv="refresh" content="60;URL='/'">
+{% endblock %}
+
+{% block portico_content %}
+
+<div class="error_page" style="padding-bottom: 60px;">
+    <div class="container">
+        <div class="row-fluid">
+            <img src="/static/images/500art.svg" alt=""/>
+            <div class="errorbox">
+                <div class="errorcontent">
+                    <h1 class="lead">Configuration error</h1>
+                    <p>Seems like you haven't properly configured authentication!</p>
+                    <p>Try restarting the development environment, as it is possible some changes you made require a restart.</p>
+                    <br/>
+                    {% if google_auth_enabled %}
+                    <p>You are using the <b>Google auth backend</b>. Please make sure of the following:</p>
+                    <p>- You have updated GOOGLE_OAUTH2_CLIENT_ID and GOOGLE_OAUTH2_CLIENT_SECRET settings.</p>
+                    <p>- You have setup an Oauth2 client ID that allows redirects, e.g. <code>https://zulip.example.com/accounts/login/google/done/</code>.</p>
+                    <p>- You have enabled the Google+ API. You can create OAuth2 apps from <code>https://console.developers.google.com</code>.</p>
+                    {% endif %}
+
+                    {% if github_auth_enabled %}
+                    <p>You are using the <b>GitHub auth backend</b>. Please make sure of the following:</p>
+                    <p>- You have updated SOCIAL_AUTH_GITHUB_KEY and SOCIAL_AUTH_GITHUB_SECRET settings.</p>
+                    <p>- You have added <code>http://localhost:9991/complete/github/</code> as the callback URL in the OAuth application in GitHub. You can create OAuth apps from <code>https://github.com/settings/developers</code>.</p>
+                    {% endif %}
+
+                    <p>For more information, have a look at our <a href="http://zulip.readthedocs.io/en/latest/settings.html#testing-google-github-authentication">authentication setup guide</a>.</p>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -145,7 +145,7 @@ if 'zproject.backends.GitHubAuthBackend' in settings.AUTHENTICATION_BACKENDS:
             "You are using the GitHub auth backend. Please make sure of the following:",
             "- You have updated SOCIAL_AUTH_GITHUB_KEY and "
             "  SOCIAL_AUTH_GITHUB_SECRET settings.",
-            "- You have added http://localhost:9991/complete/github/' ",
+            "- You have added http://localhost:9991/complete/github/ ",
             "  as the callback URL in the OAuth application in GitHub.",
             "  You can create OAuth apps from ",
             "  https://github.com/settings/developers.",

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -81,6 +81,11 @@ def redirect_to_subdomain_login_url():
     redirect_url = login_url + '?subdomain=1'
     return HttpResponseRedirect(redirect_url)
 
+def redirect_to_config_error():
+    # type: () -> HttpResponseRedirect
+    redirect_url = reverse('configuration-error', args=("google",))
+    return HttpResponseRedirect(redirect_url)
+
 def login_or_register_remote_user(request, remote_username, user_profile, full_name='',
                                   invalid_subdomain=False, mobile_flow_otp=None,
                                   is_signup=False):
@@ -210,6 +215,10 @@ def google_oauth2_csrf(request, value):
 def start_google_oauth2(request):
     # type: (HttpRequest) -> HttpResponse
     url = reverse('zerver.views.auth.send_oauth_request_to_google')
+
+    if not (settings.GOOGLE_OAUTH2_CLIENT_ID and settings.GOOGLE_OAUTH2_CLIENT_SECRET):
+        return redirect_to_config_error()
+
     is_signup = bool(request.GET.get('is_signup'))
     return redirect_to_main_site(request, url, is_signup=is_signup)
 
@@ -238,6 +247,9 @@ def redirect_to_main_site(request, url, is_signup=False):
 def start_social_login(request, backend):
     # type: (HttpRequest, Text) -> HttpResponse
     backend_url = reverse('social:begin', args=[backend])
+    if (backend == "github") and not (settings.SOCIAL_AUTH_GITHUB_KEY and settings.SOCIAL_AUTH_GITHUB_SECRET):
+        return redirect_to_config_error()
+
     return redirect_to_main_site(request, backend_url)
 
 def start_social_signup(request, backend):

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -161,6 +161,8 @@ i18n_urls = [
     # Terms of service and privacy pages.
     url(r'^terms/$', TemplateView.as_view(template_name='zerver/terms.html'), name='terms'),
     url(r'^privacy/$', TemplateView.as_view(template_name='zerver/privacy.html'), name='privacy'),
+
+    url(r'^config-error/$', TemplateView.as_view(template_name='zerver/config_error.html'), name='configuration-error'),
 ]
 
 # Make a copy of i18n_urls so that they appear without prefix for english


### PR DESCRIPTION
Continuation of #5883 -- adding a warning for devs that they haven't configured the google/github auths correctly for the case where they forget to restart the dev environment.

Not sure whether in what form the error message should appear-- as an appended text in the buttons, or as a new page that the user gets redirected to? 