### PR TITLE
Renamed 'Register' to 'Sign up' including translations

### DIFF
--- a/static/locale/bg/LC_MESSAGES/django.po
+++ b/static/locale/bg/LC_MESSAGES/django.po
@@ -160,7 +160,9 @@ msgstr ""
 msgid "You need an invitation to join this organization."
 msgstr ""
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
 #: templates/zerver/accounts_home.html:65
+#: templates/zerver/register.html:163
 msgid "Sign up"
 msgstr ""
 
@@ -339,7 +341,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -459,11 +461,6 @@ msgstr ""
 msgid "Login"
 msgstr "Вход"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr ""
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr ""
@@ -501,7 +498,7 @@ msgid "Log in now!"
 msgstr ""
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr ""
 
 #: templates/zerver/hello.html:517

--- a/static/locale/cs/LC_MESSAGES/django.po
+++ b/static/locale/cs/LC_MESSAGES/django.po
@@ -162,6 +162,8 @@ msgstr "Přihlásit se do Zulipu"
 msgid "You need an invitation to join this organization."
 msgstr "Potřebujete pozvání, abyste se mohl připojit k této organizaci."
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "Přihlásit se"
@@ -341,7 +343,7 @@ msgid "Go back to login"
 msgstr "Jít zpět pro přihlášení se"
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr "Zaregistrovat se místo toho"
 
 #: templates/zerver/create_realm.html:18
@@ -461,11 +463,6 @@ msgstr "Nová organizace"
 msgid "Login"
 msgstr "Přihlášení"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "Zaregistrovat se"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "Podmínky užití služby"
@@ -503,7 +500,7 @@ msgid "Log in now!"
 msgstr "Přihlašte se nyní!"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "Zaregistrujte se nyní!"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/de/LC_MESSAGES/django.po
+++ b/static/locale/de/LC_MESSAGES/django.po
@@ -171,6 +171,8 @@ msgstr "Bei Zulip registrieren"
 msgid "You need an invitation to join this organization."
 msgstr "Du muss eingeladen werden, um dieser Organisation beitreten zu können."
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "Registrieren"
@@ -350,7 +352,7 @@ msgid "Go back to login"
 msgstr "Zurück zur Anmeldung"
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr "Neu registrieren"
 
 #: templates/zerver/create_realm.html:18
@@ -470,11 +472,6 @@ msgstr "Neue Organisation"
 msgid "Login"
 msgstr "Anmelden"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "Registrieren"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
@@ -512,7 +509,7 @@ msgid "Log in now!"
 msgstr "Jetzt anmelden!"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "Jetzt registrieren!"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/es/LC_MESSAGES/django.po
+++ b/static/locale/es/LC_MESSAGES/django.po
@@ -164,6 +164,8 @@ msgstr "Iniciar sesión en Zulip"
 msgid "You need an invitation to join this organization."
 msgstr "Necesitas una invitación para unirte a esta organización."
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "Registrarse"
@@ -343,7 +345,7 @@ msgid "Go back to login"
 msgstr "Volver al inicio de sesión"
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr "Crear cuenta"
 
 #: templates/zerver/create_realm.html:18
@@ -463,11 +465,6 @@ msgstr "Nueva organización"
 msgid "Login"
 msgstr "Iniciar sesión"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "Registrar"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "los Términos de Servicio"
@@ -505,7 +502,7 @@ msgid "Log in now!"
 msgstr "¡Inicia sesión ya!"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "¡Regístrate ya!"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/fr/LC_MESSAGES/django.po
+++ b/static/locale/fr/LC_MESSAGES/django.po
@@ -169,6 +169,8 @@ msgstr "S'inscrire à Zulip"
 msgid "You need an invitation to join this organization."
 msgstr "Vous avez besoin d'une invitation pour rejoindre cette organisation."
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "S'inscrire"
@@ -348,7 +350,7 @@ msgid "Go back to login"
 msgstr "Retourner à la page de connexion"
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr "Inscrivez vous maintenant"
 
 #: templates/zerver/create_realm.html:18
@@ -468,11 +470,6 @@ msgstr "Nouvelle organisation"
 msgid "Login"
 msgstr "Se connecter"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "S'inscrire"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "Conditions d'utilisation"
