### PR TITLE
User settings: Fix password link to directly send user a reset email.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -104,6 +104,36 @@ exports.set_up = function () {
         }
     });
 
+    function send_pass_reset() {
+        var email = $('#email_value').text().trim();
+        var form_data = new FormData();
+
+        form_data.append("email", email);
+        channel.post({
+            url: '/accounts/password/reset/',
+            data: form_data,
+            cache: false,
+            processData: false,
+            contentType: false,
+        });
+    }
+
+    $('#forgot_password').on('click', function () {
+        $('#forgot_password').hide();
+        $('#reset_password').show();
+    });
+
+    $('#reset_password').on('click', function () {
+        $('#reset_password').hide();
+        send_pass_reset();
+        $('#reset_sent').show();
+        $('#resend_link').show();
+    });
+
+    $('#resend_link').on('click', function () {
+        send_pass_reset();
+    });
+
     $('#new_password').on('change keyup', function () {
         var field = $('#new_password');
         common.password_quality(field.val(), $('#pw_strength .bar'), field);

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -63,7 +63,10 @@
                                 <label for="old_password" class="inline-block title">{{t "Old password" }}</label>
                                 <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block" value="" />
                                 <div class="warning">
-                                    <a href="/accounts/password/reset/" class="sea-green" target="_blank">{{t "Forgotten it?" }}</a>
+                                    <a class="sea-green" id="forgot_password">{{t "Forgotten it?" }}</a>
+                                    <a class="sea-green" id="reset_password" style="display: none">{{t "Reset Password" }}</a>
+                                    <span id="reset_sent" style="display:none; padding-right: 3px">{{t "Check your email!" }}</span>
+                                    <a class="sea-green" id="resend_link" style="display:none">{{t "Resend" }}</a>
                                 </div>
                             </div>
 


### PR DESCRIPTION
Current method redirects user to another page to enter their e mail for their reset. These changes make it so the user is immediately sent a reset link when they click 'Reset Password'. 

Closes: #6342