### PR TITLE
compose: Fixup not-subscribed error styling.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -106,7 +106,7 @@ people.add(bob);
     sub.subscribed = false;
     stream_data.add_sub('social', sub);
     assert(!compose.validate_stream_message_address_info('social'));
-    assert.equal($('#error-msg').html(), "<p>You're not subscribed to the stream <b>social</b>.</p><p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>");
+    assert.equal($('#error-msg').html(), "<div>You're not subscribed to the stream <b>social</b>. <a href='#streams/101/social'>Subscribe now.</a></div>");
 
     global.page_params.narrow_stream = false;
     channel.post = function (payload) {
@@ -125,7 +125,7 @@ people.add(bob);
         payload.success(payload.data);
     };
     assert(!compose.validate_stream_message_address_info('Frontend'));
-    assert.equal($('#error-msg').html(), "<p>You're not subscribed to the stream <b>Frontend</b>.</p><p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>");
+    assert.equal($('#error-msg').html(), "<div>You're not subscribed to the stream <b>Frontend</b>. <a href='#streams/102/Frontend'>Subscribe now.</a></div>");
 
     channel.post = function (payload) {
         assert.equal(payload.data.stream, 'Frontend');

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -413,6 +413,9 @@ exports.validate_stream_message_address_info = function (stream_name) {
         return true;
     }
 
+    var stream_id = stream_data.get_stream_id(stream_name);
+    var safe_stream_name = Handlebars.Utils.escapeExpression(stream_name);
+
     var response;
 
     switch (check_unsubscribed_stream_for_send(stream_name,
@@ -427,9 +430,8 @@ exports.validate_stream_message_address_info = function (stream_name) {
         compose_error(i18n.t("Error checking subscription"), $("#stream"));
         return false;
     case "not-subscribed":
-        response = "<p>You're not subscribed to the stream <b>" +
-            Handlebars.Utils.escapeExpression(stream_name) + "</b>.</p>" +
-            "<p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>";
+        response = "<div>You're not subscribed to the stream <b>" + safe_stream_name + "</b>. " +
+        "<a href='#streams/" + stream_id + "/" + stream_name + "'>Subscribe now.</a></div>";
         compose_error(response, $('#stream'));
         return false;
     }

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -373,10 +373,10 @@ exports.setup_page = function (callback) {
                 { label: i18n.t("Subscribed"), key: "subscribed" },
                 { label: i18n.t("All streams"), key: "all-streams" },
             ],
-            callback: function (value, key) {
+            callback: function (value, key, payload) {
                 // if you aren't on a particular stream (`streams/:id/:name`)
                 // then redirect to `streams/all` when you click "all-streams".
-                if (key === "all-streams") {
+                if (key === "all-streams" && !payload.prevent_hashchange) {
                     window.location.hash = "streams/all";
                 } else if (key === "subscribed") {
                     window.location.hash = "streams/subscribed";
@@ -487,6 +487,14 @@ exports.change_state = (function () {
             } else if (/\d+/.test(hash.arguments[0])) {
                 var stream_row = $(".stream-row[data-stream-id='" + hash.arguments[0] + "']");
                 var streams_list = $(".streams-list")[0];
+
+                var stream = stream_data.get_sub_by_id(hash.arguments[0]);
+
+                if (!stream.subscribed) {
+                  components.toggle.lookup("stream-filter-toggle").goto("all-streams", {
+                      prevent_hashchange: true,
+                  });
+                }
 
                 get_active_data().row.removeClass("active");
                 stream_row.addClass("active");

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -523,6 +523,13 @@ exports.change_state = (function () {
         prevent_next = true;
     };
 
+    // this is for cases where we are leaving the state of the subs, and we don't
+    // want a hashchange prevent value from the last session leaking into the
+    // new session.
+    func.reset_state = function () {
+      prevent_next = false;
+    };
+
     return func;
 }());
 
@@ -547,6 +554,7 @@ exports.launch = function (hash) {
 exports.close = function () {
     hashchange.exit_overlay();
     subs.remove_miscategorized_streams();
+    exports.change_state.reset_state();
 };
 
 exports.switch_rows = function (event) {


### PR DESCRIPTION
This fixes the styling for the error  where when a user is
not subscribed to a stream that they are trying to write to.

Fixes: #7058.

<img width="542" alt="screen shot 2017-10-18 at 12 24 18 pm" src="https://user-images.githubusercontent.com/10321399/31738372-4bf81032-b3ff-11e7-8e16-13207923b24b.png">


This also directs them to the particular stream to subscribe to in the streams page rather than to `#streams/all`.