### PR TITLE
Travis: Remove unnecessary docker services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,6 @@ matrix:
     - python: "3.5"
       env: TEST_SUITE=backend
 sudo: required
-services:
-- docker
 addons:
   artifacts:
     paths:


### PR DESCRIPTION
OTOH, running docker service might be useful in the future. Where a docker image with all the apt dependencies already installed can be downloaded.

edit: note I'm not sure if what I have written here is clear in conveying my intent