### PR TITLE
Make Mypy coverage 100%.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ missed-message emails, desktop apps, and much more.
 Further information on the Zulip project and its features can be found
 at <https://www.zulip.org>.
 
-[![Build Status](https://travis-ci.org/zulip/zulip.svg?branch=master)](https://travis-ci.org/zulip/zulip) [![Coverage Status](https://img.shields.io/codecov/c/github/zulip/zulip.svg)](https://codecov.io/gh/zulip/zulip) [![docs](https://readthedocs.org/projects/zulip/badge/?version=latest)](http://zulip.readthedocs.io/en/latest/) [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org) [![Twitter](https://img.shields.io/badge/twitter-@zulip-blue.svg?style=flat)](http://twitter.com/zulip)
+[![Build Status](https://travis-ci.org/zulip/zulip.svg?branch=master)](https://travis-ci.org/zulip/zulip) [![Coverage Status](https://img.shields.io/codecov/c/github/zulip/zulip.svg)](https://codecov.io/gh/zulip/zulip) ![Mypy coverage](https://img.shields.io/badge/mypy-100%25-green.svg) [![docs](https://readthedocs.org/projects/zulip/badge/?version=latest)](http://zulip.readthedocs.io/en/latest/) [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org) [![Twitter](https://img.shields.io/badge/twitter-@zulip-blue.svg?style=flat)](http://twitter.com/zulip)
 
 ## Community
 

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -70,10 +70,12 @@ class JsonableError(Exception):
              data_fields = ['widget_name']
 
              def __init__(self, widget_name):
+                 # type: (str) -> None
                  self.widget_name = widget_name  # type: str
 
              @staticmethod
              def msg_format():
+                 # type: () -> str
                  return _("No such widget: {widget_name}")
 
          raise NoSuchWidgetError(widget_name)

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -10,15 +10,19 @@ from django.utils.translation import ugettext as _
 
 from zerver.lib.exceptions import JsonableError, ErrorCode
 
+from django.http import HttpRequest, HttpResponse
+
 class RequestVariableMissingError(JsonableError):
     code = ErrorCode.REQUEST_VARIABLE_MISSING
     data_fields = ['var_name']
 
     def __init__(self, var_name):
+        # type: (str) -> None
         self.var_name = var_name  # type: str
 
     @staticmethod
     def msg_format():
+        # type: () -> str
         return _("Missing '{var_name}' argument")
 
 class RequestVariableConversionError(JsonableError):
@@ -26,11 +30,13 @@ class RequestVariableConversionError(JsonableError):
     data_fields = ['var_name', 'bad_value']
 
     def __init__(self, var_name, bad_value):
+        # type: (str, Any) -> None
         self.var_name = var_name  # type: str
         self.bad_value = bad_value
 
     @staticmethod
     def msg_format():
+        # type: () -> str
         return _("Bad value for '{var_name}': {bad_value}")
 
 # Used in conjunction with @has_request_variables, below
@@ -44,6 +50,7 @@ class REQ(object):
 
     def __init__(self, whence=None, converter=None, default=NotSpecified,
                  validator=None, argument_type=None):
+        # type: (str, Callable[Any, Any], Any, Callable[Any, Any], str) -> None
         """whence: the name of the request variable that should be used
         for this parameter.  Defaults to a request variable of the
         same name as the parameter.
@@ -91,6 +98,7 @@ class REQ(object):
 # expected to call json_error or json_success, as it uses json_error
 # internally when it encounters an error
 def has_request_variables(view_func):
+    # type: (Callable[[HttpRequest, *Any, **Any], HttpResponse]) -> Callable[[HttpRequest, *Any, **Any], HttpResponse]
     num_params = view_func.__code__.co_argcount
     if view_func.__defaults__ is None:
         num_default_params = 0
@@ -112,6 +120,7 @@ def has_request_variables(view_func):
 
     @wraps(view_func)
     def _wrapped_view_func(request, *args, **kwargs):
+        # type: (HttpRequest, *Any, **Any) -> HttpResponse
         for param in post_params:
             if param.func_var_name in kwargs:
                 continue

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -42,6 +42,7 @@ else:
     secrets_file.read(os.path.join(DEPLOY_ROOT, "zproject/dev-secrets.conf"))
 
 def get_secret(key):
+    # type: (str) -> None
     if secrets_file.has_option('secrets', key):
         return secrets_file.get('secrets', key)
     return None


### PR DESCRIPTION
How the coverage is calculated:
```bash
$ grep --exclude '*.md' --exclude '*.html' 'def .*\(.*\):$' | sort > ../all_fun.txt
$ grep --exclude '*.md' --exclude '*.html' 'def .*\(.*\):\n.*# type: ' | grep 'def .*\(.*\):' | sort > ../typed_fun.txt
$ diff ../all_fun.txt ../typed_fun.txt
1068d1067
< zerver/lib/exceptions.py:76:             def msg_format():
1312d1310
< zerver/lib/request.py:116:    def _wrapped_view_func(request, *args, **kwargs):
1317d1314
< zerver/lib/request.py:95:def has_request_variables(view_func):
$ wc -l ../all_fun.txt
4516 ../all_fun.txt
$ wc -l ../typed_fun.txt
4513 ../typed_fun.txt
```

- ~~[] `zerver/lib/exceptions.py` is within a docstring, so it doesn't count. Hence, two functions remaining to be annotated to be back to 100% again.~~ Fixed!