### PR TITLE
Prep muting code for migrations.

### DIFF
--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -9,6 +9,11 @@ function timestamp_ms() {
 var last_topic_update = 0;
 
 exports.rerender = function () {
+    // Note: We tend to optimistically rerender muting preferences before
+    // the back end actually acknowledges the mute.  This gives a more
+    // immediate feel to the user, and if the back end fails temporarily,
+    // re-doing a mute or unmute is a pretty recoverable thing.
+
     stream_list.update_streams_sidebar();
     current_msg_list.rerender_after_muting_changes();
     if (current_msg_list !== home_msg_list) {
@@ -92,17 +97,28 @@ exports.dismiss_mute_confirmation = function () {
     }
 };
 
-exports.persist_and_rerender = function () {
-    // Optimistically rerender our new muting preferences.  The back
-    // end should eventually save it, and if it doesn't, it's a recoverable
-    // error--the user can just mute the topic again, and the topic might
-    // die down before the next reload anyway, making the muting moot.
-    exports.rerender();
+exports.persist_mute = function (stream_name, topic_name) {
     var data = {
-        muted_topics: JSON.stringify(muting.get_muted_topics()),
+        stream: stream_name,
+        topic: topic_name,
+        op: 'add',
     };
     last_topic_update = timestamp_ms();
-    channel.post({
+    channel.patch({
+        url: '/json/users/me/subscriptions/muted_topics',
+        idempotent: true,
+        data: data,
+    });
+};
+
+exports.persist_unmute = function (stream_name, topic_name) {
+    var data = {
+        stream: stream_name,
+        topic: topic_name,
+        op: 'remove',
+    };
+    last_topic_update = timestamp_ms();
+    channel.patch({
         url: '/json/users/me/subscriptions/muted_topics',
         idempotent: true,
         data: data,
@@ -148,7 +164,8 @@ exports.set_up_muted_topics_ui = function (muted_topics) {
 exports.mute = function (stream, topic) {
     stream_popover.hide_topic_popover();
     exports.mute_topic(stream, topic);
-    exports.persist_and_rerender();
+    exports.rerender();
+    exports.persist_mute(stream, topic);
     exports.notify_with_undo_option(stream, topic);
     exports.set_up_muted_topics_ui(muting.get_muted_topics());
 };
@@ -159,7 +176,8 @@ exports.unmute = function (stream, topic) {
     // and miss out on info.
     stream_popover.hide_topic_popover();
     exports.unmute_topic(stream, topic);
-    exports.persist_and_rerender();
+    exports.rerender();
+    exports.persist_unmute(stream, topic);
     exports.set_up_muted_topics_ui(muting.get_muted_topics());
     exports.dismiss_mute_confirmation();
 };

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -38,7 +38,6 @@ from zerver.lib.retention import move_message_to_archive
 from zerver.lib.send_email import send_email, FromAddress
 from zerver.lib.topic_mutes import (
     get_topic_mutes,
-    set_topic_mutes,
     add_topic_mute,
     remove_topic_mute,
 )
@@ -3309,12 +3308,6 @@ def do_set_alert_words(user_profile, alert_words):
     # type: (UserProfile, List[Text]) -> None
     set_user_alert_words(user_profile, alert_words)
     notify_alert_words(user_profile, alert_words)
-
-def do_set_muted_topics(user_profile, muted_topics):
-    # type: (UserProfile, List[List[Text]]) -> None
-    set_topic_mutes(user_profile, muted_topics)
-    event = dict(type="muted_topics", muted_topics=get_topic_mutes(user_profile))
-    send_event(event, [user_profile.id])
 
 def do_update_muted_topic(user_profile, stream, topic, op):
     # type: (UserProfile, str, str, str) -> None

--- a/zerver/lib/topic_mutes.py
+++ b/zerver/lib/topic_mutes.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import
 from zerver.models import UserProfile
 
-from typing import List, Text
+from typing import Callable, List, Text
 
 from zerver.models import (
     bulk_get_recipients,
     bulk_get_streams,
     Recipient,
+    Stream,
     UserProfile
 )
 from sqlalchemy.sql import (
@@ -95,3 +96,35 @@ def exclude_topic_mutes(conditions, user_profile, stream_name):
 
     condition = not_(or_(*list(map(mute_cond, muted_topics))))
     return conditions + [condition]
+
+def build_topic_mute_checker(user_profile):
+    # type: (UserProfile) -> Callable[[int, Text], bool]
+    rows = ujson.loads(user_profile.muted_topics)
+    stream_names = {row[0] for row in rows}
+    stream_dict = dict()
+    for name in stream_names:
+        try:
+            stream_id = Stream.objects.get(
+                name__iexact=name.strip(),
+                realm_id=user_profile.realm_id,
+            ).id
+            stream_dict[name.lower()] = stream_id
+        except Stream.DoesNotExist:
+            # If the stream doesn't exist, this is just a stale entry
+            # in the muted_topics structure.
+            continue
+    tups = set()
+    for row in rows:
+        stream_name = row[0].lower()
+        topic = row[1]
+        if stream_name not in stream_dict:
+            # No such stream
+            continue
+        stream_id = stream_dict[stream_name]
+        tups.add((stream_id, topic.lower()))
+
+    def is_muted(stream_id, topic):
+        # type: (int, Text) -> bool
+        return (stream_id, topic.lower()) in tups
+
+    return is_muted

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -54,7 +54,6 @@ from zerver.lib.actions import (
     do_remove_realm_emoji,
     do_remove_realm_filter,
     do_rename_stream,
-    do_set_muted_topics,
     do_set_realm_authentication_methods,
     do_set_realm_message_editing,
     do_set_realm_property,
@@ -858,10 +857,6 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('muted_topics')),
             ('muted_topics', check_list(check_list(check_string, 2))),
         ])
-        events = self.do_test(lambda: do_set_muted_topics(self.user_profile, [[u"Denmark", u"topic"]]))
-        error = muted_topics_checker('events[0]', events[0])
-        self.assert_on_error(error)
-
         events = self.do_test(lambda: do_update_muted_topic(
             self.user_profile, "Denmark", "topic", "add"))
         error = muted_topics_checker('events[0]', events[0])

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -9,30 +9,9 @@ from typing import Any, Dict
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import get_realm, get_user
-from zerver.lib.actions import do_set_muted_topics
+from zerver.lib.actions import do_update_muted_topic
 
 class MutedTopicsTests(ZulipTestCase):
-    def test_json_set(self):
-        # type: () -> None
-        email = self.example_email('hamlet')
-        self.login(email)
-
-        url = '/api/v1/users/me/subscriptions/muted_topics'
-        data = {'muted_topics': '[["stream", "topic"]]'}
-        result = self.client_post(url, data, **self.api_auth(email))
-        self.assert_json_success(result)
-
-        user = self.example_user('hamlet')
-        self.assertEqual(ujson.loads(user.muted_topics), [["stream", "topic"]])
-
-        url = '/api/v1/users/me/subscriptions/muted_topics'
-        data = {'muted_topics': '[["stream2", "topic2"]]'}
-        result = self.client_post(url, data, **self.api_auth(email))
-        self.assert_json_success(result)
-
-        user = self.example_user('hamlet')
-        self.assertEqual(ujson.loads(user.muted_topics), [["stream2", "topic2"]])
-
     def test_add_muted_topic(self):
         # type: () -> None
         email = self.example_email('hamlet')
@@ -52,7 +31,7 @@ class MutedTopicsTests(ZulipTestCase):
         email = self.user_profile.email
         self.login(email)
 
-        do_set_muted_topics(self.user_profile, [[u'Verona', u'Verona3']])
+        do_update_muted_topic(self.user_profile, u'Verona', u'Verona3', op='add')
         url = '/api/v1/users/me/subscriptions/muted_topics'
         data = {'stream': 'Verona', 'topic': 'Verona3', 'op': 'remove'}
         result = self.client_patch(url, data, **self.api_auth(email))
@@ -67,7 +46,7 @@ class MutedTopicsTests(ZulipTestCase):
         email = self.user_profile.email
         self.login(email)
 
-        do_set_muted_topics(self.user_profile, [[u'Verona', u'Verona3']])
+        do_update_muted_topic(self.user_profile, u'Verona', u'Verona3', op='add')
         url = '/api/v1/users/me/subscriptions/muted_topics'
         data = {'stream': 'Verona', 'topic': 'Verona3', 'op': 'add'}
         result = self.client_patch(url, data, **self.api_auth(email))
@@ -79,7 +58,6 @@ class MutedTopicsTests(ZulipTestCase):
         email = self.user_profile.email
         self.login(email)
 
-        do_set_muted_topics(self.user_profile, [[u'Denmark', u'Denmark3']])
         url = '/api/v1/users/me/subscriptions/muted_topics'
         data = {'stream': 'Verona', 'topic': 'Verona3', 'op': 'remove'}
         result = self.client_patch(url, data, **self.api_auth(email))

--- a/zerver/views/muting.py
+++ b/zerver/views/muting.py
@@ -7,20 +7,12 @@ import ujson
 
 from django.utils.translation import ugettext as _
 from zerver.decorator import authenticated_json_post_view
-from zerver.lib.actions import do_set_muted_topics, do_update_muted_topic
+from zerver.lib.actions import do_update_muted_topic
 from zerver.lib.request import has_request_variables, REQ
 from zerver.lib.response import json_success, json_error
 from zerver.lib.topic_mutes import topic_is_muted
 from zerver.lib.validator import check_string, check_list
 from zerver.models import UserProfile
-
-@has_request_variables
-def set_muted_topics(request, user_profile,
-                     muted_topics=REQ(validator=check_list(
-                         check_list(check_string, length=2)), default=[])):
-    # type: (HttpRequest, UserProfile, List[List[Text]]) -> HttpResponse
-    do_set_muted_topics(user_profile, muted_topics)
-    return json_success()
 
 @has_request_variables
 def update_muted_topic(request, user_profile, stream=REQ(),

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -401,8 +401,7 @@ v1_api_and_json_patterns = [
          'DELETE': 'zerver.views.streams.remove_subscriptions_backend'}),
     # muting -> zerver.views.muting
     url(r'^users/me/subscriptions/muted_topics$', rest_dispatch,
-        {'POST': 'zerver.views.muting.set_muted_topics',
-         'PATCH': 'zerver.views.muting.update_muted_topic'}),
+        {'PATCH': 'zerver.views.muting.update_muted_topic'}),
 
     # used to register for an event queue in tornado
     url(r'^register$', rest_dispatch,


### PR DESCRIPTION
This makes it so that migrating to a new table will only need to require changes to zerver/lib/muting.py, plus maybe an `access_stream_by_name` here or there, and we won't need to maintain the set-all API that is tricky when we go away from the blob methodology.