### PR TITLE
Fix is-active checks for popovers.

### DIFF
--- a/static/js/people.js
+++ b/static/js/people.js
@@ -545,19 +545,24 @@ exports.get_active_user_for_email = function (email) {
     return active_user_dict.get(person.user_id);
 };
 
-exports.realm_user_is_active_human_or_bot = function (id) {
-    if (active_user_dict.get(id) !== undefined) {
+exports.is_active_user_for_popover = function (user_id) {
+    // For popover menus, we include cross-realm bots as active
+    // users.
+
+    if (cross_realm_dict.get(user_id)) {
         return true;
     }
-    // TODO: Technically, we should probably treat deactivated bots
-    // like deactivated users here.  But we don't have the data to do
-    // that.  See #7153 for notes on fixing this.
-    var person = exports.get_person_from_user_id(id);
-    if (person === undefined) {
-        blueslip.error("Unexpectedly invalid user ID in user popover query " + id);
-        return false;
+    if (active_user_dict.has(user_id)) {
+        return true;
     }
-    return !!person.is_bot;
+
+    // TODO: We can report errors here once we start loading
+    //       deactivated users at page-load time. For now just warn.
+    if (!people_by_user_id_dict.has(user_id)) {
+        blueslip.warn("Unexpectedly invalid user_id in user popover query: " + user_id);
+    }
+
+    return false;
 };
 
 exports.get_all_persons = function () {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -100,7 +100,7 @@ function show_user_info_popover(element, user, message) {
             sent_by_uri: narrow.by_sender_uri(user.email),
             narrowed: narrow_state.active(),
             private_message_class: "respond_personal_button",
-            is_active: people.realm_user_is_active_human_or_bot(user.user_id),
+            is_active: people.is_active_user_for_popover(user.user_id),
         };
 
         var ypos = elt.offset().top;
@@ -448,7 +448,7 @@ exports.register_click_handlers = function () {
             pm_with_uri: narrow.pm_with_uri(user_email),
             sent_by_uri: narrow.by_sender_uri(user_email),
             private_message_class: "compose_private_message",
-            is_active: people.realm_user_is_active_human_or_bot(user_id),
+            is_active: people.is_active_user_for_popover(user_id),
         };
 
         target.popover({


### PR DESCRIPTION
We were incorrectly reporting active bots as non-active in
popovers, and we had no test coverage for cross-realm bots.

We also rename the function to is_active_user_for_popover,
since the old name, realm_user_is_active_human_or_bot, suggested
the wrong semantics for cross-realm bots.

Last but not least, we only do a blueslip warning if a user id
is not found.  When lookups fail, we are pretty confident that
the user is not active, so an error is overkill.  We can change
that as part of issue #7120.

Fixes #7153