### PR TITLE
Make sure mentions refer only to active users.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1530,7 +1530,8 @@ def get_full_name_info(realm_id, full_names):
     }
 
     rows = UserProfile.objects.filter(
-        realm_id=realm_id
+        realm_id=realm_id,
+        is_active=True,
     ).filter(
         functools.reduce(lambda a, b: a | b, q_list),
     ).values(


### PR DESCRIPTION
An active user can share the same full name as a deactivated
user.  We now only allow mention syntax to find users who are
activated.

Fixed #6978