### PR TITLE
hotkey: Remap `+` key to use canonical name for thumbs up emoji.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -165,6 +165,11 @@ function stubbing(func_name_to_stub, test_function) {
     set_global('emoji_picker', {
         reactions_popped: return_false,
     });
+    set_global('emoji_codes', {
+        codepoint_to_name: {
+            '1f44d': 'thumbs_up',
+        },
+    });
     set_global('hotspots', {
         is_open: return_false,
     });

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -671,7 +671,10 @@ exports.process_hotkey = function (e, hotkey) {
             reactions.open_reactions_popover();
             return true;
         case 'thumbs_up_emoji': // '+': reacts with thumbs up emoji on selected message
-            reactions.toggle_emoji_reaction(msg.id, '+1');
+            // Use canonical name.
+            var thumbs_up_codepoint = '1f44d';
+            var canonical_name = emoji_codes.codepoint_to_name[thumbs_up_codepoint];
+            reactions.toggle_emoji_reaction(msg.id, canonical_name);
             return true;
         case 'toggle_mute':
             muting_ui.toggle_mute(msg);


### PR DESCRIPTION
This fixes the weird double thumbs up emojis issue.
This doesn't handle the corner case that I mentioned in PR #6640 because that will require some work/refactoring in reactions.js that I want to avoid until we finalize our policy for collapsing reactions.