### PR TITLE
manage.py: Move the maximum digits calculation to outside of a loop.

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -345,10 +345,14 @@ class Command(BaseCommand):
                     "sales": {"description": "For sales discussion", "invite_only": False}
                 }  # type: Dict[Text, Dict[Text, Any]]
 
+                # Calculate the maximum number of digits in any extra stream's
+                # number, since a stream with name "Extra Stream 3" could show
+                # up after "Extra Stream 29". (Used later to pad numbers with
+                # 0s).
+                maximum_digits = len(str(options['extra_streams'] - 1))
+
                 for i in range(options['extra_streams']):
-                    # Since a stream with name "Extra Stream 3" could show up
-                    # after "Extra Stream 29", pad the numbers with 0s.
-                    maximum_digits = len(str(options['extra_streams'] - 1))
+                    # Pad the number with 0s based on `maximum_digits`.
                     number_str = str(i).zfill(maximum_digits)
 
                     extra_stream_name = 'Extra Stream ' + number_str


### PR DESCRIPTION
In reference to https://github.com/zulip/zulip/pull/7969#discussion_r159323046, this PR makes extra stream creation slightly more efficient by calculating the maximum number of digits in an extra stream outside of the stream creation loop.