### PR TITLE
Fix "all streams" header.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -254,11 +254,13 @@ exports.resize_page_components = function () {
     h = narrow_window ? left_userlist_get_new_heights() : get_new_heights();
 
     exports.resize_bottom_whitespace(h);
-    $("#stream-filters-container").css('max-height', h.stream_filters_max_height);
     $("#user_presences").css('max-height', h.user_presences_max_height);
     $("#group-pms").css('max-height', h.group_pms_max_height);
 
-    $('#stream-filters-container').perfectScrollbar('update');
+    $("#stream-filters-container")
+        .css('max-height', h.stream_filters_max_height)
+        // the `.css` method returns `$this`, so we can chain `perfectScrollbar`.
+        .perfectScrollbar('update');
 };
 
 var _old_width = $(window).width();

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -381,11 +381,6 @@ li.expanded_private_message a {
     color: hsl(0, 0%, 20%);
 }
 
-.all-streams-padding {
-    padding-top: 5px;
-    margin-bottom: -5px;
-}
-
 .pm-box,
 .topic-box {
     display: block;
@@ -412,9 +407,20 @@ li.expanded_private_message a {
 }
 
 #topics_header {
-    border-top: 1px solid hsl(0, 0%, 88%);
-    margin-top: 5px;
     margin-right: 10px;
+    color: hsl(0, 0%, 43%);
+}
+
+#topics_header a {
+    color: inherit;
+    text-decoration: none;
+    text-transform: uppercase;
+}
+
+#topics_header a i {
+    margin-right: 5px;
+    position: relative;
+    top: 1px;
 }
 
 #streams_header {

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -418,7 +418,7 @@ li.expanded_private_message a {
 }
 
 #topics_header a i {
-    margin-right: 5px;
+    margin: 0 5px 0 10px;
     position: relative;
     top: 1px;
 }

--- a/templates/zerver/left_sidebar.html
+++ b/templates/zerver/left_sidebar.html
@@ -51,13 +51,7 @@
                 <i id="join_unsub_stream" class="icon-vector-plus" data-toggle="tooltip" title="{{ _('Join stream')}}" ></i>
             </div>
             <div id="topics_header">
-                <div class="all-streams-padding">
-                    <ul class="filters">
-                        <li data-name="all-streams">
-                            <a href="" class="show-all-streams"> <i class="icon-vector-chevron-left"></i>{{ _('All streams') }}</a>
-                        </li>
-                    </ul>
-                </div>
+                <a href="" class="show-all-streams"> <i class="icon-vector-chevron-left"></i>{{ _('All streams') }}</a>
             </div>
             <div id="stream-filters-container" class="scrolling_list">
                 <div class="input-append notdisplayed">


### PR DESCRIPTION
The issue before was that the left sidebar would become too tall for
the screen because the standard header that has “STREAMS” and buttons
is 20px tall, and this one is 30px tall. This makes it much shorter,
changes the text to be the same style as the “STREAMS” text (medium
grey, uppercase text).

The markup is then fixed to be significantly less verbose than before —
changing a list to just a simple link.