### PR TITLE
webhooks/gci: Support approve-pending-pc event type.

### DIFF
--- a/zerver/webhooks/gci/fixtures/task_approved_by_mentor_pending_parental_consent.json
+++ b/zerver/webhooks/gci/fixtures/task_approved_by_mentor_pending_parental_consent.json
@@ -1,0 +1,12 @@
+{
+    "author_is_student": false,
+    "task_definition_name": "Sails unspread it stopped at kearney",
+    "event_type": "approve-pending-pc",
+    "task_instance": 6296903092273152,
+    "task_claimed_by": "student-yqqtag",
+    "time": 1506475323.256627,
+    "id": "1f4bab4d1820400f9b50ed8bf2bb03b3",
+    "author": "eeshangarg",
+    "task_instance_url": "https://0.0.0.0:8000/dashboard/task-instances/6694926301528064/",
+    "task_definition_url": "https://0.0.0.0:8000/dashboard/tasks/6694926301528064/"
+}

--- a/zerver/webhooks/gci/tests.py
+++ b/zerver/webhooks/gci/tests.py
@@ -38,6 +38,12 @@ class GoogleCodeInTests(WebhookTestCase):
         self.send_and_test_stream_message('task_approved_by_mentor',
                                           expected_subject, expected_message)
 
+    def test_approve_pending_pc_event_message(self) -> None:
+        expected_subject = u'student-yqqtag'
+        expected_message = u'**eeshangarg** approved the task [Sails unspread it stopped at kearney](https://codein.withgoogle.com/dashboard/task-instances/6296903092273152/) (pending parental consent).'
+        self.send_and_test_stream_message('task_approved_by_mentor_pending_parental_consent',
+                                          expected_subject, expected_message)
+
     def test_needswork_event_message(self) -> None:
         expected_subject = u'student-yqqtag'
         expected_message = u'**eeshangarg** submitted the task [Sails unspread it stopped at kearney](https://codein.withgoogle.com/dashboard/task-instances/5136918324969472/) for more work.'

--- a/zerver/webhooks/gci/view.py
+++ b/zerver/webhooks/gci/view.py
@@ -58,6 +58,15 @@ def get_approve_event_body(payload: Dict[Text, Any]) -> Text:
         task_url=build_instance_url(payload['task_instance']),
     )
 
+def get_approve_pending_pc_event_body(payload: Dict[Text, Any]) -> Text:
+    template = "{} (pending parental consent).".format(GCI_MESSAGE_TEMPLATE.rstrip('.'))
+    return template.format(
+        actor=payload['author'],
+        action='approved',
+        task_name=payload['task_definition_name'],
+        task_url=build_instance_url(payload['task_instance']),
+    )
+
 def get_needswork_event_body(payload: Dict[Text, Any]) -> Text:
     template = "{} for more work.".format(GCI_MESSAGE_TEMPLATE.rstrip('.'))
     return template.format(
@@ -85,6 +94,7 @@ def api_gci_webhook(request: HttpRequest, user_profile: UserProfile, stream: Tex
 EVENTS_FUNCTION_MAPPER = {
     'abandon': get_abandon_event_body,
     'approve': get_approve_event_body,
+    'approve-pending-pc': get_approve_pending_pc_event_body,
     'claim': get_claim_event_body,
     'comment': get_comment_event_body,
     'needswork': get_needswork_event_body,


### PR DESCRIPTION
This event is generated when a mentor approves a task but
GCI is still waiting on a student's parental consent.

@timabbott, @gnprice FYI :)