### PR TITLE
README.md: Update mypy badge with link to mypy Zulip blog article.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ missed-message emails, desktop apps, and much more.
 Further information on the Zulip project and its features can be found
 at <https://www.zulip.org>.
 
-[![Build Status](https://travis-ci.org/zulip/zulip.svg?branch=master)](https://travis-ci.org/zulip/zulip) [![Coverage Status](https://img.shields.io/codecov/c/github/zulip/zulip.svg)](https://codecov.io/gh/zulip/zulip) ![Mypy coverage](https://img.shields.io/badge/mypy-100%25-green.svg) [![docs](https://readthedocs.org/projects/zulip/badge/?version=latest)](http://zulip.readthedocs.io/en/latest/) [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org) [![Twitter](https://img.shields.io/badge/twitter-@zulip-blue.svg?style=flat)](http://twitter.com/zulip)
+[![Build Status](https://travis-ci.org/zulip/zulip.svg?branch=master)](https://travis-ci.org/zulip/zulip) [![Coverage Status](https://img.shields.io/codecov/c/github/zulip/zulip.svg)](https://codecov.io/gh/zulip/zulip) [![Mypy coverage](https://img.shields.io/badge/mypy-100%25-green.svg)](http://blog.zulip.org/2016/10/13/static-types-in-python-oh-mypy/) [![docs](https://readthedocs.org/projects/zulip/badge/?version=latest)](http://zulip.readthedocs.io/en/latest/) [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org) [![Twitter](https://img.shields.io/badge/twitter-@zulip-blue.svg?style=flat)](http://twitter.com/zulip)
 
 ## Community
 


### PR DESCRIPTION
Clicking the current version of the mypy badge takes you to the shields.io page of the badge, which isn't particularly useful. This PR changes the badge link to the Zulip blog's [article](http://blog.zulip.org/2016/10/13/static-types-in-python-oh-mypy/) on mypy coverage