### PR TITLE
drafts: Automatically delete misbehaving drafts while formatting.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -175,7 +175,8 @@ exports.setup_page = function (callback) {
     }
 
     function format_drafts(data) {
-        var drafts = _.mapObject(data, function (draft, id) {
+        var drafts = {};
+        _.each(data, function (draft, id) {
             var formatted;
             if (draft.type === "stream") {
                 // In case there is no stream for the draft, we need a
@@ -194,8 +195,6 @@ exports.setup_page = function (callback) {
                     raw_content: draft.content,
 
                 };
-
-                markdown.apply_markdown(formatted);
             } else {
                 var emails = util.extract_pm_recipients(draft.private_message_recipient);
                 var recipients = _.map(emails, function (email) {
@@ -213,9 +212,22 @@ exports.setup_page = function (callback) {
                     recipients: recipients,
                     raw_content: draft.content,
                 };
-                markdown.apply_markdown(formatted);
             }
-            return formatted;
+
+            try {
+                markdown.apply_markdown(formatted);
+            } catch (error) {
+                // In case there is some syntax in the draft content which our markdown
+                // processor is unable to process delete the draft so that drafts overlay
+                // can be opened without any error. Also report the exception to the server.
+                draft_model.deleteDraft(id);
+                blueslip.error("Error in rendering draft.", {
+                    draft_content: draft.content,
+                }, error.stack);
+                return;
+            }
+
+            drafts[id] = formatted;
         });
         return drafts;
     }


### PR DESCRIPTION
While applying formatting to drafts if any draft contains some syntax
which our markdown processor is unable to process delete the draft so
that drafts overlay can be opened without any error. Also report the
exception to the server so that error can be fixed.