### PR TITLE
Added darken to perfect-scrollbar on scroll

### DIFF
--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -66,3 +66,11 @@ a.no-underline:hover {
 .italic {
     font-style: italic;
 }
+
+.ps:hover.ps--in-scrolling.ps--x > .ps__scrollbar-x-rail > .ps__scrollbar-x {
+    background-color: #606060;
+}
+
+.ps:hover.ps--in-scrolling.ps--y > .ps__scrollbar-y-rail > .ps__scrollbar-y {
+    background-color: #606060;
+}


### PR DESCRIPTION
Changes the current behavior to the expected one, shown in the second gif. The expected behavior is how the scrollbar works in most browsers, when you hover the scrollbar it darkens, and when you click on it to scroll, it darkens once more.
![scroll1](https://user-images.githubusercontent.com/15152698/33917189-d3ce2fb8-df7a-11e7-8d0f-4d17dc4e633a.gif)
![scroll2](https://user-images.githubusercontent.com/15152698/33917190-d3e79980-df7a-11e7-9db6-9aee9fad06d5.gif)

