### PR TITLE
Allow default bots to see mentions.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -808,8 +808,8 @@ RecipientInfoResult = TypedDict('RecipientInfoResult', {
     'service_bot_tuples': List[Tuple[int, int]],
 })
 
-def get_recipient_info(recipient, sender_id, stream_topic):
-    # type: (Recipient, int, Optional[StreamTopicTarget]) -> RecipientInfoResult
+def get_recipient_info(recipient, sender_id, stream_topic, mentioned_user_ids=None):
+    # type: (Recipient, int, Optional[StreamTopicTarget], Optional[Set[int]]) -> RecipientInfoResult
     if recipient.type == Recipient.STREAM:
         # Anybody calling us w/r/t a stream message needs to supply
         # stream_topic.  We may eventually want to have different versions
@@ -855,8 +855,11 @@ def get_recipient_info(recipient, sender_id, stream_topic):
     else:
         raise ValueError('Bad recipient type')
 
-    user_ids = message_to_user_ids
-    # TODO: add mentioned users
+    message_to_user_id_set = set(message_to_user_ids)
+
+    user_ids = set(message_to_user_id_set)
+    if mentioned_user_ids:
+        user_ids |= mentioned_user_ids
 
     if user_ids:
         query = UserProfile.objects.filter(
@@ -873,7 +876,7 @@ def get_recipient_info(recipient, sender_id, stream_topic):
         # need this codepath to be fast (it's part of sending messages)
         query = query_for_ids(
             query=query,
-            user_ids=user_ids,
+            user_ids=sorted(list(user_ids)),
             field='id'
         )
         rows = list(query)
@@ -889,7 +892,7 @@ def get_recipient_info(recipient, sender_id, stream_topic):
     active_user_ids = {
         row['id']
         for row in rows
-    }
+    } & message_to_user_id_set
 
     def get_ids_for(f):
         # type: (Callable[[Dict[str, Any]], bool]) -> Set[int]
@@ -910,7 +913,7 @@ def get_recipient_info(recipient, sender_id, stream_topic):
     # Service bots don't get UserMessage rows.
     um_eligible_user_ids = get_ids_for(
         lambda r: not is_service_bot(r)
-    )
+    ) & message_to_user_id_set
 
     long_term_idle_user_ids = get_ids_for(
         lambda r: r['long_term_idle']
@@ -932,8 +935,8 @@ def get_recipient_info(recipient, sender_id, stream_topic):
     )  # type: RecipientInfoResult
     return info
 
-def get_service_bot_events(sender, service_bot_tuples, mentioned_user_ids, recipient_type):
-    # type: (UserProfile, List[Tuple[int, int]], Set[int], int) -> Dict[str, List[Dict[str, Any]]]
+def get_service_bot_events(sender, service_bot_tuples, mentioned_user_ids, active_user_ids, recipient_type):
+    # type: (UserProfile, List[Tuple[int, int]], Set[int], Set[int], int) -> Dict[str, List[Dict[str, Any]]]
 
     event_dict = defaultdict(list)  # type: Dict[str, List[Dict[str, Any]]]
 
@@ -941,27 +944,6 @@ def get_service_bot_events(sender, service_bot_tuples, mentioned_user_ids, recip
     # Service events.
     if sender.is_bot:
         return event_dict
-
-    if recipient_type == Recipient.STREAM:
-        known_ids = {user_profile_id for user_profile_id, bot_type in service_bot_tuples}
-        unknown_ids = mentioned_user_ids - known_ids
-        if unknown_ids:
-            '''
-            If we mention a service bot in a stream message, we should notify
-            them.  If the bot also happens to be subscribed to the stream, then
-            they would have already been in `service_bot_tuples`, but if
-            they are not subscribed to the stream, we need to go find them
-            in the follow up query below.  Also, it's important to filter
-            for service bots only.
-            '''
-            query = UserProfile.objects.filter(
-                id__in=unknown_ids,
-                is_active=True,
-                is_bot=True,
-                bot_type__in=UserProfile.SERVICE_BOT_TYPES,
-            ).values('id', 'bot_type')
-            tups = [(row['id'], row['bot_type']) for row in query]
-            service_bot_tuples += tups
 
     for user_profile_id, bot_type in service_bot_tuples:
         if bot_type == UserProfile.OUTGOING_WEBHOOK_BOT:
@@ -974,12 +956,14 @@ def get_service_bot_events(sender, service_bot_tuples, mentioned_user_ids, recip
                 (user_profile_id, bot_type))
             continue
 
+        is_stream = (recipient_type == Recipient.STREAM)
+
         # Mention triggers, primarily for stream messages
         if user_profile_id in mentioned_user_ids:
             trigger = 'mention'
         # PM triggers for personal and huddle messsages
-        elif recipient_type != Recipient.STREAM:
-            trigger = 'private_message'
+        elif (not is_stream) and (user_profile_id in active_user_ids):
+                trigger = 'private_message'
         else:
             continue
 
@@ -1034,6 +1018,7 @@ def do_send_messages(messages_maybe_none):
             recipient=message['message'].recipient,
             sender_id=message['message'].sender_id,
             stream_topic=stream_topic,
+            mentioned_user_ids=mention_data.get_user_ids(),
         )
 
         message['active_user_ids'] = info['active_user_ids']
