### PR TITLE
message view: Render embedded images inline.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2029,13 +2029,20 @@ div.floating_recipient {
     display: inline !important;
 }
 
+/* Hack for inserting line break <br> after element */
+.message_inline_image span::after,
+.twitter-tweet span::after {
+    content: "\a";
+    white-space: pre;
+}
+
 .twitter-image,
 .message_inline_image {
     position: relative;
-    margin-bottom: 5px;
+    margin-top: 5px;
     margin-left: 5px;
     height: 100px;
-    display: block !important;
+    display: inline-block !important;
     border: none !important;
 }
 
@@ -2053,7 +2060,6 @@ div.floating_recipient {
     height: auto;
     max-height: 100%;
     float: left;
-    margin-right: 10px;
 }
 
 .message_inline_image_title {


### PR DESCRIPTION
As a user, I felt that displaying a single image on one line took up a lot of unnecessary space, so this PR changes the display of the embedded images to be more compact.

Related to #3097 and #5122

Before:
![screenshot at nov 11 10-56-17](https://user-images.githubusercontent.com/15116870/32692568-182a37c0-c6cf-11e7-9d8f-d0e26d710846.png)

After:
![screenshot at nov 10 20-02-26](https://user-images.githubusercontent.com/15116870/32692572-20ca18be-c6cf-11e7-834d-b8b0a297d5f1.png)

Tweets:
![screenshot at nov 11 11-00-43](https://user-images.githubusercontent.com/15116870/32692588-9a2c5b54-c6cf-11e7-9ae5-5f4f43defab4.png)
