### PR TITLE
Improve email change modal in user setting

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -542,16 +542,14 @@ function test_change_allow_subdomains(change_allow_subdomains) {
     assert.equal($('#full_name').attr('disabled'), 'disabled');
     assert(name_toggled);
 
-    var email_toggled;
-    $('#change_email').toggle = function () {
-        email_toggled = true;
-    };
     var email_tooltip_toggled;
     $('.change_email_tooltip').toggle = function () {
         email_tooltip_toggled = true;
     };
+
+    $('#change_email .button').attr('disabled', false);
     settings_org.toggle_email_change_display();
-    assert(email_toggled);
+    assert.equal($("#change_email .button").attr('disabled'), 'disabled');
     assert(email_tooltip_toggled);
 
     page_params.realm_description = 'realm description';

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -61,7 +61,11 @@ exports.toggle_email_change_display = function () {
         return;
     }
 
-    $("#change_email").toggle();
+    if ($('#change_email .button').attr('disabled')) {
+        $('#change_email .button').prop('disabled', false);
+    } else {
+        $('#change_email .button').attr('disabled', 'disabled');
+    }
     $(".change_email_tooltip").toggle();
 };
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -109,6 +109,10 @@ label {
     box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);
 }
 
+#change_email_modal {
+    width: 460px;
+}
+
 .admin-realm-description {
     height: 16em;
     width: 36em;

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -8,7 +8,7 @@
                     <label class="inline-block title">{{t "Email" }}</label>
                     <a id="change_email" {{#unless page_params.realm_email_changes_disabled}}href="#change_email"{{/unless}}>
                         <button type="button" class="button small rounded inline-block" id='email_value'
-                            {{#if page_params.realm_email_changes_disabled}} disabled="true" {{/if}}>
+                            {{#if page_params.realm_email_changes_disabled}} disabled="disabled" {{/if}}>
                             {{page_params.email}}
                             <i class="fa fa-pencil"></i>
                         </button>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -29,7 +29,7 @@
                     <div class="modal-body">
                         <div class="input-group email_change_container">
                             <label for="email">{{t "New email" }}</label>
-                            <input type="text" name="email" value="{{ page_params.email }}" autocomplete="off" />
+                            <input type="text" name="email" value="{{ page_params.email }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
                         </div>
                     </div>
                     <div class="modal-footer">

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -28,13 +28,13 @@
                     </div>
                     <div class="modal-body">
                         <div class="input-group email_change_container">
-                            <label for="email">{{t "Email" }}</label>
+                            <label for="email">{{t "New email" }}</label>
                             <input type="text" name="email" value="{{ page_params.email }}" autocomplete="off" />
                         </div>
                     </div>
                     <div class="modal-footer">
                         <button id='change_email_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
-                        <button class="button white rounded" data-dismiss="modal">{{t "Close" }}</button>
+                        <button class="button white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
                     </div>
                 </div>
             </form>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -13,6 +13,8 @@
                             <i class="fa fa-pencil"></i>
                         </button>
                     </a>
+                    <i class="icon-vector-question-sign change_email_tooltip" {{#unless page_params.realm_email_changes_disabled}}style="display:none" {{/unless}} data-toggle="tooltip"
+                    title="{{t 'Changing email addresses has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"></i>
                 </div>
 
                 <i class="icon-vector-question-sign settings-info-icon change_email_tooltip" {{#unless page_params.realm_email_changes_disabled}}style="display:none" {{/unless}} data-toggle="tooltip"


### PR DESCRIPTION
* Set `?` icon's position inline with email field
![emailicon](https://user-images.githubusercontent.com/25907420/34052333-f940e3f2-e1e7-11e7-84fc-5b6339c9f89d.png)

![emailchange2](https://user-images.githubusercontent.com/25907420/34052331-f87a7a5a-e1e7-11e7-82b1-0d59d3e55293.png)

* Disable spell check in email field
* Rename title for email field in `email_change` dialog box
* Set autofocus to email field in `email_change` dialog box
![changeemaildialog](https://user-images.githubusercontent.com/25907420/34052332-f8d12bf2-e1e7-11e7-8128-af60e9b2351d.png)

![emailchangedialog2](https://user-images.githubusercontent.com/25907420/34052330-f7a1aaae-e1e7-11e7-89c8-928a0e4ef428.png)
