### PR TITLE
/privacy/: Restyle page to look like /for/ and "why" pages.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -1778,6 +1778,10 @@ nav ul li.active::after {
     color: #fff;
 }
 
+.portico-landing.why-page .hero.small-hero {
+    padding: 120px 50px 30px 50px;
+}
+
 .portico-landing.why-page .hero h1 {
     margin: 0px 0px 20px 0px;
 

--- a/templates/zerver/privacy.html
+++ b/templates/zerver/privacy.html
@@ -19,7 +19,7 @@
 {% include 'zerver/landing_nav.html' %}
 
 <div class="portico-landing why-page">
-    <div class="hero">
+    <div class="hero small-hero">
         <h1 class="center">{% trans %}Privacy policy{% endtrans %}</h1>
     </div>
     <div class="main">

--- a/templates/zerver/privacy.html
+++ b/templates/zerver/privacy.html
@@ -1,22 +1,43 @@
 {% extends "zerver/portico.html" %}
 
-{# Privacy policy. #}
+{% block title %}
+<title>Zulip: the best group chat for open source projects</title>
+{% endblock %}
+
+{% block customhead %}
+{{ super() }}
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% stylesheet 'portico' %}
+{% stylesheet 'landing-page' %}
+{{ render_bundle('landing-page') }}
+
+{% endblock %}
 
 {% block portico_content %}
 
-<div class="app terms-page flex">
-    <div class="app-main terms-page-container white-box">
+{% include 'zerver/landing_nav.html' %}
 
-        {% if privacy_policy %}
-            {{ render_markdown_path(privacy_policy) }}
-        {% else %}
-            {% trans %}
-            This installation of Zulip does not have a configured privacy policy.
-            Contact this <a href="mailto:{{ support_email }}">server's administrator</a>
-            if you have any questions.
-            {% endtrans %}
-        {% endif %}
+<div class="portico-landing why-page">
+    <div class="hero">
+        <h1 class="center">{% trans %}Privacy policy{% endtrans %}</h1>
+    </div>
+    <div class="main">
+        <div class="padded-content">
+            <div class="inner-content">
+                {% if privacy_policy %}
+                    {{ render_markdown_path(privacy_policy) }}
+                {% else %}
+                    {% trans %}
+                    This installation of Zulip does not have a configured privacy policy.
+                    Contact this <a href="mailto:{{ support_email }}">server's administrator</a>
+                    if you have any questions.
+                    {% endtrans %}
+                {% endif %}
+            </div>
+        </div>
     </div>
 </div>
+
 
 {% endblock %}

--- a/templates/zerver/terms.html
+++ b/templates/zerver/terms.html
@@ -2,19 +2,38 @@
 
 {# Terms of Service. #}
 
+{% block customhead %}
+{{ super() }}
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% stylesheet 'portico' %}
+{% stylesheet 'landing-page' %}
+{{ render_bundle('landing-page') }}
+
+{% endblock %}
+
 {% block portico_content %}
 
-<div class="app terms-page flex">
-    <div class="app-main terms-page-container white-box">
-        {% if terms_of_service %}
-            {{ render_markdown_path(terms_of_service) }}
-        {% else %}
-            {% trans %}
-            This installation of Zulip does not have a configured terms of service.
-            Contact this <a href="mailto:{{ support_email }}">server's administrator</a>
-            if you have any questions.
-            {% endtrans %}
-        {% endif %}
+{% include 'zerver/landing_nav.html' %}
+
+<div class="portico-landing why-page">
+    <div class="hero small-hero">
+        <h1 class="center">{% trans %}Terms of Service{% endtrans %}</h1>
+    </div>
+    <div class="main">
+        <div class="padded-content">
+            <div class="inner-content">
+                {% if terms_of_service %}
+                    {{ render_markdown_path(terms_of_service) }}
+                {% else %}
+                    {% trans %}
+                    This installation of Zulip does not have a configured terms of service.
+                    Contact this <a href="mailto:{{ support_email }}">server's administrator</a>
+                    if you have any questions.
+                    {% endtrans %}
+                {% endif %}
+            </div>
+        </div>
     </div>
 </div>
 

--- a/templates/zerver/why-zulip.html
+++ b/templates/zerver/why-zulip.html
@@ -19,7 +19,7 @@
 {% include 'zerver/landing_nav.html' %}
 
 <div class="portico-landing why-page">
-    <div class="hero">
+    <div class="hero small-hero">
         <h1 class="center">{% trans %}Why Zulip?{% endtrans %}</h1>
     </div>
     <div class="main">


### PR DESCRIPTION
This restyles the privacy page from an older style to a new
updated style with the mini-hero and naturally readable width
text.