### PR TITLE
accounts-settings: Reassure user if they do not have a password for API key.

### DIFF
--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -158,7 +158,7 @@
         </div>
         <div id="get_api_key_box">
             <p>{{t "Please re-enter your password to confirm your identity." }}
-              <a href="/accounts/password/reset/" target="_blank">{{t "Forgotten it?" }}</a></p>
+              <a href="/accounts/password/reset/" target="_blank">{{t "Never had one? Forgotten it?" }}</a></p>
             <form action="/json/fetch_api_key" method="post" class="form-horizontal">
                 <div class="control-group">
                     <label for="password" class="control-label">{{t "Current password" }}</label>

--- a/templates/zerver/emails/password_reset.html
+++ b/templates/zerver/emails/password_reset.html
@@ -5,7 +5,7 @@
     {% if attempted_realm %}
     Someone (possibly you) requested a password reset email for {{ email }} on {{ attempted_realm.uri }}, but {{ email }} does not have an active account in {{ attempted_realm.uri }}.  However, {{ email }} does have an active account in {{ user.realm.uri }} organization; you can try logging in or resetting your password there.
     {% else %}
-    Psst. Word on the street is that you forgot your password, {{ email }}.<br />
+    Psst. Word on the street is that you need a new password, {{ email }}.<br />
     It's all good. Follow the link below and we'll take care of the rest:<br />
     {{ protocol }}://{{ user.realm.host }}{{ url('django.contrib.auth.views.password_reset_confirm', kwargs=dict(uidb64=uid, token=token)) }}
     {% endif %}

--- a/templates/zerver/emails/password_reset.txt
+++ b/templates/zerver/emails/password_reset.txt
@@ -5,7 +5,7 @@ have an active account in {{ attempted_realm.uri }}.  However, {{ email }} does
 have an active account in {{ user.realm.uri }} organization; you
 can try logging in or resetting your password there.
 {% else %}
-Psst. Word on the street is that you forgot your password, {{ email }}.
+Psst. Word on the street is that you need a new password, {{ email }}.
 
 It's all good. Follow the link below and we'll take care of the rest:
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -256,7 +256,7 @@ class PasswordResetTest(ZulipTestCase):
         message = outbox.pop()
         self.assertIn("Zulip Account Security", message.from_email)
         self.assertIn(FromAddress.NOREPLY, message.from_email)
-        self.assertIn("Psst. Word on the street is that you forgot your password,",
+        self.assertIn("Psst. Word on the street is that you",
                       message.body)
 
     def test_redirect_endpoints(self):


### PR DESCRIPTION
Unrelatedly, these "forgot your password" links should just send you an email, rather then sending you to accounts/password/reset, right? I don't see an issue open for it.