@@ -1087,6 +1072,7 @@ def do_send_messages(messages_maybe_none):
                 sender=message['message'].sender,
                 service_bot_tuples=message['service_bot_tuples'],
                 mentioned_user_ids=mentioned_user_ids,
+                active_user_ids=message['active_user_ids'],
                 recipient_type=message['message'].recipient.type,
             )
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -902,11 +902,12 @@ def get_recipient_info(recipient, sender_id, stream_topic, possibly_mentioned_us
 
     def get_ids_for(f):
         # type: (Callable[[Dict[str, Any]], bool]) -> Set[int]
+        """Only includes users on the explicit message to line"""
         return {
             row['id']
             for row in rows
             if f(row)
-        }
+        } & message_to_user_id_set
 
     def is_service_bot(row):
         # type: (Dict[str, Any]) -> bool
@@ -919,7 +920,7 @@ def get_recipient_info(recipient, sender_id, stream_topic, possibly_mentioned_us
     # Service bots don't get UserMessage rows.
     um_eligible_user_ids = get_ids_for(
         lambda r: not is_service_bot(r)
-    ) & message_to_user_id_set
+    )
 
     long_term_idle_user_ids = get_ids_for(
         lambda r: r['long_term_idle']

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1148,7 +1148,7 @@ class UserMentionPattern(markdown.inlinepatterns.Pattern):
                 name = match
 
             wildcard = mention.user_mention_matches_wildcard(name)
-            user = db_data['full_name_info'].get(name.lower(), None)
+            user = db_data['mention_data'].get_user(name)
 
             if wildcard:
                 current_message.mentions_wildcard = True
@@ -1546,6 +1546,16 @@ def get_full_name_info(realm_id, full_names):
     }
     return dct
 
+class MentionData(object):
+    def __init__(self, realm_id, content):
+        # type: (int, Text) -> None
+        full_names = possible_mentions(content)
+        self.full_name_info = get_full_name_info(realm_id, full_names)
+
+    def get_user(self, name):
+        # type: (Text) -> Optional[FullNameInfo]
+        return self.full_name_info.get(name.lower(), None)
+
 def get_stream_name_info(realm, stream_names):
     # type: (Realm, Set[Text]) -> Dict[Text, FullNameInfo]
     if not stream_names:
@@ -1572,8 +1582,8 @@ def get_stream_name_info(realm, stream_names):
     return dct
 
 
-def do_convert(content, message=None, message_realm=None, possible_words=None, sent_by_bot=False):
-    # type: (Text, Optional[Message], Optional[Realm], Optional[Set[Text]], Optional[bool]) -> Text
+def do_convert(content, message=None, message_realm=None, possible_words=None, sent_by_bot=False, mention_data=None):
+    # type: (Text, Optional[Message], Optional[Realm], Optional[Set[Text]], Optional[bool], Optional[MentionData]) -> Text
     """Convert Markdown to HTML, with Zulip-specific settings and hacks."""
     # This logic is a bit convoluted, but the overall goal is to support a range of use cases:
     # * Nothing is passed in other than content -> just run default options (e.g. for docs)
