### PR TITLE
Update iOS app id to reflect the current app.

### DIFF
--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1173,7 +1173,7 @@ LOGIN_REDIRECT_URL = '/'
 POLL_TIMEOUT = 90 * 1000
 
 # iOS App IDs
-ZULIP_IOS_APP_ID = 'com.zulip.Zulip'
+ZULIP_IOS_APP_ID = 'org.zulip.Zulip'
 
 ########################################################################
 # SSO AND LDAP SETTINGS


### PR DESCRIPTION
With this change, we get as far as printing the message
"APNS: Sending apple push notification to devices" to the
log when a recent TestFlight build of the app is due for
a notification, and then don't hit an exception.  But
on the other hand I still don't get an actual notification
on my phone, so there's still some debugging to do.