### PR TITLE
landing-page: Change incorrect gray text to lower opacity.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -31,6 +31,10 @@ p {
     line-height: 1.5;
 }
 
+ul {
+    font-weight: normal;
+}
+
 a,
 a:hover,
 a:visited {
@@ -1807,7 +1811,6 @@ nav ul li.active::after {
 }
 
 .portico-landing.why-page .main li {
-    color: #555;
     line-height: 1.6;
     font-size: 1em;
 }

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -22,7 +22,7 @@ body {
     margin-top: 20px;
     margin-bottom: 5px;
 
-    color: #888;
+    opacity: 0.8;
 }
 
 .navbar {


### PR DESCRIPTION
This changes some text that would display gray when on a blue
body text page, so instead what this does is changes the opacity
to be less so it'll continue to be the same luminosity but the
correct hue and saturation otherwise.