### PR TITLE
Emoji picker categories overflow in Firefox at 90% zoom #7511

### DIFF
--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -257,8 +257,8 @@
 .emoji-popover-category-tabs .emoji-popover-tab-item {
     display: inline-block;
     padding-top: 8px;
-    width: 25px;
-    height: 25px;
+    width: 24px;
+    height: 24px;
     text-align: center;
     font-size: 16px;
     cursor: pointer;


### PR DESCRIPTION
Changes in height and width of emjis .
fixes #7511  