### PR TITLE
[WIP] zulip: Make background light grey.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -175,7 +175,7 @@ table.compose_table {
     z-index: 2;
     width: 100%;
 
-    background: #fff;
+    background: hsl(220, 12%, 95%);
 }
 
 #compose-container {
@@ -194,6 +194,8 @@ table.compose_table {
 
     border-left: 1px solid hsl(0, 0%, 93%);
     border-right: 1px solid hsl(0, 0%, 93%);
+
+    background-color: #fff;
 }
 
 #compose_close {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -280,13 +280,15 @@ p.n-margin {
 }
 
 .app-main .column-left .left-sidebar {
-    width: 242px;
-    padding-left: 0px;
+    width: 210px;
+    padding: 10px;
+    margin-left: 10px;
 }
 
 .app-main .column-right .right-sidebar {
-    padding-left: 10px;
-    width: 240px;
+    padding: 10px;
+    width: 210px;
+    margin-left: 10px;
 }
 
 .app-main .column-middle {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -731,12 +731,14 @@ td.pointer {
 }
 
 .message_list .recipient_row {
-    border-bottom: 1px solid hsl(0, 0%, 88%);
+    border-bottom: 1px solid hsl(220, 12%, 90%);
     margin-bottom: 10px;
+
+    background-color: #fff;
 }
 
 .floating_recipient .recipient_row {
-    border-top: 1px solid hsl(0, 0%, 88%);
+    border-top: 1px solid hsl(220, 12%, 90%);
 }
 
 .stream_label {
@@ -745,10 +747,12 @@ td.pointer {
     font-weight: normal;
     height: 17px;
     line-height: 17px;
-    background-color: hsl(0, 0%, 88%);
+    background-color: hsl(220, 12%, 90%);
     border-width: 0px;
     position: relative;
     text-decoration: none;
+
+    border-top-left-radius: 3px;
 }
 
 .stream_label .invite-stream-icon {
@@ -1012,11 +1016,13 @@ td.pointer {
 .private-message .messagebox,
 .message_header_private_message .message-header-contents {
     background-color: hsla(192, 19%, 75%, 0.2);
-    box-shadow: inset 1px 1px 0px hsl(0, 0%, 88%);
+    box-shadow: inset 1px 1px 0px hsl(220, 12%, 90%);
 }
 
 .message-header-contents {
-    border-right: 1px solid hsl(0, 0%, 88%);
+    border-right: 1px solid hsl(220, 12%, 90%);
+    border-top-right-radius: 3px;
+    border-top-left-radius: 3px;
 }
 
 .mention .messagebox {
@@ -1084,11 +1090,11 @@ td.pointer {
 }
 
 .selected_message .messagebox-content {
-    box-shadow: inset 0px 0px 0px 2px hsl(215, 47%, 50%),
-                     -1px -1px 0px 0px hsl(215, 47%, 50%),
-                      1px 1px 0px 0px hsl(215, 47%, 50%),
-                     -1px 1px 0px 0px hsl(215, 47%, 50%),
-                      1px -1px 0px 0px hsl(215, 47%, 50%);
+    box-shadow: inset 0px 0px 0px 2px hsl(170, 47%, 74%),
+                     -1px -1px 0px 0px hsl(170, 47%, 74%),
+                      1px 1px 0px 0px hsl(170, 47%, 74%),
+                     -1px 1px 0px 0px hsl(170, 47%, 74%),
+                      1px -1px 0px 0px hsl(170, 47%, 74%);
 }
 
 .message_sender {
@@ -1280,8 +1286,6 @@ div.message_table {
 
 .message_row {
     position: relative;
-    border-left: 1px solid hsla(0, 0%, 0%, 0.10);
-    border-right: 1px solid hsla(0, 0%, 0%, 0.10);
 }
 
 .message_row.selected_message {
@@ -1919,7 +1923,7 @@ div.floating_recipient {
 }
 
 .message-header-contents {
-    background: hsl(0, 0%, 88%);
+    background: hsl(220, 12%, 90%);
 }
 
 .recipient_row.sticky {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -19,7 +19,7 @@ body {
 /* Common background color */
 body,
 #tab_bar_underpadding {
-    background-color: hsl(0, 0%, 100%);
+    background-color: hsl(216, 13%, 95%);
     -webkit-transition: background-color 200ms linear;
     -moz-transition: background-color 200ms linear;
     -o-transition: background-color 200ms linear;
@@ -41,6 +41,13 @@ blockquote p {
 
 a {
     cursor: pointer;
+}
+
+.white-box {
+  background: #fff;
+  border: 1px solid hsl(220, 12%, 85%);
+  box-shadow: 0px 0px 3px rgba(0,0,0,0.06), 0px 0px 10px rgba(0, 0, 0, 0.03);
+  border-radius: 4px;
 }
 
 .no-select {
@@ -232,7 +239,7 @@ p.n-margin {
     margin: 0px auto;
     padding: 0px;
     position: relative;
-    background-color: #fff;
+    background-color: hsl(216, 13%, 95%);
 }
 
 .app-main {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -99,11 +99,11 @@ p.n-margin {
 }
 
 .top-messages-logo {
-    position: absolute;
-    left: calc(50% - 12px);
-    top: 57px;
     width: 24px;
     height: 24px;
+
+    padding: 20px 0px;
+    margin: 0px auto;
 }
 
 .top-messages-logo svg circle {
@@ -275,7 +275,7 @@ p.n-margin {
 .app-main .column-left .left-sidebar,
 .app-main .column-right .right-sidebar {
     position: fixed;
-    margin-top: 50px;
+    margin-top: 10px;
     z-index: 100;
 }
 
@@ -568,8 +568,6 @@ li.actual-dropdown-menu i {
 }
 
 .message_area_padder {
-    /* The height of the header and the tabbar plus a small gap */
-    margin-top: 93px;
     /* This is needed for the floating recipient bar
        in Firefox only, for some reason;
        otherwise it gets a scrollbar */

--- a/static/templates/message_group.handlebars
+++ b/static/templates/message_group.handlebars
@@ -11,7 +11,7 @@
         {{partial "bookend"}}
         {{/if}}
 
-        <div class="recipient_row" id="{{message_group_id}}">
+        <div class="recipient_row white-box" id="{{message_group_id}}">
             {{partial "recipient_row" "use_match_properties" ../use_match_properties}}
             {{#each message_containers}}
                 {{#with this}}

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -2,7 +2,7 @@
     class="message_row{{^msg/is_stream}} private-message{{/msg/is_stream}}{{#include_sender}} include-sender{{/include_sender}}{{#contains_mention}} mention{{/contains_mention}}{{#include_footer}} last_message{{/include_footer}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
     <div class="messagebox{{^include_sender}} prev_is_same_sender{{/include_sender}}{{^msg/is_stream}} private-message{{/msg/is_stream}} {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
-        style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">
+        style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, 0px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">
         <div class="messagebox-border">
             <div class="messagebox-content">
                 <div class="message_top_line">

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -2,7 +2,7 @@
   <div id="compose-notifications" class="notifications above-composebox">
   </div>
   <div id="compose-container">
-    <div id="compose_controls" class="compose-content new-style">
+    <div id="compose_controls" class="compose-content white-box new-style">
           <div id="nonexistent_stream_reply_error" class="alert-error">
             <span class="compose-send-status-close">&times;</span>
             <span id="compose-reply-error-msg"></span>
@@ -41,7 +41,7 @@
             </span>
           </div>
     </div>
-    <div class="message_comp compose-content">
+    <div class="message_comp compose-content white-box">
       <div class="alert" id="compose-send-status">
         <span class="compose-send-status-close">&times;</span>
         <span id="compose-error-msg"></span>

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -101,7 +101,7 @@ var page_params = {{ page_params }};
           {% include "zerver/left_sidebar.html" %}
     </div>
     <div class="column-middle">
-        <div class="column-middle-inner tab-content">
+        <div class="column-middle-inner">
             <div class="tab-pane active" id="home">
             <div class="fixed-app" id="floating_recipient_bar">
               <div class="app-main recipient_bar_content">

--- a/templates/zerver/left_sidebar.html
+++ b/templates/zerver/left_sidebar.html
@@ -1,4 +1,4 @@
-<div class="left-sidebar" id="left-sidebar">
+<div class="left-sidebar white-box" id="left-sidebar">
     <div class="bottom_sidebar">
         <ul id="global_filters" class="filters">
             {# Special-case this link so we don't actually go to page top. #}

--- a/templates/zerver/right_sidebar.html
+++ b/templates/zerver/right_sidebar.html
@@ -1,4 +1,4 @@
-<div class="right-sidebar" id="right-sidebar">
+<div class="right-sidebar white-box" id="right-sidebar">
     <div class="sidebar-items">
         {% if enable_feedback %}
         <div id="feedback_section" class="new-style">


### PR DESCRIPTION
This is a WIP series of commits to make the background in Zulip light grey to distinguish components from each other on the otherwise white background.

<img width="1920" alt="screen shot 2018-01-08 at 12 53 51 pm" src="https://user-images.githubusercontent.com/10321399/34691903-064ab184-f473-11e7-9435-ad1771777343.png">
