### PR TITLE
tornado: Disable routine logging in dev.

### DIFF
--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -412,10 +412,11 @@ def gc_event_queues():
     # not have a current handler.
     do_gc_event_queues(to_remove, affected_users, affected_realms)
 
-    logging.info(('Tornado removed %d idle event queues owned by %d users in %.3fs.' +
-                  '  Now %d active queues, %s')
-                 % (len(to_remove), len(affected_users), time.time() - start,
-                    len(clients), handler_stats_string()))
+    if settings.PRODUCTION:
+        logging.info(('Tornado removed %d idle event queues owned by %d users in %.3fs.' +
+                      '  Now %d active queues, %s')
+                     % (len(to_remove), len(affected_users), time.time() - start,
+                        len(clients), handler_stats_string()))
     statsd.gauge('tornado.active_queues', len(clients))
     statsd.gauge('tornado.active_users', len(user_clients))
 

--- a/zerver/tornado/ioloop_logging.py
+++ b/zerver/tornado/ioloop_logging.py
@@ -70,7 +70,7 @@ class InstrumentedPoll(object):
             in_poll = sum(b-a for a, b in self._times)
             if total > 0:
                 percent_busy = 100 * (1 - in_poll / total)
-                if settings.PRODUCTION or percent_busy > 20:
+                if settings.PRODUCTION:
                     logging.info('Tornado %5.1f%% busy over the past %4.1f seconds'
                                  % (percent_busy, total))
                     self._last_print = t1


### PR DESCRIPTION
This creates a lot of logging noise, and also causes confusion
for new contributors when something isn't working as they expect
and they aren't sure if this message is normal or an error.