### PR TITLE
Make tooltips more legible.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -488,6 +488,23 @@ a:hover code {
     display: inline;
 }
 
+.tooltip.in {
+    font-size: 12px;
+    line-height: 1.3;
+
+    opacity: 1;
+}
+
+.tooltip.in.left {
+    margin-left: -12px;
+    margin-top: 3px;
+}
+
+.tooltip .tooltip-inner {
+    background-color: rgba(20, 20, 20, 0.8);
+    padding: 3px 5px;
+}
+
 #message_edit_tooltip {
     float: right;
     color: hsl(0, 0%, 0%);


### PR DESCRIPTION
This makes the JavaScript tooltips more legible by increasing
the font size and decreasing the line-height, while also increasing
the opacity of the tooltip from 0.8 => 1.