### PR TITLE
hotkeys: Remap ':' to close the reactions popover in case of empty search.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -262,6 +262,11 @@ function stubbing(func_name_to_stub, test_function) {
     assert_mapping('v', 'lightbox.show_from_selected_message');
     assert_mapping('i', 'popovers.open_message_menu');
     assert_mapping(':', 'reactions.open_reactions_popover', true);
+
+    global.emoji_picker.reactions_popped = return_true;
+    assert_mapping(':', 'emoji_picker.navigate', true);
+    global.emoji_picker.reactions_popped = return_false;
+
     assert_mapping('G', 'navigate.to_end');
     assert_mapping('M', 'muting_ui.toggle_mute');
 

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -413,6 +413,12 @@ function change_focus_to_filter() {
 }
 
 exports.navigate = function (event_name) {
+    if (event_name === 'toggle_reactions_popover' && exports.reactions_popped() &&
+        (search_is_active === false || search_results.length === 0)) {
+        exports.hide_emoji_popover();
+        return true;
+    }
+
     // If search is active and results are empty then return immediately.
     if (search_is_active === true && search_results.length === 0) {
         return;
@@ -498,9 +504,9 @@ exports.navigate = function (event_name) {
 
 function process_keypress(e) {
     var is_filter_focused = $('.emoji-popover-filter').is(':focus');
-    if (!is_filter_focused) {
-        var pressed_key = e.which;
-
+    var pressed_key = e.which;
+    if (!is_filter_focused && pressed_key !== 58) {
+        // ':' => 58, is a hotkey for toggling reactions popover.
         if (pressed_key >= 32 && pressed_key <= 126 || pressed_key === 8) {
             // Handle only printable characters or backspace.
             e.preventDefault();

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -65,7 +65,7 @@ var keypress_mappings = {
     43: {name: 'thumbs_up_emoji', message_view_only: true}, // '+'
     45: {name: 'toggle_message_collapse', message_view_only: true}, // '-'
     47: {name: 'search', message_view_only: false}, // '/'
-    58: {name: 'open_reactions', message_view_only: true}, // ':'
+    58: {name: 'toggle_reactions_popover', message_view_only: true}, // ':'
     63: {name: 'show_shortcuts', message_view_only: false}, // '?'
     64: {name: 'compose_reply_with_mention', message_view_only: true}, // '@'
     65: {name: 'stream_cycle_backward', message_view_only: true}, // 'A'
@@ -670,7 +670,7 @@ exports.process_hotkey = function (e, hotkey) {
         case 'show_sender_info':
             popovers.show_sender_info();
             return true;
-        case 'open_reactions': // ':': open reactions to message
+        case 'toggle_reactions_popover': // ':': open reactions to message
             reactions.open_reactions_popover();
             return true;
         case 'thumbs_up_emoji': // '+': reacts with thumbs up emoji on selected message


### PR DESCRIPTION
Fixes: #6806.