### PR TITLE
emoji_picker: Change emoji background color when selected by hotkey.

### DIFF
--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -214,8 +214,11 @@
     width: 25px;
 }
 
-.emoji-popover-emoji:not(.reacted):hover {
+.emoji-popover-emoji:not(.reacted):hover,
+.emoji-popover-emoji:not(.reacted):focus,
+.emoji-popover-emoji:not(.reacted):active {
     background-color: hsl(0, 0%, 93%);
+    outline: none;
 }
 
 .emoji-popover-emoji.hide {


### PR DESCRIPTION
![screenshot at oct 03 11-51-02](https://user-images.githubusercontent.com/15116870/31143177-4d3c39b6-a831-11e7-9268-e079a92085db.png)

(relieved is selected by keyboard shortcut, kissy face is selected by mouse)

Fixes #6827.

Note: When a reacted emoji is selected by keyboard shortcut, outline is still preserved in order to let the user know which emoji is selected. Behavior is not replicated when a reacted emoji is hovered over because the mouse cursor should already indicate the cursor position.