### PR TITLE
portico-header: Add background to avatar images.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -769,6 +769,7 @@ input.text-error {
     vertical-align: top;
 
     border-radius: 4px 0px 0px 4px;
+    background: #fff;
 }
 
 .app {


### PR DESCRIPTION
This adds a white background color to avatar images that may
have a transparent background.