### PR TITLE
landing-page: Make <ul> formatting consistent.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -31,6 +31,10 @@ p {
     line-height: 1.5;
 }
 
+ul {
+    font-weight: normal;
+}
+
 a,
 a:hover,
 a:visited {
@@ -1807,7 +1811,6 @@ nav ul li.active::after {
 }
 
 .portico-landing.why-page .main li {
-    color: #555;
     line-height: 1.6;
     font-size: 1em;
 }


### PR DESCRIPTION
This changes the <ul> styling so that when not nested in a <p>
tag it'll have the standard font-weight (400) and be the same
color as the body text (blue/gray).