### PR TITLE
compose: Remove PM recipient box outline.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -298,8 +298,7 @@ textarea.new_message_textarea {
 }
 
 textarea.new_message_textarea,
-#subject.recipient_box,
-#stream.recipient_box {
+.compose_table .recipient_box {
     border: 1px solid hsl(0, 0%, 86%);
     box-shadow: none;
     -webkit-box-shadow: none;
@@ -307,9 +306,10 @@ textarea.new_message_textarea,
 }
 
 textarea.new_message_textarea:focus,
-#subject.recipient_box:focus,
-#stream.recipient_box:focus {
+.compose_table .recipient_box:focus {
     border: 1px solid hsl(0, 0%, 66%);
+    box-shadow: none;
+    -webkit-box-shadow: none;
 }
 
 #stream.recipient_box:focus {


### PR DESCRIPTION
This removes the old blue styled outline around the PM recipient
box that was part of the older bootstrap styling in favor of the
dark outline on :focus that had been implemented for the rest of
the recipient boxes recently.