### PR TITLE
onboarding: Remove initial whitespace in Custom invitation message. (jQuery method)

### DIFF
--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -43,6 +43,7 @@ function reset_error_messages() {
 
 function prepare_form_to_be_shown() {
     $("#invitee_emails").val("");
+    $("#custom_invite_body").val("");
     update_subscription_checkboxes();
     reset_error_messages();
 }


### PR DESCRIPTION
Fixes #6666. Please see #6676 before merging, as I believe it may be a better solution than the one implemented here.

(Closes #6676)