### PR TITLE
Add hotkey for narrowing to what is in the compose box

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -3,9 +3,19 @@ zrequire('hashchange');
 zrequire('narrow_state');
 zrequire('people');
 zrequire('stream_data');
+zrequire('util');
 zrequire('Filter', 'js/filter');
 
 zrequire('narrow');
+
+set_global('topic_data', {
+});
+
+set_global('window', {
+    location : {
+        hash : 'foobar',
+    },
+});
 
 function set_filter(operators) {
     operators = _.map(operators, function (op) {
@@ -148,4 +158,153 @@ function set_filter(operators) {
     narrow.show_empty_narrow_message();
     assert.equal(hide_id,'.empty_feed_notice');
     assert.equal(show_id, '#empty_search_narrow_message');
+}());
+
+(function test_by_stream_topic_name() {
+    var stream_ids = {
+        Veronica : 10,
+        Rome : 21,
+        zulip : 31,
+    };
+    var all_topics = {
+        10 : ['Veronica1', 'Veronica2'],
+        21 : [],
+        31 : ['issue1'],
+    };
+    stream_data.get_stream_id = function (stream) {
+        return stream_ids[stream];
+    };
+    topic_data.get_recent_names = function (stream_id) {
+        return all_topics[stream_id];
+    };
+
+
+
+    function get_operators(stream, topic) {
+        var operators;
+        narrow.activate = function (raw_operators) {
+            operators = raw_operators;
+            return;
+        };
+        narrow.by_stream_topic_name(stream, topic);
+        return operators;
+    }
+
+    // Both stream and Topic are existing
+    assert.deepEqual(get_operators('Veronica', 'Veronica1'), [
+        {operator: 'stream', operand: 'Veronica'},
+        {operator: 'topic', operand: 'Veronica1'},
+    ]);
+
+    // Only stream
+    assert.deepEqual(get_operators('Veronica', ''), [
+        {operator: 'stream', operand: 'Veronica'},
+    ]);
+
+    // Stream with incorrect topic
+    assert.deepEqual(get_operators('Veronica', 'Ver'), [
+        {operator: 'stream', operand: 'Veronica'},
+    ]);
+
+    // Stream with no topics in it
+    assert.deepEqual(get_operators('Rome', 'rome1'), [
+        {operator: 'stream', operand: 'Rome'},
+    ]);
+
+    // A topic with no stream
+    assert.deepEqual(get_operators('', 'Veronica2'), undefined);
+}());
+
+(function test_by_recipient_name() {
+
+    function get_narrow_call(recipient) {
+        var called = '';
+        narrow.by = function (type) {
+            called = type;
+        };
+        narrow.by_recipient_name(recipient);
+        return called;
+    }
+
+    var valid_emails = ['aaron@zulip.com', 'iago@github.com'];
+    people.is_valid_email_for_compose = function (email) {
+        return valid_emails.includes(email);
+    };
+
+    people.email_list_to_user_ids_string = function () {};
+
+    // Invalid recipient
+    assert.equal(get_narrow_call('foo@zulip.com'), 'is');
+    assert.equal(get_narrow_call(''), 'is');
+    assert.equal(get_narrow_call('foo@zulip.com, aaron@zulip.com'), 'is');
+
+    // Valid recipient with different types of input
+    assert.equal(get_narrow_call('aaron@zulip.com'), 'pm-with');
+    assert.equal(get_narrow_call('aaron@zulip.com, iago@github.com'), 'pm-with');
+    assert.equal(get_narrow_call('aaron@zulip.com,iago@github.com, '), 'pm-with');
+
+}());
+
+(function test_to_compose_target() {
+    set_global('compose_state', {
+    });
+
+    set_global('compose_actions', {
+        start : function () {},
+    });
+
+    function get_narrow_call() {
+        var narrow_by;
+        narrow.by_stream_topic_name = function () {
+            narrow_by = 'by_stream_topic_name';
+        };
+        narrow.by_recipient_name = function () {
+            narrow_by = 'by_recipient_name';
+        };
+        narrow.to_compose_target();
+        return narrow_by;
+    }
+
+    // Test if get_message_type is neither 'stream' nor 'private'
+    compose_state.get_message_type =  function () {
+        return '';
+    };
+    assert.equal(narrow.to_compose_target(), false);
+
+    // Test sending message to stream
+    compose_state.get_message_type =  function () {
+        return 'stream';
+    };
+
+    // Test if stream is empty
+    compose_state.stream_name = function () {
+        return '';
+    };
+    assert.equal(narrow.to_compose_target(), false);
+
+    // Test if stream is non empty with different topics.
+
+    _.each(['alpha', 'gamma'], function (stream_name) {
+        _.each(['', 'alpha-beta'], function (subject) {
+            compose_state.stream_name = function () {
+                return stream_name;
+            };
+            compose_state.subject = function () {
+                return subject;
+            };
+            assert.equal(get_narrow_call(), 'by_stream_topic_name');
+        });
+    });
+
+    // Test sending private message
+    compose_state.get_message_type =  function () {
+        return 'private';
+    };
+    _.each(['', 'alpha@beta.com, ', 'alpha@beta.com, gamma@beta.com'], function (recipient) {
+        compose_state.recipient = function () {
+            return recipient;
+        };
+        assert.equal(get_narrow_call(),'by_recipient_name');
+    });
+
 }());

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -353,6 +353,15 @@ exports.on_topic_narrow = function () {
     $('#compose-textarea').focus().select();
 };
 
+exports.on_compose_narrow = function () {
+    if (compose_state.composing()) {
+        compose_fade.update_message_list();
+        return;
+    }
+
+    exports.cancel();
+};
+
 exports.on_narrow = function () {
     if (narrow_state.narrowed_by_topic_reply()) {
         exports.on_topic_narrow();

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -40,6 +40,10 @@ var keydown_unshift_mappings = {
     40: {name: 'down_arrow', message_view_only: false}, // down arrow
 };
 
+var keydown_meta_mappings = {
+    73: {name: 'narrow_compose', message_view_only: false}, // 'i'
+};
+
 var keydown_ctrl_mappings = {
     219: {name: 'escape', message_view_only: false}, // '['
 };
@@ -95,11 +99,19 @@ var keypress_mappings = {
 };
 
 exports.get_keydown_hotkey = function (e) {
-    if (e.metaKey || e.altKey) {
+    if (e.altKey) {
         return;
     }
 
     var hotkey;
+    if (e.metaKey) {
+        hotkey = keydown_meta_mappings[e.which];
+        if (hotkey) {
+            return hotkey;
+        }
+        return;
+    }
+
     if (e.ctrlKey) {
         hotkey = keydown_ctrl_mappings[e.which];
         if (hotkey) {
@@ -526,9 +538,13 @@ exports.process_hotkey = function (e, hotkey) {
     if (exports.processing_text()) {
         // Note that there is special handling for enter/escape too, but
         // we handle this in other functions.
-
         if (event_name === 'left_arrow' && compose_state.focus_in_empty_compose()) {
             message_edit.edit_last_sent_message();
+            return true;
+        }
+
+        if (event_name === "narrow_compose" && compose_state.composing()) {
+            narrow.to_compose_target();
             return true;
         }
 


### PR DESCRIPTION
Currently, the hotkey is set to meta+I. Shortcut needs to be finalized. 
Node tests to be added.
Fixes: #6546 