### PR TITLE
webhook_docs: Organize into a numbered list of steps.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -2002,6 +2002,7 @@ nav ul li.active::after {
     display: inline-block;
     vertical-align: middle;
     max-width: 100%;
+    overflow: auto;
 
     font-family: Monaco, Menlo, Consolas, "Courier New", Courier, monospace;
     font-size: 0.85em;

--- a/templates/zerver/help/include/change-zulip-config-file-indented.md
+++ b/templates/zerver/help/include/change-zulip-config-file-indented.md
@@ -1,0 +1,13 @@
+    On your {{ settings_html|safe }}, create a bot for
+    {{ integration_display_name }}.
+
+    Next, open
+    `integrations/{{ integration_name }}/zulip_{{ integration_name }}_config.py`
+    with your favorite editor, and change the following lines to specify the
+    email address and API key for your {{ integration_display_name }} bot:
+
+    ```
+    ZULIP_USER = "{{ integration_name }}-bot@example.com"
+    ZULIP_API_KEY = "0123456789abcdef0123456789abcdef"
+    ZULIP_SITE = "{{ api_url }}"
+    ```

--- a/templates/zerver/help/include/create-bot-construct-url-indented.md
+++ b/templates/zerver/help/include/create-bot-construct-url-indented.md
@@ -1,0 +1,20 @@
+    Next, on your {{ settings_html|safe }},
+    [create a bot](/help/add-a-bot-or-integration) for
+    {{ integration_display_name }}. Make sure that you select
+    **Incoming webhook** as the **Bot type**:
+
+    ![](/static/images/help/bot_types.png)
+
+    The API keys for "Incoming webhook" bots are limited to only
+    sending messages via webhooks. Thus, this bot type lessens
+    the security risks associated with exposing the bot's API
+    key to third-party services.
+
+    Construct the URL for the {{ integration_display_name }}
+    bot using the bot API key and stream name:
+
+    {!webhook-url.md!}
+
+    Modify the parameters of the URL above, where `api_key` is the API key
+    of your Zulip bot, and `stream` is the stream name you want the
+    notifications sent to.

--- a/templates/zerver/help/include/git-webhook-url-with-branches-indented.md
+++ b/templates/zerver/help/include/git-webhook-url-with-branches-indented.md
@@ -1,0 +1,4 @@
+    You can also limit the branches you receive notifications for by
+    specifying them in a comma-separated list at the end of the URL,
+    like so:
+    `{{ api_url }}{{ integration_url }}?api_key=abcdefgh&stream={{ recommended_stream_name }}&branches=master,development`

--- a/templates/zerver/help/include/webhook-url-with-bot-email-indented.md
+++ b/templates/zerver/help/include/webhook-url-with-bot-email-indented.md
@@ -1,0 +1,7 @@
+    In the URL field, enter:
+
+    `{{ external_uri_scheme }}bot_email:bot_api_key@{{ api_url_scheme_relative }}{{ integration_url }}`
+
+    Replace `bot_email` and `bot_api_key` above with the URL-encoded email
+    address and API key of the bot.  To URL-encode the email address, you
+    just need to replace `@` in the bot's email address with `%40`.

--- a/templates/zerver/integrations/codebase.md
+++ b/templates/zerver/integrations/codebase.md
@@ -1,35 +1,35 @@
-First, create the streams you’d like to use for Codebase notifications. There
-will be two types of messages: commit-related updates and issue-related updates.
-After creating these streams (we suggest naming them `codebase commits` and
-`codebase issues`), make sure to subscribe all interested parties.
+1. First, create the streams you’d like to use for Codebase notifications. There
+   will be two types of messages: commit-related updates and issue-related updates.
+   After creating these streams (we suggest naming them `codebase commits` and
+   `codebase issues`), make sure to subscribe all interested parties.
 
-{!download-python-bindings.md!}
+2. {!download-python-bindings.md!}
 
-You will need your Codebase API Username. You can find it in the settings page
-of your account, under **API Credentials**.
+3. You will need your Codebase API Username. You can find it in the settings page
+   of your account, under **API Credentials**.
 
-{!change-zulip-config-file.md!}
+4. {!change-zulip-config-file-indented.md!}
 
-Also, edit the following Codebase credentials in `zulip_codebase_config.py`:
+5. Also, edit the following Codebase credentials in `zulip_codebase_config.py`:
 
-```
-CODEBASE_API_USERNAME = "zulip-inc/leo-franchi-15"
-CODEBASE_API_KEY = 0123456789abcdef0123456789abcdef
-```
+    ```
+    CODEBASE_API_USERNAME = "zulip-inc/leo-franchi-15"
+    CODEBASE_API_KEY = 0123456789abcdef0123456789abcdef
+    ```
 
-Before your first run of the script, you may optionally choose to configure it
-to mirror some number of hours of prior Codebase activity:
+6. Before your first run of the script, you may optionally choose to configure it
+   to mirror some number of hours of prior Codebase activity:
 
-```
-CODEBASE_INITIAL_HISTORY_HOURS = 10
-```
+    ```
+    CODEBASE_INITIAL_HISTORY_HOURS = 10
+    ```
 
-Now, simply run the `api/integrations/codebase/zulip_codebase_mirror` script.
-If needed, this script may be restarted, and it will automatically resume from
-when it was last running.
+7. Now, simply run the `api/integrations/codebase/zulip_codebase_mirror` script.
+   If needed, this script may be restarted, and it will automatically resume from
+   when it was last running.
 
-Whenever you create a new project, commit, issue, deployment, or more, you’ll
-get notifications in your selected streams with the associated information.
+8. Whenever you create a new project, commit, issue, deployment, or more, you’ll
+   get notifications in your selected streams with the associated information.
 
 {!congrats.md!}
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -699,6 +699,8 @@ def build_custom_checkers(by_lang):
             "templates/zerver/integrations/perforce.md",
             # Has some example code that could perhaps be wrapped
             "templates/zerver/api/webhook-walkthrough.md",
+            # This macro has a long indented URL
+            "templates/zerver/help/include/git-webhook-url-with-branches-indented.md",
         }
         for fn in by_lang['md']:
             max_length = None

