### PR TITLE
provision: Run clean-unused-caches.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -371,6 +371,8 @@ def main(options):
         else:
             print("No need to run `manage.py compilemessages`.")
 
+    run(["scripts/lib/clean-unused-caches"])
+
     version_file = os.path.join(UUID_VAR_PATH, 'provision_version')
     print('writing to %s\n' % (version_file,))
     open(version_file, 'w').write(PROVISION_VERSION + '\n')


### PR DESCRIPTION
This prevents the caches in /srv from growing to fill up the disk --
e.g., on my laptop after 6 months of regular development the venv cache
was 12G and the NPM cache 5G, making them by far the largest disk hogs
on the machine.

It costs about 0.4s, apart from any time spent actually removing
things.  This is a little annoyingly slow to be adding to every
provision, and seems like it could be optimized, but I think already
worth it as is.