### PR TITLE
/integrations/: Focus search bar on page load.

### DIFF
--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -370,9 +370,13 @@ function integration_events() {
         return false;
     });
 
-    $(".integrations .searchbar input[type='text']").on('input', function (e) {
-        dispatch('UPDATE_QUERY', { query : e.target.value.toLowerCase() });
-    });
+    // combine selector use for both focusing the integrations searchbar and adding
+    // the input event.
+    $(".integrations .searchbar input[type='text']")
+        .focus()
+        .on('input', function (e) {
+            dispatch('UPDATE_QUERY', { query : e.target.value.toLowerCase() });
+        });
 
     $(window).scroll(function () {
         if (document.body.scrollTop > 330) {


### PR DESCRIPTION
This focuses the search bar on initial page load.