### PR TITLE
portico-signin.css: Left-justify moving label.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -336,8 +336,7 @@ html {
 .new-style .input-box.moving-label input[type=text]:invalid + label,
 .new-style .input-box.moving-label input[type=email]:invalid + label,
 .new-style .input-box.moving-label input[type=password]:invalid + label {
-    left: 50%;
-    transform: translateY(35px) translateX(-50%);
+    transform: translateY(35px) translateX(14px);
     font-size: 1.2rem;
     font-weight: 400;
     color: hsl(0, 0%, 66%);


### PR DESCRIPTION
The moving label is acting like a placeholder here, and should be positioned
as such for consistency with the rest of the site. The two forms with a
moving label are /accounts/find/ and /accounts/password/reset.

Before:
![image](https://user-images.githubusercontent.com/890911/29799726-a00cabae-8c1a-11e7-9bcb-666814e20de1.png)

After:
![image](https://user-images.githubusercontent.com/890911/29799723-91809c58-8c1a-11e7-8a4c-65f4db0805a9.png)
