### PR TITLE
landing-page: Remove underline from logo text on :hover.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -193,6 +193,10 @@ nav {
     z-index: 4;
 }
 
+nav .brand.logo {
+    text-decoration: none;
+}
+
 nav.white {
     background-color: #fff;
 }


### PR DESCRIPTION
This removes the underline on the logo text on :hover on the
product pages.