### PR TITLE
popovers: Hide user email and PM feature for deactivated users.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -64,12 +64,15 @@ initialize();
 
     var human_user_ids = people.get_realm_human_user_ids();
     assert.deepEqual(human_user_ids, [isaac.user_id]);
+    assert.equal(people.realm_user_is_active_human(isaac.user_id), true);
 
     // Now deactivate isaac
     people.deactivate(isaac);
     person = people.realm_get(email);
     assert(!person);
     assert.equal(people.get_realm_count(), 0);
+    assert.equal(people.realm_user_is_active_human(isaac.user_id), false);
+
 
     // We can still get their info for non-realm needs.
     person = people.get_by_email(email);

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1270,8 +1270,8 @@ function render(template_name, args) {
     var html = render('user_info_popover_content', args);
     global.write_handlebars_output("user_info_popover_content", html);
 
-    var a = $(html).find("a.compose_private_message");
-    assert.equal(a.text().trim(), 'Send private message (R)');
+    var a = $(html).find("a.narrow_to_private_messages");
+    assert.equal(a.text().trim(), 'View private messages');
 }());
 
 (function user_info_popover_title() {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -530,6 +530,10 @@ exports.realm_get = function realm_get(email) {
     return realm_people_dict.get(person.user_id);
 };
 
+exports.realm_user_is_active_human = function (id) {
+    return !!realm_people_dict.get(id);
+};
+
 exports.get_all_persons = function () {
     return people_by_user_id_dict.values();
 };

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -100,6 +100,7 @@ function show_user_info_popover(element, user, message) {
             sent_by_uri: narrow.by_sender_uri(user.email),
             narrowed: narrow_state.active(),
             private_message_class: "respond_personal_button",
+            is_active: people.realm_user_is_active_human(user.user_id),
         };
 
         var ypos = elt.offset().top;

--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -57,3 +57,11 @@ a.no-underline,
 a.no-underline:hover {
     text-decoration: none;
 }
+
+.half-opacity {
+    opacity: 0.5;
+}
+
+.italic {
+    font-style: italic;
+}

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -3,21 +3,29 @@
     <div class="popover_info">
         <li class="user_{{presence_status}}">
             <b>{{user_full_name}}</b>
+            {{#if is_active }}
             <span class="user-status-indicator popover_user_presence" title="{{user_last_seen_time_status}}"></span>
+            {{/if}}
         </li>
 
+        {{#if is_active }}
         <li class='my_email'>{{user_email}}</li>
+        {{else}}
+        <li class='my_email half-opacity italic'>(This user has been deactivated)</li>
+        {{/if}}
 
         {{#if user_time}}
         <li>{{ user_time }} {{#tr this}}Local time{{/tr}}</li>
         {{/if}}
     </div>
     <hr />
+    {{#if is_active }}
     <li>
         <a href="#" class="{{ private_message_class }}">
             <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr this}}Send private message{{/tr}} (R)
         </a>
     </li>
+    {{/if}}
     <li>
         <a class="mention_user">
             <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}} (@)


### PR DESCRIPTION
This hides the emails of deactivated users from the popovers along
with the link to send a PM to them.