### PR TITLE
org setting: Clean code of realm domain modal.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -140,18 +140,10 @@ function test_realms_domain_modal(add_realm_domain) {
     assert(posted);
 
     success_callback();
-    assert(!info.hasClass('text-error'));
-    assert(info.hasClass('text-success'));
-    assert.equal(info.text(), 'translated: Added successfully!');
+    assert.equal(info.val(), 'translated: Added successfully!');
 
-    var xhr = {
-        responseText: '{"msg": "no can do"}',
-    };
-
-    error_callback(xhr);
-    assert(info.hasClass('text-error'));
-    assert(!info.hasClass('text-success'));
-    assert.equal(info.text(), 'no can do');
+    error_callback({});
+    assert.equal(info.val(), 'translated: Failed');
 }
 
 function test_submit_profile_form(submit_form) {
@@ -449,23 +441,17 @@ function test_change_allow_subdomains(change_allow_subdomains) {
     change_allow_subdomains.apply('<elem html>', [ev]);
 
     success_callback();
-    assert.equal(info.text(),
+    assert.equal(info.val(),
                  'translated: Update successful: Subdomains allowed for example.com');
-    assert(info.hasClass('text-success'));
 
-    var xhr = {
-        responseText: '{"msg": "no can do"}',
-    };
-
-    error_callback(xhr);
-    assert(info.hasClass('text-error'));
-    assert.equal(info.text(), 'no can do');
+    error_callback({});
+    assert.equal(info.val(), 'translated: Failed');
 
     allow = false;
     elem_obj.prop('checked', allow);
     change_allow_subdomains.apply('<elem html>', [ev]);
     success_callback();
-    assert.equal(info.text(),
+    assert.equal(info.val(),
                  'translated: Update successful: Subdomains no longer allowed for example.com');
 }
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -617,14 +617,10 @@ function _set_up() {
         channel.del({
             url: url,
             success: function () {
-                realm_domains_info.removeClass("text-error");
-                realm_domains_info.addClass("text-success");
-                realm_domains_info.text(i18n.t("Deleted successfully!"));
+                ui_report.success(i18n.t("Deleted successfully!"), realm_domains_info);
             },
             error: function (xhr) {
-                realm_domains_info.removeClass("text-success");
-                realm_domains_info.addClass("text-error");
-                realm_domains_info.text(JSON.parse(xhr.responseText).msg);
+                ui_report.error(i18n.t("Failed"), xhr, realm_domains_info);
             },
         });
     });
@@ -646,14 +642,10 @@ function _set_up() {
                 $("#add-realm-domain-widget .new-realm-domain").val("");
                 $("#add-realm-domain-widget .new-realm-domain-allow-subdomains").prop("checked", false);
                 $("#id_realm_restricted_to_domain").prop("disabled", false);
-                realm_domains_info.removeClass("text-error");
-                realm_domains_info.addClass("text-success");
-                realm_domains_info.text(i18n.t("Added successfully!"));
+                ui_report.success(i18n.t("Added successfully!"), realm_domains_info);
             },
             error: function (xhr) {
-                realm_domains_info.removeClass("text-success");
-                realm_domains_info.addClass("text-error");
-                realm_domains_info.text(JSON.parse(xhr.responseText).msg);
+                ui_report.error(i18n.t("Failed"), xhr, realm_domains_info);
             },
         });
     });
@@ -672,20 +664,16 @@ function _set_up() {
             url: url,
             data: data,
             success: function () {
-                realm_domains_info.removeClass("text-error");
-                realm_domains_info.addClass("text-success");
                 if (allow_subdomains) {
-                    realm_domains_info.text(i18n.t("Update successful: Subdomains allowed for __domain__",
-                                             {domain: domain}));
+                    ui_report.success(i18n.t("Update successful: Subdomains allowed for __domain__",
+                                             {domain: domain}), realm_domains_info);
                 } else {
-                    realm_domains_info.text(i18n.t("Update successful: Subdomains no longer allowed for __domain__",
-                                             {domain: domain}));
+                    ui_report.success(i18n.t("Update successful: Subdomains no longer allowed for __domain__",
+                                             {domain: domain}), realm_domains_info);
                 }
             },
             error: function (xhr) {
-                realm_domains_info.removeClass("text-success");
-                realm_domains_info.addClass("text-error");
-                realm_domains_info.text(JSON.parse(xhr.responseText).msg);
+                ui_report.error(i18n.t("Failed"), xhr, realm_domains_info);
             },
         });
     });

--- a/static/js/ui_report.js
+++ b/static/js/ui_report.js
@@ -44,7 +44,12 @@ exports.error = function (response, xhr, status_box, type) {
     if (xhr && xhr.status.toString().charAt(0) === "4") {
         // Only display the error response for 4XX, where we've crafted
         // a nice response.
-        response += ": " + escape(JSON.parse(xhr.responseText).msg);
+        var response_text = escape(JSON.parse(xhr.responseText).msg);
+        if (response_text.indexOf(':') > -1) {
+            response = response_text;
+        } else {
+            response += ": " + response_text;
+        }
     }
 
     exports.message(response, status_box, 'alert-error', type);

--- a/static/templates/settings/realm-domains-modal.handlebars
+++ b/static/templates/settings/realm-domains-modal.handlebars
@@ -22,6 +22,6 @@
         </table>
     </div>
     <div class="modal-footer centered-footer">
-        <div class="realm_domains_info"></div>
+        <div class="alert realm_domains_info"></div>
     </div>
 </div>


### PR DESCRIPTION
Remove extra lines of code for reporting alert messages on modal
and add predefined ui_report functions instead.

![domainmodal](https://user-images.githubusercontent.com/25907420/34342158-5d6bfd7a-e9cd-11e7-9f75-f0ca23e3e640.gif)

* No changes in backend, only frontend of alert message is changed(changed to other alert message).
* Add condition in `ui_report.error(extra_message, xhr, status_box, type)` function to check whether `xhr.responseText` already consist `:` or not, to prevent error message like 
`extra_message: some_text: another_text` where `some_text: another_text` is `xhr.responseText`
