### PR TITLE
/help/: Reduce margin-top for closer anchoring.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -187,9 +187,19 @@ body {
 .markdown h4[id]:before {
     display: block;
     content: " ";
-    margin-top: -40px;
-    height: 40px;
     visibility: hidden;
+}
+
+.markdown h1[id]:before {
+    margin-top: -30px;
+    height: 30px;
+}
+
+.markdown h2[id]:before,
+.markdown h3[id]:before,
+.markdown h4[id]:before {
+    margin-top: -10px;
+    height: 10px;
 }
 
 .markdown ul,


### PR DESCRIPTION
This lowers the amount of margin in the :before hack that we use
to put padding before anchored elements from 40px to 30px on <h1>
tags and 10px on everything else, which seems to be plenty.

Fixes: #7069.