### PR TITLE
create stream: Show notification stream name for announcement.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -131,8 +131,8 @@ function update_announce_stream_state() {
         return;
     }
 
-    // If the stream is invite only, or everyone's added, disable
-    // the "Announce stream" option. Otherwise enable it.
+    // If the stream is invite only, disable the "Announce stream" option.
+    // Otherwise enable it.
     var announce_stream_checkbox = $('#announce-new-stream input');
     var disable_it = false;
     var is_invite_only = $('input:radio[name=privacy]:checked').val() === 'invite-only';
@@ -140,9 +140,6 @@ function update_announce_stream_state() {
     if (is_invite_only) {
         disable_it = true;
         announce_stream_checkbox.prop('checked', false);
-    } else {
-        disable_it = $('#user-checkboxes input').length
-                    === $('#user-checkboxes input:checked').length;
     }
 
     announce_stream_checkbox.prop('disabled', disable_it);

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -134,12 +134,15 @@ function update_announce_stream_state() {
     // If the stream is invite only, disable the "Announce stream" option.
     // Otherwise enable it.
     var announce_stream_checkbox = $('#announce-new-stream input');
+    var announce_stream_label = $('#announce-new-stream');
     var disable_it = false;
     var is_invite_only = $('input:radio[name=privacy]:checked').val() === 'invite-only';
+    announce_stream_label.removeClass("control-label-disabled");
 
     if (is_invite_only) {
         disable_it = true;
         announce_stream_checkbox.prop('checked', false);
+        announce_stream_label.addClass("control-label-disabled");
     }
 
     announce_stream_checkbox.prop('disabled', disable_it);

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -368,7 +368,8 @@ $(function () {
     $("body").on("mouseover", "#announce-stream-docs", function (e) {
         var announce_stream_docs = $("#announce-stream-docs");
         announce_stream_docs.popover({placement: "right",
-                                      content: templates.render('announce_stream_docs'),
+                                      content: templates.render('announce_stream_docs', {
+                                        notifications_stream: page_params.notifications_stream}),
                                       trigger: "manual"});
         announce_stream_docs.popover('show');
         announce_stream_docs.data('popover').tip().css('z-index', 2000);

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -171,6 +171,11 @@ td .button {
     box-shadow: none;
 }
 
+.settings-info-icon {
+    padding-left: 3px;
+    opacity: 0.9;
+}
+
 .settings-section {
     display: none;
 

--- a/static/templates/announce_stream_docs.handlebars
+++ b/static/templates/announce_stream_docs.handlebars
@@ -2,8 +2,8 @@
 <div>
 
     {{#tr this}}
-    <p>Lets everyone know about the new stream,<br />
-    even if you don't add them.</p>
+    <p>Stream will be announced in <b>#__notifications_stream__</b>.</p>
     {{/tr}}
+    <p>{{t 'Admin can configure where new streams are announced in organization settings.' }}</p>
 
 </div>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -15,7 +15,7 @@
                     </a>
                 </div>
 
-                <i class="icon-vector-question-sign change_email_tooltip" {{#unless page_params.realm_email_changes_disabled}}style="display:none" {{/unless}} data-toggle="tooltip"
+                <i class="icon-vector-question-sign settings-info-icon change_email_tooltip" {{#unless page_params.realm_email_changes_disabled}}style="display:none" {{/unless}} data-toggle="tooltip"
                 title="{{t 'Changing email addresses has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"></i>
 
                 <div id="change_email_modal" class="modal hide" tabindex="-1" role="dialog"
@@ -45,7 +45,7 @@
                         <div class="input-group" id="name_change_container">
                             <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
                             <input type="text" name="full_name" id="full_name" class="w-200 inline-block" value="{{ page_params.full_name }}" {{#if page_params.realm_name_changes_disabled}}disabled="disabled" {{/if}}/>
-                            <i class="icon-vector-question-sign change_name_tooltip" data-toggle="tooltip"
+                            <i class="icon-vector-question-sign settings-info-icon change_name_tooltip" data-toggle="tooltip"
                             {{#unless page_params.realm_name_changes_disabled}}style="display:none" {{/unless}}
                             title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
                             <div class="warning"></div>

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -31,7 +31,7 @@
                     <div class="input-group">
                         <label for="bot_type">
                             {{t "Bot type" }}
-                            <i class="icon-vector-question-sign bot_type_tooltip" data-toggle="tooltip"
+                            <i class="icon-vector-question-sign settings-info-icon bot_type_tooltip" data-toggle="tooltip"
                              title='{{t "Incoming webhooks can only send messages." }}'></i>
                         </label>
                         <select name="bot_type" id="create_bot_type">

--- a/static/templates/subscription_creation_form.handlebars
+++ b/static/templates/subscription_creation_form.handlebars
@@ -52,7 +52,7 @@
                         <div class="fa fa-bullhorn" aria-hidden="true"></div>
                         {{t "Announce stream" }}
                     </label>
-                    <span class="fa fa-question-circle" aria-hidden="true" id="announce-stream-docs"></span>
+                    <span class="fa fa-question-circle settings-info-icon" aria-hidden="true" id="announce-stream-docs"></span>
                 </div>
             </section>
             <section class="block">


### PR DESCRIPTION
Display stream in which new stream notification will be announced.
![announce-stream](https://user-images.githubusercontent.com/25907420/34363285-c7e82b3c-eaa0-11e7-880f-b178a37b3541.png)

NOTE:
Stream notification is set by administrators.
If notification stream is not set by admin then `Announce stream` will not be displayed.
