### PR TITLE
mypy: Don't use condition to import types.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -22,8 +22,7 @@ from tornado import web
 from tornado.ioloop import IOLoop
 from tornado.websocket import WebSocketHandler, websocket_connect
 
-if False:
-    from typing import Any, Callable, Generator, List, Optional
+from typing import Any, Callable, Generator, List, Optional
 
 if 'posix' in os.name and os.geteuid() == 0:
     raise RuntimeError("run-dev.py should not be run as root.")


### PR DESCRIPTION
After shifting to new style type annotations, we don't need this syntax.
In fact, this causes the dev server to crash.

@showell 