### PR TITLE
message view: Change "You and" PM indicator to "PM with".

### DIFF
--- a/frontend_tests/casper_tests/02-site.js
+++ b/frontend_tests/casper_tests/02-site.js
@@ -19,7 +19,7 @@ casper.then(function () {
 
     msg.headings.forEach(function (heading) {
         casper.test.assertMatch(common.normalize_spaces(heading),
-            /(^You and )|( )/,
+            /(^PM with )|( )/,
             'Heading is well-formed');
     });
 
@@ -57,8 +57,8 @@ common.wait_for_receive(function () {
     common.expected_messages('zhome', [
         'Verona > frontend test',
         'Verona > other subject',
-        'You and Cordelia Lear, King Hamlet',
-        'You and Cordelia Lear',
+        'PM with Cordelia Lear, King Hamlet',
+        'PM with Cordelia Lear',
     ], [
         '<p>test verona A</p>',
         '<p>test verona B</p>',

--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -50,8 +50,8 @@ function expect_home() {
         casper.waitUntilVisible('#zhome', function () {
             common.expected_messages('zhome', [
                 'Verona > frontend test',
-                'You and Cordelia Lear, King Hamlet',
-                'You and Cordelia Lear',
+                'PM with Cordelia Lear, King Hamlet',
+                'PM with Cordelia Lear',
             ], [
                 '<p>test message D</p>',
                 '<p>personal D</p>',
@@ -113,7 +113,7 @@ function expect_huddle() {
     casper.then(function () {
         casper.waitUntilVisible('#zfilt', function () {
             common.expected_messages('zfilt', [
-                'You and Cordelia Lear, King Hamlet',
+                'PM with Cordelia Lear, King Hamlet',
             ], [
                 '<p>personal A</p>',
                 '<p>personal B</p>',
@@ -127,7 +127,7 @@ function expect_1on1() {
     casper.then(function () {
         casper.waitUntilVisible('#zfilt', function () {
             common.expected_messages('zfilt', [
-                'You and Cordelia Lear',
+                'PM with Cordelia Lear',
             ], [
                 '<p>personal C</p>',
                 '<p>personal E</p>',
@@ -140,8 +140,8 @@ function expect_all_pm() {
     casper.then(function () {
         casper.waitUntilVisible('#zfilt', function () {
             common.expected_messages('zfilt', [
-                'You and Cordelia Lear, King Hamlet',
-                'You and Cordelia Lear',
+                'PM with Cordelia Lear, King Hamlet',
+                'PM with Cordelia Lear',
             ], [
                 '<p>personal A</p>',
                 '<p>personal B</p>',

--- a/frontend_tests/casper_tests/14-drafts.js
+++ b/frontend_tests/casper_tests/14-drafts.js
@@ -85,7 +85,7 @@ casper.then(function () {
         casper.test.assertTextExists('Test Stream Message', 'Stream draft contains message content');
 
         casper.test.assertSelectorHasText('.draft-row .message_header_private_message .stream_label',
-                                          'You and Cordelia Lear, King Hamlet');
+                                          'PM with Cordelia Lear, King Hamlet');
         casper.test.assertTextExists('Test Private Message', 'Private draft contains message content');
     });
 });
@@ -191,7 +191,7 @@ casper.then(function () {
     waitUntilDraftsVisible(function () {
         casper.test.assertElementCount('.draft-row', 2, 'Drafts loaded');
         casper.test.assertSelectorHasText('.draft-row .message_header_private_message .stream_label',
-                                          'You and Cordelia Lear');
+                                          'PM with Cordelia Lear');
         casper.test.assertTextExists('Test Private Message');
     });
 });

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -557,7 +557,7 @@ function render(template_name, args) {
     assert.equal(row_1.find(".message_content").text().trim(), "Public draft");
 
     var row_2 = $(html).find(".draft-row[data-draft-id='2']");
-    assert.equal(row_2.find(".stream_label").text().trim(), "You and Jordan, Michael");
+    assert.equal(row_2.find(".stream_label").text().trim(), "PM with Jordan, Michael");
     assert(row_2.find(".message_row").hasClass("private-message"));
     assert.equal(row_2.find(".message_content").text().trim(), "Private draft");
 }());

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -213,7 +213,7 @@ exports.start = function (msg_type, opts) {
 
     compose_state.set_message_type(msg_type);
 
-    // Show either stream/topic fields or "You and" field.
+    // Show either stream/topic fields or "PM with" field.
     show_box(msg_type, opts);
 
     exports.complete_starting_tasks(msg_type, opts);

--- a/static/templates/draft.handlebars
+++ b/static/templates/draft.handlebars
@@ -19,7 +19,7 @@
         <div class="message_header message_header_private_message dark_background">
             <div class="message-header-contents">
                 <div class="message_label_clickable stream_label">
-                    {{#tr this}}You and __recipients__{{/tr}}
+                    {{#tr this}}PM with __recipients__{{/tr}}
                 </div>
             </div>
         </div>

--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -66,7 +66,7 @@
             <a class="message_label_clickable narrows_by_recipient stream_label"
                 href="{{pm_with_url}}"
                 title="{{#tr this}}Narrow to your private messages with __display_reply_to__{{/tr}}">
-                {{#tr this}}You and __display_reply_to__{{/tr}}
+                {{#tr this}}PM with __display_reply_to__{{/tr}}
             </a>
 
             <span class="recipient_row_date {{#if show_date}}{{else}}hide-date{{/if}}">{{{date}}}</span>

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -69,7 +69,7 @@
               </td>
               <td class="right_part">
                 <div class="pm_recipient">
-                <span class="you_text">{{ _('You and') }}</span>
+                <span class="you_text">{{ _('PM with') }}</span>
                 <input type="text" class="recipient_box" name="recipient" id="private_message_recipient"
                                value="" placeholder="{{ _('one or more people...') }}" autocomplete="off" tabindex="0"/>
                 </div>

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -156,14 +156,14 @@ def build_message_list(user_profile, messages):
         # type: (UserProfile, Message) -> Dict[str, Any]
         disp_recipient = get_display_recipient(message.recipient)
         if message.recipient.type == Recipient.PERSONAL:
-            header = u"You and %s" % (message.sender.full_name,)
+            header = u"PM with %s" % (message.sender.full_name,)
             html_link = pm_narrow_url(user_profile.realm, [message.sender.email])
             header_html = u"<a style='color: #ffffff;' href='%s'>%s</a>" % (html_link, header)
         elif message.recipient.type == Recipient.HUDDLE:
             assert not isinstance(disp_recipient, Text)
             other_recipients = [r['full_name'] for r in disp_recipient
                                 if r['email'] != user_profile.email]
-            header = u"You and %s" % (", ".join(other_recipients),)
+            header = u"PM with %s" % (", ".join(other_recipients),)
             html_link = pm_narrow_url(user_profile.realm, [r["email"] for r in disp_recipient
                                       if r["email"] != user_profile.email])
             header_html = u"<a style='color: #ffffff;' href='%s'>%s</a>" % (html_link, header)

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -95,7 +95,7 @@ class TestMissedMessages(ZulipTestCase):
         msg_id = self.send_message(self.example_email('othello'), self.example_email('hamlet'),
                                    Recipient.PERSONAL,
                                    'Extremely personal message!')
-        body = 'You and Othello, the Moor of Venice Extremely personal message!'
+        body = 'PM with Othello, the Moor of Venice Extremely personal message!'
         subject = 'Othello, the Moor of Venice sent you a message'
         self._test_cases(tokens, msg_id, body, subject, send_as_user)
 
@@ -136,7 +136,7 @@ class TestMissedMessages(ZulipTestCase):
                                    Recipient.HUDDLE,
                                    'Group personal message!')
 
-        body = ('You and Iago, Othello, the Moor of Venice Othello,'
+        body = ('PM with Iago, Othello, the Moor of Venice Othello,'
                 ' the Moor of Venice Group personal message')
         subject = 'Group PMs with Iago and Othello, the Moor of Venice'
         self._test_cases(tokens, msg_id, body, subject, send_as_user)
@@ -152,7 +152,7 @@ class TestMissedMessages(ZulipTestCase):
                                    Recipient.HUDDLE,
                                    'Group personal message!')
 
-        body = ('You and Cordelia Lear, Iago, Othello, the Moor of Venice Othello,'
+        body = ('PM with Cordelia Lear, Iago, Othello, the Moor of Venice Othello,'
                 ' the Moor of Venice Group personal message')
         subject = 'Group PMs with Cordelia Lear, Iago, and Othello, the Moor of Venice'
         self._test_cases(tokens, msg_id, body, subject, send_as_user)
@@ -171,7 +171,7 @@ class TestMissedMessages(ZulipTestCase):
                                    Recipient.HUDDLE,
                                    'Group personal message!')
 
-        body = ('You and Cordelia Lear, Iago, Othello, the Moor of Venice, Prospero from The Tempest'
+        body = ('PM with Cordelia Lear, Iago, Othello, the Moor of Venice, Prospero from The Tempest'
                 ' Othello, the Moor of Venice Group personal message')
         subject = 'Group PMs with Cordelia Lear, Iago, and 2 others'
         self._test_cases(tokens, msg_id, body, subject, send_as_user)


### PR DESCRIPTION
As discussed on the [chat](https://chat.zulip.org/#narrow/stream/design/topic/.236413), this PR  changes the "You and" PM indicator to "PM with".

![screenshot at sep 06 11-04-33](https://user-images.githubusercontent.com/15116870/30127198-3a55be9c-92f3-11e7-90da-40c4b52832ac.png)
