### PR TITLE
mypy: Improve typing of request.pyi (REQ).

### DIFF
--- a/zerver/lib/request.pyi
+++ b/zerver/lib/request.pyi
@@ -1,14 +1,31 @@
 # This mypy stubs file ensures that mypy can correctly analyze REQ.
-from typing import Any, Callable, Text, TypeVar
+#
+# Note that here REQ is claimed to be a function, with a return type to match
+# that of the parameter of which it is the default value, allowing type
+# checking. However, in request.py, REQ is a class to enable the decorator to
+# scan the parameter list for REQ objects and patch the parameters as the true
+# types.
+
+from typing import Any, Callable, Text, TypeVar, Optional, Union
 from django.http import HttpResponse
 
 from zerver.lib.exceptions import JsonableError as JsonableError
 
+Validator = Callable[[str, Any], Optional[str]]
+
+ResultT = TypeVar('ResultT')
 ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
 
 class RequestVariableMissingError(JsonableError): ...
 class RequestVariableConversionError(JsonableError): ...
 
-def REQ(*args: Any, **kwargs: Any) -> Any: ...
+class _NotSpecified: ...
+NotSpecified = _NotSpecified()
+
+def REQ(whence: Optional[str] = None,
+        converter: Optional[Callable[[str], ResultT]] = None,
+        default: Union[_NotSpecified, ResultT] = NotSpecified,
+        validator: Optional[Validator] = None,
+        argument_type: Optional[str] = None) -> ResultT: ...
 
 def has_request_variables(view_func: ViewFuncT) -> ViewFuncT: ...

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -103,13 +103,13 @@ class DecoratorTestCase(TestCase):
         # type: () -> None
 
         def my_converter(data):
-            # type: (str) -> List[str]
+            # type: (str) -> List[int]
             lst = ujson.loads(data)
             if not isinstance(lst, list):
                 raise ValueError('not a list')
             if 13 in lst:
                 raise JsonableError('13 is an unlucky number!')
-            return lst
+            return [int(elem) for elem in lst]
 
         @has_request_variables
         def get_total(request, numbers=REQ(converter=my_converter)):
@@ -149,7 +149,7 @@ class DecoratorTestCase(TestCase):
         with self.assertRaisesRegex(AssertionError, "converter and validator are mutually exclusive"):
             @has_request_variables
             def get_total(request, numbers=REQ(validator=check_list(check_int),
-                                               converter=lambda: None)):
+                                               converter=lambda x: [])):
                 # type: (HttpRequest, Iterable[int]) -> int
                 return sum(numbers)  # nocoverage -- isn't intended to be run
 

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -1,6 +1,6 @@
 # System documented in https://zulip.readthedocs.io/en/latest/logging.html
 
-from typing import Any, Dict, Optional, Text
+from typing import Any, Dict, Optional, Text, Union
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
@@ -39,7 +39,7 @@ def report_send_times(request, user_profile,
                       displayed=REQ(converter=to_non_negative_int, default="(unknown)"),
                       locally_echoed=REQ(validator=check_bool, default=False),
                       rendered_content_disparity=REQ(validator=check_bool, default=False)):
-    # type: (HttpRequest, UserProfile, int, int, int, bool, bool) -> HttpResponse
+    # type: (HttpRequest, UserProfile, int, Union[int, str], Union[int, str], bool, bool) -> HttpResponse
     request._log_data["extra"] = "[%sms/%sms/%sms/echo:%s/diff:%s]" \
         % (time, received, displayed, locally_echoed, rendered_content_disparity)
     base_key = statsd_key(user_profile.realm.string_id, clean_periods=True)

--- a/zerver/webhooks/travis/view.py
+++ b/zerver/webhooks/travis/view.py
@@ -31,7 +31,7 @@ def api_travis_webhook(request, user_profile,
                            ('status_message', check_string),
                            ('compare_url', check_string),
                        ]))):
-    # type: (HttpRequest, UserProfile, str, str, str, Dict[str, str]) -> HttpResponse
+    # type: (HttpRequest, UserProfile, str, str, bool, Dict[str, str]) -> HttpResponse
 
     message_status = message['status_message']
     if ignore_pull_requests and message['type'] == 'pull_request':


### PR DESCRIPTION
This is a minimal version of #7261, involving expanding request.pyi to cover some of the perceived advantages while retaining a separate stubs file.

Other files have been updated to pass mypy where necessary, though there is one outstanding case which I've not yet been able to resolve.

Converters and defaults must now now match the specified type in the function signatures, which wasn't previously checked by mypy, in addition to the typing of the other `REQ` parameters.

Should the types be removed from request.py?