### PR TITLE
mypy: Avoid untyped generics (last change & tool update, #7272 pt2)

### DIFF
--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -87,7 +87,8 @@ if not python_files:
 extra_args = ["--check-untyped-defs",
               "--follow-imports=silent",
               "--scripts-are-modules",
-              "-i", "--cache-dir=var/mypy-cache"]
+              "-i", "--cache-dir=var/mypy-cache",
+              "--disallow-any=generics"]
 if args.linecoverage_report:
     extra_args.append("--linecoverage-report")
     extra_args.append("var/linecoverage-report")

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -75,11 +75,11 @@ def asynchronous(method):
     return wrapper
 
 def cachify(method):
-    # type: (Callable) -> Callable
-    dct = {}  # type: Dict[Tuple, Any]
+    # type: (Callable[..., ReturnT]) -> Callable[..., ReturnT]
+    dct = {}  # type: Dict[Tuple[Any, ...], ReturnT]
 
     def cache_wrapper(*args):
-        # type: (*Any) -> Any
+        # type: (*Any) -> ReturnT
         tup = tuple(args)
         if tup in dct:
             return dct[tup]

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -805,7 +805,7 @@ def process_message_event(event_template, users):
 
     @cachify
     def get_client_payload(apply_markdown, client_gravatar):
-        # type: (bool, bool) -> Mapping[str, Any]
+        # type: (bool, bool) -> Dict[str, Any]
         dct = copy.deepcopy(wide_dict)
         MessageDict.finalize_payload(dct, apply_markdown, client_gravatar)
         return dct


### PR DESCRIPTION
This contains the last two commits that were pushed to the accidentally-closed #7272, for the typing of a new decorator and the addition of the flag to run-mypy.