### PR TITLE
subs: Add padding to Announce stream tooltip content.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -359,6 +359,7 @@ $(function () {
                                       trigger: "manual"});
         announce_stream_docs.popover('show');
         announce_stream_docs.data('popover').tip().css('z-index', 2000);
+        announce_stream_docs.data('popover').tip().find('.popover-content').css('margin', '9px 14px');
         e.stopPropagation();
     });
     $("body").on("mouseout", "#announce-stream-docs", function (e) {


### PR DESCRIPTION
The announce stream tooltip seems to be manually created as a popover; this commit uses jQuery to change the styling of that dynamic popover from the default popover padding of `5px 0px`.

![screenshot at nov 29 08-54-29](https://user-images.githubusercontent.com/15116870/33387746-ee104fde-d4e2-11e7-80fa-6bf585aa6f93.png)


Fixes #7474.

[GCI Task](https://codein.withgoogle.com/dashboard/task-instances/4719062489759744/)