### PR TITLE
invitations: send 'invites_changed' event for invitations events

### DIFF
--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -22,6 +22,12 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             event.hotspots;
         break;
 
+    case 'invites_changed':
+        if ($('#admin-invites-list').length) {
+            settings_invites.set_up();
+        }
+        break;
+
     case 'muted_topics':
         muting_ui.handle_updates(event.muted_topics);
         break;

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -20,6 +20,11 @@ function populate_invites(invites_data) {
         return;
     }
     var invites_table = $("#admin_invites_table").expectOne();
+    var invites_list = list_render.get("admin_invites_list");
+
+    if (invites_list) {
+        list_render.delete("admin_invites_list");
+    }
 
     list_render(invites_table, invites_data.invites, {
         name: "admin_invites_list",

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4077,6 +4077,9 @@ def do_invite_users(user_profile: UserProfile,
                                 "so we didn't send them an invitation. We did send "
                                 "invitations to everyone else!"),
                               skipped, sent_invitations=True)
+    event = dict(type="invites_changed")
+    admin_ids = [user.id for user in user_profile.realm.get_admin_users()]
+    send_event(event, admin_ids)
 
 def do_get_user_invites(user_profile: UserProfile) -> List[Dict[str, Any]]:
     days_to_activate = getattr(settings, 'ACCOUNT_ACTIVATION_DAYS', 7)
@@ -4118,6 +4121,9 @@ def do_revoke_user_invite(prereg_user: PreregistrationUser) -> None:
                                 object_id=prereg_user.id).delete()
     prereg_user.delete()
     clear_scheduled_invitation_emails(email)
+    event = dict(type="invites_changed")
+    admin_ids = [user.id for user in prereg_user.realm.get_admin_users()]
+    send_event(event, admin_ids)
 
 def do_resend_user_invite_email(prereg_user: PreregistrationUser) -> int:
     check_invite_limit(prereg_user.referred_by, 1)

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -569,6 +569,8 @@ def apply_event(state: Dict[str, Any],
     elif event['type'] == "update_global_notifications":
         assert event['notification_name'] in UserProfile.notification_setting_types
         state[event['notification_name']] = event['setting']
+    elif event['type'] == "invites_changed":
+        pass
     elif event['type'] == "user_group":
         if event['op'] == 'add':
             state['realm_user_groups'].append(event['group'])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -15,6 +15,7 @@ from zerver.models import (
     get_client, get_realm, get_stream_recipient, get_stream, get_user,
     Message, RealmDomain, Recipient, UserMessage, UserPresence, UserProfile,
     Realm, Subscription, Stream, flush_per_request_caches, UserGroup, Service,
+    PreregistrationUser,
 )
 
 from zerver.lib.actions import (
@@ -49,6 +50,7 @@ from zerver.lib.actions import (
     do_deactivate_stream,
     do_deactivate_user,
     do_delete_message,
+    do_invite_users,
     do_mark_hotspot_as_read,
     do_mute_topic,
     do_reactivate_user,
@@ -63,6 +65,7 @@ from zerver.lib.actions import (
     do_remove_realm_filter,
     do_remove_streams_from_default_stream_group,
     do_rename_stream,
+    do_revoke_user_invite,
     do_set_realm_authentication_methods,
     do_set_realm_message_editing,
     do_set_realm_property,
@@ -881,6 +884,40 @@ class EventsRegisterTest(ZulipTestCase):
         events = self.do_test(
             lambda: do_remove_reaction(
                 self.user_profile, message, "1f389", "unicode_emoji"),
+            state_change_expected=False,
+        )
+        error = schema_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
+    def test_invite_user_event(self) -> None:
+        schema_checker = self.check_events_dict([
+            ('type', equals('invites_changed')),
+        ])
+
+        self.user_profile = self.example_user('iago')
+        streams = []
+        for stream_name in ["Denmark", "Scotland"]:
+            streams.append(get_stream(stream_name, self.user_profile.realm))
+        events = self.do_test(
+            lambda: do_invite_users(self.user_profile, ["foo@zulip.com"], streams, False),
+            state_change_expected=False,
+        )
+        error = schema_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
+    def test_revoke_user_invite_event(self) -> None:
+        schema_checker = self.check_events_dict([
+            ('type', equals('invites_changed')),
+        ])
+
+        self.user_profile = self.example_user('iago')
+        streams = []
+        for stream_name in ["Denmark", "Verona"]:
+            streams.append(get_stream(stream_name, self.user_profile.realm))
+        do_invite_users(self.user_profile, ["foo@zulip.com"], streams, False)
+        prereg_users = PreregistrationUser.objects.filter(referred_by__realm=self.user_profile.realm)
+        events = self.do_test(
+            lambda: do_revoke_user_invite(prereg_users[0]),
             state_change_expected=False,
         )
         error = schema_checker('events[0]', events[0])


### PR DESCRIPTION
Fixes #7665

In case of invitation events, 'invites_changed' event without
any real payload is sent to all the realm admins and the user.
The event is handled by displaying a notification to reload the
page to view recent changes.