### PR TITLE
integrations: Add add_context_for_single_integration function.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -61,7 +61,6 @@ class Integration:
         self.secondary_line_text = secondary_line_text
         self.legacy = legacy
         self.doc = doc
-        self.doc_context = None  # type: Optional[Dict[Any, Any]]
 
         for category in categories:
             if category not in CATEGORIES:
@@ -86,10 +85,6 @@ class Integration:
     def is_enabled(self):
         # type: () -> bool
         return True
-
-    def add_doc_context(self, context):
-        # type: (Dict[Any, Any]) -> None
-        self.doc_context = context
 
     def get_logo_url(self):
         # type: () -> Optional[str]

--- a/zerver/views/integrations.py
+++ b/zerver/views/integrations.py
@@ -127,8 +127,6 @@ def add_context_for_single_integration(context, name, request):
     context['settings_html'] = settings_html
     context['subscriptions_html'] = subscriptions_html
 
-    INTEGRATIONS[name].add_doc_context(context)
-
 
 class IntegrationView(ApiURLView):
     template_name = 'zerver/integrations/index.html'
@@ -148,7 +146,7 @@ def integration_doc(request, integration_name=REQ(default=None)):
     except KeyError:
         return HttpResponseNotFound()
 
-    context = integration.doc_context or {}
+    context = {}  # type: Dict[str, Any]
     add_context_for_single_integration(context, integration_name, request)
 
     context['integration_name'] = integration.name

--- a/zerver/views/integrations.py
+++ b/zerver/views/integrations.py
@@ -112,8 +112,22 @@ def add_integrations_context(context):
     context['settings_html'] = settings_html
     context['subscriptions_html'] = subscriptions_html
 
-    for name in alphabetical_sorted_integration:
-        alphabetical_sorted_integration[name].add_doc_context(context)
+
+def add_context_for_single_integration(context, name, request):
+    # type: (Dict[str, Any], str, HttpRequest) -> None
+    add_api_uri_context(context, request)
+
+    if "html_settings_links" in context and context["html_settings_links"]:
+        settings_html = '<a href="../../#settings">Zulip settings page</a>'
+        subscriptions_html = '<a target="_blank" href="../../#streams">streams page</a>'
+    else:
+        settings_html = 'Zulip settings page'
+        subscriptions_html = 'streams page'
+
+    context['settings_html'] = settings_html
+    context['subscriptions_html'] = subscriptions_html
+
+    INTEGRATIONS[name].add_doc_context(context)
 
 
 class IntegrationView(ApiURLView):
@@ -135,7 +149,7 @@ def integration_doc(request, integration_name=REQ(default=None)):
         return HttpResponseNotFound()
 
     context = integration.doc_context or {}
-    add_integrations_context(context)
+    add_context_for_single_integration(context, integration_name, request)
 
     context['integration_name'] = integration.name
     context['integration_display_name'] = integration.display_name


### PR DESCRIPTION
Previously, when rendering a single integration, we tacked on the
following information to the context dict that was redundant:

* An OrderedDict containing all of the Integration objects for
  all integrations.
* An OrderedDict containing all of the integration categories.

The context dict for rendering a particular integration doc would
contain 4 OrderedDicts, 2 for categories, 2 for Integration objects
because of how many times add_integrations_context had been called.

This was very wasteful, since an Integration object doesn't need
to access any other Integration object (or itself for that matter)
to render its documentation. This commit adds a function that
allows us to only pass in the context values that are necessary.

@timabbott: FYI, this addresses the last point of the changes you requested in #7401. :)