### PR TITLE
analytics: adds more than one tooltip on same page.

### DIFF
--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -60,15 +60,18 @@ function update_last_full_update(end_times) {
     $('#id_last_full_update').closest('.last-update').show();
 }
 
-$(function () {
-    $('span[data-toggle="tooltip"]').tooltip({
+$(function tooltips() {
+    $('span[class="new_tooltip"]').tooltip({
         animation: false,
         placement: 'top',
         html: true,
         trigger: 'manual',
     });
+    $('#active_user').hover(function () {
+        $('span[data-toggle="active_user_tooltip"]').tooltip('toggle');
+    });
     $('#id_last_update_question_sign').hover(function () {
-        $('span[data-toggle="tooltip"]').tooltip('toggle');
+        $('span[data-toggle="last_update_tooltip"]').tooltip('toggle');
     });
 });
 

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -77,9 +77,12 @@
                         </div>
                     </div>
                 </div>
-
                 <div class="chart-container">
-                    <h1>{{ _("Active users") }}</h1>
+                    <h1>{{ _("Active users") }}
+                        <span data-toggle="active_user_tooltip" class="new_tooltip" title="{% trans %}Only includes users who have an active account and who have logged in in the last two weeks.{% endtrans %}">
+                            <span class="fa fa-info-circle" id ="active_user"></span>
+                        </span>
+                    </h1>
                     <div id="id_number_of_users">
                         <div class="spinner"></div>
                     </div>
@@ -94,7 +97,7 @@
 
         <div class="last-update">
             {{ _("Last update") }}: <span id="id_last_full_update"></span>
-            <span data-toggle="tooltip" title="{% trans %}A full update of all the graphs happens once a day.<br/>The “Messages Sent Over Time” graph is updated once an hour.{% endtrans %}">
+            <span data-toggle="last_update_tooltip" class="new_tooltip" title="{% trans %}A full update of all the graphs happens once a day.<br/>The “Messages Sent Over Time” graph is updated once an hour.{% endtrans %}">
                 <span class="fa fa-info-circle" id="id_last_update_question_sign"></span>
             </span>
             <br />


### PR DESCRIPTION
Fixes #4612

One can create as many tooltips as they want. Steps involved:

1. in `/templates/analytics/stats.html` add 
```
<span data-toggle="<special name>_tooltip" class="new_tooltip" title="{% trans %} TITLE {% endtrans %}"></span>
```
2.in `/static/js/stats/stats.js` go to `function tooltips( ) `and add
```
$('#<element id').hover(function () {
        $('span[data-toggle="<special name>_tooltip"]').tooltip('toggle');
    });
```

Also, created the tooltip for Number of Users graph.
![image](https://user-images.githubusercontent.com/14962324/34578167-eb5ddfd4-f1a9-11e7-9c5d-1b69b0841d2e.png)

  