### PR TITLE
onBoarding: Fix error-password overlap bug

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -335,6 +335,10 @@ html {
     transition: border 0.3s ease;
 }
 
+.new-style .input-box input[type=email] {
+    margin-bottom: 14px;
+}
+
 .new-style .input-box label {
     position: absolute;
     top: 0px;


### PR DESCRIPTION
Resolves issue #7796 
I wasn't able to replicate the exact problem, but anyway the spacing between the error message and "Password" should be more than what it is.
Before:
![a](https://user-images.githubusercontent.com/12075549/34075070-35fe62a4-e2d5-11e7-8d08-b2772568b9fa.png)
After:
![b](https://user-images.githubusercontent.com/12075549/34075073-3aa92514-e2d5-11e7-92f8-76e35f4f13c5.png)
