### PR TITLE
docs: Clarify who can collaborate in area label teams.

### DIFF
--- a/docs/zulipbot-usage.md
+++ b/docs/zulipbot-usage.md
@@ -42,7 +42,7 @@ followed by the desired labels enclosed within double quotes (`""`).
     `@zulipbot remove` followed by the desired labels enclosed with double quotes
     (`""`).
 
-* **Find unclaimed issues** - Use the [GitHub search
+* **Find unclaimed issues** — Use the [GitHub search
 feature](https://help.github.com/articles/using-search-to-filter-issues-and-pull-requests/)
 to find unclaimed issues by adding one of the following filters to your search:
 
@@ -53,8 +53,9 @@ to find unclaimed issues by adding one of the following filters to your search:
     Issues labeled with the **in progress** label and/or assigned to other users have
     already been claimed.
 
-* **Collaborate in area label teams** - Receive notifications on issues and
-pull requests within your fields of expertise on the
+* **Collaborate in area label teams**
+(only for **members** of the Zulip organization on GitHub) — Receive notifications
+on issues and pull requests within your fields of expertise on the
 [Zulip server repository](https://github.com/zulip/zulip) by joining the Zulip server
 [area label teams](https://github.com/orgs/zulip/teams?utf8=✓&query=Server). These teams
 correspond to the repository's [area labels](https://github.com/zulip/zulip/labels),


### PR DESCRIPTION
Collaboration in area label teams is only available to members of the Zulip organization on GitHub. For non-members the related links are not working, which can be confusing.

This is something I got confused about, and I think it would be great to add a little clarification. I discussed it on the #documentation stream before implementing.