### PR TITLE
invitations: Make stream labels click targets.

### DIFF
--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -5,6 +5,7 @@
     padding: 0px;
     display: inline-block;
     vertical-align: top;
+    cursor: pointer;
 }
 
 .new-style label.checkbox input[type=checkbox] {

--- a/static/templates/invite_subscription.handlebars
+++ b/static/templates/invite_subscription.handlebars
@@ -11,7 +11,7 @@
                {{#if default_stream}}checked="checked"{{/if}} />
         <span></span>
         {{#if invite_only}}<i class="fa fa-lock" aria-hidden="true"></i>{{/if}}
-        <label class="inline-block">{{name}}</label>
+        {{name}}
     </label>
     {{/each}}
 </div>


### PR DESCRIPTION
Nesting two `<label>` tags within each other was invalid HTML, so the commit removes the inner `<label>` tag so the entire label is counted as a click target.

Second commit changes the label so that the cursor changes to a pointer upon a hover so users know it can be clicked to toggle the checkbox.

Fixes #7582.

[GCI Task](https://codein.withgoogle.com/dashboard/task-instances/4954484344094720/)