### PR TITLE
Use force_login for faster tests

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -271,6 +271,14 @@ class ZulipTestCase(TestCase):
         else:
             self.assertFalse(self.client.login(username=email, password=password))
 
+    def force_login(self, user, backend=None):
+        # type: (UserProfile, str) -> None
+        """
+        backend should be a dotted path string, similar to what we write
+        in settings.AUTHENTICATION_BACKENDS.
+        """
+        self.client.force_login(user, backend=backend)
+
     def logout(self):
         # type: () -> None
         self.client.logout()


### PR DESCRIPTION
Taken from https://docs.djangoproject.com/en/1.11/topics/testing/tools/#django.test.Client.force_login:

If your site uses Django’s authentication system, you can use the force_login() method to simulate the effect of a user logging into the site. Use this method instead of login() when a test requires a user be logged in and the details of how a user logged in aren’t important.

Unlike login(), this method skips the authentication and verification steps: inactive users (is_active=False) are permitted to login and the user’s credentials don’t need to be provided.

The user will have its backend attribute set to the value of the backend argument (which should be a dotted Python path string), or to settings.AUTHENTICATION_BACKENDS[0] if a value isn’t provided. The authenticate() function called by login() normally annotates the user like this.

This method is faster than login() since the expensive password hashing algorithms are bypassed. Also, you can speed up login() by using a weaker hasher while testing.

Fixes a part of #2564.