### PR TITLE
Fix typoes in Interactive bots doc

### DIFF
--- a/templates/zerver/api/running-bots.md
+++ b/templates/zerver/api/running-bots.md
@@ -200,7 +200,7 @@ running it manually.
 
 * My bot won't start
     * Ensure that your API config file is correct (download the config file from the server).
-    * Ensure that you bot script is located in zulip_bots/bots/<my-bot>/
+    * Ensure that your bot script is located in zulip_bots/bots/<my-bot>/
     * Are you using your own Zulip development server? Ensure that you run your bot outside
       the Vagrant environment.
     * Some bots require Python 3. Try switching to a Python 3 environment before running

--- a/templates/zerver/api/writing-bots.md
+++ b/templates/zerver/api/writing-bots.md
@@ -206,7 +206,7 @@ None.
 
 #### Example implementation
 
- ```
+```
   def handle_message(self, message, bot_handler):
      original_content = message['content']
      original_sender = message['sender_email']
@@ -219,7 +219,7 @@ None.
          subject=message['sender_email'],
          content=new_content,
      ))
- ```
+```
 ### bot_handler.send_message
 
 *bot_handler.send_message(message)*
@@ -367,12 +367,12 @@ every call to `put` and `get`, respectively.
 
 ### Configuration file
 
- ```
+```
  [api]
  key=<api-key>
  email=<email>
  site=<dev-url>
- ```
+```
 
 * key - the API key you created for the bot; this is how Zulip knows
   the request is from an authorized user.


### PR DESCRIPTION
Remove this bug:

* 1
![screenshot from 2017-12-13 17-03-03](https://user-images.githubusercontent.com/25907420/33936985-94c5366a-e027-11e7-839f-ea4cea1b6439.png)

* 2
![screenshot from 2017-12-13 17-19-56](https://user-images.githubusercontent.com/25907420/33937725-8d00052e-e02a-11e7-9f25-37cd583348d6.png)

to


![screenshot from 2017-12-13 17-20-09](https://user-images.githubusercontent.com/25907420/33937738-9b7eaa92-e02a-11e7-8309-5f2418106f80.png)

![screenshot from 2017-12-13 17-25-53](https://user-images.githubusercontent.com/25907420/33937759-b2a72898-e02a-11e7-901e-0376329df2d5.png)

