### PR TITLE
portico: Fix portico dropdown bug

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -3139,7 +3139,7 @@ nav ul li.active::after {
         float: right;
     }
 
-    nav ul:before {
+    .portico-header .content > ul:before {
         content: "Zulip";
         display: block;
         margin-top: 20px;
@@ -3156,6 +3156,13 @@ nav ul li.active::after {
         background-size: 40px auto;
         background-image: url(/static/images/zulip-logo.svg);
         background-repeat: no-repeat;
+    }
+
+    .portico-header .dropdown ul {
+        width: 100%;
+        height: 85px;
+        margin: 42px 0 0 0;
+        font-size: 0.8em;
     }
 
     nav ul {


### PR DESCRIPTION
This fixes a responsiveness bug where the portico dropdown was not
showing up properly. The cause of this issue was that the `dropdown ul` was inheriting properties from the `parent ul`.

| [![imgBlocks](https://user-images.githubusercontent.com/2263909/33173924-f416ea48-d07b-11e7-8c3f-7f4e2d93c594.png)]()  | [![imgBlocks](https://user-images.githubusercontent.com/2263909/33173828-999fd0ca-d07b-11e7-98d9-d11f38d7b91a.png)]() |
|:---:|:---:|
| before | after |

<hr>

| [![imgBlocks](https://user-images.githubusercontent.com/2263909/33173933-ff19caaa-d07b-11e7-92d1-9828f15f6884.png)]()  | [![imgBlocks](https://user-images.githubusercontent.com/2263909/33174450-1dd0a804-d07e-11e7-8827-494aa08f1d0e.png)]() |
|:---:|:---:|
| before | after |

