### PR TITLE
integrations: Improve Groove integration

### DIFF
--- a/zerver/webhooks/groove/fixtures/malformed_payload.json
+++ b/zerver/webhooks/groove/fixtures/malformed_payload.json
@@ -1,0 +1,59 @@
+{
+    "created_at": "2017-12-14 20:09:19 +0530",
+    "href": "http://api.groovehq.com/v1/tickets/9",
+    "links": {
+        "customer": {
+            "id": "0070883940",
+            "href": "http://api.groovehq.com/v1/customers/customer@example.lcom"
+        },
+        "drafts": {
+            "href": "http://api.groovehq.com/v1/tickets/9/drafts"
+        },
+        "state": {
+            "href": "http://api.groovehq.com/v1/tickets/9/state"
+        },
+        "messages": {
+            "href": "http://api.groovehq.com/v1/tickets/9/messages"
+        }
+    },
+    "number": 9,
+    "priority": "low",
+    "resolution_time": null,
+    "state": "opened",
+
+    "updated_at": "2017-12-14 20:09:19 +0530",
+    "system_updated_at": "2017-12-14 20:09:19 +0530",
+    "assigned_group_id": null,
+    "assigned_group": null,
+    "closed_by": null,
+    "tags": [],
+    "tag_ids": [],
+    "mailbox": "Inbox",
+    "mailbox_id": "5063661921",
+    "message_count": 1,
+    "attachment_count": 0,
+    "summary": "The content of the body goes here.",
+    "search_summary": null,
+    "last_message_type": "enduser",
+    "last_message_author": {
+        "id": "1734497920",
+        "type": "Agent"
+    },
+    "type": "Widget",
+    "snoozed_until": null,
+    "snoozed_by_id": null,
+    "interaction_count": 1,
+    "state_changed_at": "2017-12-14 20:09:19 +0530",
+    "assigned_at": null,
+    "deleted_at": null,
+    "browser": null,
+    "page_title": null,
+    "page_url": null,
+    "platform": null,
+    "last_message": "The content of the body goes here.",
+    "assignee": null,
+    "app_url": "https://ghostfox.groovehq.com/groove_client/tickets/68659446",
+    "app_customer_url": "https://ghostfox.groovehq.com/groove_client/contacts/customers/49825873",
+
+    "last_message_plain_text": "The content of the body goes here."
+}

--- a/zerver/webhooks/groove/tests.py
+++ b/zerver/webhooks/groove/tests.py
@@ -108,5 +108,18 @@ class GrooveHookTests(WebhookTestCase):
                                   X_GROOVE_EVENT='ticket_state_changed')
         self.assert_json_success(result)
 
+    def test_groove_header_missing(self) -> None:
+        self.subscribe(self.test_user, self.STREAM_NAME)
+        result = self.client_post(self.url, self.get_body('ticket_state_changed'),
+                                  content_type="application/x-www-form-urlencoded")
+        self.assert_json_error(result, 'Missing event header')
+
+    def test_groove_malformed_payload(self) -> None:
+        self.subscribe(self.test_user, self.STREAM_NAME)
+        result = self.client_post(self.url, self.get_body('malformed_payload'),
+                                  content_type="application/x-www-form-urlencoded",
+                                  X_GROOVE_EVENT='ticket_started')
+        self.assert_json_error(result, 'Missing required data')
+
     def get_body(self, fixture_name: Text) -> Text:
         return self.fixture_data("groove", fixture_name, file_type="json")


### PR DESCRIPTION
I have made some progress in integrating [Groove](https://www.groovehq.com) with Zulip.
I am not sure if the approach I am currently doing is the right one for integrating this. 
Would like some reviews and feedback on how to proceed or if the current way I am using is fine for this integration. 
You can find the notes about the working of this integration [here](https://github.com/zulip/zulip-gci-submissions/blob/master/webhook-integrations/groove/notes.md)

Thanks

A few screenshots on how the messages look currently :
 
![image](https://user-images.githubusercontent.com/27341353/34035909-8adfcb8c-e1a9-11e7-8af8-3d242500aa55.png)
![image](https://user-images.githubusercontent.com/27341353/34036029-f5b35406-e1a9-11e7-877e-4b8b973e5f7d.png)

