### PR TITLE
docs: Fix typo in multiple-organizations.md.

### DIFF
--- a/docs/production/multiple-organizations.md
+++ b/docs/production/multiple-organizations.md
@@ -18,7 +18,7 @@ subdomain.  E.g. you'd have `org1.zulip.example.com` and
 `org2.zulip.example.com`.
 
 Web security standards mean that one subdomain per organization is
-required to support a use logging into multiple organizations on a
+required to support a user logging into multiple organizations on a
 server at the same time.
 
 When you want to create a new organization, you need to do a few


### PR DESCRIPTION
Just a minor typo in the documentation, I think `user` was intended.