### PR TITLE
Differentiate users invited as admin by showing bolt icon

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -229,6 +229,7 @@ function render(template_name, args) {
                 ref: 'iago@zulip.com',
                 invited: "2017-01-01 01:01:01",
                 id: invite_id,
+                invited_as_admin: true,
             },
         };
         html += render('admin_invites_list', args);
@@ -247,6 +248,9 @@ function render(template_name, args) {
 
     var span = $(html).find(".email:first");
     assert.equal(span.text(), "alice@zulip.com");
+
+    var icon = $(html).find(".icon-vector-bolt");
+    assert.equal(icon.attr('title'), "translated: Invited as administrator");
 
     global.write_handlebars_output("admin_invites_list", html);
 }());

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1360,3 +1360,8 @@ thead .actions {
 #payload_url_inputbox input[type=text] {
     width: 340px;
 }
+
+.invited-as-admin {
+    opacity: 0.5;
+    margin-left: 2px;
+}

--- a/static/templates/admin_invites_list.handlebars
+++ b/static/templates/admin_invites_list.handlebars
@@ -2,6 +2,9 @@
 <tr class="invite_row">
     <td>
         <span class="email">{{email}}</span>
+        {{#if invited_as_admin}}
+        <i title="{{t 'Invited as administrator'}}" class="icon-vector-bolt invited-as-admin"></i>
+        {{/if}}
     </td>
     <td>
         <span class="referred_by">{{ref}}</span>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4022,7 +4022,8 @@ def do_get_user_invites(user_profile: UserProfile) -> List[Dict[str, Any]]:
         invites.append(dict(email=invitee.email,
                             ref=invitee.referred_by.email,
                             invited=invitee.invited_at.strftime("%Y-%m-%d %H:%M:%S"),
-                            id=invitee.id))
+                            id=invitee.id,
+                            invited_as_admin=invitee.invited_as_admin))
 
     return invites
 


### PR DESCRIPTION
Fixes one issue in #7194

![screenshot from 2017-12-10 00-43-07](https://user-images.githubusercontent.com/7190633/33798693-468cb130-dd43-11e7-9ba4-66a540027475.png)

