### PR TITLE
Eliminate remaining use of get_user_profile_by_email outside validation code

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -49,7 +49,6 @@ not_yet_fully_covered = {
     # Major lib files should have 100% coverage
     'confirmation/models.py',
     'zerver/decorator.py',
-    'zerver/forms.py',
     'zerver/lib/actions.py',
     'zerver/lib/addressee.py',
     'zerver/lib/bugdown/__init__.py',

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -253,34 +253,6 @@ class CreateUserForm(forms.Form):
     email = forms.EmailField()
 
 class OurAuthenticationForm(AuthenticationForm):
-    def clean_username(self):
-        # type: () -> str
-        email = self.cleaned_data['username']
-        try:
-            user_profile = get_user_profile_by_email(email)
-        except UserProfile.DoesNotExist:
-            return email
-
-        if user_profile.realm.deactivated:
-            error_msg = u"""Sorry for the trouble, but %s has been deactivated.
-
-Please contact %s to reactivate this group.""" % (
-                user_profile.realm.name,
-                FromAddress.SUPPORT)
-            raise ValidationError(mark_safe(error_msg))
-
-        if not user_profile.is_active and not user_profile.is_mirror_dummy:
-            error_msg = (
-                u"Your account is no longer active. "
-                u"Please contact your organization administrator to reactivate it.")
-            raise ValidationError(mark_safe(error_msg))
-
-        if not user_matches_subdomain(get_subdomain(self.request), user_profile):
-            logging.warning("User %s attempted to password login to wrong subdomain %s" %
-                            (user_profile.email, get_subdomain(self.request)))
-            raise ValidationError(mark_safe(WRONG_SUBDOMAIN_ERROR))
-        return email
-
     def clean(self):
         # type: () -> Dict[str, Any]
         username = self.cleaned_data.get('username')
@@ -289,16 +261,39 @@ Please contact %s to reactivate this group.""" % (
         if username is not None and password:
             subdomain = get_subdomain(self.request)
             realm = get_realm(subdomain)
+            return_data = {}  # type: Dict[str, Any]
             self.user_cache = authenticate(self.request, username=username, password=password,
-                                           realm=realm)
+                                           realm=realm, return_data=return_data)
+            if return_data.get("inactive_realm"):
+                error_msg = (u"""Sorry for the trouble, but %s has been deactivated.
+
+                             Please contact %s to reactivate this group.""" % (
+                                 realm.name,
+                                 FromAddress.SUPPORT))
+                raise ValidationError(mark_safe(error_msg))
+
+            if return_data.get("inactive_user") and not return_data.get("is_mirror_dummy"):
+                # We exclude mirror dummy accounts here. They should be treated as the
+                # user never having had an account, so we let them fall through to the
+                # normal invalid_login case below.
+                error_msg = (
+                    u"Your account is no longer active. "
+                    u"Please contact your organization administrator to reactivate it.")
+                raise ValidationError(mark_safe(error_msg))
+
+            if return_data.get("invalid_subdomain"):
+                logging.warning("User %s attempted to password login to wrong subdomain %s" %
+                                (username, subdomain))
+                raise ValidationError(mark_safe(WRONG_SUBDOMAIN_ERROR))
+
             if self.user_cache is None:
                 raise forms.ValidationError(
                     self.error_messages['invalid_login'],
                     code='invalid_login',
                     params={'username': self.username_field.verbose_name},
                 )
-            else:
-                self.confirm_login_allowed(self.user_cache)
+
+            self.confirm_login_allowed(self.user_cache)
 
         return self.cleaned_data
 

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -264,13 +264,9 @@ class OurAuthenticationForm(AuthenticationForm):
             return_data = {}  # type: Dict[str, Any]
             self.user_cache = authenticate(self.request, username=username, password=password,
                                            realm=realm, return_data=return_data)
-            if return_data.get("inactive_realm"):
-                error_msg = (u"""Sorry for the trouble, but %s has been deactivated.
 
-                             Please contact %s to reactivate this group.""" % (
-                                 realm.name,
-                                 FromAddress.SUPPORT))
-                raise ValidationError(mark_safe(error_msg))
+            if return_data.get("inactive_realm"):
+                raise AssertionError("Programming error: inactive realm in authentication form")
 
             if return_data.get("inactive_user") and not return_data.get("is_mirror_dummy"):
                 # We exclude mirror dummy accounts here. They should be treated as the

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -507,13 +507,12 @@ class GitHubAuthBackendTest(ZulipTestCase):
 
     def test_github_backend_authenticate_nonexisting_user(self):
         # type: () -> None
-        with mock.patch('zproject.backends.get_user_profile_by_email',
-                        side_effect=UserProfile.DoesNotExist("Do not exist")):
-            response = dict(email=self.email, name=self.name)
-            return_data = dict()  # type: Dict[str, Any]
-            user = self.backend.authenticate(return_data=return_data, response=response)
-            self.assertIs(user, None)
-            self.assertTrue(return_data['valid_attestation'])
+        self.backend.strategy.session_set('subdomain', 'zulip')
+        response = dict(email="invalid@zulip.com", name=self.name)
+        return_data = dict()  # type: Dict[str, Any]
+        user = self.backend.authenticate(return_data=return_data, response=response)
+        self.assertIs(user, None)
+        self.assertTrue(return_data['valid_attestation'])
 
     def test_github_backend_authenticate_invalid_email(self):
         # type: () -> None

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -344,9 +344,13 @@ class AuthBackendTest(ZulipTestCase):
         user = self.example_user('hamlet')
         email = user.email
         good_kwargs = dict(response=dict(email=email), return_data=dict(),
-                           realm_subdomain='zulip')
+                           realm=get_realm('zulip'))
         bad_kwargs = dict(response=dict(email=email), return_data=dict(),
-                          realm_subdomain='acme')
+                          realm=None)
+        self.verify_backend(GitHubAuthBackend(),
+                            good_kwargs=good_kwargs,
+                            bad_kwargs=bad_kwargs)
+        bad_kwargs['realm'] = get_realm("zephyr")
         self.verify_backend(GitHubAuthBackend(),
                             good_kwargs=good_kwargs,
                             bad_kwargs=bad_kwargs)
@@ -425,7 +429,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
             response = dict(email=self.email, name=self.name)
             self.backend.do_auth('fake-access-token', response=response)
 
-            kwargs = {'realm_subdomain': 'zulip',
+            kwargs = {'realm': get_realm('zulip'),
                       'response': response,
                       'return_data': {}}
             result.assert_called_with(self.user_profile, 'fake-access-token', **kwargs)
@@ -440,7 +444,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
             response = dict(email=self.email, name=self.name)
 
             self.backend.do_auth('fake-access-token', response=response)
-            kwargs = {'realm_subdomain': 'zulip',
+            kwargs = {'realm': get_realm('zulip'),
                       'response': response,
                       'return_data': {}}
             result.assert_called_with(None, 'fake-access-token', **kwargs)
@@ -455,7 +459,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
             with self.settings(SOCIAL_AUTH_GITHUB_TEAM_ID='zulip-webapp'):
                 self.backend.do_auth('fake-access-token', response=response)
 
-                kwargs = {'realm_subdomain': 'zulip',
+                kwargs = {'realm': get_realm('zulip'),
                           'response': response,
                           'return_data': {}}
                 result.assert_called_with(self.user_profile, 'fake-access-token', **kwargs)
@@ -470,7 +474,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
             response = dict(email=self.email, name=self.name)
             with self.settings(SOCIAL_AUTH_GITHUB_TEAM_ID='zulip-webapp'):
                 self.backend.do_auth('fake-access-token', response=response)
-                kwargs = {'realm_subdomain': 'zulip',
+                kwargs = {'realm': get_realm('zulip'),
                           'response': response,
                           'return_data': {}}
                 result.assert_called_with(None, 'fake-access-token', **kwargs)
@@ -485,7 +489,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
             with self.settings(SOCIAL_AUTH_GITHUB_ORG_NAME='Zulip'):
                 self.backend.do_auth('fake-access-token', response=response)
 
-                kwargs = {'realm_subdomain': 'zulip',
+                kwargs = {'realm': get_realm('zulip'),
                           'response': response,
                           'return_data': {}}
                 result.assert_called_with(self.user_profile, 'fake-access-token', **kwargs)
@@ -500,7 +504,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
             response = dict(email=self.email, name=self.name)
             with self.settings(SOCIAL_AUTH_GITHUB_ORG_NAME='Zulip'):
                 self.backend.do_auth('fake-access-token', response=response)
-                kwargs = {'realm_subdomain': 'zulip',
+                kwargs = {'realm': get_realm('zulip'),
                           'response': response,
                           'return_data': {}}
                 result.assert_called_with(None, 'fake-access-token', **kwargs)
@@ -510,7 +514,8 @@ class GitHubAuthBackendTest(ZulipTestCase):
         self.backend.strategy.session_set('subdomain', 'zulip')
         response = dict(email="invalid@zulip.com", name=self.name)
         return_data = dict()  # type: Dict[str, Any]
-        user = self.backend.authenticate(return_data=return_data, response=response)
+        user = self.backend.authenticate(return_data=return_data, response=response,
+                                         realm=get_realm("zulip"))
         self.assertIs(user, None)
         self.assertTrue(return_data['valid_attestation'])
 
@@ -518,7 +523,8 @@ class GitHubAuthBackendTest(ZulipTestCase):
         # type: () -> None
         response = dict(email=None, name=self.name)
         return_data = dict()  # type: Dict[str, Any]
-        user = self.backend.authenticate(return_data=return_data, response=response)
+        user = self.backend.authenticate(return_data=return_data, response=response,
+                                         realm=get_realm("zulip"))
         self.assertIs(user, None)
         self.assertTrue(return_data['invalid_email'])
         result = self.backend.process_do_auth(user, return_data=return_data, response=response)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -421,6 +421,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
         with mock.patch('social_core.backends.github.GithubOAuth2.do_auth',
                         side_effect=self.do_auth), \
                 mock.patch('zproject.backends.SocialAuthMixin.process_do_auth') as result:
+            self.backend.strategy.session_set('subdomain', 'zulip')
             response = dict(email=self.email, name=self.name)
             self.backend.do_auth('fake-access-token', response=response)
 
@@ -435,6 +436,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
                         side_effect=AuthFailed('Not found')), \
                 mock.patch('logging.info'), \
                 mock.patch('zproject.backends.SocialAuthMixin.process_do_auth') as result:
+            self.backend.strategy.session_set('subdomain', 'zulip')
             response = dict(email=self.email, name=self.name)
 
             self.backend.do_auth('fake-access-token', response=response)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -431,7 +431,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
 
             kwargs = {'realm': get_realm('zulip'),
                       'response': response,
-                      'return_data': {}}
+                      'return_data': {'valid_attestation': True}}
             result.assert_called_with(self.user_profile, 'fake-access-token', **kwargs)
 
     def test_github_backend_do_auth_for_default_auth_failed(self):
@@ -461,7 +461,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
 
                 kwargs = {'realm': get_realm('zulip'),
                           'response': response,
-                          'return_data': {}}
+                          'return_data': {'valid_attestation': True}}
                 result.assert_called_with(self.user_profile, 'fake-access-token', **kwargs)
 
     def test_github_backend_do_auth_for_team_auth_failed(self):
@@ -491,7 +491,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
 
                 kwargs = {'realm': get_realm('zulip'),
                           'response': response,
-                          'return_data': {}}
+                          'return_data': {'valid_attestation': True}}
                 result.assert_called_with(self.user_profile, 'fake-access-token', **kwargs)
 
     def test_github_backend_do_auth_for_org_auth_failed(self):

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -103,6 +103,9 @@ def common_get_active_user(email: str, realm: Realm,
         return None
     if not user_profile.is_active:
         if return_data is not None:
+            if user_profile.is_mirror_dummy:
+                # Record whether it's a mirror dummy account
+                return_data['is_mirror_dummy'] = True
             return_data['inactive_user'] = True
         return None
     if user_profile.realm.deactivated:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -197,6 +197,9 @@ class SocialAuthMixin(ZulipAuthMixin):
         realm = kwargs.get("realm")
         if realm is None:
             return None
+        if not auth_enabled_helper([self.auth_backend_name], realm):
+            return_data["auth_backend_disabled"] = True
+            return None
 
         email_address = self.get_email_address(*args, **kwargs)
         if not email_address:
@@ -219,10 +222,6 @@ class SocialAuthMixin(ZulipAuthMixin):
 
         if not user_matches_subdomain(realm.subdomain, user_profile):
             return_data["invalid_subdomain"] = True
-            return None
-
-        if not auth_enabled_helper([self.auth_backend_name], realm):
-            return_data["auth_backend_disabled"] = True
             return None
 
         return user_profile

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -206,25 +206,8 @@ class SocialAuthMixin(ZulipAuthMixin):
             return_data['invalid_email'] = True
             return None
 
-        try:
-            user_profile = get_user_profile_by_email(email_address)
-        except UserProfile.DoesNotExist:
-            return None
         return_data["valid_attestation"] = True
-
-        if not user_profile.is_active:
-            return_data["inactive_user"] = True
-            return None
-
-        if user_profile.realm.deactivated:
-            return_data["inactive_realm"] = True
-            return None
-
-        if not user_matches_subdomain(realm.subdomain, user_profile):
-            return_data["invalid_subdomain"] = True
-            return None
-
-        return user_profile
+        return common_get_active_user(email_address, realm, return_data)
 
     def process_do_auth(self, user_profile, *args, **kwargs):
         # type: (UserProfile, *Any, **Any) -> Optional[HttpResponse]

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -206,8 +206,8 @@ class SocialAuthMixin(ZulipAuthMixin):
         try:
             user_profile = get_user_profile_by_email(email_address)
         except UserProfile.DoesNotExist:
-            return_data["valid_attestation"] = True
             return None
+        return_data["valid_attestation"] = True
 
         if not user_profile.is_active:
             return_data["inactive_user"] = True

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -249,6 +249,7 @@ class SocialAuthMixin(ZulipAuthMixin):
             logging.warning(
                 "{} got invalid email argument.".format(self.auth_backend_name)
             )
+            return None
 
         strategy = self.strategy  # type: ignore # This comes from Python Social Auth.
         request = strategy.request


### PR DESCRIPTION
The last 3 commits are still in progress, and we'll need to disable coverage checking in `zproject/backends.py` in between to merge incrementally (haven't done that since it's useful for debugging, but some intermediate commits have code that isn't tested yet just because other backends aren't converted yet), but this should otherwise be ready for review.

@hackerkid @gnprice FYI.

