### PR TITLE
hotkeys: Clear compose box warnings with escape key.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -218,6 +218,12 @@ exports.process_escape_key = function (e) {
         }
 
         if (compose_state.composing()) {
+            // Check for errors in compose box; close errors if they exist
+            if ($("#compose-send-status").css('display') !== 'none') {
+                $("#compose-send-status").hide();
+                return true;
+            }
+
             // If the user hit the escape key, cancel the current compose
             compose_actions.cancel();
             return true;


### PR DESCRIPTION
[GCI task](https://codein.withgoogle.com/dashboard/task-instances/6214217713582080/)

Fixes #7531.