### PR TITLE
Fix server searches for is:mentioned and is:alerted.

### DIFF
--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql import compiler  # type: ignore
 from zerver.models import (
     Realm, Recipient, Stream, Subscription, UserProfile, Attachment,
     get_display_recipient, get_recipient, get_realm, get_stream, get_user,
-    Reaction
+    Reaction, UserMessage
 )
 from zerver.lib.message import (
     MessageDict,
@@ -124,9 +124,31 @@ class NarrowBuilderTest(ZulipTestCase):
 
     def test_add_term_using_is_operator_non_private_operand_and_negated(self):  # NEGATED
         # type: () -> None
-        for operand in ['starred', 'mentioned', 'alerted']:
-            term = dict(operator='is', operand=operand, negated=True)
-            self._do_add_term_test(term, 'WHERE (flags & :flags_1) = :param_1')
+        term = dict(operator='is', operand='starred', negated=True)
+        where_clause = 'WHERE (flags & :flags_1) = :param_1'
+        params = dict(
+            flags_1=UserMessage.flags.starred.mask,
+            param_1=0
+        )
+        self._do_add_term_test(term, where_clause, params)
+
+        term = dict(operator='is', operand='alerted', negated=True)
+        where_clause = 'WHERE (flags & :flags_1) = :param_1'
+        params = dict(
+            flags_1=UserMessage.flags.has_alert_word.mask,
+            param_1=0
+        )
+        self._do_add_term_test(term, where_clause, params)
+
+        term = dict(operator='is', operand='mentioned', negated=True)
+        where_clause = 'WHERE NOT ((flags & :flags_1) != :param_1 OR (flags & :flags_2) != :param_2)'
+        params = dict(
+            flags_1=UserMessage.flags.mentioned.mask,
+            param_1=0,
+            flags_2=UserMessage.flags.wildcard_mentioned.mask,
+            param_2=0
+        )
+        self._do_add_term_test(term, where_clause, params)
 
     def test_add_term_using_non_supported_operator_should_raise_error(self):
         # type: () -> None
@@ -331,9 +353,13 @@ class NarrowBuilderTest(ZulipTestCase):
         query = self._build_query(term)
         self.assertEqual(str(query), 'SELECT id \nFROM zerver_message')
 
-    def _do_add_term_test(self, term, where_clause):
-        # type: (Dict[str, Any], Text) -> None
-        self.assertTrue(where_clause in str(self._build_query(term)))
+    def _do_add_term_test(self, term, where_clause, params=None):
+        # type: (Dict[str, Any], Text, Optional[Dict[str, Any]]) -> None
+        query = self._build_query(term)
+        if params is not None:
+            actual_params = query.compile().params
+            self.assertEqual(actual_params, params)
+        self.assertTrue(where_clause in str(query))
 
     def _build_query(self, term):
         # type: (Dict[str, Any]) -> Query

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -171,8 +171,13 @@ class NarrowBuilder(object):
         elif operand == 'unread':
             cond = column("flags").op("&")(UserMessage.flags.read.mask) == 0
             return query.where(maybe_negate(cond))
-        elif operand == 'mentioned' or operand == 'alerted':
-            cond = column("flags").op("&")(UserMessage.flags.mentioned.mask) != 0
+        elif operand == 'mentioned':
+            cond1 = column("flags").op("&")(UserMessage.flags.mentioned.mask) != 0
+            cond2 = column("flags").op("&")(UserMessage.flags.wildcard_mentioned.mask) != 0
+            cond = or_(cond1, cond2)
+            return query.where(maybe_negate(cond))
+        elif operand == 'alerted':
+            cond = column("flags").op("&")(UserMessage.flags.has_alert_word.mask) != 0
             return query.where(maybe_negate(cond))
         raise BadNarrowOperator("unknown 'is' operand " + operand)
 


### PR DESCRIPTION
Before this change, server searches for both
`is:mentioned` and `is:alerted` would return all messages
where the user is specifically mentioned (but not
at-all mentions).

Now we follow the JS semantics:

    is:mentioned -- all mentions, including wildcards
    is:alerted  -- has an alert word

Here is one relevant JS snippet:

        } else if (operand === 'mentioned') {
            return message.mentioned;
        } else if (operand === 'alerted') {
            return message.alerted;

And here you see that `mentioned` is OR'ed over both mention flags:

    message.mentioned = convert_flag('mentioned') || convert_flag('wildcard_mentioned');

The `alerted` flag on the JS side is a simple mapping:

    message.alerted = convert_flag('has_alert_word');

Fixes #5020