### PR TITLE
left-sidebar.css: Remove .brand selector.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -5,10 +5,6 @@
     font-size: 0.89rem;
 }
 
-#left-sidebar .brand {
-    display: table-row;
-}
-
 #left-sidebar #user-list,
 #left-sidebar #group-pm-list {
     padding-left: 10px;


### PR DESCRIPTION
This selector is unused (there is no element with class `brand` in element with ID `left-sidebar`).

Followup to #6459