### PR TITLE
Added real-time update to the 'uploaded files' UI in the settings

### DIFF
--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -2,6 +2,13 @@ var attachments_ui = (function () {
 
 var exports = {};
 
+function reset_upload_status() {
+    setTimeout(function () {
+        $('#delete-upload-status').hide().text('')
+                                  .removeClass('alert-error alert-success');
+    }, 3000);
+}
+
 function delete_attachments(attachment) {
     var status = $('#delete-upload-status');
     channel.del({
@@ -9,9 +16,11 @@ function delete_attachments(attachment) {
         idempotent: true,
         error: function (xhr) {
             ui_report.error(i18n.t("Failed"), xhr, status);
+            reset_upload_status();
         },
         success: function () {
             ui_report.success(i18n.t("Attachment deleted"), status);
+            reset_upload_status();
         },
     });
 }

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -78,21 +78,24 @@ exports.set_up_attachments = function () {
         return -1;
     });
 
-
-
     ui.set_up_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));
 
-    uploaded_files_table.empty();
-    _.each(attachments, function (attachment) {
-        var row = templates.render('uploaded_files_list', { attachment: attachment });
-        uploaded_files_table.append(row);
-    });
-
-    $('#uploaded_files_table').on('click', '.remove-attachment', function (e) {
-        var row = $(e.target).closest(".uploaded_file_row");
-        row.remove();
+    $('#uploaded_files_table').on('click', '.remove-attachment', function () {
         delete_attachments($(this).data('attachment'));
     });
+};
+
+exports.update_attachments_ui = function (attachment, op) {
+    if (op === "remove") {
+        $("#uploaded_files_table tr[data-attachment='" + attachment.id + "']").remove();
+    } else if (op === "add") {
+        attachment.create_time_str = timerender.render_now(new XDate(attachment.create_time))
+                                               .time_str;
+        attachment.size_str = exports.bytes_to_size(attachment.size);
+        var $row = templates.render("uploaded_files_list", { attachment: attachment });
+        $("#uploaded_files_table").append($row);
+    }
+    ui.set_up_scrollbar($("#uploaded_files_table").closest(".progressive-table-wrapper"));
 };
 
 return exports;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -387,6 +387,18 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         }
         settings_user_groups.reload();
         break;
+
+    case 'attachments':
+        if (event.op === 'add') {
+            page_params.attachments.push(event.attachment);
+        } else if (event.op === 'remove') {
+            page_params.attachments = page_params.attachments.filter(function (a) {
+                return a.id !== event.attachment.id;
+            });
+        }
+        attachments_ui.update_attachments_ui(event.attachment, event.op);
+        break;
+
     }
 };
 

--- a/static/templates/uploaded_files_list.handlebars
+++ b/static/templates/uploaded_files_list.handlebars
@@ -1,5 +1,5 @@
 {{#with attachment}}
-<tr class="uploaded_file_row" id="{{name}}">
+<tr class="uploaded_file_row" id="{{name}}" data-attachment="{{id}}">
     <td>
         <a type="submit" href="/user_uploads/{{path_id}}" target="_blank" title="{{t 'View file' }}">
             {{ name }}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -118,6 +118,7 @@ from zerver.lib.sessions import delete_user_sessions
 from zerver.lib.upload import attachment_url_re, attachment_url_to_path_id, \
     claim_attachment, delete_message_image
 from zerver.lib.str_utils import NonBinaryStr, force_str
+from zerver.lib.attachments import access_attachment_by_path_id
 from zerver.tornado.event_queue import request_event_queue, send_event
 
 from analytics.models import StreamCount
@@ -3722,6 +3723,14 @@ def get_average_weekly_stream_traffic(stream_id: int, stream_date_created: datet
 def is_old_stream(stream_date_created: datetime.datetime) -> bool:
     return (datetime.date.today() - stream_date_created.date()).days >= 7
 
+def notify_attachment_update(user_profile: UserProfile, op: str,
+                             attachment: Dict[str, Any]) -> None:
+    event = {
+        'type': 'attachments',
+        'op': op,
+        'attachment': attachment}
+    send_event(event, [user_profile.id])
+
 def encode_email_address(stream: Stream) -> Text:
     return encode_email_address_helper(stream.name, stream.email_token)
 
@@ -4388,6 +4397,8 @@ def do_claim_attachments(message: Message) -> None:
             continue
 
         claim_attachment(user_profile, path_id, message, is_message_realm_public)
+        attachment = access_attachment_by_path_id(user_profile, path_id)
+        notify_attachment_update(user_profile, "add", attachment)
 
 def do_delete_old_unclaimed_attachments(weeks_ago: int) -> None:
     old_unclaimed_attachments = get_old_unclaimed_attachments(weeks_ago)

--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -21,6 +21,13 @@ def access_attachment_by_id(user_profile: UserProfile, attachment_id: int,
         raise JsonableError(_("Invalid attachment"))
     return attachment
 
+def access_attachment_by_path_id(user_profile: UserProfile, path_id: str) -> Attachment:
+    query = Attachment.objects.filter(owner=user_profile).filter(path_id=path_id)
+    attachment = query.first()
+    if attachment is not None:
+        attachment = attachment.to_dict()
+    return attachment
+
 def remove_attachment(user_profile: UserProfile, attachment: Attachment) -> None:
     try:
         delete_message_image(attachment.path_id)

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -593,6 +593,9 @@ def apply_event(state: Dict[str, Any],
         elif event['op'] == 'remove':
             state['realm_user_groups'] = [ug for ug in state['realm_user_groups']
                                           if ug['id'] != event['group_id']]
+    elif event['type'] == "attachments":
+        if event['op'] == 'add' or event['op'] == 'remove':
+            state['attachments'] = user_attachments(user_profile)
     else:
         raise AssertionError("Unexpected event type %s" % (event['type'],))
 

--- a/zerver/views/attachments.py
+++ b/zerver/views/attachments.py
@@ -5,6 +5,7 @@ from zerver.lib.validator import check_int
 from zerver.lib.response import json_success
 from zerver.lib.attachments import user_attachments, remove_attachment, \
     access_attachment_by_id
+from zerver.lib.actions import notify_attachment_update
 
 
 def list_by_user(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
@@ -15,4 +16,5 @@ def remove(request: HttpRequest, user_profile: UserProfile, attachment_id: int) 
     attachment = access_attachment_by_id(user_profile, attachment_id,
                                          needs_owner=True)
     remove_attachment(user_profile, attachment)
+    notify_attachment_update(user_profile, "remove", {"id": int(attachment_id)})
     return json_success()


### PR DESCRIPTION
Fixes #6731
This creates an event when a new attachment is added and the event is
handled on the client side by updating page_params.attachments.