### PR TITLE
notification-banner: Check if mobile before displaying.

### DIFF
--- a/static/js/desktop_notifications_panel.js
+++ b/static/js/desktop_notifications_panel.js
@@ -24,6 +24,10 @@ exports.initialize = function () {
     var ls = localstorage();
 
     var should_show_notifications = (
+        // notifications *basically* don't work on any mobile platforms, so don't
+        // event show the banners. This prevents trying to access things that
+        // don't exist like `Notification.permission`.
+        !util.is_mobile() &&
         // if the user said to never show banner on this computer again, it will
         // be stored as `true` so we want to negate that.
         !ls.get("dontAskForNotifications") &&


### PR DESCRIPTION
Notifications essentially don't work on any mobile web clients,
so don't even show the banner.

This also fixes a traceback where it checks the permission state
with `notifications.permission_state()`, which calls
`Notification.permission`, which will error due to `Notification`
not existing on mobile devices.

Fixes: #7105.