### PR TITLE
subs: Allow for scrolling of stream membership table again.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -197,6 +197,8 @@ function show_subscription_settings(sub_row) {
         },
     }).init();
 
+    ui.set_up_scrollbar($(".subscriber_list_container"));
+
     sub_settings.find('input[name="principal"]').typeahead({
         source: people.get_realm_persons, // This is a function.
         items: 5,

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -291,6 +291,7 @@ form#add_new_subscription {
 }
 
 .subscriber_list_container {
+    position: relative;
     max-height: 300px;
     overflow: auto;
     text-align: left;


### PR DESCRIPTION
This adds perfectScrollbar to the `.subscriber_list_container` to
allow for the table to scroll naturally again. This was broken
because when perfectScrollbar is put on the parent element, any
naturally scrolling element within it will not scroll naturally
anymore.

Fixes: #6215.