### PR TITLE
/help/: Remove perfectScrollbar.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -1,5 +1,3 @@
-const Ps = require('perfect-scrollbar');
-
 (function () {
     var html_map = {};
     var loading = {
@@ -42,24 +40,7 @@ const Ps = require('perfect-scrollbar');
 
         var container = $(".markdown")[0];
         container.scrollTop = 0;
-        Ps.update(container);
     });
-
-    Ps.initialize($(".markdown")[0], {
-        suppressScrollX: true,
-        useKeyboard: false,
-        wheelSpeed: 0.68,
-    });
-
-    Ps.initialize($(".sidebar")[0], {
-        suppressScrollX: true,
-        useKeyboard: false,
-        wheelSpeed: 0.68,
-    });
-
-    window.onresize = function () {
-        Ps.update($(".markdown")[0]);
-    };
 
     window.addEventListener("popstate", function () {
         var path = window.location.pathname;


### PR DESCRIPTION
This removes perfectScrollbar because it breaks CTRL-F