### PR TITLE
embedded bots UI: Fix wrong _.each argument order.

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -92,9 +92,9 @@ exports.set_up = function () {
             value: bot.name,
             text: bot.name,
         }));
-        _.each(bot.config, function (key) {
+        _.each(bot.config, function (value, key) {
             var rendered_config_item = templates.render('embedded_bot_config_item',
-                {botname: bot.name, key: key, value: bot.config[key]});
+                {botname: bot.name, key: key, value: value});
             $('#config_inputbox').append(rendered_config_item);
         });
     });


### PR DESCRIPTION
When I changed Object.keys(bot.config).forEach to _.each() in #8017, I forgot to update the argument order, and didn't bother to test it. This caused the problems with giphy I experienced on playground.zulipdev.org As always, anything that can go wrong will go wrong.
@showell can you merge?