### PR TITLE
email_log: Reset the value of email after email change process.

### DIFF
--- a/zerver/views/email_log.py
+++ b/zerver/views/email_log.py
@@ -88,6 +88,9 @@ def generate_all_emails(request):
     user_profile = get_user(registered_email, realm)
     result = client.get(url)
     assert result.status_code == 200
+    # Reset the email value
+    user_profile.email = registered_email
+    user_profile.save()
 
     # Follow up day1 day2 emails
     enqueue_welcome_emails(user_profile)


### PR DESCRIPTION
Currently generate emails throws an error when run for the second time.

This commit actually only needs
```
user_profile.save()
```
but it's more readable with both the lines. Got removed in 15b3a8e4ffd74472f3cc4816602a2b5a8c87c2de

Before 15b3a8e4ffd74472f3cc4816602a2b5a8c87c2de this used to be

```
user_profile.emails = "hamlet@zulip.com"
user_profile.save()
```
I am kind of surprised that `user_profile.emails` didn't throw an error even though `emails` was an invalid attribute.