### PR TITLE
Make the tab bar more compact/clean.

### DIFF
--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -49,8 +49,7 @@ function update_table_stream_color(table, stream_name, color) {
         if ($.trim($label.text()) === stream_name) {
             var messages = $label.closest(".recipient_row").children(".message_row");
             messages.children(".messagebox").css("box-shadow", "inset 2px 0px 0px 0px " + style + ", -1px 0px 0px 0px " + style);
-            $label.css({background: style,
-                          "border-left-color": style});
+            $label.css({background: style});
             $label.removeClass(exports.color_classes);
             $label.addClass(color_class);
         }

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -129,19 +129,13 @@ exports.colorize_tab_bar = function () {
                            colorspace.getDecimalColor(color_for_stream), 0.2));
 
         if (stream_tab.hasClass("stream")) {
-            stream_tab.css('border-left-color',
-                           color_for_stream).css('background-color',
-                                                 color_for_stream);
+            stream_tab.css('background-color', color_for_stream);
             if (stream_tab.hasClass("inactive")) {
               stream_tab.hover (
                 function () {
-                 $(this).css('border-left-color',
-                             stream_light).css('background-color',
-                             stream_light);
+                 $(this).css('background-color', stream_light);
                 }, function () {
-                 $(this).css('border-left-color',
-                             color_for_stream).css('background-color',
-                                                   color_for_stream);
+                 $(this).css('background-color', color_for_stream);
                 }
               );
             }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1569,35 +1569,18 @@ blockquote p {
     padding: 0px;
     text-overflow: ellipsis;
     height: 40px;
+    padding: 0 5px;
 }
 
 #tab_list li.inactive {
-    border-top-color: hsla(0, 0%, 0%, 0.0);
-    border-right-color: hsla(0, 0%, 0%, 0.0);
-    border-bottom-color: hsla(0, 0%, 0%, 0.0);
     background-color: hsl(0, 0%, 88%);
-    border-left-color: hsl(0, 0%, 88%);
     border-width: 0px;
+    margin-right: -4px;
+    font-size: 14px;
 }
 
 #tab_list li.private_message a {
     color: #ffffff;
-}
-
-#tab_list li.inactive:after {
-    left: 100%;
-    top: 50%;
-    content: " ";
-    height: 0px;
-    width: 0px;
-    position: absolute;
-    pointer-events: none;
-    margin-top: -25px;
-    border-style: solid;
-    border-width: 25px 0 25px 12px;
-    border-color: inherit;
-    z-index: 2;
-    -moz-transform: scale(.9999);
 }
 
 #tab_list li.inactive:before {
@@ -1608,10 +1591,6 @@ blockquote p {
     width: 0px;
     position: absolute;
     pointer-events: none;
-    margin-top: -28px;
-    border-style: solid;
-    border-width: 28px 0 28px 14px;
-    border-color: hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) #ffffff;
     z-index: 1;
     -moz-transform: scale(.9999);
 }
@@ -1622,18 +1601,16 @@ blockquote p {
     border-color: inherit;
     width: 100%;
     display: inline-block;
-    padding: 0px 8px;
-    max-width: 120px;
+    padding: 0px 5px;
+    max-width: 150px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
 #tab_list li.active {
-    padding-left: 17px;
-    padding-right: 10px;
     background-color: hsl(0, 0%, 88%);
-    max-width: 120px;
+    max-width: 150px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1657,12 +1634,6 @@ blockquote p {
     border-color: hsl(0, 0%, 88%);
     background-color: hsl(0, 0%, 88%);
     margin: 0px;
-}
-
-#tab_list li.stream a,
-#tab_list li.private_message a {
-    padding-left: 17px;
-    padding-right: 4px;
 }
 
 #tab_list li.root a {
@@ -1926,6 +1897,7 @@ nav a .no-style {
 }
 
 #search_arrows {
+    margin-left: -4px;
     margin-bottom: 5px;
 
     /* Bootstrap wants font-size: 0 to eliminate space between

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1783,7 +1783,7 @@ nav a .no-style {
 
 #search_query {
     width: 100%;
-    font-size: 18px;
+    font-size: 16px;
     height: 40px;
     padding: 0px;
     color: hsl(0, 0%, 13%);

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -702,15 +702,11 @@ td.pointer {
 
 .stream_label {
     display: inline-block;
-    padding: 3px 4px 2px 4px;
+    padding: 3px 7px 2px 6px;
     font-weight: normal;
     height: 17px;
     line-height: 17px;
-    border-top-color: hsla(0, 0%, 0%, 0.0);
-    border-right-color: hsla(0, 0%, 0%, 0.0);
-    border-bottom-color: hsla(0, 0%, 0%, 0.0);
     background-color: hsl(0, 0%, 88%);
-    border-left-color: hsl(0, 0%, 88%);
     border-width: 0px;
     position: relative;
     text-decoration: none;
@@ -730,41 +726,9 @@ td.pointer {
     text-decoration: none;
 }
 
-.stream_label:after {
-    left: 100%;
-    top: 50%;
-    content: " ";
-    height: 0px;
-    width: 0px;
-    position: absolute;
-    pointer-events: none;
-    margin-top: -11px;
-    border-style: solid;
-    border-width: 11px 0 11px 5px;
-    border-color: inherit;
-    z-index: 2;
-    -moz-transform: scale(.9999);
-}
-
-.stream_label:before {
-    left: 100%;
-    top: 50%;
-    content: " ";
-    height: 0px;
-    width: 0px;
-    position: absolute;
-    pointer-events: none;
-    margin-top: -14px;
-    border-style: solid;
-    border-width: 14px 0 14px 6px;
-    border-color: hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) #ffffff;
-    z-index: 1;
-    -moz-transform: scale(.9999);
-}
-
 .stream_topic {
     display: inline-block;
-    padding: 3px 3px 2px 12px;
+    padding: 3px 4px 2px 7px;
     margin-left: -5px;
     height: 17px;
     line-height: 17px;
@@ -1003,7 +967,6 @@ td.pointer {
     font-size: 14px;
     height: 17px;
     line-height: 17px;
-    border-left-color: hsl(0, 0%, 27%);
 }
 
 /* Base color backgrounds for messageboxes,

--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -4,7 +4,7 @@
         <div class="message-header-contents">
             {{! stream link }}
             <a class="message_label_clickable narrows_by_recipient stream_label {{color_class}}"
-                style="background: {{background_color}}; border-left-color: {{background_color}};"
+                style="background: {{background_color}};"
                 href="{{stream_url}}"
                 title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;{{/tr}}">
                 {{! invite only lock }}


### PR DESCRIPTION
This change makes the tab bar look nicer, particularly on mobile web.

Before:

![image](https://user-images.githubusercontent.com/142908/29244283-51e49c60-7f82-11e7-94dd-8bf7afd93035.png)

After:

![image](https://user-images.githubusercontent.com/142908/29244284-605d2c30-7f82-11e7-927e-988cc43bc1d8.png)
