### PR TITLE
modals: Fix inconsistent modal hiding behaviors.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -160,12 +160,21 @@ exports.is_editing_stream_name = function (e) {
     return $(e.target).is(".editable-section");
 };
 
+exports.is_modal_open = function () {
+    return $(".modal").hasClass("in");
+};
+
 // Returns true if we handled it, false if the browser should.
 exports.process_escape_key = function (e) {
     var row;
 
     if (exports.is_editing_stream_name(e)) {
         return false;
+    }
+
+    if (exports.is_modal_open()) {
+        $(".modal").modal("hide").attr("aria-hidden", false);
+        return true;
     }
 
     if (overlays.is_active()) {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -149,7 +149,7 @@ exports.set_up = function () {
     $('#change_email_button').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        $('#change_email_modal').modal('hide');
+        $('#change_email_modal').modal('hide').attr('aria-hidden', true);
 
         var data = {};
         data.email = $('.email_change_container').find("input[name='email']").val();
@@ -173,7 +173,7 @@ exports.set_up = function () {
     $('#change_email').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        $('#change_email_modal').modal('show');
+        $('#change_email_modal').modal('show').attr('aria-hidden', false);
         var email = $('#email_value').text().trim();
         $('.email_change_container').find("input[name='email']").val(email);
     });

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -9,15 +9,13 @@ exports.set_up = function () {
     $("#emojiset_select").val(page_params.emojiset);
 
     $("#default_language_modal [data-dismiss]").click(function () {
-      $('#default_language_modal').attr('aria-hidden', true);
-      $("#default_language_modal").fadeOut(300);
+      $("#default_language_modal").modal("hide").attr('aria-hidden', true);
     });
 
     $("#default_language_modal .language").click(function (e) {
         e.preventDefault();
         e.stopPropagation();
-        $('#default_language_modal').show().attr('aria-hidden', true);
-        $('#default_language_modal').fadeOut(300);
+        $("#default_language_modal").modal("hide").attr('aria-hidden', true);
 
         var data = {};
         var $link = $(e.target).closest("a[data-code]");
@@ -46,7 +44,7 @@ exports.set_up = function () {
     $('#default_language').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        $('#default_language_modal').show().attr('aria-hidden', false);
+        $("#default_language_modal").modal("show").attr('aria-hidden', false);
     });
 
     $("#high_contrast_mode").change(function () {


### PR DESCRIPTION
### First commit

Fixes the inconsistency in the change email & default language modals that used different methods to show/hide them. Both were normalized to use the `.modal()` method and change `aria-hidden` attribute on change in state.

### Second commit 

Merged! Previous content:

```md
Fixes the inconsistent and broken behavior in closing modals with the Esc hotkey. Following two GIFs show behavior of the change email & default language modals (respectively) before changes made in the commit:

[![](https://i.gyazo.com/163544eed7f94c00b908f2a92b32517e.gif)](https://gyazo.com/163544eed7f94c00b908f2a92b32517e)

[![](https://i.gyazo.com/07a7f8848b08c359534b66742bc9ef34.gif)](https://gyazo.com/07a7f8848b08c359534b66742bc9ef34)
```

## Results

Current behavior of closing modals with Esc hotkey for change email & default language modals (respectively)

[![](https://i.gyazo.com/905de0cd2c80a3f86eda6a431b2bca29.gif)](https://gyazo.com/905de0cd2c80a3f86eda6a431b2bca29)

[![](https://i.gyazo.com/e9d0e332ac77ab2fb5dcd617f45f145c.gif)](https://gyazo.com/e9d0e332ac77ab2fb5dcd617f45f145c)

---

~~Fixes #4811~~ Fixed!

Possibly fixes #3791 and should close its accompanying PR #3794