### PR TITLE
bot settings: Properly hide bot_table_error.

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -354,6 +354,7 @@ exports.set_up = function () {
         $("#add-a-new-bot-form").show();
         $("#active_bots_list").hide();
         $("#inactive_bots_list").hide();
+        $('#bot_table_error').hide();
     });
 
     $("#bots_lists_navbar .active-bots-tab").click(function (e) {
@@ -378,6 +379,7 @@ exports.set_up = function () {
         $("#add-a-new-bot-form").hide();
         $("#active_bots_list").hide();
         $("#inactive_bots_list").show();
+        $('#bot_table_error').hide();
     });
 
 };


### PR DESCRIPTION
Before this change, the `bot_table_error` box didn't disappear on switching from `add bot` to `active bots` or `inactive bots`.

Reproducing this:
* go to `Add bot`
* enter a valid email, fill the name field with some spaces
* create bot -> error box should pop up
* click on "inactive bots" -> the bottom part of that view should still contain the error box.