### PR TITLE
Refactor API key validation for reusing email addresses

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -194,11 +194,11 @@ def validate_api_key(request, role, api_key, is_webhook=False):
         if not check_subdomain(get_subdomain(request), ""):
             raise JsonableError(_("This API key only works on the root subdomain"))
         return profile
-    else:
-        try:
-            profile = get_user_profile_by_email(role)
-        except UserProfile.DoesNotExist:
-            raise JsonableError(_("Invalid user: %s") % (role,))
+
+    try:
+        profile = get_user_profile_by_email(role)
+    except UserProfile.DoesNotExist:
+        raise JsonableError(_("Invalid user: %s") % (role,))
 
     if api_key != profile.api_key:
         raise JsonableError(_("Invalid API key"))

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -183,16 +183,16 @@ def validate_api_key(request, role, api_key, is_webhook=False):
     # Remove whitespace to protect users from trivial errors.
     role, api_key = role.strip(), api_key.strip()
 
-    if not is_remote_server(role):
+    if is_remote_server(role):
         try:
-            profile = get_user_profile_by_email(role)  # type: Union[UserProfile, RemoteZulipServer]
-        except UserProfile.DoesNotExist:
-            raise JsonableError(_("Invalid user: %s") % (role,))
-    else:
-        try:
-            profile = get_remote_server_by_uuid(role)
+            profile = get_remote_server_by_uuid(role)  # type: Union[UserProfile, RemoteZulipServer]
         except RemoteZulipServer.DoesNotExist:
             raise JsonableError(_("Invalid Zulip server: %s") % (role,))
+    else:
+        try:
+            profile = get_user_profile_by_email(role)
+        except UserProfile.DoesNotExist:
+            raise JsonableError(_("Invalid user: %s") % (role,))
 
     if api_key != profile.api_key:
         if len(api_key) != 32:

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -236,8 +236,12 @@ def access_user_by_api_key(request, api_key):
     if user_profile.realm.deactivated:
         raise JsonableError(_("Realm for account has been deactivated"))
 
-    if not check_subdomain(get_subdomain(request), user_profile.realm.subdomain):
-        logging.warning("User %s attempted to access webhook API on wrong subdomain %s" % (
+    if (not check_subdomain(get_subdomain(request), user_profile.realm.subdomain) and
+        # Allow access to localhost for Tornado
+        not (settings.RUNNING_INSIDE_TORNADO and
+             request.META["SERVER_NAME"] == "127.0.0.1" and
+             request.META["REMOTE_ADDR"] == "127.0.0.1")):
+        logging.warning("User %s attempted to access API on wrong subdomain %s" % (
             user_profile.email, get_subdomain(request)))
         raise JsonableError(_("Account is not associated with this subdomain"))
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -505,7 +505,7 @@ def authenticate_log_and_execute_json(request, view_func, *args, **kwargs):
             user_profile.email, get_subdomain(request)))
         raise JsonableError(_("Account is not associated with this subdomain"))
 
-    process_client(request, user_profile, True)
+    process_client(request, user_profile, is_json_view=True)
     request._email = user_profile.email
     return rate_limit()(view_func)(request, user_profile, *args, **kwargs)
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -206,9 +206,6 @@ def validate_api_key(request, role, api_key, is_webhook=False):
     profile = cast(UserProfile, profile)  # is UserProfile
     if not profile.is_active:
         raise JsonableError(_("Account not active"))
-    if profile.is_incoming_webhook and not is_webhook:
-        raise JsonableError(_("Account is not valid to post webhook messages"))
-
     if profile.realm.deactivated:
         raise JsonableError(_("Realm for account has been deactivated"))
 
@@ -220,6 +217,9 @@ def validate_api_key(request, role, api_key, is_webhook=False):
         logging.warning("User %s attempted to access API on wrong subdomain %s" % (
             profile.email, get_subdomain(request)))
         raise JsonableError(_("Account is not associated with this subdomain"))
