### PR TITLE
sidebars: Enable up and down arrow keys in user and stream search.

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -437,6 +437,57 @@ casper.waitWhileVisible('#stream_filters [data-stream-name="Denmark"]', function
 
 un_narrow();
 
+// User search at the right sidebar
+casper.then(function () {
+    casper.test.info('Search users using right sidebar');
+    casper.test.assertExists('#user_presences li [data-name="Cordelia Lear"]',
+                             'User Cordelia Lear exists');
+    casper.test.assertExists('#user_presences li [data-name="King Hamlet"]',
+                             'User King Hamlet exists');
+    casper.test.assertExists('#user_presences li [data-name="aaron"]',
+                             'User aaron exists');
+});
+
+// Enter the search box and test selected suggestion navigation
+// Click on search icon
+casper.then(function () {
+    casper.evaluate(function () {
+        $('#user_filter_icon').expectOne()
+            .focus()
+            .trigger($.Event('click'));
+    });
+});
+
+casper.waitForSelector('#user_presences .highlighted_user', function () {
+    casper.test.info('Suggestion highlighting - initial situation');
+    casper.test.assertExist('#user_presences li.highlighted_user [data-name="Cordelia Lear"]',
+                            'User Cordelia Lear is selected');
+    casper.test.assertDoesntExist('#user_presences li.highlighted_user [data-name="King Hamlet"]',
+                                  'User King Hamlet is not selected');
+    casper.test.assertDoesntExist('#user_presences li.highlighted_user [data-name="aaron"]',
+                                  'User aaron is not selected');
+});
+
+// Use arrow keys to navigate through suggestions
+casper.then(function () {
+    // Down: Cordelia -> Hamlet
+    casper.sendKeys('.user-list-filter', casper.page.event.key.Down, {keepFocus: true});
+    // Up: Hamlet -> Cordelia
+    casper.sendKeys('.user-list-filter', casper.page.event.key.Up, {keepFocus: true});
+    // Up: Cordelia -> aaron
+    casper.sendKeys('.user-list-filter', casper.page.event.key.Up, {keepFocus: true});
+});
+
+casper.waitForSelector('#user_presences li.highlighted_user [data-name="aaron"]', function () {
+    casper.test.info('Suggestion highlighting - after arrow key navigation');
+    casper.test.assertDoesntExist('#user_presences li.highlighted_user [data-name="Cordelia Lear"]',
+        'User Cordelia Lear not is selected');
+    casper.test.assertDoesntExist('#user_presences li.highlighted_user [data-name="King Hamlet"]',
+        'User King Hamlet is not selected');
+    casper.test.assertExist('#user_presences li.highlighted_user [data-name="aaron"]',
+        'User aaron is selected');
+});
+
 common.then_log_out();
 
 // Run the above queued actions.

--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -308,9 +308,51 @@ casper.then(function () {
 });
 
 casper.waitWhileSelector('#streams_list .input-append.notdisplayed', function () {
-    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]', 'Original stream list contains Denmark');
-    casper.test.assertExists('#stream_filters [data-stream-name="Scotland"]', 'Original stream list contains Scotland');
-    casper.test.assertExists('#stream_filters [data-stream-name="Verona"]', 'Original stream list contains Verona');
+    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]',
+                             'Original stream list contains Denmark');
+    casper.test.assertExists('#stream_filters [data-stream-name="Scotland"]',
+                             'Original stream list contains Scotland');
+    casper.test.assertExists('#stream_filters [data-stream-name="Verona"]',
+                             'Original stream list contains Verona');
+});
+
+// Enter the search box and test highlighted suggestion navigation
+casper.then(function () {
+    casper.evaluate(function () {
+        $('.stream-list-filter').expectOne()
+            .focus()
+            .trigger($.Event('click'));
+    });
+});
+
+casper.waitForSelector('#stream_filters .highlighted_stream', function () {
+    casper.test.info('Suggestion highlighting - initial situation');
+    casper.test.assertExist('#stream_filters [data-stream-name="Denmark"].highlighted_stream',
+                            'Stream Denmark is highlighted');
+    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Scotland"].highlighted_stream',
+                                  'Stream Scotland is not highlighted');
+    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Verona"].highlighted_stream',
+                                  'Stream Verona is not highlighted');
+});
+
+// Use arrow keys to navigate through suggestions
+casper.then(function () {
+    // Down: Denmark -> Scotland
+    casper.sendKeys('.stream-list-filter', casper.page.event.key.Down, {keepFocus: true});
+    // Up: Scotland -> Denmark
+    casper.sendKeys('.stream-list-filter', casper.page.event.key.Up, {keepFocus: true});
+    // Up: Denmark -> Verona
+    casper.sendKeys('.stream-list-filter', casper.page.event.key.Up, {keepFocus: true});
+});
+
+casper.waitForSelector('#stream_filters [data-stream-name="Verona"].highlighted_stream', function () {
+    casper.test.info('Suggestion highlighting - after arrow key navigation');
+    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Denmark"].highlighted_stream',
+                                  'Stream Denmark is not highlighted');
+    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Scotland"].highlighted_stream',
+                                  'Stream Scotland is not highlighted');
+    casper.test.assertExist('#stream_filters [data-stream-name="Verona"].highlighted_stream',
+                            'Stream Verona is highlighted');
 });
 
 // We search for the beginning of "Verona", not case sensitive
