### PR TITLE
password-reset: Add back to login page link.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -621,12 +621,24 @@ button.login-google-button {
     transform: translateX(15px) translateY(13px);
 }
 
-.login-page-container .right-side .actions {
+.login-page-container .right-side .actions,
+.forgot-password-container .actions {
     margin: 20px 0px 0px;
     text-align: left;
 }
 
-.split-view .actions a {
+.forgot-password-container .actions {
+    line-height: 0;
+}
+.forgot-password-container .actions .back-to-login i {
+    position: relative;
+    top: 5px;
+
+    font-size: 0.8em;
+}
+
+.split-view .actions a,
+.back-to-login {
     color: hsl(164, 100%, 23%);
     text-decoration: none;
     font-weight: 600;
@@ -637,7 +649,9 @@ button.login-google-button {
     transition: color 0.2s ease;
 }
 
-.split-view .actions a:hover {
+.split-view .actions a:hover,
+.back-to-login:hover {
+    text-decoration: none;
     color: hsl(156, 62%, 61%);
 }
 

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -473,6 +473,15 @@ input.text-error {
     position: relative;
 }
 
+.portico-container .if-zulip-electron {
+    display: none;
+}
+
+/* detect if the platform is `ZulipDesktop` and if so, hide this tag! */
+.portico-container[data-platform="ZulipElectron"] .if-zulip-electron {
+    display: block;
+}
+
 .footer {
     margin: 20px;
     z-index: 100;

--- a/templates/zerver/portico.html
+++ b/templates/zerver/portico.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="portico-container">
+<div class="portico-container" data-platform="{{ platform }}">
     <div class="portico-wrap">
         {% include 'zerver/portico-header.html' %}
         <div class="app portico-page {% block portico_class_name %}{% endblock %}">

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -32,6 +32,9 @@
                     </div>
                 </div>
             </form>
+            <div class="actions if-zulip-electron"><!-- only show if on `ZulipElectron` -->
+                <a class="back-to-login" href="{{login_url}}"><i class="fa fa-arrow-left"></i> Back to the login page</a>
+            </div>
         </div>
     </div>
 </div>

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -95,6 +95,11 @@ def zulip_default_context(request):
         settings_path = "/etc/zulip/settings.py"
         settings_comments_path = "/etc/zulip/settings.py"
 
+    if "ZulipElectron" in request.META['HTTP_USER_AGENT']:
+        platform = "ZulipElectron"
+    else:
+        platform = "ZulipWeb"
+
     return {
         'root_domain_landing_page': settings.ROOT_DOMAIN_LANDING_PAGE,
         'custom_logo_url': settings.CUSTOM_LOGO_URL,
@@ -137,6 +142,7 @@ def zulip_default_context(request):
         'settings_path': settings_path,
         'secrets_path': secrets_path,
         'settings_comments_path': settings_comments_path,
+        'platform': platform,
     }
 
 


### PR DESCRIPTION
This adds a link that goes back to the login page only for the
Zulip Electron application.

Fixes: #6763.