### PR TITLE
Fixed /api page CSS issues

### DIFF
--- a/templates/zerver/api/running-bots.md
+++ b/templates/zerver/api/running-bots.md
@@ -11,7 +11,7 @@ On this page you'll find:
 * A [guide](#zulip-botserver) on running a Zulip botserver.
 * Common [problems](#common-problems) when developing/running bots and their solutions.
 
-## Installing the `zulip_bots` package
+## Installing the Zulip bots package
 
 ## Running a bot
 
@@ -143,7 +143,7 @@ pip install zulip_botserver
 5.  Congrats, everything is set up! Test your botserver like you would
     test a normal bot.
 
-### Running Zulip Botserver with `supervisord`
+### Running Zulip Botserver with supervisord
 
 [supervisord](http://supervisord.org/) is a popular tool for running
 services in production.  It helps ensure the service starts on boot,

--- a/templates/zerver/api/writing-bots.md
+++ b/templates/zerver/api/writing-bots.md
@@ -26,7 +26,7 @@ On this page you'll find:
 * A [documentation](#bot-api) of the bot API.
 * Common [problems](#common-problems) when developing/running bots and their solutions.
 
-## Installing a development version of the `zulip_bots` package
+## Installing a development version of the Zulip bots package
 
 1. `git clone https://github.com/zulip/python-zulip-api.git` - clone the [python-zulip-api](
   https://github.com/zulip/python-zulip-api) repository.


### PR DESCRIPTION
Changed code blocks to normal text in the headings containing code
blocks in api/writing-bots and api/reading-bots.

Fixes: #7395 