### PR TITLE
Remove selection on longtap.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -143,7 +143,21 @@ $(function () {
         $("#main_div").on("click", ".messagebox", select_message_function);
     // on the other hand, on mobile it should be done with a long tap.
     } else {
-        $("#main_div").on("longtap", ".messagebox", select_message_function);
+        $("#main_div").on("longtap", ".messagebox", function (e) {
+            // find the correct selection API for the browser.
+            var sel = window.getSelection ? window.getSelection() : document.selection;
+            // if one matches, remove the current selections.
+            // after a longtap that is valid, there should be no text selected.
+            if (sel) {
+                if (sel.removeAllRanges) {
+                    sel.removeAllRanges();
+                } else if (sel.empty) {
+                    sel.empty();
+                }
+            }
+
+            select_message_function.call(this, e);
+        });
     }
 
     function toggle_star(message_id) {


### PR DESCRIPTION
This removes the text selection that occurs on longtap due to the
standard iOS/Android behavior.

Fixes: #6480.