### PR TITLE
topic history: Turn on server-side topic history.

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -239,9 +239,11 @@ function initialize_stream_data() {
     });
 
     topic_list.set_click_handlers = noop;
-    topic_list.is_zoomed = return_false;
+    topic_list.close = noop;
     topic_list.remove_expanded_topics = noop;
     topic_list.rebuild = noop;
+    topic_list.active_stream_id = noop;
+    stream_list.show_all_streams = noop;
     stream_list.scroll_element_into_container = noop;
 
     var scrollbar_updated = false;

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -481,6 +481,12 @@ function initialize_stream_data() {
         container_height: 10,
     }));
 
+    assert.equal(0, stream_list.scroll_delta({
+        elem_top: -5,
+        elem_bottom: 15,
+        container_height: 10,
+    }));
+
     // The top is offscreen.
     assert.equal(-3, stream_list.scroll_delta({
         elem_top: -3,
@@ -490,6 +496,12 @@ function initialize_stream_data() {
 
     assert.equal(-3, stream_list.scroll_delta({
         elem_top: -3,
+        elem_bottom: -1,
+        container_height: 10,
+    }));
+
+    assert.equal(-11, stream_list.scroll_delta({
+        elem_top: -150,
         elem_bottom: -1,
         container_height: 10,
     }));
@@ -504,6 +516,12 @@ function initialize_stream_data() {
     assert.equal(3, stream_list.scroll_delta({
         elem_top: 11,
         elem_bottom: 13,
+        container_height: 10,
+    }));
+
+    assert.equal(11, stream_list.scroll_delta({
+        elem_top: 11,
+        elem_bottom: 99,
         container_height: 10,
     }));
 

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -472,3 +472,39 @@ function initialize_stream_data() {
     assert.equal(html_dict.get(1000), '<div>stub-html-devel');
     assert.equal(html_dict.get(5000), '<div>stub-html-Denmark');
 }());
+
+(function test_scroll_delta() {
+    // If we are entirely on-screen, don't scroll
+    assert.equal(0, stream_list.scroll_delta({
+        elem_top: 1,
+        elem_bottom: 9,
+        container_height: 10,
+    }));
+
+    // The top is offscreen.
+    assert.equal(-3, stream_list.scroll_delta({
+        elem_top: -3,
+        elem_bottom: 5,
+        container_height: 10,
+    }));
+
+    assert.equal(-3, stream_list.scroll_delta({
+        elem_top: -3,
+        elem_bottom: -1,
+        container_height: 10,
+    }));
+
+    // The bottom is offscreen.
+    assert.equal(3, stream_list.scroll_delta({
+        elem_top: 7,
+        elem_bottom: 13,
+        container_height: 10,
+    }));
+
+    assert.equal(3, stream_list.scroll_delta({
+        elem_top: 11,
+        elem_bottom: 13,
+        container_height: 10,
+    }));
+
+}());

--- a/frontend_tests/node_tests/topic_list.js
+++ b/frontend_tests/node_tests/topic_list.js
@@ -1,4 +1,5 @@
 set_global('$', global.make_zjquery());
+set_global('i18n', global.stub_i18n);
 
 set_global('narrow_state', {});
 set_global('stream_data', {});
@@ -6,6 +7,9 @@ set_global('unread', {});
 set_global('muting', {});
 set_global('stream_popover', {});
 set_global('templates', {});
+set_global('feature_flags', {
+    use_server_topic_history: true,
+});
 
 zrequire('hash_util');
 zrequire('narrow');
@@ -65,11 +69,10 @@ zrequire('topic_list');
 
     var ul = $('<ul class="topic-list">');
 
-    var item_appended;
+    var list_items = [];
 
     ul.append = function (item) {
-        assert.equal(item.html(), '<topic list item>');
-        item_appended = true;
+        list_items.push(item);
     };
 
     var parent_elem = $.create('parent_elem');
@@ -89,7 +92,8 @@ zrequire('topic_list');
 
     assert(checked_mutes);
     assert(rendered);
-    assert(item_appended);
+    assert.equal(list_items[0].html(), '<topic list item>');
+    assert.equal(list_items[1], $('<li class="show-more-topics">'));
     assert(attached_to_parent);
 
     assert.equal(topic_list.active_stream_id(), stream_id);

--- a/frontend_tests/node_tests/topic_list.js
+++ b/frontend_tests/node_tests/topic_list.js
@@ -74,6 +74,8 @@ zrequire('topic_list');
         attached_to_parent = true;
     };
 
+    assert.equal(topic_list.active_stream_id(), undefined);
+
     var widget = topic_list.build_widget(parent_elem, stream_id, active_topic, max_topics);
 
     assert(widget.is_for_stream(stream_id));
@@ -83,4 +85,6 @@ zrequire('topic_list');
     assert(rendered);
     assert(item_appended);
     assert(attached_to_parent);
+
+    assert.equal(topic_list.active_stream_id(), stream_id);
 }());

--- a/frontend_tests/node_tests/topic_list.js
+++ b/frontend_tests/node_tests/topic_list.js
@@ -1,8 +1,10 @@
 set_global('$', global.make_zjquery());
 
+set_global('narrow_state', {});
 set_global('stream_data', {});
 set_global('unread', {});
 set_global('muting', {});
+set_global('stream_popover', {});
 set_global('templates', {});
 
 zrequire('hash_util');
@@ -12,8 +14,6 @@ zrequire('topic_list');
 
 (function test_topic_list_build_widget() {
     var stream_id = 555;
-    var active_topic = "testing";
-    var max_topics = 5;
 
     topic_data.reset();
     topic_data.add_message({
@@ -21,6 +21,12 @@ zrequire('topic_list');
         topic_name: 'coding',
         message_id: 400,
     });
+
+    stream_popover.hide_topic_popover = function () {};
+
+    narrow_state.topic = function () {
+        return 'testing';
+    };
 
     unread.num_unread_for_topic = function () {
         return 3;
@@ -76,7 +82,7 @@ zrequire('topic_list');
 
     assert.equal(topic_list.active_stream_id(), undefined);
 
-    var widget = topic_list.build_widget(parent_elem, stream_id, active_topic, max_topics);
+    var widget = topic_list.rebuild(parent_elem, stream_id);
 
     assert(widget.is_for_stream(stream_id));
     assert.equal(widget.get_parent(), parent_elem);

--- a/static/js/feature_flags.js
+++ b/static/js/feature_flags.js
@@ -13,7 +13,7 @@ exports.clicking_notification_causes_narrow = true;
 exports.collapsible = false;
 exports.dropbox_integration = false;
 
-exports.use_server_topic_history = false;
+exports.use_server_topic_history = true;
 
 return exports;
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -2,8 +2,6 @@ var stream_list = (function () {
 
 var exports = {};
 
-var zoomed_stream = '';
-
 exports.get_global_filter_li = function (filter_name) {
     var selector = "#global_filters li[data-name='" + filter_name + "']";
     return $(selector);
@@ -153,11 +151,10 @@ exports.get_stream_li = function (stream_id) {
     return li;
 };
 
-function zoom_in() {
+function zoom_in(options) {
     popovers.hide_all();
     topic_list.zoom_in();
     $("#streams_list").expectOne().removeClass("zoom-out").addClass("zoom-in");
-    zoomed_stream = narrow_state.stream();
 
     // Hide stream list titles and pinned stream splitter
     $(".stream-filters-label").each(function () {
@@ -169,8 +166,9 @@ function zoom_in() {
 
     $("#stream_filters li.narrow-filter").each(function () {
         var elt = $(this);
+        var stream_id = options.stream_id.toString();
 
-        if (elt.attr('data-name') === zoomed_stream) {
+        if (elt.attr('data-stream-id') === stream_id) {
             elt.show();
         } else {
             elt.hide();

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -616,10 +616,18 @@ exports.scroll_delta = function (opts) {
     var delta = 0;
 
     if (elem_top < 0) {
-        delta = elem_top;
+        delta = Math.max(
+            elem_top,
+            elem_bottom - container_height
+        );
+        delta = Math.min(0, delta);
     } else {
         if (elem_bottom > container_height) {
-            delta = elem_bottom - container_height;
+            delta = Math.min(
+                elem_top,
+                elem_bottom - container_height
+            );
+            delta = Math.max(0, delta);
         }
     }
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -182,6 +182,10 @@ function zoom_out(options) {
     popovers.hide_all();
     topic_list.zoom_out(options);
 
+    if (options.stream_li) {
+        exports.scroll_to_active_stream(options.stream_li);
+    }
+
     // Show stream list titles and pinned stream splitter
     $(".stream-filters-label").each(function () {
         $(this).show();

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -185,7 +185,10 @@ function zoom_out(options) {
     if (options.stream_li) {
         exports.scroll_stream_into_view(options.stream_li);
     }
+    exports.show_all_streams();
+}
 
+exports.show_all_streams = function () {
     // Show stream list titles and pinned stream splitter
     $(".stream-filters-label").each(function () {
         $(this).show();
@@ -196,7 +199,7 @@ function zoom_out(options) {
 
     $("#streams_list").expectOne().removeClass("zoom-in").addClass("zoom-out");
     $("#stream_filters li.narrow-filter").show();
-}
+};
 
 function reset_to_unnarrowed(narrowed_within_same_stream) {
     if (topic_list.is_zoomed() && narrowed_within_same_stream !== true) {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -183,7 +183,7 @@ function zoom_out(options) {
     topic_list.zoom_out(options);
 
     if (options.stream_li) {
-        exports.scroll_to_active_stream(options.stream_li);
+        exports.scroll_stream_into_view(options.stream_li);
     }
 
     // Show stream list titles and pinned stream splitter
@@ -380,7 +380,7 @@ exports.refresh_pinned_or_unpinned_stream = function (sub) {
             blueslip.error('passed in bad stream id ' + sub.stream_id);
             return;
         }
-        exports.scroll_to_active_stream(stream_li);
+        exports.scroll_stream_into_view(stream_li);
     }
 };
 
@@ -463,7 +463,7 @@ exports.initialize = function () {
 
         var stream_li = exports.maybe_activate_stream_item(event.filter);
         if (stream_li) {
-            exports.scroll_to_active_stream(stream_li);
+            exports.scroll_stream_into_view(stream_li);
         }
         // Update scrollbar size.
         $("#stream-filters-container").perfectScrollbar("update");
@@ -601,7 +601,7 @@ $(function () {
         .on('click', toggle_filter_displayed);
 });
 
-exports.scroll_to_active_stream = function (stream_li) {
+exports.scroll_stream_into_view = function (stream_li) {
     var container = $('#stream-filters-container');
 
     if (stream_li.length !== 1) {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -608,8 +608,26 @@ exports.scroll_to_active_stream = function (stream_li) {
     exports.scroll_element_into_container(stream_li, container);
 };
 
-exports.scroll_element_into_container = function (active_elem, container) {
-    // This is a generic function to make active_elem visible in
+exports.scroll_delta = function (opts) {
+    var elem_top = opts.elem_top;
+    var container_height = opts.container_height;
+    var elem_bottom = opts.elem_bottom;
+
+    var delta = 0;
+
+    if (elem_top < 0) {
+        delta = elem_top;
+    } else {
+        if (elem_bottom > container_height) {
+            delta = elem_bottom - container_height;
+        }
+    }
+
+    return delta;
+};
+
+exports.scroll_element_into_container = function (elem, container) {
+    // This is a generic function to make elem visible in
     // container by scrolling container appropriately.  We may want to
     // eventually move this into another module, but I couldn't find
     // an ideal landing space for this.  I considered a few modules, but
@@ -621,19 +639,16 @@ exports.scroll_element_into_container = function (active_elem, container) {
     // this will be non-intrusive to users when they already have
     // the element visible.
 
-    var active_top = active_elem.position().top;
-    var delta = 0;
+    var elem_top = elem.position().top;
+    var elem_bottom = elem_top + elem.height();
 
-    if (active_top < 0) {
-        delta = active_top;
-    } else {
-        var active_bottom = active_top + active_elem.height();
-        var container_height = container.height();
+    var opts = {
+        elem_top: elem_top,
+        elem_bottom: elem_bottom,
+        container_height: container.height(),
+    };
 
-        if (active_bottom > container_height) {
-            delta = active_bottom - container_height;
-        }
-    }
+    var delta = exports.scroll_delta(opts);
 
     if (delta === 0) {
         return;

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -418,6 +418,40 @@ function deselect_top_left_corner_items() {
     $("ul.filters li").removeClass('active-filter active-sub-filter');
 }
 
+exports.update_top_left_corner_for_narrow = function (filter) {
+    deselect_top_left_corner_items();
+
+    var ops;
+    var filter_name;
+    var filter_li;
+
+    // TODO: handle confused filters like "in:all stream:foo"
+    ops = filter.operands('in');
+    if (ops.length >= 1) {
+        filter_name = ops[0];
+        if (filter_name === 'home') {
+            filter_li = exports.get_global_filter_li(filter_name);
+            filter_li.addClass('active-filter');
+        }
+    }
+    ops = filter.operands('is');
+    if (ops.length >= 1) {
+        filter_name = ops[0];
+        if ((filter_name === 'starred') || (filter_name === 'mentioned')) {
+            filter_li = exports.get_global_filter_li(filter_name);
+            filter_li.addClass('active-filter');
+        }
+    }
+
+    var op_is = filter.operands('is');
+    var op_pm = filter.operands('pm-with');
+    if (((op_is.length >= 1) && _.contains(op_is, "private")) || op_pm.length >= 1) {
+        pm_list.expand(op_pm);
+    } else {
+        pm_list.close();
+    }
+};
+
 exports.initialize = function () {
     // TODO, Eventually topic_list won't be a big singleton,
     // and we can create more component-based click handlers for
@@ -428,38 +462,9 @@ exports.initialize = function () {
     });
 
     $(document).on('narrow_activated.zulip', function (event) {
-        deselect_top_left_corner_items();
+        exports.update_top_left_corner_for_narrow(event.filter);
+
         reset_to_unnarrowed(narrow_state.stream() === zoomed_stream);
-
-        var ops;
-        var filter_name;
-        var filter_li;
-
-        // TODO: handle confused filters like "in:all stream:foo"
-        ops = event.filter.operands('in');
-        if (ops.length >= 1) {
-            filter_name = ops[0];
-            if (filter_name === 'home') {
-                filter_li = exports.get_global_filter_li(filter_name);
-                filter_li.addClass('active-filter');
-            }
-        }
-        ops = event.filter.operands('is');
-        if (ops.length >= 1) {
-            filter_name = ops[0];
-            if ((filter_name === 'starred') || (filter_name === 'mentioned')) {
-                filter_li = exports.get_global_filter_li(filter_name);
-                filter_li.addClass('active-filter');
-            }
-        }
-
-        var op_is = event.filter.operands('is');
-        var op_pm = event.filter.operands('pm-with');
-        if (((op_is.length >= 1) && _.contains(op_is, "private")) || op_pm.length >= 1) {
-            pm_list.expand(op_pm);
-        } else {
-            pm_list.close();
-        }
 
         var stream_li = exports.maybe_activate_stream_item(event.filter);
         if (stream_li) {

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -210,7 +210,10 @@ exports.set_click_handlers = function (callbacks) {
     });
 
     $('.show-all-streams').on('click', function (e) {
-        callbacks.zoom_out({clear_topics: false});
+        callbacks.zoom_out({
+            clear_topics: false,
+            stream_li: active_widget.get_parent(),
+        });
 
         e.preventDefault();
         e.stopPropagation();

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -103,7 +103,11 @@ exports.build_widget = function (parent_elem, my_stream_id, active_topic, max_to
             ul.append(li);
         });
 
-        if (hiding_topics) {
+        // When we inline use_server_topic_history to true (i.e. we are confident
+        // with the new feature), we can remove logic around hiding_topics.
+        var show_more_topics_link = hiding_topics || feature_flags.use_server_topic_history;
+
+        if (show_more_topics_link) {
             var show_more = $('<li class="show-more-topics">');
             show_more.attr('data-stream', my_stream_name);
             var link = $('<a href="#">');

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -13,7 +13,18 @@ exports.remove_expanded_topics = function () {
 
     if (active_widget) {
         active_widget.remove();
+        active_widget = undefined;
     }
+};
+
+exports.close = function () {
+    zoomed = false;
+    exports.remove_expanded_topics();
+};
+
+exports.zoom_out = function () {
+    zoomed = false;
+    exports.rebuild(active_widget.get_parent(), active_widget.get_stream_id());
 };
 
 function update_unread_count(unread_count_elem, count) {
@@ -198,19 +209,6 @@ exports.zoom_in = function () {
     }
 };
 
-exports.zoom_out = function (options) {
-    zoomed = false;
-    if (options && options.clear_topics) {
-        exports.remove_expanded_topics();
-    } else {
-        exports.rebuild(active_widget.get_parent(), active_widget.get_stream_id());
-    }
-};
-
-exports.is_zoomed = function () {
-    return zoomed;
-};
-
 exports.set_click_handlers = function (callbacks) {
     $('#stream_filters').on('click', '.show-more-topics', function (e) {
         callbacks.zoom_in();
@@ -221,7 +219,6 @@ exports.set_click_handlers = function (callbacks) {
 
     $('.show-all-streams').on('click', function (e) {
         callbacks.zoom_out({
-            clear_topics: false,
             stream_li: active_widget.get_parent(),
         });
 

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -211,7 +211,9 @@ exports.zoom_in = function () {
 
 exports.set_click_handlers = function (callbacks) {
     $('#stream_filters').on('click', '.show-more-topics', function (e) {
-        callbacks.zoom_in();
+        callbacks.zoom_in({
+            stream_id: active_widget.get_stream_id(),
+        });
 
         e.preventDefault();
         e.stopPropagation();

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -169,6 +169,8 @@ exports.rebuild = function (stream_li, stream_id) {
     var active_topic = narrow_state.topic();
     exports.remove_expanded_topics();
     active_widget = exports.build_widget(stream_li, stream_id, active_topic, max_topics);
+
+    return active_widget; // used for testing
 };
 
 // For zooming, we only do topic-list stuff here...let stream_list

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -155,6 +155,14 @@ exports.build_widget = function (parent_elem, my_stream_id, active_topic, max_to
     return self;
 };
 
+exports.active_stream_id = function () {
+    if (!active_widget) {
+        return;
+    }
+
+    return active_widget.get_stream_id();
+};
+
 exports.rebuild = function (stream_li, stream_id) {
     var max_topics = 5;
 

--- a/static/templates/stream_sidebar_row.handlebars
+++ b/static/templates/stream_sidebar_row.handlebars
@@ -1,7 +1,7 @@
 {{! Stream sidebar rows }}
 
 <li data-name="{{name}}" class="narrow-filter{{#if not_in_home_view}} out_of_home_view{{/if}}"
-    id="stream_sidebar_{{id}}">
+    data-stream-id="{{id}}">
     <div class="subscription_block selectable_sidebar_block" data-name="{{name}}">
 
         <span id="stream_sidebar_privacy_swatch_{{id}}" class="stream-privacy" style="color: {{color}}">


### PR DESCRIPTION
The bulk of this PR fixes latent issues with "more topics" related to scrolling and kludgy redraws.  But the last commit turns on server-side topic history.