### PR TITLE
integrations: Add webhook payloads for Groove.

### DIFF
--- a/zerver/webhooks/groove/fixtures/agent_replied.json
+++ b/zerver/webhooks/groove/fixtures/agent_replied.json
@@ -1,0 +1,25 @@
+{
+    "links": {
+        "author": {
+            "href": "http://api.groovehq.com/v1/agents/agent@example.com"
+        },
+        "recipient": {
+            "href": "http://api.groovehq.com/v1/customers/rambo@example.com"
+        },
+        "ticket": {
+            "href": "http://api.groovehq.com/v1/tickets/776"
+        }
+    },
+    "created_at": "2017-12-14 21:17:29 +0530",
+    "updated_at": "2017-12-14 21:17:29 +0530",
+    "note": false,
+    "id": "5308968422",
+    "body": "Hello , This is a reply from an agent to a ticket",
+    "href": "http://api.groovehq.com/v1/messages/5308968422",
+    "plain_text_body": "Hello , This is a reply from an agent to a ticket",
+    "agent_response": true,
+    "type": "Comment",
+    "attachments": [],
+    "deliver_by": null,
+    "app_ticket_url": "https://ghostfox.groovehq.com/groove_client/tickets/68667295"
+}

--- a/zerver/webhooks/groove/fixtures/customer_replied.json
+++ b/zerver/webhooks/groove/fixtures/customer_replied.json
@@ -1,0 +1,22 @@
+{
+    "links": {
+        "author": {
+            "href": "http://api.groovehq.com/v1/customers/rambo@example.com"
+        },
+        "ticket": {
+            "href": "http://api.groovehq.com/v1/tickets/440"
+        }
+    },
+    "created_at": "2017-12-14 15:54:26 UTC",
+    "updated_at": "2017-12-14 15:54:26 UTC",
+    "note": false,
+    "id": "4810291604",
+    "body": "<p>Hello agent, thanks for getting back. This is how a reply from customer looks like.</p>",
+    "href": "http://api.groovehq.com/v1/messages/4810291604",
+    "plain_text_body": "Hello agent, thanks for getting back. This is how a reply from customer looks like.",
+    "agent_response": false,
+    "type": null,
+    "attachments": [],
+    "deliver_by": null,
+    "app_ticket_url": "https://ghostfox.groovehq.com/groove_client/tickets/68666538"
+}

--- a/zerver/webhooks/groove/fixtures/note_added.json
+++ b/zerver/webhooks/groove/fixtures/note_added.json
@@ -1,0 +1,22 @@
+{
+    "links": {
+        "author": {
+            "href": "http://api.groovehq.com/v1/agents/anotheragent@example.com"
+        },
+        "ticket": {
+            "href": "http://api.groovehq.com/v1/tickets/776"
+        }
+    },
+    "created_at": "2017-12-14 15:53:33 UTC",
+    "updated_at": "2017-12-14 15:53:33 UTC",
+    "note": true,
+    "id": "4658911092",
+    "body": "<div>This is a note added to a ticket.\n</div>",
+    "href": "http://api.groovehq.com/v1/messages/4658911092",
+    "plain_text_body": "This is a note added to  a ticket",
+    "agent_response": true,
+    "type": null,
+    "attachments": [],
+    "deliver_by": null,
+    "app_ticket_url": "https://ghostfox.groovehq.com/groove_client/tickets/68667295"
+}

