### PR TITLE
requirements: Remove pathlib2.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,9 +34,6 @@ transifex-client==0.12.4
 # Dependency of transifex-client
 urllib3==1.22
 
-# Needed for documentation_crawler
-pathlib2==2.3.0
-
 # Needed for updating the locked pip dependencies
 first==2.0.1
 pip-tools==1.9.0

--- a/requirements/dev_lock.txt
+++ b/requirements/dev_lock.txt
@@ -79,7 +79,6 @@ oauthlib==2.0.2
 olefile==0.44             # via pillow
 ordereddict==1.1          # via gitlint
 parsel==1.2.0             # via scrapy
-pathlib2==2.3.0
 pbr==3.1.1                # via mock
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
@@ -119,7 +118,6 @@ requests-oauthlib==0.8.0
 requests==2.18.4
 rsa==3.4.2
 s3transfer==0.1.10        # via boto3
-scandir==1.5              # via pathlib2
 scrapy==1.4.0
 service-identity==17.0.0  # via scrapy
 sh==1.11                  # via gitlint

--- a/tools/documentation_crawler/documentation_crawler/spiders/check_documentation.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/check_documentation.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 import os
-import pathlib2
+import pathlib
 
 from typing import List
 
@@ -16,7 +16,7 @@ def get_start_url():
     start_file = os.path.join(dir_path, os.path.join(*[os.pardir] * 4),
                               "docs/_build/html/index.html")
     return [
-        pathlib2.Path(os.path.abspath(start_file)).as_uri()
+        pathlib.Path(os.path.abspath(start_file)).as_uri()
     ]
 
 


### PR DESCRIPTION
`pathlib2` is a backport of pathlib to Python 2.x.
This dependency can be removed since:
- Zulip 1.6.0+git has been on Python 3 nowadays.
- As stated in ticket #6211, having this removed, prevents the need to
  have lockfiles for each of 3.4, 3.5, (and maybe 3.6).

This fixes #6211.