### PR TITLE
models: Update Realm.get_admin_users to not use select_related().

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -234,7 +234,7 @@ class Realm(models.Model):
     def get_admin_users(self) -> Sequence['UserProfile']:
         # TODO: Change return type to QuerySet[UserProfile]
         return UserProfile.objects.filter(realm=self, is_realm_admin=True,
-                                          is_active=True).select_related()
+                                          is_active=True)
 
     def get_active_users(self) -> Sequence['UserProfile']:
         # TODO: Change return type to QuerySet[UserProfile]


### PR DESCRIPTION
None of the uses of this function in the codebase follow any of the foreign
keys of UserProfile.

(I think the travis error is the casper test flake on message editing)