### PR TITLE
settings: Fix "Notifications stream" list scrolling.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -148,8 +148,13 @@ exports.populate_notifications_stream_dropdown = function (stream_list) {
             callback: function (item, value) {
                 return item.name.toLowerCase().indexOf(value) >= 0;
             },
+            onupdate: function () {
+                ui.update_scrollbar(dropdown_list_body);
+            },
         },
     }).init();
+
+    ui.set_up_scrollbar(dropdown_list_body);
 
     $("#id_realm_notifications_stream .dropdown-search").click(function (e) {
         e.stopPropagation();

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1064,6 +1064,7 @@ input[type=checkbox].inline-block {
 }
 
 #id_realm_notifications_stream .dropdown-list-body {
+    position: relative;
     height: auto;
     max-height: 200px;
     overflow-y: auto;


### PR DESCRIPTION
The list needs to be set to use perfectScrollbar so that it can
scroll due to the fact that it resides within another instance of
perfectScrollbar.

Fixes: #6351.