### PR TITLE
portico: Update why-zulip.

### DIFF
--- a/templates/zerver/why-zulip.md
+++ b/templates/zerver/why-zulip.md
@@ -4,28 +4,51 @@ in chat. If you haven’t seen Zulip in action, log on to our developers’
 server at <https://chat.zulip.org>, or check out our short screencast
 (coming soon) on topics and threading.
 
-## Asynchronous matters
+## Zulip vs. Slack
 
 Zulip’s threading model allows for long-running conversations to co-exist
-with real time chat. This allows remote team members, part-time contractors,
-internal clients, and others who aren’t going to be on your chat full-time
-to participate effectively.
+with real time chat. This allows senior staff, remote team members,
+part-time contractors, internal clients, and others who aren’t going to be
+on your chat full-time to participate effectively.
 
-## Usability matters
+In Slack (or Hipchat, Mattermost, or many others), if Bob starts a
+conversation in a busy channel at 10am, and Ada swings by sometime in the
+evening, there is no way for Ada to effectively participate in that
+conversation. If Ada is a senior manager who spends most of her days in
+meetings, or is a remote engineer living 8 time zones away, she won't be able
+to participate in most conversations at all. This means that in an
+organization that has adopted Slack, the vast majority of Ada's
+conversations will still be over email, during meetings, or over Slack
+direct messages.
+
+By contrast, Zulip's lightweight threading model allows senior staff and
+remote workers to fully participate, even if they are reading messages hours
+after they are sent. This enables conversation that would otherwise happen
+over meetings or email to happen in Zulip itself. It also enables easy
+participation and information spread to those that have the least time to
+attend meetings which have only a nugget of information that is relevant to
+them.
+
+## Zulip vs. Email
 
 Email is clunky for real-time communication. A thread with even 100 messages
 feels cluttered and slow, whereas real-time chat conversations (on any
 platform) regularly exceed that. Typing notifications, emoji reactions,
 keyboard shortcuts, and blazingly fast clients make Zulip a daily
-pleasure. Usability is important; if people don’t like a communications
-tool, they just won't use it.
+pleasure. Usability matters; in an organization that relies on email for
+communication, things that could have been resolved over chat end up being
+pushed to meetings instead.
 
 ## Zulip changes the way you operate
 
-The Zulip project currently has over 30 full-time engineers, working from 10
-different countries. Outside of one-on-one conversations, Zulip doesn’t have
-a single phone or video-based meeting. Zulip also has 0 internal mailing
-lists, and 0 internal email discussions.
+The Zulip project currently has over 30 full-time engineers, working from
+over 10 different countries and 25 different locations. Outside of
+one-on-one conversations, Zulip doesn’t have a single phone or video-based
+meeting. Zulip also has 0 internal mailing lists, and 0 internal email
+discussions. By contrast, even Slack doesn't rely on Slack for remote work;
+their
+[careers page](https://slack.com/careers/location/all-locations/dept/all-departments)
+doesn't list a single position where you could work from anywhere.
 
 Threaded conversations mean that all stakeholders can see and respond to
 every message, just like in meetings and email. But unlike meetings, Zulip
@@ -34,7 +57,7 @@ commitments from folks that just need a 5 minute update. And unlike email, a
 lively discussion of 300 Zulip messages is just as easy to digest and
 respond to as an in-person conversation.
 
-### Read more about how we’ve made Zulip work for you
+## Read more about how we’ve made Zulip work for you
 
 * [Zulip for companies](/for/companies)
 * [Zulip for open source projects](/for/open-source)


### PR DESCRIPTION
Originally we wanted it to be short, since we were worried about attention
spans. But it seems like people are willing to read quite a bit when
choosing a chat product, and our "10 second" pitch should just be a video,
rather than a small amount of text.