### PR TITLE
Move bankruptcy check from frontend to backend

### DIFF
--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -86,9 +86,7 @@ function consider_bankruptcy() {
         return;
     }
 
-    var now = new XDate(true).getTime() / 1000;
-    if ((page_params.unread_msgs.count > 500) &&
-        (now - page_params.furthest_read_time > 60 * 60 * 24 * 2)) { // 2 days.
+    if (page_params.should_consider_bankruptcy) {
         var unread_info = templates.render('bankruptcy_modal',
                                            {unread_count: page_params.unread_msgs.count});
         $('#bankruptcy-unread-count').html(unread_info);

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -755,6 +755,29 @@ class EventsRegisterTest(ZulipTestCase):
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
+    def test_should_consider_bankruptcy(self) -> None:
+        user = self.example_user('hamlet')
+
+        msg_id = self.send_stream_message(
+            self.example_email('hamlet'),
+            'Verona',
+            'Test'
+        )
+        user.pointer = msg_id
+        state = fetch_initial_state_data(user, ['update_message_flags', 'message'],
+                                         '', client_gravatar=False)
+        self.assertEqual(state['should_consider_bankruptcy'], False)
+
+        for i in range(501):
+            self.send_stream_message(
+                self.example_email('othello'),
+                'Verona',
+                'Test'
+            )
+        state = fetch_initial_state_data(user, ['update_message_flags', 'message'],
+                                         '', client_gravatar=False)
+        self.assertEqual(state['should_consider_bankruptcy'], False)
+
     def test_update_read_flag_removes_unread_msg_ids(self) -> None:
 
         user_profile = self.example_user('hamlet')
@@ -2616,7 +2639,7 @@ class FetchQueriesTest(ZulipTestCase):
                     client_gravatar=False,
                 )
 
-        self.assert_length(queries, 29)
+        self.assert_length(queries, 30)
 
         expected_counts = dict(
             alert_words=0,
@@ -2642,7 +2665,7 @@ class FetchQueriesTest(ZulipTestCase):
             total_uploads_size=1,
             update_display_settings=0,
             update_global_notifications=0,
-            update_message_flags=5,
+            update_message_flags=6,
             upload_quota=0,
             zulip_version=0,
         )

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -150,6 +150,7 @@ class HomeTest(ZulipTestCase):
             "server_generation",
             "server_inline_image_preview",
             "server_inline_url_embed_preview",
+            "should_consider_bankruptcy",
             "subscriptions",
             "test_suite",
             "timezone",
@@ -184,7 +185,7 @@ class HomeTest(ZulipTestCase):
             with patch('zerver.lib.cache.cache_set') as cache_mock:
                 result = self._get_home_page(stream='Denmark')
 
-        self.assert_length(queries, 41)
+        self.assert_length(queries, 42)
         self.assert_length(cache_mock.call_args_list, 7)
 
         html = result.content.decode('utf-8')
@@ -248,7 +249,7 @@ class HomeTest(ZulipTestCase):
         with queries_captured() as queries2:
             result = self._get_home_page()
 
-        self.assert_length(queries2, 35)
+        self.assert_length(queries2, 36)
 
         # Do a sanity check that our new streams were in the payload.
         html = result.content.decode('utf-8')


### PR DESCRIPTION
The "nag time" is the next time to ask the user about bankruptcy. Every time a user is bankrupted, increase their nag time by a week. Also, add a "delay nag time" option which increases the nag time by a month. This "nag time" is based on https://github.com/zulip/zulip/issues/4120#issuecomment-322906474.

(Done for the *"Issue #4120"* Google Code-in task.)