### PR TITLE
webhooks/gci: Support "extend" and "unassign" event types.

### DIFF
--- a/zerver/webhooks/gci/fixtures/student_unassigned_by_mentor.json
+++ b/zerver/webhooks/gci/fixtures/student_unassigned_by_mentor.json
@@ -1,0 +1,12 @@
+{
+    "author_is_student": false,
+    "task_definition_name": "Sails unspread it stopped at kearney",
+    "event_type": "unassign",
+    "task_instance": 6296903092273152,
+    "task_claimed_by": "student-yqqtag",
+    "time": 1506475323.256627,
+    "id": "1f4bab4d1820400f9b50ed8bf2bb03b3",
+    "author": "eeshangarg",
+    "task_instance_url": "https://0.0.0.0:8000/dashboard/task-instances/6694926301528064/",
+    "task_definition_url": "https://0.0.0.0:8000/dashboard/tasks/6694926301528064/"
+}

--- a/zerver/webhooks/gci/fixtures/task_deadline_extended_by_mentor.json
+++ b/zerver/webhooks/gci/fixtures/task_deadline_extended_by_mentor.json
@@ -1,0 +1,13 @@
+{
+    "author_is_student": false,
+    "task_definition_name": "Sails unspread it stopped at kearney",
+    "event_type": "extend",
+    "task_instance": 6296903092273152,
+    "task_claimed_by": "student-yqqtag",
+    "time": 1506475323.256627,
+    "id": "1f4bab4d1820400f9b50ed8bf2bb03b3",
+    "extension_days": 1.0,
+    "author": "eeshangarg",
+    "task_instance_url": "https://0.0.0.0:8000/dashboard/task-instances/6694926301528064/",
+    "task_definition_url": "https://0.0.0.0:8000/dashboard/tasks/6694926301528064/"
+}

--- a/zerver/webhooks/gci/tests.py
+++ b/zerver/webhooks/gci/tests.py
@@ -55,3 +55,9 @@ class GoogleCodeInTests(WebhookTestCase):
         expected_message = u'**eeshangarg** extended the deadline for the task [Sails unspread it stopped at kearney](https://codein.withgoogle.com/dashboard/task-instances/6296903092273152/) by 1.0 day(s).'
         self.send_and_test_stream_message('task_deadline_extended_by_mentor',
                                           expected_subject, expected_message)
+
+    def test_unassign_event_message(self) -> None:
+        expected_subject = u'student-yqqtag'
+        expected_message = u'**eeshangarg** unassigned **student-yqqtag** from the task [Sails unspread it stopped at kearney](https://codein.withgoogle.com/dashboard/task-instances/6296903092273152/).'
+        self.send_and_test_stream_message('student_unassigned_by_mentor',
+                                          expected_subject, expected_message)

--- a/zerver/webhooks/gci/tests.py
+++ b/zerver/webhooks/gci/tests.py
@@ -49,3 +49,9 @@ class GoogleCodeInTests(WebhookTestCase):
         expected_message = u'**eeshangarg** submitted the task [Sails unspread it stopped at kearney](https://codein.withgoogle.com/dashboard/task-instances/5136918324969472/) for more work.'
         self.send_and_test_stream_message('task_submitted_by_mentor_for_more_work',
                                           expected_subject, expected_message)
+
+    def test_extend_event_message(self) -> None:
+        expected_subject = u'student-yqqtag'
+        expected_message = u'**eeshangarg** extended the deadline for the task [Sails unspread it stopped at kearney](https://codein.withgoogle.com/dashboard/task-instances/6296903092273152/) by 1.0 day(s).'
+        self.send_and_test_stream_message('task_deadline_extended_by_mentor',
+                                          expected_subject, expected_message)

--- a/zerver/webhooks/gci/view.py
+++ b/zerver/webhooks/gci/view.py
@@ -86,6 +86,14 @@ def get_extend_event_body(payload: Dict[Text, Any]) -> Text:
         task_url=build_instance_url(payload['task_instance']),
     )
 
+def get_unassign_event_body(payload: Dict[Text, Any]) -> Text:
+    return GCI_MESSAGE_TEMPLATE.format(
+        actor=payload['author'],
+        action='unassigned **{student}** from'.format(student=payload['task_claimed_by']),
+        task_name=payload['task_definition_name'],
+        task_url=build_instance_url(payload['task_instance']),
+    )
+
 @api_key_only_webhook_view("Google-Code-In")
 @has_request_variables
 def api_gci_webhook(request: HttpRequest, user_profile: UserProfile, stream: Text=REQ(default='gci'),
@@ -110,6 +118,7 @@ EVENTS_FUNCTION_MAPPER = {
     'extend': get_extend_event_body,
     'needswork': get_needswork_event_body,
     'submit': get_submit_event_body,
+    'unassign': get_unassign_event_body,
 }
 
 def get_event(payload: Dict[Text, Any]) -> Optional[Text]:

--- a/zerver/webhooks/gci/view.py
+++ b/zerver/webhooks/gci/view.py
@@ -76,6 +76,16 @@ def get_needswork_event_body(payload: Dict[Text, Any]) -> Text:
         task_url=build_instance_url(payload['task_instance']),
     )
 
+def get_extend_event_body(payload: Dict[Text, Any]) -> Text:
+    template = "{} by {days} day(s).".format(GCI_MESSAGE_TEMPLATE.rstrip('.'),
+                                             days=payload['extension_days'])
+    return template.format(
+        actor=payload['author'],
+        action='extended the deadline for',
+        task_name=payload['task_definition_name'],
+        task_url=build_instance_url(payload['task_instance']),
+    )
+
 @api_key_only_webhook_view("Google-Code-In")
 @has_request_variables
 def api_gci_webhook(request: HttpRequest, user_profile: UserProfile, stream: Text=REQ(default='gci'),
@@ -97,6 +107,7 @@ EVENTS_FUNCTION_MAPPER = {
     'approve-pending-pc': get_approve_pending_pc_event_body,
     'claim': get_claim_event_body,
     'comment': get_comment_event_body,
+    'extend': get_extend_event_body,
     'needswork': get_needswork_event_body,
     'submit': get_submit_event_body,
 }


### PR DESCRIPTION
@showell: These new payloads were reported by `webhook_logger.log`! :) Could you please review? 