### PR TITLE
dark mode: Fix miscolored sections in settings modals.

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -335,3 +335,8 @@
 
     list-style-type: none;
 }
+
+.white-box {
+    background-color: hsl(0, 0%, 100%);
+    border: 1px solid hsl(0, 0%, 86%);
+}

--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -14,11 +14,13 @@ body.dark-mode #compose,
 body.dark-mode .column-left .left-sidebar,
 body.dark-mode .column-right .right-sidebar,
 body.dark-mode #subscription_overlay .right,
+body.dark-mode #settings_page .form-sidebar,
 body.dark-mode #settings_page .right {
     background-color: hsl(212, 28%, 18%);
 }
 
 body.dark-mode .column-left .left-sidebar,
+body.dark-mode #settings_page .form-sidebar,
 body.dark-mode .column-right .right-sidebar {
     border-left-color: hsla(0, 0%, 0%, 0.2);
 }
@@ -206,8 +208,10 @@ body.dark-mode .drafts-header,
 body.dark-mode .nav > li > a:hover,
 body.dark-mode .subscriptions-header,
 body.dark-mode .grey-box,
+body.dark-mode .white-box,
 body.dark-mode .stream-email,
 body.dark-mode #settings_page .settings-header,
+body.dark-mode #settings_page .form-sidebar .title,
 body.dark-mode #settings_page .sidebar li.active,
 body.dark-mode #settings_page .sidebar .tab-container,
 body.dark-mode .table-striped tbody tr:nth-child(odd) td,

--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -89,6 +89,7 @@ body.dark-mode .new-style .button.no-style {
 }
 
 body.dark-mode .new-style .tab-switcher .ind-tab.selected,
+body.dark-mode div.message_content thead,
 body.dark-mode .table-striped thead th,
 body.dark-mode .message_reactions .message_reaction.reacted,
 body.dark-mode .message_reactions:hover .message_reaction + .reaction_button {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -608,8 +608,6 @@ input[type=checkbox].inline-block {
     max-height: 220px;
     margin: 5px;
 
-    background-color: hsl(0, 0%, 100%);
-    border: 1px solid hsl(0, 0%, 86%);
     border-radius: 4px;
     box-sizing: border-box;
 
@@ -828,7 +826,6 @@ input[type=checkbox].inline-block {
 
 #user-groups .user-group {
     margin-bottom: 20px;
-    background-color: hsl(0, 0%, 100%);
     padding: 10px;
     border-radius: 5px;
 }
@@ -1033,8 +1030,8 @@ input[type=checkbox].inline-block {
 }
 
 #settings_page .form-sidebar .title {
-    background-color: hsl(0, 0%, 98%);
     padding: 10px 20px;
+    background-color: hsl(0, 0%, 98%);
     border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -370,13 +370,10 @@ input[type=checkbox].inline-block {
     border-left: 0px;
 }
 
-.grey-bg {
-    background: hsl(0, 0%, 89%);
+.alert-word-information-box {
+    position: relative;
     padding: 10px;
     margin: 20px auto;
-    box-shadow: 0px 0px 2px hsla(0, 0%, 0%, 0.5);
-    position: relative;
-    font-size: 14px;
 }
 
 .green-bg {
@@ -482,12 +479,14 @@ input[type=checkbox].inline-block {
 }
 
 .add-new-emoji-box,
-.add-new-user-group-box {
+.add-new-user-group-box,
+.add-new-alert-word-box {
     margin-bottom: 20px;
 }
 
 .add-new-emoji-box .new-emoji-form,
-.add-new-user-group-box .new-user-group-form {
+.add-new-user-group-box .new-user-group-form,
+.add-new-alert-word-box .new-alert-word-form {
     margin: 10px 0px;
 }
 

--- a/static/templates/admin_user_group_list.handlebars
+++ b/static/templates/admin_user_group_list.handlebars
@@ -1,5 +1,5 @@
 {{#with user_group}}
-<div class="user-group" id="{{id}}">
+<div class="user-group white-box" id="{{id}}">
     <h4>
         <span class="name" data-placeholder="{{t 'Name' }}" contenteditable="true" spellcheck="false">{{name}}</span>
         —

--- a/static/templates/alert_word_settings_item.handlebars
+++ b/static/templates/alert_word_settings_item.handlebars
@@ -1,10 +1,10 @@
 {{! Alert word in the settings page that can be removed }}
 <li class="alert-word-item" data-word='{{word}}'>
     {{#if editing}}
-    <div class="alert-word-settings-form">
-        <div class="add-new-alert-word-box grey-bg">
-            <form id="create_alert_word_form" class="form-horizontal no-padding">
-                <h4 class="new-alert-word-section-title light no-margin">{{t "Add a new alert word"}}</h4>
+    <form id="create_alert_word_form" class="form-horizontal">
+        <div class="add-new-alert-word-box grey-box">
+            <div class="new-alert-word-form">
+                <h4 class="new-alert-word-section-title settings-section-title no-padding">{{t "Add a new alert word"}}</h4>
                 <div class="new-alert-word-form">
                     <div class="input-group">
                         <label for="create_alert_word_name">{{t "New alert word" }}</label>
@@ -15,11 +15,11 @@
                         {{t 'Add alert word'}}
                     </button>
                 </div>
-            </form>
+            </div>
         </div>
-    </div>
+    </form>
     {{else}}
-    <div class="alert-word-information-box grey-bg">
+    <div class="alert-word-information-box grey-box">
         <div class="alert_word_listing">
             <span class="value">{{word}}</span>
         </div>

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -1,4 +1,4 @@
-<li class="bot-information-box">
+<li class="bot-information-box white-box">
     <div class="image overflow-hidden">
         <img src="{{avatar_url}}" class="avatar" />
         <div class="details">


### PR DESCRIPTION
## First commit

Instead of simply changing the background color of the alert words box, this PR changes the Add a new alert word form's styling to match the other forms in Custom emoji and User groups.

New design, light theme:
![screenshot at jan 13 10-20-36](https://user-images.githubusercontent.com/15116870/34908838-a6149f5a-f84b-11e7-9f22-078849101558.png)

New design, dark theme:
![screenshot at jan 13 10-20-53](https://user-images.githubusercontent.com/15116870/34908839-a62b623a-f84b-11e7-8852-488201905f23.png)

Original design:
![screenshot at jan 13 10-23-09](https://user-images.githubusercontent.com/15116870/34908850-ca1f54a8-f84b-11e7-9f4f-4b1e93374802.png)


Fixes #8065.

--- 
## Second commit

Although not reported in the original issue, sections with white backgrounds (content in Your bots, User groups, and Edit bot sidebar) don't have their backgrounds changed in dark mode. This commit resolves that issue by creating a new class `white-box` (and manual changes for the title portion of the Edit bot sidebar).

Current state:

![screenshot at jan 13 11-01-31](https://user-images.githubusercontent.com/15116870/34909205-3dceffde-f851-11e7-8a2d-0ec54f487474.png)
![screenshot at jan 13 11-01-41](https://user-images.githubusercontent.com/15116870/34909206-3de71588-f851-11e7-97bb-aaadd247a294.png)
