### PR TITLE
tests: Improve abstractions for writing tests using the Zulip API.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -331,7 +331,7 @@ class ZulipTestCase(TestCase):
         else:
             raise AssertionError("Couldn't find a confirmation email.")
 
-    def api_auth(self, identifier: Text, realm: Text="zulip") -> Dict[str, Text]:
+    def encode_credentials(self, identifier: Text, realm: Text="zulip") -> Text:
         """
         identifier: Can be an email or a remote server uuid.
         """
@@ -345,28 +345,26 @@ class ZulipTestCase(TestCase):
             API_KEYS[identifier] = api_key
 
         credentials = "%s:%s" % (identifier, api_key)
-        return {
-            'HTTP_AUTHORIZATION': 'Basic ' + base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
-        }
+        return 'Basic ' + base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
 
     def api_get(self, email: Text, *args: Any, **kwargs: Any) -> HttpResponse:
-        kwargs.update(self.api_auth(email))
+        kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(email)
         return self.client_get(*args, **kwargs)
 
     def api_post(self, identifier: Text, *args: Any, **kwargs: Any) -> HttpResponse:
-        kwargs.update(self.api_auth(identifier, kwargs.get('realm', 'zulip')))
+        kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(identifier, kwargs.get('realm', 'zulip'))
         return self.client_post(*args, **kwargs)
 
     def api_patch(self, email: Text, *args: Any, **kwargs: Any) -> HttpResponse:
-        kwargs.update(self.api_auth(email))
+        kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(email)
         return self.client_patch(*args, **kwargs)
 
     def api_put(self, email: Text, *args: Any, **kwargs: Any) -> HttpResponse:
-        kwargs.update(self.api_auth(email))
+        kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(email)
         return self.client_put(*args, **kwargs)
 
     def api_delete(self, email: Text, *args: Any, **kwargs: Any) -> HttpResponse:
-        kwargs.update(self.api_auth(email))
+        kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(email)
         return self.client_delete(*args, **kwargs)
 
     def get_streams(self, email: Text, realm: Realm) -> List[Text]:
@@ -622,7 +620,7 @@ class WebhookTestCase(ZulipTestCase):
         self.url = self.build_webhook_url()
 
     def api_stream_message(self, email: Text, *args: Any, **kwargs: Any) -> HttpResponse:
-        kwargs.update(self.api_auth(email))
+        kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(email)
         return self.send_and_test_stream_message(*args, **kwargs)
 
     def send_and_test_stream_message(self, fixture_name: Text, expected_subject: Optional[Text]=None,

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -1118,10 +1118,10 @@ class BugdownTest(ZulipTestCase):
 class BugdownApiTests(ZulipTestCase):
     def test_render_message_api(self) -> None:
         content = 'That is a **bold** statement'
-        result = self.client_post(
+        result = self.api_post(
+            self.example_email("othello"),
             '/api/v1/messages/render',
-            dict(content=content),
-            **self.api_auth(self.example_email("othello"))
+            dict(content=content)
         )
         self.assert_json_success(result)
         self.assertEqual(result.json()['rendered'],
@@ -1130,10 +1130,10 @@ class BugdownApiTests(ZulipTestCase):
     def test_render_mention_stream_api(self) -> None:
         """Determines whether we're correctly passing the realm context"""
         content = 'This mentions #**Denmark** and @**King Hamlet**.'
-        result = self.client_post(
+        result = self.api_post(
+            self.example_email("othello"),
             '/api/v1/messages/render',
-            dict(content=content),
-            **self.api_auth(self.example_email("othello"))
+            dict(content=content)
         )
         self.assert_json_success(result)
         user_id = self.example_user('hamlet').id

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -614,11 +614,11 @@ class DeactivatedRealmTest(ZulipTestCase):
                                                      "to": self.example_email("othello")})
         self.assert_json_error_contains(result, "has been deactivated", status_code=400)
 
-        result = self.client_post("/api/v1/messages", {"type": "private",
-                                                       "content": "Test message",
-                                                       "client": "test suite",
-                                                       "to": self.example_email("othello")},
-                                  **self.api_auth(self.example_email("hamlet")))
+        result = self.api_post(self.example_email("hamlet"),
+                               "/api/v1/messages", {"type": "private",
+                                                    "content": "Test message",
+                                                    "client": "test suite",
+                                                    "to": self.example_email("othello")})
         self.assert_json_error_contains(result, "has been deactivated", status_code=401)
 
     def test_fetch_api_key_deactivated_realm(self) -> None:
@@ -731,11 +731,11 @@ class InactiveUserTest(ZulipTestCase):
                                                      "to": self.example_email("othello")})
         self.assert_json_error_contains(result, "Account not active", status_code=400)
 
-        result = self.client_post("/api/v1/messages", {"type": "private",
-                                                       "content": "Test message",
-                                                       "client": "test suite",
-                                                       "to": self.example_email("othello")},
-                                  **self.api_auth(self.example_email("hamlet")))
+        result = self.api_post(self.example_email("hamlet"),
+                               "/api/v1/messages", {"type": "private",
+                                                    "content": "Test message",
+                                                    "client": "test suite",
+                                                    "to": self.example_email("othello")})
         self.assert_json_error_contains(result, "Account not active", status_code=401)
 
     def test_fetch_api_key_deactivated_user(self) -> None:
@@ -832,16 +832,14 @@ class TestIncomingWebhookBot(ZulipTestCase):
         self.webhook_bot = get_user('webhook-bot@zulip.com', zulip_realm)
 
     def test_webhook_bot_permissions(self) -> None:
-        result = self.client_post("/api/v1/messages", {
-            "type": "private",
-            "content": "Test message",
-            "client": "test suite",
-            "to": self.example_email("othello")
-        }, **self.api_auth("webhook-bot@zulip.com"))
+        result = self.api_post("webhook-bot@zulip.com",
+                               "/api/v1/messages", {"type": "private",
+                                                    "content": "Test message",
+                                                    "client": "test suite",
+                                                    "to": self.example_email("othello")})
         self.assert_json_success(result)
         post_params = {"anchor": 1, "num_before": 1, "num_after": 1}
-        result = self.client_get("/api/v1/messages", dict(post_params),
-                                 **self.api_auth("webhook-bot@zulip.com"))
+        result = self.api_get("webhook-bot@zulip.com", "/api/v1/messages", dict(post_params))
         self.assert_json_error(result, 'This API is not available to incoming webhook bots.',
                                status_code=401)
 
@@ -985,7 +983,7 @@ class TestHumanUsersOnlyDecorator(ZulipTestCase):
             "/api/v1/report/unnarrow_times",
         ]
         for endpoint in post_endpoints:
-            result = self.client_post(endpoint, **self.api_auth('default-bot@zulip.com'))
+            result = self.api_post('default-bot@zulip.com', endpoint)
             self.assert_json_error(result, "This endpoint does not accept bot requests.")
 
         patch_endpoints = [
@@ -996,7 +994,7 @@ class TestHumanUsersOnlyDecorator(ZulipTestCase):
             "/api/v1/users/me/profile_data"
         ]
         for endpoint in patch_endpoints:
-            result = self.client_patch(endpoint, **self.api_auth('default-bot@zulip.com'))
+            result = self.api_patch('default-bot@zulip.com', endpoint)
             self.assert_json_error(result, "This endpoint does not accept bot requests.")
 
         delete_endpoints = [
@@ -1004,7 +1002,7 @@ class TestHumanUsersOnlyDecorator(ZulipTestCase):
             "/api/v1/users/me/android_gcm_reg_id",
         ]
         for endpoint in delete_endpoints:
