### PR TITLE
settings: Make uploads use list_render and perfectScrollbar.

### DIFF
--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -35,6 +35,7 @@ exports.set_up_attachments = function () {
     });
 
     var uploaded_files_table = $("#uploaded_files_table").expectOne();
+    var $search_input = $("#upload_file_search");
 
     list_render(uploaded_files_table, attachments, {
         name: "uploaded-files-list",

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -36,6 +36,20 @@ exports.set_up_attachments = function () {
 
     var uploaded_files_table = $("#uploaded_files_table").expectOne();
 
+    list_render(uploaded_files_table, attachments, {
+        name: "uploaded-files-list",
+        modifier: function (attachment) {
+            return templates.render("uploaded_files_list", { attachment: attachment });
+        },
+        filter: {
+            element: $search_input,
+            callback: function (item, value) {
+                return item.name.toLocaleLowerCase().indexOf(value) >= 0;
+            },
+        },
+    }).init();
+
+
     uploaded_files_table.empty();
     _.each(attachments, function (attachment) {
         var row = templates.render('uploaded_files_list', { attachment: attachment });

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -47,9 +47,13 @@ exports.set_up_attachments = function () {
             callback: function (item, value) {
                 return item.name.toLocaleLowerCase().indexOf(value) >= 0;
             },
+            onupdate: function () {
+                ui.update_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));
+            },
         },
     }).init();
 
+    ui.set_up_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));
 
     uploaded_files_table.empty();
     _.each(attachments, function (attachment) {

--- a/static/templates/settings/attachments-settings.handlebars
+++ b/static/templates/settings/attachments-settings.handlebars
@@ -1,5 +1,6 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
     <div class='tip'>{{#tr this}}You are currently using __total_uploads_size__ of __upload_quota__ upload space.{{/tr}}</div>
+    <input id="upload_file_search" type="search" name="" value="" placeholder="{{t 'Search uploads...' }}" />
     <div class="alert" id="delete-upload-status"></div>
     <div class="progressive-table-wrapper">
         <table class="table table-condensed table-striped">

--- a/static/templates/settings/attachments-settings.handlebars
+++ b/static/templates/settings/attachments-settings.handlebars
@@ -1,7 +1,7 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
+    <div class='tip'>{{#tr this}}You are currently using __total_uploads_size__ of __upload_quota__ upload space.{{/tr}}</div>
+    <div class="alert" id="delete-upload-status"></div>
     <div class="progressive-table-wrapper">
-        <div class='tip'>{{#tr this}}You are currently using __total_uploads_size__ of __upload_quota__ upload space.{{/tr}}</div>
-        <div class="alert" id="delete-upload-status"></div>
         <table class="table table-condensed table-striped">
             <thead>
                 <th>{{t "File" }}</th>

--- a/static/templates/uploaded_files_list.handlebars
+++ b/static/templates/uploaded_files_list.handlebars
@@ -1,6 +1,10 @@
 {{#with attachment}}
 <tr class="uploaded_file_row" id="{{name}}">
-    <td>{{ name }}</td>
+    <td>
+        <a type="submit" href="/user_uploads/{{path_id}}" target="_blank" title="{{t 'View file' }}">
+            {{ name }}
+        </a>
+    </td>
     <td>{{ create_time }}</td>
     <td>
         {{#if messages }}

--- a/static/templates/uploaded_files_list.handlebars
+++ b/static/templates/uploaded_files_list.handlebars
@@ -23,7 +23,7 @@
             </button>
         </span>
         <span class="edit-attachment-buttons">
-            <a type="submit" href="/user_uploads/{{path_id}}" class="btn no-style" title="{{t 'View file' }}" id="download_attachment" download>
+            <a type="submit" href="/user_uploads/{{path_id}}" class="btn no-style" title="{{t 'Download file' }}" id="download_attachment" download>
                 <i class="icon-vector-download-alt sea-green"></i>
             </a>
         </span>


### PR DESCRIPTION
This adds the perfectScrollbar to the uploads table so that it will
function properly in the settings container since the parent node has a
perfectScrollbar.

It also adds the list_render function with a search box to filter by file name.

Fixes: #6746.