### PR TITLE
Add UI for viewing and cancelling open Zulip invitations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,7 @@
         "settings_users": false,
         "settings_streams": false,
         "settings_filters": false,
+        "settings_invites": false,
         "settings": false,
         "resize": false,
         "loading": false,

--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -62,6 +62,12 @@ def get_object_from_key(confirmation_key):
         raise ConfirmationKeyException(ConfirmationKeyException.EXPIRED)
 
     obj = confirmation.content_object
+    # Revoke invite currently deletes the PreregistrationUser object linked
+    # to the invite_id, which leaves a Confirmation object with a
+    # missing content_object. This is something that should be changed, probably.
+    # This is a temporary fix as a workaround for this issue
+    if obj is None:
+        raise ConfirmationKeyException(ConfirmationKeyException.EXPIRED)
     if hasattr(obj, "status"):
         obj.status = getattr(settings, 'STATUS_ACTIVE', 1)
         obj.save(update_fields=['status'])

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -238,6 +238,39 @@ function render(template_name, args) {
     assert.equal(filter_format.text(), 'https://trac.example.com/ticket/%(id)s');
 }());
 
+(function admin_invites_list() {
+    var html = '<table>';
+    var invites = ['alice', 'bob', 'carl'];
+    var invite_id = 0;
+    _.each(invites, function (invite) {
+        var args = {
+            invite: {
+                email: invite + '@zulip.com',
+                ref: 'iago@zulip.com',
+                invited: "2017-01-01 01:01:01",
+                id: invite_id,
+            },
+        };
+        html += render('admin_invites_list', args);
+        invite_id += 1;
+    });
+    html += "</table>";
+    var buttons = $(html).find('.button');
+
+    assert.equal($(buttons[0]).text().trim(), "Revoke");
+    assert($(buttons[0]).hasClass("revoke"));
+    assert.equal($(buttons[0]).attr("data-invite-id"), 0);
+
+    assert.equal($(buttons[3]).text().trim(), "Resend");
+    assert($(buttons[3]).hasClass("resend"));
+    assert.equal($(buttons[3]).attr("data-invite-id"), 1);
+
+    var span = $(html).find(".email:first");
+    assert.equal(span.text(), "alice@zulip.com");
+
+    global.write_handlebars_output("admin_invites_list", html);
+}());
+
 (function admin_streams_list() {
     var html = '<table>';
     var streams = ['devel', 'trac', 'zulip'];
@@ -257,7 +290,8 @@ function render(template_name, args) {
     };
     var html = render('admin_tab', args);
     var admin_features = ["admin_users_table", "admin_bots_table",
-                          "admin_streams_table", "admin_deactivated_users_table"];
+                          "admin_streams_table", "admin_deactivated_users_table",
+                          "admin_invites_table"];
     _.each(admin_features, function (admin_feature) {
         assert.notEqual($(html).find("#" + admin_feature).length, 0);
     });

--- a/static/js/admin_sections.js
+++ b/static/js/admin_sections.js
@@ -29,6 +29,9 @@ exports.load_admin_section = function (name) {
         case 'filter-settings':
             section = 'filters';
             break;
+        case 'invites-list-admin':
+            section = 'invites';
+            break;
         default:
             blueslip.error('Unknown admin id ' + name);
             return;
@@ -56,6 +59,9 @@ exports.load_admin_section = function (name) {
         case 'filters':
             settings_filters.set_up();
             break;
+        case 'invites':
+            settings_invites.set_up();
+            break;
         default:
             blueslip.error('programming error for section ' + section);
             return;
@@ -71,6 +77,7 @@ exports.reset_sections = function () {
     settings_users.reset();
     settings_streams.reset();
     settings_filters.reset();
+    settings_invites.reset();
 };
 
 return exports;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -83,6 +83,7 @@ function _setup_page() {
             "streams-list-admin": i18n.t("Streams"),
             "default-streams-list": i18n.t("Default streams"),
             "filter-settings": i18n.t("Filter settings"),
+            "invites-list-admin": i18n.t("Invitations"),
         };
     }
 

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -1,0 +1,153 @@
+var settings_invites = (function () {
+
+var exports = {};
+
+var meta = {
+    loaded: false,
+};
+
+exports.reset = function () {
+    meta.loaded = false;
+};
+
+function failed_listing_invites(xhr) {
+    loading.destroy_indicator($('#admin_page_invites_loading_indicator'));
+    ui_report.error(i18n.t("Error listing invites"), xhr, $("#organization-status"));
+}
+
+function populate_invites(invites_data) {
+    if (!meta.loaded) {
+        return;
+    }
+    var invites_table = $("#admin_invites_table").expectOne();
+
+    list_render(invites_table, invites_data.invites, {
+        name: "admin_invites_list",
+        modifier: function (item) {
+            return templates.render("admin_invites_list", { invite: item });
+        },
+        filter: {
+            element: invites_table.closest(".settings-section").find(".search"),
+            callback: function (item, value) {
+                return item.email.toLowerCase().indexOf(value) >= 0;
+            },
+        },
+    }).init();
+
+    loading.destroy_indicator($('#admin_page_invites_loading_indicator'));
+}
+
+
+exports.set_up = function () {
+    meta.loaded = true;
+
+    // create loading indicators
+    loading.make_indicator($('#admin_page_invites_loading_indicator'));
+
+    // Populate invites table
+    channel.get({
+        url: '/json/invites',
+        idempotent: true,
+        timeout:  10*1000,
+        success: exports.on_load_success,
+        error: failed_listing_invites,
+    });
+};
+
+exports.on_load_success = function (invites_data) {
+    meta.loaded = true;
+    populate_invites(invites_data);
+
+    $(".admin_invites_table").on("click", ".revoke", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        var row = $(e.target).closest(".invite_row");
+        var email = row.find('.email').text();
+        meta.current_revoke_invite_user_modal_row = row;
+        meta.invite_id = $(e.currentTarget).attr("data-invite-id");
+
+        $("#revoke_invite_modal .email").text(email);
+        $("#revoke_invite_modal #do_revoke_invite_button").attr("data-invite-id", meta.invite_id);
+        $("#revoke_invite_modal").modal("show");
+    });
+
+    $(".admin_invites_table").on("click", ".resend", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        var row = $(e.target).closest(".invite_row");
+        var email = row.find('.email').text();
+        meta.current_resend_invite_user_modal_row = row;
+        meta.invite_id = $(e.currentTarget).attr("data-invite-id");
+
+        $("#resend_invite_modal .email").text(email);
+        $("#resend_invite_modal #do_resend_invite_button").attr("data-invite-id", meta.invite_id);
+        $("#resend_invite_modal").modal("show");
+    });
+
+    $("#do_revoke_invite_button").click(function () {
+        var modal_invite_id = $("#revoke_invite_modal #do_revoke_invite_button").attr("data-invite-id");
+        var revoke_button = meta.current_revoke_invite_user_modal_row.find("button.revoke");
+
+        if (modal_invite_id !== meta.invite_id) {
+            blueslip.error("Invite revoking canceled due to non-matching fields.");
+            ui_report.message("Resending encountered an error. Please reload and try again.",
+               $("#home-error"), 'alert-error');
+        }
+        $("#revoke_invite_modal").modal("hide");
+        revoke_button.prop("disabled", true).text(i18n.t("Working…"));
+        channel.del({
+            url: '/json/invites/' + meta.invite_id,
+            error: function (xhr) {
+                if (xhr.status.toString().charAt(0) === "4") {
+                    revoke_button.closest("td").html(
+                        $("<p>").addClass("text-error").text(JSON.parse(xhr.responseText).msg)
+                    );
+                } else {
+                    revoke_button.text(i18n.t("Failed!"));
+                }
+            },
+            success: function () {
+                meta.current_revoke_invite_user_modal_row.remove();
+            },
+        });
+    });
+
+    $("#do_resend_invite_button").click(function () {
+        var modal_invite_id = $("#resend_invite_modal #do_resend_invite_button").attr("data-invite-id");
+        var resend_button = meta.current_resend_invite_user_modal_row.find("button.resend");
+
+        if (modal_invite_id !== meta.invite_id) {
+            blueslip.error("Invite resending canceled due to non-matching fields.");
+            ui_report.message("Resending encountered an error. Please reload and try again.",
+               $("#home-error"), 'alert-error');
+        }
+        $("#resend_invite_modal").modal("hide");
+        resend_button.prop("disabled", true).text(i18n.t("Working…"));
+        channel.post({
+            url: '/json/invites/resend/' + meta.invite_id,
+            error: function (xhr) {
+                if (xhr.status.toString().charAt(0) === "4") {
+                    resend_button.closest("td").html(
+                        $("<p>").addClass("text-error").text(JSON.parse(xhr.responseText).msg)
+                    );
+                } else {
+                    resend_button.text(i18n.t("Failed!"));
+                }
+            },
+            success: function (data) {
+                resend_button.text(i18n.t("Resent!"));
+                resend_button.removeClass('resend btn-warning').addClass('sea-green');
+                meta.current_resend_invite_user_modal_row.find(".invited_at").text(data.timestamp);
+            },
+        });
+    });
+};
+
+return exports;
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = settings_invites;
+}

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -858,6 +858,11 @@ input[type=checkbox].inline-block {
     width: 100px;
     height: 100px;
 }
+
+.invite-user-link i {
+    text-decoration: none;
+    margin-right: 5px;
+}
 /* -- new settings overlay -- */
 #settings_page {
     min-height: 550px;

--- a/static/templates/admin_invites_list.handlebars
+++ b/static/templates/admin_invites_list.handlebars
@@ -1,0 +1,21 @@
+{{#with invite}}
+<tr class="invite_row">
+    <td>
+        <span class="email">{{email}}</span>
+    </td>
+    <td>
+        <span class="referred_by">{{ref}}</span>
+    </td>
+    <td>
+        <span class="invited_at">{{invited}}</span>
+    </td>
+    <td>
+        <button class="button rounded small revoke btn-danger" data-invite-id="{{id}}">
+            {{t "Revoke" }}
+        </button>
+        <button class="button rounded small resend btn-warning" data-invite-id="{{id}}">
+            {{t "Resend" }}
+        </button>
+    </td>
+</tr>
+{{/with}}

--- a/static/templates/admin_tab.handlebars
+++ b/static/templates/admin_tab.handlebars
@@ -3,6 +3,8 @@
 {{ partial "deactivation-user-modal" }}
 {{ partial "deactivation-stream-modal" }}
 {{ partial "realm-domains-modal" }}
+{{ partial "revoke-invite-modal" }}
+{{ partial "resend-invite-modal" }}
 
 {{ partial "organization-profile-admin" }}
 {{ partial "organization-settings-admin" }}
@@ -23,3 +25,5 @@
 {{ partial "auth-methods-settings-admin" }}
 
 {{ partial "realm-filter-settings-admin" }}
+
+{{ partial "invites-list-admin" }}

--- a/static/templates/settings/invites-list-admin.handlebars
+++ b/static/templates/settings/invites-list-admin.handlebars
@@ -1,0 +1,18 @@
+<div id="admin-invites-list" class="settings-section" data-name="invites-list-admin">
+    <a class="invite-user-link" href="#invite"><i class="icon-vector-plus-sign"></i>{{t "Invite more users" }}</a>
+    <input type="text" class="search" placeholder="{{t 'Filter invites' }}" aria-label="{{t 'Filter invites' }}"/>
+    <div class="clear-float"></div>
+
+    <div class="progressive-table-wrapper">
+        <table class="table table-condensed table-striped">
+            <thead>
+                <th>{{t "Email" }}</th>
+                <th>{{t "Invited by" }}</th>
+                <th>{{t "Invited at"  }}</th>
+                <th class="actions">{{t "Actions" }}</th>
+            </thead>
+            <tbody id="admin_invites_table" class="required-text thick admin_invites_table" data-empty="{{t 'No invites match your current filter.' }}"></tbody>
+        </table>
+    </div>
+    <div id="admin_page_invites_loading_indicator"></div>
+</div>

--- a/static/templates/settings/resend-invite-modal.handlebars
+++ b/static/templates/settings/resend-invite-modal.handlebars
@@ -1,0 +1,13 @@
+<div id="resend_invite_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="resend_invite_modal_label" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <h3 id="resend_invite_modal_label">{{t "Resend invitation to" }} <span class="email"></span></h3>
+    </div>
+    <div class="modal-body">
+        <p>{{#tr this}}Are you sure you want to resend the invitation to <strong><span class="email"></span></strong>?{{/tr}}</p>
+    </div>
+    <div class="modal-footer">
+        <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+        <button class="button rounded btn-danger" id="do_resend_invite_button" data-invite-id="{{invite_id}}">{{t "Resend now" }}</button>
+    </div>
+</div>

--- a/static/templates/settings/revoke-invite-modal.handlebars
+++ b/static/templates/settings/revoke-invite-modal.handlebars
@@ -1,0 +1,13 @@
+<div id="revoke_invite_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="revoke_invite_modal_label" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <h3 id="revoke_invite_modal_label">{{t "Revoke invitation to" }} <span class="email"></span></h3>
+    </div>
+    <div class="modal-body">
+        <p>{{#tr this}}Are you sure you want to revoke the invitation to <strong><span class="email"></span></strong>?{{/tr}}</p>
+    </div>
+    <div class="modal-footer">
+        <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+        <button class="button rounded btn-danger" id="do_revoke_invite_button">{{t "Revoke now" }}</button>
+    </div>
+</div>

--- a/templates/zerver/settings_overlay.html
+++ b/templates/zerver/settings_overlay.html
@@ -92,6 +92,12 @@
                     <i class="icon icon-vector-font"></i>
                     <div class="text">{{ _('Filter settings') }}</div>
                 </li>
+                {% if is_admin %}
+                <li class="admin" tabindex="0" data-section="invites-list-admin">
+                    <i class="icon icon-vector-user"></i>
+                    <div class="text">{{ _('Invitations') }}</div>
+                </li>
+                {% endif %}
             </ul>
         </div>
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -402,24 +402,7 @@ class LoginTest(ZulipTestCase):
         response = self.client_get("/login/")
         self.assertEqual(response["Location"], "http://zulip.testserver")
 
-class InviteUserTest(ZulipTestCase):
-
-    def invite(self, users, streams, body=''):
-        # type: (Text, List[Text], str) -> HttpResponse
-        """
-        Invites the specified users to Zulip with the specified streams.
-
-        users should be a string containing the users to invite, comma or
-            newline separated.
-
-        streams should be a list of strings.
-        """
-
-        return self.client_post("/json/invites",
-                                {"invitee_emails": users,
-                                 "stream": streams,
-                                 "custom_body": body})
-
+class InviteUserBase(ZulipTestCase):
     def check_sent_emails(self, correct_recipients, custom_body=None, custom_from_name=None):
         # type: (List[Text], Optional[str], Optional[str]) -> None
         from django.core.mail import outbox
@@ -439,6 +422,24 @@ class InviteUserTest(ZulipTestCase):
             self.assertIn(custom_from_name, outbox[0].from_email)
 
         self.assertIn(FromAddress.NOREPLY, outbox[0].from_email)
+
+class InviteUserTest(InviteUserBase):
+
+    def invite(self, users, streams, body=''):
+        # type: (Text, List[Text], str) -> HttpResponse
+        """
+        Invites the specified users to Zulip with the specified streams.
+
+        users should be a string containing the users to invite, comma or
+            newline separated.
+
+        streams should be a list of strings.
+        """
+
+        return self.client_post("/json/invites",
+                                {"invitee_emails": users,
+                                 "stream": streams,
+                                 "custom_body": body})
 
     def test_successful_invite_user(self):
         # type: () -> None

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -12,6 +12,7 @@ from zerver.lib.test_helpers import MockLDAP
 
 from confirmation.models import Confirmation, create_confirmation_link, MultiuseInvite, \
     generate_key, confirmation_url
+from confirmation import settings as confirmation_settings
 
 from zerver.forms import HomepageForm, WRONG_SUBDOMAIN_ERROR
 from zerver.lib.actions import do_change_password, gather_subscriptions
@@ -2223,3 +2224,85 @@ class LoginOrAskForRegistrationTestCase(ZulipTestCase):
         self.assertEqual(user_id, user_profile.id)
         self.assertEqual(response.status_code, 302)
         self.assertIn('http://zulip.testserver', response.url)
+
+class InvitationsTestCase(InviteUserBase):
+
+    def test_successful_get_open_invitations(self):
+        # type: () -> None
+        """
+        A GET call to /json/invites returns all unexpired invitations
+        """
+
+        days_to_activate = getattr(settings, 'ACCOUNT_ACTIVATION_DAYS', "Wrong")
+        active_value = getattr(confirmation_settings, 'STATUS_ACTIVE', "Wrong")
+        self.assertNotEqual(days_to_activate, "Wrong")
+        self.assertNotEqual(active_value, "Wrong")
+
+        self.login(self.example_email("iago"))
+        user_profile = self.example_user("iago")
+
+        prereg_user_one = PreregistrationUser(email="TestOne@zulip.com", referred_by=user_profile)
+        prereg_user_one.save()
+        expired_datetime = timezone_now() - datetime.timedelta(days=(days_to_activate+1))
+        prereg_user_two = PreregistrationUser(email="TestTwo@zulip.com", referred_by=user_profile)
+        prereg_user_two.save()
+        PreregistrationUser.objects.filter(id=prereg_user_two.id).update(invited_at=expired_datetime)
+        prereg_user_three = PreregistrationUser(email="TestThree@zulip.com", referred_by=user_profile, status=active_value)
+        prereg_user_three.save()
+
+        result = self.client_get("/json/invites")
+        self.assertEqual(result.status_code, 200)
+        self.assert_in_success_response(["TestOne@zulip.com"], result)
+        self.assert_not_in_success_response(["TestTwo@zulip.com", "TestThree@zulip.com"], result)
+
+    def test_successful_delete_invitation(self):
+        # type: () -> None
+        """
+        A DELETE call to /json/invites/<ID> should delete the invite and any scheduled invitation reminder email
+        """
+
+        self.login(self.example_email("iago"))
+        user_profile = self.example_user("iago")
+
+        invitee = "DeleteMe@zulip.com"
+
+        prereg_user = PreregistrationUser(email=invitee, referred_by=user_profile)
+        prereg_user.save()
+
+        delete_id = prereg_user.id
+
+        result = self.client_delete('/json/invites/'+str(delete_id))
+        self.assertEqual(result.status_code, 200)
+        error_result = self.client_delete('/json/invites/'+str(delete_id))
+        self.assert_json_error(error_result, "Cannot revoke the invitation, the invite was not found.")
+
+        self.assertRaises(ScheduledEmail.DoesNotExist,
+                          lambda: ScheduledEmail.objects.get(address__iexact=invitee,
+                                                             type=ScheduledEmail.INVITATION_REMINDER))
+
+    def test_successful_resend_invitation(self):
+        # type: () -> None
+        """
+        A POST call to /json/invites/resend/<ID> should send an invitation reminder email
+        and delete any scheduled invitation reminder email
+        """
+
+        self.login(self.example_email("iago"))
+        user_profile = self.example_user("iago")
+        invitee = "ResendMe@zulip.com"
+
+        prereg_user = PreregistrationUser(email=invitee, referred_by=user_profile)
+        prereg_user.save()
+        resend_id = prereg_user.id
+
+        result = self.client_post('/json/invites/resend/'+str(resend_id))
+
+        self.assertEqual(result.status_code, 200)
+        faulty_result = self.client_post('/json/invites/resend/'+str(9999), {"prereg_id": 9999})
+        self.assert_json_error(faulty_result, "Cannot resend the invitation email, the invite was not found.")
+
+        self.check_sent_emails([invitee], custom_from_name="Zulip")
+
+        self.assertRaises(ScheduledEmail.DoesNotExist,
+                          lambda: ScheduledEmail.objects.get(address__iexact=invitee,
+                                                             type=ScheduledEmail.INVITATION_REMINDER))

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1021,6 +1021,7 @@ JS_SPECS = {
             'js/settings_users.js',
             'js/settings_streams.js',
             'js/settings_filters.js',
+            'js/settings_invites.js',
             'js/settings.js',
             'js/admin_sections.js',
             'js/admin.js',

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -129,7 +129,12 @@ v1_api_and_json_patterns = [
 
     # invites -> zerver.views.invite
     url(r'^invites$', rest_dispatch,
-        {'POST': 'zerver.views.invite.invite_users_backend'}),
+        {'GET': 'zerver.views.invite.get_user_invites',
+         'POST': 'zerver.views.invite.invite_users_backend'}),
+    url(r'^invites/(?P<prereg_id>[0-9]+)$', rest_dispatch,
+        {'DELETE': 'zerver.views.invite.revoke_user_invite'}),
+    url(r'^invites/resend/(?P<prereg_id>[0-9]+)$', rest_dispatch,
+        {'POST': 'zerver.views.invite.resend_user_invite_email'}),
 
     # mark messages as read (in bulk)
     url(r'^mark_all_as_read$', rest_dispatch,


### PR DESCRIPTION
Lets administrators view a list of open(unconfirmed) invitations and
resend or revoke a chosen invitation.

There are a few changes that we can expect for the future:

  * It is currently possible to invite an email that you have already
    invited, it might make sense to change this behavior.

  * Revoke currently deletes the PreregistrationUser object linked
    to the invite_id, which leaves a Confirmation object with a
    missing content_object. We currently work around this to prevent
    an error when clicking a revoked invitation link.

  * Resend currently sends an invite reminder instead of resending the
    original invite, this is because 'custom_body' was not stored when
    the first invite was sent.

![selfassuredblushinglemur-size_restricted](https://user-images.githubusercontent.com/24394687/31357516-5d2bebbc-ad42-11e7-880f-e3db0c466aee.gif)

Fixes: #1180