-            result = self.client_delete(endpoint, **self.api_auth('default-bot@zulip.com'))
+            result = self.api_delete('default-bot@zulip.com', endpoint)
             self.assert_json_error(result, "This endpoint does not accept bot requests.")
 
 class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -58,12 +58,11 @@ class RateLimitTests(ZulipTestCase):
         remove_ratelimit_rule(1, 5)
 
     def send_api_message(self, email: Text, content: Text) -> HttpResponse:
-        return self.client_post("/api/v1/messages", {"type": "stream",
-                                                     "to": "Verona",
-                                                     "client": "test suite",
-                                                     "content": content,
-                                                     "subject": "Test subject"},
-                                **self.api_auth(email))
+        return self.api_post(email, "/api/v1/messages", {"type": "stream",
+                                                         "to": "Verona",
+                                                         "client": "test suite",
+                                                         "content": content,
+                                                         "subject": "Test subject"})
 
     def test_headers(self) -> None:
         user = self.example_user('hamlet')

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -666,24 +666,22 @@ class StreamMessagesTest(ZulipTestCase):
         email = user_profile.email
 
         do_change_is_admin(user_profile, True, 'api_super_user')
-        result = self.client_post("/api/v1/messages", {"type": "stream",
-                                                       "to": "Verona",
-                                                       "sender": self.example_email("cordelia"),
-                                                       "client": "test suite",
-                                                       "subject": "announcement",
-                                                       "content": "Everyone knows Iago rules",
-                                                       "forged": "true"},
-                                  **self.api_auth(email))
+        result = self.api_post(email, "/api/v1/messages", {"type": "stream",
+                                                           "to": "Verona",
+                                                           "sender": self.example_email("cordelia"),
+                                                           "client": "test suite",
+                                                           "subject": "announcement",
+                                                           "content": "Everyone knows Iago rules",
+                                                           "forged": "true"})
         self.assert_json_success(result)
         do_change_is_admin(user_profile, False, 'api_super_user')
-        result = self.client_post("/api/v1/messages", {"type": "stream",
-                                                       "to": "Verona",
-                                                       "sender": self.example_email("cordelia"),
-                                                       "client": "test suite",
-                                                       "subject": "announcement",
-                                                       "content": "Everyone knows Iago rules",
-                                                       "forged": "true"},
-                                  **self.api_auth(email))
+        result = self.api_post(email, "/api/v1/messages", {"type": "stream",
+                                                           "to": "Verona",
+                                                           "sender": self.example_email("cordelia"),
+                                                           "client": "test suite",
+                                                           "subject": "announcement",
+                                                           "content": "Everyone knows Iago rules",
+                                                           "forged": "true"})
         self.assert_json_error(result, "User not authorized for this query")
 
     def test_message_to_stream(self) -> None:
