### PR TITLE
Purge use of data-name and data-stream-name from the frontend

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -279,7 +279,7 @@ search_non_existing_user('sender:dummyuser@zulip.com', '');
 // Narrow by clicking the left sidebar.
 casper.then(function () {
     casper.test.info('Narrowing with left sidebar');
-    casper.click('#stream_filters [data-name="Verona"] a');
+    casper.click('#stream_filters [data-stream-name="Verona"] a');
 });
 
 expect_stream();
@@ -308,9 +308,9 @@ casper.then(function () {
 });
 
 casper.waitWhileSelector('.input-append.notdisplayed', function () {
-    casper.test.assertExists('#stream_filters [data-name="Denmark"]', 'Original stream list contains Denmark');
-    casper.test.assertExists('#stream_filters [data-name="Scotland"]', 'Original stream list contains Scotland');
-    casper.test.assertExists('#stream_filters [data-name="Verona"]', 'Original stream list contains Verona');
+    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]', 'Original stream list contains Denmark');
+    casper.test.assertExists('#stream_filters [data-stream-name="Scotland"]', 'Original stream list contains Scotland');
+    casper.test.assertExists('#stream_filters [data-stream-name="Verona"]', 'Original stream list contains Verona');
 });
 
 // We search for the beginning of "Verona", not case sensitive
