### PR TITLE
org_settings: Fix dropup menu for notifications stream not opening.

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -26,7 +26,7 @@ casper.then(function () {
 // Test changing notifications stream
 casper.then(function () {
     casper.test.info('Changing notifications stream to Verona by filtering with "verona"');
-    casper.click("#id_realm_notifications_stream > a.dropdown-toggle");
+    casper.click("#id_realm_notifications_stream > button.dropdown-toggle");
 
     casper.waitUntilVisible('ul.dropdown-menu', function () {
         casper.sendKeys('.dropdown-search > input[type=text]', 'verona');

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -138,21 +138,19 @@
             <label for="realm_notifications_stream" id="realm_notifications_stream_label" class="inline-block"
                 title="{{t 'The stream to which new stream notifications go to.' }}">
                 {{t "Notifications stream:" }}
-                <button type="button" class="button small rounded">
-                    <span class="dropup actual-dropdown-menu" id="id_realm_notifications_stream"
-                        name="realm_notifications_stream" aria-labelledby="realm_notifications_stream_label">
-                        <a class="dropdown-toggle no-underline" data-toggle="dropdown">
-                            <span id="realm_notifications_stream_name"></span>
-                            <i class="fa fa-pencil"></i>
-                        </a>
-                        <ul class="dropdown-menu" role="menu">
-                            <li class="dropdown-search" role="presentation">
-                                <input type="text" role="menuitem" placeholder="{{t 'Filter streams' }}" autofocus/>
-                            </li>
-                            <span class="dropdown-list-body"></span>
-                        </ul>
-                    </span>
-                </button>
+                <span class="dropup actual-dropdown-menu" id="id_realm_notifications_stream"
+                    name="realm_notifications_stream" aria-labelledby="realm_notifications_stream_label">
+                    <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
+                        <span id="realm_notifications_stream_name"></span>
+                        <i class="fa fa-pencil"></i>
+                    </button>
+                    <ul class="dropdown-menu" role="menu">
+                        <li class="dropdown-search" role="presentation">
+                            <input type="text" role="menuitem" placeholder="{{t 'Filter streams' }}" autofocus/>
+                        </li>
+                        <span class="dropdown-list-body"></span>
+                    </ul>
+                </span>
             </label>
             {{#if is_admin }}
             <a class="notifications-stream-disable">{{t "[Disable]" }}</a>


### PR DESCRIPTION
We were having an anchor tag inside a button which is incorrect HTML.
Chrome and safari handle this case but firefox doesn't and hence the
dropup menu wasn't opening on firefox.
![anim](https://user-images.githubusercontent.com/16687990/30886425-86d23efc-a334-11e7-9dae-9235b111e734.gif)