@@ -914,12 +912,11 @@ class MessagePOSTTest(ZulipTestCase):
         Same as above, but for the API view
         """
         email = self.example_email("hamlet")
-        result = self.client_post("/api/v1/messages", {"type": "stream",
-                                                       "to": "Verona",
-                                                       "client": "test suite",
-                                                       "content": "Test message",
-                                                       "subject": "Test subject"},
-                                  **self.api_auth(email))
+        result = self.api_post(email, "/api/v1/messages", {"type": "stream",
+                                                           "to": "Verona",
+                                                           "client": "test suite",
+                                                           "content": "Test message",
+                                                           "subject": "Test subject"})
         self.assert_json_success(result)
 
     def test_api_message_with_default_to(self) -> None:
@@ -931,11 +928,10 @@ class MessagePOSTTest(ZulipTestCase):
         email = user_profile.email
         user_profile.default_sending_stream_id = get_stream('Verona', user_profile.realm).id
         user_profile.save()
-        result = self.client_post("/api/v1/messages", {"type": "stream",
-                                                       "client": "test suite",
-                                                       "content": "Test message no to",
-                                                       "subject": "Test subject"},
-                                  **self.api_auth(email))
+        result = self.api_post(email, "/api/v1/messages", {"type": "stream",
+                                                           "client": "test suite",
+                                                           "content": "Test message no to",
+                                                           "subject": "Test subject"})
         self.assert_json_success(result)
 
         sent_message = self.get_last_message()
@@ -1267,15 +1263,13 @@ class MessagePOSTTest(ZulipTestCase):
         user.save()
         user = get_user(email, get_realm('zulip'))
         self.subscribe(user, "IRCland")
-        result = self.client_post("/api/v1/messages",
-                                  {"type": "stream",
-                                   "forged": "true",
-                                   "sender": "irc-user@irc.zulip.com",
-                                   "content": "Test message",
-                                   "client": "irc_mirror",
-                                   "subject": "from irc",
-                                   "to": "IRCLand"},
-                                  **self.api_auth(email))
+        result = self.api_post(email, "/api/v1/messages", {"type": "stream",
+                                                           "forged": "true",
+                                                           "sender": "irc-user@irc.zulip.com",
+                                                           "content": "Test message",
+                                                           "client": "irc_mirror",
+                                                           "subject": "from irc",
+                                                           "to": "IRCLand"})
         self.assert_json_success(result)
 
 class EditMessageTest(ZulipTestCase):

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -62,7 +62,7 @@ class MutedTopicsTests(ZulipTestCase):
 
         url = '/api/v1/users/me/subscriptions/muted_topics'
         data = {'stream': 'Verona', 'topic': 'Verona3', 'op': 'add'}
-        result = self.client_patch(url, data, **self.api_auth(email))
+        result = self.api_patch(email, url, data)
         self.assert_json_success(result)
 
         user = self.example_user('hamlet')
@@ -89,7 +89,7 @@ class MutedTopicsTests(ZulipTestCase):
 
         url = '/api/v1/users/me/subscriptions/muted_topics'
         data = {'stream': 'Verona', 'topic': 'vERONA3', 'op': 'remove'}
-        result = self.client_patch(url, data, **self.api_auth(email))
+        result = self.api_patch(email, url, data)
 
         self.assert_json_success(result)
         user = self.example_user('hamlet')
@@ -112,7 +112,7 @@ class MutedTopicsTests(ZulipTestCase):
 
         url = '/api/v1/users/me/subscriptions/muted_topics'
         data = {'stream': 'Verona', 'topic': 'Verona3', 'op': 'add'}
-        result = self.client_patch(url, data, **self.api_auth(email))
+        result = self.api_patch(email, url, data)
         self.assert_json_error(result, "Topic already muted")
 
     def test_muted_topic_remove_invalid(self) -> None:
@@ -122,9 +122,9 @@ class MutedTopicsTests(ZulipTestCase):
 
         url = '/api/v1/users/me/subscriptions/muted_topics'
         data = {'stream': 'BOGUS', 'topic': 'Verona3', 'op': 'remove'}
-        result = self.client_patch(url, data, **self.api_auth(email))
+        result = self.api_patch(email, url, data)
         self.assert_json_error(result, "Topic is not there in the muted_topics list")
 
         data = {'stream': 'Verona', 'topic': 'BOGUS', 'op': 'remove'}
-        result = self.client_patch(url, data, **self.api_auth(email))
+        result = self.api_patch(email, url, data)
         self.assert_json_error(result, "Topic is not there in the muted_topics list")

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -236,9 +236,8 @@ class SingleUserPresenceTests(ZulipTestCase):
         result = self.client_post("/json/users/me/presence", {'status': 'active'})
         result = self.client_post("/json/users/me/presence", {'status': 'active'},
                                   HTTP_USER_AGENT="ZulipDesktop/1.0")
-        result = self.client_post("/api/v1/users/me/presence", {'status': 'idle'},
-                                  HTTP_USER_AGENT="ZulipAndroid/1.0",
-                                  **self.api_auth(email))
+        result = self.api_post(email, "/api/v1/users/me/presence", {'status': 'idle'},
+                               HTTP_USER_AGENT="ZulipAndroid/1.0")
         self.assert_json_success(result)
 
         # Check some error conditions
@@ -287,13 +286,11 @@ class UserPresenceAggregationTests(ZulipTestCase):
         with mock.patch(timezone_util, return_value=validate_time - datetime.timedelta(seconds=5)):
             self.client_post("/json/users/me/presence", {'status': status})
         with mock.patch(timezone_util, return_value=validate_time - datetime.timedelta(seconds=2)):
-            self.client_post("/api/v1/users/me/presence", {'status': status},
-                             HTTP_USER_AGENT="ZulipAndroid/1.0",
-                             **self.api_auth(email))
+            self.api_post(email, "/api/v1/users/me/presence", {'status': status},
+                          HTTP_USER_AGENT="ZulipAndroid/1.0")
         with mock.patch(timezone_util, return_value=validate_time - datetime.timedelta(seconds=7)):
-            latest_result = self.client_post("/api/v1/users/me/presence", {'status': status},
-                                             HTTP_USER_AGENT="ZulipIOS/1.0",
-                                             **self.api_auth(email))
+            latest_result = self.api_post(email, "/api/v1/users/me/presence", {'status': status},
+                                          HTTP_USER_AGENT="ZulipIOS/1.0")
         latest_result_dict = latest_result.json()
         self.assertDictEqual(
             latest_result_dict['presences'][email]['aggregated'],
@@ -312,9 +309,8 @@ class UserPresenceAggregationTests(ZulipTestCase):
         self._send_presence_for_aggregated_tests(str(self.example_email("othello")), 'active', validate_time)
         with mock.patch('zerver.views.presence.timezone_now',
                         return_value=validate_time - datetime.timedelta(seconds=1)):
-            result = self.client_post("/api/v1/users/me/presence", {'status': 'active'},
-                                      HTTP_USER_AGENT="ZulipTestDev/1.0",
-                                      **self.api_auth(email))
+            result = self.api_post(email, "/api/v1/users/me/presence", {'status': 'active'},
+                                   HTTP_USER_AGENT="ZulipTestDev/1.0")
         result_dict = result.json()
         self.assertDictEqual(
             result_dict['presences'][email]['aggregated'],
@@ -355,9 +351,8 @@ class UserPresenceAggregationTests(ZulipTestCase):
         validate_time = timezone_now()
         with mock.patch('zerver.views.presence.timezone_now',
                         return_value=validate_time - datetime.timedelta(seconds=3)):
-            self.client_post("/api/v1/users/me/presence", {'status': 'active'},
-                             HTTP_USER_AGENT="ZulipTestDev/1.0",
-                             **self.api_auth(email))
+            self.api_post(email, "/api/v1/users/me/presence", {'status': 'active'},
+                          HTTP_USER_AGENT="ZulipTestDev/1.0")
         result_dict = self._send_presence_for_aggregated_tests(str(email), 'idle', validate_time)
         self.assertDictEqual(
             result_dict['presence']['aggregated'],

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -106,8 +106,9 @@ class PushBouncerNotificationTest(BouncerTestCase):
         realm.string_id = ""
         realm.save()
 
-        result = self.client_post(endpoint, {'token': token, 'token_kind': token_kind},
-                                  **self.api_auth(self.example_email("hamlet"), realm=""))
+        result = self.api_post(self.example_email("hamlet"), endpoint, {'token': token,
+                                                                        'token_kind': token_kind},
+                               realm="")
         self.assert_json_error(result, "Must validate with valid Zulip server API key")
 
     def test_register_remote_push_user_paramas(self) -> None:
@@ -131,9 +132,9 @@ class PushBouncerNotificationTest(BouncerTestCase):
                                   **self.get_auth())
         self.assert_json_error(result, "Invalid token type")
 
-        result = self.client_post(endpoint, {'user_id': user_id, 'token_kind': token_kind,
-                                             'token': token},
-                                  **self.api_auth(self.example_email("hamlet")))
+        result = self.api_post(self.example_email("hamlet"), endpoint, {'user_id': user_id,
+                                                                        'token_kind': token_kind,
+                                                                        'token': token})
         self.assert_json_error(result, "Account is not associated with this subdomain",
                                status_code=401)
 
@@ -143,9 +144,9 @@ class PushBouncerNotificationTest(BouncerTestCase):
         realm.string_id = ""
         realm.save()
 
-        result = self.client_post(endpoint, {'user_id': user_id, 'token_kind': token_kind,
-                                             'token': token},
-                                  **self.api_auth(self.example_email("hamlet")))
+        result = self.api_post(self.example_email("hamlet"), endpoint, {'user_id': user_id,
+                                                                        'token_kind': token_kind,
+                                                                        'token': token})
         self.assert_json_error(result, "Must validate with valid Zulip server API key")
 
     def test_remote_push_user_endpoints(self) -> None:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1037,13 +1037,10 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         sub = old_subs[0]
         stream_id = sub['stream_id']
         new_color = "#ffffff"  # TODO: ensure that this is different from old_color
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": "color",
-                                                "stream_id": stream_id,
-                                                "value": "#ffffff"}])},
-            **self.api_auth(test_email))
-
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": "color",
+                                                                   "stream_id": stream_id,
+                                                                   "value": "#ffffff"}])})
         self.assert_json_success(result)
 
         new_subs = gather_subscriptions(get_user(test_email, test_realm))[0]
@@ -1071,12 +1068,9 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         test_user = self.example_user('hamlet')
         test_email = test_user.email
         self.login(test_email)
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": "color",
-                                                "value": "#ffffff"}])},
-            **self.api_auth(test_email))
-
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": "color",
+                                                                   "value": "#ffffff"}])})
         self.assert_json_error(
             result, "stream_id key is missing from subscription_data[0]")
 
@@ -1091,12 +1085,10 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         subscribed, unsubscribed, never_subscribed = gather_subscriptions_helper(
             get_user(test_email, test_realm))
         not_subbed = unsubscribed + never_subscribed
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": "color",
-                                                "stream_id": not_subbed[0]["stream_id"],
-                                                "value": "#ffffff"}])},
-            **self.api_auth(test_email))
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": "color",
+                                                                   "stream_id": not_subbed[0]["stream_id"],
+                                                                   "value": "#ffffff"}])})
         self.assert_json_error(
             result, "Not subscribed to stream id %d" % (not_subbed[0]["stream_id"],))
 
@@ -1108,12 +1100,9 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         test_email = test_user.email
         self.login(test_email)
         subs = gather_subscriptions(test_user)[0]
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": "color",
-                                                "stream_id": subs[0]["stream_id"]}])},
-            **self.api_auth(test_email))
-
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": "color",
+                                                                   "stream_id": subs[0]["stream_id"]}])})
         self.assert_json_error(
             result, "value key is missing from subscription_data[0]")
 
@@ -1130,13 +1119,10 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         sub = old_subs[0]
         stream_id = sub['stream_id']
         new_pin_to_top = not sub['pin_to_top']
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": "pin_to_top",
-                                                "stream_id": stream_id,
-                                                "value": new_pin_to_top}])},
-            **self.api_auth(test_email))
-
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": "pin_to_top",
+                                                                   "stream_id": stream_id,
+                                                                   "value": new_pin_to_top}])})
         self.assert_json_success(result)
 
         updated_sub = get_subscription(sub['name'], user_profile)
@@ -1154,57 +1140,42 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         subs = gather_subscriptions(test_user)[0]
 
         property_name = "in_home_view"
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": property_name,
-                                                "value": "bad",
-                                                "stream_id": subs[0]["stream_id"]}])},
-            **self.api_auth(test_email))
-
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": property_name,
+                                                                   "value": "bad",
+                                                                   "stream_id": subs[0]["stream_id"]}])})
         self.assert_json_error(result,
                                '%s is not a boolean' % (property_name,))
 
         property_name = "desktop_notifications"
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": property_name,
-                                                "value": "bad",
-                                                "stream_id": subs[0]["stream_id"]}])},
-            **self.api_auth(test_email))
-
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": property_name,
+                                                                   "value": "bad",
+                                                                   "stream_id": subs[0]["stream_id"]}])})
         self.assert_json_error(result,
                                '%s is not a boolean' % (property_name,))
 
         property_name = "audible_notifications"
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": property_name,
-                                                "value": "bad",
-                                                "stream_id": subs[0]["stream_id"]}])},
-            **self.api_auth(test_email))
-
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": property_name,
+                                                                   "value": "bad",
+                                                                   "stream_id": subs[0]["stream_id"]}])})
         self.assert_json_error(result,
                                '%s is not a boolean' % (property_name,))
 
         property_name = "push_notifications"
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": property_name,
-                                                "value": "bad",
-                                                "stream_id": subs[0]["stream_id"]}])},
-            **self.api_auth(test_email))
-
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": property_name,
+                                                                   "value": "bad",
+                                                                   "stream_id": subs[0]["stream_id"]}])})
         self.assert_json_error(result,
                                '%s is not a boolean' % (property_name,))
 
         property_name = "color"
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": property_name,
-                                                "value": False,
-                                                "stream_id": subs[0]["stream_id"]}])},
-            **self.api_auth(test_email))
-
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": property_name,
+                                                                   "value": False,
+                                                                   "stream_id": subs[0]["stream_id"]}])})
         self.assert_json_error(result,
                                '%s is not a string' % (property_name,))
 
@@ -1213,12 +1184,10 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         self.login(test_email)
 
         stream_id = 1000
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": "in_home_view",
-                                                "stream_id": stream_id,
-                                                "value": False}])},
-            **self.api_auth(test_email))
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": "in_home_view",
+                                                                   "stream_id": stream_id,
+                                                                   "value": False}])})
         self.assert_json_error(result, "Invalid stream id")
 
     def test_set_invalid_property(self) -> None:
@@ -1229,13 +1198,10 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         test_email = test_user.email
         self.login(test_email)
         subs = gather_subscriptions(test_user)[0]
-        result = self.client_post(
-            "/api/v1/users/me/subscriptions/properties",
-            {"subscription_data": ujson.dumps([{"property": "bad",
-                                                "value": "bad",
-                                                "stream_id": subs[0]["stream_id"]}])},
-            **self.api_auth(test_email))
-
+        result = self.api_post(test_email, "/api/v1/users/me/subscriptions/properties",
+                               {"subscription_data": ujson.dumps([{"property": "bad",
+                                                                   "value": "bad",
+                                                                   "stream_id": subs[0]["stream_id"]}])})
         self.assert_json_error(result,
                                "Unknown subscription property: bad")
 
@@ -1249,11 +1215,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         request = {
             'add': ujson.dumps([{'name': 'my_test_stream_1'}])
         }
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions",
-            request,
-            **self.api_auth(email)
-        )
+        result = self.api_patch(email, "/api/v1/users/me/subscriptions", request)
         self.assert_json_success(result)
         streams = self.get_streams(email, realm)
         self.assertTrue('my_test_stream_1' in streams)
@@ -1262,11 +1224,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         request = {
             'delete': ujson.dumps(['my_test_stream_1'])
         }
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions",
-            request,
-            **self.api_auth(email)
-        )
+        result = self.api_patch(email, "/api/v1/users/me/subscriptions", request)
         self.assert_json_success(result)
         streams = self.get_streams(email, realm)
         self.assertTrue('my_test_stream_1' not in streams)
@@ -1280,10 +1238,8 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
         self.login(test_email)
         subs = gather_subscriptions(test_user)[0]
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions/%d" % subs[0]["stream_id"],
-            {'property': 'color', 'value': '#c2c2c2'},
-            **self.api_auth(test_email))
+        result = self.api_patch(test_email, "/api/v1/users/me/subscriptions/%d" % subs[0]["stream_id"],
+                                {'property': 'color', 'value': '#c2c2c2'})
         self.assert_json_success(result)
 
     def test_api_invalid_property(self) -> None:
@@ -1297,10 +1253,8 @@ class SubscriptionRestApiTest(ZulipTestCase):
         self.login(test_email)
         subs = gather_subscriptions(test_user)[0]
 
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions/%d" % subs[0]["stream_id"],
-            {'property': 'invalid', 'value': 'somevalue'},
-            **self.api_auth(test_email))
+        result = self.api_patch(test_email, "/api/v1/users/me/subscriptions/%d" % subs[0]["stream_id"],
+                                {'property': 'invalid', 'value': 'somevalue'})
         self.assert_json_error(result,
                                "Unknown subscription property: invalid")
 
@@ -1310,10 +1264,8 @@ class SubscriptionRestApiTest(ZulipTestCase):
         """
         test_email = self.example_email("hamlet")
         self.login(test_email)
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions/121",
-            {'property': 'in_home_view', 'value': 'somevalue'},
-            **self.api_auth(test_email))
+        result = self.api_patch(test_email, "/api/v1/users/me/subscriptions/121",
+                                {'property': 'in_home_view', 'value': 'somevalue'})
         self.assert_json_error(result,
                                "Invalid stream id")
 
