### PR TITLE
message view: Stop combining unicode marks from overflowing.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1298,6 +1298,10 @@ div.focused_table {
     position: relative;
 }
 
+.message_row {
+    overflow: hidden;
+}
+
 .message_content:empty {
     display: none;
 }


### PR DESCRIPTION
Some combining diacritics would overflow outside of the message
box.

Fixes #7843