### PR TITLE
Update setting new user notification

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -581,6 +581,11 @@ function test_change_allow_subdomains(change_allow_subdomains) {
         assert.equal(stream_id, 75);
         return { name: 'some_stream' };
     };
+    page_params.new_user_bot_configured = false;
+    settings_org.render_signup_notifications_stream_ui(75);
+    assert.equal(elem.text(), 'translated: Disabled');
+    assert(elem.hasClass('text-warning'));
+    page_params.new_user_bot_configured = true;
     settings_org.render_signup_notifications_stream_ui(75);
     assert.equal(elem.text(), '#some_stream');
     assert(!elem.hasClass('text-warning'));

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -50,6 +50,7 @@ function _setup_page() {
         realm_message_retention_days: page_params.realm_message_retention_days,
         realm_allow_edit_history: page_params.realm_allow_edit_history,
         language_list: page_params.language_list,
+        new_user_bot_configured: page_params.new_user_bot_configured,
         realm_default_language: page_params.realm_default_language,
         realm_waiting_period_threshold: page_params.realm_waiting_period_threshold,
         realm_notifications_stream_id: page_params.realm_notifications_stream_id,

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -170,7 +170,7 @@ exports.render_signup_notifications_stream_ui = function (stream_id) {
 
     var name = stream_data.maybe_get_stream_name(stream_id);
 
-    if (!name) {
+    if (!name || !page_params.new_user_bot_configured) {
         elem.text(i18n.t("Disabled"));
         elem.addClass("text-warning");
         return;

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -171,7 +171,7 @@
                 {{t "New user notifications:" }}
                 <span class="dropup actual-dropdown-menu" id="id_realm_signup_notifications_stream"
                     name="realm_signup_notifications_stream" aria-labelledby="realm_signup_notifications_stream_label">
-                    <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
+                    <button class="button small rounded dropdown-toggle" data-toggle="dropdown" {{#unless new_user_bot_configured }} disabled="disabled" {{/unless}}>
                         <span id="realm_signup_notifications_stream_name"></span>
                         <i class="fa fa-pencil"></i>
                     </button>
@@ -184,8 +184,13 @@
                 </span>
             </label>
             {{#if is_admin }}
-            <a class="signup-notifications-stream-disable">{{t "[Disable]" }}</a>
+                {{#if new_user_bot_configured }}
+                <a class="signup-notifications-stream-disable">{{t "[Disable]" }}</a>
+                {{/if}}
             {{/if}}
+            <i class="icon-vector-question-sign signup_notification_stream_tooltip" data-toggle="tooltip"
+                {{#if new_user_bot_configured}}style="display:none" {{/if}}
+                title="{{t 'You must configured new user bot before setting a stream.' }}"/>
         </div>
 
     </form>

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -93,6 +93,7 @@ class HomeTest(ZulipTestCase):
             "narrow_stream",
             "needs_tutorial",
             "never_subscribed",
+            "new_user_bot_configured",
             "night_mode",
             "password_min_guesses",
             "password_min_length",

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -216,6 +216,10 @@ class RealmTest(ZulipTestCase):
 
         new_signup_notifications_stream_id = 4
         req = dict(signup_notifications_stream_id = ujson.dumps(new_signup_notifications_stream_id))
+        with self.settings(NEW_USER_BOT=None):
+            result = self.client_patch("/json/realm", req)
+            self.assert_json_error(result, 'NEW_USER_BOT must configured first.')
+
         result = self.client_patch('/json/realm', req)
         self.assert_json_success(result)
         realm = get_realm('zulip')

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -173,6 +173,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
     # These end up in a global JavaScript Object named 'page_params'.
     page_params = dict(
         # Server settings.
+        new_user_bot_configured = settings.NEW_USER_BOT is not None,
         development_environment = settings.DEVELOPMENT,
         debug_mode            = settings.DEBUG,
         test_suite            = settings.TEST_SUITE,

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -2,7 +2,7 @@
 from typing import Any, Dict, Optional, List, Text
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
-
+from django.conf import settings
 from zerver.decorator import require_realm_admin, to_non_negative_int, to_not_negative_int_or_none
 from zerver.lib.actions import (
     do_set_realm_message_editing,
@@ -59,6 +59,8 @@ def update_realm(
         return json_error(_("Realm name is too long."))
     if authentication_methods is not None and True not in list(authentication_methods.values()):
         return json_error(_("At least one authentication method must be enabled."))
+    if signup_notifications_stream_id is not None and settings.NEW_USER_BOT is None:
+        return json_error(_("NEW_USER_BOT must configured first."))
 
     # The user of `locals()` here is a bit of a code smell, but it's
     # restricted to the elements present in realm.property_types.


### PR DESCRIPTION
* In code, [here](https://github.com/YJDave/zulip/blob/590ca709f048f593b9195a80f7f5ba43a3b22068/zerver/views/streams.py#L377) if NOTIFICATION_BOT doesn't exists it throws error. So added condition there to check first before sending message to selected stream by notification bot of new stream creation.


----------------------------------------------------------------------------------------------------------------------------------------
![notificaitondefaultstream](https://user-images.githubusercontent.com/25907420/34218559-7fa16698-e5d4-11e7-8a6f-c781afb401f4.png)
----------------------------------------------------------------------------------------------------------------------------------------

* If there is no NOTIFICATION_BOT set then there will be no notification for new stream creation. So disable this option to select stream for `New stream notification` if NOTIFICATION_BOT is none.

* If there is no NEW_USER_BOT set then there will be no notification for new user joined. So disable this option to select stream for `New user notification` if NEW_USER_BOT is none.

