### PR TITLE
[wip!] zerver/lib/actions.py: Remove usage of get_user_profile_by_email.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -17,7 +17,7 @@ from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.http import HttpRequest
 from jinja2 import Markup as mark_safe
 
-from zerver.lib.actions import do_change_password, user_email_is_unique, \
+from zerver.lib.actions import do_change_password, \
     validate_email_for_realm
 from zerver.lib.name_restrictions import is_reserved_subdomain, is_disposable_domain
 from zerver.lib.request import JsonableError
@@ -173,7 +173,7 @@ def email_is_not_disposable(email):
 
 class RealmCreationForm(forms.Form):
     # This form determines whether users can create a new realm.
-    email = forms.EmailField(validators=[user_email_is_unique, email_is_not_disposable])
+    email = forms.EmailField(validators=[email_is_not_disposable])
 
 class LoggingSetPasswordForm(SetPasswordForm):
     def save(self, commit=True):

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3824,10 +3824,10 @@ def do_send_confirmation_email(invitee, referrer, body):
     send_email('zerver/emails/invitation', to_email=invitee.email, from_name=from_name,
                from_address=FromAddress.NOREPLY, context=context)
 
-def user_email_is_unique(email):
+def user_email_is_unique(email, realm):
     # type: (Text) -> None
     try:
-        get_user_profile_by_email(email)
+        get_user(email, realm)
         raise ValidationError('%s already has an account' % (email,))
     except UserProfile.DoesNotExist:
         pass
@@ -3835,7 +3835,7 @@ def user_email_is_unique(email):
 def validate_email_for_realm(target_realm, email):
     # type: (Optional[Realm], Text) -> None
     try:
-        existing_user_profile = get_user_profile_by_email(email)
+        existing_user_profile = get_user(email, target_realm)
     except UserProfile.DoesNotExist:
         existing_user_profile = None
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -19,7 +19,7 @@ from zerver.lib.send_email import send_email, FromAddress
 from zerver.lib.events import do_events_register
 from zerver.lib.actions import do_change_password, do_change_full_name, do_change_is_admin, \
     do_activate_user, do_create_user, do_create_realm, \
-    user_email_is_unique, compute_mit_user_fullname, validate_email_for_realm, \
+    compute_mit_user_fullname, validate_email_for_realm, \
     do_set_user_display_setting, lookup_default_stream_groups
 from zerver.forms import RegistrationForm, HomepageForm, RealmCreationForm, \
     CreateUserForm, FindMyTeamForm
@@ -326,12 +326,6 @@ def create_realm(request, creation_key=None):
             if (creation_key is not None and check_key_is_valid(creation_key)):
                 RealmCreationKey.objects.get(creation_key=creation_key).delete()
             return HttpResponseRedirect(reverse('send_confirm', kwargs={'email': email}))
-        try:
-            email = request.POST['email']
-            user_email_is_unique(email)
-        except ValidationError:
-            # Maybe the user is trying to log in
-            return redirect_to_email_login_url(email)
     else:
         form = RealmCreationForm()
     return render(request,


### PR DESCRIPTION
There is only one error in Travis here that needs to be discussed: realm is `None` at realm creation and so `get_user` can't be run.