### PR TITLE
notifications: Remove test for "webkit" in userAgent.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -471,7 +471,11 @@ function should_send_audible_notification(message) {
 }
 
 exports.granted_desktop_notifications_permission = function () {
-    return browser_desktop_notifications_on();
+    return (notifications_api &&
+            // 0 is PERMISSION_ALLOWED
+            notifications_api.checkPermission() === 0) ||
+        // window.bridge is the legacy desktop app
+        (window.bridge !== undefined);
 };
 
 


### PR DESCRIPTION
This removes a test for "webkit" in the userAgent string in order
to see whether notifications should be displayed. This is so that
the notifications process will work correctly in Firefox and not
keep registering as "false" which makes the notifications prompt
continue to re-show itself.