### PR TITLE
Clean up force_text/force_bytes/force_str calls.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -31,7 +31,6 @@ from io import BytesIO
 import urllib
 
 from typing import Union, Any, Callable, Sequence, Dict, Optional, TypeVar, Text, Tuple, cast
-from zerver.lib.str_utils import force_bytes
 from zerver.lib.logging_util import create_logger
 
 # This is a hack to ensure that RemoteZulipServer always exists even
@@ -491,7 +490,7 @@ def authenticated_rest_api_view(is_webhook=False):
                 # case insensitive per RFC 1945
                 if auth_type.lower() != "basic":
                     return json_error(_("This endpoint requires HTTP basic authentication."))
-                role, api_key = base64.b64decode(force_bytes(credentials)).decode('utf-8').split(":")
+                role, api_key = base64.b64decode(credentials).decode('utf-8').split(":")
             except ValueError:
                 return json_unauthorized(_("Invalid authorization header for basic auth"))
             except KeyError:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -149,7 +149,7 @@ def log_event(event):
 
     with lockfile(template % ('lock',)):
         with open(template % ('events',), 'a') as log:
-            log.write(force_str(ujson.dumps(event) + '\n'))
+            log.write(ujson.dumps(event) + '\n')
 
 def can_access_stream_user_ids(stream):
     # type: (Stream) -> Set[int]

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -643,7 +643,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
         # type: (Element) -> Optional[Tuple[Text, Text]]
         if e.tag == "a":
             if e.text is not None:
-                return (e.get("href"), force_text(e.text))
+                return (e.get("href"), e.text)
             return (e.get("href"), e.get("href"))
         return None
 

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -47,7 +47,7 @@ from zerver.models import (
     UserGroup,
 )
 import zerver.lib.mention as mention
-from zerver.lib.str_utils import force_str, force_text
+from zerver.lib.str_utils import force_str
 from zerver.lib.tex import render_tex
 
 FullNameInfo = TypedDict('FullNameInfo', {
@@ -508,7 +508,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                     'type': 'mention',
                     'start': match.start(),
                     'end': match.end(),
-                    'url': 'https://twitter.com/' + force_text(urllib.parse.quote(force_str(screen_name))),
+                    'url': 'https://twitter.com/' + urllib.parse.quote(force_str(screen_name)),
                     'text': mention_string,
                 })
         # Build dicts for media

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -47,7 +47,6 @@ from zerver.models import (
     UserGroup,
 )
 import zerver.lib.mention as mention
-from zerver.lib.str_utils import force_str
 from zerver.lib.tex import render_tex
 
 FullNameInfo = TypedDict('FullNameInfo', {
@@ -508,7 +507,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                     'type': 'mention',
                     'start': match.start(),
                     'end': match.end(),
-                    'url': 'https://twitter.com/' + urllib.parse.quote(force_str(screen_name)),
+                    'url': 'https://twitter.com/' + urllib.parse.quote(screen_name),
                     'text': mention_string,
                 })
         # Build dicts for media
@@ -1212,7 +1211,7 @@ class StreamPattern(VerbosePattern):
             # href when it processes a message with one of these, to
             # provide more clarity to API clients.
             el.set('href', '/#narrow/stream/{stream_name}'.format(
-                stream_name=urllib.parse.quote(force_str(name))))
+                stream_name=urllib.parse.quote(name)))
             el.text = '#{stream_name}'.format(stream_name=name)
             return el
         return None

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -115,7 +115,7 @@ def list_of_tlds():
 
     # tlds-alpha-by-domain.txt comes from http://data.iana.org/TLD/tlds-alpha-by-domain.txt
     tlds_file = os.path.join(os.path.dirname(__file__), 'tlds-alpha-by-domain.txt')
