### PR TITLE
refactor: Extract MessageDict.hydrate_recipient_info().

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1148,8 +1148,6 @@ class Message(AbstractMessage):
             'sender_id',
             'sending_client__name',
             'sender__email',
-            'sender__full_name',
-            'sender__short_name',
             'sender__realm__id',
             'sender__realm__string_id',
             'sender__avatar_source',

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -587,6 +587,7 @@ class StreamMessagesTest(ZulipTestCase):
         message = most_recent_message(user_profile)
         row = Message.get_raw_db_rows([message.id])[0]
         dct = MessageDict.build_dict_from_raw_db_row(row, apply_markdown=True)
+        MessageDict.post_process_dicts([dct])
         self.assertEqual(dct['display_recipient'], 'Denmark')
 
         stream = get_stream('Denmark', user_profile.realm)
@@ -1275,6 +1276,7 @@ class EditMessageTest(ZulipTestCase):
         msg = Message.objects.get(id=msg_id)
         cached = message_to_dict(msg, False)
         uncached = MessageDict.to_dict_uncached_helper(msg, False)
+        MessageDict.post_process_dicts([uncached])
         self.assertEqual(cached, uncached)
         if subject:
             self.assertEqual(msg.topic_name(), subject)

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -576,7 +576,12 @@ class StreamMessagesTest(ZulipTestCase):
         with queries_captured() as queries:
             send_message()
 
-        self.assert_length(queries, 12)
+        '''
+        Part of the reason we have so many queries is that we duplicate
+        a lot of code to generate messages with markdown and without
+        markdown.
+        '''
+        self.assert_length(queries, 14)
 
     def test_stream_message_dict(self):
         # type: () -> None

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -305,7 +305,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 66)
+        self.assert_length(queries, 68)
         user_profile = self.nonreg_user('test')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1628,7 +1628,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     streams_to_sub,
                     dict(principals=ujson.dumps([user1.email, user2.email])),
                 )
-        self.assert_length(queries, 39)
+        self.assert_length(queries, 41)
 
         self.assert_length(events, 7)
         for ev in [x for x in events if x['event']['type'] not in ('message', 'stream')]:

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -749,6 +749,7 @@ def get_messages_backend(request, user_profile,
                                               setter=stringify_message_dict)
 
     message_list = []
+
     for message_id in message_ids:
         msg_dict = message_dicts[message_id]
         msg_dict.update({"flags": user_message_flags[message_id]})
@@ -758,6 +759,8 @@ def get_messages_backend(request, user_profile,
         if "edit_history" in msg_dict and not user_profile.realm.allow_edit_history:
             del msg_dict["edit_history"]
         message_list.append(msg_dict)
+
+    MessageDict.post_process_dicts(message_list)
 
     statsd.incr('loaded_old_messages', len(message_list))
     ret = {'messages': message_list,


### PR DESCRIPTION
This is a first step to eventually slimming the message cache,
but there are still some moving parts there to be worked through.

The more immediate benefit of extracting this function is that
we can put tests on it.  Also, it isolates some functionality
that may go away as our clients gets smarter.