### PR TITLE
settings ui: Restrict file type for bot avatar file picker.

### DIFF
--- a/static/js/upload_widget.js
+++ b/static/js/upload_widget.js
@@ -4,18 +4,18 @@ var upload_widget = (function () {
 
     var default_max_file_size = 5;
 
+    var supported_types = [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/tiff',
+    ];
+
     function is_image_format(file) {
         var type = file.type;
         if (!type) {
             return false;
         }
-
-        var supported_types = [
-            'image/jpeg',
-            'image/png',
-            'image/gif',
-            'image/tiff',
-        ];
         return _.indexOf(supported_types, type) >= 0;
     }
 
@@ -60,6 +60,7 @@ var upload_widget = (function () {
             return false;
         });
 
+        get_file_input().attr('accept', supported_types.toString());
         get_file_input().on('change', function (e) {
             if (e.target.files.length === 0) {
                 input_error.hide();


### PR DESCRIPTION
This restricts the lsit of files displayed to the user by the file picker to those actually accepted.