### PR TITLE
linter: Add lint rule banning 'from os.path import'

### DIFF
--- a/scripts/get-django-setting
+++ b/scripts/get-django-setting
@@ -3,10 +3,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
-from os.path import dirname, abspath
 import sys
 
-BASE_DIR = dirname(dirname(abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(BASE_DIR)
 import scripts.lib.setup_path_on_import
 

--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -2,10 +2,9 @@
 
 import os
 import argparse
-from os.path import dirname, abspath
 import sys
 
-ZULIP_PATH = dirname(dirname(dirname(abspath(__file__))))
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if ZULIP_PATH not in sys.path:
     sys.path.append(ZULIP_PATH)
 

--- a/scripts/lib/node_cache.py
+++ b/scripts/lib/node_cache.py
@@ -2,14 +2,13 @@ from __future__ import print_function
 
 import os
 import hashlib
-from os.path import dirname, abspath
 
 if False:
     from typing import Optional, List, IO, Text, Tuple, Any
 
 from scripts.lib.zulip_tools import subprocess_text_output, run
 
-ZULIP_PATH = dirname(dirname(dirname(abspath(__file__))))
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 ZULIP_SRV_PATH = "/srv"
 
 if 'TRAVIS' in os.environ:

--- a/scripts/lib/queue_workers.py
+++ b/scripts/lib/queue_workers.py
@@ -4,9 +4,8 @@ from __future__ import print_function
 import argparse
 import os
 import sys
-from os.path import dirname, abspath
 
-BASE_DIR = dirname(dirname(dirname(abspath(__file__))))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(BASE_DIR)
 import scripts.lib.setup_path_on_import
 

--- a/scripts/lib/setup_path_on_import.py
+++ b/scripts/lib/setup_path_on_import.py
@@ -3,11 +3,10 @@ Use libraries from a virtualenv (by modifying sys.path) in production.
 Also add Zulip's root directory to sys.path
 """
 
-import os
-from os.path import dirname, abspath
+import os.path
 import sys
 
-BASE_DIR = dirname(dirname(dirname(abspath(__file__))))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 activate_this = os.path.join(
     BASE_DIR,
     "zulip-py3-venv",

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -2,12 +2,11 @@ from __future__ import print_function
 
 import os
 import sys
-from os.path import dirname, abspath
 import subprocess
 from scripts.lib.zulip_tools import run, ENDC, WARNING
 from scripts.lib.hash_reqs import expand_reqs
 
-ZULIP_PATH = dirname(dirname(dirname(abspath(__file__))))
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 VENV_CACHE_PATH = "/srv/zulip-venv-cache"
 
 if 'TRAVIS' in os.environ:
@@ -172,7 +171,7 @@ def get_logfile_name(venv_path):
 def create_log_entry(target_log, parent, copied_packages, new_packages):
     # type: (str, str, Set[str], Set[str]) -> None
 
-    venv_path = dirname(target_log)
+    venv_path = os.path.dirname(target_log)
     with open(target_log, 'a') as writer:
         writer.write("{}\n".format(venv_path))
         if copied_packages:

--- a/scripts/setup/generate_secrets.py
+++ b/scripts/setup/generate_secrets.py
@@ -4,12 +4,10 @@
 from __future__ import print_function
 import sys
 import os
-import os.path
-from os.path import dirname, abspath
 if False:
     from typing import Dict, List, Optional, Text
 
-BASE_DIR = dirname(dirname(dirname(abspath(__file__))))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(BASE_DIR)
 import scripts.lib.setup_path_on_import
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -323,6 +323,9 @@ def build_custom_checkers(by_lang):
         {'pattern': 'render_to_response\(',
          'description': "Use render() instead of render_to_response().",
          },
+        {'pattern': 'from os.path',
+         'description': 'Import stdlib modules from their normal path.',
+         },
     ]) + whitespace_rules
     bash_rules = [
         {'pattern': '#!.*sh [-xe]',

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import os
-from os.path import abspath
 import sys
 import subprocess
 import re
@@ -84,7 +83,7 @@ def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
         ext = os.path.splitext(fpath)[1]
         if extless_only and ext:
             continue
-        absfpath = abspath(fpath)
+        absfpath = os.path.abspath(fpath)
         if any(absfpath == expath or absfpath.startswith(expath + '/')
                for expath in exclude_abspaths):
             continue

--- a/tools/setup/emoji/build_emoji
+++ b/tools/setup/emoji/build_emoji
@@ -12,7 +12,6 @@ import sys
 import xml.etree.ElementTree as ET
 from six import unichr
 from typing import Dict, Text, Union
-from os.path import dirname
 from PIL import Image, ImageDraw, ImageFont
 
 from emoji_setup_utils import generate_emoji_catalog, generate_codepoint_to_name_map, \
@@ -169,7 +168,7 @@ def main():
     # check if directory `var/emoji_dump` exists
     subprocess.check_call(['mkdir', '-p', EMOJI_DUMP_DIR_PATH])
     success_stamp = get_success_stamp()
-    source_emoji_dump = dirname(success_stamp)
+    source_emoji_dump = os.path.dirname(success_stamp)
 
     if not os.path.exists(success_stamp):
         print("Dumping emojis ...")

--- a/tools/setup/setup_venvs.py
+++ b/tools/setup/setup_venvs.py
@@ -2,9 +2,8 @@
 
 import os
 import sys
-from os.path import dirname, abspath
 
-ZULIP_PATH = dirname(dirname(dirname(abspath(__file__))))
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if ZULIP_PATH not in sys.path:
     sys.path.append(ZULIP_PATH)
 

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -1,5 +1,5 @@
 from typing import Dict, Optional, Any, List
-from os.path import basename, splitext
+import os.path
 
 from django.conf import settings
 from django.template import Library, loader, engines
@@ -87,7 +87,7 @@ def render_markdown_path(markdown_file_path, context=None):
         if markdown_file_path.endswith('doc.md'):
             integration_dir = markdown_file_path.split('/')[0]
         elif 'integrations' in markdown_file_path.split('/'):
-            integration_dir = splitext(basename(markdown_file_path))[0]
+            integration_dir = os.path.splitext(os.path.basename(markdown_file_path))[0]
 
         integration = context['integrations_dict'][integration_dir]
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -52,7 +52,6 @@ import ujson
 import mock
 import os
 import sys
-from os.path import dirname, abspath
 from six.moves import cStringIO as StringIO
 from django.conf import settings
 
@@ -450,7 +449,7 @@ class TestReplyExtraction(ZulipTestCase):
 
         self.assertEqual(message.content, 'Reply')
 
-MAILS_DIR = os.path.join(dirname(dirname(abspath(__file__))), "fixtures", "email")
+MAILS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "fixtures", "email")
 
 
 class TestScriptMTA(ZulipTestCase):

--- a/zproject/wsgi.py
+++ b/zproject/wsgi.py
@@ -14,10 +14,9 @@ framework.
 
 """
 import os
-from os.path import dirname, abspath
 import sys
 
-BASE_DIR = dirname(dirname(abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(BASE_DIR)
 import scripts.lib.setup_path_on_import
 


### PR DESCRIPTION
Fixes: #6543