### PR TITLE
frontend: Remove IDs from alt value of inline images.

### DIFF
--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -10,7 +10,7 @@
                         {{#include_sender}}
                             {{! See ../js/notifications.js for another user of avatar_url. }}
                             <div class="u-{{msg/sender_id}} inline_profile_picture{{#status_message}} sender_info_hover{{/status_message}}">
-                                <img src="{{small_avatar_url}}" alt="{{msg/sender_id}}" class="no-drag"/>
+                                <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
                             </div>
                             {{#if status_message}}
                                 <span class="sender-status">


### PR DESCRIPTION
Makes the alt value empty, as the ID does not add any extra information (discussion [here](https://github.com/zulip/zulip/issues/5004#issuecomment-321365648)).