### PR TITLE
Recent Topics: Stage 1

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -122,6 +122,7 @@
         "realm_icon": false,
         "realm_logo": false,
         "recent_senders": false,
+        "recent_topics": false,
         "reload": false,
         "reload_state": false,
         "reminder": false,

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -96,6 +96,7 @@ alert_words.process_message = noop;
 zrequire('recent_senders');
 zrequire('unread');
 zrequire('topic_data');
+zrequire('recent_topics');
 
 // And finally require the module that we will test directly:
 zrequire('message_store');

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -12,6 +12,8 @@ zrequire('Filter', 'js/filter');
 zrequire('MessageListData', 'js/message_list_data');
 zrequire('message_list');
 zrequire('util');
+zrequire('recent_topics');
+zrequire('people');
 
 set_global('page_params', {
     have_initial_messages: true,

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,0 +1,211 @@
+var rt = zrequire('recent_topics');
+
+var people = {
+    is_my_user_id: function (id) {
+        return id === 1;
+    },
+};
+
+set_global('people', people);
+
+run_test('basic assertions',() => {
+    var stream1 = 1;
+
+    var topic1 = "topic-1";
+    var topic2 = "topic-2";
+    var topic3 = "topic-3";
+    var topic4 = "topic-4";
+    var topic5 = "topic-5";
+    var topic6 = "topic-6";
+
+    var sender1 = 1;
+    var sender2 = 2;
+
+    // New stream
+    var messages = [];
+    messages[0] = {
+        stream_id: stream1,
+        timestamp: 1000,
+        subject: topic1,
+        sender_id: sender1,
+        unread: false,
+        type: 'stream',
+    };
+
+    messages[1] = {
+        stream_id: stream1,
+        timestamp: 1010,
+        subject: topic2,
+        sender_id: sender1,
+        unread: false,
+        type: 'stream',
+    };
+    messages[2] = {
+        stream_id: stream1,
+        timestamp: messages[1].timestamp + 1,
+        subject: topic2,
+        sender_id: sender2,
+        unread: false,
+        type: 'stream',
+    };
+
+    messages[3] = {
+        stream_id: stream1,
+        timestamp: 1020,
+        subject: topic3,
+        sender_id: sender2,
+        unread: true,
+        type: 'stream',
+    };
+
+    messages[4] = {
+        stream_id: stream1,
+        timestamp: 1030,
+        subject: topic4,
+        sender_id: sender1,
+        unread: false,
+        type: 'stream',
+    };
+    messages[5] = {
+        stream_id: stream1,
+        timestamp: messages[4].timestamp + 1,
+        subject: topic4,
+        sender_id: sender2,
+        unread: true,
+        type: 'stream',
+    };
+
+    messages[6] = {
+        stream_id: stream1,
+        timestamp: 1040,
+        subject: topic5,
+        sender_id: sender1,
+        unread: false,
+        type: 'stream',
+    };
+    messages[7] = {
+        stream_id: stream1,
+        timestamp: messages[6].timestamp + 1,
+        subject: topic5,
+        sender_id: sender2,
+        unread: true,
+        type: 'stream',
+    };
+
+    messages[8] = {
+        stream_id: stream1,
+        timestamp: 1050,
+        subject: topic6,
+        sender_id: sender1,
+        unread: false,
+        type: 'stream',
+    };
+    messages[9] = {
+        stream_id: stream1,
+        timestamp: 1060,
+        subject: topic6,
+        sender_id: sender2,
+        unread: true,
+        type: 'stream',
+    };
+
+    rt.process_messages(messages);
+    var all_topics = rt.get();
+    var rel_topics = rt.get_relevant();
+
+    // Check for expected lengths.
+    assert(all_topics.num_items, 6); // Participated in 4 topics.
+    assert(rel_topics.num_items, 2); // Two unread topics.
+
+    // Last message was sent by us.
+    assert(all_topics.has(stream1 + ':' + topic1));
+    assert(!rel_topics.has(stream1 + ':' + topic1));
+    assert(all_topics.get(stream1 + ':' + topic1).read);
+
+    // Last message was sent by them but we've read it.
+    assert(all_topics.has(stream1 + ':' + topic2));
+    assert(!rel_topics.has(stream1 + ':' + topic2));
+    assert(all_topics.get(stream1 + ':' + topic2).read);
+
+    // No message was sent by us.
+    assert(!all_topics.has(stream1 + ':' + topic3));
+    assert(!rel_topics.has(stream1 + ':' + topic3));
+
+    // Last message was sent by them and is unread.
+    assert(all_topics.has(stream1 + ':' + topic4));
+    assert(rel_topics.has(stream1 + ':' + topic4));
+    assert(!all_topics.get(stream1 + ':' + topic4).read);
+
+    // Last message was sent by them and is unread.
+    assert(all_topics.has(stream1 + ':' + topic5));
+    assert(rel_topics.has(stream1 + ':' + topic5));
+    assert(!all_topics.get(stream1 + ':' + topic5).read);
+
+    // Last message was sent by them and is unread.
+    assert(all_topics.has(stream1 + ':' + topic6));
+    assert(rel_topics.has(stream1 + ':' + topic6));
+    assert(!all_topics.get(stream1 + ':' + topic6).read);
+
+    // Send new message to topic1 and mark it as unread.
+    rt.process_message({
+        stream_id: stream1,
+        timestamp: messages[1].timestamp + 1,
+        subject: topic1,
+        sender_id: sender2,
+        unread: true,
+        type: 'stream',
+    });
+
+    // Mark last message to topic4 as read.
+    rt.process_message({
+        stream_id: stream1,
+        timestamp: messages[5].timestamp,
+        subject: topic4,
+        sender_id: sender2,
+        unread: false,
+        type: 'stream',
+    });
+
+    // Send new message to topic5, and mark it as unread.
+    rt.process_message({
+        stream_id: stream1,
+        timestamp: messages[7].timestamp + 2,
+        subject: topic5,
+        sender_id: sender2,
+        unread: true,
+        type: 'stream',
+    });
+
+    // Send new message to topic6 and mark it as read.
+    rt.process_message({
+        stream_id: stream1,
+        timestamp: messages[9].timestamp + 1,
+        subject: topic6,
+        sender_id: sender2,
+        unread: false,
+        type: 'stream',
+    });
+
+    all_topics = rt.get();
+    rel_topics = rt.get_relevant();
+
+    // Check for expected lengths.
+    assert(all_topics.num_items, 6); // Participated in 4 topics.
+    assert(rel_topics.num_items, 3); // Three unread topics.
+
+    // Last message was sent by them and is unread.
+    assert(all_topics.has(stream1 + ':' + topic1));
+    assert(rel_topics.has(stream1 + ':' + topic1));
+    assert(!all_topics.get(stream1 + ':' + topic1).read);
+
+    // Last message was sent by them and is unread.
+    assert(all_topics.has(stream1 + ':' + topic5));
+    assert(rel_topics.has(stream1 + ':' + topic5));
+    assert(!all_topics.get(stream1 + ':' + topic5).read);
+
+    // Last message was sent by them but we've read it.
+    assert(all_topics.has(stream1 + ':' + topic6));
+    assert(!rel_topics.has(stream1 + ':' + topic6));
+    assert(all_topics.get(stream1 + ':' + topic6).read);
+
+});

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -200,6 +200,7 @@ import "js/ui_init.js";
 import "js/emoji_picker.js";
 import "js/compose_ui.js";
 import "js/panels.js";
+import 'js/recent_topics.js';
 import 'js/settings_ui.js';
 import 'js/search_pill.js';
 import 'js/search_pill_widget.js';

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -625,7 +625,7 @@ Filter.operator_to_prefix = function (operator, negated) {
 function describe_is_operator(operator) {
     var verb = operator.negated ? 'exclude ' : '';
     var operand = operator.operand;
-    var operand_list = ['private', 'starred', 'alerted', 'unread'];
+    var operand_list = ['private', 'starred', 'alerted', 'unread', 'recent'];
     if (operand_list.indexOf(operand) !== -1) {
         return verb + operand + ' messages';
     } else if (operand === 'mentioned') {

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -57,6 +57,8 @@ function message_matches_search_term(message, operator, operand) {
             return message.alerted;
         } else if (operand === 'unread') {
             return unread.message_unread(message);
+        } else if (operand === 'recent') {
+            return recent_topics.is_message_recent(message);
         }
         return true; // is:whatever returns true
 
@@ -446,6 +448,7 @@ Filter.prototype = {
             ['stream'],
             ['stream', 'topic'],
             ['is-private'],
+            ['is-recent']
             ['pm-with'],
         ];
         return _.any(wanted_list, function (wanted_types) {
@@ -551,7 +554,7 @@ Filter.sorted_term_types = function (term_types) {
         'pm-with', 'group-pm-with', 'sender',
         'near', 'id',
         'is-alerted', 'is-mentioned', 'is-private',
-        'is-starred', 'is-unread',
+        'is-starred', 'is-unread', 'is-recent',
         'has-link', 'has-image', 'has-attachment',
         'search',
     ];

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -448,7 +448,7 @@ Filter.prototype = {
             ['stream'],
             ['stream', 'topic'],
             ['is-private'],
-            ['is-recent']
+            ['is-recent'],
             ['pm-with'],
         ];
         return _.any(wanted_list, function (wanted_types) {

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -98,6 +98,7 @@ exports.insert_new_messages = function insert_new_messages(messages, locally_ech
     notifications.received_messages(messages);
     stream_list.update_streams_sidebar();
     pm_list.update_private_messages();
+    recent_topics.process_messages(messages);
 };
 
 exports.maybe_advance_to_recently_sent_message = function (messages) {

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -54,6 +54,7 @@ function process_result(data, opts) {
     stream_list.update_streams_sidebar();
     pm_list.update_private_messages();
     stream_list.maybe_scroll_narrow_into_view();
+    recent_topics.process_messages(messages);
 
     if (opts.cont !== undefined) {
         opts.cont(data);

--- a/static/js/message_flags.js
+++ b/static/js/message_flags.js
@@ -51,7 +51,7 @@ exports.send_read = (function () {
         if (data ===  undefined || data.messages === undefined) {
             return;
         }
-
+        recent_topics.process_messages(queue);
         queue = _.filter(queue, function (message) {
             return data.messages.indexOf(message.id) === -1;
         });

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -1,0 +1,112 @@
+var recent_topics = (function () {
+
+// Keeps track of conversations that the user has participated in
+// and might want to keep track of future replies in.
+// Usage: recent_topics.get_relevant() to get unread conversations
+// as a Dict().
+
+var exports = {};
+
+var topics = new Dict(); // Key is stream-id:subject.
+
+exports.process_all_messages = function () {
+    exports.process_messages(message_list.all.all_messages());
+};
+
+exports.process_messages = function (messages) {
+    messages.forEach(exports.process_message);
+};
+
+var reduce_message = function (msg) {
+    return {
+        id: msg.id,
+        timestamp: msg.timestamp,
+        stream_id: msg.stream_id,
+        subject: msg.subject,
+        sender_id: msg.sender_id,
+        unread: msg.unread,
+        type: msg.type,
+    };
+};
+
+exports.process_message = function (msg) {
+    var is_ours = people.is_my_user_id(msg.sender_id);
+    var is_relevant = is_ours && msg.type === 'stream';
+    var key = msg.stream_id + ':' + msg.subject;
+    var topic = topics.get(key);
+    if (topic === undefined && !is_relevant) {
+        return false;
+    }
+    if (!topic) {
+        topics.set(key, {
+            our_last_msg: reduce_message(msg),
+            last_msg: reduce_message(msg),
+            read: true,
+        });
+        return true;
+    }
+    // Update last messages sent to topic.
+    if (is_ours && topic.our_last_msg.timestamp <= msg.timestamp) {
+        topic.our_last_msg = reduce_message(msg);
+    }
+    if (topic.last_msg.timestamp <= msg.timestamp) {
+        topic.last_msg = reduce_message(msg);
+        if (msg.unread) {
+            topic.read = false;
+        } else {
+            topic.read = true;
+        }
+    }
+    topics.set(key, topic);
+    return true;
+};
+
+var get_sorted_topics = function () {
+    // Sort all recent topics by last message time.
+    topics.values().sort(function (a,b) {
+        if (a.last_msg.timestamp > b.last_msg.timestamp) {
+            return 1;
+        }
+        if (a.last_msg.timestamp < b.last_msg.timestamp) {
+            return -1;
+        }
+        return 0;
+    });
+    return topics;
+};
+
+var map_topics = function (topics) {
+    var mapped_topics = new Dict();
+    topics.each(function (elem, key) {
+        mapped_topics.set(key, {
+            read: elem.read,
+            our_last_msg_id: elem.our_last_msg.id,
+            last_msg_id: elem.last_msg.id,
+        });
+    });
+    return mapped_topics;
+};
+
+exports.get = function () {
+    return map_topics(get_sorted_topics());
+};
+
+exports.get_relevant = function () {
+    // Return only those topics where someone else has replied.
+    var all_topics = get_sorted_topics();
+    var updated_topics = new Dict();
+    all_topics.each(function (elem, key) {
+        if (elem.last_msg !== elem.our_last_msg && !elem.read) {
+            updated_topics.set(key,elem);
+        }
+    });
+    return map_topics(updated_topics);
+};
+
+return exports;
+
+}());
+if (typeof module !== 'undefined') {
+    module.exports = recent_topics;
+}
+window.recent_topics = recent_topics;

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -128,7 +128,27 @@ exports.is_message_recent = function is_message_recent(msg) {
     // return boolean for whether we have a message indexed or not.
     var key = msg.stream_id + ':' + msg.subject;
     return exports.get().has(key);
-}
+};
+
+exports.render_topic_list = function render_topic_list() {
+    var li = $("#global_filters > li[data-name='recent']");
+    var display_topics = [];
+    exports.get().each(function (elem, key) {
+        var stream = stream_data.get_sub_by_id(key.split(':')[0]);
+        var subject = key.split(':',2)[1];
+        var display_text = stream.name + " > " + subject;
+        var url = narrow.by_stream_subject_uri(stream.name, subject);
+        display_topics.push({display_text, url, key});
+    });
+    display_topics.slice(0,10);
+    var zoom_class = true;
+    var options = {
+        topics: display_topics,
+        zoom_class: zoom_class,
+    };
+    var topics_dom = templates.render('sidebar_recent_topics_list', options);
+    li.append(topics_dom);
+};
 
 return exports;
 

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -124,6 +124,12 @@ exports._print = function (all) {
     });
 };
 
+exports.is_message_recent = function is_message_recent(msg) {
+    // return boolean for whether we have a message indexed or not.
+    var key = msg.stream_id + ':' + msg.subject;
+    return exports.get().has(key);
+}
+
 return exports;
 
 }());

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -103,6 +103,27 @@ exports.get_relevant = function () {
     return map_topics(updated_topics);
 };
 
+exports._topics = topics;
+exports._print = function (all) {
+    var data;
+    if (all) {
+        data = exports.get();
+    } else {
+        data = exports.get_relevant();
+    }
+    data.each(function (elem, key) {
+        var sub = stream_data.get_sub_by_id(key.split(':')[0]);
+        var narrow = sub.name + " > " + key.split(':',2)[1];
+        var msg = message_store.get(elem.last_msg_id);
+        blueslip.log(narrow, {
+            key: key,
+            read: elem.read,
+            sender: msg.sender_email,
+            content: msg.content.substring(0,15),
+        });
+    });
+};
+
 return exports;
 
 }());

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -433,6 +433,13 @@ function get_is_filter_suggestions(last, operators) {
                 {operator: 'is', operand: 'unread'},
             ],
         },
+        {
+            search_string: 'is:recent',
+            description: 'recent messages',
+            invalid: [
+                {operator: 'is', operand: 'recent'},
+            ],
+        },
     ];
     return get_special_filter_suggestions(last, operators, suggestions);
 }

--- a/static/js/top_left_corner.js
+++ b/static/js/top_left_corner.js
@@ -46,6 +46,7 @@ function deselect_top_left_corner_items() {
     remove('private');
     remove('starred');
     remove('mentioned');
+    remove('recent');
 }
 
 exports.handle_narrow_activated = function (filter) {
@@ -67,7 +68,7 @@ exports.handle_narrow_activated = function (filter) {
     ops = filter.operands('is');
     if (ops.length >= 1) {
         filter_name = ops[0];
-        if (filter_name === 'starred' || filter_name === 'mentioned') {
+        if (filter_name === 'starred' || filter_name === 'mentioned' || filter_name === 'recent') {
             filter_li = exports.get_global_filter_li(filter_name);
             filter_li.addClass('active-filter');
         }

--- a/static/templates/sidebar_recent_topics_list.handlebars
+++ b/static/templates/sidebar_recent_topics_list.handlebars
@@ -1,0 +1,11 @@
+<ul class='expanded_private_messages {{zoom_class}}' data-name='private'>
+    {{#each topics}}
+    <li class='expanded_private_message' data-topic-key='{{key}}'>
+        <span class='pm-box'>
+            <a href='{{url}}' class="conversation-partners">
+                {{display_text}}
+            </a>
+        </span>
+    </li>
+    {{/each}}
+</ul>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -28,9 +28,9 @@
             <li data-name="recent" class="global-filter">
                 <a href="#narrow/is/recent">
                     <span class="filter-icon">
-                        <i class="fa fa-envelope" aria-hidden="true"></i>
+                        <i class="fa fa-clock-o" aria-hidden="true"></i>
                     </span>
-                    <span class="hover-underline">{{ _('Recently engaged') }}</span>
+                    <span class="hover-underline">{{ _('Recently engaged with') }}</span>
                     <span class="count">
                         <span class="value"></span>
                     </span>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -25,6 +25,17 @@
                     </span>
                 </a>
             </li>
+            <li data-name="recent" class="global-filter">
+                <a href="#narrow/is/recent">
+                    <span class="filter-icon">
+                        <i class="fa fa-envelope" aria-hidden="true"></i>
+                    </span>
+                    <span class="hover-underline">{{ _('Recently engaged') }}</span>
+                    <span class="count">
+                        <span class="value"></span>
+                    </span>
+                </a>
+            </li>
             <li data-name="starred" class="global-filter">
                 <a href="#narrow/is/starred">
                     <span class="filter-icon">


### PR DESCRIPTION
This starts work on a new feature to show list of recent topics that a user participated in, and take a quick look at the ones where someone has replied to him.

This is the module's structure so far:

1. `recent_topics.process_all_messages()` - to be called once when we have loaded all messages.
2. `recent_topics.process(message)` - to be called each time we get a message from server.
3.  `recent_topics.get()` - returns all topics where we have sent a message.
4. `recent_topics.get_updated()` - returns all topics where someone has replied after us.

@showell @timabbott any initial feedback?

Original issue: #6605 

- [x] First Draft
- [x] Node Tests
- [x] Call this module in all needed message events
- [ ] Deploy on chat.zulip.org
- [ ] Next PR: Add UI elements to show list