@@ -510,7 +507,7 @@ msgid "Log in now!"
 msgstr "Connectez vous maintenant !"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "Enregistrez vous maintenant !"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/hi/LC_MESSAGES/django.po
+++ b/static/locale/hi/LC_MESSAGES/django.po
@@ -160,6 +160,8 @@ msgstr "Zulip के लिए साइन अप करें"
 msgid "You need an invitation to join this organization."
 msgstr "आपको इस संगठन में शामिल होने के लिए आमंत्रण की आवश्यकता है।"
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "साइन अप करें"
@@ -339,7 +341,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -459,11 +461,6 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr ""
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr ""
@@ -501,7 +498,7 @@ msgid "Log in now!"
 msgstr ""
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr ""
 
 #: templates/zerver/hello.html:517

--- a/static/locale/hu/LC_MESSAGES/django.po
+++ b/static/locale/hu/LC_MESSAGES/django.po
@@ -160,6 +160,8 @@ msgstr ""
 msgid "You need an invitation to join this organization."
 msgstr ""
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "Feliratkozás"
@@ -339,7 +341,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -459,11 +461,6 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr ""
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr ""
@@ -501,7 +498,7 @@ msgid "Log in now!"
 msgstr ""
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr ""
 
 #: templates/zerver/hello.html:517

--- a/static/locale/id_ID/LC_MESSAGES/django.po
+++ b/static/locale/id_ID/LC_MESSAGES/django.po
@@ -161,6 +161,8 @@ msgstr "Mendaftar ke Zulip"
 msgid "You need an invitation to join this organization."
 msgstr "Anda memerlukan undangan untuk bergabung di organisasi ini."
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "Mendaftar"
@@ -340,7 +342,7 @@ msgid "Go back to login"
 msgstr "Kembali ke halaman masuk"
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr "Buat akun"
 
 #: templates/zerver/create_realm.html:18
@@ -460,11 +462,6 @@ msgstr "Organisasi baru"
 msgid "Login"
 msgstr "Masuk"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "Mendaftar"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "Ketentuan Layanan"
@@ -502,7 +499,7 @@ msgid "Log in now!"
 msgstr "Masuk sekarang!"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "Mendaftar sekarang!"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/it/LC_MESSAGES/django.po
+++ b/static/locale/it/LC_MESSAGES/django.po
@@ -160,6 +160,8 @@ msgstr ""
 msgid "You need an invitation to join this organization."
 msgstr ""
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr ""
@@ -344,7 +346,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -466,11 +468,6 @@ msgstr ""
 msgid "Login"
 msgstr "Login"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr ""
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr ""
@@ -508,7 +505,7 @@ msgid "Log in now!"
 msgstr ""
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr ""
 
 #: templates/zerver/hello.html:517

--- a/static/locale/ja/LC_MESSAGES/django.po
+++ b/static/locale/ja/LC_MESSAGES/django.po
@@ -162,6 +162,8 @@ msgstr "Zulipに登録する"
 msgid "You need an invitation to join this organization."
 msgstr "この組織に参加するには招待を受ける必要があります。"
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "登録"
@@ -341,7 +343,7 @@ msgid "Go back to login"
 msgstr "ログインするために戻る"
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr "代わりに登録する"
 
 #: templates/zerver/create_realm.html:18
@@ -461,11 +463,6 @@ msgstr "新しい組織"
 msgid "Login"
 msgstr "ログイン"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "登録"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "サービス利用規約"
@@ -503,7 +500,7 @@ msgid "Log in now!"
 msgstr "すぐにログイン！"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "すぐに登録！"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/ko/LC_MESSAGES/django.po
+++ b/static/locale/ko/LC_MESSAGES/django.po
@@ -162,6 +162,9 @@ msgstr "Zulip에 가입하기"
 msgid "You need an invitation to join this organization."
 msgstr "이 조직에 가입하기 위해 초대가 필요합니다."
 
+
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "가입하기"
@@ -341,7 +344,7 @@ msgid "Go back to login"
 msgstr "로그인으로 돌아가기"
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr "대신 등록"
 
 #: templates/zerver/create_realm.html:18
