### PR TITLE
Notify offline users about edited stream messages.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3146,8 +3146,10 @@ def do_update_embedded_data(user_profile, message, content, rendered_content):
 
 # We use transaction.atomic to support select_for_update in the attachment codepath.
 @transaction.atomic
-def do_update_message(user_profile, message, subject, propagate_mode, content, rendered_content):
-    # type: (UserProfile, Message, Optional[Text], str, Optional[Text], Optional[Text]) -> int
+def do_update_message(user_profile, message, subject, propagate_mode,
+                      content, rendered_content,
+                      prior_mention_user_ids, mention_user_ids):
+    # type: (UserProfile, Message, Optional[Text], str, Optional[Text], Optional[Text], Set[int], Set[int]) -> int
     event = {'type': 'update_message',
              # TODO: We probably want to remove the 'sender' field
              # after confirming it isn't used by any consumers.
@@ -3158,6 +3160,10 @@ def do_update_message(user_profile, message, subject, propagate_mode, content, r
         'user_id': user_profile.id,
     }  # type: Dict[str, Any]
     changed_messages = [message]
+
+    if message.recipient.type == Recipient.STREAM:
+        stream_id = message.recipient.type_id
+        event['stream_name'] = Stream.objects.get(id=stream_id).name
 
     # Set first_rendered_content to be the oldest version of the
     # rendered content recorded; which is the current version if the
@@ -3204,6 +3210,15 @@ def do_update_message(user_profile, message, subject, propagate_mode, content, r
         prev_content = edit_history_event['prev_content']
         if Message.content_has_attachment(prev_content) or Message.content_has_attachment(message.content):
             check_attachment_reference_change(prev_content, message)
+
+        # TODO: We may want a slightly leaner of this function for updates.
+        info = get_recipient_info(message.recipient,
+                                  message.sender_id)
+        event['push_notify_user_ids'] = list(info['push_notify_user_ids'])
+        event['stream_push_user_ids'] = list(info['stream_push_user_ids'])
+        event['prior_mention_user_ids'] = list(prior_mention_user_ids)
+        event['mention_user_ids'] = list(mention_user_ids)
+        event['presence_idle_userids'] = filter_presence_idle_userids(info['active_user_ids'])
 
     if subject is not None:
         orig_subject = message.topic_name()

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # See http://zulip.readthedocs.io/en/latest/events-system.html for
 # high-level documentation on how this system works.
-from typing import Any, Callable, Dict, List, Optional, Union, Text, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Text, Tuple, Union
 import os
 import shutil
 
@@ -544,6 +544,11 @@ class EventsRegisterTest(ZulipTestCase):
             ('flags', check_list(None)),
             ('message_id', check_int),
             ('message_ids', check_list(check_int)),
+            ('prior_mention_user_ids', check_list(check_int)),
+            ('mention_user_ids', check_list(check_int)),
+            ('presence_idle_userids', check_list(check_int)),
+            ('stream_push_user_ids', check_list(check_int)),
+            ('push_notify_user_ids', check_list(check_int)),
             ('orig_content', check_string),
             ('orig_rendered_content', check_string),
             ('orig_subject', check_string),
@@ -552,6 +557,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('rendered_content', check_string),
             ('sender', check_string),
             ('stream_id', check_int),
+            ('stream_name', check_string),
             ('subject', check_string),
             ('subject_links', check_list(None)),
             ('user_id', check_int),
@@ -562,9 +568,14 @@ class EventsRegisterTest(ZulipTestCase):
         propagate_mode = 'change_all'
         content = 'new content'
         rendered_content = render_markdown(message, content)
+        prior_mention_user_ids = set()  # type: Set[int]
+        mentioned_user_ids = set()  # type: Set[int]
+
         events = self.do_test(
             lambda: do_update_message(self.user_profile, message, topic,
-                                      propagate_mode, content, rendered_content),
+                                      propagate_mode, content, rendered_content,
+                                      prior_mention_user_ids,
+                                      mentioned_user_ids),
             state_change_expected=True,
         )
         error = schema_checker('events[0]', events[0])

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -1,0 +1,453 @@
+# -*- coding: utf-8 -*-
+
+from typing import Any, Dict, Generator, Mapping, Text, Union
+
+import mock
+
+from django.utils.timezone import now as timezone_now
+
+from zerver.lib.actions import (
+    get_client,
+)
+
+from zerver.lib.test_classes import (
+    ZulipTestCase,
+)
+
+from zerver.models import (
+    get_recipient,
+    Recipient,
+    Subscription,
+    UserPresence,
+)
+
+from zerver.tornado.event_queue import (
+    maybe_enqueue_notifications,
+)
+
+class EditMessageSideEffectsTest(ZulipTestCase):
+    def _assert_update_does_not_notify_anybody(self, message_id, content):
+        # type: (int, Text) -> None
+        url = '/json/messages/' + str(message_id)
+
+        request = dict(
+            message_id=message_id,
+            content=content,
+        )
+
+        with mock.patch('zerver.tornado.event_queue.maybe_enqueue_notifications') as m:
+            result = self.client_patch(url, request)
+
+        self.assert_json_success(result)
+        self.assertFalse(m.called)
+
+    def test_updates_with_pm_mention(self):
+        # type: () -> None
+        hamlet = self.example_user('hamlet')
+        cordelia = self.example_user('cordelia')
+
+        self.login(hamlet.email)
+
+        message_id = self.send_message(
+            hamlet.email,
+            cordelia.email,
+            Recipient.PERSONAL,
+            content='no mention'
+        )
+
+        self._assert_update_does_not_notify_anybody(
+            message_id=message_id,
+            content='now we mention @**Cordelia Lear**',
+        )
+
+    def _login_and_send_original_stream_message(self, content):
+        # type: (Text) -> int
+        '''
+            Note our conventions here:
+
+                Hamlet is our logged in user (and sender).
+                Cordelia is the receiver we care about.
+                Scotland is the stream we send messages to.
+        '''
+        hamlet = self.example_user('hamlet')
+        cordelia = self.example_user('cordelia')
+
+        self.login(hamlet.email)
+        self.subscribe(hamlet, 'Scotland')
+        self.subscribe(cordelia, 'Scotland')
+
+        message_id = self.send_message(
+            hamlet.email,
+            'Scotland',
+            Recipient.STREAM,
+            content=content,
+        )
+
+        return message_id
+
+    def _get_queued_data_for_message_update(self, message_id, content, expect_short_circuit=False):
+        # type: (int, Text, bool) -> Dict[str, Any]
+        '''
+        This function updates a message with a post to
+        /json/messages/(message_id).
+
+        By using mocks, we are able to capture two pieces of data:
+
+            enqueue_kwargs: These are the arguments passed in to
+                            maybe_enqueue_notifications.
+
+            queue_messages: These are the messages that
+                            maybe_enqueue_notifications actually
+                            puts on the queue.
+
+        Using this helper allows you to construct a test that goes
+        pretty deep into the missed-messages codepath, without actually
+        queuing the final messages.
+        '''
+        url = '/json/messages/' + str(message_id)
+
+        request = dict(
+            message_id=message_id,
+            content=content,
+        )
+
+        with mock.patch('zerver.tornado.event_queue.maybe_enqueue_notifications') as m:
+            result = self.client_patch(url, request)
+
+        cordelia = self.example_user('cordelia')
+        cordelia_calls = [
+            call_args
+            for call_args in m.call_args_list
+            if call_args[1]['user_profile_id'] == cordelia.id
+        ]
+
+        if expect_short_circuit:
+            self.assertEqual(len(cordelia_calls), 0)
+            return {}
+
+        # Normally we expect maybe_enqueue_notifications to be
+        # called for Cordelia, so continue on.
+        self.assertEqual(len(cordelia_calls), 1)
+        enqueue_kwargs = cordelia_calls[0][1]
+
+        queue_messages = []
+
+        def fake_publish(queue_name, event, *args):
+            # type: (str, Union[Mapping[str, Any], str], *Any) -> None
+            queue_messages.append(dict(
+                queue_name=queue_name,
+                event=event,
+            ))
+
+        with mock.patch('zerver.tornado.event_queue.queue_json_publish') as m:
+            m.side_effect = fake_publish
+            maybe_enqueue_notifications(**enqueue_kwargs)
+
+        self.assert_json_success(result)
+
+        return dict(
+            enqueue_kwargs=enqueue_kwargs,
+            queue_messages=queue_messages
+        )
+
+    def test_updates_with_stream_mention(self):
+        # type: () -> None
+        message_id = self._login_and_send_original_stream_message(
+            content='no mention',
+        )
+
+        info = self._get_queued_data_for_message_update(
+            message_id=message_id,
+            content='now we mention @**Cordelia Lear**',
+        )
+
+        cordelia = self.example_user('cordelia')
+        expected_enqueue_kwargs = dict(
+            user_profile_id=cordelia.id,
+            message_id=message_id,
+            private_message=False,
+            mentioned=True,
+            stream_push_notify=False,
+            stream_name='Scotland',
+            always_push_notify=False,
+            idle=True,
+        )
+
+        self.assertEqual(info['enqueue_kwargs'], expected_enqueue_kwargs)
+
+        queue_messages = info['queue_messages']
+
+        self.assertEqual(len(queue_messages), 2)
+
+        self.assertEqual(queue_messages[0]['queue_name'], 'missedmessage_mobile_notifications')
+        mobile_event = queue_messages[0]['event']
+
+        self.assertEqual(mobile_event['user_profile_id'], cordelia.id)
+        self.assertEqual(mobile_event['triggers'], dict(
+            stream_push_notify=False,
+            private_message=False,
+            mentioned=True,
+        ))
+
+        self.assertEqual(queue_messages[1]['queue_name'], 'missedmessage_emails')
+        email_event = queue_messages[1]['event']
+
+        self.assertEqual(email_event['user_profile_id'], cordelia.id)
+        self.assertEqual(email_event['triggers'], dict(
+            stream_push_notify=False,
+            private_message=False,
+            mentioned=True,
+        ))
+
+    def test_second_mention_is_ignored(self):
+        # type: () -> None
+        message_id = self._login_and_send_original_stream_message(
+            content='hello @**Cordelia Lear**'
+        )
+
+        self._get_queued_data_for_message_update(
+            message_id=message_id,
+            content='re-mention @**Cordelia Lear**',
+            expect_short_circuit=True,
+        )
+
+    def _turn_on_stream_push_for_cordelia(self):
+        # type: () -> None
+        '''
+        conventions:
+            Cordelia is the message receiver we care about.
+            Scotland is our stream.
+        '''
+        cordelia = self.example_user('cordelia')
+        stream = self.subscribe(cordelia, 'Scotland')
+        recipient = get_recipient(Recipient.STREAM, stream.id)
+        cordelia_subscription = Subscription.objects.get(
+            user_profile_id=cordelia.id,
+            recipient=recipient,
+        )
+        cordelia_subscription.push_notifications = True
+        cordelia_subscription.save()
+
+    def test_updates_with_stream_push_notify(self):
+        # type: () -> None
+        self._turn_on_stream_push_for_cordelia()
+
+        message_id = self._login_and_send_original_stream_message(
+            content='no mention'
+        )
+
+        # Even though Cordelia configured this stream for pushes,
+        # we short-ciruit the logic, assuming the original message
+        # also did a push.
+        self._get_queued_data_for_message_update(
+            message_id=message_id,
+            content='nothing special about updated message',
+            expect_short_circuit=True,
+        )
+
+    def _cordelia_connected_to_zulip(self):
+        # type: () -> Any
+        '''
+        Right now the easiest way to make Cordelia look
+        connected to Zulip is to mock the function below.
+
+        This is a bit blunt, as it affects other users too,
+        but we only really look at Cordelia's data, anyway.
+        '''
+        return mock.patch(
+            'zerver.tornado.event_queue.receiver_is_off_zulip',
+            return_value=False
+        )
+
+    def test_stream_push_notify_for_sorta_present_user(self):
+        # type: () -> None
+        self._turn_on_stream_push_for_cordelia()
+
+        message_id = self._login_and_send_original_stream_message(
+            content='no mention'
+        )
+
+        # Simulate Cordelia still has an actively polling client, but
+        # the lack of presence info should still mark her as offline.
+        #
+        # Despite Cordelia being offline, we still short circuit
+        # offline notifications due to the her stream push setting.
+        with self._cordelia_connected_to_zulip():
+            self._get_queued_data_for_message_update(
+                message_id=message_id,
+                content='nothing special about updated message',
+                expect_short_circuit=True,
+            )
+
+    def _make_cordelia_present_on_web(self):
+        # type: () -> None
+        cordelia = self.example_user('cordelia')
+        UserPresence.objects.create(
+            user_profile_id=cordelia.id,
+            status=UserPresence.ACTIVE,
+            client=get_client('web'),
+            timestamp=timezone_now(),
+        )
+
+    def test_stream_push_notify_for_fully_present_user(self):
+        # type: () -> None
+        self._turn_on_stream_push_for_cordelia()
+
+        message_id = self._login_and_send_original_stream_message(
+            content='no mention'
+        )
+
+        self._make_cordelia_present_on_web()
+
+        # Simulate Cordelia is FULLY present, not just in term of
+        # browser activity, but also in terms of her client descriptors.
+        with self._cordelia_connected_to_zulip():
+            self._get_queued_data_for_message_update(
+                message_id=message_id,
+                content='nothing special about updated message',
+                expect_short_circuit=True,
+            )
+
+    def test_always_push_notify_for_fully_present_mentioned_user(self):
+        # type: () -> None
+        cordelia = self.example_user('cordelia')
+        cordelia.enable_online_push_notifications = True
+        cordelia.save()
+
+        message_id = self._login_and_send_original_stream_message(
+            content='no mention'
+        )
+
+        self._make_cordelia_present_on_web()
+
+        # Simulate Cordelia is FULLY present, not just in term of
+        # browser activity, but also in terms of her client descriptors.
+        with self._cordelia_connected_to_zulip():
+            info = self._get_queued_data_for_message_update(
+                message_id=message_id,
+                content='newly mention @**Cordelia Lear**',
+            )
+
+        expected_enqueue_kwargs = dict(
+            user_profile_id=cordelia.id,
+            message_id=message_id,
+            private_message=False,
+            mentioned=True,
+            stream_push_notify=False,
+            stream_name='Scotland',
+            always_push_notify=True,
+            idle=False,
+        )
+
+        self.assertEqual(info['enqueue_kwargs'], expected_enqueue_kwargs)
+
+        queue_messages = info['queue_messages']
+
+        self.assertEqual(len(queue_messages), 1)
+
+    def test_always_push_notify_for_fully_present_boring_user(self):
+        # type: () -> None
+        cordelia = self.example_user('cordelia')
+        cordelia.enable_online_push_notifications = True
+        cordelia.save()
+
+        message_id = self._login_and_send_original_stream_message(
+            content='no mention'
+        )
+
+        self._make_cordelia_present_on_web()
+
+        # Simulate Cordelia is FULLY present, not just in term of
+        # browser activity, but also in terms of her client descriptors.
+        with self._cordelia_connected_to_zulip():
+            info = self._get_queued_data_for_message_update(
+                message_id=message_id,
+                content='nothing special about updated message',
+            )
+
+        expected_enqueue_kwargs = dict(
+            user_profile_id=cordelia.id,
+            message_id=message_id,
+            private_message=False,
+            mentioned=False,
+            stream_push_notify=False,
+            stream_name='Scotland',
+            always_push_notify=True,
+            idle=False,
+        )
+
+        self.assertEqual(info['enqueue_kwargs'], expected_enqueue_kwargs)
+
+        queue_messages = info['queue_messages']
+
+        # Even though Cordelia has enable_online_push_notifications set
+        # to True, we don't send her any offline notifications, since she
+        # was not mentioned.
+        self.assertEqual(len(queue_messages), 0)
+
+    def test_updates_with_stream_mention_of_sorta_present_user(self):
+        # type: () -> None
+        cordelia = self.example_user('cordelia')
+
+        message_id = self._login_and_send_original_stream_message(
+            content='no mention'
+        )
+
+        # We will simulate that the user still has a an active client,
+        # but they don't have UserPresence rows, so we will still
+        # send offline notifications.
+        with self._cordelia_connected_to_zulip():
+            info = self._get_queued_data_for_message_update(
+                message_id=message_id,
+                content='now we mention @**Cordelia Lear**',
+            )
+
+        expected_enqueue_kwargs = dict(
+            user_profile_id=cordelia.id,
+            message_id=message_id,
+            private_message=False,
+            mentioned=True,
+            stream_push_notify=False,
+            stream_name='Scotland',
+            always_push_notify=False,
+            idle=True,
+        )
+        self.assertEqual(info['enqueue_kwargs'], expected_enqueue_kwargs)
+
+        # She will get messages enqueued.  (Other tests drill down on the
+        # actual content of these messages.)
+        self.assertEqual(len(info['queue_messages']), 2)
+
+    def test_updates_with_stream_mention_of_fully_present_user(self):
+        # type: () -> None
+        cordelia = self.example_user('cordelia')
+
+        message_id = self._login_and_send_original_stream_message(
+            content='no mention'
+        )
+
+        self._make_cordelia_present_on_web()
+
+        # Simulate Cordelia is FULLY present, not just in term of
+        # browser activity, but also in terms of her client descriptors.
+        with self._cordelia_connected_to_zulip():
+            info = self._get_queued_data_for_message_update(
+                message_id=message_id,
+                content='now we mention @**Cordelia Lear**',
+            )
+
+        expected_enqueue_kwargs = dict(
+            user_profile_id=cordelia.id,
+            message_id=message_id,
+            private_message=False,
+            mentioned=True,
+            stream_push_notify=False,
+            stream_name='Scotland',
+            always_push_notify=False,
+            idle=False,
+        )
+        self.assertEqual(info['enqueue_kwargs'], expected_enqueue_kwargs)
+
+        # Because Cordelia is FULLY present, we don't need to send any offline
+        # push notifications or missed message emails.
+        self.assertEqual(len(info['queue_messages']), 0)

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -799,14 +799,100 @@ def process_userdata_event(event_template, users):
             if client.accepts_event(user_event):
                 client.add_event(user_event)
 
+def process_message_update_event(event_template, users):
+    # type: (Mapping[str, Any], Iterable[Mapping[str, Any]]) -> None
+    prior_mention_user_ids = set(event_template.get('prior_mention_user_ids', []))
+    mention_user_ids = set(event_template.get('mention_user_ids', []))
+    presence_idle_user_ids = set(event_template.get('presence_idle_userids', []))
+    stream_push_user_ids = set(event_template.get('stream_push_user_ids', []))
+    push_notify_user_ids = set(event_template.get('push_notify_user_ids', []))
+
+    stream_name = event_template.get('stream_name')
+    message_id = event_template['message_id']
+
+    for user_data in users:
+        user_profile_id = user_data['id']
+        user_event = dict(event_template)  # shallow copy, but deep enough for our needs
+        for key in user_data.keys():
+            if key != "id":
+                user_event[key] = user_data[key]
+
+        maybe_enqueue_notifications_for_message_update(
+            user_profile_id=user_profile_id,
+            message_id=message_id,
+            stream_name=stream_name,
+            prior_mention_user_ids=prior_mention_user_ids,
+            mention_user_ids=mention_user_ids,
+            presence_idle_user_ids=presence_idle_user_ids,
+            stream_push_user_ids=stream_push_user_ids,
+            push_notify_user_ids=push_notify_user_ids,
+        )
+
+        for client in get_client_descriptors_for_user(user_profile_id):
+            if client.accepts_event(user_event):
+                client.add_event(user_event)
+
+def maybe_enqueue_notifications_for_message_update(user_profile_id,
+                                                   message_id,
+                                                   stream_name,
+                                                   prior_mention_user_ids,
+                                                   mention_user_ids,
+                                                   presence_idle_user_ids,
+                                                   stream_push_user_ids,
+                                                   push_notify_user_ids):
+    # type: (UserProfile, int, Text, Set[int], Set[int], Set[int], Set[int], Set[int]) -> None
+    private_message = (stream_name is None)
+
+    if private_message:
+        # We don't do offline notifications for PMs, because
+        # we already notified the user of the original message
+        return
+
+    if (user_profile_id in prior_mention_user_ids):
+        # Don't spam people with duplicate mentions.  This is
+        # especially important considering that most message
+        # edits are simple typo corrections.
+        return
+
+    stream_push_notify = (user_profile_id in stream_push_user_ids)
+
+    if stream_push_notify:
+        # Currently we assume that if this flag is set to True, then
+        # the user already was notified about the earlier message,
+        # so we short circuit.  We may handle this more rigorously
+        # in the future by looking at something like an AlreadyNotified
+        # model.
+        return
+
+    # We can have newly mentioned people in an updated message.
+    mentioned = (user_profile_id in mention_user_ids)
+
+    always_push_notify = user_profile_id in push_notify_user_ids
+
+    idle = (user_profile_id in presence_idle_user_ids) or \
+        receiver_is_off_zulip(user_profile_id)
+
+    maybe_enqueue_notifications(
+        user_profile_id=user_profile_id,
+        message_id=message_id,
+        private_message=private_message,
+        mentioned=mentioned,
+        stream_push_notify=stream_push_notify,
+        stream_name=stream_name,
+        always_push_notify=always_push_notify,
+        idle=idle,
+    )
+
 def process_notification(notice):
     # type: (Mapping[str, Any]) -> None
     event = notice['event']  # type: Mapping[str, Any]
     users = notice['users']  # type: Union[Iterable[int], Iterable[Mapping[str, Any]]]
-    if event['type'] in ["update_message", "delete_message"]:
-        process_userdata_event(event, cast(Iterable[Mapping[str, Any]], users))
-    elif event['type'] == "message":
+    if event['type'] == "message":
         process_message_event(event, cast(Iterable[Mapping[str, Any]], users))
+    elif event['type'] == "update_message":
+        process_message_update_event(event, cast(Iterable[Mapping[str, Any]], users))
+    elif event['type'] == "delete_message":
+        process_userdata_event(event, cast(Iterable[Mapping[str, Any]], users))
     else:
         process_event(event, cast(Iterable[int], users))
 


### PR DESCRIPTION
We now do push notifications and missed message emails
for offline users who are subscribed to the stream for
a message that has been edited, but we short circuit
the offline-notification logic for any user who presumably
would have already received a notification on the original
message.

This effectively boils down to sending notifications to newly
mentioned users.  The motivating use case here is that you
forget to mention somebody in a message, and then you edit
the message to mention the person.  If they are offline, they
will now get pushed notifications and missed message emails,
with some minor caveats.

We try to mostly use the same techniques here as the
send-message code path, and we share common code with the
send-message path once we get to the Tornado layer and call
maybe_enqueue_notifications.

The major places where we differ are in a function called
maybe_enqueue_notifications_for_message_update, and the top
of that function short circuits a bunch of cases where we
can mostly assume that the original message had an offline
notification.

We can expect a couple changes in the future:

    * Requirements may change here, and it might make sense
      to send offline notifications on the update side even
      in circumstances where the original message had a
      notification.

    * We may track more notifications in a DB model, which
      may simplify our short-circuit logic.

In the view/action layer, we already had two separate codepaths
for send-message and update-message, but this mostly echoes
what the send-message path does in terms of collecting data
about recipients.