### PR TITLE
sidebars: Remove obsolete CSS classes

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -81,11 +81,6 @@
     width: 100%;
 }
 
-#stream-filters-container .ps-scrollbar-y-rail {
-    right: 0px !important;
-    width: 4px !important;
-}
-
 #stream-filters-container .ps-scrollbar-y {
     width: 4px !important;
 }

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -133,11 +133,6 @@ li.active-sub-filter {
     opacity: 1;
 }
 
-li.hidden-filter {
-    visibility: hidden;
-    display: none;
-}
-
 #left-sidebar .filter-icon {
     display: inline-block;
     width: 18px;

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -81,10 +81,6 @@
     width: 100%;
 }
 
-#stream-filters-container .ps-scrollbar-y {
-    width: 4px !important;
-}
-
 .stream-list-filter {
     margin-left: 1ex;
 }

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -85,7 +85,7 @@
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#ec7e18',GradientType=0 ); /* IE6-9 */
 }
 
-.user_offline .user-status-indicator {
+.user-status-indicator {
     background-color: none;
     border-color: hsl(0, 0%, 50%);
 }


### PR DESCRIPTION
This is a Second phase of removing the obsolete CSS class from `zulip.css`.
When I did git blame in zulip.css I found that some classes in zulip.css are split out in #2128 as right and left sidebars. So these are the classes I have removed

In `left-sidebar.css`
```
.hidden-filter
.ps-scrollbar-y-rail
.ps-scrollbar-y
```
In  `right-sidebar.css`
```
.user_offline
```
`user_offline` is a compound thing so I just removed that class because `.user-status-indicator` is used in some places in the code.
I carefully looked at both the sidebars after removing each class. I also tested it by moving to each topic and streams and hover over that. I haven't seen any changes or issues in that. If anyone find any changes feel free to point out. Will update the PR regarding that.