### PR TITLE
Provide a way to remove proxy from vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # The Zulip development environment runs on 9991 on the guest.
   host_port = 9991
-  http_proxy = https_proxy = no_proxy = ""
+  http_proxy = https_proxy = no_proxy = nil
   host_ip_addr = "127.0.0.1"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
@@ -48,20 +48,24 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  config.vm.network "forwarded_port", guest: 9991, host: host_port, host_ip: host_ip_addr
-
   if Vagrant.has_plugin?("vagrant-proxyconf")
-    if http_proxy != ""
+    if !http_proxy.nil?
       config.proxy.http = http_proxy
     end
-    if https_proxy != ""
+    if !https_proxy.nil?
       config.proxy.https = https_proxy
     end
-    if https_proxy != ""
+    if !no_proxy.nil?
       config.proxy.no_proxy = no_proxy
     end
+  elsif !http_proxy.nil? or !https_proxy.nil?
+    puts 'You have specified value for proxy in ~/.zulip-vagrant-config file but did not ' \
+         'install vagrant-proxyconf plugin. To install run `vagrant plugin install ' \
+         'vagrant-proxyconf` in terminal.'
+    exit
   end
 
+  config.vm.network "forwarded_port", guest: 9991, host: host_port, host_ip: host_ip_addr
   # Specify LXC provider before VirtualBox provider so it's preferred.
   config.vm.provider "lxc" do |lxc|
     if command? "lxc-ls"

--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -982,6 +982,10 @@ Now run `vagrant up` in your terminal to install the development
 server. If you ran `vagrant up` before and failed, you'll need to run
 `vagrant destroy` first to clean up the failed installation.
 
+**If you no longer want to use proxy with Vagrant, set values of HTTP_PROXY
+and HTTPS_PROXY to `""` in `~/.zulip-vagrant-config` file and
+restart Vagrant.**
+
 You can also change the port on the host machine that Vagrant uses by
 adding to your `~/.zulip-vagrant-config` file.  E.g. if you set:
 


### PR DESCRIPTION
Proxy can be removed from vagrant by passing empty string as proxy configuration. 

Also Fixes #5292