### PR TITLE
Add ability to search by "group-pm-with".

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -328,6 +328,27 @@ function make_sub(name, stream_id) {
         type: 'private',
         display_recipient: [{id: joe.user_id}],
     }));
+
+    predicate = get_predicate([['group-pm-with', 'nobody@example.com']]);
+    assert(!predicate({
+        type: 'private',
+        display_recipient: [{id: joe.user_id}],
+    }));
+
+    predicate = get_predicate([['group-pm-with', 'Joe@example.com']]);
+    assert(predicate({
+        type: 'private',
+        display_recipient: [{id: joe.user_id}, {id: steve.user_id}, {id: me.user_id}],
+    }));
+    assert(!predicate({ // you must be a part of the group pm
+        type: 'private',
+        display_recipient: [{id: joe.user_id}, {id: steve.user_id}],
+    }));
+    assert(!predicate({
+        type: 'private',
+        display_recipient: [{id: steve.user_id}, {id: me.user_id}],
+    }));
+    assert(!predicate({type: 'stream'}));
 }());
 
 (function test_negated_predicates() {

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -135,6 +135,11 @@ function set_filter(operators) {
     assert.equal(hide_id,'.empty_feed_notice');
     assert.equal(show_id, '#empty_narrow_private_message');
 
+    set_filter([['group-pm-with', 'alice@example.com']]);
+    narrow.show_empty_narrow_message();
+    assert.equal(hide_id,'.empty_feed_notice');
+    assert.equal(show_id, '#empty_narrow_group_private_message');
+
     set_filter([['sender', 'ray@example.com']]);
     narrow.show_empty_narrow_message();
     assert.equal(hide_id,'.empty_feed_notice');

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -572,6 +572,7 @@ initialize();
         assert.equal(msg, 'Empty recipient list in message');
     };
     people.pm_with_user_ids(message);
+    people.group_pm_with_user_ids(message);
 
     var charles = {
         email: 'charles@example.com',

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -122,6 +122,7 @@ topic_data.reset();
         "is:private is:alerted",
         "is:private pm-with:alice@zulip.com",
         "is:private sender:alice@zulip.com",
+        "is:private group-pm-with:alice@zulip.com",
         "is:private",
     ];
     assert.deepEqual(suggestions.strings, expected);
@@ -224,6 +225,7 @@ topic_data.reset();
         "is:starred has:link is:private is:alerted",
         "is:starred has:link is:private pm-with:alice@zulip.com",
         "is:starred has:link is:private sender:alice@zulip.com",
+        "is:starred has:link is:private group-pm-with:alice@zulip.com",
         "is:starred has:link is:private",
         "is:starred has:link",
         "is:starred",
@@ -759,6 +761,8 @@ init();
         "pm-with:ted@zulip.com",
         "sender:bob@zulip.com",
         "sender:ted@zulip.com",
+        "group-pm-with:bob@zulip.com",
+        "group-pm-with:ted@zulip.com",
     ];
 
     assert.deepEqual(suggestions.strings, expected);
@@ -776,6 +780,7 @@ init();
         "Ted",
         "pm-with:ted@zulip.com",
         "sender:ted@zulip.com",
+        "group-pm-with:ted@zulip.com",
     ];
 
     assert.deepEqual(suggestions.strings, expected);

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -851,6 +851,14 @@ init();
     ];
     assert.deepEqual(suggestions.strings, expected);
 
