### PR TITLE
right_sidebar: Open user popover on clicking name in userlist

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -319,26 +319,6 @@ $(function () {
         }
     });
 
-    $('#user_presences').expectOne().on('click', '.selectable_sidebar_block', function (e) {
-        var user_id = $(e.target).parents('li').attr('data-user-id');
-        var email = people.get_person_from_user_id(user_id).email;
-        activity.clear_and_hide_search();
-        narrow.by('pm-with', email, {select_first_unread: true, trigger: 'sidebar'});
-        // The preventDefault is necessary so that clicking the
-        // link doesn't jump us to the top of the page.
-        e.preventDefault();
-        // The stopPropagation is necessary so that we don't
-        // see the following sequence of events:
-        // 1. This click "opens" the composebox
-        // 2. This event propagates to the body, which says "oh, hey, the
-        //    composebox is open and you clicked out of it, you must want to
-        //    stop composing!"
-        e.stopPropagation();
-        // Since we're stopping propagation we have to manually close any
-        // open popovers.
-        popovers.hide_all();
-    });
-
     $('#group-pms').expectOne().on('click', '.selectable_sidebar_block', function (e) {
         var user_ids_string = $(e.target).parents('li').attr('data-user-ids');
         var emails = people.user_ids_string_to_emails_string(user_ids_string);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -439,7 +439,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('#user_presences').on('click', 'span.arrow', function (e) {
+    $('#user_presences').on('click', 'span.selectable_sidebar_block', function (e) {
         e.stopPropagation();
 
         // use email of currently selected user, rather than some elem comparison,

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -110,7 +110,6 @@
 }
 
 .user_sidebar_entry .selectable_sidebar_block {
-    width: 208px;
     display: block;
 }
 

--- a/static/templates/user_presence_row.handlebars
+++ b/static/templates/user_presence_row.handlebars
@@ -1,11 +1,9 @@
 <li data-user-id="{{user_id}}" class="user_sidebar_entry {{#if num_unread}}user-with-count {{/if}}narrow-filter user_{{type}}">
     <span class="selectable_sidebar_block">
         <span class="user-status-indicator"></span>
-        <a href="{{href}}"
-            data-user-id="{{user_id}}"
+        <a  data-user-id="{{user_id}}"
             data-name="{{name}}"
             title="{{name}} {{type_desc}}">{{name}}</a>
     </span>
     <span class="count"><span class="value">{{#if num_unread}}{{num_unread}}{{/if}}</span></span>
-    <span class="arrow"><i class="icon-vector-chevron-down"></i></span>
 </li>


### PR DESCRIPTION
This changes the behavior of clicking a Username on the Right sidebar from narrowing to "PMs with that user" to "User info Popover".
As chevron in username list is redundant so it is removed.
There may be some code refactoring which I'll do on the finalization of behavior.
Fixes: #7237