### PR TITLE
dark-mode: Fix background colors of modals and sidebars in mobile view.

### DIFF
--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -1,27 +1,27 @@
 body.dark-mode {
-    background-color: #212d3b;
-    color: #dddeee;
+    background-color: hsl(212, 28%, 18%);
+    color: hsl(236, 33%, 90%);
 
     -webkit-font-smoothing: antialiased;
 }
 
 body.dark-mode .app-main,
 body.dark-mode .header-main {
-    background-color: #212d3b;
+    background-color: hsl(212, 28%, 18%);
 }
 
 body.dark-mode #tab_bar_underpadding,
 body.dark-mode .floating_recipient .message-header-wrapper,
 body.dark-mode .column-middle,
 body.dark-mode #compose {
-    background-color: #212d3b;
+    background-color: hsl(212, 28%, 18%);
 }
 
 body.dark-mode .column-left .left-sidebar,
 body.dark-mode .column-right .right-sidebar,
 body.dark-mode #subscription_overlay .right,
 body.dark-mode #settings_page .right {
-    background-color: #212d3b;
+    background-color: hsl(212, 28%, 18%);
 }
 
 body.dark-mode .column-left .left-sidebar {
@@ -35,7 +35,7 @@ body.dark-mode .column-right .right-sidebar {
 body.dark-mode .dark .message_label_clickable.stream_label,
 body.dark-mode .dark .stream_label,
 body.dark-mode .stream_label {
-    color: #212d3b;
+    color: hsl(212, 28%, 18%);
 }
 
 body.dark-mode .new-style label.checkbox input[type=checkbox] ~ span {
@@ -43,7 +43,7 @@ body.dark-mode .new-style label.checkbox input[type=checkbox] ~ span {
 }
 
 body.dark-mode .modal-bg {
-    background: #212d3b;
+    background: hsl(212, 28%, 18%);
 }
 
 .streams_popover .sp-container {
@@ -68,7 +68,7 @@ body.dark-mode .message_reactions:hover .message_reaction + .reaction_button {
 on a dark background, and don't change the dark labels dark either. */
 body.dark-mode .message_header:not(.dark_background) a.stream_label:not(.dark_background):hover,
 body.dark-mode #tab_list li.stream:not(.dark_background) {
-    color: #212d3b !important;
+    color: hsl(212, 28%, 18%) !important;
 }
 
 /* these are converting grey things to "new grey" */
@@ -161,7 +161,7 @@ body.dark-mode .popover {
 body.dark-mode .dropdown .dropdown-menu li.divider,
 body.dark-mode .popover hr,
 body.dark-mode hr {
-    color: #212d3b;
+    color: hsl(212, 28%, 18%);
     opacity: 0.2;
 }
 
@@ -302,13 +302,13 @@ body.dark-mode .alert-box .alert.alert-error::before {
 }
 
 body.dark-mode .top-messages-logo svg path {
-    fill: #222d3b;
-    stroke: #222d3b;
+    fill: hsl(214, 27%, 18%);
+    stroke: hsl(214, 27%, 18%);
 }
 
 body.dark-mode .top-messages-logo svg circle {
-    fill: #fff;
-    stroke: #fff;
+    fill: hsl(0, 0%, 100%);
+    stroke: hsl(0, 0%, 100%);
 }
 
 body.dark-mode #unmute_muted_topic_notification,

--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -6,17 +6,11 @@ body.dark-mode {
 }
 
 body.dark-mode .app-main,
-body.dark-mode .header-main {
-    background-color: hsl(212, 28%, 18%);
-}
-
+body.dark-mode .header-main,
 body.dark-mode #tab_bar_underpadding,
 body.dark-mode .floating_recipient .message-header-wrapper,
 body.dark-mode .column-middle,
-body.dark-mode #compose {
-    background-color: hsl(212, 28%, 18%);
-}
-
+body.dark-mode #compose,
 body.dark-mode .column-left .left-sidebar,
 body.dark-mode .column-right .right-sidebar,
 body.dark-mode #subscription_overlay .right,

--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -17,6 +17,21 @@ body.dark-mode #compose {
     background-color: #212d3b;
 }
 
+body.dark-mode .column-left .left-sidebar,
+body.dark-mode .column-right .right-sidebar,
+body.dark-mode #subscription_overlay .right,
+body.dark-mode #settings_page .right {
+    background-color: #212d3b;
+}
+
+body.dark-mode .column-left .left-sidebar {
+    border-right-color: hsla(0, 0%, 0%, 0.2);
+}
+
+body.dark-mode .column-right .right-sidebar {
+    border-left-color: hsla(0, 0%, 0%, 0.2);
+}
+
 body.dark-mode .dark .message_label_clickable.stream_label,
 body.dark-mode .dark .stream_label,
 body.dark-mode .stream_label {
@@ -199,7 +214,7 @@ body.dark-mode .nav > li > a:hover,
 body.dark-mode .subscriptions-header,
 body.dark-mode .grey-box,
 body.dark-mode .stream-email,
-body.dark-mode #settings_page .content-wrapper .settings-header,
+body.dark-mode #settings_page .settings-header,
 body.dark-mode #settings_page .sidebar li.active,
 body.dark-mode #settings_page .sidebar .tab-container,
 body.dark-mode .table-striped tbody tr:nth-child(odd) td,


### PR DESCRIPTION
First commit fixes #7623. Second commit changes hex codes to HSL (if unnecessary, that commit can be dropped).

(Note to GCI mentors: I'll be requesting that a GCI generic issues task be created for this after my current claimed task is approved)