### PR TITLE
Set badge count as 0 for iOS push notifications

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -76,7 +76,7 @@ def modernize_apns_payload(data):
         #   'message_ids': List[int],  # always just one
         return {
             'alert': data['alert'],
-            'badge': 1,
+            'badge': 0,
             'custom': {
                 'zulip': {
                     'message_ids': data['message_ids'],
@@ -372,7 +372,7 @@ def get_apns_payload(message):
             'body': message.content[:200],
         },
         # TODO: set badge count in a better way
-        'badge': 1,
+        'badge': 0,
         'custom': {
             'zulip': {
                 'message_ids': [message.id],

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -582,7 +582,7 @@ class TestAPNs(PushNotificationTest):
     def test_modernize_apns_payload(self):
         # type: () -> None
         payload = {'alert': 'Message from Hamlet',
-                   'badge': 1,
+                   'badge': 0,
                    'custom': {'zulip': {'message_ids': [3]}}}
         self.assertEqual(
             apn.modernize_apns_payload(
@@ -668,7 +668,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'title': "New private group message from King Hamlet",
                 'body': message.content,
             },
-            'badge': 1,
+            'badge': 0,
             'custom': {
                 'zulip': {
                     'message_ids': [message.id],


### PR DESCRIPTION
Docs for badge: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html

> Include this key when you want the system to modify the badge of your app icon.
If this key is not included in the dictionary, the badge is not changed. To remove the badge, set the value of this key to 0.

And already had a discussion with Greg here 
 https://github.com/zulip/zulip/pull/6364#discussion_r140125762