### PR TITLE
run-mypy: Add --version, and clean up the CLI a bit.

### DIFF
--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -83,6 +83,9 @@ files_dict = cast(Dict[str, List[str]],
 pyi_files = set(files_dict['pyi'])
 python_files = [fpath for fpath in files_dict['py']
                 if not fpath.endswith('.py') or fpath + 'i' not in pyi_files]
+if not python_files:
+    print("There are no files to run mypy on.")
+    sys.exit(0)
 
 extra_args = ["--check-untyped-defs",
               "--follow-imports=silent",
@@ -102,17 +105,14 @@ if args.ignore_missing_imports:
 if args.quick:
     extra_args.append("--quick")
 
+rc = subprocess.call([mypy_command] + extra_args + python_files)
 
-# run mypy
-if python_files:
-    rc = subprocess.call([mypy_command] + extra_args + python_files)
-    if args.linecoverage_report:
-        # Move the coverage report to where codecov will look for it.
-        try:
-            os.rename('var/linecoverage-report/coverage.txt', 'var/.coverage')
-        except OSError:
-            # maybe mypy crashed; exit with its error code
-            pass
-    sys.exit(rc)
-else:
-    print("There are no files to run mypy on.")
+if args.linecoverage_report:
+    # Move the coverage report to where codecov will look for it.
+    try:
+        os.rename('var/linecoverage-report/coverage.txt', 'var/.coverage')
+    except OSError:
+        # maybe mypy crashed; exit with its error code
+        pass
+
+sys.exit(rc)

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -25,31 +25,29 @@ zproject/test_settings.py
 
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
 parser.add_argument('targets', nargs='*',
-                    help="""files and directories to include in the result.
-                    If this is not specified, the current directory is used""")
+                    help="files and directories to check (default: .)")
 parser.add_argument('-m', '--modified', action='store_true',
-                    help='list only modified files')
+                    help="check only modified files")
 parser.add_argument('-a', '--all', action='store_true',
-                    help="""run mypy on all python files, ignoring the exclude list.
-                    This is useful if you have to find out which files fail mypy check.""")
+                    help="check all files, bypassing the default exclude list")
 parser.add_argument('--linecoverage-report', action='store_true',
-                    help="""run the linecoverage report to see annotation coverage""")
+                    help="emit a coverage report under var/")
 parser.add_argument('--no-disallow-untyped-defs',
                     dest='disallow_untyped_defs', action='store_false',
-                    help="""Don't throw errors when functions are not annotated""")
+                    help="don't pass --disallow-untyped-defs to mypy")
 parser.add_argument('--scripts-only', action='store_true',
-                    help="""Only type check extensionless python scripts""")
+                    help="only check extensionless python scripts")
 parser.add_argument('--strict-optional', action='store_true',
-                    help="""Use the --strict-optional flag with mypy""")
+                    help="pass --strict-optional to mypy")
 parser.add_argument('--warn-unused-ignores', action='store_true',
-                    help="""Use the --warn-unused-ignores flag with mypy""")
+                    help="pass --warn-unused-ignores to mypy")
 parser.add_argument('--no-ignore-missing-imports',
                     dest='ignore_missing_imports', action='store_false',
-                    help="""Don't use the --ignore-missing-imports flag with mypy""")
+                    help="don't pass --ignore-missing-imports to mypy")
 parser.add_argument('--quick', action='store_true',
-                    help="""Use the --quick flag with mypy""")
+                    help="pass --quick to mypy")
 parser.add_argument('--force', action="store_true",
-                    help='Run tests despite possible provisioning problems.')
+                    help="run tests despite possible provisioning problems")
 args = parser.parse_args()
 
 if not args.force:

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -26,6 +26,8 @@ zproject/test_settings.py
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
 parser.add_argument('targets', nargs='*',
                     help="files and directories to check (default: .)")
