### PR TITLE
tools/test-all: Pass the `--force` arg to run-mypy script.

### DIFF
--- a/tools/test-all
+++ b/tools/test-all
@@ -38,7 +38,7 @@ run ./tools/clean-repo
 run ./tools/lint --backend $FORCEARG
 run ./tools/test-tools
 run ./tools/test-backend $FORCEARG
-run ./tools/run-mypy
+run ./tools/run-mypy $FORCEARG
 run ./tools/test-migrations
 # Not running SVG optimizing since it's low-churn
 # run ./tools/optimize-svg


### PR DESCRIPTION
While running the mypy script we were not passing the `--force`
argument correctly to the run-mypy which was causing it complain
about provision status.