### PR TITLE
compose: Update the preview after restoring a draft.

### DIFF
--- a/frontend_tests/casper_tests/14-drafts.js
+++ b/frontend_tests/casper_tests/14-drafts.js
@@ -71,6 +71,16 @@ casper.then(function () {
 });
 
 casper.then(function () {
+    casper.test.info('Opening Markdown Preview');
+    casper.waitUntilVisible('#left_bar_compose_stream_button_big', function () {
+        casper.click('#left_bar_compose_stream_button_big');
+    });
+    casper.waitUntilVisible('#markdown_preview', function () {
+        casper.click('#markdown_preview');
+    });
+});
+
+casper.then(function () {
     casper.waitUntilVisible('.drafts-link', function () {
         casper.click('.drafts-link');
     });
@@ -95,6 +105,7 @@ casper.then(function () {
     casper.click("#drafts_table .message_row:not(.private-message) .restore-draft");
     waitWhileDraftsVisible(function () {
         casper.test.assertVisible('#stream-message', 'Stream Message Box Restored');
+        casper.test.assertNotVisible('#preview_message_area', 'Preview Was Hidden');
         common.check_form('form#send_message_form', {
             stream: 'all',
             subject: 'tests',

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -143,6 +143,8 @@ exports.restore_draft = function (draft_id) {
 
     overlays.close_overlay("drafts");
     compose_fade.clear_compose();
+    compose.clear_preview_area();
+
     if (draft.type === "stream" && draft.stream === "") {
         draft_copy.subject = "";
     }


### PR DESCRIPTION
This PR attempts to fix #5951 by re-opening the preview view after a draft was opened, if it was open already.

I also thought that re-opening the editing view after opening a draft could make sense, [as suggested by @timabbott](https://github.com/zulip/zulip/issues/5951#issuecomment-318728809). Please let me know if instead of conditionally opening the preview, I should change it so that the editor is always opened.

(Done for the *"Issue #5951 Restoring message draft doesn't update rendered preview"* Google Code-in task.)