### PR TITLE
notifications: Follow up fixes.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -99,6 +99,11 @@ exports.initialize = function () {
 };
 
 exports.permission_state = function () {
+    if (typeof Notification === "undefined") {
+        // act like notifications are blocked if they do not have access to
+        // the notification API.
+        return "denied";
+    }
     return window.Notification.permission;
 };
 

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -237,8 +237,9 @@ exports.notify_above_composebox = function (note, link_class, link_msg_id, link_
                                                                         link_msg_id: link_msg_id,
                                                                         link_text: link_text}));
     exports.clear_compose_notifications();
-    $('#out-of-view-notification').append(notification_html);
-    $('#out-of-view-notification').show();
+    var $out_of_view_notification = $('#out-of-view-notification');
+    $out_of_view_notification.append(notification_html);
+    $out_of_view_notification.show();
 };
 
 function process_notification(notification) {
@@ -606,9 +607,10 @@ exports.notify_messages_outside_current_search = function (messages) {
 };
 
 exports.clear_compose_notifications = function () {
-    $('#out-of-view-notification').empty();
-    $('#out-of-view-notification').stop(true, true);
-    $('#out-of-view-notification').hide();
+    var $out_of_view_notification = $('#out-of-view-notification');
+    $out_of_view_notification.empty();
+    $out_of_view_notification.stop(true, true);
+    $out_of_view_notification.hide();
 };
 
 $(function () {
@@ -637,20 +639,21 @@ exports.reify_message_id = function (opts) {
 };
 
 exports.register_click_handlers = function () {
-    $('#out-of-view-notification').on('click', '.compose_notification_narrow_by_subject', function (e) {
+    var $out_of_view_notification = $('#out-of-view-notification');
+    $out_of_view_notification.on('click', '.compose_notification_narrow_by_subject', function (e) {
         var msgid = $(e.currentTarget).data('msgid');
         narrow.by_subject(msgid, {trigger: 'compose_notification'});
         e.stopPropagation();
         e.preventDefault();
     });
-    $('#out-of-view-notification').on('click', '.compose_notification_scroll_to_message', function (e) {
+    $out_of_view_notification.on('click', '.compose_notification_scroll_to_message', function (e) {
         var msgid = $(e.currentTarget).data('msgid');
         current_msg_list.select_id(msgid);
         navigate.scroll_to_selected();
         e.stopPropagation();
         e.preventDefault();
     });
-    $('#out-of-view-notification').on('click', '.out-of-view-notification-close', function (e) {
+    $out_of_view_notification.on('click', '.out-of-view-notification-close', function (e) {
         exports.clear_compose_notifications();
         e.stopPropagation();
         e.preventDefault();

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -17,6 +17,7 @@ var flashing = false;
 
 var notifications_api;
 if (window.webkitNotifications) {
+    blueslip.error("The `window.webkitNotifications` object should not be used anymore.");
     notifications_api = window.webkitNotifications;
 } else if (window.Notification) {
     // Build a shim to the new notification API


### PR DESCRIPTION
1. We do not want the code to lead to a path where it will attempt to
display native notifications if the “Notification” object doesn’t
exist, as this likely means that the device does not support OS
notifications.

2. In theory, nobody should be making calls to the `webkitNotifications`
API anymore since it was deprecated a while ago, but we should make
sure before actually removing this codepath.

3. This reuses the selection of `#out-of-view-notification` instead of
re-querying multiple times.