### PR TITLE
top-right gear menu: Remove the caret down icon.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1741,7 +1741,7 @@ blockquote p {
     width: 0px;
     height: 0px;
     top: -7px;
-    right: 10px;
+    right: 20px;
     display: inline-block;
     border-right: 7px solid transparent;
     border-bottom: 7px solid hsl(0, 0%, 66%);
@@ -2291,12 +2291,6 @@ button.topic_edit_cancel {
     font-weight: 700;
     text-align: center;
     text-transform: uppercase;
-}
-
-.settings-dropdown-caret {
-    margin-left: 8px;
-    margin-right: 8px;
-    font-size: 14px;
 }
 
 #notifications-area {

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -60,7 +60,7 @@
             <ul class="nav" role="navigation">
               <li class="dropdown actual-dropdown-menu" id="gear-menu">
                 <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle" data-target="nada" data-toggle="dropdown" title="{{ _('Menu') }} (g)">
-                  <i class="icon-vector-cog"></i><i class="icon-vector-caret-down settings-dropdown-caret"></i>
+                  <i class="icon-vector-cog"></i>&emsp;
                 </a>
                 <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">
                   {#


### PR DESCRIPTION
Not sure why it has been around. It might be due to some vestigial purpose that
has since been forgotten.

After:
![2017-09-25-060920_306x142_scrot](https://user-images.githubusercontent.com/395821/30792231-0fcc01a2-a1b9-11e7-864d-8c05c221dedb.png)

was discussed in: https://chat.zulip.org/#narrow/stream/feedback/topic/caret.20down.20button.20next.20to.20gear.20menu