### PR TITLE
[WIP] Exploratory generic form of check_* validators

### DIFF
--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -51,7 +51,7 @@ def check(T: Type,
         constraint_list = []  # type: List[Constraint]
         if constraints is not None:
             constraint_list = constraints
-        if isinstance(val, Mapping) and keyed_sub_validator is not None:
+        if isinstance(val, Mapping) and keyed_sub_validator:  # excludes empty list
             keys, validators = zip(*keyed_sub_validator)
             constraint_list.append(has_keys(keys))  # Ensure dict has expected keys
         for c in constraint_list:
@@ -143,11 +143,16 @@ def check_list(sub_validator: Optional[Validator], length: Optional[int]=None) -
 
 def check_dict(required_keys: Iterable[Tuple[str, Validator]],
                _allow_only_listed_keys: bool=False) -> Validator:
-    k, v = zip(*required_keys)
-    if _allow_only_listed_keys:
-        return check(Dict[Any, Any], keyed_sub_validator=required_keys, constraints=[only_keys(k)])
+    if len(required_keys) == 0:
+        keys = None
+        cons = None
     else:
-        return check(Dict[Any, Any], keyed_sub_validator=required_keys, constraints=[has_keys(k)])
+        keys, _ = zip(*required_keys)
+        if _allow_only_listed_keys:
+            cons = [only_keys(keys)]
+        else:
+            cons = [has_keys(keys)]
+    return check(Dict[Any, Any], keyed_sub_validator=required_keys, constraints=cons)
 
 def check_dict_only(required_keys: Iterable[Tuple[str, Validator]]) -> Validator:
     return check_dict(required_keys, _allow_only_listed_keys=True)

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -36,10 +36,9 @@ Validator = Callable[[str, object], Optional[str]]
 
 Constraint = Callable[[object], Optional[str]]
 
-CheckT = TypeVar('CheckT')
 KeyT = TypeVar('KeyT')
 
-def check(T: Type[CheckT],
+def check(T: Type,
           sub_validator: Optional[Validator]=None,
           keyed_sub_validator: Optional[Iterable[Tuple[KeyT, Validator]]]=None,
           constraints: Optional[List[Constraint]]=None) -> Validator:

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -28,11 +28,20 @@ for any particular type of object.
 from django.utils.translation import ugettext as _
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email, URLValidator
-from typing import Callable, Iterable, Optional, Tuple, TypeVar, Text
+from typing import Callable, Iterable, Optional, Tuple, TypeVar, Text, Type
 
 from zerver.lib.request import JsonableError
 
 Validator = Callable[[str, object], Optional[str]]
+
+CheckT = TypeVar('CheckT')
+
+def check(T: Type[CheckT]) -> Validator:
+    def checker(var_name: str, val: object) -> Optional[str]:
+        if not isinstance(val, T):
+            return _('%s is not a %s') % (val, str(T))
+        return None
+    return checker
 
 def check_string(var_name: str, val: object) -> Optional[str]:
     if not isinstance(val, str):

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -85,7 +85,7 @@ def max_length(length: int=200) -> Constraint:  # NOTE: from previous check_shor
         return None
     return checker
 
-def exact_length(length: int) -> Constraint: # NOTE: from previous check_list option
+def exact_length(length: int) -> Constraint:  # NOTE: from previous check_list option
     def checker(val: object) -> Optional[str]:
         if not isinstance(val, Sized):
             return " is not a container with a length"
@@ -94,7 +94,7 @@ def exact_length(length: int) -> Constraint: # NOTE: from previous check_list op
         return None
     return checker
 
-def has_keys(keys: Iterable[str], _only_listed_keys: bool=False) -> Constraint: # NOTE: from previous check_dict
+def has_keys(keys: Iterable[str], _only_listed_keys: bool=False) -> Constraint:  # NOTE: from previous check_dict
     def checker(val: object) -> Optional[str]:
         if not isinstance(val, Mapping):
             return " is not a mapping"
@@ -108,7 +108,7 @@ def has_keys(keys: Iterable[str], _only_listed_keys: bool=False) -> Constraint: 
         return None
     return checker
 
-def only_keys(keys: Iterable[str]) -> Constraint: # NOTE: from previous check_dict_only
+def only_keys(keys: Iterable[str]) -> Constraint:  # NOTE: from previous check_dict_only
     return has_keys(keys, _only_listed_keys=True)
 
 

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -78,6 +78,23 @@ def exact_length(length: int) -> Constraint: # NOTE: from previous check_list op
         return None
     return checker
 
+def has_keys(keys: Iterable[str], _only_listed_keys: bool=False) -> Constraint: # NOTE: from previous check_dict
+    def checker(val: object) -> Optional[str]:
+        if not isinstance(val, Mapping):
+            return " is not a mapping"
+        for key in keys:
+            if key not in val:
+                return _(' does not contain key %s') % (key,)
+        if _only_listed_keys:
+            delta_keys = set(val.keys()) - set(keys)
+            if len(delta_keys) != 0:
+                return _(" has unexpected arguments: %s" % (", ".join(list(delta_keys))))
+        return None
+    return checker
+
+def only_keys(keys: Iterable[str]) -> Constraint: # NOTE: from previous check_dict_only
+    return has_keys(keys, _only_listed_keys=True)
+
 
 def check_string(var_name: str, val: object) -> Optional[str]:
     if not isinstance(val, str):


### PR DESCRIPTION
The first two commits should be good to commit in any case, the others should be easy to follow but are a bigger change.

This is WIP since I'm not sure if this is desirable to this extent, though I think @timabbott mentioned an idea which I took to be like this in a recent conversation.

check_* functions are still present, but a good number are implemented via `check`.

Also, the error output is not as polished; I was thinking of some 'type traits' for the strings, ie. a `Dict[Type, str]`.