### PR TITLE
compose_actions: Do not collapse compose box on topic change.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -331,15 +331,12 @@ exports.on_topic_narrow = function () {
         return;
     }
 
-    if (compose_state.subject()) {
-        // If the user has filled in a subject, we have
-        // a risk of a mix, and we can't reliably guess
-        // whether the old topic is appropriate (otherwise,
-        // why did they narrow?) or the new one is
-        // appropriate (after all, they were starting to
-        // compose on the old topic and may now be looking
-        // for info), so we punt and cancel.
-        exports.cancel();
+    if (compose_state.subject() && $("#new_message_content").val().length > 0) {
+        // if the length of the message is greater than 0,
+        // we want to keep the compose box open still, but
+        // we want to make sure that the topic remains the
+        // same to avoid spilling information to the wrong
+        // topic.
         return;
     }
 


### PR DESCRIPTION
This changes the behavior from closing the compose box on topic change
to keeping it open. There are two cases which can happen now:

1. A user has typed a message and switches topics, and the compose box
will NOT change the topic in order to avoid spilling content to the
wrong topic.

2. A user has not typed a message and switches topics, and the compose
box will change the topic.

Fixes: #6473.