### PR TITLE
zerver: Block access to subdirectories when visiting user docs articles.

### DIFF
--- a/zerver/tests/test_urls.py
+++ b/zerver/tests/test_urls.py
@@ -47,7 +47,7 @@ class PublicURLTest(ZulipTestCase):
                           "/json/messages",
                           "/api/v1/streams",
                           ],
-                    404: ["/help/nonexistent"],
+                    404: ["/help/nonexistent", "/help/include/admin"],
                     }
 
         # Add all files in 'templates/zerver/help' directory (except for 'main.html' and

--- a/zerver/views/integrations.py
+++ b/zerver/views/integrations.py
@@ -56,6 +56,8 @@ class HelpView(ApiURLView):
         # type: (str) -> str
         if article == "":
             article = "index"
+        elif "/" in article:
+            article = "missing"
         return self.path_template % (article,)
 
     def get_context_data(self, **kwargs):
@@ -82,6 +84,8 @@ class HelpView(ApiURLView):
             loader.get_template(path)
         except loader.TemplateDoesNotExist:
             # Ensure a 404 response code if no such document
+            result.status_code = 404
+        if "/" in article:
             result.status_code = 404
         return result
 


### PR DESCRIPTION
Render `missing.md` and serve a 404 error whenever a user tries to access an article in the `include` subdirectory (triggered whenever `/` is in the `article` path).

Fixes #6770 