### PR TITLE
editing: Fix live update of ability to edit messages.

### DIFF
--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -197,7 +197,6 @@ exports.update_messages = function update_messages(events) {
 
                 msg.subject = event.subject;
                 msg.subject_links = event.subject_links;
-                message_store.set_topic_edit_properties(msg);
 
                 // Add the recent topics entry for the new topics; must
                 // be called after we update msg.subject

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -85,6 +85,22 @@ function add_display_time(group, message_container, prev) {
     }
 }
 
+function set_topic_edit_properties(group, message) {
+    group.always_visible_topic_edit = false;
+    group.on_hover_topic_edit = false;
+    if (!page_params.realm_allow_message_editing) {
+        return;
+    }
+
+    // Messages with no topics should always have an edit icon visible
+    // to encourage updating them. Admins can also edit any topic.
+    if (message.subject === compose.empty_topic_placeholder()) {
+        group.always_visible_topic_edit = true;
+    } else if (page_params.is_admin) {
+        group.on_hover_topic_edit = true;
+    }
+}
+
 function populate_group_from_message_container(group, message_container) {
     group.is_stream = message_container.msg.is_stream;
     group.is_private = message_container.msg.is_private;
@@ -112,9 +128,9 @@ function populate_group_from_message_container(group, message_container) {
         group.display_reply_to = message_store.get_pm_full_names(message_container.msg);
     }
     group.display_recipient = message_container.msg.display_recipient;
-    group.always_visible_topic_edit = message_container.msg.always_visible_topic_edit;
-    group.on_hover_topic_edit = message_container.msg.on_hover_topic_edit;
     group.subject_links = message_container.msg.subject_links;
+
+    set_topic_edit_properties(group, message_container.msg);
 
     var time = new XDate(message_container.msg.timestamp * 1000);
     var today = new XDate();

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -90,22 +90,6 @@ exports.insert_recent_private_message = (function () {
     };
 }());
 
-exports.set_topic_edit_properties = function (message) {
-    message.always_visible_topic_edit = false;
-    message.on_hover_topic_edit = false;
-    if (!page_params.realm_allow_message_editing) {
-        return;
-    }
-
-    // Messages with no topics should always have an edit icon visible
-    // to encourage updating them. Admins can also edit any topic.
-    if (message.subject === compose.empty_topic_placeholder()) {
-        message.always_visible_topic_edit = true;
-    } else if (page_params.is_admin) {
-        message.on_hover_topic_edit = true;
-    }
-};
-
 exports.set_message_booleans = function (message, flags) {
     function convert_flag(flag_name) {
         return flags.indexOf(flag_name) >= 0;
@@ -159,8 +143,6 @@ exports.add_message_metadata = function (message) {
             topic_name: message.subject,
             message_id: message.id,
         });
-
-        exports.set_topic_edit_properties(message);
 
         recent_senders.process_message_for_senders(message);
         break;


### PR DESCRIPTION
Previously, we didn't check the organization-level settings when
rendering a message list; instead, we only checked it when putting
messages into the message_store.  That resulted in the state being
stale in the event that the setting controlling whether one can edit
messages was changed.