### PR TITLE
settings: Properly center deactivation modal.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1107,6 +1107,11 @@ input[type=checkbox].inline-block {
     top: calc(50% - 120px);
 }
 
+.modal.fade.in {
+    top: 50%;
+    transform: translateY(-50%);
+}
+
 #id_realm_create_stream_permission {
     width: 100%;
 }


### PR DESCRIPTION
This properly vertically centers the deactivation modal in the
user settings section by setting the top to 50% and the transform
to -50% (50% of the height of the actual modal).

Fixes: (does this fix a PR)?

This is an alternate solution to #7888, which just removes the
animation, breaking the normal modal behavior. This should be
merged and that PR closed.