### PR TITLE
view: Stop unicode marks from overflowing.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1295,6 +1295,7 @@ div.focused_table {
     font-size: 14px;
     margin-left: 46px;
     display: block;
+    overflow: hidden;
     position: relative;
 }
 


### PR DESCRIPTION
Fixes #7843
