### PR TITLE
Editing (minor): Add .pyi to .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{sh,py,js,json,yml,xml,css,md,markdown,handlebars,html}]
+[*.{sh,py,pyi,js,json,yml,xml,css,md,markdown,handlebars,html}]
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
We only have one stub (.pyi) as it stands, but it's good to include it in editorconfig.