### PR TITLE
Fix reconnecting to RabbitMQ in Tornado

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -380,7 +380,7 @@ def shutdown_handler(*args, **kwargs):
     # type: (*Any, **Any) -> None
     io_loop = IOLoop.instance()
     if io_loop._callbacks:
-        io_loop.add_timeout(time.time() + 1, shutdown_handler)
+        io_loop.call_later(1, shutdown_handler)
     else:
         io_loop.stop()
 

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -1,17 +1,18 @@
 
+from collections import defaultdict
+import logging
+import random
+import threading
+import time
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Union
+
 from django.conf import settings
 import pika
 from pika.adapters.blocking_connection import BlockingChannel
 from pika.spec import Basic
-import logging
 import ujson
-import random
-import time
-import threading
-from collections import defaultdict
 
 from zerver.lib.utils import statsd
-from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Union
 
 MAX_REQUEST_RETRIES = 3
 Consumer = Callable[[BlockingChannel, Basic.Deliver, pika.BasicProperties, str], None]

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -221,9 +221,9 @@ class TornadoQueueClient(SimpleQueueClient):
                 self._reconnect()
             except pika.exceptions.AMQPConnectionError:
                 self.log.critical("Failed to reconnect to RabbitMQ, retrying...")
-                ioloop.IOLoop.instance().add_timeout(time.time() + retry_seconds, on_timeout)
+                ioloop.IOLoop.instance().call_later(retry_seconds, on_timeout)
 
-        ioloop.IOLoop.instance().add_timeout(time.time() + retry_seconds, on_timeout)
+        ioloop.IOLoop.instance().call_later(retry_seconds, on_timeout)
 
     def ensure_queue(self, queue_name: str, callback: Callable[[], None]) -> None:
         def finish(frame: Any) -> None:

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -187,7 +187,7 @@ class TornadoQueueClient(SimpleQueueClient):
         self.connection = ExceptionFreeTornadoConnection(
             self._get_parameters(),
             on_open_callback = self._on_open,
-            stop_ioloop_on_close = False)
+        )
         self.connection.add_on_close_callback(self._on_connection_closed)
 
     def _reconnect(self) -> None:

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -187,8 +187,8 @@ class TornadoQueueClient(SimpleQueueClient):
         self.connection = ExceptionFreeTornadoConnection(
             self._get_parameters(),
             on_open_callback = self._on_open,
+            on_close_callback = self._on_connection_closed,
         )
-        self.connection.add_on_close_callback(self._on_connection_closed)
 
     def _reconnect(self) -> None:
         self.connection = None

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -78,7 +78,7 @@ class ClientDescriptor:
         self.client_gravatar = client_gravatar
         self.all_public_streams = all_public_streams
         self.client_type_name = client_type_name
-        self._timeout_handle = None  # type: Any # TODO: should be return type of ioloop.add_timeout
+        self._timeout_handle = None  # type: Any # TODO: should be return type of ioloop.call_later
         self.narrow = narrow
         self.narrow_filter = build_narrow_filter(narrow)
 
@@ -189,9 +189,9 @@ class ClientDescriptor:
             # All clients get heartbeat events
             self.add_event(dict(type='heartbeat'))
         ioloop = tornado.ioloop.IOLoop.instance()
-        heartbeat_time = time.time() + HEARTBEAT_MIN_FREQ_SECS + random.randint(0, 10)
+        interval = HEARTBEAT_MIN_FREQ_SECS + random.randint(0, 10)
         if self.client_type_name != 'API: heartbeat test':
-            self._timeout_handle = ioloop.add_timeout(heartbeat_time, timeout_callback)
+            self._timeout_handle = ioloop.call_later(interval, timeout_callback)
 
     def disconnect_handler(self, client_closed: bool=False) -> None:
         if self.current_handler_id:

--- a/zerver/tornado/socket.py
+++ b/zerver/tornado/socket.py
@@ -103,7 +103,7 @@ class SocketConnection(sockjs.tornado.SockJSConnection):
             self.close_info = CloseErrorInfo(408, "Timeout while waiting for authentication")
             self.close()
 
-        self.timeout_handle = ioloop.add_timeout(time.time() + 10, auth_timeout)
+        self.timeout_handle = ioloop.call_later(10, auth_timeout)
         write_log_line(log_data, path='/socket/open', method='SOCKET',
                        remote_ip=info.ip, email='unknown', client_name='?')
 


### PR DESCRIPTION
The interesting bit here is in the last commit:
```
    Empirically, the retry in `_on_connection_closed` didn't actually work
    -- if a reconnect failed, that was it, and the exception handler
    didn't get run.  A traceback would get logged, but all its frames were
    in Tornado or Pika, not our own code; presumably something magic and
    async was happening to the exception.
    
    Moreover, though we would make one attempt to reconnect if we had a
    connection that got closed, we didn't have any form of retry if the
    original attempt at connecting failed in the first place.
    
    Happily, upstream offers a perfectly reasonable bit of API that avoids
    both of these problems: the on-open-error callback.  So use that.
```
