### PR TITLE
emoji_picker: Extend emoji picker to show the name of emojis while navigating.

### DIFF
--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -40,3 +40,38 @@ var emoji = require('js/emoji.js');
     emoji.initialize();
     assert(image_stub);
 }());
+
+(function test_get_canonical_name() {
+    emoji.active_realm_emojis = {
+        realm_emoji: 'TBD',
+    };
+    var canonical_name = emoji.get_canonical_name('realm_emoji');
+    assert.equal(canonical_name, 'realm_emoji');
+
+    global.emoji_codes = {
+        name_to_codepoint: {
+            '+1': '1f44d',
+        },
+        codepoint_to_name: {
+            '1f44d': 'thumbs_up',
+        },
+    };
+    canonical_name = emoji.get_canonical_name('+1');
+    assert.equal(canonical_name, 'thumbs_up');
+
+    emoji.active_realm_emojis = {
+        '+1': 'TBD',
+    };
+    canonical_name = emoji.get_canonical_name('+1');
+    assert.equal(canonical_name, '+1');
+
+    var errored = false;
+    set_global('blueslip', {
+        error: function (error) {
+            assert.equal(error, "Invalid emoji name: non_existent");
+            errored = true;
+        },
+    });
+    emoji.get_canonical_name('non_existent');
+    assert(errored);
+}());

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -600,8 +600,8 @@ function render(template_name, args) {
     html += render('emoji_popover_content', args);
     html += "</div>";
     // test to make sure the first emoji is present in the popover
-    var emoji_key = $(html).find(".emoji-100").attr('title');
-    assert.equal(emoji_key, '100');
+    var first_emoji = $(html).find(".emoji-100");
+    assert.equal(first_emoji.length, 1);
 
     var categories = $(html).find(".emoji-popover-tab-item");
     assert.equal(categories.length, 2);

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -557,16 +557,12 @@ function render(template_name, args) {
 (function emoji_popover() {
     var args = {
         class: "emoji-info-popover",
-        categories: [
-            { name: "Test category 1", icon: "test-icon-1" },
-            { name: "Test category 2", icon: "test-icon-2" },
-        ],
     };
-    var html = render('emoji_popover', args);
-    var categories = $(html).find(".emoji-popover-tab-item");
-    assert.equal(categories.length, 2);
-    var category_1 = $(html).find(".emoji-popover-tab-item[data-tab-name = 'Test category 1']");
-    assert(category_1.hasClass("active"));
+    var html = "<div>";
+    html += render('emoji_popover', args);
+    html += "</div>";
+    var popover = $(html).find(".popover");
+    assert(popover.hasClass("emoji-info-popover"));
     global.write_handlebars_output("emoji_popover", html);
 }());
 
@@ -586,6 +582,17 @@ function render(template_name, args) {
                     },
                 ],
             },
+            {
+                name: 'Test1',
+                emojis: [
+                    {
+                        has_reacted: false,
+                        is_realm_emoji: true,
+                        name: 'zulip',
+                        url: 'zulip',
+                    },
+                ],
+            },
         ],
     };
 
@@ -595,6 +602,13 @@ function render(template_name, args) {
     // test to make sure the first emoji is present in the popover
     var emoji_key = $(html).find(".emoji-100").attr('title');
     assert.equal(emoji_key, '100');
+
+    var categories = $(html).find(".emoji-popover-tab-item");
+    assert.equal(categories.length, 2);
+
+    var category_1 = $(html).find(".emoji-popover-tab-item[data-tab-name = 'Test']");
+    assert(category_1.hasClass("active"));
+
     global.write_handlebars_output("emoji_popover_content", html);
 }());
 

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -639,6 +639,26 @@ function render(template_name, args) {
     assert(used_emoji.hasClass("reacted"));
 }());
 
