### PR TITLE
/privacy/: Fix sizing of nested <p> tags.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -1812,7 +1812,7 @@ nav ul li.active::after {
 }
 
 .portico-landing.why-page .main p {
-    font-size: 1.2em;
+    font-size: 1.2rem;
     line-height: 1.6;
 }
 


### PR DESCRIPTION
Each nested <p> tag currently is 20% larger than the last nest. This
fixes the sizing to be 1.2x the body size rather than 1.2x the parent
size.