### PR TITLE
help: Links to anchor tags from left sidebar don't work. #6714

### DIFF
--- a/templates/zerver/help/browse-streams.md
+++ b/templates/zerver/help/browse-streams.md
@@ -1,0 +1,68 @@
+## Browse streams
+
+1. Click the cog (<i class="icon-vector-cog"></i>) icon next to **Streams**
+in the left sidebar. A tooltip labeled **Subscribe, add, or
+configure streams** will appear upon hovering above the cog.
+
+    ![Streams cog and tooltip](/static/images/help/streams-1.png)
+
+2. After clicking the cog (<i class="icon-vector-cog"></i>) icon, the
+[Streams](/#streams) page will now appear, showing all streams
+that you've subscribed to by default.
+
+    ![Streams page](/static/images/help/streams-overview.png)
+
+    Here, you can explore all the public streams in the organization.
+You can also [create a new stream](create-a-stream) by clicking the plus
+(<i class="icon-vector-plus"></i>) icon.
+
+* {!all-streams.md!}
+
+    ![All streams](/static/images/help/all-streams.png)
+
+* {!filter-streams.md!}
+
+    ![Filter streams box](/static/images/help/filter-stream.png)
+
+* Upon selecting a stream in the [Streams](/#streams) page,
+{!stream-settings.md!}
+
+    ![Stream settings](/static/images/help/stream-overview.png)
+
+## Subscribing to streams
+
+Users can choose to subscribe to any public stream in the organization.
+
+### Subscribing when a stream is created
+
+When users create a public stream, they can choose to alert all users
+in the organization about their stream's creation.
+
+Thus, you may be notified about the stream's creation with a message
+sent by the notification bot such as the one in the
+following image.
+
+![Streams subscribe alert](/static/images/help/stream-subscribe.png)
+
+The message will present to you the option of subscribing to the stream,
+and you can do so by simply clicking **Subscribe to 'stream name'**
+button.
+
+### Subscribing later
+
+However, if you were not notified about the stream's creation,
+you can subscribe to a stream by navigating to the
+[Streams](/#streams) page.
+
+{!subscriptions.md!}
+
+2. {!all-streams.md!}
+
+3. Click on the area to the left of the stream that you would like to
+subscribe to.
+
+    ![Subscribe before](/static/images/help/subscribe-before.png)
+
+    A green checkmark will appear next to the stream that you've just
+subscribed to, and you will now be able to read and send messages in
+that stream.

--- a/templates/zerver/help/include/sidebar.md
+++ b/templates/zerver/help/include/sidebar.md
@@ -39,7 +39,7 @@
 * [Enable pressing Enter to send](/help/enable-or-disable-pressing-enter-to-send)
 * [Verify a message was sent](/help/verify-that-your-message-has-been-successfully-sent)
 <!-- What to do if the server returns an error -->
-* [Status messages](/help/format-your-message-using-markdown#status-messages)
+* [Status messages](/help/status-messages)
 * [@-mention a user](/help/at-mention-a-team-member)
 * [Make an announcement](/help/make-an-announcement)
 * [Write in a different language](/help/send-a-message-in-a-different-language)

--- a/templates/zerver/help/status-messages.md
+++ b/templates/zerver/help/status-messages.md
@@ -1,0 +1,75 @@
+## Status Messages
+
+You can send messages that display your name and profile before a string by
+beginning a message with `/me`. You can utilize this feature to send status
+messages or other messages written in a similar third-person voice.
+
+For example, if your username is **Cordelia Lear** and you send the message
+`/me is now away`, your message will be displayed as:
+
+![Status message](/static/images/help/status-message.png).
+
+## Code
+
+You can surround a portion of code with `` `back-ticks` `` to display it as
+inline code.
+
+![Inline code](/static/images/help/inline-code-screenshot.png)
+
+Multi-line blocks of code are either:
+
+- Fenced by lines with three back-ticks (` ``` `).
+- Fenced by lines with three tildes (`~~~`).
+- Indented with four spaces.
+
+![No code syntax highlighting](/static/images/help/no-syntax.png)
+
+Zulip also supports syntax highlighting of multi-line code blocks using
+[Pygments](http://pygments.org). To add syntax highlighting to a multi-line code
+block, add the language's **first**
+[Pygments short name](http://pygments.org/docs/lexers/) after the first set of
+back-ticks; as you type out a code block's short name, a dropdown with short
+name suggestions will appear.
+
+!!! warn ""
+    **Note:** You can only specify the language's short name in fenced code
+    blocks. It is not possible to use the syntax highlighter in blocks
+    indented with spaces.
+
+![Python syntax highlighting](/static/images/help/python-syntax.png)
+
+![JavaScript syntax highlighting](/static/images/help/javascript-syntax.png)
+
+![Rust syntax highlighting](/static/images/help/rust-syntax.png)
+
+![C# syntax highlighting](/static/images/help/csharp-syntax.png)
+
+## Quotes
+
+To insert quotes, you can either add a greater-than symbol ```>``` and
+a space before your phrase or submit it as a quote block by following
+the code syntax highlighting format.
+
+![Quotes](/static/images/help/quotes-screenshot.png)
+
+## TeX math
+
+You can display mathematical symbols, expressions and equations using Zulip's
+[TeX](http://www.tug.org/interest.html#doc) typesetting implementation,
+based on [KaTeX](https://github.com/Khan/KaTeX).
+
+!!! tip ""
+    Visit the [KaTeX Wiki](https://github.com/Khan/KaTeX/wiki/Function-Support-in-KaTeX)
+    to view a complete of compatible commands.
+
+Surround elements in valid TeX syntax with `$$two dollar signs$$` to display it
+as inline content.
+
+![Inline TeX](/static/images/help/inline-tex-screenshot.png)
+
+Also, you can show expressions, such as expanded integrals, in TeX
+*display mode* to present them fully-sized in the center of the messages by
+fencing them with three back-ticks ` ``` ` or tildes `~~~`, with **math**,
+**tex** or **latex** immediately after the first set of back-ticks.
+
+![Display mode TeX](/static/images/help/display-mode-tex-screenshot.png)


### PR DESCRIPTION
The reference from "status" in file sidebar.md is made explicitly to a newly created file "status-messages.md".
Fixes: 6714  