### PR TITLE
/help/:sidebar-'overflow: hidden' unless hamburger clicked(<1000px)

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -1343,13 +1343,14 @@ input.new-organization-button {
         padding-right: 80px;
         transform: translateX(0);
         transition: all 0.3s ease;
-
+        overflow: hidden;
         height: 100vh;
     }
 
     .app.help .sidebar.show {
         padding-right: 20px;
         transform: translateX(280px);
+        overflow: auto !important;
     }
 
     .app.help .sidebar.show + .hamburger {


### PR DESCRIPTION
Under responsiveness i.e. <1000px `overflow` is set `hidden` and when hamburger is clicked i.e. when the sidebar is shown the `overflow` property is overridden to `auto`.
It reverses what have been done in P.R. #6717. And it also fixes #6700 
I have tested this in Chrome and Firefox (both Linux) and its working fine for me.
Fixes: #6730.
![peek 2017-09-28 14-41](https://user-images.githubusercontent.com/22238472/30960345-62c2c0cc-a460-11e7-86a5-90321b83405d.gif)
