### PR TITLE
left sidebar: Add margin to bottom of Streams list.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -48,7 +48,7 @@
 
 #stream_filters {
     overflow: visible;
-    margin: 2px 0px 2px 0px;
+    margin: 2px 0px 22px 0px;
     padding: 0;
     font-weight: normal;
 }


### PR DESCRIPTION

![screenshot at dec 09 08-43-34](https://user-images.githubusercontent.com/15116870/33797455-129df928-dcbd-11e7-8831-177c45d89733.png)


The last stream name gets covered by a Chrome link hover tooltip, so an extra 20px gets added to the bottom.

Fixes #7654.