### PR TITLE
Add node tests for checking and removing subscribers

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -211,6 +211,14 @@ zrequire('stream_data');
     };
     assert(!stream_data.user_is_subscribed('Rome', bad_email));
 
+    // Verify noop for bad stream when removing subscriber
+    var bad_stream = 'UNKNOWN';
+    global.blueslip.warn = function (msg) {
+        assert.equal(msg, "We got a remove_subscriber call for a non-existent stream " + bad_stream);
+    };
+    ok = stream_data.remove_subscriber(bad_stream, brutus.user_id);
+    assert(!ok);
+
     // Defensive code will give warnings, which we ignore for the
     // tests, but the defensive code needs to not actually blow up.
     global.blueslip.warn = function () {};

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -201,6 +201,16 @@ zrequire('stream_data');
     stream_data.update_subscribers_count(sub);
     assert.equal(sub.subscriber_count, 0);
 
+    // verify that checking subscription with bad email is a noop
+    var bad_email = 'notbrutus@zulip.org';
+    global.blueslip.error = function (msg) {
+        assert.equal(msg, "Unknown email for get_user_id: " + bad_email);
+    };
+    global.blueslip.warn = function (msg) {
+        assert.equal(msg, "Bad email passed to user_is_subscribed: " + bad_email);
+    };
+    assert(!stream_data.user_is_subscribed('Rome', bad_email));
+
     // Defensive code will give warnings, which we ignore for the
     // tests, but the defensive code needs to not actually blow up.
     global.blueslip.warn = function () {};


### PR DESCRIPTION
The blueslip.warn and blueslip.error lines are necessary this time.