### PR TITLE
onboarding: Fix error-password overlap bug

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -335,6 +335,10 @@ html {
     transition: border 0.3s ease;
 }
 
+.new-style .input-box input[type=email] {
+    margin-bottom: 10px;
+}
+
 .new-style .input-box label {
     position: absolute;
     top: 0px;


### PR DESCRIPTION
Apply appropriate spacing between password field and error message.

This is good for merge @showell, as this is just a minor margin modification of #7803 to be more inline with margins elsewhere.

Fixes: #7796.