### PR TITLE
mypy: Use Python 3 syntax for typing in multiple files.

### DIFF
--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -39,14 +39,13 @@ def avatar_url_from_dict(userdict: Dict[str, Any], medium: bool=False) -> Text:
     url += '&version=%d' % (userdict['avatar_version'],)
     return url
 
-def get_avatar_field(user_id,
-                     realm_id,
-                     email,
-                     avatar_source,
-                     avatar_version,
-                     medium,
-                     client_gravatar):
-    # type: (int, int, Text, Text, int, bool, bool) -> Optional[Text]
+def get_avatar_field(user_id: int,
+                     realm_id: int,
+                     email: Text,
+                     avatar_source: Text,
+                     avatar_version: int,
+                     medium: bool,
+                     client_gravatar: bool) -> Optional[Text]:
     '''
     Most of the parameters to this function map to fields
     by the same name in UserProfile (avatar_source, realm_id,

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -9,8 +9,10 @@ from zerver.lib.response import json_success
 from zerver.models import UserProfile
 
 @has_request_variables
-def send_notification_backend(request, user_profile, operator=REQ('op'),
-                              notification_to = REQ('to', converter=extract_recipients, default=[])):
-    # type: (HttpRequest, UserProfile, Text, List[Text]) -> HttpResponse
+def send_notification_backend(
+        request: HttpRequest, user_profile: UserProfile,
+        operator: Text=REQ('op'),
+        notification_to: List[Text]=REQ('to', converter=extract_recipients, default=[]),
+) -> HttpResponse:
     check_send_typing_notification(user_profile, notification_to, operator)
     return json_success()

--- a/zerver/webhooks/appfollow/view.py
+++ b/zerver/webhooks/appfollow/view.py
@@ -13,9 +13,10 @@ from zerver.models import UserProfile
 
 @api_key_only_webhook_view("AppFollow")
 @has_request_variables
-def api_appfollow_webhook(request, user_profile, stream=REQ(default="appfollow"),
-                          topic=REQ(default=None), payload=REQ(argument_type="body")):
-    # type: (HttpRequest, UserProfile, Text, Optional[Text], Dict[str, Any]) -> HttpResponse
+def api_appfollow_webhook(request: HttpRequest, user_profile: UserProfile,
+                          stream: Text=REQ(default="appfollow"),
+                          topic: Optional[Text]=REQ(default=None),
+                          payload: Dict[str, Any]=REQ(argument_type="body")) -> HttpResponse:
     message = payload["text"]
     app_name = re.search('\A(.+)', message).group(0)
     if topic is None:

--- a/zerver/webhooks/beanstalk/view.py
+++ b/zerver/webhooks/beanstalk/view.py
@@ -41,10 +41,9 @@ def beanstalk_decoder(view_func: ViewFuncT) -> ViewFuncT:
 @beanstalk_decoder
 @authenticated_rest_api_view(is_webhook=True)
 @has_request_variables
-def api_beanstalk_webhook(request, user_profile,
-                          payload=REQ(validator=check_dict([])),
-                          branches=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], Optional[Text]) -> HttpResponse
+def api_beanstalk_webhook(request: HttpRequest, user_profile: UserProfile,
+                          payload: Dict[str, Any]=REQ(validator=check_dict([])),
+                          branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
     # Beanstalk supports both SVN and git repositories
     # We distinguish between the two by checking for a
     # 'uri' key that is only present for git repos

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -61,11 +61,10 @@ def format_pull_request_event(payload: Dict[str, Any]) -> Text:
 
 @api_key_only_webhook_view('Gogs')
 @has_request_variables
-def api_gogs_webhook(request, user_profile,
-                     payload=REQ(argument_type='body'),
-                     stream=REQ(default='commits'),
-                     branches=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Optional[Text]) -> HttpResponse
+def api_gogs_webhook(request: HttpRequest, user_profile: UserProfile,
+                     payload: Dict[str, Any]=REQ(argument_type='body'),
+                     stream: Text=REQ(default='commits'),
+                     branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
 
     repo = payload['repository']['name']
     event = request.META['HTTP_X_GOGS_EVENT']

--- a/zerver/webhooks/greenhouse/view.py
+++ b/zerver/webhooks/greenhouse/view.py
@@ -33,10 +33,10 @@ def message_creator(action: str, application: Dict[str, Any]) -> str:
 
 @api_key_only_webhook_view('Greenhouse')
 @has_request_variables
-def api_greenhouse_webhook(request, user_profile,
-                           payload=REQ(argument_type='body'),
-                           stream=REQ(default='greenhouse'), topic=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], str, str) -> HttpResponse
+def api_greenhouse_webhook(request: HttpRequest, user_profile: UserProfile,
+                           payload: Dict[str, Any]=REQ(argument_type='body'),
+                           stream: str=REQ(default='greenhouse'),
+                           topic: str=REQ(default=None)) -> HttpResponse:
     if payload['action'] == 'update_candidate':
         candidate = payload['payload']['candidate']
     else:

--- a/zerver/webhooks/ifttt/view.py
+++ b/zerver/webhooks/ifttt/view.py
@@ -11,10 +11,9 @@ from zerver.models import UserProfile
 
 @api_key_only_webhook_view('IFTTT')
 @has_request_variables
-def api_iftt_app_webhook(request, user_profile,
-                         payload=REQ(argument_type='body'),
-                         stream=REQ(default='ifttt')):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], str) -> HttpResponse
+def api_iftt_app_webhook(request: HttpRequest, user_profile: UserProfile,
+                         payload: Dict[str, Any]=REQ(argument_type='body'),
+                         stream: str=REQ(default='ifttt')) -> HttpResponse:
     subject = payload.get('subject')
     content = payload.get('content')
     if subject is None:

--- a/zerver/webhooks/opsgenie/view.py
+++ b/zerver/webhooks/opsgenie/view.py
@@ -12,10 +12,9 @@ from zerver.models import UserProfile
 
 @api_key_only_webhook_view('OpsGenie')
 @has_request_variables
-def api_opsgenie_webhook(request, user_profile,
-                         payload=REQ(argument_type='body'),
-                         stream=REQ(default='opsgenie')):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
+def api_opsgenie_webhook(request: HttpRequest, user_profile: UserProfile,
+                         payload: Dict[str, Any]=REQ(argument_type='body'),
+                         stream: Text=REQ(default='opsgenie')) -> HttpResponse:
 
     # construct the body of the message
     info = {"additional_info": '',

--- a/zerver/webhooks/pingdom/view.py
+++ b/zerver/webhooks/pingdom/view.py
@@ -33,9 +33,9 @@ SUPPORTED_CHECK_TYPES = (
 
 @api_key_only_webhook_view('Pingdom')
 @has_request_variables
-def api_pingdom_webhook(request, user_profile, payload=REQ(argument_type='body'),
-                        stream=REQ(default='pingdom')):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
+def api_pingdom_webhook(request: HttpRequest, user_profile: UserProfile,
+                        payload: Dict[str, Any]=REQ(argument_type='body'),
+                        stream: Text=REQ(default='pingdom')) -> HttpResponse:
     check_type = get_check_type(payload)
 
     if check_type in SUPPORTED_CHECK_TYPES:


### PR DESCRIPTION
Files modified:

zerver/webhooks/appfollow/view.py
zerver/webhooks/opsgenie/view.py
zerver/webhooks/gogs/view.py
zerver/webhooks/ifttt/view.py
zerver/views/typing.py
zerver/webhooks/pingdom/view.py
zerver/lib/avatar.py
zerver/webhooks/greenhouse/view.py
zerver/webhooks/beanstalk/view.py

zerver/tests/test_subdomains.py was already fully converted.