### PR TITLE
left-sidebar: Add overflow ellipsis on long stream names.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -207,8 +207,7 @@ li.hidden-filter {
 .topic-name {
     display: block;
     line-height: 1.3em;
-    width: 100%;
-    max-width: 158px;
+    width: calc(100% - 5px);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -313,7 +312,16 @@ ul.filters li.out_of_home_view li.muted_topic {
 }
 
 #stream_filters .subscription_block .stream-name {
-    overflow-wrap: break-word;
+    display: inline-block;
+    width: calc(100% - 50px);
+
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+
+    line-height: 1;
+    position: relative;
+    top: 2px;
 }
 
 #stream_filters .subscription_block.stream-with-count {

--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -196,13 +196,6 @@
 }
 
 @media (max-width: 500px) {
-    .stream-name {
-        max-width: 120px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-
     .column-right.expanded .right-sidebar,
     .column-left.expanded .left-sidebar {
         margin-top: 31px;


### PR DESCRIPTION
On stream names that don’t quite fit, we’ll add overflow ellipsis to
them. It appears we already did this on mobile in a sub-optimal way so
we can remove that media query with preference to the new, better
styling.