### PR TITLE
Better errror message for narrow to a nonexistent stream. Fixes #6862

### DIFF
--- a/templates/zerver/home.html
+++ b/templates/zerver/home.html
@@ -93,7 +93,7 @@
         </div>
     </div>
     <div id="nonsubbed_private_nonexistent_stream_narrow_message" class="empty_feed_notice">
-        <h4>{{ _("You are not subscribed to this stream.") }}</h4>
+        <h4>{{ _("The stream you want does not exist or is private.") }}</h4>
     </div>
     <div id="empty_star_narrow_message" class="empty_feed_notice">
         <h4>{{ _("You haven't starred anything yet!") }}</h4>


### PR DESCRIPTION
Using hard coded message `The stream you want does not exist or is private.` when user tries to narrow to a nonexistent or private stream.
Fixes #6862 