### PR TITLE
list_render: Add reverse sorting order.

### DIFF
--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -183,8 +183,13 @@ var list_render = (function () {
 
             // `do_not_display` will signal to not update the DOM, likely because in
             // the next function it will be updated in the DOM.
-            sort: function (sorting_function, prop, map, do_not_display) {
+            sort: function (sorting_function, prop, map, do_not_display, reverse) {
                 meta.prop = prop;
+
+                if (reverse === true) {
+                    // simple mutable array reversal.
+                    meta.filtered_list.reverse();
+                }
 
                 if (typeof sorting_function === "function") {
                     meta.sorting_function = sorting_function;
@@ -197,17 +202,18 @@ var list_render = (function () {
                     }
                 }
 
-                if (meta.sorting_function) {
+                // we do not want to sort if we are just looking to reverse.
+                if (meta.sorting_function && !reverse) {
                     meta.filtered_list = meta.filtered_list.sort(meta.sorting_function);
+                }
 
-                    if (!do_not_display) {
-                        // clear and re-initialize the list with the newly filtered subset
-                        // of items.
-                        prototype.init();
+                if (!do_not_display) {
+                    // clear and re-initialize the list with the newly filtered subset
+                    // of items.
+                    prototype.init();
 
-                        if (opts.filter.onupdate) {
-                            opts.filter.onupdate();
-                        }
+                    if (opts.filter.onupdate) {
+                        opts.filter.onupdate();
                     }
                 }
             },
@@ -372,6 +378,13 @@ $(function () {
         }
 
         if ($this.hasClass("active")) {
+            if (!$this.hasClass("descend")) {
+                $this.addClass("descend");
+            } else {
+                $this.removeClass("descend");
+            }
+
+            list.sort(undefined, undefined, undefined, undefined, true);
             // Table has already been sorted by this property; do not re-sort.
             return;
         }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -975,6 +975,10 @@ input[type=checkbox].inline-block {
     -moz-osx-font-smoothing: grayscale;
 }
 
+#settings_page .table-striped thead th.active.descend:after {
+    content: " \f0d7";
+}
+
 #settings_page input.search {
     font-size: 0.9rem;
     margin: 0px 0px 20px 0px;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -965,7 +965,7 @@ input[type=checkbox].inline-block {
 }
 
 #settings_page .table-striped thead th.active:after {
-    content: " \f0d7";
+    content: " \f0d8";
     white-space: pre;
     display: inline-block;
     font: normal normal normal 12px/1 FontAwesome;


### PR DESCRIPTION
This allows a user to reverse the sort order by clicking again on an
active tab, which changes from ascending to descending order.

Fixes: #7254.