### PR TITLE
Fix various typos.

### DIFF
--- a/analytics/management/commands/client_activity.py
+++ b/analytics/management/commands/client_activity.py
@@ -25,7 +25,7 @@ Usage examples:
                                  "'realm' will calculate client activity of realm. "
                                  "'user' will calculate client activity of the user.")
         parser.add_argument('--user', dest='user', type=str,
-                            help="The email adress of the user you want to calculate activity.")
+                            help="The email address of the user you want to calculate activity.")
         self.add_realm_args(parser)
 
     def compute_activity(self, user_activity_objects):

--- a/docs/german.md
+++ b/docs/german.md
@@ -199,7 +199,7 @@ with Zulip could think of this as streams that are online.
 
 * Bot - **Bot**
 
-Not only is "bot" a short and easily rememberable term, it is also widely used
+Not only is "bot" a short and easily memorable term, it is also widely used
 in German technology magazines, forums, etc.
 
 *"Bot" (Transifex, Heise, Die Zeit)*

--- a/docs/hashchange-system.md
+++ b/docs/hashchange-system.md
@@ -30,7 +30,7 @@ different flows:
   equivalent to the previous one, as a *link* out of the browser history
   will be visited).
 * The user clicking some in-app click handler (e.g. "Stream settings"
-  for an invidual stream), that potentially does
+  for an individual stream), that potentially does
   several UI-manipulating things including e.g. loading the streams
   overlay, and needs to update the hash without re-triggering the open
   animation (etc.).

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -126,7 +126,7 @@ flag to take note of is the `--modified` flag, which enables you to only run
 lint checks against files that are modified in your git repo.  Most of the
 "sub-linters" respect this flag, but some will continue to process all the files.
 Generally, a good workflow is to run with `--modified` when you are iterating on
-the code, and then run without that option right before commiting new code.
+the code, and then run without that option right before committing new code.
 
 If you need to troubleshoot the linters, there is a `--verbose` option that
 can give you clues about which linters may be running slow, for example.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -120,7 +120,7 @@ overlay over the message view area, to make exceptions in testing a
 new feature hard to miss.
 
 * Blueslip is implemented in `static/js/blueslip.js`.
-* In order to capture essentially any error occuring in the browser,
+* In order to capture essentially any error occurring in the browser,
 blueslip does the following:
   * Wraps every function passed into `$.ready()`, i.e., every
   on-webapp-startup method used by Zulip.

--- a/docs/spanish.md
+++ b/docs/spanish.md
@@ -35,7 +35,7 @@ Zulip friendly and usable.
 * Message - **Mensaje**
 * Private message (PM) - **Mensaje privado (MP)**
 * Group PM - **mensaje privado grupal**: even though "MP grupal" is the most
-  precise translation, preferrably don't use that one. Many users may not
+  precise translation, preferably don't use that one. Many users may not
   associate "MP" with *private message* in a group context. Better use it
   without abbreviations.
 * Realm - **Instancia**: the literal Spanish of realm is "reino",

--- a/docs/working-copies.md
+++ b/docs/working-copies.md
@@ -19,7 +19,7 @@ the various working copies.
 Sometimes you need to get commits.  Here are some scenarios:
 
 - You may fork the official Zulip repo to your GitHub fork.
-- You may fetch commits from the offical Zulip repo to your local copy.
+- You may fetch commits from the official Zulip repo to your local copy.
 - You occasionally may fetch commits from your forked copy.
 
 Sometimes you want to publish commits.  Here are scenarios:

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -214,8 +214,8 @@ people.add(bob);
 
 (function test_validate_stream_message() {
     // This test is in kind of continuation to test_validate but since it is
-    // primarly used to get coverage over functions called from validate()
-    // we are seperating it up in different test. Though their relative position
+    // primarily used to get coverage over functions called from validate()
+    // we are separating it up in different test. Though their relative position
     // of execution should not be changed.
     global.page_params.realm_mandatory_topics = false;
     var sub = {

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -129,7 +129,7 @@ function stubbing(func_name_to_stub, test_function) {
             // An exception will be thrown here if a different
             // function is called than the one declared.  Try to
             // provide a useful error message.
-            // add a newline to seperate from other console output.
+            // add a newline to separate from other console output.
             console.log('\nERROR: Mapping for character "' + e.which + '" does not match tests.');
         }
     }
@@ -320,7 +320,7 @@ function stubbing(func_name_to_stub, test_function) {
             // An exception will be thrown here if a different
             // function is called than the one declared.  Try to
             // provide a useful error message.
-            // add a newline to seperate from other console output.
+            // add a newline to separate from other console output.
             console.log('\nERROR: Mapping for character "' + e.which + '" does not match tests.');
         }
     }

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -190,7 +190,7 @@ stream_data.add_sub('Frontend', frontend);
         assert.equal(updated, true);
     });
 
