### PR TITLE
settings: Fix default streams scrolling issue.

### DIFF
--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -25,8 +25,13 @@ function populate_streams() {
             callback: function (item, value) {
                 return item.name.toLowerCase().indexOf(value) >= 0;
             },
+            onupdate: function () {
+                ui.update_scrollbar(streams_table.closest(".progressive-table-wrapper"));
+            },
         },
     }).init();
+
+    ui.set_up_scrollbar(streams_table.closest(".progressive-table-wrapper"));
 
     loading.destroy_indicator($('#admin_page_streams_loading_indicator'));
 }

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -110,6 +110,12 @@ function populate_users(realm_people_data) {
     deactivated_users = _.sortBy(deactivated_users, 'full_name');
     bots = _.sortBy(bots, 'full_name');
 
+    var update_scrollbar = function ($sel) {
+        return function () {
+            ui.update_scrollbar($sel);
+        };
+    };
+
     var $bots_table = $("#admin_bots_table");
     list_render($bots_table, bots, {
         name: "admin_bot_list",
@@ -124,6 +130,7 @@ function populate_users(realm_people_data) {
                     item.email.toLowerCase().indexOf(value) >= 0
                 );
             },
+            onupdate: update_scrollbar($bots_table),
         },
     }).init();
 
@@ -158,6 +165,7 @@ function populate_users(realm_people_data) {
                     item.email.toLowerCase().indexOf(value) >= 0
                 );
             },
+            onupdate: update_scrollbar($users_table),
         },
     }).init();
 
@@ -175,8 +183,14 @@ function populate_users(realm_people_data) {
                     item.email.toLowerCase().indexOf(value) >= 0
                 );
             },
+            onupdate: update_scrollbar($deactivated_users_table),
         },
     }).init();
+
+    [$bots_table, $users_table, $deactivated_users_table].forEach(function ($o) {
+        ui.set_up_scrollbar($o.closest(".progressive-table-wrapper"));
+    });
+
     loading.destroy_indicator($('#admin_page_users_loading_indicator'));
     loading.destroy_indicator($('#admin_page_bots_loading_indicator'));
     loading.destroy_indicator($('#admin_page_deactivated_users_loading_indicator'));

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -600,12 +600,12 @@ input[type=checkbox].inline-block {
 
 .progressive-table-wrapper {
     position: relative;
-    max-height: calc(95vh - 200px);
+    max-height: calc(95vh - 220px);
     overflow: auto;
 }
 
 #admin-default-streams-list .progressive-table-wrapper {
-    max-height: calc(95vh - 270px);
+    max-height: calc(95vh - 280px);
 }
 
 .bots_list {


### PR DESCRIPTION
The progressively rendered table extends too far down, causing the page
to scroll needlessly, which then causes there to be two scrollbars — a
scrollbar for the table and a view scrollbar outside that.

Fixes: #6391.