### PR TITLE
subs: Fix jerky stream subscriptions scrolling with arrow keys.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -442,14 +442,39 @@ exports.change_state = (function () {
             } else if (hash.arguments[0] === "all") {
                 components.toggle.lookup("stream-filter-toggle").goto("all-streams");
             } else if (hash.arguments[0] === "subscribed") {
-                components.toggle.lookup("stream-filter-toggle").goto("subscribed"
-              );
+                components.toggle.lookup("stream-filter-toggle").goto("subscribed");
             // if the first argument is a valid number.
             } else if (/\d+/.test(hash.arguments[0])) {
-                var $stream_row = $(".stream-row[data-stream-id='" + hash.arguments[0] + "']");
-                var top = $stream_row.click()[0].offsetTop;
+                var stream_row = $(".stream-row[data-stream-id='" + hash.arguments[0] + "']");
+                var streams_list = $(".streams-list")[0];
 
-                $(".streams-list").animate({ scrollTop: top }, 200);
+                get_active_data().row.removeClass("active");
+                stream_row.addClass("active");
+
+                if ($(".stream-row:not(.notdisplayed):first")[0] === stream_row[0]) {
+                    streams_list.scrollTop = 0;
+                }
+
+                if ($(".stream-row:not(.notdisplayed):last")[0] === stream_row[0]) {
+                    streams_list.scrollTop = streams_list.scrollHeight - $(".streams-list").height();
+                }
+
+                if (stream_row.position().top < 70) {
+                    streams_list.scrollTop -= streams_list.clientHeight / 2;
+                }
+
+                var dist_from_top = stream_row.position().top;
+                var total_dist = dist_from_top + stream_row[0].clientHeight;
+                var dist_from_bottom = streams_list.clientHeight - total_dist;
+                if (dist_from_bottom < -4) {
+                    streams_list.scrollTop += streams_list.clientHeight / 2;
+                }
+
+                setTimeout(function () {
+                    if (hash.arguments[0] === get_active_data().id) {
+                        stream_row.click();
+                    }
+                }, 100);
             }
         }
     };


### PR DESCRIPTION
This PR imports the scrolling functionality from drafts into the stream subscriptions.

Ideal, expected behavior (rapid scrolling through streams when arrow keys are held down):
![](https://gyazo.com/dd52af233237d5851c662cd4e72ba554.gif)

However, because the data of every stream is loaded even though the stream is scrolled past, there's considerable lag scrolling through the streams and thus the issue isn't really resolved. This is what the current behavior is instead (the arrow keys have been held down the entire duration of the GIF):

![](https://i.gyazo.com/905a271eb4c01b1f0703d24ff641d3e1.gif)

Will hopefully fix #4230 in the future

Seeking advice/feedback from @brockwhittaker and @timabbott on how lazy loading could be possible implemented to reduce scrolling lag