### PR TITLE
tests: Move queue publishing call sites to call real consume method.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1083,7 +1083,7 @@ def do_send_messages(messages_maybe_none):
                 'message_content': message['message'].content,
                 'message_realm_id': message['realm'].id,
                 'urls': links_for_embed}
-            queue_json_publish('embed_links', event_data, lambda x: None)
+            queue_json_publish('embed_links', event_data, lambda x: None, call_consume_in_tests=True)
 
         if (settings.ENABLE_FEEDBACK and settings.FEEDBACK_BOT and
                 message['message'].recipient.type == Recipient.PERSONAL):

--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -59,7 +59,7 @@ def queue_digest_recipient(user_profile, cutoff):
     # Convert cutoff to epoch seconds for transit.
     event = {"user_profile_id": user_profile.id,
              "cutoff": cutoff.strftime('%s')}
-    queue_json_publish("digest_emails", event, lambda event: None)
+    queue_json_publish("digest_emails", event, lambda event: None, call_consume_in_tests=True)
 
 def enqueue_emails(cutoff):
     # type: (datetime.datetime) -> None

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -384,6 +384,7 @@ def mirror_email_message(data):
             "message": data['msg_text'],
             "rcpt_to": rcpt_to
         },
-        lambda x: None
+        lambda x: None,
+        call_consume_in_tests=True
     )
     return {"status": "success"}

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -353,7 +353,7 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile, missed_messages, m
         'from_address': from_address,
         'reply_to_email': formataddr((reply_to_name, reply_to_address)),
         'context': context}
-    queue_json_publish("missedmessage_email_senders", email_dict, send_email_from_dict)
+    queue_json_publish("missedmessage_email_senders", email_dict, send_email_from_dict, call_consume_in_tests=True)
 
     user_profile.last_reminder = timezone_now()
     user_profile.save(update_fields=['last_reminder'])

--- a/zerver/logging_handlers.py
+++ b/zerver/logging_handlers.py
@@ -107,7 +107,7 @@ class AdminZulipHandler(logging.Handler):
                 queue_json_publish('error_reports', dict(
                     type = "server",
                     report = report,
-                ), lambda x: None)
+                ), lambda x: None, call_consume_in_tests=True)
         except Exception:
             # If this breaks, complain loudly but don't pass the traceback up the stream
             # However, we *don't* want to use logging.exception since that could trigger a loop.

--- a/zerver/management/commands/enqueue_file.py
+++ b/zerver/management/commands/enqueue_file.py
@@ -57,4 +57,4 @@ You can use "-" to represent stdin.
             # Verify that payload is valid json.
             data = ujson.loads(payload)
 
-            queue_json_publish(queue_name, data, error)
+            queue_json_publish(queue_name, data, error, call_consume_in_tests=True)

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -208,7 +208,7 @@ def write_log_line(log_data, path, method, remote_ip, email, client_name,
         logger.info(logger_line)
 
     if (is_slow_query(time_delta, path)):
-        queue_json_publish("slow_queries", "%s (%s)" % (logger_line, email), lambda e: None)
+        queue_json_publish("slow_queries", "%s (%s)" % (logger_line, email), lambda e: None, call_consume_in_tests=True)
 
     if settings.PROFILE_ALL_REQUESTS:
         log_data["prof"].disable()

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -530,8 +530,8 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
             mail_template = template_file.read()
         mail = mail_template.format(stream_to_address=to_address, sender=sender)
 
-        def check_queue_json_publish(queue_name, event, processor):
-            # type: (str, Union[Mapping[str, Any], str], Callable[[Any], None]) -> None
+        def check_queue_json_publish(queue_name, event, processor, call_consume_in_tests):
+            # type: (str, Union[Mapping[str, Any], str], Callable[[Any], None], bool) -> None
             self.assertEqual(queue_name, "email_mirror")
             self.assertEqual(event, {"rcpt_to": to_address, "message": mail})
 

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -1130,7 +1130,7 @@ def update_message_backend(request, user_profile,
             # `render_incoming_message` call earlier in this function.
             'message_realm_id': user_profile.realm_id,
             'urls': links_for_embed}
-        queue_json_publish('embed_links', event_data, lambda x: None)
+        queue_json_publish('embed_links', event_data, lambda x: None, call_consume_in_tests=True)
     return json_success()
 
 

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -128,6 +128,6 @@ def report_error(request, user_profile, message=REQ(), stacktrace=REQ(),
             log = log,
             more_info = more_info,
         )
-    ), lambda x: None)
+    ), lambda x: None, call_consume_in_tests=True)
 
     return json_success()

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -418,7 +418,7 @@ class MessageSenderWorker(QueueProcessingWorker):
         self.redis_client.hmset(redis_key, {'status': 'complete',
                                             'response': resp_content})
 
