### PR TITLE
compose: Fix rendering error with message edit forms.

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -496,7 +496,7 @@ exports.MessageList.prototype = {
     show_edit_message: function MessageList_show_edit_message(row, edit_obj) {
         row.find(".message_edit_form").empty().append(edit_obj.form);
         row.find(".message_content, .status-message").hide();
-        row.find(".message_edit").show();
+        row.find(".message_edit").css("display", "block");
         row.find(".message_edit_content").autosize();
     },
 


### PR DESCRIPTION
When a new message was posted, the UI would decide to re-render the message which was being edited. This would only happen if you were editing the last sent message in the narrow.

After re-rendering the message into a new element, it sees that the message was previously being edited and so hides the `message_content` and calls the `show_edit_message` function which adds the edit form to the element and calls `.show()` on the form. The `.message_edit` element has the default `display: none` property in the stylesheets but the custom jQuery element has the `display` property blank (I think this is because of it not being in the DOM so it doesn't show the inherited properties). Because of this, the show function doesn't make any chance to the display property and the message gets rendered with both the message_content and edit form hidden.

To fix this, we explicitly set the display to block instead of using show.
Fixes #6412

(PS, such a simple fix for a bug that took hours to figure out)