### PR TITLE
/apps/: Add link to installation instructions.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -111,6 +111,10 @@ a:hover {
     font-weight: 600;
 }
 
+.silver.bold {
+    font-weight: 600;
+}
+
 .padded-content {
     padding: 50px;
 }
@@ -211,6 +215,16 @@ nav .brand.logo {
 
 nav.white {
     background-color: #fff;
+}
+
+.silver {
+    color: #fff;
+    opacity: 0.8;
+}
+
+.silver:hover {
+    color: #fff;
+    opacity: 1;
 }
 
 nav.white li a,

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -25,7 +25,8 @@
             <div class="flex">
                 <div class="cta">
                     <h1>Zulip for <span class="platform"></span></h1>
-                    <p><span class="description"></span></p>
+                    <p class="description"></p>
+                    <p>For download instructions, go to the <a class="silver bold" href="/help/desktop-app-install-guide" target="_blank">desktop app install guide</a>.</p>
                     <a class="link no-action" href="">
                         <button type="button" name="button">Download Zulip for <span class="platform"></span></button>
                     </a>

--- a/templates/zerver/help/desktop-app-install-guide.md
+++ b/templates/zerver/help/desktop-app-install-guide.md
@@ -10,7 +10,7 @@ There are two versions available -
 - **stable:** these releases are more thoroughly tested; they receive
     new features later, but there's a lower chance that things will go wrong.
 
-## MAC
+## Mac
 
 **DMG or zip**:
 

--- a/templates/zerver/help/desktop-app-install-guide.md
+++ b/templates/zerver/help/desktop-app-install-guide.md
@@ -1,0 +1,73 @@
+# How to install Desktop app
+
+[LR]: https://github.com/zulip/zulip-electron/releases/latest
+
+If you download from the [releases page][LR], be careful what version you pick.
+There are two versions available -
+
+- **beta:** these releases are the right balance between getting
+    new features early while staying away from nasty bugs.
+- **stable:** these releases are more thoroughly tested; they receive
+    new features later, but there's a lower chance that things will go wrong.
+
+## MAC
+
+**DMG or zip**:
+
+1. Download [Zulip-x.x.x.dmg][LR] or [Zulip-x.x.x-mac.zip][LR]
+2. Open or unzip the file and drag the app into the `Applications` folder
+3. Done! The app will update automatically
+
+**Using brew**:
+
+1. Run `brew cask install zulip` in your terminal
+2. The app will be installed in your `Applications`
+3. Done! The app will update automatically (you can also use `brew update && brew upgrade zulip`)
+
+## Windows
+
+**Installer (recommended)**:
+
+1. Download [Zulip-Web-Setup-x.x.x.exe][LR]
+2. Run the installer, wait until it finishes
+3. Done! The app will update automatically
+
+**Portable**:
+
+1. Download [zulip-x.x.x-arch.nsis.7z][LR]  [*here arch = ia32 (32-bit), x64 (64-bit)*]
+2. Extract the zip wherever you want (e.g. a flash drive) and run the app from there
+
+## Linux
+
+**Ubuntu, Debian 8+ (deb package)**:
+
+1. Download [Zulip-x.x.x-amd64.deb][LR]
+2. Double click and install, or run `dpkg -i Zulip-x.x.x-amd64.deb` in the terminal
+3. Start the app with your app launcher or by running `zulip` in a terminal
+4. Done! The app will NOT update automatically, but you can still check for updates
+
+**Other distros (Fedora, CentOS, Arch Linux etc)** :
+
+1. Download [Zulip-x.x.x-x86_64.AppImage][LR]
+2. Make it executable using `chmod a+x Zulip-x.x.x-x86_64.AppImage`
+3. Start the app with your app launcher
+
+**You can also use `apt-get` (recommended)**:
+
+* First download our signing key to make sure the deb you download is correct:
+
+```
+sudo apt-key adv --keyserver pool.sks-keyservers.net --recv 69AD12704E71A4803DCA3A682424BE5AE9BD10D9
+```
+
+* Add the repo to your apt source list :
+```
+echo "deb https://dl.bintray.com/zulip/debian/ beta main" |
+  sudo tee -a /etc/apt/sources.list.d/zulip.list
+```
+
+* Now install the client :
+```
+sudo apt-get update
+sudo apt-get install zulip
+```

--- a/templates/zerver/help/sidebar.md
+++ b/templates/zerver/help/sidebar.md
@@ -97,6 +97,9 @@
 * [Import users and channels from Slack](/help/import-users-and-channels-from-slack)
 * [Analytics](/help/analytics)
 
+## Desktop Application
+* [Installation guides](/help/desktop-app-install-guide)
+
 ## Misc
 * [Tips for Zulip on Windows](/help/zulip-on-windows)
 * [Tips for Zulip on Android](/help/zulip-on-android)


### PR DESCRIPTION
This adds a link to installation instructions for each of the operating systems for the Zulip app.