### PR TITLE
compose: Align Press Enter to send checkbox with label.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -143,11 +143,6 @@ table.compose_table {
     border: none;
 }
 
-#enter-sends-label {
-    margin-bottom: 0px;
-    margin-top: 2px;
-}
-
 #send_message_form .message_content {
     margin-right: 0px;
 }
@@ -351,11 +346,6 @@ input.recipient_box {
     margin-right: 2px;
 }
 
-#send_controls .compose_checkbox_label input {
-    position: relative;
-    top: -3px;
-}
-
 #send_controls #compose-send-button {
     border-radius: 4px;
     padding-top: 3px;
@@ -421,8 +411,9 @@ input.recipient_box {
 }
 
 #enter_sends {
-    margin-top: 0px;
-    margin-right: 5px;
+    vertical-align: middle;
+    margin-top: -2px;
+    margin-right: 4px;
 }
 
 .inline-subscribe-error {

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -105,8 +105,9 @@
                   <a class="drafts-link" href="#drafts" title="{{ _('Drafts') }} (d)">{{ _('Drafts') }}</a>
                   <span id="sending-indicator">{{ _('Sending...') }}</span>
                   <div id="send_controls" class="new-style">
-                    <input type="checkbox" id="enter_sends" name="enter_sends" value="enter_sends" />
-                    <label id="enter-sends-label" class="compose_checkbox_label" for="enter_sends">{{ _('Press Enter to send') }}&nbsp;</label>
+                    <label id="enter-sends-label" class="compose_checkbox_label">
+                        <input type="checkbox" id="enter_sends" />{{ _('Press Enter to send') }}
+                    </label>
                     <button type="submit" id="compose-send-button" class="button small send_message" tabindex="150" title="{{ _('Send') }} (Ctrl + Enter)">{{ _('Send') }}</button>
                   </div>
                 </div>


### PR DESCRIPTION
Tested on both Firefox and Chrome.


![screenshot at dec 01 09-28-58](https://user-images.githubusercontent.com/15116870/33528409-bbdc4218-d814-11e7-90a8-0994c39979e6.png)

(with outlines to show alignment)
![screenshot at dec 01 09-27-21firefox](https://user-images.githubusercontent.com/15116870/33528408-bbaeae70-d814-11e7-9438-b3efe8e3b30a.png)

Fixes #7604.

[GCI Task](https://codein.withgoogle.com/dashboard/task-instances/5562717479895040/)