### PR TITLE
Add a trigger field to the GCM push notification payload 

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -385,14 +385,15 @@ def get_alert_from_message(message: Message) -> Text:
     Determine what alert string to display based on the missed messages.
     """
     sender_str = message.sender.full_name
-    if message.recipient.type == Recipient.HUDDLE and message.trigger == 'private_message':
+    if message.trigger == 'group_message':
         return "New private group message from %s" % (sender_str,)
-    elif message.recipient.type == Recipient.PERSONAL and message.trigger == 'private_message':
+    elif message.trigger == 'group_mention':
+        return "New private group mention from %s" % (sender_str,)
+    elif message.trigger == 'private_message':
         return "New private message from %s" % (sender_str,)
-    elif message.is_stream_message() and message.trigger == 'mentioned':
+    elif message.trigger == 'stream_mention':
         return "New mention from %s" % (sender_str,)
-    elif (message.is_stream_message() and
-            (message.trigger == 'stream_push_notify' and message.stream_name)):
+    elif message.trigger == 'stream_message':
         return "New stream message from %s in %s" % (sender_str, message.stream_name,)
     else:
         return "New Zulip mentions and private messages from %s" % (sender_str,)

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -456,6 +456,7 @@ def get_apns_payload(message: Message) -> Dict[str, Any]:
                 'sender_id': message.sender.id,
                 'server': settings.EXTERNAL_HOST,
                 'realm_id': message.sender.realm.id,
+                'trigger': message.trigger,
             }
         }
     }  # type: Dict[str, Any]
@@ -486,6 +487,7 @@ def get_gcm_payload(user_profile: UserProfile, message: Message) -> Dict[str, An
         'sender_email': message.sender.email,
         'sender_full_name': message.sender.full_name,
         'sender_avatar_url': absolute_avatar_url(message.sender),
+        'trigger': message.trigger,
     }
 
     if message.is_stream_message():

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -179,13 +179,13 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         mobile_event = queue_messages[0]['event']
 
         self.assertEqual(mobile_event['user_profile_id'], cordelia.id)
-        self.assertEqual(mobile_event['trigger'], 'mentioned')
+        self.assertEqual(mobile_event['mentioned'], True)
 
         self.assertEqual(queue_messages[1]['queue_name'], 'missedmessage_emails')
         email_event = queue_messages[1]['event']
 
         self.assertEqual(email_event['user_profile_id'], cordelia.id)
-        self.assertEqual(email_event['trigger'], 'mentioned')
+        self.assertEqual(email_event['mentioned'], True)
 
     def test_second_mention_is_ignored(self) -> None:
         message_id = self._login_and_send_original_stream_message(

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -675,14 +675,7 @@ def maybe_enqueue_notifications(user_profile_id, message_id, private_message,
 
     if (idle or always_push_notify) and (private_message or mentioned or stream_push_notify):
         notice = build_offline_notification(user_profile_id, message_id)
-        if private_message:
-            notice['trigger'] = 'private_message'
-        elif mentioned:
-            notice['trigger'] = 'mentioned'
-        elif stream_push_notify:
-            notice['trigger'] = 'stream_push_notify'
-        else:
-            raise AssertionError("Unknown notification trigger!")
+        notice['mentioned'] = mentioned
         notice['stream_name'] = stream_name
         if not already_notified.get("push_notified"):
             queue_json_publish("missedmessage_mobile_notifications", notice, lambda notice: None)


### PR DESCRIPTION
Used some constant strings to denote the event instead of using the whole trigger object to save some space for the payload
```
message.triggers = {
            'private_message': False,
            'mentioned': False,
            'stream_push_notify': True,
}
```

And haven't tested the newly added condition in a server but should work! 