### PR TITLE
Fix timestamps for local echo (and simplify the code a bit).

### DIFF
--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -207,8 +207,6 @@ exports.reify_message_id = function reify_message_id(local_id, server_id) {
 };
 
 exports.process_from_server = function process_from_server(messages) {
-    var updated = false;
-    var locally_processed_ids = [];
     var msgs_to_rerender = [];
     var non_echo_messages = [];
 
@@ -229,24 +227,19 @@ exports.process_from_server = function process_from_server(messages) {
 
         if (client_message.content !== message.content) {
             client_message.content = message.content;
-            updated = true;
             sent_messages.mark_disparity(message.local_id);
         }
         msgs_to_rerender.push(client_message);
-        locally_processed_ids.push(client_message.id);
         delete waiting_for_ack[client_message.id];
     });
 
-    if (updated) {
+    if (msgs_to_rerender.length > 0) {
         home_msg_list.view.rerender_messages(msgs_to_rerender);
         if (current_msg_list === message_list.narrowed) {
             message_list.narrowed.view.rerender_messages(msgs_to_rerender);
         }
-    } else {
-        _.each(locally_processed_ids, function (id) {
-            ui.show_local_message_arrived(id);
-        });
     }
+
     return non_echo_messages;
 };
 

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -229,6 +229,9 @@ exports.process_from_server = function process_from_server(messages) {
             client_message.content = message.content;
             sent_messages.mark_disparity(message.local_id);
         }
+
+        client_message.timestamp = message.timestamp;
+
         msgs_to_rerender.push(client_message);
         delete waiting_for_ack[client_message.id];
     });

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -102,21 +102,6 @@ exports.update_starred = function (message_id, starred) {
     });
 };
 
-var local_messages_to_show = [];
-var show_message_timestamps = _.throttle(function () {
-    _.each(local_messages_to_show, function (message_id) {
-        update_message_in_all_views(message_id, function update_row(row) {
-            row.find('.message_time').toggleClass('notvisible', false);
-        });
-    });
-    local_messages_to_show = [];
-}, 100);
-
-exports.show_local_message_arrived = function (message_id) {
-    local_messages_to_show.push(message_id);
-    show_message_timestamps();
-};
-
 exports.show_message_failed = function (message_id, failed_msg) {
     // Failed to send message, so display inline retry/cancel
     update_message_in_all_views(message_id, function update_row(row) {


### PR DESCRIPTION
I think the first commit here should go directly to master, as it's just cleanup.

We should test deploy the 2nd/3rd to see if we see flicker.  If there's flicker, we'll want to do a more complex solution.

Note that this will fix #6638 if we keep it on master, but I didn't update the commit message for the third commit yet to say "Fixes...".