### PR TITLE
hotkeys: Fix the multiple `thumbs_up` reactions issue.

### DIFF
--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -270,7 +270,7 @@ function filter_emojis() {
     }
 }
 
-function get_alias_to_be_used(message_id, emoji_name) {
+exports.get_alias_to_be_used = function (message_id, emoji_name) {
     // If the user has reacted to this message, then this function
     // returns the alias of this emoji he used, otherwise, returns
     // the passed name as it is.
@@ -293,7 +293,7 @@ function get_alias_to_be_used(message_id, emoji_name) {
         return reaction.emoji_name;
     }
     return emoji_name;
-}
+};
 
 function toggle_reaction(emoji_name) {
     var message_id = current_msg_list.selected_id();
@@ -303,7 +303,7 @@ function toggle_reaction(emoji_name) {
         return;
     }
 
-    var alias = get_alias_to_be_used(message_id, emoji_name);
+    var alias = exports.get_alias_to_be_used(message_id, emoji_name);
     reactions.toggle_emoji_reaction(message_id, alias);
 }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -671,7 +671,13 @@ exports.process_hotkey = function (e, hotkey) {
             reactions.open_reactions_popover();
             return true;
         case 'thumbs_up_emoji': // '+': reacts with thumbs up emoji on selected message
-            reactions.toggle_emoji_reaction(msg.id, '+1');
+            var thumbs_up_codepoint = '1f44d';
+            // If the user has reacted to the message before with thumbs up then
+            // use the alias used by the user otherwise use the canonical name
+            // given by the `codepoint_to_name`.
+            var canonical_name = emoji_codes.codepoint_to_name[thumbs_up_codepoint];
+            var alias_used = emoji_picker.get_alias_to_be_used(msg.id, canonical_name);
+            reactions.toggle_emoji_reaction(msg.id, alias_used);
             return true;
         case 'toggle_mute':
             muting_ui.toggle_mute(msg);


### PR DESCRIPTION
Due to some recent changes in the emoji infrastructure, the canonical
name for 'thumbs_up' emoji was changed from `+1` to `thumbs_up` which
was causing multiple 'thumbs_up` reactions to appear on the same message
if two reacted to that, one using the emoji picker and other using the
hotkey. This commit fixes this behavior by always using the canonical
name for the emoji if the user hasn't reacted to the emoji before and
using the alias he used if reacted to the message before.

Replaces PR: #6640.