+(function emoji_showcase() {
+    var args = {
+        emoji_dict: {
+            name: "thumbs_up",
+            is_realm_emoji: false,
+            css_class: "1f44d",
+            has_reacted: false,
+        },
+    };
+    var html = render("emoji_showcase", args);
+    var emoji_div = $(html).find(".emoji");
+    var canonical_name = $(html).find(".emoji-canonical-name");
+
+    assert.equal(emoji_div.length, 1);
+    assert(emoji_div.hasClass("emoji-1f44d"));
+    assert.equal(canonical_name.text(), "thumbs_up");
+    assert.equal(canonical_name.attr("title"), "thumbs_up");
+    global.write_handlebars_output("emoji_showcase", html);
+}());
+
 (function group_pms() {
     var args = {
         group_pms: [

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -96,6 +96,19 @@ exports.build_emoji_upload_widget = function () {
     );
 };
 
+exports.get_canonical_name = function (emoji_name) {
+    if (exports.active_realm_emojis.hasOwnProperty(emoji_name)) {
+        return emoji_name;
+    }
+    if (!emoji_codes.name_to_codepoint.hasOwnProperty(emoji_name)) {
+        blueslip.error("Invalid emoji name: " + emoji_name);
+        return;
+    }
+    var codepoint = emoji_codes.name_to_codepoint[emoji_name];
+
+    return emoji_codes.codepoint_to_name[codepoint];
+};
+
 return exports;
 }());
 if (typeof module !== 'undefined') {

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -23,22 +23,6 @@ var search_is_active = false;
 var search_results = [];
 var section_head_offsets = [];
 
-function get_rendered_emoji_categories() {
-    if (exports.complete_emoji_catalog.length === 0) {
-        blueslip.error('emoji_picker: Emoji catalog empty');
-        return;
-    }
-
-    var current_emoji_categories = [];
-    _.each(exports.complete_emoji_catalog, function (category) {
-        current_emoji_categories.push({
-            name: category.name,
-            icon: category.icon,
-        });
-    });
-    return current_emoji_categories;
-}
-
 function get_all_emoji_categories() {
     return [
         { name: "Popular", icon: "fa-thumbs-o-up" },
@@ -563,7 +547,6 @@ function register_popover_events(popover) {
 exports.render_emoji_popover = function (elt, id) {
     var template_args = {
         class: "emoji-info-popover",
-        categories: get_rendered_emoji_categories(),
     };
     var placement = popovers.compute_placement(elt, APPROX_HEIGHT, APPROX_WIDTH, true);
 

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -4,7 +4,7 @@ var exports = {};
 
 // Emoji picker is of fixed width and height. Update these
 // whenever these values are changed in `reactions.css`.
-var APPROX_HEIGHT = 330;
+var APPROX_HEIGHT = 375;
 var APPROX_WIDTH = 255;
 
 // The functionalities for reacting to a message with an emoji
@@ -322,12 +322,36 @@ function round_off_to_previous_multiple(number_to_round, multiple) {
     return (number_to_round - (number_to_round % multiple));
 }
 
+function reset_emoji_showcase() {
+    $(".emoji-showcase-container").html("");
+}
+
+function update_emoji_showcase($focused_emoji) {
+    // Don't use jQuery's data() function here. It has the side-effect
+    // of converting emoji names like :100:, :1234: etc to number.
+    var focused_emoji_name = $focused_emoji.attr("data-emoji-name");
+    var focused_emoji_dict = exports.emoji_collection[focused_emoji_name];
+    if (search_is_active) {
+        focused_emoji_dict = search_results[current_index];
+    }
+
+    var emoji_dict = _.extend({}, focused_emoji_dict, {
+        name: focused_emoji_name.replace(/_/g, ' '),
+    });
+    var rendered_showcase = templates.render("emoji_showcase", {
+        emoji_dict: emoji_dict,
+    });
+
+    $(".emoji-showcase-container").html(rendered_showcase);
+}
+
 function may_be_change_focused_emoji(next_section, next_index) {
     var next_emoji = get_rendered_emoji(next_section, next_index);
     if (next_emoji) {
         current_section = next_section;
         current_index = next_index;
         next_emoji.focus();
+        update_emoji_showcase(next_emoji);
         return true;
     }
     return false;
@@ -387,6 +411,7 @@ function change_focus_to_filter() {
         current_section = 0;
         current_index = 0;
     }
+    reset_emoji_showcase();
 }
 
 exports.navigate = function (event_name) {
@@ -409,10 +434,12 @@ exports.navigate = function (event_name) {
             if (current_section === 0 && current_index < 6) {
                 $(".emoji-popover-emoji-map").scrollTop(0);
             }
+            update_emoji_showcase(selected_emoji);
             return true;
         }
         if (event_name === "tab") {
             selected_emoji.focus();
+            update_emoji_showcase(selected_emoji);
             return true;
         }
         return false;
@@ -431,6 +458,7 @@ exports.navigate = function (event_name) {
             $(".emoji-search-results-container").scrollTop(0);
             current_section = 0;
             current_index = 0;
+            reset_emoji_showcase();
             return true;
         }
     } else if (event_name === 'tab') {
@@ -605,6 +633,7 @@ exports.toggle_emoji_popover = function (element, id) {
         elt.addClass("reaction_button_visible");
         emoji_picker.render_emoji_popover(elt, id);
     }
+    reset_emoji_showcase();
 };
 
 exports.register_click_handlers = function () {
@@ -664,6 +693,10 @@ exports.register_click_handlers = function () {
         if (offset) {
             $(".emoji-popover-emoji-map").scrollTop(offset.position_y);
         }
+    });
+
+    $("body").on("click", ".emoji-popover-filter", function () {
+        reset_emoji_showcase();
     });
 };
 

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -330,10 +330,8 @@ function update_emoji_showcase($focused_emoji) {
     // Don't use jQuery's data() function here. It has the side-effect
     // of converting emoji names like :100:, :1234: etc to number.
     var focused_emoji_name = $focused_emoji.attr("data-emoji-name");
-    var focused_emoji_dict = exports.emoji_collection[focused_emoji_name];
-    if (search_is_active) {
-        focused_emoji_dict = search_results[current_index];
-    }
+    var canonical_name = emoji.get_canonical_name(focused_emoji_name);
+    var focused_emoji_dict = exports.emoji_collection[canonical_name];
 
     var emoji_dict = _.extend({}, focused_emoji_dict, {
         name: focused_emoji_name.replace(/_/g, ' '),
@@ -697,6 +695,11 @@ exports.register_click_handlers = function () {
 
     $("body").on("click", ".emoji-popover-filter", function () {
         reset_emoji_showcase();
+    });
+
+    $("body").on("mouseenter", ".emoji-popover-emoji .emoji", function () {
+        var hovered_emoji = $(this).parent();
+        update_emoji_showcase(hovered_emoji);
     });
 };
 

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -132,7 +132,7 @@
 
 .emoji-info-popover {
     padding: 0;
-    height: 326px;
+    height: 370px;
 }
 
 .emoji-info-popover .popover-content {
@@ -262,4 +262,31 @@
 
 .typeahead .emoji {
     top: 2px;
+}
+
+.emoji-showcase-container {
+    position: relative;
+    background-color: #eee;
+    min-height: 44px;
+    width: 250px;
+}
+
+.emoji-preview {
+    position: absolute;
+    width: 32px;
+    height: 32px;
+    left: 5px;
+    top: 6px;
+    margin-top: 0px;
+}
+
+.emoji-canonical-name {
+    position: relative;
+    top: 12px;
+    margin-left: 50px;
+    font-size: 16px;
+    font-weight: 600;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -240,8 +240,6 @@
 
 .emoji-popover-category-tabs {
     background-color: #eee;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
     width: 100%;
     box-sizing: border-box;
     overflow: hidden;

--- a/static/templates/emoji_popover.handlebars
+++ b/static/templates/emoji_popover.handlebars
@@ -3,4 +3,5 @@
     <div class="popover-content">
         <div></div>
     </div>
+    <div class="emoji-showcase-container"></div>
 </div>

--- a/static/templates/emoji_popover.handlebars
+++ b/static/templates/emoji_popover.handlebars
@@ -3,9 +3,4 @@
     <div class="popover-content">
         <div></div>
     </div>
-    <div class="emoji-popover-category-tabs">
-        {{#each categories}}
-        <span class="emoji-popover-tab-item {{#if @first}} active {{/if}}" data-tab-name='{{name}}' title='{{name}}'><i class="fa {{icon}}"></i></span>
-        {{/each}}
-    </div>
 </div>

--- a/static/templates/emoji_popover_content.handlebars
+++ b/static/templates/emoji_popover_content.handlebars
@@ -3,6 +3,11 @@
         <input class="emoji-popover-filter" type="text" autofocus placeholder={{t 'Search' }} />
         <i class="icon-vector-search"></i>
     </div>
+    <div class="emoji-popover-category-tabs">
+        {{#each emoji_categories}}
+        <span class="emoji-popover-tab-item {{#if @first}} active {{/if}}" data-tab-name='{{name}}' title='{{name}}'><i class="fa {{icon}}"></i></span>
+        {{/each}}
+    </div>
     <div class="emoji-popover-emoji-map" data-message-id="{{message_id}}">
         {{#each emoji_categories }}
         <div class="emoji-popover-subheading" data-section="{{name}}">{{name}}</div>

--- a/static/templates/emoji_popover_emoji.handlebars
+++ b/static/templates/emoji_popover_emoji.handlebars
@@ -1,9 +1,9 @@
 {{#with emoji_dict}}
 <div class="emoji-popover-emoji {{# if ../message_id }}{{#if has_reacted}} reacted {{/if}} reaction {{else}} composition {{/if}}" data-emoji-name={{name}} tabindex="0" data-emoji-id="{{../type}}_{{../section}}_{{../index}}">
     {{#if is_realm_emoji}}
-    <img src="{{url}}" class="emoji" title="{{name}}" />
+    <img src="{{url}}" class="emoji"/>
     {{else}}
-    <div class="emoji emoji-{{css_class}}" title="{{name}}"></div>
+    <div class="emoji emoji-{{css_class}}"></div>
     {{/if}}
 </div>
 {{/with}}

--- a/static/templates/emoji_showcase.handlebars
+++ b/static/templates/emoji_showcase.handlebars
@@ -1,0 +1,10 @@
+{{#with emoji_dict}}
+<div class="emoji-showcase">
+    {{#if is_realm_emoji}}
+    <img src="{{url}}" class="emoji emoji-preview"/>
+    {{else}}
+    <div class="emoji emoji-preview emoji-{{css_class}}"></div>
+    {{/if}}
+    <div class="emoji-canonical-name" title="{{name}}">{{name}}</div>
+</div>
+{{/with}}


### PR DESCRIPTION
![anim](https://user-images.githubusercontent.com/16687990/29753937-23b40fa6-8b99-11e7-9bf8-9a8899a1b93f.gif)
This PR is based off of my another PR #6268 which is a per-requisite for this PR. Currently the realm emoji images are not properly aligned, PR #6089 will fix it.
Only issue remaining to fix:
How to properly wrap very long emoji names like `raised_hand_with_splayed_fingers`

![image](https://user-images.githubusercontent.com/16687990/29753978-edf7246a-8b99-11e7-90a0-cbf7b083f0bf.png)

Fixes: #6110 and #6111.