@@ -1325,11 +1277,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
             request = {
                 'add': ujson.dumps(val)
             }
-            result = self.client_patch(
-                "/api/v1/users/me/subscriptions",
-                request,
-                **self.api_auth(email)
-            )
+            result = self.api_patch(email, "/api/v1/users/me/subscriptions", request)
             self.assert_json_error(result, expected_message)
 
         check_for_error(['foo'], 'add[0] is not a dict')
@@ -1344,11 +1292,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
             'add': ujson.dumps([{'name': 'my_new_stream'}]),
             'principals': ujson.dumps([{}]),
         }
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions",
-            request,
-            **self.api_auth(email)
-        )
+        result = self.api_patch(email, "/api/v1/users/me/subscriptions", request)
         self.assert_json_error(result, 'principals[0] is not a string')
 
     def test_bad_delete_parameters(self) -> None:
@@ -1358,22 +1302,14 @@ class SubscriptionRestApiTest(ZulipTestCase):
         request = {
             'delete': ujson.dumps([{'name': 'my_test_stream_1'}])
         }
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions",
-            request,
-            **self.api_auth(email)
-        )
+        result = self.api_patch(email, "/api/v1/users/me/subscriptions", request)
         self.assert_json_error(result, "delete[0] is not a string")
 
     def test_add_or_delete_not_specified(self) -> None:
         email = self.example_email('hamlet')
         self.login(email)
 
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions",
-            {},
-            **self.api_auth(email)
-        )
+        result = self.api_patch(email, "/api/v1/users/me/subscriptions", {})
         self.assert_json_error(result,
                                'Nothing to do. Specify at least one of "add" or "delete".')
 
