### PR TITLE
(wip) Improve caching for streams.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2500,18 +2500,8 @@ def do_rename_stream(stream, new_name, log=True):
     recipient = get_recipient(Recipient.STREAM, stream.id)
     messages = Message.objects.filter(recipient=recipient).only("id")
 
-    # Update the display recipient and stream, which are easy single
-    # items to set.
     old_cache_key = get_stream_cache_key(old_name, stream.realm_id)
-    new_cache_key = get_stream_cache_key(stream.name, stream.realm_id)
-    if old_cache_key != new_cache_key:
-        cache_delete(old_cache_key)
-        cache_set(new_cache_key, stream)
-    cache_set(display_recipient_cache_key(recipient.id), stream.name)
-
-    # Delete cache entries for everything else, which is cheaper and
-    # clearer than trying to set them. display_recipient is the out of
-    # date field in all cases.
+    cache_delete(old_cache_key)
     cache_delete_many(
         to_dict_cache_key_id(message.id, True) for message in messages)
     cache_delete_many(

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -155,15 +155,15 @@ def can_access_stream_user_ids(stream):
     if stream.is_public():
         return set(active_user_ids(stream.realm_id))
     else:
-        return private_stream_user_ids(stream)
+        return private_stream_user_ids(stream.id)
 
-def private_stream_user_ids(stream):
-    # type: (Stream) -> Set[int]
+def private_stream_user_ids(stream_id):
+    # type: (int) -> Set[int]
 
     # TODO: Find similar queries elsewhere and de-duplicate this code.
     subscriptions = Subscription.objects.filter(
         recipient__type=Recipient.STREAM,
-        recipient__type_id=stream.id,
+        recipient__type_id=stream_id,
         active=True)
 
     return {sub['user_profile_id'] for sub in subscriptions.values('user_profile_id')}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1968,6 +1968,10 @@ def bulk_add_subscriptions(streams, users, from_stream_creation=False, acting_us
         subs_by_user[user_profile.id].append(sub_to_add)
         subs_to_add.append((sub_to_add, stream))
 
+    # Note that we are grabbing the last user_profile from the loop
+    # above to get the realm.
+    is_zephyr_realm = user_profile.realm.is_zephyr_mirror_realm
+
     # TODO: XXX: This transaction really needs to be done at the serializeable
     # transaction isolation level.
     with transaction.atomic():
@@ -2017,7 +2021,7 @@ def bulk_add_subscriptions(streams, users, from_stream_creation=False, acting_us
 
     def fetch_stream_subscriber_emails(stream):
         # type: (Stream) -> List[Text]
-        if stream.realm.is_zephyr_mirror_realm and not stream.invite_only:
+        if is_zephyr_realm and not stream.invite_only:
             return []
         users = all_subs_by_stream[stream.id]
         return [u.email for u in users]
@@ -2052,7 +2056,7 @@ def bulk_add_subscriptions(streams, users, from_stream_creation=False, acting_us
     # subscribers lists of streams in their browser; everyone for
     # public streams and only existing subscribers for private streams.
     for stream in streams:
-        if stream.realm.is_zephyr_mirror_realm and not stream.invite_only:
+        if is_zephyr_realm and not stream.invite_only:
             continue
 
         new_users = [user for user in users if (user.id, stream.id) in new_streams]
@@ -2112,6 +2116,10 @@ def bulk_remove_subscriptions(users, streams, acting_user=None):
         for recipient_id in recipients_to_unsub:
             not_subscribed.append((user_profile, stream_map[recipient_id]))
 
+    # Note that we are grabbing the last user_profile from the loop
+    # above to get the realm.
+    is_zephyr_realm = user_profile.realm.is_zephyr_mirror_realm
+
     # TODO: XXX: This transaction really needs to be done at the serializeable
     # transaction isolation level.
     with transaction.atomic():
@@ -2164,7 +2172,7 @@ def bulk_remove_subscriptions(users, streams, acting_user=None):
     all_subs_by_stream = query_all_subs_by_stream(streams=streams)
 
     for stream in streams:
-        if stream.realm.is_zephyr_mirror_realm and not stream.invite_only:
+        if is_zephyr_realm and not stream.invite_only:
             continue
 
         altered_users = altered_user_dict[stream.id]

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1546,7 +1546,7 @@ def check_message(sender, client, addressee,
         if not stream.invite_only:
             # This is a public stream
             pass
-        elif subscribed_to_stream(sender, stream):
+        elif subscribed_to_stream(sender, stream.id):
             # Or it is private, but your are subscribed
             pass
         elif sender.is_api_super_user or (forwarder_user_profile is not None and
@@ -1554,7 +1554,7 @@ def check_message(sender, client, addressee,
             # Or this request is being done on behalf of a super user
             pass
         elif sender.is_bot and (sender.bot_owner is not None and
-                                subscribed_to_stream(sender.bot_owner, stream)):
+                                subscribed_to_stream(sender.bot_owner, stream.id)):
             # Or you're a bot and your owner is subscribed.
             pass
         elif sender.email == settings.WELCOME_BOT:
@@ -1731,7 +1731,7 @@ def validate_user_access_to_subscribers(user_profile, stream):
          "invite_only": stream.invite_only},
         # We use a lambda here so that we only compute whether the
         # user is subscribed if we have to
-        lambda: subscribed_to_stream(cast(UserProfile, user_profile), stream))
+        lambda: subscribed_to_stream(cast(UserProfile, user_profile), stream.id))
 
 def validate_user_access_to_subscribers_helper(user_profile, stream_dict, check_user_subscribed):
     # type: (Optional[UserProfile], Mapping[str, Any], Callable[[], bool]) -> None
@@ -2392,7 +2392,7 @@ def _default_stream_permision_check(user_profile, stream):
             user = user_profile.bot_owner
         else:
             user = user_profile
-        if stream.invite_only and (user is None or not subscribed_to_stream(user, stream)):
+        if stream.invite_only and (user is None or not subscribed_to_stream(user, stream.id)):
             raise JsonableError(_('Insufficient permission'))
 
 def do_change_default_sending_stream(user_profile, stream, log=True):
@@ -2971,13 +2971,13 @@ def do_update_message_flags(user_profile, operation, flag, messages):
     statsd.incr("flags.%s.%s" % (flag, operation), count)
     return count
 
-def subscribed_to_stream(user_profile, stream):
-    # type: (UserProfile, Stream) -> bool
+def subscribed_to_stream(user_profile, stream_id):
+    # type: (UserProfile, int) -> bool
     try:
         if Subscription.objects.get(user_profile=user_profile,
                                     active=True,
                                     recipient__type=Recipient.STREAM,
-                                    recipient__type_id=stream.id):
+                                    recipient__type_id=stream_id):
             return True
         return False
     except Subscription.DoesNotExist:

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.contrib.auth.models import UserManager
 from django.utils.timezone import now as timezone_now
-from zerver.models import UserProfile, Recipient, Subscription, Realm, Stream
+from zerver.models import UserProfile, Recipient, Subscription, Realm, StreamLite
 import base64
 import ujson
 import os
@@ -57,15 +57,17 @@ def create_user(email, password, realm, full_name, short_name,
                 is_mirror_dummy=False, default_sending_stream=None,
                 default_events_register_stream=None,
                 default_all_public_streams=None, user_profile_id=None):
-    # type: (Text, Optional[Text], Realm, Text, Text, bool, bool, Optional[int], Optional[UserProfile], Optional[Text], Text, Text, bool, Optional[Stream], Optional[Stream], Optional[bool], Optional[int]) -> UserProfile
+    # type: (Text, Optional[Text], Realm, Text, Text, bool, bool, Optional[int], Optional[UserProfile], Optional[Text], Text, Text, bool, Optional[StreamLite], Optional[StreamLite], Optional[bool], Optional[int]) -> UserProfile
     user_profile = create_user_profile(realm, email, password, active, bot_type,
                                        full_name, short_name, bot_owner,
                                        is_mirror_dummy, tos_version, timezone)
     user_profile.is_realm_admin = is_realm_admin
     user_profile.avatar_source = avatar_source
     user_profile.timezone = timezone
-    user_profile.default_sending_stream = default_sending_stream
-    user_profile.default_events_register_stream = default_events_register_stream
+    if default_sending_stream:
+        user_profile.default_sending_stream_id = default_sending_stream.id
+    if default_events_register_stream is not None:
+        user_profile.default_events_register_stream_id = default_events_register_stream.id
     # Allow the ORM default to be used if not provided
     if default_all_public_streams is not None:
         user_profile.default_all_public_streams = default_all_public_streams

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -297,7 +297,7 @@ def access_message(user_profile, message_id):
             # You can't access private messages you didn't receive
             raise JsonableError(_("Invalid message(s)"))
         stream = Stream.objects.get(id=message.recipient.type_id)
-        if not stream.is_public():
+        if not stream.is_public(user_profile.realm):
             # You can't access messages sent to invite-only streams
             # that you didn't receive
             raise JsonableError(_("Invalid message(s)"))

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -53,7 +53,7 @@ def access_stream_common(user_profile, stream, error):
         sub = None
 
     # If the stream is in your realm and public, you can access it.
-    if stream.is_public():
+    if stream.is_public(user_profile.realm):
         return (recipient, sub)
 
     # Or if you are subscribed to the stream, you can access it.
@@ -135,7 +135,7 @@ def is_public_stream_by_name(stream_name, realm):
         stream = get_stream(stream_name, realm)
     except Stream.DoesNotExist:
         return False
-    return stream.is_public()
+    return stream.is_public(realm)
 
 def filter_stream_authorization(user_profile, streams):
     # type: (UserProfile, Iterable[Stream]) -> Tuple[List[Stream], List[Stream]]

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -42,6 +42,7 @@ from zerver.models import (
     Realm,
     Recipient,
     Stream,
+    StreamLite,
     Subscription,
     UserMessage,
     UserProfile,
@@ -484,7 +485,7 @@ class ZulipTestCase(TestCase):
                                             "../webhooks/%s/fixtures/%s.%s" % (type, action, file_type))).read())
 
     def make_stream(self, stream_name, realm=None, invite_only=False):
