### PR TITLE
service bot tests: Remove bot stream subscription.

### DIFF
--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -193,9 +193,6 @@ class TestServiceBotEventTriggers(ZulipTestCase):
                                                  bot_type=UserProfile.OUTGOING_WEBHOOK_BOT,
                                                  bot_owner=self.user_profile)
 
-        # TODO: In future versions this won't be required
-        self.subscribe(self.bot_profile, 'Denmark')
-
     @mock.patch('zerver.lib.actions.queue_json_publish')
     def test_trigger_on_stream_mention_from_user(self, mock_queue_json_publish):
         # type: (mock.Mock) -> None


### PR DESCRIPTION
Since service bots react to all @-mentions, the
stream subscription was redundant.