### PR TITLE
/register/: Make the text error fall on own line.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -227,6 +227,17 @@ html {
     margin: 0px 30px 10px 32px;
 }
 
+.register-account .terms-of-service .text-error {
+    position: relative;
+    display: block;
+    top: -5px;
+    padding: 0;
+    height: 0;
+
+    font-size: 0.7em;
+    font-weight: 600;
+}
+
 .account-creation {
     font-weight: 400;
 }

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -264,7 +264,7 @@ body {
 }
 
 .help-inline.text-error {
-    color: hsl(1, 44%, 50%);
+    color: hsl(1, 54%, 61%);
 }
 
 a.title {

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -152,7 +152,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                     </label>
                     {% if form.terms.errors %}
                         {% for error in form.terms.errors %}
-                        <div class="help-inline text-error">{{ error }}</div>
+                        <p class="help-inline text-error">{{ error }}</p>
                         {% endfor %}
                     {% endif %}
                 </div>


### PR DESCRIPTION
This makes the text error fall on its own line rather than being inline
and pushing the checkbox over out of line with the rest of the elements.