### PR TITLE
Change stream settings for admin view

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1143,6 +1143,7 @@ function render(template_name, args) {
         invite_only: true,
         can_make_public: true,
         can_make_private: true, /* not logical, but that's ok */
+        can_change_subscription_type: true,
         email_address: 'xxxxxxxxxxxxxxx@zulip.com',
         stream_id: 888,
         in_home_view: true,

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -175,6 +175,7 @@ exports.update_calculated_fields = function (sub) {
     sub.should_display_subscription_button = !sub.invite_only || sub.subscribed;
     sub.can_make_public = page_params.is_admin && sub.invite_only && sub.subscribed;
     sub.can_make_private = page_params.is_admin && !sub.invite_only;
+    sub.can_change_subscription_type = sub.can_make_public || sub.can_make_private;
     sub.can_add_subscribers = !sub.invite_only || (sub.invite_only && sub.subscribed);
     sub.preview_url = narrow.by_stream_uri(sub.name);
     exports.render_stream_description(sub);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -176,6 +176,8 @@ exports.update_calculated_fields = function (sub) {
     sub.can_make_public = page_params.is_admin && sub.invite_only && sub.subscribed;
     sub.can_make_private = page_params.is_admin && !sub.invite_only;
     sub.can_change_subscription_type = sub.can_make_public || sub.can_make_private;
+    // User can access subscribers as well as add other users to stream
+    // if sub.can_add_subscribers is true.
     sub.can_add_subscribers = !sub.invite_only || (sub.invite_only && sub.subscribed);
     sub.preview_url = narrow.by_stream_uri(sub.name);
     exports.render_stream_description(sub);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -325,6 +325,12 @@ function change_stream_privacy(e) {
 
             redraw_privacy_related_stuff(sub_row, sub);
             $("#stream_privacy_modal").remove();
+
+            // For auto update, without rendering whole template
+            stream_data.update_calculated_fields(sub);
+            if (!sub.can_change_subscription_type) {
+                $(".change-stream-privacy").hide();
+            }
         },
         error: function () {
             $("#change-stream-privacy-button").text(i18n.t("Try again"));

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -165,6 +165,12 @@ function show_subscription_settings(sub_row) {
 
     var emails = get_email_of_subscribers(sub.subscribers);
 
+    // If user can not access subscribers no need for search widget.
+    if (!sub.can_add_subscribers) {
+        $("[data-stream-id='" + stream_id + "'] .search").hide();
+    } else {
+        $("[data-stream-id='" + stream_id + "'] .search").show();
+    }
     list_render(list, emails.sort(), {
         name: "stream_subscribers/" + stream_id,
         modifier: function (item) {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -270,7 +270,9 @@ exports.create_sidebar_row = function (sub) {
 exports.redraw_stream_privacy = function (sub) {
     var li = exports.get_stream_li(sub.stream_id);
     if (!li) {
-        blueslip.error('passed in bad stream: ' + sub.name);
+        // We don't want to raise error here, if we can't find stream in subscription
+        // stream list. Cause we allow org admin to update stream privacy
+        // even if they don't subscribe to public stream.
         return;
     }
 

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -314,6 +314,13 @@ form#add_new_subscription {
     display: inline-block;
 }
 
+.hide-subscriber-list {
+    display: block;
+    padding: 5px;
+    text-align: center;
+    color: hsl(0, 0%, 66%);
+}
+
 .subscriber-list tbody:empty::after,
 .subscriber-list:empty::after {
     content: "No subscribers to this stream.";

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -704,7 +704,8 @@ form#add_new_subscription {
     margin-left: 10px;
 }
 
-.stream-row .sub-info-box .top-bar .subscriber-count-text {
+.stream-row .sub-info-box .top-bar .subscriber-count-text,
+.stream-row .sub-info-box .top-bar .subscriber-count-lock {
     margin-right: 5px;
 }
 

--- a/static/templates/subscription.handlebars
+++ b/static/templates/subscription.handlebars
@@ -11,7 +11,11 @@
         <div class="top-bar">
             <div class="stream-name">{{name}}</div>
             <div class="subscriber-count">
+                {{#if can_add_subscribers}}
                 <span class="subscriber-count-text">{{subscriber_count}}</span>
+                {{else}}
+                <i class="subscriber-count-lock icon-vector-lock"></i>
+                {{/if}}
                 <i class="icon-vector-user"></i>
             </div>
         </div>

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -117,7 +117,13 @@
         <div class="subscriber-list-box">
             <div class="subscriber_list_container">
                 <div class="subscriber_list_loading_indicator"></div>
+                {{#if can_add_subscribers}}
                 <table class="subscriber-list"></table>
+                {{else}}
+                <div class="hide-subscriber-list">
+                    {{t "You can not access private stream subscribers, which you aren't subscribed." }}
+                </div>
+                {{/if}}
             </div>
         </div>
         {{/render_subscribers}}

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -32,15 +32,15 @@
             <span class="checkmark" data-finish-editing=".stream-description-editable">✓</span>
             {{/if}}
         </div>
-        <div class="regular_subscription_settings collapse {{#subscribed}}in{{/subscribed}}">
-            <div class="subscription-type">
-                <div class="subscription-type-text">
-                    {{partial "subscription_type"}}
-                </div>
-                {{#if is_admin}}
-                <a class="change-stream-privacy" data-is-private="{{#if can_make_public }}true{{else}}false{{/if}}">[{{t "Change" }}]</a>
-                {{/if}}
+        <div class="subscription-type">
+            <div class="subscription-type-text">
+                {{partial "subscription_type"}}
             </div>
+            {{#if can_change_subscription_type}}
+            <a class="change-stream-privacy" data-is-private="{{#if can_make_public }}true{{else}}false{{/if}}">[{{t "Change" }}]</a>
+            {{/if}}
+        </div>
+        <div class="regular_subscription_settings collapse {{#subscribed}}in{{/subscribed}}">
             <div class="subscription-config">
                 <ul class="grey-box">
                     <li>

--- a/static/templates/subscription_table_body.handlebars
+++ b/static/templates/subscription_table_body.handlebars
@@ -33,8 +33,10 @@
                     <div id="stream_settings_title" class="stream-info-title">{{t 'Stream settings' }}</div>
                 </div>
                 <div class="nothing-selected">
+                    {{#if can_create_streams}}
                     <button type="button" class="create_stream_button button small rounded">Create Stream</button>
                     <span>{{t 'First time? Read our <a href="/help/create-a-stream" target="_blank">guidelines</a> for creating and naming streams.' }}</span>
+                    {{/if}}
                 </div>
                 <div class="settings">
                     {{!-- edit stream here --}}


### PR DESCRIPTION
**stream settings: Only show option to change type of stream if subscribed.**
    
    As per backend restrictions for changing stream subscription(private/public).

**stream settings: Always show stream type, regardless of subscribed or not.**

**stream settings: Display warning if user can not access subscribers.**
    
    Display warning, saying "You can not access private stream subscribers,
    in which you aren't subscribed", if user can not access subscribers;
    instead of showing zero subscriber to stream.

![streamprivateaccess](https://user-images.githubusercontent.com/25907420/34685452-60ef0e36-f4ce-11e7-9f8f-340b62f86d55.png)

**all streams: Show lock-icon for subscriber count, if user can't access.**
    
    Previoulsy, we display "0 subscribers" if user can't access stream
    subscribers. Replace subscriber count with lock icon in case of
    unsubscribed private stream, in "All stream" list.

![lockcount](https://user-images.githubusercontent.com/25907420/35142769-539dcdbc-fd25-11e7-92b7-23a5fe46e396.png)
