### PR TITLE
sidebar: Narrow to latest topic if not in stream.

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -282,6 +282,11 @@ casper.then(function () {
     casper.click('#stream_filters [data-stream-name="Verona"] a');
 });
 
+expect_stream_subject();
+
+// Click again to now narrow to stream.
+casper.thenClick('#stream_filters [data-stream-name="Verona"] a');
+
 expect_stream();
 
 casper.then(check_narrow_title('Verona - Zulip Dev - Zulip'));

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -468,7 +468,15 @@ exports.initialize = function () {
         var stream_id = $(e.target).parents('li').attr('data-stream-id');
         var sub = stream_data.get_sub_by_id(stream_id);
         popovers.hide_all();
-        narrow.by('stream', sub.name, {select_first_unread: true, trigger: 'sidebar'});
+        var operators = [{operator: "stream", operand: sub.name}];
+        // If we are not in the stream already, narrow to most recent topic in stream.
+        if (!narrow_state.is_for_stream_id(stream_id)) {
+            var history = topic_data.get_recent_names(stream_id);
+            if (history.length > 0) {
+                operators.push({operator: "topic", operand: history[0]});
+            }
+        }
+        narrow.activate(operators, {select_first_unread: true, trigger: "sidebar"});
 
         e.preventDefault();
         e.stopPropagation();


### PR DESCRIPTION
We now narrow to the latest topic in stream if we are narrowing from
outside the stream, and show all topics grouped together (previous
default) if we are already narrowed to the stream.

Fixes #7555.