### PR TITLE
Restoring message draft switches back to write mode.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -148,6 +148,12 @@ exports.restore_draft = function (draft_id) {
     }
     compose_actions.start(draft_copy.type, draft_copy);
     compose_ui.autosize_textarea();
+    if ($("#preview_message_area").is(":visible") && $("#undo_markdown_preview").is(":visible")) {
+        $("#markdown_preview").show();
+        $("#undo_markdown_preview").hide();
+        $("#preview_message_area").hide();
+        $("#new_message_content").show();
+    }
     $("#new_message_content").data("draft-id", draft_id);
 };
 


### PR DESCRIPTION
Fix #5951 
This solves the problem for the above stated issue so that if the user was viewing a message in preview mode and then selects a message from the drafts section, the content for the new message is now rendered in write mode.