### PR TITLE
requirements: Remove unused `diff-match-patch` package.

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -51,9 +51,6 @@ cryptography==2.1.2
 # Needed for integrations
 defusedxml==0.5.0
 
-# Needed to generate diffs for edits
-diff-match-patch==20121119
-
 # Needed for LDAP support
 django-auth-ldap==1.2.16
 

--- a/requirements/dev_lock.txt
+++ b/requirements/dev_lock.txt
@@ -43,7 +43,6 @@ cssselect==1.0.1          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
-diff-match-patch==20121119
 django-auth-ldap==1.2.16
 django-bitfield==1.9.3
 django-pipeline==1.6.13

--- a/requirements/prod_lock.txt
+++ b/requirements/prod_lock.txt
@@ -29,7 +29,6 @@ cssselect==1.0.1          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
-diff-match-patch==20121119
 django-auth-ldap==1.2.16
 django-bitfield==1.9.3
 django-pipeline==1.6.13


### PR DESCRIPTION
This package was used for generating diffs for message edits. But
we have now switched to `lxml` for producing diffs so this is no
longer required.
@timabbott Lately it occurred to me that I have forgot to remove the package.