### PR TITLE
Slack importer: Refactor the script and add message conversion tests.

### DIFF
--- a/tools/test-slack-importer
+++ b/tools/test-slack-importer
@@ -10,5 +10,5 @@ EOF
 
 ./manage.py migrate --noinput
 wget https://github.com/houstondatavis/slack-export/archive/master.zip -O /tmp/slack-export-master.zip
-./manage.py convert_slack_data /tmp/slack-export-master.zip "slack_importer_test_realm" --output /tmp/slack_importer_test_data
+./manage.py convert_slack_data /tmp/slack-export-master.zip "slack-importer-test-realm" --output /tmp/slack_importer_test_data
 ./manage.py import --destroy-rebuild-database /tmp/slack_importer_test_data

--- a/zerver/fixtures/slack_message_conversion.json
+++ b/zerver/fixtures/slack_message_conversion.json
@@ -1,0 +1,54 @@
+{
+  "regular_tests": [
+    {
+      "name": "slack_link",
+      "input": ">Google logo today:\n><https://www.google.com/images/srpr/logo4w.png>\n>Kinda boring",
+      "conversion_output": ">Google logo today:\n>https://www.google.com/images/srpr/logo4w.png\n>Kinda boring"
+    },
+    {
+      "name": "slack_link_with_pipe",
+      "input": ">Google logo today:\n><https://foo.com|foo>\n>Kinda boring",
+      "conversion_output": ">Google logo today:\n>https://foo.com|foo\n>Kinda boring"
+    },
+    {
+      "name": "valid_strikethrough_test",
+      "input": "(~str ike!~, text. ~Also ~)",
+      "conversion_output": "(~~str ike!~~, text. ~~Also ~~)"
+    },
+    {
+      "name": "invalid_strikethrough_test",
+      "input": "Mid~word~ strike. Also ~~strike~~)",
+      "conversion_output": "Mid~word~ strike. Also ~~strike~~)"
+    },
+    {
+      "name": "valid_italic_test",
+      "input": "ital ^_lic_, _wo r@d_.",
+      "conversion_output": "ital ^*lic*, *wo r@d*."
+    },
+    {
+      "name": "invalid_italic_test",
+      "input": "mid_word_, @_italics_",
+      "conversion_output": "mid_word_, @_italics_"
+    },
+    {
+      "name": "valid_bold_test",
+      "input": "(*text*} and normal :* bold*.",
+      "conversion_output": "(**text**} and normal :** bold**."
+    },
+    {
+      "name": "invalid_bold_test",
+      "input": "*mid*word **word**",
+      "conversion_output": "*mid*word **word**"
+    },
+    {
+      "name": "bold_and_strike_conversion",
+      "input": "~*bold*~ and *~strike~*.",
+      "conversion_output": "~~**bold**~~ and **~~strike~~**."
+    },
+    {
+      "name": "italic_and_strike_conversion",
+      "input": "_~italic~_ and ~_strike_~",
+      "conversion_output": "*~~italic~~* and ~~*strike*~~"
+    }
+  ]
+}

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, List, Tuple
 from zerver.models import UserProfile, Realm, Stream, UserMessage, \
     Subscription, Message, Recipient, DefaultStream
 from zerver.forms import check_subdomain_available
+from zerver.lib.slack_message_conversion import convert_to_zulip_markdown, \
+    get_user_full_name
 
 # stubs
 ZerverFieldsT = Dict[str, Any]
@@ -27,15 +29,6 @@ def get_model_id(model: Any) -> int:
         return model.objects.all().last().id + 1
     else:
         return 1
-
-def get_user_full_name(user: ZerverFieldsT) -> str:
-    if user['deleted'] is False:
-        if user['real_name'] == '':
-            return user['name']
-        else:
-            return user['real_name']
-    else:
-        return user['name']
 
 def users_to_zerver_userprofile(slack_data_dir: str, realm_id: int, timestamp: Any,
                                 domain_name: str) -> Tuple[List[ZerverFieldsT], AddedUsersT]:
