### PR TITLE
Vagrantfile: Bump Ubuntu version to Xenial.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # For LXC. VirtualBox hosts use a different box, described below.
-  config.vm.box = "fgrehm/trusty64-lxc"
+  config.vm.box = "developerinlondon/ubuntu_lxc_xenial_x64"
 
   # The Zulip development environment runs on 9991 on the guest.
   host_port = 9991
@@ -90,14 +90,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provider "virtualbox" do |vb, override|
-    override.vm.box = "ubuntu/trusty64"
+    override.vm.box = "ubuntu/xenial64"
     # It's possible we can get away with just 1.5GB; more testing needed
     vb.memory = 2048
     vb.cpus = 2
   end
 
   config.vm.provider "vmware_fusion" do |vb, override|
-    override.vm.box = "puphpet/ubuntu1404-x64"
+    override.vm.box = "puphpet/ubuntu1604-x64"
     vb.vmx["memsize"] = "2048"
     vb.vmx["numvcpus"] = "2"
   end

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -194,6 +194,15 @@ def setup_shell_profile(shell_profile):
 
 def install_apt_deps():
     # type: () -> None
+
+    # Workaround for installing redis on Ubuntu Xenial.
+    # See https://bugs.launchpad.net/ubuntu/+source/redis/+bug/1663911
+    # for tracking the stage of this bug
+    if codename == 'xenial':
+        run(["sudo", "mkdir", "/etc/systemd/system/redis-server.service.d/"])
+        run(["sudo", "echo", "'[Service]\nPrivateDevices=no'", ">",
+             "/etc/systemd/system/redis-server.service.d/redis.override.conf"])
+
     # setup-apt-repo does an `apt-get update`
     run(["sudo", "./scripts/lib/setup-apt-repo"])
     run(["sudo", "apt-get", "-y", "install", "--no-install-recommends"] + APT_DEPENDENCIES[codename])


### PR DESCRIPTION
While both 14.04 and 16.04 are supported, if both choices are available, shouldn't the latter be preferred?