### PR TITLE
markdown: Update regex for strikethrough.

### DIFF
--- a/zerver/fixtures/markdown_test_cases.json
+++ b/zerver/fixtures/markdown_test_cases.json
@@ -189,6 +189,12 @@
       "text_content": "I  like software  love hardware"
     },
     {
+      "name": "strikthrough_link",
+      "input": "~~test http://xx.xx link~~",
+      "expected_output": "<p><del>test <a href=\"http://xx.xx\" target=\"_blank\" title=\"http://xx.xx\">http://xx.xx</a> link</del></p>",
+      "text_content": "test http://xx.xx link"
+    },
+    {
       "name": "underscore_disabled",
       "input": "_foo_",
       "expected_output": "<p>_foo_</p>"

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1389,7 +1389,7 @@ class Bugdown(markdown.Extension):
         # Custom strikethrough syntax: ~~foo~~
         md.inlinePatterns.add('del',
                               markdown.inlinepatterns.SimpleTagPattern(
-                                  r'(?<!~)(\~\~)([^~{0}\n]+?)\2(?!~)', 'del'), '>strong')
+                                  r'(?<!~)(\~\~)([^~\n]+?)(\~\~)(?!~)', 'del'), '>strong')
 
         # Text inside ** must start and end with a word character
         # it need for things like "const char *x = (char *)y"


### PR DESCRIPTION
This uses the correct regex for strikethrough.

Fixes #7596.