### PR TITLE
django-auth-ldap: Upgrade to 1.2.15.

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -55,7 +55,7 @@ defusedxml==0.5.0
 diff-match-patch==20121119
 
 # Needed for LDAP support
-django-auth-ldap==1.2.12
+django-auth-ldap==1.2.15
 
 # Django extension providing bitfield support
 django-bitfield==1.9.3

--- a/requirements/dev_lock.txt
+++ b/requirements/dev_lock.txt
@@ -45,7 +45,7 @@ decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
 dicttoxml==1.7.4          # via moto
 diff-match-patch==20121119
-django-auth-ldap==1.2.12
+django-auth-ldap==1.2.15
 django-bitfield==1.9.3
 django-pipeline==1.6.13
 django-statsd-mozilla==0.4.0
@@ -54,7 +54,6 @@ django==1.11.4
 docopt==0.6.2
 docutils==0.14
 first==2.0.1              # via pip-tools
-fonttools==3.15.1
 gitdb==0.6.4
 gitlint==0.8.2
 google-api-python-client==1.6.3

--- a/requirements/prod_lock.txt
+++ b/requirements/prod_lock.txt
@@ -30,7 +30,7 @@ cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
 diff-match-patch==20121119
-django-auth-ldap==1.2.12
+django-auth-ldap==1.2.15
 django-bitfield==1.9.3
 django-pipeline==1.6.13
 django-statsd-mozilla==0.4.0

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -432,7 +432,9 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
             elif settings.LDAP_EMAIL_ATTR is not None:
                 self._realm = get_realm_by_email_domain(username)
             username = self.django_to_ldap_username(username)
-            user_profile = ZulipLDAPAuthBackendBase.authenticate(self, username, password)
+            user_profile = ZulipLDAPAuthBackendBase.authenticate(self,
+                                                                 username=username,
+                                                                 password=password)
             if user_profile is None:
                 return None
             if not check_subdomain(realm_subdomain, user_profile.realm.subdomain):


### PR DESCRIPTION
In 1.2.15 version of django-auth-ldap the authenticate() function of LDAPBackend takes
username and password as keyword arguments. This commit updates the code
to match this change.

Fixes #6588