### PR TITLE
notifications: Prompt user to enable desktop notifications.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -154,7 +154,8 @@
         "emoji_picker": false,
         "hotspots": false,
         "compose_ui": false,
-        "common": false
+        "common": false,
+        "desktop_notifications_panel": false
     },
     "rules": {
         "array-callback-return": "error",

--- a/static/js/desktop_notifications_panel.js
+++ b/static/js/desktop_notifications_panel.js
@@ -28,7 +28,10 @@ exports.initialize = function () {
         // if the user said to never show banner on this computer again, it will
         // be stored as `true` so we want to negate that.
         !ls.get("dontAskForNotifications") &&
-        !notifications.granted_desktop_notifications_permission()
+        // if permission has not been granted yet.
+        !notifications.granted_desktop_notifications_permission() &&
+        // if permission is allowed to be requested (e.g. not in "denied" state).
+        notifications.permission_state() !== "denied"
     );
 
     if (should_show_notifications) {

--- a/static/js/desktop_notifications_panel.js
+++ b/static/js/desktop_notifications_panel.js
@@ -5,7 +5,12 @@ var exports = {};
 var resize_app = function () {
     var panels_height = $("#panels").height();
     $("body > .app").height("calc(100% - " + panels_height + "px)");
+    // the floating recipient bar is usually positioned 10px below the
+    // header, so add that to the panels height to get the new `top` value.
+    $("#floating_recipient_bar").css("top", panels_height + $(".header").height() + 10 + "px");
 };
+
+exports.resize_app = resize_app;
 
 var show_step = function (step) {
     $("#panels [data-step]").hide().filter("[data-step=" + step + "]").show();

--- a/static/js/desktop_notifications_panel.js
+++ b/static/js/desktop_notifications_panel.js
@@ -1,0 +1,64 @@
+var desktop_notifications_panel = (function () {
+
+var exports = {};
+
+var resize_app = function () {
+    var panels_height = $("#panels").height();
+    $("body > .app").height("calc(100% - " + panels_height + "px)");
+};
+
+var show_step = function (step) {
+    $("#panels [data-step]").hide().filter("[data-step=" + step + "]").show();
+};
+
+var get_step = function () {
+    return $("#panels [data-step]").filter(":visible").data("step");
+};
+
+exports.initialize = function () {
+    var ls = localstorage();
+
+    var should_show_notifications = (
+        !page_params.needs_tutorial &&
+        // if the user said to never show banner on this computer again, it will
+        // be stored as `true` so we want to negate that.
+        !ls.get("dontAskForNotifications") &&
+        !notifications.granted_desktop_notifications_permission()
+    );
+
+    if (should_show_notifications) {
+        $("#desktop-notifications-panel").show();
+        resize_app();
+    }
+
+    $(".request-desktop-notifications").on("click", function (e) {
+        e.preventDefault();
+        $(this).closest(".alert").hide();
+        notifications.request_desktop_notifications_permission();
+        resize_app();
+    });
+
+    $(".reject-notifications").on("click", function () {
+        $(this).closest(".alert").hide();
+        ls.set("dontAskForNotifications", true);
+        resize_app();
+    });
+
+    $("#panels").on("click", ".alert .close, .alert .exit", function (e) {
+        e.stopPropagation();
+        if (get_step() === 1) {
+            show_step(2);
+        } else {
+            $(this).closest(".alert").hide();
+        }
+        resize_app();
+    });
+};
+
+return exports;
+
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = desktop_notifications_panel;
+}

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -98,6 +98,10 @@ exports.initialize = function () {
     }
 };
 
+exports.permission_state = function () {
+    return window.Notification.permission;
+};
+
 // For web pages, the initial favicon is the same as the favicon we
 // set for no unread messages and the initial page title is the same
 // as the page title we set for no unread messages.  However, for the

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -8,7 +8,6 @@ var notice_memory = {};
 // case after a server-initiated reload.
 var window_has_focus = document.hasFocus && document.hasFocus();
 
-var asked_permission_already = false;
 var supports_sound;
 
 var unread_pms_favicon = '/static/images/favicon/favicon-pms.png';
@@ -96,19 +95,6 @@ exports.initialize = function () {
                                       .attr("loop", "yes")
                                       .attr("src", "/static/audio/zulip.mp3"));
         }
-    }
-
-    if (notifications_api) {
-        $(document).click(function () {
-            if (!page_params.enable_desktop_notifications || asked_permission_already) {
-                return;
-            }
-            if (notifications_api.checkPermission() !== 0) { // 0 is PERMISSION_ALLOWED
-                notifications_api.requestPermission(function () {
-                    asked_permission_already = true;
-                });
-            }
-        });
     }
 };
 
