### PR TITLE
Remove `active` parameter from `do_create_user()`.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -428,16 +428,16 @@ def notify_created_bot(user_profile):
     send_event(event, bot_owner_user_ids(user_profile))
 
 def do_create_user(email, password, realm, full_name, short_name,
-                   active=True, is_realm_admin=False, bot_type=None, bot_owner=None, tos_version=None,
+                   is_realm_admin=False, bot_type=None, bot_owner=None, tos_version=None,
                    timezone=u"", avatar_source=UserProfile.AVATAR_FROM_GRAVATAR,
                    default_sending_stream=None, default_events_register_stream=None,
                    default_all_public_streams=None, prereg_user=None,
                    newsletter_data=None, default_stream_groups=[]):
-    # type: (Text, Optional[Text], Realm, Text, Text, bool, bool, Optional[int], Optional[UserProfile], Optional[Text], Text, Text, Optional[Stream], Optional[Stream], bool, Optional[PreregistrationUser], Optional[Dict[str, str]], List[DefaultStreamGroup]) -> UserProfile
+    # type: (Text, Optional[Text], Realm, Text, Text, bool, Optional[int], Optional[UserProfile], Optional[Text], Text, Text, Optional[Stream], Optional[Stream], bool, Optional[PreregistrationUser], Optional[Dict[str, str]], List[DefaultStreamGroup]) -> UserProfile
 
     user_profile = create_user(email=email, password=password, realm=realm,
                                full_name=full_name, short_name=short_name,
-                               active=active, is_realm_admin=is_realm_admin,
+                               is_realm_admin=is_realm_admin,
                                bot_type=bot_type, bot_owner=bot_owner,
                                tos_version=tos_version, timezone=timezone, avatar_source=avatar_source,
                                default_sending_stream=default_sending_stream,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -388,8 +388,13 @@ class HomeTest(ZulipTestCase):
             realm=realm,
             full_name=name,
             short_name=name,
-            active=False
         )
+
+        # Doing a full-stack deactivation would be expensive here,
+        # and we really only need to flip the flag to get a valid
+        # test.
+        user.is_active = False
+        user.save()
         return user
 
     @slow('creating users and loading home page')

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -649,7 +649,6 @@ class StreamMessagesTest(ZulipTestCase):
             realm=realm,
             full_name='Normal Bot',
             short_name='',
-            active=True,
             bot_type=UserProfile.DEFAULT_BOT,
             bot_owner=cordelia,
         )
@@ -2313,7 +2312,6 @@ class CheckMessageTest(ZulipTestCase):
             realm=parent.realm,
             full_name='',
             short_name='',
-            active=True,
             bot_type=UserProfile.DEFAULT_BOT,
             bot_owner=parent
         )

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -438,7 +438,6 @@ class RecipientInfoTest(ZulipTestCase):
             realm=realm,
             full_name='',
             short_name='',
-            active=True,
             bot_type=UserProfile.EMBEDDED_BOT,
         )
 
@@ -459,7 +458,6 @@ class RecipientInfoTest(ZulipTestCase):
             realm=realm,
             full_name='',
             short_name='',
-            active=True,
             bot_type=UserProfile.DEFAULT_BOT,
         )
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -297,7 +297,7 @@ def add_bot_backend(request, user_profile, full_name_raw=REQ("full_name"), short
 
     bot_profile = do_create_user(email=email, password='',
                                  realm=user_profile.realm, full_name=full_name,
-                                 short_name=short_name, active=True,
+                                 short_name=short_name,
                                  bot_type=bot_type,
                                  bot_owner=user_profile,
                                  avatar_source=avatar_source,


### PR DESCRIPTION
Almost all callers to do_create_user were trying to
create active users, except for one test.  The
active=False codepath was kind of broken (things
like sending welcome messages had sort of undefined
behavior there), so instead of trying to maintain it,
we just update the one test (`test_people`) to flip the
`is_active` flag manually.

Fixes #7197