@@ -1620,8 +1630,9 @@ def do_convert(content, message=None, message_realm=None, possible_words=None, s
         # if there is syntax in the message that might use them, since
         # the fetches are somewhat expensive and these types of syntax
         # are uncommon enough that it's a useful optimization.
-        full_names = possible_mentions(content)
-        full_name_info = get_full_name_info(message_realm.id, full_names)
+
+        if mention_data is None:
+            mention_data = MentionData(message_realm.id, content)
 
         emails = possible_avatar_emails(content)
         email_info = get_email_info(message_realm.id, emails)
@@ -1637,7 +1648,7 @@ def do_convert(content, message=None, message_realm=None, possible_words=None, s
         db_data = {
             'possible_words': possible_words,
             'email_info': email_info,
-            'full_name_info': full_name_info,
+            'mention_data': mention_data,
             'realm_emoji': realm_emoji,
             'sent_by_bot': sent_by_bot,
             'stream_names': stream_name_info,
@@ -1691,9 +1702,9 @@ def bugdown_stats_finish():
     bugdown_total_requests += 1
     bugdown_total_time += (time.time() - bugdown_time_start)
 
-def convert(content, message=None, message_realm=None, possible_words=None, sent_by_bot=False):
-    # type: (Text, Optional[Message], Optional[Realm], Optional[Set[Text]], Optional[bool]) -> Text
+def convert(content, message=None, message_realm=None, possible_words=None, sent_by_bot=False, mention_data=None):
+    # type: (Text, Optional[Message], Optional[Realm], Optional[Set[Text]], Optional[bool], Optional[MentionData]) -> Text
     bugdown_stats_start()
-    ret = do_convert(content, message, message_realm, possible_words, sent_by_bot)
+    ret = do_convert(content, message, message_realm, possible_words, sent_by_bot, mention_data)
     bugdown_stats_finish()
     return ret

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1551,10 +1551,24 @@ class MentionData(object):
         # type: (int, Text) -> None
         full_names = possible_mentions(content)
         self.full_name_info = get_full_name_info(realm_id, full_names)
+        self.user_ids = {
+            row['id']
+            for row in self.full_name_info.values()
+        }
 
     def get_user(self, name):
         # type: (Text) -> Optional[FullNameInfo]
         return self.full_name_info.get(name.lower(), None)
+
+    def get_user_ids(self):
+        # type: () -> Set[int]
+        """
+        Returns the user IDs that might have been mentioned by this
+        content.  Note that because this data structure has not parsed
+        the message and does not know about escaping/code blocks, this
+        will overestimate the list of user ids.
+        """
+        return self.user_ids
 
 def get_stream_name_info(realm, stream_names):
     # type: (Realm, Set[Text]) -> Dict[Text, FullNameInfo]

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -445,8 +445,8 @@ def access_message(user_profile, message_id):
     # stream in your realm, so return the message, user_message pair
     return (message, user_message)
 
-def render_markdown(message, content, realm=None, realm_alert_words=None, user_ids=None):
-    # type: (Message, Text, Optional[Realm], Optional[RealmAlertWords], Optional[Set[int]]) -> Text
+def render_markdown(message, content, realm=None, realm_alert_words=None, user_ids=None, mention_data=None):
+    # type: (Message, Text, Optional[Realm], Optional[RealmAlertWords], Optional[Set[int]], Optional[bugdown.MentionData]) -> Text
     """Return HTML for given markdown. Bugdown may add properties to the
     message object such as `mentions_user_ids` and `mentions_wildcard`.
     These are only on this Django object and are not saved in the
@@ -481,9 +481,14 @@ def render_markdown(message, content, realm=None, realm_alert_words=None, user_i
         sent_by_bot = get_user_profile_by_id(message.sender_id).is_bot
 
     # DO MAIN WORK HERE -- call bugdown to convert
-    rendered_content = bugdown.convert(content, message=message, message_realm=realm,
-                                       possible_words=possible_words,
-                                       sent_by_bot=sent_by_bot)
+    rendered_content = bugdown.convert(
+        content,
+        message=message,
+        message_realm=realm,
+        possible_words=possible_words,
+        sent_by_bot=sent_by_bot,
+        mention_data=mention_data,
+    )
 
     if message is not None:
         message.user_ids_with_alert_words = set()

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -201,6 +201,18 @@ class BugdownMiscTest(ZulipTestCase):
             id=fred2.id
         ))
 
+    def test_mention_data(self):
+        # type: () -> None
+        realm = get_realm('zulip')
+        hamlet = self.example_user('hamlet')
+        cordelia = self.example_user('cordelia')
+        content = '@**King Hamlet** @**Cordelia lear**'
+        mention_data = bugdown.MentionData(realm.id, content)
+        self.assertEqual(mention_data.get_user_ids(), {hamlet.id, cordelia.id})
+
+        user = mention_data.get_user('king hamLET')
+        self.assertEqual(user['email'], hamlet.email)
+
 class BugdownTest(ZulipTestCase):
     def load_bugdown_tests(self):
         # type: () -> Tuple[Dict[Text, Any], List[List[Text]]]

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -69,7 +69,7 @@ import DNS
 import mock
 import time
 import ujson
-from typing import Any, Dict, List, Optional, Text
+from typing import Any, Dict, List, Optional, Set, Text
 
 from collections import namedtuple
 
@@ -602,6 +602,20 @@ class StreamMessagesTest(ZulipTestCase):
         message = most_recent_message(user_profile)
         assert(UserMessage.objects.get(user_profile=user_profile, message=message).flags.mentioned.is_set)
 
+    def _send_stream_message(self, email, stream_name, content):
+        # type: (Text, Text, Text) -> Set[int]
+        with mock.patch('zerver.lib.actions.send_event') as m:
+            self.send_message(
+                email,
+                stream_name,
+                Recipient.STREAM,
+                content=content
+            )
+        self.assertEqual(m.call_count, 1)
+        users = m.call_args[0][1]
+        user_ids = {u['id'] for u in users}
+        return user_ids
+
     def test_unsub_mention(self):
         # type: () -> None
         cordelia = self.example_user('cordelia')
@@ -616,15 +630,15 @@ class StreamMessagesTest(ZulipTestCase):
         ).delete()
 
         def mention_cordelia():
-            # type: () -> None
+            # type: () -> Set[int]
             content = 'test @**Cordelia Lear** rules'
 
-            self.send_message(
-                hamlet.email,
-                stream_name,
-                Recipient.STREAM,
+            user_ids = self._send_stream_message(
+                email=hamlet.email,
+                stream_name=stream_name,
                 content=content
             )
+            return user_ids
 
         def num_cordelia_messages():
             # type: () -> int
@@ -632,15 +646,16 @@ class StreamMessagesTest(ZulipTestCase):
                 user_profile=cordelia
             ).count()
 
-        mention_cordelia()
-
+        user_ids = mention_cordelia()
         self.assertEqual(0, num_cordelia_messages())
+        self.assertNotIn(cordelia.id, user_ids)
 
         # Make sure test isn't too brittle-subscribing
         # Cordelia and mentioning her should give her a
         # message.
         self.subscribe(cordelia, stream_name)
-        mention_cordelia()
+        user_ids = mention_cordelia()
+        self.assertIn(cordelia.id, user_ids)
         self.assertEqual(1, num_cordelia_messages())
 
     def test_message_bot_mentions(self):
@@ -664,27 +679,18 @@ class StreamMessagesTest(ZulipTestCase):
             bot_owner=cordelia,
         )
 
-        UserMessage.objects.filter(
-            user_profile=normal_bot
-        ).delete()
-
         content = 'test @**Normal Bot** rules'
 
-        self.send_message(
-            hamlet.email,
-            stream_name,
-            Recipient.STREAM,
+        user_ids = self._send_stream_message(
+            email=hamlet.email,
+            stream_name=stream_name,
             content=content
         )
 
-        # As of now, we don't support mentioning
-        # bots who aren't subscribed.
-        self.assertEqual(
-            UserMessage.objects.filter(
-                user_profile=normal_bot
-            ).count(),
-            0
-        )
+        self.assertIn(normal_bot.id, user_ids)
+        user_message = most_recent_usermessage(normal_bot)
+        self.assertEqual(user_message.message.content, content)
+        self.assertTrue(user_message.flags.mentioned)
 
     def test_stream_message_mirroring(self):
         # type: () -> None

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -49,6 +49,7 @@ class TestServiceBotBasics(ZulipTestCase):
             service_bot_tuples=[
                 (outgoing_bot.id, outgoing_bot.bot_type),
             ],
+            active_user_ids={outgoing_bot.id},
             mentioned_user_ids=set(),
             recipient_type=Recipient.PERSONAL,
         )
@@ -73,43 +74,8 @@ class TestServiceBotBasics(ZulipTestCase):
             service_bot_tuples=[
                 (outgoing_bot.id, outgoing_bot.bot_type),
             ],
+            active_user_ids=set(),
             mentioned_user_ids={outgoing_bot.id},
-            recipient_type=Recipient.STREAM,
-        )
-
-        expected = dict(
-            outgoing_webhooks=[
-                dict(trigger='mention', user_profile_id=outgoing_bot.id),
-            ],
-        )
-
-        self.assertEqual(event_dict, expected)
-
-    def test_service_events_for_unsubscribed_stream_mentions(self):
-        # type: () -> None
-        sender = self.example_user('hamlet')
-        assert(not sender.is_bot)
-
-        outgoing_bot = self._get_outgoing_bot()
-
-        '''
-        If an outgoing bot is mentioned on a stream message, we will
-        create an event for it even if it is not subscribed to the
-        stream and not part of our original `service_bot_tuples`.
-
-        Note that we add Cordelia as a red herring value that the
-        code should ignore, since she is not a bot.
-        '''
-
-        cordelia = self.example_user('cordelia')
-
-        event_dict = get_service_bot_events(
-            sender=sender,
-            service_bot_tuples=[],
-            mentioned_user_ids={
-                outgoing_bot.id,
-                cordelia.id,  # should be excluded, not a service bot
-            },
             recipient_type=Recipient.STREAM,
         )
 

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -31,6 +31,7 @@ from zerver.lib.actions import (
     do_deactivate_user,
     do_reactivate_user,
     do_change_is_admin,
+    do_create_user,
 )
 from zerver.lib.topic_mutes import add_topic_mute
 from zerver.lib.stream_topic import StreamTopicTarget
@@ -428,6 +429,27 @@ class RecipientInfoTest(ZulipTestCase):
         )
 
         self.assertEqual(info['stream_push_user_ids'], set())
+
+        # Add a service bot.
+        service_bot = do_create_user(
+            email='service-bot@zulip.com',
+            password='',
+            realm=realm,
+            full_name='',
+            short_name='',
+            active=True,
+            bot_type=UserProfile.EMBEDDED_BOT,
+        )
+
+        info = get_recipient_info(
+            recipient=recipient,
+            sender_id=hamlet.id,
+            stream_topic=stream_topic,
+            mentioned_user_ids={service_bot.id}
+        )
+        self.assertEqual(info['service_bot_tuples'], [
+            (service_bot.id, UserProfile.EMBEDDED_BOT),
+        ])
 
 class BulkUsersTest(ZulipTestCase):
     def test_client_gravatar_option(self):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -445,7 +445,7 @@ class RecipientInfoTest(ZulipTestCase):
             recipient=recipient,
             sender_id=hamlet.id,
             stream_topic=stream_topic,
-            mentioned_user_ids={service_bot.id}
+            possibly_mentioned_user_ids={service_bot.id}
         )
         self.assertEqual(info['service_bot_tuples'], [
             (service_bot.id, UserProfile.EMBEDDED_BOT),

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -409,6 +409,7 @@ class RecipientInfoTest(ZulipTestCase):
             stream_push_user_ids={hamlet.id},
             um_eligible_user_ids=all_user_ids,
             long_term_idle_user_ids=set(),
+            default_bot_user_ids=set(),
             service_bot_tuples=[],
         )
 
@@ -450,6 +451,25 @@ class RecipientInfoTest(ZulipTestCase):
         self.assertEqual(info['service_bot_tuples'], [
             (service_bot.id, UserProfile.EMBEDDED_BOT),
         ])
+
+        # Add a normal bot.
+        normal_bot = do_create_user(
+            email='normal-bot@zulip.com',
+            password='',
+            realm=realm,
+            full_name='',
+            short_name='',
+            active=True,
+            bot_type=UserProfile.DEFAULT_BOT,
+        )
+
+        info = get_recipient_info(
+            recipient=recipient,
+            sender_id=hamlet.id,
+            stream_topic=stream_topic,
+            possibly_mentioned_user_ids={service_bot.id, normal_bot.id}
+        )
+        self.assertEqual(info['default_bot_user_ids'], {normal_bot.id})
 
 class BulkUsersTest(ZulipTestCase):
     def test_client_gravatar_option(self):


### PR DESCRIPTION
We now have a MentionData class that encapsulates
the users who are possibly mentioned in a message.

Not that the rendering code may not keep all the mentions,
since things like backticks will suppress the mention.

We populate this now in do_send_messages, so that we can use
the info earlier in the message-sending process.  This info
now gets passed down the call stack as an optional parameter.

Note that bugdown.convert() still populates the data when its
callers decline to pass in a MentionData object.

This is mostly a preparatory commit, as we don't take advantage
of the data yet in do_send_messages.