### PR TITLE
Display an error for the ZulipDesktop unsupported platform.

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -46,6 +46,16 @@ function update_message_in_all_views(message_id, callback) {
     });
 }
 
+exports.show_error_for_unsupported_platform = function () {
+    if (/ZulipDesktop/.test(navigator.userAgent)) {
+        var error = "Hello! You're using the unsupported old Zulip desktop app," +
+            " which is no longer developed. We recommend switching to the new, " +
+            "modern desktop app, which you can download at zulipchat.com/apps.";
+
+        ui_report.generic_embed_error(error);
+    }
+};
+
 exports.find_message = function (message_id) {
     // Try to find the message object. It might be in the narrow list
     // (if it was loaded when narrowed), or only in the message_list.all
@@ -285,6 +295,7 @@ $(function () {
 
 exports.initialize = function () {
     i18n.ensure_i18n(_setup_info_overlay);
+    exports.show_error_for_unsupported_platform();
 };
 
 return exports;

--- a/static/js/ui_report.js
+++ b/static/js/ui_report.js
@@ -43,6 +43,13 @@ exports.success = function (response, status_box, type) {
     exports.message(response, status_box, 'alert-success', type);
 };
 
+exports.generic_embed_error = function (error) {
+    var $alert = $("<div class='alert home-error-bar'></div>");
+    var $exit = "<div class='exit'></div>";
+
+    $(".alert-box").append($alert.html($exit + "<div class='content'>" + error + "</div>").addClass("show"));
+};
+
 exports.hide_error = function ($target) {
     $target.addClass("fade-out");
     setTimeout(function () {


### PR DESCRIPTION
This displays an error at the top of the screen on page load that
will inform any user with the userAgent string "ZulipDesktop" that
they should upgrade to our newer electron app

Fixes: #6551.