### PR TITLE
portico: Style "confirm email change" page.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -535,6 +535,10 @@ html {
     margin: 0px;
 }
 
+.confirm-email-change-page .white-box {
+    max-width: 500px;
+}
+
 .portico-page .or {
     width: 328px;
     display: block;

--- a/templates/confirmation/confirm_email_change.html
+++ b/templates/confirmation/confirm_email_change.html
@@ -2,12 +2,17 @@
 
 {% block portico_content %}
 
-<div class="pitch">
-    <hr/>
-    <p>
-        This confirms that the email address for your Zulip account has changed
-        from {{old_email}} to {{ new_email }}.
-    </p>
+<div class="app confirm-email-change-page flex full-page">
+    <div class="inline-block new-style">
+        <div class="lead">
+            <h1 class="get-started">{{ _('Email changed!') }}</h1>
+        </div>
+
+        <div class="app-main white-box">
+            This confirms that the email address for your Zulip account has changed
+            from <a href="mailto:{{old_email}}">{{old_email}}</a> to <a href="mailto:{{new_email}}">{{new_email}}</a>.
+        </div>
+    </div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
This adds the white box styling to the "confirm email change" page.

Fixes: #6706.