### PR TITLE
add GPU hardware acceleration for scrolling performance

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1271,6 +1271,8 @@ div.message_table {
     margin-left: auto;
     display: none;
     width: 100%;
+    /* Ensure GPU acceleration is used for this component to speed up scrolling */
+    transform: translateZ(0);
 }
 
 .message_row {


### PR DESCRIPTION
I came across this issue because I was frustrated that the Electron app had very slow scrolling (laggy, low FPS). I was unsure if that was from Electron framework overhead, from application level code, or from something else entirely. So first, I created a super basic Electron app that just loads Zulip and has no extra code at all. I found that when I measured FPS in this app when scrolling, I was getting 15-20 FPS on larger streams like #backend (although as per the actual Electron app, I get 30 FPS on small streams).

What I then did was apply a CSS rule, `.message_table { transform: translateZ(0) }`. I measured the FPS again and found that it was steady around 30 FPS (and you can tell, it's very smooth) on large streams and 60 FPS on small streams. Here is the Electron project where I tested this: https://github.com/levthedev/electron-performance. You can test it yourself by running npm install; electron ., opening up the dev tools, and hitting more tools -> rendering settings -> show FPS meter. You should see that it is between 30-60 FPS when scrolling. Now, if you open up your editor and remove line 19 (which injects the transform property), restart the app, open up the FPS meter, and scroll, you will see that you get significantly lower FPS (in my case, 10-15 FPS).

Explanation: setting a translateZ attribute on the messages table tells the browser that it is a 3D layer (this is true for any 3D transform CSS attribute, and it doens't make a difference that I used `translateZ` and not `translate3d` or `scale3d`). The browser then passes of this layer to the GPU, which helps out with the rendering and then sends it back to the browser to be painted. This results in significantly faster scrolling at the expense of a small amount of GPU memory (on my 3 year old Macbook, about 30mb extra of memory out of 512mb that I have total).

The scrolling performance improvement makes a huge difference in the Electron application. For me, it improved scrolling performance by 100%. In the browser, the improvement is subtler, but still very noticeable (especially when profiled with the FPS meter) - for me it was an increase of about 50%. I suspect this difference is because browsers automatically optimize some rendering through the GPU and Electron does not, though I'm not certain about that.

** Summary: tiny CSS change gives big scrolling FPS performance boost, in exchange for a little bit of GPU memory **

Here are some links about this topic:

* https://www.smashingmagazine.com/2016/12/gpu-animation-doing-it-right/
* https://www.urbaninsight.com/2013/01/04/improving-html5-app-performance-gpu-accelerated-css-transitions
* https://www.sitepoint.com/introduction-to-hardware-acceleration-css-animations/
* http://blog.teamtreehouse.com/increase-your-sites-performance-with-hardware-accelerated-css