### PR TITLE
Popover of use profile appears when clicked on mentions.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -347,6 +347,12 @@ exports.register_click_handlers = function () {
         show_message_info_popover(this, rows.id(row));
     });
 
+    $("#main_div").on("click", ".user-mention", function (e) {
+        var row = $(this).closest(".message_row");
+        e.stopPropagation();
+        show_message_info_popover(this, rows.id(row));
+    });
+
     $('body').on('click', '.user_popover .narrow_to_private_messages', function (e) {
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var email = people.get_person_from_user_id(user_id).email;


### PR DESCRIPTION
I have updated popover as required please review it , regarding issue #6380 in which they want to reveal the profile picture popover on clicking over @mentions in chat.
I hope it works :) 
![screenshot from 2017-09-16 16-28-52](https://user-images.githubusercontent.com/17461330/30511710-713c6ad0-9afc-11e7-825b-557307d437db.png)
