### PR TITLE
message view: Maintain stream color border on @-mention messages.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1018,7 +1018,7 @@ td.pointer {
     border-right: 1px solid hsl(0, 0%, 88%);
 }
 
-.mention .messagebox-content {
+.mention .messagebox {
     background-color: hsl(8, 94%, 94%);
 }
 


### PR DESCRIPTION
Before:
![](https://user-images.githubusercontent.com/12458563/29633091-5e8b9776-885a-11e7-974b-71c71029b5a7.png)

After:
![screenshot at aug 24 21-58-29](https://user-images.githubusercontent.com/15116870/29700212-7dd41bea-8917-11e7-908e-ffe36938e900.png)

Fixes #6241