### PR TITLE
Draft support for per-subdomain alternative hosts.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -146,6 +146,7 @@ Contents:
    emoji
    hotspots
    full-text-search
+   oauth
    email
    analytics
    translating

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,51 @@
+# Google & GitHub authentication with OAuth 2
+
+Among the many [authentication methods](prod-authentication-methods.html)
+we support, a server can be configured to allow users to sign in with
+their Google accounts or GitHub accounts, using the OAuth protocol.
+
+## Testing OAuth in development
+
+Because these authentication methods involve an interaction between
+Zulip, an external service, and the user's browser, and particularly
+because browsers can (rightly!) be picky about the identity of sites
+you interact with, the preferred way to set them up in a development
+environment is to set up the real Google and GitHub to process auth
+requests for your development environment.
+
+The steps to do this are a variation of the steps documented in
+`prod_settings_template.py`. Here are the full procedures for dev:
+
+### Google
+
+* Visit https://console.developers.google.com, click on Credentials on
+the left sidebar and create a Oauth2 client ID that allows redirects
+to `https://localhost:9991/accounts/login/google/done/`.
+
+* Go to the Library (left sidebar), then under "Social APIs" click on
+"Google+ API" and click the button to enable the API.
+
+* Uncomment `'zproject.backends.GoogleMobileOauth2Backend'` in
+`AUTHENTICATION_BACKENDS` in `dev_settings.py`.
+
+* Uncomment `GOOGLE_OAUTH2_CLIENT_ID` in `prod_settings_template.py` &
+assign it the Client ID you got from Google.
+
+* Put the Client Secret you got from Google as
+`google_oauth2_client_secret` in `dev-secrets.conf`.
+
+### GitHub
+
+* Register an OAuth2 application with GitHub at one of
+https://github.com/settings/developers or
+https://github.com/organizations/ORGNAME/settings/developers.
+Specify `http://localhost:9991/complete/github/` as the callback URL.
+
+* Uncomment `'zproject.backends.GitHubAuthBackend'` in
+`AUTHENTICATION_BACKENDS` in `dev_settings.py`.
+
+* Uncomment `SOCIAL_AUTH_GITHUB_KEY` in `prod_settings_template.py` &
+assign it the Client ID you got from GitHub.
+
+* Put the Client Secret you got from GitHub as
+`social_auth_github_secret` in `dev-secrets.conf`.

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -18,34 +18,37 @@ The steps to do this are a variation of the steps documented in
 
 ### Google
 
-* Visit https://console.developers.google.com, click on Credentials on
-the left sidebar and create a Oauth2 client ID that allows redirects
-to `https://localhost:9991/accounts/login/google/done/`.
+* Visit https://console.developers.google.com and navigate to "APIs &
+  services" > "Credentials".  Create a "Project" which will correspond
+  to your dev environment.
 
-* Go to the Library (left sidebar), then under "Social APIs" click on
-"Google+ API" and click the button to enable the API.
+* Navigate to "APIs & services" > "Library", and find the "Google+
+  API".  Choose "Enable".
+
+* Return to "Credentials", and select "Create credentials".  Choose
+  "OAuth client ID", and follow prompts to create a consent screen, etc.
+  For "Authorized redirect URIs", fill in
+  `https://zulipdev.com:9991/accounts/login/google/done/` .
+
+* You should get a client ID and a client secret. Copy them. In
+  `dev_settings.py`, set `GOOGLE_OAUTH2_CLIENT_ID` to the client ID,
+  and in `dev-secrets.conf`, set `google_oauth2_client_secret` to the
+  client secret.
 
 * Uncomment `'zproject.backends.GoogleMobileOauth2Backend'` in
