### PR TITLE
orgs_settings: Add modal for message content edit time limits.

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -318,7 +318,7 @@ casper.then(function () {
 });
 
 function submit_org_settings_change() {
-    casper.click('form.org-settings-form button.button');
+    casper.click('form.org-settings-form button.button.save-message-org-settings');
 }
 
 casper.then(function () {

--- a/frontend_tests/casper_tests/12-toggle-message-editing.js
+++ b/frontend_tests/casper_tests/12-toggle-message-editing.js
@@ -168,7 +168,7 @@ submit_checked();
 
 casper.then(function () {
     casper.waitUntilVisible('#admin-realm-message-editing-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-message-editing-status', 'Users can now edit topics for all their messages, and the content of messages which are less than 10 minutes old.');
+        casper.test.assertSelectorHasText('#admin-realm-message-editing-status', 'Setting updated!');
         casper.test.assertEval(function () {
             return document.querySelector('input[type="checkbox"][id="id_realm_allow_message_editing"]').checked;
         }, 'Allow message editing Setting re-activated');
@@ -195,7 +195,7 @@ casper.then(function () {
 casper.then(function () {
     casper.waitUntilVisible('input[type="checkbox"][id="id_realm_allow_message_editing"] + span', function () {
         casper.evaluate(function () {
-            $('input[type="text"][id="id_realm_message_content_edit_limit_minutes"]').val('4');
+            $('input[type="text"][id="id_realm_message_content_edit_limit"]').val('4');
         });
     });
 });
@@ -210,7 +210,7 @@ casper.then(function () {
             return !(document.querySelector('input[type="checkbox"][id="id_realm_allow_message_editing"]').checked);
         }, 'Allow message editing Setting de-activated');
         casper.test.assertEval(function () {
-            return $('input[type="text"][id="id_realm_message_content_edit_limit_minutes"]').val() === '4';
+            return $('input[type="text"][id="id_realm_message_content_edit_limit"]').val() === '4';
         }, 'Message content edit limit now 4');
     });
 });
@@ -223,12 +223,12 @@ submit_checked();
 
 casper.then(function () {
     casper.waitUntilVisible('#admin-realm-message-editing-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-message-editing-status', 'Users can now edit topics for all their messages, and the content of messages which are less than 4 minutes old.');
+        casper.test.assertSelectorHasText('#admin-realm-message-editing-status', 'Setting updated!');
         casper.test.assertEval(function () {
             return document.querySelector('input[type="checkbox"][id="id_realm_allow_message_editing"]').checked;
         }, 'Allow message editing Setting activated');
         casper.test.assertEval(function () {
-            return $('input[type="text"][id="id_realm_message_content_edit_limit_minutes"]').val() === '4';
+            return $('input[type="text"][id="id_realm_message_content_edit_limit"]').val() === '4';
         }, 'Message content edit limit still 4');
     });
 });
@@ -240,7 +240,7 @@ casper.then(function () {
     // allow arbitrary message editing
     casper.waitUntilVisible('input[type="checkbox"][id="id_realm_allow_message_editing"] + span', function () {
         casper.evaluate(function () {
-            $('input[type="text"][id="id_realm_message_content_edit_limit_minutes"]').val('0');
+            $('input[type="text"][id="id_realm_message_content_edit_limit"]').val('0');
         });
     });
 });
@@ -248,12 +248,12 @@ submit_checked();
 
 casper.then(function () {
     casper.waitUntilVisible('#admin-realm-message-editing-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-message-editing-status', 'Users can now edit the content and topics of all their past messages!');
+        casper.test.assertSelectorHasText('#admin-realm-message-editing-status', 'Setting updated!');
         casper.test.assertEval(function () {
             return document.querySelector('input[type="checkbox"][id="id_realm_allow_message_editing"]').checked;
         }, 'Allow message editing Setting still activated');
         casper.test.assertEval(function () {
-            return $('input[type="text"][id="id_realm_message_content_edit_limit_minutes"]').val() === '0';
+            return $('input[type="text"][id="id_realm_message_content_edit_limit"]').val() === '0';
         }, 'Message content edit limit is 0');
     });
 });
@@ -265,7 +265,7 @@ casper.then(function () {
     // disallow message editing, with illegal edit limit value. should be fixed by admin.js
     casper.waitUntilVisible('input[type="checkbox"][id="id_realm_allow_message_editing"] + span', function () {
         casper.evaluate(function () {
-            $('input[type="text"][id="id_realm_message_content_edit_limit_minutes"]').val('moo');
+            $('input[type="text"][id="id_realm_message_content_edit_limit"]').val('moo');
         });
     });
 });
@@ -274,12 +274,13 @@ submit_unchecked();
 
 casper.then(function () {
     casper.waitUntilVisible('#admin-realm-message-editing-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-message-editing-status', 'Users can no longer edit their past messages!');
+        casper.test.assertSelectorHasText('#admin-realm-message-editing-status', 'Failed: Must be a positive number');
         casper.test.assertEval(function () {
             return !(document.querySelector('input[type="checkbox"][id="id_realm_allow_message_editing"]').checked);
         }, 'Allow message editing Setting de-activated');
         casper.test.assertEval(function () {
-            return $('input[type="text"][id="id_realm_message_content_edit_limit_minutes"]').val() === '10';
+            // if illegal edit limit value is submitted the value of edit limit is same as before
+            return $('input[type="text"][id="id_realm_message_content_edit_limit"]').val() === '0';
         }, 'Message content edit limit has been reset to its default');
     });
 });

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -45,8 +45,6 @@ function _setup_page() {
             page_params.realm_create_generic_bot_by_admins_only,
         realm_allow_message_deleting: page_params.realm_allow_message_deleting,
         realm_allow_message_editing: page_params.realm_allow_message_editing,
-        realm_message_content_edit_limit_minutes:
-            Math.ceil(page_params.realm_message_content_edit_limit_seconds / 60),
         realm_message_retention_days: page_params.realm_message_retention_days,
         realm_allow_edit_history: page_params.realm_allow_edit_history,
         language_list: page_params.language_list,

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -440,6 +440,11 @@ input[type=checkbox].inline-block {
     margin: 0px 5px;
 }
 
+#id_realm_message_content_edit_limit_label,
+#change_content_edit_button_label {
+    display: inline;
+}
+
 .control-label-disabled {
     color: hsl(0, 0%, 82%);
 }
