### PR TITLE
lightbox: Fix hotkey-related bugs.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -147,11 +147,3 @@ var draft_2 = {
 
     drafts.initialize();
 }());
-
-(function test_drafts_overlay_open() {
-    var overlay = $("#draft_overlay");
-    assert(!drafts.drafts_overlay_open());
-    overlay.addClass("show");
-    assert(drafts.drafts_overlay_open());
-}());
-

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -14,9 +14,6 @@
 set_global('activity', {
 });
 
-set_global('drafts', {
-});
-
 set_global('page_params', {
 });
 
@@ -225,7 +222,13 @@ function stubbing(func_name_to_stub, test_function) {
     assert_mapping('C', 'compose_actions.start');
     assert_mapping('P', 'narrow.by');
     assert_mapping('g', 'gear_menu.open');
+
+    overlays.is_active = return_true;
+    overlays.drafts_open = return_true;
     assert_mapping('d', 'drafts.toggle');
+    overlays.drafts_open = return_false;
+    assert_unmapped('d');
+    overlays.is_active = return_false;
 
     // Next, test keys that only work on a selected message.
     var message_view_only_keys = '@*+RjJkKsSuvi:GM';
@@ -317,7 +320,6 @@ function stubbing(func_name_to_stub, test_function) {
 
     list_util.inside_list = return_false;
     global.current_msg_list.empty = return_true;
-    global.drafts.drafts_overlay_open = return_false;
     overlays.settings_open = return_false;
     overlays.streams_open = return_false;
     overlays.lightbox_open = return_false;
@@ -377,8 +379,10 @@ function stubbing(func_name_to_stub, test_function) {
     assert_mapping('down_arrow', 'settings.handle_down_arrow');
     overlays.settings_open = return_false;
 
-    global.drafts.drafts_overlay_open = return_true;
+    overlays.is_active = return_true;
+    overlays.drafts_open = return_true;
     assert_mapping('up_arrow', 'drafts.drafts_handle_events');
     assert_mapping('down_arrow', 'drafts.drafts_handle_events');
-    global.drafts.drafts_overlay_open = return_false;
+    overlays.is_active = return_false;
+    overlays.drafts_open = return_false;
 }());

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -244,10 +244,6 @@ exports.setup_page = function (callback) {
     populate_and_fill();
 };
 
-exports.drafts_overlay_open = function () {
-    return $("#draft_overlay").hasClass("show");
-};
-
 function drafts_initialize_focus(event_name) {
     // If a draft is not focused in draft modal, then focus the last draft
     // if up_arrow is clicked or the first draft if down_arrow is clicked.
@@ -366,7 +362,7 @@ exports.drafts_handle_events = function (e, event_key) {
 };
 
 exports.toggle = function () {
-    if (exports.drafts_overlay_open()) {
+    if (overlays.drafts_open()) {
         overlays.close_overlay("drafts");
     } else {
         exports.launch();
@@ -383,7 +379,6 @@ exports.launch = function () {
             },
         });
 
-        $("#draft_overlay").addClass("show");
         var draft_list = drafts.draft_model.get();
         var draft_id_list = Object.getOwnPropertyNames(draft_list);
         if (draft_id_list.length > 0) {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -291,7 +291,7 @@ exports.process_enter_key = function (e) {
 
     // This handles when pressing enter while looking at drafts.
     // It restores draft that is focused.
-    if (drafts.drafts_overlay_open()) {
+    if (overlays.drafts_open()) {
         drafts.drafts_handle_events(e, "enter");
         return true;
     }
@@ -406,7 +406,7 @@ exports.process_hotkey = function (e, hotkey) {
         case 'up_arrow':
         case 'down_arrow':
         case 'backspace':
-            if (drafts.drafts_overlay_open()) {
+            if (overlays.drafts_open()) {
                 drafts.drafts_handle_events(e, event_name);
                 return true;
             }
@@ -597,6 +597,9 @@ exports.process_hotkey = function (e, hotkey) {
             narrow.narrow_to_next_topic();
             return true;
         case 'open_drafts':
+            if (overlays.is_active() && !overlays.drafts_open()) {
+                return false;
+            }
             drafts.toggle();
             return true;
         case 'reply_message': // 'r': respond to message

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -420,8 +420,8 @@ exports.process_hotkey = function (e, hotkey) {
             subs.keyboard_sub();
             return true;
         }
-        if (overlays.lightbox_open()) {
-            overlays.close_active();
+        if (event_name === 'show_lightbox' && overlays.lightbox_open()) {
+            overlays.close_overlay('lightbox');
             return true;
         }
         return false;

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -36,9 +36,13 @@ exports.lightbox_open = function () {
     return open_overlay_name === 'lightbox';
 };
 
+exports.drafts_open = function () {
+    return open_overlay_name === 'drafts';
+};
+
 exports.active_modal = function () {
     if (!exports.is_modal_open()) {
-        blueslip.error("Programming error — Called open_modal when there is no modal open");
+        blueslip.error("Programming error — Called active_modal when there is no modal open");
         return;
     }
     return $(".modal.in").attr("id");


### PR DESCRIPTION
- [x] Prevent the lightbox from closing when a message view hotkey is pressed. (99c41ce)
- [x] Prevent drafts overlay from showing while lightbox is open. (87befe6)
  * Commit was later amended to prevent drafts overlay from showing while any overlay was open. Problematic lightbox behavior was observed while trying to open the drafts overlay via hotkey when streams subscriptions overlay was open. Looks like we haven't been counting drafts overlay as an overlay in `overlays.js`, hence a lot of issues regarding its functionality.

Fixes #6757.