### PR TITLE
settings: Make CSS selector more specific in table rows in org settings.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -150,7 +150,7 @@ label {
     vertical-align: middle;
 }
 
-#settings_content table + .progressive-table-wrapper table tr td:first-of-type {
+#settings_content table + .progressive-table-wrapper table tr.user_row td:first-of-type {
     width: 20%;
 }
 


### PR DESCRIPTION
Fixes #7374. 

Since we use `table-layout: fixed`, the width of the first
row are applied to all the remaining rows, thus wrapping all the columns
to 20% width. This is fixed by making the selector specific to only
user_rows and not the editable data row.

Also, this bug was present in the Organization Settings > Users as well due to the same reason.