### PR TITLE
compose: don't clear compose box if narrowed topic is same as subject

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -353,7 +353,12 @@ exports.on_topic_narrow = function () {
         // appropriate (after all, they were starting to
         // compose on the old topic and may now be looking
         // for info), so we punt and cancel.
-        exports.cancel();
+
+        // If subject is not same as topic narrowed to then
+        // stop composing
+        if (compose_state.subject().toLowerCase() !== narrow_state.topic().toLowerCase()) {
+            exports.cancel();
+        }
         return;
     }
 


### PR DESCRIPTION
Fixes #6510
If it is a topic narrow, and the subject is the same as
narrowed topic then leave it open, otherwise close the
compose box.