### PR TITLE
Remove the slide animation from product pages.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -343,24 +343,14 @@ nav ul li.active::after {
 
     padding-top: 120px;
 
-    transition: all 0.5s ease;
-    -webkit-transform: translateY(120px);
-    transform: translateY(120px);
+    transition: opacity 0.3s ease;
+
     opacity: 0;
 
     z-index: 1;
 }
 
-.portico-landing.no-slide {
-    -webkit-transform: translateY(0px);
-    transform: translateY(0px);
-
-    opacity: 1;
-}
-
 .portico-landing.show {
-    -webkit-transform: translateY(0px);
-    transform: translateY(0px);
     opacity: 1;
 }
 

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -18,7 +18,7 @@
 {% include 'zerver/landing_nav.html' %}
 {% include 'zerver/gradients.html' %}
 
-<div class="portico-landing apps no-slide">
+<div class="portico-landing apps">
     <div class="hero">
         <div id="waves"></div>
         <div class="info">

--- a/templates/zerver/for-companies.html
+++ b/templates/zerver/for-companies.html
@@ -18,7 +18,7 @@
 
 {% include 'zerver/landing_nav.html' %}
 
-<div class="portico-landing why-page no-slide">
+<div class="portico-landing why-page">
     <div class="hero">
         <h1 class="center">{% trans %}The best chat for workplaces{% endtrans %}</h1>
         <p>Make better use of your managers' time, integrate your remote workers, and replace your low-content meetings</p>

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -18,7 +18,7 @@
 
 {% include 'zerver/landing_nav.html' %}
 
-<div class="portico-landing why-page no-slide">
+<div class="portico-landing why-page">
     <div class="hero">
         <h1 class="center">{% trans %}The best chat for open source projects{% endtrans %}</h1>
         <p>Engage your community with fun, thoughtful, and organized discussion</p>

--- a/templates/zerver/for-working-groups-and-communities.html
+++ b/templates/zerver/for-working-groups-and-communities.html
@@ -18,7 +18,7 @@
 
 {% include 'zerver/landing_nav.html' %}
 
-<div class="portico-landing why-page no-slide">
+<div class="portico-landing why-page">
     <div class="hero">
         <h1 class="center">{% trans %}The best chat for working groups and communities{% endtrans %}</h1>
         <p>Make good use of your users' time, and engage your community with thoughtful, organized discussion</p>

--- a/templates/zerver/why-zulip.html
+++ b/templates/zerver/why-zulip.html
@@ -18,7 +18,7 @@
 
 {% include 'zerver/landing_nav.html' %}
 
-<div class="portico-landing why-page no-slide">
+<div class="portico-landing why-page">
     <div class="hero">
         <h1 class="center">{% trans %}Why Zulip?{% endtrans %}</h1>
     </div>


### PR DESCRIPTION
This removes the slide animation from the landing pages where the page will fade in and slide down from the top. Now it just fades in over a half second.