### PR TITLE
settings: Increase specificity of sidebar <li> selector.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -812,7 +812,7 @@ $(function () {
                         $("li[data-section='organization-profile']").click();
                     }
                 } else {
-                    $("li:not(.admin)").show();
+                    $(".settings-list li:not(.admin)").show();
                     if (!payload.dont_switch_tab) {
                         $("li[data-section='your-account']").click();
                     }


### PR DESCRIPTION
This was interfering with <li> elements outside of the settings page.