### PR TITLE
user-settings: Move password reset into a modal.

### DIFF
--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -102,6 +102,8 @@ exports.open_modal = function (name) {
     blueslip.debug('open modal: ' + name);
 
     $("#" + name).modal("show").attr("aria-hidden", false);
+    // Remove previous alert messsages from modal, if exists.
+    $("#" + name).find(".alert").hide();
 };
 
 exports.close_overlay = function (name) {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -113,7 +113,6 @@ exports.set_up = function () {
         var data = {
             old_password: $('#old_password').val(),
             new_password: $('#new_password').val(),
-            confirm_password: $('#confirm_password').val(),
         };
 
         channel.patch({

--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -73,3 +73,31 @@ a.no-underline:hover {
 .ps:hover.ps--in-scrolling.ps--y > .ps__scrollbar-y-rail > .ps__scrollbar-y {
     background-color: #606060;
 }
+
+/* -- flex forms -- */
+.flex-row * {
+    box-sizing: border-box;
+}
+
+.flex-row input[type=text],
+.flex-row input[type=password] {
+    height: auto;
+    width: 100%;
+}
+
+.flex-row {
+    display: flex;
+}
+
+.flex-row.normal {
+    width: 500px;
+}
+
+.flex-row .field {
+    margin: 10px 10px;
+    width: 100%;
+}
+
+.flex-row .field + .field {
+    margin-left: 10px;
+}

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1092,6 +1092,14 @@ input[type=checkbox].inline-block {
     cursor: pointer;
 }
 
+#settings_page #change_password_modal {
+    width: auto;
+}
+
+#settings_page #change_password_modal .change_password_info {
+    margin: 10px;
+}
+
 #deactivation_user_modal.fade.in {
     top: calc(50% - 120px);
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2359,8 +2359,8 @@ button.topic_edit_cancel {
 
 /* FIXME: Combine this rule with the one in portico.css somehow? */
 #pw_strength {
-    width: 220px;
-    height: 25px;
+    width: 100%;
+    height: 10px;
     margin-bottom: 0px;
 }
 

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -57,35 +57,25 @@
                         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
                         <h3 id="change_password_modal_label">{{t "Change password" }}</h3>
                     </div>
-                    <div class="modal-body">
-                        <div id="pw_change_controls">
-                            <div class="input-group inline-block">
-                                <label for="old_password" class="inline-block title">{{t "Old password" }}</label>
-                                <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block" value="" />
-                                <div class="warning">
-                                    <a href="/accounts/password/reset/" class="sea-green" target="_blank">{{t "Forgotten it?" }}</a>
-                                </div>
+                    <div class="flex-row normal">
+                        <div class="field">
+                            <label for="old_password" class="title">{{t "Old password" }}</label>
+                            <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block" value="" />
+                            <div class="info">
+                                <a href="/accounts/password/reset/" class="sea-green" target="_blank">{{t "Forgotten it?" }}</a>
                             </div>
-
-                            <div class="input-group inline-block">
-                                <label for="new_password" class="inline-block title">{{t "New password" }}</label>
-                                <input type="password" autocomplete="off" name="new_password" id="new_password" class="w-200 inline-block" value=""
-                                 data-min-length="{{ page_params.password_min_length }}" data-min-guesses="{{ page_params.password_min_guesses }}" />
-                                <div class="warning">
-                                    <div class="progress inline-block" id="pw_strength">
-                                        <div class="bar bar-danger fade" style="width: 10%;"></div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="input-group">
-                                <label class="inline-block title" for="confirm_password title">{{t "Confirm password" }}</label>
-                                <input type="password" autocomplete="off" name="confirm_password" id="confirm_password" class="w-200 inline-block" value="" />
+                        </div>
+                        <div class="field">
+                            <label for="new_password" class="title">{{t "New password" }}</label>
+                            <input type="password" autocomplete="off" name="new_password" id="new_password" class="w-200 inline-block" value=""
+                             data-min-length="{{ page_params.password_min_length }}" data-min-guesses="{{ page_params.password_min_guesses }}" />
+                            <div class="progress inline-block" id="pw_strength">
+                                <div class="bar bar-danger fade" style="width: 10%;"></div>
                             </div>
                         </div>
                     </div>
+                    <div class="alert change_password_info"></div>
                     <div class="modal-footer">
-                        <div class="alert change_password_info"></div>
                         <button class="button white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
                         <button id='change_password_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
                     </div>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -39,29 +39,27 @@
                 </div>
             </form>
 
-            <form action="/json/settings" method="patch"
-                class="form-horizontal your-account-settings">
-
-                <div class="m-10 inline-block grid user-name-parent">
-                    <div class="user-name-section inline-block">
-                        <div class="input-group" id="name_change_container">
-                            <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
-                            <input type="text" name="full_name" id="full_name" class="w-200 inline-block" value="{{ page_params.full_name }}" {{#if page_params.realm_name_changes_disabled}}disabled="disabled" {{/if}}/>
-                            <i class="icon-vector-question-sign settings-info-icon change_name_tooltip" data-toggle="tooltip"
-                            {{#unless page_params.realm_name_changes_disabled}}style="display:none" {{/unless}}
-                            title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
-                            <div class="warning"></div>
-                        </div>
-
-                        <!-- password start -->
+            <form class="password-change-form grid">
+                <div class="input-group user-name-section">
+                    <label class="inline-block title">{{t "Password" }}</label>
+                    <a id="change_password" {{#if page_params.realm_email_auth_enabled}}href="#change_password"{{/if}}>
                         {{#if page_params.realm_email_auth_enabled}}
-                        <div class="input-group" id="pw_change_link">
-                            <label for="change_password_button" class="inline-block title">{{t "Password" }}</label>
-                            <button class="change_password_button button rounded inline-block input-size" data-dismiss="modal">{{t "Change password" }}</button>
+                        <div class="input-group inline-block" id="pw_change_link">
+                            <button type="button" class="change_password_button button rounded inline-block input-size" data-dismiss="modal">{{t "Change password" }}</button>
                         </div>
+                        {{/if}}
+                    </a>
+                </div>
 
+                <div id="change_password_modal" class="modal hide" tabindex="-1" role="dialog"
+                    aria-labelledby="change_password_modal_label" aria-hidden="true">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+                        <h3 id="change_password_modal_label">{{t "Change password" }}</h3>
+                    </div>
+                    <div class="modal-body">
                         <div id="pw_change_controls">
-                            <div class="input-group">
+                            <div class="input-group inline-block">
                                 <label for="old_password" class="inline-block title">{{t "Old password" }}</label>
                                 <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block" value="" />
                                 <div class="warning">
@@ -69,7 +67,7 @@
                                 </div>
                             </div>
 
-                            <div class="input-group">
+                            <div class="input-group inline-block">
                                 <label for="new_password" class="inline-block title">{{t "New password" }}</label>
                                 <input type="password" autocomplete="off" name="new_password" id="new_password" class="w-200 inline-block" value=""
                                  data-min-length="{{ page_params.password_min_length }}" data-min-guesses="{{ page_params.password_min_guesses }}" />
@@ -85,7 +83,26 @@
                                 <input type="password" autocomplete="off" name="confirm_password" id="confirm_password" class="w-200 inline-block" value="" />
                             </div>
                         </div>
-                        {{/if}}
+                    </div>
+                    <div class="modal-footer">
+                        <div class="alert change_password_info"></div>
+                        <button class="button white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+                        <button id='change_password_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
+                    </div>
+                </div>
+            </form>
+
+            <form class="form-horizontal your-account-settings">
+                <div class="m-10 inline-block grid user-name-parent">
+                    <div class="user-name-section inline-block">
+                        <div class="input-group" id="name_change_container">
+                            <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
+                            <input type="text" name="full_name" id="full_name" class="w-200 inline-block" value="{{ page_params.full_name }}" {{#if page_params.realm_name_changes_disabled}}disabled="disabled" {{/if}}/>
+                            <i class="icon-vector-question-sign change_name_tooltip" data-toggle="tooltip"
+                            {{#unless page_params.realm_name_changes_disabled}}style="display:none" {{/unless}}
+                            title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
+                            <div class="warning"></div>
+                        </div>
 
                         <div class="input-group no-border">
                             <label for="" class="inline-block"></label>

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -73,14 +73,11 @@ def json_change_settings(request: HttpRequest, user_profile: UserProfile,
                          full_name: Text=REQ(default=""),
                          email: Text=REQ(default=""),
                          old_password: Text=REQ(default=""),
-                         new_password: Text=REQ(default=""),
-                         confirm_password: Text=REQ(default="")) -> HttpResponse:
+                         new_password: Text=REQ(default="")) -> HttpResponse:
     if not (full_name or new_password or email):
         return json_error(_("No new data supplied"))
 
-    if new_password != "" or confirm_password != "":
-        if new_password != confirm_password:
-            return json_error(_("New password must match confirmation password!"))
+    if new_password != "":
         if not authenticate(username=user_profile.email, password=old_password,
                             realm=user_profile.realm):
             return json_error(_("Wrong password!"))

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -75,7 +75,7 @@ def json_change_settings(request: HttpRequest, user_profile: UserProfile,
                          old_password: Text=REQ(default=""),
                          new_password: Text=REQ(default="")) -> HttpResponse:
     if not (full_name or new_password or email):
-        return json_error(_("No new data supplied"))
+        return json_error(_("Please fill out all fields."))
 
     if new_password != "":
         if not authenticate(username=user_profile.email, password=old_password,


### PR DESCRIPTION
This moves the password reset form into a modal that pops up instead of being embedded in the settings page. 

This includes a fixed up design and some fixed up error messages, along with the removal of the password confirmation requirement – building directly on #7892.

<img width="515" alt="screen shot 2018-01-11 at 11 29 54 am" src="https://user-images.githubusercontent.com/10321399/34843727-24a9e872-f6c4-11e7-9c96-472db38a169c.png">
