### PR TITLE
Add: Profile picture popover on clicking mentions in chats.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -349,6 +349,15 @@ exports.register_click_handlers = function () {
         show_user_info_popover(this, user, message);
     });
 
+    $("#main_div").on("click", ".user-mention", function (e) {
+        var row = $(this).closest(".message_row");
+        e.stopPropagation();
+        var message = current_msg_list.get(rows.id(row));
+        var id = $(this).attr('data-user-id');
+        var user = people.get_person_from_user_id(id);
+        show_user_info_popover(this, user, message);
+    });
+
     $('body').on('click', '.user_popover .narrow_to_private_messages', function (e) {
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var email = people.get_person_from_user_id(user_id).email;


### PR DESCRIPTION
Fixes #6380 

Clicking the user mention creates the desired popover.

![screenshot from 2017-09-30 22-56-18](https://user-images.githubusercontent.com/24482726/31048010-9c116c74-a632-11e7-8211-cf89bb311dff.png)
