### PR TITLE
[WIP] markdown: Add automatic numbering of ordered lists.

### DIFF
--- a/zerver/fixtures/markdown_test_cases.json
+++ b/zerver/fixtures/markdown_test_cases.json
@@ -218,6 +218,24 @@
       "text_content": "1. A\n 2. B"
     },
     {
+      "name": "auto_renumbered_list",
+      "input": "1. A\n1. B\n 1. C\n1. D",
+      "expected_output": "<p>1. A<br>\n2. B<br>\n 3. C<br>\n4. D</p>",
+      "text_content": "1. A\n2. B\n 3. C\n4. D"
+    },
+    {
+      "name": "auto_renumbered_list_from",
+      "input": "3. A\n3. B\n3. C\n3. D",
+      "expected_output": "<p>3. A<br>\n4. B<br>\n5. C<br>\n6. D</p>",
+      "text_content": "3. A\n4. B\n5. C\n6. D"
+    },
+    {
+      "name": "not_auto_renumbered_list",
+      "input": "1. A\n3. B\n 2. C\n1. D",
+      "expected_output": "<p>1. A<br>\n3. B<br>\n 2. C<br>\n1. D</p>",
+      "text_content": "1. A\n3. B\n 2. C\n1. D"
+    },
+    {
       "name": "linkify_interference",
       "input": "link: xx, x xxxxx xx xxxx xx\n\n[xxxxx #xx](http://xxxxxxxxx:xxxx/xxx/xxxxxx%xxxxxx/xx/):**xxxxxxx**\n\nxxxxxxx xxxxx xxxx xxxxx:\n`xxxxxx`: xxxxxxx\n`xxxxxx`: xxxxx\n`xxxxxx`: xxxxx xxxxx",
       "expected_output": "<p>link: xx, x xxxxx xx xxxx xx</p>\n<p><a href=\"http://xxxxxxxxx:xxxx/xxx/xxxxxx%xxxxxx/xx/\" target=\"_blank\" title=\"http://xxxxxxxxx:xxxx/xxx/xxxxxx%xxxxxx/xx/\">xxxxx #xx</a>:<strong>xxxxxxx</strong></p>\n<p>xxxxxxx xxxxx xxxx xxxxx:<br>\n<code>xxxxxx</code>: xxxxxxx<br>\n<code>xxxxxx</code>: xxxxx<br>\n<code>xxxxxx</code>: xxxxx xxxxx</p>",

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1078,6 +1078,68 @@ class BugdownUListPreprocessor(markdown.preprocessors.Preprocessor):
                 inserts += 1
         return copy
 
+class AutoNumberOListPreprocessor(markdown.preprocessors.Preprocessor):
+    """ Finds a sequence of lines numbered by the same number"""
+    RE = re.compile(r'^([ ]*)(\d+)\.[ ]+(.*)')
+    TAB_LENGTH = 2
+
+    def run(self, lines):
+        # type: (List[Text]) -> List[Text]
+        new_lines = []  # type: List[Text]
+        current_list = []  # type: List[Match[Text]]
+        current_indent = 0
+
+        for line in lines:
+            m = self.RE.match(line)
+
+            # Remember if this line is a continuation of already started list
+            is_next_item = (m and current_list
+                            and current_indent == len(m.group(1)) // self.TAB_LENGTH)
+
+            if not is_next_item:
+                # There is no more items in the list we were processing
+                new_lines.extend(self.renumber(current_list))
+                current_list = []
+
+            if not m:
+                # Ordinary line
+                new_lines.append(line)
+            elif is_next_item:
+                # Another list item
+                current_list.append(m)
+            else:
+                # First list item
+                current_list = [m]
+                current_indent = len(m.group(1)) // self.TAB_LENGTH
+
+        new_lines.extend(self.renumber(current_list))
+
+        return new_lines
+
+    def renumber(self, mlist):
+        # type: (List[Match[Text]]) -> List[Text]
+        if not mlist:
+            return []
+
+        start_number = int(mlist[0].group(2))
+
+        # Change numbers only if every one is the same
+        change_numbers = True
+        for m in mlist:
+            if int(m.group(2)) != start_number:
+                change_numbers = False
+                break
+
+        lines = []  # type: List[Text]
+        counter = start_number
+
+        for m in mlist:
+            number = str(counter) if change_numbers else m.group(2)
+            lines.append('%s%s. %s' % (m.group(1), number, m.group(3)))
+            counter += 1
+
+        return lines
+
 # Based on markdown.inlinepatterns.LinkPattern
 class LinkPattern(markdown.inlinepatterns.Pattern):
     """ Return a link element from the given match. """
@@ -1395,6 +1457,10 @@ class Bugdown(markdown.Extension):
 
         md.preprocessors.add('hanging_ulists',
                              BugdownUListPreprocessor(md),
+                             "_begin")
+
+        md.preprocessors.add('auto_number_olist',
+                             AutoNumberOListPreprocessor(md),
                              "_begin")
 
         md.treeprocessors.add("inline_interesting_links", InlineInterestingLinkProcessor(md, self), "_end")


### PR DESCRIPTION
Implements #5159 

Uses a preprocessor because Markdown handles ordered/unordered lists in a way that differs too much from the entered text, and disabling the ordered ones doesn't quite work as intended. As a consequence, detects lists with one-line items. Won't break sending a list over several messages, since a single item is a list that starts at the item's number.

If solving it this way makes sense, I'll add a mention in Markdown help.