### PR TITLE
testing: Remove obsolete coveralls conf file.

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-pro
-repo_token: hnXUEBKsORKHc8xIENGs9JjktlTb2HKlG


### PR DESCRIPTION
Instead of coveralls, we now use codecov.