### PR TITLE
Replace all of optparse with argparse.

### DIFF
--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_send_receive_time
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_send_receive_time
@@ -9,7 +9,7 @@ It must be run on a machine that is using the live database for the
 Django ORM.
 """
 import sys
-import optparse
+import argparse
 import random
 import subprocess
 import time
@@ -28,40 +28,42 @@ usage = """Usage: send-receive.py [options] [config]
        'config' is optional, if present will return config info.
         Otherwise, returns the output data."""
 
-parser = optparse.OptionParser(usage=usage)
-parser.add_option('--site',
-                  dest='site',
-                  default="https://api.zulip.com",
-                  action='store')
+parser = argparse.ArgumentParser(usage=usage)
+parser.add_argument('--site',
+                    dest='site',
+                    default="https://api.zulip.com",
+                    action='store')
 
-parser.add_option('--nagios',
-                  dest='nagios',
-                  action='store_true')
+parser.add_argument('--nagios',
+                    dest='nagios',
+                    action='store_true')
 
-parser.add_option('--insecure',
-                  dest='insecure',
-                  action='store_true')
+parser.add_argument('--insecure',
+                    dest='insecure',
+                    action='store_true')
 
-parser.add_option('--munin',
-                  dest='munin',
-                  action='store_true')
+parser.add_argument('--munin',
+                    dest='munin',
+                    action='store_true')
 
-parser.add_option('--websocket',
-                  dest='websocket',
-                  action='store_true')
+parser.add_argument('--websocket',
+                    dest='websocket',
+                    action='store_true')
 
-(options, args) = parser.parse_args()
+parser.add_argument('config', nargs=argparse.REMAINDER)
+
+options = parser.parse_args()
 
 if not options.nagios and not options.munin:
     print('No output options specified! Please provide --munin or --nagios')
     sys.exit(0)
 
-if len(args) > 2:
+if len(options.config) > 2:
     print(usage)
     sys.exit(0)
 
 if options.munin:
-    if len(args) and args[0] == 'config':
+    if len(options.config) and options.config[0] == 'config':
         print("""graph_title Send-Receive times
 graph_info The number of seconds it takes to send and receive a message from the server
 graph_args -u 5 -l 0

--- a/scripts/lib/email-mirror-postfix
+++ b/scripts/lib/email-mirror-postfix
@@ -42,7 +42,7 @@ import os
 import ssl
 import sys
 
-from optparse import OptionParser
+import argparse
 
 import posix
 import json
@@ -53,28 +53,28 @@ from urllib.error import HTTPError
 from configparser import RawConfigParser
 
 
-parser = OptionParser()
+parser = argparse.ArgumentParser()
 
-parser.add_option('-r', '--recipient', dest="recipient", type='string', default='',
-                  help="Original recipient.")
+parser.add_argument('-r', '--recipient', dest="recipient", type=str, default='',
+                    help="Original recipient.")
 
-parser.add_option('-s', '--shared-secret', dest="shared_secret", type='string', default='',
-                  help="Secret access key.")
+parser.add_argument('-s', '--shared-secret', dest="shared_secret", type=str, default='',
+                    help="Secret access key.")
 
-parser.add_option('-d', '--dst-host', dest="host", type='string', default='https://127.0.0.1',
-                  help="Destination server address for uploading email from email mirror. "
-                       "Address must contain a HTTP protocol.")
+parser.add_argument('-d', '--dst-host', dest="host", type=str, default='https://127.0.0.1',
+                    help="Destination server address for uploading email from email mirror. "
+                         "Address must contain a HTTP protocol.")
 
-parser.add_option('-u', '--dst-url', dest="url", type='string', default='/email_mirror_message',
-                  help="Destination relative url for uploading email from email mirror.")
+parser.add_argument('-u', '--dst-url', dest="url", type=str, default='/email_mirror_message',
+                    help="Destination relative url for uploading email from email mirror.")
 
-parser.add_option('-n', '--not-verify-ssl', dest="verify_ssl", action='store_false', default=True,
-                  help="Disable ssl certificate verifying for self-signed certificates")
+parser.add_argument('-n', '--not-verify-ssl', dest="verify_ssl", action='store_false', default=True,
+                    help="Disable ssl certificate verifying for self-signed certificates")
 
