### PR TITLE
create stream: Show current user on top of "People to add" list

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -152,9 +152,6 @@ function create_stream() {
     var is_invite_only = $('#stream_creation_form input[name=privacy]:checked').val() === "invite-only";
     var principals = get_principals();
 
-    // You are always subscribed to streams you create.
-    principals.push(people.my_current_email());
-
     created_stream = stream_name;
 
     var announce = (!!page_params.notifications_stream &&
@@ -206,8 +203,12 @@ exports.new_stream_clicked = function (stream_name) {
 exports.show_new_stream_modal = function () {
     $("#stream-creation").removeClass("hide");
     $(".right .settings").hide();
+
+    var all_users = people.get_rest_of_realm();
+    // Add current user on top of list
+    all_users.unshift(people.get_person_from_user_id(page_params.user_id));
     $('#people_to_add').html(templates.render('new_stream_users', {
-        users: people.get_rest_of_realm(),
+        users: all_users,
         streams: stream_data.get_streams_for_settings_page(),
     }));
 

--- a/static/templates/new_stream_users.handlebars
+++ b/static/templates/new_stream_users.handlebars
@@ -30,7 +30,7 @@
 <div id="user-checkboxes">
     {{#each users}}
     <label class="checkbox add-user-label" data-user-id="{{this.user_id}}" data-email="{{this.email}}">
-        <input type="checkbox" name="user" value="{{this.email}}" />
+        <input type="checkbox" name="user" value="{{this.email}}" {{#if @first}}checked="checked"{{/if}}/>
         <span></span>
         {{this.full_name}} ({{this.email}})
     </label>


### PR DESCRIPTION
This is a modification of #7524 that does two things:

1. It changes a more fragile object creation to prepend into the people object to just fetching the current user’s object.

2. Changing `all_user` => `all_users`.

Fixes #7475