### PR TITLE
mypy: Remove un-necessary comment re mypy issue #3145.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -11,8 +11,7 @@ from .printer import print_err, colors
 
 from typing import cast, Any, Callable, Dict, List, Optional, Tuple
 
-RuleList = List[Dict[str, Any]]  # mypy currently requires Aliases at global scope
-# https://github.com/python/mypy/issues/3145
+RuleList = List[Dict[str, Any]]
 
 def custom_check_file(fn, identifier, rules, color, skip_rules=None, max_length=None):
     # type: (str, str, RuleList, str, Optional[Any], Optional[int]) -> bool


### PR DESCRIPTION
RuleList is required at global scope now, for later functions.