@@ -461,11 +464,6 @@ msgstr "새 단체"
 msgid "Login"
 msgstr "로그인"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "등록"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "서비스 약관"
@@ -503,7 +501,7 @@ msgid "Log in now!"
 msgstr "로그인하세요!"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "가입하세요!"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/ml/LC_MESSAGES/django.po
+++ b/static/locale/ml/LC_MESSAGES/django.po
@@ -161,6 +161,8 @@ msgstr ""
 msgid "You need an invitation to join this organization."
 msgstr ""
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "സൈനപ്പ്"
@@ -340,7 +342,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -460,11 +462,6 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "രെജിസ്റ്റർ"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "സേവന നിബന്ധനകൾ"
@@ -502,7 +499,7 @@ msgid "Log in now!"
 msgstr ""
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "ഇപ്പോൾ തന്നെ രെജിസ്റ്റർ ചെയ്യൂ"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/nl/LC_MESSAGES/django.po
+++ b/static/locale/nl/LC_MESSAGES/django.po
@@ -160,6 +160,8 @@ msgstr "Aanmelden voor Zulip"
 msgid "You need an invitation to join this organization."
 msgstr ""
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "Aanmelden"
@@ -339,7 +341,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -459,11 +461,6 @@ msgstr ""
 msgid "Login"
 msgstr "Inloggen"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "Registreren"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr ""
@@ -501,7 +498,7 @@ msgid "Log in now!"
 msgstr "Nu inloggen!"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "Meld je nu aan!"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/pl/LC_MESSAGES/django.po
+++ b/static/locale/pl/LC_MESSAGES/django.po
@@ -161,6 +161,8 @@ msgstr " Zarejestruj się w Zulipie"
 msgid "You need an invitation to join this organization."
 msgstr ""
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "Zarejestruj"
@@ -340,7 +342,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -460,11 +462,6 @@ msgstr ""
 msgid "Login"
 msgstr "Zaloguj się"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "Zarejestruj się"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr ""
@@ -502,7 +499,7 @@ msgid "Log in now!"
 msgstr "Zaloguj się teraz!"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "Zarejestruj się teraz!"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/pt/LC_MESSAGES/django.po
+++ b/static/locale/pt/LC_MESSAGES/django.po
@@ -160,6 +160,8 @@ msgstr ""
 msgid "You need an invitation to join this organization."
 msgstr ""
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "Inscreva-se"
@@ -339,7 +341,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -459,11 +461,6 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "Registrar"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr ""
@@ -501,7 +498,7 @@ msgid "Log in now!"
 msgstr ""
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr ""
 
 #: templates/zerver/hello.html:517

--- a/static/locale/ru/LC_MESSAGES/django.po
+++ b/static/locale/ru/LC_MESSAGES/django.po
@@ -163,6 +163,8 @@ msgstr ""
 msgid "You need an invitation to join this organization."
 msgstr ""
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "Зарегистрироваться"
@@ -342,7 +344,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -462,11 +464,6 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "Зарегистрироваться"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "Условия использования"
@@ -504,7 +501,7 @@ msgid "Log in now!"
 msgstr "Войдите сейчас!"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "Зарегистрируйтесь сейчас!"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/sr/LC_MESSAGES/django.po
+++ b/static/locale/sr/LC_MESSAGES/django.po
@@ -160,6 +160,8 @@ msgstr ""
 msgid "You need an invitation to join this organization."
 msgstr ""
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "Упишите се"
@@ -339,7 +341,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -459,11 +461,6 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "Региструј се"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "Услови коришћења"
@@ -501,7 +498,7 @@ msgid "Log in now!"
 msgstr "Пријавите се сада!"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "Упишите се одмах!"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/ta/LC_MESSAGES/django.po
+++ b/static/locale/ta/LC_MESSAGES/django.po
@@ -160,6 +160,8 @@ msgstr ""
 msgid "You need an invitation to join this organization."
 msgstr ""
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr ""
@@ -339,7 +341,7 @@ msgid "Go back to login"
 msgstr ""
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr ""
 
 #: templates/zerver/create_realm.html:18
@@ -459,11 +461,6 @@ msgstr ""
 msgid "Login"
 msgstr "புகுபதிகை"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "பதிவேடு"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr ""
