### PR TITLE
docs/dev-env: Recommend setting up lxc network config on Debian.

### DIFF
--- a/docs/dev-env-first-time-contributors.md
+++ b/docs/dev-env-first-time-contributors.md
@@ -193,6 +193,10 @@ command is
 sudo apt-get install build-essential git ruby lxc redir
 ```
 
+Debian's packages do not ship any default network setup for containers. So,
+you will have to setup networking for `lxc` containers by following the
+steps outlined [here](https://wiki.debian.org/LXC#network_setup) before
+proceeding to the next step.
 
 #### Windows 10
 


### PR DESCRIPTION
lxc on Debian does not ship with a default network config for
containers, so we now recommend setting up the lxc network config
manually.

@gnprice: Thanks for your help with this! (I just remembered that we should probably update our docs for this) :)