### PR TITLE
quick fix: Stop tracebacks with missedmessage_hook.

### DIFF
--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -631,7 +631,14 @@ def missedmessage_hook(user_profile_id: int, client: ClientDescriptor, last_for_
             continue
         assert 'flags' in event
 
-        flags = event['flags']
+        flags = event.get('flags')
+        if flags is None:
+            # If we have no flags, this is probably in the
+            # API-watching-all-streams codepath, and we don't want
+            # to send a missed-message email
+            logging.error('Ignore missedmessage_hook for user {}.'.format(user_profile_id))
+            return
+
         mentioned = 'mentioned' in flags and 'read' not in flags
         private_message = event['message']['type'] == 'private'
         # stream_push_notify is set in process_message_event.


### PR DESCRIPTION
A `None` value is not properly handled in this function, which
indicates some lack of testing or a recent regression we don't
understand.  We were getting lots of tracebacks from this line
of code on our test server:

    mentioned = 'mentioned' in flags and 'read' not in flags