### PR TITLE
emoji_picker: Change background color upon hover for unreacted emojis.

### DIFF
--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -214,6 +214,10 @@
     width: 25px;
 }
 
+.emoji-popover-emoji:not(.reacted):hover {
+    background-color: hsl(0, 0%, 93%);
+}
+
 .emoji-popover-emoji.hide {
     display: none;
 }


### PR DESCRIPTION
Change an unreacted emoji's background color when you hover over it in the emoji picker.

![](https://i.gyazo.com/f302b8de284830d12c0a49322b1386c6.gif)