### PR TITLE
Fix missedmessage_hook exceptions.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -377,8 +377,10 @@ class ZulipTestCase(TestCase):
         sender = get_user_profile_by_email(sender_name)
         if message_type in [Recipient.PERSONAL, Recipient.HUDDLE]:
             message_type_name = "private"
-        else:
+        elif message_type == Recipient.STREAM:
             message_type_name = "stream"
+        else:
+            raise AssertionError("Recipient type should be an Recipient.STREAM type enum")
         if isinstance(raw_recipients, six.string_types):
             recipient_list = [raw_recipients]
         else:

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -1,0 +1,88 @@
+import mock
+
+from typing import Any, Callable, Dict, Tuple
+
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.tornado.event_queue import maybe_enqueue_notifications
+
+class MissedMessageNotificationsTest(ZulipTestCase):
+    """Tests the logic for when missed-message notifications
+    should be triggered, based on user settings"""
+    def check_will_notify(self, *args, **kwargs):
+        # type: (*Any, **Any) -> Tuple[str, str]
+        email_notice = None
+        mobile_notice = None
+        with mock.patch("zerver.tornado.event_queue.queue_json_publish") as mock_queue_publish:
+            notified = maybe_enqueue_notifications(*args, **kwargs)
+            if notified is None:
+                notified = {}
+            for entry in mock_queue_publish.call_args_list:
+                args = entry[0]
+                if args[0] == "missedmessage_mobile_notifications":
+                    mobile_notice = args[1]
+                if args[0] == "missedmessage_emails":
+                    email_notice = args[1]
+
+            # Now verify the return value matches the queue actions
+            if email_notice:
+                self.assertTrue(notified['email_notified'])
+            else:
+                self.assertFalse(notified.get('email_notified', False))
+            if mobile_notice:
+                self.assertTrue(notified['push_notified'])
+            else:
+                self.assertFalse(notified.get('push_notified', False))
+        return email_notice, mobile_notice
+
+    def test_enqueue_notifications(self):
+        # type: () -> None
+        user_profile = self.example_user("hamlet")
+        message_id = 32
+
+        # Boring message doesn't send a notice
+        email_notice, mobile_notice = self.check_will_notify(
+            user_profile.id, message_id, private_message=False,
+            mentioned=False, stream_push_notify=False, stream_name=None,
+            always_push_notify=False, idle=True)
+        self.assertTrue(email_notice is None)
+        self.assertTrue(mobile_notice is None)
+
+        # Private message sends a notice
+        email_notice, mobile_notice = self.check_will_notify(
+            user_profile.id, message_id, private_message=True,
+            mentioned=False, stream_push_notify=False, stream_name=None,
+            always_push_notify=False, idle=True)
+        self.assertTrue(email_notice is not None)
+        self.assertTrue(mobile_notice is not None)
+
+        # Mention sends a notice
+        email_notice, mobile_notice = self.check_will_notify(
+            user_profile.id, message_id, private_message=False,
+            mentioned=True, stream_push_notify=False, stream_name=None,
+            always_push_notify=False, idle=True)
+        self.assertTrue(email_notice is not None)
+        self.assertTrue(mobile_notice is not None)
+
+        # stream_push_notify pushes but doesn't email
+        email_notice, mobile_notice = self.check_will_notify(
+            user_profile.id, message_id, private_message=False,
+            mentioned=False, stream_push_notify=True, stream_name="Denmark",
+            always_push_notify=False, idle=True)
+        self.assertTrue(email_notice is None)
+        self.assertTrue(mobile_notice is not None)
+
+        # Private message doesn't send a notice if not idle
+        email_notice, mobile_notice = self.check_will_notify(
+            user_profile.id, message_id, private_message=True,
+            mentioned=False, stream_push_notify=False, stream_name=None,
+            always_push_notify=False, idle=False)
+        self.assertTrue(email_notice is None)
+        self.assertTrue(mobile_notice is None)
+
+        # Private message sends push but not email if not idle but always_push_notify
+        email_notice, mobile_notice = self.check_will_notify(
+            user_profile.id, message_id, private_message=True,
+            mentioned=False, stream_push_notify=False, stream_name=None,
+            always_push_notify=True, idle=False)
+        self.assertTrue(email_notice is None)
+        self.assertTrue(mobile_notice is not None)

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -20,8 +20,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         mobile_notice = None
         with mock.patch("zerver.tornado.event_queue.queue_json_publish") as mock_queue_publish:
             notified = maybe_enqueue_notifications(*args, **kwargs)
-            if notified is None:
-                notified = {}
             for entry in mock_queue_publish.call_args_list:
                 args = entry[0]
                 if args[0] == "missedmessage_mobile_notifications":

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -1,9 +1,15 @@
 import mock
+import ujson
 
