### PR TITLE
organization-settings: Update user table list on deactivation.

### DIFF
--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -285,6 +285,13 @@ function info_for(user_id) {
         return;
     }
 
+    // for the intents and purposes of viewing users in the right sidebar,
+    // an unknown status should just be considered "offline", since we don't
+    // care about the semantics of status beyond not being active in any way.
+    if (status === "unknown") {
+        status = "offline";
+    }
+
     return {
         href: narrow.pm_with_uri(person.email),
         name: person.full_name,

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -121,6 +121,13 @@ var list_render = (function () {
             // initializing a new progressive list render instance, you can just
             // update the data of an existing one.
             data: function (data) {
+                // if no args are provided then just return the existing data.
+                // this interface is similar to how many jQuery functions operate,
+                // where a call to the method without data returns the existing data.
+                if (typeof data === "undefined" && arguments.length === 0) {
+                    return meta.list;
+                }
+
                 if (Array.isArray(data)) {
                     meta.list = data;
 

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -255,6 +255,15 @@ exports.on_load_success = function (realm_people_data) {
                 }
             },
             success: function () {
+                var user_table_list = list_render.get("users_table_list");
+
+                var user = _.find(user_table_list.data(), function (user) {
+                    return user.email === email;
+                });
+
+                user.is_active = false;
+                user_table_list.render();
+
                 var button = meta.current_deactivate_user_modal_row.find("button.deactivate");
                 button.prop("disabled", false);
                 button.addClass("btn-warning reactivate").removeClass("btn-danger deactivate");

--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -13,9 +13,8 @@
     <td>
         <span class="bot type">{{bot_type}}</span>
     </td>
-    {{else if is_active}}
-    <td class="last_active">
-    </td>
+    {{else}}
+    <td class="last_active"></td>
     {{/if}}
     {{#if ../can_modify}}
     <td>


### PR DESCRIPTION
This updates the user table list on deactivation to correctly display
the statuses of users when filtered.

Fixes: #5451.