### PR TITLE
message view: Remove dates from date separators.

### DIFF
--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -78,30 +78,6 @@ var timerender = require('js/timerender.js');
 
 (function test_render_date_renders_time_html() {
     var today = new XDate(1555091573000); // Friday 4/12/2019 5:52:53 PM (UTC+0)
-    var message_time  = today.clone();
-    var expected_html = i18n.t('Today');
-
-    var attrs = new Dict();
-    var span_stub = $('<span />');
-
-    span_stub.attr = function (name, val) {
-        attrs.set(name, val);
-        return span_stub;
-    };
-
-    span_stub.append = function (str) {
-        span_stub.html(str);
-        return span_stub;
-    };
-
-    var actual = timerender.render_date(message_time, undefined, today);
-    assert.equal(expected_html, actual.html());
-    assert.equal(attrs.get('title'), 'Friday, April 12, 2019');
-    assert.equal(attrs.get('class'), 'timerender0');
-}());
-
-(function test_render_date_renders_time_above_html() {
-    var today = new XDate(1555091573000); // Friday 4/12/2019 5:52:53 PM (UTC+0)
     var message_time = today.clone();
     var message_time_above = today.clone().addDays(-1);
 
@@ -114,9 +90,6 @@ var timerender = require('js/timerender.js');
     };
 
     var expected = [
-        '<i class="date-direction icon-vector-caret-up"></i>',
-        i18n.t('Yesterday'),
-        '<hr class="date-line">',
         '<i class="date-direction icon-vector-caret-down"></i>',
         i18n.t('Today'),
     ];

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -117,20 +117,13 @@ function maybe_add_update_list_entry(entry) {
     }
 }
 
-function render_date_span(elem, rendered_time, rendered_time_above) {
+function render_date_span(elem, rendered_time) {
     elem.text("");
-    if (rendered_time_above !== undefined) {
-        var pieces = [
-            '<i class="date-direction icon-vector-caret-up"></i>',
-            rendered_time_above.time_str,
-            '<hr class="date-line">',
-            '<i class="date-direction icon-vector-caret-down"></i>',
-            rendered_time.time_str,
+    var pieces = [
+        '<i class="date-direction icon-vector-caret-down"></i>',
+        rendered_time.time_str,
         ];
-        elem.append(pieces);
-        return elem;
-    }
-    elem.append(rendered_time.time_str);
+    elem.append(pieces);
     return elem.attr('title', rendered_time.formal_time_str);
 }
 
@@ -148,12 +141,8 @@ exports.render_date = function (time, time_above, today) {
     next_timerender_id += 1;
     var rendered_time = exports.render_now(time, today);
     var node = $("<span />").attr('class', className);
-    if (time_above !== undefined) {
-        var rendered_time_above = exports.render_now(time_above, today);
-        node = render_date_span(node, rendered_time, rendered_time_above);
-    } else {
-        node = render_date_span(node, rendered_time);
-    }
+    node = render_date_span(node, rendered_time);
+
     maybe_add_update_list_entry({
       needs_update: rendered_time.needs_update,
       className: className,


### PR DESCRIPTION
Date bar still preserved, marks the date of messages which follow under it.

Fixes #6311

![image](https://user-images.githubusercontent.com/24482726/31232670-317c2ce4-aa08-11e7-8d67-bc3e720c1175.png)
