### PR TITLE
Embedded bots UI [Update on #5811]

### DIFF
--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -54,8 +54,16 @@ zrequire('settings_bots');
 function test_create_bot_type_input_box_toggle(f) {
     var create_payload_url = $('#create_payload_url');
     var payload_url_inputbox = $('#payload_url_inputbox');
+    var EMBEDDED_BOT_TYPE = '4';
     var OUTGOING_WEBHOOK_BOT_TYPE = '3';
     var GENERIC_BOT_TYPE = '1';
+
+    $('#create_bot_type :selected').val(EMBEDDED_BOT_TYPE);
+    f.apply();
+    assert(!create_payload_url.hasClass('required'));
+    assert(!payload_url_inputbox.visible());
+    assert($('#select_service_name').hasClass('required'));
+    assert($('#service_name_list').visible());
 
     $('#create_bot_type :selected').val(OUTGOING_WEBHOOK_BOT_TYPE);
     f.apply();

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -1,5 +1,6 @@
 set_global("page_params", {
     realm_uri: "https://chat.example.com",
+    realm_embedded_bots: ["converter", "xkcd"],
 });
 
 set_global("avatar", {});
@@ -91,9 +92,15 @@ function test_create_bot_type_input_box_toggle(f) {
         }
     };
 
+    var embedded_bots_added = 0;
+    $('#select_service_name').append = function () {
+        embedded_bots_added += 1;
+    };
+
     avatar.build_bot_create_widget = function () {};
     avatar.build_bot_edit_widget = function () {};
 
     settings_bots.set_up();
+    assert(embedded_bots_added === page_params.realm_embedded_bots.length);
 }());
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -86,6 +86,12 @@ exports.set_up = function () {
     $('#payload_url_inputbox').hide();
     $('#create_payload_url').val('');
     $('#service_name_list').hide();
+    page_params.realm_embedded_bots.forEach(function (bot_name) {
+        $('#select_service_name').append($('<option>', {
+            value: bot_name,
+            text: bot_name,
+        }));
+    });
     $('#select_service_name').val('converter'); // TODO: Use 'select a bot'.
 
     $('#download_flaskbotrc').click(function () {

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -85,6 +85,8 @@ exports.generate_flaskbotrc_content = function (email, api_key) {
 exports.set_up = function () {
     $('#payload_url_inputbox').hide();
     $('#create_payload_url').val('');
+    $('#service_name_list').hide();
+    $('#select_service_name').val('converter'); // TODO: Use 'select a bot'.
 
     $('#download_flaskbotrc').click(function () {
         var OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
@@ -116,6 +118,7 @@ exports.set_up = function () {
     var create_avatar_widget = avatar.build_bot_create_widget();
     var OUTGOING_WEBHOOK_BOT_TYPE = '3';
     var GENERIC_BOT_TYPE = '1';
+    var EMBEDDED_BOT_TYPE = '4';
 
     var GENERIC_INTERFACE = '1';
 
@@ -130,6 +133,7 @@ exports.set_up = function () {
             var short_name = $('#create_bot_short_name').val() || $('#create_bot_short_name').text();
             var payload_url = $('#create_payload_url').val();
             var interface_type = $('#create_interface_type').val();
+            var service_name = $('#select_service_name :selected').val();
             var formData = new FormData();
 
             formData.append('csrfmiddlewaretoken', csrf_token);
@@ -141,6 +145,8 @@ exports.set_up = function () {
             if (bot_type === OUTGOING_WEBHOOK_BOT_TYPE) {
                 formData.append('payload_url', JSON.stringify(payload_url));
                 formData.append('interface_type', interface_type);
+            } else if (bot_type === EMBEDDED_BOT_TYPE) {
+                formData.append('service_name', service_name);
             }
             jQuery.each($('#bot_avatar_file_input')[0].files, function (i, file) {
                 formData.append('file-'+i, file);
@@ -159,6 +165,8 @@ exports.set_up = function () {
                     $('#create_payload_url').val('');
                     $('#payload_url_inputbox').hide();
                     $('#create_bot_type').val(GENERIC_BOT_TYPE);
+                    $('#select_service_name').val('xkcd'); // TODO: Later we can change this to hello bot or similar
+                    $('#service_name_list').hide();
                     $('#create_bot_button').show();
                     $('#create_interface_type').val(GENERIC_INTERFACE);
                     create_avatar_widget.clear();
@@ -177,13 +185,19 @@ exports.set_up = function () {
 
     $("#create_bot_type").on("change", function () {
         var bot_type = $('#create_bot_type :selected').val();
-        // If the selected bot_type is Outgoing webhook
+        // For "generic bot" or "incoming webhook" both these fields need not be displayed.
+        $('#service_name_list').hide();
+        $('#select_service_name').removeClass('required');
+
+        $('#payload_url_inputbox').hide();
+        $('#create_payload_url').removeClass('required');
         if (bot_type === OUTGOING_WEBHOOK_BOT_TYPE) {
             $('#payload_url_inputbox').show();
             $('#create_payload_url').addClass('required');
-        } else {
-            $('#payload_url_inputbox').hide();
-            $('#create_payload_url').removeClass('required');
+
+        } else if (bot_type === EMBEDDED_BOT_TYPE) {
+            $('#service_name_list').show();
+            $('#select_service_name').addClass('required');
         }
     });
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1271,6 +1271,10 @@ thead .actions {
     width: 340px;
 }
 
+#service_name_list input[type=text] {
+    width: 340px;
+}
+
 .invited-as-admin {
     opacity: 0.5;
     margin-left: 2px;

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -73,6 +73,13 @@
                             <div><label for="create_interface_type" generated="true" class="text-error"></label></div>
                         </div>
                     </div>
+                    <div class="input-group" id="service_name_list">
+                        <label for="select_service_name">{{t "Bot"}}</label>
+                        <select name="service_name" id="select_service_name">
+                            <option value="converter">{{t "Converter" }}</option>
+                            <option value="encrypt">{{t "Encrypt" }}</option>
+                        </select>
+                    </div>
                     <div class="input-group">
                         <div id="bot_avatar_file"></div>
                         <input type="file" name="bot_avatar_file_input" class="notvisible" id="bot_avatar_file_input" value="{{t 'Upload avatar' }}" />

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -76,8 +76,6 @@
                     <div class="input-group" id="service_name_list">
                         <label for="select_service_name">{{t "Bot"}}</label>
                         <select name="service_name" id="select_service_name">
-                            <option value="converter">{{t "Converter" }}</option>
-                            <option value="encrypt">{{t "Encrypt" }}</option>
                         </select>
                     </div>
                     <div class="input-group">

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -43,6 +43,7 @@ from zerver.context_processors import common_context
 from zerver.lib.outgoing_webhook import do_rest_call, get_outgoing_webhook_service_handler
 from zerver.models import get_bot_services
 from zulip import Client
+from zulip_bots.lib import extract_query_without_mention
 from zerver.lib.bot_lib import EmbeddedBotHandler, get_bot_handler
 
 import os
@@ -530,6 +531,13 @@ class EmbeddedBotWorker(QueueProcessingWorker):
                 logging.error("Error: User %s has bot with invalid embedded bot service %s" % (
                     user_profile_id, service.name))
                 continue
+            if event['trigger'] == 'mention':
+                message['content'] = extract_query_without_mention(
+                    message=message,
+                    client=self.get_bot_api_client(user_profile),
+                )
+                if message['content'] is None:
+                    return
             bot_handler.handle_message(
                 message=message,
                 bot_handler=self.get_bot_api_client(user_profile)


### PR DESCRIPTION
This PR is based on @abhijeetkaur 's PR for adding embedded bots to the UI.

### How does this differ from #5811?

I didn't modify Abhijeet's commits, but added two code clean-up commits on top of them. Additionally, I added a commit to fetch the embedded bots list automatically instead of hard-coding it in the template.

The original PR contains the request:
> Can we display the name of the specific embedded bot being used somewhere here? I'd consider putting it in the "bot type" row: e.g. "Embedded bot: converter". Might need to do some tweaking to the bots flow to pass that through the system, but seems like it'd be helpful.

From what I've seen in the code path, we need to either add some database field to bot users, or make some query to the service table to implement this. I think this could go hand in hand with https://github.com/zulip/zulip/pull/5665

### Why is this WIP?

* While an added embedded bot is responsive, there seems to be some problem with the message handling, which I still need to look into. Once that's fixed, all commits but `Add view to fetch embedded bots for user selection.` should be good to merge.

@timabbott pinging you because this is WIP, and it would be good to have some feedback if this is the right direction (also in the context of other PRs for embedded bots like state handling, etc.).