### PR TITLE
settings: Create autosave mechanism.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -552,6 +552,34 @@ $(function () {
             }
         });
 
+        $.fn.autosave = function ($target) {
+            var self = this;
+            var meta = {
+                save: null,
+            };
+
+            $target.blur(function () {
+                $(self).click();
+                if (meta.save) {
+                    meta.save.call($target[0], $target);
+                }
+            });
+
+            $(this).on("mousedown", function () {
+                if ($target.is("[disabled]")) {
+                    $target.removeAttr("disabled");
+                } else {
+                    $target.attr("disabled", true);
+                }
+            });
+
+            return {
+                onsave: function (callback) {
+                    meta.save = callback;
+                },
+            };
+        };
+
         $("body").on("click", "[data-make-editable]", function () {
             var selector = $(this).attr("data-make-editable");
             var edit_area = $(this).parent().find(selector);

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -109,6 +109,29 @@ exports.set_up = function () {
         common.password_quality(field.val(), $('#pw_strength .bar'), field);
     });
 
+    var update_account = {
+        name: function (full_name) {
+            $.ajax({
+                url: "/json/settings",
+                type: "PATCH",
+                data: { full_name: full_name },
+                contentType: "application/x-www-form-urlencoded",
+                success: function () {
+                    settings_change_success("Updated name to '" + full_name + "'!");
+                },
+                error: function (xhr) {
+                    settings_change_error("Error changing name!", xhr);
+                },
+            });
+        },
+    };
+
+    $("#name_change_container .save").autosave($("#name_change_container .autosave"))
+        // when a `save` is triggered by the input.
+        .onsave(function () {
+            update_account.name(this.value);
+        });
+
     $("form.your-account-settings").ajaxForm({
         dataType: 'json', // This seems to be ignored. We still get back an xhr.
         beforeSubmit: function () {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -294,6 +294,36 @@ td .button {
     margin: 20px 0px;
 }
 
+.autosave:not([disabled]) {
+    color: #0088cc !important;
+}
+
+.autosave ~ .save {
+    position: relative;
+    top: 3px;
+
+    left: -25px;
+    margin-top: 1px;
+
+    font-size: 1.2em;
+    color: #0088cc;
+    cursor: pointer;
+
+    transition: opacity 0.2s ease;
+}
+
+.autosave ~ .save::before {
+    content: "\f0c7";
+
+    font-family: "FontAwesome";
+}
+
+.autosave[disabled] ~ .save::before {
+    content: "\f040";
+
+    color: initial;
+}
+
 .input-group.thinner {
     margin: 10px 0px;
 }

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -44,11 +44,13 @@
                     <div class="user-name-section inline-block">
                         <div class="input-group" id="name_change_container">
                             <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
-                            <input type="text" name="full_name" id="full_name" class="w-200 inline-block" value="{{ page_params.full_name }}" {{#if page_params.realm_name_changes_disabled}}disabled="disabled" {{/if}}/>
+                            <input type="text" name="full_name" id="full_name" class="w-200 inline-block autosave" value="{{ page_params.full_name }}" disabled="disabled" />
                             <i class="icon-vector-question-sign change_name_tooltip" data-toggle="tooltip"
                             {{#unless page_params.realm_name_changes_disabled}}style="display:none" {{/unless}}
-                            title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
-                            <div class="warning"></div>
+                            title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}" />
+                            {{#unless page_params.realm_name_changes_disabled}}
+                            <span class="save"></span>
+                            {{/unless}}
                         </div>
 
                         <!-- password start -->


### PR DESCRIPTION
This converts the full_name input in the /account-settings/ section of
the settings panel to be autosaved whenever the input is blurred or the
save button is clicked.