### PR TITLE
/features/: Fix wave position.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -458,7 +458,7 @@ nav ul li.active::after {
     display: block;
 
     position: absolute;
-    top: -170px;
+    top: -169px;
     right: 0;
 
     width: 685px;


### PR DESCRIPTION
On some monitors it appears as though there's a slight gap between
the bottom of the wave and the top of the section below. This moves
the wave down a pixel to ensure the gap disappears.

Fixes: #6064.