### PR TITLE
Utilize lower 40px of the page for the left sidebar.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -56,7 +56,7 @@ function get_new_heights() {
 
     res.main_div_min_height = viewport_height - top_navbar_height;
 
-    res.bottom_sidebar_height = viewport_height - top_navbar_height - 40;
+    res.bottom_sidebar_height = viewport_height - top_navbar_height;
 
     res.right_sidebar_height = viewport_height - parseInt($("#right-sidebar").css("marginTop"), 10);
 


### PR DESCRIPTION
This makes the total left sidebar real estate 40px taller and brings
it flush with the bottom of the screen, giving more room to the
streams list.

Fixes: #6549.