--- a/zerver/webhooks/groove/fixtures/ticket_assigned.json
+++ b/zerver/webhooks/groove/fixtures/ticket_assigned.json
@@ -1,0 +1,63 @@
+{
+    "created_at": "2017-12-14 20:09:19 +0530",
+    "href": "http://api.groovehq.com/v1/tickets/9",
+    "links": {
+        "customer": {
+            "id": "0070883940",
+            "href": "http://api.groovehq.com/v1/customers/customer@example.lcom"
+        },
+        "drafts": {
+            "href": "http://api.groovehq.com/v1/tickets/9/drafts"
+        },
+        "state": {
+            "href": "http://api.groovehq.com/v1/tickets/9/state"
+        },
+        "messages": {
+            "href": "http://api.groovehq.com/v1/tickets/9/messages"
+        },
+        "assignee": {
+            "id": "9804030737",
+            "href": "http://api.groovehq.com/v1/agents/agent@example.com"
+        }
+    },
+    "number": 9,
+    "priority": "low",
+    "resolution_time": null,
+    "state": "opened",
+    "title": "Test Subject",
+    "updated_at": "2017-12-14 20:17:57 +0530",
+    "system_updated_at": "2017-12-14 20:17:57 +0530",
+    "assigned_group_id": null,
+    "assigned_group": null,
+    "closed_by": null,
+    "tags": [],
+    "tag_ids": [],
+    "mailbox": "Inbox",
+    "mailbox_id": "5063661921",
+    "message_count": 1,
+    "attachment_count": 0,
+    "summary": "The content of the body goes here.",
+    "search_summary": null,
+    "last_message_type": "enduser",
+    "last_message_author": {
+        "id": "1734497920",
+        "type": "Agent"
+    },
+    "type": "Widget",
+    "snoozed_until": null,
+    "snoozed_by_id": null,
+    "interaction_count": 1,
+    "state_changed_at": "2017-12-14 20:09:19 +0530",
+    "assigned_at": "2017-12-14 20:17:57 +0530",
+    "deleted_at": null,
+    "browser": null,
+    "page_title": null,
+    "page_url": null,
+    "platform": null,
+    "last_message": "The content of the body goes here.",
+    "assignee": "agent@example.com",
+    "app_url": "https://testteam.groovehq.com/groove_client/tickets/68659446",
+    "app_customer_url": "https://testteam.groovehq.com/groove_client/contacts/customers/49825873",
+    "customer_name": "Test Name",
+    "last_message_plain_text": "The content of the body goes here."
+}

--- a/zerver/webhooks/groove/fixtures/ticket_assigned2.json
+++ b/zerver/webhooks/groove/fixtures/ticket_assigned2.json
@@ -1,0 +1,63 @@
+{
+    "created_at": "2017-12-14 20:09:19 +0530",
+    "href": "http://api.groovehq.com/v1/tickets/9",
+    "links": {
+        "customer": {
+            "id": "0070883940",
+            "href": "http://api.groovehq.com/v1/customers/customer@example.com"
+        },
+        "drafts": {
+            "href": "http://api.groovehq.com/v1/tickets/9/drafts"
+        },
+        "state": {
+            "href": "http://api.groovehq.com/v1/tickets/9/state"
+        },
+        "messages": {
+            "href": "http://api.groovehq.com/v1/tickets/9/messages"
+        },
+        "assignee": {
+            "id": "1734497920",
+            "href": "http://api.groovehq.com/v1/agents/agent@example.com"
+        }
+    },
+    "number": 9,
+    "priority": "low",
+    "resolution_time": null,
+    "state": "opened",
+    "title": "Test Subject",
+    "updated_at": "2017-12-14 20:52:26 +0530",
+    "system_updated_at": "2017-12-14 20:52:26 +0530",
+    "assigned_group_id": "1414937220",
+    "assigned_group": "group2",
+    "closed_by": null,
+    "tags": [],
+    "tag_ids": [],
+    "mailbox": "Inbox",
+    "mailbox_id": "5063661921",
+    "message_count": 1,
+    "attachment_count": 0,
+    "summary": "The content of the body goes here.",
+    "search_summary": null,
+    "last_message_type": "enduser",
+    "last_message_author": {
+        "id": "1734497920",
+        "type": "Agent"
+    },
+    "type": "Widget",
+    "snoozed_until": null,
+    "snoozed_by_id": null,
+    "interaction_count": 1,
+    "state_changed_at": "2017-12-14 20:09:19 +0530",
+    "assigned_at": "2017-12-14 20:52:26 +0530",
+    "deleted_at": null,
+    "browser": null,
+    "page_title": null,
+    "page_url": null,
+    "platform": null,
+    "last_message": "The content of the body goes here.",
+    "assignee": "agent@example.com",
+    "app_url": "https://testteam.groovehq.com/groove_client/tickets/68659446",
+    "app_customer_url": "https://testteam.groovehq.com/groove_client/contacts/customers/49825873",
+    "customer_name": "Test Name",
+    "last_message_plain_text": "The content of the body goes here."
+}

