### PR TITLE
left-sidebar: Remove topics help code.

### DIFF
--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -161,11 +161,6 @@ exports.widget = function (parent_elem, my_stream_id) {
         self.no_more_topics = true;
     };
 
-    self.show_help_link = function () {
-        var elem = self.dom.find('.sidebar-topics-help');
-        elem.show();
-    };
-
     self.build = function (active_topic, no_more_topics) {
         self.no_more_topics = false; // for now
 
@@ -184,10 +179,6 @@ exports.widget = function (parent_elem, my_stream_id) {
         // the initial zooming.
         if (no_more_topics) {
             self.show_no_more_topics();
-        }
-
-        if (zoomed) {
-            self.show_help_link();
         }
 
         if (active_topic) {

--- a/static/templates/more_topics.handlebars
+++ b/static/templates/more_topics.handlebars
@@ -7,4 +7,3 @@
 <li class="no-more-topics-found">
     {{t "No more topics." }}
 </li>
-<li class="sidebar-topics-help"></li>


### PR DESCRIPTION
This removes code associated with the dead topic help feature that is
below “more topics”.