### PR TITLE
empty-feed: text alignment of empty conversation/feed message fixed.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2318,19 +2318,11 @@ button.topic_edit_cancel {
 .empty_feed_notice {
     padding: 3em 4em;
     display: none;
-}
-
-.empty_feed_notice h4 {
     text-align: center;
 }
 
 .notification {
     cursor: pointer;
-}
-
-#empty_narrow_private_message p,
-#empty_narrow_message p {
-    text-align: center;
 }
 
 .message-fade,

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2316,7 +2316,7 @@ button.topic_edit_cancel {
 }
 
 .empty_feed_notice {
-    padding: 3em 4em;
+    padding: 3em 1em;
     display: none;
     text-align: center;
 }


### PR DESCRIPTION
Fix: Previously in the empty group conversation or when there are no private messages and all private messages are narrowed from the sidebar, Notice-"Why not start the conversation" was miss-aligned.

I simply set the `text-align: center` property to all the empty feed notices as it seems to be desired property for all empty feed notices and also would be a better choice rather than explicitly mentioning this property to the individual id of each type of conversation.
Fixes: #6150