### PR TITLE
Fix issues with left-sidebar stream search

### DIFF
--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -20,9 +20,9 @@ stream_data.add_sub('scalene', {
     stream_id: 1,
     pin_to_top: true,
 });
-stream_data.add_sub('tortoise', {
+stream_data.add_sub('fast tortoise', {
     subscribed: true,
-    name: 'tortoise',
+    name: 'fast tortoise',
     stream_id: 2,
     pin_to_top: false,
 });
@@ -53,7 +53,7 @@ with_overrides(function (override) {
     // Test sorting into categories/alphabetized
     var sorted = stream_sort.sort_groups("");
     assert.deepEqual(sorted.pinned_streams, ['scalene']);
-    assert.deepEqual(sorted.normal_streams, ['clarinet', 'tortoise']);
+    assert.deepEqual(sorted.normal_streams, ['clarinet', 'fast tortoise']);
     assert.deepEqual(sorted.dormant_streams, ['pneumonia']);
 
     // Test filtering
@@ -67,4 +67,16 @@ with_overrides(function (override) {
     assert.deepEqual(sorted.pinned_streams, []);
     assert.deepEqual(sorted.normal_streams, []);
     assert.deepEqual(sorted.dormant_streams, ['pneumonia']);
+
+    // Test searching part of word
+    sorted = stream_sort.sort_groups("tortoise");
+    assert.deepEqual(sorted.pinned_streams, []);
+    assert.deepEqual(sorted.normal_streams, ['fast tortoise']);
+    assert.deepEqual(sorted.dormant_streams, []);
+
+    // Test searching stream with spaces
+    sorted = stream_sort.sort_groups("fast t");
+    assert.deepEqual(sorted.pinned_streams, []);
+    assert.deepEqual(sorted.normal_streams, ['fast tortoise']);
+    assert.deepEqual(sorted.dormant_streams, []);
 });

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -25,8 +25,10 @@ function filter_streams_by_search(streams, search_term) {
 
     var filtered_streams = _.filter(streams, function (stream) {
         return _.any(search_terms, function (search_term) {
-            var lower_stream_name = stream.toLowerCase().split(" ");
-            return _.any(lower_stream_name, function (name) {
+            var lower_stream_name = stream.toLowerCase();
+            var cands = lower_stream_name.split(" ");
+            cands.push(lower_stream_name);
+            return _.any(cands, function (name) {
                 return name.indexOf(search_term) === 0;
             });
         });


### PR DESCRIPTION
If you typed in more than one word for a stream with multiple words in it's name, it would not show up in the search list. This PR fixes that and adds some more tests covering the entire functionality of the filter.