### PR TITLE
Ensure big log files don't slip through the cracks

### DIFF
--- a/puppet/zulip/files/logrotate/zulip
+++ b/puppet/zulip/files/logrotate/zulip
@@ -1,4 +1,4 @@
-/var/log/zulip/workers.log /var/log/zulip/manage.log /var/log/zulip/errors.log /var/log/zulip/analytics.log /var/log/zulip/digest.log /var/log/zulip/send_email.log {
+/var/log/zulip/*.log {
     missingok
     rotate 3
     size 25M


### PR DESCRIPTION
In the chat.fhir.org server, the following files (at least) can get big but aren't covered by Zulip's default logrotate config:

```
/var/log/zulip# find . -type f -size +500M
./events-deliver_enqueued_emails.log
./tornado.log
./events-user-presence.log
```

This PR proposes covering all zulip logs with a `*.log`.