### PR TITLE
typeahead: show typeahead for syntax of the from @**... or #**...

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -202,6 +202,18 @@ global.user_groups.add(backend);
     expected_value = '@**Othello, the Moor of Venice** ';
     assert.equal(actual_value, expected_value);
 
+    fake_this.query = '@**oth';
+    fake_this.token = 'oth';
+    actual_value = ct.content_typeahead_selected.call(fake_this, othello);
+    expected_value = '@**Othello, the Moor of Venice** ';
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = '@*oth';
+    fake_this.token = 'oth';
+    actual_value = ct.content_typeahead_selected.call(fake_this, othello);
+    expected_value = '@**Othello, the Moor of Venice** ';
+    assert.equal(actual_value, expected_value);
+
     // user group mention
     var document_stub_group_trigger_called = false;
     $('document-stub').trigger = function (event, params) {
@@ -211,6 +223,12 @@ global.user_groups.add(backend);
     };
 
     fake_this.query = '@back';
+    fake_this.token = 'back';
+    actual_value = ct.content_typeahead_selected.call(fake_this, backend);
+    expected_value = '@*Backend* ';
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = '@*back';
     fake_this.token = 'back';
     actual_value = ct.content_typeahead_selected.call(fake_this, backend);
     expected_value = '@*Backend* ';
@@ -226,6 +244,12 @@ global.user_groups.add(backend);
     };
 
     fake_this.query = '#swed';
+    fake_this.token = 'swed';
+    actual_value = ct.content_typeahead_selected.call(fake_this, sweden_stream);
+    expected_value = '#**Sweden** ';
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = '#**swed';
     fake_this.token = 'swed';
     actual_value = ct.content_typeahead_selected.call(fake_this, sweden_stream);
     expected_value = '#**Sweden** ';
@@ -805,7 +829,9 @@ global.user_groups.add(backend);
 
     assert_typeahead_equals("@", false);
     assert_typeahead_equals(" @", false);
-    assert_typeahead_equals("test @**o", false);
+    assert_typeahead_equals("test @**o", all_mentions);
+    assert_typeahead_equals("test @*o", all_mentions);
+    assert_typeahead_equals("test @*h", all_mentions);
     assert_typeahead_equals("test @", false);
     assert_typeahead_equals("test no@o", false);
     assert_typeahead_equals("@ ", all_mentions);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -321,6 +321,11 @@ exports.compose_content_begins_typeahead = function (query) {
 
     if (this.options.completions.mention && current_token[0] === '@') {
         current_token = current_token.substring(1);
+        if (current_token.startsWith('**')) {
+            current_token = current_token.substring(2);
+        } else if (current_token.startsWith('*')) {
+            current_token = current_token.substring(1);
+        }
         if (current_token.length < 1 || current_token.lastIndexOf('*') !== -1) {
             return false;
         }
@@ -352,6 +357,9 @@ exports.compose_content_begins_typeahead = function (query) {
         }
 
         current_token = current_token.substring(1);
+        if (current_token.startsWith('**')) {
+            current_token = current_token.substring(2);
+        }
 
         // Don't autocomplete if there is a space following a '#'
         if (current_token[0] === " ") {
@@ -401,6 +409,11 @@ exports.content_typeahead_selected = function (item) {
         }
     } else if (this.completing === 'mention') {
         beginning = beginning.substring(0, beginning.length - this.token.length - 1);
+        if (beginning.endsWith('@*')) {
+            beginning = beginning.substring(0, beginning.length - 2);
+        } else if (beginning.endsWith('@')) {
+            beginning = beginning.substring(0, beginning.length - 1);
+        }
         if (user_groups.is_user_group(item)) {
             beginning += '@*' + item.name + '* ';
             $(document).trigger('usermention_completed.zulip', {user_group: item});
@@ -409,8 +422,11 @@ exports.content_typeahead_selected = function (item) {
             $(document).trigger('usermention_completed.zulip', {mentioned: item});
         }
     } else if (this.completing === 'stream') {
-        beginning = (beginning.substring(0, beginning.length - this.token.length - 1)
-                + '#**' + item.name + '** ');
+        beginning = beginning.substring(0, beginning.length - this.token.length - 1);
+        if (beginning.endsWith('#*')) {
+            beginning = beginning.substring(0, beginning.length - 2);
+        }
+        beginning += '#**' + item.name + '** ';
         $(document).trigger('streamname_completed.zulip', {stream: item});
     } else if (this.completing === 'syntax') {
         // Isolate the end index of the triple backticks/tildes, including


### PR DESCRIPTION
This adds to the current behavior of mention and stream typeahead that they will now pop up if we have typed `@*`, `@**` or `#**`
Fixes: #7494.