### PR TITLE
compose: Warn users when posting to the #announce stream.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -507,6 +507,18 @@ function render(template_name, args) {
     assert.equal(error_msg, "translated: Are you sure you want to mention all 101 people in this stream?");
 }());
 
+(function compose_announce() {
+    var args = {
+        count: '101',
+    };
+    var html = render('compose_announce', args);
+    global.write_handlebars_output("compose_announce", html);
+    var button = $(html).find("button:first");
+    assert.equal(button.text(), "translated: Yes, send");
+    var error_msg = $(html).find('span.compose-announce-msg').text().trim();
+    assert.equal(error_msg, "translated:         This stream is reserved for announcements.\n        \n        Are you sure you want to message all 101 people in this stream?");
+}());
+
 (function compose_notification() {
     var args = {
         note: "You sent a message to a muted topic.",

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -489,10 +489,21 @@ function validate_stream_message() {
         }
     }
 
-    if (!exports.validate_stream_message_address_info(stream_name) ||
-        !validate_stream_message_mentions(stream_name) ||
-        !validate_stream_message_announce(stream_name)) {
-        return false;
+    // If both `@all` is mentioned and it's in `#announce`, just validate
+    // for `@all`. Users shouldn't have to hit "yes" more than once.
+    if (util.is_all_or_everyone_mentioned(compose_state.message_content()) &&
+        stream_name === "announce") {
+        if (!exports.validate_stream_message_address_info(stream_name) ||
+            !validate_stream_message_mentions(stream_name)) {
+            return false;
+        }
+    // If either criteria isn't met, just do the normal validation.
+    } else {
+      if (!exports.validate_stream_message_address_info(stream_name) ||
+          !validate_stream_message_mentions(stream_name) ||
+          !validate_stream_message_announce(stream_name)) {
+          return false;
+      }
     }
 
     return true;

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -92,8 +92,10 @@ function clear_box() {
 
     // TODO: Better encapsulate at-mention warnings.
     compose.clear_all_everyone_warnings();
+    compose.clear_announce_warnings();
     compose.clear_private_stream_alert();
     compose.reset_user_acknowledged_all_everyone_flag();
+    compose.reset_user_acknowledged_announce_flag();
 
     exports.clear_textarea();
     $("#compose-textarea").removeData("draft-id");

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -215,6 +215,7 @@ table.compose_table {
 }
 
 .compose-all-everyone-controls,
+.compose-announce-controls,
 .compose_invite_user_controls,
 .compose_private_stream_alert_controls {
     float: right;

--- a/static/templates/compose_announce.handlebars
+++ b/static/templates/compose_announce.handlebars
@@ -1,0 +1,12 @@
+<div class="compose-announce">
+    <span class="compose-announce-msg">
+        {{#tr this}}
+        This stream is reserved for <strong>announcements</strong>.
+        <br />
+        Are you sure you want to message all <strong>__count__</strong> people in this stream?
+        {{/tr}}
+    </span>
+    <span class="compose-announce-controls">
+        <button type="button" class="btn btn-warning compose-announce-confirm">{{t "Yes, send" }}</button>
+    </span>
+</div>

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -47,6 +47,7 @@
       </div>
       <div  id="compose_invite_users" class="alert home-error-bar"></div>
       <div  id="compose-all-everyone" class="alert home-error-bar"></div>
+      <div  id="compose-announce" class="alert home-error-bar"></div>
       <div  id="compose_private_stream_alert" class="alert home-error-bar"></div>
       <div  id="out-of-view-notification" class="notification-alert"></div>
      <div class="composition-area">


### PR DESCRIPTION
Currently, users are warned for `@all` and `@everyone`, but not `#announce`. This pull request ideally would resolve #6928. This solution was discussed [on chat.zulip.org in this topic](https://chat.zulip.org/#narrow/stream/GCI.20tasks/subject/.22Prevent.20spam.20on.20.23announce.20stream.22.20task.20ideas/near/394947).

(Done for the *Issue #6928 Prevent spam on #announce stream* Google Code-in task.)