### PR TITLE
outgoing webhooks: Rename "Base URL" to "Endpoint URL".

### DIFF
--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -59,7 +59,7 @@
                     </div>
                     <div id="payload_url_inputbox">
                         <div class="input-group">
-                            <label for="create_payload_url">{{t "Base URL" }}</label>
+                            <label for="create_payload_url">{{t "Endpoint URL" }}</label>
                             <input type="text" name="payload_url" id="create_payload_url"
                                 maxlength=100 placeholder="https://hostname.example.com/bots/followup" value="" />
                             <div><label for="create_payload_url" generated="true" class="text-error"></label></div>

--- a/templates/zerver/api/running-bots.md
+++ b/templates/zerver/api/running-bots.md
@@ -123,7 +123,7 @@ pip install zulip_botserver
     If omitted, `hostname` defaults to `127.0.0.1` and `port` to `5002`.
 
 4.  Now set up the outgoing webhook service which will interact with
-    the server: Create an **Outgoing webhook** bot with its base url
+    the server: Create an **Outgoing webhook** bot with its Endpoint URL
     of the form:
 
     ```

--- a/templates/zerver/help/add-a-bot-or-integration.md
+++ b/templates/zerver/help/add-a-bot-or-integration.md
@@ -47,9 +47,9 @@ You can create three types of bots:
       https://github.com/zulip/zulip/tree/master/zerver/webhooks).
 
 * **Outgoing webhook:** Bots of this type are the same as a **Generic bot**,
-  except **Outgoing webhooks** bots have an extra field for the base URL of the
+  except **Outgoing webhooks** bots have an extra field for the Endpoint URL of the
   third-party service being requested. **Outgoing webhook** bots send POST requests
-  to this base URL.
+  to this Endpoint URL.
   Choose this type if you want to:
     * make Zulip post messages to a URL.
     * deploy Zulip's [botserver](https://github.com/zulip/python-zulip-api/tree/master/zulip_botserver).

--- a/zerver/management/commands/convert_bot_to_outgoing_webhook.py
+++ b/zerver/management/commands/convert_bot_to_outgoing_webhook.py
@@ -15,7 +15,7 @@ class Command(ZulipBaseCommand):
         parser.add_argument('service_name', metavar='<service_name>', type=str,
                             help='name of Service object to create')
         parser.add_argument('base_url', metavar='<base_url>', type=str,
-                            help='base url of outgoing webhook')
+                            help='Endpoint URL of outgoing webhook')
         # TODO: Add token and interface as arguments once OutgoingWebhookWorker
         # uses these fields on the Service object.
 
@@ -35,7 +35,7 @@ class Command(ZulipBaseCommand):
             exit(1)
 
         if not base_url:
-            print('Base URL of outgoing webhook must be provided')
+            print('Endpoint URL of outgoing webhook must be provided')
             exit(1)
 
         # TODO: Normalize email?


### PR DESCRIPTION
Based on user feedback. "Endpoint URL" gives a clearer
idea of the field's purpose.

This is the relevant input field, some doc entries needed to be changed as well:
![image](https://user-images.githubusercontent.com/7950151/34455434-8a314fa8-ed7f-11e7-963f-2b1355a1754a.png)


Searching for a good replacement for "Base URL" lead me to three alternatives:
* "Callback URL"
* "Endpoint URL"
* "Outgoing URL"

Callback URL and Endpoint URL where used by many other services, I find Endpoint URL the most expressive.

There is one reference in the perforce integration docs I didn't touch: Perforce seems to use the field base URL in its docs.