### PR TITLE
/apps/: Add max-width constraint to hero content.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -1630,6 +1630,11 @@ nav ul li.active::after {
     overflow: hidden;
 }
 
+.portico-landing.apps .hero .inner-content {
+    max-width: 1600px;
+    margin: 0 auto;
+}
+
 .portico-landing.apps .hero h1 {
     font-size: 3em;
     margin-bottom: 0px;
@@ -1679,8 +1684,10 @@ nav ul li.active::after {
     height: 100%;
 }
 
-.portico-landing.apps .hero .info .flex {
-    height: 100%;
+.portico-landing.apps .hero .info .flex,
+.portico-landing.apps .hero .image .flex {
+    height: 500px;
+    min-height: 0px;
 }
 
 .portico-landing.apps .hero .info button {
@@ -2996,6 +3003,13 @@ nav ul li.active::after {
         font-size: 1.9em;
         font-weight: 400;
     }
+
+    .portico-landing.apps .hero .info .flex,
+    .portico-landing.apps .hero .image .flex {
+        height: 300px;
+        min-height: 0px;
+    }
+
 
     .portico-landing.apps .other-apps {
         padding: 50px 5px 120px 5px;

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -21,21 +21,23 @@
 <div class="portico-landing apps">
     <div class="hero">
         <div id="waves"></div>
-        <div class="info">
-            <div class="flex">
-                <div class="cta">
-                    <h1>Zulip for <span class="platform"></span></h1>
-                    <p class="description"></p>
-                    <p class="download-instructions">For download instructions, go to the <a class="silver bold" href="/help/desktop-app-install-guide" target="_blank">desktop app install guide</a>.</p>
-                    <a class="link no-action" href="">
-                        <button type="button" name="button">Download Zulip for <span class="platform"></span></button>
-                    </a>
+        <div class="inner-content">
+            <div class="info">
+                <div class="flex">
+                    <div class="cta">
+                        <h1>Zulip for <span class="platform"></span></h1>
+                        <p class="description"></p>
+                        <p class="download-instructions">For download instructions, go to the <a class="silver bold" href="/help/desktop-app-install-guide" target="_blank">desktop app install guide</a>.</p>
+                        <a class="link no-action" href="">
+                            <button type="button" name="button">Download Zulip for <span class="platform"></span></button>
+                        </a>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="image">
-            <div class="flex">
-                <img src="" />
+            <div class="image">
+                <div class="flex">
+                    <img src="" />
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This adds a max-width constraint to the hero content so that the images
inside the hero don’t keep expanding forever and eventually outside of
the hero’s bounds.

Fixes: #6713.