### PR TITLE
[WIP] Disallow certain markdown characters in stream and user names.

### DIFF
--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -140,6 +140,16 @@ casper.then(function () {
         casper.click('form#stream_creation_form button.button.white');
         casper.fill('form#add_new_subscription', {stream_name: '  '});
         casper.click('#add_new_subscription .create_stream_button');
+        casper.fill('form#stream_creation_form', {stream_name: 'Waseemio@'});
+        casper.click('form#stream_creation_form button.button.sea-green');
+    });
+});
+casper.then(function () {
+    casper.waitForSelectorText('#stream_name_error', 'Stream names cannot contain #, *, `, or @.', function () {
+        casper.test.assertTextExists('Stream names cannot contain #, *, `, or @.', "Can't create a stream with invalid characters");
+        casper.click('form#stream_creation_form button.button.white');
+        casper.fill('form#add_new_subscription', {stream_name: '  '});
+        casper.click('#add_new_subscription .create_stream_button');
         casper.fill('form#stream_creation_form', {stream_name: 'Waseemio'});
         casper.click('form#stream_creation_form button.button.sea-green');
     });

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -33,6 +33,11 @@ var stream_name_error = (function () {
         $("#stream_name_error").show();
     };
 
+    self.report_invalid_chars = function () {
+        $("#stream_name_error").text(i18n.t("Stream names cannot contain #, *, `, or @."));
+        $("#stream_name_error").show();
+    };
+
     self.select = function () {
         $("#create_stream_name").focus().select();
     };
@@ -62,6 +67,13 @@ var stream_name_error = (function () {
 
         if (stream_data.get_sub(stream_name)) {
             self.report_already_exists();
+            self.select();
+            return false;
+        }
+
+        // Keep characters in sync with Stream.NAME_INVALID_CHARS
+        if (/[#*`@]/.test(stream_name)) {
+            self.report_invalid_chars();
             self.select();
             return false;
         }

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1650,6 +1650,9 @@ def check_stream_name(stream_name: Text) -> None:
         raise JsonableError(_("Invalid stream name '%s'" % (stream_name)))
     if len(stream_name) > Stream.MAX_NAME_LENGTH:
         raise JsonableError(_("Stream name too long (limit: %s characters)" % (Stream.MAX_NAME_LENGTH)))
+    if set(stream_name).intersection(Stream.NAME_INVALID_CHARS):
+        raise JsonableError(_("Invalid characters in stream name (disallowed characters: %s)."
+                            % ((', ').join(Stream.NAME_INVALID_CHARS))))
     for i in stream_name:
         if ord(i) == 0:
             raise JsonableError(_("Stream name '%s' contains NULL (0x00) characters." % (stream_name)))

--- a/zerver/migrations/0126_disallow_chars_in_stream_and_user_name.py
+++ b/zerver/migrations/0126_disallow_chars_in_stream_and_user_name.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from django.db import models, migrations
+from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from typing import Text
+
+def remove_special_chars_from_streamname(apps, schema_editor):
+    # type: (StateApps, DatabaseSchemaEditor) -> None
+    Stream = apps.get_model('zerver', 'Stream')
+    NAME_INVALID_CHARS = ['*', '@', '`', '#']
+    for stream in Stream.objects.all():
+        if (set(stream.name).intersection(NAME_INVALID_CHARS)):
+            for char in NAME_INVALID_CHARS:
+                stream.name = stream.name.replace(char, ' ').strip()
+
+            while Stream.objects.filter(name__iexact=stream.name, realm=stream.realm).exists():
+                stream.name = stream.name + '^'
+                if len(stream.name) > 60:
+                    # extremely unlikely, so just do something valid
+                    stream.name = stream.name[-60:]
+            stream.save(update_fields=['name'])
+
+def remove_special_chars_from_username(apps, schema_editor):
+    # type: (StateApps, DatabaseSchemaEditor) -> None
+    UserProfile = apps.get_model('zerver', 'UserProfile')
+    NAME_INVALID_CHARS = ['*', '`', '>', '"', '@', '#']
+    for userprofile in UserProfile.objects.all():
+        if (set(userprofile.full_name).intersection(NAME_INVALID_CHARS)):
+            for char in NAME_INVALID_CHARS:
+                userprofile.full_name = userprofile.full_name.replace(char, ' ').strip()
+            userprofile.save(update_fields=['full_name'])
+
+        if (set(userprofile.short_name).intersection(NAME_INVALID_CHARS)):
+            for char in NAME_INVALID_CHARS:
+                userprofile.short_name = userprofile.short_name.replace(char, ' ').strip()
+            userprofile.save(update_fields=['short_name'])
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0125_realm_max_invites'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_special_chars_from_streamname),
+        migrations.RunPython(remove_special_chars_from_username),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -529,7 +529,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     MAX_NAME_LENGTH = 100
     MIN_NAME_LENGTH = 3
     API_KEY_LENGTH = 32
-    NAME_INVALID_CHARS = ['*', '`', '>', '"', '@']
+    NAME_INVALID_CHARS = ['*', '`', '>', '"', '@', '#']
 
     # Our custom site-specific fields
     full_name = models.CharField(max_length=MAX_NAME_LENGTH)  # type: Text

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -851,6 +851,8 @@ def generate_email_token_for_stream() -> str:
 
 class Stream(models.Model):
     MAX_NAME_LENGTH = 60
+    # Keep in sync with stream_create.js
+    NAME_INVALID_CHARS = ['*', '@', '`', '#']
     name = models.CharField(max_length=MAX_NAME_LENGTH, db_index=True)  # type: Text
     realm = models.ForeignKey(Realm, db_index=True, on_delete=CASCADE)  # type: Realm
     invite_only = models.NullBooleanField(default=False)  # type: Optional[bool]

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1266,7 +1266,7 @@ class MessagePOSTTest(ZulipTestCase):
         user.is_api_super_user = True
         user.save()
         user = get_user(email, get_realm('zulip'))
-        self.subscribe(user, "#IRCland")
+        self.subscribe(user, "IRCland")
         result = self.client_post("/api/v1/messages",
                                   {"type": "stream",
                                    "forged": "true",
@@ -1275,16 +1275,6 @@ class MessagePOSTTest(ZulipTestCase):
                                    "client": "irc_mirror",
                                    "subject": "from irc",
                                    "to": "IRCLand"},
-                                  **self.api_auth(email))
-        self.assert_json_error(result, "IRC stream names must start with #")
-        result = self.client_post("/api/v1/messages",
-                                  {"type": "stream",
-                                   "forged": "true",
-                                   "sender": "irc-user@irc.zulip.com",
-                                   "content": "Test message",
-                                   "client": "irc_mirror",
-                                   "subject": "from irc",
-                                   "to": "#IRCLand"},
                                   **self.api_auth(email))
         self.assert_json_success(result)
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1409,6 +1409,22 @@ class SubscriptionRestApiTest(ZulipTestCase):
         self.assert_json_error(result,
                                "Stream name too long (limit: 60 characters)")
 
+    def test_stream_name_has_invalid_characters(self) -> None:
+        email = self.example_email('hamlet')
+        self.login(email)
+
+        stream_name = "a*"
+        request = {
+            'delete': ujson.dumps([stream_name])
+        }
+        result = self.client_patch(
+            "/api/v1/users/me/subscriptions",
+            request,
+            **self.api_auth(email)
+        )
+        self.assert_json_error(result,
+                               "Invalid characters in stream name (disallowed characters: *, @, `, #).")
+
     def test_stream_name_contains_null(self) -> None:
         email = self.example_email('hamlet')
         self.login(email)

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -936,9 +936,7 @@ def send_message_backend(request: HttpRequest, user_profile: UserProfile,
         #
         # For stream messages, the message must be (1) being forwarded
         # by an API superuser for your realm and (2) being sent to a
-        # mirrored stream (any stream for the Zephyr and Jabber
-        # mirrors, but only streams with names starting with a "#" for
-        # IRC mirrors)
+        # mirrored stream.
         #
         # The security checks are split between the below code
         # (especially create_mirrored_message_users which checks the
@@ -954,9 +952,6 @@ def send_message_backend(request: HttpRequest, user_profile: UserProfile,
             return json_error(_("Invalid mirrored message"))
         if client.name == "zephyr_mirror" and not user_profile.realm.is_zephyr_mirror_realm:
             return json_error(_("Invalid mirrored realm"))
-        if (client.name == "irc_mirror" and message_type_name != "private" and
-                not message_to[0].startswith("#")):
-            return json_error(_("IRC stream names must start with #"))
         sender = mirror_sender
     else:
         sender = user_profile


### PR DESCRIPTION
fix for issue #6534.
step 1:  disallowing the following four characters from stream names and userprofile names: *, #, @, and ` 