### PR TITLE
informational-overlays: Remove outline on focus.

### DIFF
--- a/static/styles/informational-overlays.css
+++ b/static/styles/informational-overlays.css
@@ -30,6 +30,7 @@
 
 .informational-overlays .overlay-modal {
     padding-bottom: 10px;
+    outline: none;
 }
 
 .informational-overlays .overlay-modal .modal-body {


### PR DESCRIPTION
This removes the outline that comes on focus of one of the overlay
sections.

Fixes: #6188.