### PR TITLE
dark-mode: Make alert words compatible.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2525,7 +2525,7 @@ button.topic_edit_cancel {
 }
 
 .alert-word {
-    background-color: hsl(112, 88%, 87%);
+    background-color: hsla(102, 85%, 57%, 0.5);
 }
 
 #organization h1,


### PR DESCRIPTION
The alert word highlighting is too light to work with the font
when it is white, so this changes it to have a translucent background
so that the color adjusts to be more visible on a darker background.

This is originally taken from #7844 and is a modification of the
solution in #7847.

The reason this approach is better for the codebase is now there is
only one color to change for alert words which reduces the likelihood
that someone in the future will change the color of one theme's
alert words and not the other.

Fixes: #7844.