### PR TITLE
user settings: Improve Uploaded Files design.

### DIFF
--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -346,12 +346,15 @@ $(function () {
     you MUST specify the `data-list-render` in the `.progressive-table-wrapper`
     otherwise it will not know what `list_render` instance to look up.
 
+    <table>
+        <tr>
+            <td data-sort="alphabetic" data-sort-prop="name">
+            <td data-sort="numeric" data-sort-prop="age">
+        </tr>
+    </table>
     <div class="progressive-table-wrapper" data-list-render="some-list">
         <table>
-            <tr>
-                <td data-sort="alphabetic" data-sort-prop="name">
-                <td data-sort="numeric" data-sort-prop="age">
-            </tr>
+            <tbody></tbody>
         </table>
     </div>
     */
@@ -359,7 +362,7 @@ $(function () {
         var $this = $(this);
         var sort_type = $this.data("sort");
         var prop_name = $this.data("sort-prop");
-        var list_name = $this.closest(".progressive-table-wrapper").data("list-render");
+        var list_name = $this.parents("table").next(".progressive-table-wrapper").data("list-render");
 
         var list = list_render.get(list_name);
 

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -371,8 +371,16 @@ $(function () {
             return;
         }
 
+        if ($this.hasClass("active")) {
+            // Table has already been sorted by this property; do not re-sort.
+            return;
+        }
+
         // if `prop_name` is defined, it will trigger the generic codepath,
         // and not if it is undefined.
         list.sort(sort_type, prop_name);
+
+        $this.siblings(".active").removeClass("active");
+        $this.addClass("active");
     });
 });

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -440,11 +440,13 @@ input[type=checkbox].inline-block {
     padding: 1px 4px 1px 2px;
 }
 
-#attachments-settings table th.upload-size {
+#attachments-settings table th.upload-size,
+#attachments-settings table td.upload-size {
     width: 50px;
 }
 
-#attachments-settings table th.upload-actions {
+#attachments-settings table th.upload-actions,
+#attachments-settings table td.upload-actions {
     width: 75px;
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -953,6 +953,26 @@ input[type=checkbox].inline-block {
 #settings_page .table-striped thead th {
     background-color: inherit;
     color: inherit;
+    opacity: 0.5;
+}
+
+#settings_page .table-striped thead th.active {
+    opacity: 1;
+    -webkit-transition: opacity 100ms ease-out;
+    -moz-transition: opacity 100ms ease-out;
+    -o-transition: opacity 100ms ease-out;
+    transition: opacity 100ms ease-out;
+}
+
+#settings_page .table-striped thead th.active:after {
+  content: " \f0d7";
+  white-space: pre;
+  display: inline-block;
+  font: normal normal normal 12px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 #settings_page input.search {

--- a/static/templates/settings/attachments-settings.handlebars
+++ b/static/templates/settings/attachments-settings.handlebars
@@ -1,16 +1,19 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
     <div class='tip'>{{#tr this}}You are currently using __total_uploads_size__ of __upload_quota__ upload space.{{/tr}}</div>
-    <input id="upload_file_search" type="search" name="" value="" placeholder="{{t 'Search uploads...' }}" />
+    <input id="upload_file_search" class="search" type="text" placeholder="{{t 'Search uploads...' }}" aria-label="{{t 'Search uploads...' }}"/>
+    <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>
+    <table class="table table-condensed table-striped wrapped-table">
+        <thead>
+            <th data-sort="alphabetic" data-sort-prop="name" class="wrapped-cell">{{t "File" }}</th>
+            <th data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
+            <th data-sort="mentioned-in">{{t "Mentioned in" }}</th>
+            <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
+            <th class="upload-actions">{{t "Actions" }}</th>
+        </thead>
+    </table>
     <div class="progressive-table-wrapper" data-list-render="uploaded-files-list">
-        <table class="table table-condensed table-striped">
-            <thead>
-                <th data-sort="alphabetic" data-sort-prop="name">{{t "File" }}</th>
-                <th data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
-                <th data-sort="mentioned-in">{{t "Mentioned in" }}</th>
-                <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
-                <th class="upload-actions">{{t "Actions" }}</th>
-            </thead>
+        <table class="table table-condensed table-striped wrapped-table">
             <tbody class="required-text" data-empty="{{t 'You have not uploaded any files.' }}"
                    id="uploaded_files_table" ></tbody>
         </table>

--- a/static/templates/settings/attachments-settings.handlebars
+++ b/static/templates/settings/attachments-settings.handlebars
@@ -6,7 +6,7 @@
     <table class="table table-condensed table-striped wrapped-table">
         <thead>
             <th data-sort="alphabetic" data-sort-prop="name" class="wrapped-cell">{{t "File" }}</th>
-            <th data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
+            <th class="active" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
             <th data-sort="mentioned-in">{{t "Mentioned in" }}</th>
             <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
             <th class="upload-actions">{{t "Actions" }}</th>

--- a/static/templates/uploaded_files_list.handlebars
+++ b/static/templates/uploaded_files_list.handlebars
@@ -17,8 +17,8 @@
         </div>
         {{/if}}
     </td>
-    <td>{{ size_str }}</td>
-    <td>
+    <td class="upload-size">{{ size_str }}</td>
+    <td class="upload-actions">
         <span class="edit-attachment-buttons">
             <button type="submit"
                 class="button small no-style remove-attachment"


### PR DESCRIPTION
Before:

![](https://user-images.githubusercontent.com/15116870/32114689-ec9cb9e8-baf8-11e7-85e8-7d4d46e62fdc.png)

After:

[![https://gyazo.com/2e34e63909ca7cc80db797106750ddf2](https://i.gyazo.com/2e34e63909ca7cc80db797106750ddf2.gif)](https://gyazo.com/2e34e63909ca7cc80db797106750ddf2)

- [x] Prevent long file names from corrupting table display.
- [x] Add sticky table header.
- [x] Initially sort all files by date
- [x] Visually indicate the functionality of the info titles (provide a feedback on hovering, clicking, etc.)

Fixes #7189 and fixes #7149 .
