### PR TITLE
settings: <tbody> ::after hack no longer required.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1229,12 +1229,8 @@ thead .actions {
     color: hsl(0, 0%, 66%);
 }
 
-/* This is a hack; essentially the issue is that if the ::after element is on
-   a table, then the width of the ::after @ 100% will be the width of the first
-   table column, so we'll just make the ::after 200% to add more space.
-   This is NOT a pattern that should be repeated or built on for other cases. */
 .required-text.thick:empty::after {
-    width: 200%;
+    width: 100%;
 }
 
 #payload_url_inputbox input[type=text] {


### PR DESCRIPTION
The hack used to make the placeholders in the ::after element
work correctly is no longer needed, so we can revert the width
of 200% back to 100%.

The hack is no longer required because Vaida split these into
two tables, of which in the second table there are no columns,
which means that 100% represents the table width rather than
the width of the first column.

Fixes: #6271.