-    tlds = [force_text(tld).lower().strip() for tld in open(tlds_file, 'r')
+    tlds = [tld.lower().strip() for tld in open(tlds_file, 'r')
             if tld not in blacklist and not tld[0].startswith('#')]
     tlds.sort(key=len, reverse=True)
     return tlds

--- a/zerver/lib/bugdown/fenced_code.py
+++ b/zerver/lib/bugdown/fenced_code.py
@@ -81,7 +81,6 @@ import subprocess
 import markdown
 from django.utils.html import escape
 from markdown.extensions.codehilite import CodeHilite, CodeHiliteExtension
-from zerver.lib.str_utils import force_bytes
 from zerver.lib.tex import render_tex
 from typing import Any, Dict, Iterable, List, MutableSequence, Optional, Tuple, Union, Text
 

--- a/zerver/lib/logging_util.py
+++ b/zerver/lib/logging_util.py
@@ -10,7 +10,6 @@ import traceback
 from typing import Optional
 from datetime import datetime, timedelta
 from django.conf import settings
-from zerver.lib.str_utils import force_bytes
 from logging import Logger
 
 # Adapted http://djangosnippets.org/snippets/2242/ by user s29 (October 25, 2010)
@@ -37,10 +36,10 @@ class _RateLimitFilter:
 
             if use_cache:
                 if record.exc_info is not None:
-                    tb = force_bytes('\n'.join(traceback.format_exception(*record.exc_info)))
+                    tb = '\n'.join(traceback.format_exception(*record.exc_info))
                 else:
-                    tb = force_bytes('%s' % (record,))
-                key = self.__class__.__name__.upper() + hashlib.sha1(tb).hexdigest()
+                    tb = str(record)
+                key = self.__class__.__name__.upper() + hashlib.sha1(tb.encode()).hexdigest()
                 duplicate = cache.get(key) == 1
                 if not duplicate:
                     cache.set(key, 1, rate)

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -15,7 +15,6 @@ from zerver.lib.cache import (
     to_dict_cache_key_id,
 )
 from zerver.lib.request import JsonableError
-from zerver.lib.str_utils import dict_with_str_keys
 from zerver.lib.stream_subscription import (
     get_stream_subscriptions_for_user,
 )
@@ -111,7 +110,7 @@ def sew_messages_and_reactions(messages, reactions):
 
 def extract_message_dict(message_bytes):
     # type: (bytes) -> Dict[str, Any]
-    return dict_with_str_keys(ujson.loads(zlib.decompress(message_bytes).decode("utf-8")))
+    return ujson.loads(zlib.decompress(message_bytes).decode("utf-8"))
 
 def stringify_message_dict(message_dict):
     # type: (Dict[str, Any]) -> bytes

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -15,7 +15,7 @@ from zerver.lib.cache import (
     to_dict_cache_key_id,
 )
 from zerver.lib.request import JsonableError
-from zerver.lib.str_utils import force_bytes, dict_with_str_keys
+from zerver.lib.str_utils import dict_with_str_keys
 from zerver.lib.stream_subscription import (
     get_stream_subscriptions_for_user,
 )
@@ -115,7 +115,7 @@ def extract_message_dict(message_bytes):
 
 def stringify_message_dict(message_dict):
     # type: (Dict[str, Any]) -> bytes
-    return zlib.compress(force_bytes(ujson.dumps(message_dict)))
+    return zlib.compress(ujson.dumps(message_dict).encode())
 
 @cache_with_key(to_dict_cache_key, timeout=3600*24)
 def message_to_dict_json(message):

--- a/zerver/lib/response.py
+++ b/zerver/lib/response.py
@@ -3,7 +3,6 @@ from django.http import HttpResponse, HttpResponseNotAllowed
 import ujson
 
 from typing import Optional, Any, Dict, List, Text
-from zerver.lib.str_utils import force_bytes
 from zerver.lib.exceptions import JsonableError
 
 class HttpResponseUnauthorized(HttpResponse):
@@ -22,16 +21,16 @@ class HttpResponseUnauthorized(HttpResponse):
 def json_unauthorized(message, www_authenticate=None):
     # type: (Text, Optional[Text]) -> HttpResponse
     resp = HttpResponseUnauthorized("zulip", www_authenticate=www_authenticate)
-    resp.content = force_bytes(ujson.dumps({"result": "error",
-                                            "msg": message}) + "\n")
+    resp.content = (ujson.dumps({"result": "error",
+                                 "msg": message}) + "\n").encode()
     return resp
 
 def json_method_not_allowed(methods):
     # type: (List[Text]) -> HttpResponseNotAllowed
     resp = HttpResponseNotAllowed(methods)
-    resp.content = force_bytes(ujson.dumps({"result": "error",
-                                            "msg": "Method Not Allowed",
-                                            "allowed_methods": methods}))
+    resp.content = ujson.dumps({"result": "error",
+                                "msg": "Method Not Allowed",
+                                "allowed_methods": methods}).encode()
     return resp
 
 def json_response(res_type="success", msg="", data=None, status=200):

--- a/zerver/lib/str_utils.py
+++ b/zerver/lib/str_utils.py
@@ -66,11 +66,6 @@ def force_str(s, encoding='utf-8'):
     else:
         raise TypeError("force_str expects a string type")
 
-def dict_with_str_keys(dct, encoding='utf-8'):
-    # type: (Mapping[NonBinaryStr, Any], str) -> Dict[str, Any]
-    """applies force_str on the keys of a dict (non-recursively)"""
-    return {force_str(key, encoding): value for key, value in dct.items()}
-
 class ModelReprMixin:
     """
     This mixin provides a python 2 and 3 compatible way of handling string representation of a model.

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -13,7 +13,6 @@ from django.http import HttpResponse
 from django.db.utils import IntegrityError
 
 from zerver.lib.initial_password import initial_password
-from zerver.lib.str_utils import force_text
 from zerver.lib.utils import is_remote_server
 from zerver.views.users import add_service
 
@@ -509,8 +508,11 @@ class ZulipTestCase(TestCase):
 
     def fixture_data(self, type, action, file_type='json'):
         # type: (Text, Text, Text) -> Text
-        return force_text(open(os.path.join(os.path.dirname(__file__),
-                                            "../webhooks/%s/fixtures/%s.%s" % (type, action, file_type))).read())
+        fn = os.path.join(
+            os.path.dirname(__file__),
+            "../webhooks/%s/fixtures/%s.%s" % (type, action, file_type)
+        )
+        return open(fn).read()
 
     def make_stream(self, stream_name, realm=None, invite_only=False):
         # type: (Text, Optional[Realm], Optional[bool]) -> Stream

--- a/zerver/lib/tex.py
+++ b/zerver/lib/tex.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 from django.conf import settings
 from typing import Optional, Text
-from zerver.lib.str_utils import force_bytes
 
 def render_tex(tex, is_inline=True):
     # type: (Text, bool) -> Optional[Text]
@@ -32,7 +31,7 @@ def render_tex(tex, is_inline=True):
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
-    stdout = katex.communicate(input=force_bytes(tex))[0]
+    stdout = katex.communicate(input=tex.encode())[0]
     if katex.returncode == 0:
         # stdout contains a newline at the end
         assert stdout is not None

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -59,7 +59,7 @@ def attachment_url_to_path_id(attachment_url):
     # Remove any extra '.' after file extension. These are probably added by the user
     return re.sub('[.]+$', '', path_id_raw, re.M)
 
-def sanitize_name(raw_value):
+def sanitize_name(value):
     # type: (NonBinaryStr) -> Text
     """
     Sanitizes a value to be safe to store in a Linux filesystem, in
@@ -68,11 +68,9 @@ def sanitize_name(raw_value):
 
     This implementation is based on django.utils.text.slugify; it is
     modified by:
-    * hardcoding allow_unicode=True.
     * adding '.' and '_' to the list of allowed characters.
     * preserving the case of the value.
     """
-    value = force_text(raw_value)
     value = unicodedata.normalize('NFKC', value)
     value = re.sub('[^\w\s._-]', '', value, flags=re.U).strip()
     return mark_safe(re.sub('[-\s]+', '-', value, flags=re.U))

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -11,7 +11,7 @@ import unicodedata
 
 from zerver.lib.avatar_hash import user_avatar_path
 from zerver.lib.exceptions import JsonableError, ErrorCode
-from zerver.lib.str_utils import force_text, force_str, NonBinaryStr
+from zerver.lib.str_utils import force_str, NonBinaryStr
 
 from boto.s3.bucket import Bucket
 from boto.s3.key import Key
@@ -240,7 +240,7 @@ def get_file_info(request, user_file):
 def get_signed_upload_url(path):
     # type: (Text) -> Text
     conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
-    return force_text(conn.generate_url(15, 'GET', bucket=settings.S3_AUTH_UPLOADS_BUCKET, key=force_str(path)))
+    return conn.generate_url(15, 'GET', bucket=settings.S3_AUTH_UPLOADS_BUCKET, key=force_str(path))
 
 def get_realm_for_filename(path):
     # type: (Text) -> Optional[int]

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -186,7 +186,7 @@ def upload_image_to_s3(
     conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
     bucket = get_bucket(conn, bucket_name)
     key = Key(bucket)
-    key.key = force_str(file_name)
+    key.key = file_name
     key.set_metadata("user_profile_id", str(user_profile.id))
     key.set_metadata("realm_id", str(user_profile.realm_id))
 
@@ -240,7 +240,7 @@ def get_file_info(request, user_file):
 def get_signed_upload_url(path):
     # type: (Text) -> Text
     conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
-    return conn.generate_url(15, 'GET', bucket=settings.S3_AUTH_UPLOADS_BUCKET, key=force_str(path))
+    return conn.generate_url(15, 'GET', bucket=settings.S3_AUTH_UPLOADS_BUCKET, key=path)
 
 def get_realm_for_filename(path):
     # type: (Text) -> Optional[int]

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -225,7 +225,7 @@ def get_file_info(request, user_file):
     if content_type is None:
         guessed_type = guess_type(uploaded_file_name)[0]
         if guessed_type is not None:
-            content_type = force_text(guessed_type)
+            content_type = guessed_type
     else:
         extension = guess_extension(content_type)
         if extension is not None:

--- a/zerver/lib/utils.py
+++ b/zerver/lib/utils.py
@@ -12,7 +12,6 @@ from time import sleep
 from itertools import zip_longest
 
 from django.conf import settings
-from zerver.lib.str_utils import force_text
 
 T = TypeVar('T')
 
@@ -93,7 +92,7 @@ def make_safe_digest(string, hash_func=hashlib.sha1):
     """
     # hashlib.sha1, md5, etc. expect bytes, so non-ASCII strings must
     # be encoded.
-    return force_text(hash_func(string.encode('utf-8')).hexdigest())
+    return hash_func(string.encode('utf-8')).hexdigest()
 
 
 def log_statsd_event(name):

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -6,7 +6,6 @@ from django.template import Library, loader, engines
 from django.utils.safestring import mark_safe
 from django.utils.lru_cache import lru_cache
 
-from zerver.lib.utils import force_text
 import zerver.lib.bugdown.fenced_code
 
 import markdown

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -22,7 +22,6 @@ from zerver.lib.test_classes import (
     ZulipTestCase,
 )
 from zerver.lib.test_runner import slow
-from zerver.lib.str_utils import force_str
 from zerver.models import (
     realm_in_local_realm_filters_cache,
     flush_per_request_caches,
@@ -1015,7 +1014,7 @@ class BugdownTest(ZulipTestCase):
             render_markdown(msg, content),
             u'<p><a class="stream" data-stream-id="{s.id}" href="/#narrow/stream/{url}">#{s.name}</a></p>'.format(
                 s=uni,
-                url=urllib.parse.quote(force_str(uni.name))
+                url=urllib.parse.quote(uni.name)
             ))
 
     def test_stream_invalid(self):

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -8,7 +8,6 @@ from zerver.lib import bugdown
 from zerver.decorator import JsonableError
 from zerver.lib.test_runner import slow
 from zerver.lib.cache import get_stream_cache_key, cache_delete
-from zerver.lib.str_utils import force_text
 
 from zerver.lib.addressee import Addressee
 
@@ -2655,10 +2654,10 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         soft_deactivated_user_msg_count = len(get_user_messages(long_term_idle_user))
         message = 'Test Message 1'
         send_stream_message(message)
-        assert_last_um_content(long_term_idle_user, force_text(message), negate=True)
+        assert_last_um_content(long_term_idle_user, message, negate=True)
         assert_um_count(long_term_idle_user, soft_deactivated_user_msg_count)
         assert_um_count(cordelia, general_user_msg_count + 1)
-        assert_last_um_content(cordelia, force_text(message))
+        assert_last_um_content(cordelia, message)
 
         # Test sending a private message to soft deactivated user creates
         # UserMessage row.
@@ -2666,7 +2665,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         message = 'Test PM'
         send_personal_message(message)
         assert_um_count(long_term_idle_user, soft_deactivated_user_msg_count + 1)
-        assert_last_um_content(long_term_idle_user, force_text(message))
+        assert_last_um_content(long_term_idle_user, message)
 
         # Test UserMessage row is created while user is deactivated if
         # user itself is mentioned.
@@ -2674,10 +2673,10 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         soft_deactivated_user_msg_count = len(get_user_messages(long_term_idle_user))
         message = 'Test @**King Hamlet** mention'
         send_stream_message(message)
-        assert_last_um_content(long_term_idle_user, force_text(message))
+        assert_last_um_content(long_term_idle_user, message)
         assert_um_count(long_term_idle_user, soft_deactivated_user_msg_count + 1)
         assert_um_count(cordelia, general_user_msg_count + 1)
-        assert_last_um_content(cordelia, force_text(message))
+        assert_last_um_content(cordelia, message)
 
         # Test UserMessage row is not created while user is deactivated if
         # anyone is mentioned but the user.
@@ -2685,10 +2684,10 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         soft_deactivated_user_msg_count = len(get_user_messages(long_term_idle_user))
         message = 'Test @**Cordelia Lear**  mention'
         send_stream_message(message)
-        assert_last_um_content(long_term_idle_user, force_text(message), negate=True)
+        assert_last_um_content(long_term_idle_user, message, negate=True)
         assert_um_count(long_term_idle_user, soft_deactivated_user_msg_count)
         assert_um_count(cordelia, general_user_msg_count + 1)
-        assert_last_um_content(cordelia, force_text(message))
+        assert_last_um_content(cordelia, message)
 
         # Test UserMessage row is created while user is deactivated if
         # there is a wildcard mention such as @all or @everyone
@@ -2696,19 +2695,19 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         soft_deactivated_user_msg_count = len(get_user_messages(long_term_idle_user))
         message = 'Test @**all** mention'
         send_stream_message(message)
-        assert_last_um_content(long_term_idle_user, force_text(message))
+        assert_last_um_content(long_term_idle_user, message)
         assert_um_count(long_term_idle_user, soft_deactivated_user_msg_count + 1)
         assert_um_count(cordelia, general_user_msg_count + 1)
-        assert_last_um_content(cordelia, force_text(message))
+        assert_last_um_content(cordelia, message)
 
         general_user_msg_count = len(get_user_messages(cordelia))
         soft_deactivated_user_msg_count = len(get_user_messages(long_term_idle_user))
         message = 'Test @**everyone** mention'
         send_stream_message(message)
-        assert_last_um_content(long_term_idle_user, force_text(message))
+        assert_last_um_content(long_term_idle_user, message)
         assert_um_count(long_term_idle_user, soft_deactivated_user_msg_count + 1)
         assert_um_count(cordelia, general_user_msg_count + 1)
-        assert_last_um_content(cordelia, force_text(message))
+        assert_last_um_content(cordelia, message)
 
         # Test UserMessage row is not created while user is deactivated if there
         # is a alert word in message.
@@ -2717,10 +2716,10 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         soft_deactivated_user_msg_count = len(get_user_messages(long_term_idle_user))
         message = 'Testing test_alert_word'
         send_stream_message(message)
-        assert_last_um_content(long_term_idle_user, force_text(message))
+        assert_last_um_content(long_term_idle_user, message)
         assert_um_count(long_term_idle_user, soft_deactivated_user_msg_count + 1)
         assert_um_count(cordelia, general_user_msg_count + 1)
-        assert_last_um_content(cordelia, force_text(message))
+        assert_last_um_content(cordelia, message)
 
         # Test UserMessage row is created while user is deactivated if
         # message is a me message.
@@ -2728,10 +2727,10 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         soft_deactivated_user_msg_count = len(get_user_messages(long_term_idle_user))
         message = '/me says test'
         send_stream_message(message)
-        assert_last_um_content(long_term_idle_user, force_text(message), negate=True)
+        assert_last_um_content(long_term_idle_user, message, negate=True)
         assert_um_count(long_term_idle_user, soft_deactivated_user_msg_count)
         assert_um_count(cordelia, general_user_msg_count + 1)
-        assert_last_um_content(cordelia, force_text(message))
+        assert_last_um_content(cordelia, message)
 
 class MessageHydrationTest(ZulipTestCase):
     def test_hydrate_stream_recipient_info(self):

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -20,7 +20,6 @@ from zerver.lib.narrow import (
     build_narrow_filter,
 )
 from zerver.lib.request import JsonableError
-from zerver.lib.str_utils import force_bytes
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.test_helpers import (
     POSTRequestMock,

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -8,7 +8,7 @@ from django.db import connection
 from django.http import HttpRequest, HttpResponse
 from typing import Dict, List, Set, Text, Any, Callable, Iterable, \
     Optional, Tuple, Union
-from zerver.lib.str_utils import force_text, force_bytes
+from zerver.lib.str_utils import force_text
 from zerver.lib.exceptions import JsonableError, ErrorCode
 from zerver.lib.html_diff import highlight_html_differences
 from zerver.decorator import has_request_variables, \

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -8,7 +8,6 @@ from django.db import connection
 from django.http import HttpRequest, HttpResponse
 from typing import Dict, List, Set, Text, Any, Callable, Iterable, \
     Optional, Tuple, Union
-from zerver.lib.str_utils import force_text
 from zerver.lib.exceptions import JsonableError, ErrorCode
 from zerver.lib.html_diff import highlight_html_differences
 from zerver.decorator import has_request_variables, \


### PR DESCRIPTION
This replaces force_text/force_bytes/force_str calls with either no call at all (yay!) or more explicit calls to encode().

I did this PR pretty methodically by having the force_* functions raise exceptions to generate failing tests, so all of the changes here have some test coverage.  (Of course, it's still plausible that some of these functions have strange codepaths that aren't tested, and there are code organization problems that are going to be exposed here.)

I stayed clear of making risky fixes to some codepaths I don't know well--basically the email mirror, oath stuff, and zephyr.