### PR TITLE
docs: Fix typo in plans.html

### DIFF
--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -128,7 +128,7 @@
                                 <ul class="feature-list">
                                     <li>Convenient web service</li>
                                     <li>No sysadmin work required</li>
-                                    <li>Priority commerical support</li>
+                                    <li>Priority commercial support</li>
                                     <li>Funds the Zulip open source project</li>
                                 </ul>
                             </div>


### PR DESCRIPTION
This was **not** found by a typechecker, I just stumbled across it :/
It would be really great to have a reliable tool for these sorts of issues, especially on these critical pages.