### PR TITLE
mypy: Use Python 3 syntax for typing in multiple files.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1660,9 +1660,8 @@ class UserPresence(models.Model):
         return user_statuses
 
     @staticmethod
-    def to_presence_dict(client_name, status, dt, push_enabled=False,
-                         has_push_devices=False):
-        # type: (Text, int, datetime.datetime, bool, bool) -> Dict[str, Any]
+    def to_presence_dict(client_name: Text, status: int, dt: datetime.datetime, push_enabled: bool=False,
+                         has_push_devices: bool=False) -> Dict[str, Any]:
         presence_val = UserPresence.status_to_string(status)
 
         timestamp = datetime_to_timestamp(dt)

--- a/zerver/webhooks/codeship/view.py
+++ b/zerver/webhooks/codeship/view.py
@@ -25,9 +25,9 @@ CODESHIP_STATUS_MAPPER = {
 
 @api_key_only_webhook_view('Codeship')
 @has_request_variables
-def api_codeship_webhook(request, user_profile, payload=REQ(argument_type='body'),
-                         stream=REQ(default='codeship')):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], str) -> HttpResponse
+def api_codeship_webhook(request: HttpRequest, user_profile: UserProfile,
+                         payload: Dict[str, Any]=REQ(argument_type='body'),
+                         stream: str=REQ(default='codeship')) -> HttpResponse:
     payload = payload['build']
     subject = get_subject_for_http_request(payload)
     body = get_body_for_http_request(payload)

--- a/zerver/webhooks/delighted/view.py
+++ b/zerver/webhooks/delighted/view.py
@@ -17,11 +17,10 @@ def body_template(score: int) -> str:
 
 @api_key_only_webhook_view("Delighted")
 @has_request_variables
-def api_delighted_webhook(request, user_profile,
-                          payload=REQ(argument_type='body'),
-                          stream=REQ(default='delighted'),
-                          topic=REQ(default='Survey Response')):
-    # type: (HttpRequest, UserProfile, Dict[str, Dict[str, Any]], str, str) -> HttpResponse
+def api_delighted_webhook(request: HttpRequest, user_profile: UserProfile,
+                          payload: Dict[str, Dict[str, Any]]=REQ(argument_type='body'),
+                          stream: str=REQ(default='delighted'),
+                          topic: str=REQ(default='Survey Response')) -> HttpResponse:
     person = payload['event_data']['person']
     selected_payload = {'email': person['email']}
     selected_payload['score'] = payload['event_data']['score']

--- a/zerver/webhooks/deskdotcom/view.py
+++ b/zerver/webhooks/deskdotcom/view.py
@@ -16,10 +16,9 @@ from zerver.models import UserProfile, get_client
 # from the "data" param and post it, which this does.
 @authenticated_rest_api_view(is_webhook=True)
 @has_request_variables
-def api_deskdotcom_webhook(request, user_profile, data=REQ(),
-                           topic=REQ(default="Desk.com notification"),
-                           stream=REQ(default="desk.com")):
-    # type: (HttpRequest, UserProfile, Text, Text, Text) -> HttpResponse
+def api_deskdotcom_webhook(request: HttpRequest, user_profile: UserProfile, data: Text=REQ(),
+                           topic: Text=REQ(default="Desk.com notification"),
+                           stream: Text=REQ(default="desk.com")) -> HttpResponse:
     check_send_stream_message(user_profile, get_client("ZulipDeskWebhook"),
                               stream, topic, data)
     return json_success()

--- a/zerver/webhooks/github_webhook/view.py
+++ b/zerver/webhooks/github_webhook/view.py
@@ -368,9 +368,8 @@ EVENT_FUNCTION_MAPPER = {
 @api_key_only_webhook_view('GitHub')
 @has_request_variables
 def api_github_webhook(
-        request, user_profile, payload=REQ(argument_type='body'),
-        stream=REQ(default='github'), branches=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Text) -> HttpResponse
+        request: HttpResponse, user_profile: UserProfile, payload: Dict[str, Any]=REQ(argument_type='body'),
+        stream: Text=REQ(default='github'), branches: Text=REQ(default=None)) -> HttpResponse:
     event = get_event(request, payload, branches)
     if event is not None:
         subject = get_subject_based_on_type(payload, event)

--- a/zerver/webhooks/librato/view.py
+++ b/zerver/webhooks/librato/view.py
@@ -143,9 +143,9 @@ class LibratoWebhookHandler(LibratoWebhookParser):
 
 @api_key_only_webhook_view('Librato')
 @has_request_variables
-def api_librato_webhook(request, user_profile, payload=REQ(converter=ujson.loads, default={}),
-                        stream=REQ(default='librato'), topic=REQ(default=None)):
-    # type: (HttpRequest, UserProfile, Dict[str, Any], Text, Text) -> HttpResponse
+def api_librato_webhook(request: HttpRequest, user_profile: UserProfile,
+                        payload: Dict[str, Any]=REQ(converter=ujson.loads, default={}),
+                        stream: Text=REQ(default='librato'), topic: Text=REQ(default=None)) -> HttpResponse:
     try:
         attachments = ujson.loads(request.body).get('attachments', [])
     except ValueError:

--- a/zerver/webhooks/zendesk/view.py
+++ b/zerver/webhooks/zendesk/view.py
@@ -16,9 +16,9 @@ def truncate(string: Text, length: int) -> Text:
 
 @authenticated_rest_api_view(is_webhook=True)
 @has_request_variables
-def api_zendesk_webhook(request, user_profile, ticket_title=REQ(), ticket_id=REQ(),
-                        message=REQ(), stream=REQ(default="zendesk")):
-                        # type: (HttpRequest, UserProfile, str, str, str, str) -> HttpResponse
+def api_zendesk_webhook(request: HttpRequest, user_profile: UserProfile,
+                        ticket_title: str=REQ(), ticket_id: str=REQ(),
+                        message: str=REQ(), stream: str=REQ(default="zendesk")) -> HttpResponse:
     """
     Zendesk uses trigers with message templates. This webhook uses the
     ticket_id and ticket_title to create a subject. And passes with zendesk


### PR DESCRIPTION
mypy: Use Python 3 type syntax in zerver/webhooks/zendesk/view.py
mypy: Use Python 3 type syntax in zerver/webhooks/librato/view.py
mypy: Use Python 3 type syntax in zerver/webhooks/github_webhook/view.py
mypy: Use Python 3 type syntax in zerver/webhooks/deskdotcom/view.py
mypy: Use Python 3 type syntax in zerver/webhooks/delighted/view.py
mypy: Use Python 3 type syntax in zerver/webhooks/codeship/view.py
mypy: Use Python 3 type syntax in zerver/models.py

