### PR TITLE
portico: Header deduplication and user login status

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -56,4 +56,9 @@
             $(".sidebar.show").toggleClass("show");
         }
     });
+
+    $('#top_navbar a .logout').on('click', function () {
+        $('#logout_form').submit();
+        return false;
+    });
 }());

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -186,6 +186,11 @@ var events = function () {
         $("nav ul").addClass("show");
     });
 
+    $('nav a .logout').on('click', function () {
+        $('#logout_form').submit();
+        return false;
+    });
+
     if (path_parts().includes("apps")) {
         apps_events();
     }

--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -60,4 +60,9 @@ $(function () {
         errorClass: "text-error",
         wrapper: "div",
     });
+
+    $('#top_navbar a .logout').on('click', function () {
+        $('#logout_form').submit();
+        return false;
+    });
 });

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -538,6 +538,12 @@ input.text-error {
     padding: 6px 0px 6px 0px;
 }
 
+.header-realm-icon {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+}
+
 .app {
     width: 100%;
     z-index: 99;

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -30,30 +30,30 @@
                 <a href="/help/">Help Center</a>
             </li>
             {% if user_is_authenticated %}
-            <li>
-                {% include 'zerver/logout.html' %}
-                <a class="no-style" href="#logout">
-                    <span class="logout">Log out</span>
-                </a>
-            </li>
-            <li>
-                <a class="no-style" href="/">
-                    <img class="header-realm-icon" src="{{ realm_icon }}" alt="{{ _('Go to Zulip') }}"/>
-                </a>
-            </li>
+                <li>
+                    {% include 'zerver/logout.html' %}
+                    <a class="no-style" href="#logout">
+                        <span class="logout">Log out</span>
+                    </a>
+                </li>
+                <li>
+                    <a class="no-style" href="/">
+                        <img class="header-realm-icon" src="{{ realm_icon }}" alt="{{ _('Go to Zulip') }}"/>
+                    </a>
+                </li>
             {% else %}
-            {% if register_link_disabled %}
-            {% else %}
-            <li>
-                <a href="/login/">Login</a>
-            </li>
-            {% endif %}
-            {% if register_link_disabled %}
-            {% else %}
-            <li>
-                <a href="/register/">Register</a>
-            </li>
-            {% endif %}
+                {% if register_link_disabled %}
+                {% else %}
+                <li>
+                    <a href="/login/">Login</a>
+                </li>
+                {% endif %}
+                {% if register_link_disabled %}
+                {% else %}
+                <li>
+                    <a href="/register/">Register</a>
+                </li>
+                {% endif %}
             {% endif %}
             {% if find_team_link_disabled %}
             {% else %}

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -29,6 +29,14 @@
             <li on-page="help">
                 <a href="/help/">Help Center</a>
             </li>
+            {% if user_is_authenticated %}
+            <li>
+                {% include 'zerver/logout.html' %}
+                <a class="no-style" href="#logout">
+                    <span class="logout">Log out</span>
+                </a>
+            </li>
+            {% else %}
             {% if register_link_disabled %}
             {% else %}
             <li>
@@ -40,6 +48,7 @@
             <li>
                 <a href="/register/">Register</a>
             </li>
+            {% endif %}
             {% endif %}
             {% if find_team_link_disabled %}
             {% else %}

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -36,6 +36,11 @@
                     <span class="logout">Log out</span>
                 </a>
             </li>
+            <li>
+                <a class="no-style" href="/">
+                    <img class="header-realm-icon" src="{{ realm_icon }}" alt="{{ _('Go to Zulip') }}"/>
+                </a>
+            </li>
             {% else %}
             {% if register_link_disabled %}
             {% else %}

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -22,6 +22,12 @@
         </div>
 
         <div class="column-right top-links">
+            {% if user_is_authenticated %}
+            {% include 'zerver/logout.html' %}
+            <a class="no-style" href="#logout">
+                <span class="logout">Log out</span>
+            </a>
+            {% else %}
             {% if login_link_disabled %}
             {% elif not only_sso %}
             <a href="{{login_url}}">{{ _('Log in') }}</a>
@@ -32,6 +38,7 @@
             <a href="{{ url('login-sso') }}">{{ _('Log in') }}</a>
             {% else %}
             <a href="{{ url('register') }}">{{ _('Register') }}</a>
+            {% endif %}
             {% endif %}
         </div>
     </div>

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -23,25 +23,25 @@
 
         <div class="column-right top-links">
             {% if user_is_authenticated %}
-            {% include 'zerver/logout.html' %}
-            <a class="no-style" href="#logout">
-                <span class="logout">Log out</span>
-            </a>
-            <a class="no-style" href="/">
-                <img class="header-realm-icon" src="{{ realm_icon }}" alt="{{ _('Go to Zulip') }}"/>
-            </a>
+                {% include 'zerver/logout.html' %}
+                <a class="no-style" href="#logout">
+                    <span class="logout">Log out</span>
+                </a>
+                <a class="no-style" href="/">
+                    <img class="header-realm-icon" src="{{ realm_icon }}" alt="{{ _('Go to Zulip') }}"/>
+                </a>
             {% else %}
-            {% if login_link_disabled %}
-            {% elif not only_sso %}
-            <a href="{{login_url}}">{{ _('Log in') }}</a>
-            {% endif %}
+                {% if login_link_disabled %}
+                {% elif not only_sso %}
+                <a href="{{login_url}}">{{ _('Log in') }}</a>
+                {% endif %}
 
-            {% if register_link_disabled %}
-            {% elif only_sso %}
-            <a href="{{ url('login-sso') }}">{{ _('Log in') }}</a>
-            {% else %}
-            <a href="{{ url('register') }}">{{ _('Register') }}</a>
-            {% endif %}
+                {% if register_link_disabled %}
+                {% elif only_sso %}
+                <a href="{{ url('login-sso') }}">{{ _('Log in') }}</a>
+                {% else %}
+                <a href="{{ url('register') }}">{{ _('Register') }}</a>
+                {% endif %}
             {% endif %}
         </div>
     </div>

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -27,6 +27,9 @@
             <a class="no-style" href="#logout">
                 <span class="logout">Log out</span>
             </a>
+            <a class="no-style" href="/">
+                <img class="header-realm-icon" src="{{ realm_icon }}" alt="{{ _('Go to Zulip') }}"/>
+            </a>
             {% else %}
             {% if login_link_disabled %}
             {% elif not only_sso %}

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -271,7 +271,6 @@ class POSTRequestMock(object):
         self._tornado_handler = DummyHandler()
         self._log_data = {}  # type: Dict[str, Any]
         self.META = {'PATH_INFO': 'test'}
-        self.path = ''
 
 class HostRequestMock(object):
     """A mock request object where get_host() works.  Useful for testing
@@ -283,7 +282,6 @@ class HostRequestMock(object):
         self.GET = {}  # type: Dict[str, Any]
         self.POST = {}  # type: Dict[str, Any]
         self.META = {'PATH_INFO': 'test'}
-        self.path = ''
         self.user = user_profile
         self.method = ''
         self.body = ''


### PR DESCRIPTION
There are two headers for the portico pages, the markdown for which is located in `portico-header.html` and `landing-nav.html`.

`portico-header`, logged out:
![image](https://user-images.githubusercontent.com/12771126/29236577-49248f34-7ec1-11e7-850a-947e887edda8.png)

`portico-header`, logged in:
![image](https://user-images.githubusercontent.com/12771126/29236572-3732ada6-7ec1-11e7-85ae-d71b5d76826e.png)

`landing-nav`, logged out:
![image](https://user-images.githubusercontent.com/12771126/29236588-573aed52-7ec1-11e7-8a5f-3e97a682a5a6.png)

`landing-nav`, logged in:
![image](https://user-images.githubusercontent.com/12771126/29236560-0ac5ddce-7ec1-11e7-9ace-6aa12ced4480.png)