### PR TITLE
/help/: Remove "overflow: hidden" from sidebar on mobile.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -1344,7 +1344,6 @@ input.new-organization-button {
         transform: translateX(0);
         transition: all 0.3s ease;
 
-        overflow: hidden;
         height: 100vh;
     }
 


### PR DESCRIPTION
This removes the "overflow: hidden" value in CSS on screens that
are less than 1000px wide.

Fixes: #6700.