### PR TITLE
popover: Pass value of is_active to userlist popover.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -448,6 +448,7 @@ exports.register_click_handlers = function () {
             pm_with_uri: narrow.pm_with_uri(user_email),
             sent_by_uri: narrow.by_sender_uri(user_email),
             private_message_class: "compose_private_message",
+            is_active: people.realm_user_is_active_human(user.user_id),
         };
 
         target.popover({


### PR DESCRIPTION
This was left out in 4f088292eef2d500221c060955652ca2b06ceadb
@timabbott  @brockwhittaker