### PR TITLE
message-feed: Do not autoscroll new messages if popovers open.

### DIFF
--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -719,6 +719,11 @@ MessageListView.prototype = {
             return;
         }
 
+        // do not scroll if there are any active popovers.
+        if (popovers.any_active()) {
+            return;
+        }
+
         // This next decision is fairly debatable.  For a big message that
         // would push the pointer off the screen, we do a partial autoscroll,
         // which has the following implications:


### PR DESCRIPTION
Do not attempt to autoscroll down to view new messages if popovers are
open. This prevents the issue where someone can be viewing a profile or
reacting to a message and not be able to due to a new message coming in.

Fixes: #7319.