### PR TITLE
signup: Redirect to /register instead of sending mail when user has no account.

### DIFF
--- a/templates/zerver/confirm_continue_registration.html
+++ b/templates/zerver/confirm_continue_registration.html
@@ -38,16 +38,10 @@
                                     {{ _("Go back to login") }}
                                 </button>
                             </form>
-                            {# TODO: Ideally, this should use whatever auth #}
-                            {# method the user had used to get here, not just #}
-                            {# send an email. #}
+                            {# TODO: Ideally, this should allow users to register #}
+                            {# without going over to /register and re-authenticating. #}
                             <form class="form-inline" id="send_confirm" name="send_confirm"
-                                action="/register/" method="post">
-                                {{ csrf_input }}
-                                <input type="hidden"
-                                       id="email"
-                                       name="email"
-                                       value="{{ email }}" />
+                                action="/register/" method="get">
                                 <button class="outline">
                                     {{ _("Register instead") }}
                                 </button>

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -61,6 +61,10 @@ POST_MIGRATION_CACHE_FLUSHING = True  # type: bool
 # Enable inline open graph preview in development for now
 INLINE_URL_EMBED_PREVIEW = True
 
+# Keys for testing OAuth live, belonging to greg@zulipchat.com.
+GOOGLE_OAUTH2_CLIENT_ID = '846058479714-pq9tm13j4p6blhv22s6ohoqmf6tu2ee1.apps.googleusercontent.com'
+SOCIAL_AUTH_GITHUB_KEY = '101594a50459573e2ede'
+
 # Don't require anything about password strength in development
 PASSWORD_MIN_LENGTH = 0
 PASSWORD_MIN_GUESSES = 0


### PR DESCRIPTION
When a user with no account try to login using GitHub/Google auth they are given an option to register. If the user choose to register a mail is sent for verification and the user has to continue registration as if he/she signed up using email. This is confusing and a bit annoying so instead of sending email have changed the procedure to just redirect to /register where they can start registration over and process normally. An ideal implementation for this would be to just allow users to continue registration without email or going back to register.

https://chat.zulip.org/#narrow/stream/development.20help/topic/trying.20to.20login.20when.20there.20is.20no.20account