### PR TITLE
i18n: Optimize get_language_list().

### DIFF
--- a/static/.gitignore
+++ b/static/.gitignore
@@ -9,4 +9,5 @@
 /generated/github-contributors.json
 /locale/en
 /locale/language_options.json
+/locale/language_name_map.json
 /third/emoji-data


### PR DESCRIPTION
compilemessages command now does all the heavy lifting by creating a
language_name_map.json file under locale directory. This file is used
by get_language_list to retrieve the require information.

Fixes: #6486