### PR TITLE
fixes #1189 prompt for permission to display notifications

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -154,7 +154,8 @@
         "emoji_picker": false,
         "hotspots": false,
         "compose_ui": false,
-        "common": false
+        "common": false,
+        "panel": false
     },
     "rules": {
         "array-callback-return": "error",

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -480,6 +480,17 @@ function should_send_audible_notification(message) {
     return false;
 }
 
+exports.granted_desktop_notifications_permission = function () {
+    return browser_desktop_notifications_on();
+};
+
+
+exports.request_desktop_notifications_permission = function () {
+    if (notifications_api) {
+        return notifications_api.requestPermission;
+    }
+};
+
 exports.received_messages = function (messages) {
     _.each(messages, function (message) {
         if (!message_is_notifiable(message)) {

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -1,0 +1,32 @@
+var panel = (function () {
+
+var exports = {};
+
+function show_element_with_id(id) {
+    $('#' + id).css({ 'margin-bottom' : '0px'});
+    $('#' + id).show();
+}
+
+
+function display_panel() {
+    if (!page_params.needs_tutorial &&
+        !notifications.granted_desktop_notifications_permission()) {
+        show_element_with_id('desktop-notifications-panel');
+    }
+}
+
+exports.initialize = function () {
+    $('#request-desktop-notifications').on('click', function () {
+        $('#desktop-notifications-panel').hide();
+        notifications.request_desktop_notifications_permission();
+    });
+    display_panel();
+};
+
+return exports;
+
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = panel;
+}

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -273,6 +273,7 @@ $(function () {
     compose.initialize();
     hotspots.initialize();
     ui.initialize();
+    panel.initialize();
 });
 
 

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -1,3 +1,13 @@
+<div id="panel">
+  <div id="desktop-notifications-panel" class="alert alert-info alert-dismissable">
+    Zulip needs your permission to enable desktop notifications.
+    <a id="request-desktop-notifications" class="alert-link" href="javascript:void(0);">
+      Enable desktop notifications.
+    </a>
+    In future you can disable notices from Zulip's Settings.
+    <span class="close" data-dismiss="alert" aria-label="{{ _('Close') }}">&times;</span>
+  </div>
+</div>
 <div class="header">
 <nav class="header-main rightside-userlist" id="top_navbar">
   <div class="column-left">

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1021,6 +1021,7 @@ JS_SPECS = {
             'js/ui_init.js',
             'js/emoji_picker.js',
             'js/compose_ui.js',
+            'js/panel.js'
         ],
         'output_filename': 'min/app.js'
     },


### PR DESCRIPTION
This is to prompt user to enable desktop notifications. A panel is displayed at the top. On closing the panel, user is again warned about the importance of enabling desktop notifications.

This is my first time contributing to Zulip. Please review it and let me know if any changes are required.