### PR TITLE
Avoid double-escaping HTML for settings notifications.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -126,7 +126,7 @@ exports.set_up = function () {
                             'Sorry for the trouble!');
                         return false;
                     } else if (!password_ok) {
-                        settings_change_error('New password is too weak');
+                        settings_change_error(i18n.t('New password is too weak'));
                         return false;
                     }
                 }
@@ -134,10 +134,10 @@ exports.set_up = function () {
             return true;
         },
         success: function () {
-            settings_change_success("Updated settings!");
+            settings_change_success(i18n.t("Updated settings!"));
         },
         error: function (xhr) {
-            settings_change_error("Error changing settings", xhr);
+            settings_change_error(i18n.t("Error changing settings"), xhr);
         },
         complete: function () {
             // Whether successful or not, clear the password boxes.
@@ -169,7 +169,7 @@ exports.set_up = function () {
                 }
             },
             error: function (xhr) {
-                settings_change_error("Error changing settings", xhr);
+                settings_change_error(i18n.t("Error changing settings"), xhr);
             },
         });
     });

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -92,7 +92,7 @@ exports.on_load_success = function (invites_data) {
 
         if (modal_invite_id !== meta.invite_id) {
             blueslip.error("Invite revoking canceled due to non-matching fields.");
-            ui_report.message("Resending encountered an error. Please reload and try again.",
+            ui_report.message(i18n.t("Resending encountered an error. Please reload and try again."),
                $("#home-error"), 'alert-error');
         }
         $("#revoke_invite_modal").modal("hide");
@@ -120,7 +120,7 @@ exports.on_load_success = function (invites_data) {
 
         if (modal_invite_id !== meta.invite_id) {
             blueslip.error("Invite resending canceled due to non-matching fields.");
-            ui_report.message("Resending encountered an error. Please reload and try again.",
+            ui_report.message(i18n.t("Resending encountered an error. Please reload and try again."),
                $("#home-error"), 'alert-error');
         }
         $("#resend_invite_modal").modal("hide");

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -170,7 +170,7 @@ exports.set_up = function () {
     $("#do_deactivate_stream_button").click(function () {
         if ($("#deactivation_stream_modal .stream_name").text() !== $(".active_stream_row").find('.stream_name').text()) {
             blueslip.error("Stream deactivation canceled due to non-matching fields.");
-            ui_report.message("Deactivation encountered an error. Please reload and try again.",
+            ui_report.message(i18n.t("Deactivation encountered an error. Please reload and try again."),
                $("#home-error"), 'alert-error');
         }
         $("#deactivation_stream_modal").modal("hide");

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -243,7 +243,7 @@ exports.on_load_success = function (realm_people_data) {
 
         if ($("#deactivation_user_modal .email").html() !== email) {
             blueslip.error("User deactivation canceled due to non-matching fields.");
-            ui_report.message("Deactivation encountered an error. Please reload and try again.",
+            ui_report.message(i18n.t("Deactivation encountered an error. Please reload and try again."),
                $("#home-error"), 'alert-error');
         }
         $("#deactivation_user_modal").modal("hide");

--- a/static/js/ui_report.js
+++ b/static/js/ui_report.js
@@ -18,22 +18,33 @@ exports.message = function (response, status_box, cls, type) {
         type = ' ';
     }
 
+    // Note we use html() below, since we can rely on our callers escaping HTML
+    // via i18n.t when interpolating data.
     if (type === 'subscriptions-status') {
         status_box.removeClass(common.status_classes).addClass(cls).children('#response')
-              .text(response).stop(true).fadeTo(0, 1);
+              .html(response).stop(true).fadeTo(0, 1);
     } else {
         status_box.removeClass(common.status_classes).addClass(cls)
-              .text(response).stop(true).fadeTo(0, 1);
+              .html(response).stop(true).fadeTo(0, 1);
     }
 
     status_box.addClass("show");
 };
 
+function escape(html) {
+  return html
+    .toString()
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 exports.error = function (response, xhr, status_box, type) {
     if (xhr && xhr.status.toString().charAt(0) === "4") {
         // Only display the error response for 4XX, where we've crafted
         // a nice response.
-        response += ": " + JSON.parse(xhr.responseText).msg;
+        response += ": " + escape(JSON.parse(xhr.responseText).msg);
     }
 
     exports.message(response, status_box, 'alert-error', type);


### PR DESCRIPTION
The i18n.t function already escapes HTML, so we should avoid
calling jQuery's text() method, which double escapes the HTML.

The bug report that led to this changes didn't have an issue
filed for it, but the symptom was that if you changed your
timezone to something like like America/Mexico_City, you'd
see `&#x2F;` instead of `/`.