### PR TITLE
left sidebar: Change Home to All messages.

### DIFF
--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -59,10 +59,11 @@ members of particular groups (using email domain names or corporate
 single-sign-on login for verification). For more on security
 considerations, see [the security model section](../production/security-model.html).
 
-The default Zulip home screen is like a chronologically ordered inbox;
+The Zulip "All messages" screen is like a chronologically ordered inbox;
 it displays messages, starting at the oldest message that the user
 hasn't viewed yet (for more on that logic, see [the guide to the
-pointer and unread counts](../subsystems/pointer.html)). The home screen displays
+pointer and unread counts](../subsystems/pointer.html)). The "All messages" screen displays
+>>>>>>> left sidebar: Change Home to All messages.:docs/architecture-overview.md
 the most recent messages in all the streams a user has joined (except
 for the streams they've muted), as well as private messages from other
 users, in strict chronological order. A user can *narrow* to view only
@@ -295,8 +296,8 @@ are welcome!
 
 * **star**: Zulip allows a user to mark any message they can see,
     public or private, as "starred". A user can easily access messages
-    they've starred through the "Starred messages" link in the menu
-    near "Home", or use "is:starred" as a narrow or a search
+    they've starred through the "Starred messages" link in the
+    left sidebar, or use "is:starred" as a narrow or a search
     constraint. Whether a user has or has not starred a particular
     message is private; other users and realm admins don't know
     whether a message has been starred, or by whom.

--- a/docs/subsystems/pointer.md
+++ b/docs/subsystems/pointer.md
@@ -51,22 +51,22 @@ or in muted topics within non-muted streams.)
 ### Unnarrow: previous sequence
 
 When you unnarrow using e.g. the escape key, you will automatically be
-taken to the same message that was selected in the home view before
+taken to the same message that was selected in the All messages view before
 you narrowed, unless in the narrow you read new messages, in which
 case you will be jumped forward to the first unread and non-muted
-message in the home view (or the bottom of the feed if there is
-none). This makes for a nice experience reading threads via the home
+message in the All messages view (or the bottom of the feed if there is
+none). This makes for a nice experience reading threads via the All messages
 view in sequence.
 
-### New home view: "high watermark"
+### New All messages view: "high watermark"
 
