### PR TITLE
night-mode: Add experimental text.

### DIFF
--- a/static/templates/settings/display-settings.handlebars
+++ b/static/templates/settings/display-settings.handlebars
@@ -37,7 +37,7 @@
                     {{/if}} />
                     <span></span>
                 </label>
-                <label for="night_mode" class="inline-block">{{t "Night mode" }}</label>
+                <label for="night_mode" class="inline-block">{{t "Night mode (experimental)" }}</label>
             </div>
 
             <div class="input-group">


### PR DESCRIPTION
This adds "(experimental)" after the night mode text in the
checkbox line so that people know it is not a fully stable
feature.