### PR TITLE
[WIP] Message Edit hotkeys: fix Firebox bug: ESC removes message feed focus

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -166,6 +166,9 @@ exports.process_escape_key = function (e) {
     }
 
     if (message_edit.is_editing(current_msg_list.selected_id())) {
+        // Using this definition of "row" instead of "current_msg_list.selected_row()"
+        // because it returns a more complete object.
+        // Necessary for refocusing on message list.
         row = $(".message_edit_content").filter(":focus").closest(".message_row");
         row.find('.message_edit_content').blur();
         message_edit.end(row);

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -166,7 +166,9 @@ exports.process_escape_key = function (e) {
     }
 
     if (message_edit.is_editing(current_msg_list.selected_id())) {
-        message_edit.end(current_msg_list.selected_row());
+        row = $(".message_edit_content").filter(":focus").closest(".message_row");
+        row.find('.message_edit_content').blur();
+        message_edit.end(row);
         return true;
     }
 


### PR DESCRIPTION
We correct a bug on Firefox where using the ESC key to close
an edit box that was opened by the left arrow key
caused the message feed to lose focus,
making it difficult to navigate the message feed by keyboard.

We fix this bug by changing the function that handles the ESC key
during an edit to pass the correct object to the
message_edit.end function.

Fixes: #7072