### PR TITLE
Use /srv for Travis cache path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ cache:
   yarn: true
   apt: false
   directories:
-    - $HOME/zulip-venv-cache
-    - $HOME/zulip-npm-cache
-    - $HOME/zulip-emoji-cache
+    - /srv/zulip-venv-cache
+    - /srv/zulip-npm-cache
+    - /srv/zulip-emoji-cache
     - $HOME/node
 env:
   global:

--- a/scripts/lib/install-node
+++ b/scripts/lib/install-node
@@ -3,9 +3,6 @@ set -e
 
 ZULIP_PATH="$(dirname "$0")/../.."
 ZULIP_SRV="/srv"
-if [ "$TRAVIS" ] ; then
-    ZULIP_SRV="/home/travis"
-fi
 YARN_BIN="$ZULIP_SRV/zulip-yarn/bin/yarn"
 node_version=6.6.0
 yarn_version=0.27.5

--- a/scripts/lib/node_cache.py
+++ b/scripts/lib/node_cache.py
@@ -12,10 +12,6 @@ from scripts.lib.zulip_tools import subprocess_text_output, run
 ZULIP_PATH = dirname(dirname(dirname(abspath(__file__))))
 ZULIP_SRV_PATH = "/srv"
 
-if 'TRAVIS' in os.environ:
-    # In Travis CI, we don't have root access
-    ZULIP_SRV_PATH = "/home/travis"
-
 
 NODE_MODULES_CACHE_PATH = os.path.join(ZULIP_SRV_PATH, 'zulip-npm-cache')
 YARN_BIN = os.path.join(ZULIP_SRV_PATH, 'zulip-yarn/bin/yarn')

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -10,10 +10,6 @@ from scripts.lib.hash_reqs import expand_reqs
 ZULIP_PATH = dirname(dirname(dirname(abspath(__file__))))
 VENV_CACHE_PATH = "/srv/zulip-venv-cache"
 
-if 'TRAVIS' in os.environ:
-    # In Travis CI, we don't have root access
-    VENV_CACHE_PATH = "/home/travis/zulip-venv-cache"
-
 if False:
     # Don't add a runtime dependency on typing
     from typing import List, Optional, Tuple, Set

--- a/tools/clean-emoji-cache
+++ b/tools/clean-emoji-cache
@@ -9,15 +9,14 @@ ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 EMOJI_CACHE_SYMLINK = os.path.join(ZULIP_PATH, 'static', 'generated', 'emoji')
 EMOJI_CACHE_PATH = "/srv/zulip-emoji-cache"
-if "--travis" in sys.argv:
-    EMOJI_CACHE_PATH = os.path.join(os.environ["HOME"], "zulip-emoji-cache")
 
 curr_emoji_cache_dir = os.path.dirname(os.path.realpath(EMOJI_CACHE_SYMLINK))
 
-for cache_dir_base in os.listdir(EMOJI_CACHE_PATH):
-    emoji_cache_dir = os.path.join(EMOJI_CACHE_PATH, cache_dir_base)
-    if emoji_cache_dir not in curr_emoji_cache_dir:
-        print("Cleaning unused emoji cache dir %s" % (emoji_cache_dir,))
-        subprocess.check_call(["sudo", "rm", "-rf", emoji_cache_dir])
-    else:
-        print("Keeping used emoji cache dir %s" % (emoji_cache_dir,))
+if os.path.isdir(EMOJI_CACHE_PATH):
+    for cache_dir_base in os.listdir(EMOJI_CACHE_PATH):
+        emoji_cache_dir = os.path.join(EMOJI_CACHE_PATH, cache_dir_base)
+        if emoji_cache_dir not in curr_emoji_cache_dir:
+            print("Cleaning unused emoji cache dir %s" % (emoji_cache_dir,))
+            subprocess.check_call(["sudo", "rm", "-rf", emoji_cache_dir])
+        else:
+            print("Keeping used emoji cache dir %s" % (emoji_cache_dir,))

