### PR TITLE
registration: Move send_initial_pms into create_user.

### DIFF
--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -77,4 +77,7 @@ def create_user(email, password, realm, full_name, short_name,
     recipient = Recipient.objects.create(type_id=user_profile.id,
                                          type=Recipient.PERSONAL)
     Subscription.objects.create(user_profile=user_profile, recipient=recipient)
+
+    from zerver.lib.onboarding import send_initial_pms
+    send_initial_pms(user_profile)
     return user_profile

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -27,7 +27,7 @@ from zerver.lib.actions import is_inactive, do_set_user_display_setting
 from django_auth_ldap.backend import LDAPBackend, _LDAPUser
 from zerver.decorator import require_post, has_request_variables, \
     JsonableError, get_user_profile_by_email, REQ
-from zerver.lib.onboarding import send_initial_pms, setup_initial_streams, \
+from zerver.lib.onboarding import setup_initial_streams, \
     setup_initial_private_stream, send_initial_realm_messages
 from zerver.lib.response import json_success
 from zerver.lib.utils import get_subdomain
@@ -219,8 +219,6 @@ def accounts_register(request):
                                           tos_version=settings.TOS_VERSION,
                                           timezone=timezone,
                                           newsletter_data={"IP": request.META['REMOTE_ADDR']})
-
-        send_initial_pms(user_profile)
 
         if realm_creation:
             setup_initial_private_stream(user_profile)


### PR DESCRIPTION
Previously we only called send_initial_pms in the accounts_register pathway,
which means that it didn't get called when users were created via the API,
or various other means (e.g. SSO, mirror users, etc).

It's sort of hard to avoid an import loop here, since onboarding.py heavily
relies on functions in actions.py (which calls the functions in
create_user.py).