### PR TITLE
urls: Change the method for adding alert words from PUT to POST.

### DIFF
--- a/static/js/alert_words_ui.js
+++ b/static/js/alert_words_ui.js
@@ -43,7 +43,7 @@ function add_alert_word(alert_word) {
 
     var words_to_be_added = [alert_word];
 
-     channel.put({
+     channel.post({
         url: '/json/users/me/alert_words',
         data: {alert_words: JSON.stringify(words_to_be_added)},
         success: function () {

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -39,7 +39,7 @@ class AlertWordTests(ZulipTestCase):
         params = {
             'alert_words': ujson.dumps(['milk', 'cookies'])
         }
-        result = self.client_put('/json/users/me/alert_words', params)
+        result = self.client_post('/json/users/me/alert_words', params)
         self.assert_json_success(result)
         user = self.example_user(user_name)
         words = user_alert_words(user)
@@ -119,7 +119,7 @@ class AlertWordTests(ZulipTestCase):
         # type: () -> None
         self.login(self.example_email("hamlet"))
 
-        result = self.client_put('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one ', '\n two', 'three'])})
+        result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one ', '\n two', 'three'])})
         self.assert_json_success(result)
 
         result = self.client_get('/json/users/me/alert_words')
@@ -130,7 +130,7 @@ class AlertWordTests(ZulipTestCase):
         # type: () -> None
         self.login(self.example_email("hamlet"))
 
-        result = self.client_put('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
+        result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
         self.assert_json_success(result)
 
         result = self.client_delete('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one'])})
@@ -152,7 +152,7 @@ class AlertWordTests(ZulipTestCase):
         self.login(self.example_email("hamlet"))
         user_profile_hamlet = self.example_user('hamlet')
 
-        result = self.client_put('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
+        result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
         self.assert_json_success(result)
 
         result = self.client_get('/json/users/me/alert_words')
@@ -184,7 +184,7 @@ class AlertWordTests(ZulipTestCase):
         me_email = user_profile.email
 
         self.login(me_email)
-        result = self.client_put('/json/users/me/alert_words', {'alert_words': ujson.dumps(['ALERT'])})
+        result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['ALERT'])})
 
         content = 'this is an ALERT for you'
         self.send_message(me_email, "Denmark", Recipient.STREAM, content)

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -39,7 +39,7 @@ class AlertWordTests(ZulipTestCase):
         params = {
             'alert_words': ujson.dumps(['milk', 'cookies'])
         }
-        result = self.client_post('/json/users/me/alert_words', params)
+        result = self.client_put('/json/users/me/alert_words', params)
         self.assert_json_success(result)
         user = self.example_user(user_name)
         words = user_alert_words(user)
@@ -139,20 +139,6 @@ class AlertWordTests(ZulipTestCase):
         result = self.client_get('/json/users/me/alert_words')
         self.assert_json_success(result)
         self.assertEqual(result.json()['alert_words'], ['two', 'three'])
-
-    def test_json_list_set(self):
-        # type: () -> None
-        self.login(self.example_email("hamlet"))
-
-        result = self.client_put('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
-        self.assert_json_success(result)
-
-        result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['a', 'b', 'c'])})
-        self.assert_json_success(result)
-
-        result = self.client_get('/json/users/me/alert_words')
-        self.assert_json_success(result)
-        self.assertEqual(result.json()['alert_words'], ['a', 'b', 'c'])
 
     def message_does_alert(self, user_profile, message):
         # type: (UserProfile, Text) -> bool

--- a/zerver/views/alert_words.py
+++ b/zerver/views/alert_words.py
@@ -9,7 +9,7 @@ from zerver.decorator import has_request_variables, REQ
 from zerver.lib.response import json_success
 from zerver.lib.validator import check_list, check_string
 
-from zerver.lib.actions import do_add_alert_words, do_remove_alert_words, do_set_alert_words
+from zerver.lib.actions import do_add_alert_words, do_remove_alert_words
 from zerver.lib.alert_words import user_alert_words
 
 def list_alert_words(request, user_profile):
@@ -20,13 +20,6 @@ def clean_alert_words(alert_words):
     # type: (List[Text]) -> List[Text]
     alert_words = [w.strip() for w in alert_words]
     return [w for w in alert_words if w != ""]
-
-@has_request_variables
-def set_alert_words(request, user_profile,
-                    alert_words=REQ(validator=check_list(check_string), default=[])):
-    # type: (HttpRequest, UserProfile, List[Text]) -> HttpResponse
-    do_set_alert_words(user_profile, clean_alert_words(alert_words))
-    return json_success()
 
 @has_request_variables
 def add_alert_words(request, user_profile,

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -365,7 +365,7 @@ v1_api_and_json_patterns = [
     # users/me/alert_words -> zerver.views.alert_words
     url(r'^users/me/alert_words$', rest_dispatch,
         {'GET': 'zerver.views.alert_words.list_alert_words',
-         'PUT': 'zerver.views.alert_words.add_alert_words',
+         'POST': 'zerver.views.alert_words.add_alert_words',
          'DELETE': 'zerver.views.alert_words.remove_alert_words'}),
 
     # users/me/custom_profile_data -> zerver.views.custom_profile_data

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -365,7 +365,6 @@ v1_api_and_json_patterns = [
     # users/me/alert_words -> zerver.views.alert_words
     url(r'^users/me/alert_words$', rest_dispatch,
         {'GET': 'zerver.views.alert_words.list_alert_words',
-         'POST': 'zerver.views.alert_words.set_alert_words',
          'PUT': 'zerver.views.alert_words.add_alert_words',
          'DELETE': 'zerver.views.alert_words.remove_alert_words'}),
 


### PR DESCRIPTION
This deals with the last 1/4 of the issue #5676.

I think the best way to go about this issue is to simply switch the POST and PUT endpoints places, so that the POST endpoint is responsible for adding new values to the list of alert words, and the PUT endpoint is responsible for replacing the list of alert words with new values.

I corrected all related POST and PUT requests within the project, and did my best to make sure that apps like zulip-electron, zulip-mobile, etc. are not using this API, but it is always good to have someone else look over and check.

Please let me know if I missed something or there is a better way to approach this issue.