### PR TITLE
APNs: Accept 1.6-format payloads in bouncer.

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -580,6 +580,20 @@ class TestAPNs(PushNotificationTest):
                     "APNs: Success sending for user %d to device %s",
                     self.user_profile.id, device.token)
 
+    def test_modernize_apns_payload(self):
+        # type: () -> None
+        payload = {'alert': 'Message from Hamlet',
+                   'badge': 1,
+                   'custom': {'zulip': {'message_ids': [3]}}}
+        self.assertEqual(
+            apn.modernize_apns_payload(
+                {'alert': 'Message from Hamlet',
+                 'message_ids': [3]}),
+            payload)
+        self.assertEqual(
+            apn.modernize_apns_payload(payload),
+            payload)
+
 class TestGetAlertFromMessage(PushNotificationTest):
     def test_get_alert_from_private_group_message(self):
         # type: () -> None


### PR DESCRIPTION
This is just enough of a quick fix to work with a stock Zulip 1.6
server.  We should really also make this robust to arbitrary input
from the remote Zulip server, even though it'll be a little tedious.
