### PR TITLE
footer: Responsively remove extra space and compact footer.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -4,11 +4,11 @@ html {
 
 .flex {
     display: flex;
-    padding: 100px 0px;
+    padding: 80px 0px;
     align-items: center;
     justify-content: center;
 
-    min-height: calc(100vh - 495px);
+    min-height: calc(100vh - 407px);
 }
 
 .m-10 {
@@ -761,6 +761,11 @@ button.login-google-button {
     }
 }
 
+@media (max-width: 815px) {
+    .flex {
+        min-height: calc(100vh - 530px);
+    }
+}
 
 @media (max-width: 795px) {
     .register-account #registration {
@@ -853,5 +858,16 @@ button.login-google-button {
 
     .account-creation {
         font-weight: 400;
+    }
+
+    .flex {
+        /* the header becomes smaller, so comp for that. */
+        min-height: calc(100vh - 505px);
+    }
+}
+
+@media (max-width: 400px) {
+    .flex {
+        min-height: calc(100vh - 560px);
     }
 }

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -471,6 +471,9 @@ input.text-error {
     text-transform: uppercase;
     font-size: 1em;
     font-weight: 600;
+    line-height: 1.2;
+
+    margin-bottom: 5px;
 }
 
 .footer section ul {
@@ -1480,15 +1483,6 @@ input.new-organization-button {
         padding: 0;
     }
 
-    .footer {
-        width: 100%;
-    }
-
-    .footer section {
-        margin: 0px 3px;
-        width: calc(50% - 8px);
-    }
-
     .app-main,
     .header-main,
     .footer-main {
@@ -1535,9 +1529,22 @@ input.new-organization-button {
 
 }
 
-@media (max-width: 350px) {
+@media (max-width: 475px) {
+    .footer {
+        width: auto;
+    }
+
     .footer section {
-        width: calc(100% - 20px);
+        margin: 0px 3px;
+        width: calc(50% - 8px);
+    }
+}
+
+@media (max-width: 400px) {
+    .footer section {
+        width: calc(100% - 40px);
+        max-width: none;
+        text-align: center;
     }
 }
 

--- a/templates/zerver/privacy.html
+++ b/templates/zerver/privacy.html
@@ -4,8 +4,8 @@
 
 {% block portico_content %}
 
-<div class="app terms-page inline-block">
-    <div class="app-main terms-page-container">
+<div class="app terms-page flex">
+    <div class="app-main terms-page-container white-box">
 
         {% if privacy_policy %}
             {{ render_markdown_path(privacy_policy) }}

--- a/templates/zerver/terms.html
+++ b/templates/zerver/terms.html
@@ -4,8 +4,8 @@
 
 {% block portico_content %}
 
-<div class="app terms-page inline-block">
-    <div class="app-main terms-page-container">
+<div class="app terms-page flex">
+    <div class="app-main terms-page-container white-box">
         {% if terms_of_service %}
             {{ render_markdown_path(terms_of_service) }}
         {% else %}


### PR DESCRIPTION
This adds the white box around the empty terms and privacy page
statements along with putting them in the flex center box.