### PR TITLE
recent senders: Add sort by overall message recency.

### DIFF
--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -223,8 +223,8 @@ _.each(matches, function (person) {
     assert.deepEqual(get_typeahead_result("h", "Linux", "Linux Topic"), [
         'zman@test.net',
         'b_user_3@zulip.net',
-        'a_user@zulip.org',
         'b_bot@example.com',
+        'a_user@zulip.org',
         'a_bot@zulip.com',
         'b_user_1@zulip.net',
         'b_user_2@zulip.net',


### PR DESCRIPTION
If both the users have neither posted on the current topic nor
in the current stream, then as a tiebreaker, check whether
who have posted recently in the organization as a whole.
Fixes: #5956.
(Test to be updated).