### PR TITLE
Travis: Add test for Xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # See https://zulip.readthedocs.io/en/latest/events-system.html for
 # high-level documentation on our Travis CI setup.
-dist: trusty
+dist: xenial
 install:
   # Install moreutils so we can use `ts` and `mispipe` in the following.
   - sudo ./tools/travis/install-moreutils
@@ -53,6 +53,9 @@ matrix:
       env: TEST_SUITE=production
     - python: "3.5"
       env: TEST_SUITE=backend
+      #- python: "3.5"
+      #- dist: xenial
+      #- env: TEST_SUITE=backend
 sudo: required
 addons:
   artifacts:


### PR DESCRIPTION
3.5 is chosen because it is the default version of python3 in Ubuntu 16.04.