### PR TITLE
/beta/: Fix broken styling from one column to two.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -621,6 +621,11 @@ button.login-google-button {
     color: hsl(156, 62%, 61%);
 }
 
+/* the /beta/ page otherwise breaks into one column from two. */
+.beta-signup-container #registration {
+    margin: 30px 0px;
+}
+
 #registration {
     width: auto;
     padding: 0;


### PR DESCRIPTION
The inputs broke to a single column becuase the #registration
container width was too small. This removes the margin, making the
container bigger and re-instating the two column architecture.