### PR TITLE
refactor: Move default_sending_stream logic to Addressee.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1546,12 +1546,6 @@ def check_message(sender, client, addressee,
 
     if addressee.is_stream():
         stream_name = addressee.stream_name()
-        if stream_name is None:
-            if sender.default_sending_stream:
-                # Use the users default stream
-                stream_name = sender.default_sending_stream.name
-            else:
-                raise JsonableError(_('Missing stream'))
 
         stream_name = stream_name.strip()
         check_stream_name(stream_name)

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -97,7 +97,11 @@ class Addressee(object):
                 # This is a hack to deal with the fact that we still support
                 # default streams (and the None will be converted later in the
                 # callpath).
-                stream_name = None
+                if sender.default_sending_stream:
+                    # Use the users default stream
+                    stream_name = sender.default_sending_stream.name
+                else:
+                    raise JsonableError(_('Missing stream'))
 
             return Addressee.for_stream(stream_name, topic_name)
         elif message_type_name == 'private':


### PR DESCRIPTION
Having Addressee take care of setting stream_name to
sender.default_sending_stream.name makes us able to have
the invariant that stream_name is never None when the
message type is 'stream', which will help for mypy, among
other things.

One thing to be aware of is that Addressee does do a little
bit of validation work, and this adds yet another JsonableError
exception.  I don't view this as a bad thing, just something to
know.