### PR TITLE
settings: Display "Never" over "Invalid Date" for inactive users.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -145,8 +145,13 @@ function populate_users(realm_people_data) {
             } else if (presence.presence_info[item.user_id]) {
                 // XDate takes number of milliseconds since UTC epoch.
                 var last_active = presence.presence_info[item.user_id].last_active * 1000;
-                var last_active_date = new XDate(last_active);
-                activity_rendered = timerender.render_date(last_active_date, undefined, today);
+
+                if (!isNaN(last_active)) {
+                    var last_active_date = new XDate(last_active);
+                    activity_rendered = timerender.render_date(last_active_date, undefined, today);
+                } else {
+                    activity_rendered = $("<span></span>").text(i18n.t("Never"));
+                }
             } else {
                 activity_rendered = $("<span></span>").text(i18n.t("Unknown"));
             }


### PR DESCRIPTION
This shows the text "Never" for users who are part of a realm but
have never been active, rather than a more vague JavaScript output
of "Invalid Date" due to the fact that their last presence
evaluates to NaN.