### PR TITLE
docs: Fix a typo in text of user doc for allow image/link previews.

### DIFF
--- a/templates/zerver/help/allow-image-link-previews.md
+++ b/templates/zerver/help/allow-image-link-previews.md
@@ -3,7 +3,7 @@
 {!admin-only.md!}
 
 By default, when a user uploads or links to an image or links to a website, a
-preview of the content will be showed. You can choose to disable previews of
+preview of the content will be shown. You can choose to disable previews of
 images and links separately.
 
 {!go-to-the.md!} [Organization settings](/#organization/organization-settings)


### PR DESCRIPTION
Fixes #7144