### PR TITLE
Clean up user_activity `query` for `log_into_subdomain` et al.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -417,7 +417,6 @@ def require_server_admin(view_func):
     @wraps(view_func)
     def _wrapped_view_func(request, *args, **kwargs):
         # type: (HttpRequest, *Any, **Any) -> HttpResponse
-        request._query = view_func.__name__
         if not request.user.is_staff:
             return HttpResponseRedirect(settings.HOME_NOT_LOGGED_IN)
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -527,7 +527,8 @@ def authenticate_log_and_execute_json(request, view_func, *args, **kwargs):
     if user_profile.is_incoming_webhook:
         raise JsonableError(_("Webhook bots can only access webhooks"))
 
-    process_client(request, user_profile, is_browser_view=True)
+    process_client(request, user_profile, is_browser_view=True,
+                   query=view_func.__name__)
     request._email = user_profile.email
     return rate_limit()(view_func)(request, user_profile, *args, **kwargs)
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -375,6 +375,15 @@ def do_login(request, user_profile):
     request._email = user_profile.email
     process_client(request, user_profile, is_browser_view=True)
 
+def log_view_func(view_func):
+    # type: (ViewFuncT) -> ViewFuncT
+    @wraps(view_func)
+    def _wrapped_view_func(request, *args, **kwargs):
+        # type: (HttpRequest, *Any, **Any) -> HttpResponse
+        request._query = view_func.__name__
+        return view_func(request, *args, **kwargs)
+    return _wrapped_view_func  # type: ignore # https://github.com/python/mypy/issues/1927
+
 def add_logging_data(view_func):
     # type: (ViewFuncT) -> ViewFuncT
     @wraps(view_func)

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -29,7 +29,6 @@ from zerver.lib.request import \
     RequestVariableConversionError
 from zerver.decorator import (
     api_key_only_webhook_view,
-    authenticated_json_post_view, authenticated_json_view,
     authenticate_notify,
     get_client_name, internal_notify_view, is_local_addr,
     rate_limit, validate_api_key, logged_in_and_active,

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest, HttpResponse
 from zerver.models import get_client, UserProfile, Client
 
 from zerver.decorator import asynchronous, \
-    authenticated_json_post_view, internal_notify_view, RespondAsynchronously, \
+    internal_notify_view, RespondAsynchronously, \
     has_request_variables, REQ, _RespondAsynchronously
 
 from zerver.lib.response import json_success, json_error

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -7,7 +7,7 @@ from django.contrib.auth.views import login as django_login_page, \
     logout_then_login as django_logout_then_login
 from django.core.urlresolvers import reverse
 from zerver.decorator import authenticated_json_post_view, require_post, \
-    process_client, do_login
+    process_client, do_login, log_view_func
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, \
     HttpResponseNotFound
 from django.middleware.csrf import get_token
@@ -172,6 +172,7 @@ def login_or_register_remote_user(request, remote_username, user_profile, full_n
     do_login(request, user_profile)
     return HttpResponseRedirect(user_profile.realm.uri)
 
+@log_view_func
 def remote_user_sso(request):
     # type: (HttpRequest) -> HttpResponse
     try:
@@ -189,6 +190,7 @@ def remote_user_sso(request):
     return login_or_register_remote_user(request, remote_user, user_profile)
 
 @csrf_exempt
+@log_view_func
 def remote_user_jwt(request):
     # type: (HttpRequest) -> HttpResponse
     subdomain = get_subdomain(request)
@@ -311,6 +313,7 @@ def send_oauth_request_to_google(request):
     }
     return redirect(google_uri + urllib.parse.urlencode(params))
 
+@log_view_func
 def finish_google_oauth2(request):
     # type: (HttpRequest) -> HttpResponse
     error = request.GET.get('error')
@@ -418,6 +421,7 @@ def authenticate_remote_user(realm, email_address):
 
 _subdomain_token_salt = 'zerver.views.auth.log_into_subdomain'
 
+@log_view_func
 def log_into_subdomain(request, token):
     # type: (HttpRequest, Text) -> HttpResponse
     try:

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 from typing import List, Optional, Set, Text
 
-from zerver.decorator import authenticated_json_post_view, require_realm_admin, to_non_negative_int
+from zerver.decorator import require_realm_admin, to_non_negative_int
 from zerver.lib.actions import do_invite_users, do_revoke_user_invite, do_resend_user_invite_email, \
     get_default_subs, do_get_user_invites
 from zerver.lib.request import REQ, has_request_variables, JsonableError

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Set, Text, Any, Callable, Iterable, \
 from zerver.lib.str_utils import force_text, force_bytes
 from zerver.lib.exceptions import JsonableError, ErrorCode
 from zerver.lib.html_diff import highlight_html_differences
-from zerver.decorator import authenticated_json_post_view, has_request_variables, \
+from zerver.decorator import has_request_variables, \
     REQ, to_non_negative_int
 from django.utils.html import escape as escape_html
 from zerver.lib import bugdown

--- a/zerver/views/muting.py
+++ b/zerver/views/muting.py
@@ -5,7 +5,6 @@ from typing import List, Text
 import ujson
 
 from django.utils.translation import ugettext as _
-from zerver.decorator import authenticated_json_post_view
 from zerver.lib.actions import do_mute_topic, do_unmute_topic
 from zerver.lib.request import has_request_variables, REQ
 from zerver.lib.response import json_success, json_error

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -9,7 +9,7 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import ugettext as _
 
-from zerver.decorator import authenticated_json_post_view, human_users_only
+from zerver.decorator import human_users_only
 from zerver.lib.actions import get_status_dict, update_user_presence
 from zerver.lib.request import has_request_variables, REQ, JsonableError
 from zerver.lib.response import json_success, json_error

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -3,7 +3,7 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 from typing import Text
 
-from zerver.decorator import authenticated_json_post_view,\
+from zerver.decorator import \
     has_request_variables, REQ, to_non_negative_int
 from zerver.lib.actions import do_add_reaction_legacy,\
     do_remove_reaction_legacy

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Text
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 
-from zerver.decorator import authenticated_json_post_view, human_users_only, \
+from zerver.decorator import human_users_only, \
     to_non_negative_int
 from zerver.lib.bugdown import privacy_clean_markdown
 from zerver.lib.request import has_request_variables, REQ

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -8,7 +8,7 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.exceptions import JsonableError, ErrorCode
 from zerver.lib.request import REQ, has_request_variables
 from zerver.decorator import authenticated_json_post_view, \
-    authenticated_json_view, require_realm_admin, to_non_negative_int
+    require_realm_admin, to_non_negative_int
 from zerver.lib.actions import bulk_remove_subscriptions, \
     do_change_subscription_property, internal_prep_private_message, \
     internal_prep_stream_message, \

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -2,8 +2,7 @@
 from django.http import HttpRequest, HttpResponse
 from typing import List, Text
 
-from zerver.decorator import authenticated_json_post_view,\
-    has_request_variables, REQ, JsonableError
+from zerver.decorator import has_request_variables, REQ, JsonableError
 from zerver.lib.actions import check_send_typing_notification, \
     extract_recipients
 from zerver.lib.response import json_success

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -5,7 +5,6 @@ from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, FileRe
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 
-from zerver.decorator import authenticated_json_post_view
 from zerver.lib.request import has_request_variables, REQ
 from zerver.lib.response import json_success, json_error
 from zerver.lib.upload import upload_message_image_from_request, get_local_file_path, \

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 
-from zerver.decorator import authenticated_json_post_view, has_request_variables, \
+from zerver.decorator import has_request_variables, \
     zulip_login_required, REQ, human_users_only
 from zerver.lib.actions import do_change_password, \
     do_change_enter_sends, do_change_notification_settings, \


### PR DESCRIPTION
This is a followup to #7116, cleaning up some of how we populate the `query` field of `user_activity` events, and in particular preventing it from blowing up in a number of views, as it started doing in `log_into_subdomain` after early parts of #7116.
