### PR TITLE
lightbox: Allow for clicking top and bottom to close overlay.

### DIFF
--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -235,6 +235,12 @@ $(function () {
             overlays.close_active();
         }
     });
+
+    $("#lightbox_overlay").on("click", ".image-info-wrapper, .center", function (e) {
+        if ($(e.target).is(".image-info-wrapper, .center")) {
+            overlays.close_overlay("lightbox");
+        }
+    });
 });
 
 return exports;


### PR DESCRIPTION
The top and bottom sections of the lightbox overlay do not close the
lightbox when clicked. Now, this triggers the close_overlay path when a
valid non-actionable background element is clicked.

Fixes: #7500.