### PR TITLE
urls: Move the json/fetch_api_key endpoint to be an API-style route.

### DIFF
--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1065,8 +1065,10 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
         do_reactivate_realm(user_profile.realm)
 
     def _do_test(self, user_email: Text) -> HttpResponse:
-        data = {"password": initial_password(user_email)}
-        return self.client_post(r'/json/fetch_api_key', data)
+        stream_name = "stream name"
+        self.common_subscribe_to_streams(user_email, [stream_name])
+        data = {"password": initial_password(user_email), "stream": stream_name}
+        return self.client_post(r'/json/subscriptions/exists', data)
 
     def _login(self, user_email: Text, user_realm: Realm, password: str=None) -> None:
         if password:
@@ -1100,7 +1102,7 @@ class TestAuthenticatedJsonViewDecorator(ZulipTestCase):
 
     def _do_test(self, user_email: str) -> HttpResponse:
         data = {"password": initial_password(user_email)}
-        return self.client_post(r'/json/fetch_api_key', data)
+        return self.client_post(r'/accounts/webathena_kerberos_login/', data)
 
 class TestZulipLoginRequiredDecorator(ZulipTestCase):
     def test_zulip_login_required_if_subdomain_is_invalid(self) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -731,7 +731,6 @@ def api_get_server_settings(request: HttpRequest) -> HttpResponse:
             result[settings_item] = context[settings_item]
     return json_success(result)
 
-@authenticated_json_post_view
 @has_request_variables
 def json_fetch_api_key(request: HttpRequest, user_profile: UserProfile,
                        password: str=REQ(default='')) -> HttpResponse:

--- a/zproject/legacy_urls.py
+++ b/zproject/legacy_urls.py
@@ -16,6 +16,4 @@ legacy_urls = [
     # any more to find out about subscriptions, since they are already
     # pushed to us via the event system.
     url(r'^json/subscriptions/exists$', zerver.views.streams.json_stream_exists),
-
-    url(r'^json/fetch_api_key$', zerver.views.auth.json_fetch_api_key),
 ]

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -517,6 +517,12 @@ for incoming_webhook in WEBHOOK_INTEGRATIONS:
 
 urls.append(url(r'^api/v1/external/github', github_dispatcher.api_github_webhook_dispatch))
 
+# Desktop-specific authentication URLs
+urls += [
+    url(r'^json/fetch_api_key$', rest_dispatch,
+        {'POST': 'zerver.views.auth.json_fetch_api_key'}),
+]
+
 # Mobile-specific authentication URLs
 urls += [
     # This json format view used by the mobile apps lists which


### PR DESCRIPTION
This is the continuation of my work on moving endpoints out of legacy urls:
* https://github.com/zulip/zulip/pull/6877 – moving the tutorial endpoints
* https://github.com/zulip/zulip/pull/7055 – moving the report endpoints

I split the changes into two commits the same way we did in #6877, but I can squash them if necessary. Please let me know if anything could be improved.