### PR TITLE
prod install: Move certbot setup to be after puppet apply.

### DIFF
--- a/puppet/zulip/files/cron.d/certbot-renew
+++ b/puppet/zulip/files/cron.d/certbot-renew
@@ -1,0 +1,6 @@
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+USER=root
+
+# Cron job to renew certbot twice a day.
+52 0,12 * * * root /root/certbot-auto renew --quiet

--- a/puppet/zulip/manifests/app_frontend.pp
+++ b/puppet/zulip/manifests/app_frontend.pp
@@ -36,6 +36,15 @@ class zulip::app_frontend {
     source => "puppet:///modules/zulip/cron.d/send-digest-emails",
   }
 
+  # Trigger 2x a day certbot renew
+  file { "/etc/cron.d/certbot-renew":
+    ensure => file,
+    owner  => "root",
+    group  => "root",
+    mode   => 644,
+    source => "puppet:///modules/zulip/cron.d/certbot-renew",
+  }
+
   # Restart the server regularly to avoid potential memory leak problems.
   file { "/etc/cron.d/restart-zulip":
     ensure => file,

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -82,10 +82,6 @@ ZULIP_PATH="$(realpath $(dirname $0)/../..)"
 # Handle issues around upstart on Ubuntu Xenial
 "$ZULIP_PATH"/scripts/lib/check-upstart
 
-if [ -n "$USE_CERTBOT" ]; then
-    "$ZULIP_PATH"/scripts/setup/setup-certbot --hostname "$EXTERNAL_HOST" --email "$ZULIP_ADMINISTRATOR"
-fi
-
 # Check for missing SSL certificates early as well
 if [ "$PUPPET_CLASSES" = "zulip::voyager" ] && { ! [ -e "/etc/ssl/private/zulip.key" ] || ! [ -e "/etc/ssl/certs/zulip.combined-chain.crt" ]; }; then
    set +x
@@ -136,6 +132,10 @@ mkdir -p /etc/zulip
     fi
 ) > /etc/zulip/zulip.conf
 "$ZULIP_PATH"/scripts/zulip-puppet-apply -f
+
+if [ -n "$USE_CERTBOT" ]; then
+    "$ZULIP_PATH"/scripts/setup/setup-certbot --hostname "$EXTERNAL_HOST" --email "$ZULIP_ADMINISTRATOR"
+fi
 
 # Detect which features were selected for the below
 set +e


### PR DESCRIPTION
So that the certbot nginx patch can be automatically applied after the nginx confs have be set up by puppet.