### PR TITLE
linter: Ban shebang lines in files ending with '.py'.

### DIFF
--- a/zerver/views/email_log.py
+++ b/zerver/views/email_log.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render, redirect


### PR DESCRIPTION
This creates ~45 linter conflicts. I think most of the files can be simply renamed, but there might be some instances where another piece of code contains their filename or uses them as a module.

Coming from #6872 :
> Let's leave that issue in the code-style guide

If we lint for it, shouldn't we be able to remove it?