### PR TITLE
models: Set UserProfile.MIN_NAME_LENGTH to two.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -527,7 +527,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
 
     USERNAME_FIELD = 'email'
     MAX_NAME_LENGTH = 100
-    MIN_NAME_LENGTH = 3
+    MIN_NAME_LENGTH = 2
     API_KEY_LENGTH = 32
     NAME_INVALID_CHARS = ['*', '`', '>', '"', '@']
 


### PR DESCRIPTION
Chinese names are often two characters.