--- a/tools/clean-npm-cache
+++ b/tools/clean-npm-cache
@@ -10,7 +10,6 @@ from scripts.lib.node_cache import generate_sha1sum_node_modules
 
 NODE_MODULES_CACHE_PATH = "/srv/zulip-npm-cache"
 if "--travis" in sys.argv:
-    NODE_MODULES_CACHE_PATH = os.path.join(os.environ["HOME"], "zulip-npm-cache")
     try:
         subprocess.check_output([os.path.join(NODE_MODULES_CACHE_PATH, "yarn/bin/yarn"), '--version'])
     except OSError:

--- a/tools/clean-venv-cache
+++ b/tools/clean-venv-cache
@@ -8,8 +8,6 @@ import sys
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 VENV_CACHE_DIR = "/srv/zulip-venv-cache"
-if "--travis" in sys.argv:
-    VENV_CACHE_DIR = os.path.join(os.environ["HOME"], "zulip-venv-cache")
 
 used_caches = set()
 hash_reqs = os.path.join(ZULIP_PATH, 'scripts', 'lib', 'hash_reqs.py')
@@ -19,10 +17,11 @@ for filename in os.listdir(os.path.join(ZULIP_PATH, "requirements")):
     hash_val = subprocess.check_output([hash_reqs, requirements_file]).strip()
     used_caches.add(os.path.join(VENV_CACHE_DIR, hash_val.decode('utf-8')))
 
-for cache_dir_base in os.listdir(VENV_CACHE_DIR):
-    cache_dir = os.path.join(VENV_CACHE_DIR, cache_dir_base)
-    if cache_dir not in used_caches:
-        print("Cleaning unused venv %s" % (cache_dir,))
-        subprocess.check_call(["sudo", "rm", "-rf", cache_dir])
-    else:
-        print("Keeping used venv %s" % (cache_dir,))
+if os.path.isdir(VENV_CACHE_DIR):
+    for cache_dir_base in os.listdir(VENV_CACHE_DIR):
+        cache_dir = os.path.join(VENV_CACHE_DIR, cache_dir_base)
+        if cache_dir not in used_caches:
+            print("Cleaning unused venv %s" % (cache_dir,))
+            subprocess.check_call(["sudo", "rm", "-rf", cache_dir])
+        else:
+            print("Keeping used venv %s" % (cache_dir,))

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -44,9 +44,6 @@ NODE_TEST_COVERAGE_DIR_PATH = os.path.join(VAR_DIR_PATH, 'node-coverage')
 
 # TODO: De-duplicate this with emoji_dump.py
 EMOJI_CACHE_PATH = "/srv/zulip-emoji-cache"
-if 'TRAVIS' in os.environ:
-    # In Travis CI, we don't have root access
-    EMOJI_CACHE_PATH = "/home/travis/zulip-emoji-cache"
 
 if PY2:
     VENV_PATH = PY2_VENV_PATH

--- a/tools/setup/emoji/build_emoji
+++ b/tools/setup/emoji/build_emoji
@@ -87,10 +87,6 @@ EMOJI_POS_INFO_TEMPLATE = """\
 # change directory
 os.chdir(EMOJI_SCRIPT_DIR_PATH)
 
-if 'TRAVIS' in os.environ:
-    # In Travis CI, we don't have root access
-    EMOJI_CACHE_PATH = "/home/travis/zulip-emoji-cache"
-
 class MissingGlyphError(Exception):
     pass
 


### PR DESCRIPTION
This further ensures what is tested in Travis and what is run in
the dev/prod env has the same ACL set. Should the installation steps be
fixed with fewer number of `sudo`'s later on, then this is to be done
via changing ZULIP_SRV / ZULIP_SRV_PATH, VENV_CACHE_PATH,
EMOJI_CACHE_PATH, NODE_MODULE_CACHE_PATH.