### PR TITLE
setting: Align elements properly in invite users.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2309,6 +2309,10 @@ button.topic_edit_cancel {
     text-transform: uppercase;
 }
 
+#invite-user .invite-stream-controls {
+    margin-top: 5px;
+}
+
 .settings-dropdown-caret {
     margin-left: 8px;
     margin-right: 8px;

--- a/static/templates/invite_subscription.handlebars
+++ b/static/templates/invite_subscription.handlebars
@@ -1,6 +1,8 @@
 {{! Client-side Mustache template for rendering subscriptions in the "invite user" form.}}
-<a href="#" class="invite_check_all_button">{{t "Check all" }}</a> |
-<a href="#" class="invite_uncheck_all_button">{{t "Uncheck all" }}</a>
+<div class="invite-stream-controls">
+    <a href="#" class="invite_check_all_button">{{t "Check all" }}</a> |
+    <a href="#" class="invite_uncheck_all_button">{{t "Uncheck all" }}</a>
+</div>
 <div id="invite-stream-checkboxes" class="new-style">
     {{#each streams}}
 


### PR DESCRIPTION
Adds a margin-top to `Check all` and `Uncheck all` elements.

Fixes #7488.