+from django.http import HttpRequest, HttpResponse
 from typing import Any, Callable, Dict, Tuple
 
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.tornado.event_queue import maybe_enqueue_notifications
+from zerver.lib.test_helpers import POSTRequestMock
+from zerver.models import Recipient, Subscription, UserProfile, get_stream
+from zerver.tornado.event_queue import maybe_enqueue_notifications, \
+    get_client_descriptor, missedmessage_hook
+from zerver.tornado.views import get_events_backend
 
 class MissedMessageNotificationsTest(ZulipTestCase):
     """Tests the logic for when missed-message notifications
@@ -86,3 +92,65 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             always_push_notify=True, idle=False)
         self.assertTrue(email_notice is None)
         self.assertTrue(mobile_notice is not None)
+
+    def tornado_call(self, view_func, user_profile, post_data):
+        # type: (Callable[[HttpRequest, UserProfile], HttpResponse], UserProfile, Dict[str, Any]) -> HttpResponse
+        request = POSTRequestMock(post_data, user_profile)
+        return view_func(request, user_profile)
+
+    def test_end_to_end_missedmessage_hook(self):
+        # type: () -> None
+        """Tests what arguments missedmessage_hook passes into maybe_enqueue_notifications.
+        Combined with the previous test, this ensures that the missedmessage_hook is correct"""
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
+        self.login(email)
+
+        result = self.tornado_call(get_events_backend, user_profile,
+                                   {"apply_markdown": ujson.dumps(True),
+                                    "event_types": ujson.dumps(["message"]),
+                                    "user_client": "website",
+                                    "dont_block": ujson.dumps(True),
+                                    })
+        self.assert_json_success(result)
+        queue_id = ujson.loads(result.content)["queue_id"]
+        client_descriptor = get_client_descriptor(queue_id)
+
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            # To test the missed_message hook, we first need to send a message
+            msg_id = self.send_message(self.example_email("iago"), "Denmark", Recipient.STREAM)
+
+            # Verify that nothing happens if you call it as not the last client
+            missedmessage_hook(user_profile.id, client_descriptor, False)
+            mock_enqueue.assert_not_called()
+
+            # Now verify that we called the appropriate enqueue function
+            missedmessage_hook(user_profile.id, client_descriptor, True)
+            mock_enqueue.assert_called_once()
+            args_list = mock_enqueue.call_args_list[0][0]
+
+            self.assertEqual(args_list, (user_profile.id, msg_id, False, False, False, None, False, True))
+
+        # Clear the event queue, before repeating with a private message
+        client_descriptor.event_queue.pop()
+        self.assertTrue(client_descriptor.event_queue.empty())
+        msg_id = self.send_message(self.example_email("iago"), [email], Recipient.PERSONAL)
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            missedmessage_hook(user_profile.id, client_descriptor, True)
+            mock_enqueue.assert_called_once()
+            args_list = mock_enqueue.call_args_list[0][0]
+
+            self.assertEqual(args_list, (user_profile.id, msg_id, False, False, False, None, False, True))
+
+        # Clear the event queue, now repeat with a mention
+        client_descriptor.event_queue.pop()
+        self.assertTrue(client_descriptor.event_queue.empty())
+        msg_id = self.send_message(self.example_email("iago"), "Denmark", Recipient.STREAM,
+                                   content="@**King Hamlet** what's up?")
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            # Clear the event queue, before repeating with a private message
+            missedmessage_hook(user_profile.id, client_descriptor, True)
+            mock_enqueue.assert_called_once()
+            args_list = mock_enqueue.call_args_list[0][0]
+
+            self.assertEqual(args_list, (user_profile.id, msg_id, False, True, False, None, False, True))

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -127,7 +127,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             mock_enqueue.assert_called_once()
             args_list = mock_enqueue.call_args_list[0][0]
 
-            self.assertEqual(args_list, (user_profile.id, msg_id, False, False, False, None, False, True))
+            self.assertEqual(args_list, (user_profile.id, msg_id, False, False, False, "Denmark", False, True))
 
         # Clear the event queue, before repeating with a private message
         client_descriptor.event_queue.pop()
@@ -151,4 +151,26 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             mock_enqueue.assert_called_once()
             args_list = mock_enqueue.call_args_list[0][0]
 
-            self.assertEqual(args_list, (user_profile.id, msg_id, False, True, False, None, False, True))
+            self.assertEqual(args_list, (user_profile.id, msg_id, False, True, False, "Denmark", False, True))
+
+        # Clear the event queue, now repeat with stream message with stream_push_notify
+        stream = get_stream("Denmark", user_profile.realm)
+        sub = Subscription.objects.get(user_profile=user_profile, recipient__type=Recipient.STREAM,
+                                       recipient__type_id=stream.id)
+        sub.push_notifications = True
+        sub.save()
+        client_descriptor.event_queue.pop()
+        self.assertTrue(client_descriptor.event_queue.empty())
+        msg_id = self.send_message(self.example_email("iago"), "Denmark", Recipient.STREAM,
+                                   content="what's up everyone?")
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            # Clear the event queue, before repeating with a private message
+            missedmessage_hook(user_profile.id, client_descriptor, True)
+            mock_enqueue.assert_called_once()
+            args_list = mock_enqueue.call_args_list[0][0]
+
+            self.assertEqual(args_list, (user_profile.id, msg_id, False, False, True, "Denmark", False, True))
+
+        # Clean up the state
+        sub.push_notifications = True
+        sub.save()

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -140,7 +140,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             mock_enqueue.assert_called_once()
             args_list = mock_enqueue.call_args_list[0][0]
 
-            self.assertEqual(args_list, (user_profile.id, msg_id, False, False, False, None, False, True))
+            self.assertEqual(args_list, (user_profile.id, msg_id, True, False, False, None, False, True))
 
         # Clear the event queue, now repeat with a mention
         client_descriptor.event_queue.pop()

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -616,14 +616,14 @@ def build_offline_notification(user_profile_id, message_id):
             "message_id": message_id,
             "timestamp": time.time()}
 
-def missedmessage_hook(user_profile_id, queue, last_for_client):
+def missedmessage_hook(user_profile_id, client, last_for_client):
     # type: (int, ClientDescriptor, bool) -> None
     # Only process missedmessage hook when the last queue for a
     # client has been garbage collected
     if not last_for_client:
         return
 
-    for event in queue.event_queue.contents():
+    for event in client.event_queue.contents():
         if event['type'] != 'message':
             continue
         assert 'flags' in event

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -625,10 +625,13 @@ def missedmessage_hook(user_profile_id, queue, last_for_client):
 
     message_ids_to_notify = []  # type: List[Dict[str, Any]]
     for event in queue.event_queue.contents():
-        if not event['type'] == 'message' or not event['flags']:
+        if event['type'] != 'message':
             continue
+        assert 'flags' in event
 
-        if 'mentioned' in event['flags'] and 'read' not in event['flags']:
+        flags = event['flags']
+        mentioned = 'mentioned' in flags and 'read' not in flags
+        if mentioned:
             notify_info = dict(message_id=event['message']['id'])
 
             if not event.get('push_notified', False):
@@ -720,7 +723,7 @@ def process_message_event(event_template, users):
         # If the recipient was offline and the message was a single or group PM to them
         # or they were @-notified potentially notify more immediately
         private_message = message_type == "private" and user_profile_id != sender_id
-        mentioned = 'mentioned' in flags
+        mentioned = 'mentioned' in flags and 'read' not in flags
         stream_push_notify = user_data.get('stream_push_notify', False)
 
         # We first check if a message is potentially mentionable,

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -630,13 +630,13 @@ def missedmessage_hook(user_profile_id, queue, last_for_client):
 
         flags = event['flags']
         mentioned = 'mentioned' in flags and 'read' not in flags
+        private_message = event['message']['type'] == 'private'
         # TODO: These next variables should be extracted from the
-        # event, but to match the historical effect of this function
-        # in only supporting mentions, we've just hardcoded them to
-        # False.  Fixing this will correct currently buggy behavior in
-        # our handling of private message and users who've requested
-        # stream push notifications.
-        private_message = False
+        # event and client descriptor, but to match the historical
+        # effect of this function in only supporting mentions, we've
+        # just hardcoded them to False.  Fixing this will correct
+        # currently buggy behavior in our handling of users who've
+        # requested stream push notifications.
         stream_push_notify = False
         stream_name = None
         always_push_notify = False

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -660,6 +660,9 @@ def maybe_enqueue_notifications(user_profile_id, message_id, private_message,
                                 mentioned, stream_push_notify, stream_name,
                                 always_push_notify, idle):
     # type: (int, int, bool, bool, bool, Optional[str], bool, bool) -> Optional[Dict[str, bool]]
+    """This function has a complete unit test suite in
+    `test_enqueue_notifications` that should be expanded as we add
+    more features here."""
     notified = dict()  # type: Dict[str, bool]
 
     if (idle or always_push_notify) and (private_message or mentioned or stream_push_notify):

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -686,9 +686,7 @@ def maybe_enqueue_notifications(user_profile_id, message_id, private_message,
         queue_json_publish("missedmessage_emails", notice, lambda notice: None)
         notified['email_notified'] = True
 
-    if len(notified) > 0:
-        return notified
-    return None
+    return notified
 
 def process_message_event(event_template, users):
     # type: (Mapping[str, Any], Iterable[Mapping[str, Any]]) -> None
@@ -737,8 +735,7 @@ def process_message_event(event_template, users):
             result = maybe_enqueue_notifications(user_profile_id, message_id, private_message,
                                                  mentioned, stream_push_notify, stream_name,
                                                  always_push_notify, idle)
-            if result is not None:
-                extra_user_data[user_profile_id] = result
+            extra_user_data[user_profile_id] = result
 
     for client_data in six.itervalues(send_to_clients):
         client = client_data['client']


### PR DESCRIPTION
This is a first version of fixing #6612.  I'd like to add tests before we merge this, since breaking this code path would have significant unfortunate consequences.