### PR TITLE
docs: Add reference to zulip-bot-output script.

### DIFF
--- a/docs/bots-guide.md
+++ b/docs/bots-guide.md
@@ -64,6 +64,9 @@ server.  It assumes you want to use one of the existing `zulip_bots/bots`
 bots in your Zulip organization.  If you want to write a new one, you
 just need to write the `<my-bot>.py` script and put it into `zulip_bots/bots/<my-bot>` directory.
 
+*Looking for an easy way to test a bot's output? Check out [this](
+ #testing-a-bots-output) section.*
+
 You need:
 
 * An account in an organization on a Zulip server
@@ -133,6 +136,32 @@ You need:
   typing `@<your bot name>` followed by some commands. If the bot is
   the `helloworld` bot, you should expect the bot to respond with
   "beep boop".
+
+### Testing a bot's output
+
+If you just want to see how a bot reacts to a message, but don't want to set it up on a server,
+we have a little tool to help you out: `zulip-bot-output`
+
+1. Install all requirements. You can either
+
+    * run `pip install zulip_bots` for a stable version, or
+
+    * clone the [`zulip_bots`](https://github.com/zulip/python-zulip-api/tree/master/zulip_bots)
+      repository for the latest code. Install it with
+      `pip -e <path/to/zulip_bots>`; you will be able to make changes to the code.
+
+  * Run `zulip-bot-output <bot-name> --message "<your-message>"` to test one of the bots in
+    [`zulip_bots/bots`](https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots)
+
+    * Example: `zulip-bot-output converter --message "12 meter yard"`
+
+      Response: `12.0 meter = 13.12336 yard`
+
+  * Run `zulip-bot-output <path/to/bot.py> --message "<your-message>"` to specify the bot's path yourself.
+
+    * Example: `zulip-bot-output zulip_bots/zulip_bots/bots/converter/converter.py --message "12 meter yard"`
+
+      Response: `12.0 meter = 13.12336 yard`
 
 ## Zulip Botserver
 


### PR DESCRIPTION
The second example command will be possible once [python_zulip_api: Refactor zulip bot scripts.](https://github.com/zulip/python-zulip-api/pull/102) gets merged.
