### PR TITLE
Add title and body field to apns payload for iOS push notifications

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -510,7 +510,7 @@ class TestAPNs(PushNotificationTest):
         return list(PushDeviceToken.objects.filter(
             user=self.user_profile, kind=PushDeviceToken.APNS))
 
-    def send(self, payload_data={}):
+    def send(self, payload_data={'alert': {}, 'custom': {}}):
         # type: (Dict[str, Any]) -> None
         apn.send_apple_push_notification(
             self.user_profile.id, self.devices(), payload_data)
@@ -564,8 +564,10 @@ class TestGetAPNsPayload(PushNotificationTest):
         message = self.get_message(Recipient.HUDDLE)
         payload = apn.get_apns_payload(message)
         expected = {
-            'alert': "New private group message from King Hamlet",
-            'badge': 1,
+            'alert': {
+                'title': "New private group message from King Hamlet",
+                'body': message.content,
+            },
             'custom': {
                 'zulip': {
                     'message_ids': [message.id],


### PR DESCRIPTION
This adds a title and body keys, so the final should look something like this 

`{'zulip': {'message_ids': [31]}, 'aps': {'alert': {'body': 'This is test content', 'title': 'New private message from King Hamlet'}}}`

And the previous one was 
`{'zulip': {'message_ids': [31]}, 'aps': {'badge': 1, 'alert': 'New private message from King Hamlet'}}`

Also removed the badge because setting the badge as 1 will show the badge count as 1 even if there are multiple messages received
https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html
 
Apns payload: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html