@@ -1388,11 +1324,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         request = {
             'delete': ujson.dumps([invalid_stream_name])
         }
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions",
-            request,
-            **self.api_auth(email)
-        )
+        result = self.api_patch(email, "/api/v1/users/me/subscriptions", request)
         self.assert_json_error(result,
                                "Invalid stream name '%s'" % (invalid_stream_name,))
 
@@ -1404,11 +1336,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         request = {
             'delete': ujson.dumps([long_stream_name])
         }
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions",
-            request,
-            **self.api_auth(email)
-        )
+        result = self.api_patch(email, "/api/v1/users/me/subscriptions", request)
         self.assert_json_error(result,
                                "Stream name too long (limit: 60 characters)")
 
@@ -1420,11 +1348,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         request = {
             'delete': ujson.dumps([stream_name])
         }
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions",
-            request,
-            **self.api_auth(email)
-        )
+        result = self.api_patch(email, "/api/v1/users/me/subscriptions", request)
         self.assert_json_error(result,
                                "Invalid characters in stream name (disallowed characters: *, @, `, #).")
 
@@ -1436,11 +1360,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         request = {
             'delete': ujson.dumps([stream_name])
         }
-        result = self.client_patch(
-            "/api/v1/users/me/subscriptions",
-            request,
-            **self.api_auth(email)
-        )
+        result = self.api_patch(email, "/api/v1/users/me/subscriptions", request)
         self.assert_json_error(result,
                                "Stream name '%s' contains NULL (0x00) characters." % (stream_name))
 
@@ -1504,7 +1424,7 @@ class SubscriptionAPITest(ZulipTestCase):
         Calling /api/v1/users/me/subscriptions should successfully return your subscriptions.
         """
         email = self.test_email
-        result = self.client_get("/api/v1/users/me/subscriptions", **self.api_auth(email))
+        result = self.api_get(email, "/api/v1/users/me/subscriptions")
         self.assert_json_success(result)
         json = result.json()
         self.assertIn("subscriptions", json)
@@ -2385,8 +2305,8 @@ class GetPublicStreamsTest(ZulipTestCase):
         self.login(email)
 
         # Check it correctly lists the user's subs with include_public=false
-        result = self.client_get("/api/v1/streams?include_public=false", **self.api_auth(email))
-        result2 = self.client_get("/api/v1/users/me/subscriptions", **self.api_auth(email))
+        result = self.api_get(email, "/api/v1/streams?include_public=false")
+        result2 = self.api_get(email, "/api/v1/users/me/subscriptions")
 
         self.assert_json_success(result)
         json = result.json()
@@ -2402,8 +2322,7 @@ class GetPublicStreamsTest(ZulipTestCase):
                          sorted([s["name"] for s in json2["subscriptions"]]))
 
         # Check it correctly lists all public streams with include_subscribed=false
-        result = self.client_get("/api/v1/streams?include_public=true&include_subscribed=false",
-                                 **self.api_auth(email))
+        result = self.api_get(email, "/api/v1/streams?include_public=true&include_subscribed=false")
         self.assert_json_success(result)
 
         json = result.json()
@@ -2413,8 +2332,7 @@ class GetPublicStreamsTest(ZulipTestCase):
                          sorted(all_streams))
 
         # Check non-superuser can't use include_all_active
-        result = self.client_get("/api/v1/streams?include_all_active=true",
-                                 **self.api_auth(email))
+        result = self.api_get(email, "/api/v1/streams?include_all_active=true")
         self.assertEqual(result.status_code, 400)
 
 class StreamIdTest(ZulipTestCase):
@@ -2461,7 +2379,7 @@ class InviteOnlyStreamTest(ZulipTestCase):
         self.assert_json_success(result1)
         result2 = self.common_subscribe_to_streams(email, ["Normandy"], invite_only=False)
         self.assert_json_success(result2)
-        result = self.client_get("/api/v1/users/me/subscriptions", **self.api_auth(email))
+        result = self.api_get(email, "/api/v1/users/me/subscriptions")
         self.assert_json_success(result)
         self.assertIn("subscriptions", result.json())
         for sub in result.json()["subscriptions"]:
@@ -2517,8 +2435,7 @@ class InviteOnlyStreamTest(ZulipTestCase):
 
         # Make sure both users are subscribed to this stream
         stream_id = get_stream(stream_name, user_profile.realm).id
-        result = self.client_get("/api/v1/streams/%d/members" % (stream_id,),
-                                 **self.api_auth(email))
+        result = self.api_get(email, "/api/v1/streams/%d/members" % (stream_id,))
         self.assert_json_success(result)
         json = result.json()
 
@@ -2561,8 +2478,7 @@ class GetSubscribersTest(ZulipTestCase):
     def make_subscriber_request(self, stream_id: int, email: Optional[Text]=None) -> HttpResponse:
         if email is None:
             email = self.email
-        return self.client_get("/api/v1/streams/%d/members" % (stream_id,),
-                               **self.api_auth(email))
+        return self.api_get(email, "/api/v1/streams/%d/members" % (stream_id,))
 
     def make_successful_subscriber_request(self, stream_name: Text) -> None:
         stream_id = get_stream(stream_name, self.user_profile.realm).id

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -16,8 +16,7 @@ class TypingNotificationOperatorTest(ZulipTestCase):
         """
         sender = self.example_email("hamlet")
         recipient = self.example_email("othello")
-        result = self.client_post('/api/v1/typing', {'to': recipient},
-                                  **self.api_auth(sender))
+        result = self.api_post(sender, '/api/v1/typing', {'to': recipient})
         self.assert_json_error(result, 'Missing \'op\' argument')
 
     def test_invalid_parameter(self) -> None:
@@ -26,8 +25,7 @@ class TypingNotificationOperatorTest(ZulipTestCase):
         """
         sender = self.example_email("hamlet")
         recipient = self.example_email("othello")
-        result = self.client_post('/api/v1/typing', {'to': recipient, 'op': 'foo'},
-                                  **self.api_auth(sender))
+        result = self.api_post(sender, '/api/v1/typing', {'to': recipient, 'op': 'foo'})
         self.assert_json_error(result, 'Invalid \'op\' value (should be start or stop)')
 
 class TypingNotificationRecipientsTest(ZulipTestCase):
@@ -36,8 +34,7 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
         Sending typing notification without recipient fails
         """
         sender = self.example_email("hamlet")
-        result = self.client_post('/api/v1/typing', {'op': 'start'},
-                                  **self.api_auth(sender))
+        result = self.api_post(sender, '/api/v1/typing', {'op': 'start'})
         self.assert_json_error(result, 'Missing parameter: \'to\' (recipient)')
 
     def test_invalid_recipient(self) -> None:
