### PR TITLE
linter: Add '===' rule to eslint for JavaScript.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -175,7 +175,7 @@
         "curly": 2,
         "dot-notation": [ "error", { "allowKeywords": true } ],
         "eol-last": [ "error", "always" ],
-        "eqeqeq": [ "error", "allow-null" ],
+        "eqeqeq": 2,
         "func-style": [ "off", "expression" ],
         "guard-for-in": 2,
         "keyword-spacing": [ "error",


### PR DESCRIPTION
This adds the rule to force '===' so that contributors are unable
to use the dangerous soft-match '==' sign.

Fortunately there are no current examples of this in the codebase
so no modifications are required within the codebase to allow it
to pass.