### PR TITLE
navbar: Re-center home icon within <li> tab.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1592,7 +1592,7 @@ blockquote p {
 }
 
 #tab_list li.active.root {
-    padding-left: 10px;
+    padding: 0px 10px;
 }
 
 #tab_list li.private_message {


### PR DESCRIPTION
The home icon was too far to the right and did not have equal
padding within the <li> tab so this makes the padding an equal
10px on the left and right and none on the top and bottom.