### PR TITLE
popovers: Hide opened popover on navigating back.

### DIFF
--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -49,6 +49,8 @@ exports.active_modal = function () {
 };
 
 exports.open_overlay = function (opts) {
+    popovers.hide_all();
+
     if (!opts.name || !opts.overlay || !opts.on_close) {
         blueslip.error('Programming error in open_overlay');
         return;


### PR DESCRIPTION
Hides popover if remained open and modals like setting are opened on navigating back (given that the settings are opened last).
(The bug was with all type of popovers.)
Fixes: #7230.
my GIF tool is not working so I can't give the working gif at present.