### PR TITLE
org setting: Remove title strings from settings.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1271,6 +1271,10 @@ thead .actions {
     width: 340px;
 }
 
+#service_name_list input[type=text] {
+    width: 340px;
+}
+
 .invited-as-admin {
     opacity: 0.5;
     margin-left: 2px;

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -18,9 +18,7 @@
                            {{#if realm_restricted_to_domain}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_restricted_to_domain" id="realm_restricted_to_domains_label" class="inline-block"
-                    title="{{#tr this}}If checked, only users with an e-mail address ending in these domains will be able to join the organization.{{/tr}}">
-                </label>
+                <label for="id_realm_restricted_to_domain" id="realm_restricted_to_domains_label" class="inline-block" />
                 {{#if is_admin }}
                 <a data-toggle="modal" href="#realm_domains_modal">{{t "[Configure]" }}</a>
                 {{/if}}
@@ -32,8 +30,7 @@
                            {{#if realm_invite_required}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_invite_required" id="realm_invite_required_label" class="inline-block"
-                    title="{{t 'If checked, users must be invited in order to join your organization.' }}">
+                <label for="id_realm_invite_required" id="realm_invite_required_label" class="inline-block">
                     {{t "Users need an invitation to join" }}
                 </label>
             </div>
@@ -45,8 +42,7 @@
                            {{#if realm_invite_by_admins_only}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_invite_by_admins_only" id="id_realm_invite_by_admins_only_label" class="inline-block"
-                    title="{{t 'If checked, only administrators may invite new users.' }}">
+                <label for="id_realm_invite_by_admins_only" id="id_realm_invite_by_admins_only_label" class="inline-block">
                     {{t "Only admins can invite new users" }}
                 </label>
             </div>
@@ -60,8 +56,7 @@
                            {{#if realm_name_changes_disabled}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_name_changes_disabled" id="id_realm_name_changes_disabled_label" class="inline-block"
-                    title="{{t 'If checked, users will be unable to change their name.' }}">
+                <label for="id_realm_name_changes_disabled" id="id_realm_name_changes_disabled_label" class="inline-block">
                     {{t "Prevent users from changing their name" }}
                 </label>
             </div>
@@ -72,8 +67,7 @@
                            {{#if realm_email_changes_disabled}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_email_changes_disabled" id="id_realm_email_changes_disabled_label" class="inline-block"
-                    title="{{t 'If checked, users will be unable to change their email address.' }}">
+                <label for="id_realm_email_changes_disabled" id="id_realm_email_changes_disabled_label" class="inline-block">
                     {{t "Prevent users from changing their email address" }}
                 </label>
             </div>
@@ -87,8 +81,7 @@
                            {{#if realm_create_stream_by_admins_only}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_create_stream_by_admins_only" id="id_realm_create_stream_by_admins_only_label" class="inline-block"
-                    title="{{t 'If checked, only administrators may create new streams.' }}">
+                <label for="id_realm_create_stream_by_admins_only" id="id_realm_create_stream_by_admins_only_label" class="inline-block">
                     {{t "Prevent users from creating streams" }}
                 </label>
             </div>
@@ -108,8 +101,7 @@
                            {{#if realm_add_emoji_by_admins_only}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_add_emoji_by_admins_only" id="id_realm_add_emoji_by_admins_only_label" class="inline-block"
-                    title="{{t 'If checked, only administrators may add new emoji.'}}">
+                <label for="id_realm_add_emoji_by_admins_only" id="id_realm_add_emoji_by_admins_only_label" class="inline-block">
                     {{t "Prevent users from adding custom emoji" }}
                 </label>
             </div>

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -19,16 +19,14 @@
                            {{#if realm_allow_message_editing}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_allow_message_editing" class="inline-block"
-                    title="{{t 'If checked, users can edit the content and topics of their old messages.' }}">
+                <label for="id_realm_allow_message_editing" class="inline-block">
                     {{t "Users can edit their messages" }}
                 </label>
             </div>
 
             <div class="input-group disableable {{#unless realm_allow_message_editing}}control-label-disabled{{/unless}}">
                 <label for="id_realm_message_content_edit_limit_minutes"
-                    id="id_realm_message_content_edit_limit_minutes_label"
-                    title="{{t 'If non-zero, users can edit their message for this many minutes after it is sent. If zero, users can edit all their past messages.' }}">
+                    id="id_realm_message_content_edit_limit_minutes_label">
                     {{t 'Message edit limit in minutes (0 for no limit)' }}
                 </label>
                 <input type="text" id="id_realm_message_content_edit_limit_minutes"
@@ -44,10 +42,11 @@
                            {{#if realm_allow_message_deleting}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_allow_message_deleting" id="id_realm_allow_message_deleting_label" class="inline-block"
-                    title="{{t 'If checked, users can delete their messages.  By default, only administrators can delete messages.' }}">
+                <label for="id_realm_allow_message_deleting" id="id_realm_allow_message_deleting_label" class="inline-block">
                     {{t "Users can delete their messages" }}
                 </label>
+                <i class="icon-vector-info-sign settings-info-icon realm_allow_message_deleting_tooltip" data-toggle="tooltip"
+                title="{{t 'Administrators can always delete any message.' }}"/>
             </div>
 
             <div class="input-group">
@@ -56,8 +55,7 @@
                            {{#if realm_allow_edit_history}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_allow_edit_history" id="id_realm_allow_edit_history_label" class="inline-block"
-                    title="{{t 'If checked, users will be able view message edit history.'}}">
+                <label for="id_realm_allow_edit_history" id="id_realm_allow_edit_history_label" class="inline-block">
                     {{t "Enable message edit history" }}
                 </label>
             </div>
@@ -68,8 +66,7 @@
             {{#if false}}
             <div class="input-group">
                 <label for="realm_message_retention_days"
-                    id="id_realm_message_retention_days_label"
-                    title="{{t 'Messages older than the configured number of days will be automatically deleted' }}">
+                    id="id_realm_message_retention_days_label">
                     {{t 'Messages retention period in days (blank means messages are retained forever)' }}
                 </label>
                 <input type="text" id="id_realm_message_retention_days"
@@ -85,8 +82,7 @@
                            {{#if realm_mandatory_topics}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_mandatory_topics" id="id_realm_mandatory_topics_label" class="inline-block"
-                    title="{{t 'If checked, topics are required.'}}">
+                <label for="id_realm_mandatory_topics" id="id_realm_mandatory_topics_label" class="inline-block">
                     {{t "Require topics in stream messages" }}
                 </label>
             </div>
@@ -98,8 +94,7 @@
                            {{#if realm_inline_image_preview}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_inline_image_preview" id="id_realm_inline_image_preview_label" class="inline-block"
-                    title="{{t 'If checked, image previews will be shown.' }}">
+                <label for="id_realm_inline_image_preview" id="id_realm_inline_image_preview_label" class="inline-block">
                     {{t "Show previews of uploaded and linked images" }}
                 </label>
             </div>
@@ -112,8 +107,7 @@
                            {{#if realm_inline_url_embed_preview}}checked="checked"{{/if}} />
                     <span></span>
                 </label>
-                <label for="id_realm_inline_url_embed_preview" id="id_realm_inline_url_embed_preview_label" class="inline-block"
-                    title="{{t 'If checked, previews of linked websites will be shown.' }}">
+                <label for="id_realm_inline_url_embed_preview" id="id_realm_inline_url_embed_preview_label" class="inline-block">
                     {{t "Show previews of linked websites" }}
                 </label>
             </div>


### PR DESCRIPTION
Fixes #7882

* Remove all title string from `Organization settings` and `Organization permissions`
* Add `!` icon in `realm_deleting` with tooltip `Administrators can always delete any message.`