### PR TITLE
settings: Add timer for alert message notification.

### DIFF
--- a/static/js/ui_report.js
+++ b/static/js/ui_report.js
@@ -29,6 +29,10 @@ exports.message = function (response, status_box, cls, type) {
     }
 
     status_box.addClass("show");
+    // Show alert message for maximum 7 seconds and minimum 3 seconds.
+    setTimeout(function () {
+        status_box.hide();
+    }, Math.min(7000, Math.max(3000, response.length * 50)));
 };
 
 function escape(html) {


### PR DESCRIPTION
Currently all alert messages are shown permanently.
![alert-message-still](https://user-images.githubusercontent.com/25907420/34362334-aabdaef4-ea98-11e7-92e0-a8842a7d7520.gif)

I changed it to:
Show alert message notifications for maximum 7 seconds and
minimum 3 seconds, depending on length of alert message.
![alert-message-new](https://user-images.githubusercontent.com/25907420/34362339-b82f518c-ea98-11e7-922c-c673bf28fe96.gif)

We can change the max/min time limit.