### PR TITLE
Add Addressee class.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1166,7 +1166,7 @@ def recipient_for_emails(emails, not_forged_mirror_message,
                          forwarder_user_profile, sender):
     # type: (Iterable[Text], bool, Optional[UserProfile], UserProfile) -> Recipient
 
-    user_profiles = user_profiles_from_unvalidated_emails(emails)
+    user_profiles = user_profiles_from_unvalidated_emails(emails, sender)
 
     return recipient_for_user_profiles(
         user_profiles=user_profiles,
@@ -1238,6 +1238,7 @@ def check_send_message(sender, client, message_type_name, message_to,
     # type: (UserProfile, Client, Text, Sequence[Text], Optional[Text], Text, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[Text], Optional[Text]) -> int
 
     addressee = Addressee.legacy_build(
+        sender,
         message_type_name,
         message_to,
         subject_name)
@@ -1449,6 +1450,7 @@ def internal_prep_message(realm, sender_email, recipient_type_name, recipients,
     parsed_recipients = extract_recipients(recipients)
 
     addressee = Addressee.legacy_build(
+        sender,
         recipient_type_name,
         parsed_recipients,
         subject)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -15,7 +15,10 @@ from zerver.lib.bugdown import (
     version as bugdown_version,
     url_embed_preview_enabled_for_realm
 )
-from zerver.lib.addressee import Addressee
+from zerver.lib.addressee import (
+    Addressee,
+    user_profiles_from_unvalidated_emails,
+)
 from zerver.lib.cache import (
     delete_user_profile_caches,
     to_dict_cache_key,
@@ -1171,17 +1174,6 @@ def recipient_for_emails(emails, not_forged_mirror_message,
         forwarder_user_profile=forwarder_user_profile,
         sender=sender
     )
-
-def user_profiles_from_unvalidated_emails(emails):
-    # type: (Iterable[Text]) -> List[UserProfile]
-    user_profiles = []  # type: List[UserProfile]
-    for email in emails:
-        try:
-            user_profile = get_user_profile_by_email(email)
-        except UserProfile.DoesNotExist:
-            raise ValidationError(_("Invalid email '%s'") % (email,))
-        user_profiles.append(user_profile)
-    return user_profiles
 
 def recipient_for_user_profiles(user_profiles, not_forged_mirror_message,
                                 forwarder_user_profile, sender):

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1300,7 +1300,7 @@ def send_pm_if_empty_stream(sender, stream, stream_name, realm):
                (sender.full_name, stream_name, error_msg))
 
     internal_send_private_message(realm, get_system_bot(settings.NOTIFICATION_BOT),
-                                  sender.bot_owner.email, content)
+                                  sender.bot_owner, content)
 
     sender.last_reminder = timezone_now()
     sender.save(update_fields=['last_reminder'])
@@ -1474,12 +1474,12 @@ def internal_prep_stream_message(realm, sender, stream_name, topic, content):
         content=content,
     )
 
-def internal_prep_private_message(realm, sender, recipient_email, content):
-    # type: (Realm, UserProfile, Text, Text) -> Optional[Dict[str, Any]]
+def internal_prep_private_message(realm, sender, recipient_user, content):
+    # type: (Realm, UserProfile, UserProfile, Text) -> Optional[Dict[str, Any]]
     """
     See _internal_prep_message for details of how this works.
     """
-    addressee = Addressee.for_email(recipient_email)
+    addressee = Addressee.for_user_profile(recipient_user)
 
     return _internal_prep_message(
         realm=realm,
@@ -1500,9 +1500,9 @@ def internal_send_message(realm, sender_email, recipient_type_name, recipients,
 
     do_send_messages([msg])
 
-def internal_send_private_message(realm, sender, recipient_email, content):
-    # type: (Realm, UserProfile, Text, Text) -> None
-    message = internal_prep_private_message(realm, sender, recipient_email, content)
+def internal_send_private_message(realm, sender, recipient_user, content):
+    # type: (Realm, UserProfile, UserProfile, Text) -> None
+    message = internal_prep_private_message(realm, sender, recipient_user, content)
     if message is None:
         return
     do_send_messages([message])

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1163,6 +1163,17 @@ def recipient_for_emails(emails, not_forged_mirror_message,
                          forwarder_user_profile, sender):
     # type: (Iterable[Text], bool, Optional[UserProfile], UserProfile) -> Recipient
 
+    user_profiles = user_profiles_from_unvalidated_emails(emails)
+
+    return recipient_for_user_profiles(
+        user_profiles=user_profiles,
+        not_forged_mirror_message=not_forged_mirror_message,
+        forwarder_user_profile=forwarder_user_profile,
+        sender=sender
+    )
+
+def user_profiles_from_unvalidated_emails(emails):
+    # type: (Iterable[Text]) -> List[UserProfile]
     user_profiles = []  # type: List[UserProfile]
     for email in emails:
         try:
@@ -1170,6 +1181,11 @@ def recipient_for_emails(emails, not_forged_mirror_message,
         except UserProfile.DoesNotExist:
             raise ValidationError(_("Invalid email '%s'") % (email,))
         user_profiles.append(user_profile)
+    return user_profiles
+
+def recipient_for_user_profiles(user_profiles, not_forged_mirror_message,
+                                forwarder_user_profile, sender):
+    # type: (List[UserProfile], bool, Optional[UserProfile], UserProfile) -> Recipient
 
     recipient_profile_ids = validate_recipient_user_profiles(user_profiles, sender)
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -15,6 +15,7 @@ from zerver.lib.bugdown import (
     version as bugdown_version,
     url_embed_preview_enabled_for_realm
 )
+from zerver.lib.addressee import Addressee
 from zerver.lib.cache import (
     delete_user_profile_caches,
     to_dict_cache_key,
@@ -1227,8 +1228,14 @@ def check_send_message(sender, client, message_type_name, message_to,
                        forged_timestamp=None, forwarder_user_profile=None, local_id=None,
                        sender_queue_id=None):
     # type: (UserProfile, Client, Text, Sequence[Text], Optional[Text], Text, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[Text], Optional[Text]) -> int
-    message = check_message(sender, client, message_type_name, message_to,
-                            subject_name, message_content, realm, forged, forged_timestamp,
+
+    addressee = Addressee.legacy_build(
+        message_type_name,
+        message_to,
+        subject_name)
+
+    message = check_message(sender, client, addressee,
+                            message_content, realm, forged, forged_timestamp,
                             forwarder_user_profile, local_id, sender_queue_id)
     return do_send_messages([message])[0]
 
@@ -1292,17 +1299,13 @@ def send_pm_if_empty_stream(sender, stream, stream_name, realm):
 
 # check_message:
 # Returns message ready for sending with do_send_message on success or the error message (string) on error.
-def check_message(sender, client, message_type_name, message_to,
-                  subject_name, message_content_raw, realm=None, forged=False,
+def check_message(sender, client, addressee,
+                  message_content_raw, realm=None, forged=False,
                   forged_timestamp=None, forwarder_user_profile=None, local_id=None,
                   sender_queue_id=None):
-    # type: (UserProfile, Client, Text, Sequence[Text], Optional[Text], Text, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[Text], Optional[Text]) -> Dict[str, Any]
+    # type: (UserProfile, Client, Addressee, Text, Optional[Realm], bool, Optional[float], Optional[UserProfile], Optional[Text], Optional[Text]) -> Dict[str, Any]
     stream = None
-    if not message_to and message_type_name == 'stream' and sender.default_sending_stream:
-        # Use the users default stream
-        message_to = [sender.default_sending_stream.name]
-    if len(message_to) == 0:
-        raise JsonableError(_("Message must have recipients"))
+
     message_content = message_content_raw.rstrip()
     if len(message_content) == 0:
         raise JsonableError(_("Message must not be empty"))
@@ -1311,13 +1314,19 @@ def check_message(sender, client, message_type_name, message_to,
     if realm is None:
         realm = sender.realm
 
-    if message_type_name == 'stream':
-        if len(message_to) > 1:
-            raise JsonableError(_("Cannot send to multiple streams"))
+    if addressee.is_stream():
+        stream_name = addressee.stream_name()
+        if stream_name is None:
+            if sender.default_sending_stream:
+                # Use the users default stream
+                stream_name = sender.default_sending_stream.name
+            else:
+                raise JsonableError(_('Missing stream'))
 
-        stream_name = message_to[0].strip()
+        stream_name = stream_name.strip()
         check_stream_name(stream_name)
 
+        subject_name = addressee.topic()
         if subject_name is None:
             raise JsonableError(_("Missing topic"))
         subject = subject_name.strip()
@@ -1356,11 +1365,16 @@ def check_message(sender, client, message_type_name, message_to,
             # All other cases are an error.
             raise JsonableError(_("Not authorized to send to stream '%s'") % (stream.name,))
 
-    elif message_type_name == 'private':
+    elif addressee.is_private():
+        emails = addressee.emails()
+
+        if emails is None or len(emails) == 0:
+            raise JsonableError(_("Message must have recipients"))
+
         mirror_message = client and client.name in ["zephyr_mirror", "irc_mirror", "jabber_mirror", "JabberMirror"]
         not_forged_mirror_message = mirror_message and not forged
         try:
-            recipient = recipient_for_emails(message_to, not_forged_mirror_message,
+            recipient = recipient_for_emails(emails, not_forged_mirror_message,
                                              forwarder_user_profile, sender)
         except ValidationError as e:
             assert isinstance(e.messages[0], six.string_types)
@@ -1372,7 +1386,7 @@ def check_message(sender, client, message_type_name, message_to,
     message.sender = sender
     message.content = message_content
     message.recipient = recipient
-    if message_type_name == 'stream':
+    if addressee.is_stream():
         message.subject = subject
     if forged and forged_timestamp is not None:
         # Forged messages come with a timestamp
@@ -1392,9 +1406,8 @@ def check_message(sender, client, message_type_name, message_to,
     return {'message': message, 'stream': stream, 'local_id': local_id,
             'sender_queue_id': sender_queue_id, 'realm': realm}
 
-def _internal_prep_message(realm, sender, recipient_type_name, parsed_recipients,
-                           subject, content):
-    # type: (Realm, UserProfile, str, List[Text], Text, Text) -> Optional[Dict[str, Any]]
+def _internal_prep_message(realm, sender, addressee, content):
+    # type: (Realm, UserProfile, Addressee, Text) -> Optional[Dict[str, Any]]
     """
     Create a message object and checks it, but doesn't send it or save it to the database.
     The internal function that calls this can therefore batch send a bunch of created
@@ -1407,12 +1420,12 @@ def _internal_prep_message(realm, sender, recipient_type_name, parsed_recipients
     if realm is None:
         raise RuntimeError("None is not a valid realm for internal_prep_message!")
 
-    if recipient_type_name == "stream":
-        stream, _ = create_stream_if_needed(realm, parsed_recipients[0])
+    if addressee.is_stream():
+        stream, _ = create_stream_if_needed(realm, addressee.stream_name())
 
     try:
-        return check_message(sender, get_client("Internal"), recipient_type_name,
-                             parsed_recipients, subject, content, realm=realm)
+        return check_message(sender, get_client("Internal"), addressee,
+                             content, realm=realm)
     except JsonableError as e:
         logging.error(u"Error queueing internal message by %s: %s" % (sender.email, e))
 
@@ -1427,12 +1440,15 @@ def internal_prep_message(realm, sender_email, recipient_type_name, recipients,
     sender = get_system_bot(sender_email)
     parsed_recipients = extract_recipients(recipients)
 
+    addressee = Addressee.legacy_build(
+        recipient_type_name,
+        parsed_recipients,
+        subject)
+
     return _internal_prep_message(
         realm=realm,
         sender=sender,
-        recipient_type_name=recipient_type_name,
-        parsed_recipients=parsed_recipients,
-        subject=subject,
+        addressee=addressee,
         content=content,
     )
 
@@ -1441,14 +1457,12 @@ def internal_prep_stream_message(realm, sender, stream_name, topic, content):
     """
     See _internal_prep_message for details of how this works.
     """
-    parsed_recipients = [stream_name]
+    addressee = Addressee.for_stream(stream_name, topic)
 
     return _internal_prep_message(
         realm=realm,
         sender=sender,
-        recipient_type_name='stream',
-        parsed_recipients=parsed_recipients,
-        subject=topic,
+        addressee=addressee,
         content=content,
     )
 
@@ -1457,14 +1471,12 @@ def internal_prep_private_message(realm, sender, recipient_email, content):
     """
     See _internal_prep_message for details of how this works.
     """
-    parsed_recipients = [recipient_email]
+    addressee = Addressee.for_email(recipient_email)
 
     return _internal_prep_message(
         realm=realm,
         sender=sender,
-        recipient_type_name='private',
-        parsed_recipients=parsed_recipients,
-        subject='',
+        addressee=addressee,
         content=content,
     )
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1374,16 +1374,16 @@ def check_message(sender, client, addressee,
             raise JsonableError(_("Not authorized to send to stream '%s'") % (stream.name,))
 
     elif addressee.is_private():
-        emails = addressee.emails()
+        user_profiles = addressee.user_profiles()
 
-        if emails is None or len(emails) == 0:
+        if user_profiles is None or len(user_profiles) == 0:
             raise JsonableError(_("Message must have recipients"))
 
         mirror_message = client and client.name in ["zephyr_mirror", "irc_mirror", "jabber_mirror", "JabberMirror"]
         not_forged_mirror_message = mirror_message and not forged
         try:
-            recipient = recipient_for_emails(emails, not_forged_mirror_message,
-                                             forwarder_user_profile, sender)
+            recipient = recipient_for_user_profiles(user_profiles, not_forged_mirror_message,
+                                                    forwarder_user_profile, sender)
         except ValidationError as e:
             assert isinstance(e.messages[0], six.string_types)
             raise JsonableError(e.messages[0])

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -124,9 +124,9 @@ class Addressee(object):
         )
 
     @staticmethod
-    def for_email(email):
-        # type: (Text) -> Addressee
-        user_profiles = get_user_profiles([email])
+    def for_user_profile(user_profile):
+        # type: (UserProfile) -> Addressee
+        user_profiles = [user_profile]
         return Addressee(
             msg_type='private',
             user_profiles=user_profiles,

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -1,0 +1,105 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+from typing import Optional, Sequence, Text
+
+from django.utils.translation import ugettext as _
+from zerver.lib.request import JsonableError
+
+class Addressee(object):
+    # This is really just a holder for vars that tended to be passed
+    # around in a non-type-safe way before this class was introduced.
+    #
+    # It also avoids some nonsense where you have to think about whether
+    # topic should be None or '' for a PM, or you have to make an array
+    # of one stream.
+    #
+    # Eventually we can use this to cache Stream and UserProfile objects
+    # in memory.
+    #
+    # This should be treated as an immutable class.
+    def __init__(self, msg_type, emails=None, stream_name=None, topic=None):
+        # type: (str, Optional[Sequence[Text]], Optional[Text], Text) -> None
+        assert(msg_type in ['stream', 'private'])
+        self._msg_type = msg_type
+        self._emails = emails
+        self._stream_name = stream_name
+        self._topic = topic
+
+    def msg_type(self):
+        # type: () -> str
+        return self._msg_type
+
+    def is_stream(self):
+        # type: () -> bool
+        return self._msg_type == 'stream'
+
+    def is_private(self):
+        # type: () -> bool
+        return self._msg_type == 'private'
+
+    def emails(self):
+        # type: () -> Sequence[Text]
+        assert(self.is_private())
+        return self._emails
+
+    def stream_name(self):
+        # type: () -> Text
+        assert(self.is_stream())
+        return self._stream_name
+
+    def topic(self):
+        # type: () -> Text
+        assert(self.is_stream())
+        return self._topic
+
+    @staticmethod
+    def legacy_build(message_type_name, message_to, topic_name):
+        # type: (Text, Sequence[Text], Text) -> Addressee
+
+        # For legacy reason message_to used to be either a list of
+        # emails or a list of streams.  We haven't fixed all of our
+        # callers yet.
+        if message_type_name == 'stream':
+            if len(message_to) > 1:
+                raise JsonableError(_("Cannot send to multiple streams"))
+
+            if message_to:
+                stream_name = message_to[0]
+            else:
+                # This is a hack to deal with the fact that we still support
+                # default streams (and the None will be converted later in the
+                # callpath).
+                stream_name = None
+
+            return Addressee.for_stream(stream_name, topic_name)
+        elif message_type_name == 'private':
+            emails = message_to
+            return Addressee.for_private(emails=emails)
+        else:
+            raise JsonableError(_("Invalid message type"))
+
+    @staticmethod
+    def for_stream(stream_name, topic):
+        # type: (Text, Text) -> Addressee
+        return Addressee(
+            msg_type='stream',
+            stream_name=stream_name,
+            topic=topic,
+        )
+
+    @staticmethod
+    def for_private(emails):
+        # type: (Sequence[Text]) -> Addressee
+        return Addressee(
+            msg_type='private',
+            emails=emails,
+        )
+
+    @staticmethod
+    def for_email(email):
+        # type: (Text) -> Addressee
+        return Addressee(
+            msg_type='private',
+            emails=[email],
+        )

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -1,10 +1,26 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from typing import Optional, Sequence, Text
+from typing import Iterable, List, Optional, Sequence, Text
 
+from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 from zerver.lib.request import JsonableError
+from zerver.models import (
+    UserProfile,
+    get_user_profile_by_email,
+)
+
+def user_profiles_from_unvalidated_emails(emails):
+    # type: (Iterable[Text]) -> List[UserProfile]
+    user_profiles = []  # type: List[UserProfile]
+    for email in emails:
+        try:
+            user_profile = get_user_profile_by_email(email)
+        except UserProfile.DoesNotExist:
+            raise ValidationError(_("Invalid email '%s'") % (email,))
+        user_profiles.append(user_profile)
+    return user_profiles
 
 class Addressee(object):
     # This is really just a holder for vars that tended to be passed

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -24,7 +24,7 @@ def send_initial_pms(user):
         "keyboards, that's okay too; clicking anywhere on this message will also do the trick!")
 
     internal_send_private_message(user.realm, get_system_bot(settings.WELCOME_BOT),
-                                  user.email, content)
+                                  user, content)
 
 def setup_initial_streams(realm):
     # type: (Realm) -> None

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -276,7 +276,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 67)
+        self.assert_length(queries, 66)
         user_profile = self.nonreg_user('test')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -263,9 +263,14 @@ def add_subscriptions_backend(request, user_profile,
     (subscribed, already_subscribed) = bulk_add_subscriptions(streams, subscribers,
                                                               acting_user=user_profile)
 
+    # We can assume unique emails here for now, but we should eventually
+    # convert this function to be more id-centric.
+    email_to_user_profile = dict()  # type: Dict[Text, UserProfile]
+
     result = dict(subscribed=defaultdict(list), already_subscribed=defaultdict(list))  # type: Dict[str, Any]
     for (subscriber, stream) in subscribed:
         result["subscribed"][subscriber.email].append(stream.name)
+        email_to_user_profile[subscriber.email] = subscriber
     for (subscriber, stream) in already_subscribed:
         result["already_subscribed"][subscriber.email].append(stream.name)
 
@@ -304,7 +309,7 @@ def add_subscriptions_backend(request, user_profile,
                 internal_prep_private_message(
                     realm=user_profile.realm,
                     sender=sender,
-                    recipient_email=email,
+                    recipient_user=email_to_user_profile[email],
                     content=msg))
 
     if announce and len(created_streams) > 0:


### PR DESCRIPTION
This class simplifies the calling sequence to methods like
check_message and _internal_prep_message, and it's also more
type safe.

Checking for message types is encapsulated with calls to is_stream()
and is_private().  There are also shortcut constructors when you
know that the type of the address (stream vs. private), which is often.