@@ -501,7 +498,7 @@ msgid "Log in now!"
 msgstr ""
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr ""
 
 #: templates/zerver/hello.html:517

--- a/static/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/static/locale/zh_Hans/LC_MESSAGES/django.po
@@ -164,6 +164,8 @@ msgstr "注册Zulip"
 msgid "You need an invitation to join this organization."
 msgstr "您需要邀请才能加入本社群。"
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "注册"
@@ -343,7 +345,7 @@ msgid "Go back to login"
 msgstr "返回登录"
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr "注册替换"
 
 #: templates/zerver/create_realm.html:18
@@ -463,11 +465,6 @@ msgstr "新社区"
 msgid "Login"
 msgstr "登录"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "注册"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "服务条款"
@@ -505,7 +502,7 @@ msgid "Log in now!"
 msgstr "现在登录！"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "立即注册！"
 
 #: templates/zerver/hello.html:517

--- a/static/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/static/locale/zh_Hant/LC_MESSAGES/django.po
@@ -160,6 +160,8 @@ msgstr "註冊 Zulip"
 msgid "You need an invitation to join this organization."
 msgstr "您需要邀請才能加入這個組織"
 
+#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
+#: templates/zerver/register.html:163
 #: templates/zerver/accounts_home.html:65
 msgid "Sign up"
 msgstr "註冊"
@@ -339,7 +341,7 @@ msgid "Go back to login"
 msgstr "回到登入"
 
 #: templates/zerver/confirm_continue_registration.html:52
-msgid "Register instead"
+msgid "Sign up instead"
 msgstr "註冊新帳戶"
 
 #: templates/zerver/create_realm.html:18
@@ -459,11 +461,6 @@ msgstr "新的組織"
 msgid "Login"
 msgstr "登入"
 
-#: templates/zerver/footer.html:41 templates/zerver/portico-header.html:34
-#: templates/zerver/register.html:163
-msgid "Register"
-msgstr "註冊"
-
 #: templates/zerver/footer.html:43 templates/zerver/terms.html:21
 msgid "Terms of Service"
 msgstr "服務條款"
@@ -501,7 +498,7 @@ msgid "Log in now!"
 msgstr "現在登入！"
 
 #: templates/zerver/hello.html:48 templates/zerver/hello.html:614
-msgid "Register now!"
+msgid "Sign up now!"
 msgstr "立即註冊！"
 
 #: templates/zerver/hello.html:517

--- a/templates/zerver/confirm_continue_registration.html
+++ b/templates/zerver/confirm_continue_registration.html
@@ -18,7 +18,7 @@
                             Please click the following button if you wish to register.
                             {% endtrans %}
                         </p>
-                        <a href='/register/' class="button-new sea-green">Register</a>
+                        <a href='/register/' class="button-new sea-green">Sign up</a>
                         {% else %}
                         <p>
                             {% trans %}
@@ -43,7 +43,7 @@
                             <form class="form-inline" id="send_confirm" name="send_confirm"
                                 action="/register/" method="get">
                                 <button class="outline">
-                                    {{ _("Register instead") }}
+                                    {{ _("Sign up instead") }}
                                 </button>
                             </form>
                         </div>

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -36,7 +36,7 @@
             {% if register_link_disabled %}
             {% elif only_sso %}
             {% else %}
-            <li><a href="{{ url('register') }}">{{ _("Register") }}</a></li>
+            <li><a href="{{ url('register') }}">{{ _("Sign up") }}</a></li>
             {% endif %}
             <li><a href="{{ root_domain_uri }}/terms/">{{ _("Terms of Service") }}</a></li>
             <li><a href="{{ root_domain_uri }}/privacy/">{{ _("Privacy policy") }}</a></li>

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -45,7 +45,7 @@
                 {% else %}
                 <a href="{{ url('register') }}">
                    <button href="" class="download-button" type="button"
-                           name="button">{{ _('Register now!') }}</button>
+                           name="button">{{ _('Sign up now!') }}</button>
                 </a>
                 {% endif %}
                 <!-- we want this to be il-block so we'll put a <br> above so it's on
