### PR TITLE
user docs: Highlight currently selected user docs article.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -17,10 +17,24 @@ function registerCodeSection($codeSection) {
     $li.eq(0).click();
 }
 
+function highlight_current_article() {
+    $('.help .sidebar a').removeClass('highlighted');
+    var path = window.location.href.match(/\/(help|api)\/.+/);
+
+    if (!path) {
+        return;
+    }
+
+    var article = $('.help .sidebar a[href="' + path[0] + '"]');
+    article.addClass('highlighted');
+}
+
 function render_code_sections() {
     $(".code-section").each(function () {
         registerCodeSection($(this));
     });
+
+    highlight_current_article();
 }
 
 (function () {
@@ -52,7 +66,6 @@ function render_code_sections() {
     $(".sidebar a").click(function (e) {
         var path = $(this).attr("href");
         var container = $(".markdown")[0];
-
 
         if (loading.name === path) {
             return;

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -19,7 +19,7 @@ function registerCodeSection($codeSection) {
 
 function highlight_current_article() {
     $('.help .sidebar a').removeClass('highlighted');
-    var path = window.location.href.match(/\/(help|api)\/.+/);
+    var path = window.location.href.match(/\/(help|api)\/.*/);
 
     if (!path) {
         return;

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -1733,7 +1733,7 @@ input.new-organization-button {
         position: fixed;
         top: 70px;
         left: 9px;
-        fill: hsl(222, 33%, 33%);
+        fill: hsl(0, 0%, 100%);
         z-index: 2;
 
 

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -205,6 +205,15 @@ body {
     display: block;
 }
 
+.help .sidebar li a.highlighted {
+    background-color: hsl(152, 40%, 42%);
+
+    /* Extend highlight to entire width of sidebar, not just link area */
+    width: calc(100% + 20px);
+    margin-left: -40px;
+    padding-left: 40px;
+}
+
 .app.help .hamburger {
     display: none;
 }

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -145,21 +145,25 @@ body {
 
 .help .sidebar h1,
 .help .sidebar h2 {
-    font-size: 1.2em;
     font-weight: 400;
-    margin-bottom: 5px;
-    line-height: 105%;
 }
 
 .help .sidebar h1 {
     font-size: 1.25em;
+    line-height: 1.5;
+    margin-bottom: 0px;
 }
 
 .help .sidebar h1:not(:first-of-type) {
     margin-top: 20px;
 }
 
-.help .sidebar.slide h1,
+.help .sidebar h2 {
+    font-size: 1.2em;
+    line-height: 1.05;
+    margin-bottom: 5px;
+}
+
 .help .sidebar.slide h2 {
     cursor: pointer;
 }
@@ -205,7 +209,7 @@ body {
     display: block;
 }
 
-.help .sidebar li a.highlighted {
+.help .sidebar a.highlighted {
     background-color: hsl(152, 40%, 42%);
 
     /* Extend highlight to entire width of sidebar, not just link area */


### PR DESCRIPTION
![screenshot at dec 26 22-41-09](https://user-images.githubusercontent.com/15116870/34388583-517678b6-eae9-11e7-9011-2ec8273b7991.png)


Fixes #7053.


Note: Third commit (user docs: Apply highlights to documentation indexes) is optional and can be dropped if unnecessary. Without that commit, Index links in documentation sidebars will **not** be highlighted.

![screenshot at dec 27 10-13-33](https://user-images.githubusercontent.com/15116870/34389458-9d1c67bc-eaee-11e7-8519-b903654a1059.png)
