### PR TITLE
mypy: Use Python 3 syntax for typing in zerver/webhooks/bitbucket2/tests.py and zerver/tornado/event_queue.py.

### DIFF
--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -57,10 +57,17 @@ MAX_QUEUE_TIMEOUT_SECS = 7 * 24 * 60 * 60
 HEARTBEAT_MIN_FREQ_SECS = 45
 
 class ClientDescriptor:
-    def __init__(self, user_profile_id, user_profile_email, realm_id, event_queue,
-                 event_types, client_type_name, apply_markdown=True, client_gravatar=True,
-                 all_public_streams=False, lifespan_secs=0, narrow=[]):
-        # type: (int, Text, int, 'EventQueue', Optional[Sequence[str]], Text, bool, bool, bool, int, Iterable[Sequence[Text]]) -> None
+    def __init__(self,
+                 user_profile_id: int,
+                 user_profile_email: Text,
+                 realm_id: int, event_queue: 'EventQueue',
+                 event_types: Optional[Sequence[str]],
+                 client_type_name: Text,
+                 apply_markdown: bool=True,
+                 client_gravatar: bool=True,
+                 all_public_streams: bool=False,
+                 lifespan_secs: int=0,
+                 narrow: Iterable[Sequence[str]]=[]) -> None:
         # These objects are serialized on shutdown and restored on restart.
         # If fields are added or semantics are changed, temporary code must be
         # added to load_event_queues() to update the restored objects.
@@ -664,10 +671,10 @@ def receiver_is_off_zulip(user_profile_id: int) -> bool:
     off_zulip = len(message_event_queues) == 0
     return off_zulip
 
-def maybe_enqueue_notifications(user_profile_id, message_id, private_message,
-                                mentioned, stream_push_notify, stream_name,
-                                always_push_notify, idle, already_notified):
-    # type: (int, int, bool, bool, bool, Optional[str], bool, bool, Dict[str, bool]) -> Dict[str, bool]
+def maybe_enqueue_notifications(user_profile_id: int, message_id: int, private_message: bool,
+                                mentioned: bool, stream_push_notify: bool, stream_name: Optional[str],
+                                always_push_notify: bool, idle: bool,
+                                already_notified: Dict[str, bool]) -> Dict[str, bool]:
     """This function has a complete unit test suite in
     `test_enqueue_notifications` that should be expanded as we add
     more features here."""
@@ -879,15 +886,14 @@ def process_message_update_event(event_template: Mapping[str, Any],
             if client.accepts_event(user_event):
                 client.add_event(user_event)
 
-def maybe_enqueue_notifications_for_message_update(user_profile_id,
-                                                   message_id,
-                                                   stream_name,
-                                                   prior_mention_user_ids,
-                                                   mention_user_ids,
-                                                   presence_idle_user_ids,
-                                                   stream_push_user_ids,
-                                                   push_notify_user_ids):
-    # type: (UserProfile, int, Text, Set[int], Set[int], Set[int], Set[int], Set[int]) -> None
+def maybe_enqueue_notifications_for_message_update(user_profile_id: UserProfile,
+                                                   message_id: int,
+                                                   stream_name: str,
+                                                   prior_mention_user_ids: Set[int],
+                                                   mention_user_ids: Set[int],
+                                                   presence_idle_user_ids: Set[int],
+                                                   stream_push_user_ids: Set[int],
+                                                   push_notify_user_ids: Set[int]) -> None:
     private_message = (stream_name is None)
 
     if private_message:

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -226,8 +226,7 @@ class Bitbucket2HookTests(WebhookTestCase):
 
     @patch('zerver.webhooks.bitbucket2.view.check_send_stream_message')
     def test_bitbucket2_on_push_event_filtered_by_branches_ignore(
-            self, check_send_stream_message_mock):
-        # type: (MagicMock) -> None
+            self, check_send_stream_message_mock: MagicMock) -> None:
         self.url = self.build_webhook_url(branches='changes,devlopment')
         payload = self.get_body('push')
         result = self.client_post(self.url, payload, content_type="application/json")
@@ -236,8 +235,7 @@ class Bitbucket2HookTests(WebhookTestCase):
 
     @patch('zerver.webhooks.bitbucket2.view.check_send_stream_message')
     def test_bitbucket2_on_push_commits_above_limit_filtered_by_branches_ignore(
-            self, check_send_stream_message_mock):
-        # type: (MagicMock) -> None
+            self, check_send_stream_message_mock: MagicMock) -> None:
         self.url = self.build_webhook_url(branches='changes,devlopment')
         payload = self.get_body('push_commits_above_limit')
         result = self.client_post(self.url, payload, content_type="application/json")
@@ -246,8 +244,7 @@ class Bitbucket2HookTests(WebhookTestCase):
 
     @patch('zerver.webhooks.bitbucket2.view.check_send_stream_message')
     def test_bitbucket2_on_force_push_event_filtered_by_branches_ignore(
-            self, check_send_stream_message_mock):
-        # type: (MagicMock) -> None
+            self, check_send_stream_message_mock: MagicMock) -> None:
         self.url = self.build_webhook_url(branches='changes,devlopment')
         payload = self.get_body('force_push')
         result = self.client_post(self.url, payload, content_type="application/json")
@@ -256,8 +253,7 @@ class Bitbucket2HookTests(WebhookTestCase):
 
     @patch('zerver.webhooks.bitbucket2.view.check_send_stream_message')
     def test_bitbucket2_on_push_multiple_committers_filtered_by_branches_ignore(
-            self, check_send_stream_message_mock):
-        # type: (MagicMock) -> None
+            self, check_send_stream_message_mock: MagicMock) -> None:
         self.url = self.build_webhook_url(branches='changes,devlopment')
         payload = self.get_body('push_multiple_committers')
         result = self.client_post(self.url, payload, content_type="application/json")
@@ -266,8 +262,7 @@ class Bitbucket2HookTests(WebhookTestCase):
 
     @patch('zerver.webhooks.bitbucket2.view.check_send_stream_message')
     def test_bitbucket2_on_push_multiple_committers_with_others_filtered_by_branches_ignore(
-            self, check_send_stream_message_mock):
-        # type: (MagicMock) -> None
+            self, check_send_stream_message_mock: MagicMock) -> None:
         self.url = self.build_webhook_url(branches='changes,devlopment')
         payload = self.get_body('push_multiple_committers_with_others')
         result = self.client_post(self.url, payload, content_type="application/json")


### PR DESCRIPTION
For GCI task: https://codein.withgoogle.com/dashboard/task-instances/5578183917174784/
zerver/tests/test_events.py was supposed to be done aswell, but it had already been done.