### PR TITLE
settings: Remove whitespace on left side of bot key.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -51,6 +51,14 @@ a {
     user-select: none;
 }
 
+.auto-select {
+    -webkit-touch-callout: auto;
+    -webkit-user-select: auto;
+    -moz-user-select: auto;
+    -ms-user-select: auto;
+    user-select: auto;
+}
+
 p.n-margin {
     margin: 10px 0px 0px 0px;
 }

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -30,8 +30,9 @@
         {{#if is_active}}
         <div class="api_key">
             <span class="field">{{t "API key" }}</span>
-            <span class="api-key-value-and-button">
-                <span class="value">{{api_key}}</span>
+            <span class="api-key-value-and-button no-select">
+                <!-- have the `.auto-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
+                <span class="value auto-select">{{api_key}}</span>
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-email="{{email}}">
                     <i class="icon-vector-refresh"></i>
                 </button>


### PR DESCRIPTION
The bot API key when selected in the "Your bots" panel would have
some whitespace due to the fact that the HTML markup would make
some space between the span and button.

Fixes: #6189.