### PR TITLE
Improve text insertion logic for compose box.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -621,10 +621,6 @@ function test_raw_file_drop(raw_drop_func) {
     assert(compose_actions_start_checked);
     assert.equal($("#new_message_content").val(), 'Old content new contents');
     assert(compose_ui_autosize_textarea_checked);
-
-    // Now test the insert syntax code
-    $('#new_message_content').caret = noop;
-    compose_state.insert_syntax_and_focus('funtimes');
 }
 
 (function test_initialize() {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -57,13 +57,22 @@ function make_textbox(s) {
     assert.equal(textbox.val(), 'abc :smile: :airplane:');
     assert(textbox.focused);
 
-    // Test the current slightly-broken behavior.
     textbox.caret(0);
     textbox.blur();
     compose_ui.smart_insert(textbox, ':octopus:');
-    assert.equal(textbox.insert_text, ':octopus:');
-    assert.equal(textbox.val(), ':octopus:abc :smile: :airplane:');
+    assert.equal(textbox.insert_text, ':octopus: ');
+    assert.equal(textbox.val(), ':octopus: abc :smile: :airplane:');
     assert(textbox.focused);
 
+    textbox.caret(textbox.val().length);
+    textbox.blur();
+    compose_ui.smart_insert(textbox, ':heart:');
+    assert.equal(textbox.insert_text, ' :heart:');
+    assert.equal(textbox.val(), ':octopus: abc :smile: :airplane: :heart:');
+    assert(textbox.focused);
+
+    // Note that we don't have any special logic for strings that are
+    // already surrounded by spaces, since we are usually inserting things
+    // like emojis and file links.
 }());
 

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -1,0 +1,62 @@
+zrequire('compose_ui');
+
+function make_textbox(s) {
+    // Simulate a jQuery textbox for testing purposes.
+    var widget = {};
+
+    widget.s = s;
+    widget.focused = false;
+
+    widget.caret = function (arg) {
+        if (typeof arg === 'number') {
+            widget.pos = arg;
+            return;
+        }
+
+        if (arg) {
+            widget.insert_pos = widget.pos;
+            widget.insert_text = arg;
+            var before = widget.s.slice(0, widget.pos);
+            var after = widget.s.slice(widget.pos);
+            widget.s = before + arg + after;
+            widget.pos += arg.length;
+            return;
+        }
+
+        return widget.pos;
+    };
+
+    widget.focus = function () {
+        widget.focused = true;
+    };
+
+    widget.blur = function () {
+        widget.focused = false;
+    };
+
+    widget.val = function () {
+        return widget.s;
+    };
+
+    return widget;
+}
+
+(function test_smart_insert() {
+    var textbox = make_textbox('abc ');
+    textbox.caret(4);
+
+    compose_ui.smart_insert(textbox, ':smile:');
+    assert.equal(textbox.insert_pos, 4);
+    assert.equal(textbox.insert_text, ':smile:');
+    assert.equal(textbox.val(), 'abc :smile:');
+    assert(textbox.focused);
+
+    // Test the current slightly-broken behavior.
+    textbox.blur();
+    compose_ui.smart_insert(textbox, ':airplane:');
+    assert.equal(textbox.insert_text, ':airplane:');
+    assert.equal(textbox.val(), 'abc :smile::airplane:');
+    assert(textbox.focused);
+
+}());
+

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -51,11 +51,18 @@ function make_textbox(s) {
     assert.equal(textbox.val(), 'abc :smile:');
     assert(textbox.focused);
 
-    // Test the current slightly-broken behavior.
     textbox.blur();
     compose_ui.smart_insert(textbox, ':airplane:');
-    assert.equal(textbox.insert_text, ':airplane:');
-    assert.equal(textbox.val(), 'abc :smile::airplane:');
+    assert.equal(textbox.insert_text, ' :airplane:');
+    assert.equal(textbox.val(), 'abc :smile: :airplane:');
+    assert(textbox.focused);
+
+    // Test the current slightly-broken behavior.
+    textbox.caret(0);
+    textbox.blur();
+    compose_ui.smart_insert(textbox, ':octopus:');
+    assert.equal(textbox.insert_text, ':octopus:');
+    assert.equal(textbox.val(), ':octopus:abc :smile: :airplane:');
     assert(textbox.focused);
 
 }());

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -656,7 +656,7 @@ exports.initialize = function () {
         var video_call_id = util.random_int(100000000000000, 999999999999999);
         var video_call_link = 'https://meet.jit.si/' +  video_call_id;
         var video_call_link_text = '[' + _('Click to join video call') + '](' + video_call_link + ')';
-        compose_state.insert_syntax_and_focus(video_call_link_text);
+        compose_ui.insert_syntax_and_focus(video_call_link_text);
     });
 
     $("#compose").on("click", "#markdown_preview", function (e) {

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -51,15 +51,6 @@ exports.has_message_content = function () {
     return exports.message_content() !== "";
 };
 
-exports.insert_syntax_and_focus = function (syntax) {
-    // Generic helper for inserting syntax into the main compose box
-    // where the cursor was and focusing the area.  Mostly a thin
-    // wrapper around $.caret.
-    var textarea = $('#new_message_content');
-    textarea.caret(syntax);
-    textarea.focus();
-};
-
 return exports;
 }());
 

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -7,6 +7,20 @@ exports.autosize_textarea = function () {
 };
 
 exports.smart_insert = function (textarea, syntax) {
+    function is_space(c) {
+        return (c === ' ') || (c === '\t') || (c === '\n');
+    }
+
+    var pos = textarea.caret();
+    var before_str = textarea.val().slice(0, pos);
+
+
+    if (pos > 0) {
+        if (!is_space(before_str.slice(-1))) {
+            syntax = ' ' + syntax;
+        }
+    }
+
     textarea.caret(syntax);
     textarea.focus();
 };

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -6,13 +6,17 @@ exports.autosize_textarea = function () {
     $("#new_message_content").trigger("autosize.resize");
 };
 
