### PR TITLE
Confirm continue register cleanup

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -135,6 +135,10 @@ html {
     font-weight: 400;
 }
 
+.app-main.confirm-continue-page-container .white-box {
+    min-width: 365px;
+}
+
 .app-main.confirm-continue-page-container .form-inline {
     display: inline-block;
     width: 180px;

--- a/templates/zerver/confirm_continue_registration.html
+++ b/templates/zerver/confirm_continue_registration.html
@@ -6,54 +6,55 @@
         <div class="center-container">
             <div class="center-block">
                 <div class="register-form new-style">
-                    <p class="lead">
-                        <div class="register-page-header">{{ _("Zulip account not found.") }}</div>
-                    </p>
-                    <br />
+                    <div class="lead">
+                        <h1 class="get-started">{{ _("Zulip account not found.") }}</h1>
+                    </div>
+                    <div class="white-box">
                     {% if invalid_email %}
                     {# If the email address is invalid, we can't send the user #}
                     {# to the preregistered user code path. #}
-                    <p>
-                        {% trans %}
-                        Please click the following button if you wish to register.
-                        {% endtrans %}
-                    </p>
-                    <a href='/register/' class="button-new sea-green">Register</a>
-                    {% else %}
-                    <p>
-                        {% trans %}
+                        <p>
+                            {% trans %}
+                            Please click the following button if you wish to register.
+                            {% endtrans %}
+                        </p>
+                        <a href='/register/' class="button-new sea-green">Register</a>
+                        {% else %}
+                        <p>
+                            {% trans %}
 
-                        No account found for {{ email }}. Would you like to register instead?
+                            No account found for {{ email }}. Would you like to register instead?
 
-                        {% endtrans %}
-                    </p>
-                    <div style="text-align: left;">
-                        <form class="form-inline" id="send_confirm" name="send_confirm"
-                            action="/login/" method="get">
-                            <input type="hidden"
-                                   id="email"
-                                   name="email"
-                                   value="{{ email }}" />
-                            <button>
-                                {{ _("Go back to login") }}
-                            </button>
-                        </form>
-                        {# TODO: Ideally, this should use whatever auth #}
-                        {# method the user had used to get here, not just #}
-                        {# send an email. #}
-                        <form class="form-inline" id="send_confirm" name="send_confirm"
-                            action="/register/" method="post">
-                            {{ csrf_input }}
-                            <input type="hidden"
-                                   id="email"
-                                   name="email"
-                                   value="{{ email }}" />
-                            <button class="outline">
-                                {{ _("Register instead") }}
-                            </button>
-                        </form>
+                            {% endtrans %}
+                        </p>
+                        <div style="text-align: left;">
+                            <form class="form-inline" id="send_confirm" name="send_confirm"
+                                action="/login/" method="get">
+                                <input type="hidden"
+                                       id="email"
+                                       name="email"
+                                       value="{{ email }}" />
+                                <button>
+                                    {{ _("Go back to login") }}
+                                </button>
+                            </form>
+                            {# TODO: Ideally, this should use whatever auth #}
+                            {# method the user had used to get here, not just #}
+                            {# send an email. #}
+                            <form class="form-inline" id="send_confirm" name="send_confirm"
+                                action="/register/" method="post">
+                                {{ csrf_input }}
+                                <input type="hidden"
+                                       id="email"
+                                       name="email"
+                                       value="{{ email }}" />
+                                <button class="outline">
+                                    {{ _("Register instead") }}
+                                </button>
+                            </form>
+                        </div>
+                        {% endif %}
                     </div>
-                    {% endif %}
                 </div>
             </div>
         </div>

--- a/templates/zerver/github-error.md
+++ b/templates/zerver/github-error.md
@@ -8,3 +8,5 @@ in the OAuth application in GitHub. You can create OAuth apps from
 * You have set `SOCIAL_AUTH_GITHUB_KEY` in `{{ settings_path }}` and
 `social_auth_github_secret` in `{{ secrets_path }}` with the values
 from your OAuth application.
+
+* Navigate back to the login page and attempt the GitHub auth flow again.

--- a/templates/zerver/google-error.md
+++ b/templates/zerver/google-error.md
@@ -9,3 +9,5 @@ server's Google auth URL: `{{ server_uri }}/accounts/login/google/done/`.
 
 * You have set `GOOGLE_OAUTH2_CLIENT_ID` in `{{ settings_path }}` and
 `google_oauth2_client_secret` in `{{ secrets_path }}`.
+
+* Navigate back to the login page and attempt the Google auth flow again.


### PR DESCRIPTION
This cleans up the styling of the page by adding the white box
around the text content, and by making the header the same
`.get-started` class as other headers in the portico-signup group.