### PR TITLE
zulip.css: Remove text-decoration from brand logo link.

### DIFF
--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -1,7 +1,7 @@
 <div class="header">
 <nav class="header-main rightside-userlist" id="top_navbar">
   <div class="column-left">
-      <a class="brand" href="#">
+      <a class="brand no-style" href="#">
           <img src="/static/images/logo/zulip-icon-128x128.png" class="nav-logo no-drag" alt=""/>
           <div class="company-name">
               zulip


### PR DESCRIPTION
Before, when hovering over the brand logo, a weird line would appear over the logo:

![screenshot at sep 10 08-37-18](https://user-images.githubusercontent.com/15116870/30250565-5365fdc4-9605-11e7-8845-aafa59e1366d.png)

This commit removes the line by setting the text-decoration attribute of that logo link to none.