### PR TITLE
onboarding: Remove initial whitespace in Custom invitation message. (non-jQuery method)

### DIFF
--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -42,7 +42,6 @@ function reset_error_messages() {
 }
 
 function prepare_form_to_be_shown() {
-    $("#invitee_emails").val("");
     update_subscription_checkboxes();
     reset_error_messages();
 }

--- a/templates/zerver/invite_user.html
+++ b/templates/zerver/invite_user.html
@@ -12,17 +12,11 @@
                     <div id="invite-result"></div>
                     <label class="control-label" for="invitee_emails">{{ _('Emails (one on each line or comma-separated)') }}</label>
                     <div class="controls">
-                        <textarea rows="2" id="invitee_emails"
-                            name="invitee_emails"
-                            placeholder="{{ _('One or more email addresses...') }}">
-                        </textarea>
+                        <textarea rows="2" id="invitee_emails" name="invitee_emails" placeholder="{{ _('One or more email addresses...') }}"></textarea>
                     </div>
                     <label class="control-label" for="custom_invite_body">{{ _('Custom invitation message (if you want to add one)') }}</label>
                     <div class="controls">
-                        <textarea rows="2" id="custom_invite_body"
-                            name="custom_body"
-                            placeholder="{{ _('Custom message') }}">
-                        </textarea>
+                        <textarea rows="2" id="custom_invite_body" name="custom_body" placeholder="{{ _('Custom message') }}"></textarea>
                     </div>
                 </div>
                 <div class="alert" id="invite_status"></div>


### PR DESCRIPTION
An alternate solution to #6675 that fixes #6666.

Instead of using jQuery to remove the whitespace in the invite fields, is to remove the whitespace between the `<textarea>` tags in `templates/zerver/invite_user.html` and concatenate them into one line, given that any content between textarea tags will be included as a default value.

I personally believe that this is the better solution of the two, but feel free to merge whatever seems better.

(Closes #6675)