### PR TITLE
mypy: Use Python 3 syntax for typing in decorator.py, pointer.py and test_auth_backends.py

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -163,9 +163,11 @@ def get_client_name(request: HttpRequest, is_browser_view: bool) -> Text:
         else:
             return "Unspecified"
 
-def process_client(request, user_profile, *, is_browser_view=False, client_name=None,
-                   remote_server_request=False, query=None):
-    # type: (HttpRequest, UserProfile, bool, Optional[Text], bool, Optional[Text]) -> None
+def process_client(request: HttpRequest, user_profile: UserProfile,
+                   *, is_browser_view: bool=False,
+                   client_name: Optional[Text]=None,
+                   remote_server_request: bool=False,
+                   query: Optional[Text]=None) -> None:
     if client_name is None:
         client_name = get_client_name(request, is_browser_view)
 
@@ -189,9 +191,9 @@ class InvalidZulipServerKeyError(JsonableError):
     def msg_format() -> Text:
         return "Zulip server auth failure: key does not match role {role}"
 
-def validate_api_key(request, role, api_key, is_webhook=False,
-                     client_name=None):
-    # type: (HttpRequest, Optional[Text], Text, bool, Optional[Text]) -> Union[UserProfile, RemoteZulipServer]
+def validate_api_key(request: HttpRequest, role: Optional[Text],
+                     api_key: Text, is_webhook: bool=False,
+                     client_name: Optional[Text]=None) -> Union[UserProfile, RemoteZulipServer]:
     # Remove whitespace to protect users from trivial errors.
     api_key = api_key.strip()
     if role is not None:
@@ -268,9 +270,8 @@ def api_key_only_webhook_view(client_name: Text) -> WrappedViewFuncT:
         @csrf_exempt
         @has_request_variables
         @wraps(view_func)
-        def _wrapped_func_arguments(request, api_key=REQ(),
-                                    *args, **kwargs):
-            # type: (HttpRequest, Text, *Any, **Any) -> HttpResponse
+        def _wrapped_func_arguments(request: HttpRequest, api_key: Text=REQ(),
+                                    *args: Any, **kwargs: Any) -> HttpResponse:
             user_profile = validate_api_key(request, None, api_key, is_webhook=True,
                                             client_name="Zulip{}Webhook".format(client_name))
 
@@ -309,9 +310,8 @@ body:
     return _wrapped_view_func
 
 # From Django 1.8, modified to leave off ?next=/
-def redirect_to_login(next, login_url=None,
-                      redirect_field_name=REDIRECT_FIELD_NAME):
-    # type: (Text, Optional[Text], Text) -> HttpResponseRedirect
+def redirect_to_login(next: Text, login_url: Optional[Text]=None,
+                      redirect_field_name: Text=REDIRECT_FIELD_NAME) -> HttpResponseRedirect:
     """
     Redirects the user to the login page, passing the given 'next' page
     """
@@ -396,10 +396,12 @@ def human_users_only(view_func: ViewFuncT) -> ViewFuncT:
     return _wrapped_view_func  # type: ignore # https://github.com/python/mypy/issues/1927
 
 # Based on Django 1.8's @login_required
