### PR TITLE
Frontend:Change anchor tag containing buttons to form tag.Fixes #6126.

### DIFF
--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -26,9 +26,9 @@
                         <h1>Zulip for <span class="platform"></span></h1>
                         <p class="description"></p>
                         <p class="download-instructions">For download instructions, go to the <a class="silver bold" href="/help/desktop-app-install-guide" target="_blank">desktop app install guide</a>.</p>
-                        <a class="link no-action" href="">
+                        <form class="link no-action" action="" method="get">
                             <button type="button" name="button">Download Zulip for <span class="platform"></span></button>
-                        </a>
+                        </form>
                     </div>
                 </div>
             </div>

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -38,15 +38,16 @@
                 </p>
                 {% if register_link_disabled %}
                 {% elif only_sso %}
-                <a href="{{ url('login-sso') }}">
-                    <button href="" class="download-button" type="button"
-                            name="button">{{ _('Log in now!') }}</button>
-                </a>
+
+                    <form class="form-inline" action="{{ url('login-sso') }}" method="get">
+                        <button href="" class="download-button" type="button"
+                                name="button">{{ _('Log in now!') }}</button>
+                    </form>
                 {% else %}
-                <a href="{{ url('register') }}">
-                    <button href="" class="download-button" type="button"
-                            name="button">{{ _('Sign up now!') }}</button>
-                </a>
+                <form class="form-inline" action="{{ url('register') }}" method="get">
+                   <button href="" class="download-button" type="button"
+                           name="button">{{ _('Sign up now!') }}</button>
+                </form>
                 {% endif %}
                 <!-- we want this to be il-block so we'll put a <br> above so it's on
                 the next line.


### PR DESCRIPTION
The buttons in apps.html and home.html were contained in an anchor element. This isn't valid HTML5 and causes the buttons to be focused on twice when using tab-based navigation. Replacing the anchor with a form element fixes this issue.
I have changed it to form tag.