### PR TITLE
custom linter rules test: Add pattern test.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -131,7 +131,9 @@ def build_custom_checkers(by_lang):
          'description': 'Fix trailing whitespace'},
         {'pattern': '^#+[A-Za-z0-9]',
          'strip': '\n',
-         'description': 'Missing space after # in heading'},
+         'description': 'Missing space after # in heading',
+         'good_lines': ['### some heading', '# another heading'],
+         'bad_lines': ['###some heading', '#another heading']},
     ]  # type: RuleList
     js_rules = cast(RuleList, [
         {'pattern': '[^_]function\(',


### PR DESCRIPTION
The pattern test method `test_rule_patterns` tests each rule by
fetching two strings from it: `test_good` and `test_bad`. Each string
is then presented as an input file to `custom_check_file`, which
should return True or False.
All lines in a string need to end with `\n`. Since the linter
expects an additional newline at the end of a file, the test case
adds `\n` to each string on top of that.

Fixes #6320.