### PR TITLE
soft_deactivation: Fix flaky tests by seeding message for users.

### DIFF
--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -509,13 +509,16 @@ class HomeTest(ZulipTestCase):
     def test_multiple_user_soft_deactivations(self):
         # type: () -> None
         long_term_idle_user = self.example_user('hamlet')
+        # We are sending this message to ensure that long_term_idle_user has
+        # at least one UserMessage row.
+        self.send_stream_message('Testing', sender_name='hamlet')
         do_soft_deactivate_users([long_term_idle_user])
 
         message = 'Test Message 1'
         self.send_stream_message(message)
         self.login(long_term_idle_user.email)
         with queries_captured() as queries:
-            self.assertEqual(self.soft_activate_and_get_unread_count(), 1)
+            self.assertEqual(self.soft_activate_and_get_unread_count(), 2)
         query_count = len(queries)
         long_term_idle_user.refresh_from_db()
         self.assertFalse(long_term_idle_user.long_term_idle)
@@ -525,7 +528,7 @@ class HomeTest(ZulipTestCase):
         message = 'Test Message 2'
         self.send_stream_message(message)
         with queries_captured() as queries:
-            self.assertEqual(self.soft_activate_and_get_unread_count(), 2)
+            self.assertEqual(self.soft_activate_and_get_unread_count(), 3)
         # Test here for query count to be at least 5 less than previous count.
         # This will assure add_missing_messages() isn't repeatedly called.
         self.assertGreaterEqual(query_count - len(queries), 5)
@@ -539,7 +542,7 @@ class HomeTest(ZulipTestCase):
         self.send_stream_message(message)
         self.login(long_term_idle_user.email)
         with queries_captured() as queries:
-            self.assertEqual(self.soft_activate_and_get_unread_count(), 3)
+            self.assertEqual(self.soft_activate_and_get_unread_count(), 4)
         query_count = len(queries)
         long_term_idle_user.refresh_from_db()
         self.assertFalse(long_term_idle_user.long_term_idle)
@@ -549,7 +552,7 @@ class HomeTest(ZulipTestCase):
         message = 'Test Message 4'
         self.send_stream_message(message)
         with queries_captured() as queries:
-            self.assertEqual(self.soft_activate_and_get_unread_count(), 4)
+            self.assertEqual(self.soft_activate_and_get_unread_count(), 5)
         self.assertGreaterEqual(query_count - len(queries), 5)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assertEqual(idle_user_msg_list[-1].content, message)

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -2161,6 +2161,10 @@ class SoftDeactivationMessageTest(ZulipTestCase):
             ).order_by('-event_time')[0]
 
         long_term_idle_user = self.example_user('hamlet')
+        # We are sending this message to ensure that long_term_idle_user has
+        # at least one UserMessage row.
+        self.send_message(long_term_idle_user.email, stream_name,
+                          Recipient.STREAM)
         do_soft_deactivate_users([long_term_idle_user])
 
         message = 'Test Message 1'
@@ -2203,6 +2207,8 @@ class SoftDeactivationMessageTest(ZulipTestCase):
                                           sending_client = sending_client)
 
         long_term_idle_user = self.example_user('hamlet')
+        self.send_message(long_term_idle_user.email, stream_name,
+                          Recipient.STREAM)
         do_soft_deactivate_users([long_term_idle_user])
 
         # Test that add_missing_messages() in simplest case of adding a
@@ -2343,6 +2349,8 @@ class SoftDeactivationMessageTest(ZulipTestCase):
                               Recipient.PERSONAL, content)
 
         long_term_idle_user = self.example_user('hamlet')
+        self.send_message(long_term_idle_user.email, stream_name,
+                          Recipient.STREAM)
         do_soft_deactivate_users([long_term_idle_user])
 
         def assert_um_count(user, count):

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -10,7 +10,9 @@ from zerver.lib.soft_deactivation import (
     do_soft_activate_users
 )
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import Client, UserProfile, UserActivity, get_realm
+from zerver.models import (
+    Client, UserProfile, UserActivity, get_realm, Recipient
+)
 
 class UserSoftDeactivationTests(ZulipTestCase):
 
@@ -34,6 +36,11 @@ class UserSoftDeactivationTests(ZulipTestCase):
         for user in users:
             self.assertFalse(user.long_term_idle)
 
+        # We are sending this message to ensure that users have at least
+        # one UserMessage row.
+        self.send_message(users[0].email,
+                          [user.email for user in users],
+                          Recipient.HUDDLE)
         do_soft_deactivate_users(users)
 
         for user in users:
@@ -77,6 +84,9 @@ class UserSoftDeactivationTests(ZulipTestCase):
             self.example_user('iago'),
             self.example_user('cordelia'),
         ]
+        self.send_message(users[0].email,
+                          [user.email for user in users],
+                          Recipient.HUDDLE)
         do_soft_deactivate_users(users)
         for user in users:
             self.assertTrue(user.long_term_idle)


### PR DESCRIPTION
In this we basically seed a single message for the user which will
be soft deactivated by sending a stream message / group PM to
ensure that is has at least one UserMessage row, since in real
world every human user will always have at least one User Message
row.