### PR TITLE
travis/setup-backend: Remove the '--travis' flag in tools/provision.

### DIFF
--- a/tools/travis/setup-backend
+++ b/tools/travis/setup-backend
@@ -6,9 +6,9 @@ set -x
 # Provisioning may fail due to many issues but most of the times a network
 # connection issue is the reason. So we are going to retry entire provisioning
 # once again if that fixes our problem.
-if ! tools/provision --travis; then
+if ! tools/provision; then
     echo "\`provision\`: Something went wrong with the provisioning, might be a network issue, Retrying to provision..."
-    tools/provision --travis
+    tools/provision
 fi
 
 # Create nagios state so that we can test-run the Nagios checks


### PR DESCRIPTION
Whether the env is Travis or not, this has been detected via $TRAVIS env var.
Proof:
https://github.com/zulip/zulip/blob/6fbf41bdbc960ab7af81123b81b8aea71113359a/tools/provision#L38