### PR TITLE
queue processors: Add coverage for SlowQueryWorker.

### DIFF
--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -209,7 +209,8 @@ def write_log_line(log_data, path, method, remote_ip, email, client_name,
     if (is_slow_query(time_delta, path)):
         # Since the slow query worker patches code, we can't directly
         # use call_consume_in_tests here without further work.
-        queue_json_publish("slow_queries", "%s (%s)" % (logger_line, email), lambda e: None)
+        queue_json_publish("slow_queries", "%s (%s)" % (logger_line, email), lambda e: None,
+                           call_consume_in_tests=True)
 
     if settings.PROFILE_ALL_REQUESTS:
         log_data["prof"].disable()

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -1,9 +1,11 @@
+import time
 
-from django.test import TestCase
-
+from unittest.mock import Mock, patch
+from zerver.lib.test_classes import ZulipTestCase
 from zerver.middleware import is_slow_query
+from zerver.middleware import write_log_line
 
-class SlowQueryTest(TestCase):
+class SlowQueryTest(ZulipTestCase):
     def test_is_slow_query(self):
         # type: () -> None
         self.assertFalse(is_slow_query(1.1, '/some/random/url'))
@@ -16,3 +18,22 @@ class SlowQueryTest(TestCase):
         self.assertFalse(is_slow_query(2, '/user_activity/whatever'))
         self.assertFalse(is_slow_query(9, '/accounts/webathena_kerberos_login/'))
         self.assertTrue(is_slow_query(11, '/accounts/webathena_kerberos_login/'))
+
+    @patch('logging.info')
+    def test_slow_query_log(self, mock_logging_info):
+        # type: (Mock) -> None
+        SLOW_QUERY_TIME = 10
+        log_data = {'extra': '[transport=websocket]',
+                    'time_started': time.time() - SLOW_QUERY_TIME,
+                    'bugdown_requests_start': 0,
+                    'bugdown_time_start': 0,
+                    'remote_cache_time_start': 0,
+                    'remote_cache_requests_start': 0}
+        write_log_line(log_data, path='/socket/open', method='SOCKET',
+                       remote_ip='123.456.789.012', email='unknown', client_name='?')
+        last_message = self.get_last_message()
+        self.assertEqual(last_message.sender.email, "error-bot@zulip.com")
+        self.assertIn("logs", str(last_message.recipient))
+        self.assertEqual(last_message.topic_name(), "testserver: slow queries")
+        self.assertRegexpMatches(last_message.content,
+                                 "123\.456\.789\.012 SOCKET  200 10\.0s .*")


### PR DESCRIPTION
The first commit replaces #7284.

I manually tested both queues with print statements in my dev server. The log looked like
```
Starting development server at http://127.0.0.1:9992/
Quit the server with CONTROL-C.
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming
consuming missedmessages
consuming
consuming missedmessages
```
(consuming = slowqueryworker)