-parser.add_option('-t', '--test', dest="test", action='store_true', default=False,
-                  help="Test mode.")
+parser.add_argument('-t', '--test', dest="test", action='store_true', default=False,
+                    help="Test mode.")
 
-(options, args) = parser.parse_args(args=None, values=None)
+options = parser.parse_args()
 
 MAX_ALLOWED_PAYLOAD = 25 * 1024 * 1024
 

--- a/scripts/nagios/check-rabbitmq-consumers
+++ b/scripts/nagios/check-rabbitmq-consumers
@@ -2,7 +2,7 @@
 
 import sys
 import time
-import optparse
+import argparse
 from collections import defaultdict
 import os
 import subprocess
@@ -23,14 +23,14 @@ if 'USER' in os.environ and not os.environ['USER'] in ['root', 'rabbitmq']:
 
 usage = """Usage: check-rabbitmq-consumers --queue=[queue-name] --min-threshold=[min-threshold]"""
 
-parser = optparse.OptionParser(usage=usage)
-parser.add_option('--min-threshold',
-                  dest='min_count',
-                  type="int",
-                  default=1,
-                  action='store')
+parser = argparse.ArgumentParser(usage=usage)
+parser.add_argument('--min-threshold',
+                    dest='min_count',
+                    type=int,
+                    default=1,
+                    action='store')
 
-(options, args) = parser.parse_args()
+options = parser.parse_args()
 
 output = subprocess.check_output(['/usr/sbin/rabbitmqctl', 'list_consumers'],
                                  universal_newlines=True)

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -2,7 +2,7 @@
 
 from typing import List, Any
 import glob
-import optparse
+import argparse
 import os
 import sys
 import subprocess
@@ -198,64 +198,63 @@ if __name__ == "__main__":
     test-backend zerver.tests.test_bugdown.BugdownTest.test_inline_youtube # run a single test
     test-backend BugdownTest.test_inline_youtube # run a single test"""
 
-    parser = optparse.OptionParser(usage)
+    parser = argparse.ArgumentParser(usage)
 
-    parser.add_option('--nonfatal-errors', action="store_false", default=True,
-                      dest="fatal_errors", help="Continue past test failures to run all tests")
-    parser.add_option('--coverage', dest='coverage',
-                      action="store_true",
-                      default=False,
-                      help='Compute test coverage.')
-    parser.add_option('--verbose-coverage', dest='verbose_coverage',
-                      action="store_true",
-                      default=False, help='Enable verbose print of coverage report.')
+    parser.add_argument('--nonfatal-errors', action="store_false", default=True,
+                        dest="fatal_errors", help="Continue past test failures to run all tests")
+    parser.add_argument('--coverage', dest='coverage',
+                        action="store_true",
+                        default=False,
+                        help='Compute test coverage.')
+    parser.add_argument('--verbose-coverage', dest='verbose_coverage',
+                        action="store_true",
+                        default=False, help='Enable verbose print of coverage report.')
 
-    def allow_positive_int(option, opt_str, value, parser):
-        # type: (optparse.Option, str, int, optparse.OptionParser) -> None
-        if value < 1:
-            raise optparse.OptionValueError(
-                "option {}: Only positive integers are allowed.".format(opt_str))
-        setattr(parser.values, option.dest, value)
+    parser.add_argument('--processes', dest='processes',
+                        type=int,
+                        action='store',
+                        default=4,
+                        help='Specify the number of processes to run the '
+                             'tests in. Default is 4.')
+    parser.add_argument('--profile', dest='profile',
+                        action="store_true",
+                        default=False, help='Profile test runtime.')
+    parser.add_argument('--force', dest='force',
+                        action="store_true",
+                        default=False, help='Run tests despite possible problems.')
+    parser.add_argument('--no-shallow', dest='no_shallow',
+                        action="store_true",
+                        default=False,
+                        help="Don't allow shallow testing of templates (deprecated)")
+    parser.add_argument('--verbose', dest='verbose',
+                        action="store_true",
+                        default=False,
+                        help="Show detailed output")
+    parser.add_argument('--generate-fixtures', action="store_true", default=False,
+                        dest="generate_fixtures",
+                        help=("Force a call to generate-fixtures."))
+    parser.add_argument('--report-slow-tests', dest='report_slow_tests',
+                        action="store_true",
+                        default=False,
+                        help="Show which tests are slowest.")
+    parser.add_argument('--reverse', dest='reverse',
+                        action="store_true",
+                        default=False,
+                        help="Run tests in reverse order.")
+    parser.add_argument('--rerun', dest="rerun",
+                        action="store_true",
+                        default=False,
+                        help=("Run the tests which failed the last time "
+                              "test-backend was run.  Implies --nonfatal-errors."))
+    parser.add_argument('args', nargs=argparse.REMAINDER)
 
