### PR TITLE
stats: Remove hourly data from messages sent over time.

### DIFF
--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -117,10 +117,7 @@ function populate_messages_sent_over_time(data) {
                            $.extend({stepmode: 'backward'}, button2),
                            {step: 'all', label: 'All time'}] };
     }
-    var hourly_rangeselector = make_rangeselector(
-        0.66, -0.62,
-        {count: 24, label: i18n.t('Last 24 hours'), step: 'hour'},
-        {count: 72, label: i18n.t('Last 72 hours'), step: 'hour'});
+
     // This is also the cumulative rangeselector
     var daily_rangeselector = make_rangeselector(
         0.68, -0.62,
@@ -208,7 +205,6 @@ function populate_messages_sent_over_time(data) {
         return format_date(date, true);
     };
     var values = {me: data.user.human, human: data.realm.human, bot: data.realm.bot};
-    var hourly_traces = make_traces(start_dates, values, 'bar', date_formatter);
 
     var info = aggregate_data('day');
     date_formatter = function (date) {
@@ -241,7 +237,7 @@ function populate_messages_sent_over_time(data) {
     var clicked_cumulative = false;
 
     function draw_or_update_plot(rangeselector, traces, last_value_is_partial, initial_draw) {
-        $('#daily_button, #weekly_button, #hourly_button, #cumulative_button').removeClass("selected");
+        $('#daily_button, #weekly_button, #cumulative_button').removeClass("selected");
         if (initial_draw) {
             traces.human.visible = true;
             traces.bot.visible = 'legendonly';
@@ -266,12 +262,6 @@ function populate_messages_sent_over_time(data) {
     }
 
     // Click handlers for aggregation buttons
-    $('#hourly_button').click(function () {
-        draw_or_update_plot(hourly_rangeselector, hourly_traces, false, false);
-        $(this).addClass("selected");
-        clicked_cumulative = false;
-    });
-
     $('#daily_button').click(function () {
         draw_or_update_plot(daily_rangeselector, daily_traces, last_day_is_partial, false);
         $(this).addClass("selected");

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -22,7 +22,6 @@
         <div class="button-container">
           <label>{{ _("Aggregation") }}</label>
           <div class="buttons">
-            <button class="button" type="button" id='hourly_button'>{{ _("Hourly") }} </button>
             <button class="button" type="button" id='daily_button'>{{ _("Daily") }} </button>
             <button class="button" type="button" id='weekly_button'>{{ _("Weekly") }} </button>
             <button class="button" type="button" id='cumulative_button'>{{ _("Cumulative") }} </button>


### PR DESCRIPTION
Removes hourly data tab to enable speedup of the stats page.

Fixes #6564.