### PR TITLE
typeahead: Show typeahead only if cursor is before space or punctiation.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -521,7 +521,10 @@ global.user_groups.add(backend);
             $element: {},
         };
         var caret_called = false;
-        fake_this.$element.caret = function () { caret_called = true; };
+        fake_this.$element.caret = function () {
+            caret_called = true;
+            return 7;
+        };
         fake_this.options = options;
         var actual_value = options.source.call(fake_this, 'test #s');
         var expected_value = stream_list;
@@ -902,6 +905,27 @@ global.user_groups.add(backend);
     assert_typeahead_equals("~~~ f", lang_list);
     assert_typeahead_equals("test\n~~~ p", lang_list);
     assert_typeahead_equals("test\n~~~  p", lang_list);
+
+    // Following tests place the cursor before the last character
+    ct.split_at_cursor = function (word) {
+        var cursor = word.length - 1;
+        return [word.slice(0, cursor), word.slice(cursor)];
+    };
+    assert_typeahead_equals("#test", false);
+    assert_typeahead_equals("#test ", stream_list);
+    assert_typeahead_equals("#test,", stream_list);
+    assert_typeahead_equals("#test.", stream_list);
+    assert_typeahead_equals("#test?", stream_list);
+    assert_typeahead_equals("#test!", stream_list);
+    assert_typeahead_equals("#test)", stream_list);
+    assert_typeahead_equals("@test", false);
+    assert_typeahead_equals("@test ", all_mentions);
+    assert_typeahead_equals(":test", false);
+    assert_typeahead_equals(":test ", emoji_list);
+    assert_typeahead_equals("```test", false);
+    assert_typeahead_equals("```test ", lang_list);
+    assert_typeahead_equals("~~~test", false);
+    assert_typeahead_equals("~~~test ", lang_list);
 }());
 
 (function test_tokenizing() {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -274,10 +274,22 @@ exports.tokenize_compose_str = function (s) {
 };
 
 exports.compose_content_begins_typeahead = function (query) {
-    var q = exports.split_at_cursor(query, this.$element)[0];
-
+    var split = exports.split_at_cursor(query, this.$element);
+    var q = split[0];
+    var rest = split[1];
     var current_token = exports.tokenize_compose_str(q);
     if (current_token === '') {
+        return false;
+    }
+
+    // If the remaining content after the mention isn't a space or
+    // punctuation (or end of the message), don't try to typeahead; we
+    // probably just have the cursor in the middle of an
+    // already-completed object.
+
+    // TODO: Make this a better list.
+    var terminal_symbols = ',.?!) ';
+    if (rest !== '' && terminal_symbols.indexOf(rest[0]) === -1) {
         return false;
     }
 


### PR DESCRIPTION
This solves the issue with typeahead appearing in the middle of a word.

Example: Earlier, '@ran|dom' would also trigger the typeahead and show
'random', but selecting it would turn it into '@**random** dom'.

Relevant conversation: https://chat.zulip.org/#narrow/stream/feedback/topic/typeahead.20in.20middle