### PR TITLE
integrations: Remove link underline from back arrow icon.

### DIFF
--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -121,7 +121,7 @@
 
                 <div id="integration-instructions-group">
                     <div id="integration-instruction-block" class="integration-instruction-block">
-                        <a href="/integrations" id="integration-list-link"><i class="icon-vector-circle-arrow-left"></i><span>Back to list</span></a>
+                        <a href="/integrations" id="integration-list-link" class="no-underline"><i class="icon-vector-circle-arrow-left"></i><span>Back to list</span></a>
                         <h3 class="name"></h3>
                         <div class="categories"></div>
                     </div>


### PR DESCRIPTION
Fixes #7137.