### PR TITLE
python3: Add missing Python 3 dependencies to Puppet.

### DIFF
--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -5,6 +5,7 @@ class zulip::postgres_appdb_base {
 
   $appdb_packages = [# Needed to run process_fts_updates
                      "python-psycopg2", # TODO: use a virtualenv instead
+                     "python3-psycopg2", # TODO: use a virtualenv instead
                      # Needed for our full text search system
                      "postgresql-${zulip::base::postgres_version}-tsearch-extras",
                      ]

--- a/puppet/zulip/manifests/postgres_common.pp
+++ b/puppet/zulip/manifests/postgres_common.pp
@@ -6,7 +6,9 @@ class zulip::postgres_common {
                         # Python modules used in our monitoring/worker threads
                         "python-gevent",
                         "python-tz", # TODO: use a virtualenv instead
+                        "python3-tz",
                         "python-dateutil", # TODO: use a virtualenv instead
+                        "python3-dateutil",
                         # Needed just to support adding postgres user to 'zulip' group
                         "ssl-cert",
                         # our dictionary

--- a/puppet/zulip_ops/manifests/base.pp
+++ b/puppet/zulip_ops/manifests/base.pp
@@ -18,9 +18,11 @@ class zulip_ops::base {
                         "debian-goodies",
                         # Needed for zulip-ec2-configure-network-interfaces
                         "python-six",
+                        "python3-six",
                           # This one is needed for postgres as well
                         "python-boto",
                         "python-netifaces",
+                        "python3-netifaces",
                         # Popular editors
                         "vim",
                         "emacs-nox",

--- a/puppet/zulip_ops/manifests/postgres_common.pp
+++ b/puppet/zulip_ops/manifests/postgres_common.pp
@@ -5,6 +5,7 @@ class zulip_ops::postgres_common {
                                  "lzop",
                                  "pv",
                                  "python-pip",
+                                 "python3-pip",
                                  # Postgres Nagios check plugin
                                  "check-postgres",
                                  ]
@@ -25,7 +26,7 @@ class zulip_ops::postgres_common {
     minute => 0,
     target => "postgres",
     user => "postgres",
-    require => [ File["/usr/local/bin/pg_backup_and_purge.py"], Package["postgresql-${zulip::base::postgres_version}", "python-dateutil"] ]
+    require => [ File["/usr/local/bin/pg_backup_and_purge.py"], Package["postgresql-${zulip::base::postgres_version}", "python3-dateutil", "python-dateutil"] ]
   }
 
   exec { "sysctl_p":

--- a/puppet/zulip_ops/manifests/zmirror.pp
+++ b/puppet/zulip_ops/manifests/zmirror.pp
@@ -13,6 +13,7 @@ class zulip_ops::zmirror {
                        "libzephyr-dev",
                        "comerr-dev",
                        "python-dev",
+                       "python3-dev",
                        "cython",
                        ]
   package { $zmirror_packages: ensure => "installed" }

--- a/puppet/zulip_ops/manifests/zmirror_personals.pp
+++ b/puppet/zulip_ops/manifests/zmirror_personals.pp
@@ -13,6 +13,7 @@ class zulip_ops::zmirror_personals {
                        "libzephyr-dev",
                        "comerr-dev",
                        "python-dev",
+                       "python3-dev",
                        "cython",
                        ]
   package { $zmirror_packages: ensure => "installed" }


### PR DESCRIPTION
This isn't complete, because there isn't a Python 3 port of boto
(needed for wal-e; see #6068), and similarly Ubuntu Trusty needs a
backported Python 3 version of gevent (also needed for wal-e).