### PR TITLE
Further clean up organization of Travis files

### DIFF
--- a/tools/find-add-class
+++ b/tools/find-add-class
@@ -29,9 +29,14 @@ def process_files():
     parser.add_argument('-v', '--verbose',
                         action='store_true', default=False,
                         help='show where calls are')
+    parser.add_argument('targets', nargs=argparse.REMAINDER)
     args = parser.parse_args()
 
-    fns = glob.glob('static/js/*.js')
+    if args.targets == []:
+        fns = glob.glob('static/js/*.js')
+    else:
+        fns = args.targets
+
     if args.verbose:
         display(fns)
     else:

--- a/tools/lint
+++ b/tools/lint
@@ -157,7 +157,7 @@ def run():
 
         lint_functions[name] = run_linter
 
-    external_linter('add_class', ['tools/find-add-class'])
+    external_linter('add_class', ['tools/find-add-class'], ['js'])
     external_linter('css', ['tools/check-css'], ['css'])
     external_linter('eslint', ['node', 'node_modules/.bin/eslint', '--quiet'], ['js'])
     external_linter('tslint', ['node', 'node_modules/.bin/tslint', '-c',

--- a/tools/lint
+++ b/tools/lint
@@ -164,7 +164,7 @@ def run():
                                'static/ts/tslint.json'], ['ts'])
     external_linter('puppet', ['puppet', 'parser', 'validate'], ['pp'])
     external_linter('templates', ['tools/check-templates'], ['handlebars', 'html'])
-    external_linter('urls', ['tools/check-urls'])
+    external_linter('urls', ['tools/check-urls'], ['py'])
     external_linter('swagger', ['node', 'tools/check-swagger'], ['yaml'])
 
     # gitlint disabled until we can stabilize it more

--- a/tools/lint
+++ b/tools/lint
@@ -47,9 +47,6 @@ def run():
     parser.add_argument('--full',
                         action='store_true',
                         help='Check some things we typically ignore')
-    parser.add_argument('--pep8',
-                        action='store_true',
-                        help='Run the pep8 checker')
     parser.add_argument('--no-gitlint',
                         action='store_true',
                         help='Disable gitlint')
@@ -62,6 +59,13 @@ def run():
     parser.add_argument('targets',
                         nargs='*',
                         help='Specify directories to check')
+    limited_tests_group = parser.add_mutually_exclusive_group()
+    limited_tests_group.add_argument('--frontend',
+                                     action='store_true',
+                                     help='Only check files relevant to frontend')
+    limited_tests_group.add_argument('--backend',
+                                     action='store_true',
+                                     help='Only check files relevant to backend')
     args = parser.parse_args()
 
     tools_dir = os.path.dirname(os.path.abspath(__file__))
@@ -86,10 +90,17 @@ def run():
             print('If you really know what you are doing, use --force to run anyway.')
             sys.exit(1)
 
+    backend_file_types = ['py', 'sh', 'pp', 'json', 'md', 'txt', 'text', 'yaml']
+    frontend_file_types = ['js', 'css', 'handlebars', 'html']
+    file_types = []
+    if not args.backend:
+        file_types += frontend_file_types
+    if not args.frontend:
+        file_types += backend_file_types
+
     by_lang = cast(Dict[str, List[str]],
                    lister.list_files(args.targets, modified_only=args.modified,
-                                     ftypes=['py', 'sh', 'js', 'pp', 'css', 'handlebars',
-                                             'html', 'json', 'md', 'txt', 'text', 'yaml'],
+                                     ftypes=file_types,
                                      use_shebang=True, group_by_ftype=True, exclude=EXCLUDED_FILES))
 
     # Invoke the appropriate lint checker for each language,
@@ -178,12 +189,11 @@ def run():
         failed = check_pyflakes(args, by_lang)
         return 1 if failed else 0
 
-    if args.pep8:
-        @lint
-        def pep8():
-            # type: () -> int
-            failed = check_pep8(by_lang['py'])
-            return 1 if failed else 0
+    @lint
+    def pep8():
+        # type: () -> int
+        failed = check_pep8(by_lang['py'])
+        return 1 if failed else 0
 
     failed = run_parallel(lint_functions)
 

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -16,10 +16,10 @@ if [ -z "$changed_files" ]; then
 fi
 
 if [ -z "$VIRTUAL_ENV" ] && `which vagrant > /dev/null` && [ -e .vagrant ]; then
-    vcmd="/srv/zulip/tools/lint --pep8 --no-gitlint --force $changed_files || true"
+    vcmd="/srv/zulip/tools/lint --no-gitlint --force $changed_files || true"
     echo "Running lint using vagrant..."
     vagrant ssh -c "$vcmd"
 else
-    ./tools/lint --pep8 --no-gitlint --force $changed_files || true
+    ./tools/lint --no-gitlint --force $changed_files || true
 fi
 exit 0

--- a/tools/test-all
+++ b/tools/test-all
@@ -38,7 +38,7 @@ run ./tools/clean-repo
 run ./tools/run-mypy
 
 # travis/backend
-run ./tools/lint --pep8 $FORCEARG
+run ./tools/lint $FORCEARG
 run ./manage.py makemessages --locale en
 run env PYTHONWARNINGS=ignore ./tools/check-capitalization --no-generate
 run env PYTHONWARNINGS=ignore ./tools/check-frontend-i18n --no-generate

--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -5,7 +5,7 @@ source tools/travis/activate-venv
 set -e
 set -x
 
-./tools/lint --pep8 # Include the slow and thus non-default pep8 linter check
+./tools/lint
 ./manage.py makemessages --locale en
 PYTHONWARNINGS=ignore ./tools/check-capitalization --no-generate
 PYTHONWARNINGS=ignore ./tools/check-frontend-i18n --no-generate

--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -5,7 +5,7 @@ source tools/travis/activate-venv
 set -e
 set -x
 
-./tools/lint
+./tools/lint --backend
 ./manage.py makemessages --locale en
 PYTHONWARNINGS=ignore ./tools/check-capitalization --no-generate
 PYTHONWARNINGS=ignore ./tools/check-frontend-i18n --no-generate

--- a/tools/travis/frontend
+++ b/tools/travis/frontend
@@ -5,6 +5,7 @@ source tools/travis/activate-venv
 set -e
 set -x
 
+./tools/lint --frontend
 ./tools/test-js-with-node --coverage
 ./tools/test-js-with-casper
 


### PR DESCRIPTION
Following #6170, has some commits to consider that:
(1) Get rid of the `static-analysis` build, which at this point was just `mypy`, and instead just runs `mypy` as part of the `backend` suite.  Intentionally, we run `mypy` after `test-backend`, so that test failures (which are generally more important in the sense that mypy fixes to PRs after often just fixing annotations) show up if both are present.  It would be reasonable to do a follow-up to run mypy even if the backend tests fail, too.  The main benefit of this is saving Travis CI's 1m of startup overhead, though maybe it's also easier to understand?
(2) Moves the capitalization and frontend i18n linters to the `frontend` suite, since it's generally catching frontend-side in HTML/CSS anyway.  This one seems pretty clear to me we want to do.

@gnprice @showell @derAnfaenger FYI.