### PR TITLE
Fix errors in stream email address

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -160,7 +160,7 @@ function add_email_hint(row, email_address_hint_content) {
     var hint_id = "#email-address-hint-" + row.stream_id;
 
     $("body").on("mouseover", hint_id, function (e) {
-        $(hint_id).popover({placement: "bottom",
+        $(hint_id).popover({placement: "right",
                 title: "Email integration",
                 content: email_address_hint_content,
                 trigger: "manual"});

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -158,18 +158,17 @@ exports.rerender_subscribers_count = function (sub) {
 function add_email_hint(row, email_address_hint_content) {
     // Add a popover explaining stream e-mail addresses on hover.
     var hint_id = "#email-address-hint-" + row.stream_id;
-    var email_address_hint = $(hint_id);
-    email_address_hint.popover({placement: "bottom",
+
+    $("body").on("mouseover", hint_id, function (e) {
+        $(hint_id).popover({placement: "bottom",
                 title: "Email integration",
                 content: email_address_hint_content,
                 trigger: "manual"});
-
-    $("body").on("mouseover", hint_id, function (e) {
-        email_address_hint.popover('show');
+        $(hint_id).popover('show');
         e.stopPropagation();
     });
     $("body").on("mouseout", hint_id, function (e) {
-        email_address_hint.popover('hide');
+        $(hint_id).popover('hide');
         e.stopPropagation();
     });
 }


### PR DESCRIPTION
**BUGS**

* Doesn't shows popover on `?` sign for `Email address` in stream settings.
* It was not showing correctly on screen, cause it's placement was at `bottom`.

**CHANGES**

* Fix bug in popover.
* Changed it's placement to `right` which is same placement for `Announce stream` popover in stream creation.

![emailaddresspopoverfinal](https://user-images.githubusercontent.com/25907420/34444850-12510c9a-ecf7-11e7-94ff-5e520a6bf819.gif)