@@ -319,21 +361,28 @@ casper.then(function () {
         $('.stream-list-filter').expectOne()
             .focus()
             .val('ver')
-            .trigger($.Event('input'));
+            .trigger($.Event('input'))
+            .trigger($.Event('click'));
     });
 });
 
 // There will be no race condition between these two waits because we
 // expect them to happen in parallel.
 casper.waitWhileVisible('#stream_filters [data-stream-name="Denmark"]', function () {
-    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Denmark"]', 'Filtered stream list does not contain Denmark');
+    casper.test.info('Search term entered');
+    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Denmark"]',
+                                  'Filtered stream list does not contain Denmark');
 });
 casper.waitWhileVisible('#stream_filters [data-stream-name="Scotland"]', function () {
-    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Scotland"]', 'Filtered stream list does not contain Scotland');
+    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Scotland"]',
+                                  'Filtered stream list does not contain Scotland');
 });
 
 casper.then(function () {
-    casper.test.assertExists('#stream_filters [data-stream-name="Verona"]', 'Filtered stream list does contain Verona');
+    casper.test.assertExists('#stream_filters [data-stream-name="Verona"]',
+                             'Filtered stream list does contain Verona');
+    casper.test.assertExists('#stream_filters [data-stream-name="Verona"].highlighted_stream',
+                             'Stream Verona is highlighted');
 });
 
 // Clearing the list should give us back all the streams in the list
