### PR TITLE
sidebars: Replace chevron icons with other icons.

### DIFF
--- a/static/templates/sidebar_private_message_list.handlebars
+++ b/static/templates/sidebar_private_message_list.handlebars
@@ -9,9 +9,6 @@
                 <div class="value">{{unread}}</div>
             </div>
         </span>
-        <span class="arrow topic-sidebar-arrow">
-            <i class="icon-vector-chevron-down"></i>
-        </span>
     </li>
     {{/each}}
     {{#if want_show_more_messages_links}}

--- a/static/templates/stream_sidebar_row.handlebars
+++ b/static/templates/stream_sidebar_row.handlebars
@@ -13,6 +13,6 @@
 
         <div class="count"><div class="value"></div></div>
     </div>
-    <span class="arrow stream-sidebar-arrow"><i class="icon-vector-chevron-down"></i></span>
+    <span class="arrow stream-sidebar-arrow"><i class="fa fa-bars" aria-hidden="true"></i></span>
 
 </li>

--- a/static/templates/topic_list_item.handlebars
+++ b/static/templates/topic_list_item.handlebars
@@ -8,6 +8,6 @@
         </div>
     </span>
     <span class="arrow topic-sidebar-arrow">
-        <i class="fa fa-chevron-down" aria-hidden="true"></i>
+        <i class="fa fa-bars" aria-hidden="true"></i>
     </span>
 </li>

--- a/static/templates/user_presence_row.handlebars
+++ b/static/templates/user_presence_row.handlebars
@@ -7,5 +7,5 @@
             title="{{name}} {{type_desc}}">{{name}}</a>
     </span>
     <span class="count"><span class="value">{{#if num_unread}}{{num_unread}}{{/if}}</span></span>
-    <span class="arrow"><i class="icon-vector-chevron-down"></i></span>
+    <span class="arrow"><i class="fa fa-info-circle" aria-hidden="true"></i></span>
 </li>


### PR DESCRIPTION
In the left sidebar, down chevron icons are converted into bars icons. In the right sidebar, down chevron icons are converted to info icons.

![screenshot at dec 13 19-02-25](https://user-images.githubusercontent.com/15116870/33973527-38bee2f6-e038-11e7-95af-98fc25166511.png)
![screenshot at dec 13 19-02-43](https://user-images.githubusercontent.com/15116870/33973528-38d8ab32-e038-11e7-9824-65537e9d02ae.png)


Fixes #7115.