### PR TITLE
Simplify "code style" guide where we could be using the linter instead.

### DIFF
--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -300,9 +300,6 @@ type changes in the future.
 -   Don't put a shebang line on a Python file unless it's meaningful to
     run it as a script. (Some libraries can also be run as scripts, e.g.
     to run a test suite.)
--   Scripts should be executed directly (`./script.py`), so that the
-    interpreter is implicitly found from the shebang line, rather than
-    explicitly overridden (`python script.py`).
 -   Put all imports together at the top of the file, absent a compelling
     reason to do otherwise.
 -   Unpacking sequences doesn't require list brackets:

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -297,12 +297,9 @@ type changes in the future.
 
 ### Python
 
--   Scripts should start with `#!/usr/bin/env python3` and not
-    `#/usr/bin/python` (the right Python may not be installed in
-    `/usr/bin`) or `#/usr/bin/env python` (we require Python 3
-    compatibility).  Don't put a shebang line on a Python file unless
-    it's meaningful to run it as a script. (Some libraries can also be
-    run as scripts, e.g. to run a test suite.)
+-   Don't put a shebang line on a Python file unless it's meaningful to
+    run it as a script. (Some libraries can also be run as scripts, e.g.
+    to run a test suite.)
 -   Scripts should be executed directly (`./script.py`), so that the
     interpreter is implicitly found from the shebang line, rather than
     explicitly overridden (`python script.py`).

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -309,16 +309,6 @@ type changes in the future.
 
 -   For string formatting, use `x % (y,)` rather than `x % y`, to avoid
     ambiguity if `y` happens to be a tuple.
--   When selecting by id, don't use `foo.pk` when you mean `foo.id`.
-    E.g.
-
-        recipient = Recipient(type_id=huddle.pk, type=Recipient.HUDDLE)
-
-    should be written as
-
-        recipient = Recipient(type_id=huddle.id, type=Recipient.HUDDLE)
-
-    in case we ever change the primary keys.
 
 ### Tests
 

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -240,11 +240,6 @@ we should still avoid extremely long lines. A general guideline is:
 refactor stuff to get it under 85 characters, unless that makes the
 code a lot uglier, in which case it's fine to go up to 120 or so.
 
-Whitespace guidelines:
-
--   Put no space before or after the open paren for function calls and
-    no space before the close paren for function calls.
-
 ### JavaScript
 
 When calling a function with an anonymous function as an argument, use

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -359,6 +359,14 @@ def build_custom_checkers(by_lang):
          'description': "Logger.warn is a deprecated alias for Logger.warning; Use 'warning' instead of 'warn'.",
          'good_lines': ["logging.warning('I am a warning.')", "logger.warning('warning')"],
          'bad_lines': ["logging.warn('I am a warning.')", "logger.warn('warning')"]},
+        {'pattern': '#!/usr/bin/python',
+         'description': "Use `#!/usr/bin/env python3` instead of `#!/usr/bin/python`",
+         'good_lines': ['#!/usr/bin/env python3'],
+         'bad_lines': ['#!/usr/bin/python', '#!/usr/bin/python3']},
+        {'pattern': '#!/usr/bin/env python$',
+         'description': "Use `#!/usr/bin/env python3` instead of `#!/usr/bin/env python`.",
+         'good_lines': ["#!/usr/bin/env python3"],
+         'bad_lines': ["#!/usr/bin/env python"]},
     ]) + whitespace_rules
     bash_rules = [
         {'pattern': '#!.*sh [-xe]',

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -373,6 +373,10 @@ def build_custom_checkers(by_lang):
          'description': "Use `#!/usr/bin/env python3` instead of `#!/usr/bin/env python`.",
          'good_lines': ["#!/usr/bin/env python3"],
          'bad_lines': ["#!/usr/bin/env python"]},
+        {'pattern': '\.pk',
+         'description': "Use `id` instead of `pk`.",
+         'good_lines': ['if my_django_model.id == 42'],
+         'bad_lines': ['if my_django_model.pk == 42']}
     ]) + whitespace_rules
     bash_rules = cast(RuleList, [
         calling_scripts_rule,

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -192,7 +192,13 @@ def build_custom_checkers(by_lang):
          'good_lines': ['$(function () {foo();}'],
          'bad_lines': ['$(document).ready(function () {foo();}']},
     ]) + whitespace_rules
