### PR TITLE
add shift key to restore last draft

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -207,8 +207,7 @@ function stubbing(func_name_to_stub, test_function) {
     assert_mapping('q', 'activity.initiate_search');
     assert_mapping('w', 'stream_list.initiate_search');
 
-    assert_mapping('A', 'narrow.stream_cycle_backward');
-    assert_mapping('D', 'narrow.stream_cycle_forward');
+    assert_mapping('D', 'restore_latest_draft');
 
     assert_mapping('c', 'compose_actions.start');
     assert_mapping('C', 'compose_actions.start');

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -237,6 +237,7 @@ function stubbing(func_name_to_stub, test_function) {
     assert_mapping('-', 'condense.toggle_collapse');
     assert_mapping('r', 'compose_actions.respond_to_message');
     assert_mapping('R', 'compose_actions.respond_to_message', true);
+    assert_mapping('D', 'drafts.restore_draft_for_hotkey');
     assert_mapping('j', 'navigate.down');
     assert_mapping('J', 'navigate.page_down');
     assert_mapping('k', 'navigate.up');

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -366,7 +366,7 @@ exports.drafts_handle_events = function (e, event_key) {
     }
 };
 
-exports.restore_draft_for_hotkey = function() {
+exports.restore_draft_for_hotkey = function () {
     var draft_arrow = draft_model.get();
     var draft_id_arrow = Object.getOwnPropertyNames(draft_arrow);
     var first_draft = draft_id_arrow[draft_id_arrow.length-1];

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -112,7 +112,7 @@ exports.delete_draft_after_send = function () {
     $("#new_message_content").removeData("draft-id");
 };
 
-exports.restore_draft = function (draft_id) {
+exports.restore_draft = function (draft_id, is_overlay_closed) {
     var draft = draft_model.getDraft(draft_id);
     if (!draft) {
         return;
@@ -140,8 +140,9 @@ exports.restore_draft = function (draft_id) {
                              {select_first_unread: true, trigger: "restore draft"});
         }
     }
-
-    overlays.close_overlay("drafts");
+    if(!is_overlay_closed) {
+        overlays.close_overlay("drafts");
+    }
     compose_fade.clear_compose();
     if (draft.type === "stream" && draft.stream === "") {
         draft_copy.subject = "";
@@ -363,6 +364,13 @@ exports.drafts_handle_events = function (e, event_key) {
             exports.restore_draft(first_draft);
         }
     }
+};
+
+exports.restore_draft_on_shiftd = function() {
+   var draft_arrow = draft_model.get();
+   var draft_id_arrow = Object.getOwnPropertyNames(draft_arrow);
+   var first_draft = draft_id_arrow[draft_id_arrow.length-1];
+   exports.restore_draft(first_draft, true);
 };
 
 exports.toggle = function () {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -367,10 +367,10 @@ exports.drafts_handle_events = function (e, event_key) {
 };
 
 exports.restore_draft_for_hotkey = function() {
-   var draft_arrow = draft_model.get();
-   var draft_id_arrow = Object.getOwnPropertyNames(draft_arrow);
-   var first_draft = draft_id_arrow[draft_id_arrow.length-1];
-   exports.restore_draft(first_draft, true);
+    var draft_arrow = draft_model.get();
+    var draft_id_arrow = Object.getOwnPropertyNames(draft_arrow);
+    var first_draft = draft_id_arrow[draft_id_arrow.length-1];
+    exports.restore_draft(first_draft, true);
 };
 
 exports.toggle = function () {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -140,7 +140,7 @@ exports.restore_draft = function (draft_id, is_overlay_closed) {
                              {select_first_unread: true, trigger: "restore draft"});
         }
     }
-    if(!is_overlay_closed) {
+    if (!is_overlay_closed) {
         overlays.close_overlay("drafts");
     }
     compose_fade.clear_compose();
@@ -366,7 +366,7 @@ exports.drafts_handle_events = function (e, event_key) {
     }
 };
 
-exports.restore_draft_on_shiftd = function() {
+exports.restore_draft_for_hotkey = function() {
    var draft_arrow = draft_model.get();
    var draft_id_arrow = Object.getOwnPropertyNames(draft_arrow);
    var first_draft = draft_id_arrow[draft_id_arrow.length-1];

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -41,7 +41,7 @@ var keydown_shift_mappings = {
     // these can be triggered by shift + key only
     9: {name: 'shift_tab', message_view_only: false}, // tab
     32: {name: 'shift_spacebar', message_view_only: true},  // space bar
-    /*68: {name: 'shift_d', message_view_only: false},*/
+    68: {name: 'shift_d', message_view_only: false},
 };
 
 var keydown_unshift_mappings = {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -41,6 +41,7 @@ var keydown_shift_mappings = {
     // these can be triggered by shift + key only
     9: {name: 'shift_tab', message_view_only: false}, // tab
     32: {name: 'shift_spacebar', message_view_only: true},  // space bar
+    68: {name: 'shift_d', message_view_only: false},
 };
 
 var keydown_unshift_mappings = {
@@ -644,6 +645,9 @@ exports.process_hotkey = function (e, hotkey) {
         case 'vim_page_up':
         case 'shift_spacebar':
             navigate.page_up();
+            return true;
+        case 'shift_d':
+            drafts.restore_draft_on_shiftd();
             return true;
         case 'page_down':
         case 'vim_page_down':

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -41,7 +41,6 @@ var keydown_shift_mappings = {
     // these can be triggered by shift + key only
     9: {name: 'shift_tab', message_view_only: false}, // tab
     32: {name: 'shift_spacebar', message_view_only: true},  // space bar
-    68: {name: 'shift_d', message_view_only: false},
 };
 
 var keydown_unshift_mappings = {
@@ -90,6 +89,7 @@ var keypress_mappings = {
     65: {name: 'stream_cycle_backward', message_view_only: true}, // 'A'
     67: {name: 'compose_private_message', message_view_only: true}, // 'C'
     68: {name: 'stream_cycle_forward', message_view_only: true}, // 'D'
+    68: {name: 'restore_latest_draft', message_view_only: false}, // 'D'
     71: {name: 'G_end', message_view_only: true}, // 'G'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
     75: {name: 'vim_page_up', message_view_only: true}, // 'K'
@@ -593,6 +593,9 @@ exports.process_hotkey = function (e, hotkey) {
         case 'stream_cycle_forward':
             narrow.stream_cycle_forward();
             return true;
+        case 'restore_latest_draft':
+            drafts.restore_draft_for_hotkey();
+            return true;
         case 'view_selected_stream':
             if (overlays.streams_open()) {
                 subs.view_stream();
@@ -645,9 +648,6 @@ exports.process_hotkey = function (e, hotkey) {
         case 'vim_page_up':
         case 'shift_spacebar':
             navigate.page_up();
-            return true;
-        case 'shift_d':
-            drafts.restore_draft_for_hotkey();
             return true;
         case 'page_down':
         case 'vim_page_down':

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -647,7 +647,7 @@ exports.process_hotkey = function (e, hotkey) {
             navigate.page_up();
             return true;
         case 'shift_d':
-            drafts.restore_draft_on_shiftd();
+            drafts.restore_draft_for_hotkey();
             return true;
         case 'page_down':
         case 'vim_page_down':

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -86,9 +86,7 @@ var keypress_mappings = {
     58: {name: 'open_reactions', message_view_only: true}, // ':'
     63: {name: 'show_shortcuts', message_view_only: false}, // '?'
     64: {name: 'compose_reply_with_mention', message_view_only: true}, // '@'
-    65: {name: 'stream_cycle_backward', message_view_only: true}, // 'A'
     67: {name: 'compose_private_message', message_view_only: true}, // 'C'
-    68: {name: 'stream_cycle_forward', message_view_only: true}, // 'D'
     68: {name: 'restore_latest_draft', message_view_only: false}, // 'D'
     71: {name: 'G_end', message_view_only: true}, // 'G'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
@@ -586,12 +584,6 @@ exports.process_hotkey = function (e, hotkey) {
             return true;
         case 'show_shortcuts': // Show keyboard shortcuts page
             ui.maybe_show_keyboard_shortcuts();
-            return true;
-        case 'stream_cycle_backward':
-            narrow.stream_cycle_backward();
-            return true;
-        case 'stream_cycle_forward':
-            narrow.stream_cycle_forward();
             return true;
         case 'restore_latest_draft':
             drafts.restore_draft_for_hotkey();

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -41,7 +41,7 @@ var keydown_shift_mappings = {
     // these can be triggered by shift + key only
     9: {name: 'shift_tab', message_view_only: false}, // tab
     32: {name: 'shift_spacebar', message_view_only: true},  // space bar
-    68: {name: 'shift_d', message_view_only: false},
+    /*68: {name: 'shift_d', message_view_only: false},*/
 };
 
 var keydown_unshift_mappings = {

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -298,39 +298,6 @@ exports.activate_stream_for_cycle_hotkey = function (stream_name) {
     exports.activate(filter_expr, opts);
 };
 
-
-exports.stream_cycle_backward = function () {
-    var curr_stream = narrow_state.stream();
-
-    if (!curr_stream) {
-        return;
-    }
-
-    var stream_name = topic_generator.get_prev_stream(curr_stream);
-
-    if (!stream_name) {
-        return;
-    }
-
-    exports.activate_stream_for_cycle_hotkey(stream_name);
-};
-
-exports.stream_cycle_forward = function () {
-    var curr_stream = narrow_state.stream();
-
-    if (!curr_stream) {
-        return;
-    }
-
-    var stream_name = topic_generator.get_next_stream(curr_stream);
-
-    if (!stream_name) {
-        return;
-    }
-
-    exports.activate_stream_for_cycle_hotkey(stream_name);
-};
-
 exports.narrow_to_next_topic = function () {
     var curr_info = exports.stream_topic();
 


### PR DESCRIPTION
In reference to issue #6547, shift key functionality is added along with enter key for restoring draft. Unlike the enter key, the Shift+d key will restore only the last draft. 