### PR TITLE
emails: Change "Server" and "Account" to render links.

### DIFF
--- a/templates/zerver/emails/notify_new_login.source.html
+++ b/templates/zerver/emails/notify_new_login.source.html
@@ -9,8 +9,8 @@
 <p>This is a notification that a new login to your Zulip account has just occurred.</p>
 <p><b>Login details:</b></p>
 <blockquote>
-    <p>Server: {{ realm_uri }}</p>
-    <p>Account: {{ user.email }}</p>
+    <p>Server: <a href="{{ realm_uri }}" target="_blank">{{ realm_uri }}</a></p>
+    <p>Account: <a href="mailto:{{ user.email }}" target="_blank">{{ user.email }}</a></p>
     <p>Time: {{ device_info.login_time }}</p>
     <p>Device: {{ device_info.device_browser if device_info.device_browser else 'An unknown browser' }} on {{ device_info.device_os if device_info.device_os else 'an unknown operating system' }}.</p>
     <p>IP Address: {{ device_info.device_ip }}</p>


### PR DESCRIPTION
This changes the "Server" and "Account" attributes in the info log
to render links so that they are guaranteed to have our styling
and behavior across all email clients.