### PR TITLE
subs: Immediately hide row in Subscribed tab once unsubscribed.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -549,10 +549,6 @@ exports.keyboard_sub = function () {
     var row_data = get_row_data(active_data.row);
     if (row_data) {
         subs.sub_or_unsub(row_data.object);
-        if (row_data.object.subscribed && active_data.tab.text() === 'Subscribed') {
-            active_data.row.addClass('notdisplayed');
-            active_data.row.removeClass('active');
-        }
     }
 };
 
@@ -608,6 +604,14 @@ function ajaxSubscribe(stream) {
 
 function ajaxUnsubscribe(sub) {
     // TODO: use stream_id when backend supports it
+
+    var active_data = get_active_data();
+
+    // immediately hide row, reveal it again if unsubscribing failed
+    if (active_data.tab.text() === 'Subscribed') {
+        active_data.row.addClass("notdisplayed").removeClass("active");
+    }
+
     return channel.del({
         url: "/json/users/me/subscriptions",
         data: {subscriptions: JSON.stringify([sub.name]) },
@@ -618,6 +622,7 @@ function ajaxUnsubscribe(sub) {
         error: function (xhr) {
             ui_report.error(i18n.t("Error removing subscription"), xhr,
                             $("#subscriptions-status"), 'subscriptions-status');
+            active_data.row.removeClass("notdisplayed").addClass("active");
         },
     });
 }


### PR DESCRIPTION
Immediately hide a stream row when it is unsubscribed through the Subscribed tab in the Stream settings modal, so that a user cannot immediately subscribe back to it through the Subscribed tab and cause rendering errors.

Fixes #4779