### PR TITLE
docs: Add setting to conf.py to disable sticky_navigation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,7 +117,9 @@ if not on_rtd:
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    'sticky_navigation': False,
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []


### PR DESCRIPTION
Fix for #5265.

There’s a [setting](https://github.com/rtfd/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/theme.conf#L8:1) that can be changed in conf.py to disable the default "sticky" left nav. This fix prevents the nav from scrolling along as you read through an article.

**Sticky Nav**

![zulip_sticky_nav](https://user-images.githubusercontent.com/2343554/32473291-7cb20354-c32c-11e7-8d7d-3ae831794480.gif)

---

**Improved Nav**

![zulip_improved_nav](https://user-images.githubusercontent.com/2343554/32473367-e8025a46-c32c-11e7-9ce5-06bb9c50cb8b.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zulip/zulip/7313)
<!-- Reviewable:end -->
