### PR TITLE
portico-header: Fix vertical positioning issues with portico header.

### DIFF
--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -19,6 +19,10 @@ body.dark-mode #settings_page .right {
     background-color: hsl(212, 28%, 18%);
 }
 
+.message_embed .data-container::after {
+    background: linear-gradient(0deg, hsl(212, 28%, 18%), transparent 10%);
+}
+
 body.dark-mode .column-left .left-sidebar,
 body.dark-mode #settings_page .form-sidebar,
 body.dark-mode .column-right .right-sidebar {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2556,9 +2556,14 @@ button.topic_edit_cancel {
     margin: 5px 0px;
     border: none;
     border-left: 3px solid hsl(0, 0%, 93%);
-    height: 70px;
+    height: 80px;
     padding: 5px;
     z-index: 1;
+
+    -moz-osx-font-smoothing: grayscale;
+    font-smoothing: antialiased;
+    -webkit-font-smoothing: antialiased;
+    text-shadow: rgba(0, 0, 0, .01) 0 0 1px;
 }
 
 .message_content .message_embed > * {
@@ -2570,17 +2575,16 @@ button.topic_edit_cancel {
 .message_embed .message_embed_title {
     padding-top: 0px;
     /* to remove the spacing that the font has from the top of the container. */
-    margin-top: -1px;
+    margin-top: -5px;
 
-    font-size: 1em;
-    font-weight: 600;
+    font-size: 1.2em;
     line-height: normal;
 }
 
 .message_embed .message_embed_description {
     position: relative;
-    margin-top: -5px;
     max-width: 500px;
+    margin-top: 3px;
 
     /* to put it below the container gradient. */
     z-index: -1;
@@ -2588,24 +2592,35 @@ button.topic_edit_cancel {
 
 .message_embed .message_embed_image {
     display: inline-block;
-    width: 60px;
-    height: 60px;
+    width: 70px;
+    height: 70px;
     background-size: cover;
     background-position: center;
 }
 
 .message_embed .data-container {
+    position: relative;
     padding: 0px 5px;
     display: inline-block;
     vertical-align: top;
     max-width: calc(100% - 115px);
-    max-height: 70px;
+    max-height: 80px;
     overflow: hidden;
 }
 
 .message_embed .data-container div {
     display: block;
     border: none;
+}
+
+.message_embed .data-container::after {
+    content: " ";
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+
+    background: linear-gradient(0deg, #fff, transparent 10%);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
This is a combination two fixes to help fix the vertical padding of the portico header.

Before:
<img width="1920" alt="screen shot 2018-01-09 at 1 52 56 pm" src="https://user-images.githubusercontent.com/10321399/34745197-8abc1b5c-f544-11e7-8906-a3504eab83dd.png">

After:
<img width="1920" alt="screen shot 2018-01-09 at 1 53 12 pm" src="https://user-images.githubusercontent.com/10321399/34745198-8ad1d0b4-f544-11e7-9199-37e864e561bc.png">

