### PR TITLE
Remove `from __future__ import absolute_import`.

### DIFF
--- a/analytics/lib/fixtures.py
+++ b/analytics/lib/fixtures.py
@@ -1,4 +1,4 @@
-from __future__ import division, absolute_import
+from __future__ import division
 
 from zerver.models import Realm, UserProfile, Stream, Message
 from analytics.models import InstallationCount, RealmCount, UserCount, StreamCount

--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -2,8 +2,6 @@
 
 # Copyright: (c) 2008, Jarek Zgoda <jarek.zgoda@gmail.com>
 
-from __future__ import absolute_import
-
 __revision__ = '$Id: models.py 28 2009-10-22 15:03:02Z jarek.zgoda $'
 
 import datetime

--- a/docs/webhook-walkthrough.md
+++ b/docs/webhook-walkthrough.md
@@ -58,7 +58,6 @@ python file, `zerver/webhooks/mywebhook/view.py`.
 The Hello World integration is in `zerver/webhooks/helloworld/view.py`:
 
 ```
-from __future__ import absolute_import
 from django.utils.translation import ugettext as _
 from zerver.lib.actions import check_send_stream_message
 from zerver.lib.response import json_success, json_error

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import absolute_import
-
 import os
 import sys
 

--- a/scripts/get-django-setting
+++ b/scripts/get-django-setting
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import absolute_import
-
 import os
 import sys
 

--- a/scripts/lib/email-mirror-postfix
+++ b/scripts/lib/email-mirror-postfix
@@ -37,7 +37,6 @@ Also you can use optional keys to configure the script and change default values
 
 -t                  Disable sending request to the Zulip server. Default value: False.
 """
-from __future__ import absolute_import
 
 import os
 import ssl

--- a/static/assets/favicon/generate
+++ b/static/assets/favicon/generate
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import absolute_import
 import xml.etree.ElementTree as ET
 import subprocess
 from six.moves import range

--- a/tools/linter_lib/printer.py
+++ b/tools/linter_lib/printer.py
@@ -1,4 +1,5 @@
-from __future__ import print_function, absolute_import
+from __future__ import print_function
+from __future__ import absolute_import
 
 import sys
 import os

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from __future__ import print_function
-from __future__ import absolute_import
 
 import os
 import sys


### PR DESCRIPTION
Except in:
- docs/writing-bots-guide.md, because bots are supposed to be Python 2
  compatible
- puppet/zulip_ops/files/zulip-ec2-configure-interfaces, because this
  script is still on python2.7
- tools/lint
- tools/linter_lib