### PR TITLE
linter: Revise options.

### DIFF
--- a/tools/lint
+++ b/tools/lint
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import logging
 import os
 import sys
-import optparse
+import argparse
 import subprocess
 
 from linter_lib.printer import print_err, colors
@@ -40,26 +40,29 @@ def run_parallel(lint_functions):
 
 def run():
     # type: () -> None
-    parser = optparse.OptionParser()
-    parser.add_option('--force', default=False,
-                      action="store_true",
-                      help='Run tests despite possible problems.')
-    parser.add_option('--full',
-                      action='store_true',
-                      help='Check some things we typically ignore')
-    parser.add_option('--pep8',
-                      action='store_true',
-                      help='Run the pep8 checker')
-    parser.add_option('--no-gitlint',
-                      action='store_true',
-                      help='Disable gitlint')
-    parser.add_option('--modified', '-m',
-                      action='store_true',
-                      help='Only check modified files')
-    parser.add_option('--verbose', '-v',
-                      action='store_true',
-                      help='Print verbose timing output')
-    (options, args) = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--force', default=False,
+                        action="store_true",
+                        help='Run tests despite possible problems.')
+    parser.add_argument('--full',
+                        action='store_true',
+                        help='Check some things we typically ignore')
+    parser.add_argument('--pep8',
+                        action='store_true',
+                        help='Run the pep8 checker')
+    parser.add_argument('--no-gitlint',
+                        action='store_true',
+                        help='Disable gitlint')
+    parser.add_argument('--modified', '-m',
+                        action='store_true',
+                        help='Only check modified files')
+    parser.add_argument('--verbose', '-v',
+                        action='store_true',
+                        help='Print verbose timing output')
+    parser.add_argument('targets',
+                        nargs='*',
+                        help='Specify directories to check')
+    args = parser.parse_args()
 
     tools_dir = os.path.dirname(os.path.abspath(__file__))
     root_dir = os.path.dirname(tools_dir)
@@ -76,7 +79,7 @@ def run():
 
     os.chdir(root_dir)
 
-    if not options.force:
+    if not args.force:
         ok, msg = get_provisioning_status()
         if not ok:
             print(msg)
