### PR TITLE
Clean up node tests.

### DIFF
--- a/docs/testing-with-node.md
+++ b/docs/testing-with-node.md
@@ -87,19 +87,15 @@ For deeper dependencies, you want to categorize each module as follows:
     isolation?
 -   Do some combination of the above?
 
-For all the modules where you want to run actual code, add a statement
-like the following to the top of your test file:
+For all the modules where you want to run actual code, add statements
+like the following toward the top of your test file:
 
->     add_dependencies({
->         _: 'node_modules/underscore/underscore.js',
->         util: 'js/util.js',
->         Dict: 'js/dict.js',
->         Handlebars: 'handlebars',
->         Filter: 'js/filter.js',
->         typeahead_helper: 'js/typeahead_helper.js',
->         stream_data: 'js/stream_data.js',
->         narrow: 'js/narrow.js'
->     });
+>     zrequire('util');
+>     zrequire('stream_data');
+>     zrequire('Filter', 'js/filter');
+
+(Deprecation note: you may see code where we use `add_dependencies` or
+direct `require` statements.  We should use `zrequire` instead.)
 
 For modules that you want to completely stub out, please use a pattern
 like this:

--- a/frontend_tests/.eslintrc.json
+++ b/frontend_tests/.eslintrc.json
@@ -8,7 +8,8 @@
 	"casper": false,
 	"document": false,
 	"set_global": false,
-	"window": false
+	"window": false,
+	"zrequire": false
     },
     "rules": {
 	"no-sync": 0

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -18,22 +18,17 @@ set_global('blueslip', function () {});
 set_global('channel', {});
 set_global('compose_actions', {});
 
-add_dependencies({
-    Handlebars: 'handlebars',
-    templates: 'js/templates',
-    util: 'js/util.js',
-    compose_fade: 'js/compose_fade.js',
-    people: 'js/people.js',
-    unread: 'js/unread.js',
-    hash_util: 'js/hash_util.js',
-    hashchange: 'js/hashchange.js',
-    narrow: 'js/narrow.js',
-    presence: 'js/presence.js',
-    activity: 'js/activity.js',
-    timerender: 'js/timerender.js',
-});
-
-var presence = global.presence;
+zrequire('compose_fade');
+zrequire('Handlebars', 'handlebars');
+zrequire('templates');
+zrequire('unread');
+zrequire('hash_util');
+zrequire('hashchange');
+zrequire('narrow');
+zrequire('util');
+zrequire('presence');
+zrequire('people');
+zrequire('activity');
 
 set_global('resize', {
     resize_page_components: function () {},

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -1,13 +1,11 @@
-add_dependencies({
-    hash_util: 'js/hash_util.js',
-    hashchange: 'js/hashchange.js',
-    narrow_state: 'js/narrow_state.js',
-    people: 'js/people.js',
-    stream_data: 'js/stream_data.js',
-    Filter: 'js/filter.js',
-});
+zrequire('hash_util');
+zrequire('hashchange');
+zrequire('narrow_state');
+zrequire('people');
+zrequire('stream_data');
+zrequire('Filter', 'js/filter');
 
-var narrow = require('js/narrow.js');
+zrequire('narrow');
 
 var narrow_state = global.narrow_state;
 

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -1,14 +1,5 @@
 set_global('$', global.make_zjquery());
 
-add_dependencies({
-    Handlebars: 'handlebars',
-    templates: 'js/templates',
-    hash_util: 'js/hash_util',
-    hashchange: 'js/hashchange',
-    narrow: 'js/narrow',
-    people: 'js/people',
-});
-
 set_global('message_store', {
     recent_private_messages: new global.Array(),
 });
@@ -27,9 +18,13 @@ set_global('popovers', {
     hide_all: function () {},
 });
 
-var pm_list = require('js/pm_list.js');
-
-global.compile_template('sidebar_private_message_list');
+zrequire('hash_util');
+zrequire('hashchange');
+zrequire('narrow');
+zrequire('Handlebars', 'handlebars');
+zrequire('templates');
+zrequire('people');
+zrequire('pm_list');
 
 var alice = {
     email: 'alice@zulip.com',

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -6,22 +6,15 @@ set_global('page_params', {
 set_global('$', function () {
 });
 
-add_dependencies({
-    marked: 'third/marked/lib/marked.js',
-    people: 'js/people.js',
-    stream_color: 'js/stream_color.js',
-    narrow: 'js/narrow.js',
-    hash_util: 'js/hash_util.js',
-    hashchange: 'js/hashchange.js',
-    topic_data: 'js/topic_data.js',
-    util: 'js/util.js',
-});
-
 set_global('blueslip', {});
 
-var stream_data = require('js/stream_data.js');
-
-var people = global.people;
+zrequire('util');
+zrequire('hash_util');
+zrequire('narrow');
+zrequire('topic_data');
+zrequire('people');
+zrequire('stream_color');
+zrequire('stream_data');
 
 (function test_basics() {
     var denmark = {

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -2,21 +2,18 @@ set_global('$', global.make_zjquery());
 
 set_global('templates', {});
 
-add_dependencies({
-    colorspace: 'js/colorspace',
-    Filter: 'js/filter',
-    hash_util: 'js/hash_util',
-    narrow: 'js/narrow',
-    stream_color: 'js/stream_color',
-    stream_data: 'js/stream_data',
-    stream_sort: 'js/stream_sort',
-    topic_data: 'js/topic_data',
-    unread: 'js/unread',
-    unread_ui: 'js/unread_ui',
-    util: 'js/util',
-});
-
-var stream_list = require('js/stream_list.js');
+zrequire('unread_ui');
+zrequire('Filter', 'js/filter');
+zrequire('util');
+zrequire('topic_data');
+zrequire('stream_sort');
+zrequire('colorspace');
+zrequire('stream_color');
+zrequire('hash_util');
+zrequire('narrow');
+zrequire('unread');
+zrequire('stream_data');
+zrequire('stream_list');
 
 var noop = function () {};
 var return_false = function () { return false; };

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -1,3 +1,5 @@
+set_global('$', global.make_zjquery());
+
 add_dependencies({
     people: 'js/people.js',
 });

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -17,6 +17,7 @@ var namespace = require('./namespace.js');
 global.set_global = namespace.set_global;
 global.patch_builtin = namespace.patch_builtin;
 global.add_dependencies = namespace.add_dependencies;
+global.zrequire = namespace.zrequire;
 global.stub_out_jquery = namespace.stub_out_jquery;
 global.with_overrides = namespace.with_overrides;
 

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -19,12 +19,19 @@ exports.patch_builtin = function (name, val) {
     return val;
 };
 
+exports.zrequire = function (name, fn) {
+    if (fn === undefined) {
+        fn = 'js/' + name;
+    }
+    delete require.cache[require.resolve(fn)];
+    var obj = require(fn);
+    requires.push(fn);
+    set_global(name, obj);
+};
+
 exports.add_dependencies = function (dct) {
     _.each(dct, function (fn, name) {
-        delete require.cache[require.resolve(fn)];
-        var obj = require(fn);
-        requires.push(fn);
-        set_global(name, obj);
+        exports.zrequire(name, fn);
     });
 };
 


### PR DESCRIPTION
This is starting to deprecate `add_dependencies` and `require` in favor of the new `zrequire`.

It also does some zjquery-related cleanup.