### PR TITLE
event_queue: Fix stream push notifications.

### DIFF
--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -697,7 +697,7 @@ def process_message_event(event_template, users):
             idle = receiver_is_off_zulip(user_profile_id) or (user_profile_id in missed_message_userids)
             always_push_notify = user_data.get('always_push_notify', False)
 
-            if (idle or always_push_notify):
+            if (idle or always_push_notify or stream_push_notify):
                 notice = build_offline_notification(user_profile_id, message_id)
                 notice['triggers'] = {
                     'private_message': private_message,
@@ -708,7 +708,7 @@ def process_message_event(event_template, users):
                 queue_json_publish("missedmessage_mobile_notifications", notice, lambda notice: None)
                 notified = dict(push_notified=True)  # type: Dict[str, bool]
                 # Don't send missed message emails if always_push_notify or stream_push_notify is True
-                if idle:
+                if idle and not (stream_push_notify is True and mentioned is False):
                     # We require RabbitMQ to do this, as we can't call the email handler
                     # from the Tornado process. So if there's no rabbitmq support do nothing
                     queue_json_publish("missedmessage_emails", notice, lambda notice: None)


### PR DESCRIPTION
Send push notifications for streams a user has tagged and do not send email notifications for stream messages when a user has not received a mention in the message.

I believe the unnecessary missed message emails are coming from the second ``if idle`` condition, so I added an extra condition to not send emails if a user didn't receive a mention from a stream but did opt to receive push notifications from the stream.

@timabbott, when I was testing manually, I wasn't getting push notifications without ``stream_push_notify`` inside the ``if idle or always_push_notify`` statement, although I know you took that piece out earlier. Here, I think ``stream_push_notify`` represents whether this message is coming from a stream in which this user has subscribed to push notifications, so it should only be true for a message from a stream in which the user wants push notifications. However, I'll take this out again if I'm not understanding it correctly and it shouldn't be here :)

Thanks for your help!