### PR TITLE
Move inviting users modal to be part of the settings system

### DIFF
--- a/static/templates/settings/user-list-admin.handlebars
+++ b/static/templates/settings/user-list-admin.handlebars
@@ -1,4 +1,5 @@
 <div id="admin-user-list" class="settings-section" data-name="user-list-admin">
+    <a id="invite-user-link" href="#invite"><i class="icon-vector-plus-sign"></i>{{t 'Invite more users' }}</a>    
     <input type="text" class="search" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
     <div class="clear-float"></div>
 


### PR DESCRIPTION
Moved inviting users button to "Settings -> Manage organization -> Users"

Fixes: #5145