### PR TITLE
outgoing webhooks: Notify bot owner on failure response.

### DIFF
--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -6,8 +6,8 @@ from zerver.models import Realm, Stream, UserProfile, Huddle, \
     Subscription, Recipient, Client, RealmAuditLog, get_huddle_hash
 from zerver.lib.create_user import create_user_profile
 
-def bulk_create_users(realm, users_raw, bot_type=None, tos_version=None, timezone=u""):
-    # type: (Realm, Set[Tuple[Text, Text, Text, bool]], Optional[int], Optional[Text], Text) -> None
+def bulk_create_users(realm, users_raw, bot_type=None, bot_owner=None, tos_version=None, timezone=u""):
+    # type: (Realm, Set[Tuple[Text, Text, Text, bool]], Optional[int], Optional[UserProfile], Optional[Text], Text) -> None
     """
     Creates and saves a UserProfile with the given email.
     Has some code based off of UserManage.create_user, but doesn't .save()
@@ -20,7 +20,7 @@ def bulk_create_users(realm, users_raw, bot_type=None, tos_version=None, timezon
     for (email, full_name, short_name, active) in users:
         profile = create_user_profile(realm, email,
                                       initial_password(email), active, bot_type,
-                                      full_name, short_name, None, False, tos_version,
+                                      full_name, short_name, bot_owner, False, tos_version,
                                       timezone, tutorial_status=UserProfile.TUTORIAL_FINISHED,
                                       enter_sends=True)
         profiles_to_create.append(profile)

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -227,6 +227,7 @@ class ZulipTestCase(TestCase):
         aaron=u'aaron@zulip.com',
         ZOE=u'ZOE@zulip.com',
         webhook_bot=u'webhook-bot@zulip.com',
+        outgoing_webhook_bot=u'outgoing-webhook@zulip.com'
     )
 
     mit_user_map = dict(

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import logging
 import mock
 import requests
 from typing import Any, Dict, Tuple, Text, Optional
@@ -21,11 +22,11 @@ class ResponseMock(object):
 
 def request_exception_error(http_method, final_url, data, **request_kwargs):
     # type: (Any, Any, Any, **Any) -> Any
-    raise requests.exceptions.RequestException
+    raise requests.exceptions.RequestException("I'm a generic exception :(")
 
 def timeout_error(http_method, final_url, data, **request_kwargs):
     # type: (Any, Any, Any, **Any) -> Any
-    raise requests.exceptions.Timeout
+    raise requests.exceptions.Timeout()
 
 class MockServiceHandler(OutgoingWebhookServiceInterface):
     def process_success(self, response, event):
@@ -39,17 +40,25 @@ class DoRestCallTests(ZulipTestCase):
         # type: () -> None
         realm = get_realm("zulip")
         user_profile = get_user("outgoing-webhook@zulip.com", realm)
-        self.mock_event = {'message': {'display_recipient': '',
-                                       'subject': '',
-                                       'id': ''},
-                           'user_profile_id': user_profile.id,
-                           'command': '',
-                           'service_name': ''}
+        self.mock_event = {
+            # In the tests there is no active queue processor, so retries don't get processed.
+            # Therefore, we need to emulate `retry_event` in the last stage when the maximum
+            # retries have been exceeded.
+            'failed_tries': 3,
+            'message': {'display_recipient': 'Verona',
+                        'subject': 'Foo',
+                        'id': '',
+                        'type': 'stream'},
+            'user_profile_id': user_profile.id,
+            'command': '',
+            'service_name': ''}
 
         self.rest_operation = {'method': "POST",
                                'relative_url_path': "",
                                'request_kwargs': {},
                                'base_url': ""}
+        self.bot_user = self.example_user('outgoing_webhook_bot')
+        logging.disable(logging.WARNING)
 
     @mock.patch('zerver.lib.outgoing_webhook.succeed_with_message')
     def test_successful_request(self, mock_succeed_with_message):
@@ -59,13 +68,18 @@ class DoRestCallTests(ZulipTestCase):
             do_rest_call(self.rest_operation, None, self.mock_event, service_handler, None)
             self.assertTrue(mock_succeed_with_message.called)
 
-    @mock.patch('zerver.lib.outgoing_webhook.request_retry')
-    def test_retry_request(self, mock_request_retry):
+    def test_retry_request(self):
         # type: (mock.Mock) -> None
         response = ResponseMock(500, {"message": "testing"}, '')
+
+        self.mock_event['failed_tries'] = 3
         with mock.patch('requests.request', return_value=response):
             do_rest_call(self.rest_operation, None, self.mock_event, service_handler, None)
-            self.assertTrue(mock_request_retry.called)
+            bot_owner_notification = self.get_last_message()
+            self.assertEqual(bot_owner_notification.content,
+                             "[A message](http://testserver/#narrow/stream/Verona/subject/Foo/near/) triggered an outgoing webhook.")
+            self.assertEqual(bot_owner_notification.recipient_id, self.bot_user.bot_owner.id)
+        self.mock_event['failed_tries'] = 0
 
     @mock.patch('zerver.lib.outgoing_webhook.fail_with_message')
     def test_fail_request(self, mock_fail_with_message):
@@ -73,15 +87,22 @@ class DoRestCallTests(ZulipTestCase):
         response = ResponseMock(400, {"message": "testing"}, '')
         with mock.patch('requests.request', return_value=response):
             do_rest_call(self.rest_operation, None, self.mock_event, service_handler, None)
+            bot_owner_notification = self.get_last_message()
             self.assertTrue(mock_fail_with_message.called)
+            self.assertEqual(bot_owner_notification.content,
+                             '''[A message](http://testserver/#narrow/stream/Verona/subject/Foo/near/) triggered an outgoing webhook.
+The webhook got a response with status code *400*.''')
+            self.assertEqual(bot_owner_notification.recipient_id, self.bot_user.bot_owner.id)
 
     @mock.patch('logging.info')
     @mock.patch('requests.request', side_effect=timeout_error)
-    @mock.patch('zerver.lib.outgoing_webhook.request_retry')
-    def test_timeout_request(self, mock_request_retry, mock_requests_request, mock_logger):
+    def test_timeout_request(self, mock_requests_request, mock_logger):
         # type: (mock.Mock, mock.Mock, mock.Mock) -> None
         do_rest_call(self.rest_operation, None, self.mock_event, service_handler, None)
-        self.assertTrue(mock_request_retry.called)
+        bot_owner_notification = self.get_last_message()
+        self.assertEqual(bot_owner_notification.content,
+                         '''[A message](http://testserver/#narrow/stream/Verona/subject/Foo/near/) triggered an outgoing webhook.''')
+        self.assertEqual(bot_owner_notification.recipient_id, self.bot_user.bot_owner.id)
 
     @mock.patch('logging.exception')
     @mock.patch('requests.request', side_effect=request_exception_error)
@@ -89,4 +110,12 @@ class DoRestCallTests(ZulipTestCase):
     def test_request_exception(self, mock_fail_with_message, mock_requests_request, mock_logger):
         # type: (mock.Mock, mock.Mock, mock.Mock) -> None
         do_rest_call(self.rest_operation, None, self.mock_event, service_handler, None)
+        bot_owner_notification = self.get_last_message()
         self.assertTrue(mock_fail_with_message.called)
+        self.assertEqual(bot_owner_notification.content,
+                         '''[A message](http://testserver/#narrow/stream/Verona/subject/Foo/near/) triggered an outgoing webhook.
+When trying to send a request to the webhook service, an exception of type RequestException occured:
+```
+I'm a generic exception :(
+```''')
+        self.assertEqual(bot_owner_notification.recipient_id, self.bot_user.bot_owner.id)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -25,7 +25,7 @@ import os
 import ujson
 import itertools
 from six.moves import range
-from typing import Any, Callable, Dict, List, Iterable, Mapping, Sequence, Set, Tuple, Text
+from typing import Any, Callable, Dict, List, Iterable, Mapping, Optional, Sequence, Set, Tuple, Text
 
 settings.TORNADO_SERVER = None
 # Disable using memcached caches to avoid 'unsupported pickle
@@ -35,14 +35,14 @@ settings.CACHES['default'] = {
     'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
 }
 
-def create_users(realm, name_list, bot_type=None):
-    # type: (Realm, Iterable[Tuple[Text, Text]], int) -> None
+def create_users(realm, name_list, bot_type=None, bot_owner=None):
+    # type: (Realm, Iterable[Tuple[Text, Text]], Optional[int], Optional[UserProfile]) -> None
     user_set = set()  # type: Set[Tuple[Text, Text, Text, bool]]
     for full_name, email in name_list:
         short_name = email_to_username(email)
         user_set.add((email, full_name, short_name, True))
     tos_version = settings.TOS_VERSION if bot_type is None else None
-    bulk_create_users(realm, user_set, bot_type=bot_type, tos_version=tos_version)
+    bulk_create_users(realm, user_set, bot_type=bot_type, bot_owner=bot_owner, tos_version=tos_version)
 
 class Command(BaseCommand):
     help = "Populate a test database"
@@ -294,8 +294,9 @@ class Command(BaseCommand):
             zulip_outgoing_bots = [
                 ("Outgoing Webhook", "outgoing-webhook@zulip.com")
             ]
+            aaron = get_user("AARON@zulip.com", zulip_realm)
             create_users(zulip_realm, zulip_outgoing_bots,
-                         bot_type=UserProfile.OUTGOING_WEBHOOK_BOT)
+                         bot_type=UserProfile.OUTGOING_WEBHOOK_BOT, bot_owner=aaron)
             # TODO: Clean up this initial bot creation code
             Service.objects.create(
                 name="test",


### PR DESCRIPTION
This addresses my comment on https://github.com/zulip/python-zulip-api/pull/99; such a logging would have made debugging my case much easier, since the response's content is printed as well :)

As said in #6145, this also logs a link to the message triggering the webhook.