@@ -46,8 +43,7 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
         """
         sender = self.example_email("hamlet")
         invalid = 'invalid email'
-        result = self.client_post('/api/v1/typing', {'op': 'start', 'to': invalid},
-                                  **self.api_auth(sender))
+        result = self.api_post(sender, '/api/v1/typing', {'op': 'start', 'to': invalid})
         self.assert_json_error(result, 'Invalid email \'' + invalid + '\'')
 
     def test_single_recipient(self) -> None:
@@ -62,9 +58,8 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
 
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_post('/api/v1/typing', {'to': recipient.email,
-                                                         'op': 'start'},
-                                      **self.api_auth(sender.email))
+            result = self.api_post(sender.email, '/api/v1/typing', {'to': recipient.email,
+                                                                    'op': 'start'})
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -91,9 +86,9 @@ class TypingNotificationRecipientsTest(ZulipTestCase):
         expected_recipient_ids = set([user.id for user in expected_recipients])
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_post('/api/v1/typing', {'to': ujson.dumps([user.email for user in recipient]),
-                                                         'op': 'start'},
-                                      **self.api_auth(sender.email))
+            result = self.api_post(sender.email, '/api/v1/typing',
+                                   {'to': ujson.dumps([user.email for user in recipient]),
+                                    'op': 'start'})
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -121,9 +116,8 @@ class TypingStartedNotificationTest(ZulipTestCase):
         expected_recipient_ids = set([user.id])
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_post('/api/v1/typing', {'to': email,
-                                                         'op': 'start'},
-                                      **self.api_auth(email))
+            result = self.api_post(email, '/api/v1/typing', {'to': email,
+                                                             'op': 'start'})
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -152,9 +146,8 @@ class TypingStartedNotificationTest(ZulipTestCase):
 
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_post('/api/v1/typing', {'to': recipient.email,
-                                                         'op': 'start'},
-                                      **self.api_auth(sender.email))
+            result = self.api_post(sender.email, '/api/v1/typing', {'to': recipient.email,
+                                                                    'op': 'start'})
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -183,9 +176,8 @@ class StoppedTypingNotificationTest(ZulipTestCase):
 
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_post('/api/v1/typing', {'to': email,
-                                                         'op': 'stop'},
-                                      **self.api_auth(email))
+            result = self.api_post(email, '/api/v1/typing', {'to': email,
+                                                             'op': 'stop'})
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 
@@ -214,9 +206,8 @@ class StoppedTypingNotificationTest(ZulipTestCase):
 
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_post('/api/v1/typing', {'to': recipient.email,
-                                                         'op': 'stop'},
-                                      **self.api_auth(sender.email))
+            result = self.api_post(sender.email, '/api/v1/typing', {'to': recipient.email,
+                                                                    'op': 'stop'})
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
 

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -54,8 +54,7 @@ class PointerTest(ZulipTestCase):
         email = user.email
         self.assertEqual(user.pointer, -1)
         msg_id = self.send_stream_message(self.example_email("othello"), "Verona")
-        result = self.client_post("/api/v1/users/me/pointer", {"pointer": msg_id},
-                                  **self.api_auth(email))
+        result = self.api_post(email, "/api/v1/users/me/pointer", {"pointer": msg_id})
         self.assert_json_success(result)
         self.assertEqual(get_user(email, user.realm).pointer, msg_id)
 

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -65,8 +65,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp.name = "zulip.txt"
 
         # Upload file via API
-        auth_headers = self.api_auth(self.example_email("hamlet"))
-        result = self.client_post('/api/v1/user_uploads', {'file': fp}, **auth_headers)
+        result = self.api_post(self.example_email("hamlet"), '/api/v1/user_uploads', {'file': fp})
         self.assertIn("uri", result.json())
         uri = result.json()['uri']
         base = '/user_uploads/'
@@ -74,7 +73,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         # Download file via API
         self.logout()
-        response = self.client_get(uri, **auth_headers)
+        response = self.api_get(self.example_email("hamlet"), uri)
         data = b"".join(response.streaming_content)
         self.assertEqual(b"zulip!", data)
 

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -525,7 +525,7 @@ class GetProfileTest(ZulipTestCase):
         user_profile = self.example_user(user_id)
         self.send_stream_message(user_profile.email, "Verona", "hello")
 
-        result = self.client_get("/api/v1/users/me", **self.api_auth(user_profile.email))
+        result = self.api_get(user_profile.email, "/api/v1/users/me")
 
         max_id = most_recent_message(user_profile).id
 
@@ -607,7 +607,7 @@ class GetProfileTest(ZulipTestCase):
 
     def test_get_all_profiles_avatar_urls(self) -> None:
         user_profile = self.example_user('hamlet')
-        result = self.client_get("/api/v1/users", **self.api_auth(self.example_email("hamlet")))
+        result = self.api_get(self.example_email("hamlet"), "/api/v1/users")
         self.assert_json_success(result)
 
         for user in result.json()['members']:

--- a/zerver/webhooks/beanstalk/tests.py
+++ b/zerver/webhooks/beanstalk/tests.py
@@ -15,9 +15,8 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master.
 
 * add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
-        self.send_and_test_stream_message('git_singlecommit', expected_subject, expected_message,
-                                          content_type=None,
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'git_singlecommit', expected_subject, expected_message,
+                                content_type=None)
 
     def test_git_single_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches='master,development')
@@ -25,9 +24,8 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master.
 
 * add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
-        self.send_and_test_stream_message('git_singlecommit', expected_subject, expected_message,
-                                          content_type=None,
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'git_singlecommit', expected_subject, expected_message,
+                                content_type=None)
 
     def test_git_multiple_committers(self) -> None:
         expected_subject = "work-test / master"
@@ -36,9 +34,8 @@ class BeanstalkHookTests(WebhookTestCase):
 * Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
 * More work to fix some bugs ([2009815](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
-        self.send_and_test_stream_message('git_multiple_committers', expected_subject, expected_message,
-                                          content_type=None,
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'git_multiple_committers', expected_subject, expected_message,
+                                content_type=None)
 
     def test_git_multiple_committers_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches='master,development')
@@ -48,9 +45,8 @@ class BeanstalkHookTests(WebhookTestCase):
 * Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
 * More work to fix some bugs ([2009815](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
-        self.send_and_test_stream_message('git_multiple_committers', expected_subject, expected_message,
-                                          content_type=None,
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'git_multiple_committers', expected_subject, expected_message,
+                                content_type=None)
 
     def test_git_multiple(self) -> None:
         expected_subject = "work-test / master"
@@ -59,9 +55,8 @@ class BeanstalkHookTests(WebhookTestCase):
 * Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
 * More work to fix some bugs ([2009815](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
-        self.send_and_test_stream_message('git_multiple', expected_subject, expected_message,
-                                          content_type=None,
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'git_multiple', expected_subject, expected_message,
+                                content_type=None)
 
     def test_git_multiple_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches='master,development')
@@ -71,9 +66,8 @@ class BeanstalkHookTests(WebhookTestCase):
 * Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
 * More work to fix some bugs ([2009815](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
-        self.send_and_test_stream_message('git_multiple', expected_subject, expected_message,
-                                          content_type=None,
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'git_multiple', expected_subject, expected_message,
+                                content_type=None)
 
     def test_git_more_than_limit(self) -> None:
         commits_info = "* add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))\n"
@@ -81,9 +75,8 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master.
 
 {}[and {} more commit(s)]""".format((commits_info * COMMITS_LIMIT), 50 - COMMITS_LIMIT)
-        self.send_and_test_stream_message('git_morethanlimitcommits', expected_subject, expected_message,
-                                          content_type=None,
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'git_morethanlimitcommits', expected_subject, expected_message,
+                                content_type=None)
 
     def test_git_more_than_limit_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches='master,development')
