### PR TITLE
message send: Cut is_active from the values query in get_recipient_info.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -796,7 +796,6 @@ def get_recipient_info(recipient, sender_id):
         ).values(
             'id',
             'enable_online_push_notifications',
-            'is_active',
             'is_bot',
             'bot_type',
             'long_term_idle',


### PR DESCRIPTION
This is unused since the query started filtering on is_active=True, in
51d4f16fe "Ignore inactive users in get_recipient_info()."