### PR TITLE
logging: Clear out the Django default config on logger `django`.

### DIFF
--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1274,6 +1274,12 @@ LOGGING = {
         },
 
         # Django, alphabetized
+        'django': {
+            # Django's default logging config has already set some
+            # things on this logger.  Just mentioning it here causes
+            # `logging.config` to reset it to defaults, as if never
+            # configured; which is what we want for it.
+        },
         'django.request': {
             'level': 'WARNING',
             'filters': ['skip_boring_404s'],


### PR DESCRIPTION
By default, Django sets up two handlers on this logger, one of them
its AdminEmailHandler.  We have our own handler for sending email on
error, and we want to stick to that -- we like the format somewhat
better, and crucially we've given it some rate-limiting through
ZulipLimiter.

Since we cleaned out our logging config in e0a5e6fad, though, we've
been sending error emails through both paths.  The config we'd had
before that for `django` was redundant with the config on the root --
but having *a* config there was essential for causing
`logging.config.dictConfig`, when Django passes it our LOGGING dict,
to clear out that logger's previous config.  So, give it an empty
config.

Django by default configures two loggers: `django` and
`django.server`.  We have our own settings for `django.server`
anyway, so this is the only one we need to add.

The stdlib `logging` and `logging.config` docs aren't 100% clear, and
while the source of `logging` is admirably straightforward the source
of `logging.config` is a little twisty, so it's not easy to become
totally confident that this has the right effect just by reading.
Fortunately we can put some of that source-diving to work in writing
a test for it.