### PR TITLE
[WIP] Default stream groups

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -33,14 +33,16 @@ from zerver.lib.actions import (
     validate_user_access_to_subscribers_helper,
     do_get_streams, get_default_streams_for_realm,
     gather_subscriptions_helper, get_cross_realm_dicts,
-    get_status_dict, streams_to_dicts_sorted
+    get_status_dict, streams_to_dicts_sorted,
+    default_stream_groups_to_dicts_sorted
 )
 from zerver.lib.upload import get_total_uploads_size_for_user
 from zerver.tornado.event_queue import request_event_queue, get_user_events
 from zerver.models import Client, Message, Realm, UserPresence, UserProfile, \
     get_user_profile_by_id, \
     get_realm_user_dicts, realm_filters_for_realm, get_user,\
-    get_owned_bot_dicts, custom_profile_fields_for_realm, get_realm_domains
+    get_owned_bot_dicts, custom_profile_fields_for_realm, get_realm_domains, \
+    get_default_stream_groups
 from zproject.backends import email_auth_enabled, password_auth_enabled
 from version import ZULIP_VERSION
 
@@ -208,6 +210,9 @@ def fetch_initial_state_data(user_profile, event_types, queue_id,
         state['streams'] = do_get_streams(user_profile)
     if want('default_streams'):
         state['realm_default_streams'] = streams_to_dicts_sorted(get_default_streams_for_realm(user_profile.realm_id))
+    if want('default_stream_groups'):
+        state['realm_default_stream_groups'] = default_stream_groups_to_dicts_sorted(
+            get_default_stream_groups(user_profile.realm))
 
     if want('update_display_settings'):
         for prop in UserProfile.property_types:
@@ -370,6 +375,8 @@ def apply_event(state, event, user_profile, include_subscribers):
             state['streams'] = [s for s in state['streams'] if s["stream_id"] not in stream_ids]
     elif event['type'] == 'default_streams':
         state['realm_default_streams'] = event['default_streams']
+    elif event['type'] == 'default_stream_groups':
+        state['realm_default_stream_groups'] = event['default_stream_groups']
     elif event['type'] == 'realm':
         if event['op'] == "update":
             field = 'realm_' + event['property']

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -28,6 +28,7 @@ from zerver.lib.actions import (
     do_add_reaction_legacy,
     do_add_realm_domain,
     do_add_realm_filter,
+    do_add_streams_to_default_stream_group,
     do_change_avatar_fields,
     do_change_bot_owner,
     do_change_default_all_public_streams,
@@ -41,6 +42,7 @@ from zerver.lib.actions import (
     do_change_stream_description,
     do_change_subscription_property,
     do_create_user,
+    do_create_default_stream_group,
     do_deactivate_stream,
     do_deactivate_user,
     do_delete_message,
@@ -50,10 +52,12 @@ from zerver.lib.actions import (
     do_regenerate_api_key,
     do_remove_alert_words,
     do_remove_default_stream,
+    do_remove_default_stream_group,
     do_remove_reaction_legacy,
     do_remove_realm_domain,
     do_remove_realm_emoji,
     do_remove_realm_filter,
+    do_remove_streams_from_default_stream_group,
     do_rename_stream,
     do_set_realm_authentication_methods,
     do_set_realm_message_editing,
@@ -917,6 +921,45 @@ class EventsRegisterTest(ZulipTestCase):
 
         events = self.do_test(lambda: do_remove_alert_words(self.user_profile, ["alert_word"]))
         error = alert_words_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
+    def test_default_stream_groups_events(self):
+        # type: () -> None
+        default_stream_groups_checker = self.check_events_dict([
+            ('type', equals('default_stream_groups')),
+            ('default_stream_groups', check_list(check_dict_only([
+                ('name', check_string),
+                ('streams', check_list(check_dict_only([
+                    ('description', check_string),
+                    ('invite_only', check_bool),
+                    ('name', check_string),
+                    ('stream_id', check_int)]))),
+            ]))),
+        ])
+
+        streams = []
+        for stream_name in ["Scotland", "Verona", "Denmark"]:
+            streams.append(get_stream(stream_name, self.user_profile.realm))
+
+        events = self.do_test(lambda: do_create_default_stream_group(self.user_profile.realm,
+                                                                     "group1", streams))
+        error = default_stream_groups_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
+        venice_stream = get_stream("Venice", self.user_profile.realm)
+        events = self.do_test(lambda: do_add_streams_to_default_stream_group(self.user_profile.realm,
+                                                                             "group1", [venice_stream]))
+        error = default_stream_groups_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
+        events = self.do_test(lambda: do_remove_streams_from_default_stream_group(self.user_profile.realm,
+                                                                                  "group1", [venice_stream]))
+        error = default_stream_groups_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
+        events = self.do_test(lambda: do_remove_default_stream_group(self.user_profile.realm,
+                                                                     "group1"))
+        error = default_stream_groups_checker('events[0]', events[0])
         self.assert_on_error(error)
 
     def test_default_streams_events(self):
@@ -2212,13 +2255,14 @@ class FetchQueriesTest(ZulipTestCase):
                     queue_id='x',
                 )
 
-        self.assert_length(queries, 28)
+        self.assert_length(queries, 29)
 
         expected_counts = dict(
             alert_words=0,
             attachments=1,
             custom_profile_fields=1,
             default_streams=1,
+            default_stream_groups=1,
             hotspots=0,
             message=1,
             muted_topics=1,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -110,6 +110,7 @@ class HomeTest(ZulipTestCase):
             "realm_bots",
             "realm_create_stream_by_admins_only",
             "realm_default_language",
+            "realm_default_stream_groups",
             "realm_default_streams",
             "realm_description",
             "realm_domains",
@@ -178,7 +179,7 @@ class HomeTest(ZulipTestCase):
             with patch('zerver.lib.cache.cache_set') as cache_mock:
                 result = self._get_home_page(stream='Denmark')
 
-        self.assert_length(queries, 40)
+        self.assert_length(queries, 41)
         self.assert_length(cache_mock.call_args_list, 10)
 
         html = result.content.decode('utf-8')
@@ -243,7 +244,7 @@ class HomeTest(ZulipTestCase):
         with queries_captured() as queries2:
             result = self._get_home_page()
 
-        self.assert_length(queries2, 34)
+        self.assert_length(queries2, 35)
 
         # Do a sanity check that our new streams were in the payload.
         html = result.content.decode('utf-8')

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -17,6 +17,8 @@ from zerver.lib.actions import bulk_remove_subscriptions, \
     do_deactivate_stream, do_change_stream_invite_only, do_add_default_stream, \
     do_change_stream_description, do_get_streams, \
     do_remove_default_stream, get_topic_history_for_stream, \
+    do_create_default_stream_group, do_add_streams_to_default_stream_group, \
+    do_remove_streams_from_default_stream_group, do_remove_default_stream_group, \
     prep_stream_welcome_message
 from zerver.lib.response import json_success, json_error, json_response
 from zerver.lib.streams import access_stream_by_id, access_stream_by_name, \
@@ -70,6 +72,42 @@ def add_default_stream(request, user_profile, stream_name=REQ()):
     # type: (HttpRequest, UserProfile, Text) -> HttpResponse
     (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name)
     do_add_default_stream(stream)
+    return json_success()
+
+@require_realm_admin
+@has_request_variables
+def create_default_stream_group(request: HttpRequest, user_profile: UserProfile,
+                                group_name: Text=REQ(),
+                                stream_names: List[Text]=REQ(validator=check_list(check_string))) -> None:
+    streams = []
+    for stream_name in stream_names:
+        (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name)
+        streams.append(stream)
+    do_create_default_stream_group(user_profile.realm, group_name, streams)
+    return json_success()
+
+@require_realm_admin
+@has_request_variables
+def update_default_stream_group(request: HttpRequest, user_profile: UserProfile,
+                                group_name: Text=REQ(), op: Text=REQ(),
+                                stream_names: List[Text]=REQ(validator=check_list(check_string))) -> None:
+    streams = []
+    for stream_name in stream_names:
+        (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name)
+        streams.append(stream)
+
+    if op == 'add':
+        do_add_streams_to_default_stream_group(user_profile.realm, group_name, streams)
+    elif op == 'remove':
+        do_remove_streams_from_default_stream_group(user_profile.realm, group_name, streams)
+    else:
+        return json_error(_('Nothing to do. Specify at least one of "add" or "remove".'))
+    return json_success()
+
+@require_realm_admin
+@has_request_variables
+def remove_default_stream_group(request: HttpRequest, user_profile: UserProfile, group_name: Text=REQ()) -> None:
+    do_remove_default_stream_group(user_profile.realm, group_name)
     return json_success()
 
 @require_realm_admin

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -273,6 +273,10 @@ v1_api_and_json_patterns = [
     url(r'^default_streams$', rest_dispatch,
         {'POST': 'zerver.views.streams.add_default_stream',
          'DELETE': 'zerver.views.streams.remove_default_stream'}),
+    url(r'^default_stream_groups', rest_dispatch,
+        {'POST': 'zerver.views.streams.create_default_stream_group',
+         'PATCH': 'zerver.views.streams.update_default_stream_group',
+         'DELETE': 'zerver.views.streams.remove_default_stream_group'}),
     # GET lists your streams, POST bulk adds, PATCH bulk modifies/removes
     url(r'^users/me/subscriptions$', rest_dispatch,
         {'GET': 'zerver.views.streams.list_subscriptions_backend',


### PR DESCRIPTION
To test run

```
./tools/provision
./manage.py create_default_stream_groups -s gci-1,gci-2,gci-3 -d "Google code-in"  -r zulip
./manage.py create_default_stream_groups -s gsoc-1,gsoc-2,gsoc-3 -d "Google summer of code"  -r zulip
```

Now try to create a new user

**The command is not meant to be merged**