### PR TITLE
[WIP] integrations: Move integration-specific context to integration_doc.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -210,9 +210,7 @@ class HubotIntegration(Integration):
         super().__init__(
             name, name, categories,
             logo=logo, display_name=display_name,
-            # HACK: This isn't actually used.  We'll rewrite this to
-            # `hubot_common.md` in `app_filters.py`
-            doc = 'zerver/integrations/%s.md' % (name,),
+            doc = 'zerver/integrations/hubot_common.md',
             legacy=legacy
         )
 

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -82,26 +82,6 @@ def render_markdown_path(markdown_file_path, context=None):
     if context is None:
         context = {}
 
-    if context.get('integrations_dict') is not None:
-        integration_dir = None
-        if markdown_file_path.endswith('doc.md'):
-            integration_dir = os.path.basename(os.path.dirname(markdown_file_path))
-        elif 'integrations' in markdown_file_path.split('/'):
-            integration_dir = os.path.splitext(os.path.basename(markdown_file_path))[0]
-
-        integration = context['integrations_dict'][integration_dir]
-
-        context['integration_name'] = integration.name
-        context['integration_display_name'] = integration.display_name
-        if hasattr(integration, 'stream_name'):
-            context['recommended_stream_name'] = integration.stream_name
-        if hasattr(integration, 'url'):
-            context['integration_url'] = integration.url[3:]
-        if hasattr(integration, 'hubot_docs_url'):
-            context['hubot_docs_url'] = integration.hubot_docs_url
-            # HACK: The actual file doesn't exist; we rewrite it here.
-            markdown_file_path = 'zerver/integrations/hubot_common.md'
-
     jinja = engines['Jinja2']
     markdown_string = jinja.env.loader.get_source(jinja.env, markdown_file_path)[0]
     html = md_engine.convert(markdown_string)

--- a/zerver/views/integrations.py
+++ b/zerver/views/integrations.py
@@ -135,6 +135,16 @@ def integration_doc(request, integration_name=REQ(default=None)):
 
     context = integration.doc_context or {}
     add_integrations_context(context)
+
+    context['integration_name'] = integration.name
+    context['integration_display_name'] = integration.display_name
+    if hasattr(integration, 'stream_name'):
+        context['recommended_stream_name'] = integration.stream_name
+    if hasattr(integration, 'url'):
+        context['integration_url'] = integration.url[3:]
+    if hasattr(integration, 'hubot_docs_url'):
+        context['hubot_docs_url'] = integration.hubot_docs_url
+
     doc_html_str = render_markdown_path(integration.doc, context)
 
     return HttpResponse(doc_html_str)


### PR DESCRIPTION
Instead of populating the context dict with integration-specific
information in render_markdown_path, we now do that in
zerver.views.integrations.integration_doc instead.

Fixes: #7401.

@timabbott: This works as expected but I keep getting the following `mypy` errors:

```
zerver/views/integrations.py:144: error: "Integration" has no attribute "url"
zerver/views/integrations.py:146: error: "Integration" has no attribute "hubot_docs_url"
```

I've been trying to fix these for a few hours and have never had to deal with these errors before. It seems to be complaining about the fact that `Integration` doesn't have the attributes `url` and `hubot_docs_url`. But `Integrations's` subclasses do have those attributes. I looked online and found [this typeshed bug](https://github.com/python/mypy/issues/4026). Is something similar happening here or am I missing something here? Thanks! :)