### PR TITLE
Add filters for toMarkdown to paste data to compose-box.

### DIFF
--- a/frontend_tests/node_tests/copy_and_paste.js
+++ b/frontend_tests/node_tests/copy_and_paste.js
@@ -33,4 +33,12 @@ var copy_and_paste = zrequire('copy_and_paste');
     // and the '  \n' is a bit strange as well
     assert.equal(copy_and_paste.paste_handler_converter(input),
                  '  \n1\\. text');
+
+    input = '<meta http-equiv="content-type" content="text/html; charset=utf-8"><h1 style="box-sizing: border-box; font-size: 2em; margin-top: 0px !important; margin-right: 0px; margin-bottom: 16px; margin-left: 0px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgb(234, 236, 239); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial;">Zulip overview</h1>';
+    assert.equal(copy_and_paste.paste_handler_converter(input),
+                 'Zulip overview');
+
+    input = '<meta http-equiv="content-type" content="text/html; charset=utf-8"><i style="box-sizing: inherit; color: rgb(0, 0, 0); font-family: Verdana, sans-serif; font-size: 15px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-style: initial; text-decoration-color: initial;">This text is italic</i>';
+    assert.equal(copy_and_paste.paste_handler_converter(input),
+                 '*This text is italic*');
 }());

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -141,7 +141,24 @@ function copy_handler() {
 }
 
 exports.paste_handler_converter = function (paste_html) {
-    var markdown_html = toMarkdown(paste_html);
+    converters = {
+        converters: [
+            {
+                filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+                replacement: function (content) {
+                    return content;
+                }
+            },
+
+            {
+                filter: ['em', 'i'],
+                replacement: function (content) {
+                    return '*' + content + '*';
+                }
+            }
+        ]
+    };
+    var markdown_html = toMarkdown(paste_html, converters);
 
     // Now that we've done the main conversion, we want to remove
     // any HTML tags that weren't converted to markdown-style

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -141,22 +141,22 @@ function copy_handler() {
 }
 
 exports.paste_handler_converter = function (paste_html) {
-    converters = {
+    var converters = {
         converters: [
             {
                 filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
                 replacement: function (content) {
                     return content;
-                }
+                },
             },
 
             {
                 filter: ['em', 'i'],
                 replacement: function (content) {
                     return '*' + content + '*';
-                }
-            }
-        ]
+                },
+            },
+        ],
     };
     var markdown_html = toMarkdown(paste_html, converters);
 


### PR DESCRIPTION
Before this, there were bugs with pasting headings and italic styling.

Fixes #7485