@@ -325,15 +325,15 @@ casper.then(function () {
 
 // There will be no race condition between these two waits because we
 // expect them to happen in parallel.
-casper.waitWhileVisible('#stream_filters [data-name="Denmark"]', function () {
-    casper.test.assertDoesntExist('#stream_filters [data-name="Denmark"]', 'Filtered stream list does not contain Denmark');
+casper.waitWhileVisible('#stream_filters [data-stream-name="Denmark"]', function () {
+    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Denmark"]', 'Filtered stream list does not contain Denmark');
 });
-casper.waitWhileVisible('#stream_filters [data-name="Scotland"]', function () {
-    casper.test.assertDoesntExist('#stream_filters [data-name="Scotland"]', 'Filtered stream list does not contain Scotland');
+casper.waitWhileVisible('#stream_filters [data-stream-name="Scotland"]', function () {
+    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Scotland"]', 'Filtered stream list does not contain Scotland');
 });
 
 casper.then(function () {
-    casper.test.assertExists('#stream_filters [data-name="Verona"]', 'Filtered stream list does contain Verona');
+    casper.test.assertExists('#stream_filters [data-stream-name="Verona"]', 'Filtered stream list does contain Verona');
 });
 
 // Clearing the list should give us back all the streams in the list
@@ -348,14 +348,14 @@ casper.then(function () {
 
 // There will be no race condition between these waits because we
 // expect them to happen in parallel.
-casper.waitUntilVisible('#stream_filters [data-name="Denmark"]', function () {
-    casper.test.assertExists('#stream_filters [data-name="Denmark"]', 'Restored stream list contains Denmark');
+casper.waitUntilVisible('#stream_filters [data-stream-name="Denmark"]', function () {
+    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]', 'Restored stream list contains Denmark');
 });
-casper.waitUntilVisible('#stream_filters [data-name="Scotland"]', function () {
-    casper.test.assertExists('#stream_filters [data-name="Denmark"]', 'Restored stream list contains Scotland');
+casper.waitUntilVisible('#stream_filters [data-stream-name="Scotland"]', function () {
+    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]', 'Restored stream list contains Scotland');
 });
-casper.waitUntilVisible('#stream_filters [data-name="Verona"]', function () {
-    casper.test.assertExists('#stream_filters [data-name="Denmark"]', 'Restored stream list contains Verona');
+casper.waitUntilVisible('#stream_filters [data-stream-name="Verona"]', function () {
+    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]', 'Restored stream list contains Verona');
 });
 
 

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1159,7 +1159,7 @@ function render(template_name, args) {
 
     global.write_handlebars_output("topic_list_item", html);
 
-    assert.equal($(html).attr('data-name'), 'lunch');
+    assert.equal($(html).attr('data-topic-name'), 'lunch');
 }());
 
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -461,9 +461,10 @@ exports.initialize = function () {
         if (overlays.is_active()) {
             ui_util.change_tab_to('#home');
         }
-        var stream = $(e.target).parents('li').attr('data-name');
+        var stream_id = $(e.target).parents('li').attr('data-stream-id');
+        var stream = stream_data.get_sub_by_id(stream_id);
         popovers.hide_all();
-        narrow.by('stream', stream, {select_first_unread: true, trigger: 'sidebar'});
+        narrow.by('stream', stream.name, {select_first_unread: true, trigger: 'sidebar'});
 
         e.preventDefault();
         e.stopPropagation();

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -529,14 +529,16 @@ function maybe_select_stream(e) {
     if (e.keyCode === 13) {
         // Enter key was pressed
 
-        var topStream = $('#stream_filters li.narrow-filter').first().data('name');
-        if (topStream !== undefined) {
-            // undefined if there are no results
+        var top_stream_id = $('#stream_filters li.narrow-filter').first().data('stream-id');
+        // undefined if there are no results
+        if (top_stream_id !== undefined) {
+            var top_stream = stream_data.get_sub_by_id(top_stream_id);
             if (overlays.is_active()) {
                 ui_util.change_tab_to('#home');
             }
             exports.clear_and_hide_search();
-            narrow.by('stream', topStream, {select_first_unread: true, trigger: 'sidebar enter key'});
+            narrow.by('stream', top_stream.name,
+                      {select_first_unread: true, trigger: 'sidebar enter key'});
             e.preventDefault();
             e.stopPropagation();
         }

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -177,7 +177,7 @@ exports.register_stream_handlers = function () {
         // the template for subs needs to render.
 
         subs.onlaunch("narrow_to_row", function () {
-            $(".stream-row[data-stream-name='" + sub.name + "']").click();
+            $(".stream-row[data-stream-id='" + sub.stream_id + "']").click();
         }, true);
     });
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -118,24 +118,24 @@ function build_topic_popover(e) {
         return;
     }
 
-    var stream_name = $(elt).closest('.topic-list').expectOne().attr('data-stream');
+    var stream_id = $(elt).closest('.narrow-filter').expectOne().attr('data-stream-id');
     var topic_name = $(elt).closest('li').expectOne().attr('data-name');
 
-    var sub = stream_data.get_sub(stream_name);
+    var sub = stream_data.get_sub_by_id(stream_id);
     if (!sub) {
-        blueslip.error('cannot build topic popover for stream: ' + stream_name);
+        blueslip.error('cannot build topic popover for stream: ' + stream_id);
         return;
     }
 
     popovers.hide_all();
     exports.show_streamlist_sidebar();
 
-    var is_muted = muting.is_topic_muted(stream_name, topic_name);
+    var is_muted = muting.is_topic_muted(sub.name, topic_name);
     var can_mute_topic = !is_muted;
     var can_unmute_topic = is_muted;
 
     var content = templates.render('topic_sidebar_actions', {
-        stream_name: stream_name,
+        stream_name: sub.name,
         stream_id: sub.stream_id,
         topic_name: topic_name,
         can_mute_topic: can_mute_topic,

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -99,7 +99,7 @@ function build_stream_popover(e) {
 
     $(elt).popover("show");
     var data_id = stream_data.get_sub(stream).stream_id;
-    var popover = $('.streams_popover[data-id=' + data_id + ']');
+    var popover = $('.streams_popover[data-stream-id=' + data_id + ']');
 
     update_spectrum(popover, function (colorpicker) {
         colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options);

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -43,11 +43,10 @@ exports.restore_stream_list_size = function () {
 
 
 function stream_popover_sub(e) {
-    // TODO: use data-stream-id in stream list
-    var stream_name = $(e.currentTarget).parents('ul').attr('data-name');
-    var sub = stream_data.get_sub(stream_name);
+    var stream_id = $(e.currentTarget).parents('ul').attr('data-stream-id');
+    var sub = stream_data.get_sub_by_id(stream_id);
     if (!sub) {
-        blueslip.error('Unknown stream: ' + stream_name);
+        blueslip.error('Unknown stream: ' + stream_id);
         return;
     }
     return sub;

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -119,7 +119,7 @@ function build_topic_popover(e) {
     }
 
     var stream_id = $(elt).closest('.narrow-filter').expectOne().attr('data-stream-id');
-    var topic_name = $(elt).closest('li').expectOne().attr('data-name');
+    var topic_name = $(elt).closest('li').expectOne().attr('data-topic-name');
 
     var sub = stream_data.get_sub_by_id(stream_id);
     if (!sub) {

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -83,11 +83,11 @@ function build_stream_popover(e) {
     popovers.hide_all();
     exports.show_streamlist_sidebar();
 
-    var stream = $(elt).parents('li').attr('data-name');
+    var stream_id = $(elt).parents('li').attr('data-stream-id');
 
     var content = templates.render(
         'stream_sidebar_actions',
-        {stream: stream_data.get_sub(stream)}
+        {stream: stream_data.get_sub_by_id(stream_id)}
     );
 
     $(elt).popover({
@@ -97,8 +97,7 @@ function build_stream_popover(e) {
     });
 
     $(elt).popover("show");
-    var data_id = stream_data.get_sub(stream).stream_id;
-    var popover = $('.streams_popover[data-stream-id=' + data_id + ']');
+    var popover = $('.streams_popover[data-stream-id=' + stream_id + ']');
 
     update_spectrum(popover, function (colorpicker) {
         colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options);

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -243,10 +243,11 @@ exports.set_click_handlers = function (callbacks) {
             ui_util.change_tab_to('#home');
         }
 
-        var stream = $(e.target).parents('ul').attr('data-stream');
+        var stream_id = $(e.target).parents('.narrow-filter').attr('data-stream-id');
+        var stream = stream_data.get_sub_by_id(stream_id);
         var topic = $(e.target).parents('li').attr('data-name');
 
-        narrow.activate([{operator: 'stream',  operand: stream},
+        narrow.activate([{operator: 'stream',  operand: stream.name},
                          {operator: 'topic', operand: topic}],
                         {select_first_unread: true, trigger: 'sidebar'});
 

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -245,7 +245,7 @@ exports.set_click_handlers = function (callbacks) {
 
         var stream_id = $(e.target).parents('.narrow-filter').attr('data-stream-id');
         var stream = stream_data.get_sub_by_id(stream_id);
-        var topic = $(e.target).parents('li').attr('data-name');
+        var topic = $(e.target).parents('li').attr('data-topic-name');
 
         narrow.activate([{operator: 'stream',  operand: stream.name},
                          {operator: 'topic', operand: topic}],

--- a/static/templates/stream_sidebar_actions.handlebars
+++ b/static/templates/stream_sidebar_actions.handlebars
@@ -1,5 +1,5 @@
 {{! Contents of the "stream actions" popup }}
-<ul class="nav nav-list streams_popover" data-id="{{ stream.stream_id }}" data-name="{{ stream.name }}">
+<ul class="nav nav-list streams_popover" data-stream-id="{{ stream.stream_id }}" data-name="{{ stream.name }}">
     <li>
         <a class="open_stream_settings">
             <i class="icon-vector-cog"></i>

--- a/static/templates/stream_sidebar_row.handlebars
+++ b/static/templates/stream_sidebar_row.handlebars
@@ -1,7 +1,7 @@
 {{! Stream sidebar rows }}
 
-<li data-name="{{name}}" class="narrow-filter{{#if not_in_home_view}} out_of_home_view{{/if}}"
-    data-stream-id="{{id}}">
+<li class="narrow-filter{{#if not_in_home_view}} out_of_home_view{{/if}}"
+    data-stream-id="{{id}}" data-stream-name="{{name}}">
     <div class="subscription_block selectable_sidebar_block">
 
         <span id="stream_sidebar_privacy_swatch_{{id}}" class="stream-privacy" style="color: {{color}}">

--- a/static/templates/stream_sidebar_row.handlebars
+++ b/static/templates/stream_sidebar_row.handlebars
@@ -2,7 +2,7 @@
 
 <li data-name="{{name}}" class="narrow-filter{{#if not_in_home_view}} out_of_home_view{{/if}}"
     data-stream-id="{{id}}">
-    <div class="subscription_block selectable_sidebar_block" data-name="{{name}}">
+    <div class="subscription_block selectable_sidebar_block">
 
         <span id="stream_sidebar_privacy_swatch_{{id}}" class="stream-privacy" style="color: {{color}}">
             {{! This controls whether the swatchnext to streams in the left sidebar has a lock icon. }}

--- a/static/templates/topic_list_item.handlebars
+++ b/static/templates/topic_list_item.handlebars
@@ -1,4 +1,4 @@
-<li class='{{#if is_zero}}zero-subject-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} topic-list-item' data-name='{{topic_name}}'>
+<li class='{{#if is_zero}}zero-subject-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
     <span class='topic-box'>
         <a href='{{url}}' class="topic-name" title="{{topic_name}}">
             {{topic_name}}


### PR DESCRIPTION
We've been getting a few production tracebacks related to these bad selectors not working super well accessing unusual stream names.  And as we know, anything using this data-stream-name apparatus is unlikely to work correctly with renamed streams.  So I attempted to purge all of the remaining ones in the codebase, with the small exception of the Casper tests, which could probably be refactored to use a different selector style based on the actual name field, so that we can eliminate data-stream-name altogether.

@showell can you give this a review?  I think I've tested this pretty carefully, but obviously it's a somewhat risky change and a second eye would be valuable.