### PR TITLE
requirements: Upgrade sphinx to 1.6.4.

### DIFF
--- a/requirements/dev_lock.txt
+++ b/requirements/dev_lock.txt
@@ -140,7 +140,7 @@ social-auth-core==1.4.0   # via social-auth-app-django
 sockjs-tornado==1.0.3
 sourcemap==0.2.1
 sphinx-rtd-theme==0.2.4
-sphinx==1.6.2
+sphinx==1.6.4
 sphinxcontrib-websupport==1.0.1  # via sphinx
 sqlalchemy==1.1.14
 statsd==2.1.2             # via django-statsd-mozilla

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,7 +7,7 @@
 # See requirements/README.md for more detail.
 
 # Needed to build RTD docs
-sphinx==1.6.2
+sphinx==1.6.4
 sphinx-rtd-theme==0.2.4
 
 # Needed to build markdown docs


### PR DESCRIPTION
This fix was merged to sphinx 1.6.4:
https://github.com/sphinx-doc/sphinx/commit/9f889932815dea46f8e97c732aaa8216e4b37c08

That was previously causing problems building the zulip docs.