### PR TITLE
urls: Move the report endpoints to be API-style routes.

### DIFF
--- a/static/js/blueslip.js
+++ b/static/js/blueslip.js
@@ -128,7 +128,7 @@ function report_error(msg, stack, opts) {
     // setup is done or do it ourselves and then retry.
     $.ajax({
         type:     'POST',
-        url:      '/json/report_error',
+        url:      '/json/report/error',
         dataType: 'json',
         data:     { message: msg,
                     stacktrace: stack,

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -6,7 +6,7 @@ var unnarrow_times;
 
 function report_narrow_time(initial_core_time, initial_free_time, network_time) {
     channel.post({
-        url: '/json/report_narrow_time',
+        url: '/json/report/narrow_times',
         data: {initial_core: initial_core_time.toString(),
                initial_free: initial_free_time.toString(),
                network: network_time.toString()},
@@ -36,7 +36,7 @@ function report_unnarrow_time() {
     var initial_free_time = unnarrow_times.initial_free_time - unnarrow_times.start_time;
 
     channel.post({
-        url: '/json/report_unnarrow_time',
+        url: '/json/report/unnarrow_times',
         data: {initial_core: initial_core_time.toString(),
                initial_free: initial_free_time.toString()},
     });

--- a/static/js/sent_messages.js
+++ b/static/js/sent_messages.js
@@ -27,7 +27,7 @@ function report_send_time(send_time, receive_time,
     }
 
     channel.post({
-        url: '/json/report_send_time',
+        url: '/json/report/send_times',
         data: data,
     });
 }

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -89,7 +89,7 @@ def is_slow_query(time_delta, path):
     if time_delta < 1.2:
         return False
     is_exempt = \
-        path in ["/activity", "/json/report_error",
+        path in ["/activity", "/json/report/error",
                  "/api/v1/deployments/report_error"] \
         or path.startswith("/realm_activity/") \
         or path.startswith("/user_activity/")

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -10,7 +10,7 @@ class SlowQueryTest(TestCase):
         self.assertTrue(is_slow_query(2, '/some/random/url'))
         self.assertTrue(is_slow_query(5.1, '/activity'))
         self.assertFalse(is_slow_query(2, '/activity'))
-        self.assertFalse(is_slow_query(2, '/json/report_error'))
+        self.assertFalse(is_slow_query(2, '/json/report/error'))
         self.assertFalse(is_slow_query(2, '/api/v1/deployments/report_error'))
         self.assertFalse(is_slow_query(2, '/realm_activity/whatever'))
         self.assertFalse(is_slow_query(2, '/user_activity/whatever'))

--- a/zerver/tests/test_report.py
+++ b/zerver/tests/test_report.py
@@ -50,7 +50,7 @@ class TestReport(ZulipTestCase):
 
         stats_mock = StatsMock(self.settings)
         with mock.patch('zerver.views.report.statsd', wraps=stats_mock):
-            result = self.client_post("/json/report_send_time", params)
+            result = self.client_post("/json/report/send_times", params)
         self.assert_json_success(result)
 
         expected_calls = [
@@ -75,7 +75,7 @@ class TestReport(ZulipTestCase):
 
         stats_mock = StatsMock(self.settings)
         with mock.patch('zerver.views.report.statsd', wraps=stats_mock):
-            result = self.client_post("/json/report_narrow_time", params)
+            result = self.client_post("/json/report/narrow_times", params)
         self.assert_json_success(result)
 
         expected_calls = [
@@ -97,7 +97,7 @@ class TestReport(ZulipTestCase):
 
         stats_mock = StatsMock(self.settings)
         with mock.patch('zerver.views.report.statsd', wraps=stats_mock):
-            result = self.client_post("/json/report_unnarrow_time", params)
+            result = self.client_post("/json/report/unnarrow_times", params)
         self.assert_json_success(result)
 
         expected_calls = [
@@ -128,7 +128,7 @@ class TestReport(ZulipTestCase):
             side_effect=KeyError('foo')
         )
         with publish_mock as m, subprocess_mock:
-            result = self.client_post("/json/report_error", params)
+            result = self.client_post("/json/report/error", params)
         self.assert_json_success(result)
 
         report = m.call_args[0][1]['report']
@@ -141,11 +141,11 @@ class TestReport(ZulipTestCase):
         # Teset with no more_info
         del params['more_info']
         with publish_mock as m, subprocess_mock:
-            result = self.client_post("/json/report_error", params)
+            result = self.client_post("/json/report/error", params)
         self.assert_json_success(result)
 
         with self.settings(BROWSER_ERROR_REPORTING=False):
-            result = self.client_post("/json/report_error", params)
+            result = self.client_post("/json/report/error", params)
         self.assert_json_success(result)
 
         # If js_source_map is present, then the stack trace should be annotated.
@@ -154,7 +154,7 @@ class TestReport(ZulipTestCase):
         with \
                 self.settings(DEVELOPMENT=False, TEST_SUITE=False), \
                 mock.patch('zerver.lib.unminify.SourceMap.annotate_stacktrace') as annotate:
-            result = self.client_post("/json/report_error", params)
+            result = self.client_post("/json/report/error", params)
         self.assert_json_success(result)
         # fix_params (see above) adds quotes when JSON encoding.
         annotate.assert_called_once_with('"trace"')

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -31,14 +31,13 @@ def get_js_source_map():
         ])
     return js_source_map
 
-@authenticated_json_post_view
 @has_request_variables
-def json_report_send_time(request, user_profile,
-                          time=REQ(converter=to_non_negative_int),
-                          received=REQ(converter=to_non_negative_int, default="(unknown)"),
-                          displayed=REQ(converter=to_non_negative_int, default="(unknown)"),
-                          locally_echoed=REQ(validator=check_bool, default=False),
-                          rendered_content_disparity=REQ(validator=check_bool, default=False)):
+def report_send_times(request, user_profile,
+                      time=REQ(converter=to_non_negative_int),
+                      received=REQ(converter=to_non_negative_int, default="(unknown)"),
+                      displayed=REQ(converter=to_non_negative_int, default="(unknown)"),
+                      locally_echoed=REQ(validator=check_bool, default=False),
+                      rendered_content_disparity=REQ(validator=check_bool, default=False)):
     # type: (HttpRequest, UserProfile, int, int, int, bool, bool) -> HttpResponse
     request._log_data["extra"] = "[%sms/%sms/%sms/echo:%s/diff:%s]" \
         % (time, received, displayed, locally_echoed, rendered_content_disparity)
@@ -54,12 +53,11 @@ def json_report_send_time(request, user_profile,
         statsd.incr('render_disparity')
     return json_success()
 
-@authenticated_json_post_view
 @has_request_variables
-def json_report_narrow_time(request, user_profile,
-                            initial_core=REQ(converter=to_non_negative_int),
-                            initial_free=REQ(converter=to_non_negative_int),
-                            network=REQ(converter=to_non_negative_int)):
+def report_narrow_times(request, user_profile,
+                        initial_core=REQ(converter=to_non_negative_int),
+                        initial_free=REQ(converter=to_non_negative_int),
+                        network=REQ(converter=to_non_negative_int)):
     # type: (HttpRequest, UserProfile, int, int, int) -> HttpResponse
     request._log_data["extra"] = "[%sms/%sms/%sms]" % (initial_core, initial_free, network)
     base_key = statsd_key(user_profile.realm.string_id, clean_periods=True)
@@ -68,11 +66,10 @@ def json_report_narrow_time(request, user_profile,
     statsd.timing("narrow.network.%s" % (base_key,), network)
     return json_success()
 
-@authenticated_json_post_view
 @has_request_variables
-def json_report_unnarrow_time(request, user_profile,
-                              initial_core=REQ(converter=to_non_negative_int),
-                              initial_free=REQ(converter=to_non_negative_int)):
+def report_unnarrow_times(request, user_profile,
+                          initial_core=REQ(converter=to_non_negative_int),
+                          initial_free=REQ(converter=to_non_negative_int)):
     # type: (HttpRequest, UserProfile, int, int) -> HttpResponse
     request._log_data["extra"] = "[%sms/%sms]" % (initial_core, initial_free)
     base_key = statsd_key(user_profile.realm.string_id, clean_periods=True)
@@ -80,12 +77,11 @@ def json_report_unnarrow_time(request, user_profile,
     statsd.timing("unnarrow.initial_free.%s" % (base_key,), initial_free)
     return json_success()
 
-@authenticated_json_post_view
 @has_request_variables
-def json_report_error(request, user_profile, message=REQ(), stacktrace=REQ(),
-                      ui_message=REQ(validator=check_bool), user_agent=REQ(),
-                      href=REQ(), log=REQ(),
-                      more_info=REQ(validator=check_dict([]), default=None)):
+def report_error(request, user_profile, message=REQ(), stacktrace=REQ(),
+                 ui_message=REQ(validator=check_bool), user_agent=REQ(),
+                 href=REQ(), log=REQ(),
+                 more_info=REQ(validator=check_dict([]), default=None)):
     # type: (HttpRequest, UserProfile, Text, Text, bool, Text, Text, Text, Optional[Dict[str, Any]]) -> HttpResponse
     """Accepts an error report and stores in a queue for processing.  The
     actual error reports are later handled by do_report_error (below)"""

--- a/zproject/legacy_urls.py
+++ b/zproject/legacy_urls.py
@@ -18,12 +18,4 @@ legacy_urls = [
     url(r'^json/subscriptions/exists$', zerver.views.streams.json_stream_exists),
 
     url(r'^json/fetch_api_key$', zerver.views.auth.json_fetch_api_key),
-
-    # A version of these reporting views may make sense to support in
-    # the API for getting mobile analytics, but we may want something
-    # totally different.
-    url(r'^json/report_error$', zerver.views.report.json_report_error),
-    url(r'^json/report_send_time$', zerver.views.report.json_report_send_time),
-    url(r'^json/report_narrow_time$', zerver.views.report.json_report_narrow_time),
-    url(r'^json/report_unnarrow_time$', zerver.views.report.json_report_unnarrow_time),
 ]

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -421,6 +421,16 @@ v1_api_and_json_patterns = [
     url(r'^events$', rest_dispatch,
         {'GET': 'zerver.tornado.views.get_events_backend',
          'DELETE': 'zerver.tornado.views.cleanup_event_queue'}),
+
+    # report -> zerver.views.report
+    url(r'^report/error$', rest_dispatch,
+        {'POST': 'zerver.views.report.report_error'}),
+    url(r'^report/send_times$', rest_dispatch,
+        {'POST': 'zerver.views.report.report_send_times'}),
+    url(r'^report/narrow_times$', rest_dispatch,
+        {'POST': 'zerver.views.report.report_narrow_times'}),
+    url(r'^report/unnarrow_times$', rest_dispatch,
+        {'POST': 'zerver.views.report.report_unnarrow_times'}),
 ]
 
 # Include the dual-use patterns twice


### PR DESCRIPTION
The report endpoints were moved from `legacy_urls.py` to `urls.py` and slightly modified:

`json/report_error` → `json/report/error`
`json/report_send_time` → `json/report/send_times`
`json/report_narrow_time` → `json/report/narrow_times`
`json/report_unnarrow_time` → `json/report/unnarrow_times`

The related views were renamed and had legacy decorators removed from them.

I squashed the changes into a single commit, but I can split them by endpoints if necessary.