### PR TITLE
unicode: Replace "×" with HTML and HEX entities.

### DIFF
--- a/static/styles/alerts.css
+++ b/static/styles/alerts.css
@@ -95,7 +95,7 @@
 
 .alert-box .alert .exit::after {
     padding: 10px;
-    content: "×";
+    content: "\d7";
 }
 
 /* animation section */

--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -934,7 +934,7 @@ nav ul li.active::after {
 }
 
 .compare tbody tr td.no::before {
-    content: "×";
+    content: "\d7";
 
     position: relative;
     display: inline-block;

--- a/static/templates/compose-invite-users.handlebars
+++ b/static/templates/compose-invite-users.handlebars
@@ -2,6 +2,6 @@
     {{#tr this}}<strong>__name__</strong> is not subscribed to this stream.{{/tr}}
     <div class="compose_invite_user_controls">
         <span class="compose_invite_user_error alert alert-error" style="display: none;">{{t "Unable to subscribe user" }}</span>
-        <button href="" class="btn btn-warning compose_invite_link" >{{t "Subscribe" }}</button><button type="button" class="compose_invite_close close">×</button>
+        <button href="" class="btn btn-warning compose_invite_link" >{{t "Subscribe" }}</button><button type="button" class="compose_invite_close close">&times;</button>
     </div>
 </div>

--- a/static/templates/compose_notification.handlebars
+++ b/static/templates/compose_notification.handlebars
@@ -1,5 +1,5 @@
 {{! Content of sent-message notifications }}
 <div class="compose-notifications-content">
     {{note}} {{#if link_class}}<a href="#" class="{{link_class}}" data-msgid="{{link_msg_id}}">{{link_text}}</a>{{/if}}
-    <button type="button" class="out-of-view-notification-close close">×</button>
+    <button type="button" class="out-of-view-notification-close close">&times;</button>
 </div>

--- a/static/templates/default_language_modal.handlebars
+++ b/static/templates/default_language_modal.handlebars
@@ -1,7 +1,7 @@
 <div id="default_language_modal" class="modal hide" tabindex="-1" role="dialog"
     aria-labelledby="default_language_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="default_language_modal_label">{{t "Select default language" }}</h3>
     </div>
     <div class="modal-body">

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -21,7 +21,7 @@
                 <div id="change_email_modal" class="modal hide" tabindex="-1" role="dialog"
                     aria-labelledby="change_email_modal_label" aria-hidden="true">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
                         <h3 id="change_email_modal_label">{{t "Change email" }}</h3>
                     </div>
                     <div class="modal-body">
@@ -124,7 +124,7 @@
 
         <div id="deactivate_self_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_self_modal_label" aria-hidden="true">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
                 <h3 id="deactivation_self_modal_label">{{t "Deactivate your account" }} </h3>
             </div>
             <div class="modal-body">

--- a/static/templates/settings/deactivation-stream-modal.handlebars
+++ b/static/templates/settings/deactivation-stream-modal.handlebars
@@ -1,6 +1,6 @@
 <div id="deactivation_stream_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_stream_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="deactivation_stream_modal_label">{{t "Delete stream" }} <span class="stream_name"></span></h3>
     </div>
     <div class="modal-body">

--- a/static/templates/settings/deactivation-user-modal.handlebars
+++ b/static/templates/settings/deactivation-user-modal.handlebars
@@ -1,6 +1,6 @@
 <div id="deactivation_user_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_user_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="deactivation_user_modal_label">{{t "Deactivate" }} <span class="email"></span></h3>
     </div>
     <div class="modal-body">

--- a/static/templates/settings/realm-domains-modal.handlebars
+++ b/static/templates/settings/realm-domains-modal.handlebars
@@ -1,6 +1,6 @@
 <div id="realm_domains_modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="realm_domains_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="realm_domains_modal_label">{{t "Allowed domains" }}</h3>
     </div>
     <div class="modal-body">

--- a/static/templates/subscription_invites_warning_modal.handlebars
+++ b/static/templates/subscription_invites_warning_modal.handlebars
@@ -1,7 +1,7 @@
 <div id='invites-warning-overlay' class='overlay new-style show' style='z-index:1000;'>
     <div class="modal" id="invites-warning-modal" tabindex="-1" role="dialog" aria-labelledby="invites-warning-label" aria-hidden="true">
         <div class="modal-header">
-            <button type="button" class="close close-invites-warning-modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
+            <button type="button" class="close close-invites-warning-modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
             <h3 id="invites-warning-label">{{t "Large number of subscribers" }}</h3>
         </div>
         <div class="modal-body">

--- a/static/templates/subscription_stream_privacy_modal.handlebars
+++ b/static/templates/subscription_stream_privacy_modal.handlebars
@@ -1,6 +1,6 @@
 <div id="stream_privacy_modal" class="modal" tabindex="-1" role="dialog" aria-labelledby="stream_privacy_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close close-privacy-modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">×</span></button>
+        <button type="button" class="close close-privacy-modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="stream_privacy_modal_label">{{t "Change stream privacy" }} <span class="email"></span></h3>
     </div>
     <div class="modal-body">

--- a/templates/zerver/bankruptcy.html
+++ b/templates/zerver/bankruptcy.html
@@ -2,7 +2,7 @@
     aria-labelledby="bankruptcy-label" aria-hidden="true">
 
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">×</span></button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="bankruptcy-label">{{ _('Welcome back') }}</h3>
     </div>
 

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -38,7 +38,7 @@
       <div  id="compose-all-everyone" class="alert home-error-bar"></div>
       <div  id="out-of-view-notification" class="notification-alert"></div>
      <div class="composition-area">
-      <button type="button" class="close" id='compose_close'>×</button>
+      <button type="button" class="close" id='compose_close'>&times;</button>
       <form id="send_message_form" action="/json/messages" method="post">
         {{ csrf_input }}
         <table class="compose_table">

--- a/templates/zerver/delete_message.html
+++ b/templates/zerver/delete_message.html
@@ -1,6 +1,6 @@
 <div id="delete_message_modal" class="modal hide fade new-style" tabindex="-1" role="dialog" aria-labelledby="delete_message_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">×</span></button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="delete_message_modal_label">{{ _("Delete message") }} </h3>
     </div>
     <div class="modal-body">

--- a/templates/zerver/invite_user.html
+++ b/templates/zerver/invite_user.html
@@ -2,7 +2,7 @@
     aria-labelledby="invite-user-label" aria-hidden="true">
     <div class="overlay-content">
         <div class="modal-header">
-            <button type="button" class="exit" aria-label="{{ _('Close') }}"><span aria-hidden="true">×</span></button>
+            <button type="button" class="exit" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
             <h3 id="invite-user-label">{% trans %}Invite users to Zulip{% endtrans %}</h3>
         </div>
         <form id="invite_user_form" class="form-horizontal"

--- a/templates/zerver/message_history.html
+++ b/templates/zerver/message_history.html
@@ -1,7 +1,7 @@
 <div class="modal hide" id="message-edit-history" tabindex="-1" role="dialog"
     aria-labelledby="message-history-label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">×</span></button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="message-history-label">{{ _('Message edit history') }}</h3>
     </div>
     <div class="modal-body">


### PR DESCRIPTION
This refactors and fixes unicode issues where entities don't display
properly due to being a special character that seems to be rendered
incorrectly in a non-deterministic way every time.