### PR TITLE
click_handlers: Include expanded mobile sidebars as popovers.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -722,7 +722,7 @@ $(function () {
         }
 
         // Dismiss popovers if the user has clicked outside them
-        if ($('.popover-inner, .emoji-info-popover').has(e.target).length === 0) {
+        if ($('.popover-inner, .emoji-info-popover, .app-main [class^="column-"].expanded').has(e.target).length === 0) {
             popovers.hide_all();
         }
 


### PR DESCRIPTION
This prevents the sidebars from automatically closing when users click inside the sidebar area. Fixes #7896.