### PR TITLE
Fix self-deactivate-modal in mobile screens.

### DIFF
--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -122,7 +122,7 @@
         </div>
         <div class="clear-float"></div>
 
-        <div id="deactivate_self_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_self_modal_label" aria-hidden="true">
+        <div id="deactivate_self_modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="deactivation_self_modal_label" aria-hidden="true">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
                 <h3 id="deactivation_self_modal_label">{{t "Deactivate your account" }} </h3>


### PR DESCRIPTION
For mobile screens, self deactivate modal is not visible as shown in image.
![deactivatedialob](https://user-images.githubusercontent.com/25907420/34328574-10a5a100-e908-11e7-8f72-f7f0b822d955.png)

**After:**
![deactivatedialogmy](https://user-images.githubusercontent.com/25907420/34328575-1a33dbce-e908-11e7-80de-a74f32098210.png)
