### PR TITLE
[WIP] mypy: Avoid untyped generics

### DIFF
--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -87,7 +87,8 @@ if not python_files:
 extra_args = ["--check-untyped-defs",
               "--follow-imports=silent",
               "--scripts-are-modules",
-              "-i", "--cache-dir=var/mypy-cache"]
+              "-i", "--cache-dir=var/mypy-cache",
+              "--disallow-any=generics"]
 if args.linecoverage_report:
     extra_args.append("--linecoverage-report")
     extra_args.append("var/linecoverage-report")

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -110,7 +110,7 @@ def add_missing_messages(user_profile):
         modified_stream__id__in=stream_ids,
         event_type__in=events).order_by('event_last_message_id'))
 
-    all_stream_subscription_logs = defaultdict(list)  # type: DefaultDict[int, List]
+    all_stream_subscription_logs = defaultdict(list)  # type: DefaultDict[int, List[RealmAuditLog]]
     for log in subscription_logs:
         all_stream_subscription_logs[log.modified_stream.id].append(log)
 
@@ -141,7 +141,7 @@ def add_missing_messages(user_profile):
     all_stream_msgs = [msg for msg in all_stream_msgs
                        if msg['id'] not in already_created_ums]
 
-    stream_messages = defaultdict(list)  # type: DefaultDict[int, List]
+    stream_messages = defaultdict(list)  # type: DefaultDict[int, List[Message]]
     for msg in all_stream_msgs:
         stream_messages[msg['recipient__type_id']].append(msg)
 

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -527,7 +527,7 @@ def deserialize_suite(args):
 class RemoteTestRunner(django_runner.RemoteTestRunner):
     resultclass = RemoteTestResult
 
-class SubSuiteList(list):
+class SubSuiteList(List[Tuple[Type[TestSuite], List[str]]]):
     """
     This class allows us to avoid changing the main logic of
     ParallelTestSuite and still make it serializable.

--- a/zerver/lib/url_preview/oembed/__init__.py
+++ b/zerver/lib/url_preview/oembed/__init__.py
@@ -1,9 +1,9 @@
-from typing import Optional, Text, Dict
+from typing import Optional, Text, Dict, Any
 from pyoembed import oEmbed, PyOembedException
 
 
 def get_oembed_data(url, maxwidth=640, maxheight=480):
-    # type: (Text, Optional[int], Optional[int]) -> Optional[Dict]
+    # type: (Text, Optional[int], Optional[int]) -> Optional[Dict[Any, Any]]
     try:
         data = oEmbed(url, maxwidth=maxwidth, maxheight=maxheight)
     except PyOembedException:

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -32,7 +32,7 @@ def cache_key_func(url):
 
 @cache_with_key(cache_key_func, cache_name=CACHE_NAME, with_statsd_key="urlpreview_data")
 def get_link_embed_data(url, maxwidth=640, maxheight=480):
-    # type: (Text, Optional[int], Optional[int]) -> Optional[Dict]
+    # type: (Text, Optional[int], Optional[int]) -> Optional[Dict[Any, Any]]
     if not is_link(url):
         return None
     # Fetch information from URL.

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1275,8 +1275,8 @@ class GetOldMessagesTest(ZulipTestCase):
         self.assert_json_error_contains(result, 'elem["operand"] is not a string')
 
     def exercise_bad_narrow_operand(self, operator, operands, error_msg):
-        # type: (Text, Sequence, Text) -> None
-        other_params = [("anchor", 0), ("num_before", 0), ("num_after", 0)]  # type: List
+        # type: (Text, Sequence[Any], Text) -> None
+        other_params = [("anchor", 0), ("num_before", 0), ("num_after", 0)]  # type: List[Tuple[str, Any]]
         for operand in operands:
             post_params = dict(other_params + [
                 ("narrow", ujson.dumps([[operator, operand]]))])

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1290,7 +1290,7 @@ class GetOldMessagesTest(ZulipTestCase):
         returned.
         """
         self.login(self.example_email("hamlet"))
-        bad_stream_content = (0, [], ["x", "y"])  # type: Sequence
+        bad_stream_content = (0, [], ["x", "y"])  # type: Tuple[int, List[None], List[Text]]
         self.exercise_bad_narrow_operand("stream", bad_stream_content,
                                          "Bad value for 'narrow'")
 

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -135,7 +135,7 @@ class TestMoveMessageToArchive(ZulipTestCase):
             create_attachment(file_name, path_id, user_profile, size)
 
     def _check_messages_before_archiving(self, msg_id):
-        # type: (int) -> List
+        # type: (int) -> List[int]
         user_messages_ids_before = list(UserMessage.objects.filter(
             message_id=msg_id).order_by('id').values_list('id', flat=True))
         self.assertEqual(ArchivedUserMessage.objects.count(), 0)

--- a/zerver/webhooks/pivotal/view.py
+++ b/zerver/webhooks/pivotal/view.py
@@ -14,7 +14,7 @@ from defusedxml.ElementTree import fromstring as xml_fromstring
 import logging
 import re
 import ujson
-from typing import Dict, List, Optional, Tuple, Text
+from typing import Dict, List, Optional, Tuple, Text, Any
 
 
 def api_pivotal_webhook_v3(request: HttpRequest, user_profile: UserProfile,
@@ -96,7 +96,7 @@ def api_pivotal_webhook_v5(request: HttpRequest, user_profile: UserProfile,
     content = ""
     subject = "#%s: %s" % (story_id, story_name)
 
-    def extract_comment(change: Dict[str, Dict]) -> Optional[Text]:
+    def extract_comment(change: Dict[str, Any]) -> Optional[Text]:
         if change.get("kind") == "comment":
             return change.get("new_values", {}).get("text", None)
         return None


### PR DESCRIPTION
Following improved typing of Callables in #7233 I realized that unparameterized generic types could slip through, like `Dict` (or `Callable`). In some cases this is essentially reasonable (though the parameterization is important IMO), and we should maybe document this by using `object` or more `TypeVar`s instead of `Any` to distinguish generic or true dynamic code?

This PR simply tries to specify the type parameters (whether very narrowly, or using `...` and `Any`), or broaden them where it seemed appropriate. As reiterated below, it is easier to then search for `Any` at a later stage, than looking for unparameterized types. 

Some commits are WIP, with questions or since they lead to an outstanding issue (test_runner.py); there are also 3 outstanding issues with test_narrow.py. The first commit should be made [LAST] since it actually enforces the mypy testing. However, other commits should be fine to commit separately first.

Description from the first commit:

This adds the "--disallow-any=generics" option to run-mypy, which no longer permits:
- inheriting from "list"; use "List[sometype]" (or a TypeVar)
- generic types with no following square brackets specifying the type
  (even if initially 'Any')

Any (and '...' for Callable) is a lot easier to search for than an
absence of square brackets, and should improve overall typing quality.

--
This may be of interest to @alenavolk and @rht, in addition to @gnprice and @timabbott.