### PR TITLE
Issue 1348 followup

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -43,7 +43,6 @@ else:
     get_remote_server_by_uuid = Mock()
     RemoteZulipServer = Mock()  # type: ignore # https://github.com/JukkaL/mypy/issues/1188
 
-FuncT = TypeVar('FuncT', bound=Callable[..., Any])
 ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
 ReturnT = TypeVar('ReturnT')
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -712,11 +712,9 @@ def rate_limit(domain='all'):
         return wrapped_func
     return wrapper
 
-def return_success_on_head_request(view_func):
-    # type: (Callable) -> Callable
+def return_success_on_head_request(view_func: Callable[..., HttpResponse]) -> Callable[..., HttpResponse]:
     @wraps(view_func)
-    def _wrapped_view_func(request, *args, **kwargs):
-        # type: (HttpResponse, *Any, **Any) -> Callable
+    def _wrapped_view_func(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         if request.method == 'HEAD':
             return json_success()
         return view_func(request, *args, **kwargs)

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -45,6 +45,7 @@ else:
 
 FuncT = TypeVar('FuncT', bound=Callable[..., Any])
 ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
+ReturnT = TypeVar('ReturnT')
 
 ## logger setup
 webhook_logger = create_logger(
@@ -631,16 +632,16 @@ def to_utc_datetime(timestamp):
     return timestamp_to_datetime(float(timestamp))
 
 def statsd_increment(counter, val=1):
-    # type: (Text, int) -> Callable[[Callable[..., Any]], Callable[..., Any]]
+    # type: (Text, int) -> Callable[[Callable[..., ReturnT]], Callable[..., ReturnT]]
     """Increments a statsd counter on completion of the
     decorated function.
 
     Pass the name of the counter to this decorator-returning function."""
     def wrapper(func):
-        # type: (Callable[..., Any]) -> Callable[..., Any]
+        # type: (Callable[..., ReturnT]) -> Callable[..., ReturnT]
         @wraps(func)
         def wrapped_func(*args, **kwargs):
-            # type: (*Any, **Any) -> Any
+            # type: (*Any, **Any) -> ReturnT
             ret = func(*args, **kwargs)
             statsd.incr(counter, val)
             return ret

--- a/zerver/lib/profile.py
+++ b/zerver/lib/profile.py
@@ -2,12 +2,11 @@
 import cProfile
 
 from functools import wraps
-from typing import Any
+from typing import Any, TypeVar, Callable
 
-from zerver.decorator import FuncT
+ReturnT = TypeVar('ReturnT')
 
-def profiled(func):
-    # type: (FuncT) -> FuncT
+def profiled(func: Callable[..., ReturnT]) -> Callable[..., ReturnT]:
     """
     This decorator should obviously be used only in a dev environment.
     It works best when surrounding a function that you expect to be
@@ -25,11 +24,10 @@ def profiled(func):
 
     """
     @wraps(func)
-    def wrapped_func(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def wrapped_func(*args: Any, **kwargs: Any) -> ReturnT:
         fn = func.__name__ + ".profile"
         prof = cProfile.Profile()
-        retval = prof.runcall(func, *args, **kwargs)  # type: Any
+        retval = prof.runcall(func, *args, **kwargs)  # type: ReturnT
         prof.dump_stats(fn)
         return retval
-    return wrapped_func  # type: ignore # https://github.com/python/mypy/issues/1927
+    return wrapped_func


### PR DESCRIPTION
Following up from PR #7202 looking at resolving #1348, these seem like most of the remaining obvious tidying commits (pending the following comments):

* Tie the `statsd_increment` decorator function return type (using `ReturnT` instead of using `Any`)
* `FuncT` was unused in decorator.py, but was used in profile.py, so one commit adds more explicit return typing to the other decorator
* The typing of `return_success_on_head_request` was quite inaccurate and is hopefully better now.

Two commits switched to the python3 type annotations, since I saw that in another commit following #7202, but I'm not sure if that's the consensus when changing a function, anything in a file, or if generally it's going to happen in a separate migration?

Also, using the explicit `Callable[..., SomeType]` format may work around python/mypy#1927, though is arguably more verbose; should we keep to using an #ignore or use something like this if it works?

One reason for the bad typing sneaking through is that as much as we type with `HttpRequest` and `HttpResponse`, they are actually synonyms for `Any` (based on reveal_type, at least). I know there was some work on this, and there's an external project I've seen for django, though I'm not sure how close to use any of that is.

FYI @gnprice @timabbott 