### PR TITLE
docs: Remove integration docs from tutorials/index.

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -5,9 +5,6 @@ Developer Tutorials
 .. toctree::
    :maxdepth: 3
 
-   integration-guide
-   integration-docs-guide
-   webhook-walkthrough
    new-feature-tutorial
    writing-views
    life-of-a-request


### PR DESCRIPTION
Merged PR #7414 moved integration docs to /api, so
this commit updates tutorials/index.rst accordingly.

There weren't any developer documents containing links to integration docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zulip/zulip/7436)
<!-- Reviewable:end -->
