### PR TITLE
profiling: Add snakeviz to dev tools.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,6 +28,9 @@ tblib==1.3.2
 # Needed to lint Git commit messages
 gitlint==0.8.2
 
+# Needed for visualising cprofile reports
+snakeviz==0.4.2
+
 # Needed to sync translations from transifex
 transifex-client==0.12.4
 

--- a/requirements/dev_lock.txt
+++ b/requirements/dev_lock.txt
@@ -129,6 +129,7 @@ simplegeneric==0.8.1      # via ipython
 simplejson==3.11.1
 six==1.10.0
 smmap==0.9.0
+snakeviz==0.4.2
 snowballstemmer==1.2.1
 social-auth-app-django==1.2.0
 social-auth-core==1.4.0   # via social-auth-app-django

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -401,6 +401,9 @@ if __name__ == "__main__":
         prof.dump_stats("/tmp/profile.data")
         print("Profile data saved to /tmp/profile.data")
         print("You can visualize it using e.g. `snakeviz /tmp/profile.data`")
+        print("Note: If you are using vagrant for development environment you will need to do:")
+        print("1.) `vagrant ssh -- -L 8080:127.0.0.1:8080`")
+        print("2.) `snakeviz -s /tmp/profile.data`")
 
     if options.report_slow_tests:
         from zerver.lib.test_runner import report_slow_tests


### PR DESCRIPTION
This adds snakeviz to dev tools and also updates the message displayed
upon running `test-backend` with `--profile` option to say how to run
snakeviz correctly when using vagrant development environment.

I was not able to use the proxying method which is used for other stuff in run-dev because this tool basically runs a server of its own and expects some `/static/` files to be served from it. Now problem was to forward all the `/static/` requests to snakeviz which I thought would be problematic. So best solution here is that we just print a message regarding how to bind a ssh session on the right ports to establish a connection for the server running in vagrant with the outside world.