@@ -611,7 +611,7 @@
         {% else %}
         <a href="{{ url('register') }}">
           <button href="" type="button"
-                  name="button">{{ _('Register now!') }}</button>
+                  name="button">{{ _('Sign up now!') }}</button>
         </a>
         {% endif %}
         <div class="zulip-octopus"></div>

--- a/templates/zerver/help/join-a-zulip-organization.md
+++ b/templates/zerver/help/join-a-zulip-organization.md
@@ -6,7 +6,7 @@ controlling the specific settings of the organizations that they own.
 
 1. To join a Zulip organization, first navigate to the URL of the Zulip server.
 
-2. Click the **Register** button in the top right hand corner of the screen.
+2. Click the **Sign up** button in the top right hand corner of the screen.
 
 3. You will be taken to the register page and prompted to
  **Enter your email address**. Enter your email address
@@ -25,7 +25,7 @@ controlling the specific settings of the organizations that they own.
  your **Full name** and to agree to the **Terms of Service**.
 
 6. Once you have entered your name and checked the checkbox to confirm that
-you have read the Terms of Service, click the **Register** button.
+you have read the Terms of Service, click the **Sign up** button.
 
 You have now joined the Zulip organization and will be taken to your Zulip
 home page.

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -41,7 +41,7 @@
                 {% if register_link_disabled %}
                 {% else %}
                 <li>
-                    <a href="/register/">Register</a>
+                    <a href="/register/">Sign up</a>
                 </li>
                 {% endif %}
             {% endif %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -143,7 +143,7 @@ common.autofocus('#id_username');
                     <a class="forgot-password" href="/accounts/password/reset/">Forgot your password?</a>
                     {% endif %}
                     {% if not register_link_disabled %}
-                    <a class="register-link float-right" href="/register/">Register</a>
+                    <a class="register-link float-right" href="/register/">Sign up</a>
                     {% endif %}
                 </div>
                 {% endif %}

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -40,7 +40,7 @@
             {% else %}
                 {% if user_is_authenticated %}
                 {% else %}
-                <a href="{{ url('register') }}">{{ _('Register') }}</a>
+                <a href="{{ url('register') }}">{{ _('Sign up') }}</a>
                 {% endif %}
             {% endif %}
         </div>

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -173,7 +173,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                 </div>
                 {% endif %}
                 <div class="register-button-box">
-                    <button class="register-button" type="submit">{{ _('Register') }}</button>
+                    <button class="register-button" type="submit">{{ _('Sign up') }}</button>
                     <input type="hidden" name="next" value="{{ next }}" />
                 </div>
             </div>

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -34,9 +34,9 @@ class TranslationTestCase(ZulipTestCase):
         return response
 
     def test_accept_language_header(self) -> None:
-        languages = [('en', u'Register'),
+        languages = [('en', u'Sign up'),
                      ('de', u'Registrieren'),
-                     ('sr', u'Региструј се'),
+                     ('sr', u'Упишите се'),
                      ('zh-hans', u'注册'),
                      ]
 
@@ -46,9 +46,9 @@ class TranslationTestCase(ZulipTestCase):
             self.assert_in_response(word, response)
 
     def test_cookie(self) -> None:
-        languages = [('en', u'Register'),
+        languages = [('en', u'Sign up'),
                      ('de', u'Registrieren'),
-                     ('sr', u'Региструј се'),
+                     ('sr', u'Упишите се'),
                      ('zh-hans', u'注册'),
                      ]
 
@@ -61,9 +61,9 @@ class TranslationTestCase(ZulipTestCase):
             self.assert_in_response(word, response)
 
     def test_i18n_urls(self) -> None:
-        languages = [('en', u'Register'),
+        languages = [('en', u'Sign up'),
                      ('de', u'Registrieren'),
-                     ('sr', u'Региструј се'),
+                     ('sr', u'Упишите се'),
                      ('zh-hans', u'注册'),
                      ]
 


### PR DESCRIPTION
Updated the translations by removing 'Register' and adding its corresponding lines to the 'Sign up' which already existed. Then changed all the relevant 'Register' matches to 'Sign up'. Also edited the test for test_i18n.py  to the definition of 'Sign up' rather than 'Register'. For #7759 