### PR TITLE
node tests: Cover exports.operators, collect_single

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -94,9 +94,11 @@ function assert_hidden(sel) {
     compose_actions.clear_textarea = noop;
 
     // Start stream message
-    global.narrow_state.set_compose_defaults = function (opts) {
+    global.narrow_state.set_compose_defaults = function () {
+        var opts = {};
         opts.stream = 'stream1';
         opts.subject = 'topic1';
+        return opts;
     };
 
     var opts = {};
@@ -111,8 +113,10 @@ function assert_hidden(sel) {
     assert(compose_state.composing());
 
     // Start PM
-    global.narrow_state.set_compose_defaults = function (opts) {
+    global.narrow_state.set_compose_defaults = function () {
+        var opts = {};
         opts.private_message_recipient = 'foo@example.com';
+        return opts;
     };
 
     opts = {

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -105,6 +105,10 @@ function set_filter(operators) {
 
     assert.equal(result[2].operator, 'search');
     assert.equal(result[2].operand, 'yo');
+
+    narrow_state.reset_current_filter();
+    result = narrow_state.operators();
+    assert.equal(result.length, 0);
 }());
 
 (function test_muting_enabled() {

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -136,6 +136,9 @@ function set_filter(operators) {
     var pm_test = narrow_state.set_compose_defaults();
     assert.equal(pm_test.private_message_recipient, 'foo@bar.com');
 
+    set_filter([['topic', 'duplicate'], ['topic', 'duplicate']]);
+    assert.deepEqual(narrow_state.set_compose_defaults(), {});
+
     stream_data.add_sub('ROME', {name: 'ROME', stream_id: 99});
     set_filter([['stream', 'rome']]);
 

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -128,21 +128,19 @@ function set_filter(operators) {
 (function test_set_compose_defaults() {
     set_filter([['stream', 'Foo'], ['topic', 'Bar']]);
 
-    var opts = {};
-    narrow_state.set_compose_defaults(opts);
-    assert.equal(opts.stream, 'Foo');
-    assert.equal(opts.subject, 'Bar');
+    var stream_and_subject = narrow_state.set_compose_defaults();
+    assert.equal(stream_and_subject.stream, 'Foo');
+    assert.equal(stream_and_subject.subject, 'Bar');
 
     set_filter([['pm-with', 'foo@bar.com']]);
-    narrow_state.set_compose_defaults(opts);
-    assert.equal(opts.private_message_recipient, 'foo@bar.com');
+    var pm_test = narrow_state.set_compose_defaults();
+    assert.equal(pm_test.private_message_recipient, 'foo@bar.com');
 
     stream_data.add_sub('ROME', {name: 'ROME', stream_id: 99});
     set_filter([['stream', 'rome']]);
 
-    opts = {};
-    narrow_state.set_compose_defaults(opts);
-    assert.equal(opts.stream, 'ROME');
+    var stream_test = narrow_state.set_compose_defaults();
+    assert.equal(stream_test.stream, 'ROME');
 }());
 
 (function test_update_email() {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -164,7 +164,8 @@ function fill_in_opts_from_current_narrowed_view(msg_type, opts) {
     };
 
     // Set default parameters based on the current narrowed view.
-    narrow_state.set_compose_defaults(default_opts);
+    var compose_opts = narrow_state.set_compose_defaults();
+    default_opts = _.extend(default_opts, compose_opts);
     opts = _.extend(default_opts, opts);
     return opts;
 }

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -73,7 +73,8 @@ function collect_single(operators) {
 // This logic is here and not in the 'compose' module because
 // it will get more complicated as we add things to the narrow
 // operator language.
-exports.set_compose_defaults = function (opts) {
+exports.set_compose_defaults = function () {
+    var opts = {};
     var single = collect_single(exports.operators());
 
     // Set the stream, subject, and/or PM recipient if they are
@@ -90,6 +91,7 @@ exports.set_compose_defaults = function (opts) {
     if (single.has('pm-with')) {
         opts.private_message_recipient = single.get('pm-with');
     }
+    return opts;
 };
 
 exports.stream = function () {


### PR DESCRIPTION
Covers narrow_state.js fully and returns `opts` in `exports.set_compose_defaults` or changes the passed in `opts`.
/cc @showell is this what you wanted, make function return `opts`.