### PR TITLE
cache_cleaning_scripts: Expand cache cleaning scripts so that they can be used in prod as well.

### DIFF
--- a/scripts/lib/clean-emoji-cache
+++ b/scripts/lib/clean-emoji-cache
@@ -50,7 +50,8 @@ def main():
     # type: () -> None
     args = parse_args()
     caches_in_use = get_caches_in_use(args.threshold_days)
-    purge_unused_caches(EMOJI_CACHE_PATH, caches_in_use, args.threshold_days, args.dry_run, "emoji")
+    purge_unused_caches(
+        EMOJI_CACHE_PATH, caches_in_use, args.threshold_days, args.dry_run, "emoji cache")
 
 if __name__ == "__main__":
     main()

--- a/scripts/lib/clean-npm-cache
+++ b/scripts/lib/clean-npm-cache
@@ -61,7 +61,8 @@ def main():
     args = parse_args()
     caches_in_use = get_caches_in_use(args.threshold_days)
     purge_unused_caches(
-        NODE_MODULES_CACHE_PATH, caches_in_use, args.threshold_days, args.dry_run, "node modules")
+        NODE_MODULES_CACHE_PATH, caches_in_use, args.threshold_days,
+        args.dry_run, "node modules cache")
 
 if __name__ == "__main__":
     main()

--- a/scripts/lib/clean-venv-cache
+++ b/scripts/lib/clean-venv-cache
@@ -50,7 +50,8 @@ def main():
     # type: () -> None
     args = parse_args()
     caches_in_use = get_caches_in_use(args.threshold_days)
