### PR TITLE
travis/setup-backend: Remove the '--travis' flag in tools/provision.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -43,7 +43,8 @@ NODE_TEST_COVERAGE_DIR_PATH = os.path.join(VAR_DIR_PATH, 'node-coverage')
 
 # TODO: De-duplicate this with emoji_dump.py
 EMOJI_CACHE_PATH = "/srv/zulip-emoji-cache"
-if 'TRAVIS' in os.environ:
+is_travis = 'TRAVIS' in os.environ
+if is_travis:
     # In Travis CI, we don't have root access
     EMOJI_CACHE_PATH = "/home/travis/zulip-emoji-cache"
 
@@ -254,7 +255,7 @@ def main(options):
     # Import tools/setup_venv.py instead of running it so that we get an
     # activated virtualenv for the rest of the provisioning process.
     from tools.setup import setup_venvs
-    setup_venvs.main(options.is_travis)
+    setup_venvs.main(is_travis)
 
     setup_shell_profile('~/.bash_profile')
     setup_shell_profile('~/.zprofile')
@@ -289,7 +290,7 @@ def main(options):
     run(["scripts/setup/generate_secrets.py", "--development"])
     run(["tools/update-authors-json", "--use-fixture"])
     run(["tools/inline-email-css"])
-    if options.is_travis and not options.is_production_travis:
+    if is_travis and not options.is_production_travis:
         run(["sudo", "service", "rabbitmq-server", "restart"])
         run(["sudo", "service", "redis-server", "restart"])
         run(["sudo", "service", "memcached", "restart"])
@@ -379,14 +380,10 @@ if __name__ == "__main__":
                         default=False,
                         help="Ignore all provisioning optimizations.")
 
-    parser.add_argument('--travis', action='store_true', dest='is_travis',
-                        default=False,
-                        help="Provision for Travis but without production settings.")
-
     parser.add_argument('--production-travis', action='store_true',
                         dest='is_production_travis',
                         default=False,
-                        help="Provision for Travis but with production settings.")
+                        help="Provision for Travis with production settings.")
 
     parser.add_argument('--docker', action='store_true',
                         dest='is_docker',

--- a/tools/travis/setup-backend
+++ b/tools/travis/setup-backend
@@ -6,9 +6,9 @@ set -x
 # Provisioning may fail due to many issues but most of the times a network
 # connection issue is the reason. So we are going to retry entire provisioning
 # once again if that fixes our problem.
-if ! tools/provision --travis; then
+if ! tools/provision; then
     echo "\`provision\`: Something went wrong with the provisioning, might be a network issue, Retrying to provision..."
-    tools/provision --travis
+    tools/provision
 fi
 
 # Create nagios state so that we can test-run the Nagios checks

--- a/tools/travis/setup-production
+++ b/tools/travis/setup-production
@@ -24,9 +24,9 @@ sudo apt-get remove postgresql-9.2 postgresql-client-9.2 postgresql-contrib-9.2 
 # Provisioning may fail due to many issues but most of the times a network
 # connection issue is the reason. So we are going to retry entire provisioning
 # once again if that fixes our problem.
-if ! tools/provision --travis --production-travis; then
+if ! tools/provision --production-travis; then
     echo "\`provision\`: Something went wrong with the provisioning, might be a network issue, Retrying to provision..."
-    tools/provision --travis --production-travis
+    tools/provision --production-travis
 fi
 
 cp -a tools/travis/success-http-headers.txt ~/


### PR DESCRIPTION
Whether the env is Travis or not, this has been detected via $TRAVIS env var.
Proof:
https://github.com/zulip/zulip/blob/6fbf41bdbc960ab7af81123b81b8aea71113359a/tools/provision#L38