### PR TITLE
[WIP] Bump Django 1.11.6 -> 2.0.1.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -3,7 +3,7 @@
 # and requirements/prod.txt.
 # See requirements/README.md for more detail.
 # Django itself
-Django==1.11.6
+Django==2.0.1
 
 # needed for mypy TypedDict
 mypy_extensions==0.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -50,7 +50,7 @@ django-pipeline==1.6.13
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.6.2
 django-webpack-loader==0.5.0
-django==1.11.6
+django==2.0.1
 docker-pycreds==0.2.1     # via docker
 docker==2.6.1             # via moto
 docopt==0.6.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -38,7 +38,7 @@ django-pipeline==1.6.13
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.6.2
 django-webpack-loader==0.5.0
-django==1.11.6
+django==2.0.1
 docopt==0.6.2
 gitdb==0.6.4
 google-api-python-client==1.6.4

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '14.7'
+PROVISION_VERSION = '15.0'

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -80,7 +80,7 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
 
     user_is_authenticated = False
     if hasattr(request, 'user') and hasattr(request.user, 'is_authenticated'):
-        user_is_authenticated = request.user.is_authenticated.value
+        user_is_authenticated = request.user.is_authenticated
 
     if settings.DEVELOPMENT:
         secrets_path = "zproject/dev-secrets.conf"

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3041,7 +3041,7 @@ def do_create_default_stream_group(realm: Realm, group_name: Text,
         raise JsonableError(_("Default stream group '%(group_name)s' already exists")
                             % {'group_name': group_name})
 
-    group.streams = streams
+    group.streams.set(streams)
     group.save()
     notify_default_stream_groups(realm)
 

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import Dict, List, Optional, TypeVar, Any, Text
 from django.conf import settings
 from django.conf.urls import url
-from django.urls.resolvers import LocaleRegexProvider
+from django.urls.resolvers import RegexPattern
 from django.utils.module_loading import import_string
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
@@ -183,7 +183,7 @@ class WebhookIntegration(Integration):
         self.doc = doc
 
     @property
-    def url_object(self) -> LocaleRegexProvider:
+    def url_object(self) -> RegexPattern:
         return url(self.url, self.function)
 
 class HubotIntegration(Integration):

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -5,7 +5,7 @@ from typing import (
 )
 
 from django.core import signing
-from django.urls.resolvers import LocaleRegexURLResolver
+from django.urls import URLResolver
 from django.conf import settings
 from django.test import TestCase, override_settings
 from django.test.client import (
@@ -344,7 +344,7 @@ def write_instrumentation_reports(full_suite: bool) -> None:
 
         def find_pattern(pattern: Any, prefixes: List[str]) -> None:
 
-            if isinstance(pattern, type(LocaleRegexURLResolver)):
+            if isinstance(pattern, type(URLResolver)):
                 return  # nocoverage -- shouldn't actually happen
 
             if hasattr(pattern, 'url_patterns'):

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -229,7 +229,7 @@ def destroy_test_databases(database_id: Optional[int]=None) -> None:
     for alias in connections:
         connection = connections[alias]
         try:
-            connection.creation.destroy_test_db(number=database_id)
+            connection.creation.destroy_test_db(suffix=str(database_id))
         except ProgrammingError:
             # DB doesn't exist. No need to do anything.
             pass
@@ -238,7 +238,7 @@ def create_test_databases(database_id: int) -> None:
     for alias in connections:
         connection = connections[alias]
         connection.creation.clone_test_db(
-            number=database_id,
+            suffix=str(database_id),
             keepdb=True,
         )
 

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -284,7 +284,7 @@ def init_worker(counter: Synchronized) -> None:
                                                 _worker_id)
 
     def is_upload_avatar_url(url: URLPattern) -> bool:
-        if url.regex.pattern == r'^user_avatars/(?P<path>.*)$':
+        if url.pattern == r'^user_avatars/(?P<path>.*)$':
             return True
         return False
 

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -9,7 +9,7 @@ from unittest.result import TestResult
 
 from django.conf import settings
 from django.db import connections, ProgrammingError
-from django.urls.resolvers import RegexURLPattern
+from django.urls.resolvers import URLPattern
 from django.test import TestCase
 from django.test import runner as django_runner
 from django.test.runner import DiscoverRunner
@@ -283,7 +283,7 @@ def init_worker(counter: Synchronized) -> None:
     settings.LOCAL_UPLOADS_DIR = '{}_{}'.format(settings.LOCAL_UPLOADS_DIR,
                                                 _worker_id)
 
-    def is_upload_avatar_url(url: RegexURLPattern) -> bool:
+    def is_upload_avatar_url(url: URLPattern) -> bool:
         if url.regex.pattern == r'^user_avatars/(?P<path>.*)$':
             return True
         return False

--- a/zerver/management/commands/create_default_stream_groups.py
+++ b/zerver/management/commands/create_default_stream_groups.py
@@ -57,7 +57,7 @@ Create default stream groups which the users can choose during sign up.
         except DefaultStreamGroup.DoesNotExist:
             default_stream_group = DefaultStreamGroup.objects.create(
                 name=options["name"], realm=realm, description=options["description"])
-        default_stream_group.streams = streams
+        default_stream_group.streams.set(streams)
         default_stream_group.save()
 
         default_stream_groups = DefaultStreamGroup.objects.all()

--- a/zerver/management/commands/generate_multiuse_invite_link.py
+++ b/zerver/management/commands/generate_multiuse_invite_link.py
@@ -43,7 +43,7 @@ class Command(ZulipBaseCommand):
         invite = MultiuseInvite.objects.create(realm=realm, referred_by=referred_by)
 
         if streams:
-            invite.streams = streams
+            invite.streams.set(streams)
             invite.save()
 
         invite_link = create_confirmation_link(invite, realm.host, Confirmation.MULTIUSE_INVITE)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -892,7 +892,7 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         # Now confirm an invitation link works
         referrer = self.example_user("hamlet")
         multiuse_obj = MultiuseInvite.objects.create(realm=realm, referred_by=referrer)
-        multiuse_obj.streams = streams
+        multiuse_obj.streams.set(streams)
         multiuse_obj.save()
         invite_link = create_confirmation_link(multiuse_obj, realm.host,
                                                Confirmation.MULTIUSE_INVITE)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1026,7 +1026,7 @@ class MultiuseInviteTest(ZulipTestCase):
         invite.save()
 
         if streams is not None:
-            invite.streams = streams
+            invite.streams.set(streams)
             invite.save()
 
         if date_sent is None:

--- a/zerver/tests/test_urls.py
+++ b/zerver/tests/test_urls.py
@@ -106,7 +106,7 @@ class PublicURLTest(ZulipTestCase):
             self.assertEqual('ABCD', data['google_client_id'])
 
 class URLResolutionTest(TestCase):
-    def get_callback_string(self, pattern: django.urls.resolvers.RegexURLPattern) -> Optional[str]:
+    def get_callback_string(self, pattern: django.urls.resolvers.URLPattern) -> Optional[str]:
         callback_str = hasattr(pattern, 'lookup_str') and 'lookup_str'
         callback_str = callback_str or '_callback_str'
         return getattr(pattern, callback_str, None)

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -14,7 +14,7 @@ from django.core.exceptions import MiddlewareNotUsed
 from django.core.handlers import base
 from django.core.handlers.exception import convert_exception_to_response
 from django.core.handlers.wsgi import WSGIRequest, get_script_name
-from django.urls import set_script_prefix, set_urlconf
+from django.urls import set_script_prefix
 from django.http import HttpRequest, HttpResponse
 from django.utils.module_loading import import_string
 from tornado.wsgi import WSGIContainer
@@ -190,8 +190,8 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
             try:
                 # Setup default url resolver for this thread.
                 urlconf = settings.ROOT_URLCONF
-                set_urlconf(urlconf)
-                resolver = resolvers.RegexURLResolver(r'^/', urlconf)
+                resolvers.set_urlconf(urlconf)
+                resolver = resolvers.URLResolver(r'^/', urlconf)
 
                 response = None
 
@@ -204,8 +204,8 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
                 if hasattr(request, "urlconf"):
                     # Reset url resolver with a custom urlconf.
                     urlconf = request.urlconf
-                    set_urlconf(urlconf)
-                    resolver = resolvers.RegexURLResolver(r'^/', urlconf)
+                    resolvers.set_urlconf(urlconf)
+                    resolver = resolvers.URLResolver(r'^/', urlconf)
 
                 ### ADDED BY ZULIP
                 request._resolver = resolver
@@ -298,7 +298,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
                 return self.handle_uncaught_exception(request, resolver, exc_info)
         finally:
             # Reset urlconf on the way out for isolation
-            set_urlconf(None)
+            resolvers.set_urlconf(None)
 
         ### ZULIP CHANGE: The remainder of this function was moved
         ### into its own function, just below, so we can call it from
@@ -309,7 +309,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
 
     ### Copied from get_response (above in this file)
     def apply_response_middleware(self, request: HttpRequest, response: HttpResponse,
-                                  resolver: resolvers.RegexURLResolver) -> HttpResponse:
+                                  resolver: resolvers.URLResolver) -> HttpResponse:
         try:
             # Apply response middleware, regardless of the response
             for middleware_method in self._response_middleware:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -90,7 +90,7 @@ def maybe_send_to_registration(request: HttpRequest, email: Text, full_name: Tex
             del request.session["multiuse_object_key"]
             request.session.modified = True
             if streams_to_subscribe is not None:
-                prereg_user.streams = streams_to_subscribe
+                prereg_user.streams.set(streams_to_subscribe)
             prereg_user.save()
 
         return redirect("".join((

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -304,7 +304,7 @@ def prepare_activation_url(email: str, request: HttpRequest,
     prereg_user = create_preregistration_user(email, request, realm_creation)
 
     if streams is not None:
-        prereg_user.streams = streams
+        prereg_user.streams.set(streams)
         prereg_user.save()
 
     confirmation_type = Confirmation.USER_REGISTRATION


### PR DESCRIPTION
List of API changes:
1. `models.Foreignkey`: `on_delete` argument is no longer optional.
2. Functions in `django.core.urlresolvers` are moved to `django.urls`
   and `django.urls.resolvers`.
3. `django.core.urlresolvers.LocaleRegexProvider` is renamed to
   `django.urls.resolvers.RegexPattern`. See
   arteria/django-compat#61.
4. `django.core.urlresolvers.RegexURLPattern` is renamed to
   `django.urls.resolvers.URLPattern`. See
   encode/django-rest-framework#5485.
5. `django.core.urlresolvers.LocaleRegexURLResolver` is renamed to
   `django.urls.URLResolver` with a locale argument. See
   https://github.com/django/django/pull/7482/files#diff-ebbd729cb6cf937dea8ce3de4e3332f2R17
6. `django.core.management.call_command`'s argument app_labels is
   renamed to app_label.

~~This is blocked by https://github.com/python-social-auth/social-app-django/issues/6~~.
 Edit: I updated social-app-django to 2.1.0 and the installation succeeded.
 Edit2: added list of API changes from the commit message.