### PR TITLE
api docs: Start exhaustively documenting our API.

### DIFF
--- a/templates/zerver/api/arguments.json
+++ b/templates/zerver/api/arguments.json
@@ -44,5 +44,31 @@
             "required":"Required",
             "example":"Hello"
         }
+    ],
+    "get-all-streams.md":[
+        {
+            "argument":"include_public",
+            "description":"Include all public streams. Default is `True`.",
+            "required":"Optional",
+            "example":"`True` or `False`"
+        },
+        {
+            "argument":"include_subscribed",
+            "description":"Include all streams that the user is subscribed to. Default is `True`.",
+            "required":"Optional",
+            "example":"`True` or `False`"
+        },
+        {
+            "argument":"include_all_active",
+            "description":"Include all active streams. The user must have administrative privileges to use this parameter. Default is `False`.",
+            "required":"Optional",
+            "example":"`True` or `False`"
+        },
+        {
+            "argument":"include_default",
+            "description":"Include all default streams for the user's realm. Default is `False`.",
+            "required":"Optional",
+            "example":"`True` or `False`"
+        }
     ]
 }

--- a/templates/zerver/api/arguments.json
+++ b/templates/zerver/api/arguments.json
@@ -1,0 +1,48 @@
+{
+    "private-message.md":[
+        {
+            "argument":"type",
+            "description":"The type of message to be sent. `private` for a private message and `stream` for a [stream message](/api/stream-message).",
+            "required":"Required",
+            "example":"private"
+        },
+        {
+            "argument":"to",
+            "description":"A JSON-encoded list containing the usernames of the recipients.",
+            "required":"Required",
+            "example":"wdaher@example.com"
+        },
+        {
+            "argument":"content",
+            "description":"The content of the message. Maximum message size of 10000 bytes.",
+            "required":"Required",
+            "example":"Hello"
+        }
+    ],
+    "stream-message.md":[
+        {
+            "argument":"type",
+            "description":"The type of message to be sent. `stream` for a stream message and `private` for a [private message](/api/private-message).",
+            "required":"Required",
+            "example":"stream"
+        },
+        {
+            "argument":"to",
+            "description":"A string identifying the stream.",
+            "required":"Required",
+            "example":"Denmark"
+        },
+        {
+            "argument":"subject",
+            "description":"The topic of the message. Only required if `type` is `stream`. Defaults to `None`. Maximum length of 60 characters.",
+            "required":"Optional",
+            "example":"Castle"
+        },
+        {
+            "argument":"content",
+            "description":"The content of the message. Maximum message size of 10000 bytes.",
+            "required":"Required",
+            "example":"Hello"
+        }
+    ]
+}

