### PR TITLE
Add a couple cross-realm bots.

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2498,7 +2498,7 @@ class FetchQueriesTest(ZulipTestCase):
                     client_gravatar=False,
                 )
 
-        self.assert_length(queries, 29)
+        self.assert_length(queries, 31)
 
         expected_counts = dict(
             alert_words=0,
@@ -2516,7 +2516,7 @@ class FetchQueriesTest(ZulipTestCase):
             realm_embedded_bots=0,
             realm_emoji=1,
             realm_filters=1,
-            realm_user=4,
+            realm_user=6,
             realm_user_groups=1,
             stream=2,
             subscription=5,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -180,8 +180,8 @@ class HomeTest(ZulipTestCase):
             with patch('zerver.lib.cache.cache_set') as cache_mock:
                 result = self._get_home_page(stream='Denmark')
 
-        self.assert_length(queries, 41)
-        self.assert_length(cache_mock.call_args_list, 10)
+        self.assert_length(queries, 43)
+        self.assert_length(cache_mock.call_args_list, 12)
 
         html = result.content.decode('utf-8')
 
@@ -245,7 +245,7 @@ class HomeTest(ZulipTestCase):
         with queries_captured() as queries2:
             result = self._get_home_page()
 
-        self.assert_length(queries2, 35)
+        self.assert_length(queries2, 37)
 
         # Do a sanity check that our new streams were in the payload.
         html = result.content.decode('utf-8')
@@ -469,12 +469,28 @@ class HomeTest(ZulipTestCase):
         self.assertNotIn('defunct-1@zulip.com', active_emails)
 
         cross_bots = page_params['cross_realm_bots']
-        self.assertEqual(len(cross_bots), 3)
+        self.assertEqual(len(cross_bots), 5)
         cross_bots.sort(key=lambda d: d['email'])
 
         notification_bot = self.notification_bot()
 
-        self.assertEqual(cross_bots, [
+        by_email = lambda d: d['email']
+
+        self.assertEqual(sorted(cross_bots, key=by_email), sorted([
+            dict(
+                user_id=get_user('new-user-bot@zulip.com', get_realm('zulip')).id,
+                is_admin=False,
+                email='new-user-bot@zulip.com',
+                full_name='Zulip New User Bot',
+                is_bot=True
+            ),
+            dict(
+                user_id=get_user('emailgateway@zulip.com', get_realm('zulip')).id,
+                is_admin=False,
+                email='emailgateway@zulip.com',
+                full_name='Email Gateway',
+                is_bot=True
+            ),
             dict(
                 user_id=get_user('feedback@zulip.com', get_realm('zulip')).id,
                 is_admin=False,
@@ -496,7 +512,7 @@ class HomeTest(ZulipTestCase):
                 full_name='Welcome Bot',
                 is_bot=True
             ),
-        ])
+        ], key=by_email))
 
     def test_new_stream(self):
         # type: () -> None

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1466,6 +1466,12 @@ if PRODUCTION:
 # This is a debugging option only
 PROFILE_ALL_REQUESTS = False
 
-CROSS_REALM_BOT_EMAILS = set(('feedback@zulip.com', 'notification-bot@zulip.com', 'welcome-bot@zulip.com'))
+CROSS_REALM_BOT_EMAILS = {
+    'feedback@zulip.com',
+    'notification-bot@zulip.com',
+    'welcome-bot@zulip.com',
+    'new-user-bot@zulip.com',
+    'emailgateway@zulip.com',
+}
 
 CONTRIBUTORS_DATA = os.path.join(STATIC_ROOT, 'generated/github-contributors.json')


### PR DESCRIPTION
These are new:

    new-user-bot
    emailgateway

Our cross-realm bots are hard coded to have email addresses
in the `zulip.com` domain, and they're not part of ordinary
realms.