### PR TITLE
Rewrite password reset to send an email even if no account exists

### DIFF
--- a/templates/zerver/emails/password_reset.source.html
+++ b/templates/zerver/emails/password_reset.source.html
@@ -2,12 +2,19 @@
 
 {% block content %}
 <p>
-    {% if attempted_realm %}
-    Someone (possibly you) requested a password reset email for {{ email }} on {{ attempted_realm.uri }}, but {{ email }} does not have an active account in {{ attempted_realm.uri }}.  However, {{ email }} does have an active account in {{ user.realm.uri }} organization; you can try logging in or resetting your password there.
+    {% if no_account_in_realm %}
+        Someone (possibly you) requested a password reset email for {{ email }}
+        on {{ realm_uri }}, but {{ email }} does not have an
+        active account in {{ realm_uri }}.
+
+        {% if account_exists_another_realm %}
+        However, {{ email }} does have an active account in the {{ user.realm.uri }}
+        organization; you can try logging in or resetting your password there.
+        {% endif %}
     {% else %}
-    Psst. Word on the street is that you need a new password, {{ email }}.<br />
-    It's all good. Follow the link below and we'll take care of the rest:<br />
-    {{ protocol }}://{{ user.realm.host }}{{ url('django.contrib.auth.views.password_reset_confirm', kwargs=dict(uidb64=uid, token=token)) }}
+        Psst. Word on the street is that you need a new password, {{ email }}.<br />
+        It's all good. Follow the link below and we'll take care of the rest:<br />
+        {{ protocol }}://{{ user.realm.host }}{{ url('django.contrib.auth.views.password_reset_confirm', kwargs=dict(uidb64=uid, token=token)) }}
     {% endif %}
 </p>
 <p>

--- a/templates/zerver/emails/password_reset.txt
+++ b/templates/zerver/emails/password_reset.txt
@@ -1,9 +1,12 @@
-{% if attempted_realm %}
+{% if no_account_in_realm %}
 Someone (possibly you) requested a password reset email for {{ email }} on
-{{ attempted_realm.uri }}, but {{ email }} does not
-have an active account in {{ attempted_realm.uri }}.  However, {{ email }} does
+{{ realm_uri }}, but {{ email }} does not
+have an active account in {{ realm_uri }}.
+{% if account_exists_another_realm %}
+However, {{ email }} does
 have an active account in {{ user.realm.uri }} organization; you
 can try logging in or resetting your password there.
+{% endif %}
 {% else %}
 Psst. Word on the street is that you need a new password, {{ email }}.
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -202,9 +202,8 @@ class PasswordResetTest(ZulipTestCase):
         # type: () -> None
         email = 'nonexisting@mars.com'
 
-        with patch('logging.info'):
-            # start the password reset process by supplying an email address
-            result = self.client_post('/accounts/password/reset/', {'email': email})
+        # start the password reset process by supplying an email address
+        result = self.client_post('/accounts/password/reset/', {'email': email})
 
         # check the redirect link telling you to check mail for password reset link
         self.assertEqual(result.status_code, 302)
@@ -291,7 +290,9 @@ class PasswordResetTest(ZulipTestCase):
         # type: () -> None
         """If the email auth backend is not enabled, password reset should do nothing"""
         email = self.example_email("hamlet")
-        result = self.client_post('/accounts/password/reset/', {'email': email})
+        with patch('logging.info') as mock_logging:
+            result = self.client_post('/accounts/password/reset/', {'email': email})
+            mock_logging.assert_called_once()
 
         # check the redirect link telling you to check mail for password reset link
         self.assertEqual(result.status_code, 302)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -227,19 +227,11 @@ class PasswordResetTest(ZulipTestCase):
     def test_wrong_subdomain(self):
         # type: () -> None
         email = self.example_email("hamlet")
-        string_id = 'hamlet'
-        name = 'Hamlet'
-        do_create_realm(
-            string_id,
-            name,
-            restricted_to_domain=False,
-            invite_required=False
-        )
 
-        with patch('zerver.forms.get_subdomain', return_value=string_id):
-            # start the password reset process by supplying an email address
-            result = self.client_post(
-                '/accounts/password/reset/', {'email': email})
+        # start the password reset process by supplying an email address
+        result = self.client_post(
+            '/accounts/password/reset/', {'email': email},
+            subdomain="zephyr")
 
         # check the redirect link telling you to check mail for password reset link
         self.assertEqual(result.status_code, 302)
@@ -258,31 +250,22 @@ class PasswordResetTest(ZulipTestCase):
         self.assertIn("hamlet@zulip.com does not\nhave an active account in http://",
                       message.body)
 
-    def test_correct_subdomain(self):
+    def test_invalid_subdomain(self):
         # type: () -> None
         email = self.example_email("hamlet")
-        string_id = 'zulip'
 
-        with patch('zerver.forms.get_subdomain', return_value=string_id):
-            # start the password reset process by supplying an email address
-            result = self.client_post(
-                '/accounts/password/reset/', {'email': email})
+        # start the password reset process by supplying an email address
+        result = self.client_post(
+            '/accounts/password/reset/', {'email': email},
+            subdomain="invalid")
 
         # check the redirect link telling you to check mail for password reset link
-        self.assertEqual(result.status_code, 302)
-        self.assertTrue(result["Location"].endswith(
-            "/accounts/password/reset/done/"))
-        result = self.client_get(result["Location"])
-
-        self.assert_in_response("Check your email to finish the process.", result)
+        self.assertEqual(result.status_code, 200)
+        self.assert_in_success_response(["There is no Zulip organization hosted at this subdomain."],
+                                        result)
 
         from django.core.mail import outbox
-        self.assertEqual(len(outbox), 1)
-        message = outbox.pop()
-        self.assertIn("Zulip Account Security", message.from_email)
-        self.assertIn(FromAddress.NOREPLY, message.from_email)
-        self.assertIn("Psst. Word on the street is that you",
-                      message.body)
+        self.assertEqual(len(outbox), 0)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
                                                 'zproject.backends.ZulipDummyBackend'))


### PR DESCRIPTION
This is based on @umairwaheed's https://github.com/zulip/zulip/pull/6084, though I've mostly rewritten the logic, because it was a lot more readable without trying to copy the structure of the original Django form.

@umairwaheed can you give this a review?

@hackerkid I'd also like you to give this a review, and while you're at it, do these things:
* Testing that the whitespace is correct in all 3 cases in the plain-text version (I haven't triggered them manually)
* Add a commit to use a nice button for the "password reset" link in the HTML template, like how our confirmation emails do it.

This is a priority item, since this issue is one of the main remaining blockers to being able to use the same email in multiple organizations.