### PR TITLE
modals: Create and implement modal methods to manage showing/hiding modals.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -160,10 +160,6 @@ exports.is_editing_stream_name = function (e) {
     return $(e.target).is(".editable-section");
 };
 
-exports.is_modal_open = function () {
-    return $(".modal").hasClass("in");
-};
-
 // Returns true if we handled it, false if the browser should.
 exports.process_escape_key = function (e) {
     var row;
@@ -172,8 +168,8 @@ exports.process_escape_key = function (e) {
         return false;
     }
 
-    if (exports.is_modal_open()) {
-        $(".modal").modal("hide").attr("aria-hidden", false);
+    if (overlays.is_modal_open()) {
+        overlays.close_active_modal();
         return true;
     }
 

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -16,6 +16,10 @@ exports.is_active = function () {
     return !!open_overlay_name;
 };
 
+exports.is_modal_open = function () {
+    return $(".modal").hasClass("in");
+};
+
 exports.info_overlay_open = function () {
     return open_overlay_name === 'informationalOverlays';
 };
@@ -30,6 +34,14 @@ exports.streams_open = function () {
 
 exports.lightbox_open = function () {
     return open_overlay_name === 'lightbox';
+};
+
+exports.active_modal = function () {
+    if (!exports.is_modal_open()) {
+        blueslip.error("Programming error — Called open_modal when there is no modal open");
+        return;
+    }
+    return $(".modal.in").attr("id");
 };
 
 exports.open_overlay = function (opts) {
@@ -69,6 +81,23 @@ exports.open_overlay = function (opts) {
     };
 };
 
+exports.open_modal = function (name) {
+    if (name === undefined) {
+        blueslip.error('Undefined name was passed into open_modal');
+        return;
+    }
+
+    if (exports.is_modal_open()) {
+        blueslip.error('open_modal() was called while ' + exports.active_modal() +
+            ' modal was open.');
+        return;
+    }
+
+    blueslip.debug('open modal: ' + name);
+
+    $("#" + name).modal("show").attr("aria-hidden", false);
+};
+
 exports.close_overlay = function (name) {
     if (name !== open_overlay_name) {
         blueslip.error("Trying to close " + name + " when " + open_overlay_name + " is open." );
@@ -104,6 +133,37 @@ exports.close_active = function () {
     }
 
     exports.close_overlay(open_overlay_name);
+};
+
+exports.close_modal = function (name) {
+    if (name === undefined) {
+        blueslip.error('Undefined name was passed into close_modal');
+        return;
+    }
+
+    if (!exports.is_modal_open()) {
+        blueslip.warn('close_active_modal() called without checking is_modal_open()');
+        return;
+    }
+
+    if (exports.active_modal() !== name) {
+        blueslip.error("Trying to close " + name +
+            " modal when " + exports.active_modal() + " is open." );
+        return;
+    }
+
+    blueslip.debug('close modal: ' + name);
+
+    $("#" + name).modal("hide").attr("aria-hidden", true);
+};
+
+exports.close_active_modal = function () {
+    if (!exports.is_modal_open()) {
+        blueslip.warn('close_active_modal() called without checking is_modal_open()');
+        return;
+    }
+
+    $(".modal.in").modal("hide").attr("aria-hidden", true);
 };
 
 exports.close_for_hash_change = function () {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -42,6 +42,15 @@ $("body").ready(function () {
     });
 
     $("body").on("click", "[data-sidebar-form-close]", close_sidebar);
+
+    $("#settings_overlay_container").click(function (e) {
+        if (!overlays.is_modal_open()) {
+            return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        overlays.close_active_modal();
+    });
 });
 
 

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -149,7 +149,7 @@ exports.set_up = function () {
     $('#change_email_button').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        $('#change_email_modal').modal('hide');
+        overlays.close_modal('change_email_modal');
 
         var data = {};
         data.email = $('.email_change_container').find("input[name='email']").val();
@@ -173,7 +173,7 @@ exports.set_up = function () {
     $('#change_email').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        $('#change_email_modal').modal('show');
+        overlays.open_modal('change_email_modal');
         var email = $('#email_value').text().trim();
         $('.email_change_container').find("input[name='email']").val(email);
     });

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -9,15 +9,13 @@ exports.set_up = function () {
     $("#emojiset_select").val(page_params.emojiset);
 
     $("#default_language_modal [data-dismiss]").click(function () {
-      $('#default_language_modal').attr('aria-hidden', true);
-      $("#default_language_modal").fadeOut(300);
+        overlays.close_modal('default_language_modal');
     });
 
     $("#default_language_modal .language").click(function (e) {
         e.preventDefault();
         e.stopPropagation();
-        $('#default_language_modal').show().attr('aria-hidden', true);
-        $('#default_language_modal').fadeOut(300);
+        overlays.close_modal('default_language_modal');
 
         var data = {};
         var $link = $(e.target).closest("a[data-code]");
@@ -46,7 +44,7 @@ exports.set_up = function () {
     $('#default_language').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        $('#default_language_modal').show().attr('aria-hidden', false);
+        overlays.open_modal('default_language_modal');
     });
 
     $("#high_contrast_mode").change(function () {


### PR DESCRIPTION
### First & second commits
Implement several modal methods in `overlays.js` to manage showing/hiding modals.

Continuing #6306

### Third commit

Utilize new modal methods to prevent backdrop leaks when clicking outside of modal area while overlay is open.

Fixes #3791 and closes #3794

---

### Testing

1. Open console to check for errors/debug messages while testing.
2. Open the settings page, and open the Change email modal on Your Account page.
3. Close the modal with Escape key. Only the Change email modal should disappear.
4. Open the modal again and click on an area outside the modal (gray area, modal in background, etc.) to close the Change email modal.
5. Repeat steps for Default language modal (Display settings) and any other modals encountered.