### PR TITLE
hotkeys: Disable n hotkey functionality if user cannot create streams.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -607,7 +607,9 @@ exports.process_hotkey = function (e, hotkey) {
             return true;
         case 'n_key':
             if (overlays.streams_open()) {
-                subs.new_stream_clicked();
+                if (page_params.can_create_streams) {
+                    subs.new_stream_clicked();
+                }
             } else {
                 narrow.narrow_to_next_topic();
             }


### PR DESCRIPTION
Previously, a user could use the `n` hotkey in the stream subscriptions modal to open the Create new stream panel even though organization settings disabled a user from doing so. This commit prevents that from happening.