@@ -479,6 +465,17 @@ function should_send_audible_notification(message) {
 
     return false;
 }
+
+exports.granted_desktop_notifications_permission = function () {
+    return browser_desktop_notifications_on();
+};
+
+
+exports.request_desktop_notifications_permission = function () {
+    if (notifications_api) {
+        return notifications_api.requestPermission();
+    }
+};
 
 exports.received_messages = function (messages) {
     _.each(messages, function (message) {

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -264,6 +264,8 @@ exports.resize_page_components = function () {
 
     activity.update_scrollbar.users();
     activity.update_scrollbar.group_pms();
+
+    desktop_notifications_panel.resize_app();
 };
 
 var _old_width = $(window).width();

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -273,6 +273,7 @@ $(function () {
     compose.initialize();
     hotspots.initialize();
     ui.initialize();
+    desktop_notifications_panel.initialize();
 });
 
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -181,6 +181,42 @@ p.n-margin {
     height: 40px;
 }
 
+#panels {
+    -webkit-font-smoothing: antialiased;
+
+    font-size: 1rem;
+}
+
+#panels .alert {
+    margin: 0;
+    padding-top: 12px;
+    padding-bottom: 12px;
+
+    border: none;
+    border-radius: 0;
+
+    text-align: center;
+    text-shadow: none;
+    color: #fff;
+}
+
+#panels .alert.alert-info {
+    background: #54c0ae;
+}
+
+#panels .alert .close {
+    line-height: 24px;
+}
+
+#panels .alert .alert-link {
+    color: #c6fff5;
+    font-weight: 600;
+}
+
+#panels .alert .buttons .alert-link {
+    margin: 0px 5px;
+}
+
 .app {
     width: 100%;
     height: 100%;

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -1,3 +1,25 @@
+<div id="panels">
+  <div id="desktop-notifications-panel" class="alert alert-info">
+    <span class="close" data-dismiss="alert" aria-label="{{ _('Close') }}">&times;</span>
+    <div data-step="1">
+      {{ _('Zulip needs your permission to enable desktop notifications.') }}
+      {{ _('In future you can disable notices from Zulip\'s Settings.') }}
+      <a class="request-desktop-notifications alert-link">
+        {{ _('Enable notifications.') }}
+      </a>
+    </div>
+    <div data-step="2" style="display: none">
+      {{ _('We recommend allowing notifications. You can customize these at any time in your settings.') }}
+      <span class="buttons">
+        <a class="alert-link request-desktop-notifications">{{ _('Enable notifications') }}</a>
+        &bull;
+        <a class="alert-link exit">{{ _('Ask me later') }}</a>
+        &bull;
+        <a class="alert-link reject-notifications">{{ _('Never ask on this computer') }}</a>
+      </span>
+    </div>
+  </div>
+</div>
 <div class="header">
 <nav class="header-main rightside-userlist" id="top_navbar">
   <div class="column-left">

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1034,6 +1034,7 @@ JS_SPECS = {
             'js/ui_init.js',
             'js/emoji_picker.js',
             'js/compose_ui.js',
+            'js/desktop_notifications_panel.js'
         ],
         'output_filename': 'min/app.js'
     },


### PR DESCRIPTION
This is a two-step notifications process that will ask a user
to enable notifications and if they click exit give them three
options:

1. Enable notifications.
2. Ask later.
3. Never ask on this computer again.

The first two are self-explanatory (ask later = next session it
asks again). The third is captured and stored in localStorage and
a check is done on page load to see whether or not notifications
should be displayed.

Commit modified heavily by Brock Whittaker <brock@zulipchat.com>.

Fixes #1189.