### PR TITLE
user docs: Modify sidebar and index styling.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -146,9 +146,17 @@ body {
 .help .sidebar h2 {
     font-size: 1.2em;
     font-weight: 400;
-    margin-bottom: 0px;
-    line-height: 100%;
+    margin-bottom: 5px;
+    line-height: 105%;
     cursor: pointer;
+}
+
+.help .sidebar h1 {
+    font-size: 1.25em;
+}
+
+.help .sidebar h1:not(:first-of-type) {
+    margin-top: 20px;
 }
 
 .help .sidebar.slide h2::before {
@@ -165,34 +173,8 @@ body {
     opacity: 0.5;
 }
 
-.help .sidebar h2.no-arrow::before {
-    content: "";
-}
-
-.help .sidebar.slide h2.no-arrow {
-    margin-left: 12px;
-}
-
-.help .sidebar:not(.slide) h2 {
-    margin-left: 0px;
-}
-
-.help .sidebar h2.no-arrow a {
-    color: inherit;
-}
-
-.help .sidebar h3 {
-    font-size: 1em;
-    font-weight: 400;
-    text-transform: uppercase;
-    color: #badcd6;
-
-    line-height: 1;
-    margin: 10px 0 5px 10px;
-}
-
 .help .sidebar ul {
-    margin: 10px 0px 10px 12px;
+    margin: 5px 0px 10px 12px;
 }
 
 .help .sidebar.slide ul {
@@ -1534,6 +1516,14 @@ input.new-organization-button {
     border-bottom: 1px solid #eee;
     padding-bottom: 10px;
     margin-bottom: 15px;
+}
+
+.markdown h1#using-zulip,
+.markdown h1#zulip-administration {
+    font-size: 1.75em;
+    padding: 10px 0;
+    margin-bottom: 0px;
+    line-height: 100%;
 }
 
 .markdown h2,

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -122,7 +122,7 @@ body {
     box-shadow: 0px -20px 50px rgba(0, 0, 0, 0.04);
     overflow: auto;
 
-    color: hsl(222, 33%, 33%);
+    color: hsl(0, 0%, 27%);
 }
 
 .help .sidebar {
@@ -137,7 +137,8 @@ body {
     border-right: 1px solid hsl(219, 10%, 97%);
     overflow: auto;
 
-    background: hsl(219, 10%, 97%);
+    background-color: hsl(153, 32%, 55%);
+    color: hsl(0, 0%, 100%);
 
     -webkit-overflow-scrolling: touch;
 }

--- a/templates/zerver/help/main.html
+++ b/templates/zerver/help/main.html
@@ -5,7 +5,7 @@
 {% block portico_content %}
 <div class="app help terms-page inline-block">
     <div class="sidebar slide">
-        <h1 class="no-arrow"><a href="/help/" class="no-underline">Index</a></h1>
+        <h1><a href="/help/" class="no-underline">Index</a></h1>
         {{ render_markdown_path("zerver/help/include/sidebar.md") }}
     </div>
 


### PR DESCRIPTION
Followup to #6829 that reimplements the green user docs sidebar and improves some small visual details. 

![screen shot 2017-10-12 at 12 22 12 pm](https://user-images.githubusercontent.com/15116870/31514879-0dcb00be-af48-11e7-80c4-ec1710aa4254.png)

Current docs, for reference:

![screenshot at oct 12 12-24-02](https://user-images.githubusercontent.com/15116870/31514940-4acc8cf8-af48-11e7-83e4-8157c4517ae2.png)
