### PR TITLE
linter: Add rule against misspelled "Terms of Service".

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -354,6 +354,8 @@ def build_custom_checkers(by_lang):
          'description': "Organization is spelled with a z"},
         {'pattern': '!!! warning',
          'description': "!!! warning is invalid; it's spelled '!!! warn'"},
+        {'pattern': 'Terms of service',
+         'description': "The S in Terms of Service is capitalized"},
     ]  # type: RuleList
     html_rules = whitespace_rules + prose_style_rules + [
         {'pattern': 'placeholder="[^{]',


### PR DESCRIPTION
@showell followup from #6402.

I have a couple questions:

* Right now, the linter rule only covers `Terms of service`, yet there are a few occurrences of `terms of service`, when it is not in the beginning of a phrase. I think we should captitalize all of those as well?

* `Privacy Policy` is analogous to this case: Right now, we have a happy mix of `Privacy Policy`, `Privacy policy` and `privacy policy`. What should be our policy here? (hehe)

* I guess we should add this (and potential following) linter rules to `zulip-mobile` as well?