### PR TITLE
mypy: Use Python 3 syntax for typing in .py files in zerver

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -175,17 +175,16 @@ class LoggingSetPasswordForm(SetPasswordForm):
 
 class ZulipPasswordResetForm(PasswordResetForm):
     def save(self,
-             domain_override=None,  # type: Optional[bool]
-             subject_template_name='registration/password_reset_subject.txt',  # type: Text
-             email_template_name='registration/password_reset_email.html',  # type: Text
-             use_https=False,  # type: bool
-             token_generator=default_token_generator,  # type: PasswordResetTokenGenerator
-             from_email=None,  # type: Optional[Text]
-             request=None,  # type: HttpRequest
-             html_email_template_name=None,  # type: Optional[Text]
-             extra_email_context=None  # type: Optional[Dict[str, Any]]
-             ):
-        # type: (...) -> None
+             domain_override: Optional[bool]=None,
+             subject_template_name: Text='registration/password_reset_subject.txt',
+             email_template_name: Text='registration/password_reset_email.html',
+             use_https: bool=False,
+             token_generator: PasswordResetTokenGenerator=default_token_generator,
+             from_email: Optional[Text]=None,
+             request: HttpRequest=None,
+             html_email_template_name: Optional[Text]=None,
+             extra_email_context: Optional[Dict[str, Any]]=None
+             ) -> None:
         """
         If the email address has an account in the target realm,
         generates a one-use only link for resetting password and sends

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -191,14 +191,13 @@ class Config:
 
     '''
 
-    def __init__(self, table=None, model=None,
-                 normal_parent=None, virtual_parent=None,
-                 filter_args=None, custom_fetch=None, custom_tables=None,
-                 post_process_data=None,
-                 concat_and_destroy=None, id_source=None, source_filter=None,
-                 parent_key=None, use_all=False, is_seeded=False, exclude=None):
-        # type: (str, Any, Config, Config, FilterArgs, CustomFetch, List[TableName], PostProcessData, List[TableName], IdSource, SourceFilter, Field, bool, bool, List[Field]) -> None
-
+    def __init__(self, table: str=None, model: Any=None,
+                 normal_parent: 'Config'=None, virtual_parent: 'Config'=None,
+                 filter_args: FilterArgs=None, custom_fetch: CustomFetch=None,
+                 custom_tables: List[TableName]=None, post_process_data: PostProcessData=None,
+                 concat_and_destroy: List[TableName]=None, id_source: IdSource=None,
+                 source_filter: SourceFilter=None, parent_key: Field=None,
+                 use_all: bool=False, is_seeded: bool=False, exclude: List[Field]=None) -> None:
         assert table or custom_tables
         self.table = table
         self.model = model
@@ -773,10 +772,9 @@ def export_partial_message_files(realm: Realm,
 
     return all_message_ids
 
-def write_message_partial_for_query(realm, message_query, dump_file_id,
-                                    all_message_ids, output_dir,
-                                    chunk_size, user_profile_ids):
-    # type: (Realm, Any, int, Set[int], Path, int, Set[int]) -> int
+def write_message_partial_for_query(realm: Realm, message_query: Any, dump_file_id: int,
+                                    all_message_ids: Set[int], output_dir: Path,
+                                    chunk_size: int, user_profile_ids: Set[int]) -> int:
     min_id = -1
 
     while True:

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -53,9 +53,10 @@ class Integration:
     DEFAULT_LOGO_STATIC_PATH_PNG = 'static/images/integrations/logos/{name}.png'
     DEFAULT_LOGO_STATIC_PATH_SVG = 'static/images/integrations/logos/{name}.svg'
 
-    def __init__(self, name, client_name, categories, logo=None, secondary_line_text=None,
-                 display_name=None, doc=None, stream_name=None, legacy=False):
-        # type: (str, str, List[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[bool]) -> None
+    def __init__(self, name: str, client_name: str, categories: List[str],
+                 logo: Optional[str]=None, secondary_line_text: Optional[str]=None,
+                 display_name: Optional[str]=None, doc: Optional[str]=None,
+                 stream_name: Optional[str]=None, legacy: Optional[bool]=False) -> None:
         self.name = name
         self.client_name = client_name
         self.secondary_line_text = secondary_line_text
@@ -107,9 +108,9 @@ class BotIntegration(Integration):
     ZULIP_LOGO_STATIC_PATH_PNG = 'static/images/logo/zulip-icon-128x128.png'
     DEFAULT_DOC_PATH = '{name}/doc.md'
 
-    def __init__(self, name, categories, logo=None, secondary_line_text=None,
-                 display_name=None, doc=None):
-        # type: (str, List[str], Optional[str], Optional[str], Optional[str], Optional[str]) -> None
+    def __init__(self, name: str, categories: List[str], logo: Optional[str]=None,
+                 secondary_line_text: Optional[str]=None, display_name: Optional[str]=None,
+                 doc: Optional[str]=None) -> None:
         super().__init__(
             name,
             client_name=name,
@@ -146,9 +147,11 @@ class WebhookIntegration(Integration):
     DEFAULT_CLIENT_NAME = 'Zulip{name}Webhook'
     DEFAULT_DOC_PATH = '{name}/doc.{ext}'
 
-    def __init__(self, name, categories, client_name=None, logo=None, secondary_line_text=None,
-                 function=None, url=None, display_name=None, doc=None, stream_name=None, legacy=None):
-        # type: (str, List[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[bool]) -> None
+    def __init__(self, name: str, categories: List[str], client_name: Optional[str]=None,
+                 logo: Optional[str]=None, secondary_line_text: Optional[str]=None,
+                 function: Optional[str]=None, url: Optional[str]=None,
+                 display_name: Optional[str]=None, doc: Optional[str]=None,
+                 stream_name: Optional[str]=None, legacy: Optional[bool]=None) -> None:
         if client_name is None:
             client_name = self.DEFAULT_CLIENT_NAME.format(name=name.title())
         super().__init__(
@@ -210,9 +213,11 @@ class GithubIntegration(WebhookIntegration):
     We need this class to don't creating url object for git integrations.
     We want to have one generic url with dispatch function for github service and github webhook.
     """
