### PR TITLE
settings UI: Make disabled checkboxes darker.

### DIFF
--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -288,7 +288,7 @@
 }
 
 .new-style label.checkbox input[type=checkbox]:disabled ~ span {
-    opacity: 0.3;
+    opacity: 0.5;
 }
 
 .new-style input[type=text] {


### PR DESCRIPTION
Before:
![screenshot at aug 28 17-39-26](https://user-images.githubusercontent.com/15116870/29799341-df976b22-8c17-11e7-996d-191e2610a922.png)

After:
![screenshot at aug 28 17-39-06](https://user-images.githubusercontent.com/15116870/29799347-e45c90ec-8c17-11e7-83e9-ab35f0a33540.png)

For reference to see if there's enough contrast between enabled/disabled states, here's a picture of enabled checkboxes:
![screenshot at aug 28 17-40-54](https://user-images.githubusercontent.com/15116870/29799389-213fc3e4-8c18-11e7-9e3a-5fef98684161.png)


Fixes #6331