### PR TITLE
emails: Move enqueue_welcome_emails outside of signups queue.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -93,7 +93,8 @@ from zerver.lib.utils import log_statsd_event, statsd
 from zerver.lib.html_diff import highlight_html_differences
 from zerver.lib.alert_words import user_alert_words, add_user_alert_words, \
     remove_user_alert_words, set_user_alert_words
-from zerver.lib.notifications import clear_scheduled_emails, clear_scheduled_invitation_emails
+from zerver.lib.notifications import clear_scheduled_emails, \
+    clear_scheduled_invitation_emails, enqueue_welcome_emails
 from zerver.lib.narrow import check_supported_events_narrow_filter
 from zerver.lib.exceptions import JsonableError, ErrorCode
 from zerver.lib.sessions import delete_user_sessions
@@ -355,6 +356,7 @@ def process_new_human_user(user_profile, prereg_user=None, newsletter_data=None)
         PreregistrationUser.objects.filter(email__iexact=user_profile.email).update(status=0)
 
     notify_new_user(user_profile)
+    enqueue_welcome_emails(user_profile.id)
 
     if newsletter_data is not None:
         # If the user was created automatically via the API, we may

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -356,7 +356,7 @@ def process_new_human_user(user_profile, prereg_user=None, newsletter_data=None)
         PreregistrationUser.objects.filter(email__iexact=user_profile.email).update(status=0)
 
     notify_new_user(user_profile)
-    enqueue_welcome_emails(user_profile.id)
+    enqueue_welcome_emails(user_profile)
 
     if newsletter_data is not None:
         # If the user was created automatically via the API, we may

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -413,8 +413,8 @@ def log_digest_event(msg):
     logging.basicConfig(filename=settings.DIGEST_LOG_PATH, level=logging.INFO)
     logging.info(msg)
 
-def enqueue_welcome_emails(user_id):
-    # type: (int) -> None
+def enqueue_welcome_emails(user):
+    # type: (UserProfile) -> None
     from zerver.context_processors import common_context
     if settings.WELCOME_EMAIL_SENDER is not None:
         # line break to avoid triggering lint rule
@@ -424,20 +424,19 @@ def enqueue_welcome_emails(user_id):
         from_name = None
         from_address = FromAddress.SUPPORT
 
-    user_profile = get_user_profile_by_id(user_id)
-    unsubscribe_link = one_click_unsubscribe_link(user_profile, "welcome")
-    context = common_context(user_profile)
+    unsubscribe_link = one_click_unsubscribe_link(user, "welcome")
+    context = common_context(user)
     context.update({
         'unsubscribe_link': unsubscribe_link,
         'organization_setup_advice_link':
-        user_profile.realm.uri + '%s/help/getting-your-organization-started-with-zulip',
-        'is_realm_admin': user_profile.is_realm_admin,
+        user.realm.uri + '%s/help/getting-your-organization-started-with-zulip',
+        'is_realm_admin': user.is_realm_admin,
     })
     send_future_email(
-        "zerver/emails/followup_day1", to_user_id=user_id, from_name=from_name,
+        "zerver/emails/followup_day1", to_user_id=user.id, from_name=from_name,
         from_address=from_address, context=context, delay=datetime.timedelta(hours=1))
     send_future_email(
-        "zerver/emails/followup_day2", to_user_id=user_id, from_name=from_name,
+        "zerver/emails/followup_day2", to_user_id=user.id, from_name=from_name,
         from_address=from_address, context=context, delay=datetime.timedelta(days=1))
 
 def convert_html_to_markdown(html):

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -314,7 +314,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 63)
+        self.assert_length(queries, 68)
         user_profile = self.nonreg_user('test')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -314,7 +314,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 68)
+        self.assert_length(queries, 67)
         user_profile = self.nonreg_user('test')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)
@@ -841,7 +841,7 @@ class EmailUnsubscribeTests(ZulipTestCase):
         """
         user_profile = self.example_user('hamlet')
         # Simulate a new user signing up, which enqueues 2 welcome e-mails.
-        enqueue_welcome_emails(user_profile.id)
+        enqueue_welcome_emails(user_profile)
         self.assertEqual(2, ScheduledEmail.objects.filter(user=user_profile).count())
 
         # Simulate unsubscribing from the welcome e-mails.

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -167,8 +167,6 @@ class SignupWorker(QueueProcessingWorker):
             else:
                 r.raise_for_status()
 
-        enqueue_welcome_emails(data['user_id'])
-
 @assign_queue('invites')
 class ConfirmationEmailWorker(QueueProcessingWorker):
     def consume(self, data):


### PR DESCRIPTION
Probably the "signups" queue should be renamed "newsletter_signup" or similar, but wasn't sure if renaming a queue would cause a complicated migration. 