### PR TITLE
portico: Enhanced password warning

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -27,11 +27,11 @@ $(function () {
         errorPlacement: function (error, element) {
             // NB: this is called at most once, when the error element
             // is created.
-            element.next('.help-inline.text-error').remove();
+            element.next('.help-inline.alert.alert-error').remove();
             if (element.next().is('label[for="' + element.attr('id') + '"]')) {
-                error.insertAfter(element.next()).addClass('help-inline text-error');
+                error.insertAfter(element.next()).addClass('help-inline alert alert-error');
             } else {
-                error.insertAfter(element).addClass('help-inline text-error');
+                error.insertAfter(element).addClass('help-inline alert alert-error');
             }
         },
         highlight:   highlight('error'),


### PR DESCRIPTION
Enhanced the form-error message in Signup page and Forgot password page.
Error message was overlapping the password-bar before, in case of long password warning.

BEFORE:
1. Forgot password page:
![reset](https://user-images.githubusercontent.com/25907420/32412299-34de631a-c219-11e7-9f4b-1cb33292c4f3.png)

2. Register page:
![register](https://user-images.githubusercontent.com/25907420/32412300-355b1568-c219-11e7-9189-cf10712b5780.png)

AFTER:
![password_warning](https://user-images.githubusercontent.com/25907420/32412301-3b8be534-c219-11e7-859c-49ba96f4c03e.png)
