### PR TITLE
color-picker: Fix input height to display correct on FF.

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -39,6 +39,15 @@
     z-index: 100;
 }
 
+.colorpicker-container .sp-container input {
+    -webkit-box-sizing: initial;
+    -moz-box-sizing: inherit;
+    -ms-box-sizing: inherit;
+    box-sizing: initial;
+
+    width: calc(100% - 13px);
+}
+
 .streams_popover .sp-palette-container {
     border-right: none;
 }


### PR DESCRIPTION
This fixes the input to not be too short on FF and to have proper
padding on Chrome.

Fixes: #6361.