-    // reset overriden value
+    // reset overridden value
     set_global('narrow_state', { is_for_stream_id: noop });
 
     with_overrides(function (override) {

--- a/frontend_tests/zjsunit/i18n.js
+++ b/frontend_tests/zjsunit/i18n.js
@@ -1,7 +1,7 @@
 var i18n = {};
 
 i18n.t = function (str, context) {
-    // We are currently assuming that we will recieve context in form of a Dict
+    // We are currently assuming that we will receive context in form of a Dict
     // of key value pairs and string will be having substitution for keywords
     // like these "__keyword__".
     if (context === undefined) {

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -188,5 +188,5 @@ social-auth-app-django==1.2.0
 # Needed for messages' rendered content parsing in push notifications.
 lxml==4.1.0
 
-# One occurance left in home.py
+# One occurrence left in home.py
 simplejson==3.11.1

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
-# Dependancies for setting up pip to install our requirements.txt file.
+# Dependencies for setting up pip to install our requirements.txt file.
 setuptools==36.6.0
 pip==9.0.1
 wheel==0.30.0

--- a/scripts/lib/docker-functions.sh
+++ b/scripts/lib/docker-functions.sh
@@ -349,10 +349,10 @@ zulip_first_start_init() {
     fi
     set -e
     touch "$DATA_DIR/.initiated"
-    echo "Zulip first start init sucessful."
+    echo "Zulip first start init successful."
 }
 # migrate_zulip_database Runs the zulip database migrations
-# This runs the migration everytime the container runs, to make sure Zulip has the
+# This runs the migration every time the container runs, to make sure Zulip has the
 # uptodate database version.
 migrate_zulip_database() {
     echo "Migrating Zulip to new version ..."

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -613,7 +613,7 @@ exports.get_filter_text = function () {
     if (!meta.$user_list_filter) {
         // This may be overly defensive, but there may be
         // situations where get called before everything is
-        // fully intialized.  The empty string is a fine
+        // fully initialized.  The empty string is a fine
         // default here.
         blueslip.warn('get_filter_text() is called before initialization');
         return '';

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -169,7 +169,7 @@ Filter.canonicalize_term = function (opts) {
     var operator = opts.operator;
     var operand = opts.operand;
 
-    // Make negated be explictly false for both clarity and
+    // Make negated be explicitly false for both clarity and
     // simplifying deepEqual checks in the tests.
     if (!negated) {
         negated = false;

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -53,7 +53,7 @@ function get_old_messages_success(data, opts) {
         return;
     }
     if (! data) {
-        // The server occationally returns no data during a
+        // The server occasionally returns no data during a
         // restart.  Ignore those responses and try again
         setTimeout(function () {
             exports.load_old_messages(opts);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -657,7 +657,7 @@ exports.compute_placement = function (elt, popover_height, popover_width,
     }
 
     if (prefer_vertical_positioning && placement !== 'viewport_center') {
-        // If vertical positioning is prefered and the popover fits in
+        // If vertical positioning is preferred and the popover fits in
         // either top or bottom position then return.
         return placement;
     }

--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -4,7 +4,7 @@ var exports = {};
 
 exports.default_color = "#c2c2c2";
 // Auto-assigned colors should be from the default palette so it's easy to undo
-// changes, so if that pallete changes, change these colors.
+// changes, so if that palette changes, change these colors.
 var stream_assignment_colors = ["#76ce90", "#fae589", "#a6c7e5", "#e79ab5",
                                 "#bfd56f", "#f4ae55", "#b0a5fd", "#addfe5",
                                 "#f5ce6e", "#c2726a", "#94c849", "#bd86e5",

--- a/templates/corporate/terms.md
+++ b/templates/corporate/terms.md
@@ -99,7 +99,7 @@ Services to share content with others, anyone you've shared content with
 content.
 
 In order to provide the Services, our servers save a record of the messages
-received by each Zulip Account (the "Received Messsage Information" for the
+received by each Zulip Account (the "Received Message Information" for the
 account). If you are using our Services on behalf of a business and a
 representative of that business sends [data@zulip.com](mailto:data@zulip.com)
 a request to delete all of your business' accounts with us, then within a

--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -27,5 +27,5 @@ def remove_attachment(user_profile, attachment):
     try:
         delete_message_image(attachment.path_id)
     except Exception:
-        raise JsonableError(_("An error occured while deleting the attachment. Please try again later."))
+        raise JsonableError(_("An error occurred while deleting the attachment. Please try again later."))
     attachment.delete()

--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -28,7 +28,7 @@ def avatar_url_from_dict(userdict, medium=False):
     '''
     DEPRECATED: We should start using
                 get_avatar_field to populate users,
-                particulary for codepaths where the
+                particularly for codepaths where the
                 client can compute gravatar URLS
                 on the client side.
     '''

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -955,7 +955,7 @@ def sanitize_url(url):
     locless_schemes = ['mailto', 'news', 'file']
     if netloc == '' and scheme not in locless_schemes:
         # This fails regardless of anything else.
-        # Return immediately to save additional proccessing
+        # Return immediately to save additional processing
         return None
 
     # Upstream code will accept a URL like javascript://foo because it

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -104,6 +104,6 @@ def fill_remote_cache(cache):
             cache_set_many(items_for_remote_cache, timeout=3600*24)
             items_for_remote_cache = {}
     cache_set_many(items_for_remote_cache, timeout=3600*24*7)
-    logging.info("Succesfully populated %s cache!  Consumed %s remote cache queries (%s time)" %
+    logging.info("Successfully populated %s cache!  Consumed %s remote cache queries (%s time)" %
                  (cache, get_remote_cache_requests() - remote_cache_requests_start,
                   round(get_remote_cache_time() - remote_cache_time_start, 2)))

--- a/zerver/lib/generate_test_data.py
+++ b/zerver/lib/generate_test_data.py
@@ -49,7 +49,7 @@ def parse_file(config, gens, corpus_file):
     paragraphs = []  # type: List[str]
 
     with open(corpus_file, "r") as infile:
-        # OUR DATA: we need to seperate the person talking and what they say
+        # OUR DATA: we need to separate the person talking and what they say
         paragraphs = remove_line_breaks(infile)
         paragraphs = add_flair(paragraphs, gens)
 

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -190,7 +190,7 @@ def notify_bot_owner(event, request_data, status_code=None, response_content=Non
                                 "```\n%s\n```" % (response_content,)
     if exception:
         notification_message += "\nWhen trying to send a request to the webhook service, an exception " \
-                                "of type %s occured:\n```\n%s\n```" % (type(exception).__name__, str(exception))
+                                "of type %s occurred:\n```\n%s\n```" % (type(exception).__name__, str(exception))
     send_response_message(bot_id, message_info, notification_message)
 
 def request_retry(event, request_data, failure_message, exception=None):
@@ -256,7 +256,7 @@ def do_rest_call(rest_operation, request_data, event, service_handler, timeout=N
         request_retry(event, request_data, response_message, exception=e)
 
     except requests.exceptions.RequestException as e:
-        response_message = "An exception of type *%s* occured for message `%s`! " \
+        response_message = "An exception of type *%s* occurred for message `%s`! " \
                            "See the Zulip server logs for more information." % (type(e).__name__, event["command"],)
         logging.exception("Outhook trigger failed:\n %s" % (e,))
         fail_with_message(event, response_message)

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -45,7 +45,7 @@ def slow(slowness_reason):
     '''
     This is a decorate that annotates a test as being "known
     to be slow."  The decorator will set expected_run_time and slowness_reason
-    as atributes of the function.  Other code can use this annotation
+    as attributes of the function.  Other code can use this annotation
     as needed, e.g. to exclude these tests in "fast" mode.
     '''
     def decorator(f):

--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -31,7 +31,7 @@ class AttachmentsTests(ZulipTestCase):
         self.login(user_profile.email)
         with mock.patch('zerver.lib.attachments.delete_message_image', side_effect=Exception()):
             result = self.client_delete('/json/attachments/{id}'.format(id=self.attachment.id))
-        self.assert_json_error(result, "An error occured while deleting the attachment. Please try again later.")
+        self.assert_json_error(result, "An error occurred while deleting the attachment. Please try again later.")
 
     @mock.patch('zerver.lib.attachments.delete_message_image')
     def test_remove_attachment(self, ignored):

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1017,7 +1017,7 @@ class MessagePOSTTest(ZulipTestCase):
     def test_personal_message_copying_self(self):
         # type: () -> None
         """
-        Sending a personal message to yourself plus another user is succesful,
+        Sending a personal message to yourself plus another user is successful,
         and counts as a message just to that user.
         """
         self.login(self.example_email("hamlet"))

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -104,7 +104,7 @@ The webhook got a response with status code *400*.''')
         bot_owner_notification = self.get_last_message()
         self.assertEqual(bot_owner_notification.content,
                          '''[A message](http://zulip.testserver/#narrow/stream/Verona/subject/Foo/near/) triggered an outgoing webhook.
-When trying to send a request to the webhook service, an exception of type Timeout occured:
+When trying to send a request to the webhook service, an exception of type Timeout occurred:
 ```
 Time is up!
 ```''')
@@ -120,7 +120,7 @@ Time is up!
         self.assertTrue(mock_fail_with_message.called)
         self.assertEqual(bot_owner_notification.content,
                          '''[A message](http://zulip.testserver/#narrow/stream/Verona/subject/Foo/near/) triggered an outgoing webhook.
-When trying to send a request to the webhook service, an exception of type RequestException occured:
+When trying to send a request to the webhook service, an exception of type RequestException occurred:
 ```
 I'm a generic exception :(
 ```''')

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -262,7 +262,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         d2_attachment.create_time = two_week_ago
         d2_attachment.save()
 
-        # Send message refering only dummy_1
+        # Send message referring only dummy_1
         self.subscribe(self.example_user("hamlet"), "Denmark")
         body = "Some files here ...[zulip.txt](http://localhost:9991/user_uploads/" + d1_path_id + ")"
         self.send_stream_message(self.example_email("hamlet"), "Denmark", body, "test")
@@ -302,7 +302,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
     def test_multiple_claim_attachments_different_owners(self):
         # type: () -> None
         """This test tries to claim the same attachment more than once, first
-        with a private stream and then with differnet recipients."""
+        with a private stream and then with different recipients."""
         self.login(self.example_email("hamlet"))
         d1 = StringIO("zulip!")
         d1.name = "dummy_1.txt"

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -237,7 +237,7 @@ def remote_user_jwt(request):
 def google_oauth2_csrf(request, value):
     # type: (HttpRequest, str) -> str
     # In Django 1.10, get_token returns a salted token which changes
-    # everytime get_token is called.
+    # every time get_token is called.
     from django.middleware.csrf import _unsalt_cipher_token
     token = _unsalt_cipher_token(get_token(request))
     return hmac.new(token.encode('utf-8'), value.encode("utf-8"), hashlib.sha256).hexdigest()
@@ -372,7 +372,7 @@ def finish_google_oauth2(request):
     try:
         full_name = body['name']['formatted']
     except KeyError:
-        # Only google+ users have a formated name. I am ignoring i18n here.
+        # Only google+ users have a formatted name. I am ignoring i18n here.
         full_name = u'{} {}'.format(
             body['name']['givenName'], body['name']['familyName']
         )


### PR DESCRIPTION
The typos and their corrections were found with the
aid of https://github.com/lucasdemarchi/codespell.

I found these with
```.sh
find . -type f \( -name '*.py' -o -name '*.js' -o -name '*.sh' -o -name '*.md' -o -name '*.txt' \) -exec codespell -w -i 1 {} +
```
There were surprisingly few false positives: The only ones I encountered were:
* ECT -> ETC
* iff -> if
* a test file where the fixture had the same mistake. Ironically, the line read
  > It looks like you accidently spelled 'commit' with two 't's.\n~~~