@@ -92,16 +85,14 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master.
 
 {}[and {} more commit(s)]""".format((commits_info * COMMITS_LIMIT), 50 - COMMITS_LIMIT)
-        self.send_and_test_stream_message('git_morethanlimitcommits', expected_subject, expected_message,
-                                          content_type=None,
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'git_morethanlimitcommits', expected_subject, expected_message,
+                                content_type=None)
 
     @patch('zerver.webhooks.beanstalk.view.check_send_stream_message')
     def test_git_single_filtered_by_branches_ignore(self, check_send_stream_message_mock: MagicMock) -> None:
         self.url = self.build_webhook_url(branches='changes,development')
         payload = self.get_body('git_singlecommit')
-        result = self.client_post(self.url, payload,
-                                  **self.api_auth(self.TEST_USER_EMAIL))
+        result = self.api_post(self.TEST_USER_EMAIL, self.url, payload)
         self.assertFalse(check_send_stream_message_mock.called)
         self.assert_json_success(result)
 
@@ -111,8 +102,7 @@ class BeanstalkHookTests(WebhookTestCase):
         # type: (MagicMock) -> None
         self.url = self.build_webhook_url(branches='changes,development')
         payload = self.get_body('git_multiple_committers')
-        result = self.client_post(self.url, payload,
-                                  **self.api_auth(self.TEST_USER_EMAIL))
+        result = self.api_post(self.TEST_USER_EMAIL, self.url, payload)
         self.assertFalse(check_send_stream_message_mock.called)
         self.assert_json_success(result)
 
@@ -122,8 +112,7 @@ class BeanstalkHookTests(WebhookTestCase):
         # type: (MagicMock) -> None
         self.url = self.build_webhook_url(branches='changes,development')
         payload = self.get_body('git_multiple')
-        result = self.client_post(self.url, payload,
-                                  **self.api_auth(self.TEST_USER_EMAIL))
+        result = self.api_post(self.TEST_USER_EMAIL, self.url, payload)
         self.assertFalse(check_send_stream_message_mock.called)
         self.assert_json_success(result)
 
@@ -133,8 +122,7 @@ class BeanstalkHookTests(WebhookTestCase):
         # type: (MagicMock) -> None
         self.url = self.build_webhook_url(branches='changes,development')
         payload = self.get_body('git_morethanlimitcommits')
-        result = self.client_post(self.url, payload,
-                                  **self.api_auth(self.TEST_USER_EMAIL))
+        result = self.api_post(self.TEST_USER_EMAIL, self.url, payload)
         self.assertFalse(check_send_stream_message_mock.called)
         self.assert_json_success(result)
 
@@ -143,18 +131,16 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = """Leo Franchi pushed [revision 3](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/3):
 
 > Removed a file and added another one!"""
-        self.send_and_test_stream_message('svn_addremove', expected_subject, expected_message,
-                                          content_type=None,
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'svn_addremove', expected_subject, expected_message,
+                                content_type=None)
 
     def test_svn_changefile(self) -> None:
         expected_subject = "svn r2"
         expected_message = """Leo Franchi pushed [revision 2](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/2):
 
 > Added some code"""
-        self.send_and_test_stream_message('svn_changefile', expected_subject, expected_message,
-                                          content_type=None,
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'svn_changefile', expected_subject, expected_message,
+                                content_type=None)
 
     def get_body(self, fixture_name: Text) -> Dict[str, Text]:
         return {'payload': self.fixture_data('beanstalk', fixture_name)}

--- a/zerver/webhooks/bitbucket/tests.py
+++ b/zerver/webhooks/bitbucket/tests.py
@@ -17,7 +17,8 @@ class BitbucketHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))'
         expected_message = u"kolaszek pushed 1 commit to branch master.\n\n{}".format(commit_info)
-        self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS,
+                                expected_message)
 
     def test_bitbucket_on_push_event_filtered_by_branches(self) -> None:
         fixture_name = 'push'
@@ -25,14 +26,16 @@ class BitbucketHookTests(WebhookTestCase):
                                           branches='master,development')
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))'
         expected_message = u"kolaszek pushed 1 commit to branch master.\n\n{}".format(commit_info)
-        self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS,
+                                expected_message)
 
     def test_bitbucket_on_push_commits_above_limit_event(self) -> None:
         fixture_name = 'push_commits_above_limit'
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n'
         expected_message = u"kolaszek pushed 50 commits to branch master.\n\n{}[and 30 more commit(s)]".format(commit_info * 20)
-        self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS,
+                                expected_message)
 
     def test_bitbucket_on_push_commits_above_limit_event_filtered_by_branches(self) -> None:
         fixture_name = 'push_commits_above_limit'
@@ -40,13 +43,15 @@ class BitbucketHookTests(WebhookTestCase):
                                           branches='master,development')
         commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n'
         expected_message = u"kolaszek pushed 50 commits to branch master.\n\n{}[and 30 more commit(s)]".format(commit_info * 20)
-        self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, fixture_name, self.EXPECTED_SUBJECT_BRANCH_EVENTS,
+                                expected_message)
 
     def test_bitbucket_on_force_push_event(self) -> None:
         fixture_name = 'force_push'
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         expected_message = u"kolaszek [force pushed](https://bitbucket.org/kolaszek/repository-name)"
-        self.send_and_test_stream_message(fixture_name, self.EXPECTED_SUBJECT, expected_message, **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, fixture_name, self.EXPECTED_SUBJECT,
+                                expected_message)
 
     @patch('zerver.webhooks.bitbucket.view.check_send_stream_message')
     def test_bitbucket_on_push_event_filtered_by_branches_ignore(self, check_send_stream_message_mock: MagicMock) -> None:
@@ -54,9 +59,7 @@ class BitbucketHookTests(WebhookTestCase):
         payload = self.get_body(fixture_name)
         self.url = self.build_webhook_url(payload=payload,
                                           branches='changes,development')
-        result = self.client_post(self.url, payload,
-                                  content_type="application/json,",
-                                  **self.api_auth(self.TEST_USER_EMAIL))
+        result = self.api_post(self.TEST_USER_EMAIL, self.url, payload, content_type="application/json,")
         self.assertFalse(check_send_stream_message_mock.called)
         self.assert_json_success(result)
 
@@ -68,9 +71,7 @@ class BitbucketHookTests(WebhookTestCase):
         payload = self.get_body(fixture_name)
         self.url = self.build_webhook_url(payload=payload,
                                           branches='changes,development')
-        result = self.client_post(self.url, payload,
-                                  content_type="application/json,",
-                                  **self.api_auth(self.TEST_USER_EMAIL))
+        result = self.api_post(self.TEST_USER_EMAIL, self.url, payload, content_type="application/json,")
         self.assertFalse(check_send_stream_message_mock.called)
         self.assert_json_success(result)
 

--- a/zerver/webhooks/deskdotcom/tests.py
+++ b/zerver/webhooks/deskdotcom/tests.py
@@ -23,9 +23,8 @@ class DeskDotComHookTests(WebhookTestCase):
         expected_subject = u"static text notification"
         expected_message = u"This is a custom action."
 
-        self.send_and_test_stream_message('static_text', expected_subject, expected_message,
-                                          content_type="application/x-www-form-urlencoded",
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'static_text', expected_subject, expected_message,
+                                content_type="application/x-www-form-urlencoded")
 
     def test_case_updated_message(self) -> None:
         expected_subject = u"case updated notification"
@@ -33,9 +32,8 @@ class DeskDotComHookTests(WebhookTestCase):
                             u"Link: <a href='https://deskdotcomtest.desk.com/web/agent/case/2'>"
                             u"I have a question</a>")
 
-        self.send_and_test_stream_message('case_updated', expected_subject, expected_message,
-                                          content_type="application/x-www-form-urlencoded",
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'case_updated', expected_subject, expected_message,
+                                content_type="application/x-www-form-urlencoded")
 
     def test_unicode_text_italian(self) -> None:
 
@@ -44,9 +42,8 @@ class DeskDotComHookTests(WebhookTestCase):
                             u"Link: <a href='https://deskdotcomtest.desk.com/web/agent/case/2'>"
                             u"Il mio hovercraft è pieno di anguille.</a>")
 
-        self.send_and_test_stream_message('unicode_text_italian', expected_subject, expected_message,
-                                          content_type="application/x-www-form-urlencoded",
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'unicode_text_italian', expected_subject, expected_message,
+                                content_type="application/x-www-form-urlencoded")
 
     def test_unicode_text_japanese(self) -> None:
 
@@ -55,9 +52,8 @@ class DeskDotComHookTests(WebhookTestCase):
                             u"Link: <a href='https://deskdotcomtest.desk.com/web/agent/case/2'>"
                             u"私のホバークラフトは鰻でいっぱいです</a>")
 
-        self.send_and_test_stream_message('unicode_text_japanese', expected_subject, expected_message,
-                                          content_type="application/x-www-form-urlencoded",
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'unicode_text_japanese', expected_subject, expected_message,
+                                content_type="application/x-www-form-urlencoded")
 
     def get_body(self, fixture_name: Text) -> Text:
         return self.fixture_data("deskdotcom", fixture_name, file_type="txt")

--- a/zerver/webhooks/freshdesk/tests.py
+++ b/zerver/webhooks/freshdesk/tests.py
@@ -22,7 +22,8 @@ Test ticket description ☃.
 Type: **Incident**
 Priority: **High**
 Status: **Pending**"""
