### PR TITLE
modals: Make settings page selectors more specific.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -989,7 +989,7 @@ form#add_new_subscription {
     #subscription_overlay .left,
     #subscription_overlay .right,
     #settings_page .left,
-    #settings_page .right {
+    #settings_page .content-wrapper.right {
         position: absolute;
         display: block;
         margin: 0;
@@ -1008,7 +1008,7 @@ form#add_new_subscription {
     }
 
     #subscription_overlay .right,
-    #settings_page .right {
+    #settings_page .content-wrapper.right {
         position: absolute;
         left: 101%;
 
@@ -1022,7 +1022,7 @@ form#add_new_subscription {
     }
 
     #subscription_overlay .right.show,
-    #settings_page .right.show {
+    #settings_page .content-wrapper.right.show {
         left: 0%;
     }
 


### PR DESCRIPTION
The `#settings_page .right.show` selector was breaking the Emoji style inputs in Display settings in mobile responsive view.

Fixes #7624.