### PR TITLE
date-separator: makes date unselectable.

### DIFF
--- a/static/templates/message_group.handlebars
+++ b/static/templates/message_group.handlebars
@@ -4,7 +4,7 @@
     {{#with this}}
 
         {{#if show_date_separator}}
-        <div class="date_row">{{{show_date}}}</div>
+        <div class="date_row no-select">{{{show_date}}}</div>
         {{/if}}
 
         {{#if bookend_top}}


### PR DESCRIPTION
From the [conversation](https://chat.zulip.org/#narrow/stream/design/subject/.236311/near/280002), we came to conclusion that keeping the dates in date-separators unselectable works fine.
Fixes: #6311.