### PR TITLE
sidebars: Move arrows and unread counts away from scrollbars.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -367,13 +367,11 @@ li.topic-list-item {
 li.show-more-private-messages,
 li.expanded_private_message {
     position: relative;
-    padding-left: 24px;
-    padding-bottom: 1px;
-    padding-top: 2px;
+    padding: 1px 0px 1px 24px;
 }
 
 li.expanded_private_message a {
-    margin-top: 3px;
+    margin: 2px 0px;
 }
 
 .show-all-streams a {

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -189,7 +189,7 @@ li.hidden-filter {
 }
 
 #global_filters .count {
-    margin-right: 15px;
+    margin-right: 20px;
     margin-top: 2px;
     display: none;
 
@@ -197,7 +197,7 @@ li.hidden-filter {
 }
 
 #stream_filters .count {
-    margin-right: 10px;
+    margin-right: 15px;
 }
 
 .topic-box {
@@ -231,12 +231,12 @@ li.hidden-filter {
 }
 
 .topic-unread-count {
-    right: 25px;
+    right: 30px;
     top: 2px;
 }
 
 .private_message_count {
-    right: 15px;
+    right: 20px;
 }
 
 ul.filters i {
@@ -249,7 +249,7 @@ ul.filters i {
 ul.filters .arrow {
     position: absolute;
     top: 2px;
-    right: 5px;
+    right: 10px;
     font-size: 0.8em;
     display: none;
 }

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -104,7 +104,7 @@
 }
 
 .user_sidebar_entry .selectable_sidebar_block {
-    width: 218px;
+    width: 208px;
     display: block;
 }
 
@@ -146,7 +146,7 @@
 .user_sidebar_entry .count,
 .group-pms-sidebar-entry .count {
     position: absolute;
-    right: 24px;
+    right: 29px;
     top: 4px;
     padding: 1px 4px 2px 4px;
     background: hsl(105, 2%, 50%);
@@ -160,7 +160,7 @@
 }
 
 .group-pms-sidebar-entry .count {
-    right: 24px;
+    right: 29px;
 }
 
 .user_sidebar_entry .count,


### PR DESCRIPTION
The arrows were too close to the scrollbars that it would be
difficult to click them sometimes. This moves over the arrows and
unread counts to combat the issue.