-When you open a new browser window or tab to the home view (a.k.a. the
+When you open a new browser window or tab to the All messages view (a.k.a. the
 interleaved view you get if you visit `/`), Zulip will select the
-furthest down that your cursor has ever reached in the home
+furthest down that your cursor has ever reached in the All messages
 view. Because of the logic around unnarrowing in the last bullet, this
-is usually just before the first unread message in the home view, but
-if you never go to the home view, or you leave messages unread on some
-streams in your home view, this can lag.
+is usually just before the first unread message in the All messages view, but
+if you never go to the All messages view, or you leave messages unread on some
+streams in your All messages view, this can lag.
 
 We plan to change this to automatically advance the pointer in a way
 similar to the unnarrow logic.
@@ -75,7 +75,7 @@ similar to the unnarrow logic.
 
 When you load a new browser tab or window to a narrowed view, Zulip
 will select the message closest to your pointer, which is what you
-would have got had you loaded the browser window to your home view and
+would have got had you loaded the browser window to your All messages view and
 then clicked on the nearest message matching your narrow (which might
 have been offscreen).
 

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -51,7 +51,7 @@ Try using all the navigation hotkeys:
 
 Try narrowing from the message view:
 - Hotkeys
-    - use Esc to go to home
+    - use Esc to go to All messages
     - use s to narrow to a stream (select message first
       and verify in sidebar)
     - use S to narrow to the topic (and verify in sidebar)
@@ -63,7 +63,7 @@ Try narrowing from the message view:
     - narrow to a group PM
 - Click on the Zulip logo
     - narrow to a topic
-    - click on the Zulip logo (and verify you're in the home view)
+    - click on the Zulip logo (and verify you're in the All messages view)
 
 ### Message editing ###
 
@@ -123,7 +123,7 @@ For each of the above types of messages, you will want to cycle
 through the following views for Cordelia (and have Hamlet send new
 messages after each narrow):
 
-- Go to Home view.
+- Go to All Messages view.
 - Go to Private Messages view.
 - Go to Private Messages w/Hamlet.
 - Go to Private Messages w/Hamlet and Othello.
@@ -391,8 +391,8 @@ Test per-stream options:
 - Do mute and unmute, have Hamlet send messages
 - Test notifications on/off, have Hamlet send messages
 - Test pin and unpin, view left sidebar
-- Change stream color, and then view the left sidebar and the Home
-  message view
+- Change stream color, and then view the left sidebar and the All
+  messages view
 - Verify stream subscriber counts in the main stream view
 
 ### User Settings ###

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -661,7 +661,7 @@ function make_sub(name, stream_id) {
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [];
-    string = 'Go to Home view';
+    string = 'all messages';
     assert.equal(Filter.describe(narrow), string);
 }());
 

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -485,7 +485,7 @@ Filter.operator_to_prefix = function (operator, negated) {
 // Convert a list of operators to a human-readable description.
 Filter.describe = function (operators) {
     if (operators.length === 0) {
-        return 'Go to Home view';
+        return 'all messages';
     }
 
     var parts = [];

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -430,7 +430,7 @@ function get_special_filter_suggestions(last, operators) {
 
     // Only show home if there's an empty bar
     if (operators.length === 0 && last_string === '') {
-        suggestions.unshift({search_string: '', description: 'Home'});
+        suggestions.unshift({search_string: '', description: 'All messages'});
     }
     return suggestions;
 }

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -110,7 +110,7 @@ function make_tab_data() {
     }
 
     if (tabs.length === 0) {
-        tabs.push(make_tab('Home', "#", "home", "root", true));
+        tabs.push(make_tab('All messages', "#", "home", "root", true));
     }
 
     // Last tab is not a link

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -42,7 +42,7 @@
                         <div id="sub_setting_not_in_home_view" class="sub_setting_checkbox sub-mute-setting">
                             <input id="mutestream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#unless in_home_view}}checked{{/unless}} />
                             <label class="subscription-control-label">{{t "Mute stream" }}</label>
-                            <p class="mute-note {{#if in_home_view}}hide-mute-note{{/if}}">{{t "Muted streams don't show up in your home view or generate notifications unless you are mentioned." }}</p>
+                            <p class="mute-note {{#if in_home_view}}hide-mute-note{{/if}}">{{t "Muted streams don't show up \"All messages\" or generate notifications unless you are mentioned." }}</p>
                         </div>
                     </li>
                     <li>

--- a/static/templates/tab_bar.handlebars
+++ b/static/templates/tab_bar.handlebars
@@ -7,7 +7,7 @@
         {{! Most tabs are links, but some are not since we don't have a narrow for them (e.g. Search) }}
         {{#if hash}}
             {{#if home}}
-            <a href="{{hash}}" title="{{t 'Home' }} (Esc)"><i class="icon-vector-home"></i></a>
+            <a href="{{hash}}" title="{{t 'All messages' }} (Esc)"><i class="icon-vector-home"></i></a>
             {{else}}
             <a href="{{hash}}">{{title}}</a>
             {{/if}}

--- a/templates/zerver/help/browse-and-subscribe-to-streams.md
+++ b/templates/zerver/help/browse-and-subscribe-to-streams.md
@@ -47,7 +47,7 @@ When users create a public stream, they can choose to alert all users
 in the organization about their stream's creation.
 
 Thus, you may be notified about the stream's creation with a message
-in the **Home** view sent by the notification bot such as the one in the
+sent by the notification bot such as the one in the
 following image.
 
 ![Streams subscribe alert](/static/images/help/stream-subscribe.png)

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -79,7 +79,7 @@ below, and add more to your repertoire as needed.
 
 * **Cycle between stream narrows**: `A` (previous) and `D` (next)
 
-* **Narrow to home view**: `Esc` or `Ctrl` + `[`
+* **Narrow to all messages**: `Esc` or `Ctrl` + `[` — Shows all unmuted messages.
 
 ## Composing messages
 
@@ -129,7 +129,7 @@ title="thumbs up"/>**: `+`
 * **Collapse/show message**: `-`
 
 * **Toggle topic mute**: `M` — Muted topics don't show up in any views
-  (include Home), and don't contribute to unread counts. Read more about
+  (including All messages), and don't contribute to unread counts. Read more about
   [muting topics](/help/mute-a-topic).
 
 ## Drafts

--- a/templates/zerver/help/mute-a-topic.md
+++ b/templates/zerver/help/mute-a-topic.md
@@ -23,9 +23,9 @@ confirming the success of your muting of the topic.
 
 ## Mute a topic through your current view
 
-1. The default **Home** view displays all messages from unmuted streams and topics
+1. The **All messages** view displays all messages from unmuted streams and topics
 that you are subscribed to. Find a message belonging to the topic that you wish
-to mute in your current filter or in the **Home** view.
+to mute in your current filter or in the **All messages** view.
 
     !!! tip ""
         Alternatively, you can narrow your view to messages sent to the topic

--- a/templates/zerver/help/the-zulip-browser-window.md
+++ b/templates/zerver/help/the-zulip-browser-window.md
@@ -14,9 +14,8 @@ allows you to narrow your view to show specific messages using
 [search constraints](/help/search-for-messages).
 
 !!! tip ""
-    If your current filter is not the **Home** view, clicking on the home ((<i
-    class="icon-vector-home"></i>) icon to the left of the search bar will also
-    narrow your view to that of the **Home** view.
+    Clicking on the home (<i class="icon-vector-home"></i>) icon to the left of
+    the search bar will narrow you to the **All messages** view.
 
 ### Message table
 The **message table** displays your messages in the middle of your browser
@@ -50,13 +49,12 @@ options for narrowing your view.
 ### Preset filters
 Preset filters are located at the top of the left sidebar.
 
-* Clicking on the **Home** filter narrows your view to show all messages from
+* Clicking on the **All messages** filter narrows your view to show all messages from
 unmuted streams that you're subscribed to as well as private messages that
 you have received.
 
     !!! tip ""
-        If your current filter is not the **Home** view, clicking on the Zulip
-        logo will also narrow your view to that of the **Home** view.
+        Clicking on the Zulip logo will also narrow you to the **All messages** view.
 
 * Clicking on the **Private messages** filter narrows your view to show all
 private messages that you have received.

--- a/templates/zerver/help/unread-counter-and-pointer.md
+++ b/templates/zerver/help/unread-counter-and-pointer.md
@@ -58,15 +58,15 @@ search box, Zulip will instead select the first unread message
 matching that narrow, or if there are none, the most recent message
 matching that narrow.
 
-* When you narrow back to your home view, you will automatically be
-taken to the same message that was selected in the home view before
+* When you narrow to the All messages view, you will automatically be
+taken to the same message that was selected in that view before
 you narrowed. If you read new messages in your previous narrow, you
-will be fast-forwarded to the first unread message in the home view.
+will be fast-forwarded to the first unread message in the All messages view.
 
-* When you open a new browser window or tab to the home view, Zulip
-will select the lowest message in your home view, which is usually
+* When you open a new browser window or tab to the All messages view, Zulip
+will select the lowest message in that view, which is usually
 just before the first unread message.
 
 * When you load a new browser tab or window to a narrowed view, Zulip
 will exhibit behavior similar to when you narrow to that view after
-loading the browser window to your home view.
+loading the browser window to your All messages view.

--- a/templates/zerver/help/zulip-glossary.md
+++ b/templates/zerver/help/zulip-glossary.md
@@ -68,7 +68,7 @@ order to send them as new messages.
 
 Also known as a [view](#view), a **filter** is one of the options for viewing
 different kinds of messages, listed in the upper left corner of the Zulip
-browser window, such as **Home**, **Private messages**, **Starred messages**,
+browser window, such as **All messages**, **Private messages**, **Starred messages**,
 and **Mentions**.
 
 ### group PM
@@ -77,12 +77,13 @@ Shorthand for **group private message**, a **group PM** is a
 [private message](#private-message) sent directly to two or more other
 users rather than through a [stream](#stream).
 
-### home
+### all messages
 
-**Home** is a specific [view](#view) (or [filter](#filter)) that shows all
+**All messages** is a specific [view](#view) (or [filter](#filter)) that shows all
 messages to the user's [subscribed](#subscribing) [streams](#stream) and all of
-the user's private messages in chronological order. This view is accessible by
-clicking the **Home** link, Zulip logo in the upper left sidebar, home (<i
+the user's private messages in chronological order, excluding messages to muted
+streams and topics. This view is accessible by
+clicking the **All messages** link, Zulip logo in the upper left sidebar, home (<i
 class="icon-vector-home"></i>) icon to the left of the search bar, or pressing
 the escape key.
 
@@ -231,4 +232,4 @@ stop receiving all messages from the stream that they unsubscribed from.
 
 Also known as [filter](#filter), a **view** is an option for viewing different
 kinds of messages, listed in the upper left sidebar, including sections
-**Home**, **Private messages**, **Starred messages**, and **Mentions**.
+**All messages**, **Private messages**, **Starred messages**, and **Mentions**.

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -116,7 +116,7 @@
         </tr>
         <tr>
           <td class="hotkey">Esc, Ctrl + [</td>
-          <td class="definition">{% trans %}Return to home view{% endtrans %}</td>
+          <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
         </tr>
       </table>
       <table class="hotkeys_table table table-striped table-bordered table-condensed">

--- a/templates/zerver/left_sidebar.html
+++ b/templates/zerver/left_sidebar.html
@@ -2,12 +2,12 @@
     <div class="bottom_sidebar">
         <ul id="global_filters" class="filters">
             {# Special-case this link so we don't actually go to page top. #}
-            <li data-name="home" class="global-filter active-filter home-link" title="{{ _('Home') }} (Esc)">
+            <li data-name="home" class="global-filter active-filter home-link" title="{{ _('All messages') }} (Esc)">
                 <a href="#">
                     <span class="filter-icon">
                         <i class="icon-vector-home"></i>
                     </span>
-                    <span class="hover-underline">{{ _('Home') }}</span>
+                    <span class="hover-underline">{{ _('All messages') }}</span>
                     <span class="count">
                         <span class="value"></span>
                     </span>


### PR DESCRIPTION
This commit leaves everything as "home" in the code, and only changes
user-visible strings. Changing the code will be a big project; there are
hundreds of relevant occurrences in variable names, etc.