### PR TITLE
lightbox: Fix repeated code in exports.open.

### DIFF
--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -90,12 +90,6 @@ exports.open = function (image, options) {
     // asset, just recall that metadata.
     if (asset_map[$image.attr("src")]) {
         payload = asset_map[$image.attr("src")];
-
-        if (payload.type === "youtube-video") {
-            display_youtube_video(payload);
-        } else if (payload.type === "image") {
-            display_image(payload, options);
-        }
     // otherwise retrieve the metadata from the DOM and store into the asset_map.
     } else {
         var $parent = $image.parent();
@@ -110,12 +104,12 @@ exports.open = function (image, options) {
         };
 
         asset_map[payload.preview] = payload;
+    }
 
-        if (payload.type === "youtube-video") {
-            display_youtube_video(payload);
-        } else if (payload.type === "image") {
-            display_image(payload, options);
-        }
+    if (payload.type === "youtube-video") {
+        display_youtube_video(payload);
+    } else if (payload.type === "image") {
+        display_image(payload, options);
     }
 
     if (is_open) {


### PR DESCRIPTION
Call display_XXX function after the payload if-clause, don't repeat
the same thing.

I found it as a problem when I was implementing a new display function. My new display function was not used when I clicked an image first time and it worked only from the second time. That was because the original display function was still used in the else-if clause, I had edited the if clause only.