### PR TITLE
quick fix: Turn off git lint for Travis builds.

### DIFF
--- a/tools/travis/backend
+++ b/tools/travis/backend
@@ -6,7 +6,9 @@ echo "Test suite is running under $(python --version)."
 set -e
 set -x
 
-./tools/lint --backend ${CIRCLECI:+--no-gitlint}
+#./tools/lint --backend ${CIRCLECI:+--no-gitlint}
+# TEMP: turn off git lint
+./tools/lint --backend --no-gitlint
 ./tools/test-tools
 ./tools/test-backend --coverage
 

--- a/tools/travis/frontend
+++ b/tools/travis/frontend
@@ -5,7 +5,9 @@ source tools/travis/activate-venv
 set -e
 set -x
 
-./tools/lint --frontend
+# ./tools/lint --frontend
+# TEMP: turn off git lint
+./tools/lint --frontend --no-gitlint
 
 # Run the node tests first, since they're fast and deterministic
 ./tools/test-js-with-node --coverage


### PR DESCRIPTION
We may be having problems with git lint, so this is a quick
fix to hopefully get builds working again.