### PR TITLE
Recommend virtualbox version should be a fixed version (fixes #6448)

### DIFF
--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -47,7 +47,7 @@ proxy](#specifying-a-proxy) if you need a proxy to access the internet.)
 
 - **All**: 2GB available RAM, Active broadband internet connection, [GitHub account][set-up-git].
 - **macOS**: macOS (10.11 El Capitan or 10.12 Sierra recommended), Git,
-  [VirtualBox][vbox-dl], [Vagrant][vagrant-dl-macos].
+  [VirtualBox][vbox-dl-macos], [Vagrant][vagrant-dl-macos].
 - **Ubuntu**: 14.04 64-bit or 16.04 64-bit, Git, [Vagrant][vagrant-dl-deb], lxc.
   - or **Debian**: 9.0 "stretch" 64-bit
 - **Windows**: Windows 64-bit (Win 10 recommended), hardware
@@ -81,7 +81,7 @@ Jump to:
 #### macOS
 
 1. Install [Vagrant][vagrant-dl-macos] (1.8.4-1.8.6, do not use 1.8.7).
-2. Install [VirtualBox][vbox-dl] (>= 5.1.8).
+2. Install [VirtualBox][vbox-dl-macos] (5.1.8).
 
 (For a non-free option, but better performance, you can also use [VMWare
 Fusion][vmware-fusion-dl] with the [VMWare Fusion Vagrant
@@ -1017,6 +1017,7 @@ for the IP address that means any IP address can connect to your development ser
 [vagrant-dl-deb]: https://releases.hashicorp.com/vagrant/1.8.6/vagrant_1.8.6_x86_64.deb
 [vagrant-lxc]: https://github.com/fgrehm/vagrant-lxc
 [vbox-dl]: https://www.virtualbox.org/wiki/Downloads
+[vbox-dl-macos]: http://download.virtualbox.org/virtualbox/5.1.8/VirtualBox-5.1.8-111374-OSX.dmg
 [vmware-fusion-dl]: http://www.vmware.com/products/fusion.html
 [vagrant-vmware-fusion-dl]: https://www.vagrantup.com/vmware/
 [avoiding-sudo]: https://github.com/fgrehm/vagrant-lxc#avoiding-sudo-passwords


### PR DESCRIPTION
# Description

- 5.1.26 will meet some unknown issue on macos virtualbox
- 5.1.8 is the original recommended lowest version, which works well on macos virtualbox.
- For 5.1.9~5.1.25, I have not checked them one by one, however, I don't think we need to check that while 5.1.8 works well in any case.

Thus I suggest to set a fixed version. The best choice might be the lowest supported version.