@@ -448,7 +453,7 @@ input[type=checkbox].inline-block {
     margin-left: 25px;
 }
 
-.admin-realm-message-content-edit-limit-minutes {
+.admin-realm-message-content-edit-limit {
     width: 5ch;
     text-align: right;
 }
@@ -1370,4 +1375,16 @@ thead .actions {
 .invited-as-admin {
     opacity: 0.5;
     margin-left: 2px;
+}
+
+#content_edit_limit {
+    text-decoration: none;
+}
+
+#edit_limit_unit {
+    display: inline;
+}
+
+#edit_limit_unit_select {
+    width: 100px;
 }

--- a/static/templates/settings/message_edit_limit_modal.handlebars
+++ b/static/templates/settings/message_edit_limit_modal.handlebars
@@ -1,0 +1,31 @@
+<div id="message_edit_limit_modal" class="modal hide" tabindex="-1" role="dialog"
+    aria-labelledby="change_content_edit_limit_modal" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <h3 id="change_message_content_edit_limit_modal_label">{{t "Change edit time limit" }}</h3>
+    </div>
+    <div class="modal-body">
+        <div class="input-group change_edit_limit_container">
+            <label for="id_realm_message_content_edit_limit"
+                id="id_realm_message_content_edit_limit_label"
+                title="{{t 'If non-zero, users can edit their message for this much time after it is sent. If no limit, users can edit all their past messages.' }}">
+                {{t 'New limit:' }}
+            </label>
+            <input type="text" id="id_realm_message_content_edit_limit"
+                name="realm_message_content_edit_limit"
+                class="admin-realm-message-content-edit-limit" value=""
+            {{#unless realm_allow_message_editing}}disabled="disabled"{{/unless}} />
+            <div class="input-group" id="edit_limit_unit">
+                <select name="edit_limit_unit_select" id="edit_limit_unit_select">
+                    <option value='minutes'>{{t 'Minutes' }}</option>
+                    <option value='hours'>{{t 'Hours' }}</option>
+                    <option value='days'>{{t 'Days' }}</option>
+                </select>
+            </div>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button id='change_message_edit_limit_button' class="button rounded sea-green" data-dismiss="modal">{{t "Save" }}</button>
+        <button id='close_message_edit_modal' class="button white rounded" data-dismiss="modal">{{t "Close" }}</button>
+    </div>
+</div>

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -88,7 +88,7 @@
                 <label for="aitin" class="inline-block">{{t "Minimum account age (N)" }}:</label>
                 <input type="text" id="id_realm_waiting_period_threshold"
                      name="realm_waiting_period_threshold"
-                     class="admin-realm-message-content-edit-limit-minutes"
+                     class="admin-realm-message-content-edit-limit"
                      value="{{ realm_waiting_period_threshold }}"/>
             </div>
         </div>

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -25,15 +25,22 @@
             </div>
 
             <div class="input-group disableable {{#unless realm_allow_message_editing}}control-label-disabled{{/unless}}">
-                <label for="id_realm_message_content_edit_limit_minutes"
-                    id="id_realm_message_content_edit_limit_minutes_label">
-                    {{t 'Message edit limit in minutes (0 for no limit)' }}
+                <label for="change_content_edit_limit"
+                    id="change_content_edit_button_label">
+                    {{t 'Message edit limit:' }}
                 </label>
-                <input type="text" id="id_realm_message_content_edit_limit_minutes"
-                       name="realm_message_content_edit_limit_minutes"
-                       class="admin-realm-message-content-edit-limit-minutes"
-                       value="{{ realm_message_content_edit_limit_minutes }}"
-                  {{#unless realm_allow_message_editing}}disabled="disabled"{{/unless}} />
+                <a id="content_edit_limit">
+                    <button type="button" class="button rounded small inline-block"
+                        id="change_content_edit_limit"
+                        {{#unless realm_allow_message_editing}}disabled="disabled"{{/unless}} >
+                        <span id="content_edit_limit_button"></span>
+                        <i class="fa fa-pencil"></i>
+                    </button>
+                    {{#if is_admin }}
+                    <a id="set_no_edit_limit">{{t "[No limit]" }}</a>
+                    {{/if}}
+                </a>
+                {{ partial "message_edit_limit_modal"}}
             </div>
 
             <div class="input-group">


### PR DESCRIPTION
This adds a modal to edit the time limit to edit message content under "Organisation Settings" section.
Fixes: #6809.
Though the scope of the issue was to add modal for all time limits in settings which I figured out that there are 2: one under "Organisation Settings->Message editing" and another under "Organisation Permission->Streams & custom emoji" but currently, this adds the modal for Message edit limit only, I want the feedback regarding this and also guidance regarding the tests.
I have manually tested this on Chrome and Firefox (in Linux) and this works as expected.
@timabbott @rishig .
![peek 2017-10-29 19-10](https://user-images.githubusercontent.com/22238472/32144311-f73ba36a-bcdc-11e7-95ff-365e6217d550.gif)
