### PR TITLE
Don't require email for LDAP

### DIFF
--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -73,10 +73,18 @@ common.autofocus('#id_username');
 
                     <!-- .no-validation is for removing the red star in CSS -->
                     <div class="input-box no-validation">
-                        <input id="id_username" type="email" name="username" class="email required"
+                        <input id="id_username" type="{% if not require_email_format_usernames %}text{% else %}email{% endif %}"
+                               name="username" class="{% if require_email_format_usernames %}email {% endif %}required"
                             {% if email %} value="{{ email }}" {% else %} value="" {% endif %}
                             maxlength="72" required />
-                        <label for="id_username">{{ _('Email') }}</label>
+                        <label for="id_username">
+                            {% if not require_email_format_usernames and email_auth_enabled %}
+                                {{ _('Email or username') }}
+                            {% elif not require_email_format_usernames %}
+                                {{ _('Username') }}
+                            {% else %}
+                                {{ _('Email') }}
+                            {% endif %}</label>
                     </div>
 
                     <div class="input-box no-validation">

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -11,6 +11,8 @@ from zproject.backends import (
     github_auth_enabled,
     google_auth_enabled,
     password_auth_enabled,
+    email_auth_enabled,
+    require_email_format_usernames,
     auth_enabled_helper,
     AUTH_BACKEND_NAME_MAP
 )
@@ -127,6 +129,8 @@ def zulip_default_context(request):
         'dev_auth_enabled': dev_auth_enabled(realm),
         'google_auth_enabled': google_auth_enabled(realm),
         'github_auth_enabled': github_auth_enabled(realm),
+        'email_auth_enabled': email_auth_enabled(realm),
+        'require_email_format_usernames': require_email_format_usernames(realm),
         'any_oauth_backend_enabled': any_oauth_backend_enabled(realm),
         'no_auth_enabled': not auth_enabled_helper(list(AUTH_BACKEND_NAME_MAP.keys()), realm),
         'development_environment': settings.DEVELOPMENT,

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1897,6 +1897,23 @@ class TestLDAP(ZulipTestCase):
             self.assertEqual(user_profile.email, self.example_email("hamlet"))
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
+    def test_login_success_with_email_attr(self):
+        # type: () -> None
+        self.mock_ldap.directory = {
+            'uid=letham,ou=users,dc=zulip,dc=com': {
+                'userPassword': 'testing',
+                'email': ['hamlet@zulip.com'],
+            }
+        }
+        with self.settings(LDAP_EMAIL_ATTR='email',
+                           AUTH_LDAP_BIND_PASSWORD='',
+                           AUTH_LDAP_USER_DN_TEMPLATE='uid=%(user)s,ou=users,dc=zulip,dc=com'):
+            user_profile = self.backend.authenticate("letham", 'testing')
+
+            assert (user_profile is not None)
+            self.assertEqual(user_profile.email, self.example_email("hamlet"))
+
+    @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_failure_due_to_wrong_password(self):
         # type: () -> None
         self.mock_ldap.directory = {
@@ -2021,6 +2038,19 @@ class TestLDAP(ZulipTestCase):
             email = 'nonexisting@zulip.com'
             backend._realm = None
             with self.assertRaisesRegex(Exception, 'Realm is None'):
+                backend.get_or_create_user(email, _LDAPUser())
+
+    @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
+    def test_get_or_create_user_when_ldap_has_no_email_attr(self):
+        # type: () -> None
+        class _LDAPUser(object):
+            attrs = {'fn': ['Full Name'], 'sn': ['Short Name']}
+
+        nonexisting_attr = 'email'
+        with self.settings(LDAP_EMAIL_ATTR=nonexisting_attr):
+            backend = self.backend
+            email = 'nonexisting@zulip.com'
+            with self.assertRaisesRegex(Exception, 'LDAP user doesn\'t have email attribute'):
                 backend.get_or_create_user(email, _LDAPUser())
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -83,6 +83,13 @@ def any_oauth_backend_enabled(realm=None):
     'OR' for login with Google"""
     return auth_enabled_helper([u'GitHub', u'Google'], realm)
 
+def require_email_format_usernames(realm=None):
+    # type: (Optional[Realm]) -> bool
+    if ldap_auth_enabled(realm):
+        if settings.LDAP_EMAIL_ATTR or settings.LDAP_APPEND_DOMAIN:
+            return False
+    return True
+
 def common_get_active_user_by_email(email, return_data=None):
     # type: (Text, Optional[Dict[str, Any]]) -> Optional[UserProfile]
     try:

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -313,17 +313,22 @@ EMAIL_GATEWAY_IMAP_FOLDER = "INBOX"
 # * Fill in the LDAP configuration options below so that Zulip can
 # connect to your LDAP server
 #
-# * Setup the mapping between email addresses (used as login names in
-# Zulip) and LDAP usernames.  There are two supported ways to setup
-# the username mapping:
+# * Setup the mapping between LDAP attributes and Zulip.
+# There are three supported ways to setup the username and/or email mapping:
 #
-#   (A) If users' email addresses are in LDAP, set
+#   (A) If users' email addresses are in LDAP and used as username, set
 #       LDAP_APPEND_DOMAIN = None
 #       AUTH_LDAP_USER_SEARCH to lookup users by email address
 #
 #   (B) If LDAP only has usernames but email addresses are of the form
 #       username@example.com, you should set:
 #       LDAP_APPEND_DOMAIN = example.com and
+#       AUTH_LDAP_USER_SEARCH to lookup users by username
+#
+#   (C) If LDAP username are completely unrelated to email addresses,
+#       you should set:
+#       LDAP_EMAIL_ATTR = "email"
+#       LDAP_APPEND_DOMAIN = None
 #       AUTH_LDAP_USER_SEARCH to lookup users by username
 #
 # You can quickly test whether your configuration works by running:
@@ -364,6 +369,10 @@ AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=users,dc=example,dc=com",
 # If the value of a user's "uid" (or similar) property is not their email
 # address, specify the domain to append here.
 LDAP_APPEND_DOMAIN = None  # type: Optional[str]
+
+# If username and email are two different LDAP attribute, specify the email
+# attribute here
+LDAP_EMAIL_ATTR = None  # type: Optional[str]
 
 # This map defines how to populate attributes of a Zulip user from LDAP.
 AUTH_LDAP_USER_ATTR_MAP = {


### PR DESCRIPTION
This PR adds the ability to support LDAP authentication with a username unrelated to email as wanted  in #210.
The backend uses an `LDAP_EMAIL_ATTR` setting that maps an LDAP attribute to an email in order to ensure that users have an email address.
On the frontend side, this PR removes the email requirement when LDAP auth is enable. Maybe i'm missing something since I didn't find how it previously worked with the `LDAP_APPEND_DOMAIN` mechanism as it didn't accept non email username.

### zulip-mobile
With the new `zulip-moblie` app, the login still requires the username to be an email address and using `LDAP_EMAIL_ATTR` won't work. On the other hand, the `zulip-android` has no issue.

### Notes
On a side note, from what I saw, LDAP auth requires that `get_realm_by_email_domain(email)` returns something different than `None`. In my production env, I had to manually create a `RealmDomain` since a `Realm` (and its associated `RealmDomain`) is required at user creation. If I'm correct, maybe this should be written somewhere.
