### PR TITLE
portico-header: Remove border between image and realm name.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -732,8 +732,6 @@ input.text-error {
     margin: 0px 5px 0px -4px;
     padding: 1px 0px 1px 5px;
 
-    border-left: 1px solid rgba(0,0,0,0.2);
-
     font-size: 0.9em;
     font-weight: 600;
 


### PR DESCRIPTION
This removes the border between the realm image and the realm name in
the portico header that is shown when logged in.