### PR TITLE
Don't handle json payload key errors inside webhooks.

### DIFF
--- a/docs/webhook-walkthrough.md
+++ b/docs/webhook-walkthrough.md
@@ -82,12 +82,8 @@ def api_helloworld_webhook(request, user_profile,
   body = 'Hello! I am happy to be here! :smile:'
 
   # try to add the Wikipedia article of the day
-  # return appropriate error if not successful
-  try:
-      body_template = '\nThe Wikipedia featured article for today is **[{featured_title}]({featured_url})**'
-      body += body_template.format(**payload)
-  except KeyError as e:
-      return json_error(_("Missing key {} in JSON").format(str(e)))
+    body_template = '\nThe Wikipedia featured article for today is **[{featured_title}]({featured_url})**'
+    body += body_template.format(**payload)
 
   # send the message
   check_send_message(user_profile, request.client, 'stream',
@@ -137,10 +133,11 @@ functions.
 
 In the body of the function we define the body of the message as `Hello! I am
 happy to be here! :smile:`. The `:smile:` indicates an emoji. Then we append a
-link to the Wikipedia article of the day as provided by the json payload. If
-the json payload does not include data for `featured_title` and `featured_url`
-we catch a `KeyError` and use `json_error` to return the appropriate
-information: a 400 http status code with relevant details.
+link to the Wikipedia article of the day as provided by the json payload.
+
+* Sometimes, it might occur that a json payload does not contain all required keys your
+  integration checks for. In such a case, any `KeyError` thrown is handled by the server
+  backend and will create an appropriate response.
 
 Then we send a public (stream) message with `check_send_message` which will
 validate the message and then send it.

--- a/zerver/webhooks/airbrake/view.py
+++ b/zerver/webhooks/airbrake/view.py
@@ -17,12 +17,8 @@ def api_airbrake_webhook(request, user_profile,
                          payload=REQ(argument_type='body'),
                          stream=REQ(default='airbrake')):
     # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
-    try:
-        subject = get_subject(payload)
-        body = get_body(payload)
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
-
+    subject = get_subject(payload)
+    body = get_body(payload)
     check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()
 

--- a/zerver/webhooks/appfollow/view.py
+++ b/zerver/webhooks/appfollow/view.py
@@ -17,10 +17,7 @@ from typing import Dict, Any, Text
 def api_appfollow_webhook(request, user_profile, stream=REQ(default="appfollow"),
                           payload=REQ(argument_type="body")):
     # type: (HttpRequest, UserProfile, Text, Dict[str, Any]) -> HttpResponse
-    try:
-        message = payload["text"]
-    except KeyError:
-        return json_error(_("Missing 'text' argument in JSON"))
+    message = payload["text"]
     app_name = re.search('\A(.+)', message).group(0)
 
     check_send_message(user_profile, request.client, "stream", [stream], app_name, convert_markdown(message))

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -44,25 +44,20 @@ class UnknownTriggerType(Exception):
 def api_bitbucket2_webhook(request, user_profile, payload=REQ(argument_type='body'),
                            stream=REQ(default='bitbucket'), branches=REQ(default=None)):
     # type: (HttpRequest, UserProfile, Dict[str, Any], str, Optional[Text]) -> HttpResponse
-    try:
-        type = get_type(request, payload)
-        if type != 'push':
-            subject = get_subject_based_on_type(payload, type)
-            body = get_body_based_on_type(type)(payload)
+    type = get_type(request, payload)
+    if type != 'push':
+        subject = get_subject_based_on_type(payload, type)
+        body = get_body_based_on_type(type)(payload)
+        check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
+    else:
+        branch = get_branch_name_for_push_event(payload)
+        if branch and branches:
+            if branches.find(branch) == -1:
+                return json_success()
+        subjects = get_push_subjects(payload)
+        bodies_list = get_push_bodies(payload)
+        for body, subject in zip(bodies_list, subjects):
             check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
-        else:
-            branch = get_branch_name_for_push_event(payload)
-            if branch and branches:
-                if branches.find(branch) == -1:
-                    return json_success()
-            subjects = get_push_subjects(payload)
-            bodies_list = get_push_bodies(payload)
-            for body, subject in zip(bodies_list, subjects):
-                check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
-
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
-
     return json_success()
 
 def get_subject_for_branch_specified_events(payload, branch_name=None):

--- a/zerver/webhooks/codeship/view.py
+++ b/zerver/webhooks/codeship/view.py
@@ -29,12 +29,9 @@ CODESHIP_STATUS_MAPPER = {
 def api_codeship_webhook(request, user_profile, payload=REQ(argument_type='body'),
                          stream=REQ(default='codeship')):
     # type: (HttpRequest, UserProfile, Dict[str, Any], str) -> HttpResponse
-    try:
-        payload = payload['build']
-        subject = get_subject_for_http_request(payload)
-        body = get_body_for_http_request(payload)
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+    payload = payload['build']
+    subject = get_subject_for_http_request(payload)
+    body = get_body_for_http_request(payload)
 
     check_send_message(user_profile, request.client, 'stream', [stream], subject, body)
     return json_success()

--- a/zerver/webhooks/crashlytics/view.py
+++ b/zerver/webhooks/crashlytics/view.py
@@ -22,23 +22,20 @@ VERIFICATION_EVENT = 'verification'
 def api_crashlytics_webhook(request, user_profile, payload=REQ(argument_type='body'),
                             stream=REQ(default='crashlytics')):
     # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
-    try:
-        event = payload['event']
-        if event == VERIFICATION_EVENT:
-            subject = CRASHLYTICS_SETUP_SUBJECT_TEMPLATE
-            body = CRASHLYTICS_SETUP_MESSAGE_TEMPLATE
-        else:
-            issue_body = payload['payload']
-            subject = CRASHLYTICS_SUBJECT_TEMPLATE.format(
-                display_id=issue_body['display_id'],
-                title=issue_body['title']
-            )
-            body = CRASHLYTICS_MESSAGE_TEMPLATE.format(
-                impacted_devices_count=issue_body['impacted_devices_count'],
-                url=issue_body['url']
-            )
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON".format(str(e))))
+    event = payload['event']
+    if event == VERIFICATION_EVENT:
+        subject = CRASHLYTICS_SETUP_SUBJECT_TEMPLATE
+        body = CRASHLYTICS_SETUP_MESSAGE_TEMPLATE
+    else:
+        issue_body = payload['payload']
+        subject = CRASHLYTICS_SUBJECT_TEMPLATE.format(
+            display_id=issue_body['display_id'],
+            title=issue_body['title']
+        )
+        body = CRASHLYTICS_MESSAGE_TEMPLATE.format(
+            impacted_devices_count=issue_body['impacted_devices_count'],
+            url=issue_body['url']
+        )
 
     check_send_message(user_profile, request.client, 'stream', [stream],
                        subject, body)

--- a/zerver/webhooks/delighted/view.py
+++ b/zerver/webhooks/delighted/view.py
@@ -24,13 +24,10 @@ def api_delighted_webhook(request, user_profile,
                           stream=REQ(default='delighted'),
                           topic=REQ(default='Survey Response')):
     # type: (HttpRequest, UserProfile, Dict[str, Dict[str, Any]], text_type, text_type) -> HttpResponse
-    try:
-        person = payload['event_data']['person']
-        selected_payload = {'email': person['email']}
-        selected_payload['score'] = payload['event_data']['score']
-        selected_payload['comment'] = payload['event_data']['comment']
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+    person = payload['event_data']['person']
+    selected_payload = {'email': person['email']}
+    selected_payload['score'] = payload['event_data']['score']
+    selected_payload['comment'] = payload['event_data']['comment']
 
     BODY_TEMPLATE = body_template(selected_payload['score'])
     body = BODY_TEMPLATE.format(**selected_payload)

--- a/zerver/webhooks/freshdesk/view.py
+++ b/zerver/webhooks/freshdesk/view.py
@@ -133,11 +133,7 @@ def api_freshdesk_webhook(request, user_profile, payload=REQ(argument_type='body
     ticket = TicketDict(ticket_data)
 
     subject = "#%s: %s" % (ticket.id, ticket.subject)
-
-    try:
-        event_info = parse_freshdesk_event(ticket.triggered_event)
-    except ValueError:
-        return json_error(_("Malformed event %s") % (ticket.triggered_event,))
+    event_info = parse_freshdesk_event(ticket.triggered_event)
 
     if event_info[1] == "created":
         content = format_freshdesk_ticket_creation_message(ticket)

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -71,35 +71,31 @@ def api_gogs_webhook(request, user_profile,
 
     repo = payload['repository']['name']
     event = request.META['HTTP_X_GOGS_EVENT']
-
-    try:
-        if event == 'push':
-            branch = payload['ref'].replace('refs/heads/', '')
-            if branches is not None and branches.find(branch) == -1:
-                return json_success()
-            body = format_push_event(payload)
-            topic = SUBJECT_WITH_BRANCH_TEMPLATE.format(
-                repo=repo,
-                branch=branch
-            )
-        elif event == 'create':
-            body = format_new_branch_event(payload)
-            topic = SUBJECT_WITH_BRANCH_TEMPLATE.format(
-                repo=repo,
-                branch=payload['ref']
-            )
-        elif event == 'pull_request':
-            body = format_pull_request_event(payload)
-            topic = SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(
-                repo=repo,
-                type='PR',
-                id=payload['pull_request']['id'],
-                title=payload['pull_request']['title']
-            )
-        else:
-            return json_error(_('Invalid event "{}" in request headers').format(event))
-    except KeyError as e:
-        return json_error(_('Missing key {} in JSON').format(str(e)))
+    if event == 'push':
+        branch = payload['ref'].replace('refs/heads/', '')
+        if branches is not None and branches.find(branch) == -1:
+            return json_success()
+        body = format_push_event(payload)
+        topic = SUBJECT_WITH_BRANCH_TEMPLATE.format(
+            repo=repo,
+            branch=branch
+        )
+    elif event == 'create':
+        body = format_new_branch_event(payload)
+        topic = SUBJECT_WITH_BRANCH_TEMPLATE.format(
+            repo=repo,
+            branch=payload['ref']
+        )
+    elif event == 'pull_request':
+        body = format_pull_request_event(payload)
+        topic = SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(
+            repo=repo,
+            type='PR',
+            id=payload['pull_request']['id'],
+            title=payload['pull_request']['title']
+        )
+    else:
+        return json_error(_('Invalid event "{}" in request headers').format(event))
 
     check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
     return json_success()

--- a/zerver/webhooks/gosquared/view.py
+++ b/zerver/webhooks/gosquared/view.py
@@ -18,14 +18,10 @@ def api_gosquared_webhook(request, user_profile,
                           stream=REQ(default='gosquared'),
                           topic=REQ(default=None)):
     # type: (HttpRequest, UserProfile, Dict[str, Dict[str, Any]], Text, Text) -> HttpResponse
-    try:
-        domain_name = payload['siteDetails']['domain']
-        user_num = payload['concurrents']
-        user_acc = payload['siteDetails']['acct']
-        acc_url = 'https://www.gosquared.com/now/' + user_acc
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
-
+    domain_name = payload['siteDetails']['domain']
+    user_num = payload['concurrents']
+    user_acc = payload['siteDetails']['acct']
+    acc_url = 'https://www.gosquared.com/now/' + user_acc
     body = BODY_TEMPLATE.format(website_name=domain_name, website_url=acc_url, user_num=user_num)
     # allows for customisable topics
     if topic is None:

--- a/zerver/webhooks/greenhouse/view.py
+++ b/zerver/webhooks/greenhouse/view.py
@@ -40,25 +40,21 @@ def api_greenhouse_webhook(request, user_profile,
                            payload=REQ(argument_type='body'),
                            stream=REQ(default='greenhouse'), topic=REQ(default=None)):
     # type: (HttpRequest, UserProfile, Dict[str, Any], str, str) -> HttpResponse
-    try:
-        if payload['action'] == 'update_candidate':
-            candidate = payload['payload']['candidate']
-        else:
-            candidate = payload['payload']['application']['candidate']
-        action = payload['action'].replace('_', ' ').title()
-        body = "{}\n>{} {}\nID: {}\n{}".format(
-            action,
-            candidate['first_name'],
-            candidate['last_name'],
-            str(candidate['id']),
-            message_creator(payload['action'],
-                            payload['payload']['application']))
+    if payload['action'] == 'update_candidate':
+        candidate = payload['payload']['candidate']
+    else:
+        candidate = payload['payload']['application']['candidate']
+    action = payload['action'].replace('_', ' ').title()
+    body = "{}\n>{} {}\nID: {}\n{}".format(
+        action,
+        candidate['first_name'],
+        candidate['last_name'],
+        str(candidate['id']),
+        message_creator(payload['action'],
+                        payload['payload']['application']))
 
-        if topic is None:
-            topic = "{} - {}".format(action, str(candidate['id']))
-
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+    if topic is None:
+        topic = "{} - {}".format(action, str(candidate['id']))
 
     check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
     return json_success()

--- a/zerver/webhooks/hellosign/view.py
+++ b/zerver/webhooks/hellosign/view.py
@@ -48,12 +48,7 @@ def api_hellosign_webhook(request, user_profile,
                           stream=REQ(default='hellosign'),
                           topic=REQ(default=None)):
     # type: (HttpRequest, UserProfile, Dict[str, Dict[str, Any]], text_type, text_type) -> HttpResponse
-    try:
-        model_payload = ready_payload(payload['signature_request']['signatures'],
-                                      payload)
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
-
+    model_payload = ready_payload(payload['signature_request']['signatures'], payload)
     body = format_body(payload['signature_request']['signatures'], model_payload)
     topic = topic or model_payload['contract_title']
     check_send_message(user_profile, request.client, 'stream', [stream],

--- a/zerver/webhooks/helloworld/view.py
+++ b/zerver/webhooks/helloworld/view.py
@@ -21,12 +21,8 @@ def api_helloworld_webhook(request, user_profile,
     body = 'Hello! I am happy to be here! :smile:'
 
     # try to add the Wikipedia article of the day
-    # return appropriate error if not successful
-    try:
-        body_template = '\nThe Wikipedia featured article for today is **[{featured_title}]({featured_url})**'
-        body += body_template.format(**payload)
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+    body_template = '\nThe Wikipedia featured article for today is **[{featured_title}]({featured_url})**'
+    body += body_template.format(**payload)
 
     # send the message
     check_send_message(user_profile, request.client, 'stream', [stream], topic, body)

--- a/zerver/webhooks/homeassistant/view.py
+++ b/zerver/webhooks/homeassistant/view.py
@@ -18,10 +18,7 @@ def api_homeassistant_webhook(request, user_profile,
     # type: (HttpRequest, UserProfile, Dict[str, str], Text) -> HttpResponse
 
     # construct the body of the message
-    try:
-        body = payload["message"]
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+    body = payload["message"]
 
     # set the topic to the topic parameter, if given
     if "topic" in payload:

--- a/zerver/webhooks/mention/view.py
+++ b/zerver/webhooks/mention/view.py
@@ -17,14 +17,9 @@ def api_mention_webhook(request, user_profile,
                         stream=REQ(default='mention'),
                         topic=REQ(default='news')):
     # type: (HttpRequest, UserProfile, Dict[str, Iterable[Dict[str, Any]]], Text, Optional[Text]) -> HttpResponse
-
-    try:
-        title = payload["title"]
-        source_url = payload["url"]
-        description = payload["description"]
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
-
+    title = payload["title"]
+    source_url = payload["url"]
+    description = payload["description"]
     # construct the body of the message
     body = '**[%s](%s)**:\n%s' % (title, source_url, description)
 

--- a/zerver/webhooks/opsgenie/view.py
+++ b/zerver/webhooks/opsgenie/view.py
@@ -41,14 +41,11 @@ def api_opsgenie_webhook(request, user_profile,
     if 'message' in payload['alert']:
         info['additional_info'] += "Message: *{}*\n".format(payload['alert']['message'])
     body = ''
-    try:
-        body_template = "**OpsGenie: [Alert for {integration_name}.](https://app.opsgenie.com/alert/V2#/show/{alert_id})**\n" \
-                        "Type: *{alert_type}*\n" \
-                        "{additional_info}" \
-                        "{tags}"
-        body += body_template.format(**info)
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+    body_template = "**OpsGenie: [Alert for {integration_name}.](https://app.opsgenie.com/alert/V2#/show/{alert_id})**\n" \
+                    "Type: *{alert_type}*\n" \
+                    "{additional_info}" \
+                    "{tags}"
+    body += body_template.format(**info)
     # send the message
     check_send_message(user_profile, request.client, 'stream', [stream], topic, body)
 

--- a/zerver/webhooks/papertrail/view.py
+++ b/zerver/webhooks/papertrail/view.py
@@ -19,25 +19,22 @@ def api_papertrail_webhook(request, user_profile,
     # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Text) -> HttpResponse
 
     # construct the message of the message
-    try:
-        message_template = '**"{}"** search found **{}** matches - {}\n```'
-        message = [message_template.format(payload["saved_search"]["name"],
-                                           str(len(payload["events"])),
-                                           payload["saved_search"]["html_search_url"])]
-        for i, event in enumerate(payload["events"]):
-            event_text = '{} {} {}:\n  {}'.format(event["display_received_at"],
-                                                  event["source_name"],
-                                                  payload["saved_search"]["query"],
-                                                  event["message"])
-            message.append(event_text)
-            if i >= 3:
-                message.append('```\n[See more]({})'.format(payload["saved_search"]["html_search_url"]))
-                break
-        else:
-            message.append('```')
-        post = '\n'.join(message)
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+    message_template = '**"{}"** search found **{}** matches - {}\n```'
+    message = [message_template.format(payload["saved_search"]["name"],
+                                       str(len(payload["events"])),
+                                       payload["saved_search"]["html_search_url"])]
+    for i, event in enumerate(payload["events"]):
+        event_text = '{} {} {}:\n  {}'.format(event["display_received_at"],
+                                              event["source_name"],
+                                              payload["saved_search"]["query"],
+                                              event["message"])
+        message.append(event_text)
+        if i >= 3:
+            message.append('```\n[See more]({})'.format(payload["saved_search"]["html_search_url"]))
+            break
+    else:
+        message.append('```')
+    post = '\n'.join(message)
 
     # send the message
     check_send_message(user_profile, request.client, 'stream', [stream], topic, post)

--- a/zerver/webhooks/pivotal/view.py
+++ b/zerver/webhooks/pivotal/view.py
@@ -167,14 +167,9 @@ def api_pivotal_webhook(request, user_profile, stream=REQ()):
     subject = content = None
     try:
         subject, content = api_pivotal_webhook_v3(request, user_profile, stream)
-    except AttributeError:
-        return json_error(_("Failed to extract data from Pivotal XML response"))
     except Exception:
         # Attempt to parse v5 JSON payload
-        try:
-            subject, content = api_pivotal_webhook_v5(request, user_profile, stream)
-        except AttributeError:
-            return json_error(_("Failed to extract data from Pivotal V5 JSON response"))
+        subject, content = api_pivotal_webhook_v5(request, user_profile, stream)
 
     if subject is None or content is None:
         return json_error(_("Unable to handle Pivotal payload"))

--- a/zerver/webhooks/semaphore/view.py
+++ b/zerver/webhooks/semaphore/view.py
@@ -23,35 +23,26 @@ def api_semaphore_webhook(request, user_profile,
 
     # semaphore only gives the last commit, even if there were multiple commits
     # since the last build
-    try:
-        branch_name = payload["branch_name"]
-        project_name = payload["project_name"]
-        result = payload["result"]
-        event = payload["event"]
-        commit_id = payload["commit"]["id"]
-        commit_url = payload["commit"]["url"]
-        author_email = payload["commit"]["author_email"]
-        message = payload["commit"]["message"]
-    except KeyError as e:
-        return json_error(_("Missing key %s in JSON") % (str(e),))
+    branch_name = payload["branch_name"]
+    project_name = payload["project_name"]
+    result = payload["result"]
+    event = payload["event"]
+    commit_id = payload["commit"]["id"]
+    commit_url = payload["commit"]["url"]
+    author_email = payload["commit"]["author_email"]
+    message = payload["commit"]["message"]
 
     if event == "build":
-        try:
-            build_url = payload["build_url"]
-            build_number = payload["build_number"]
-        except KeyError as e:
-            return json_error(_("Missing key %s in JSON") % (str(e),))
+        build_url = payload["build_url"]
+        build_number = payload["build_number"]
         content = u"[build %s](%s): %s\n" % (build_number, build_url, result)
 
     elif event == "deploy":
-        try:
-            build_url = payload["build_html_url"]
-            build_number = payload["build_number"]
-            deploy_url = payload["html_url"]
-            deploy_number = payload["number"]
-            server_name = payload["server_name"]
-        except KeyError as e:
-            return json_error(_("Missing key %s in JSON") % (str(e),))
+        build_url = payload["build_html_url"]
+        build_number = payload["build_number"]
+        deploy_url = payload["html_url"]
+        deploy_number = payload["number"]
+        server_name = payload["server_name"]
         content = u"[deploy %s](%s) of [build %s](%s) on server %s: %s\n" % \
                   (deploy_number, deploy_url, build_number, build_url, server_name, result)
 

--- a/zerver/webhooks/solano/view.py
+++ b/zerver/webhooks/solano/view.py
@@ -23,16 +23,13 @@ def api_solano_webhook(request, user_profile,
     if event == 'test':
         return handle_test_event(user_profile, request.client, stream, topic)
     try:
-        try:
-            author = payload['committers'][0]
-        except KeyError:
-            author = 'Unknown'
-        status = payload['status']
-        build_log = payload['url']
-        repository = payload['repository']['url']
-        commit_id = payload['commit_id']
-    except KeyError as e:
-        return json_error(_('Missing key {} in JSON').format(str(e)))
+        author = payload['committers'][0]
+    except KeyError:
+        author = 'Unknown'
+    status = payload['status']
+    build_log = payload['url']
+    repository = payload['repository']['url']
+    commit_id = payload['commit_id']
 
     good_status = ['passed']
     bad_status  = ['failed', 'error']

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -20,145 +20,142 @@ def api_stripe_webhook(request, user_profile,
     # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Optional[Text]) -> HttpResponse
     body = None
     event_type = payload["type"]
-    try:
-        data_object = payload["data"]["object"]
-        if event_type.startswith('charge'):
+    data_object = payload["data"]["object"]
+    if event_type.startswith('charge'):
 
-            charge_url = "https://dashboard.stripe.com/payments/{}"
-            amount_string = amount(payload["data"]["object"]["amount"], payload["data"]["object"]["currency"])
+        charge_url = "https://dashboard.stripe.com/payments/{}"
+        amount_string = amount(payload["data"]["object"]["amount"], payload["data"]["object"]["currency"])
 
-            if event_type.startswith('charge.dispute'):
-                charge_id = data_object["charge"]
-                link = charge_url.format(charge_id)
-                body_template = "A charge dispute for **{amount}** has been {rest}.\n"\
-                                "The charge in dispute {verb} **[{charge}]({link})**."
+        if event_type.startswith('charge.dispute'):
+            charge_id = data_object["charge"]
+            link = charge_url.format(charge_id)
+            body_template = "A charge dispute for **{amount}** has been {rest}.\n"\
+                            "The charge in dispute {verb} **[{charge}]({link})**."
 
-                if event_type == "charge.dispute.closed":
-                    rest = "closed as **{}**".format(data_object['status'])
-                    verb = 'was'
+            if event_type == "charge.dispute.closed":
+                rest = "closed as **{}**".format(data_object['status'])
+                verb = 'was'
+            else:
+                rest = "created"
+                verb = 'is'
+
+            body = body_template.format(amount=amount_string, rest=rest, verb=verb, charge=charge_id, link=link)
+
+        else:
+            charge_id = data_object["id"]
+            link = charge_url.format(charge_id)
+            body_template = "A charge with id **[{charge_id}]({link})** for **{amount}** has {verb}."
+
+            if event_type == "charge.failed":
+                verb = "failed"
+            else:
+                verb = "succeeded"
+            body = body_template.format(charge_id=charge_id, link=link, amount=amount_string, verb=verb)
+
+        if topic is None:
+            topic = "Charge {}".format(charge_id)
+
+    elif event_type.startswith('customer'):
+        object_id = data_object["id"]
+        if event_type.startswith('customer.subscription'):
+            link = "https://dashboard.stripe.com/subscriptions/{}".format(object_id)
+
+            if event_type == "customer.subscription.created":
+                amount_string = amount(data_object["plan"]["amount"], data_object["plan"]["currency"])
+
+                body_template = "A new customer subscription for **{amount}** " \
+                                "every **{interval}** has been created.\n" \
+                                "The subscription has id **[{id}]({link})**."
+                body = body_template.format(
+                    amount=amount_string,
+                    interval=data_object['plan']['interval'],
+                    id=object_id,
+                    link=link
+                )
+
+            elif event_type == "customer.subscription.deleted":
+                body_template = "The customer subscription with id **[{id}]({link})** was deleted."
+                body = body_template.format(id=object_id, link=link)
+
+            else:  # customer.subscription.trial_will_end
+                DAY = 60 * 60 * 24  # seconds in a day
+                # days_left should always be three according to
+                # https://stripe.com/docs/api/python#event_types, but do the
+                # computation just to be safe.
+                days_left = int((data_object["trial_end"] - time.time() + DAY//2) // DAY)
+                body_template = "The customer subscription trial with id **[{id}]({link})** will end in {days} days."
+                body = body_template.format(id=object_id, link=link, days=days_left)
+
+        else:
+            link = "https://dashboard.stripe.com/customers/{}".format(object_id)
+            body_template = "{beginning} customer with id **[{id}]({link})** {rest}."
+
+            if event_type == "customer.created":
+                beginning = "A new"
+                if data_object["email"] is None:
+                    rest = "has been created"
                 else:
-                    rest = "created"
-                    verb = 'is'
-
-                body = body_template.format(amount=amount_string, rest=rest, verb=verb, charge=charge_id, link=link)
-
+                    rest = "and email **{}** has been created".format(data_object['email'])
             else:
-                charge_id = data_object["id"]
-                link = charge_url.format(charge_id)
-                body_template = "A charge with id **[{charge_id}]({link})** for **{amount}** has {verb}."
+                beginning = "A"
+                rest = "has been deleted"
+            body = body_template.format(beginning=beginning, id=object_id, link=link, rest=rest)
 
-                if event_type == "charge.failed":
-                    verb = "failed"
-                else:
-                    verb = "succeeded"
-                body = body_template.format(charge_id=charge_id, link=link, amount=amount_string, verb=verb)
+        if topic is None:
+            topic = "Customer {}".format(object_id)
 
-            if topic is None:
-                topic = "Charge {}".format(charge_id)
+    elif event_type == "invoice.payment_failed":
+        object_id = data_object['id']
+        link = "https://dashboard.stripe.com/invoices/{}".format(object_id)
+        amount_string = amount(data_object["amount_due"], data_object["currency"])
+        body_template = "An invoice payment on invoice with id **[{id}]({link})** and "\
+                        "with **{amount}** due has failed."
+        body = body_template.format(id=object_id, amount=amount_string, link=link)
 
-        elif event_type.startswith('customer'):
-            object_id = data_object["id"]
-            if event_type.startswith('customer.subscription'):
-                link = "https://dashboard.stripe.com/subscriptions/{}".format(object_id)
+        if topic is None:
+            topic = "Invoice {}".format(object_id)
 
-                if event_type == "customer.subscription.created":
-                    amount_string = amount(data_object["plan"]["amount"], data_object["plan"]["currency"])
+    elif event_type.startswith('order'):
+        object_id = data_object['id']
+        link = "https://dashboard.stripe.com/orders/{}".format(object_id)
+        amount_string = amount(data_object["amount"], data_object["currency"])
+        body_template = "{beginning} order with id **[{id}]({link})** for **{amount}** has {end}."
 
-                    body_template = "A new customer subscription for **{amount}** " \
-                                    "every **{interval}** has been created.\n" \
-                                    "The subscription has id **[{id}]({link})**."
-                    body = body_template.format(
-                        amount=amount_string,
-                        interval=data_object['plan']['interval'],
-                        id=object_id,
-                        link=link
-                    )
+        if event_type == "order.payment_failed":
+            beginning = "An order payment on"
+            end = "failed"
+        elif event_type == "order.payment_succeeded":
+            beginning = "An order payment on"
+            end = "succeeded"
+        else:
+            beginning = "The"
+            end = "been updated"
 
-                elif event_type == "customer.subscription.deleted":
-                    body_template = "The customer subscription with id **[{id}]({link})** was deleted."
-                    body = body_template.format(id=object_id, link=link)
+        body = body_template.format(beginning=beginning, id=object_id, link=link, amount=amount_string, end=end)
 
-                else:  # customer.subscription.trial_will_end
-                    DAY = 60 * 60 * 24  # seconds in a day
-                    # days_left should always be three according to
-                    # https://stripe.com/docs/api/python#event_types, but do the
-                    # computation just to be safe.
-                    days_left = int((data_object["trial_end"] - time.time() + DAY//2) // DAY)
-                    body_template = "The customer subscription trial with id **[{id}]({link})** will end in {days} days."
-                    body = body_template.format(id=object_id, link=link, days=days_left)
+        if topic is None:
+            topic = "Order {}".format(object_id)
 
-            else:
-                link = "https://dashboard.stripe.com/customers/{}".format(object_id)
-                body_template = "{beginning} customer with id **[{id}]({link})** {rest}."
+    elif event_type.startswith('transfer'):
+        object_id = data_object['id']
+        link = "https://dashboard.stripe.com/transfers/{}".format(object_id)
+        amount_string = amount(data_object["amount"], data_object["currency"])
+        body_template = "The transfer with description **{description}** and id **[{id}]({link})** " \
+                        "for amount **{amount}** has {end}."
+        if event_type == "transfer.failed":
+            end = 'failed'
+        else:
+            end = "been paid"
+        body = body_template.format(
+            description=data_object['description'],
+            id=object_id,
+            link=link,
+            amount=amount_string,
+            end=end
+        )
 
-                if event_type == "customer.created":
-                    beginning = "A new"
-                    if data_object["email"] is None:
-                        rest = "has been created"
-                    else:
-                        rest = "and email **{}** has been created".format(data_object['email'])
-                else:
-                    beginning = "A"
-                    rest = "has been deleted"
-                body = body_template.format(beginning=beginning, id=object_id, link=link, rest=rest)
-
-            if topic is None:
-                topic = "Customer {}".format(object_id)
-
-        elif event_type == "invoice.payment_failed":
-            object_id = data_object['id']
-            link = "https://dashboard.stripe.com/invoices/{}".format(object_id)
-            amount_string = amount(data_object["amount_due"], data_object["currency"])
-            body_template = "An invoice payment on invoice with id **[{id}]({link})** and "\
-                            "with **{amount}** due has failed."
-            body = body_template.format(id=object_id, amount=amount_string, link=link)
-
-            if topic is None:
-                topic = "Invoice {}".format(object_id)
-
-        elif event_type.startswith('order'):
-            object_id = data_object['id']
-            link = "https://dashboard.stripe.com/orders/{}".format(object_id)
-            amount_string = amount(data_object["amount"], data_object["currency"])
-            body_template = "{beginning} order with id **[{id}]({link})** for **{amount}** has {end}."
-
-            if event_type == "order.payment_failed":
-                beginning = "An order payment on"
-                end = "failed"
-            elif event_type == "order.payment_succeeded":
-                beginning = "An order payment on"
-                end = "succeeded"
-            else:
-                beginning = "The"
-                end = "been updated"
-
-            body = body_template.format(beginning=beginning, id=object_id, link=link, amount=amount_string, end=end)
-
-            if topic is None:
-                topic = "Order {}".format(object_id)
-
-        elif event_type.startswith('transfer'):
-            object_id = data_object['id']
-            link = "https://dashboard.stripe.com/transfers/{}".format(object_id)
-            amount_string = amount(data_object["amount"], data_object["currency"])
-            body_template = "The transfer with description **{description}** and id **[{id}]({link})** " \
-                            "for amount **{amount}** has {end}."
-            if event_type == "transfer.failed":
-                end = 'failed'
-            else:
-                end = "been paid"
-            body = body_template.format(
-                description=data_object['description'],
-                id=object_id,
-                link=link,
-                amount=amount_string,
-                end=end
-            )
-
-            if topic is None:
-                topic = "Transfer {}".format(object_id)
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON".format(str(e))))
+        if topic is None:
+            topic = "Transfer {}".format(object_id)
 
     if body is None:
         return json_error(_("We don't support {} event".format(event_type)))

--- a/zerver/webhooks/taiga/view.py
+++ b/zerver/webhooks/taiga/view.py
@@ -252,10 +252,7 @@ def parse_message(message):
 def generate_content(data):
     # type: (Mapping[str, Any]) -> str
     """ Gets the template string and formats it with parsed data. """
-    try:
-        return templates[data['type']][data['event']] % data['values']
-    except KeyError:
-        return json_error(_("Unknown message"))
+    return templates[data['type']][data['event']] % data['values']
 
 def get_owner_name(message):
     # type: (Mapping[str, Any]) -> str

--- a/zerver/webhooks/updown/view.py
+++ b/zerver/webhooks/updown/view.py
@@ -16,12 +16,9 @@ SUBJECT_TEMPLATE = "{service_url}"
 
 def send_message_for_event(event, user_profile, client, stream):
     # type: (Dict[str, Any], UserProfile, Client, str) -> None
-    try:
-        event_type = get_event_type(event)
-        subject = SUBJECT_TEMPLATE.format(service_url=event['check']['url'])
-        body = EVENT_TYPE_BODY_MAPPER[event_type](event)
-    except KeyError as e:
-        return json_error(_("Missing key {} in JSON").format(str(e)))
+    event_type = get_event_type(event)
+    subject = SUBJECT_TEMPLATE.format(service_url=event['check']['url'])
+    body = EVENT_TYPE_BODY_MAPPER[event_type](event)
     check_send_message(user_profile, client, 'stream', [stream], subject, body)
 
 def get_body_for_up_event(event):


### PR DESCRIPTION
Fixes first part of  #6213.

There are still some cases where the existence of keys is checked (e.g. by `get` instead of `KeyError`), and `json_errors` are thrown. Should we remove those as well?