### PR TITLE
[hotfix] Fix breaking tests on master.

### DIFF
--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -224,7 +224,8 @@ class WorkerTest(ZulipTestCase):
         invitor = self.example_user('iago')
         prereg_alice = PreregistrationUser.objects.create(
             email=self.nonreg_email('alice'), referred_by=invitor, realm=invitor.realm)
-        prereg_bob = PreregistrationUser.objects.create(
+        # prereg_bob
+        PreregistrationUser.objects.create(
             email=self.nonreg_email('bob'), referred_by=invitor, realm=invitor.realm)
         data = [
             dict(prereg_id=prereg_alice.id, referrer_id=invitor.id, email_body=None),
@@ -240,10 +241,10 @@ class WorkerTest(ZulipTestCase):
             worker = queue_processors.ConfirmationEmailWorker()
             worker.setup()
             with patch('zerver.worker.queue_processors.do_send_confirmation_email'), \
-                 patch('zerver.worker.queue_processors.create_confirmation_link'), \
-                 patch('zerver.worker.queue_processors.send_future_email') \
-                     as send_mock, \
-                 patch('logging.info'):
+                    patch('zerver.worker.queue_processors.create_confirmation_link'), \
+                    patch('zerver.worker.queue_processors.send_future_email') \
+                    as send_mock, \
+                    patch('logging.info'):
                 worker.start()
                 self.assertEqual(send_mock.call_count, 2)
 


### PR DESCRIPTION
Looks like some linting errors were accidentally merged into master recently as part of the recent invitations overhaul. This PR fixes them.