--- a/templates/zerver/api/get-all-streams.md
+++ b/templates/zerver/api/get-all-streams.md
@@ -1,0 +1,150 @@
+# Get all streams
+
+Get all streams that the user has access to.
+
+`GET {{ api_url }}/v1/streams`
+
+## Arguments
+
+**Note**: The following arguments are all URL query parameters.
+
+{generate_api_arguments_table|arguments.json|get-all-streams.md}
+
+## Usage examples
+<div class="code-section" markdown="1">
+<ul class="nav">
+<li data-language="curl">curl</li>
+<li data-language="python">Python</li>
+<li data-language="javascript">JavaScript</li>
+</ul>
+<div class="blocks">
+
+<div data-language="curl" markdown="1">
+
+```
+curl {{ api_url }}/v1/streams -u BOT_EMAIL_ADDRESS:BOT_API_KEY
+```
+
+You may pass in one or more of the parameters mentioned above
+as URL query parameters, like so:
+
+```
+curl {{ api_url }}/v1/streams?include_public=false \
+    -u BOT_EMAIL_ADDRESS:BOT_API_KEY
+```
+
+</div>
+
+<div data-language="python" markdown="1">
+
+```
+#!/usr/bin/env python
+
+import zulip
+import sys
+
+# Keyword arguments 'email' and 'api_key' are not required if you are using ~/.zuliprc
+client = zulip.Client(email="othello-bot@example.com",
+                      api_key="a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5",
+                      site="{{ api_url }}")
+
+# Get all streams that the user has access to
+print(client.get_streams())
+
+# You may pass in one or more of the query parameters mentioned above
+# as keyword arguments, like so:
+print(client.get_streams(include_public=False))
+```
+
+</div>
+
+<div data-language="javascript" markdown="1">
+More examples and documentation can be found [here](https://github.com/zulip/zulip-js).
+```js
+const zulip = require('zulip-js');
+
+const config = {
+  username: 'othello-bot@example.com',
+  apiKey: 'a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5',
+  realm: '{{ api_url }}'
+};
+
+const client = zulip(config);
+
+// Get all streams that the user has access to
+client.streams.retrieve().then(res => {
+    console.log(res);
+});
+
+```
+</div>
+
+</div>
+
+</div>
+
+## Response
+
+#### Return values
+
+* `stream_id`: The unique ID of a stream.
+* `name`: The name of a stream.
+* `description`: A short description of a stream.
+* `invite-only`: Specifies whether a stream is invite-only or not.
+  Only people who have been invited can access an invite-only stream.
+
+#### Example response
+
+A typical successful JSON response may look like:
+
+```
+{
+    'result':'success',
+    'streams':[
+        {
+            'stream_id':15,
+            'name':'Denmark',
+            'invite_only':False,
+            'description':'A Scandinavian country'
+        },
+        {
+            'stream_id':16,
+            'name':'Rome',
+            'invite_only':False,
+            'description':'Yet another Italian city'
+        },
+        {
+            'stream_id':17,
+            'name':'Scotland',
+            'invite_only':False,
+            'description':'Located in the United Kingdom'
+        },
+        {
+            'stream_id':18,
+            'name':'Venice',
+            'invite_only':False,
+            'description':'A northeastern Italian city'
+        },
+        {
+            'stream_id':19,
+            'name':'Verona',
+            'invite_only':False,
+            'description':'A city in Italy'
+        }
+    ],
+    'msg':''
+}
+```
+
+An example of a JSON response for when the user is not authorized
+to use the `include_all_active` parameter:
+
+```
+{
+    'code':'BAD_REQUEST',
+    'result':'error',
+    'msg':'User not authorized for this query'
+}
+```
+
+{!invalid-api-key-json-response.md!}

--- a/templates/zerver/api/private-message.md
+++ b/templates/zerver/api/private-message.md
@@ -1,4 +1,8 @@
-# Usage examples
+# Private message
+
+Send a private message to a user.
+
+## Usage examples
 <div class="code-section" markdown="1">
 <ul class="nav">
 <li data-language="curl">curl</li>
@@ -9,18 +13,7 @@
 <div class="blocks">
 
 <div data-language="curl" markdown="1">
-#### Stream message
 
-```
-curl {{ api_url }}/v1/messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
-    -d "type=stream" \
-    -d "to=Denmark" \
-    -d "subject=Castle" \
-    -d "content=Something is rotten in the state of Denmark."
-```
-
-#### Private message
 ```
 curl {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
@@ -42,13 +35,6 @@ client = zulip.Client(email="othello-bot@example.com",
                       api_key="a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5",
                       site="{{ api_url }}")
 
-# Send a stream message
-client.send_message({
-    "type": "stream",
-    "to": "Denmark",
-    "subject": "Castle",
-    "content": "Something is rotten in the state of Denmark."
-})
 # Send a private message
 client.send_message({
     "type": "private",
@@ -71,28 +57,8 @@ client.call_on_each_event(lambda msg: sys.stdout.write(str(msg) + "\n"))
 (available after you `pip install zulip`) to easily send Zulips from
 the command-line, providing the message content via STDIN.
 
-#### Stream message
-
-```bash
-zulip-send --stream Denmark --subject Castle \
-    --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
-```
-
-#### Private message
-
 ```bash
 zulip-send hamlet@example.com \
-    --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
-```
-
-#### Passing in the message on the command-line
-
-If you'd like, you can also provide the message on the command-line with the `-m` flag, as follows:
-
-
-```bash
-zulip-send --stream Denmark --subject Castle \
-    -m "Something is rotten in the state of Denmark." \
     --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
 ```
 
@@ -113,14 +79,6 @@ const config = {
 };
 
 const client = zulip(config);
-
-// Send a message
-client.messages.send({
-  to: 'Denmark',
-  type: 'stream',
-  subject: 'Castle',
-  content: 'Something is rotten in the state of Denmark.'
-});
 
 // Send a private message
 client.messages.send({

--- a/templates/zerver/api/private-message.md
+++ b/templates/zerver/api/private-message.md
@@ -68,7 +68,7 @@ See also the [full API endpoint documentation](/api/endpoints).
 <div data-language="javascript" markdown="1">
 More examples and documentation can be found [here](https://github.com/zulip/zulip-js).
 ```js
-const zulip = require('zulip');
+const zulip = require('zulip-js');
 
 const config = {
   username: 'othello-bot@example.com',

--- a/templates/zerver/api/private-message.md
+++ b/templates/zerver/api/private-message.md
@@ -115,15 +115,7 @@ client.messages.send({
 
 #### Example response
 
-A typical successful JSON response may look like:
-
-```
-{
-    'msg':'',
-    'id':134,
-    'result':'success'
-}
-```
+{!successful-api-send-message-json-response.md!}
 
 A typical failed JSON response for when the recipient's email
 address is invalid:

--- a/templates/zerver/api/private-message.md
+++ b/templates/zerver/api/private-message.md
@@ -128,11 +128,4 @@ address is invalid:
 }
 ```
 
-A typical failed JSON response for when the API key is invalid:
-
-```
-{
-    'msg':'Invalid API key',
-    'result':'error'
-}
-```
+{!invalid-api-key-json-response.md!}

--- a/templates/zerver/api/private-message.md
+++ b/templates/zerver/api/private-message.md
@@ -6,22 +6,7 @@ Send a private message to a user or multiple users.
 
 ## Arguments
 
-| Argument        | Example              | Required  | Description                    |
-| --------------- | -------------------- | --------- | -----------------------------  |
-| `type`          | `private`            | Required  | The type of message to be      |
-|                 |                      |           | sent. `private` for a private  |
-|                 |                      |           | message and `stream` for a     |
-|                 |                      |           | [stream message][1].           |
-|                 |                      |           |                                |
-| `to`            | `wdaher@example.com` | Required  | A JSON-encoded list containing |
-|                 |                      |           | the usernames of the           |
-|                 |                      |           | recipients.                    |
-|                 |                      |           |                                |
-| `content`       | `Hello`              | Required  | The content of the message.    |
-|                 |                      |           | Maximum message size of        |
-|                 |                      |           | 10000 bytes.                   |
-
-[1]: /api/stream-message
+{generate_api_arguments_table|arguments.json|private-message.md}
 
 ## Usage examples
 <div class="code-section" markdown="1">

--- a/templates/zerver/api/private-message.md
+++ b/templates/zerver/api/private-message.md
@@ -1,6 +1,27 @@
 # Private message
 
-Send a private message to a user.
+Send a private message to a user or multiple users.
+
+`POST {{ api_url }}/v1/messages`
+
+## Arguments
+
+| Argument        | Example              | Required  | Description                    |
+| --------------- | -------------------- | --------- | -----------------------------  |
+| `type`          | `private`            | Required  | The type of message to be      |
+|                 |                      |           | sent. `private` for a private  |
+|                 |                      |           | message and `stream` for a     |
+|                 |                      |           | [stream message][1].           |
+|                 |                      |           |                                |
+| `to`            | `wdaher@example.com` | Required  | A JSON-encoded list containing |
+|                 |                      |           | the usernames of the           |
+|                 |                      |           | recipients.                    |
+|                 |                      |           |                                |
+| `content`       | `Hello`              | Required  | The content of the message.    |
+|                 |                      |           | Maximum message size of        |
+|                 |                      |           | 10000 bytes.                   |
+
+[1]: /api/stream-message
 
 ## Usage examples
 <div class="code-section" markdown="1">
@@ -42,14 +63,6 @@ client.send_message({
     "content": "I come not, friends, to steal away your hearts."
 })
 
-# Print each message the user receives
-# This is a blocking call that will run forever
-client.call_on_each_message(lambda msg: sys.stdout.write(str(msg) + "\n"))
-
-# Print every event relevant to the user
-# This is a blocking call that will run forever
-# This will never be reached unless you comment out the previous line
-client.call_on_each_event(lambda msg: sys.stdout.write(str(msg) + "\n"))
 ```
 </div>
 
@@ -64,7 +77,7 @@ zulip-send hamlet@example.com \
 
 You can omit the `user` and `api-key` arguments if you have a `~/.zuliprc` file.
 
-See also the [full API endpoint documentation.](/api/endpoints).
+See also the [full API endpoint documentation](/api/endpoints).
 </div>
 
 <div data-language="javascript" markdown="1">
@@ -87,21 +100,47 @@ client.messages.send({
   content: 'I come not, friends, to steal away your hearts.'
 });
 
-// Register queue to receive messages for user
-client.queues.register({
-  event_types: ['message']
-}).then((res) => {
-  // Retrieve events from a queue
-  // Blocking until there is an event (or the request times out)
-  client.events.retrieve({
-    queue_id: res.queue_id,
-    last_event_id: -1,
-    dont_block: false
-  }).then(console.log);
-});
 ```
 </div>
 
 </div>
 
 </div>
+
+## Response
+
+#### Return values
+
+* `id`: The ID of the newly created message
+
+#### Example response
+
+A typical successful JSON response may look like:
+
+```
+{
+    'msg':'',
+    'id':134,
+    'result':'success'
+}
+```
+
+A typical failed JSON response for when the recipient's email
+address is invalid:
+
+```
+{
+    'code':'BAD_REQUEST',
+    'msg':"Invalid email 'hamlet@example.com'",
+    'result':'error'
+}
+```
+
+A typical failed JSON response for when the API key is invalid:
+
+```
+{
+    'msg':'Invalid API key',
+    'result':'error'
+}
+```

--- a/templates/zerver/api/sidebar.md
+++ b/templates/zerver/api/sidebar.md
@@ -8,6 +8,10 @@
 * [Stream message](/api/stream-message)
 * [Private message](/api/private-message)
 
+#### Streams
+
+* [Get all streams](/api/get-all-streams)
+
 ## Integrations
 
 * [Overview](/api/integration-guide)

--- a/templates/zerver/api/sidebar.md
+++ b/templates/zerver/api/sidebar.md
@@ -2,7 +2,11 @@
 
 * [Installation instructions](/api/installation-instructions)
 * [API keys](/api/api-keys)
-* [Usage](/api/usage)
+
+#### Messages
+
+* [Stream message](/api/stream-message)
+* [Private message](/api/private-message)
 
 ## Integrations
 

--- a/templates/zerver/api/stream-message.md
+++ b/templates/zerver/api/stream-message.md
@@ -82,7 +82,7 @@ See also the [full API endpoint documentation](/api/endpoints).
 <div data-language="javascript" markdown="1">
 More examples and documentation can be found [here](https://github.com/zulip/zulip-js).
 ```js
-const zulip = require('zulip');
+const zulip = require('zulip-js');
 
 const config = {
   username: 'othello-bot@example.com',

--- a/templates/zerver/api/stream-message.md
+++ b/templates/zerver/api/stream-message.md
@@ -2,6 +2,32 @@
 
 Send a message to a stream.
 
+`POST {{ api_url }}/v1/messages`
+
+## Arguments
+
+| Argument        | Example           | Required  | Description                 |
+| --------------- | ----------------- | --------- | --------------------------- |
+| `type`          | `stream`          | Required  | The type of message to be   |
+|                 |                   |           | sent. `stream` for a stream |
+|                 |                   |           | message and `private` for a |
+|                 |                   |           | [private message][1].       |
+|                 |                   |           |                             |
+| `to`            | `Denmark`         | Required  | A string identifying the    |
+|                 |                   |           | stream.                     |
+|                 |                   |           |                             |
+| `subject`       | `Castle`          | Optional  | The topic of the message.   |
+|                 |                   |           | Only required if `type` is  |
+|                 |                   |           | `stream`. Defaults to       |
+|                 |                   |           | `None`. Maximum length of   |
+|                 |                   |           | 60 characters.              |
+|                 |                   |           |                             |
+| `content`       | `Hello`           | Required  | The content of the message. |
+|                 |                   |           | Maximum message size of     |
+|                 |                   |           | 10000 bytes.                |
+
+[1]: /api/private-message
+
 ## Usage examples
 <div class="code-section" markdown="1">
 <ul class="nav">
@@ -45,14 +71,6 @@ client.send_message({
     "content": "Something is rotten in the state of Denmark."
 })
 
-# Print each message the user receives
-# This is a blocking call that will run forever
-client.call_on_each_message(lambda msg: sys.stdout.write(str(msg) + "\n"))
-
-# Print every event relevant to the user
-# This is a blocking call that will run forever
-# This will never be reached unless you comment out the previous line
-client.call_on_each_event(lambda msg: sys.stdout.write(str(msg) + "\n"))
 ```
 </div>
 
@@ -78,7 +96,7 @@ zulip-send --stream Denmark --subject Castle \
 
 You can omit the `user` and `api-key` arguments if you have a `~/.zuliprc` file.
 
-See also the [full API endpoint documentation.](/api/endpoints).
+See also the [full API endpoint documentation](/api/endpoints).
 </div>
 
 <div data-language="javascript" markdown="1">
@@ -102,21 +120,46 @@ client.messages.send({
   content: 'Something is rotten in the state of Denmark.'
 });
 
-// Register queue to receive messages for user
-client.queues.register({
-  event_types: ['message']
-}).then((res) => {
-  // Retrieve events from a queue
-  // Blocking until there is an event (or the request times out)
-  client.events.retrieve({
-    queue_id: res.queue_id,
-    last_event_id: -1,
-    dont_block: false
-  }).then(console.log);
-});
 ```
 </div>
 
 </div>
 
 </div>
+
+## Response
+
+#### Return values
+
+* `id`: The ID of the newly created message
+
+#### Example response
+
+A typical successful JSON response may look like:
+
+```
+{
+    'msg':'',
+    'id':134,
+    'result':'success'
+}
+```
+
+A typical failed JSON response for when the target stream does not exist:
+
+```
+{
+    'code':'BAD_REQUEST',
+    'msg':"Stream 'Denmarkk' does not exist",
+    'result':'error'
+}
+```
+
+A typical failed JSON response for when the API key is invalid:
+
+```
+{
+    'msg':'Invalid API key',
+    'result':'error'
+}
+```

--- a/templates/zerver/api/stream-message.md
+++ b/templates/zerver/api/stream-message.md
@@ -6,27 +6,7 @@ Send a message to a stream.
 
 ## Arguments
 
-| Argument        | Example           | Required  | Description                 |
-| --------------- | ----------------- | --------- | --------------------------- |
-| `type`          | `stream`          | Required  | The type of message to be   |
-|                 |                   |           | sent. `stream` for a stream |
-|                 |                   |           | message and `private` for a |
-|                 |                   |           | [private message][1].       |
-|                 |                   |           |                             |
-| `to`            | `Denmark`         | Required  | A string identifying the    |
-|                 |                   |           | stream.                     |
-|                 |                   |           |                             |
-| `subject`       | `Castle`          | Optional  | The topic of the message.   |
-|                 |                   |           | Only required if `type` is  |
-|                 |                   |           | `stream`. Defaults to       |
-|                 |                   |           | `None`. Maximum length of   |
-|                 |                   |           | 60 characters.              |
-|                 |                   |           |                             |
-| `content`       | `Hello`           | Required  | The content of the message. |
-|                 |                   |           | Maximum message size of     |
-|                 |                   |           | 10000 bytes.                |
-
-[1]: /api/private-message
+{generate_api_arguments_table|arguments.json|stream-message.md}
 
 ## Usage examples
 <div class="code-section" markdown="1">

--- a/templates/zerver/api/stream-message.md
+++ b/templates/zerver/api/stream-message.md
@@ -1,0 +1,122 @@
+# Stream message
+
+Send a message to a stream.
+
+## Usage examples
+<div class="code-section" markdown="1">
+<ul class="nav">
+<li data-language="curl">curl</li>
+<li data-language="python">Python</li>
+<li data-language="zulip-send">zulip-send</li>
+<li data-language="javascript">JavaScript</li>
+</ul>
+<div class="blocks">
+
+<div data-language="curl" markdown="1">
+
+```
+curl {{ api_url }}/v1/messages \
+    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
+    -d "type=stream" \
+    -d "to=Denmark" \
+    -d "subject=Castle" \
+    -d "content=Something is rotten in the state of Denmark."
+```
+
+</div>
+
+<div data-language="python" markdown="1">
+```python
+#!/usr/bin/env python
+
+import zulip
+import sys
+
+# Keyword arguments 'email' and 'api_key' are not required if you are using ~/.zuliprc
+client = zulip.Client(email="othello-bot@example.com",
+                      api_key="a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5",
+                      site="{{ api_url }}")
+
+# Send a stream message
+client.send_message({
+    "type": "stream",
+    "to": "Denmark",
+    "subject": "Castle",
+    "content": "Something is rotten in the state of Denmark."
+})
+
+# Print each message the user receives
+# This is a blocking call that will run forever
+client.call_on_each_message(lambda msg: sys.stdout.write(str(msg) + "\n"))
+
+# Print every event relevant to the user
+# This is a blocking call that will run forever
+# This will never be reached unless you comment out the previous line
+client.call_on_each_event(lambda msg: sys.stdout.write(str(msg) + "\n"))
+```
+</div>
+
+<div data-language="zulip-send" markdown="1"> You can use `zulip-send`
+(available after you `pip install zulip`) to easily send Zulips from
+the command-line, providing the message content via STDIN.
+
+```bash
+zulip-send --stream Denmark --subject Castle \
+    --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
+```
+
+#### Passing in the message on the command-line
+
+If you'd like, you can also provide the message on the command-line with the `-m` flag, as follows:
+
+
+```bash
+zulip-send --stream Denmark --subject Castle \
+    -m "Something is rotten in the state of Denmark." \
+    --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
+```
+
+You can omit the `user` and `api-key` arguments if you have a `~/.zuliprc` file.
+
+See also the [full API endpoint documentation.](/api/endpoints).
+</div>
+
+<div data-language="javascript" markdown="1">
+More examples and documentation can be found [here](https://github.com/zulip/zulip-js).
+```js
+const zulip = require('zulip');
+
+const config = {
+  username: 'othello-bot@example.com',
+  apiKey: 'a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5',
+  realm: '{{ api_url }}'
+};
+
+const client = zulip(config);
+
+// Send a message
+client.messages.send({
+  to: 'Denmark',
+  type: 'stream',
+  subject: 'Castle',
+  content: 'Something is rotten in the state of Denmark.'
+});
+
+// Register queue to receive messages for user
+client.queues.register({
+  event_types: ['message']
+}).then((res) => {
+  // Retrieve events from a queue
+  // Blocking until there is an event (or the request times out)
+  client.events.retrieve({
+    queue_id: res.queue_id,
+    last_event_id: -1,
+    dont_block: false
+  }).then(console.log);
+});
+```
+</div>
+
+</div>
+
+</div>

--- a/templates/zerver/api/stream-message.md
+++ b/templates/zerver/api/stream-message.md
@@ -135,15 +135,7 @@ client.messages.send({
 
 #### Example response
 
-A typical successful JSON response may look like:
-
-```
-{
-    'msg':'',
-    'id':134,
-    'result':'success'
-}
-```
+{!successful-api-send-message-json-response.md!}
 
 A typical failed JSON response for when the target stream does not exist:
 

--- a/templates/zerver/api/stream-message.md
+++ b/templates/zerver/api/stream-message.md
@@ -147,11 +147,4 @@ A typical failed JSON response for when the target stream does not exist:
 }
 ```
 
-A typical failed JSON response for when the API key is invalid:
-
-```
-{
-    'msg':'Invalid API key',
-    'result':'error'
-}
-```
+{!invalid-api-key-json-response.md!}

--- a/templates/zerver/help/include/invalid-api-key-json-response.md
+++ b/templates/zerver/help/include/invalid-api-key-json-response.md
@@ -1,0 +1,8 @@
+A typical failed JSON response for when the API key is invalid:
+
+```
+{
+    'msg':'Invalid API key',
+    'result':'error'
+}
+```

--- a/templates/zerver/help/include/successful-api-send-message-json-response.md
+++ b/templates/zerver/help/include/successful-api-send-message-json-response.md
@@ -1,0 +1,9 @@
+A typical successful JSON response may look like:
+
+```
+{
+    'msg':'',
+    'id':134,
+    'result':'success'
+}
+```

--- a/zerver/lib/bugdown/api_arguments_table_generator.py
+++ b/zerver/lib/bugdown/api_arguments_table_generator.py
@@ -1,0 +1,113 @@
+import re
+import os
+import ujson
+
+from markdown.extensions import Extension
+from markdown.preprocessors import Preprocessor
+from typing import Any, Dict, Optional, List
+import markdown
+
+REGEXP = re.compile(r'\{generate_api_arguments_table\|\s*(.+?)\s*\|\s*(.+?)\s*\}')
+
+
+class MarkdownArgumentsTableGenerator(Extension):
+    def __init__(self, configs: Optional[Dict[str, Any]]={}) -> None:
+        self.config = {
+            'base_path': ['.', 'Default location from which to evaluate relative paths for the JSON files.'],
+        }
+        for key, value in configs.items():
+            self.setConfig(key, value)
+
+    def extendMarkdown(self, md: markdown.Markdown, md_globals: Dict[str, Any]) -> None:
+        md.preprocessors.add(
+            'generate_api_arguments', APIArgumentsTablePreprocessor(md, self.getConfigs()), '_begin'
+        )
+
+
+class APIArgumentsTablePreprocessor(Preprocessor):
+    def __init__(self, md: markdown.Markdown, config: Dict[str, Any]) -> None:
+        super(APIArgumentsTablePreprocessor, self).__init__(md)
+        self.base_path = config['base_path']
+
+    def run(self, lines: List[str]) -> List[str]:
+        done = False
+        while not done:
+            for line in lines:
+                loc = lines.index(line)
+                match = REGEXP.search(line)
+
+                if match:
+                    json_filename = match.group(1)
+                    doc_filename = match.group(2)
+                    json_filename = os.path.expanduser(json_filename)
+                    if not os.path.isabs(json_filename):
+                        json_filename = os.path.normpath(os.path.join(self.base_path, json_filename))
+                    try:
+                        with open(json_filename, 'r') as fp:
+                            json_obj = ujson.loads(fp.read())
+                            arguments = json_obj[doc_filename]
+                            text = self.render_table(arguments)
+                    except Exception as e:
+                        print('Warning: could not find file {}. Ignoring '
+                              'statement. Error: {}'.format(json_filename, e))
+                        # If the file cannot be opened, just substitute an empty line
+                        # in place of the macro include line
+                        lines[loc] = REGEXP.sub('', line)
+                        break
+
+                    # The line that contains the directive to include the macro
+                    # may be preceded or followed by text or tags, in that case
+                    # we need to make sure that any preceding or following text
+                    # stays the same.
+                    line_split = REGEXP.split(line, maxsplit=0)
+                    preceding = line_split[0]
+                    following = line_split[-1]
+                    text = [preceding] + text + [following]
+                    lines = lines[:loc] + text + lines[loc+1:]
+                    break
+            else:
+                done = True
+        return lines
+
+    def render_table(self, arguments: List[Dict[str, Any]]) -> List[str]:
+        table = []
+        beginning = """
+<table class="table">
+  <thead>
+    <tr>
+      <th>Argument</th>
+      <th>Example</th>
+      <th>Required</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+<tbody>
+"""
+        tr = """
+<tr>
+  <td><code>{argument}</code></td>
+  <td><code>{example}</code></td>
+  <td>{required}</td>
+  <td>{description}</td>
+</tr>
+"""
+
+        table.append(beginning)
+
+        md_engine = markdown.Markdown(extensions=[])
+
+        for argument in arguments:
+            table.append(tr.format(
+                argument=argument['argument'],
+                example=argument['example'],
+                required=argument['required'],
+                description=md_engine.convert(argument['description']),
+            ))
+
+        table.append("</tbody>")
+        table.append("</table>")
+
+        return table
+
+def makeExtension(*args: Any, **kwargs: str) -> MarkdownArgumentsTableGenerator:
+    return MarkdownArgumentsTableGenerator(kwargs)

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -13,6 +13,7 @@ from django.utils.lru_cache import lru_cache
 from django.utils.safestring import mark_safe
 
 import zerver.lib.bugdown.fenced_code
+import zerver.lib.bugdown.api_arguments_table_generator
 
 register = Library()
 
@@ -83,6 +84,8 @@ def render_markdown_path(markdown_file_path, context=None):
                 guess_lang=False
             ),
             zerver.lib.bugdown.fenced_code.makeExtension(),
+            zerver.lib.bugdown.api_arguments_table_generator.makeExtension(
+                base_path='templates/zerver/api/'),
         ]
     if md_macro_extension is None:
         md_macro_extension = markdown_include.include.makeExtension(

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -55,7 +55,8 @@ class DocPageTest(ZulipTestCase):
         self._test('/api/endpoints/', 'pre-built API bindings for')
         self._test('/api/api-keys', 'you can use its email and API key')
         self._test('/api/installation-instructions', 'No download required!')
-        self._test('/api/usage', 'steal away your hearts')
+        self._test('/api/private-message', 'steal away your hearts')
+        self._test('/api/stream-message', 'rotten in the state of Denmark')
         self._test('/team/', 'industry veterans')
         self._test('/history/', 'Cambridge, Massachusetts')
         # Test the i18n version of one of these pages.


### PR DESCRIPTION
@showell, @timabbott: I would really appreciate some feedback so that I can go ahead and document all of our API. Once I have a go-ahead from you, I just want to rinse and repeat the same process outlined in this PR for every API endpoint that we have till everything follows a macro-based structure similar to our webhooks' docs. Another side goal is to develop a way to test all Python code examples! :)

Also, I used [Slack's Web API docs](https://api.slack.com/methods/api.test) for a little bit of inspiration! Thanks! :)