### PR TITLE
Update strikethrough regex

### DIFF
--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -105,6 +105,10 @@ function set_filter(operators) {
 
     assert.equal(result[2].operator, 'search');
     assert.equal(result[2].operand, 'yo');
+
+    narrow_state.reset_current_filter();
+    result = narrow_state.operators();
+    assert.equal(result.length, 0);
 }());
 
 (function test_muting_enabled() {

--- a/zerver/fixtures/markdown_test_cases.json
+++ b/zerver/fixtures/markdown_test_cases.json
@@ -155,12 +155,6 @@
       "text_content": "int x = 3\n* 4;\n"
     },
     {
-      "name": "malformed_fence",
-      "input": "~~~~~~~~xxxxxxxxx:  xxxxxxxxxxxx xxxxx x xxxxxxxx~~~~~~",
-      "expected_output": "<p>~~~~~~~~xxxxxxxxx:  xxxxxxxxxxxx xxxxx x xxxxxxxx~~~~~~</p>",
-      "text_content": "~~~~~~~~xxxxxxxxx:  xxxxxxxxxxxx xxxxx x xxxxxxxx~~~~~~"
-    },
-    {
       "name": "strikthrough_basic",
       "input": "I like ~~software~~ hardware",
       "expected_output": "<p>I like <del>software</del> hardware</p>",
@@ -173,10 +167,11 @@
       "text_content": "I like software love hardware"
     },
     {
-      "name": "strikthrough_multiword",
+      "name": "strikthrough_multiword_spaces",
       "input": "I ~~ like software ~~ love hardware",
-      "expected_output": "<p>I <del> like software </del> love hardware</p>",
-      "text_content": "I  like software  love hardware"
+      "expected_output": "<p>I <del>like software</del> love hardware</p>",
+      "marked_expected_output": "<p>I <del> like software </del> love hardware</p>",
+      "text_content": "I like software love hardware"
     },
     {
       "name": "underscore_disabled",

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1297,7 +1297,7 @@ class Bugdown(markdown.Extension):
         # Custom strikethrough syntax: ~~foo~~
         md.inlinePatterns.add('del',
                               markdown.inlinepatterns.SimpleTagPattern(
-                                  r'(?<!~)(\~\~)([^~{0}\n]+?)\2(?!~)', 'del'), '>strong')
+                                  r'(\~\~)\s{0,}(?=\S)([\s\S]*?\S)\s{0,}~~', 'del'), '>strong')
 
         # Text inside ** must start and end with a word character
         # it need for things like "const char *x = (char *)y"


### PR DESCRIPTION
Fixes - #7596.

<img width="1030" alt="screen shot 2017-12-05 at 12 04 12 am" src="https://user-images.githubusercontent.com/2263909/33569925-3d84dc3e-d951-11e7-9af1-07f77f5b2e29.png">

<img width="943" alt="screen shot 2017-12-05 at 12 04 35 am" src="https://user-images.githubusercontent.com/2263909/33569926-3e8ec59a-d951-11e7-9264-654832a609d7.png">

You can test the regex [here](https://pythex.org/?regex=(%5C~%5C~)%5Cs%7B0%2C%7D(%3F%3D%5CS)(%5B%5Cs%5CS%5D*%3F%5CS)%5Cs%7B0%2C%7D~~&test_string=~~%20%20hello%20~~&ignorecase=0&multiline=0&dotall=0&verbose=0).