### PR TITLE
streams: Vastly increase new stream modal performance.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -904,10 +904,15 @@ function render(template_name, args) {
         ],
     };
 
-    var html = render('new_stream_users', args);
-    global.write_handlebars_output("new_stream_users", html);
+    var $html = $(render('new_stream_users', args));
+    var $table = $html.find("#user-checkboxes");
+    args.users.forEach(function (user) {
+        $table.append($(render('new_stream_users_table', { user: user })));
+    });
 
-    var label = $(html).find("label:first");
+    global.write_handlebars_output("new_stream_users", $html[0].outerHTML);
+
+    var label = $html.find("label:first");
     assert.equal(label.text().trim(), 'King Lear (lear@zulip.com)');
 }());
 

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -133,7 +133,9 @@ var list_render = (function () {
 
                     if (opts.filter && opts.filter.element) {
                         var value = $(opts.filter.element).val().toLocaleLowerCase();
-                        meta.filter_list(value, opts.filter.callback);
+                        if (value.length > 0) {
+                            meta.filter_list(value, opts.filter.callback);
+                        }
                     }
 
                     prototype.clear();

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -694,6 +694,9 @@ $(function () {
     $("#subscriptions_table").on("click", ".create_stream_button", function (e) {
         e.preventDefault();
         exports.new_stream_clicked();
+        // this will change the hash which will attempt to retrigger the create
+        // stream code, so we prevent this once.
+        exports.change_state.prevent_once();
     });
 
     $(".subscriptions").on("click", "[data-dismiss]", function (e) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -477,7 +477,6 @@ exports.change_state = (function () {
         if (hash.arguments.length > 0) {
             // if in #streams/new form.
             if (hash.arguments[0] === "new") {
-                components.toggle.lookup("stream-filter-toggle").goto("all-streams");
                 exports.new_stream_clicked();
             } else if (hash.arguments[0] === "all") {
                 components.toggle.lookup("stream-filter-toggle").goto("all-streams");

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -749,6 +749,15 @@ form#add_new_subscription {
     padding: 15px;
 }
 
+#stream-creation .stream-creation-body .progressive-table-wrapper {
+    max-height: 200px;
+    margin-top: 10px;
+}
+
+#stream-creation .stream-creation-body .progressive-table-wrapper tbody {
+    border-bottom: none;
+}
+
 .stream-row .settings-dropdown-trigger {
     float: right;
     margin-left: 10px;

--- a/static/templates/new_stream_users.handlebars
+++ b/static/templates/new_stream_users.handlebars
@@ -27,12 +27,9 @@
     <a href="#" draggable="false" class="subs_unset_all_users">{{t "Uncheck all" }}</a>
 </div>
 
-<div id="user-checkboxes">
-    {{#each users}}
-    <label class="checkbox add-user-label" data-user-id="{{this.user_id}}" data-email="{{this.email}}">
-        <input type="checkbox" name="user" value="{{this.email}}" />
-        <span></span>
-        {{this.full_name}} ({{this.email}})
-    </label>
-    {{/each}}
+<div class="progressive-table-wrapper grey-box">
+    <table class="table table-condensed table-striped wrapped-table">
+        <tbody id="user-checkboxes" class="admin_user_table required-text thick"
+               data-empty="{{t 'No users found.' }}"></tbody>
+    </table>
 </div>

--- a/static/templates/new_stream_users_table.handlebars
+++ b/static/templates/new_stream_users_table.handlebars
@@ -1,0 +1,5 @@
+<label class="checkbox add-user-label" data-user-id="{{user.user_id}}" data-email="{{user.email}}">
+    <input type="checkbox" name="user" value="{{user.email}}" {{#if checked}}checked{{/if}} />
+    <span></span>
+    {{user.full_name}} ({{user.email}})
+</label>


### PR DESCRIPTION
This changes the user list to render progressively rather than to
render all at once (in chat.zulip.org, that’s 4000+ people who are
rendered!).

This decreases the time to render from a linear speed of render of
around 0.1ms + 4ms to a max of 8ms => means CZO render time goes from
around 400ms => 8ms.

In practice, this actually cuts down on more than a second compared to
CZO.

We also now track whether users are checked in a different way. We make
a single user list from `people.get_rest_of_realm()`, that we add a
custom `__meta` attribute to that tracks whether a user is checked. Now
instead of querying the DOM (which wouldn’t work anymore since it’s a
partial list), we check the attribute.

All said and done, without the duplicated functions and such, a realm with 4000 users will now take around 40ms from start to finish to render the screen rather than 3s. :)

**Orthogonal Performance Benefits:**

Aside from the direct cost of loading, the scrolling in the streams modal is now up back close to 60fps again rather than around 8fps on my computer due to the huge amount of DOM nodes not being rendered anymore.