@@ -84,7 +87,7 @@ def run():
             sys.exit(1)
 
     by_lang = cast(Dict[str, List[str]],
-                   lister.list_files(args, modified_only=options.modified,
+                   lister.list_files(args.targets, modified_only=args.modified,
                                      ftypes=['py', 'sh', 'js', 'pp', 'css', 'handlebars',
                                              'html', 'json', 'md', 'txt', 'text', 'yaml'],
                                      use_shebang=True, group_by_ftype=True, exclude=EXCLUDED_FILES))
@@ -94,7 +97,7 @@ def run():
 
     logging.basicConfig(format="%(asctime)s %(message)s")
     logger = logging.getLogger()
-    if options.verbose:
+    if args.verbose:
         logger.setLevel(logging.INFO)
     else:
         logger.setLevel(logging.WARNING)
@@ -154,7 +157,7 @@ def run():
     external_linter('swagger', ['node', 'tools/check-swagger'], ['yaml'])
 
     # gitlint disabled until we can stabilize it more
-    # if not options.no_gitlint:
+    # if not args.no_gitlint:
     #     external_linter('commit_messages', ['tools/commit-message-lint'])
 
     @lint
@@ -172,10 +175,10 @@ def run():
     @lint
     def pyflakes():
         # type: () -> int
-        failed = check_pyflakes(options, by_lang)
+        failed = check_pyflakes(args, by_lang)
         return 1 if failed else 0
 
-    if options.pep8:
+    if args.pep8:
         @lint
         def pep8():
             # type: () -> int

--- a/tools/lint
+++ b/tools/lint
@@ -47,9 +47,6 @@ def run():
     parser.add_argument('--full',
                         action='store_true',
                         help='Check some things we typically ignore')
-    parser.add_argument('--pep8',
-                        action='store_true',
-                        help='Run the pep8 checker')
     parser.add_argument('--no-gitlint',
                         action='store_true',
                         help='Disable gitlint')
@@ -62,6 +59,13 @@ def run():
     parser.add_argument('targets',
                         nargs='*',
                         help='Specify directories to check')
+    limited_tests_group = parser.add_mutually_exclusive_group()
+    limited_tests_group.add_argument('--frontend',
+                                     action='store_true',
+                                     help='Only check files relevant to frontend')
+    limited_tests_group.add_argument('--backend',
+                                     action='store_true',
+                                     help='Only check files relevant to backend')
     args = parser.parse_args()
 
     tools_dir = os.path.dirname(os.path.abspath(__file__))
@@ -146,44 +150,46 @@ def run():
 
         lint_functions[name] = run_linter
 
-    external_linter('add_class', ['tools/find-add-class'])
-    external_linter('css', ['tools/check-css'], ['css'])
-    external_linter('eslint', ['node', 'node_modules/.bin/eslint', '--quiet'], ['js'])
-    external_linter('tslint', ['node', 'node_modules/.bin/tslint', '-c',
-                               'static/ts/tslint.json'], ['ts'])
-    external_linter('puppet', ['puppet', 'parser', 'validate'], ['pp'])
-    external_linter('templates', ['tools/check-templates'], ['handlebars', 'html'])
-    external_linter('urls', ['tools/check-urls'])
-    external_linter('swagger', ['node', 'tools/check-swagger'], ['yaml'])
+    if not args.backend:
+        external_linter('add_class', ['tools/find-add-class'])
+        external_linter('css', ['tools/check-css'], ['css'])
+        external_linter('eslint', ['node', 'node_modules/.bin/eslint', '--quiet'], ['js'])
+        external_linter('tslint', ['node', 'node_modules/.bin/tslint', '-c',
+                                   'static/ts/tslint.json'], ['ts'])
+        external_linter('templates', ['tools/check-templates'], ['handlebars', 'html'])
+        external_linter('urls', ['tools/check-urls'])
+    if not args.frontend:
+        external_linter('puppet', ['puppet', 'parser', 'validate'], ['pp'])
+        external_linter('swagger', ['node', 'tools/check-swagger'], ['yaml'])
 
     # gitlint disabled until we can stabilize it more
     # if not args.no_gitlint:
     #     external_linter('commit_messages', ['tools/commit-message-lint'])
 
-    @lint
-    def custom_py():
-        # type: () -> int
-        failed = check_custom_checks_py()
-        return 1 if failed else 0
+    if not args.frontend:
+        @lint
+        def custom_py():
+            # type: () -> int
+            failed = check_custom_checks_py()
+            return 1 if failed else 0
+
+        @lint
+        def pyflakes():
+            # type: () -> int
+            failed = check_pyflakes(args, by_lang)
+            return 1 if failed else 0
+
+        @lint
+        def pep8():
+            # type: () -> int
+            failed = check_pep8(by_lang['py'])
+            return 1 if failed else 0
 
     @lint
     def custom_nonpy():
         # type: () -> int
         failed = check_custom_checks_nonpy()
         return 1 if failed else 0
-
-    @lint
-    def pyflakes():
-        # type: () -> int
-        failed = check_pyflakes(args, by_lang)
-        return 1 if failed else 0
-
-    if args.pep8:
-        @lint
-        def pep8():
-            # type: () -> int
-            failed = check_pep8(by_lang['py'])
-            return 1 if failed else 0
 
     failed = run_parallel(lint_functions)
 

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -16,10 +16,10 @@ if [ -z "$changed_files" ]; then
 fi
 
 if [ -z "$VIRTUAL_ENV" ] && `which vagrant > /dev/null` && [ -e .vagrant ]; then
-    vcmd="/srv/zulip/tools/lint --pep8 --no-gitlint --force $changed_files || true"
+    vcmd="/srv/zulip/tools/lint --no-gitlint --force $changed_files || true"
     echo "Running lint using vagrant..."
     vagrant ssh -c "$vcmd"
 else
-    ./tools/lint --pep8 --no-gitlint --force $changed_files || true
+    ./tools/lint --no-gitlint --force $changed_files || true
 fi
 exit 0

--- a/tools/test-all
+++ b/tools/test-all
@@ -38,7 +38,7 @@ run ./tools/clean-repo
 run ./tools/run-mypy
 
 # travis/backend
-run ./tools/lint --pep8 $FORCEARG
+run ./tools/lint $FORCEARG
 run ./manage.py makemessages --locale en
 run env PYTHONWARNINGS=ignore ./tools/check-capitalization --no-generate
 run env PYTHONWARNINGS=ignore ./tools/check-frontend-i18n --no-generate

--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -5,7 +5,7 @@ source tools/travis/activate-venv
 set -e
 set -x
 
-./tools/lint --pep8 # Include the slow and thus non-default pep8 linter check
+./tools/lint
 ./manage.py makemessages --locale en
 PYTHONWARNINGS=ignore ./tools/check-capitalization --no-generate
 PYTHONWARNINGS=ignore ./tools/check-frontend-i18n --no-generate

--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -5,7 +5,7 @@ source tools/travis/activate-venv
 set -e
 set -x
 
-./tools/lint
+./tools/lint --backend
 ./manage.py makemessages --locale en
 PYTHONWARNINGS=ignore ./tools/check-capitalization --no-generate
 PYTHONWARNINGS=ignore ./tools/check-frontend-i18n --no-generate

--- a/tools/travis/frontend
+++ b/tools/travis/frontend
@@ -5,6 +5,7 @@ source tools/travis/activate-venv
 set -e
 set -x
 
+./tools/lint --backend
 ./tools/test-js-with-node --coverage
 ./tools/test-js-with-casper
 


### PR DESCRIPTION
This removes the --pep8 option, pycodestyle is now checked by default. Adds --py and --js options, which exclude expensive checks not related to their filetype, respectively.