-    parser.add_option('--processes', dest='processes',
-                      type="int",
-                      callback=allow_positive_int,
-                      action='callback',
-                      default=None,
-                      help='Specify the number of processes to run the '
-                           'tests in. Default is 4.')
-    parser.add_option('--profile', dest='profile',
-                      action="store_true",
-                      default=False, help='Profile test runtime.')
-    parser.add_option('--force', dest='force',
-                      action="store_true",
-                      default=False, help='Run tests despite possible problems.')
-    parser.add_option('--no-shallow', dest='no_shallow',
-                      action="store_true",
-                      default=False,
-                      help="Don't allow shallow testing of templates (deprecated)")
-    parser.add_option('--verbose', dest='verbose',
-                      action="store_true",
-                      default=False,
-                      help="Show detailed output")
-    parser.add_option('--generate-fixtures', action="store_true", default=False,
-                      dest="generate_fixtures",
-                      help=("Force a call to generate-fixtures."))
-    parser.add_option('--report-slow-tests', dest='report_slow_tests',
-                      action="store_true",
-                      default=False,
-                      help="Show which tests are slowest.")
-    parser.add_option('--reverse', dest='reverse',
-                      action="store_true",
-                      default=False,
-                      help="Run tests in reverse order.")
-    parser.add_option('--rerun', dest="rerun",
-                      action = "store_true",
-                      default=False,
-                      help=("Run the tests which failed the last time "
-                            "test-backend was run.  Implies --nonfatal-errors."))
+    options = parser.parse_args()
+    args = options.args
 
-    (options, args) = parser.parse_args()
+    if options.processes < 1:
+        raise argparse.ArgumentError(
+            "option processes: Only positive integers are allowed.")
+
     zerver_test_dir = 'zerver/tests/'
 
     # While running --rerun, we read var/last_test_failure.json to get
@@ -357,9 +356,6 @@ if __name__ == "__main__":
         subprocess.call(generate_fixtures_command)
 
     subprocess.check_call(['tools/webpack', '--test'])
-
-    if options.processes is None:
-        options.processes = 4
 
     TestRunner = get_runner(settings)
     parallel = options.processes

--- a/zerver/webhooks/semaphore/fixtures/eption_message.json
+++ b/zerver/webhooks/semaphore/fixtures/eption_message.json
@@ -319,7 +319,7 @@
           ],
           "vars": {
             "'root'": "<logging.Logger object at 0x107ba5b10>",
-            "'parser'": "<optparse.OptionParser instance at 0x107ba3368>",
+            "'parser'": "<argparse.ArgumentParser instance at 0x107ba3368>",
             "'dsn'": "'https://ebc35f33e151401f9deac549978bda11:f3403f81e12e4c24942d505f086b2cad@sentry.io/1'",
             "'opts'": "<Values at 0x107ba3b00: {'data': None, 'tags': None}>",
             "'client'": "<raven.base.Client object at 0x107bb8210>",

--- a/zerver/webhooks/sentry/fixtures/exception_message.json
+++ b/zerver/webhooks/sentry/fixtures/exception_message.json
@@ -319,7 +319,7 @@
           ],
           "vars": {
             "'root'": "<logging.Logger object at 0x107ba5b10>",
-            "'parser'": "<optparse.OptionParser instance at 0x107ba3368>",
+            "'parser'": "<argparse.ArgumentParser instance at 0x107ba3368>",
             "'dsn'": "'https://ebc35f33e151401f9deac549978bda11:f3403f81e12e4c24942d505f086b2cad@sentry.io/1'",
             "'opts'": "<Values at 0x107ba3b00: {'data': None, 'tags': None}>",
             "'client'": "<raven.base.Client object at 0x107bb8210>",


### PR DESCRIPTION
Only 1 remaining:
```
tools/zulip-export/zulip-export
26:import optparse
42:parser = optparse.OptionParser(usage=usage)
```
This requires a change in the python-zulip-api to use argparse instead of optparse.