### PR TITLE
prod install docs: Move info on email backend to settings comment.

### DIFF
--- a/docs/prod-install.md
+++ b/docs/prod-install.md
@@ -86,12 +86,6 @@ heading `### MANDATORY SETTINGS`.  These settings include:
   [our guide for outgoing email](prod-email.html) for help configuring
   this.
 
-- If desired, you can also configure additional
-  [authentication backends](prod-authentication-methods.html) while
-  you're editing /etc/zulip/settings.py.  Note, however, that the
-  default (email) backend must be enabled when you complete Step 6
-  (creating an organization) below.
-
 ## Step 4: Test email configuration
 
 If you haven't already,

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -86,6 +86,10 @@ EMAIL_USE_TLS = True
 # Enable at least one of the following authentication backends.
 # See http://zulip.readthedocs.io/en/latest/prod-authentication-methods.html
 # for documentation on our authentication backends.
+#
+# The install process requires EmailAuthBackend (the default) to be
+# enabled.  If you want to disable it, do so after creating the
+# initial realm and user.
 AUTHENTICATION_BACKENDS = (
     'zproject.backends.EmailAuthBackend',  # Email and password; just requires SMTP setup
     # 'zproject.backends.GoogleMobileOauth2Backend',  # Google Apps, setup below


### PR DESCRIPTION
Fixes #6985. Place the warning sign exactly at where the loophole is located.