### PR TITLE
urls: Move the tutorial-related endpoints out of legacy urls.

### DIFF
--- a/static/js/tutorial.js
+++ b/static/js/tutorial.js
@@ -4,7 +4,7 @@ var exports = {};
 
 function set_tutorial_status(status, callback) {
     return channel.post({
-        url:      '/json/tutorial_status',
+        url:      '/json/users/me/tutorial_status',
         data:     {status: JSON.stringify(status)},
         success:  callback,
     });

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1116,8 +1116,8 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
 
     def _do_test(self, user_email):
         # type: (Text) -> HttpResponse
-        data = {"status": '"started"'}
-        return self.client_post(r'/json/tutorial_status', data)
+        data = {"password": initial_password(user_email)}
+        return self.client_post(r'/json/fetch_api_key', data)
 
     def _login(self, user_email, user_realm, password=None):
         # type: (Text, Realm, str) -> None
@@ -1153,8 +1153,8 @@ class TestAuthenticatedJsonViewDecorator(ZulipTestCase):
 
     def _do_test(self, user_email):
         # type: (str) -> HttpResponse
-        data = {"status": '"started"'}
-        return self.client_post(r'/json/tutorial_status', data)
+        data = {"password": initial_password(user_email)}
+        return self.client_post(r'/json/fetch_api_key', data)
 
 class TestZulipLoginRequiredDecorator(ZulipTestCase):
     def test_zulip_login_required_if_subdomain_is_invalid(self):

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -18,7 +18,7 @@ class TutorialTests(ZulipTestCase):
         ]
         for incoming_status, expected_db_status in cases:
             params = dict(status=ujson.dumps(incoming_status))
-            result = self.client_post('/json/tutorial_status', params)
+            result = self.client_post('/json/users/me/tutorial_status', params)
             self.assert_json_success(result)
             user = self.example_user('hamlet')
             self.assertEqual(user.tutorial_status, expected_db_status)

--- a/zerver/views/tutorial.py
+++ b/zerver/views/tutorial.py
@@ -1,15 +1,14 @@
 
 from django.http import HttpRequest, HttpResponse
 
-from zerver.decorator import authenticated_json_post_view, has_request_variables, REQ
+from zerver.decorator import has_request_variables, REQ
 from zerver.lib.response import json_success
 from zerver.lib.validator import check_string
 from zerver.models import UserProfile
 
-@authenticated_json_post_view
 @has_request_variables
-def json_tutorial_status(request, user_profile,
-                         status=REQ(validator=check_string)):
+def set_tutorial_status(request, user_profile,
+                        status=REQ(validator=check_string)):
     # type: (HttpRequest, UserProfile, str) -> HttpResponse
     if status == 'started':
         user_profile.tutorial_status = UserProfile.TUTORIAL_STARTED

--- a/zproject/legacy_urls.py
+++ b/zproject/legacy_urls.py
@@ -18,8 +18,7 @@ legacy_urls = [
     url(r'^json/subscriptions/exists$', zerver.views.streams.json_stream_exists),
 
     url(r'^json/fetch_api_key$', zerver.views.auth.json_fetch_api_key),
-    # This old-style tutorial is due to be eliminated soon.
-    url(r'^json/tutorial_status$', zerver.views.tutorial.json_tutorial_status),
+
     # A version of these reporting views may make sense to support in
     # the API for getting mobile analytics, but we may want something
     # totally different.

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -356,6 +356,10 @@ v1_api_and_json_patterns = [
     url(r'^users/me/hotspots$', rest_dispatch,
         {'POST': 'zerver.views.hotspots.mark_hotspot_as_read'}),
 
+    # users/me/tutorial_status -> zerver.views.tutorial
+    url(r'^users/me/tutorial_status$', rest_dispatch,
+        {'POST': 'zerver.views.tutorial.set_tutorial_status'}),
+
     # settings -> zerver.views.user_settings
     url(r'^settings$', rest_dispatch,
         {'PATCH': 'zerver.views.user_settings.json_change_settings'}),


### PR DESCRIPTION
The first commit deletes the `json/tutorial_send_message` endpoint, and slightly refactors `test_tutorial_status`.

The second commit:
1. Moves the `json/tutorial_status` endpoint from `zproject/legacy_urls.py` to `zproject/urls.py`.
2. Renames the related view from `json_tutorial_status` to `set_tutorial_status` (to match the JS function that uses this API), and removes the `authenticated_json_post_view` decorator from it.
4. Makes the tests for the `authenticated_json_post_view` and `authenticated_json_view` decorators use the `json/fetch_api_key` endpoint instead of `json/tutorial_status`.

Please let me know if anything could be improved.