### PR TITLE
hotspots: Add welcome bot reply hotspot.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -42,8 +42,8 @@ from zerver.lib.topic_mutes import (
 )
 from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, \
     RealmDomain, \
-    Subscription, Recipient, Message, Attachment, UserMessage, RealmAuditLog, \
-    UserHotspot, \
+    Subscription, Recipient, Message, ArchivedMessage, Attachment, UserMessage, \
+    RealmAuditLog, UserHotspot, \
     Client, DefaultStream, UserPresence, PushDeviceToken, ScheduledEmail, \
     MAX_SUBJECT_LENGTH, \
     MAX_MESSAGE_LENGTH, get_client, get_stream, get_recipient, get_huddle, \
@@ -702,6 +702,17 @@ def create_mirror_user_if_needed(realm, email, email_to_fullname):
         except IntegrityError:
             return get_user(email, realm)
 
+def send_welcome_bot_response(message):
+    # type: (MutableMapping[str, Any]) -> None
+    welcome_bot = get_system_bot(settings.WELCOME_BOT)
+    human_recipient = get_recipient(Recipient.PERSONAL, message['message'].sender.id)
+    if Message.objects.filter(sender=welcome_bot, recipient=human_recipient).count() < 2:
+        internal_send_private_message(
+            message['realm'], welcome_bot, message['message'].sender,
+            "Congratulations on your first reply! :tada:\n\n"
+            "Feel free to continue using this space to practice your new messaging "
+            "skills. Or, try clicking on some of the stream names to your left!")
+
 def render_incoming_message(message, content, user_ids, realm):
     # type: (Message, Text, Set[int], Realm) -> Text
     realm_alert_words = alert_words_in_realm(realm)
@@ -1083,6 +1094,12 @@ def do_send_messages(messages_maybe_none):
                     message_to_dict(message['message'], apply_markdown=False),
                     lambda x: None
                 )
+
+        if message['message'].recipient.type == Recipient.PERSONAL:
+            welcome_bot_id = get_user_profile_by_email(settings.WELCOME_BOT).id
+            if (welcome_bot_id in message['active_user_ids'] and
+                    welcome_bot_id != message['message'].sender_id):
+                send_welcome_bot_response(message)
 
         for queue_name, events in message['message'].service_queue_events.items():
             for event in events:

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -224,6 +224,7 @@ class ZulipTestCase(TestCase):
         aaron=u'aaron@zulip.com',
         ZOE=u'ZOE@zulip.com',
         webhook_bot=u'webhook-bot@zulip.com',
+        welcome_bot=u'welcome-bot@zulip.com',
         outgoing_webhook_bot=u'outgoing-webhook@zulip.com'
     )
 

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1526,6 +1526,6 @@ class GetOldMessagesTest(ZulipTestCase):
             'say hello')
         self.assertEqual(
             meeting_message['match_content'],
-            ('<p>How are you doing, <span class="user-mention" data-user-email="%s" data-user-id="6">' +
+            ('<p>How are you doing, <span class="user-mention" data-user-email="%s" data-user-id="7">' +
              '@<span class="highlight">Othello</span>, the Moor of Venice</span>?</p>') % (
                  self.example_email("othello"),))

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -305,7 +305,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 66)
+        self.assert_length(queries, 67)
         user_profile = self.nonreg_user('test')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -1,12 +1,37 @@
 # -*- coding: utf-8 -*-
 
 from typing import Any, Dict
+
+from zerver.lib.test_helpers import (
+    message_stream_count,
+    most_recent_message
+)
+
+from zerver.lib.test_classes import (
+    ZulipTestCase,
+)
+
+from zerver.models import (
+    get_realm,
+    get_user,
+    Recipient,
+    UserProfile
+)
+
 import ujson
 
-from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import UserProfile
-
 class TutorialTests(ZulipTestCase):
+
+    def setUp(self):
+        # type: () -> None
+        # This emulates the welcome message sent by the welcome bot to hamlet@zulip.com
+        # This is only a quick fix - ideally, we would have this message sent by the initialization
+        # code in populate_db.py
+        user_email = 'hamlet@zulip.com'
+        bot_email = 'welcome-bot@zulip.com'
+        content = 'Shortened welcome message.'
+        self.send_message(bot_email, user_email, Recipient.PERSONAL, content)
+
     def test_tutorial_status(self):
         # type: () -> None
         email = self.example_email('hamlet')
@@ -22,3 +47,37 @@ class TutorialTests(ZulipTestCase):
             self.assert_json_success(result)
             user = self.example_user('hamlet')
             self.assertEqual(user.tutorial_status, expected_db_status)
+
+    def test_single_response_to_pm(self):
+        # type: () -> None
+        realm = get_realm('zulip')  # Assume realm is always 'zulip'
+        user_email = 'hamlet@zulip.com'
+        bot_email = 'welcome-bot@zulip.com'
+        content = 'whatever'
+        self.login(user_email)
+        self.send_message(user_email, bot_email, Recipient.PERSONAL, content)
+        user = get_user(user_email, realm)
+        user_messages = message_stream_count(user)
+        expected_response = ("Congratulations on your first reply! :tada:\n\n"
+                             "Feel free to continue using this space to practice your new messaging "
+                             "skills. Or, try clicking on some of the stream names to your left!")
+        self.assertEqual(most_recent_message(user).content, expected_response)
+        self.send_message(user_email, bot_email, Recipient.PERSONAL, content)
+        # Welcome bot shouldn't respond to further PMs.
+        self.assertEqual(message_stream_count(user), user_messages+1)
+
+    def test_no_response_to_group_pm(self):
+        # type: () -> None
+        realm = get_realm('zulip')  # Assume realm is always 'zulip'
+        user1_email = self.example_email('hamlet')
+        user2_email = self.example_email('cordelia')
+        bot_email = self.example_email('welcome_bot')
+        content = "whatever"
+        self.login(user1_email)
+        self.send_message(user1_email, [bot_email, user2_email], Recipient.PERSONAL, content)
+        user1 = get_user(user1_email, realm)
+        user1_messages = message_stream_count(user1)
+        self.assertEqual(most_recent_message(user1).content, content)
+        self.send_message(user1_email, bot_email, Recipient.PERSONAL, content)
+        # Welcome bot should still respond to initial PM after group PM.
+        self.assertEqual(message_stream_count(user1), user1_messages+2)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -136,6 +136,12 @@ class Command(BaseCommand):
                     invite_required=False, org_type=Realm.CORPORATE)
                 RealmDomain.objects.create(realm=mit_realm, domain="mit.edu")
 
+            # Create welcome bot as the first required bot
+            zulip_welcome_bot = [
+                ("Welcome Bot", "welcome-bot@zulip.com"),
+            ]
+            create_users(zulip_realm, zulip_welcome_bot, bot_type=UserProfile.DEFAULT_BOT)
+
             # Create test Users (UserProfiles are automatically created,
             # as are subscriptions to the ability to receive personals).
             names = [


### PR DESCRIPTION
Fixes #6030.

The hotspot doesn't look optimal to me yet. Ideally, it would pop up directly over the private message from the welcome bot, but I guess that's not how the hotspot system works.

My first migration :))