### PR TITLE
Added a local echo for message editing. Fixes #3530.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -111,11 +111,19 @@ exports.save = function (row, from_topic_edited_only) {
         // If they didn't change anything, just cancel it.
         message_edit.end(row);
         return;
+    } else if (!topic_changed && !markdown.contains_backend_only_syntax(new_content)) {
+        message.content = new_content;
+        row = current_msg_list.get_row(message_id);
+        message_edit.end(row);
+        row.find(".message_content p").text(new_content);
+        row.find(".edit_content").hide();
+        message.backend_edit_in_flight = true;
     }
     channel.patch({
         url: '/json/messages/' + message.id,
         data: request,
         success: function () {
+            message.backend_edit_in_flight = false;
             if (msg_list === current_msg_list) {
                 row.find(".edit_error").text(i18n.t("Message successfully edited!")).removeClass("alert-error").addClass("alert-success").show();
             }

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -150,6 +150,7 @@ exports.toggle_actions_popover = function (element, id) {
         var editability = message_edit.get_editability(message);
         var use_edit_icon;
         var editability_menu_item;
+        var show_edit_option = !message.backend_edit_in_flight;
         if (editability === message_edit.editability_types.FULL) {
             use_edit_icon = true;
             editability_menu_item = i18n.t("Edit");
@@ -177,6 +178,7 @@ exports.toggle_actions_popover = function (element, id) {
         var args = {
             message: message,
             use_edit_icon: use_edit_icon,
+            show_edit_option: show_edit_option,
             editability_menu_item: editability_menu_item,
             can_mute_topic: can_mute_topic,
             can_unmute_topic: can_unmute_topic,

--- a/static/templates/actions_popover_content.handlebars
+++ b/static/templates/actions_popover_content.handlebars
@@ -1,11 +1,13 @@
 {{! Contents of the "message actions" popup }}
 <ul class="nav nav-list actions_popover">
+    {{#if show_edit_option}}
     <li>
         <a href="#" class="popover_edit_message" data-message-id="{{message.id}}">
             {{! Can consider http://fontawesome.io/icon/file-code-o/ when we upgrade to font awesome 4.}}
             <i class="{{#if use_edit_icon}}fa fa-pencil{{else}}fa fa-file-text-o{{/if}}" aria-hidden="true"></i> {{editability_menu_item}}
         </a>
     </li>
+    {{/if}}
 
     <li>
         <a href="#" class="respond_button" data-message-id="{{message.id}}">


### PR DESCRIPTION
Also removed `icon-vector-pencil` and `Edit` option in popover till backend message does not renders.
Fixes #3530 .
![ezgif com-video-to-gif 3](https://user-images.githubusercontent.com/25428397/34297586-feb57e54-e73e-11e7-8d1e-ac68ba7833c5.gif)
