### PR TITLE
user settings: directly send password reset email.

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -28,10 +28,11 @@ casper.then(function () {
     casper.waitUntilVisible("#settings_content .account-settings-form", function () {
         casper.test.assertUrlMatch(/^http:\/\/[^/]+\/#settings/, 'URL suggests we are on settings page');
         casper.test.assertVisible('.account-settings-form', 'Settings page is active');
-
         casper.test.assertNotVisible("#pw_change_controls");
-
-        // casper.click(".change_password_button");
+        casper.click(".change_password_button");
+        casper.test.assertVisible('#forgot_password', 'Forgot password is visible');
+        casper.click("#forgot_password");
+        casper.test.assertVisible('#reset_password', 'Reset password is visible');
         casper.click('#api_key_button');
     });
 });
@@ -65,7 +66,6 @@ casper.then(function () {
     });
 });
 */
-
 casper.then(function () {
     casper.waitUntilVisible('#get_api_key_password', function () {
         casper.fill('form[action^="/json/fetch_api_key"]', {password:test_credentials.default_user.password});

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -104,6 +104,63 @@ exports.set_up = function () {
         }
     });
 
+    function show_reset_email_loader() {
+        var spinner_elem = $(".loading_indicator_spinner");
+        spinner_elem.html(templates.render("loader"));
+        spinner_elem.show();
+        $('.loading_indicator_message').show();
+    }
+
+    function hide_reset_email_loader() {
+        var spinner_elem = $(".loading_indicator_spinner");
+        spinner_elem.html(null);
+        spinner_elem.hide();
+        $('.loading_indicator_message').hide();
+    }
+
+    function send_password_reset() {
+        var email = people.my_current_email();
+        var form_data = new FormData();
+
+        form_data.append("email", email);
+        channel.post({
+            url: '/accounts/password/reset/',
+            data: form_data,
+            cache: false,
+            processData: false,
+            contentType: false,
+            success: function () {
+                hide_reset_email_loader();
+                $('#reset_sent').show();
+                $('#resend_link').show();
+            },
+            error: function () {
+                hide_reset_email_loader();
+                $('#reset_failed').show();
+                $('#resend_link').show();
+            },
+        });
+    }
+
+    $('#forgot_password').on('click', function () {
+        $('#forgot_password').hide();
+        $('#reset_password').show();
+    });
+
+    $('#reset_password').on('click', function () {
+        $('#reset_password').hide();
+        show_reset_email_loader();
+        send_password_reset();
+    });
+
+    $('#resend_link').on('click', function () {
+        $('#resend_link').hide();
+        $('#reset_sent').hide();
+        $('#reset_failed').hide();
+        show_reset_email_loader();
+        send_password_reset();
+    });
+
     $('#new_password').on('change keyup', function () {
         var field = $('#new_password');
         common.password_quality(field.val(), $('#pw_strength .bar'), field);

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -56,11 +56,17 @@ label {
 .new-style .grid .warning {
     display: inline-block;
     vertical-align: top;
-
     width: 150px;
     padding: 5px 10px;
-
     text-align: left;
+}
+
+.new-style #account-settings .loading_indicator_spinner {
+    display: inline-block;
+    width: 32px;
+    height: 15px;
+    float: none;
+    margin-top: 0;
 }
 
 .new-style .warning #pw_strength {

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -63,7 +63,13 @@
                                 <label for="old_password" class="inline-block title">{{t "Old password" }}</label>
                                 <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block" value="" />
                                 <div class="warning">
-                                    <a href="/accounts/password/reset/" class="sea-green" target="_blank">{{t "Forgotten it?" }}</a>
+                                    <a class="sea-green" id="forgot_password">{{t "Forgotten it?" }}</a>
+                                    <a class="sea-green" id="reset_password" style="display: none">{{t "Reset password" }}</a>
+                                    <div class="loading_indicator_spinner" style="display:none"></div>
+                                    <span class="loading_indicator_message" style="display:none">{{t "Sending ..." }}</span>
+                                    <span id="reset_sent" style="display:none; padding-right: 3px">{{t "Check your email!" }}</span>
+                                    <span id="reset_failed" style="display:none; padding-right: 3px">{{t "Reset failed to send" }}</span>
+                                    <a class="sea-green" id="resend_link" style="display:none">{{t "Resend" }}</a>
                                 </div>
                             </div>
 


### PR DESCRIPTION
This sends a password reset to the user's current email
instead of redirecting them to another page to enter their
email. An option to resend the link is also added.

Fixes: #6342.