### PR TITLE
markdown: Add test for strikethrough.

### DIFF
--- a/zerver/fixtures/markdown_test_cases.json
+++ b/zerver/fixtures/markdown_test_cases.json
@@ -189,6 +189,12 @@
       "text_content": "I  like software  love hardware"
     },
     {
+      "name": "strikthrough_link",
+      "input": "~~test http://xx.xx link~~",
+      "expected_output": "<p><del>test <a href=\"http://xx.xx\" target=\"_blank\" title=\"http://xx.xx\">http://xx.xx</a> link</del></p>",
+      "text_content": "test http://xx.xx link"
+    },
+    {
       "name": "underscore_disabled",
       "input": "_foo_",
       "expected_output": "<p>_foo_</p>"


### PR DESCRIPTION
This test make sure that strikethrough works when it contains link with whitespace.