### PR TITLE
Add node tests for notifications

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -444,3 +444,23 @@ zrequire('stream_data');
     stream_data.add_subscriber('India', 103);
     assert.equal(stream_data.get_subscriber_count('India'), 2);
 }());
+
+(function test_notifications() {
+	var india = {
+		stream_id: 102,
+		name: 'India',
+		subscribed: true,
+	};
+	var rome = {
+		stream_id: 33,
+		name: 'Rome',
+		subscribed: false,
+	};
+	stream_data.clear_subscriptions();
+	stream_data.add_sub('India', india);
+	stream_data.add_sub('Rome', rome);
+
+	assert(!stream_data.receives_desktop_notifications('India'));
+	global.blueslip.error = function () {};
+	assert(!stream_data.receives_desktop_notifications('Indiana'));
+}());

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -463,4 +463,8 @@ zrequire('stream_data');
 	assert(!stream_data.receives_desktop_notifications('India'));
 	global.blueslip.error = function () {};
 	assert(!stream_data.receives_desktop_notifications('Indiana'));
+	
+	assert(!stream_data.receives_audible_notifications('India'));
+	global.blueslip.error = function () {};
+	assert(!stream_data.receives_audible_notifications('Indiana'));
 }());


### PR DESCRIPTION
Cover exports.receives_desktop_notifications and exports.receives_audible_notifications.