-`AUTHENTICATION_BACKENDS` in `dev_settings.py`.
-
-* Uncomment `GOOGLE_OAUTH2_CLIENT_ID` in `prod_settings_template.py` &
-assign it the Client ID you got from Google.
-
-* Put the Client Secret you got from Google as
-`google_oauth2_client_secret` in `dev-secrets.conf`.
+  `AUTHENTICATION_BACKENDS` in `dev_settings.py`.
 
 ### GitHub
 
 * Register an OAuth2 application with GitHub at one of
-https://github.com/settings/developers or
-https://github.com/organizations/ORGNAME/settings/developers.
-Specify `http://localhost:9991/complete/github/` as the callback URL.
+  https://github.com/settings/developers or
+  https://github.com/organizations/ORGNAME/settings/developers.
+  Specify `http://zulipdev.com:9991/complete/github/` as the callback URL.
+
+* You should get a page with settings for your new application,
+  showing a client ID and a client secret.  In `dev_settings.py`, set
+  `SOCIAL_AUTH_GITHUB_KEY` to the client ID, and in
+  `dev-secrets.conf`, set `social_auth_github_secret` to the client secret.
 
 * Uncomment `'zproject.backends.GitHubAuthBackend'` in
-`AUTHENTICATION_BACKENDS` in `dev_settings.py`.
-
-* Uncomment `SOCIAL_AUTH_GITHUB_KEY` in `prod_settings_template.py` &
-assign it the Client ID you got from GitHub.
-
-* Put the Client Secret you got from GitHub as
-`social_auth_github_secret` in `dev-secrets.conf`.
+  `AUTHENTICATION_BACKENDS` in `dev_settings.py`.

--- a/docs/prod-install.md
+++ b/docs/prod-install.md
@@ -76,12 +76,10 @@ Configure the Zulip server instance by editing `/etc/zulip/settings.py` and
 providing values for the mandatory settings, which are all found under the
 heading `### MANDATORY SETTINGS`.  These settings include:
 
-- `EXTERNAL_HOST`: the user-accessible Zulip domain name for your
+- `EXTERNAL_HOST`: the user-accessible domain name for your
   Zulip installation (i.e., what users will type in their web
   browser). This should of course match the DNS name you configured to
   point to your server and for which you configured SSL certificates.
-  If you plan to use multiple domains, add the others to
-  `ALLOWED_HOSTS`.
 
 - `ZULIP_ADMINISTRATOR`: the email address of the person or team
   maintaining this installation and who will get support and error

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -112,48 +112,7 @@ maximize convenience of testing all of Zulip's features; they should
 be enabled by default in production if we expect most Zulip sites to
 want those settings.
 
-#### Testing Google & GitHub authentication
-
-In order to set up Google or GitHub authentication in the development
-environment, you'll have to go through the steps detailed in
-`prod_settings_template.py` with some changes. Here is the full
-procedure:
-
-##### Google
-
-* Visit https://console.developers.google.com, click on Credentials on
-the left sidebar and create a Oauth2 client ID that allows redirects
-to `https://localhost:9991/accounts/login/google/done/`.
-
-* Go to the Library (left sidebar), then under "Social APIs" click on
-"Google+ API" and click the button to enable the API.
-
-* Uncomment `'zproject.backends.GoogleMobileOauth2Backend'` in
-`AUTHENTICATION_BACKENDS` in `dev_settings.py`.
-
-* Uncomment `GOOGLE_OAUTH2_CLIENT_ID` in `prod_settings_template.py` &
-assign it the Client ID you got from Google.
-
-* Put the Client Secret you got from Google as
-`google_oauth2_client_secret` in `dev-secrets.conf`.
-
-##### GitHub
-
-* Register an OAuth2 application with GitHub at one of
-https://github.com/settings/developers or
-https://github.com/organizations/ORGNAME/settings/developers.
-Specify `http://localhost:9991/complete/github/` as the callback URL.
-
-* Uncomment `'zproject.backends.GitHubAuthBackend'` in
-`AUTHENTICATION_BACKENDS` in `dev_settings.py`.
-
-* Uncomment `SOCIAL_AUTH_GITHUB_KEY` in `prod_settings_template.py` &
-assign it the Client ID you got from GitHub.
-
-* Put the Client Secret you got from GitHub as
-`social_auth_github_secret` in `dev-secrets.conf`.
-
-#### Testing non-default settings
+### Testing non-default settings
 
 You can write tests for settings using e.g. `with
 self.settings(GOOGLE_CLIENT_ID=None)`.  However, this only works for

