### PR TITLE
mypy: Any-reduction (part 2: #6048 followup)

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -9,13 +9,13 @@ import traceback
 
 from .printer import print_err, colors
 
-from typing import cast, Any, Callable, Dict, List, Optional, Tuple
+from typing import cast, Any, Callable, Dict, List, Optional, Tuple, Iterable
 
 RuleList = List[Dict[str, Any]]  # mypy currently requires Aliases at global scope
 # https://github.com/python/mypy/issues/3145
 
 def custom_check_file(fn, identifier, rules, color, skip_rules=None, max_length=None):
-    # type: (str, str, RuleList, str, Optional[Any], Optional[int]) -> bool
+    # type: (str, str, RuleList, str, Optional[Iterable[str]], Optional[int]) -> bool
     failed = False
 
     line_tups = []
@@ -23,8 +23,8 @@ def custom_check_file(fn, identifier, rules, color, skip_rules=None, max_length=
         line_newline_stripped = line.strip('\n')
         line_fully_stripped = line_newline_stripped.strip()
         skip = False
-        for rule in skip_rules or []:
-            if re.match(rule, line):
+        for skip_rule in skip_rules or []:
+            if re.match(skip_rule, line):
                 skip = True
         if line_fully_stripped.endswith('  # nolint'):
             continue

--- a/zerver/lib/parallel.py
+++ b/zerver/lib/parallel.py
@@ -1,16 +1,18 @@
-from typing import Any, Dict, Generator, Iterable, Tuple
+from typing import Dict, Iterable, Tuple, Callable, TypeVar, Iterator
 
 import os
 import pty
 import sys
 import errno
 
+JobData = TypeVar('JobData')
+
 def run_parallel(job, data, threads=6):
-    # type: (Any, Iterable[Any], int) -> Generator[Tuple[int, Any], None, None]
-    pids = {}  # type: Dict[int, Any]
+    # type: (Callable[[JobData], int], Iterable[JobData], int) -> Iterator[Tuple[int, JobData]]
+    pids = {}  # type: Dict[int, JobData]
 
     def wait_for_one():
-        # type: () -> Tuple[int, Any]
+        # type: () -> Tuple[int, JobData]
         while True:
             try:
                 (pid, status) = os.wait()

--- a/zerver/lib/url_preview/oembed/__init__.py
+++ b/zerver/lib/url_preview/oembed/__init__.py
@@ -1,9 +1,9 @@
-from typing import Optional, Any, Text
+from typing import Optional, Text, Dict
 from pyoembed import oEmbed, PyOembedException
 
 
 def get_oembed_data(url, maxwidth=640, maxheight=480):
-    # type: (Text, Optional[int], Optional[int]) -> Any
+    # type: (Text, Optional[int], Optional[int]) -> Optional[Dict]
     try:
         data = oEmbed(url, maxwidth=maxwidth, maxheight=maxheight)
     except PyOembedException:

--- a/zerver/lib/url_preview/parsers/generic.py
+++ b/zerver/lib/url_preview/parsers/generic.py
@@ -1,17 +1,17 @@
-from typing import Any, Dict
+from typing import Dict, Optional, Text
 from zerver.lib.url_preview.parsers.base import BaseParser
 
 
 class GenericParser(BaseParser):
     def extract_data(self):
-        # type: () -> Dict
+        # type: () -> Dict[str, Optional[Text]]
         return {
             'title': self._get_title(),
             'description': self._get_description(),
             'image': self._get_image()}
 
     def _get_title(self):
-        # type: () -> Any
+        # type: () -> Optional[Text]
         soup = self._soup
         if (soup.title and soup.title.text != ''):
             return soup.title.text
@@ -20,7 +20,7 @@ class GenericParser(BaseParser):
         return None
 
     def _get_description(self):
-        # type: () -> Any
+        # type: () -> Optional[Text]
         soup = self._soup
         meta_description = soup.find('meta', attrs={'name': 'description'})
         if (meta_description and meta_description['content'] != ''):
@@ -36,7 +36,7 @@ class GenericParser(BaseParser):
         return None
 
     def _get_image(self):
-        # type: () -> Any
+        # type: () -> Optional[Text]
         """
         Finding a first image after the h1 header.
         Presumably it will be the main image.

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -1,7 +1,7 @@
 import re
 import logging
 import traceback
-from typing import Any, Optional, Text
+from typing import Any, Optional, Text, Dict
 from typing.re import Match
 import requests
 from zerver.lib.cache import cache_with_key, get_cache_with_key
@@ -32,7 +32,7 @@ def cache_key_func(url):
 
 @cache_with_key(cache_key_func, cache_name=CACHE_NAME, with_statsd_key="urlpreview_data")
 def get_link_embed_data(url, maxwidth=640, maxheight=480):
-    # type: (Text, Optional[int], Optional[int]) -> Any
+    # type: (Text, Optional[int], Optional[int]) -> Optional[Dict]
     if not is_link(url):
         return None
     # Fetch information from URL.

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -61,10 +61,10 @@ class AdminZulipHandlerTest(ZulipTestCase):
         settings.LOGGING_NOT_DISABLED = True
 
     def get_admin_zulip_handler(self):
-        # type: () -> Any
+        # type: () -> AdminZulipHandler
         return [
             h for h in logging.getLogger('').handlers
-            if h.__class__.__name__ == "AdminZulipHandler"
+            if isinstance(h, AdminZulipHandler)
         ][0]
 
     def test_basic(self):


### PR DESCRIPTION
This PR contains rebased work with conflicts removed, from #6048.

The only commit I expect to be contentious is the AdminZulipHandler one, since I'm unsure if `isinstance` is a sufficient substitution for testing `__class__.__name__` in this case.