### PR TITLE
docs: Fix disappearing texts on integration guide.

### DIFF
--- a/templates/zerver/api/integration-docs-guide.md
+++ b/templates/zerver/api/integration-docs-guide.md
@@ -71,8 +71,9 @@ Here are a few common macros used to document Zulip's integrations:
 * **Contents:**
   See [source][1].
 
-    **Note:** `{{ integration_display_name }}` is replaced by
-    [Integration.display_name][2] and `{{ recommended_stream_name }}`
+    **Note:** `{` `{ integration_display_name }` `}` is replaced by
+    [Integration.display_name][2] and  
+    `{` `{ recommended_stream_name }` `}`
     is replaced by [Integration.stream_name][3].
 
 * **Example usage:**


### PR DESCRIPTION
Screenshots:  
Before:  
![](https://lambda.sx/U4x.png)

After:  
![](https://lambda.sx/xc6.png)

Relevant link(s): 
[create-stream.md macro guide](https://zulipchat.com/api/integration-docs-guide#create-streammd-macro)
[create-stream.md](https://github.com/zulip/zulip/blob/master/templates/zerver/help/include/create-stream.md)