### PR TITLE
Strip trailing & leading whitespace in email field

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -103,5 +103,16 @@ $(function () {
 if (window.location.hash.substring(0, 1) === "#") {
     document.email_form.action += window.location.hash;
 }
+
+$("#email").on('focusout', function (e) {
+    $('#email').val($.trim($('#email').val()));
+});
+
+$("#email").on('keydown', function (e) {
+    if(e.which == 13) {
+        $('#email').val($.trim($('#email').val()));
+    }
+});
+
 </script>
 {% endblock %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -154,6 +154,11 @@ common.autofocus('#id_username');
 if (window.location.hash.substring(0, 1) === "#") {
     document.login_form.action += window.location.hash;
 }
+
+$("#id_username").on('focusout', function (e) {
+    $('#id_username').val($.trim($('#id_username').val()));
+});
+
 </script>
 
 {% endblock %}


### PR DESCRIPTION
Strip trailing and leading whitespace of data entered in email field by user in registrations and login page. And then validate the data for email field.