### PR TITLE
css: Allow the bot API key to be selected on all browsers.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -59,6 +59,14 @@ a {
     user-select: auto;
 }
 
+.text-select {
+    -webkit-touch-callout: text;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
+}
+
 p.n-margin {
     margin: 10px 0px 0px 0px;
 }

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -31,8 +31,8 @@
         <div class="api_key">
             <span class="field">{{t "API key" }}</span>
             <span class="api-key-value-and-button no-select">
-                <!-- have the `.auto-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
-                <span class="value auto-select">{{api_key}}</span>
+                <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
+                <span class="value text-select">{{api_key}}</span>
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-email="{{email}}">
                     <i class="icon-vector-refresh"></i>
                 </button>


### PR DESCRIPTION
The problem that prompted this PR is that I couldn't select the API key of a bot on chrome, but I could on Firefox.

Using the `auto` proerty value to override the `user-select`
property  of a parent does not seem to be compatible
with all browsers.

A made a little fiddle to demonstrate the issue and various solutions: https://jsfiddle.net/xaviercooney/Labwt64q/.
I would think that `user-select: all;` would be better for the bot API key, but it seems as if this does not work on chrome. 

(By the way, this is not part of a GCI task)