+    query = 'group-';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'group-',
+        'group-pm-with:',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
     query = '-s';
     suggestions = search.get_suggestions(query);
     expected = [

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -121,12 +121,12 @@ function message_matches_search_term(message, operator, operand) {
         if (!operand_ids) {
             return false;
         }
-        var message_ids = people.pm_with_user_ids(message);
-        if (!message_ids) {
+        var user_ids = people.pm_with_user_ids(message);
+        if (!user_ids) {
             return false;
         }
 
-        return _.isEqual(operand_ids, message_ids);
+        return _.isEqual(operand_ids, user_ids);
     }
 
     return true; // unknown operators return true (effectively ignored)

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -113,15 +113,15 @@ function message_matches_search_term(message, operator, operand) {
         return people.id_matches_email_operand(message.sender_id, operand);
 
     case 'group-pm-with':
-        var operand_id = people.get_user_id(operand);
-        if (!operand_id) {
+        var operand_ids = people.pm_with_operand_ids(operand);
+        if (!operand_ids) {
             return false;
         }
         var user_ids = people.group_pm_with_user_ids(message);
         if (!user_ids) {
             return false;
         }
-        return (user_ids.includes(operand_id));
+        return (user_ids.includes(operand_ids[0]));
         // We should also check if the current user is in the recipient list (user_ids) of the
         // message, but it is implicit by the fact that the current user has access to the message.
 
@@ -130,7 +130,7 @@ function message_matches_search_term(message, operator, operand) {
         if (message.type !== 'private') {
             return false;
         }
-        var operand_ids = people.pm_with_operand_ids(operand);
+        operand_ids = people.pm_with_operand_ids(operand);
         if (!operand_ids) {
             return false;
         }

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -112,6 +112,19 @@ function message_matches_search_term(message, operator, operand) {
     case 'sender':
         return people.id_matches_email_operand(message.sender_id, operand);
 
+    case 'group-pm-with':
+        var operand_id = people.get_user_id(operand);
+        if (!operand_id) {
+            return false;
+        }
+        var user_ids = people.group_pm_with_user_ids(message);
+        if (!user_ids) {
+            return false;
+        }
+        return (user_ids.includes(operand_id));
+        // We should also check if the current user is in the recipient list (user_ids) of the
+        // message, but it is implicit by the fact that the current user has access to the message.
+
     case 'pm-with':
         // TODO: use user_ids, not emails here
         if (message.type !== 'private') {
@@ -121,7 +134,7 @@ function message_matches_search_term(message, operator, operand) {
         if (!operand_ids) {
             return false;
         }
-        var user_ids = people.pm_with_user_ids(message);
+        user_ids = people.pm_with_user_ids(message);
         if (!user_ids) {
             return false;
         }
@@ -182,6 +195,9 @@ Filter.canonicalize_term = function (opts) {
             operand = people.my_current_email();
         }
         break;
+    case 'group-pm-with':
+        operand = operand.toString().toLowerCase();
+        break;
     case 'search':
         // The mac app automatically substitutes regular quotes with curly
         // quotes when typing in the search bar.  Curly quotes don't trigger our
@@ -218,7 +234,7 @@ function encodeOperand(operand) {
 
 function decodeOperand(encoded, operator) {
     encoded = encoded.replace(/"/g, '');
-    if (operator !== 'pm-with' && operator !== 'sender' && operator !== 'from') {
+    if (_.contains(['group-pm-with','pm-with','sender','from'],operator) === false) {
         encoded = encoded.replace(/\+/g, ' ');
     }
     return util.robust_uri_decode(encoded).trim();
@@ -383,6 +399,7 @@ Filter.prototype = {
     update_email: function (user_id, new_email) {
         _.each(this._operators, function (term) {
             switch (term.operator) {
+                case 'group-pm-with':
                 case 'pm-with':
                 case 'sender':
                 case 'from':
@@ -458,6 +475,9 @@ Filter.operator_to_prefix = function (operator, negated) {
     // Note: We hack around using this in "describe" below.
     case 'is':
         return verb + 'messages that are';
+
+    case 'group-pm-with':
+        return verb + 'group personal messages with';
     }
     return '';
 };

--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -12,7 +12,7 @@ exports.encodeHashComponent = function (str) {
 };
 
 exports.encode_operand = function (operator, operand) {
-    if ((operator === 'pm-with') || (operator === 'sender')) {
+    if ((operator === 'group-pm-with') || (operator === 'pm-with') || (operator === 'sender')) {
         var slug = people.emails_to_slug(operand);
         if (slug) {
             return slug;
@@ -27,7 +27,7 @@ exports.decodeHashComponent = function (str) {
 };
 
 exports.decode_operand = function (operator, operand) {
-    if ((operator === 'pm-with') || (operator === 'sender')) {
+    if ((operator === 'group-pm-with') || (operator === 'pm-with') || (operator === 'sender')) {
         var emails = people.slug_to_emails(operand);
         if (emails) {
             return emails;

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -69,8 +69,10 @@ exports.activate = function (raw_operators, opts) {
         }
     } else if (filter.has_operator("is")) {
         exports.narrow_title = filter.operands("is")[0];
-    } else if (filter.has_operator("pm-with")) {
+    } else if (filter.has_operator("pm-with") ) {
         exports.narrow_title = "private";
+    } else if (filter.has_operator("group-pm-with") ) {
+        exports.narrow_title = "private group";
     }
 
     notifications.redraw_title();

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -554,6 +554,8 @@ function pick_empty_narrow_banner() {
             return $("#silent_user");
         }
         return $("#non_existing_user");
+    } else if (first_operator === "group-pm-with") {
+        return $("#empty_narrow_group_private_message");
     }
     return default_banner;
 }

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -338,6 +338,30 @@ exports.pm_with_user_ids = function (message) {
     return sorted_other_user_ids(user_ids);
 };
 
+exports.group_pm_with_user_ids = function (message) {
+    if (message.type !== 'private') {
+        return;
+    }
+
+    if (message.display_recipient.length === 0) {
+        blueslip.error('Empty recipient list in message');
+        return;
+    }
+    var user_ids = _.map(message.display_recipient, function (elem) {
+        return elem.user_id || elem.id;
+    });
+    var is_user_present = _.some(user_ids, function (user_id) {
+        return people.is_my_user_id(user_id);
+    });
+    if (is_user_present) {
+        user_ids.sort();
+        if (user_ids.length > 2) {
+            return user_ids;
+        }
+    }
+    return false;
+};
+
 exports.pm_with_url = function (message) {
     var user_ids = exports.pm_with_user_ids(message);
 

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -572,6 +572,9 @@ exports.get_suggestions = function (query) {
     suggestions = get_person_suggestions(persons, last, base_operators, 'from');
     attach_suggestions(result, base, suggestions);
 
+    suggestions = get_person_suggestions(persons, last, base_operators, 'group-pm-with');
+    attach_suggestions(result, base, suggestions);
+
     suggestions = get_group_suggestions(persons, last, base_operators);
     attach_suggestions(result, base, suggestions);
 

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -497,7 +497,7 @@ function get_operator_suggestions(last) {
             last.operand = last.operand.slice(1);
         }
 
-        var choices = ['stream', 'topic', 'pm-with', 'sender', 'near', 'has', 'from'];
+        var choices = ['stream', 'topic', 'pm-with', 'sender', 'near', 'has', 'from', 'group-pm-with'];
         choices = _.filter(choices, function (choice) {
             return phrase_match(choice, last.operand);
         });

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -73,6 +73,12 @@ function make_tab_data() {
                 tabs.push(make_tab(names.join(', '), hashed));
             }
 
+        } else if (filter.has_operator("group-pm-with")) {
+
+            tabs.push(make_tab("Group Private", '#narrow/group-pm-with',
+                                undefined, 'private_message '));
+
+
         } else if (filter.has_operand("is", "starred")) {
             tabs.push(make_tab("Starred", hashed));
         } else if (filter.has_operator("near")) {

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -55,6 +55,10 @@ Listed below are all Zulip search operators.
 * `pm-with:foo@bar.com` - This operator narrows the view to show only
   private messages sent from the user with the email address
   `foo@bar.com`.
+* `group-pm-with:foo@bar.com` - This operator narrows the view to show all
+  private messages from groups that contain both you and the user with
+  email address `foo@bar.com`. This operator does not show 1:1 private messages
+  between you and the user with email address `foo@bar.com`
 * `sender:foo@bar.com` - This operator narrows the view to show all
   messages sent by the user with the email address `foo@bar.com`.
 * `sender:me` - This operator narrows the view to show all messages sent by you.

--- a/templates/zerver/home.html
+++ b/templates/zerver/home.html
@@ -46,6 +46,14 @@
             start the conversation</a>?</p>
         {% endtrans %}
       </div>
+      <div id="empty_narrow_group_private_message" class="empty_feed_notice">
+        <h4>{{ _('You have no group private messages with this person yet!') }}</h4>
+
+        {% trans %}
+        <p>Why not <a href="#" class="empty_feed_compose_private">
+            start the conversation</a>?</p>
+        {% endtrans %}
+      </div>
       <div id="empty_narrow_multi_private_message" class="empty_feed_notice">
         <h4>{{ _('You have no private messages with these people yet!') }}</h4>
 

--- a/templates/zerver/search_operators.html
+++ b/templates/zerver/search_operators.html
@@ -21,6 +21,10 @@
                 <td class="definition">{{ _('Narrow to private messages with') }} <span class="operator_value">email</span></td>
             </tr>
             <tr>
+                <td class="operator">group-pm-with:<span class="operator_value">email</span></td>
+                <td class="definition">{{ _('Narrow to group private messages with') }} <span class="operator_value">email</span></td>
+            </tr>
+            <tr>
                 <td class="operator">sender:<span class="operator_value">email</span></td>
                 <td class="definition">{{ _('Narrow to messages sent by') }} <span class="operator_value">email</span></td>
             </tr>


### PR DESCRIPTION
Re-submission of #4279.

A bit of modification was needed on the original PR to get it to be compatible with the current `search_suggestions` code. 

Beyond that, I added a couple extra tweaks (autocomplete operator, better error handling, empty narrow msg), and finish test coverage. (100% test coverage should be maintained in `search_suggestions.js`, `filter.js`, `people.js`)

![image](https://user-images.githubusercontent.com/8433005/30785188-9c96f59e-a130-11e7-83d8-2da0e075d9e2.png)
