### PR TITLE
Make draft recovery narrow to stream if new topic.

### DIFF
--- a/frontend_tests/casper_tests/14-drafts.js
+++ b/frontend_tests/casper_tests/14-drafts.js
@@ -100,7 +100,7 @@ casper.then(function () {
             subject: 'tests',
             content: 'Test Stream Message',
         }, "Stream message box filled with draft content");
-        casper.test.assertSelectorHasText('title', 'tests - Zulip Dev - Zulip', 'Narrowed to topic');
+        casper.test.assertSelectorHasText('title', 'all - Zulip Dev - Zulip', 'Narrowed to stream');
     });
 });
 

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -130,9 +130,18 @@ exports.restore_draft = function (draft_id) {
 
     if (draft.type === "stream") {
         if (draft.stream !== "") {
-            narrow.activate([{operator: "stream", operand: draft.stream},
-                             {operator: "topic", operand: draft.subject}],
-                             {select_first_unread: true, trigger: "restore draft"});
+            var stream_id = stream_data.get_stream_id("Scotland");
+            var topics = topic_data.get_recent_names(stream_id);
+
+            // Only narrow to topic if this topic has already been created.
+            if (_.contains(topics, draft.subject)) {
+                narrow.activate([{operator: "stream", operand: draft.stream},
+                                 {operator: "topic", operand: draft.subject}],
+                                 {select_first_unread: true, trigger: "restore draft"});
+            } else {
+                narrow.activate([{operator: "stream", operand: draft.stream}],
+                                 {select_first_unread: true, trigger: "restore draft"});
+            }
         }
     } else {
         if (draft.private_message_recipient !== "") {


### PR DESCRIPTION
Fixes #5903. If in the draft, you're composing to a new topic, narrow to the whole stream, and not this non-existent topic. Casper test updated to not break.

Note that drafts.js currently has very little node coverage, and doesn't have any testing in place for restoring drafts. (I might look into improving coverage on drafts in the future)