### PR TITLE
emoji picker: Fix categories overflow in Firefox at 90% zoom.

### DIFF
--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -247,6 +247,7 @@
 }
 
 .emoji-popover-category-tabs {
+    display: flex;
     background-color: hsl(0, 0%, 93%);
     width: 100%;
     box-sizing: border-box;
@@ -261,6 +262,7 @@
     text-align: center;
     font-size: 16px;
     cursor: pointer;
+    flex-grow: 1;
 }
 
 .emoji-popover-category-tabs .emoji-popover-tab-item.active {


### PR DESCRIPTION
@brockwhittaker Can you give this a review? Thanks! :)

Fixes: #7511.