### PR TITLE
Use user_ids, not emails, for bulk stream operations.

### DIFF
--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -148,7 +148,7 @@ stream_data.add_sub('Frontend', frontend);
 
     set_global('stream_data', {
         subscribe_myself: noop,
-        set_subscriber_emails: noop,
+        set_subscribers: noop,
         get_colors: noop,
     });
     set_global('subs', { update_settings_for_subscribed: noop });
@@ -218,16 +218,12 @@ stream_data.add_sub('Frontend', frontend);
     // Test assigning subscriber emails
     with_overrides(function (override) {
         global.with_stub(function (stub) {
-            override('stream_data.set_subscriber_emails', stub.f);
-            var emails = [
-                'me@example.com',
-                'you@example.com',
-                'zooly@zulip.com',
-            ];
-            stream_events.mark_subscribed(frontend, emails, '');
+            override('stream_data.set_subscribers', stub.f);
+            var user_ids = [15, 20, 25];
+            stream_events.mark_subscribed(frontend, user_ids, '');
             var args = stub.get_args('sub', 'subscribers');
             assert.deepEqual(frontend, args.sub);
-            assert.deepEqual(emails, args.subscribers);
+            assert.deepEqual(user_ids, args.subscribers);
         });
 
         // assign self as well

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -292,17 +292,6 @@ exports.set_subscribers = function (sub, user_ids) {
     sub.subscribers = Dict.from_array(user_ids || []);
 };
 
-exports.set_subscriber_emails = function (sub, emails) {
-    _.each(emails, function (email) {
-        var user_id = people.get_user_id(email);
-        if (!user_id) {
-            blueslip.error("We tried to set invalid subscriber: " + email);
-        } else {
-            sub.subscribers.set(user_id, true);
-        }
-    });
-};
-
 exports.add_subscriber = function (stream_name, user_id) {
     var sub = exports.get_sub(stream_name);
     if (typeof sub === 'undefined') {

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -103,7 +103,7 @@ exports.mark_subscribed = function (sub, subscribers, color) {
     }
     stream_data.subscribe_myself(sub);
     if (subscribers) {
-        stream_data.set_subscriber_emails(sub, subscribers);
+        stream_data.set_subscribers(sub, subscribers);
     }
 
     subs.update_settings_for_subscribed(sub);

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -355,15 +355,7 @@ def apply_event(state, event, user_profile, include_subscribers):
             return
 
         if event['op'] in ["add"]:
-            if include_subscribers:
-                # Convert the emails to user_profile IDs since that's what register() returns
-                # TODO: Clean up this situation by making the event also have IDs
-                for item in event["subscriptions"]:
-                    item["subscribers"] = [
-                        get_user(email, user_profile.realm).id
-                        for email in item["subscribers"]
-                    ]
-            else:
+            if not include_subscribers:
                 # Avoid letting 'subscribers' entries end up in the list
                 for i, sub in enumerate(event['subscriptions']):
                     event['subscriptions'][i] = copy.deepcopy(event['subscriptions'][i])


### PR DESCRIPTION
We now return user_ids for subscribers to streams in add-stream
events.  This allows us to eliminate the UserLite class for
both bulk adds and bulk removes.  It also simplifies some JS
code that already wanted to use user_ids, not emails.

Fixes #6898