+
+    if profile.is_incoming_webhook and not is_webhook:
+        raise JsonableError(_("This API is not available to incoming webhook bots."))
 
     return profile
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -169,11 +169,6 @@ def process_client(request, user_profile, is_json_view=False, client_name=None,
     if client_name is None:
         client_name = get_client_name(request, is_json_view)
 
-    # Transitional hack for early 2014.  Eventually the ios clients
-    # will all report ZulipiOS, and we can remove the next couple lines.
-    if client_name == 'ios':
-        client_name = 'ZulipiOS'
-
     request.client = get_client(client_name)
     if not remote_server_request:
         update_user_activity(request, user_profile)

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -185,15 +185,15 @@ def validate_api_key(request, role, api_key, is_webhook=False):
 
     if settings.ZILENCER_ENABLED and is_remote_server(role):
         try:
-            profile = get_remote_server_by_uuid(role)  # type: Union[UserProfile, RemoteZulipServer]
+            remote_server = get_remote_server_by_uuid(role)
         except RemoteZulipServer.DoesNotExist:
             raise JsonableError(_("Invalid Zulip server: %s") % (role,))
-        if api_key != profile.api_key:
+        if api_key != remote_server.api_key:
             raise JsonableError(_("Invalid API key"))
 
         if not check_subdomain(get_subdomain(request), ""):
             raise JsonableError(_("This API key only works on the root subdomain"))
-        return profile
+        return remote_server
 
     try:
         profile = get_user_profile_by_email(role)

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -195,11 +195,11 @@ def validate_api_key(request, role, api_key, is_webhook=False):
             raise JsonableError(_("This API key only works on the root subdomain"))
         return remote_server
 
-    profile = access_user_by_api_key(request, api_key, email=role)
-    if profile.is_incoming_webhook and not is_webhook:
+    user_profile = access_user_by_api_key(request, api_key, email=role)
+    if user_profile.is_incoming_webhook and not is_webhook:
         raise JsonableError(_("This API is not available to incoming webhook bots."))
 
-    return profile
+    return user_profile
 
 def access_user_by_api_key(request, api_key, email=None):
     # type: (HttpRequest, Text, Optional[Text]) -> UserProfile

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -203,7 +203,6 @@ def validate_api_key(request, role, api_key, is_webhook=False):
     if api_key != profile.api_key:
         raise JsonableError(_("Invalid API key"))
 
-    profile = cast(UserProfile, profile)  # is UserProfile
     if not profile.is_active:
         raise JsonableError(_("Account not active"))
     if profile.realm.deactivated:

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -26,7 +26,6 @@ from functools import wraps
 import base64
 import datetime
 import logging
-import cProfile
 import ujson
 from io import BytesIO
 from six.moves import zip, urllib
@@ -691,34 +690,6 @@ def rate_limit(domain='all'):
             return func(request, *args, **kwargs)
         return wrapped_func
     return wrapper
-
-def profiled(func):
-    # type: (FuncT) -> FuncT
-    """
-    This decorator should obviously be used only in a dev environment.
-    It works best when surrounding a function that you expect to be
-    called once.  One strategy is to write a backend test and wrap the
-    test case with the profiled decorator.
-
-    You can run a single test case like this:
-
-        # edit zerver/tests/test_external.py and place @profiled above the test case below
-        ./tools/test-backend zerver.tests.test_external.RateLimitTests.test_ratelimit_decrease
-
-    Then view the results like this:
-
-        ./tools/show-profile-results.py test_ratelimit_decrease.profile
-
-    """
-    @wraps(func)
-    def wrapped_func(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
-        fn = func.__name__ + ".profile"
-        prof = cProfile.Profile()
-        retval = prof.runcall(func, *args, **kwargs)  # type: Any
-        prof.dump_stats(fn)
-        return retval
-    return wrapped_func  # type: ignore # https://github.com/python/mypy/issues/1927
 
 def return_success_on_head_request(view_func):
     # type: (Callable) -> Callable

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -195,12 +195,7 @@ def validate_api_key(request, role, api_key, is_webhook=False):
             raise JsonableError(_("Invalid user: %s") % (role,))
 
     if api_key != profile.api_key:
-        if len(api_key) != 32:
-            reason = _("Incorrect API key length (keys should be 32 "
-                       "characters long) for role '%s'")
-        else:
-            reason = _("Invalid API key for role '%s'")
-        raise JsonableError(reason % (role,))
+        raise JsonableError(_("Invalid API key"))
 
     # early exit for RemoteZulipServer instances
     if settings.ZILENCER_ENABLED and isinstance(profile, RemoteZulipServer):

--- a/zerver/lib/profile.py
+++ b/zerver/lib/profile.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+import cProfile
+
+from functools import wraps
+from typing import Any
+
+from zerver.decorator import FuncT
+
+def profiled(func):
+    # type: (FuncT) -> FuncT
+    """
+    This decorator should obviously be used only in a dev environment.
+    It works best when surrounding a function that you expect to be
+    called once.  One strategy is to write a backend test and wrap the
+    test case with the profiled decorator.
+
+    You can run a single test case like this:
+
+        # edit zerver/tests/test_external.py and place @profiled above the test case below
+        ./tools/test-backend zerver.tests.test_external.RateLimitTests.test_ratelimit_decrease
+
+    Then view the results like this:
+
+        ./tools/show-profile-results.py test_ratelimit_decrease.profile
+
+    """
+    @wraps(func)
+    def wrapped_func(*args, **kwargs):
+        # type: (*Any, **Any) -> Any
+        fn = func.__name__ + ".profile"
+        prof = cProfile.Profile()
+        retval = prof.runcall(func, *args, **kwargs)  # type: Any
+        prof.dump_stats(fn)
+        return retval
+    return wrapped_func  # type: ignore # https://github.com/python/mypy/issues/1927

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -279,6 +279,9 @@ class HostRequestMock(object):
     def __init__(self, host=settings.EXTERNAL_HOST):
         # type: (Text) -> None
         self.host = host
+        self.GET = {}  # type: Dict[str, Any]
+        self.POST = {}  # type: Dict[str, Any]
+        self.META = {'PATH_INFO': 'test'}
 
     def get_host(self):
         # type: () -> Text

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1062,7 +1062,7 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
                                                 "Account is not associated with this "
                                                 "subdomain")
                 mock_warning.assert_called_with(
-                    "User {} attempted to access JSON API on wrong "
+                    "User {} attempted to access API on wrong "
                     "subdomain {}".format(user_email, ''))
 
             with mock.patch('logging.warning') as mock_warning, \
@@ -1071,7 +1071,7 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
                                                 "Account is not associated with this "
                                                 "subdomain")
                 mock_warning.assert_called_with(
-                    "User {} attempted to access JSON API on wrong "
+                    "User {} attempted to access API on wrong "
                     "subdomain {}".format(user_email, 'acme'))
 
     def test_authenticated_json_post_view_if_user_is_incoming_webhook(self):
