### PR TITLE
message-editing: toggle topic-edit-pencil according to message editin…

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -37,6 +37,7 @@ set_global('settings_emoji', {
 
 set_global('settings_org', {
     reset_realm_default_language: noop,
+    toggle_allow_message_editing_pencil: noop,
     toggle_email_change_display: noop,
     toggle_name_change_display: noop,
     update_message_retention_days: noop,

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -38,6 +38,7 @@ set_global('templates', {
     settings_org.reset();
     settings_org.populate_realm_domains();
     settings_org.reset_realm_default_language();
+    settings_org.toggle_allow_message_editing_pencil();
     settings_org.toggle_name_change_display();
     settings_org.toggle_email_change_display();
     settings_org.update_realm_description();

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -54,6 +54,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         var realm_settings = {
             add_emoji_by_admins_only: settings_emoji.update_custom_emoji_ui,
             allow_edit_history: noop,
+            allow_message_editing: noop,
             create_stream_by_admins_only: noop,
             default_language: settings_org.reset_realm_default_language,
             description: settings_org.update_realm_description,
@@ -85,6 +86,9 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         } else if (event.op === 'update_dict' && event.property === 'default') {
             _.each(event.data, function (value, key) {
                 page_params['realm_' + key] = value;
+                if (key === 'allow_message_editing') {
+                    settings_org.toggle_allow_message_editing_pencil();
+                }
             });
             if (event.data.authentication_methods !== undefined) {
                 settings_org.populate_auth_methods(event.data.authentication_methods);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -65,6 +65,14 @@ exports.toggle_email_change_display = function () {
     $(".change_email_tooltip").toggle();
 };
 
+exports.toggle_allow_message_editing_pencil = function () {
+    if (!meta.loaded) {
+        return;
+    }
+
+    $(".on_hover_topic_edit").toggle();
+};
+
 exports.update_realm_description = function () {
     if (!meta.loaded) {
         return;

--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -36,6 +36,8 @@
                 {{else}}
                     {{#if on_hover_topic_edit}}
                     <i class="icon-vector-pencil on_hover_topic_edit"></i>
+                    {{else}}
+                    <i class="icon-vector-pencil on_hover_topic_edit" style="display: none"></i>
                     {{/if}}
                 {{/if}}
 


### PR DESCRIPTION
…g setting.

- Fixes: #5946

- Notes: 
    * it displays/hides the icon on the home stream (or any current stream selected when changing 
       the setting), but it doesn't re-render all the streams without re-loading the page
    * I noticed when closing the org settings view and re-opening it seems like a new event handler is 
      attached to the view / ’update' button every time the settings view is opened and it’s not being 
      destroyed when the view is closed. 
      This results in the functions being called one additional time, every time the view gets closed 
      and reopened. I found this issue to be existing in the master branch as well. 
      This seemed out of the scope for this PR, should this be added as an issue or do we think it’s 
      fine if the user needs to refresh the page?