-    purge_unused_caches(VENV_CACHE_DIR, caches_in_use, args.threshold_days, args.dry_run, "venv")
+    purge_unused_caches(
+        VENV_CACHE_DIR, caches_in_use, args.threshold_days, args.dry_run, "venv cache")
 
 if __name__ == "__main__":
     main()

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -227,19 +227,7 @@ def purge_unused_caches(caches_dir, caches_in_use, threshold_days, dry_run, cach
     caches_to_purge = get_caches_to_be_purged(caches_dir, caches_in_use, threshold_days)
     caches_to_keep = all_caches - caches_to_purge
 
-    if dry_run:
-        print("Performing a dry run...")
-    else:
-        print("Cleaning unused %s caches..." % (cache_type,))
-
-    for cache_dir in caches_to_purge:
-        print("Cleaning unused %s cache: %s" % (cache_type, cache_dir))
-        if not dry_run:
-            subprocess.check_call(["sudo", "rm", "-rf", cache_dir])
-
-    for cache_dir in caches_to_keep:
-        print("Keeping used %s cache: %s" % (cache_type, cache_dir))
-
+    may_be_perform_purging(caches_to_purge, caches_to_keep, cache_type, dry_run)
     print("Done!\n")
 
 def generate_sha1sum_emoji(zulip_path):
@@ -264,3 +252,18 @@ def generate_sha1sum_emoji(zulip_path):
     sha.update(emoji_datasource_version)
 
     return sha.hexdigest()
+
+def may_be_perform_purging(dirs_to_purge, dirs_to_keep, dir_type, dry_run):
+    # type: (Set[Text], Set[Text], Text, bool) -> None
+    if dry_run:
+        print("Performing a dry run...")
+    else:
+        print("Cleaning unused %ss..." % (dir_type,))
+
+    for directory in dirs_to_purge:
+        print("Cleaning unused %s: %s" % (dir_type, directory))
+        if not dry_run:
+            subprocess.check_call(["sudo", "rm", "-rf", directory])
+
+    for directory in dirs_to_keep:
+        print("Keeping used %s: %s" % (dir_type, directory))

--- a/scripts/purge-old-deployments
+++ b/scripts/purge-old-deployments
@@ -1,40 +1,59 @@
 #!/usr/bin/env python3
-import sys
+import argparse
 import os
-import logging
-import datetime
-import shutil
+import subprocess
+import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, TIMESTAMP_FORMAT
+if False:
+    from typing import Set, Text
 
-logging.basicConfig(format="%(asctime)s purge-deployments: %(message)s",
-                    level=logging.INFO)
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(ZULIP_PATH)
+from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, get_recent_deployments, \
+    may_be_perform_purging
 
-deployments_in_use = set()
-for basename in ['current', 'last', 'next']:
-    # Note which symlinks are current
-    path = os.path.abspath(os.readlink(os.path.join(DEPLOYMENTS_DIR, basename)))
-    deployments_in_use.add(path)
+def parse_args():
+    # type: () -> argparse.Namespace
+    parser = argparse.ArgumentParser(
+        description="This script can be used for cleaning old unused deployments.",
+        epilog="Orphaned/unused caches older than threshold days will be automatically "
+        "examined and removed.")
+    parser.add_argument(
+        "--threshold", dest="threshold_days", type=int, default=14,
+        nargs="?", metavar="<days>", help="Deployments older than "
+        "threshold days will be deleted. (defaults to 14)")
+    parser.add_argument(
+        "--dry-run", dest="dry_run", action="store_true",
+        help="If specified then script will only print the deployments and "
+        "caches that it will delete/keep back. It will not delete anything.")
+    args = parser.parse_args()
+    return args
 
-one_week_ago = datetime.datetime.now() - datetime.timedelta(days=7)
-to_purge = []
-for filename in os.listdir(DEPLOYMENTS_DIR):
-    try:
-        date = datetime.datetime.strptime(filename, TIMESTAMP_FORMAT)
-        if date < one_week_ago:
-            if os.path.abspath(os.path.join(DEPLOYMENTS_DIR, filename)) in deployments_in_use:
-                # Never purge an in-use deployment
-                continue
-            to_purge.append(filename)
-    except ValueError:
-        pass
+def get_deployments_to_be_purged(recent_deployments):
+    # type: (Set[Text]) -> Set[Text]
+    all_deployments = set([os.path.join(DEPLOYMENTS_DIR, deployment)
+                           for deployment in os.listdir(DEPLOYMENTS_DIR)])
+    deployments_to_purge = set()
+    for deployment in all_deployments:
+        if deployment not in recent_deployments:
+            deployments_to_purge.add(deployment)
+    return deployments_to_purge
 
-if to_purge:
-    to_purge.sort()
-    logging.info("Purging the following old deployments directories: %s" % (", ".join(to_purge),))
-    for filename in to_purge:
-        shutil.rmtree(os.path.join(DEPLOYMENTS_DIR, filename))
-        logging.info("Finished %s" % (filename))
-else:
-    logging.info("No old deployment directories to purge")
+def main():
+    # type: () -> None
+    args = parse_args()
+    deployments_to_keep = get_recent_deployments(args.threshold_days)
+    deployments_to_purge = get_deployments_to_be_purged(deployments_to_keep)
+
+    may_be_perform_purging(deployments_to_purge, deployments_to_keep, "deployment", args.dry_run)
+
+    if not args.dry_run:
+        print("Deployments cleaned successfully...")
+        print("Cleaning orphaned/unused caches...")
+
+    # Call 'clean-unused-caches' script to clean any orphaned/unused caches.
+    subprocess.check_call(["./scripts/clean-unused-caches"] + sys.argv[1:])
+    print("Done!\n")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR is an effort to expand all the three cache cleaning scripts by making them aware of the deployments directory. This includes:
* Complete re-write of all the three cache cleaning scripts.
* Moving them from `tools/` to `scripts/` folder so that they are accessible in prod.
* Addition of a new `clean-unused-caches` script which can be used to run all the three scripts in one go(useful mainly for dev env).
* Complete rewrite of `purge-old-deployments` script to make it more configurable in terms of the threshold days and to also make it clean all the orphaned caches automatically.

Fixes: #5726.