### PR TITLE
docs: Move bot docs to /api.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,8 +82,6 @@ Contents:
    integration-guide
    integration-docs-guide
    webhook-walkthrough
-   running-bots-guide
-   writing-bots-guide
    new-feature-tutorial
    writing-views
    life-of-a-request

--- a/templates/zerver/api/running-bots.md
+++ b/templates/zerver/api/running-bots.md
@@ -22,7 +22,7 @@ https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots
 in your Zulip organization.
 
 *Hint: Looking for an easy way to test a bot's output? Check out [this](
- writing-bots-guide.html#testing-a-bot-s-output) guide.*
+ writing-bots#testing-a-bot-s-output) guide.*
 
 You need:
 
@@ -40,7 +40,7 @@ You need:
 
 *Hint: Do you want to install the latest development version? Check
  out [this](
- writing-bots-guide.html#installing-a-development-version-of-the-zulip-bots-package)
+ writing-bots#installing-a-development-version-of-the-zulip-bots-package)
  guide.*
 
 2. Register a new bot user on the Zulip server's web interface.
@@ -54,7 +54,7 @@ You need:
 
     * In the *Active bots* panel, click on the little green download icon
       to download its configuration file *.zuliprc* (the structure of this file is
-      explained [here](writing-bots-guide.html#configuration-file)).
+      explained [here](writing-bots#configuration-file)).
     * Copy the file to a destination of your choice, e.g. to `~/.zuliprc`.
 
 4. Run the bot.

--- a/templates/zerver/api/running-bots.md
+++ b/templates/zerver/api/running-bots.md
@@ -22,7 +22,7 @@ https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots
 in your Zulip organization.
 
 *Hint: Looking for an easy way to test a bot's output? Check out [this](
- writing-bots#testing-a-bot-s-output) guide.*
+ writing-bots#testing-a-bots-output) guide.*
 
 You need:
 
@@ -38,10 +38,10 @@ You need:
 
 1. Run `pip install zulip_bots` to install the package.
 
-*Hint: Do you want to install the latest development version? Check
- out [this](
- writing-bots#installing-a-development-version-of-the-zulip-bots-package)
- guide.*
+     *Hint: Do you want to install the latest development version? Check
+     out [this](
+     writing-bots#installing-a-development-version-of-the-zulip-bots-package)
+     guide.*
 
 2. Register a new bot user on the Zulip server's web interface.
 

--- a/templates/zerver/api/sidebar.md
+++ b/templates/zerver/api/sidebar.md
@@ -17,5 +17,5 @@
 
 ## Interactive bots (experimental)
 
-* [Running bots](https://zulip.readthedocs.io/en/latest/running-bots-guide.html)
-* [Writing bots](https://zulip.readthedocs.io/en/latest/writing-bots-guide.html)
+* [Running bots](/api/running-bots)
+* [Writing bots](/api/writing-bots)

--- a/templates/zerver/api/writing-bots.md
+++ b/templates/zerver/api/writing-bots.md
@@ -15,6 +15,7 @@ third-party service.
  [guide for running bots](running-bots).
 
 On this page you'll find:
+
 * A step-by-step
   [guide](#installing-a-development-version-of-the-zulip-bots-package)
   on how to set up a development environment for writing bots with all

--- a/templates/zerver/api/writing-bots.md
+++ b/templates/zerver/api/writing-bots.md
@@ -12,7 +12,7 @@ third-party service.
 
 * This guide is about writing and testing interactive bots. We assume
  familiarity with our
- [guide for running bots](running-bots-guide.html).
+ [guide for running bots](running-bots).
 
 On this page you'll find:
 * A step-by-step

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -651,7 +651,7 @@ def build_custom_checkers(by_lang):
         color = next(colors)
         markdown_docs_length_exclude = {
             "api/bots/converter/readme.md",
-            "docs/running-bots-guide.md",
+            "templates/zerver/api/running-bots.md",
             "docs/dev-env-first-time-contributors.md",
             "docs/webhook-walkthrough.md",
             "docs/life-of-a-request.md",


### PR DESCRIPTION
A couple points of interest:
* This invalidates many links in `python-zulip-api` that point to readthedocs. I didn't make a PR to update them yet, as I'm not sure if we want to actually remove these docs from readthedocs. I thought we could create a symlink to them, at least, so they're still included.

* The rendering of relative links in /api seems to be different than on readthedocs: `Testing a bot's output` is `#testing-a-bot-s-output` on readthedocs and `#testing-a-bots-output` in /api. I don't know which party to blame here.

* Bullet list rendering seems to break for text directly followed by a bullet list in the next line (see commit 
 "docs: Fix rendering of running-bots.md"

* Some relative links seem to fail nondeterministically for me, I couldn't reproduce this in my last run though.