### PR TITLE
docs: Move the mandatory config value to Step 2.

### DIFF
--- a/docs/prod-install.md
+++ b/docs/prod-install.md
@@ -40,7 +40,7 @@ tar -xf zulip-server-latest.tar.gz
 Then, run the Zulip install script:
 ```
 sudo -s  # If not already root
-./zulip-server-*/scripts/setup/install
+./zulip-server-*/scripts/setup/install --hostname <hostname> --email <admin email>
 ```
 
 This may take a while to run, since it will install a large number of
@@ -63,6 +63,8 @@ symbolic link to it.
 * Installs Zulip's various dependencies.
 * Cconfigures the various third-party services Zulip uses, including
 Postgres, RabbitMQ, Memcached and Redis.
+* Edits `/ect/zulip/settings.py` by inserting the value of hostname into
+  `EXTERNAL_HOST` and the value of email into `ZULIP_ADMINISTRATOR`.
 
 ## Step 3: Configure Zulip
 
@@ -88,9 +90,7 @@ heading `### MANDATORY SETTINGS`.  These settings include:
 
 - If desired, you can also configure additional
   [authentication backends](prod-authentication-methods.html) while
-  you're editing /etc/zulip/settings.py.  Note, however, that the
-  default (email) backend must be enabled when you complete Step 6
-  (creating an organization) below.
+  you're editing /etc/zulip/settings.py.
 
 ## Step 4: Test email configuration
 

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -86,6 +86,8 @@ EMAIL_USE_TLS = True
 # Enable at least one of the following authentication backends.
 # See http://zulip.readthedocs.io/en/latest/prod-authentication-methods.html
 # for documentation on our authentication backends.
+# The default (email) backend must be enabled in order for Step 6 of production
+# installation to be completed.
 AUTHENTICATION_BACKENDS = (
     'zproject.backends.EmailAuthBackend',  # Email and password; just requires SMTP setup
     # 'zproject.backends.GoogleMobileOauth2Backend',  # Google Apps, setup below


### PR DESCRIPTION
And move the comment on the default auth backend into the settings file.

The objective of this PR is to reduce the number of necessary words to describe the prod install step.
I think moving all the required 4 params to the `scripts/setup/install` stage could shrink a lot of content of Step 3. So that Step 3 is read only for uncommon setup that deviates from most of the cases.