### PR TITLE
subs: Properly focus on Stream name box while creating a new stream.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -477,8 +477,8 @@ exports.change_state = (function () {
         if (hash.arguments.length > 0) {
             // if in #streams/new form.
             if (hash.arguments[0] === "new") {
-                exports.new_stream_clicked();
                 components.toggle.lookup("stream-filter-toggle").goto("all-streams");
+                exports.new_stream_clicked();
             } else if (hash.arguments[0] === "all") {
                 components.toggle.lookup("stream-filter-toggle").goto("all-streams");
             } else if (hash.arguments[0] === "subscribed") {


### PR DESCRIPTION
`components.toggle.lookup("stream-filter-toggle").goto("all-streams");` was responsible for changing the focus to the All streams tab in the Streams modal, so the initialize function was moved to run after the All Streams tab was focused :)

Fixes #7473.