@@ -1131,7 +1131,7 @@ class TestAuthenticatedJsonViewDecorator(ZulipTestCase):
                                                 "Account is not associated with this "
                                                 "subdomain")
                 mock_warning.assert_called_with(
-                    "User {} attempted to access JSON API on wrong "
+                    "User {} attempted to access API on wrong "
                     "subdomain {}".format(user_email, ''))
 
             with mock.patch('logging.warning') as mock_warning, \
@@ -1140,7 +1140,7 @@ class TestAuthenticatedJsonViewDecorator(ZulipTestCase):
                                                 "Account is not associated with this "
                                                 "subdomain")
                 mock_warning.assert_called_with(
-                    "User {} attempted to access JSON API on wrong "
+                    "User {} attempted to access API on wrong "
                     "subdomain {}".format(user_email, 'acme'))
 
     def _do_test(self, user_email):

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -247,7 +247,7 @@ class DecoratorTestCase(TestCase):
                     api_result = my_webhook(request)
 
                 mock_warning.assert_called_with(
-                    "User {} attempted to access webhook API on wrong "
+                    "User {} attempted to access API on wrong "
                     "subdomain {}".format(webhook_bot_email, ''))
 
             with mock.patch('logging.warning') as mock_warning:
@@ -257,7 +257,7 @@ class DecoratorTestCase(TestCase):
                     api_result = my_webhook(request)
 
                 mock_warning.assert_called_with(
-                    "User {} attempted to access webhook API on wrong "
+                    "User {} attempted to access API on wrong "
                     "subdomain {}".format(webhook_bot_email, 'acme'))
 
         # Test when content_type is application/json and request.body

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1602,7 +1602,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     streams_to_sub,
                     dict(principals=ujson.dumps([email1, email2])),
                 )
-        self.assert_length(queries, 42)
+        self.assert_length(queries, 43)
 
         self.assert_length(events, 7)
         for ev in [x for x in events if x['event']['type'] not in ('message', 'stream')]:
@@ -1630,7 +1630,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     streams_to_sub,
                     dict(principals=ujson.dumps([self.test_email])),
                 )
-        self.assert_length(queries, 15)
+        self.assert_length(queries, 16)
 
         self.assert_length(events, 2)
         add_event, add_peer_event = events
@@ -1849,7 +1849,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # Make sure Zephyr mirroring realms such as MIT do not get
         # any tornado subscription events
         self.assert_length(events, 0)
-        self.assert_length(queries, 8)
+        self.assert_length(queries, 9)
 
     def test_bulk_subscribe_many(self):
         # type: () -> None
@@ -1866,7 +1866,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     dict(principals=ujson.dumps([self.test_email])),
                 )
         # Make sure we don't make O(streams) queries
-        self.assert_length(queries, 19)
+        self.assert_length(queries, 20)
 
     @slow("common_subscribe_to_streams is slow")
     def test_subscriptions_add_for_principal(self):


### PR DESCRIPTION
This accomplishes several goals:
* Eliminates a significant amount of duplicated code between the various auth decorators.
* Restructures things so that all of the API key based auth decorators start by using the API key to look up the user, and then validating, instead of first looking up the user by email, which won't still be correct when we move to having multiple users with the same email address.

@showell @gnprice since this is our core authentication code, I'd appreciate a careful review from at least one of you, and perhaps both :).