### PR TITLE
markdown: Fix error in markdown documentation and tests.

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -50,14 +50,14 @@ this file:
   `true` in the fixtures; this will automatically verify that
   `markdown.contains_backend_only_syntax` rejects the syntax, ensuring
   it will be rendered only by the backend processor.
-* When the two processors disagree, we set `expected_marked_output` in
+* When the two processors disagree, we set `marked_expected_output` in
   the fixtures; this will ensure that the syntax stays that way.  If
-  the differenes are important (i.e. not just whitespace), we should
+  the differences are important (i.e. not just whitespace), we should
   also open an issue on GitHub to track the problem.
 * When those above settings are not in use, we set
   `bugdown_matches_marked` to `false`.  `bugdown_matches_marked` is
   the predescessor to the more descriptive `backend_only_rendering`
-  and `expected_marked_output` fields, and when `false`, should be
+  and `marked_expected_output` fields, and when `false`, should be
   replaced be one of those.  We plan to eliminate it once we're out of
   cases where it is `false`.
 * For mobile push notifications, we need a text version of the

--- a/zerver/fixtures/markdown_test_cases.json
+++ b/zerver/fixtures/markdown_test_cases.json
@@ -33,14 +33,14 @@
       "input": "\n```\nfenced code\n```\n\n```inline code```\n",
       "expected_output": "<div class=\"codehilite\"><pre><span></span>fenced code\n</pre></div>\n\n\n<p><code>inline code</code></p>",
       "bugdown_matches_marked": true,
-      "test_content": "fenced code\n\n\n\ninline code"
+      "text_content": "fenced code\n\n\n\ninline code"
     },
     {
       "name": "hanging_multi_codeblock",
       "input": "Hamlet said:\n~~~~\ndef speak(self):\n    x = 1\n# Comment to make this code block longer to test Trac #1162\n~~~~\n\nThen he mentioned ````y = 4 + x**2```` and\n~~~~\ndef foobar(self):\n    return self.baz()",
       "expected_output": "<p>Hamlet said:</p>\n<div class=\"codehilite\"><pre><span></span>def speak(self):\n    x = 1\n# Comment to make this code block longer to test Trac #1162\n</pre></div>\n\n\n<p>Then he mentioned <code>y = 4 + x**2</code> and</p>\n<div class=\"codehilite\"><pre><span></span>def foobar(self):\n    return self.baz()\n</pre></div>",
       "bugdown_matches_marked": true,
-      "test_content": "Hamlet said:\ndef speak(self):\n    x = 1\n# Comment to make this code block longer to test Trac #1162\n\n\n\nThen he mentioned y = 4 + x**2 and\ndef foobar(self):\n    return self.baz()\n"
+      "text_content": "Hamlet said:\ndef speak(self):\n    x = 1\n# Comment to make this code block longer to test Trac #1162\n\n\n\nThen he mentioned y = 4 + x**2 and\ndef foobar(self):\n    return self.baz()\n"
     },
     {
       "name": "fenced_quote",


### PR DESCRIPTION
While trying to fix #7099, I observed that in the docs, the term should be `marked_expected_output` and not `expected_marked_output` as seen in https://github.com/zulip/zulip/blob/master/zerver/fixtures/markdown_test_cases.json#L7. Also in markdown_test_cases.json, the field should be `text_content` and not `test_content`.