### PR TITLE
Change messaging for bankruptcy.

### DIFF
--- a/static/templates/bankruptcy_modal.handlebars
+++ b/static/templates/bankruptcy_modal.handlebars
@@ -1,6 +1,6 @@
 {{! The unread count in the bankruptcy modal }}
 
 <div class="modal-body">
-    <p>{{#tr this}}It's been a while! Since you were last here, you received <b>__unread_count__</b> new messages.{{/tr}}</p>
-    <p>{{t "Do you want to skip to your latest messages?" }}</p>
+    <p>{{#tr this}}It looks like you may have been away for a while.  You have <b>__unread_count__</b> unread messages (including muted topics).{{/tr}}</p>
+    <p>{{t "Do you want to mark these messages as read?" }}</p>
 </div>


### PR DESCRIPTION
The new messaging is not as folksy, but it is a little more
accurate and a little less presumptive.  We should refine this
further; this commit just avoids a common source of confusion.

The old prompt says "Do you want to skip to your latest
messages?", but that question might not make sense to somebody
who mostly uses stream/topic views.