### PR TITLE
Avoid DB queries in bugdown rendering path.

### DIFF
--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from typing import Text
 # Match multi-word string between @** ** or match any one-word
 # sequences after @
-find_mentions = r'(?<![^\s\'\"\(,:<])@(\*\*[^\*]+\*\*|\w+)'
+find_mentions = r'(?<![^\s\'\"\(,:<])@(\*\*[^\*]+\*\*|all|everyone)'
 
 wildcards = ['all', 'everyone']
 

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
-from typing import Text
+from typing import Optional, Set, Text
+
+import re
+
 # Match multi-word string between @** ** or match any one-word
 # sequences after @
 find_mentions = r'(?<![^\s\'\"\(,:<])@(\*\*[^\*]+\*\*|all|everyone)'
@@ -10,3 +13,21 @@ wildcards = ['all', 'everyone']
 def user_mention_matches_wildcard(mention):
     # type: (Text) -> bool
     return mention in wildcards
+
+def extract_name(s):
+    # type: (Text) -> Optional[Text]
+    if s.startswith("**") and s.endswith("**"):
+        name = s[2:-2]
+        if name in wildcards:
+            return None
+        return name
+
+    # We don't care about @all or @everyone
+    return None
+
+def possible_mentions(content):
+    # type: (Text) -> Set[Text]
+    matches = re.findall(find_mentions, content)
+    names = {extract_name(match) for match in matches}
+    names = {name for name in names if name}
+    return names

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -1034,6 +1034,19 @@ class BugdownErrorTests(ZulipTestCase):
 
 
 class BugdownAvatarTestCase(ZulipTestCase):
+    def test_possible_avatar_emails(self):
+        # type: () -> None
+        content = '''
+            hello !avatar(foo@example.com) my email is ignore@ignore.com
+            !gravatar(bar@yo.tv)
+
+            smushing!avatar(hamlet@example.org) is allowed
+        '''
+        self.assertEqual(
+            bugdown.possible_avatar_emails(content),
+            {'foo@example.com', 'bar@yo.tv', 'hamlet@example.org'},
+        )
+
     def test_avatar_with_id(self):
         # type: () -> None
         sender_user_profile = self.example_user('othello')

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -844,6 +844,17 @@ class BugdownTest(ZulipTestCase):
             render_markdown(msg, content),
             '<p>#<strong>casesens</strong></p>')
 
+    def test_possible_stream_names(self):
+        # type: () -> None
+        content = '''#**test here**
+            This mentions #**Denmark** too.
+            #**garçon** #**천국** @**Ignore Person**
+        '''
+        self.assertEqual(
+            bugdown.possible_linked_stream_names(content),
+            {'test here', 'Denmark', 'garçon', '천국'}
+        )
+
     def test_stream_unicode(self):
         # type: () -> None
         realm = get_realm('zulip')

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -500,6 +500,17 @@ class BugdownTest(ZulipTestCase):
         with self.settings(TEST_SUITE=False, TWITTER_CONSUMER_KEY=None):
             self.assertIs(None, bugdown.fetch_tweet_data('287977969287315459'))
 
+    def test_content_has_emoji(self):
+        # type: () -> None
+        self.assertFalse(bugdown.content_has_emoji_syntax('boring'))
+        self.assertFalse(bugdown.content_has_emoji_syntax('hello: world'))
+        self.assertFalse(bugdown.content_has_emoji_syntax(':foobar'))
+        self.assertFalse(bugdown.content_has_emoji_syntax('::: hello :::'))
+
+        self.assertTrue(bugdown.content_has_emoji_syntax('foo :whatever:'))
+        self.assertTrue(bugdown.content_has_emoji_syntax('\n:whatever:'))
+        self.assertTrue(bugdown.content_has_emoji_syntax(':smile: ::::::'))
+
     def test_realm_emoji(self):
         # type: () -> None
         def emoji_img(name, file_name, realm_id):

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -577,7 +577,7 @@ class StreamMessagesTest(ZulipTestCase):
         with queries_captured() as queries:
             send_message()
 
-        self.assert_length(queries, 13)
+        self.assert_length(queries, 12)
 
     def test_stream_message_dict(self):
         # type: () -> None

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -577,7 +577,7 @@ class StreamMessagesTest(ZulipTestCase):
         with queries_captured() as queries:
             send_message()
 
-        self.assert_length(queries, 14)
+        self.assert_length(queries, 13)
 
     def test_stream_message_dict(self):
         # type: () -> None

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -577,7 +577,7 @@ class StreamMessagesTest(ZulipTestCase):
         with queries_captured() as queries:
             send_message()
 
-        self.assert_length(queries, 15)
+        self.assert_length(queries, 14)
 
     def test_stream_message_dict(self):
         # type: () -> None

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -314,7 +314,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 65)
+        self.assert_length(queries, 64)
         user_profile = self.nonreg_user('test')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -314,7 +314,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 63)
+        self.assert_length(queries, 62)
         user_profile = self.nonreg_user('test')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -314,7 +314,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 64)
+        self.assert_length(queries, 63)
         user_profile = self.nonreg_user('test')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1629,7 +1629,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     streams_to_sub,
                     dict(principals=ujson.dumps([email1, email2])),
                 )
-        self.assert_length(queries, 41)
+        self.assert_length(queries, 40)
 
         self.assert_length(events, 7)
         for ev in [x for x in events if x['event']['type'] not in ('message', 'stream')]:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1629,7 +1629,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     streams_to_sub,
                     dict(principals=ujson.dumps([email1, email2])),
                 )
-        self.assert_length(queries, 40)
+        self.assert_length(queries, 39)
 
         self.assert_length(events, 7)
         for ev in [x for x in events if x['event']['type'] not in ('message', 'stream')]:


### PR DESCRIPTION
We do regex checks for at-mention/stream-link/avatar syntax before querying the DB at all for user info, and then we only get the data we need.