### PR TITLE
popovers: Fix padding to be more uniform.

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -2,6 +2,10 @@
     width: auto;
 }
 
+.popover-content {
+    padding: 5px 0px;
+}
+
 .popover-title {
     overflow-x: hidden;
     text-overflow: ellipsis;

--- a/static/templates/actions_popover_content.handlebars
+++ b/static/templates/actions_popover_content.handlebars
@@ -1,5 +1,5 @@
 {{! Contents of the "message actions" popup }}
-<ul class="nav nav-list actions_popover pull-right">
+<ul class="nav nav-list actions_popover">
     <li>
         <a href="#" class="popover_edit_message" data-message-id="{{message.id}}">
             {{! Can consider http://fontawesome.io/icon/file-code-o/ when we upgrade to font awesome 4.}}


### PR DESCRIPTION
The popovers for the message down chevron and left sidebar had
strange side padding and non-uniform padding between the top and
bottom. This changes them to all have the same padding as the
nav `#gear_menu`; none on the sides and 5px on the top and bottom.

<img width="239" alt="screen shot 2017-09-27 at 10 26 29 am" src="https://user-images.githubusercontent.com/10321399/30927878-c334bf8e-a36e-11e7-9940-9f6c2813e328.png">
<img width="343" alt="screen shot 2017-09-27 at 10 26 38 am" src="https://user-images.githubusercontent.com/10321399/30927879-c33d68f0-a36e-11e7-90b6-01b47e563a82.png">
