### PR TITLE
left-sidebar: Allow for more space for unread counts.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -300,7 +300,7 @@ ul.filters li.out_of_home_view li.muted_topic {
 }
 
 #stream_filters .subscription_block {
-    padding: 1px 0px;
+    padding: 0px;
     margin-right: 18px;
     margin-left: 10px;
 }
@@ -319,9 +319,9 @@ ul.filters li.out_of_home_view li.muted_topic {
     white-space: nowrap;
     overflow: hidden;
 
-    line-height: 1;
+    line-height: 1.2;
     position: relative;
-    top: 2px;
+    top: 4px;
 }
 
 #stream_filters .subscription_block.stream-with-count {

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -313,7 +313,7 @@ ul.filters li.out_of_home_view li.muted_topic {
 
 #stream_filters .subscription_block .stream-name {
     display: inline-block;
-    width: calc(100% - 50px);
+    width: calc(100% - 76px);
 
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
This leaves enough space for up to 100,000 unread message counts, which
perhaps above we should change to say something like “102K”.