@@ -349,20 +398,24 @@ casper.then(function () {
 // There will be no race condition between these waits because we
 // expect them to happen in parallel.
 casper.waitUntilVisible('#stream_filters [data-stream-name="Denmark"]', function () {
-    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]', 'Restored stream list contains Denmark');
+    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]',
+                             'Restored stream list contains Denmark');
 });
 casper.waitUntilVisible('#stream_filters [data-stream-name="Scotland"]', function () {
-    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]', 'Restored stream list contains Scotland');
+    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]',
+                             'Restored stream list contains Scotland');
 });
 casper.waitUntilVisible('#stream_filters [data-stream-name="Verona"]', function () {
-    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]', 'Restored stream list contains Verona');
+    casper.test.assertExists('#stream_filters [data-stream-name="Denmark"]',
+                             'Restored stream list contains Verona');
 });
 
 
 casper.thenClick('#streams_header .sidebar-title');
 
 casper.waitForSelector('.input-append.notdisplayed', function () {
-    casper.test.assertExists('.input-append.notdisplayed', 'Stream filter box not visible after second click');
+    casper.test.assertExists('.input-append.notdisplayed',
+                             'Stream filter box not visible after second click');
 });
 
 // We search for the beginning of "Verona", not case sensitive

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -302,6 +302,13 @@ function set_stream_unread_count(stream_id, count) {
 exports.update_streams_sidebar = function () {
     exports.build_stream_list();
 
+    // highlight new top stream
+    $('#stream_filters li.highlighted_stream').removeClass('highlighted_stream');
+    if (exports.searching()) {
+        var all_streams = $('#stream_filters li.narrow-filter');
+        exports.highlight_first(all_streams, 'highlighted_stream');
+    }
+
     if (! narrow_state.active()) {
         return;
     }
@@ -520,6 +527,10 @@ exports.initiate_search = function () {
         stream_popover.show_streamlist_sidebar();
     }
     filter.focus();
+
+    // Highlight first result
+    var all_streams = $('#stream_filters li.narrow-filter');
+    exports.highlight_first(all_streams, 'highlighted_stream');
 };
 
 exports.clear_and_hide_search = function () {
@@ -533,28 +544,138 @@ exports.clear_and_hide_search = function () {
 };
 
 function focus_stream_filter(e) {
+    if ($('#stream_filters li.narrow-filter.highlighted_stream').length === 0) {
+        // Highlight
+        var all_streams = $('#stream_filters li.narrow-filter');
+        exports.highlight_first(all_streams, 'highlighted_stream');
+    }
     e.stopPropagation();
 }
 
-function maybe_select_stream(e) {
-    if (e.keyCode === 13) {
-        // Enter key was pressed
+function focusout_stream_filter() {
+    // Undo highlighting
+    $('#stream_filters li.narrow-filter.highlighted_stream').removeClass('highlighted_stream');
+}
 
-        var top_stream_id = $('#stream_filters li.narrow-filter').first().data('stream-id');
-        // undefined if there are no results
-        if (top_stream_id !== undefined) {
-            var top_stream = stream_data.get_sub_by_id(top_stream_id);
-            if (overlays.is_active()) {
-                ui_util.change_tab_to('#home');
-            }
-            exports.clear_and_hide_search();
-            narrow.by('stream', top_stream.name,
-                      {select_first_unread: true, trigger: 'sidebar enter key'});
-            e.preventDefault();
-            e.stopPropagation();
+function keydown_enter_key() {
+    // Is there at least one stream?
+    if ($('#stream_filters li.narrow-filter').length > 0) {
+        var selected_stream_id = $('#stream_filters li.narrow-filter.highlighted_stream')
+                                    .expectOne().data('stream-id');
+
+        var top_stream = stream_data.get_sub_by_id(selected_stream_id);
+
+        if (overlays.is_active()) {
+            ui_util.change_tab_to('#home');
         }
+        exports.clear_and_hide_search();
+        narrow.by('stream', top_stream.name,
+                  {select_first_unread: true, trigger: 'sidebar enter key'});
     }
 }
+
+function next_sibing_in_dir(elm, dir_up) {
+    if (dir_up) {
+        return elm.prev();
+    }
+    return elm.next();
+}
+
+function keydown_arrow_key(dir_up, all_streams_selector,
+                           scroll_container, highlighting_class) {
+    // Are there streams to cyle through?
+    if ($(all_streams_selector).length > 0) {
+        var current_sel = $(all_streams_selector + '.' + highlighting_class).expectOne();
+        var next_sibling = next_sibing_in_dir(current_sel, dir_up);
+
+        if (highlighting_class === 'highlighted_stream'
+            && next_sibling.is('hr.stream-split')) {
+            // Only for the left sidebar
+            // Skip separator
+            next_sibling = next_sibing_in_dir(next_sibling, dir_up);
+        }
+
+        if (!next_sibling.is('li.narrow-filter')) {
+            // At the every bottom or top
+            var all_streams = $(all_streams_selector);
+            if (dir_up) {
+                // top -> start at the bottom
+                next_sibling = all_streams.last();
+            } else {
+                // bottom -> start at the top
+                next_sibling = all_streams.first();
+            }
+        }
+
+        // Classes must be explicitly named
+        if (highlighting_class === 'highlighted_stream') {
+            current_sel.removeClass('highlighted_stream');
+            next_sibling.addClass('highlighted_stream');
+        } else if (highlighting_class === 'highlighted_user') {
+            current_sel.removeClass('highlighted_user');
+            next_sibling.addClass('highlighted_user');
+        }
+
+        exports.scroll_element_into_container(next_sibling, scroll_container);
+    }
+}
+
+exports.keydown_filter = function (e, all_streams_selector, scroll_container,
+                                   highlighting_class, enter_press_function) {
+    // Function for left and right sidebar
+    // Could be placed somewhere else but ui.js is already very full
+
+    // Catch <enter> and <up-arrow>, <down-arrow> key presses
+    var handled = false;
+
+    switch (e.keyCode) {
+        case 13: {
+            // Enter key was pressed
+            enter_press_function();
+            handled = true;
+            break;
+        }
+        case 38: {
+            // Up-arrow key was pressed
+            keydown_arrow_key(true, all_streams_selector,
+                              scroll_container, highlighting_class);
+            handled = true;
+            break;
+        }
+        case 40: {
+            // Down-arrow key was pressed
+            keydown_arrow_key(false, all_streams_selector,
+                              scroll_container, highlighting_class);
+            handled = true;
+            break;
+        }
+    }
+
+    if (handled) {
+        // Since we already handled the key event above, suppress the browser handling it.
+        // We don't want the cursor to move when <arrow-up/down> is pressed.
+        // In the <enter> case:
+        // Prevent a newline from being entered into the soon-to-be-opened composebox
+        e.preventDefault();
+        e.stopPropagation();
+    }
+};
+
+function keydown_stream_filter(e) {
+    exports.keydown_filter(e, '#stream_filters li.narrow-filter',
+     $('#stream-filters-container'), 'highlighted_stream', keydown_enter_key);
+}
+
+exports.highlight_first = function (all_streams, highlighting_class) {
+    if (all_streams.length > 0) {
+        // Classes must be explicitly named
+        if (highlighting_class === 'highlighted_stream') {
+            all_streams.first().addClass('highlighted_stream');
+        } else if (highlighting_class === 'highlighted_user') {
+            all_streams.first().addClass('highlighted_user');
+        }
+    }
+};
 
 exports.toggle_filter_displayed = function (e) {
     if (e.target.id === 'streams_inline_cog') {
@@ -571,8 +692,9 @@ exports.toggle_filter_displayed = function (e) {
 $(function () {
     $(".stream-list-filter").expectOne()
         .on('click', focus_stream_filter)
+        .on('focusout', focusout_stream_filter)
         .on('input', update_streams_for_search)
-        .on('keydown', maybe_select_stream);
+        .on('keydown', keydown_stream_filter);
     $('#clear_search_stream_button').on('click', exports.clear_search);
 });
 

--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -201,7 +201,8 @@ body.dark-mode #global_filters li:hover,
 body.dark-mode #stream_filters li:hover,
 body.dark-mode #stream_filters li.highlighted_stream,
 body.dark-mode #group-pms li:hover,
-body.dark-mode #user_presences li:hover {
+body.dark-mode #user_presences li:hover,
+body.dark-mode #user_presences li.highlighted_user {
     background-color: hsla(136, 25%, 73%, 0.2);
 }
 

--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -199,6 +199,7 @@ body.dark-mode li.active-sub-filter {
 
 body.dark-mode #global_filters li:hover,
 body.dark-mode #stream_filters li:hover,
+body.dark-mode #stream_filters li.highlighted_stream,
 body.dark-mode #group-pms li:hover,
 body.dark-mode #user_presences li:hover {
     background-color: hsla(136, 25%, 73%, 0.2);

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -84,7 +84,8 @@
 }
 
 #global_filters li:hover,
-#stream_filters li:hover {
+#stream_filters li:hover,
+#stream_filters li.highlighted_stream {
     background-color: hsl(93, 19%, 88%);
 }
 

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -8,7 +8,8 @@
 }
 
 #group-pms li:hover,
-#user_presences li:hover {
+#user_presences li:hover,
+#user_presences li.highlighted_user {
     background-color: hsl(93, 19%, 88%);
 }
 


### PR DESCRIPTION
This fixes [#5920](https://github.com/zulip/zulip/issues/5920).

As soon as the search-bar is in focus, the first element becomes highlighted by an assigned CSS class. Then, the key-down events are processed to find arrow key presses and change the element in focus.

The tests are done with Casper as the user interactions can be implemented more easily there compared to the Node tests.

![image](https://user-images.githubusercontent.com/13962498/33527659-caa93522-d854-11e7-9983-675be5429d2b.png)
