### PR TITLE
Use realistic filepaths in zuliprc docs and hints.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -97,9 +97,6 @@ function _setup_page() {
         return tab;
     }());
 
-    // Most browsers do not allow filenames to start with `.` without the user manually changing it.
-    // So we use zuliprc, not .zuliprc.
-
     var settings_tab = templates.render('settings_tab', {
         full_name: people.my_full_name(),
         page_params: page_params,

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -8,7 +8,7 @@
                 <button type="submit" class="btn open_edit_bot_form" data-sidebar-form="edit-bot" title="{{t 'Edit bot' }}" data-email="{{email}}">
                     <i class="icon-vector-pencil blue"></i>
                 </button>
-                <a type="submit" download="{{zuliprc}}" class="btn download_bot_zuliprc" title="{{t 'Download .zuliprc' }}" data-email="{{email}}">
+                <a type="submit" download="{{zuliprc}}" class="btn download_bot_zuliprc" title="{{t 'Download zuliprc' }}" data-email="{{email}}">
                     <i class="icon-vector-download-alt sea-green"></i>
                 </a>
                 <button type="submit" class="btn delete_bot" title="{{t 'Delete bot' }}" data-email="{{email}}">

--- a/templates/zerver/api/running-bots.md
+++ b/templates/zerver/api/running-bots.md
@@ -50,20 +50,23 @@ You need:
       Select *Generic bot* for bot type, fill out the form and click on *Create bot*.
     * A new bot user should appear in the *Active bots* panel.
 
-3. Download the bot's `.zuliprc` configuration file to your computer.
+3. Download the bot's `zuliprc` configuration file to your computer.
 
+    * Go to *Settings* -> *Your bots*
     * In the *Active bots* panel, click on the little green download icon
-      to download its configuration file *.zuliprc* (the structure of this file is
+      to download its configuration file *zuliprc* (the structure of this file is
       explained [here](writing-bots#configuration-file)).
-    * Copy the file to a destination of your choice, e.g. to `~/.zuliprc`.
+    * The file will be downloaded to some place like `~/Downloads/zuliprc` (depends
+      on your browser and OS).
+    * Copy the file to a destination of your choice, e.g. to `~/zuliprc-my-bot`.
 
 4. Run the bot.
 
     * Run
       ```
-      zulip-run-bot <bot-name> --config-file ~/.zuliprc
+      zulip-run-bot <bot-name> --config-file ~/zuliprc-my-bot
       ```
-      (using the path to the `.zuliprc` file from step 3).
+      (using the path to the `zuliprc` file from step 3).
     * Check the output of the command. It should start with the text
       the `usage` function returns, followed by logging output similar
       to this:
@@ -111,7 +114,7 @@ pip install zulip_botserver
 
 2.  Download the `flaskbotrc` from the `your-bots` settings page. It
     contains the configuration details for all the active outgoing
-    webhook bots. It's structure is very similar to that of .zuliprc.
+    webhook bots. It's structure is very similar to that of zuliprc.
 
 3.  Run the Zulip Botserver by passing the `flaskbotrc` to it. The
     command format is:


### PR DESCRIPTION
The first part of this change is to have the "Your bots"
tooltip not lie about creating `.zuliprc`, because it
doesn't put a dot in front of the file.

And then the more significant change here is to make
the "Running a bot" documentation use realistic filepaths,
both in terms of where the download typically puts the file,
and where you want to move it to.