### PR TITLE
tools/setup: Delete static/generated/bots before repopulating.

### DIFF
--- a/tools/setup/generate_zulip_bots_static_files
+++ b/tools/setup/generate_zulip_bots_static_files
@@ -15,6 +15,10 @@ from zulip_bots.lib import get_bots_directory_path
 
 
 bots_dir = os.path.join(settings.STATIC_ROOT, 'generated/bots')
+if os.path.isdir(bots_dir):
+    # delete old static files, they could be outdated
+    shutil.rmtree(bots_dir)
+
 os.makedirs(bots_dir, exist_ok=True)
 
 def copyfiles(paths):


### PR DESCRIPTION
tools/setup/generate_zulip_bots_static_files now starts off by
deleting static/generated/bots/ (if it hasn't been removed already)
so that outdated static files from older versions of the zulip_bots
package don't supress errors in the main repo that would otherwise
break.

For more info, see #7542

Fixes: #7542.