### PR TITLE
reload: Continually attempt to reload page.

### DIFF
--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -204,6 +204,17 @@ function do_reload_app(send_after_reload, save_pointer, save_narrow, save_compos
     }
 
     window.location.reload(true);
+
+    // in theory, we should just continually trigger this because if the `setTimeout`
+    // occurs, then it still hasn't reloaded and eventually this will happen when the
+    // user is active on the page again, which will allow it to actually reload in
+    // chrome.
+    // there's also essentially no overhead to this function so there's no problem
+    // with running it in the background, especially since we're about to clear tab
+    // memory anyways.
+    setInterval(function () {
+        window.location.reload(true);
+    }, 5000);
 }
 
 exports.initiate = function (options) {


### PR DESCRIPTION
This will continually attempt to reload the page every 5s to
try and compensate for the behavior in Chrome where it appears that
the tab has to be active or semi-active for `location.reload` to be
respected, which means that it should just continually try until
the page is active again, in which case the `location.reload` func
will work and reload the page.

Fixes: #6821.