### PR TITLE
design: Remove unnecessary background from realm-icon

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -3204,7 +3204,8 @@ nav ul li.active::after {
     }
 
     nav ul li,
-    nav ul li a {
+    nav ul li a,
+    .portico-header .dropdown-pill .realm-name {
         color: hsl(0, 0%, 27%) !important;
     }
 

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -714,9 +714,8 @@ input.text-error {
 .portico-header .dropdown-pill {
     border: 1px solid rgba(0,0,0,0.2);
     border-radius: 4px;
-
     font-weight: 400;
-
+    padding: 4px;
     cursor: pointer;
 }
 
@@ -755,11 +754,8 @@ input.text-error {
 .portico-header .dropdown-pill .header-realm-icon {
     width: 26px;
     height: 26px;
-
     vertical-align: top;
-
-    border-radius: 4px 0px 0px 4px;
-    background: #fff;
+    border-radius: 4px;
 }
 
 .app {


### PR DESCRIPTION
This PR removes unnecessary white background from realm-icon. I have given padding and border-radius to make it look good. Also, fixed a bug where realm-name doesn't show up (`min-width< 686 px`) because of the white font color.


before: 

![image](https://user-images.githubusercontent.com/2263909/33152393-5b0a558e-d002-11e7-87aa-c2c2a205a097.png)

![image](https://user-images.githubusercontent.com/2263909/33152415-7e007528-d002-11e7-9e8b-26a5e6e945a0.png)


on mobile ( width < 686 px )

![image](https://user-images.githubusercontent.com/2263909/33152373-3f2c8cd8-d002-11e7-957b-fc5a74fa2e43.png)

![image](https://user-images.githubusercontent.com/2263909/33152380-47a63652-d002-11e7-8232-714c96988008.png)



After: 

![image](https://user-images.githubusercontent.com/2263909/33152242-b7029e38-d001-11e7-9b99-a5de7fadd187.png)

![image](https://user-images.githubusercontent.com/2263909/33152295-f5ec7268-d001-11e7-9084-d9a37b80a7a9.png)

on mobile ( width < 686 px ) - 

![image](https://user-images.githubusercontent.com/2263909/33152257-ce4e00e6-d001-11e7-9166-3392a595398f.png)


![image](https://user-images.githubusercontent.com/2263909/33152327-14eb6e8a-d002-11e7-876b-afe43592037a.png)

![image](https://user-images.githubusercontent.com/2263909/33152354-290e09ea-d002-11e7-88af-3770dcc4a2e7.png)

(The bug can be seen when logged in on [plans](https://chat.zulip.org/plans/), [features](https://chat.zulip.org/plans/features/) page etc)