### PR TITLE
onboarding: Revise text in prompt to enable desktop notifications.

### DIFF
--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -2,14 +2,12 @@
   <div id="desktop-notifications-panel" class="alert alert-info">
     <span class="close" data-dismiss="alert" aria-label="{{ _('Close') }}">&times;</span>
     <div data-step="1">
-      {{ _('Zulip needs your permission to enable desktop notifications.') }}
-      {{ _('You can fully configure notifications in Zulip\'s Settings.') }}
-      <a class="request-desktop-notifications alert-link">
-        {{ _('Enable notifications.') }}
-      </a>
+        {% trans %}Zulip needs your permission to
+        <a class="request-desktop-notifications alert-link">enable desktop notifications.</a>
+        {% endtrans %}
     </div>
     <div data-step="2" style="display: none">
-      {{ _('We recommend allowing notifications. You can fully customize these at any time in your settings.') }}
+      {{ _('We strongly recommend enabling desktop notifications. They help Zulip keep your team connected.') }}
       <span class="buttons">
         <a class="alert-link request-desktop-notifications">{{ _('Enable notifications') }}</a>
         &bull;


### PR DESCRIPTION
Making the same point (that you can configure the notifications in
settings) at both steps felt pushy.  I think the first prompt is
actually best kept to a minimum of words, so leave that one with
just the ask.

In the second step, try an active pitch.  This could go either way, or
be any number of other messages, but the settings line felt a little
defensive to me, like it was suggesting that our notifications would
be noisy and here's a way you can try to mitigate that.  I think with
our default settings (and in an org with mostly-reasonable humans, but
even a large and busy one) they're actually not at all noisy; and if
we learn of situations where that's not true, we'll work to fix that.
So, try this line instead.

A style note: I chose "your team" here to refer to the people the user
communicates with in their organization.  We consistently say either
"organization" or sometimes "realm" for the concrete thing in the
product that is the whole universe of streams and users, etc., that a
given account lives in; but that feels too formal here.  Conversely,
one reason we don't say "team" for an organization is that it feels
too cozy and small, more appropriate for 8 people who interact every
day than for 80 or 8000 people; but this line is mainly about those
8 people even if the organization has 8000.  There are some examples
of this already in the codebase; see `git grep -w team`.

i18n note: These passages of a couple of connected sentences should
generally be marked for translation as one message, not several
separate ones.  That helps the translator be sure of the context so
they can translate appropriately.  For example, in the second prompt
in this version, there's an implicit "because" relationship between
the two sentences, and in some languages (I'm 90% sure this is true in
Japanese), it would be weird to leave it implicit and the second
sentence should contain the equivalent of "That's because".
