### PR TITLE
Automatically tag backend strings.

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -8,7 +8,7 @@ from django.db.models.query import QuerySet
 from django.http import HttpResponseNotFound, HttpRequest, HttpResponse
 from django.template import RequestContext, loader
 from django.utils.timezone import now as timezone_now
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.shortcuts import render
 from jinja2 import Markup as mark_safe
 
@@ -80,12 +80,12 @@ def get_chart_data(request, user_profile, chart_name=REQ(),
         labels_sort_function = sort_client_labels
         include_empty_subgroups = False
     else:
-        raise JsonableError(_("Unknown chart name: %s") % (chart_name,))
+        raise JsonableError(err_("Unknown chart name: %s") % (chart_name,))
 
     # Most likely someone using our API endpoint. The /stats page does not
     # pass a start or end in its requests.
     if start is not None and end is not None and start > end:
-        raise JsonableError(_("Start time is later than end time. Start: %(start)s, End: %(end)s") %
+        raise JsonableError(err_("Start time is later than end time. Start: %(start)s, End: %(end)s") %
                             {'start': start, 'end': end})
 
     realm = user_profile.realm
@@ -98,7 +98,7 @@ def get_chart_data(request, user_profile, chart_name=REQ(),
                         "start time: %s (creation time of realm) is later than the computed "
                         "end time: %s (last successful analytics update). Is the "
                         "analytics cron job running?" % (realm.string_id, start, end))
-        raise JsonableError(_("No analytics data available. Please contact your server administrator."))
+        raise JsonableError(err_("No analytics data available. Please contact your server administrator."))
 
     end_times = time_range(start, end, stat.frequency, min_length)
     data = {'end_times': end_times, 'frequency': stat.frequency}

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -181,7 +181,7 @@ def build_custom_checkers(by_lang):
                          ]),
          'exclude_line': set([
              ('zerver/views/users.py',
-              "return json_error(_(\"Email '%(email)s' not allowed for realm '%(realm)s'\") %"),
+              "return json_error(err_(\"Email '%(email)s' not allowed for realm '%(realm)s'\") %"),
              ('zproject/settings.py',
               "'format': '%(asctime)s %(levelname)-8s %(message)s'"),
              ('static/templates/settings/bot-settings.handlebars',
@@ -234,10 +234,10 @@ def build_custom_checkers(by_lang):
          'description': 'Test strings should not be tagged for translationx'},
         {'pattern': 'json_success\({}\)',
          'description': 'Use json_success() to return nothing'},
-        # To avoid json_error(_variable) and json_error(_(variable))
-        {'pattern': '\Wjson_error\(_\(?\w+\)',
+        # To avoid json_error(_(variable)), json_error(err_variable), and json_error(err_(variable))
+        {'pattern': '\Wjson_error\((err)?_\(?\w+\)',
          'exclude': set(['zerver/tests']),
-         'description': 'Argument to json_error should be a literal string enclosed by _()'},
+         'description': 'Argument to json_error should be a literal string enclosed by err_()'},
         {'pattern': '\Wjson_error\([\'"].+[),]$',
          'exclude': set(['zerver/tests']),
          'exclude_line': set([
@@ -245,13 +245,13 @@ def build_custom_checkers(by_lang):
              ('zerver/views/compatibility.py', 'return json_error("Client is too old")'),
          ]),
          'description': 'Argument to json_error should a literal string enclosed by _()'},
-        # To avoid JsonableError(_variable) and JsonableError(_(variable))
-        {'pattern': '\WJsonableError\(_\(?\w.+\)',
+        # To avoid JsonableError(_(variable), JsonableError(err_variable), and JsonableError(err_(variable))
+        {'pattern': '\WJsonableError\((err)?_\(?\w.+\)',
          'exclude': set(['zerver/tests']),
-         'description': 'Argument to JsonableError should be a literal string enclosed by _()'},
+         'description': 'Argument to JsonableError should be a literal string enclosed by err_()'},
         {'pattern': '\WJsonableError\(["\'].+\)',
          'exclude': set(['zerver/tests']),
-         'description': 'Argument to JsonableError should be a literal string enclosed by _()'},
+         'description': 'Argument to JsonableError should be a literal string enclosed by err_()'},
         {'pattern': '([a-zA-Z0-9_]+)=REQ\([\'"]\\1[\'"]',
          'description': 'REQ\'s first argument already defaults to parameter name'},
         {'pattern': 'self\.client\.(get|post|patch|put|delete)',

--- a/tools/tagmessages
+++ b/tools/tagmessages
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+
+from hashlib import md5
+import polib
+
+username = 'transifex_username'
+password = 'transifex_password'
+tools_dir = os.path.dirname(os.path.abspath(__file__))
+root_dir = os.path.dirname(tools_dir)
+# Choose any translation file for processing all strings.
+po = polib.pofile(os.path.join(root_dir, 'static', 'locale', 'de', 'LC_MESSAGES', 'django.po'))
+for entry in po:
+    tag = entry.comment
+    if tag:
+        keys = [entry.msgid, entry.msgctxt or '']
+        msg_hash = md5(':'.join(keys).encode('utf-8')).hexdigest()
+        curl_call = 'curl -i -L --user {}:{} -X PUT -H "Content-Type: application/json" ' \
+                    '--data \'{{"tags": ["{}"]}}\' https://www.transifex.com/api/2/project/zulip/resource' \
+                    '/djangopo/source/{}'.format(username, password, tag, msg_hash)
+        os.system(curl_call)

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.core.validators import validate_email
 from django.db.models.query import QuerySet
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from jinja2 import Markup as mark_safe
 
 from zerver.lib.actions import do_change_password, is_inactive, user_email_is_unique

--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from typing import Any, Dict, List
 
 from zerver.lib.request import JsonableError
@@ -20,7 +20,7 @@ def access_attachment_by_id(user_profile, attachment_id, needs_owner=False):
 
     attachment = query.first()
     if attachment is None:
-        raise JsonableError(_("Invalid attachment"))
+        raise JsonableError(err_("Invalid attachment"))
     return attachment
 
 def remove_attachment(user_profile, attachment):

--- a/zerver/lib/domains.py
+++ b/zerver/lib/domains.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 import re
 from typing import Text

--- a/zerver/lib/emoji.py
+++ b/zerver/lib/emoji.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import os
 import re
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from typing import Optional, Text
 from zerver.lib.bugdown import name_to_codepoint
 from zerver.lib.request import JsonableError
@@ -19,7 +19,7 @@ def check_valid_emoji(realm, emoji_name):
         return
     if emoji_name == 'zulip':
         return
-    raise JsonableError(_("Emoji '%s' does not exist" % (emoji_name,)))
+    raise JsonableError(err_("Emoji '%s' does not exist" % (emoji_name,)))
 
 def check_emoji_admin(user_profile, emoji_name=None):
     # type: (UserProfile, Optional[Text]) -> None
@@ -30,7 +30,7 @@ def check_emoji_admin(user_profile, emoji_name=None):
     if user_profile.is_realm_admin:
         return
     if user_profile.realm.add_emoji_by_admins_only:
-        raise JsonableError(_("Must be a realm administrator"))
+        raise JsonableError(err_("Must be a realm administrator"))
 
     # Otherwise, normal users can add emoji
     if emoji_name is None:
@@ -42,13 +42,13 @@ def check_emoji_admin(user_profile, emoji_name=None):
                               emoji.author is not None and
                               emoji.author.id == user_profile.id)
     if not user_profile.is_realm_admin and not current_user_is_author:
-        raise JsonableError(_("Must be a realm administrator or emoji author"))
+        raise JsonableError(err_("Must be a realm administrator or emoji author"))
 
 def check_valid_emoji_name(emoji_name):
     # type: (Text) -> None
     if re.match('^[0-9a-z.\-_]+(?<![.\-_])$', emoji_name):
         return
-    raise JsonableError(_("Invalid characters in emoji name"))
+    raise JsonableError(err_("Invalid characters in emoji name"))
 
 def get_emoji_url(emoji_file_name, realm_id):
     # type: (Text, int) -> Text

--- a/zerver/lib/error_notify.py
+++ b/zerver/lib/error_notify.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from django.conf import settings
 from django.core.mail import mail_admins
 from django.http import HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from typing import Any, Dict, Text
 
 from zerver.models import get_system_bot
@@ -130,5 +130,5 @@ def do_report_error(deployment_name, type, report):
     elif type == 'server':
         notify_server_error(report)
     else:
-        return json_error(_("Invalid type parameter"))
+        return json_error(err_("Invalid type parameter"))
     return json_success()

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -7,7 +7,7 @@ import copy
 import six
 import ujson
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.conf import settings
 from importlib import import_module
 from six.moves import filter, map
@@ -500,7 +500,7 @@ def do_events_register(user_profile, user_client, apply_markdown=True,
                                    narrow=narrow)
 
     if queue_id is None:
-        raise JsonableError(_("Could not allocate event queue"))
+        raise JsonableError(err_("Could not allocate event queue"))
 
     if fetch_event_types is not None:
         event_types_set = set(fetch_event_types)  # type: Optional[Set[str]]

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -46,7 +46,7 @@ class JsonableError(Exception):
 
      * Easiest, but completely machine-unreadable:
 
-         raise JsonableError(_("No such widget: {}").format(widget_name))
+         raise JsonableError(err_("No such widget: {}").format(widget_name))
 
        The message may be passed through to clients and shown to a user,
        so translation is required.  Because the text will vary depending
@@ -55,7 +55,7 @@ class JsonableError(Exception):
 
      * Partially machine-readable, with an error code:
 
-         raise JsonableError(_("No such widget: {}").format(widget_name),
+         raise JsonableError(err_("No such widget: {}").format(widget_name),
                              ErrorCode.NO_SUCH_WIDGET)
 
        Now the error's `code` attribute can be used, both in server

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -4,7 +4,7 @@ import operator
 
 from django.conf import settings
 from django.utils import translation
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from six.moves import urllib, zip_longest, zip, range
 from typing import Any, List, Dict, Optional, Text

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -7,7 +7,7 @@ from django.conf.urls import url
 from django.core.urlresolvers import LocaleRegexProvider
 from django.utils.module_loading import import_string
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.template import loader
 
 from zerver.templatetags.app_filters import render_markdown_path

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -4,7 +4,7 @@ import datetime
 import ujson
 import zlib
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from six import binary_type
 
 from zerver.lib.avatar import avatar_url_from_dict
@@ -267,7 +267,7 @@ def access_message(user_profile, message_id):
     try:
         message = Message.objects.select_related().get(id=message_id)
     except Message.DoesNotExist:
-        raise JsonableError(_("Invalid message(s)"))
+        raise JsonableError(err_("Invalid message(s)"))
 
     try:
         user_message = UserMessage.objects.select_related().get(user_profile=user_profile,
@@ -278,16 +278,16 @@ def access_message(user_profile, message_id):
     if user_message is None:
         if message.recipient.type != Recipient.STREAM:
             # You can't access private messages you didn't receive
-            raise JsonableError(_("Invalid message(s)"))
+            raise JsonableError(err_("Invalid message(s)"))
         stream = Stream.objects.get(id=message.recipient.type_id)
         if not stream.is_public():
             # You can't access messages sent to invite-only streams
             # that you didn't receive
-            raise JsonableError(_("Invalid message(s)"))
+            raise JsonableError(err_("Invalid message(s)"))
         # So the message is to a public stream
         if stream.realm != user_profile.realm:
             # You can't access public stream messages in other realms
-            raise JsonableError(_("Invalid message(s)"))
+            raise JsonableError(err_("Invalid message(s)"))
 
     # Otherwise, the message must have been sent to a public
     # stream in your realm, so return the message, user_message pair

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -1,5 +1,5 @@
 from zerver.lib.request import JsonableError
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from typing import Any, Callable, Iterable, Mapping, Sequence, Text
 
@@ -9,7 +9,7 @@ def check_supported_events_narrow_filter(narrow):
     for element in narrow:
         operator = element[0]
         if operator not in ["stream", "topic", "sender", "is"]:
-            raise JsonableError(_("Operator %s not supported.") % (operator,))
+            raise JsonableError(err_("Operator %s not supported.") % (operator,))
 
 def build_narrow_filter(narrow):
     # type: (Iterable[Sequence[Text]]) -> Callable[[Mapping[str, Any]], bool]

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -11,7 +11,7 @@ from six.moves import urllib
 from functools import reduce
 from requests import Response
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.models import Realm, UserProfile, get_realm_by_email_domain, get_user_profile_by_id, get_client, \
     GENERIC_INTERFACE, Service, SLACK_INTERFACE, email_to_domain, get_service_profile

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -21,7 +21,7 @@ from gcm import GCM
 
 from django.conf import settings
 from django.utils.timezone import now as timezone_now
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from six.moves import urllib
 
 import base64
@@ -445,7 +445,7 @@ def remove_push_device_token(user_profile, token_str, kind):
         token = PushDeviceToken.objects.get(token=token_str, kind=kind)
         token.delete()
     except PushDeviceToken.DoesNotExist:
-        raise JsonableError(_("Token does not exist"))
+        raise JsonableError(err_("Token does not exist"))
 
 def send_json_to_push_bouncer(method, endpoint, post_data):
     # type: (str, str, Dict[str, Any]) -> None
@@ -477,14 +477,14 @@ def send_to_push_bouncer(method, endpoint, post_data, extra_headers=None):
 
     # TODO: Think more carefully about how this error hanlding should work.
     if res.status_code >= 500:
-        raise JsonableError(_("Error received from push notification bouncer"))
+        raise JsonableError(err_("Error received from push notification bouncer"))
     elif res.status_code >= 400:
         try:
             msg = ujson.loads(res.content)['msg']
         except Exception:
-            raise JsonableError(_("Error received from push notification bouncer"))
+            raise JsonableError(err_("Error received from push notification bouncer"))
         raise JsonableError(msg)
     elif res.status_code != 200:
-        raise JsonableError(_("Error received from push notification bouncer"))
+        raise JsonableError(err_("Error received from push notification bouncer"))
 
     # If we don't throw an exception, it's a successful bounce!

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -6,7 +6,7 @@ from functools import wraps
 import ujson
 from six.moves import zip
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.lib.exceptions import JsonableError, ErrorCode
 
@@ -120,7 +120,7 @@ def has_request_variables(view_func):
                 try:
                     val = ujson.loads(request.body)
                 except ValueError:
-                    raise JsonableError(_('Malformed JSON'))
+                    raise JsonableError(err_('Malformed JSON'))
                 kwargs[param.func_var_name] = val
                 continue
             elif param.argument_type is not None:
@@ -151,7 +151,7 @@ def has_request_variables(view_func):
                 try:
                     val = ujson.loads(val)
                 except Exception:
-                    raise JsonableError(_('Argument "%s" is not valid JSON.') % (param.post_var_name,))
+                    raise JsonableError(err_('Argument "%s" is not valid JSON.') % (param.post_var_name,))
 
                 error = param.validator(param.post_var_name, val)
                 if error:

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from typing import Any, Dict
 
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 
 from zerver.decorator import authenticated_json_view, authenticated_rest_api_view, \

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from typing import Any, Iterable, List, Mapping, Set, Text, Tuple
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.lib.actions import check_stream_name, create_streams_if_needed
 from zerver.lib.request import JsonableError
@@ -60,7 +60,7 @@ def check_stream_name_available(realm, name):
     check_stream_name(name)
     try:
         get_stream(name, realm)
-        raise JsonableError(_("Stream name '%s' is already taken") % (name,))
+        raise JsonableError(err_("Stream name '%s' is already taken") % (name,))
     except Stream.DoesNotExist:
         pass
 
@@ -144,9 +144,9 @@ def list_to_streams(streams_raw, user_profile, autocreate=False):
     else:
         # autocreate=True path starts here
         if not user_profile.can_create_streams():
-            raise JsonableError(_('User cannot create streams.'))
+            raise JsonableError(err_('User cannot create streams.'))
         elif not autocreate:
-            raise JsonableError(_("Stream(s) (%s) do not exist") % ", ".join(
+            raise JsonableError(err_("Stream(s) (%s) do not exist") % ", ".join(
                 stream_dict["name"] for stream_dict in missing_stream_dicts))
 
         # We already filtered out existing streams, so dup_streams

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from typing import Any, Dict, Mapping, Optional, Tuple, Text
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.conf import settings
 from django.template.defaultfilters import slugify
 from django.core.files import File

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from typing import Text
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.lib.actions import do_change_full_name
 from zerver.lib.request import JsonableError
@@ -11,18 +11,18 @@ def check_full_name(full_name_raw):
     # type: (Text) -> Text
     full_name = full_name_raw.strip()
     if len(full_name) > UserProfile.MAX_NAME_LENGTH:
-        raise JsonableError(_("Name too long!"))
+        raise JsonableError(err_("Name too long!"))
     if len(full_name) < UserProfile.MIN_NAME_LENGTH:
-        raise JsonableError(_("Name too short!"))
+        raise JsonableError(err_("Name too short!"))
     if list(set(full_name).intersection(UserProfile.NAME_INVALID_CHARS)):
-        raise JsonableError(_("Invalid characters in name!"))
+        raise JsonableError(err_("Invalid characters in name!"))
     return full_name
 
 def check_short_name(short_name_raw):
     # type: (Text) -> Text
     short_name = short_name_raw.strip()
     if len(short_name) == 0:
-        raise JsonableError(_("Bad name or username"))
+        raise JsonableError(err_("Bad name or username"))
     return short_name
 
 def check_change_full_name(user_profile, full_name_raw, acting_user):
@@ -38,9 +38,9 @@ def check_change_full_name(user_profile, full_name_raw, acting_user):
 def check_valid_bot_type(bot_type):
     # type: (int) -> None
     if bot_type not in UserProfile.ALLOWED_BOT_TYPES:
-        raise JsonableError(_('Invalid bot type'))
+        raise JsonableError(err_('Invalid bot type'))
 
 def check_valid_interface_type(interface_type):
     # type: (int) -> None
     if interface_type not in Service.ALLOWED_INTERFACE_TYPES:
-        raise JsonableError(_('Invalid interface type'))
+        raise JsonableError(err_('Invalid interface type'))

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -26,7 +26,7 @@ To extend this concept, it's simply a matter of writing your own validator
 for any particular type of object.
 '''
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email, URLValidator
 import six

--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -59,6 +59,8 @@ regexes = ['{{#tr .*?}}([\s\S]*?){{/tr}}',  # '.' doesn't match '\n' by default
            'i18n\.t\("([^\"]*?)"\)',
            'i18n\.t\("(.*?)",.*?[^,]\)',
            ]
+tags = [('err_', "error"),
+        ]
 
 frontend_compiled_regexes = [re.compile(regex) for regex in regexes]
 multiline_js_comment = re.compile("/\*.*?\*/", re.DOTALL)
@@ -71,6 +73,10 @@ def strip_whitespaces(src):
     return src
 
 class Command(makemessages.Command):
+
+    xgettext_options = makemessages.Command.xgettext_options
+    for func, tag in tags:
+        xgettext_options += ['--keyword={}:1,"{}"'.format(func, tag)]
 
     def add_arguments(self, parser):
         # type: (ArgumentParser) -> None

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -5,7 +5,7 @@ from typing import Any, AnyStr, Callable, Dict, Iterable, List, MutableMapping, 
 
 from django.conf import settings
 from django.core.exceptions import DisallowedHost
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.utils.deprecation import MiddlewareMixin
 
 from zerver.lib.response import json_error, json_response_from_error
@@ -289,7 +289,7 @@ class JsonErrorHandler(MiddlewareMixin):
             return json_response_from_error(exception)
         if request.error_format == "JSON":
             logging.error(traceback.format_exc())
-            return json_error(_("Internal server error"), status=500)
+            return json_error(err_("Internal server error"), status=500)
         return None
 
 class TagRequests(MiddlewareMixin):

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -99,7 +99,7 @@ class JsonTranslationTestCase(ZulipTestCase):
                                         expected_error,
                                         status_code=400)
 
-    @mock.patch('zerver.views.auth._')
+    @mock.patch('zerver.views.auth.err_')
     def test_jsonable_error(self, mock_gettext):
         # type: (Any) -> None
         dummy_value = "Some other language"

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from typing import cast, AbstractSet, Any, Callable, Dict, List, \
     Mapping, MutableMapping, Optional, Iterable, Sequence, Set, Text, Union
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.conf import settings
 from django.utils.timezone import now as timezone_now
 from collections import deque
@@ -508,15 +508,15 @@ def fetch_events(query):
                 client = allocate_client_descriptor(new_queue_data)
                 queue_id = client.event_queue.id
             else:
-                raise JsonableError(_("Missing 'queue_id' argument"))
+                raise JsonableError(err_("Missing 'queue_id' argument"))
         else:
             if last_event_id is None:
-                raise JsonableError(_("Missing 'last_event_id' argument"))
+                raise JsonableError(err_("Missing 'last_event_id' argument"))
             client = get_client_descriptor(queue_id)
             if client is None:
                 raise BadEventQueueIdError(queue_id)
             if user_profile_id != client.user_profile_id:
-                raise JsonableError(_("You are not authorized to get events from this queue"))
+                raise JsonableError(err_("You are not authorized to get events from this queue"))
             client.event_queue.prune(last_event_id)
             was_connected = client.finish_current_handler()
 

--- a/zerver/tornado/exceptions.py
+++ b/zerver/tornado/exceptions.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from typing import Text
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.lib.exceptions import JsonableError, ErrorCode
 

--- a/zerver/tornado/socket.py
+++ b/zerver/tornado/socket.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Mapping, Optional, Text, Union
 
 from django.conf import settings
 from django.utils.timezone import now as timezone_now
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.contrib.sessions.models import Session as djSession
 try:
     from django.middleware.csrf import _compare_salted_tokens
@@ -127,14 +127,14 @@ class SocketConnection(sockjs.tornado.SockJSConnection):
 
         user_profile = get_user_profile(self.browser_session_id)
         if user_profile is None:
-            raise JsonableError(_('Unknown or missing session'))
+            raise JsonableError(err_('Unknown or missing session'))
         self.session.user_profile = user_profile
 
         if not _compare_salted_tokens(msg['request']['csrf_token'], self.csrf_token):
-            raise JsonableError(_('CSRF token does not match that in cookie'))
+            raise JsonableError(err_('CSRF token does not match that in cookie'))
 
         if 'queue_id' not in msg['request']:
-            raise JsonableError(_("Missing 'queue_id' argument"))
+            raise JsonableError(err_("Missing 'queue_id' argument"))
 
         queue_id = msg['request']['queue_id']
         client = get_client_descriptor(queue_id)
@@ -142,7 +142,7 @@ class SocketConnection(sockjs.tornado.SockJSConnection):
             raise BadEventQueueIdError(queue_id)
 
         if user_profile.id != client.user_profile_id:
-            raise JsonableError(_("You are not the owner of the queue with id '%s'") % (queue_id,))
+            raise JsonableError(err_("You are not the owner of the queue with id '%s'") % (queue_id,))
 
         self.authenticated = True
         register_connection(queue_id, self)

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 
 from zerver.models import get_client, UserProfile, Client
@@ -33,7 +33,7 @@ def cleanup_event_queue(request, user_profile, queue_id=REQ()):
     if client is None:
         raise BadEventQueueIdError(queue_id)
     if user_profile.id != client.user_profile_id:
-        return json_error(_("You are not authorized to access this queue"))
+        return json_error(err_("You are not authorized to access this queue"))
     request._log_data['extra'] = "[%s]" % (queue_id,)
     client.cleanup()
     return json_success()

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -6,7 +6,7 @@ import logging
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, connection
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.decorator import has_request_variables, REQ, require_realm_admin, \
     human_users_only
@@ -31,10 +31,10 @@ def create_realm_custom_profile_field(request, user_profile, name=REQ(),
                                       field_type=REQ(validator=check_int)):
     # type: (HttpRequest, UserProfile, Text, int) -> HttpResponse
     if not name.strip():
-        return json_error(_("Name cannot be blank."))
+        return json_error(err_("Name cannot be blank."))
 
     if field_type not in CustomProfileField.FIELD_VALIDATORS:
-        return json_error(_("Invalid field type."))
+        return json_error(err_("Invalid field type."))
 
     try:
         field = try_add_realm_custom_profile_field(
@@ -44,7 +44,7 @@ def create_realm_custom_profile_field(request, user_profile, name=REQ(),
         )
         return json_success({'id': field.id})
     except IntegrityError:
-        return json_error(_("A field with that name already exists."))
+        return json_error(err_("A field with that name already exists."))
 
 @require_realm_admin
 def delete_realm_custom_profile_field(request, user_profile, field_id):
@@ -52,7 +52,7 @@ def delete_realm_custom_profile_field(request, user_profile, field_id):
     try:
         field = CustomProfileField.objects.get(id=field_id)
     except CustomProfileField.DoesNotExist:
-        return json_error(_('Field id {id} not found.').format(id=field_id))
+        return json_error(err_('Field id {id} not found.').format(id=field_id))
 
     do_remove_realm_custom_profile_field(realm=user_profile.realm,
                                          field=field)
@@ -64,18 +64,18 @@ def update_realm_custom_profile_field(request, user_profile, field_id,
                                       name=REQ()):
     # type: (HttpRequest, UserProfile, int, Text) -> HttpResponse
     if not name.strip():
-        return json_error(_("Name cannot be blank."))
+        return json_error(err_("Name cannot be blank."))
 
     realm = user_profile.realm
     try:
         field = CustomProfileField.objects.get(realm=realm, id=field_id)
     except CustomProfileField.DoesNotExist:
-        return json_error(_('Field id {id} not found.').format(id=field_id))
+        return json_error(err_('Field id {id} not found.').format(id=field_id))
 
     try:
         try_update_realm_custom_profile_field(realm, field, name)
     except IntegrityError:
-        return json_error(_('A field with that name already exists.'))
+        return json_error(err_('A field with that name already exists.'))
     return json_success()
 
 @human_users_only
@@ -90,7 +90,7 @@ def update_user_custom_profile_data(
         try:
             field = CustomProfileField.objects.get(id=field_id)
         except CustomProfileField.DoesNotExist:
-            return json_error(_('Field id {id} not found.').format(id=field_id))
+            return json_error(err_('Field id {id} not found.').format(id=field_id))
 
         validator = CustomProfileField.FIELD_VALIDATORS[field.field_type]
         result = validator('value[{}]'.format(field_id), item['value'])

--- a/zerver/views/hotspots.py
+++ b/zerver/views/hotspots.py
@@ -1,5 +1,5 @@
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.decorator import has_request_variables, REQ, human_users_only
 from zerver.lib.actions import do_mark_hotspot_as_read
@@ -13,6 +13,6 @@ from zerver.models import UserProfile
 def mark_hotspot_as_read(request, user, hotspot=REQ(validator=check_string)):
     # type: (HttpRequest, UserProfile, str) -> HttpResponse
     if hotspot not in ALL_HOTSPOTS:
-        return json_error(_('Unknown hotspot: %s') % (hotspot,))
+        return json_error(err_('Unknown hotspot: %s') % (hotspot,))
     do_mark_hotspot_as_read(user, hotspot)
     return json_success()

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from typing import List, Optional, Set, Text
 
 from zerver.decorator import authenticated_json_post_view
@@ -23,9 +23,9 @@ def invite_users_backend(request, user_profile,
                          body=REQ("custom_body", default=None)):
     # type: (HttpRequest, UserProfile, str, Optional[str]) -> HttpResponse
     if user_profile.realm.invite_by_admins_only and not user_profile.is_realm_admin:
-        return json_error(_("Must be a realm administrator"))
+        return json_error(err_("Must be a realm administrator"))
     if not invitee_emails_raw:
-        return json_error(_("You must specify at least one email address."))
+        return json_error(err_("You must specify at least one email address."))
     if body == '':
         body = None
 
@@ -33,7 +33,7 @@ def invite_users_backend(request, user_profile,
 
     stream_names = request.POST.getlist('stream')
     if not stream_names:
-        return json_error(_("You must specify at least one stream for invitees to join."))
+        return json_error(err_("You must specify at least one stream for invitees to join."))
 
     # We unconditionally sub you to the notifications stream if it
     # exists and is public.
@@ -46,7 +46,7 @@ def invite_users_backend(request, user_profile,
         try:
             (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name)
         except JsonableError:
-            return json_error(_("Stream does not exist: %s. No invites were sent.") % (stream_name,))
+            return json_error(err_("Stream does not exist: %s. No invites were sent.") % (stream_name,))
         streams.append(stream)
 
     do_invite_users(user_profile, invitee_emails, streams, body)

--- a/zerver/views/muting.py
+++ b/zerver/views/muting.py
@@ -5,7 +5,7 @@ from typing import List, Text
 
 import ujson
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.decorator import authenticated_json_post_view
 from zerver.lib.actions import do_set_muted_topics, do_update_muted_topic
 from zerver.lib.request import has_request_variables, REQ
@@ -28,11 +28,11 @@ def update_muted_topic(request, user_profile, stream=REQ(),
     muted_topics = ujson.loads(user_profile.muted_topics)
     if op == 'add':
         if [stream, topic] in muted_topics:
-            return json_error(_("Topic already muted"))
+            return json_error(err_("Topic already muted"))
         muted_topics.append([stream, topic])
     elif op == 'remove':
         if [stream, topic] not in muted_topics:
-            return json_error(_("Topic is not there in the muted_topics list"))
+            return json_error(err_("Topic is not there in the muted_topics list"))
         muted_topics.remove([stream, topic])
 
     do_update_muted_topic(user_profile, stream, topic, op)

--- a/zerver/views/pointer.py
+++ b/zerver/views/pointer.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from typing import Text
 
 from zerver.decorator import to_non_negative_int
@@ -27,7 +27,7 @@ def update_pointer_backend(request, user_profile,
             message__id=pointer
         )
     except UserMessage.DoesNotExist:
-        raise JsonableError(_("Invalid message ID"))
+        raise JsonableError(err_("Invalid message ID"))
 
     request._log_data["extra"] = "[%s]" % (pointer,)
     update_flags = (request.client.name.lower() in ['android', "zulipandroid"])

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Text
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now as timezone_now
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.decorator import authenticated_json_post_view, human_users_only
 from zerver.lib.actions import get_status_dict, update_user_presence
@@ -28,15 +28,15 @@ def get_presence_backend(request, user_profile, email):
     try:
         target = get_user(email, user_profile.realm)
     except UserProfile.DoesNotExist:
-        return json_error(_('No such user'))
+        return json_error(err_('No such user'))
     if not target.is_active:
-        return json_error(_('No such user'))
+        return json_error(err_('No such user'))
     if target.is_bot:
-        return json_error(_('Presence is not supported for bot users.'))
+        return json_error(err_('Presence is not supported for bot users.'))
 
     presence_dict = UserPresence.get_status_dict_by_user(target)
     if len(presence_dict) == 0:
-        return json_error(_('No presence data for %s' % (target.email,)))
+        return json_error(err_('No presence data for %s' % (target.email,)))
 
     # For initial version, we just include the status and timestamp keys
     result = dict(presence=presence_dict[target.email])
@@ -57,7 +57,7 @@ def update_active_status_backend(request, user_profile, status=REQ(),
     # type: (HttpRequest, UserProfile, str, bool, bool) -> HttpResponse
     status_val = UserPresence.status_from_string(status)
     if status_val is None:
-        raise JsonableError(_("Invalid status: %s") % (status,))
+        raise JsonableError(err_("Invalid status: %s") % (status,))
     else:
         update_user_presence(user_profile, request.client, timezone_now(),
                              status_val, new_user_input)

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -7,7 +7,7 @@ from typing import Optional, Text
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.decorator import human_users_only
 from zerver.lib.push_notifications import add_push_device_token, \
@@ -20,13 +20,13 @@ from zerver.models import PushDeviceToken, UserProfile
 def validate_token(token_str, kind):
     # type: (bytes, int) -> None
     if token_str == '' or len(token_str) > 4096:
-        raise JsonableError(_('Empty or invalid length token'))
+        raise JsonableError(err_('Empty or invalid length token'))
     if kind == PushDeviceToken.APNS:
         # Validate that we can actually decode the token.
         try:
             b64_to_hex(token_str)
         except Exception:
-            raise JsonableError(_('Invalid APNS token'))
+            raise JsonableError(err_('Invalid APNS token'))
 
 @human_users_only
 @has_request_variables

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from typing import Text
 
 from zerver.decorator import authenticated_json_post_view,\
@@ -28,7 +28,7 @@ def add_reaction_backend(request, user_profile, message_id, emoji_name):
     if Reaction.objects.filter(user_profile=user_profile,
                                message=message,
                                emoji_name=emoji_name).exists():
-        raise JsonableError(_("Reaction already exists"))
+        raise JsonableError(err_("Reaction already exists"))
 
     if user_message is None:
         # Users can see and react to messages sent to streams they
@@ -59,7 +59,7 @@ def remove_reaction_backend(request, user_profile, message_id, emoji_name):
     if not Reaction.objects.filter(user_profile=user_profile,
                                    message=message,
                                    emoji_name=emoji_name).exists():
-        raise JsonableError(_("Reaction does not exist"))
+        raise JsonableError(err_("Reaction does not exist"))
 
     do_remove_reaction(user_profile, message, emoji_name)
 

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from typing import Any, Dict, Optional, List, Text
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.decorator import require_realm_admin, to_non_negative_int, to_not_negative_int_or_none
 from zerver.lib.actions import (
@@ -47,11 +47,11 @@ def update_realm(request, user_profile, name=REQ(validator=check_string, default
     # Additional validation/error checking beyond types go here, so
     # the entire request can succeed or fail atomically.
     if default_language is not None and default_language not in get_available_language_codes():
-        raise JsonableError(_("Invalid language '%s'" % (default_language,)))
+        raise JsonableError(err_("Invalid language '%s'" % (default_language,)))
     if description is not None and len(description) > 1000:
-        return json_error(_("Realm description is too long."))
+        return json_error(err_("Realm description is too long."))
     if authentication_methods is not None and True not in list(authentication_methods.values()):
-        return json_error(_("At least one authentication method must be enabled."))
+        return json_error(err_("At least one authentication method must be enabled."))
 
     # The user of `locals()` here is a bit of a code smell, but it's
     # restricted to the elements present in realm.property_types.

--- a/zerver/views/realm_domains.py
+++ b/zerver/views/realm_domains.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.decorator import has_request_variables, require_realm_admin, REQ
 from zerver.lib.actions import do_add_realm_domain, do_change_realm_domain, \
@@ -28,11 +28,11 @@ def create_realm_domain(request, user_profile, domain=REQ(validator=check_string
     try:
         validate_domain(domain)
     except ValidationError as e:
-        return json_error(_('Invalid domain: {}').format(e.messages[0]))
+        return json_error(err_('Invalid domain: {}').format(e.messages[0]))
     if RealmDomain.objects.filter(realm=user_profile.realm, domain=domain).exists():
-        return json_error(_("The domain %(domain)s is already a part of your organization.") % {'domain': domain})
+        return json_error(err_("The domain %(domain)s is already a part of your organization.") % {'domain': domain})
     if not can_add_realm_domain(domain):
-        return json_error(_("The domain %(domain)s belongs to another organization.") % {'domain': domain})
+        return json_error(err_("The domain %(domain)s belongs to another organization.") % {'domain': domain})
     realm_domain = do_add_realm_domain(user_profile.realm, domain, allow_subdomains)
     return json_success({'new_domain': [realm_domain.id, realm_domain.domain]})
 
@@ -44,7 +44,7 @@ def patch_realm_domain(request, user_profile, domain, allow_subdomains=REQ(valid
         realm_domain = RealmDomain.objects.get(realm=user_profile.realm, domain=domain)
         do_change_realm_domain(realm_domain, allow_subdomains)
     except RealmDomain.DoesNotExist:
-        return json_error(_('No entry found for domain %(domain)s.' % {'domain': domain}))
+        return json_error(err_('No entry found for domain %(domain)s.' % {'domain': domain}))
     return json_success()
 
 @require_realm_admin
@@ -55,5 +55,5 @@ def delete_realm_domain(request, user_profile, domain):
         realm_domain = RealmDomain.objects.get(realm=user_profile.realm, domain=domain)
         do_remove_realm_domain(realm_domain)
     except RealmDomain.DoesNotExist:
-        return json_error(_('No entry found for domain %(domain)s.' % {'domain': domain}))
+        return json_error(err_('No entry found for domain %(domain)s.' % {'domain': domain}))
     return json_success()

--- a/zerver/views/realm_emoji.py
+++ b/zerver/views/realm_emoji.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from typing import Text
 
 from zerver.lib.upload import upload_emoji_image
@@ -29,10 +29,10 @@ def upload_emoji(request, user_profile, emoji_name=REQ()):
     check_valid_emoji_name(emoji_name)
     check_emoji_admin(user_profile)
     if len(request.FILES) != 1:
-        return json_error(_("You must upload exactly one file."))
+        return json_error(err_("You must upload exactly one file."))
     emoji_file = list(request.FILES.values())[0]
     if (settings.MAX_EMOJI_FILE_SIZE * 1024 * 1024) < emoji_file.size:
-        return json_error(_("Uploaded file is larger than the allowed limit of %s MB") % (
+        return json_error(err_("Uploaded file is larger than the allowed limit of %s MB") % (
             settings.MAX_EMOJI_FILE_SIZE))
     emoji_file_name = get_emoji_file_name(emoji_file.name, emoji_name)
     upload_emoji_image(emoji_file, emoji_file_name, user_profile)

--- a/zerver/views/realm_filters.py
+++ b/zerver/views/realm_filters.py
@@ -4,7 +4,7 @@ from typing import Text
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.decorator import has_request_variables, REQ, require_realm_admin
 from zerver.lib.actions import do_add_realm_filter, do_remove_realm_filter
@@ -43,5 +43,5 @@ def delete_filter(request, user_profile, filter_id):
     try:
         do_remove_realm_filter(realm=user_profile.realm, id=filter_id)
     except RealmFilter.DoesNotExist:
-        return json_error(_('Filter not found'))
+        return json_error(err_('Filter not found'))
     return json_success()

--- a/zerver/views/realm_icon.py
+++ b/zerver/views/realm_icon.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.shortcuts import redirect
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpResponse, HttpRequest
 
 from zerver.decorator import require_realm_admin
@@ -16,11 +16,11 @@ def upload_icon(request, user_profile):
     # type: (HttpRequest, UserProfile) -> HttpResponse
 
     if len(request.FILES) != 1:
-        return json_error(_("You must upload exactly one icon."))
+        return json_error(err_("You must upload exactly one icon."))
 
     icon_file = list(request.FILES.values())[0]
     if ((settings.MAX_ICON_FILE_SIZE * 1024 * 1024) < icon_file.size):
-        return json_error(_("Uploaded file is larger than the allowed limit of %s MB") % (
+        return json_error(err_("Uploaded file is larger than the allowed limit of %s MB") % (
             settings.MAX_ICON_FILE_SIZE))
     upload_icon_image(icon_file, user_profile)
     do_change_icon_source(user_profile.realm, user_profile.realm.ICON_UPLOADED)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from typing import Any, List, Dict, Mapping, Optional, Text
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.conf import settings
 from django.contrib.auth import authenticate, login, get_backends
 from django.core.urlresolvers import reverse

--- a/zerver/views/tutorial.py
+++ b/zerver/views/tutorial.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import authenticated_json_post_view, has_request_variables, REQ
@@ -27,7 +27,7 @@ def json_tutorial_send_message(request, user_profile, type=REQ(validator=check_s
                               "stream", recipient, topic, content)
         return json_success()
     # For now, there are no PM cases.
-    return json_error(_('Bad data passed in to tutorial_send_message'))
+    return json_error(err_('Bad data passed in to tutorial_send_message'))
 
 @authenticated_json_post_view
 @has_request_variables

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, FileResponse, \
     HttpResponseNotFound
 from django.shortcuts import redirect
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.decorator import authenticated_json_post_view
 from zerver.lib.request import has_request_variables, REQ
@@ -51,17 +51,17 @@ def serve_file_backend(request, user_profile, realm_id_str, filename):
 def upload_file_backend(request, user_profile):
     # type: (HttpRequest, UserProfile) -> HttpResponse
     if len(request.FILES) == 0:
-        return json_error(_("You must specify a file to upload"))
+        return json_error(err_("You must specify a file to upload"))
     if len(request.FILES) != 1:
-        return json_error(_("You may only upload one file at a time"))
+        return json_error(err_("You may only upload one file at a time"))
 
     user_file = list(request.FILES.values())[0]
     file_size = user_file._get_size()
     if settings.MAX_FILE_UPLOAD_SIZE * 1024 * 1024 < file_size:
-        return json_error(_("Uploaded file is larger than the allowed limit of %s MB") % (
+        return json_error(err_("Uploaded file is larger than the allowed limit of %s MB") % (
             settings.MAX_FILE_UPLOAD_SIZE))
     if not within_upload_quota(user_profile, file_size):
-        return json_error(_("Upload would exceed your maximum quota."))
+        return json_error(err_("Upload would exceed your maximum quota."))
 
     if not isinstance(user_file.name, str):
         # It seems that in Python 2 unicode strings containing bytes are

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from typing import Optional, Any, Dict, Text
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.conf import settings
 from django.contrib.auth import authenticate, update_session_auth_hash
 from django.http import HttpRequest, HttpResponse
@@ -34,7 +34,7 @@ def confirm_email_change(request, confirmation_key):
     # type: (HttpRequest, str) -> HttpResponse
     user_profile = request.user
     if user_profile.realm.email_changes_disabled:
-        raise JsonableError(_("Email address changes are disabled in this organization."))
+        raise JsonableError(err_("Email address changes are disabled in this organization."))
 
     confirmation_key = confirmation_key.lower()
     try:
@@ -92,13 +92,13 @@ def json_change_settings(request, user_profile,
                          confirm_password=REQ(default="")):
     # type: (HttpRequest, UserProfile, Text, Text, Text, Text, Text) -> HttpResponse
     if not (full_name or new_password or email):
-        return json_error(_("No new data supplied"))
+        return json_error(err_("No new data supplied"))
 
     if new_password != "" or confirm_password != "":
         if new_password != confirm_password:
-            return json_error(_("New password must match confirmation password!"))
+            return json_error(err_("New password must match confirmation password!"))
         if not authenticate(username=user_profile.email, password=old_password):
-            return json_error(_("Wrong password!"))
+            return json_error(err_("Wrong password!"))
         do_change_password(user_profile, new_password)
         # In Django 1.10, password changes invalidates sessions, see
         # https://docs.djangoproject.com/en/1.10/topics/auth/default/#session-invalidation-on-password-change
@@ -119,7 +119,7 @@ def json_change_settings(request, user_profile,
     new_email = email.strip()
     if user_profile.email != email and new_email != '':
         if user_profile.realm.email_changes_disabled:
-            return json_error(_("Email address changes are disabled in this organization."))
+            return json_error(err_("Email address changes are disabled in this organization."))
         error, skipped = validate_email(user_profile, new_email)
         if error or skipped:
             return json_error(error or skipped)
@@ -151,15 +151,15 @@ def update_display_settings_backend(request, user_profile,
     # type: (HttpRequest, UserProfile, Optional[bool], Optional[bool], Optional[str], Optional[bool], Optional[bool], Optional[Text], Optional[Text]) -> HttpResponse
     if (default_language is not None and
             default_language not in get_available_language_codes()):
-        raise JsonableError(_("Invalid language '%s'" % (default_language,)))
+        raise JsonableError(err_("Invalid language '%s'" % (default_language,)))
 
     if (timezone is not None and
             timezone not in get_all_timezones()):
-        raise JsonableError(_("Invalid timezone '%s'" % (timezone,)))
+        raise JsonableError(err_("Invalid timezone '%s'" % (timezone,)))
 
     if (emojiset is not None and
             emojiset not in UserProfile.emojiset_choices()):
-        raise JsonableError(_("Invalid emojiset '%s'" % (emojiset,)))
+        raise JsonableError(err_("Invalid emojiset '%s'" % (emojiset,)))
 
     request_settings = {k: v for k, v in list(locals().items()) if k in user_profile.property_types}
     result = {}  # type: Dict[str, Any]
@@ -208,11 +208,11 @@ def json_change_notify_settings(request, user_profile,
 def set_avatar_backend(request, user_profile):
     # type: (HttpRequest, UserProfile) -> HttpResponse
     if len(request.FILES) != 1:
-        return json_error(_("You must upload exactly one avatar."))
+        return json_error(err_("You must upload exactly one avatar."))
 
     user_file = list(request.FILES.values())[0]
     if ((settings.MAX_AVATAR_FILE_SIZE * 1024 * 1024) < user_file.size):
-        return json_error(_("Uploaded file is larger than the allowed limit of %s MB") % (
+        return json_error(err_("Uploaded file is larger than the allowed limit of %s MB") % (
             settings.MAX_AVATAR_FILE_SIZE))
     upload_avatar_image(user_file, user_profile, user_profile)
     do_change_avatar_fields(user_profile, UserProfile.AVATAR_FROM_USER)

--- a/zerver/views/zephyr.py
+++ b/zerver/views/zephyr.py
@@ -3,7 +3,7 @@ from typing import Any, List, Dict, Optional, Callable, Tuple, Iterable, Sequenc
 
 from django.conf import settings
 from django.http import HttpResponse, HttpRequest
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.decorator import authenticated_json_view
 from zerver.lib.ccache import make_ccache
 from zerver.lib.request import has_request_variables, REQ, JsonableError
@@ -30,9 +30,9 @@ def webathena_kerberos_login(request, user_profile,
     # type: (HttpRequest, UserProfile, Text) -> HttpResponse
     global kerberos_alter_egos
     if cred is None:
-        return json_error(_("Could not find Kerberos credential"))
+        return json_error(err_("Could not find Kerberos credential"))
     if not user_profile.realm.webathena_enabled:
-        return json_error(_("Webathena login not enabled"))
+        return json_error(err_("Webathena login not enabled"))
 
     try:
         parsed_cred = ujson.loads(cred)
@@ -42,7 +42,7 @@ def webathena_kerberos_login(request, user_profile,
         assert(user == user_profile.email.split("@")[0])
         ccache = make_ccache(parsed_cred)
     except Exception:
-        return json_error(_("Invalid Kerberos cache"))
+        return json_error(err_("Invalid Kerberos cache"))
 
     # TODO: Send these data via (say) rabbitmq
     try:
@@ -53,6 +53,6 @@ def webathena_kerberos_login(request, user_profile,
                                force_str(base64.b64encode(ccache))])
     except Exception:
         logging.exception("Error updating the user's ccache")
-        return json_error(_("We were unable to setup mirroring for you"))
+        return json_error(err_("We were unable to setup mirroring for you"))
 
     return json_success()

--- a/zerver/webhooks/airbrake/view.py
+++ b/zerver/webhooks/airbrake/view.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from typing import Dict, Any, Text
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -21,7 +21,7 @@ def api_airbrake_webhook(request, user_profile,
         subject = get_subject(payload)
         body = get_body(payload)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/webhooks/appfollow/view.py
+++ b/zerver/webhooks/appfollow/view.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import re
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
@@ -20,7 +20,7 @@ def api_appfollow_webhook(request, user_profile, stream=REQ(default="appfollow")
     try:
         message = payload["text"]
     except KeyError:
-        return json_error(_("Missing 'text' argument in JSON"))
+        return json_error(err_("Missing 'text' argument in JSON"))
     app_name = re.search('\A(.+)', message).group(0)
 
     check_send_message(user_profile, request.client, "stream", [stream], app_name, convert_markdown(message))

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -5,7 +5,7 @@ from functools import partial
 from six.moves import zip
 from typing import Any, Callable, Dict, List, Optional, Text
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -61,7 +61,7 @@ def api_bitbucket2_webhook(request, user_profile, payload=REQ(argument_type='bod
                 check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
 
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     return json_success()
 

--- a/zerver/webhooks/codeship/view.py
+++ b/zerver/webhooks/codeship/view.py
@@ -1,7 +1,7 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 from typing import Any, Dict
 
@@ -34,7 +34,7 @@ def api_codeship_webhook(request, user_profile, payload=REQ(argument_type='body'
         subject = get_subject_for_http_request(payload)
         body = get_body_for_http_request(payload)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/webhooks/crashlytics/view.py
+++ b/zerver/webhooks/crashlytics/view.py
@@ -1,6 +1,6 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -38,7 +38,7 @@ def api_crashlytics_webhook(request, user_profile, payload=REQ(argument_type='bo
                 url=issue_body['url']
             )
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON".format(str(e))))
+        return json_error(err_("Missing key {} in JSON".format(str(e))))
 
     check_send_message(user_profile, request.client, 'stream', [stream],
                        subject, body)

--- a/zerver/webhooks/delighted/view.py
+++ b/zerver/webhooks/delighted/view.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -30,7 +30,7 @@ def api_delighted_webhook(request, user_profile,
         selected_payload['score'] = payload['event_data']['score']
         selected_payload['comment'] = payload['event_data']['comment']
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     BODY_TEMPLATE = body_template(selected_payload['score'])
     body = BODY_TEMPLATE.format(**selected_payload)

--- a/zerver/webhooks/freshdesk/view.py
+++ b/zerver/webhooks/freshdesk/view.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.models import get_client, UserProfile
 from zerver.lib.actions import check_send_message
@@ -128,7 +128,7 @@ def api_freshdesk_webhook(request, user_profile, payload=REQ(argument_type='body
         if ticket_data.get(key) is None:
             logging.warning("Freshdesk webhook error. Payload was:")
             logging.warning(request.body)
-            return json_error(_("Missing key %s in JSON") % (key,))
+            return json_error(err_("Missing key %s in JSON") % (key,))
 
     ticket = TicketDict(ticket_data)
 
@@ -137,7 +137,7 @@ def api_freshdesk_webhook(request, user_profile, payload=REQ(argument_type='body
     try:
         event_info = parse_freshdesk_event(ticket.triggered_event)
     except ValueError:
-        return json_error(_("Malformed event %s") % (ticket.triggered_event,))
+        return json_error(err_("Malformed event %s") % (ticket.triggered_event,))
 
     if event_info[1] == "created":
         content = format_freshdesk_ticket_creation_message(ticket)

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -97,9 +97,9 @@ def api_gogs_webhook(request, user_profile,
                 title=payload['pull_request']['title']
             )
         else:
-            return json_error(_('Invalid event "{}" in request headers').format(event))
+            return json_error(err_('Invalid event "{}" in request headers').format(event))
     except KeyError as e:
-        return json_error(_('Missing key {} in JSON').format(str(e)))
+        return json_error(err_('Missing key {} in JSON').format(str(e)))
 
     check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
     return json_success()

--- a/zerver/webhooks/gosquared/view.py
+++ b/zerver/webhooks/gosquared/view.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -24,7 +24,7 @@ def api_gosquared_webhook(request, user_profile,
         user_acc = payload['siteDetails']['acct']
         acc_url = 'https://www.gosquared.com/now/' + user_acc
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     body = BODY_TEMPLATE.format(website_name=domain_name, website_url=acc_url, user_num=user_num)
     # allows for customisable topics

--- a/zerver/webhooks/greenhouse/view.py
+++ b/zerver/webhooks/greenhouse/view.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 from typing import Any, Dict, List
 
@@ -58,7 +58,7 @@ def api_greenhouse_webhook(request, user_profile,
             topic = "{} - {}".format(action, str(candidate['id']))
 
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
     return json_success()

--- a/zerver/webhooks/hellosign/view.py
+++ b/zerver/webhooks/hellosign/view.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -52,7 +52,7 @@ def api_hellosign_webhook(request, user_profile,
         model_payload = ready_payload(payload['signature_request']['signatures'],
                                       payload)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     body = format_body(payload['signature_request']['signatures'], model_payload)
     topic = topic or model_payload['contract_title']

--- a/zerver/webhooks/helloworld/view.py
+++ b/zerver/webhooks/helloworld/view.py
@@ -1,6 +1,6 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -26,7 +26,7 @@ def api_helloworld_webhook(request, user_profile,
         body_template = '\nThe Wikipedia featured article for today is **[{featured_title}]({featured_url})**'
         body += body_template.format(**payload)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     # send the message
     check_send_message(user_profile, request.client, 'stream', [stream], topic, body)

--- a/zerver/webhooks/homeassistant/view.py
+++ b/zerver/webhooks/homeassistant/view.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -21,7 +21,7 @@ def api_homeassistant_webhook(request, user_profile,
     try:
         body = payload["message"]
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     # set the topic to the topic parameter, if given
     if "topic" in payload:

--- a/zerver/webhooks/ifttt/view.py
+++ b/zerver/webhooks/ifttt/view.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from typing import Any, Callable, Dict
 from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
@@ -17,8 +17,8 @@ def api_iftt_app_webhook(request, user_profile,
     subject = payload.get('subject')
     content = payload.get('content')
     if subject is None:
-        return json_error(_("Subject can't be empty"))
+        return json_error(err_("Subject can't be empty"))
     if content is None:
-        return json_error(_("Content can't be empty"))
+        return json_error(err_("Content can't be empty"))
     check_send_message(user_profile, request.client, "stream", [stream], subject, content)
     return json_success()

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from typing import Any, Dict, List, Optional, Text, Tuple
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.db.models import Q
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
@@ -261,7 +261,7 @@ def api_jira_webhook(request, user_profile,
             if not settings.TEST_SUITE:
                 message = u"Got JIRA event with None event type: {}".format(payload)
                 logging.warning(message)
-            return json_error(_("Event is not given by JIRA"))
+            return json_error(err_("Event is not given by JIRA"))
         else:
             if not settings.TEST_SUITE:
                 logging.warning("Got JIRA event type we don't support: {}".format(event))

--- a/zerver/webhooks/librato/view.py
+++ b/zerver/webhooks/librato/view.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Callable, Tuple, Text
 from six.moves import zip
 
 from django.utils.timezone import utc as timezone_utc
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import api_key_only_webhook_view, REQ, has_request_variables
@@ -169,7 +169,7 @@ def api_librato_webhook(request, user_profile, payload=REQ(converter=ujson.loads
         attachments = []
 
     if not attachments and not payload:
-        return json_error(_("Malformed JSON input"))
+        return json_error(err_("Malformed JSON input"))
 
     message_handler = LibratoWebhookHandler(payload, attachments)
 
@@ -179,7 +179,7 @@ def api_librato_webhook(request, user_profile, payload=REQ(converter=ujson.loads
     try:
         content = message_handler.handle()
     except Exception as e:
-        return json_error(_(str(e)))
+        return json_error(err_(str(e)))
 
     check_send_message(user_profile, request.client, "stream", [stream], topic, content)
     return json_success()

--- a/zerver/webhooks/mention/view.py
+++ b/zerver/webhooks/mention/view.py
@@ -1,6 +1,6 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -23,7 +23,7 @@ def api_mention_webhook(request, user_profile,
         source_url = payload["url"]
         description = payload["description"]
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     # construct the body of the message
     body = '**[%s](%s)**:\n%s' % (title, source_url, description)

--- a/zerver/webhooks/newrelic/view.py
+++ b/zerver/webhooks/newrelic/view.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Text
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 
 from zerver.lib.actions import check_send_message
@@ -31,7 +31,7 @@ def api_newrelic_webhook(request, user_profile, stream=REQ(default='newrelic'),
 
 %(changelog)s""" % (deployment)
     else:
-        return json_error(_("Unknown webhook request"))
+        return json_error(err_("Unknown webhook request"))
 
     check_send_message(user_profile, request.client, "stream",
                        [stream], subject, content)

--- a/zerver/webhooks/papertrail/view.py
+++ b/zerver/webhooks/papertrail/view.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -37,7 +37,7 @@ def api_papertrail_webhook(request, user_profile,
             message.append('```')
         post = '\n'.join(message)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
 
     # send the message
     check_send_message(user_profile, request.client, 'stream', [stream], topic, post)

--- a/zerver/webhooks/pingdom/view.py
+++ b/zerver/webhooks/pingdom/view.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from typing import Any, Dict, Text
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 
 from zerver.lib.actions import check_send_message
@@ -43,7 +43,7 @@ def api_pingdom_webhook(request, user_profile, payload=REQ(argument_type='body')
         subject = get_subject_for_http_request(payload)
         body = get_body_for_http_request(payload)
     else:
-        return json_error(_('Unsupported check_type: {check_type}').format(check_type=check_type))
+        return json_error(err_('Unsupported check_type: {check_type}').format(check_type=check_type))
 
     check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/webhooks/pivotal/view.py
+++ b/zerver/webhooks/pivotal/view.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
@@ -168,16 +168,16 @@ def api_pivotal_webhook(request, user_profile, stream=REQ()):
     try:
         subject, content = api_pivotal_webhook_v3(request, user_profile, stream)
     except AttributeError:
-        return json_error(_("Failed to extract data from Pivotal XML response"))
+        return json_error(err_("Failed to extract data from Pivotal XML response"))
     except Exception:
         # Attempt to parse v5 JSON payload
         try:
             subject, content = api_pivotal_webhook_v5(request, user_profile, stream)
         except AttributeError:
-            return json_error(_("Failed to extract data from Pivotal V5 JSON response"))
+            return json_error(err_("Failed to extract data from Pivotal V5 JSON response"))
 
     if subject is None or content is None:
-        return json_error(_("Unable to handle Pivotal payload"))
+        return json_error(err_("Unable to handle Pivotal payload"))
 
     check_send_message(user_profile, request.client, "stream",
                        [stream], subject, content)

--- a/zerver/webhooks/semaphore/view.py
+++ b/zerver/webhooks/semaphore/view.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.models import get_client
 from zerver.lib.actions import check_send_message
@@ -33,14 +33,14 @@ def api_semaphore_webhook(request, user_profile,
         author_email = payload["commit"]["author_email"]
         message = payload["commit"]["message"]
     except KeyError as e:
-        return json_error(_("Missing key %s in JSON") % (str(e),))
+        return json_error(err_("Missing key %s in JSON") % (str(e),))
 
     if event == "build":
         try:
             build_url = payload["build_url"]
             build_number = payload["build_number"]
         except KeyError as e:
-            return json_error(_("Missing key %s in JSON") % (str(e),))
+            return json_error(err_("Missing key %s in JSON") % (str(e),))
         content = u"[build %s](%s): %s\n" % (build_number, build_url, result)
 
     elif event == "deploy":
@@ -51,7 +51,7 @@ def api_semaphore_webhook(request, user_profile,
             deploy_number = payload["number"]
             server_name = payload["server_name"]
         except KeyError as e:
-            return json_error(_("Missing key %s in JSON") % (str(e),))
+            return json_error(err_("Missing key %s in JSON") % (str(e),))
         content = u"[deploy %s](%s) of [build %s](%s) on server %s: %s\n" % \
                   (deploy_number, deploy_url, build_number, build_url, server_name, result)
 

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message, create_stream_if_needed
 from zerver.lib.response import json_success, json_error
 from zerver.lib.validator import check_string, check_int
@@ -22,7 +22,7 @@ def api_slack_webhook(request, user_profile,
     # type: (HttpRequest, UserProfile, str, str, str, str, str) -> HttpResponse
 
     if channels_map_to_topics not in list(VALID_OPTIONS.values()):
-        return json_error(_('Error: channels_map_to_topics parameter other than 0 or 1'))
+        return json_error(err_('Error: channels_map_to_topics parameter other than 0 or 1'))
 
     if channels_map_to_topics == VALID_OPTIONS['SHOULD_BE_MAPPED']:
         subject = "channel: {}".format(channel_name)

--- a/zerver/webhooks/solano/view.py
+++ b/zerver/webhooks/solano/view.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
 from zerver.lib.actions import check_send_message
@@ -32,7 +32,7 @@ def api_solano_webhook(request, user_profile,
         repository = payload['repository']['url']
         commit_id = payload['commit_id']
     except KeyError as e:
-        return json_error(_('Missing key {} in JSON').format(str(e)))
+        return json_error(err_('Missing key {} in JSON').format(str(e)))
 
     good_status = ['passed']
     bad_status  = ['failed', 'error']

--- a/zerver/webhooks/splunk/view.py
+++ b/zerver/webhooks/splunk/view.py
@@ -1,6 +1,6 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -1,6 +1,6 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from zerver.lib.actions import check_send_message
 from zerver.lib.response import json_success, json_error
 from zerver.decorator import REQ, has_request_variables, api_key_only_webhook_view
@@ -158,10 +158,10 @@ def api_stripe_webhook(request, user_profile,
             if topic is None:
                 topic = "Transfer {}".format(object_id)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON".format(str(e))))
+        return json_error(err_("Missing key {} in JSON".format(str(e))))
 
     if body is None:
-        return json_error(_("We don't support {} event".format(event_type)))
+        return json_error(err_("We don't support {} event".format(event_type)))
 
     check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
 

--- a/zerver/webhooks/taiga/view.py
+++ b/zerver/webhooks/taiga/view.py
@@ -21,7 +21,7 @@ subject of US/task should be in bold.
 from __future__ import absolute_import
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Text
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 
 from zerver.lib.actions import check_send_message
@@ -255,7 +255,7 @@ def generate_content(data):
     try:
         return templates[data['type']][data['event']] % data['values']
     except KeyError:
-        return json_error(_("Unknown message"))
+        return json_error(err_("Unknown message"))
 
 def get_owner_name(message):
     # type: (Mapping[str, Any]) -> str

--- a/zerver/webhooks/transifex/view.py
+++ b/zerver/webhooks/transifex/view.py
@@ -1,6 +1,6 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 from zerver.models import UserProfile
 from zerver.lib.actions import check_send_message
@@ -22,6 +22,6 @@ def api_transifex_webhook(request, user_profile,
     elif reviewed:
         body = "Resource {} fully reviewed.".format(resource)
     else:
-        return json_error(_("Transifex wrong request"))
+        return json_error(err_("Transifex wrong request"))
     check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/webhooks/trello/view/__init__.py
+++ b/zerver/webhooks/trello/view/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 import ujson
 from typing import Mapping, Any, Tuple, Text, Optional
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
 from zerver.decorator import return_success_on_head_request
@@ -28,7 +28,7 @@ def api_trello_webhook(request, user_profile, payload=REQ(argument_type='body'),
         else:
             subject, body = message
     except UnsupportedAction:
-        return json_error(_('Unsupported action_type: {action_type}'.format(action_type=action_type)))
+        return json_error(err_('Unsupported action_type: {action_type}'.format(action_type=action_type)))
 
     check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/webhooks/updown/view.py
+++ b/zerver/webhooks/updown/view.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 
 from zerver.lib.actions import check_send_message
 from zerver.lib.exceptions import JsonableError
@@ -21,7 +21,7 @@ def send_message_for_event(event, user_profile, client, stream):
         subject = SUBJECT_TEMPLATE.format(service_url=event['check']['url'])
         body = EVENT_TYPE_BODY_MAPPER[event_type](event)
     except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+        return json_error(err_("Missing key {} in JSON").format(str(e)))
     check_send_message(user_profile, client, 'stream', [stream], subject, body)
 
 def get_body_for_up_event(event):
@@ -84,4 +84,4 @@ def get_event_type(event):
         event_type = event_type_match.group(1)
         if event_type in EVENT_TYPE_BODY_MAPPER:
             return event_type
-    raise JsonableError(_('Unsupported Updown event type: %s') % (event['event'],))
+    raise JsonableError(err_('Unsupported Updown event type: %s') % (event['event'],))

--- a/zerver/webhooks/wordpress/view.py
+++ b/zerver/webhooks/wordpress/view.py
@@ -1,6 +1,6 @@
 # Webhooks for external integrations.
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.http import HttpRequest, HttpResponse
 from zerver.models import get_client, UserProfile
 from zerver.lib.actions import check_send_message
@@ -40,7 +40,7 @@ def api_wordpress_webhook(request, user_profile,
         data = WP_LOGIN_TEMPLATE.format(name=user_login)
 
     else:
-        return json_error(_("Unknown WordPress webhook action: " + hook))
+        return json_error(err_("Unknown WordPress webhook action: " + hook))
 
     check_send_message(user_profile, get_client("ZulipWordPressWebhook"), "stream",
                        [stream], topic, data)

--- a/zerver/webhooks/zapier/view.py
+++ b/zerver/webhooks/zapier/view.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from typing import Any, Callable, Dict
 from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message
@@ -17,8 +17,8 @@ def api_zapier_webhook(request, user_profile,
     subject = payload.get('subject')
     content = payload.get('content')
     if subject is None:
-        return json_error(_("Subject can't be empty"))
+        return json_error(err_("Subject can't be empty"))
     if content is None:
-        return json_error(_("Content can't be empty"))
+        return json_error(err_("Content can't be empty"))
     check_send_message(user_profile, request.client, "stream", [stream], subject, content)
     return json_success()

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext as err_
 from django.utils import timezone
 from django.http import HttpResponse, HttpRequest
 
@@ -21,12 +21,12 @@ from typing import Any, Dict, Optional, Union, Text, cast
 def validate_entity(entity):
     # type: (Union[UserProfile, RemoteZulipServer]) -> None
     if not isinstance(entity, RemoteZulipServer):
-        raise JsonableError(_("Must validate with valid Zulip server API key"))
+        raise JsonableError(err_("Must validate with valid Zulip server API key"))
 
 def validate_bouncer_token_request(entity, token, kind):
     # type: (Union[UserProfile, RemoteZulipServer], bytes, int) -> None
     if kind not in [RemotePushDeviceToken.APNS, RemotePushDeviceToken.GCM]:
-        raise JsonableError(_("Invalid token type"))
+        raise JsonableError(err_("Invalid token type"))
     validate_entity(entity)
     validate_token(token, kind)
 
@@ -70,7 +70,7 @@ def remote_server_unregister_push(request, entity, token=REQ(),
                                                    kind=token_kind,
                                                    server=server).delete()
     if deleted[0] == 0:
-        return json_error(_("Token does not exist"))
+        return json_error(err_("Token does not exist"))
 
     return json_success()
 


### PR DESCRIPTION
This implements the approach discussed in [#translations](https://chat.zulip.org/#narrow/stream/translation/topic/prioritizing.20entries).

 A few sidenotes:

* This approach is extensible in a way that we can add more functios like `err_`, which would then make different types of strings get a different tag. 

* This approach limits tagging to one tag per string in the backend. This is due to `xgettext` adding comments only based on the name of the function wrapping a string.

* `tools/tagmessages` is a rather rough POC. Further alterations would e.g. allow to use `requests` instead of an `os.sys` call, and add a decent way to enter username and password for transifex. Right now, these need to be hardcoded.

* **Executing `tools/tagmessages` overwrites any existing tags!**