+parser.add_argument('--version', action='store_true',
+                    help="just run mypy --version")
 parser.add_argument('--quick', action='store_true',
                     help="pass --quick to mypy")
 parser.add_argument('-m', '--modified', action='store_true',
@@ -57,6 +59,18 @@ if not args.force:
         print('If you really know what you are doing, use --force to run anyway.')
         sys.exit(1)
 
+# Use zulip-py3-venv's mypy if it's available.
+VENV_DIR = "/srv/zulip-py3-venv"
+MYPY_VENV_PATH = os.path.join(VENV_DIR, "bin", "mypy")
+if os.path.exists(MYPY_VENV_PATH):
+    mypy_command = MYPY_VENV_PATH
+    print("Using mypy from", mypy_command)
+else:
+    mypy_command = "mypy"
+
+if args.version:
+    sys.exit(subprocess.call([mypy_command, "--version"]))
+
 if args.all:
     exclude = []
 
@@ -69,15 +83,6 @@ files_dict = cast(Dict[str, List[str]],
 pyi_files = set(files_dict['pyi'])
 python_files = [fpath for fpath in files_dict['py']
                 if not fpath.endswith('.py') or fpath + 'i' not in pyi_files]
-
-# Use zulip-py3-venv's mypy if it's available.
-VENV_DIR = "/srv/zulip-py3-venv"
-MYPY_VENV_PATH = os.path.join(VENV_DIR, "bin", "mypy")
-if os.path.exists(MYPY_VENV_PATH):
-    mypy_command = MYPY_VENV_PATH
-    print("Using mypy from", mypy_command)
-else:
-    mypy_command = "mypy"
 
 extra_args = ["--check-untyped-defs",
               "--follow-imports=silent",

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -27,7 +27,7 @@ parser = argparse.ArgumentParser(description="Run mypy on files tracked by git."
 parser.add_argument('targets', nargs='*',
                     help="files and directories to check (default: .)")
 parser.add_argument('--version', action='store_true',
-                    help="just run mypy --version")
+                    help="show mypy version information and exit")
 parser.add_argument('--quick', action='store_true',
                     help="pass --quick to mypy")
 parser.add_argument('-m', '--modified', action='store_true',
@@ -64,11 +64,11 @@ VENV_DIR = "/srv/zulip-py3-venv"
 MYPY_VENV_PATH = os.path.join(VENV_DIR, "bin", "mypy")
 if os.path.exists(MYPY_VENV_PATH):
     mypy_command = MYPY_VENV_PATH
-    print("Using mypy from", mypy_command)
 else:
     mypy_command = "mypy"
 
 if args.version:
+    print("mypy command:", mypy_command)
     sys.exit(subprocess.call([mypy_command, "--version"]))
 
 if args.all:

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -24,29 +24,31 @@ zproject/test_settings.py
 """.split()
 
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
-parser.add_argument('targets', nargs='*', default=[],
+parser.add_argument('targets', nargs='*',
                     help="""files and directories to include in the result.
                     If this is not specified, the current directory is used""")
-parser.add_argument('-m', '--modified', action='store_true', default=False, help='list only modified files')
-parser.add_argument('-a', '--all', dest='all', action='store_true', default=False,
+parser.add_argument('-m', '--modified', action='store_true',
+                    help='list only modified files')
+parser.add_argument('-a', '--all', action='store_true',
                     help="""run mypy on all python files, ignoring the exclude list.
                     This is useful if you have to find out which files fail mypy check.""")
-parser.add_argument('--linecoverage-report', dest='linecoverage_report', action='store_true', default=False,
+parser.add_argument('--linecoverage-report', action='store_true',
                     help="""run the linecoverage report to see annotation coverage""")
-parser.add_argument('--no-disallow-untyped-defs', dest='disallow_untyped_defs', action='store_false', default=True,
+parser.add_argument('--no-disallow-untyped-defs',
+                    dest='disallow_untyped_defs', action='store_false',
                     help="""Don't throw errors when functions are not annotated""")
-parser.add_argument('--scripts-only', dest='scripts_only', action='store_true', default=False,
+parser.add_argument('--scripts-only', action='store_true',
                     help="""Only type check extensionless python scripts""")
-parser.add_argument('--strict-optional', dest='strict_optional', action='store_true', default=False,
+parser.add_argument('--strict-optional', action='store_true',
                     help="""Use the --strict-optional flag with mypy""")
-parser.add_argument('--warn-unused-ignores', dest='warn_unused_ignores', action='store_true', default=False,
+parser.add_argument('--warn-unused-ignores', action='store_true',
                     help="""Use the --warn-unused-ignores flag with mypy""")
-parser.add_argument('--no-ignore-missing-imports', dest='ignore_missing_imports', action='store_false', default=True,
+parser.add_argument('--no-ignore-missing-imports',
+                    dest='ignore_missing_imports', action='store_false',
                     help="""Don't use the --ignore-missing-imports flag with mypy""")
-parser.add_argument('--quick', action='store_true', default=False,
+parser.add_argument('--quick', action='store_true',
                     help="""Use the --quick flag with mypy""")
-parser.add_argument('--force', default=False,
-                    action="store_true",
+parser.add_argument('--force', action="store_true",
                     help='Run tests despite possible provisioning problems.')
 args = parser.parse_args()
 

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -66,7 +66,7 @@ if args.all:
 files_dict = cast(Dict[str, List[str]],
                   lister.list_files(targets=args.targets, ftypes=['py', 'pyi'],
                                     use_shebang=True, modified_only=args.modified,
-                                    exclude = exclude + ['stubs'], group_by_ftype=True,
+                                    exclude=exclude, group_by_ftype=True,
                                     extless_only=args.scripts_only))
 pyi_files = set(files_dict['pyi'])
 python_files = [fpath for fpath in files_dict['py']

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -26,17 +26,21 @@ zproject/test_settings.py
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
 parser.add_argument('targets', nargs='*',
                     help="files and directories to check (default: .)")
+parser.add_argument('--quick', action='store_true',
+                    help="pass --quick to mypy")
 parser.add_argument('-m', '--modified', action='store_true',
                     help="check only modified files")
+parser.add_argument('--scripts-only', action='store_true',
+                    help="only check extensionless python scripts")
 parser.add_argument('-a', '--all', action='store_true',
                     help="check all files, bypassing the default exclude list")
+parser.add_argument('--force', action="store_true",
+                    help="run tests despite possible provisioning problems")
 parser.add_argument('--linecoverage-report', action='store_true',
                     help="emit a coverage report under var/")
 parser.add_argument('--no-disallow-untyped-defs',
                     dest='disallow_untyped_defs', action='store_false',
                     help="don't pass --disallow-untyped-defs to mypy")
-parser.add_argument('--scripts-only', action='store_true',
-                    help="only check extensionless python scripts")
 parser.add_argument('--strict-optional', action='store_true',
                     help="pass --strict-optional to mypy")
 parser.add_argument('--warn-unused-ignores', action='store_true',
@@ -44,10 +48,6 @@ parser.add_argument('--warn-unused-ignores', action='store_true',
 parser.add_argument('--no-ignore-missing-imports',
                     dest='ignore_missing_imports', action='store_false',
                     help="don't pass --ignore-missing-imports to mypy")
-parser.add_argument('--quick', action='store_true',
-                    help="pass --quick to mypy")
-parser.add_argument('--force', action="store_true",
-                    help="run tests despite possible provisioning problems")
 args = parser.parse_args()
 
 if not args.force:

--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -12,6 +12,7 @@ set -x
 
 # We run mypy after the backend tests so we get output from the
 # backend tests, which tend to uncover more serious problems, first.
+./tools/run-mypy --version
 ./tools/run-mypy --linecoverage-report
 
 ./tools/test-migrations


### PR DESCRIPTION
Locally on master I'm getting a few errors when I run `tools/run-mypy`, though things are passing in Travis. That's puzzling, so I went to add to the Travis build a record of the mypy version in use, because I found I couldn't easily confirm that. And ended up making a number of cleanups to the run-mypy CLI first.

(Result: it is in fact the same version of mypy, so the issue is somewhere else.)
