### PR TITLE
user docs: Allow redirection of external URLs in documentation sidebars.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -65,6 +65,14 @@ function render_code_sections() {
 
     $(".sidebar a").click(function (e) {
         var path = $(this).attr("href");
+        var path_dir = path.split('/')[1];
+        var current_dir = window.location.pathname.split('/')[1];
+
+        // Do not block redirecting to external URLs
+        if (path_dir !== current_dir) {
+            return;
+        }
+
         var container = $(".markdown")[0];
 
         if (loading.name === path) {

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -182,6 +182,22 @@ body {
     opacity: 0.5;
 }
 
+.help .sidebar h1.home-link {
+    font-size: 1em;
+}
+
+.help .sidebar h1.home-link a::before {
+    display: inline-block;
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: inherit;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+
+    content: "\f0d9";
+    margin-right: 10px;
+}
+
 .help .sidebar ul {
     margin: 5px 0px 10px 12px;
 }

--- a/templates/zerver/api/main.html
+++ b/templates/zerver/api/main.html
@@ -7,6 +7,7 @@
     <div class="sidebar">
         <h1 class="no-arrow"><a href="/api/" class="no-underline">Index</a></h1>
         {{ render_markdown_path("zerver/api/sidebar.md") }}
+        <h1 class="home-link"><a href="/" class="no-underline">Back to Home</a></h1>
     </div>
 
     <svg height="32px" class="hamburger" style="enable-background:new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="32px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/templates/zerver/help/main.html
+++ b/templates/zerver/help/main.html
@@ -7,6 +7,7 @@
     <div class="sidebar slide">
         <h1><a href="/help/" class="no-underline">Index</a></h1>
         {{ render_markdown_path("zerver/help/include/sidebar.md") }}
+        <h1 class="home-link"><a href="/" class="no-underline">Back to Home</a></h1>
     </div>
 
     <svg height="32px" class="hamburger" style="enable-background:new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="32px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
Fixes #7916.

(Second commit is an optional UX enhancement adding a link back to the homepage, can be dropped if unnecessary)

![screenshot at dec 29 10-47-33](https://user-images.githubusercontent.com/15116870/34444829-c2977282-ec85-11e7-9d05-df873c4b8003.png)
