### PR TITLE
Fix MissedMessageWorker.

### DIFF
--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -276,7 +276,6 @@ class MissedMessageWorker(LoopQueueProcessingWorker):
     sleep_delay = 2 * 60
 
     def consume_batch(self, missed_events: List[Dict[str, Any]]) -> None:
-        missed_events = self.q.drain_queue("missedmessage_emails", json=True)
         by_recipient = defaultdict(list)  # type: Dict[int, List[Dict[str, Any]]]
 
         for event in missed_events:


### PR DESCRIPTION
This fixes a regression in 25c669df52720876155de8d3493252dcaa8e4c37.

We were draining the queue in both the superclass and the subclass,
so by the time the subclass started processing events, there were
no events to process.  Now the subclass properly uses the events
passed in from the superclass.