### PR TITLE
left-sidebar: Style "More topics" to be more consistent.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -434,7 +434,8 @@ li.expanded_private_message a {
 }
 
 li.show-more-topics a {
-    font-size: 75%;
+    margin-left: 5px;
+    opacity: 0.5;
 }
 
 li.show-more-private-messages a {


### PR DESCRIPTION
The "More topics" link was not lined up with the topics due to
a recent change anymore, and the text was much smaller than the
surrounding text, so instead of de-emphasis by size, I changed it
to de-emphasis by color.

Fixes: #6090.