### PR TITLE
/apps/: page styling follow up.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -217,13 +217,16 @@ nav.white {
     background-color: #fff;
 }
 
+a.silver {
+    text-decoration: underline;
+}
+
 .silver {
-    color: #fff;
+    color: #fff !important;
     opacity: 0.8;
 }
 
 .silver:hover {
-    color: #fff;
     opacity: 1;
 }
 


### PR DESCRIPTION
This changes the link color from green to white.

This shows the download instructions only selectively based on
whether the device has download instructions for it. This means
currently it shows the page for Windows, Mac, and Linux.