### PR TITLE
lightbox: Fix image metadata not displaying at full width when possible.

### DIFF
--- a/static/styles/lightbox.css
+++ b/static/styles/lightbox.css
@@ -154,6 +154,7 @@
 }
 
 #lightbox_overlay .image-description {
+    width: 100%;
     /* approx width of screen minus action buttons on the side. */
     max-width: calc(100% - 450px);
     /* add some extra margin top and remove some bottom to keep the


### PR DESCRIPTION
![screenshot at nov 24 04-33-29](https://user-images.githubusercontent.com/15116870/33210858-ada368ac-d0d0-11e7-92a3-fcbbbd69c28e.png)
