### PR TITLE
email: Fix identification of chrome as safari on iOS

### DIFF
--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -21,7 +21,7 @@ def get_device_browser(user_agent):
         return "Edge"
     elif "opera" in user_agent or "opr/" in user_agent:
         return "Opera"
-    elif "chrome" in user_agent and "chromium" not in user_agent:
+    elif ("chrome" in user_agent or "crios" in user_agent) and "chromium" not in user_agent:
         return 'Chrome'
     elif "firefox" in user_agent and "seamonkey" not in user_agent and "chrome" not in user_agent:
         return "Firefox"

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -71,6 +71,9 @@ class TestBrowserAndOsUserAgentStrings(ZulipTestCase):
                 'like gecko', 'Internet Explorer', 'Windows'),
             ('Mozilla/5.0 (Android; Mobile; rv:27.0) ' +
                 'Gecko/27.0 Firefox/27.0', 'Firefox', 'Android'),
+            ('Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) '
+             'AppleWebKit/602.1.50 (KHTML, like Gecko) '
+             'CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1', 'Chrome', 'iOS'),
             ('Mozilla/5.0 (iPad; CPU OS 6_1_3 like Mac OS X) ' +
                 'AppleWebKit/536.26 (KHTML, like Gecko) ' +
                 'Version/6.0 Mobile/10B329 Safari/8536.25', 'Safari', 'iOS'),


### PR DESCRIPTION
The user agent(UA) string for chrome on ios contains "crios" instead of "chrome".
(Source: https://developer.chrome.com/multidevice/user-agent#chrome_for_ios_user_agent)
Added the missing test for corresponding case.
Fixes: #7441.