### PR TITLE
compose: Refocus compose box if message view link is clicked.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -704,6 +704,11 @@ $(function () {
             popovers.hide_all();
         }
 
+        // Refocus compose message text box if link is clicked
+        if (compose_state.composing() && $(e.target).is("a")) {
+            $("#new_message_content").focus();
+        }
+
         // Unfocus our compose area if we click out of it. Don't let exits out
         // of overlays or selecting text (for copy+paste) trigger cancelling.
         if (compose_state.composing() && !$(e.target).is("a") &&


### PR DESCRIPTION
Fixes #4331 and closes #4397

Was unsure whether all links should cause refocusing, or only those that lead to external pages. Willing to implement external link refocusing only if necessary :)