### PR TITLE
hotkeys: Fix "n" key to work inside a muted stream.

### DIFF
--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -255,8 +255,6 @@ function is_odd(i) { return i % 2 === 1; }
 
     // Now test the deeper function that is wired up to
     // real functions stream_data/stream_sort/unread.
-    var curr_stream = 'announce';
-    var curr_topic = 'whatever';
 
     global.stream_sort.get_streams = function () {
         return ['announce', 'muted', 'devel', 'test here'];
@@ -273,7 +271,7 @@ function is_odd(i) { return i % 2 === 1; }
     topic_data.get_recent_names = function (stream_id) {
         switch (stream_id) {
             case muted_stream_id:
-                return ['red herring'];
+                return ['ms-topic1', 'ms-topic2'];
             case devel_stream_id:
                 return ['muted', 'python'];
         }
@@ -290,16 +288,22 @@ function is_odd(i) { return i % 2 === 1; }
     };
 
     global.unread.topic_has_any_unread = function (stream_id) {
-        return (stream_id === devel_stream_id);
+        return _.contains([devel_stream_id, muted_stream_id], stream_id);
     };
 
     global.muting.is_topic_muted = function (stream_name, topic) {
         return (topic === 'muted');
     };
 
-    var next_item = tg.get_next_topic(curr_stream, curr_topic);
+    var next_item = tg.get_next_topic('announce', 'whatever');
     assert.deepEqual(next_item, {
         stream: 'devel',
         topic: 'python',
+    });
+
+    next_item = tg.get_next_topic('muted', undefined);
+    assert.deepEqual(next_item, {
+        stream: 'muted',
+        topic: 'ms-topic1',
     });
 }());

--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -198,7 +198,15 @@ exports.get_next_topic = function (curr_stream, curr_topic) {
     var my_streams = stream_sort.get_streams();
 
     my_streams = _.filter(my_streams, function (stream_name) {
-        return stream_data.name_in_home_view(stream_name);
+        if (stream_data.name_in_home_view(stream_name)) {
+            return true;
+        }
+        if  (stream_name === curr_stream) {
+            // We can use n within a muted stream if we are
+            // currently narrowed to it.
+            return true;
+        }
+        return false;
     });
 
     function get_unmuted_topics(stream_name) {


### PR DESCRIPTION
Normally the "n" key skips over muted streams, but if we
are currently narrowed inside a muted stream, it will now
go to the next topics within that stream.

For me the use case was that I have a stream I check up on
about once a day, and "n" would be super useful for me to
clear out unread counts while still skimming some content,
and without having to temporarily unmute the stream.