--- a/templates/zerver/integrations/hubot.md
+++ b/templates/zerver/integrations/hubot.md
@@ -15,7 +15,7 @@
    variables by running:
 
 ```
-export HUBOT_ZULIP_SITE="{{ api_url_scheme_relative }}"
+export HUBOT_ZULIP_SITE="{{ api_url }}"
 export HUBOT_ZULIP_BOT="hubot-bot@example.com"
 export HUBOT_ZULIP_API_KEY="your_key"
 ```

--- a/templates/zerver/integrations/redmine.md
+++ b/templates/zerver/integrations/redmine.md
@@ -39,9 +39,10 @@ you want these settings to apply.
 To configure Zulip notifications for a particular Redmine project,
 visit the project's **Settings** page.
 
-In either case, fill out zulip server by `{{ api_url_scheme_relative }}`
-the bot email address, and API key, and the Zulip stream that should
-receive notifications. Apply your changes.
+In either case, fill out the settings with the Zulip server
+(`{{ api_url_scheme_relative }}`), the bot's email address and API key,
+and the Zulip stream that should receive notifications, and apply your
+changes.
 
 To test the plugin, create an issue or update an existing issue
 in a Redmine project that has Zulip notifications configured (any

--- a/zerver/lib/subdomains.py
+++ b/zerver/lib/subdomains.py
@@ -17,10 +17,10 @@ def get_subdomain(request):
     # X-Forwarded-Host, it passes right through the same way.  So our
     # logic is a bit complicated to allow for that variation.
     #
-    # For EXTERNAL_HOST, we take a missing port to mean that any port
-    # should be accepted in Host.  It's not totally clear that's the
-    # right behavior, but it keeps compatibility with older versions
-    # of Zulip, so that's a start.
+    # For both EXTERNAL_HOST and REALM_HOSTS, we take a missing port
+    # to mean that any port should be accepted in Host.  It's not
+    # totally clear that's the right behavior, but it keeps
+    # compatibility with older versions of Zulip, so that's a start.
 
     host = request.get_host().lower()
 
@@ -31,6 +31,11 @@ def get_subdomain(request):
         if subdomain in settings.ROOT_SUBDOMAIN_ALIASES:
             return Realm.SUBDOMAIN_FOR_ROOT_DOMAIN
         return subdomain
+
+    for subdomain, realm_host in settings.REALM_HOSTS.items():
+        if re.search('^%s(:\d+)?$' % (realm_host,),
+                     host):
+            return subdomain
 
     return Realm.SUBDOMAIN_FOR_ROOT_DOMAIN
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -280,9 +280,10 @@ class Realm(models.Model):
     @staticmethod
     def host_for_subdomain(subdomain):
         # type: (str) -> str
-        if subdomain not in [None, ""]:
-            return "%s.%s" % (subdomain, settings.EXTERNAL_HOST)
-        return settings.EXTERNAL_HOST
+        if subdomain == Realm.SUBDOMAIN_FOR_ROOT_DOMAIN:
+            return settings.EXTERNAL_HOST
+        default_host = "%s.%s" % (subdomain, settings.EXTERNAL_HOST)
+        return settings.REALM_HOSTS.get(subdomain, default_host)
 
     @property
     def is_zephyr_mirror_realm(self):

--- a/zerver/tests/test_subdomains.py
+++ b/zerver/tests/test_subdomains.py
@@ -1,6 +1,6 @@
 
 import mock
-from typing import Any, List
+from typing import Any, Dict, List
 
 from django.test import TestCase, override_settings
 
@@ -18,9 +18,10 @@ class SubdomainsTest(TestCase):
             return request
 
         def test(expected, host, *, plusport=True,
-                 external_host='example.org', root_aliases=[]):
-            # type: (str, str, bool, str, List[str]) -> None
+                 external_host='example.org', realm_hosts={}, root_aliases=[]):
+            # type: (str, str, bool, str, Dict[str, str], List[str]) -> None
             with self.settings(EXTERNAL_HOST=external_host,
+                               REALM_HOSTS=realm_hosts,
                                ROOT_SUBDOMAIN_ALIASES=root_aliases):
                 self.assertEqual(get_subdomain(request_mock(host)), expected)
                 if plusport and ':' not in host:
@@ -38,11 +39,18 @@ class SubdomainsTest(TestCase):
         test(ROOT, 'arbitrary.com')
         test(ROOT, 'foo.example.org.evil.com')
 
-        # Any port is fine in Host if there's none in EXTERNAL_HOST
+        # REALM_HOSTS adds a name,
+        test('bar', 'chat.barbar.com', realm_hosts={'bar': 'chat.barbar.com'})
+        # ... exactly, ...
+        test(ROOT, 'surchat.barbar.com', realm_hosts={'bar': 'chat.barbar.com'})
+        test(ROOT, 'foo.chat.barbar.com', realm_hosts={'bar': 'chat.barbar.com'})
+        # ... and leaves the subdomain in place too.
+        test('bar', 'bar.example.org', realm_hosts={'bar': 'chat.barbar.com'})
+
+        # Any port is fine in Host if there's none in EXTERNAL_HOST, ...
         test('foo', 'foo.example.org:443', external_host='example.org')
         test('foo', 'foo.example.org:12345', external_host='example.org')
-
-        # Explicit port in EXTERNAL_HOST must be explicitly matched in Host
+        # ... but an explicit port in EXTERNAL_HOST must be explicitly matched in Host.
         test(ROOT, 'foo.example.org', external_host='example.org:12345')
         test(ROOT, 'foo.example.org', external_host='example.org:443', plusport=False)
         test('foo', 'foo.example.org:443', external_host='example.org:443')

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -19,22 +19,6 @@ from typing import Optional
 # EXTERNAL_HOST to e.g. zulip.example.com:1234 here.
 EXTERNAL_HOST = 'zulip.example.com'
 
-# A comma-separated list of strings representing the host/domain names
-# that your users will enter in their browsers to access your Zulip
-# server. This is a security measure to prevent an attacker from
-# poisoning caches and triggering password reset emails with links to
-# malicious hosts by submitting requests with a fake HTTP Host
-# header. See Django's documentation here:
-# <https://docs.djangoproject.com/en/1.9/ref/settings/#allowed-hosts>.
-# Zulip adds 'localhost' and '127.0.0.1' to the list automatically.
-#
-# The default should work unless you are using multiple hostnames or
-# connecting directly to your server's IP address.  If this is set
-# wrong, all requests will get a 400 "Bad Request" error.
-#
-# Note that these should just be hostnames, without port numbers.
-ALLOWED_HOSTS = [EXTERNAL_HOST.split(":")[0]]
-
 # The email address for the person or team who maintains the Zulip
 # installation. Note that this is a public-facing email address; it may
 # appear on 404 pages, is used as the sender's address for many automated
@@ -87,6 +71,18 @@ EMAIL_USE_TLS = True
 # this setting.
 # The address should have no newlines.
 #PHYSICAL_ADDRESS = ''
