### PR TITLE
mypy: Use Python 3 syntax for typing in many `zerver` files.

### DIFF
--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -21,11 +21,13 @@ def random_api_key() -> Text:
 # Only use this for bulk_create -- for normal usage one should use
 # create_user (below) which will also make the Subscription and
 # Recipient objects
-def create_user_profile(realm, email, password, active, bot_type, full_name,
-                        short_name, bot_owner, is_mirror_dummy, tos_version,
-                        timezone, tutorial_status=UserProfile.TUTORIAL_WAITING,
-                        enter_sends=False):
-    # type: (Realm, Text, Optional[Text], bool, Optional[int], Text, Text, Optional[UserProfile], bool, Text, Optional[Text], Optional[Text], bool) -> UserProfile
+def create_user_profile(realm: Realm, email: Text, password: Optional[Text],
+                        active: bool, bot_type: Optional[int], full_name: Text,
+                        short_name: Text, bot_owner: Optional[UserProfile],
+                        is_mirror_dummy: bool, tos_version: Text,
+                        timezone: Optional[Text],
+                        tutorial_status: Optional[Text] = UserProfile.TUTORIAL_WAITING,
+                        enter_sends: bool = False) -> UserProfile:
     now = timezone_now()
     email = UserManager.normalize_email(email)
 
