### PR TITLE
wip - add docker compose intergration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+services:
+  zulip:
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    ports:
+      - "9991:9991"
+    volumes:
+      - ".:/srv/zulip"
+    command: /srv/zulip/tools/start-compose
+    depends_on:
+      - zulip-postgres
+      - zulip-memcached
+      - zulip-rabbitmq
+      - zulip-redis
+
+  zulip-postgres:
+    image: postgres:9.5
+
+  zulip-memcached:
+   image: memcached
+
+  zulip-rabbitmq:
+    image: rabbitmq:3.5.5
+
+  zulip-redis:
+    image: redis

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -206,6 +206,11 @@ def main(options):
     # hash the apt dependencies
     sha_sum = hashlib.sha1()
 
+    # if, using docker compose, don't need memcached etc
+    if options.is_compose:
+        COMPOSE_IGNORE_PACKAGES = ['memcached', 'rabbitmq-server', 'rabbitmq-redis-server', ]
+        APT_DEPENDENCIES[codename] = [package for package in UBUNTU_COMMON_APT_DEPENDENCIES if package not in COMPOSE_IGNORE_PACKAGES]
+
     for apt_depedency in APT_DEPENDENCIES[codename]:
         sha_sum.update(apt_depedency.encode('utf8'))
     # hash the content of setup-apt-repo
@@ -264,7 +269,10 @@ def main(options):
     setup_shell_profile('~/.bash_profile')
     setup_shell_profile('~/.zprofile')
 
-    run(["sudo", "cp", REPO_STOPWORDS_PATH, TSEARCH_STOPWORDS_PATH])
+    if options.is_compose:
+        pass
+    else:
+        run(["sudo", "cp", REPO_STOPWORDS_PATH, TSEARCH_STOPWORDS_PATH])
 
     # create log directory `zulip/var/log`
     run(["mkdir", "-p", LOG_DIR_PATH])
@@ -317,6 +325,14 @@ def main(options):
 
         from zerver.lib.str_utils import force_bytes
         from zerver.lib.test_fixtures import is_template_database_current
+
+        # change settings for docker compose
+        from django.conf import settings
+        if options.is_compose:
+            settings.RABBITMQ_HOST = 'zulip-rabbitmq'
+            settings.RABBITMQ_USERNAME = 'zulip',
+            settings.REDIS_HOST = 'zulip-redis'
+            settings.REMOTE_POSTGRES_HOST = 'zulip-postgres'
 
         try:
             from zerver.lib.queue import SimpleQueueClient
@@ -395,6 +411,11 @@ if __name__ == "__main__":
                         dest='is_docker',
                         default=False,
                         help="Provision for Docker.")
+
+    parser.add_argument('--compose', action='store_true',
+                        dest='is_compose',
+                        default=False,
+                        help="Provision for Docker Compose.")
 
     options = parser.parse_args()
     sys.exit(main(options))

--- a/tools/start-compose
+++ b/tools/start-compose
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+export LANG="en_US.UTF-8"
+export LC_COLLATE="en_US.UTF-8"
+export LC_CTYPE="en_US.UTF-8"
+export LC_MESSAGES="en_US.UTF-8"
+export LC_MONETARY="en_US.UTF-8"
+export LC_NUMERIC="en_US.UTF-8"
+export LC_TIME="en_US.UTF-8"
+export LC_ALL="en_US.UTF-8"
+/srv/zulip/tools/provision --compose
+/srv/zulip/scripts/setup/configure-rabbitmq
+/srv/zulip/tools/run-dev.py --interface=''


### PR DESCRIPTION
Currently we are using a single Docker container to host all the components of Zulip - Postgres, memcached, rabbitmq, redis. 

Problems with this approach:
 - Many devs already have containers of redis, postgres etc on their machine and we aren't leveraging them currently 
- The monolithic docker container breaks very often due to numerous reasons like improper order of starting the components,  timeouts in flushing memcached etc

This PR breaks the single docker container into 5 containers - postgres, memcached, rabbitmq, redis and zulip core. 