### PR TITLE
navbar: Show the Zulip version when hovering over the logo.

### DIFF
--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -21,7 +21,9 @@
 <div class="header">
 <nav class="header-main rightside-userlist" id="top_navbar">
   <div class="column-left">
-      <a class="brand no-style" href="#">
+      <a class="brand no-style" href="#"
+         title="{{ _('Zulip version ') + (zulip_version[:-4] if zulip_version.endswith('+git') else zulip_version) }}"
+      >
           <img src="/static/images/logo/zulip-icon-128x128.png" class="nav-logo no-drag" alt=""/>
           <div class="company-name">
               zulip

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -195,6 +195,7 @@ class TemplateTestCase(ZulipTestCase):
                          "login_time": "9:33am NewYork, NewYork",
                          },
             api_uri_context={},
+            zulip_version='1.7.1+git',
         )
 
         context.update(kwargs)


### PR DESCRIPTION
Also, check if `zulip_version` ends in `+git` and remove that part if it does. (When working on this, it ended in `+git`, but I thought that there was a possibility that it wouldn't be there in some cases, so I added a conditional. If that's unnecessary, then let me know. Thanks!)

Fix #8005.