### PR TITLE
invitations:  remove spaces in email reformat

### DIFF
--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -108,9 +108,6 @@ exports.initialize = function () {
 
                 if (arr.sent_invitations) {
                     invitee_emails.val(invitee_emails_errored.join('\n'));
-                } else { // Invitations not sent -- keep all emails in the list
-                    var current_emails = invitee_emails.val().split(/\n|,/);
-                    invitee_emails.val(util.move_array_elements_to_front(current_emails, invitee_emails_errored).join('\n'));
                 }
 
             }


### PR DESCRIPTION
This fixes a bug where leading spaces are included in reformatted
emails in the input box. An edit to the regex in the str.split()
to remove spaces after commas solves this.

Fixes #7581.