### PR TITLE
digests: Fix new stream links.

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -162,7 +162,7 @@ def gather_new_streams(user_profile: UserProfile,
         new_streams = list(get_active_streams(user_profile.realm).filter(
             invite_only=False, date_created__gt=threshold))
 
-    base_url = u"%s/  # narrow/stream/" % (user_profile.realm.uri,)
+    base_url = u"%s/#narrow/stream/" % (user_profile.realm.uri,)
 
     streams_html = []
     streams_plain = []


### PR DESCRIPTION
@timabbott This was broken while adding PEP-8 compliance, here is the relevant commit: 3687dcdb3f53cff66e0d2584788f804ac623986d.

Fixes: #7479.