+    calling_scripts_rule = {
+        'pattern': 'python[23]? \w+\.py',
+        'description': "Use `./<my_program>.py` instead of `python <my_program>.py.",
+        'good_lines': ['./program.py'],
+        'bad_lines': ['python program.py']}
     python_rules = cast(RuleList, [
+        calling_scripts_rule,
         {'pattern': '^(?!#)@login_required',
          'description': '@login_required is unsupported; use @zulip_login_required',
          'good_lines': ['@zulip_login_required', '# foo @login_required'],
@@ -368,11 +374,12 @@ def build_custom_checkers(by_lang):
          'good_lines': ["#!/usr/bin/env python3"],
          'bad_lines': ["#!/usr/bin/env python"]},
     ]) + whitespace_rules
-    bash_rules = [
+    bash_rules = cast(RuleList, [
+        calling_scripts_rule,
         {'pattern': '#!.*sh [-xe]',
          'description': 'Fix shebang line with proper call to /usr/bin/env for Bash path, change -x|-e switches'
                         ' to set -x|set -e'},
-    ] + whitespace_rules[0:1]  # type: RuleList
+    ]) + whitespace_rules[0:1]  # type: RuleList
     css_rules = cast(RuleList, [
         {'pattern': '^[^:]*:\S[^:]*;$',
          'description': "Missing whitespace after : in CSS"},

--- a/zerver/lib/sessions.py
+++ b/zerver/lib/sessions.py
@@ -16,7 +16,7 @@ def get_session_dict_user(session_dict):
     # type: (Mapping[Text, int]) -> Optional[int]
     # Compare django.contrib.auth._get_user_session_key
     try:
-        return get_user_model()._meta.pk.to_python(session_dict[SESSION_KEY])
+        return get_user_model()._meta.id.to_python(session_dict[SESSION_KEY])
     except KeyError:
         return None
 

--- a/zerver/management/commands/send_password_reset_email.py
+++ b/zerver/management/commands/send_password_reset_email.py
@@ -52,7 +52,7 @@ class Command(ZulipBaseCommand):
                 'email': user_profile.email,
                 'domain': user_profile.realm.host,
                 'site_name': "zulipo",
-                'uid': urlsafe_base64_encode(force_bytes(user_profile.pk)),
+                'uid': urlsafe_base64_encode(force_bytes(user_profile.id)),
                 'user': user_profile,
                 'token': token_generator.make_token(user_profile),
                 'protocol': 'https' if use_https else 'http',

--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -30,7 +30,7 @@ class AttachmentsTests(ZulipTestCase):
         user_profile = self.example_user('cordelia')
         self.login(user_profile.email)
         with mock.patch('zerver.lib.attachments.delete_message_image', side_effect=Exception()):
-            result = self.client_delete('/json/attachments/{pk}'.format(pk=self.attachment.pk))
+            result = self.client_delete('/json/attachments/{id}'.format(id=self.attachment.id))
         self.assert_json_error(result, "An error occured while deleting the attachment. Please try again later.")
 
     @mock.patch('zerver.lib.attachments.delete_message_image')
@@ -38,7 +38,7 @@ class AttachmentsTests(ZulipTestCase):
         # type: (Any) -> None
         user_profile = self.example_user('cordelia')
         self.login(user_profile.email)
-        result = self.client_delete('/json/attachments/{pk}'.format(pk=self.attachment.pk))
+        result = self.client_delete('/json/attachments/{id}'.format(id=self.attachment.id))
         self.assert_json_success(result)
         attachments = user_attachments(user_profile)
         self.assertEqual(attachments, [])
@@ -55,7 +55,7 @@ class AttachmentsTests(ZulipTestCase):
         # type: () -> None
         user_profile = self.example_user('iago')
         self.login(user_profile.email)
-        result = self.client_delete('/json/attachments/{pk}'.format(pk=self.attachment.pk))
+        result = self.client_delete('/json/attachments/{id}'.format(id=self.attachment.id))
         self.assert_json_error(result, 'Invalid attachment')
         user_profile_to_remove = self.example_user('cordelia')
         attachments = user_attachments(user_profile_to_remove)
@@ -68,5 +68,5 @@ class AttachmentsTests(ZulipTestCase):
 
     def test_delete_unauthenticated(self):
         # type: () -> None
-        result = self.client_delete('/json/attachments/{pk}'.format(pk=self.attachment.pk))
+        result = self.client_delete('/json/attachments/{id}'.format(id=self.attachment.id))
         self.assert_json_error(result, 'Not logged in: API authentication or user session required', status_code=401)

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -916,7 +916,7 @@ class TestValidateApiKey(ZulipTestCase):
         profile = validate_api_key(HostRequestMock(host="zulip.testserver"),
                                    self.webhook_bot.email, self.webhook_bot.api_key,
                                    is_webhook=True)
-        self.assertEqual(profile.pk, self.webhook_bot.pk)
+        self.assertEqual(profile.id, self.webhook_bot.id)
 
     def test_valid_api_key_if_user_is_on_wrong_subdomain(self):
         # type: () -> None

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -213,7 +213,7 @@ class TestCrossRealmPMs(ZulipTestCase):
         def assert_message_received(to_user, from_user):
             # type: (UserProfile, UserProfile) -> None
             messages = get_user_messages(to_user)
-            self.assertEqual(messages[-1].sender.pk, from_user.pk)
+            self.assertEqual(messages[-1].sender.id, from_user.id)
 
         def assert_invalid_email():
             # type: () -> Any

--- a/zerver/tornado/websocket_client.py
+++ b/zerver/tornado/websocket_client.py
@@ -49,7 +49,7 @@ class WebsocketClient(object):
         session_auth_hash = self.user_profile.get_session_auth_hash()
         engine = import_module(settings.SESSION_ENGINE)
         session = engine.SessionStore()  # type: ignore # import_module
-        session[SESSION_KEY] = self.user_profile._meta.pk.value_to_string(self.user_profile)
+        session[SESSION_KEY] = self.user_profile._meta.id.value_to_string(self.user_profile)
         session[BACKEND_SESSION_KEY] = auth_backend
         session[HASH_SESSION_KEY] = session_auth_hash
         session.save()

--- a/zilencer/management/commands/add_new_user.py
+++ b/zilencer/management/commands/add_new_user.py
@@ -23,7 +23,7 @@ and will otherwise fall back to the zulip realm."""
                                  .order_by('-string_id').first()
         if realm is None:
             print('Warning: Using default zulip realm, which has an unusual configuration.\n'
-                  'Try running `python manage.py add_new_realm`, and then running this again.')
+                  'Try running `./manage.py add_new_realm`, and then running this again.')
             realm = Realm.objects.get(string_id='zulip')
             domain = 'zulip.com'
         else:


### PR DESCRIPTION
This PR addresses every point in #6855, except three:

> 1. Don't use the style= attribute in HTML. Instead, define logical classes and
put your styles in external files such as zulip.css.

  - I made the following linter rule:
    ```python
        {'pattern': 'style ?=',
         'description': "Don't use the `style=` attribute. Instead, define logical classes and"
                        "put your styles in external files such as `zulip.css`.",
         'good_lines': ['#my-style {color: blue;}'],
         'bad_lines': ['<p style="color: blue;">Foo</p>', 'style = "color: blue;"']}
    ```
    It counted 74 occurrences of violations of this rule. Changing all these to classes seems like a bigger, 
    tedious task to do that is worth its own issue, should we decide to include this rule.

---

> 6. When selecting by id, don't use foo.pk when you mean foo.id.
   This is easy to do with linting for [.]pk, we've got like a dozen violations we can fix.

   - I don't really understand this case - `pk` is the primary key in Django, right? From what I've read 
     about this on SO, it appears to be more common to mistakenly use `id` instead of `pk`. Moreover, I 
     didn't see which of these ~dozen occurrences does in fact mistakenly use `pk`.

---

> (For this, I think a good strategy would be to ban shebang lines in .py files, and to add a lint section for files without an extension, and require that those shebang lines follow these rules).

* I didn't see an easy way to make this work. Files with a python shebang get by default included in the 
  `py` file list by `lister`, so banning shebang lines in `.py`-only files doesn't seem possible. On the other 
  hand, moving all extensionless files to a new section doesn't make sense to me either, since this would 
  prevent all extensionless python files to be linted with python rules.