--- a/zerver/webhooks/groove/fixtures/ticket_started.json
+++ b/zerver/webhooks/groove/fixtures/ticket_started.json
@@ -1,0 +1,59 @@
+{
+    "created_at": "2017-12-14 20:09:19 +0530",
+    "href": "http://api.groovehq.com/v1/tickets/9",
+    "links": {
+        "customer": {
+            "id": "0070883940",
+            "href": "http://api.groovehq.com/v1/customers/customer@example.lcom"
+        },
+        "drafts": {
+            "href": "http://api.groovehq.com/v1/tickets/9/drafts"
+        },
+        "state": {
+            "href": "http://api.groovehq.com/v1/tickets/9/state"
+        },
+        "messages": {
+            "href": "http://api.groovehq.com/v1/tickets/9/messages"
+        }
+    },
+    "number": 9,
+    "priority": "low",
+    "resolution_time": null,
+    "state": "opened",
+    "title": "Test Subject",
+    "updated_at": "2017-12-14 20:09:19 +0530",
+    "system_updated_at": "2017-12-14 20:09:19 +0530",
+    "assigned_group_id": null,
+    "assigned_group": null,
+    "closed_by": null,
+    "tags": [],
+    "tag_ids": [],
+    "mailbox": "Inbox",
+    "mailbox_id": "5063661921",
+    "message_count": 1,
+    "attachment_count": 0,
+    "summary": "The content of the body goes here.",
+    "search_summary": null,
+    "last_message_type": "enduser",
+    "last_message_author": {
+        "id": "1734497920",
+        "type": "Agent"
+    },
+    "type": "Widget",
+    "snoozed_until": null,
+    "snoozed_by_id": null,
+    "interaction_count": 1,
+    "state_changed_at": "2017-12-14 20:09:19 +0530",
+    "assigned_at": null,
+    "deleted_at": null,
+    "browser": null,
+    "page_title": null,
+    "page_url": null,
+    "platform": null,
+    "last_message": "The content of the body goes here.",
+    "assignee": null,
+    "app_url": "https://ghostfox.groovehq.com/groove_client/tickets/68659446",
+    "app_customer_url": "https://ghostfox.groovehq.com/groove_client/contacts/customers/49825873",
+    "customer_name": "Test Name",
+    "last_message_plain_text": "The content of the body goes here."
+}

--- a/zerver/webhooks/groove/fixtures/ticket_state_changed.json
+++ b/zerver/webhooks/groove/fixtures/ticket_state_changed.json
@@ -1,0 +1,69 @@
+{
+    "href": "/v1/tickets/776",
+    "state": "pending",
+    "ticket_number": 776,
+    "ticket": {
+        "created_at": "2017-12-14 21:12:24 +0530",
+        "href": "http://api.groovehq.com/v1/tickets/776",
+        "links": {
+            "customer": {
+                "id": "6383949050",
+                "href": "http://api.groovehq.com/v1/customers/rambo@example.com"
+            },
+            "drafts": {
+                "href": "http://api.groovehq.com/v1/tickets/776/drafts"
+            },
+            "state": {
+                "href": "http://api.groovehq.com/v1/tickets/776/state"
+            },
+            "messages": {
+                "href": "http://api.groovehq.com/v1/tickets/776/messages"
+            },
+            "assignee": {
+                "id": "1734497920",
+                "href": "http://api.groovehq.com/v1/agents/agent@example.com"
+            }
+        },
+        "number": 776,
+        "priority": "low",
+        "resolution_time": null,
+        "state": "pending",
+        "title": "Subject will be here",
+        "updated_at": "2017-12-14 21:17:29 +0530",
+        "system_updated_at": "2017-12-14 21:17:29 +0530",
+        "assigned_group_id": null,
+        "assigned_group": null,
+        "closed_by": null,
+        "tags": [],
+        "tag_ids": [],
+        "mailbox": "Inbox",
+        "mailbox_id": "5063661921",
+        "message_count": 2,
+        "attachment_count": 0,
+        "summary": "Hello , This is a reply from an agent to a ticket",
+        "search_summary": null,
+        "last_message_type": "enduser",
+        "last_message_author": {
+            "id": "1734497920",
+            "type": "Agent"
+        },
+        "type": "Email",
+        "snoozed_until": null,
+        "snoozed_by_id": null,
+        "interaction_count": 4,
+        "state_changed_at": "2017-12-14 21:17:29 +0530",
+        "assigned_at": "2017-12-14 21:17:29 +0530",
+        "deleted_at": null,
+        "browser": null,
+        "page_title": null,
+        "page_url": null,
+        "platform": null,
+        "last_message": "Hello , This is a reply from an agent to a ticket",
+        "assignee": "agent@example.com",
+        "app_url": "https://ghostfox.groovehq.com/groove_client/tickets/68667295",
+        "app_customer_url": "https://ghostfox.groovehq.com/groove_client/contacts/customers/49829231",
+        "customer_name": "RAMBO",
+        "last_message_plain_text": "Hello , This is a reply from an agent to a ticket"
+    },
+    "app_url": "https://ghostfox.groovehq.com/groove_client/tickets/68667295"
+}


### PR DESCRIPTION
This has been done as a GCI task.  Added payloads from [Groove](https://www.groovehq.com) webhooks.
I have the notes in [zulip-gci-submissons](https://github.com/zulip/zulip-gci-submissions/pull/210) repo.
