### PR TITLE
Updated documentation to use `git clone -c` method

### DIFF
--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -270,9 +270,12 @@ Now you are ready for [Step 2: Get Zulip Code.](#step-2-get-zulip-code)
    do this.
 2. Open Terminal (macOS/Ubuntu) or Git BASH (Windows; must
    **run as an Administrator**).
-3. In Terminal/Git BASH, clone your fork:
+3. In Terminal/Git BASH, clone your fork to your local machine using -c
+flag to set the git pull mode to be rebase by default in the repository
+configuration:
+
 ```
-git clone git@github.com:YOURUSERNAME/zulip.git
+git clone -c pull.rebase git@github.com:YOURUSERNAME/zulip.git
 ```
 
 This will create a 'zulip' directory and download the Zulip code into it.
@@ -282,7 +285,7 @@ something like:
 
 ```
 christie@win10 ~
-$ git clone git@github.com:YOURUSERNAME/zulip.git
+$ git clone -c pull.rebase git@github.com:YOURUSERNAME/zulip.git
 Cloning into 'zulip'...
 remote: Counting objects: 73571, done.
 remote: Compressing objects: 100% (2/2), done.

--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -270,9 +270,7 @@ Now you are ready for [Step 2: Get Zulip Code.](#step-2-get-zulip-code)
    do this.
 2. Open Terminal (macOS/Ubuntu) or Git BASH (Windows; must
    **run as an Administrator**).
-3. In Terminal/Git BASH, clone your fork to your local machine using -c
-flag to set the git pull mode to be rebase by default in the repository
-configuration:
+3. In Terminal/Git BASH, [clone your fork to your local machine using -c flag](#step-1b-clone-to-your-machine):
 
 ```
 git clone -c pull.rebase git@github.com:YOURUSERNAME/zulip.git

--- a/docs/dev-setup-non-vagrant.md
+++ b/docs/dev-setup-non-vagrant.md
@@ -8,8 +8,10 @@ Contents:
 
 ## Installing directly on Ubuntu
 
-Start by cloning this repository: `git clone
-https://github.com/zulip/zulip.git`
+Start by cloning this repository using -c flag to set the git pull
+mode to be rebase by default in the repository configuration:
+
+`git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
 If you'd like to install a Zulip development environment on a computer
 that's already running Ubuntu 16.04 Xenial or Ubuntu 14.04 Trusty, you
@@ -61,9 +63,10 @@ Install the following non-Python dependencies:
 
 #### Using the official Ubuntu repositories, PGroonga PPA and `tsearch-extras` deb package:
 
-Start by cloning this repository: `git clone
-https://github.com/zulip/zulip.git`
+Start by cloning this repository using -c flag to set the git pull
+mode to be rebase by default in the repository configuration:
 
+`git clone -c pull.rebase https://github.com/zulip/zulip.git`
 ```
 sudo apt-get install closure-compiler libfreetype6-dev libffi-dev \
     memcached rabbitmq-server libldap2-dev redis-server \
@@ -119,8 +122,10 @@ Now continue with the [All Systems](#all-systems) instructions below.
 
 [zulip-ppa]: https://launchpad.net/~tabbott/+archive/ubuntu/zulip/+packages
 
-Start by cloning this repository: `git clone
-https://github.com/zulip/zulip.git`
+Start by cloning this repository using -c flag to set the git pull
+mode to be rebase by default in the repository configuration:
+
+`git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
 ```
 sudo add-apt-repository ppa:tabbott/zulip
@@ -139,8 +144,10 @@ Now continue with the [All Systems](#all-systems) instructions below.
 These instructions are experimental and may have bugs; patches
 welcome!
 
-Start by cloning this repository: `git clone
-https://github.com/zulip/zulip.git`
+Start by cloning this repository using -c flag to set the git pull
+mode to be rebase by default in the repository configuration:
+
+`git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
 ```
 sudo dnf install libffi-devel memcached rabbitmq-server \
@@ -156,8 +163,10 @@ Now continue with the [Common to Fedora/CentOS](#common-to-fedora-centos-instruc
 These instructions are experimental and may have bugs; patches
 welcome!
 
-Start by cloning this repository: `git clone
-https://github.com/zulip/zulip.git`
+Start by cloning this repository using -c flag to set the git pull
+mode to be rebase by default in the repository configuration:
+
+`git clone -c pull.rebase https://github.com/zulip/zulip.git``
 
 ```
 # Add user zulip to the system (not necessary if you configured zulip
@@ -189,8 +198,9 @@ sudo yum install libffi-devel memcached rabbitmq-server openldap-devel \
 # We need these packages to compile tsearch-extras
 sudo yum groupinstall "Development Tools"
 
-# clone Zulip's git repo and cd into it
-cd && git clone https://github.com/zulip/zulip && cd zulip/
+# clone Zulip's git repo using -c flag to set the git pull mode to be
+# rebase by default in the repository configuration and cd into it
+cd && git clone -c pull.rebase https://github.com/zulip/zulip && cd zulip/
 
 ## NEEDS TESTING: The next few DB setup items may not be required at all.
 # Initialize the postgres db
@@ -214,8 +224,10 @@ Now continue with the [Common to Fedora/CentOS](#common-to-fedora-centos-instruc
 These instructions are experimental and may have bugs; patches
 welcome!
 
-Start by cloning this repository: `git clone
-https://github.com/zulip/zulip.git`
+Start by cloning this repository using -c flag to set the git pull
+mode to be rebase by default in the repository configuration:
+
+`git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
 ```
 doas pkg_add sudo bash gcc postgresql-server redis rabbitmq \
@@ -248,8 +260,10 @@ Finally continue with the [All Systems](#all-systems) instructions below.
 
 ### Common to Fedora/CentOS instructions
 
-Start by cloning this repository: `git clone
-https://github.com/zulip/zulip.git`
+Start by cloning this repository using -c flag to set the git pull
+mode to be rebase by default in the repository configuration:
+
+`git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
 ```
 # Build and install postgres tsearch-extras module
@@ -367,8 +381,10 @@ proxy in the environment as follows:
 
 ## Using Docker (experimental)
 
-Start by cloning this repository: `git clone
-https://github.com/zulip/zulip.git`
+Start by cloning this repository using -c flag to set the git pull
+mode to be rebase by default in the repository configuration:
+
+`git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
 The docker instructions for development are experimental, so they may
 have bugs.  If you try them and run into any issues, please report

--- a/docs/dev-setup-non-vagrant.md
+++ b/docs/dev-setup-non-vagrant.md
@@ -8,8 +8,7 @@ Contents:
 
 ## Installing directly on Ubuntu
 
-Start by cloning this repository using -c flag to set the git pull
-mode to be rebase by default in the repository configuration:
+Start by [cloning this repository using -c flag](#step-1b-clone-to-your-machine):
 
 `git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
@@ -63,8 +62,7 @@ Install the following non-Python dependencies:
 
 #### Using the official Ubuntu repositories, PGroonga PPA and `tsearch-extras` deb package:
 
-Start by cloning this repository using -c flag to set the git pull
-mode to be rebase by default in the repository configuration:
+Start by [cloning this repository using -c flag](#step-1b-clone-to-your-machine):
 
 `git clone -c pull.rebase https://github.com/zulip/zulip.git`
 ```
@@ -122,8 +120,7 @@ Now continue with the [All Systems](#all-systems) instructions below.
 
 [zulip-ppa]: https://launchpad.net/~tabbott/+archive/ubuntu/zulip/+packages
 
-Start by cloning this repository using -c flag to set the git pull
-mode to be rebase by default in the repository configuration:
+Start by [cloning this repository using -c flag](#step-1b-clone-to-your-machine):
 
 `git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
@@ -144,8 +141,7 @@ Now continue with the [All Systems](#all-systems) instructions below.
 These instructions are experimental and may have bugs; patches
 welcome!
 
-Start by cloning this repository using -c flag to set the git pull
-mode to be rebase by default in the repository configuration:
+Start by [cloning this repository using -c flag](#step-1b-clone-to-your-machine):
 
 `git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
@@ -163,8 +159,7 @@ Now continue with the [Common to Fedora/CentOS](#common-to-fedora-centos-instruc
 These instructions are experimental and may have bugs; patches
 welcome!
 
-Start by cloning this repository using -c flag to set the git pull
-mode to be rebase by default in the repository configuration:
+Start by [cloning this repository using -c flag](#step-1b-clone-to-your-machine):
 
 `git clone -c pull.rebase https://github.com/zulip/zulip.git``
 
@@ -198,8 +193,7 @@ sudo yum install libffi-devel memcached rabbitmq-server openldap-devel \
 # We need these packages to compile tsearch-extras
 sudo yum groupinstall "Development Tools"
 
-# clone Zulip's git repo using -c flag to set the git pull mode to be
-# rebase by default in the repository configuration and cd into it
+# clone Zulip's git repo and cd into it
 cd && git clone -c pull.rebase https://github.com/zulip/zulip && cd zulip/
 
 ## NEEDS TESTING: The next few DB setup items may not be required at all.
@@ -224,8 +218,7 @@ Now continue with the [Common to Fedora/CentOS](#common-to-fedora-centos-instruc
 These instructions are experimental and may have bugs; patches
 welcome!
 
-Start by cloning this repository using -c flag to set the git pull
-mode to be rebase by default in the repository configuration:
+Start by [cloning this repository using -c flag](#step-1b-clone-to-your-machine):
 
 `git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
@@ -260,8 +253,7 @@ Finally continue with the [All Systems](#all-systems) instructions below.
 
 ### Common to Fedora/CentOS instructions
 
-Start by cloning this repository using -c flag to set the git pull
-mode to be rebase by default in the repository configuration:
+Start by [cloning this repository using -c flag](#step-1b-clone-to-your-machine):
 
 `git clone -c pull.rebase https://github.com/zulip/zulip.git`
 
@@ -381,8 +373,7 @@ proxy in the environment as follows:
 
 ## Using Docker (experimental)
 
-Start by cloning this repository using -c flag to set the git pull
-mode to be rebase by default in the repository configuration:
+Start by [cloning this repository using -c flag](#step-1b-clone-to-your-machine):
 
 `git clone -c pull.rebase https://github.com/zulip/zulip.git`
 

--- a/docs/git-guide.md
+++ b/docs/git-guide.md
@@ -270,10 +270,11 @@ the main server app, this is [zulip/zulip][github-zulip-zulip].
 
 ### Step 1b: Clone to your machine
 
-Next, clone your fork to your local machine:
+Next, clone your fork to your local machine using -c flag to set the git pull
+mode to be rebase by default in the repository configuration:
 
 ```
-$ git clone git@github.com:christi3k/zulip.git
+$ git clone -c pull.rebase git@github.com:christi3k/zulip.git
 Cloning into 'zulip'
 remote: Counting objects: 86768, done.
 remote: Compressing objects: 100% (15/15), done.

--- a/docs/git-guide.md
+++ b/docs/git-guide.md
@@ -270,8 +270,10 @@ the main server app, this is [zulip/zulip][github-zulip-zulip].
 
 ### Step 1b: Clone to your machine
 
-Next, clone your fork to your local machine using -c flag to set the git pull
-mode to be rebase by default in the repository configuration:
+Next, clone your fork to your local machine using -c/--config flag to set the git
+pull mode to rebase in the repository configuration, because in zulip we do not
+use the default `git pull`, which is a shortcut for `git fetch && git merge FETCH_HEAD`,
+instead we use `git fetch` and then `git rebase`.
 
 ```
 $ git clone -c pull.rebase git@github.com:christi3k/zulip.git


### PR DESCRIPTION
Updated documentation to use `git clone -c` to set the git pull
mode to be rebase by default in the repository configuration.

Fixes: #7022