### PR TITLE
zephyr: Fix bogus uses of `force_bytes` that break on Python 3.

### DIFF
--- a/zerver/lib/ccache.py
+++ b/zerver/lib/ccache.py
@@ -41,17 +41,17 @@ import six
 def der_encode_length(length):
     # type: (int) -> bytes
     if length <= 127:
-        return force_bytes(chr(length))
+        return struct.pack('!B', length)
     out = b""
     while length > 0:
-        out = force_bytes(chr(length & 0xff)) + out
+        out = struct.pack('!B', length & 0xff) + out
         length >>= 8
-    out = force_bytes(chr(len(out) | 0x80)) + out
+    out = struct.pack('!B', len(out) | 0x80) + out
     return out
 
 def der_encode_tlv(tag, value):
     # type: (int, bytes) -> bytes
-    return force_bytes(chr(tag)) + der_encode_length(len(value)) + value
+    return struct.pack('!B', tag) + der_encode_length(len(value)) + value
 
 def der_encode_integer_value(val):
     # type: (int) -> bytes
@@ -71,7 +71,7 @@ def der_encode_integer_value(val):
     # We can stop once sign-extension matches the remaining value.
     while val != sign:
         byte = val & 0xff
-        out = force_bytes(chr(byte)) + out
+        out = struct.pack('!B', byte) + out
         sign = -1 if byte & 0x80 == 0x80 else 0
         val >>= 8
     return out


### PR DESCRIPTION
An expression like `force_bytes(chr(...))`, on Python 3 where the
`force_bytes` finds itself with something to do because `chr` returns
a text string, gives the UTF-8 encoding of the given value as a
Unicode codepoint.

Here, we don't want that -- rather we want the given value as a
single byte.  We can do that with `struct.pack`.

This fixes an issue where the "Link with Webathena" flow was producing
invalid credential caches when run on Python 3, breaking the Zephyr
mirror for any user who went through it anew.