-    def __init__(self, name, categories, client_name=None, logo=None, secondary_line_text=None,
-                 function=None, url=None, display_name=None, doc=None, stream_name=None, legacy=False):
-        # type: (str, List[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[bool]) -> None
+    def __init__(self, name: str, categories: List[str], client_name: Optional[str]=None,
+                 logo: Optional[str]=None, secondary_line_text: Optional[str]=None,
+                 function: Optional[str]=None, url: Optional[str]=None,
+                 display_name: Optional[str]=None, doc: Optional[str]=None,
+                 stream_name: Optional[str]=None, legacy: Optional[bool]=False) -> None:
         url = self.DEFAULT_URL.format(name='github')
 
         super().__init__(

--- a/zerver/webhooks/bitbucket/view.py
+++ b/zerver/webhooks/bitbucket/view.py
@@ -13,9 +13,10 @@ from zerver.models import UserProfile, get_client
 
 @authenticated_rest_api_view(is_webhook=True)
 @has_request_variables
-def api_bitbucket_webhook(request, user_profile, payload=REQ(validator=check_dict([])),
-                          stream=REQ(default='commits'), branches=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Mapping[Text, Any], Text, Optional[Text]) -> HttpResponse
+def api_bitbucket_webhook(request: HttpRequest, user_profile: UserProfile,
+                          payload: Mapping[Text, Any]=REQ(validator=check_dict([])),
+                          stream: Text=REQ(default='commits'),
+                          branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
     repository = payload['repository']
 
     commits = [

--- a/zerver/webhooks/circleci/view.py
+++ b/zerver/webhooks/circleci/view.py
@@ -18,9 +18,9 @@ FAILED_STATUS = 'failed'
 
 @api_key_only_webhook_view('CircleCI')
 @has_request_variables
-def api_circleci_webhook(request, user_profile, payload=REQ(argument_type='body'),
-                         stream=REQ(default='circleci')):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
+def api_circleci_webhook(request: HttpRequest, user_profile: UserProfile,
+                         payload: Dict[str, Any]=REQ(argument_type='body'),
+                         stream: Text=REQ(default='circleci')) -> HttpResponse:
     payload = payload['payload']
     subject = get_subject(payload)
     body = get_body(payload)

--- a/zerver/webhooks/transifex/view.py
+++ b/zerver/webhooks/transifex/view.py
@@ -12,12 +12,11 @@ from zerver.models import UserProfile
 
 @api_key_only_webhook_view('Transifex')
 @has_request_variables
-def api_transifex_webhook(request, user_profile,
-                          project=REQ(), resource=REQ(),
-                          language=REQ(), translated=REQ(default=None),
-                          reviewed=REQ(default=None),
-                          stream=REQ(default='transifex')):
-    # type: (HttpRequest, UserProfile, str, str, str, Optional[int], Optional[int], str) -> HttpResponse
+def api_transifex_webhook(request: HttpRequest, user_profile: UserProfile,
+                          project: str=REQ(), resource: str=REQ(),
+                          language: str=REQ(), translated: Optional[int]=REQ(default=None),
+                          reviewed: Optional[int]=REQ(default=None),
+                          stream: str=REQ(default='transifex')) -> HttpResponse:
     subject = "{} in {}".format(project, language)
     if translated:
         body = "Resource {} fully translated.".format(resource)


### PR DESCRIPTION
Hi, here from GCI 2017
While running the lint test there was an error which I was unable to fix despite the type being previously specified as `Config`:
```
pyflakes  | zerver/lib/export.py:195: undefined name 'Config'
pyflakes  | zerver/lib/export.py:195: undefined name 'Config'
```
Is it ok?