+exports.smart_insert = function (textarea, syntax) {
+    textarea.caret(syntax);
+    textarea.focus();
+};
+
 exports.insert_syntax_and_focus = function (syntax) {
     // Generic helper for inserting syntax into the main compose box
     // where the cursor was and focusing the area.  Mostly a thin
-    // wrapper around $.caret.
+    // wrapper around smart_insert.
     var textarea = $('#new_message_content');
-    textarea.caret(syntax);
-    textarea.focus();
+    exports.smart_insert(textarea, syntax);
 };
 
 return exports;

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -13,11 +13,17 @@ exports.smart_insert = function (textarea, syntax) {
 
     var pos = textarea.caret();
     var before_str = textarea.val().slice(0, pos);
-
+    var after_str = textarea.val().slice(pos);
 
     if (pos > 0) {
         if (!is_space(before_str.slice(-1))) {
             syntax = ' ' + syntax;
+        }
+    }
+
+    if (after_str.length > 0) {
+        if (!is_space(after_str[0])) {
+            syntax += ' ';
         }
     }
 

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -6,6 +6,15 @@ exports.autosize_textarea = function () {
     $("#new_message_content").trigger("autosize.resize");
 };
 
+exports.insert_syntax_and_focus = function (syntax) {
+    // Generic helper for inserting syntax into the main compose box
+    // where the cursor was and focusing the area.  Mostly a thin
+    // wrapper around $.caret.
+    var textarea = $('#new_message_content');
+    textarea.caret(syntax);
+    textarea.focus();
+};
+
 return exports;
 
 }());

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -678,7 +678,7 @@ exports.register_click_handlers = function () {
     $(document).on('click', '.emoji-popover-emoji.composition', function (e) {
         var emoji_name = $(this).data("emoji-name");
         var emoji_text = ':' + emoji_name + ':';
-        compose_state.insert_syntax_and_focus(emoji_text);
+        compose_ui.insert_syntax_and_focus(emoji_text);
         e.stopPropagation();
         emoji_picker.hide_emoji_popover();
     });


### PR DESCRIPTION
This is prep for #7273, and then we can continue on that PR to make sure all the right places are calling compose_ui.insert_syntax_and_focus().