### PR TITLE
missed_messages: Fixes misalignment of emojis with the text and removes the ugly inactive scrollbar.

### DIFF
--- a/templates/zerver/emails/missed_message.html
+++ b/templates/zerver/emails/missed_message.html
@@ -17,7 +17,7 @@
         While you were away you received {{ message_count }} new message{{ message_count|pluralize }}{% if mention %} in which you were mentioned{% endif %}!
     </p>
 
-    <div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
+    <div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: auto;">
         {% for recipient_block in messages %}
         <div class='recipient_block' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}border: 1px solid black;margin-bottom: 4px;">
             <div class='recipient_header' style="{% if recipient_block.header.stream_message %}background-color: #9ecaff;{% else %}color: #ffffff;background-color: #444444;{% endif %}border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -129,9 +129,9 @@ def build_message_list(user_profile, messages):
         # with a simple hyperlink.
         return re.sub(r"\[(\S*)\]\((\S*)\)", r"\2", content)
 
-    def fix_emoji_sizes(html):
+    def fix_emojis(html):
         # type: (Text) -> Text
-        return html.replace(' class="emoji"', ' height="20px"')
+        return html.replace(' class="emoji"', ' height="20px" style="position: relative;top: 6px;"')
 
     def build_message_payload(message):
         # type: (Message) -> Dict[str, Text]
@@ -142,7 +142,7 @@ def build_message_list(user_profile, messages):
         assert message.rendered_content is not None
         html = message.rendered_content
         html = relative_to_full_url(html)
-        html = fix_emoji_sizes(html)
+        html = fix_emojis(html)
 
         return {'plain': plain, 'html': html}
 

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -337,7 +337,7 @@ class TestMissedMessages(ZulipTestCase):
         msg_id = self.send_message(self.example_email('othello'), self.example_email('hamlet'),
                                    Recipient.PERSONAL,
                                    'Extremely personal message with a realm emoji :green_tick:!')
-        body = '<img alt=":green_tick:" height="20px" src="http://zulip.testserver/user_avatars/1/emoji/green_tick.png" title="green tick">'
+        body = '<img alt=":green_tick:" height="20px" style="position: relative;top: 6px;" src="http://zulip.testserver/user_avatars/1/emoji/green_tick.png" title="green tick">'
         subject = 'Othello, the Moor of Venice sent you a message'
         self._test_cases(tokens, msg_id, body, subject, send_as_user=False, verify_html_body=True)
 


### PR DESCRIPTION
If the emoji image doesn't get loaded then the alt gets misaligned with the rest of the text:
![image](https://user-images.githubusercontent.com/16687990/30653170-00fbf23c-9e48-11e7-8f93-edb9e289f968.png)

I am not sure if it is easy/possible to fix. This issue also exists in the webapp:
![image](https://user-images.githubusercontent.com/16687990/30653111-cf164f60-9e47-11e7-8f97-2c8cb998a641.png)

Emoji web PR will resolve this problem anyway.

Fixes: #6579.