@@ -48,13 +50,17 @@ def create_user_profile(realm, email, password, active, bot_type, full_name,
     user_profile.api_key = random_api_key()
     return user_profile
 
-def create_user(email, password, realm, full_name, short_name,
-                active=True, is_realm_admin=False, bot_type=None, bot_owner=None, tos_version=None,
-                timezone="", avatar_source=UserProfile.AVATAR_FROM_GRAVATAR,
-                is_mirror_dummy=False, default_sending_stream=None,
-                default_events_register_stream=None,
-                default_all_public_streams=None, user_profile_id=None):
-    # type: (Text, Optional[Text], Realm, Text, Text, bool, bool, Optional[int], Optional[UserProfile], Optional[Text], Text, Text, bool, Optional[Stream], Optional[Stream], Optional[bool], Optional[int]) -> UserProfile
+def create_user(email: Text, password: Optional[Text], realm: Realm,
+                full_name: Text, short_name: Text, active: bool = True,
+                is_realm_admin: bool = False, bot_type: Optional[int] = None,
+                bot_owner: Optional[UserProfile] = None,
+                tos_version: Optional[Text] = None, timezone: Text = "",
+                avatar_source: Text = UserProfile.AVATAR_FROM_GRAVATAR,
+                is_mirror_dummy: bool = False,
+                default_sending_stream: Optional[Stream] = None,
+                default_events_register_stream: Optional[Stream] = None,
+                default_all_public_streams: Optional[bool] = None,
+                user_profile_id: Optional[int] = None) -> UserProfile:
     user_profile = create_user_profile(realm, email, password, active, bot_type,
                                        full_name, short_name, bot_owner,
                                        is_mirror_dummy, tos_version, timezone)

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -93,9 +93,10 @@ def always_want(msg_type: str) -> bool:
 # all event types.  Whenever you add new code to this function, you
 # should also add corresponding events for changes in the data
 # structures and new code to apply_events (and add a test in EventsRegisterTest).
-def fetch_initial_state_data(user_profile, event_types, queue_id, client_gravatar,
-                             include_subscribers=True):
-    # type: (UserProfile, Optional[Iterable[str]], str, bool, bool) -> Dict[str, Any]
+def fetch_initial_state_data(user_profile: UserProfile,
+                             event_types: Optional[Iterable[str]],
+                             queue_id: str, client_gravatar: bool,
+                             include_subscribers: bool = True) -> Dict[str, Any]:
     state = {'queue_id': queue_id}  # type: Dict[str, Any]
 
     if event_types is None:
@@ -269,9 +270,10 @@ def remove_message_id_from_unread_mgs(state: Dict[str, Dict[str, Any]],
     raw_unread['unmuted_stream_msgs'].discard(message_id)
     raw_unread['mentions'].discard(message_id)
 
-def apply_events(state, events, user_profile, client_gravatar, include_subscribers=True,
-                 fetch_event_types=None):
-    # type: (Dict[str, Any], Iterable[Dict[str, Any]], UserProfile, bool, bool, Optional[Iterable[str]]) -> None
+def apply_events(state: Dict[str, Any], events: Iterable[Dict[str, Any]],
+                 user_profile: UserProfile, client_gravatar: bool,
+                 include_subscribers: bool = True,
+                 fetch_event_types: Optional[Iterable[str]] = None) -> None:
     for event in events:
         if fetch_event_types is not None and event['type'] not in fetch_event_types:
             # TODO: continuing here is not, most precisely, correct.
@@ -582,11 +584,15 @@ def apply_event(state: Dict[str, Any],
     else:
         raise AssertionError("Unexpected event type %s" % (event['type'],))
 
-def do_events_register(user_profile, user_client, apply_markdown=True, client_gravatar=False,
-                       event_types=None, queue_lifespan_secs=0, all_public_streams=False,
-                       include_subscribers=True, narrow=[], fetch_event_types=None):
-    # type: (UserProfile, Client, bool, bool, Optional[Iterable[str]], int, bool, bool, Iterable[Sequence[Text]], Optional[Iterable[str]]) -> Dict[str, Any]
-
+def do_events_register(user_profile: UserProfile, user_client: Client,
+                       apply_markdown: bool = True,
+                       client_gravatar: bool = False,
+                       event_types: Optional[Iterable[str]] = None,
+                       queue_lifespan_secs: int = 0,
+                       all_public_streams: bool = False,
+                       include_subscribers: bool = True,
+                       narrow: Iterable[Sequence[Text]] = [],
+                       fetch_event_types: Optional[Iterable[str]] = None) -> Dict[str, Any]:
     # Technically we don't need to check this here because
     # build_narrow_filter will check it, but it's nicer from an error
     # handling perspective to do it before contacting Tornado

--- a/zerver/webhooks/airbrake/view.py
+++ b/zerver/webhooks/airbrake/view.py
@@ -15,10 +15,9 @@ AIRBRAKE_MESSAGE_TEMPLATE = '[{error_class}]({error_url}): "{error_message}" occ
 
 @api_key_only_webhook_view('Airbrake')
 @has_request_variables
-def api_airbrake_webhook(request, user_profile,
-                         payload=REQ(argument_type='body'),
-                         stream=REQ(default='airbrake')):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], Text) -> HttpResponse
+def api_airbrake_webhook(request: HttpRequest, user_profile: UserProfile,
+                         payload: Dict[str, Any] = REQ(argument_type='body'),
+                         stream: Text = REQ(default='airbrake')) -> HttpResponse:
     subject = get_subject(payload)
     body = get_body(payload)
     check_send_stream_message(user_profile, request.client,

--- a/zerver/webhooks/mention/view.py
+++ b/zerver/webhooks/mention/view.py
@@ -13,11 +13,10 @@ from zerver.models import UserProfile
 
 @api_key_only_webhook_view('Mention')
 @has_request_variables
-def api_mention_webhook(request, user_profile,
-                        payload=REQ(argument_type='body'),
-                        stream=REQ(default='mention'),
-                        topic=REQ(default='news')):
-    # type: (HttpRequest, UserProfile, Dict[str, Iterable[Dict[str, Any]]], Text, Optional[Text]) -> HttpResponse
+def api_mention_webhook(request: HttpRequest, user_profile: UserProfile,
+                        payload: Dict[str, Iterable[Dict[str, Any]]] = REQ(argument_type='body'),
+                        stream: Text = REQ(default='mention'),
+                        topic: Optional[Text] = REQ(default='news')) -> HttpResponse:
     title = payload["title"]
     source_url = payload["url"]
     description = payload["description"]

--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -11,10 +11,9 @@ from zerver.models import UserProfile
 
 @api_key_only_webhook_view('Sentry')
 @has_request_variables
-def api_sentry_webhook(request, user_profile,
-                       payload=REQ(argument_type='body'),
-                       stream=REQ(default='sentry')):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], str) -> HttpResponse
+def api_sentry_webhook(request: HttpRequest, user_profile: UserProfile,
+                       payload: Dict[str, Any] = REQ(argument_type='body'),
+                       stream: str = REQ(default='sentry')) -> HttpResponse:
     subject = "{}".format(payload.get('project_name'))
     body = "New {} [issue]({}): {}.".format(payload['level'].upper(),
                                             payload.get('url'),

--- a/zerver/webhooks/travis/view.py
+++ b/zerver/webhooks/travis/view.py
@@ -23,16 +23,15 @@ MESSAGE_TEMPLATE = (
 
 @api_key_only_webhook_view('Travis')
 @has_request_variables
-def api_travis_webhook(request, user_profile,
-                       stream=REQ(default='travis'),
-                       topic=REQ(default=None),
-                       ignore_pull_requests=REQ(validator=check_bool, default=True),
-                       message=REQ('payload', validator=check_dict([
+def api_travis_webhook(request: HttpRequest, user_profile: UserProfile,
+                       stream: str = REQ(default='travis'),
+                       topic: str = REQ(default=None),
+                       ignore_pull_requests: bool = REQ(validator=check_bool, default=True),
+                       message: Dict[str, str]=REQ('payload', validator=check_dict([
                            ('author_name', check_string),
                            ('status_message', check_string),
                            ('compare_url', check_string),
-                       ]))):
-    # type: (HttpRequest, UserProfile, str, str, bool, Dict[str, str]) -> HttpResponse
+                       ]))) -> HttpResponse:
 
     message_status = message['status_message']
     if ignore_pull_requests and message['type'] == 'pull_request':

--- a/zerver/webhooks/yo/view.py
+++ b/zerver/webhooks/yo/view.py
@@ -12,11 +12,11 @@ from zerver.models import UserProfile, get_user
 
 @api_key_only_webhook_view('Yo')
 @has_request_variables
-def api_yo_app_webhook(request, user_profile, email=REQ(default=""),
-                       username=REQ(default='Yo Bot'), topic=REQ(default=None),
-                       user_ip=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, str, str, Optional[str], Optional[str]) -> HttpResponse
-
+def api_yo_app_webhook(request: HttpRequest, user_profile: UserProfile,
+                       email: str = REQ(default=""),
+                       username: str = REQ(default='Yo Bot'),
+                       topic: Optional[str] = REQ(default=None),
+                       user_ip: Optional[str] = REQ(default=None)) -> HttpResponse:
     body = ('Yo from %s') % (username,)
     receiving_user = get_user(email, user_profile.realm)
     check_send_private_message(user_profile, request.client, receiving_user, body)


### PR DESCRIPTION
Update the syntax in
 - `zerver/webhooks/travis/view.py`
 - `zerver/lib/create_user.py`
 - `zerver/webhooks/mention/view.py`
 - `zerver/lib/events.py`
 - `zerver/webhooks/airbrake/view.py`
 - `zerver/webhooks/yo/view.py`
 - `zerver/webhooks/sentry/view.py`

(Done for the *"Update mypy annotations to Python 3 syntax"* Google Code-in task.)