### PR TITLE
mypy: Callable improvements

### DIFF
--- a/tools/diagnose
+++ b/tools/diagnose
@@ -15,7 +15,7 @@ from scripts.lib.zulip_tools import get_dev_uuid_var_path
 UUID_VAR_PATH = get_dev_uuid_var_path()
 
 def run(check_func):
-    # type: (Callable) -> None
+    # type: (Callable[[], bool]) -> None
     '''
     This decorator simply runs functions.  It makes it more
     convenient to add new checks without a big main() function.

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -23,7 +23,6 @@ if False:
     # These modules have to be imported for type annotations but
     # they cannot be imported at runtime due to cyclic dependency.
 
-FuncT = TypeVar('FuncT', bound=Callable[..., Any])
 ReturnT = TypeVar('ReturnT')  # Useful for matching return types via Callable[..., ReturnT]
 
 class NotFoundInCache(Exception):

--- a/zerver/lib/fix_unreads.py
+++ b/zerver/lib/fix_unreads.py
@@ -63,7 +63,7 @@ def update_unread_flags(cursor, user_message_ids):
 
 
 def get_timing(message, f):
-    # type: (str, Callable) -> None
+    # type: (str, Callable[[], None]) -> None
     start = time.time()
     logger.info(message)
     f()

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -42,6 +42,8 @@ class RequestVariableConversionError(JsonableError):
         # type: () -> str
         return _("Bad value for '{var_name}': {bad_value}")
 
+ConvertT = TypeVar('ConvertT')
+
 # Used in conjunction with @has_request_variables, below
 class REQ(object):
     # NotSpecified is a sentinel value for determining whether a
@@ -53,7 +55,7 @@ class REQ(object):
 
     def __init__(self, whence=None, converter=None, default=NotSpecified,
                  validator=None, argument_type=None):
-        # type: (str, Callable[Any, Any], Any, Callable[Any, Any], str) -> None
+        # type: (str, Callable[[str], ConvertT], ConvertT, Callable[[str], ConvertT], str) -> None
         """whence: the name of the request variable that should be used
         for this parameter.  Defaults to a request variable of the
         same name as the parameter.

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -3,7 +3,7 @@ from functools import partial
 import random
 
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, \
-    Text, Type, cast, Union
+    Text, Type, cast, Union, TypeVar
 from unittest import loader, runner  # type: ignore  # Mypy cannot pick these up.
 from unittest.result import TestResult
 
@@ -38,8 +38,10 @@ if False:
 
 _worker_id = 0  # Used to identify the worker process.
 
+ReturnT = TypeVar('ReturnT')  # Constrain return type to match
+
 def slow(slowness_reason):
-    # type: (str) -> Callable[[Callable], Callable]
+    # type: (str) -> Callable[[Callable[..., ReturnT]], Callable[..., ReturnT]]
     '''
     This is a decorate that annotates a test as being "known
     to be slow."  The decorator will set expected_run_time and slowness_reason
@@ -47,7 +49,7 @@ def slow(slowness_reason):
     as needed, e.g. to exclude these tests in "fast" mode.
     '''
     def decorator(f):
-        # type: (Any) -> Any
+        # type: (Any) -> ReturnT
         f.slowness_reason = slowness_reason
         return f
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1624,7 +1624,7 @@ class UserPresence(models.Model):
 
     @staticmethod
     def get_status_dict_by_user(user_profile):
-        # type: (UserProfile) -> Dict[Text, Dict[Any, Any]]
+        # type: (UserProfile) -> Dict[str, Dict[str, Any]]
         query = UserPresence.objects.filter(user_profile=user_profile).values(
             'client__name',
             'status',
@@ -1643,7 +1643,7 @@ class UserPresence(models.Model):
 
     @staticmethod
     def get_status_dict_by_realm(realm_id):
-        # type: (int) -> Dict[Text, Dict[Any, Any]]
+        # type: (int) -> Dict[str, Dict[str, Any]]
         user_profile_ids = UserProfile.objects.filter(
             realm_id=realm_id,
             is_active=True,
@@ -1692,9 +1692,9 @@ class UserPresence(models.Model):
 
     @staticmethod
     def get_status_dicts_for_rows(presence_rows, mobile_user_ids):
-        # type: (List[Dict[str, Any]], Set[int]) -> Dict[Text, Dict[Any, Any]]
+        # type: (List[Dict[str, Any]], Set[int]) -> Dict[str, Dict[str, Any]]
 
-        info_row_dct = defaultdict(list)  # type: DefaultDict[Text, List[Dict[str, Any]]]
+        info_row_dct = defaultdict(list)  # type: DefaultDict[str, List[Dict[str, Any]]]
         for row in presence_rows:
             email = row['user_profile__email']
             client_name = row['client__name']

--- a/zerver/tornado/websocket_client.py
+++ b/zerver/tornado/websocket_client.py
@@ -24,7 +24,8 @@ from typing import Any, Callable, Dict, Generator, Iterable, Optional
 class WebsocketClient(object):
     def __init__(self, host_url, sockjs_url, sender_email, run_on_start, validate_ssl=True,
                  **run_kwargs):
-        # type: (str, str, str, Callable, bool, **Any) -> None
+        # NOTE: Callable should take a WebsocketClient & kwargs, but this is not standardised
+        # type: (str, str, str, Callable[..., None], bool, **Any) -> None
         self.validate_ssl = validate_ssl
         self.auth_email = sender_email
         self.user_profile = get_system_bot(sender_email)

--- a/zerver/webhooks/librato/view.py
+++ b/zerver/webhooks/librato/view.py
@@ -79,7 +79,7 @@ class LibratoWebhookHandler(LibratoWebhookParser):
         }
 
     def find_handle_method(self):
-        # type: () -> Callable
+        # type: () -> Callable[[], Text]
         for available_type in self.payload_available_types:
             if self.payload.get(available_type):
                 return self.payload_available_types[available_type]


### PR DESCRIPTION
This follows from my work on decorators, often here involving expanding simple `Callable` annotation to specify parameter and return types, where known. Some involve `HttpRequest` or `HttpResponse`, which currently evaluate to `Any`, but at least should constrain the length of an argument list.

Incremental annotation is useful, but I'm not sure there's a constraint/option in mypy to check for cases such as this, eg. `List` vs `List[Type]`?