### PR TITLE
/help/: Add a slide class for sidebars that should have slide mechanism.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -39,7 +39,7 @@ function render_code_sections() {
         });
     };
 
-    $(".sidebar h2").click(function (e) {
+    $(".sidebar.slide h2").click(function (e) {
         var $next = $(e.target).next();
 
         if ($next.is("ul")) {

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -151,7 +151,7 @@ body {
     cursor: pointer;
 }
 
-.help .sidebar h2::before {
+.help .sidebar.slide h2::before {
     display: inline-block;
     font: normal normal normal 14px/1 FontAwesome;
     font-size: inherit;
@@ -169,8 +169,12 @@ body {
     content: "";
 }
 
-.help .sidebar h2.no-arrow {
+.help .sidebar.slide h2.no-arrow {
     margin-left: 12px;
+}
+
+.help .sidebar:not(.slide) h2 {
+    margin-left: 0px;
 }
 
 .help .sidebar h2.no-arrow a {
@@ -188,8 +192,15 @@ body {
 }
 
 .help .sidebar ul {
+    margin: 10px 0px 10px 12px;
+}
+
+.help .sidebar.slide ul {
+    margin-left: 19px;
+}
+
+.help .sidebar.slide ul {
     display: none;
-    margin: 10px 0px 10px 19px;
 }
 
 .help .sidebar li {

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -76,20 +76,6 @@ body {
     -moz-osx-font-smoothing: grayscale;
 }
 
-.app.api-docs .sidebar {
-    background-color: #fff;
-    border-right: 1px solid #ddd;
-    color: #444;
-}
-
-.app.api-docs .sidebar h2 {
-    color: #444;
-}
-
-.app.api-docs .sidebar li {
-    opacity: 0.8;
-}
-
 .code-section ul.nav {
     margin: 0;
 }

--- a/templates/zerver/api/main.html
+++ b/templates/zerver/api/main.html
@@ -5,7 +5,7 @@
 {% block portico_content %}
 <div class="app help api-docs terms-page inline-block">
     <div class="sidebar">
-        <h2 class="no-arrow"><a href="/api-new/" class="no-underline">Index</a></h2>
+        <h1 class="no-arrow"><a href="/api-new/" class="no-underline">Index</a></h1>
         {{ render_markdown_path("zerver/api/sidebar.md") }}
     </div>
 

--- a/templates/zerver/help/main.html
+++ b/templates/zerver/help/main.html
@@ -4,8 +4,8 @@
 
 {% block portico_content %}
 <div class="app help terms-page inline-block">
-        <h2 class="no-arrow"><a href="/help/" class="no-underline">Index</a></h2>
     <div class="sidebar slide">
+        <h1 class="no-arrow"><a href="/help/" class="no-underline">Index</a></h1>
         {{ render_markdown_path("zerver/help/include/sidebar.md") }}
     </div>
 

--- a/templates/zerver/help/main.html
+++ b/templates/zerver/help/main.html
@@ -4,8 +4,8 @@
 
 {% block portico_content %}
 <div class="app help terms-page inline-block">
-    <div class="sidebar">
         <h2 class="no-arrow"><a href="/help/" class="no-underline">Index</a></h2>
+    <div class="sidebar slide">
         {{ render_markdown_path("zerver/help/include/sidebar.md") }}
     </div>
 


### PR DESCRIPTION
This adds a slide class that specifies that the JS actions for sliding
up and down sections is the desired behavior, along with a bit of CSS
to help display correctly in the case of not being a sliding section.

This also includes some ancillary fixes.