### PR TITLE
templates: Add links to user docs for empty starred/mentioned msg feeds.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2330,7 +2330,7 @@ button.topic_edit_cancel {
 }
 
 .empty_feed_notice {
-    padding: 3em 4em;
+    padding: 3em 1em;
     display: none;
     text-align: center;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2332,19 +2332,11 @@ button.topic_edit_cancel {
 .empty_feed_notice {
     padding: 3em 4em;
     display: none;
-}
-
-.empty_feed_notice h4 {
     text-align: center;
 }
 
 .notification {
     cursor: pointer;
-}
-
-#empty_narrow_private_message p,
-#empty_narrow_message p {
-    text-align: center;
 }
 
 .message-fade,

--- a/templates/zerver/home.html
+++ b/templates/zerver/home.html
@@ -73,12 +73,22 @@
       </div>
       <div id="empty_star_narrow_message" class="empty_feed_notice">
         <h4>{{ _("You haven't starred anything yet!") }}</h4>
+
+        {% trans %}
+        <p>Learn more about starring messages at <a href="/help/star-a-message">
+           {{ realm_uri }}/help/star-a-message</a>.</p>
+        {% endtrans %}
       </div>
       <div id="no_unread_narrow_message" class="empty_feed_notice">
         <h4>{{ _("You have no unread messages!") }}</h4>
       </div>
       <div id="empty_narrow_all_mentioned" class="empty_feed_notice">
         <h4>{{ _("You haven't been mentioned yet!") }}</h4>
+
+        {% trans %}
+        <p>Learn more about mentions at <a href="/help/at-mention-a-team-member">
+           {{ realm_uri }}/help/at-mention-a-team-member</a>.</p>
+        {% endtrans %}
       </div>
       <div id="empty_search_narrow_message" class="empty_feed_notice">
         <h4>{{ _('Nobody has talked about that yet!') }}</h4>


### PR DESCRIPTION
New view example:

![screenshot at sep 01 22-31-42](https://user-images.githubusercontent.com/15116870/29993209-5e8b6a28-8f65-11e7-9ca1-322edcc1a5cb.png)

Fixes #6376 and closes #6197