### PR TITLE
Clean out /root/zulip from install instructions

### DIFF
--- a/docs/prod-install.md
+++ b/docs/prod-install.md
@@ -38,27 +38,33 @@ tarball](https://www.zulip.org/dist/releases/zulip-server-latest.tar.gz)
 with the following commands:
 
 ```
-sudo -i  # If not already root
-cd /root
+cd $(mktemp -d)
 wget https://www.zulip.org/dist/releases/zulip-server-latest.tar.gz
-rm -rf /root/zulip && mkdir /root/zulip
-tar -xf zulip-server-latest.tar.gz --directory=/root/zulip --strip-components=1
+tar -xf zulip-server-latest.tar.gz
 ```
 
 Then, run the Zulip install script:
 ```
-/root/zulip/scripts/setup/install
+sudo -s  # If not already root
+./zulip-server-*/scripts/setup/install
 ```
 
 This may take a while to run, since it will install a large number of
-dependencies. It also creates a `zulip` user, which will be used to run
-the various Zulip servers.
+dependencies.
 
 The Zulip install script is designed to be idempotent, so if it fails,
 you can just rerun it after correcting the issue that caused it to
 fail.  Also note that it automatically logs a transcript to
 `/var/log/zulip/install.log`; please include a copy of that file in
 any bug reports.
+
+The install script creates a `zulip` user, which the various Zulip
+servers will run as, and the Zulip deployment (and future deployments
+when you upgrade) go into `/home/zulip/deployments/`.  At the very end
+of the install process, the script moves the Zulip code tree it's
+running from (which you unpacked from a tarball above) to a directory
+there, and makes `/home/zulip/deployments/current` as a symbolic link
+to it.
 
 ## Step 3: Configure Zulip
 

--- a/docs/prod-maintain-secure-upgrade.md
+++ b/docs/prod-maintain-secure-upgrade.md
@@ -77,14 +77,16 @@ upgrade.
 
 The Zulip upgrade process works by creating a new deployment under
 `/home/zulip/deployments/` containing a complete copy of the Zulip server code,
-and then moving the symlinks at `/home/zulip/deployments/current` and
-`/root/zulip` as part of the upgrade process.
+and then moving the symlinks at `/home/zulip/deployments/{current,last,next}`
+as part of the upgrade process.
 
 This means that if the new version isn't working,
-you can quickly downgrade to the old version by using
-`/home/zulip/deployments/<date>/scripts/restart-server` to return to
-a previous version that you've deployed (the version is specified
-via the path to the copy of `restart-server` you call).
+you can quickly downgrade to the old version by running
+`/home/zulip/deployments/last/scripts/restart-server`, or to an
+earlier previous version by running
+`/home/zulip/deployments/DATE/scripts/restart-server`.  The
+`restart-server` script stops any running Zulip server, and starts
+the version corresponding to the `restart-server` path you call.
 
 ### Updating settings
 

--- a/scripts/setup/postgres-init-db
+++ b/scripts/setup/postgres-init-db
@@ -30,7 +30,8 @@ if [ -e "/var/run/supervisor.sock" ]; then
 fi
 
 # Drop any open connections to any old database.  Hackishly call using
-# source because postgres user can't read /root/zulip/scripts/setup.
+# `source`, because postgres user may not be able to read this directory
+# if unpacked by root.
 source "$(dirname "$0")/terminate-psql-sessions" postgres zulip zulip_base
 
 (

--- a/tools/setup/install-aws-server
+++ b/tools/setup/install-aws-server
@@ -92,7 +92,7 @@ sed -i 's/localhost$/localhost $hostname/' /etc/hosts
 apt-get update
 apt-get -y upgrade
 
-cd /root
+cd "$(mktemp -d)"
 if ! [ -e "zulip" ]; then
     # need to install git to clone the repo
     apt-get install -y git crudini
@@ -102,7 +102,8 @@ cd zulip
 git fetch
 git checkout origin/$branch
 # The main Zulip production install script can take things from here!
-env VIRTUALENV_NEEDED=$VIRTUALENV_NEEDED PUPPET_CLASSES="$type" /root/zulip/scripts/setup/install
+env VIRTUALENV_NEEDED=$VIRTUALENV_NEEDED PUPPET_CLASSES="$type" \
+  ./scripts/setup/install
 EOF
 
 set +x

--- a/tools/travis/production-helper
+++ b/tools/travis/production-helper
@@ -9,9 +9,8 @@ apt-get install -y openssl ssl-cert
 ln -nsf /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/zulip.combined-chain.crt
 ln -nsf /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/zulip.key
 
-rm -rf /root/zulip
-tar -xf zulip-server-travis.tar.gz
-mv zulip-server-travis /root/zulip
+ZULIP_PATH=$(mktemp -d)
+tar -xf zulip-server-travis.tar.gz -C "$ZULIP_PATH" --strip-components=1
 
 # Do an apt upgrade to start with an up-to-date machine
 export APT_OPTIONS="-o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
@@ -36,7 +35,7 @@ service rabbitmq-server stop
 rm -rf /var/lib/rabbitmq/mnesia/
 
 # Install Zulip
-env TRAVIS=1 /root/zulip/scripts/setup/install
+env TRAVIS=1 "$ZULIP_PATH"/scripts/setup/install
 
 cat >>/etc/zulip/settings.py <<EOF
 # Travis CI override settings above


### PR DESCRIPTION
This leaves just one spot in the source tree that still mentions `/root/zulip` -- the Nagios config in `puppet/zulip_ops/`. Which is actually already broken, in that it depends on `/root/zulip/api/`, so we'll have to sort that out. Doesn't affect normal users, though.