+
+# A comma-separated list of strings representing the host/domain names
+# that your users can enter in their browsers to access Zulip.
+# This is a security measure; for details, see the Django documentation:
+# https://docs.djangoproject.com/en/1.11/ref/settings/#allowed-hosts
+#
+# Zulip automatically adds to this list 'localhost', '127.0.0.1', and
+# patterns representing EXTERNAL_HOST and subdomains of it.  If you are
+# accessing your server by other hostnames, list them here.
+#
+# Note that these should just be hostnames, without port numbers.
+#ALLOWED_HOSTS = ['zulip-alias.example.com']
 
 ### AUTHENTICATION SETTINGS
 #

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -97,38 +97,47 @@ AUTHENTICATION_BACKENDS = (
     # 'zproject.backends.ZulipRemoteUserBackend',  # Local SSO, setup docs on readthedocs
 )
 
-# To enable Google authentication, you need to do the following:
+# To set up Google authentication, you'll need to do the following:
 #
-# (1) Visit https://console.developers.google.com, click on Credentials on
-# the left sidebar and create a Oauth2 client ID
-# e.g. https://zulip.example.com/accounts/login/google/done/.
+# (1) Visit https://console.developers.google.com/ , navigate to
+# "APIs & Services" > "Credentials", and create a "Project" which will
+# correspond to your Zulip instance.
 #
-# (2) Go to the Library (left sidebar), then under "Social APIs" click on
-# "Google+ API" and click the button to enable the API.
+# (2) Navigate to "APIs & services" > "Library", and find the
+# "Google+ API".  Choose "Enable".
 #
-# (3) put your client secret as "google_oauth2_client_secret" in
-# zulip-secrets.conf, and your client ID right here:
-# GOOGLE_OAUTH2_CLIENT_ID=<your client ID from Google>
+# (3) Return to "Credentials", and select "Create credentials".
+# Choose "OAuth client ID", and follow prompts to create a consent
+# screen.  Fill in "Authorized redirect URIs" with a value like
+#   https://zulip.example.com/accounts/login/google/done/
+# based on your value for EXTERNAL_HOST.
+#
+# (4) You should get a client ID and a client secret. Copy them.
+# Use the client ID as `GOOGLE_OAUTH2_CLIENT_ID` here, and put the
+# client secret in zulip-secrets.conf as `google_oauth2_client_secret`.
+#GOOGLE_OAUTH2_CLIENT_ID = <your client ID from Google>
 
-
-# To enable GitHub authentication, you will need to need to do the following:
+# To set up GitHub authentication, you'll need to do the following:
 #
 # (1) Register an OAuth2 application with GitHub at one of:
 #   https://github.com/settings/developers
 #   https://github.com/organizations/ORGNAME/settings/developers
-# Specify e.g. https://zulip.example.com/complete/github/ as the callback URL.
+# Fill in "Callback URL" with a value like
+#   https://zulip.example.com/complete/github/ as
+# based on your value for EXTERNAL_HOST.
 #