--- a/zerver/webhooks/beanstalk/doc.md
+++ b/zerver/webhooks/beanstalk/doc.md
@@ -1,18 +1,18 @@
 Zulip supports both SVN and Git notifications from Beanstalk.
 
-First, create the stream `commits` and subscribe all
-interested parties to this stream.
+1. First, create the stream `commits` and subscribe all
+   interested parties to this stream.
 
-Next, in the Beanstalk web application, go to the **Setup** page
-and choose the **Integrations** tab.
+2. Next, in the Beanstalk web application, go to the **Setup** page
+   and choose the **Integrations** tab.
 
-Choose the **Webhooks** integration from the list presented.
+3. Choose the **Webhooks** integration from the list presented.
 
-{!webhook-url-with-bot-email.md!}
+4. {!webhook-url-with-bot-email-indented.md!}
 
-{!git-append-branches.md!}
+5. {!git-append-branches.md!}
 
-![](/static/images/integrations/beanstalk/001.png)
+    ![](/static/images/integrations/beanstalk/001.png)
 
 {!congrats.md!}
 

--- a/zerver/webhooks/github_webhook/doc.md
+++ b/zerver/webhooks/github_webhook/doc.md
@@ -2,32 +2,31 @@ For the integration based on the deprecated
 [GitHub Services](https://github.com/github/github-services),
 see [here](./github).
 
-{!create-stream.md!}
+1. {!create-stream.md!}
 
-{!create-bot-construct-url.md!}
+2. {!create-bot-construct-url-indented.md!}
 
-{!git-webhook-url-with-branches.md!}
+3. {!git-webhook-url-with-branches-indented.md!}
 
-Next, go to your repository page and click **Settings**:
+4. Next, go to your repository page and click **Settings**:
+   ![](/static/images/integrations/github_webhook/001.png)
 
-![](/static/images/integrations/github_webhook/001.png)
+5. From there, select **Webhooks**:
 
-From there, select **Webhooks**:
+    ![](/static/images/integrations/github_webhook/002.png)
 
-![](/static/images/integrations/github_webhook/002.png)
+6. Click **Add webhook**.
 
-Click **Add webhook**.
+    ![](/static/images/integrations/github_webhook/003.png)
 
-![](/static/images/integrations/github_webhook/003.png)
+7. Authorize yourself and configure your webhook.
 
-Authorize yourself and configure your webhook.
+8. In the **Payload URL** field, enter the URL constructed above.
 
-In the **Payload URL** field, enter the URL constructed above.
+9. Then, set **Content type** to `application/json`.
 
-Then, set **Content type** to `application/json`.
-
-Next, select the actions that you want to result in a Zulip
-notification and click **Add Webhook**.
+10. Next, select the actions that you want to result in a Zulip
+    notification and click **Add Webhook**.
 
 {!congrats.md!}
 


### PR DESCRIPTION
This commit organizes the documentation for github_webhook into
a numbered list of steps, similar to our /help documentation.

@brockwhittaker: Tim told me that you would be the right person to speak to about this. When our documentation steps are organised into a numbered list similar to our `/help` docs, they are rendered like so:
![screenshot from 2017-11-10 19-17-08](https://user-images.githubusercontent.com/7251823/32681881-3eebe8a0-c64c-11e7-9685-f1ddf2e6ec2a.png)

The list numbers repeat after a few steps. This is probably because the Markdown macros have line breaks inside them. I was wondering, is there a way to manipulate the CSS for the numbered lists in a way that the steps are rendered in the correct numerical order?

Looking forward to hearing from you! @timabbott: FYI! :)

Thanks,
\-Eeshan