-        # type: (Text, Optional[Realm], Optional[bool]) -> Stream
+        # type: (Text, Optional[Realm], Optional[bool]) -> StreamLite
         if realm is None:
             realm = self.DEFAULT_REALM
 
@@ -502,11 +503,11 @@ class ZulipTestCase(TestCase):
                 that is not already in use.''' % (stream_name,))
 
         Recipient.objects.create(type_id=stream.id, type=Recipient.STREAM)
-        return stream
+        return StreamLite.for_stream_id(stream.id)
 
     # Subscribe to a stream directly
     def subscribe(self, user_profile, stream_name):
-        # type: (UserProfile, Text) -> Stream
+        # type: (UserProfile, Text) -> StreamLite
         try:
             stream = get_stream(stream_name, user_profile.realm)
             from_stream_creation = False

--- a/zerver/lib/topic_mutes.py
+++ b/zerver/lib/topic_mutes.py
@@ -12,7 +12,7 @@ from zerver.models import (
     get_stream,
     MutedTopic,
     Recipient,
-    Stream,
+    StreamLite,
     UserProfile
 )
 from sqlalchemy.sql import (
@@ -81,7 +81,7 @@ def remove_topic_mute(user_profile, stream_id, topic_name):
     row.delete()
 
 def topic_is_muted(user_profile, stream, topic_name):
-    # type: (UserProfile, Stream, Text) -> bool
+    # type: (UserProfile, StreamLite, Text) -> bool
     is_muted = MutedTopic.objects.filter(
         user_profile=user_profile,
         stream_id=stream.id,

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1026,12 +1026,14 @@ def get_client_remote_cache(name):
     (client, _) = Client.objects.get_or_create(name=name)
     return client
 
-# get_stream_backend takes either a realm id or a realm
 @cache_with_key(get_stream_cache_key, timeout=3600*24*7)
 def get_stream_backend(stream_name, realm_id):
     # type: (Text, int) -> Stream
-    return Stream.objects.select_related("realm").get(
-        name__iexact=stream_name.strip(), realm_id=realm_id)
+    stream = Stream.objects.get(
+        name__iexact=stream_name.strip(),
+        realm_id=realm_id
+    )
+    return stream
 
 def stream_name_in_use(stream_name, realm_id):
     # type: (Text, int) -> bool

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -931,14 +931,19 @@ class Stream(ModelReprMixin, models.Model):
     class Meta(object):
         unique_together = ("name", "realm")
 
-    def num_subscribers(self):
-        # type: () -> int
+    @staticmethod
+    def num_subscribers_for_stream_id(stream_id):
+        # type: (int) -> int
         return Subscription.objects.filter(
             recipient__type=Recipient.STREAM,
-            recipient__type_id=self.id,
+            recipient__type_id=stream_id,
             user_profile__is_active=True,
             active=True
         ).count()
+
+    def num_subscribers(self):
+        # type: () -> int
+        return Stream.num_subscribers_for_stream_id(self.id)
 
     # This is stream information that is sent to clients
     def to_dict(self):

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -920,10 +920,13 @@ class Stream(ModelReprMixin, models.Model):
         # type: () -> Text
         return u"<Stream: %s>" % (self.name,)
 
-    def is_public(self):
-        # type: () -> bool
+    def is_public(self, realm=None):
+        # type: (Optional[Realm]) -> bool
         # All streams are private in Zephyr mirroring realms.
-        return not self.invite_only and not self.realm.is_zephyr_mirror_realm
+        # We allow the caller to supply the realm to avoid DB hops.
+        if realm is None:
+            realm = self.realm
+        return not self.invite_only and not realm.is_zephyr_mirror_realm
 
     class Meta(object):
         unique_together = ("name", "realm")

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -114,12 +114,12 @@ class TestRealmAuditLog(ZulipTestCase):
         subscription_creation_logs = RealmAuditLog.objects.filter(event_type='subscription_created',
                                                                   event_time__gte=now)
         self.assertEqual(subscription_creation_logs.count(), 1)
-        self.assertEqual(subscription_creation_logs[0].modified_stream, stream[0])
+        self.assertEqual(subscription_creation_logs[0].modified_stream.id, stream[0].id)
         self.assertEqual(subscription_creation_logs[0].modified_user, user[0])
 
         bulk_remove_subscriptions(user, stream)
         subscription_deactivation_logs = RealmAuditLog.objects.filter(event_type='subscription_deactivated',
                                                                       event_time__gte=now)
         self.assertEqual(subscription_deactivation_logs.count(), 1)
-        self.assertEqual(subscription_deactivation_logs[0].modified_stream, stream[0])
+        self.assertEqual(subscription_deactivation_logs[0].modified_stream.id, stream[0].id)
         self.assertEqual(subscription_deactivation_logs[0].modified_user, user[0])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -15,7 +15,7 @@ from django.utils.timezone import now as timezone_now
 from zerver.models import (
     get_client, get_realm, get_recipient, get_stream, get_user,
     Message, RealmDomain, Recipient, UserMessage, UserPresence, UserProfile,
-    Realm, Subscription, Stream,
+    Realm, Subscription, Stream, StreamLite
 )
 
 from zerver.lib.actions import (
@@ -1655,7 +1655,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
     def test_unread_msgs(self):
         # type: () -> None
         def mute_stream(user_profile, stream):
-            # type: (UserProfile, Stream) -> None
+            # type: (UserProfile, StreamLite) -> None
             recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
             subscription = Subscription.objects.get(
                 user_profile=user_profile,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -357,7 +357,7 @@ class HomeTest(ZulipTestCase):
         # type: () -> None
         email = self.example_email("hamlet")
         realm = get_realm('zulip')
-        realm.notifications_stream = get_stream('Denmark', realm)
+        realm.notifications_stream_id = get_stream('Denmark', realm).id
         realm.save()
         self.login(email)
         result = self._get_home_page()

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -890,7 +890,7 @@ class MessagePOSTTest(ZulipTestCase):
         """
         user_profile = self.example_user('hamlet')
         email = user_profile.email
-        user_profile.default_sending_stream = get_stream('Verona', user_profile.realm)
+        user_profile.default_sending_stream_id = get_stream('Verona', user_profile.realm).id
         user_profile.save()
         result = self.client_post("/api/v1/messages", {"type": "stream",
                                                        "client": "test suite",

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -45,7 +45,7 @@ from zerver.models import (
     MAX_MESSAGE_LENGTH, MAX_SUBJECT_LENGTH,
     Message, Realm, Recipient, Stream, UserMessage, UserProfile, Attachment,
     RealmAuditLog, RealmDomain, get_realm, UserPresence, Subscription,
-    get_stream, get_recipient, get_system_bot, get_user, Reaction,
+    get_stream, get_recipient, get_system_bot, get_user, Reaction, StreamLite,
     sew_messages_and_reactions, flush_per_request_caches
 )
 
@@ -2328,7 +2328,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         subject = 'foo'
 
         def send_fake_message(message_content, stream):
-            # type: (str, Stream) -> Message
+            # type: (str, StreamLite) -> Message
             recipient = get_recipient(Recipient.STREAM, stream.id)
             return Message.objects.create(sender = sender,
                                           recipient = recipient,

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -136,7 +136,7 @@ class TestNotifyNewUser(ZulipTestCase):
         # type: () -> None
         new_user = self.example_user('cordelia')
         stream = self.make_stream('announce')
-        new_user.realm.notifications_stream = stream
+        new_user.realm.notifications_stream_id = stream.id
         new_user.realm.save()
         new_user = self.example_user('cordelia')
         notify_new_user(new_user)

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -207,11 +207,11 @@ class RealmTest(ZulipTestCase):
         # type: () -> None
         realm = get_realm("zulip")
         verona = get_stream("verona", realm)
-        realm.notifications_stream = verona
+        realm.notifications_stream_id = verona.id
         realm.save()
 
         notifications_stream = realm.get_notifications_stream()
-        self.assertEqual(notifications_stream, verona)
+        self.assertEqual(notifications_stream.id, verona.id)
         do_deactivate_stream(notifications_stream)
         self.assertIsNone(realm.get_notifications_stream())
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -508,7 +508,7 @@ class InviteUserTest(ZulipTestCase):
         """
         realm = get_realm('zulip')
         notifications_stream = get_stream('Verona', realm)
-        realm.notifications_stream = notifications_stream
+        realm.notifications_stream_id = notifications_stream.id
         realm.save()
 
         self.login(self.example_email("hamlet"))
@@ -518,8 +518,8 @@ class InviteUserTest(ZulipTestCase):
         self.check_sent_emails([invitee])
 
         prereg_user = get_prereg_user_by_email(invitee)
-        streams = list(prereg_user.streams.all())
-        self.assertTrue(notifications_stream in streams)
+        stream_ids = [stream.id for stream in prereg_user.streams.all()]
+        self.assertTrue(notifications_stream.id in stream_ids)
 
     def test_invite_user_signup_initial_history(self):
         # type: () -> None

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -214,18 +214,18 @@ class StreamAdminTest(ZulipTestCase):
         # type: () -> None
         stream = self.make_stream('new_stream')
         do_add_default_stream(stream)
-        self.assertEqual(1, DefaultStream.objects.filter(stream=stream).count())
+        self.assertEqual(1, DefaultStream.objects.filter(stream_id=stream.id).count())
         do_deactivate_stream(stream)
-        self.assertEqual(0, DefaultStream.objects.filter(stream=stream).count())
+        self.assertEqual(0, DefaultStream.objects.filter(stream_id=stream.id).count())
 
     def test_vacate_private_stream_removes_default_stream(self):
         # type: () -> None
         stream = self.make_stream('new_stream', invite_only=True)
         self.subscribe(self.example_user("hamlet"), stream.name)
         do_add_default_stream(stream)
-        self.assertEqual(1, DefaultStream.objects.filter(stream=stream).count())
+        self.assertEqual(1, DefaultStream.objects.filter(stream_id=stream.id).count())
         self.unsubscribe(self.example_user("hamlet"), stream.name)
-        self.assertEqual(0, DefaultStream.objects.filter(stream=stream).count())
+        self.assertEqual(0, DefaultStream.objects.filter(stream_id=stream.id).count())
         # Fetch stream again from database.
         stream = Stream.objects.get(id=stream.id)
         self.assertTrue(stream.deactivated)
@@ -1393,7 +1393,7 @@ class SubscriptionAPITest(ZulipTestCase):
             'announce': 'true',
         }
         notifications_stream = get_stream(self.streams[0], self.test_realm)
-        self.test_realm.notifications_stream = notifications_stream
+        self.test_realm.notifications_stream_id = notifications_stream.id
         self.test_realm.save()
 
         # Delete the UserProfile from the cache so the realm change will be
@@ -1436,7 +1436,7 @@ class SubscriptionAPITest(ZulipTestCase):
         invite_streams = self.make_random_stream_names([current_stream])[:1]
 
         notifications_stream = get_stream(current_stream, self.test_realm)
-        self.test_realm.notifications_stream = notifications_stream
+        self.test_realm.notifications_stream_id = notifications_stream.id
         self.test_realm.save()
 
         # Delete the UserProfile from the cache so the realm change will be
@@ -1509,7 +1509,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         current_stream = self.get_streams(invitee, self.test_realm)[0]
         notifications_stream = get_stream(current_stream, self.test_realm)
-        self.test_realm.notifications_stream = notifications_stream
+        self.test_realm.notifications_stream_id = notifications_stream.id
         self.test_realm.save()
 
         invite_streams = ['strange ) \\ test']
@@ -2694,11 +2694,11 @@ class AccessStreamTest(ZulipTestCase):
 
         # Hamlet can access the private stream
         (stream_ret, rec_ret, sub_ret) = access_stream_by_id(hamlet, stream.id)
-        self.assertEqual(stream, stream_ret)
+        self.assertEqual(stream.id, stream_ret.id)
         self.assertEqual(sub_ret.recipient, rec_ret)
         self.assertEqual(sub_ret.recipient.type_id, stream.id)
         (stream_ret2, rec_ret2, sub_ret2) = access_stream_by_name(hamlet, stream.name)
-        self.assertEqual(stream_ret, stream_ret2)
+        self.assertEqual(stream_ret.id, stream_ret2.id)
         self.assertEqual(sub_ret, sub_ret2)
         self.assertEqual(rec_ret, rec_ret2)
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -37,6 +37,7 @@ from zerver.lib.test_runner import (
 from zerver.models import (
     get_display_recipient, Message, Realm, Recipient, Stream, Subscription,
     DefaultStream, UserProfile, get_user_profile_by_id, active_user_ids,
+    StreamLite
 )
 
 from zerver.lib.actions import (
@@ -453,7 +454,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def set_up_stream_for_deletion(self, stream_name, invite_only=False,
                                    subscribed=True):
-        # type: (str, bool, bool) -> Stream
+        # type: (str, bool, bool) -> StreamLite
         """
         Create a stream for deletion by an administrator.
         """
@@ -471,12 +472,12 @@ class StreamAdminTest(ZulipTestCase):
         return stream
 
     def delete_stream(self, stream):
-        # type: (Stream) -> None
+        # type: (StreamLite) -> None
         """
         Delete the stream and assess the result.
         """
         active_name = stream.name
-        realm = stream.realm
+        realm = Realm.objects.get(id=stream.realm_id)
         stream_id = stream.id
 
         events = []  # type: List[Mapping[str, Any]]

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -13,7 +13,7 @@ from zerver.lib.request import REQ, has_request_variables, JsonableError
 from zerver.lib.response import json_success, json_error
 from zerver.lib.streams import access_stream_by_name
 from zerver.lib.validator import check_string, check_list
-from zerver.models import PreregistrationUser, Stream, UserProfile
+from zerver.models import PreregistrationUser, Stream, UserProfile, StreamLite
 
 import re
 
@@ -41,7 +41,7 @@ def invite_users_backend(request, user_profile,
     if notifications_stream and not notifications_stream.invite_only:
         stream_names.append(notifications_stream.name)
 
-    streams = []  # type: List[Stream]
+    streams = []  # type: List[StreamLite]
     for stream_name in stream_names:
         try:
             (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name)

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -224,7 +224,7 @@ class NarrowBuilder(object):
             # that specific stream.  So it would be a bug to hit this
             # codepath after relying on this term there.  But all streams in
             # a Zephyr realm are private, so that doesn't happen.
-            assert(not stream.is_public())
+            assert(not stream.is_public(self.user_profile.realm))
 
             m = re.search(r'^(?:un)*(.+?)(?:\.d)*$', stream.name, re.IGNORECASE)
             # Since the regex has a `.+` in it and "" is invalid as a

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -169,7 +169,7 @@ def remove_subscriptions_backend(request, user_profile,
 
     for stream in streams:
         if removing_someone_else and stream.invite_only and \
-                not subscribed_to_stream(user_profile, stream):
+                not subscribed_to_stream(user_profile, stream.id):
             # Even as an admin, you can't remove other people from an
             # invite-only stream you're not on.
             return json_error(_("Cannot administer invite-only streams this way"))

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -184,10 +184,10 @@ def remove_subscriptions_backend(request, user_profile,
     (removed, not_subscribed) = bulk_remove_subscriptions(people_to_unsub, streams,
                                                           acting_user=user_profile)
 
-    for (subscriber, stream) in removed:
-        result["removed"].append(stream.name)
-    for (subscriber, stream) in not_subscribed:
-        result["not_subscribed"].append(stream.name)
+    for (subscriber, removed_stream) in removed:
+        result["removed"].append(removed_stream.name)
+    for (subscriber, not_subscribed_stream) in not_subscribed:
+        result["not_subscribed"].append(not_subscribed_stream.name)
 
     return json_success(result)
 
@@ -276,8 +276,8 @@ def add_subscriptions_backend(request, user_profile,
 
     bots = dict((subscriber.email, subscriber.is_bot) for subscriber in subscribers)
 
-    newly_created_stream_names = {stream.name for stream in created_streams}
-    private_stream_names = {stream.name for stream in streams if stream.invite_only}
+    newly_created_stream_names = {s.name for s in created_streams}
+    private_stream_names = {s.name for s in streams if s.invite_only}
 
     # Inform the user if someone else subscribed them to stuff,
     # or if a new stream was created with the "announce" option.
@@ -343,7 +343,7 @@ def add_subscriptions_backend(request, user_profile,
     result["subscribed"] = dict(result["subscribed"])
     result["already_subscribed"] = dict(result["already_subscribed"])
     if not authorization_errors_fatal:
-        result["unauthorized"] = [stream.name for stream in unauthorized_streams]
+        result["unauthorized"] = [s.name for s in unauthorized_streams]
     return json_success(result)
 
 @has_request_variables

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -27,7 +27,8 @@ from zerver.lib.users import check_valid_bot_type, check_change_full_name, \
     check_full_name, check_short_name, check_valid_interface_type
 from zerver.lib.utils import generate_random_token
 from zerver.models import UserProfile, Stream, Message, email_allowed_for_realm, \
-    get_user_profile_by_id, get_user, Service, get_user_including_cross_realm
+    get_user_profile_by_id, get_user, Service, get_user_including_cross_realm, \
+    StreamLite
 from zerver.lib.create_user import random_api_key
 
 
@@ -177,7 +178,7 @@ def patch_bot_backend(request, user_profile, email,
         do_change_bot_owner(bot, owner, user_profile)
     if default_sending_stream is not None:
         if default_sending_stream == "":
-            stream = None  # type: Optional[Stream]
+            stream = None  # type: Optional[StreamLite]
         else:
             (stream, recipient, sub) = access_stream_by_name(
                 user_profile, default_sending_stream)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -329,13 +329,13 @@ class Command(BaseCommand):
                 }  # type: Dict[Text, Dict[Text, Any]]
                 bulk_create_streams(zulip_realm, zulip_stream_dict)
                 # Now that we've created the notifications stream, configure it properly.
-                zulip_realm.notifications_stream = get_stream("announce", zulip_realm)
+                zulip_realm.notifications_stream_id = get_stream("announce", zulip_realm).id
                 zulip_realm.save(update_fields=['notifications_stream'])
 
                 # Add a few default streams
                 for default_stream_name in ["design", "devel", "social", "support"]:
                     DefaultStream.objects.create(realm=zulip_realm,
-                                                 stream=get_stream(default_stream_name, zulip_realm))
+                                                 stream_id=get_stream(default_stream_name, zulip_realm).id)
 
                 # Now subscribe everyone to these streams
                 subscriptions_to_add = []


### PR DESCRIPTION
This series has two major goals:
* Add a super-slim, super-fast cache for active user ids.
* Streamline our stream cache not to have realm data.

This series is basically structured so that the first 16 commits should be fairly uncontroversial, but the last five are going to require more scrutiny, and the very last commit might be rejected.

The commits here may change a bit, but here's an overview of the progression.

Add test coverage:

~~~
pick bebe8e0 tests: Count queries for home page.
pick f49bde8 Add test_num_queries_with_streams() for home page.
~~~

Do some basic code cleanup, partly in support of the upcoming commit, but justifiable in their own right:

~~~
pick e8e60a4 Simplify get_stream_cache_key().
pick c3bed5c Only require realm_id for get_active_user_dicts_in_realm().
pick 858e06c Only require realm_id for active_user_ids().
~~~

**Add the user_ids cache**

~~~
pick fdd7059 Cache active_user_ids() more directly.
~~~

Do some simple prep commits that stand on their own merits:

~~~
pick 8a9b1e9 Use `prereg.users.set()` in do_invite_users.
pick c2825a6 Extract stream_name_in_use().
pick aed8d50 Have exclude_topic_mutes() accept a stream id.
pick df94e57 Use update_fields in do_deactivate_stream.
pick 83efcae Only require ids for finding DefaultStream objects.
~~~

Try to streamline our Zephyr codes.  I think these stand on their own merit, but they're also in support of streamlining our cache.

~~~
pick d0fe4a3 Extract is_zephyr_realm local var for bulk operations.
pick 4a8ae80 Add realm param to Stream.is_public().
~~~

Do some simple prep commits that mostly stand on their own merits:

~~~
pick 70b46be Only require stream_id in subscribed_to_stream().
pick a575820 Only require stream_id in  private_stream_user_ids().
~~~

**Make the stream cache slimmer**

~~~
pick 8175a3c Make the stream cache slimmer.
~~~

If we can get everything merged up to the above commit, I'd be pretty happy.  The subsequent commits have a less clear risk/reward tradeoff.  One nice thing about the following commits is that they helped prove to me that the prior commit is valid, and we don't lose anything by removing clunky out-of-date realm data from our stream cache.

The next couple commits are fine, but they're not a major win unless you go to the end.

~~~
pick 431bfad Use stream ids in various tests.
pick 6b609fd Extract Stream.num_subscribers_for_stream_id.
~~~

This next commit is superficially ugly, and it's driven by the end commit:

~~~
pick 1caf1d2 Avoid shadowing stream variables.
~~~

The following commit, while driven by the refactoring, makes sense to me on its own merits, but it deserves some scrutiny:

~~~
pick 63b530c Clear caches more aggressively in do_rename_stream().
~~~

Finally, there's this last commit, which I suspect you may reject, but I encourage you to read its long commit message.
~~~
pick ece529a Streamline stream objects that we get out of cache.
~~~
