### PR TITLE
webhooks/taiga: Support relateduserstory events.

### DIFF
--- a/zerver/webhooks/taiga/fixtures/relateduserstory_created.json
+++ b/zerver/webhooks/taiga/fixtures/relateduserstory_created.json
@@ -1,0 +1,132 @@
+{
+    "date":"2017-10-25T00:48:47.094Z",
+    "by":{
+        "photo":null,
+        "permalink":"https://tree.taiga.io/profile/eeshangarg",
+        "full_name":"Eeshan Garg",
+        "username":"eeshangarg",
+        "id":258659,
+        "gravatar_id":"cd181af88d928dab53c55600c9f7551d"
+    },
+    "action":"create",
+    "type":"relateduserstory",
+    "data":{
+        "epic":{
+            "assigned_to":null,
+            "description":"An epic about supporting epics!",
+            "custom_attributes_values":{
+
+            },
+            "status":{
+                "slug":"new",
+                "id":1004969,
+                "color":"#999999",
+                "name":"New",
+                "is_closed":false
+            },
+            "project":{
+                "permalink":"https://tree.taiga.io/project/eeshangarg-zulip",
+                "logo_big_url":null,
+                "id":229096,
+                "name":"Zulip"
+            },
+            "epics_order":1508892504131,
+            "created_date":"2017-10-25T00:48:24.157Z",
+            "team_requirement":false,
+            "tags":[
+
+            ],
+            "id":50717,
+            "subject":"This is Epic!",
+            "owner":{
+                "photo":null,
+                "permalink":"https://tree.taiga.io/profile/eeshangarg",
+                "full_name":"Eeshan Garg",
+                "username":"eeshangarg",
+                "id":258659,
+                "gravatar_id":"cd181af88d928dab53c55600c9f7551d"
+            },
+            "ref":9,
+            "client_requirement":false,
+            "modified_date":"2017-10-25T00:48:24.175Z",
+            "color":"#888a85",
+            "watchers":[
+
+            ]
+        },
+        "order":1508892527009,
+        "id":187087,
+        "user_story":{
+            "assigned_to":null,
+            "custom_attributes_values":{
+
+            },
+            "is_blocked":false,
+            "status":{
+                "is_archived":false,
+                "color":"#999999",
+                "is_closed":false,
+                "slug":"new",
+                "name":"New",
+                "id":1364773
+            },
+            "project":{
+                "permalink":"https://tree.taiga.io/project/eeshangarg-zulip",
+                "logo_big_url":null,
+                "id":229096,
+                "name":"Zulip"
+            },
+            "finish_date":null,
+            "created_date":"2017-10-25T00:42:40.254Z",
+            "team_requirement":false,
+            "watchers":[
+
+            ],
+            "owner":{
+                "photo":null,
+                "permalink":"https://tree.taiga.io/profile/eeshangarg",
+                "full_name":"Eeshan Garg",
+                "username":"eeshangarg",
+                "id":258659,
+                "gravatar_id":"cd181af88d928dab53c55600c9f7551d"
+            },
+            "client_requirement":false,
+            "modified_date":"2017-10-25T00:42:40.255Z",
+            "tribe_gig":null,
+            "generated_from_issue":null,
+            "description":"",
+            "points":[
+                {
+                    "value":null,
+                    "role":"UX",
+                    "name":"?"
+                },
+                {
+                    "value":null,
+                    "role":"Design",
+                    "name":"?"
+                },
+                {
+                    "value":null,
+                    "role":"Front",
+                    "name":"?"
+                },
+                {
+                    "value":null,
+                    "role":"Back",
+                    "name":"?"
+                }
+            ],
+            "is_closed":false,
+            "external_reference":null,
+            "blocked_note":"",
+            "subject":"A related user story",
+            "tags":[
+
+            ],
+            "ref":8,
+            "milestone":null,
+            "id":1825616
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/relateduserstory_deleted.json
+++ b/zerver/webhooks/taiga/fixtures/relateduserstory_deleted.json
@@ -1,0 +1,132 @@
+{
+    "data":{
+        "id":187087,
+        "user_story":{
+            "description":"",
+            "custom_attributes_values":{
+
+            },
+            "id":1825616,
+            "milestone":null,
+            "owner":{
+                "permalink":"https://tree.taiga.io/profile/eeshangarg",
+                "username":"eeshangarg",
+                "full_name":"Eeshan Garg",
+                "photo":null,
+                "id":258659,
+                "gravatar_id":"cd181af88d928dab53c55600c9f7551d"
+            },
+            "modified_date":"2017-10-25T00:53:02.074Z",
+            "external_reference":null,
+            "points":[
+                {
+                    "value":null,
+                    "role":"UX",
+                    "name":"?"
+                },
+                {
+                    "value":null,
+                    "role":"Design",
+                    "name":"?"
+                },
+                {
+                    "value":null,
+                    "role":"Front",
+                    "name":"?"
+                },
+                {
+                    "value":null,
+                    "role":"Back",
+                    "name":"?"
+                }
+            ],
+            "watchers":[
+
+            ],
+            "assigned_to":null,
+            "is_blocked":false,
+            "ref":8,
+            "subject":"A related user story, which is epic",
+            "tribe_gig":null,
+            "finish_date":null,
+            "blocked_note":"",
+            "status":{
+                "is_archived":false,
+                "slug":"new",
+                "name":"New",
+                "id":1364773,
+                "is_closed":false,
+                "color":"#999999"
+            },
+            "project":{
+                "permalink":"https://tree.taiga.io/project/eeshangarg-zulip",
+                "id":229096,
+                "name":"Zulip",
+                "logo_big_url":null
+            },
+            "team_requirement":false,
+            "created_date":"2017-10-25T00:42:40.254Z",
+            "client_requirement":false,
+            "generated_from_issue":null,
+            "is_closed":false,
+            "tags":[
+
+            ]
+        },
+        "order":1508892527009,
+        "epic":{
+            "description":"An epic about supporting epics!",
+            "subject":"This is Epic!",
+            "watchers":[
+
+            ],
+            "epics_order":1508892504131,
+            "created_date":"2017-10-25T00:48:24.157Z",
+            "id":50717,
+            "assigned_to":null,
+            "status":{
+                "id":1004969,
+                "is_closed":false,
+                "slug":"new",
+                "name":"New",
+                "color":"#999999"
+            },
+            "color":"#888a85",
+            "project":{
+                "permalink":"https://tree.taiga.io/project/eeshangarg-zulip",
+                "id":229096,
+                "name":"Zulip",
+                "logo_big_url":null
+            },
+            "team_requirement":false,
+            "ref":9,
+            "client_requirement":false,
+            "custom_attributes_values":{
+
+            },
+            "owner":{
+                "permalink":"https://tree.taiga.io/profile/eeshangarg",
+                "username":"eeshangarg",
+                "full_name":"Eeshan Garg",
+                "photo":null,
+                "id":258659,
+                "gravatar_id":"cd181af88d928dab53c55600c9f7551d"
+            },
+            "modified_date":"2017-10-25T00:48:24.175Z",
+            "tags":[
+
+            ]
+        }
+    },
+    "type":"relateduserstory",
+    "date":"2017-10-25T00:53:52.348Z",
+    "by":{
+        "permalink":"https://tree.taiga.io/profile/eeshangarg",
+        "username":"eeshangarg",
+        "full_name":"Eeshan Garg",
+        "photo":null,
+        "id":258659,
+        "gravatar_id":"cd181af88d928dab53c55600c9f7551d"
+    },
+    "action":"delete"
+}

--- a/zerver/webhooks/taiga/tests.py
+++ b/zerver/webhooks/taiga/tests.py
@@ -276,3 +276,13 @@ class TaigaHookTests(WebhookTestCase):
         # type: () -> None
         message = u':cross_mark: Eeshan Garg deleted epic **Zulip is great!**'
         self.send_and_test_stream_message("epic_deleted", u'subject', message)
+
+    def test_taiga_relateduserstory_created(self):
+        # type: () -> None
+        message = u':package: Eeshan Garg added a related user story **A related user story** to the epic **This is Epic!**'
+        self.send_and_test_stream_message("relateduserstory_created", u'subject', message)
+
+    def test_taiga_relateduserstory_deleted(self):
+        # type: () -> None
+        message = u':cross_mark: Eeshan Garg removed a related user story **A related user story, which is epic** from the epic **This is Epic!**'
+        self.send_and_test_stream_message("relateduserstory_deleted", u'subject', message)

--- a/zerver/webhooks/taiga/view.py
+++ b/zerver/webhooks/taiga/view.py
@@ -64,6 +64,10 @@ templates = {
         'commented': u':thought_balloon: %(user)s commented on epic **%(subject)s**',
         'delete': u':cross_mark: %(user)s deleted epic **%(subject)s**',
     },
+    'relateduserstory': {
+        'create': u':package: %(user)s added a related user story **%(userstory_subject)s** to the epic **%(epic_subject)s**',
+        'delete': u':cross_mark: %(user)s removed a related user story **%(userstory_subject)s** from the epic **%(epic_subject)s**',
+    },
     'userstory': {
         'create': u':package: %(user)s created user story **%(subject)s**.',
         'set_assigned_to': u':busts_in_silhouette: %(user)s assigned user story **%(subject)s** to %(new)s.',
@@ -168,6 +172,17 @@ def parse_comment(message):
 def parse_create_or_delete(message):
     # type: (Mapping[str, Any]) -> Dict[str, Any]
     """ Parses create or delete event. """
+    if message["type"] == 'relateduserstory':
+        return {
+            'type': message["type"],
+            'event': message["action"],
+            'values': {
+                'user': get_owner_name(message),
+                'epic_subject': message['data']['epic']['subject'],
+                'userstory_subject': message['data']['user_story']['subject'],
+            }
+        }
+
     return {
         'type': message["type"],
         'event': message["action"],


### PR DESCRIPTION
This commit adds support for the following:

1. When a user story is added to an epic.
2. When a user story is removed from an epic.

@timabbott: FYI. I believe events of type `relateduserstory` only have two variants, as mentioned above. :)