### PR TITLE
typeahead: Fix typeahead positioning for iOS keyboard case.

### DIFF
--- a/static/third/bootstrap/js/bootstrap.js
+++ b/static/third/bootstrap/js/bootstrap.js
@@ -1874,6 +1874,8 @@
         height: this.$element[0].offsetHeight
       })
 
+      pos.top = this.$element.offset().top;
+
       var top_pos = pos.top + pos.height
       if (this.dropup) {
         top_pos = pos.top - this.$menu.outerHeight()


### PR DESCRIPTION
When the iOS keyboard is open and up, the positioning gotten by
getBoundingClientRect will display a `top` value that is short by the
height of the keyboard, which will usually end up placing things north
of the top of the screen.

By changing to jQuery $.fn.offset instead, the positioning appears to
be correct in all cases; iOS keyboard up, down, and desktop usage.

Fixes: #6366.