### PR TITLE
Restyle invalid organization page.

### DIFF
--- a/templates/zerver/invalid_realm.html
+++ b/templates/zerver/invalid_realm.html
@@ -1,9 +1,17 @@
 {% extends "zerver/portico.html" %}
 {% block portico_content %}
 
-<h3>{{ _('Organization does not exist') }}</h3>
+<div class="app find-account-page flex full-page">
+    <div class="inline-block new-style">
+        <div class="lead">
+            <h1 class="get-started">{{ _('Organization does not exist') }}…</h1>
+        </div>
 
-<p>{{ _('Hi there! Thank you for your interest in Zulip.') }}</p>
-<p>{% trans %}There is no Zulip organization hosted at this subdomain.{% endtrans %}</p>
-
+        <div class="app-main white-box">
+            {{ _('Hi there! Thank you for your interest in Zulip.') }}
+            <br />
+            {% trans %}There is no Zulip organization hosted at this subdomain.{% endtrans %}
+        </div>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
This restyles the `invalid_realm.html` template that displays when
a subdomain does not lead to a valid organization.

Fixes: #6667.

<img width="1680" alt="screen shot 2017-09-25 at 6 06 55 pm" src="https://user-images.githubusercontent.com/10321399/30837889-15b663a0-a21d-11e7-8929-885cbed14a71.png">
