### PR TITLE
left-sidebar: Remove leading whitespace underline on global filters.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -148,6 +148,14 @@ li.hidden-filter {
     padding-right: 10px;
 }
 
+#global_filters .global-filter a:hover {
+    text-decoration: none;
+}
+
+#global_filters .global-filter:hover .hover-underline {
+    text-decoration: underline;
+}
+
 .left-sidebar li {
     padding-top: 2px;
     padding-bottom: 2px;

--- a/templates/zerver/left_sidebar.html
+++ b/templates/zerver/left_sidebar.html
@@ -7,7 +7,7 @@
                     <span class="filter-icon">
                         <i class="icon-vector-home"></i>
                     </span>
-                    {{ _('Home') }}
+                    <span class="hover-underline">{{ _('Home') }}</span>
                     <span class="count">
                         <span class="value"></span>
                     </span>
@@ -18,7 +18,7 @@
                     <span class="filter-icon">
                         <i class="icon-vector-envelope"></i>
                     </span>
-                    <span>{{ _('Private messages') }}</span>
+                    <span class="hover-underline">{{ _('Private messages') }}</span>
                     <span class="count">
                         <span class="value"></span>
                     </span>
@@ -29,7 +29,7 @@
                     <span class="filter-icon">
                         <i class="icon-vector-star"></i>
                     </span>
-                    {{ _('Starred messages') }}
+                    <span class="hover-underline">{{ _('Starred messages') }}</span>
                 </a>
             </li>
             <li data-name="mentioned" class="global-filter">
@@ -37,7 +37,7 @@
                     <span class="filter-icon">
                         <i class="fa fa-at"></i>
                     </span>
-                    {{ _('Mentions') }}
+                    <span class="hover-underline">{{ _('Mentions') }}</span>
                     <span class="count">
                         <span class="value"></span>
                     </span>


### PR DESCRIPTION
This removes the leading whitespace that was approximately the width of
a space character that would get underlined when hovering over any one
of the global filters.