### PR TITLE
get_user_group_from_name: Remove existence check.

### DIFF
--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -1,0 +1,15 @@
+zrequire('user_groups');
+
+var error_called = 0;
+set_global('blueslip', {
+    error: function () {
+        error_called += 1;
+        return undefined;
+    },
+});
+
+
+(function test_get_user_group_from_name() {
+    assert(!user_groups.get_user_group_from_name('not_existing'));
+    assert.equal(error_called, 0);
+}());

--- a/static/js/user_groups.js
+++ b/static/js/user_groups.js
@@ -29,10 +29,6 @@ exports.get_user_group_from_id = function (group_id) {
 };
 
 exports.get_user_group_from_name = function (name) {
-    if (!user_group_name_dict.has(name)) {
-        blueslip.error('Unknown name in get_user_group_from_name: ' + name);
-        return undefined;
-    }
     return user_group_name_dict.get(name);
 };
 


### PR DESCRIPTION
Using user_group_name_dict.get() will return `undefined`.
`blueslip.error` statement caused an exception notification to the
admins.

@timabbott 