### PR TITLE
docs: Clarify webhook-specific guides.

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -95,7 +95,11 @@ handles that incoming data.
 
 New Zulip webhook integrations can take just a few hours to write,
 including tests and documentation, if you use the right process.
-Here's how we recommend doing it:
+
+**For detailed instructions, check out the ["Hello World" webhook walkthrough](
+webhook-walkthrough.html)**.
+
+For a quick guide, read on.
 
 * First, use <http://requestb.in/> or a similar site to capture an
   example webhook payload from the service you're integrating.  You
@@ -137,9 +141,6 @@ Here's how we recommend doing it:
 
 * Finally, write documentation for the integration; there's a
   [detailed guide](#documenting-your-integration) below.
-
-See the "Hello World" example in the [webhook walkthrough](webhook-walkthrough.html) for
-a detailed look at how to write a simple webhook.
 
 ### Files that need to be created
 

--- a/templates/zerver/help/add-a-bot-or-integration.md
+++ b/templates/zerver/help/add-a-bot-or-integration.md
@@ -30,17 +30,30 @@ You can create three types of bots:
 ![Bot types](/static/images/help/bot_types.png)
 
 * **Generic bot:** A generic bot can send *and* receive messages.
+  Choose this type if you want to:
+    * *test* and deploy a simple Python bot using the [Zulip bots](
+      https://github.com/zulip/python-zulip-api/tree/master/zulip_bots) framework.
+    * interact with Zulip using the [Zulip Python API](
+      https://github.com/zulip/python-zulip-api/tree/master/zulip).
 
 * **Incoming webhook:**  The API keys for such bots are limited to
   only sending messages and can't receive messages. Thus, this bot
   type lessens the security risks associated with exposing such API
-  keys to third-party services, since they can't be used to read
-  messages.
+  keys to third-party services.
+  Choose this type if you want to:
+    * deploy one of our [integrations](/integrations).
+    * develop your own integration that posts to Zulip. Note that
+      `Incoming Webhook` integrations can only be developed in the [Zulip repository](
+      https://github.com/zulip/zulip/tree/master/zerver/webhooks).
 
-* **Outgoing webhook:** Bots of this type are the same as a
-  **Generic bot**, except **Outgoing webhooks** bots have an extra field
-  for the base URL of the third-party service being requested.
-  **Outgoing webhook** bots send POST requests to this base URL.
+* **Outgoing webhook:** Bots of this type are the same as a **Generic bot**,
+  except **Outgoing webhooks** bots have an extra field for the base URL of the
+  third-party service being requested. **Outgoing webhook** bots send POST requests
+  to this base URL.
+  Choose this type if you want to:
+    * make Zulip post messages to a URL.
+    * deploy Zulip's [botserver](https://github.com/zulip/python-zulip-api/tree/master/zulip_botserver).
+      *This is the default way of deploying bots used in production.*
 
 ## Add an integration
 


### PR DESCRIPTION
This is based on feedback we have received in #integrations about our docs being confusing.