### PR TITLE
settings: Set the upload table actions col width.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -440,6 +440,14 @@ input[type=checkbox].inline-block {
     padding: 1px 4px 1px 2px;
 }
 
+#attachments-settings table th.upload-size {
+    width: 50px;
+}
+
+#attachments-settings table th.upload-actions {
+    width: 75px;
+}
+
 .grey-bg {
     background: hsl(0, 0%, 89%);
     padding: 10px;

--- a/static/templates/settings/attachments-settings.handlebars
+++ b/static/templates/settings/attachments-settings.handlebars
@@ -8,8 +8,8 @@
                 <th data-sort="alphabetic" data-sort-prop="name">{{t "File" }}</th>
                 <th data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
                 <th data-sort="mentioned-in">{{t "Mentioned in" }}</th>
-                <th data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
-                <th>{{t "Actions" }}</th>
+                <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
+                <th class="upload-actions">{{t "Actions" }}</th>
             </thead>
             <tbody class="required-text" data-empty="{{t 'You have not uploaded any files.' }}"
                    id="uploaded_files_table" ></tbody>


### PR DESCRIPTION
This sets the column width of the upload table actions to always
be 75 so that the buttons are always in the same line and take up
the least amount of space possible with that constraint.