### PR TITLE
puppet: Use pip instead of apt to install Python dependencies.

### DIFF
--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -14,15 +14,17 @@ class zulip::postgres_appdb_base {
   safepackage { $appdb_packages: ensure => "installed" }
 
   exec {"pip3_process_fts_updates_deps":
-    command => "/usr/bin/pip3 install 'psycopg2==2.7.1'",
+    command => "/usr/local/bin/pip3 install 'psycopg2==2.7.1'",
     creates => "/usr/local/lib/python3.4/dist-packages/psycopg2",
-    require => Package['python3-pip'],
+    require => Exec['pip3_ensure_latest'],
+    refreshonly => true,
   }
 
   exec {"pip2_process_fts_updates_deps":
-    command => "/usr/bin/pip2 install 'psycopg2==2.7.1'",
+    command => "/usr/local/bin/pip2 install 'psycopg2==2.7.1'",
     creates => "/usr/local/lib/python2.7/dist-packages/psycopg2",
-    require => Package['python-pip']
+    require => Exec['pip2_ensure_latest'],
+    refreshonly => true,
   }
 
   # We bundle a bunch of other sysctl parameters into 40-postgresql.conf

--- a/puppet/zulip/manifests/postgres_common.pp
+++ b/puppet/zulip/manifests/postgres_common.pp
@@ -17,16 +17,30 @@ class zulip::postgres_common {
   }
   safepackage { $postgres_packages: ensure => "installed" }
 
+  exec {"pip3_ensure_latest":
+    command => "/usr/bin/pip3 install -U pip==9.0.1",
+    creates => "/usr/local/bin/pip3",
+    require => Package['python3-pip'],
+  }
+
   exec {"pip3_python_deps":
-    command => "/usr/bin/pip3 install 'pytz==2017.2' 'python-dateutil==2.6.1'",
-    creates => "/usr/local/lib/python3.4/dist-packages/dateutil",
-    require => Package['python3-pip']
+    command     => "/usr/local/bin/pip3 install 'pytz==2017.2' 'python-dateutil==2.6.1'",
+    creates     => "/usr/local/lib/python3.4/dist-packages/dateutil",
+    require     => Exec['pip3_ensure_latest'],
+    refreshonly => true,
+  }
+
+  exec {"pip2_ensure_latest":
+    command => "/usr/bin/pip2 install -U pip==9.0.1",
+    creates => "/usr/local/bin/pip2",
+    require => Package['python-pip'],
   }
 
   exec {"pip2_python_deps":
-    command => "/usr/bin/pip2 install 'pytz==2017.2' 'python-dateutil==2.6.1'",
-    creates => "/usr/local/lib/python2.7/dist-packages/dateutil",
-    require => Package['python-pip']
+    command     => "/usr/local/bin/pip2 install 'pytz==2017.2' 'python-dateutil==2.6.1'",
+    creates     => "/usr/local/lib/python2.7/dist-packages/dateutil",
+    require     => Exec['pip2_ensure_latest'],
+    refreshonly => true,
   }
 
   exec { "disable_logrotate":

--- a/puppet/zulip/manifests/postgres_common.pp
+++ b/puppet/zulip/manifests/postgres_common.pp
@@ -3,13 +3,8 @@ class zulip::postgres_common {
                         "postgresql-${zulip::base::postgres_version}",
                         # tools for database monitoring
                         "ptop",
-                        # Python modules used in our monitoring/worker threads
-                        # "python3-gevent", # missing on trusty
-                        "python-gevent",
-                        "python3-tz", # TODO: use a virtualenv instead
-                        "python-tz", # TODO: use a virtualenv instead
-                        "python3-dateutil", # TODO: use a virtualenv instead
-                        "python-dateutil", # TODO: use a virtualenv instead
+                        "python3-pip",
+                        "python-pip",
                         # Needed just to support adding postgres user to 'zulip' group
                         "ssl-cert",
                         # our dictionary
@@ -21,6 +16,18 @@ class zulip::postgres_common {
     }
   }
   safepackage { $postgres_packages: ensure => "installed" }
+
+  exec {"pip3_python_deps":
+    command => "/usr/bin/pip3 install 'pytz==2017.2' 'python-dateutil==2.6.1'",
+    creates => "/usr/local/lib/python3.4/dist-packages/dateutil",
+    require => Package['python3-pip']
+  }
+
+  exec {"pip2_python_deps":
+    command => "/usr/bin/pip2 install 'pytz==2017.2' 'python-dateutil==2.6.1'",
+    creates => "/usr/local/lib/python2.7/dist-packages/dateutil",
+    require => Package['python-pip']
+  }
 
   exec { "disable_logrotate":
     command => "/usr/bin/dpkg-divert --rename --divert /etc/logrotate.d/postgresql-common.disabled --add /etc/logrotate.d/postgresql-common",

--- a/puppet/zulip_ops/manifests/base.pp
+++ b/puppet/zulip_ops/manifests/base.pp
@@ -40,17 +40,19 @@ class zulip_ops::base {
   exec {"pip3_ops_python_deps":
     # six is eeded for zulip-ec2-configure-network-interfaces
     # netiface is needed for zulip-ec2-configure-network-interfaces and postgres
-    command => "/usr/bin/pip3 install 'six==1.10.0' 'netifaces==0.10.5'",
+    command => "/usr/local/bin/pip3 install 'six==1.10.0' 'netifaces==0.10.5'",
     creates => "/usr/local/lib/python3.4/dist-packages/six",
-    require => Package['python3-pip'],
+    require => Exec['pip3_ensure_latest'],
+    refreshonly => true,
   }
 
   exec {"pip2_ops_python_deps":
     # six is eeded for zulip-ec2-configure-network-interfaces
     # netiface is needed for zulip-ec2-configure-network-interfaces and postgres
-    command => "/usr/bin/pip2 install 'six==1.10.0' 'netifaces==0.10.5'",
+    command => "/usr/local/bin/pip2 install 'six==1.10.0' 'netifaces==0.10.5'",
     creates => "/usr/local/lib/python2.7/dist-packages/six",
-    require => Package['python-pip'],
+    require => Exec['pip2_ensure_latest'],
+    refreshonly => true,
   }
 
   file { '/etc/apt/apt.conf.d/02periodic':

--- a/puppet/zulip_ops/manifests/base.pp
+++ b/puppet/zulip_ops/manifests/base.pp
@@ -16,14 +16,6 @@ class zulip_ops::base {
                         "iptables-persistent",
                         # For managing our current Debian packages
                         "debian-goodies",
-                        # Needed for zulip-ec2-configure-network-interfaces
-                        "python3-six",
-                        "python-six",
-                          # This one is needed for postgres as well
-                        # "python3-boto", # missing on trusty
-                        "python-boto",
-                        "python3-netifaces",
-                        "python-netifaces",
                         # Popular editors
                         "vim",
                         "emacs-nox",
@@ -44,6 +36,22 @@ class zulip_ops::base {
 
   # Add hosts to monitor here
   $hosts = []
+
+  exec {"pip3_ops_python_deps":
+    # six is eeded for zulip-ec2-configure-network-interfaces
+    # netiface is needed for zulip-ec2-configure-network-interfaces and postgres
+    command => "/usr/bin/pip3 install 'six==1.10.0' 'netifaces==0.10.5'",
+    creates => "/usr/local/lib/python3.4/dist-packages/six",
+    require => Package['python3-pip'],
+  }
+
+  exec {"pip2_ops_python_deps":
+    # six is eeded for zulip-ec2-configure-network-interfaces
+    # netiface is needed for zulip-ec2-configure-network-interfaces and postgres
+    command => "/usr/bin/pip2 install 'six==1.10.0' 'netifaces==0.10.5'",
+    creates => "/usr/local/lib/python2.7/dist-packages/six",
+    require => Package['python-pip'],
+  }
 
   file { '/etc/apt/apt.conf.d/02periodic':
     ensure     => file,

--- a/puppet/zulip_ops/manifests/postgres_common.pp
+++ b/puppet/zulip_ops/manifests/postgres_common.pp
@@ -12,12 +12,11 @@ class zulip_ops::postgres_common {
   package { $internal_postgres_packages: ensure => "installed" }
 
   exec {"pip_wal-e":
-    command  => "/usr/bin/pip install git+git://github.com/zbenjamin/wal-e.git#egg=wal-e",
+    command  => "/usr/bin/pip install 'boto==2.0.0' 'gevent==1.2.2' git+git://github.com/zbenjamin/wal-e.git#egg=wal-e",
     creates  => "/usr/local/bin/wal-e",
-    require  => Package['python3-pip',
-                        # 'python3-boto', 'python3-gevent', # missing on trusty
-                        'python-pip', 'python-boto', 'python-gevent',
-                        'lzop', 'pv'],
+    require  => [ Package['python3-pip',
+                          'python-pip',
+                          'lzop', 'pv'] ],
   }
 
   cron { "pg_backup_and_purge":
@@ -29,10 +28,10 @@ class zulip_ops::postgres_common {
     target => "postgres",
     user => "postgres",
     require => [ File["/usr/local/bin/pg_backup_and_purge.py"],
-                 Package["postgresql-${zulip::base::postgres_version}",
-                         "python3-dateutil",
-                         "python-dateutil"
-                 ] ]
+                 Package["postgresql-${zulip::base::postgres_version}"],
+                 Exec['pip3_python_deps'],
+                 Exec['pip2_python_deps'],
+               ]
   }
 
   exec { "sysctl_p":

--- a/puppet/zulip_ops/manifests/stats.pp
+++ b/puppet/zulip_ops/manifests/stats.pp
@@ -8,15 +8,17 @@ class zulip_ops::stats {
   package { $stats_packages: ensure => "installed" }
 
   exec {"pip3_stats_python_deps":
-    command => "/usr/bin/pip3 install 'twisted==17.5.0' 'django==1.11.2' 'django-tagging==0.4.5' 'pycairo==1.10.0' 'whisper==0.9.12' 'carbon==1.0.2' 'graphite-web==1.0.2'",
+    command => "/usr/local/bin/pip3 install 'twisted==17.5.0' 'django==1.11.2' 'django-tagging==0.4.5' 'pycairo==1.10.0' 'whisper==0.9.12' 'carbon==1.0.2' 'graphite-web==1.0.2'",
     creates => "/usr/local/lib/python3.4/dist-packages/django",
-    require => Package['python3-pip'],
+    require => Exec['pip3_ensure_latest'],
+    refreshonly => true,
   }
 
   exec {"pip2_stats_python_deps":
-    command => "/usr/bin/pip2 install 'twisted==17.5.0' 'django==1.11.2' 'django-tagging==0.4.5' 'pycairo==1.10.0' 'whisper==0.9.12' 'carbon==1.0.2' 'graphite-web==1.0.2'",
+    command => "/usr/local/bin/pip2 install 'twisted==17.5.0' 'django==1.11.2' 'django-tagging==0.4.5' 'pycairo==1.10.0' 'whisper==0.9.12' 'carbon==1.0.2' 'graphite-web==1.0.2'",
     creates => "/usr/local/lib/python2.7/dist-packages/django",
-    require => Package['python-pip'],
+    require => Exec['pip2_ensure_latest'],
+    refreshonly => true,
   }
 
   file { "/root/setup_disks.sh":

--- a/puppet/zulip_ops/manifests/stats.pp
+++ b/puppet/zulip_ops/manifests/stats.pp
@@ -4,15 +4,20 @@ class zulip_ops::stats {
   include zulip::supervisor
 
   $stats_packages = [ "libssl-dev", "zlib1g-dev", "redis-server",
-                      # "python3-twisted", "python3-django", # missing on trusty
-                      # "python3-django-tagging", # missing on trusty and xenial!
-                      "python-twisted", "python-django", "python-django-tagging",
-                      "python-carbon", "python-graphite-web", # can't find these anywhere! did this ever work?
-                      "python3-cairo",
-                      # "python3-whisper", # missing on trusty and xenial!
-                      "python-cairo", "python-whisper"
                       ]
   package { $stats_packages: ensure => "installed" }
+
+  exec {"pip3_stats_python_deps":
+    command => "/usr/bin/pip3 install 'twisted==17.5.0' 'django==1.11.2' 'django-tagging==0.4.5' 'pycairo==1.10.0' 'whisper==0.9.12' 'carbon==1.0.2' 'graphite-web==1.0.2'",
+    creates => "/usr/local/lib/python3.4/dist-packages/django",
+    require => Package['python3-pip'],
+  }
+
+  exec {"pip2_stats_python_deps":
+    command => "/usr/bin/pip2 install 'twisted==17.5.0' 'django==1.11.2' 'django-tagging==0.4.5' 'pycairo==1.10.0' 'whisper==0.9.12' 'carbon==1.0.2' 'graphite-web==1.0.2'",
+    creates => "/usr/local/lib/python2.7/dist-packages/django",
+    require => Package['python-pip'],
+  }
 
   file { "/root/setup_disks.sh":
     ensure => file,


### PR DESCRIPTION
This way, installation of Python dependencies in Puppet modules is no
longer constrained by whether the system packages are available or not.