### PR TITLE
your-account: Change "no changes made" error to success.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -161,7 +161,7 @@ exports.set_up = function () {
                 if ('account_email' in data) {
                     settings_change_success(data.account_email);
                 } else {
-                    settings_change_error(i18n.t("Error changing settings: No new data supplied."));
+                    settings_change_success(i18n.t("No changes made."));
                 }
             },
             error: function (xhr) {


### PR DESCRIPTION
This changes the alert error "Error changing settings: No new data
supplied" to "No changes made" as a success bar.