### PR TITLE
[WIP] Remove stream endpoints, which are not supported from backend

### DIFF
--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -535,8 +535,10 @@ function pick_empty_narrow_banner() {
             return $("#no_unread_narrow_message");
         }
     } else if ((first_operator === "stream") && !stream_data.is_subscribed(first_operand)) {
-        // You are narrowed to a stream to which you aren't subscribed.
-        if (!stream_data.get_sub(narrow_state.stream())) {
+        // You are narrowed to a stream which does not exist or is a private stream
+        // in which you were never subscribed.
+        var stream_sub = stream_data.get_sub(narrow_state.stream());
+        if (!stream_sub || stream_sub.invite_only) {
             return $("#nonsubbed_private_nonexistent_stream_narrow_message");
         }
         return $("#nonsubbed_stream_narrow_message");

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -166,6 +166,10 @@ exports.render_stream_description = function (sub) {
 
 exports.update_calculated_fields = function (sub) {
     sub.is_admin = page_params.is_admin;
+    // Admin can change stream name/description either stream is public or
+    // stream is private and admin is subscribed to private stream.
+    sub.can_change_name_description = page_params.is_admin &&
+                                     (!sub.invite_only || (sub.invite_only && sub.subscribed));
     sub.can_make_public = page_params.is_admin && sub.invite_only && sub.subscribed;
     sub.can_make_private = page_params.is_admin && !sub.invite_only;
     sub.preview_url = narrow.by_stream_uri(sub.name);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -170,6 +170,9 @@ exports.update_calculated_fields = function (sub) {
     // stream is private and admin is subscribed to private stream.
     sub.can_change_name_description = page_params.is_admin &&
                                      (!sub.invite_only || (sub.invite_only && sub.subscribed));
+    // If stream is public then any user can subscribe. If stream is private then only
+    // subscribed users can unsubscribe.
+    sub.should_display_subscription_button = !sub.invite_only || sub.subscribed;
     sub.can_make_public = page_params.is_admin && sub.invite_only && sub.subscribed;
     sub.can_make_private = page_params.is_admin && !sub.invite_only;
     sub.preview_url = narrow.by_stream_uri(sub.name);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -175,6 +175,7 @@ exports.update_calculated_fields = function (sub) {
     sub.should_display_subscription_button = !sub.invite_only || sub.subscribed;
     sub.can_make_public = page_params.is_admin && sub.invite_only && sub.subscribed;
     sub.can_make_private = page_params.is_admin && !sub.invite_only;
+    sub.can_add_subscribers = !sub.invite_only || (sub.invite_only && sub.subscribed);
     sub.preview_url = narrow.by_stream_uri(sub.name);
     exports.render_stream_description(sub);
     exports.update_subscribers_count(sub);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -380,6 +380,7 @@ exports.change_stream_name = function (e) {
             ui_report.success(i18n.t("The stream has been renamed!"), $(".stream_change_property_info"));
         },
         error: function (xhr) {
+            new_name_box.text(stream_data.maybe_get_stream_name(stream_id));
             ui_report.error(i18n.t("Error renaming stream"), xhr, $(".stream_change_property_info"));
         },
     });

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -247,6 +247,12 @@ exports.update_settings_for_unsubscribed = function (sub) {
         stream_edit.rerender_subscribers_list(sub);
     }
 
+    // If user unsubscribed from private stream then user can not subscribe to
+    // stream without invitation. So hide subscribe button.
+    stream_data.update_calculated_fields(sub);
+    if (!sub.should_display_subscription_button) {
+        settings_button.hide();
+    }
     row_for_stream_id(subs.stream_id).attr("data-temp-view", true);
 };
 

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -18,8 +18,10 @@
                 {{/if}}
             </div>
             <div class="button-group">
+                {{#if should_display_subscription_button}}
                 <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" title="{{t 'Toggle subscription'}} (S)">
                     {{#if subscribed }}{{#tr oneself }}Unsubscribe{{/tr}}{{else}}{{#tr oneself }}Subscribe{{/tr}}{{/if}}</button>
+                {{/if}}
                 <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button" title="{{t 'View stream'}} (V)">{{t "View stream"}}</a>
             </div>
         </div>

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -12,7 +12,7 @@
             {{/if}}
             <div class="stream-name">
                 <span class="stream-name-editable editable-section">{{name}}</span>
-                {{#if is_admin}}
+                {{#if can_change_name_description}}
                 <span class="editable" data-make-editable=".stream-name-editable"></span>
                 <span class="checkmark" data-finish-editing=".stream-name-editable">✓</span>
                 {{/if}}
@@ -25,7 +25,7 @@
         </div>
         <div class="stream-description" data-no-description="{{t 'No description.' }}">
             <span class="stream-description-editable editable-section">{{{rendered_description}}}</span>
-            {{#if is_admin}}
+            {{#if can_change_name_description}}
             <span class="editable" data-make-editable=".stream-description-editable"></span>
             <span class="checkmark" data-finish-editing=".stream-description-editable">✓</span>
             {{/if}}

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -101,10 +101,12 @@
             <div class="subscriber_list_add float-right">
                 <form class="form-inline">
                     <input type="text" class="search" placeholder="{{t 'Search subscribers' }}" />
+                    {{#if can_add_subscribers}}
                     <input type="text" name="principal" placeholder="{{t 'Email address' }}" value="" class="input-block" autocomplete="off" tabindex="-1" />
                     <button type="submit" name="add_subscriber" class="button add-subscriber-button small rounded" tabindex="-1 ">
                         {{t 'Add' }}
                     </button>
+                    {{/if}}
                 </form>
             </div>
             <div class="clear-float"></div>


### PR DESCRIPTION
**Changes are:**

**1.  Display edit icon only if user is allowed to edit.**
    
    Only show edit option for stream name and description 
    if user is admin and either stream is public or stream is private and admin is subscribed to
    private stream.
    As per backend restrictions for editing stream name/description.

**2. Show subscription-btn only if user can change subscription.**
    
    For public stream, always show subscription option.
    For private stream, if user is subscribed display unsubscribe option.
    If user is not subscribe, do not display subscription option.

**3. Show subscription-btn only if user can change subscription.**
    
    For public stream, always show subscription option.
    For private stream, if user is subscribed display unsubscribe option.
    If user is not subscribe, do not display subscription option.

When user unsubscribe from private stream, rather than renaming button `Unsubscribe` to `Subscribe` , remove button of subscription.

**4. stream membership: Display add-subscribers option only if user can add.**
    
    Display add-subscribers-to-stream option only if stream is
    public or user is subscribed to private stream.

**5. stream narrow: Set message if narrows to never-subscribed private stream.**
    
    If user narrows to never-subscribed private stream, display
    nonsubbed_private_nonexistent_stream_narrow_message.

When admin narrows to private stream in which he/she is not subscribed, will display following message.
NOTE: If admin/user had previously subscribed to private stream then messages will be displayed which are sent when he/she was subscribed to the stream.

![privatestreamnarrow](https://user-images.githubusercontent.com/25907420/34563522-f3eb2ad4-f178-11e7-8a35-a49437953773.png)

  