### PR TITLE
certbot: Modify nginx configuration to support automated renewal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You might be interested in:
 * **Running a Zulip server**. Setting up a server takes just a couple of
   minutes. Zulip runs on Ubuntu 16.04 Xenial and Ubuntu 14.04 Trusty. The
   installation process is
-  [documented here](https://zulip.readthedocs.io/en/latest/production/overview.html).
+  [documented here](https://zulip.readthedocs.io/en/1.7.0/prod.html).
   Commercial support is available; see <https://zulipchat.com/plans> for
   details.
 

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -44,7 +44,7 @@
                                     <div class="pricing-details">
                                         Free and open source forever!
                                     </div>
-                                    <a href="https://zulip.readthedocs.io/en/latest/production/overview.html">
+                                    <a href="https://zulip.readthedocs.io/en/1.7.0/prod.html">
                                         <button class="green" type="button">
                                             Install a Zulip server
                                         </button>

--- a/version.py
+++ b/version.py
@@ -1,2 +1,6 @@
+# When bumping this for a release, we should also update the handful
+# of places we link to docs for the latest release, rather than master.
+# To find them:   git grep 'zulip.readthedocs.io/en/[0-9]'
 ZULIP_VERSION = "1.7.0+git"
+
 PROVISION_VERSION = '12.0'


### PR DESCRIPTION
This should work; I've partially tested it on chat.zulip.org.

Before we merge this, I think we should think a bit more about the paths involved and make sure we're happy being stuck with them for a long time:
* /var/www/certbot
* /root/certbot-auto

@gnprice @rht FYI.