-def zulip_login_required(function=None,
-                         redirect_field_name=REDIRECT_FIELD_NAME,
-                         login_url=settings.HOME_NOT_LOGGED_IN):
-    # type: (Optional[Callable[..., HttpResponse]], Text, Text) -> Union[Callable[[Callable[..., HttpResponse]], Callable[..., HttpResponse]], Callable[..., HttpResponse]]
+def zulip_login_required(
+        function: Optional[Callable[..., HttpResponse]]=None,
+        redirect_field_name: Text=REDIRECT_FIELD_NAME,
+        login_url: Text=settings.HOME_NOT_LOGGED_IN,
+) -> Union[Callable[[Callable[..., HttpResponse]], Callable[..., HttpResponse]],
+           Callable[..., HttpResponse]]:
     actual_decorator = user_passes_test(
         logged_in_and_active,
         login_url=login_url,
@@ -430,10 +432,10 @@ def authenticated_api_view(is_webhook: bool=False) -> WrappedViewFuncT:
         @require_post
         @has_request_variables
         @wraps(view_func)
-        def _wrapped_func_arguments(request, email=REQ(), api_key=REQ(default=None),
-                                    api_key_legacy=REQ('api-key', default=None),
-                                    *args, **kwargs):
-            # type: (HttpRequest, Text, Optional[Text], Optional[Text], *Any, **Any) -> HttpResponse
+        def _wrapped_func_arguments(request: HttpRequest, email: Text=REQ(),
+                                    api_key: Optional[Text]=REQ(default=None),
+                                    api_key_legacy: Optional[Text]=REQ('api-key', default=None),
+                                    *args: Any, **kwargs: Any) -> HttpResponse:
             if api_key is None:
                 api_key = api_key_legacy
             if api_key is None:
@@ -530,17 +532,15 @@ def authenticated_json_post_view(view_func: ViewFuncT) -> ViewFuncT:
     @require_post
     @has_request_variables
     @wraps(view_func)
-    def _wrapped_view_func(request,
-                           *args, **kwargs):
-        # type: (HttpRequest, *Any, **Any) -> HttpResponse
+    def _wrapped_view_func(request: HttpRequest,
+                           *args: Any, **kwargs: Any) -> HttpResponse:
         return authenticate_log_and_execute_json(request, view_func, *args, **kwargs)
     return _wrapped_view_func  # type: ignore # https://github.com/python/mypy/issues/1927
 
 def authenticated_json_view(view_func: ViewFuncT) -> ViewFuncT:
     @wraps(view_func)
-    def _wrapped_view_func(request,
-                           *args, **kwargs):
-        # type: (HttpRequest, *Any, **Any) -> HttpResponse
+    def _wrapped_view_func(request: HttpRequest,
+                           *args: Any, **kwargs: Any) -> HttpResponse:
         return authenticate_log_and_execute_json(request, view_func, *args, **kwargs)
     return _wrapped_view_func  # type: ignore # https://github.com/python/mypy/issues/1927
 
@@ -612,8 +612,8 @@ def to_utc_datetime(timestamp: Text) -> datetime.datetime:
     return timestamp_to_datetime(float(timestamp))
 
 WrapperT = Callable[[Callable[..., ReturnT]], Callable[..., ReturnT]]
-def statsd_increment(counter, val=1):
-    # type: (Text, int) -> Callable[[Callable[..., ReturnT]], Callable[..., ReturnT]]
+def statsd_increment(counter: Text, val: int=1,
+                     ) -> Callable[[Callable[..., ReturnT]], Callable[..., ReturnT]]:
     """Increments a statsd counter on completion of the
     decorated function.
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -306,8 +306,7 @@ class AuthBackendTest(ZulipTestCase):
                                             realm=get_realm('zephyr')))
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',))
-    def test_remote_user_backend_invalid_realm(self):
-        # type: () -> None
+    def test_remote_user_backend_invalid_realm(self) -> None:
         username = self.get_username()
         self.verify_backend(ZulipRemoteUserBackend(),
                             good_kwargs=dict(remote_user=username,

--- a/zerver/views/pointer.py
+++ b/zerver/views/pointer.py
@@ -13,9 +13,8 @@ def get_pointer_backend(request: HttpRequest, user_profile: UserProfile) -> Http
     return json_success({'pointer': user_profile.pointer})
 
 @has_request_variables
-def update_pointer_backend(request, user_profile,
-                           pointer=REQ(converter=to_non_negative_int)):
-    # type: (HttpRequest, UserProfile, int) -> HttpResponse
+def update_pointer_backend(request: HttpRequest, user_profile: UserProfile,
+                           pointer: int=REQ(converter=to_non_negative_int)) -> HttpResponse:
     if pointer <= user_profile.pointer:
         return json_success()
 


### PR DESCRIPTION
I'm not quite sure about `zulip_login_required` in decorator.py