-        queue_json_publish(server_meta['return_queue'], result, lambda e: None)
+        queue_json_publish(server_meta['return_queue'], result, lambda e: None, call_consume_in_tests=True)
 
 @assign_queue('digest_emails')
 class DigestWorker(QueueProcessingWorker):


### PR DESCRIPTION
`tests: Call real consume method of queue processors.` is for 
> (1) move all the publish call sites that we can do easily,
---
`tests: Enable call_consume_in_tests for email mirror queue.` deals with a case that is not perfectly straightforward. The tests for `email_mirror` mock out the queue processor, making it ultimately irrelevant if `call_consume_on_tests` is set. I see usefulness in this commit since we might change these tests or add new ones, and since we are planning on making the `True` value the default anyway.

The same goes for the service bot queue call - the respective commit is in the embedded bot UI PR, it can be merged independently. Can you cherry-pick it?
 https://github.com/zulip/zulip/pull/6927/commits/20712e99ff427df9015ac048ba9acd405c961435

---
For other queue_json_publish calls, I encountered a variety of hazzles:

* actions.py, `queue_json_publish("signups",...)`: Calling the real consume here fails for some signup test that asserts the query calls. We should be able to just change the respective value.
```
    def test_register(self):
        # type: () -> None
        realm = get_realm("zulip")
        stream_dict = {"stream_"+str(i): {"description": "stream_%s_description" % i, "invite_only": False}
                       for i in range(40)}  # type: Dict[Text, Dict[Text, Any]]
        for stream_name in stream_dict.keys():
            self.make_stream(stream_name, realm=realm)

        set_default_streams(realm, stream_dict)
        # Clear all the caches.
        flush_per_request_caches()
        ContentType.objects.clear_cache()
        Site.objects.clear_cache()

        with queries_captured() as queries:
            self.register(self.nonreg_email('test'), "test")
        # Ensure the number of queries we make is not O(streams)
        self.assert_length(queries, 68) # <<<<<<<<<<<<<<<<<<<<<<< This is incremented by 1!
        user_profile = self.nonreg_user('test')
        self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
        self.assertFalse(user_profile.enable_stream_desktop_notifications)
```

* queue.py: Updating the `retry_event()` method leads to problems in multiple tests. One of them is `test_end_to_end_connection_error` in `test_push_notifications.py`:
```python
    def test_end_to_end_connection_error(self):
         ...
        with self.settings(PUSH_NOTIFICATION_BOUNCER_URL=''), \
                mock.patch('zerver.lib.push_notifications.requests.request',
                           side_effect=self.bounce_request), \
                mock.patch('zerver.lib.push_notifications.gcm') as mock_gcm, \
                mock.patch('zerver.lib.push_notifications.send_notifications_to_bouncer',
                           side_effect=requests.ConnectionError), \
                mock.patch('zerver.lib.queue.queue_json_publish',
                           side_effect=retry) as mock_retry, \
                mock.patch('logging.warning') as mock_warn:
            gcm_devices = [
                (apn.b64_to_hex(device.token), device.ios_app_id, device.token)
                for device in RemotePushDeviceToken.objects.filter(
                    kind=PushDeviceToken.GCM)
            ]
            mock_gcm.json_request.return_value = {
                'success': {gcm_devices[0][2]: message.id}}
            apn.handle_push_notification(self.user_profile.id, missed_message)
            self.assertEqual(mock_retry.call_count, 3) <<<<<<<<<<<<<<<<<<<<< This is only 1!
            mock_warn.assert_called_with("Maximum retries exceeded for "
                                         "trigger:%s event:"
                                         "push_notification" % (self.user_profile.id,))
```
I haven't yet figured out why calling consume here leads to `mock_retry` being only called once (we mock it, so it should behave just fine?). I think however, that we probably want to replace most of the heavy mocking here with the actual functions?

* everything in `tornado/`. Tornado is not running during the test suites, so I assume that's why any update here to `call_consume_on_tests` fails?

* Finally, we got large amounts of tests that mock out `queue_json_publish`. Since the code behaves more realistically now during tests, we probably want to reconsider each of these mocks.