### PR TITLE
Slack importer: Mapping messages.

### DIFF
--- a/templates/zerver/help/import-data-from-slack.md
+++ b/templates/zerver/help/import-data-from-slack.md
@@ -1,9 +1,9 @@
-# Import users and channels from Slack
+# Import data from Slack
 
-{!follow-steps.md!} import users and channels from Slack to Zulip.
+{!follow-steps.md!} import users, channels, and messages from Slack to Zulip.
 
 !!! warn ""
-    **Note:** Please ensure that you have admin rights before importing users and channels from Slack.
+    **Note:** Please ensure that you have admin rights before importing data from Slack.
 
 1. Export your team's data and message history by visiting the **Export Data**
    page, https://my.slack.com/services/export. You will receive a zip file

--- a/templates/zerver/help/include/sidebar.md
+++ b/templates/zerver/help/include/sidebar.md
@@ -118,7 +118,7 @@
 * [Change your organization avatar](/help/change-your-organizations-avatar)
 * [Update your organization's settings](/help/change-your-organization-settings)
 * [Link to your Zulip from the web](/help/join-zulip-chat-badge)
-* [Import users and channels from Slack](/help/import-users-and-channels-from-slack)
+* [Import data from Slack](/help/import-data-from-slack)
 * [Restrict new users by email domain](/help/restrict-user-email-addresses-to-certain-domains)
 * [Allow joining without an invitation](/help/allow-anyone-to-join-without-an-invitation)
 * [Manage who can send invitations](/help/only-allow-admins-to-invite-new-users)

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -280,7 +280,7 @@ def channels_to_zerver_stream(slack_data_dir: str, realm_id: int, added_users: A
 def do_convert_data(slack_zip_file: str, realm_name: str, output_dir: str) -> None:
     slack_data_dir = slack_zip_file.replace('.zip', '')
     zip_file_dir = os.path.dirname(slack_data_dir)
-    subprocess.check_call(['unzip', slack_zip_file, '-d', zip_file_dir])
+    subprocess.check_call(['unzip', '-q', slack_zip_file, '-d', zip_file_dir])
     # with zipfile.ZipFile(slack_zip_file, 'r') as zip_ref:
     #     zip_ref.extractall(slack_data_dir)
 

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -287,8 +287,6 @@ def do_convert_data(slack_zip_file: str, realm_name: str, output_dir: str) -> No
     # TODO fetch realm config from zulip config
     DOMAIN_NAME = "zulipchat.com"
 
-    # TODO: Hardcode this to 1, will implement later for zulipchat.com's case
-    # where it has multiple realms
     REALM_ID = get_model_id(Realm)
     NOW = float(timezone_now().timestamp())
 

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -348,7 +348,7 @@ def do_convert_data(slack_zip_file: str, realm_name: str, output_dir: str) -> No
     message_json['zerver_message'] = zerver_message
     message_json['zerver_usermessage'] = zerver_usermessage
     # IO message.json
-    message_file = output_dir + '/message-000001.json'
+    message_file = output_dir + '/messages-000001.json'
     json.dump(message_json, open(message_file, 'w'))
 
     # IO avatar records

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -26,6 +26,15 @@ def get_model_id(model: Any) -> int:
     else:
         return 1
 
+def get_user_full_name(user: ZerverFieldsT) -> str:
+    if user['deleted'] is False:
+        if user['real_name'] == '':
+            return user['name']
+        else:
+            return user['real_name']
+    else:
+        return user['name']
+
 def users_to_zerver_userprofile(slack_data_dir: str, realm_id: int, timestamp: Any,
                                 domain_name: str) -> Tuple[List[ZerverFieldsT], AddedUsersT]:
     """
@@ -64,14 +73,6 @@ def users_to_zerver_userprofile(slack_data_dir: str, realm_id: int, timestamp: A
         if timezone is None or '/' not in timezone:
             timezone = _default_timezone
 
-        if user['deleted'] is False:
-            if user['real_name'] == '':
-                full_name = user['name']
-            else:
-                full_name = user['real_name']
-        else:
-            full_name = user['name']
-
         # userprofile's quota is hardcoded as per
         # https://github.com/zulip/zulip/blob/e1498988d9094961e6f9988fb308b3e7310a8e74/zerver/migrations/0059_userprofile_quota.py#L18
         userprofile = dict(
@@ -98,7 +99,7 @@ def users_to_zerver_userprofile(slack_data_dir: str, realm_id: int, timestamp: A
             last_login=timestamp,
             tos_version=None,
             default_all_public_streams=False,
-            full_name=full_name,
+            full_name=get_user_full_name(user),
             twenty_four_hour_time=False,
             groups=[],  # This is Zulip-specific
             enable_online_push_notifications=False,


### PR DESCRIPTION
Gist of this pull request:

All of the messages in the channels are checked Slack's markdown regex and are converted to Zulip's markdown.
for eg:
1. For strikethrough formatting: Slack's `~strike~` to Zulip's `~~strike~~`(similarly, done for all messages formatting options).
2. For mentioning formatting: Slack's `<@slack_id|short_name>` to  Zulip's `@**full_name**`.
3. Checking links.

Corresponding to every messages, usermessage are mapped

This ensure that all the messages are displayed in the converted and imported slack data instance.

The followup from this would be:

- Finish markdown mapping with taking care every small detail.
- Automated tests being an entire dataset.
-  Avatar mapping.
-  Uploaded files mapping.
  
  