### PR TITLE
[WIP] CSS refactor.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -997,16 +997,6 @@ td.pointer {
     }
 }
 
-.messagebox-bottom {
-    height: 3px;
-    background-color: hsl(0, 0%, 100%);
-    border-radius: 0px 0px 3px 0px;
-    /* box-shadow: 0px 2px 2px -1px hsl(0, 0%, 80%); */
-    border: 1px solid hsl(166, 26%, 80%);
-    border-top: none;
-    border-left: none;
-}
-
 .messagebox-bottom-colorblock {
     border-radius: 0px 0px 0px 3px;
     /* box-shadow: 0px 2px 2px -1px hsl(0, 0%, 80%); */

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2579,10 +2579,6 @@ button.topic_edit_cancel {
     margin-top: 41px;
 }
 
-.message-pane {
-    padding-left: 0.3em;
-}
-
 .screen {
     position: absolute;
     left: 0;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -512,11 +512,6 @@ a:hover code {
     max-width: 250px;
 }
 
-.edit-profile {
-    font-weight: 300;
-    font-size: 12px;
-}
-
 .logout {
     white-space: nowrap;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -401,12 +401,6 @@ li,
     position: absolute !important;
 }
 
-/* Relative positioning */
-
-.position-relative {
-    position: relative;
-}
-
 /* Lighter strong */
 
 strong {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -997,14 +997,6 @@ td.pointer {
     }
 }
 
-.messagebox-bottom-colorblock {
-    border-radius: 0px 0px 0px 3px;
-    /* box-shadow: 0px 2px 2px -1px hsl(0, 0%, 80%); */
-    border: 1px solid hsl(166, 26%, 80%);
-    border-top: none;
-    border-right: none;
-}
-
 .floating_recipient .message_header_private_message {
     border-bottom: 0px;
     border-left: 0px;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -495,17 +495,6 @@ a:hover code {
     -moz-box-sizing: initial !important;
 }
 
-.sidebar-nav {
-    padding: 0px 10px 20px 0px;
-    margin-top: 1em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    /* This is a little hacky, but for whatever reason, span2 in a row-fluid
-       doesn't consistently take on the right width when it's in an affix, so
-       we need to specify a max size. */
-    max-width: 250px;
-}
-
 .logout {
     white-space: nowrap;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1274,10 +1274,6 @@ a.dark_background:hover,
     margin-top: 6px;
 }
 
-.message-right {
-    float: right;
-}
-
 .small {
     font-size: 80%;
 }


### PR DESCRIPTION
This is a First phase of removing the obsolete CSS class from `zulip.css`.
I git grep the following classes and they are not used anywhere in the code.
Here are the classes I have removed yet.
```
 .edit-profile	  
 .message-pane	  
 .message-right
 .messagebox-bottom
 .messagebox-bottom-colorblock
 .position-relative
 .sidebar-nav
```

I will squash the commit after reviewing.