@@ -297,104 +290,13 @@ def channel_message_to_zerver_message(constants: List[Any], channel: str,
     zerver_message = []
     zerver_usermessage = []
 
-    # Slack link can be in the format <http://www.foo.com|www.foo.com> and <http://foo.com/>
-    LINK_REGEX = r"""
-                  ^<(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?
-                  [a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?
-                  (\/.*)?(\|)?(?:\|([^>]+))?>$
-                  """
-    SLACK_USERMENTION_REGEX = r"""
-                               (<@)                  # Start with <@
-                                   ([a-zA-Z0-9]+)    # Here we have the Slack id
-                               (\|)?                 # We not always have a Vertical line in mention
-                                   ([a-zA-Z0-9]+)?   # If Vertical line is present, this is short name
-                               (>)                   # ends with >
-                               """
-    # Slack doesn't have mid-word message-formatting like Zulip.
-    # Hence, ~stri~ke doesn't format the word in slack, but ~~stri~~ke
-    # formats the word in Zulip
-    SLACK_STRIKETHROUGH_REGEX = r"""
-                                 (^|[ -(]|[+-/]|[:-?]|\{|\[|\||\^)     # Start after specified characters
-                                 (\~)                                  # followed by an asterisk
-                                     ([ -)+-}—]*)([!-}]+)              # any character except asterisk
-                                 (\~)                                  # followed by an asterisk
-                                 ($|[ -']|[+-/]|[:-?]|\}|\)|\]|\||\^)  # ends with specified characters
-                                 """
-    SLACK_ITALIC_REGEX = r"""
-                          (^|[ -(]|[+-/]|[:-?]|\{|\[|\||\^)
-                          (\_)
-                              ([ -~—]*)([!-}]+)                  # any character
-                          (\_)
-                          ($|[ -']|[+-/]|[:-?]|\}|\)|\]|\||\^)
-                          """
-    SLACK_BOLD_REGEX = r"""
-                        (^|[ -(]|[+-/]|[:-?]|\{|\[|\||\^)
-                        (\*)
-                            ([ -~—]*)([!-}]+)                   # any character
-                        (\*)
-                        ($|[ -']|[+-/]|[:-?]|\}|\)|\]|\||\^)
-                        """
-
-    # Markdown mapping
-    def convert_to_zulip_markdown(text: str) -> Tuple[str, List[int], bool]:
-        mentioned_users_id = []
-        has_link = False
-
-        text = convert_markdown_syntax(text, SLACK_STRIKETHROUGH_REGEX, "~~")
-        text = convert_markdown_syntax(text, SLACK_ITALIC_REGEX, "*")
-        text = convert_markdown_syntax(text, SLACK_BOLD_REGEX, "**")
-
-        # Map Slack's mention all: '<!everyone>' to '@**all** '
-        # No regex for this as it can be present anywhere in the sentence
-        text = text.replace('<!everyone>', '@**all**')
-        tokens = text.split(' ')
-        for iterator in range(len(tokens)):
-            # Check user mentions and change mention format from
-            # '<@slack_id|short_name>' to '@**full_name**'
-            if (re.compile(SLACK_USERMENTION_REGEX, re.VERBOSE).match(tokens[iterator])):
-                tokens[iterator], user_id = get_user_mentions(tokens[iterator])
-                mentioned_users_id.append(user_id)
-
-            # Check link
-            if (re.compile(LINK_REGEX, re.VERBOSE).match(tokens[iterator])):
-                tokens[iterator] = tokens[iterator].replace('<', '').replace('>', '')
-                has_link = True
-
-        token = ' '.join(tokens)
-        return token, mentioned_users_id, has_link
-
-    def get_user_mentions(token: str) -> Tuple[str, int]:
-        slack_usermention_match = re.search(SLACK_USERMENTION_REGEX, token, re.VERBOSE)
-        short_name = slack_usermention_match.group(4)
-        slack_id = slack_usermention_match.group(2)
-        for user in users:
-            if (user['id'] == slack_id and user['name'] == short_name and short_name) or \
-               (user['id'] == slack_id and short_name is None):
-                full_name = get_user_full_name(user)
-                user_id = added_users[slack_id]
-                mention = "@**" + full_name + "** "
-        token = re.sub(SLACK_USERMENTION_REGEX, mention, token, flags=re.VERBOSE)
-        return token, user_id
-
-    # Map italic, bold and strikethrough markdown
-    def convert_markdown_syntax(text: str, regex: str, zulip_keyword: str) -> str:
-        """
-        Returns:
-        1. For strikethrough formatting: This maps Slack's '~strike~' to Zulip's '~~strike~~'
-        2. For bold formatting: This maps Slack's '*bold*' to Zulip's '**bold**'
-        3. For italic formatting: This maps Slack's '_italic_' to Zulip's '*italic*'
-        """
-        for match in re.finditer(regex, text, re.VERBOSE):
-            converted_token = (match.group(1) + zulip_keyword + match.group(3)
-                               + match.group(4) + zulip_keyword + match.group(6))
-            text = re.sub(regex, converted_token, text, flags=re.VERBOSE)
-        return text
-
     for json_name in json_names:
         messages = json.load(open(slack_data_dir + '/%s/%s' % (channel, json_name)))
         for message in messages:
             has_attachment = False
-            content, mentioned_users_id, has_link = convert_to_zulip_markdown(message['text'])
+            content, mentioned_users_id, has_link = convert_to_zulip_markdown(message['text'],
+                                                                              users,
+                                                                              added_users)
             rendered_content = None
             if 'subtype' in message.keys():
                 subtype = message['subtype']

--- a/zerver/lib/slack_message_conversion.py
+++ b/zerver/lib/slack_message_conversion.py
@@ -1,0 +1,127 @@
+import re
+from typing import Any, Dict, Tuple, List
+
+# stubs
+ZerverFieldsT = Dict[str, Any]
+AddedUsersT = Dict[str, int]
+
+# Slack link can be in the format <http://www.foo.com|www.foo.com> and <http://foo.com/>
+LINK_REGEX = r"""
+              (<)                                                     # match '>'
+              (http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?
+                  ([a-z0-9]+([\-\.]{1}[a-z0-9]+)*)(\.)                # subdomain
+                  ([a-z]{3,63}(:[0-9]{1,5})?)(\/[^>]*)?               # domain name has chars in range {3,63}
+              (\|)?(?:\|([^>]+))?                                     # char after pipe (for slack links)
+              (>)
+              """
+SLACK_USERMENTION_REGEX = r"""
+                           (<@)                  # Start with '<@'
+                               ([a-zA-Z0-9]+)    # Here we have the Slack id
+                           (\|)?                 # We not always have a Vertical line in mention
+                               ([a-zA-Z0-9]+)?   # If Vertical line is present, this is short name
+                           (>)                   # ends with '>'
+                           """
+# Slack doesn't have mid-word message-formatting like Zulip.
+# Hence, ~stri~ke doesn't format the word in slack, but ~~stri~~ke
+# formats the word in Zulip
+SLACK_STRIKETHROUGH_REGEX = r"""
+                             (^|[ -(]|[+-/]|\*|\_|[:-?]|\{|\[|\||\^)     # Start after specified characters
+                             (\~)                                  # followed by an asterisk
+                                 ([ -)+-}—]*)([ -}]+)              # any character except asterisk
+                             (\~)                                  # followed by an asterisk
+                             ($|[ -']|[+-/]|[:-?]|\*|\_|\}|\)|\]|\||\^)  # ends with specified characters
+                             """
+SLACK_ITALIC_REGEX = r"""
+                      (^|[ -(]|[+-/]|[:-?]|\{|\[|\||\^|~)
+                      (\_)
+                          ([ -^`~—]*)([ -^`-~]+)                  # any character
+                      (\_)
+                      ($|[ -']|[+-/]|[:-?]|\}|\)|\]|\||\^|~)
+                      """
+SLACK_BOLD_REGEX = r"""
+                    (^|[ -(]|[+-/]|[:-?]|\{|\[|\||\^|~)
+                    (\*)
+                        ([ -)+-~—]*)([ -)+-~]+)                   # any character
+                    (\*)
+                    ($|[ -']|[+-/]|[:-?]|\}|\)|\]|\||\^|~)
+                    """
+
+def get_user_full_name(user: ZerverFieldsT) -> str:
+    if user['deleted'] is False:
+        if user['real_name'] == '':
+            return user['name']
+        else:
+            return user['real_name']
+    else:
+        return user['name']
+
+# Markdown mapping
+def convert_to_zulip_markdown(text: str, users: List[ZerverFieldsT],
+                              added_users: AddedUsersT) -> Tuple[str, List[int], bool]:
+    mentioned_users_id = []
+    text = convert_markdown_syntax(text, SLACK_BOLD_REGEX, "**")
+    text = convert_markdown_syntax(text, SLACK_STRIKETHROUGH_REGEX, "~~")
+    text = convert_markdown_syntax(text, SLACK_ITALIC_REGEX, "*")
+
+    # Map Slack's mention all: '<!everyone>' to '@**all** '
+    # No regex for this as it can be present anywhere in the sentence
+    text = text.replace('<!everyone>', '@**all**')
+
+    tokens = text.split(' ')
+    for iterator in range(len(tokens)):
+
+        # Check user mentions and change mention format from
+        # '<@slack_id|short_name>' to '@**full_name**'
+        if (re.findall(SLACK_USERMENTION_REGEX, tokens[iterator], re.VERBOSE)):
+            tokens[iterator], user_id = get_user_mentions(tokens[iterator],
+                                                          users, added_users)
+            if user_id is not None:
+                mentioned_users_id.append(user_id)
+
+    text = ' '.join(tokens)
+
+    # Check and convert link format
+    text, has_link = convert_link_format(text)
+
+    return text, mentioned_users_id, has_link
+
+def get_user_mentions(token: str, users: List[ZerverFieldsT],
+                      added_users: AddedUsersT) -> Tuple[str, int]:
+    slack_usermention_match = re.search(SLACK_USERMENTION_REGEX, token, re.VERBOSE)
+    short_name = slack_usermention_match.group(4)
+    slack_id = slack_usermention_match.group(2)
+    for user in users:
+        if (user['id'] == slack_id and user['name'] == short_name and short_name) or \
+           (user['id'] == slack_id and short_name is None):
+                full_name = get_user_full_name(user)
+                user_id = added_users[slack_id]
+                mention = "@**" + full_name + "**"
+                token = re.sub(SLACK_USERMENTION_REGEX, mention, token, flags=re.VERBOSE)
+                return token, user_id
+    return token, None
+
+# Map italic, bold and strikethrough markdown
+def convert_markdown_syntax(text: str, regex: str, zulip_keyword: str) -> str:
+    """
+    Returns:
+    1. For strikethrough formatting: This maps Slack's '~strike~' to Zulip's '~~strike~~'
+    2. For bold formatting: This maps Slack's '*bold*' to Zulip's '**bold**'
+    3. For italic formatting: This maps Slack's '_italic_' to Zulip's '*italic*'
+    """
+    for match in re.finditer(regex, text, re.VERBOSE):
+        converted_token = (match.group(1) + zulip_keyword + match.group(3)
+                           + match.group(4) + zulip_keyword + match.group(6))
+        text = text.replace(match.group(0), converted_token)
+    return text
+
+def convert_link_format(text: str) -> Tuple[str, bool]:
+    """
+    1. Converts '<https://foo.com>' to 'https://foo.com'
+    2. Converts '<https://foo.com|foo>' to 'https://foo.com|foo'
+    """
+    has_link = False
+    for match in re.finditer(LINK_REGEX, text, re.VERBOSE):
+        converted_text = match.group(0).replace('>', '').replace('<', '')
+        has_link = True
+        text = text.replace(match.group(0), converted_text)
+    return text, has_link

--- a/zerver/tests/test_slack_message_conversion.py
+++ b/zerver/tests/test_slack_message_conversion.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+
+from zerver.lib.slack_message_conversion import (
+    convert_to_zulip_markdown,
+    get_user_full_name
+)
+from zerver.lib.test_classes import (
+    ZulipTestCase,
+)
+from zerver.lib.test_runner import slow
+from zerver.lib import mdiff
+import ujson
+
+import os
+from typing import Any, AnyStr, Dict, List, Optional, Set, Tuple, Text
+
+class SlackMessageConversion(ZulipTestCase):
+    def assertEqual(self, first: Any, second: Any, msg: Text = "") -> None:
+        if isinstance(first, Text) and isinstance(second, Text):
+            if first != second:
+                raise AssertionError("Actual and expected outputs do not match; showing diff.\n" +
+                                     mdiff.diff_strings(first, second) + msg)
+        else:
+            super().assertEqual(first, second)
+
+    def load_slack_message_conversion_tests(self) -> Dict[Any, Any]:
+        test_fixtures = {}
+        data_file = open(os.path.join(os.path.dirname(__file__), '../fixtures/slack_message_conversion.json'), 'r')
+        data = ujson.loads('\n'.join(data_file.readlines()))
+        for test in data['regular_tests']:
+            test_fixtures[test['name']] = test
+
+        return test_fixtures
+
+    @slow("Aggregate of runs of individual slack message conversion tests")
+    def test_message_conversion_fixtures(self) -> None:
+        format_tests = self.load_slack_message_conversion_tests()
+        valid_keys = set(['name', "input", "conversion_output"])
+
+        for name, test in format_tests.items():
+            # Check that there aren't any unexpected keys as those are often typos
+            self.assertEqual(len(set(test.keys()) - valid_keys), 0)
+            slack_user_map = {}  # type: Dict[str, int]
+            users = [{}]         # type: List[Dict[str, Any]]
+            converted = convert_to_zulip_markdown(test['input'], users, slack_user_map)
+            converted_text = converted[0]
+            print("Running Slack Message Conversion test: %s" % (name,))
+            self.assertEqual(converted_text, test['conversion_output'])
+
+    def test_mentioned_data(self) -> None:
+        slack_user_map = {'U08RGD1RD': 540,
+                          'U0CBK5KAT': 554,
+                          'U09TYF5SK': 571}
+        # For this test, only relevant keys are 'id', 'name', 'deleted'
+        # and 'real_name'
+        users = [{"id": "U0CBK5KAT",
+                  "name": "aaron.anzalone",
+                  "deleted": False,
+                  "real_name": ""},
+                 {"id": "U08RGD1RD",
+                  "name": "john",
+                  "deleted": False,
+                  "real_name": "John Doe"},
+                 {"id": "U09TYF5Sk",
+                  "name": "Jane",
+                  "deleted": True}]              # Deleted users don't have 'real_name' key in Slack
+        message = 'Hi <@U08RGD1RD|john>: How are you?'
+        text, mentioned_users, has_link = convert_to_zulip_markdown(message, users, slack_user_map)
+        full_name = get_user_full_name(users[1])
+        self.assertEqual(full_name, 'John Doe')
+        self.assertEqual(get_user_full_name(users[2]), 'Jane')
+
+        self.assertEqual(text, 'Hi @**%s**: How are you?' % (full_name))
+        self.assertEqual(mentioned_users, [540])
+
+        # multiple mentioning
+        message = 'Hi <@U08RGD1RD|john>: How are you?<@U0CBK5KAT> asked.'
+        text, mentioned_users, has_link = convert_to_zulip_markdown(message, users, slack_user_map)
+        self.assertEqual(text, 'Hi @**%s**: How are you?@**%s** asked.' %
+                         ('John Doe', 'aaron.anzalone'))
+        self.assertEqual(mentioned_users, [540, 554])
+
+        # Check wrong mentioning
+        message = 'Hi <@U08RGD1RD|jon>: How are you?'
+        text, mentioned_users, has_link = convert_to_zulip_markdown(message, users, slack_user_map)
+        self.assertEqual(text, message)
+        self.assertEqual(mentioned_users, [])


### PR DESCRIPTION
Overview of this PR:

1. Improves the implementation for checking if the realm subdomain is available ( by using the existing function `check_subdomain_available`)

2. Move the inner message conversions to another module `slack_message_conversions`.

3. Add tests specific to message conversions which checks:
     

- valid and invalid user mentioning.
- valid and invalid regex conversions.

There are some minor issues while converting the slack markdown to zulip markdown (where conversions would be lossy:)
- In slack a text is allowed to be bold and italic at the same time, like this _**fvfdv**_, but in Zulip as far as my knowledge goes, we can't have a bold and italic text at the same time as this is italic in zulip: `*italic*`  and bold: `**bold**`

However we can have strikethrough and bold text together as well as strikethrough and italic, which I  have taken care of, as seen in the unit test.