### PR TITLE
refactoring: replaced mkdir_p methods copies

### DIFF
--- a/scripts/lib/upgrade-zulip
+++ b/scripts/lib/upgrade-zulip
@@ -10,7 +10,7 @@ os.environ["PYTHONUNBUFFERED"] = "y"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, \
-    mkdir_p, su_to_zulip, get_deployment_lock, release_deployment_lock
+    su_to_zulip, get_deployment_lock, release_deployment_lock
 
 logging.basicConfig(format="%(asctime)s upgrade-zulip: %(message)s",
                     level=logging.INFO)
@@ -34,7 +34,7 @@ try:
     # we can unpack using the Zulip user even if the original path was
     # not readable by the Zulip user.
     logging.info("Archiving the tarball under %s" % (TARBALL_ARCHIVE_PATH,))
-    mkdir_p(TARBALL_ARCHIVE_PATH)
+    os.makedirs(TARBALL_ARCHIVE_PATH, exist_ok=True)
     archived_tarball_path = os.path.join(TARBALL_ARCHIVE_PATH, os.path.basename(tarball_path))
     shutil.copy(tarball_path, archived_tarball_path)
     subprocess.check_output(["chown", "-R", "zulip:zulip", TARBALL_ARCHIVE_PATH])

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -100,17 +100,6 @@ if __name__ == '__main__':
     if cmd == 'make_deploy_path':
         print(make_deploy_path())
 
-def mkdir_p(path):
-    # type: (str) -> None
-    # Python doesn't have an analog to `mkdir -p` < Python 3.2.
-    try:
-        os.makedirs(path)
-    except OSError as e:
-        if e.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
-
 def get_dev_uuid_var_path(create_if_missing=False):
     # type: (bool) -> str
     zulip_path = os.path.realpath(os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))))
@@ -129,7 +118,7 @@ def get_dev_uuid_var_path(create_if_missing=False):
             raise AssertionError("Missing UUID file; please run tools/provision!")
 
     result_path = os.path.join(zulip_path, "var", zulip_uuid)
-    mkdir_p(result_path)
+    os.makedirs(result_path, exist_ok=True)
     return result_path
 
 def get_deployment_lock(error_rerun_script):

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -23,7 +23,6 @@ from zerver.models import UserProfile, Realm, Client, Huddle, Stream, \
     UserPresence, UserActivity, UserActivityInterval, \
     get_display_recipient, Attachment, get_system_bot
 from zerver.lib.parallel import run_parallel
-from zerver.lib.utils import mkdir_p
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 # Custom mypy types follow:
@@ -940,7 +939,7 @@ def export_uploads_from_local(realm, local_dir, output_dir):
     for attachment in Attachment.objects.filter(realm_id=realm.id):
         local_path = os.path.join(local_dir, attachment.path_id)
         output_path = os.path.join(output_dir, attachment.path_id)
-        mkdir_p(os.path.dirname(output_path))
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
         subprocess.check_call(["cp", "-a", local_path, output_path])
         stat = os.stat(local_path)
         record = dict(realm_id=attachment.realm_id,
@@ -984,7 +983,7 @@ def export_avatars_from_local(realm, local_dir, output_dir):
                 user.email, local_path))
             fn = os.path.relpath(local_path, local_dir)
             output_path = os.path.join(output_dir, fn)
-            mkdir_p(str(os.path.dirname(output_path)))
+            os.makedirs(str(os.path.dirname(output_path)), exist_ok=True)
             subprocess.check_call(["cp", "-a", str(local_path), str(output_path)])
             stat = os.stat(local_path)
             record = dict(realm_id=realm.id,

--- a/zerver/lib/utils.py
+++ b/zerver/lib/utils.py
@@ -116,17 +116,6 @@ def generate_random_token(length):
     # type: (int) -> str
     return str(base64.b16encode(os.urandom(length // 2)).decode('utf-8').lower())
 
-def mkdir_p(path):
-    # type: (str) -> None
-    # Python doesn't have an analog to `mkdir -p` < Python 3.2.
-    try:
-        os.makedirs(path)
-    except OSError as e:
-        if e.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
-
 def query_chunker(queries, id_collector=None, chunk_size=1000, db_chunk_size=None):
     # type: (List[Any], Set[int], int, int) -> Iterable[Any]
     '''

--- a/zerver/tests/test_export.py
+++ b/zerver/tests/test_export.py
@@ -23,7 +23,6 @@ from zerver.lib.upload import (
     upload_message_image,
 )
 from zerver.lib.utils import (
-    mkdir_p,
     query_chunker,
 )
 from zerver.lib.test_classes import (
@@ -185,7 +184,7 @@ class ExportTest(ZulipTestCase):
         # type: () -> str
         output_dir = 'var/test-export'
         rm_tree(output_dir)
-        mkdir_p(output_dir)
+        os.makedirs(output_dir, exist_ok=True)
         return output_dir
 
     def _export_realm(self, realm, exportable_user_ids=None):


### PR DESCRIPTION
replaced mkdir_p methods copies with system library os.makedirs method
-> os.makedirs(path, exist_ok=True)

It will create the desired directory and does not raise exception if the
directory exists.

edited files:
    scripts/lib/upgrade-zulip
    scripts/lib/zulip_tools.py
    zerver/lib/export.py
    zerver/tests/test_export.py

Fix: #7082
