### PR TITLE
settings: Make col-width consistent between tables.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -146,6 +146,10 @@ label {
     vertical-align: middle;
 }
 
+#settings_content table + .progressive-table-wrapper table tr td:first-of-type {
+    width: 20%;
+}
+
 td .button {
     margin: 2px 0px;
     box-shadow: none;


### PR DESCRIPTION
This makes the column width consistent between tables in the
organization users section by making the "Name" section 20%.