### PR TITLE
streams: Close other overlays before launching subscriptions overlay.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -528,6 +528,7 @@ exports.change_state = (function () {
 
 exports.launch = function (hash) {
     exports.setup_page(function () {
+        overlays.close_active();
         overlays.open_overlay({
             name: 'subscriptions',
             overlay: $("#subscription_overlay"),


### PR DESCRIPTION
This closes any other open overlays before opening up the subscriptions
overlay, fixing the traceback in issue #7398.

Fixes: #7398.