### PR TITLE
reactions: Disable ability to highlight message reactions.

### DIFF
--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -1,6 +1,11 @@
 .message_reactions {
     padding-left: 46px;
     overflow: hidden;
+
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .message_reactions .message_reaction {


### PR DESCRIPTION
This adds the `user-select: none` property to `.message_reactions`
to disable accidental highlighting or selecting of the text.