### PR TITLE
puppet: Use pip to install wal-e dependencies.

### DIFF
--- a/puppet/zulip_ops/manifests/base.pp
+++ b/puppet/zulip_ops/manifests/base.pp
@@ -19,8 +19,6 @@ class zulip_ops::base {
                         # Needed for zulip-ec2-configure-network-interfaces
                         "python3-six",
                         "python-six",
-                        # "python3-boto", # missing on trusty
-                        "python-boto", # needed for postgres_common too
                         "python3-netifaces",
                         "python-netifaces",
                         # Popular editors

--- a/puppet/zulip_ops/manifests/base.pp
+++ b/puppet/zulip_ops/manifests/base.pp
@@ -19,8 +19,6 @@ class zulip_ops::base {
                         # Needed for zulip-ec2-configure-network-interfaces
                         "python3-six",
                         "python-six",
-                        "python3-netifaces",
-                        "python-netifaces",
                         # Popular editors
                         "vim",
                         "emacs-nox",
@@ -35,6 +33,12 @@ class zulip_ops::base {
                         "nagios-plugins-contrib",
                          ]
   package { $org_base_packages: ensure => "installed" }
+
+  exec {"pip_ec2_wal-e":
+    # pip dependencies to run ec2-configure-interfaces and wal-e
+    command  => "/usr/bin/pip2 install 'boto==2.4.0' 'netifaces==0.10.6'",
+    require  => Package['python-pip'],
+  }
 
   # Add system users here
   $users = []

--- a/puppet/zulip_ops/manifests/postgres_common.pp
+++ b/puppet/zulip_ops/manifests/postgres_common.pp
@@ -6,8 +6,6 @@ class zulip_ops::postgres_common {
                                  "pv",
                                  "python3-pip",
                                  "python-pip",
-                                 # "python3-gevent", # missing on trusty
-                                 "python-gevent",
                                  # Postgres Nagios check plugin
                                  "check-postgres",
                                  ]
@@ -16,10 +14,9 @@ class zulip_ops::postgres_common {
   exec {"pip_wal-e":
     # On trusty, there is no python3-boto or python3-gevent package,
     # so we keep our `wal-e` explicitly on Python 2 for now.
-    command  => "/usr/bin/pip2 install git+git://github.com/zbenjamin/wal-e.git#egg=wal-e",
+    command  => "/usr/bin/pip2 install 'boto==2.4.0' 'gevent==1.2.2' git+git://github.com/zbenjamin/wal-e.git#egg=wal-e",
     creates  => "/usr/local/bin/wal-e",
-    require  => Package['python-pip', 'python-boto', 'python-gevent',
-                        'lzop', 'pv'],
+    require  => Package['python-pip', 'lzop', 'pv'],
   }
 
   cron { "pg_backup_and_purge":


### PR DESCRIPTION
This allows the versions to be pinned.