### PR TITLE
popover: Populate compose_box with popover user's email.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -501,7 +501,11 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
     $('body').on('click', '.respond_personal_button', function (e) {
-        compose_actions.respond_to_message({reply_type: 'personal', trigger: 'popover respond pm'});
+        var user_id = $(e.target).parents('ul').attr('data-user-id');
+        var email = people.get_person_from_user_id(user_id).email;
+        compose_actions.start('private', {
+            trigger: 'popover send private',
+            private_message_recipient: email});
         popovers.hide_all();
         e.stopPropagation();
         e.preventDefault();


### PR DESCRIPTION
Replaces use of compose.respond_to_message with compose.start, manually
populating the email field with the popovered user's email.

Fixes #7526.