### PR TITLE
/integrations/: Fix sidebar overflowing parent container.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -1990,7 +1990,7 @@ nav ul li.active::after {
     position: sticky;
     top: 40px;
     margin: auto;
-    height: 426px;
+    height: 490px;
     z-index: 10;
 }
 


### PR DESCRIPTION
The sidebar height was set to shorter than what the sidebar actually
was and so it would overflow the parent. By resetting it, it now
will not overflow.

Fixes: #6315.