### PR TITLE
Check if push notification bouncer is enabled & include with server_settings API

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -491,6 +491,17 @@ def get_gcm_payload(user_profile: UserProfile, message: Message) -> Dict[str, An
     })
     return data
 
+def push_notification_enabled() -> Dict[str, Any]:
+    data = {
+        'push_bouncer': False,
+        'android': False,
+        'ios': False,
+    }
+    data['push_bouncer'] = settings.PUSH_NOTIFICATION_BOUNCER_URL is not None
+    data['ios'] = all(p is not None for p in [settings.ZULIP_ORG_ID, settings.ZULIP_ORG_KEY])
+    data['android'] = settings.ANDROID_GCM_API_KEY is not None
+    return data
+
 @statsd_increment("push_notifications")
 def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any]) -> None:
     """

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1315,6 +1315,7 @@ class FetchAuthBackends(ZulipTestCase):
                                  subdomain="")
         self.assert_json_success(result)
         data = result.json()
+        print(data)
         schema_checker = check_dict_only([
             ('authentication_methods', check_dict_only([
                 ('google', check_bool),
@@ -1328,6 +1329,7 @@ class FetchAuthBackends(ZulipTestCase):
             ('require_email_format_usernames', check_bool),
             ('realm_uri', check_string),
             ('zulip_version', check_string),
+            ('push_notification_bouncer_enabled', check_bool),
             ('msg', check_string),
             ('result', check_string),
         ])
@@ -1351,6 +1353,7 @@ class FetchAuthBackends(ZulipTestCase):
                 ('require_email_format_usernames', check_bool),
                 ('realm_uri', check_string),
                 ('zulip_version', check_string),
+                ('push_notification_bouncer_enabled', check_bool),
                 ('msg', check_string),
                 ('result', check_string),
             ])
@@ -1369,6 +1372,7 @@ class FetchAuthBackends(ZulipTestCase):
             ('realm_icon', check_string),
             ('email_auth_enabled', check_bool),
             ('require_email_format_usernames', check_bool),
+            ('push_notification_bouncer_enabled', check_bool),
             ('authentication_methods', check_dict_only([
                 ('google', check_bool),
                 ('github', check_bool),

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -25,6 +25,7 @@ from zerver.context_processors import zulip_default_context, get_realm_from_requ
 from zerver.forms import HomepageForm, OurAuthenticationForm, \
     WRONG_SUBDOMAIN_ERROR, ZulipPasswordResetForm
 from zerver.lib.mobile_auth_otp import is_valid_otp, otp_encrypt_api_key
+from zerver.lib.push_notifications import push_notification_enabled
 from zerver.lib.request import REQ, has_request_variables, JsonableError
 from zerver.lib.response import json_success, json_error
 from zerver.lib.subdomains import get_subdomain, is_subdomain_root_or_alias
@@ -713,6 +714,7 @@ def api_get_server_settings(request: HttpRequest) -> HttpResponse:
     result = dict(
         authentication_methods=get_auth_backends_data(request),
         zulip_version=ZULIP_VERSION,
+        push_notification_bouncer_enabled=all(push_notification_enabled().values()),
     )
     context = zulip_default_context(request)
     # IMPORTANT NOTE:


### PR DESCRIPTION
As suggested by Tim here, this is to send the boolean if the notification bouncer is setup on the server to be used in the mobile app 
https://github.com/zulip/zulip-mobile/issues/1507#issuecomment-350589242