-# (2) Put your "Client ID" as SOCIAL_AUTH_GITHUB_KEY below and your
-# "Client secret" as social_auth_github_secret in
-# /etc/zulip/zulip-secrets.conf.
-# SOCIAL_AUTH_GITHUB_KEY = <your client ID from GitHub>
-#
-# (3) You can also configure the GitHub integration to only allow
-# members of a particular GitHub team or organization to login to your
-# Zulip server using GitHub authentication; to enable this, set one of the
-# two parameters below:
-# SOCIAL_AUTH_GITHUB_TEAM_ID = <your team id>
-# SOCIAL_AUTH_GITHUB_ORG_NAME = <your org name>
+# (2) You should get a page with settings for your new application,
+# showing a client ID and a client secret.  Use the client ID as
+# `SOCIAL_AUTH_GITHUB_KEY` here, and put the client secret in
+# zulip-secrets.conf as `social_auth_github_secret`.
+#SOCIAL_AUTH_GITHUB_KEY = <your client ID from GitHub>
+
+# (3) Optionally, you can configure the GitHub integration to only
+# allow members of a particular GitHub team or organization to log
+# into your Zulip server through GitHub authentication.  To enable
+# this, set one of the two parameters below:
+#SOCIAL_AUTH_GITHUB_TEAM_ID = <your team id>
+#SOCIAL_AUTH_GITHUB_ORG_NAME = <your org name>
 
 
 # If you are using the ZulipRemoteUserBackend authentication backend,

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -115,6 +115,9 @@ else:
 # prod_settings_template.py, and in the initial /etc/zulip/settings.py on a new
 # install of the Zulip server.
 DEFAULT_SETTINGS = {
+    # Extra HTTP "Host" values to allow (standard ones added below)
+    'ALLOWED_HOSTS': [],
+
     # Basic email settings
     'EMAIL_HOST': None,
     'NOREPLY_EMAIL_ADDRESS': "noreply@" + EXTERNAL_HOST.split(":")[0],
@@ -352,9 +355,6 @@ for setting_name, setting_val in DEFAULT_SETTINGS.items():
     if setting_name not in vars():
         vars()[setting_name] = setting_val
 
-# Extend ALLOWED_HOSTS with localhost (needed to RPC to Tornado).
-ALLOWED_HOSTS += ['127.0.0.1', 'localhost']
-
 # These are the settings that we will check that the user has filled in for
 # production deployments before starting the app.  It consists of a series
 # of pairs of (setting name, default value that it must be changed from)
@@ -408,6 +408,12 @@ DEPLOY_ROOT = os.path.join(os.path.realpath(os.path.dirname(__file__)), '..')
 DEVELOPMENT_LOG_DIRECTORY = os.path.join(DEPLOY_ROOT, 'var', 'log')
 # Make redirects work properly behind a reverse proxy
 USE_X_FORWARDED_HOST = True
+
+# Extend ALLOWED_HOSTS with localhost (needed to RPC to Tornado),
+ALLOWED_HOSTS += ['127.0.0.1', 'localhost']
+# and with hosts corresponding to EXTERNAL_HOST.
+ALLOWED_HOSTS += [EXTERNAL_HOST.split(":")[0],
+                  '.' + EXTERNAL_HOST.split(":")[0]]
 
 MIDDLEWARE = (
     # With the exception of it's dependencies,

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -245,6 +245,12 @@ DEFAULT_SETTINGS.update({
     # purpose now that the REALMS_HAVE_SUBDOMAINS migration is finished.
     'SYSTEM_ONLY_REALMS': {"zulip"},
 
+    # Alternate hostnames to serve particular realms on, in addition to
+    # their usual subdomains.  Keys are realm string_ids (aka subdomains),
+    # and values are alternate hosts.
+    # The values will also be added to ALLOWED_HOSTS.
+    'REALM_HOSTS': {},
+
     # Whether the server is using the Pgroonga full-text search
     # backend.  Plan is to turn this on for everyone after further
     # testing.
@@ -411,9 +417,11 @@ USE_X_FORWARDED_HOST = True
 
 # Extend ALLOWED_HOSTS with localhost (needed to RPC to Tornado),
 ALLOWED_HOSTS += ['127.0.0.1', 'localhost']
-# and with hosts corresponding to EXTERNAL_HOST.
+# ... with hosts corresponding to EXTERNAL_HOST,
 ALLOWED_HOSTS += [EXTERNAL_HOST.split(":")[0],
                   '.' + EXTERNAL_HOST.split(":")[0]]
+# ... and with the hosts in REALM_HOSTS.
+ALLOWED_HOSTS += REALM_HOSTS.values()
 
 MIDDLEWARE = (
     # With the exception of it's dependencies,


### PR DESCRIPTION
The first N commits here are small cleanup refactors to the subdomains code. They should be mergeable if they pass CI (branch `domain0` in my repo.)

Then there's a sketch of an implementation for allowing the admins of a server at example.org to serve one subdomain at e.g. chat.alice.org (rather than alice.example.org), another at zulip.bob.com, and so on. More work needed.
