### PR TITLE
Add node tests for notifications

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -451,9 +451,13 @@ zrequire('stream_data');
         name: 'India',
         subscribed: true,
         desktop_notifications: true,
+        audible_notifications: true,
     };
     stream_data.clear_subscriptions();
     stream_data.add_sub('India', india);
     assert(stream_data.receives_desktop_notifications('India'));
     assert(!stream_data.receives_desktop_notifications('Indiana'));
+
+    assert(stream_data.receives_audible_notifications('India'));
+    assert(!stream_data.receives_audible_notifications('Indiana'));
 }());

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -444,3 +444,16 @@ zrequire('stream_data');
     stream_data.add_subscriber('India', 103);
     assert.equal(stream_data.get_subscriber_count('India'), 2);
 }());
+
+(function test_notifications() {
+    var india = {
+        stream_id: 102,
+        name: 'India',
+        subscribed: true,
+        desktop_notifications: true,
+    };
+    stream_data.clear_subscriptions();
+    stream_data.add_sub('India', india);
+    assert(stream_data.receives_desktop_notifications('India'));
+    assert(!stream_data.receives_desktop_notifications('Indiana'));
+}());


### PR DESCRIPTION
Cover exports.receives_desktop_notifications and exports.receives_audible_notifications.