### PR TITLE
Lighten apps/ page visuals

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -1560,7 +1560,7 @@ nav ul li.active::after {
     position: relative;
 
     padding: 100px 50px 50px 50px;
-    background: linear-gradient(35deg, #003b52, #45b59b);
+    background: linear-gradient(35deg, #12516a, #69b7a5);
     height: 600px;
 
     color: #fff;
@@ -1587,6 +1587,7 @@ nav ul li.active::after {
     background-image: url(/static/images/waves.svg);
     background-size: cover;
     background-repeat: no-repeat;
+    opacity: 0.3;
 }
 
 .portico-landing.apps .hero .info,

--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -1603,6 +1603,7 @@ nav ul li.active::after {
 
 .portico-landing.apps .hero .info .cta {
     text-shadow: 0px 0px 60px rgba(0,0,0,0.3);
+    max-width: 600px;
 }
 
 .portico-landing.apps .hero .image img[src="/static/images/landing-page/tar.gz.svg"] {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13666710/29617520-15a91706-880d-11e7-8b5a-ea1e4caa1167.png)

Also reduced the container size for the cta as the lines would get quite long.
