### PR TITLE
drafts: Add timestamps showing when last modified.

### DIFF
--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -17,6 +17,12 @@ set_global('timerender', {
         }
         return [{outerHTML: String(time1.getTime()) + ' - ' + String(time2.getTime())}];
     },
+    stringify_time : function (time) {
+        if (page_params.twenty_four_hour_time) {
+            return time.toString('HH:mm');
+        }
+        return time.toString('h:mm TT');
+    },
 });
 
 (function test_merge_message_groups() {

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -1,6 +1,8 @@
 set_global('$', global.make_zjquery());
 set_global('i18n', global.stub_i18n);
-
+set_global('page_params' , {
+    twenty_four_hour_time: true,
+});
 zrequire('XDate', 'xdate');
 zrequire('timerender');
 
@@ -261,4 +263,22 @@ zrequire('timerender');
     assert_same(function (d) { return d.addYears(-3); },
                 i18n.t("Last seen on Mar 01, 2013"));
 
+}());
+
+(function test_set_full_datetime() {
+    var time = new XDate(1549958107000); // Tuesday 2/12/2019 07:55:07 AM (UTC+0)
+    var time_str = timerender.stringify_time(time);
+    var expected = '07:55';
+    assert.equal(expected, time_str);
+
+    page_params.twenty_four_hour_time = false;
+    time_str = timerender.stringify_time(time);
+    expected = '7:55 AM';
+    assert.equal(expected, time_str);
+
+    time = new XDate(1549979707000); // Tuesday 2/12/2019 13:55:07 PM (UTC+0)
+    page_params.twenty_four_hour_time = false;
+    time_str = timerender.stringify_time(time);
+    expected = '1:55 PM';
+    assert.equal(expected, time_str);
 }());

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -185,7 +185,16 @@ exports.setup_page = function (callback) {
 
     function format_drafts(data) {
         var drafts = {};
+        var data_array = [];
         _.each(data, function (draft, id) {
+            data_array.push([id, data[id]]);
+        });
+        var data_sorted = data_array.sort(function (draft_a,draft_b) {
+            return draft_a[1].updatedAt-draft_b[1].updatedAt;
+        });
+        _.each(data_sorted, function (data_element) {
+            var draft = data_element[1];
+            var id = data_element[0];
             var formatted;
             var time = new XDate(draft.updatedAt);
             var time_stamp = timerender.render_now(time).time_str;

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -187,6 +187,11 @@ exports.setup_page = function (callback) {
         var drafts = {};
         _.each(data, function (draft, id) {
             var formatted;
+            var time = new XDate(draft.updatedAt);
+            var time_stamp = timerender.render_now(time).time_str;
+            if (time_stamp === "Today") {
+                time_stamp = timerender.stringify_time(time);
+            }
             if (draft.type === "stream") {
                 // In case there is no stream for the draft, we need a
                 // single space char for proper rendering of the stream label
@@ -202,7 +207,7 @@ exports.setup_page = function (callback) {
                     stream_color: stream_data.get_color(draft.stream),
                     topic: draft_topic,
                     raw_content: draft.content,
-
+                    time_stamp: time_stamp,
                 };
             } else {
                 var emails = util.extract_pm_recipients(draft.private_message_recipient);
@@ -220,6 +225,7 @@ exports.setup_page = function (callback) {
                     is_stream: false,
                     recipients: recipients,
                     raw_content: draft.content,
+                    time_stamp: time_stamp,
                 };
             }
 

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -32,13 +32,6 @@ function mention_button_refers_to_me(elem) {
     return false;
 }
 
-function stringify_time(time) {
-    if (page_params.twenty_four_hour_time) {
-        return time.toString('HH:mm');
-    }
-    return time.toString('h:mm TT');
-}
-
 function same_day(earlier_msg, later_msg) {
     if (earlier_msg === undefined || later_msg === undefined) {
         return false;
@@ -81,7 +74,7 @@ function add_display_time(group, message_container, prev) {
     }
 
     if (message_container.timestr === undefined) {
-        message_container.timestr = stringify_time(time);
+        message_container.timestr = timerender.stringify_time(time);
     }
 }
 
@@ -153,7 +146,7 @@ MessageListView.prototype = {
             var today = new XDate();
             message_container.last_edit_timestr =
                 (timerender.render_date(last_edit_time, undefined, today))[0].textContent
-                + " at " + stringify_time(last_edit_time);
+                + " at " + timerender.stringify_time(last_edit_time);
         }
     },
 

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -210,6 +210,12 @@ exports.get_full_time = function (timestamp) {
     return new XDate(timestamp * 1000).toISOString();
 };
 
+exports.stringify_time = function (time) {
+    if (page_params.twenty_four_hour_time) {
+        return time.toString('HH:mm');
+    }
+    return time.toString('h:mm TT');
+};
 
 // this is for rendering absolute time based off the preferences for twenty-four
 // hour time in the format of "%mmm %d, %h:%m %p".

--- a/static/templates/draft.handlebars
+++ b/static/templates/draft.handlebars
@@ -13,6 +13,7 @@
                         {{topic}}
                     </div>
                 </span>
+                <div class="recipient_row_date" title="{{t 'Last modified'}}">{{ time_stamp }}</div>
             </div>
         </div>
         {{else}}
@@ -21,7 +22,9 @@
                 <div class="message_label_clickable stream_label">
                     {{#tr this}}You and __recipients__{{/tr}}
                 </div>
+                <div class="recipient_row_date" title="{{t 'Last modified'}}">{{ time_stamp }}</div>
             </div>
+
         </div>
         {{/if}}
         <div class="message_row{{^is_stream}} private-message{{/is_stream}}">


### PR DESCRIPTION
![draft timestamp](https://user-images.githubusercontent.com/22238472/34356301-a1b5518a-ea62-11e7-8325-a82c8399ace5.png)
I think I need to discuss what we should show as a timestamp, currently, it is showing day when it is last modified.
Also noticed when we update an old draft it doesn't move to bottom(don't know if it's intentional, and if not then this might be itself a new issue).
Fixes: #3790.