### PR TITLE
overlays: Move overlays earlier in index.html.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -30,8 +30,6 @@
 }
 
 .subscriptions {
-    margin-top: 55px;
-    padding-left: 15px;
     -webkit-font-smoothing: antialiased;
 }
 

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -45,13 +45,16 @@ var page_params = {{ page_params }};
 
 {% endblock %}
 {% block content %}
+{% include "zerver/lightbox_overlay.html" %}
+{% include "zerver/subscriptions.html" %}
+{% include "zerver/drafts.html" %}
+<div id="settings_overlay_container" class="overlay" data-overlay="settings" aria-hidden="true">
+  {% include "zerver/settings_overlay.html" %}
+</div>
+
 <div id="css-loading">
     <h3>{{ _('Loading...') }}</h3>
     <p>{% trans %}If this message does not go away, please wait a couple seconds and <a href="javascript:location.reload(true)">reload</a> the page.{% endtrans %}</p>
-</div>
-
-<div id="settings_overlay_container" class="overlay" data-overlay="settings" aria-hidden="true">
-  {% include "zerver/settings_overlay.html" %}
 </div>
 {% include "zerver/navbar.html" %}
 
@@ -133,9 +136,6 @@ var page_params = {{ page_params }};
     <div class="column-right">
           {% include "zerver/right_sidebar.html" %}
     </div><!--/right sidebar-->
-    {% include "zerver/lightbox_overlay.html" %}
-    {% include "zerver/subscriptions.html" %}
-    {% include "zerver/drafts.html" %}
 </div><!--/row-->
     <div class="informational-overlays overlay new-style" data-overlay="informationalOverlays" aria-hidden="true">
         <div class="overlay-content">


### PR DESCRIPTION
It appears as though the ordering of the overlays in the DOM is
overriding their z-index in Safari on mobile. This moves them up to the
top of the template ahead of the header so that the header will no
longer display above the overlays in positioning.

Fixes: #7248.

WARNING: THIS IS RISKY SINCE IT MOVES LARGE CHUNKS OF CODE OUT OF
VARIOUS SELECTORS. It appears to test fine, however there could be
selector bugs that are more tricky to find.