### PR TITLE
message view: Set mininum height for embedded tweets.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2366,6 +2366,7 @@ button.topic_edit_cancel {
     padding: .5em .75em;
     margin-bottom: 0.25em;
     word-break: break-word;
+    min-height: 48px;
 }
 
 .twitter-avatar {


### PR DESCRIPTION
Before: (note bottom overlap)
![screenshot at aug 28 17-37-29](https://user-images.githubusercontent.com/15116870/29799290-9851b402-8c17-11e7-8d12-33ef70b9edcb.png)

After:
![screenshot at aug 28 17-37-09](https://user-images.githubusercontent.com/15116870/29799299-a27fd544-8c17-11e7-9e09-518dfb736ef8.png)

Fixes #5973