-        self.send_and_test_stream_message('ticket_created', expected_subject, expected_message, content_type="application/x-www-form-urlencoded", **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'ticket_created', expected_subject, expected_message,
+                                content_type="application/x-www-form-urlencoded")
 
     def test_status_change(self) -> None:
         """
@@ -33,9 +34,8 @@ Status: **Pending**"""
         expected_message = """Requester Bob <requester-bob@example.com> updated [ticket #11](http://test1234zzz.freshdesk.com/helpdesk/tickets/11):
 
 Status: **Resolved** => **Waiting on Customer**"""
-        self.send_and_test_stream_message('status_changed', expected_subject, expected_message,
-                                          content_type="application/x-www-form-urlencoded",
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'status_changed', expected_subject, expected_message,
+                                content_type="application/x-www-form-urlencoded")
 
     def test_priority_change(self) -> None:
         """
@@ -46,9 +46,8 @@ Status: **Resolved** => **Waiting on Customer**"""
         expected_message = """Requester Bob <requester-bob@example.com> updated [ticket #11](http://test1234zzz.freshdesk.com/helpdesk/tickets/11):
 
 Priority: **High** => **Low**"""
-        self.send_and_test_stream_message('priority_changed', expected_subject, expected_message,
-                                          content_type="application/x-www-form-urlencoded",
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, 'priority_changed', expected_subject, expected_message,
+                                content_type="application/x-www-form-urlencoded")
 
     def note_change(self, fixture: Text, note_type: Text) -> None:
         """
@@ -57,9 +56,8 @@ Priority: **High** => **Low**"""
         """
         expected_subject = u"#11: Test ticket subject"
         expected_message = """Requester Bob <requester-bob@example.com> added a {} note to [ticket #11](http://test1234zzz.freshdesk.com/helpdesk/tickets/11).""".format(note_type)
-        self.send_and_test_stream_message(fixture, expected_subject, expected_message,
-                                          content_type="application/x-www-form-urlencoded",
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, fixture, expected_subject, expected_message,
+                                content_type="application/x-www-form-urlencoded")
 
     def test_private_note_change(self) -> None:
         self.note_change("private_note", "private")
@@ -75,9 +73,8 @@ Priority: **High** => **Low**"""
         """
         expected_subject = u"#12: Not enough ☃ guinea pigs"
         expected_message = u"Requester \u2603 Bob <requester-bob@example.com> created [ticket #12](http://test1234zzz.freshdesk.com/helpdesk/tickets/12):\n\n~~~ quote\nThere are too many cat pictures on the internet \u2603. We need more guinea pigs. Exhibit 1:\n\n  \n\n\n[guinea_pig.png](http://cdn.freshdesk.com/data/helpdesk/attachments/production/12744808/original/guinea_pig.png)\n~~~\n\nType: **Problem**\nPriority: **Urgent**\nStatus: **Open**"
-        self.send_and_test_stream_message("inline_images", expected_subject, expected_message,
-                                          content_type="application/x-www-form-urlencoded",
-                                          **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, "inline_images", expected_subject, expected_message,
+                                content_type="application/x-www-form-urlencoded")
 
     def get_body(self, fixture_name: Text) -> Text:
         return self.fixture_data("freshdesk", fixture_name, file_type="json")

--- a/zerver/webhooks/zendesk/tests.py
+++ b/zerver/webhooks/zendesk/tests.py
@@ -25,8 +25,8 @@ class ZenDeskHookTests(WebhookTestCase):
         }
 
     def do_test(self, expected_subject: Optional[Text]=None, expected_message: Optional[Text]=None) -> None:
-        self.send_and_test_stream_message("", expected_subject, expected_message,
-                                          content_type=None, **self.api_auth(self.TEST_USER_EMAIL))
+        self.api_stream_message(self.TEST_USER_EMAIL, "", expected_subject, expected_message,
+                                content_type=None)
         self.TICKET_TITLE = self.DEFAULT_TICKET_TITLE
         self.TICKET_ID = self.DEFAULT_TICKET_ID
         self.MESSAGE = self.DEFAULT_MESSAGE


### PR DESCRIPTION
@showell Hey Steve, I would really appreciate your opinion on this one. This is the refactoring Tim suggested in #5287.
 
The changes I made:

1. Added the `api_get`, `api_post`, `api_patch`, `api_put`, and `api_delete` methods to `ZulipTestCase`. Replaced all `**self.api_auth(...)` usages in `zerver/tests` with their calls:
```
client_get(..., **self.api_auth(...)) → api_get(...)
client_post(..., **self.api_auth(...)) → api_post(...)
client_patch(..., **self.api_auth(...)) → api_patch(...)
client_put(..., **self.api_auth(...)) → api_put(...)
client_delete(..., **self.api_auth(...)) → api_delete(...)
```

2. Added a method called `api_stream_message` to `WebhookTestCase`, and replaced all `**self.api_auth(...)` usages in `zerver/webhooks` as follows:
```
client_post(..., **self.api_auth(...)) → api_post(...)
send_and_test_stream_message(..., **self.api_auth(...)) → api_steam_message(...)
```

3. Replaced all `**self.get_auth(...)` usages with the `api_post` calls:
```
client_post(..., **self.get_auth(...)) → api_post(...)
```
and deleted the method from `BouncerTestCase`.

4. Refactored (and renamed) the `api_auth` method to make the authentication methods closer to what was suggested in the issue:
```
def api_post(email, *args, **kwargs): 
    kwargs['HTTP_AUTHORIZATION'] = encode_credentials(email)
    return client_post(*args, **kwargs)
```

Fixes #5287. I haven't mentioned the issue in any of the commit messages yet, but I'll do that as soon as it's clear that the PR is ready to be merged.