### PR TITLE
[nomerge] Fixes and logging for iOS push notifs

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -84,9 +84,9 @@ def response_listener(error_response):
 
     errmsg = ERROR_CODES[code]
     data = redis_client.hgetall(key)
-    token = data['token']
-    user_id = int(data['user_id'])
-    b64_token = hex_to_b64(token)
+    token = data[b'token']
+    user_id = int(data[b'user_id'])
+    b64_token = hex_to_b64(token.decode('utf-8'))
 
     logging.warn("APNS: Failed to deliver APNS notification to %s, reason: %s" % (b64_token, errmsg))
     if code == 8:
@@ -168,7 +168,7 @@ def send_apple_push_notification(user_id, devices, **extra_data):
     for token in valid_tokens:
         identifier = random.getrandbits(32)
         key = get_apns_key(identifier)
-        redis_client.hmset(key, {'token': token, 'user_id': user_id})
+        redis_client.hmset(key, {b'token': token, b'user_id': user_id})
         redis_client.expire(key, expiry)
         connection.gateway_server.send_notification(
             token, payload, identifier=identifier, expiry=expiry)

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -395,6 +395,9 @@ def send_notifications_to_bouncer(user_profile_id, apns_payload, gcm_payload):
 def add_push_device_token(user_profile, token_str, kind, ios_app_id=None):
     # type: (UserProfile, bytes, int, Optional[str]) -> None
 
+    logging.warn("New push device: %d %r %d %r",
+                 user_profile.id, token_str, kind, ios_app_id)
+
     # If we're sending things to the push notification bouncer
     # register this user with them here
     if uses_notification_bouncer():
@@ -408,6 +411,7 @@ def add_push_device_token(user_profile, token_str, kind, ios_app_id=None):
         if kind == PushDeviceToken.APNS:
             post_data['ios_app_id'] = ios_app_id
 
+        logging.warn("Sending new push device to bouncer: %r", post_data)
         send_to_push_bouncer('POST', 'register', post_data)
         return
 
@@ -422,8 +426,11 @@ def add_push_device_token(user_profile, token_str, kind, ios_app_id=None):
                                                                kind=kind,
                                                                ios_app_id=ios_app_id))
     if not created:
+        logging.warn("Existing push device updated.")
         token.last_updated = timezone_now()
         token.save(update_fields=['last_updated'])
+    else:
+        logging.warn("New push device created.")
 
 def remove_push_device_token(user_profile, token_str, kind):
     # type: (UserProfile, bytes, int) -> None

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -152,9 +152,7 @@ def send_apple_push_notification(user_id, devices, **extra_data):
                         "This may be because we could not find the APNS Certificate file.")
         return
 
-    # Plain b64 token kept for debugging purposes
-    tokens = [(b64_to_hex(device.token), device.ios_app_id, device.token)
-              for device in devices]
+    tokens = [(device.token, device.ios_app_id) for device in devices]
 
     valid_devices = [device for device in tokens if device[1] in [settings.ZULIP_IOS_APP_ID, None]]
     valid_tokens = [device[0] for device in valid_devices]

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -114,6 +114,8 @@ def response_listener(error_response):
     if code == 8:
         # Invalid Token, remove from our database
         logging.warn("APNS: Removing token from database due to above failure")
+        logging.warn("APNS: nm, debugging")
+        return
         try:
             PushDeviceToken.objects.get(user_id=user_id, token=b64_token).delete()
             return  # No need to check RemotePushDeviceToken

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -84,6 +84,8 @@ def response_listener(error_response):
 
     errmsg = ERROR_CODES[code]
     data = redis_client.hgetall(key)
+    logging.warn("APNS: Error response: %r" % (error_response,))
+    logging.warn("APNS: Our data for %r: %r" % (identifier, data))
     token = data[b'token']
     user_id = int(data[b'user_id'])
     b64_token = hex_to_b64(token.decode('utf-8'))
@@ -170,6 +172,7 @@ def send_apple_push_notification(user_id, devices, **extra_data):
         key = get_apns_key(identifier)
         redis_client.hmset(key, {b'token': token, b'user_id': user_id})
         redis_client.expire(key, expiry)
+        logging.info("APNs: Sending to %s: %r", token, payload)
         connection.gateway_server.send_notification(
             token, payload, identifier=identifier, expiry=expiry)
 


### PR DESCRIPTION
This branch comprises a couple of fixes, a maybe-fix, and some debug logging for investigating why our iOS push notifications through APNs aren't working. This code is deployed right now on zulipstaging.com.

Two fixes ought to be merged: switching to the message-at-a-time API (it's easier to get working, and the efficiency difference is immaterial right now), and dealing with the bytes/str distinction in what we get from the Redis client. The latter commit needs a bit more polish, and the other doesn't trivially rebase to the front of the branch, so they aren't immediately mergeable.

Posting this branch mainly for reference as we continue debugging.
