### PR TITLE
Update documentation for git and markdown

### DIFF
--- a/docs/git/cheat-sheet.md
+++ b/docs/git/cheat-sheet.md
@@ -11,7 +11,8 @@ See also [fixing commits][fix-commit]
     - `git checkout master`
     - `git checkout old-branch-name`
 - commit
-    - `git commit --amend`
+    - `git commit -m "topic: Commit message title."`
+    - `git commit --amend`: Modify the previous commit.
 - config
     - `git config --global core.editor nano`
     - `git config --global core.symlinks true`
@@ -27,7 +28,8 @@ See also [fixing commits][fix-commit]
 - log
     - `git log`
 - pull
-    - **do not use for Zulip**
+    - `git pull`: **DO NOT use for Zulip**
+    - `git pull --rebase`: **Use this**. Zulip uses a [rebase oriented workflow][git-overview].
 - push
     - `git push origin +branch-name`
 - rebase
@@ -54,11 +56,15 @@ See also [fixing commits][fix-commit]
 - add
     - `git add foo.py`: add `foo.py` to the staging area
     - `git add foo.py bar.py`: add `foo.py` AND `bar.py` to the staging area
+    - `git add -u`: Adds all tracked files to the staging area.
 - checkout
     - `git checkout -b new-branch-name`: create branch `new-branch-name` and switch/checkout to that new branch
     - `git checkout master`: switch to your `master` branch
     - `git checkout old-branch-name`: switch to an existing branch `old-branch-name`
 - commit
+    - `git commit -m "commit message"`: It is recommended to type a
+       multiline commit message, however.
+    - `git commit`: Opens your default text editor to write a commit message.
     - `git commit --amend`: changing the last commit message. Read more [here][fix-commit]
 - config
     - `git config --global core.editor nano`: set core editor to `nano` (you can set this to `vim` or others)
@@ -74,13 +80,16 @@ See also [fixing commits][fix-commit]
     - `git grep update_unread_counts -- '*.js'`: search all files (ending in `.js`) for `update_unread_counts`
 - log
     - `git log`: show commit logs
+    - `git log --oneline | head`: To quickly see the latest ten commits on a branch.
 - pull
     - `git pull --rebase`: rebase your changes on top of master.
     - `git pull` (with no options): Will either create a merge commit
       (which you don't want) or do the asme as `git pull --rebase`,
       depending on [whether you're configured Git properly][git-clone-config]
 - push
-    - `git push origin +branch-name`: push your commits to your origin repository
+    - `git push origin branch-name`: push you commits to the origin repository *only if* there are no conflicts.
+      Use this when collaborating with others to prevent overwriting their work.
+    - `git push origin +branch-name`: force push your commits to your origin repository.
 - rebase
     - `git rebase -i HEAD~3`: interactive rebasing current branch with first three items on HEAD
     - `git rebase -i master`: interactive rebasing current branch with master branch
@@ -102,3 +111,4 @@ See also [fixing commits][fix-commit]
 
 [fix-commit]: fixing-commits.html
 [git-config-clone]: cloning.html#step-1b-clone-to-your-machine
+[git-overview]: overview.html

--- a/docs/git/overview.md
+++ b/docs/git/overview.md
@@ -38,10 +38,14 @@ with these details in mind:
   integration with [Travis CI][travis-ci], and [mypy][zulip-rtd-mypy].
 
 - We use [zulipbot][zulip-rtd-zulipbot-usage] to manage our issues and
-pull requests to create a better GitHub workflow for contributors.
+  pull requests to create a better GitHub workflow for contributors.
 
-Finally, take a quick look at [Zulip-specific Git scripts][zulip-rtd-zulip-tools],
-install the [Zulip developer environment][zulip-rtd-dev-overview], and then
+- We provide some handy **[Zulip-specific Git scripts][zulip-rtd-zulip-tools]**
+  for developers to easily do tasks like fetching and rebasing a pull
+  request, cleaning unimportant branches, etc. These reduce the common
+  tasks of testing other contributors' pull requests to single commands.
+
+Finally, install the [Zulip developer environment][zulip-rtd-dev-overview], and then
 [configure your fork for use with Travis CI][zulip-git-guide-travisci].
 
 ***

--- a/docs/subsystems/markdown.md
+++ b/docs/subsystems/markdown.md
@@ -86,6 +86,7 @@ places:
 * The test suite, probably via adding entries to `zerver/fixtures/markdown_test_cases.json`.
 * The in-app markdown documentation (`templates/zerver/markdown_help.html`).
 * The list of changes to markdown at the end of this document.
+* The list of [external documentation](#external-documentation) at the end of this document.
 
 Important considerations for any changes are:
 
@@ -225,3 +226,12 @@ be non-standard.
   is used primarily by version control integrations.
 
 * We added the `~~~ quote` block quote syntax.
+
+## External Documentation
+
+Helpful backend implementation resources:
+
+* **[Python Markdown Extensions API](https://pythonhosted.org/Markdown/extensions/api.html)**
+  is used by Zulip to make the above listed changes to markdown syntax.
+* **[XML Element Tree](https://docs.python.org/3/library/xml.etree.elementtree.html)**
+  is used by Python Markdown and the extensions to modify the output HTML.


### PR DESCRIPTION
1. Adds @tommyip 's suggestions to the cheat-sheet.
2. Adds external docs for Bugdown.
3. Modifies text for Zulip's git tools. (Unsure about the wording on this, could use some suggestions.)