### PR TITLE
Replace `String.prototype.startsWith` with `indexOf`.

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -190,7 +190,7 @@ function handleTex(tex, fullmatch) {
     try {
         return katex.renderToString(tex);
     } catch (ex) {
-        if (ex.message.startsWith('KaTeX parse error')) { // TeX syntax error
+        if (ex.message.indexOf('KaTeX parse error') === 0) { // TeX syntax error
             return '<span class="tex-error">' + escape(fullmatch) + '</span>';
         }
         blueslip.error(ex);

--- a/static/js/translations.js
+++ b/static/js/translations.js
@@ -70,7 +70,7 @@ $(function () {
     var current_generation_key = 'i18next:' + page_params.server_generation;
     // remove cached translations of older versions.
     translations.forEach(function (translation_key) {
-        if (!translation_key.startsWith(current_generation_key)) {
+        if (!translation_key.indexOf(current_generation_key) === 0) {
             localStorage.removeItem(translation_key);
         }
     });


### PR DESCRIPTION
This replaces the `startsWith` string prototype method with `indexOf`
because no versions of Internet Explorer support this feature, and
it really is not difficult to just use `indexOf` instead and check
whether the starting index of the full string is 0.