### PR TITLE
Capitalize s in Terms of service.

### DIFF
--- a/docs/prod-customize.md
+++ b/docs/prod-customize.md
@@ -54,7 +54,7 @@ By the end of summer 2017, all of the Zulip apps will have full
 support for multiple accounts, potentially on different Zulip servers,
 with a convenient UI for switching between them.
 
-### Terms of service and Privacy policy
+### Terms of Service and Privacy policy
 
 Zulip allows you to configure your server's Terms of Service and
 Privacy Policy pages (`/terms` and `/privacy`, respectively).  You can

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -40,7 +40,7 @@
             {% else %}
             <li><a href="{{ url('register') }}">{{ _("Register") }}</a></li>
             {% endif %}
-            <li><a href="{{ root_domain_uri }}/terms/">{{ _("Terms of service") }}</a></li>
+            <li><a href="{{ root_domain_uri }}/terms/">{{ _("Terms of Service") }}</a></li>
             <li><a href="{{ root_domain_uri }}/privacy/">{{ _("Privacy policy") }}</a></li>
         </ul>
     </section>

--- a/templates/zerver/terms.html
+++ b/templates/zerver/terms.html
@@ -1,6 +1,6 @@
 {% extends "zerver/portico.html" %}
 
-{# Terms of service. #}
+{# Terms of Service. #}
 
 {% block portico_content %}
 

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -159,7 +159,7 @@ i18n_urls = [
     url(r'^for/companies/$', TemplateView.as_view(template_name='zerver/for-companies.html')),
     url(r'^for/working-groups-and-communities/$', TemplateView.as_view(template_name='zerver/for-working-groups-and-communities.html')),
 
-    # Terms of service and privacy pages.
+    # Terms of Service and privacy pages.
     url(r'^terms/$', TemplateView.as_view(template_name='zerver/terms.html'), name='terms'),
     url(r'^privacy/$', TemplateView.as_view(template_name='zerver/privacy.html'), name='privacy'),
 


### PR DESCRIPTION
A few strings used `Terms of service`
instead of `Terms of Service`. This change
makes the latter form consistent over the repo.