### PR TITLE
Remove unnecessary imports imports in various files

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -55,8 +55,6 @@ import re
 import ujson
 import urllib
 
-from contextlib import contextmanager
-
 API_KEYS = {}  # type: Dict[Text, Text]
 
 def flush_caches_for_testing() -> None:

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -63,7 +63,6 @@ import urllib
 from zerver.lib.str_utils import NonBinaryStr
 from moto import mock_s3_deprecated
 
-from contextlib import contextmanager
 import fakeldap
 import ldap
 

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -16,6 +16,14 @@ from zerver.lib.actions import (
     get_active_presence_idle_user_ids,
     get_user_info_for_message_updates,
     internal_send_private_message,
+    check_message,
+    check_send_stream_message,
+    do_deactivate_user,
+    do_set_realm_property,
+    extract_recipients,
+    do_create_user,
+    get_client,
+    do_add_alert_words,
 )
 
 from zerver.lib.message import (
@@ -50,16 +58,6 @@ from zerver.models import (
     flush_per_request_caches
 )
 
-from zerver.lib.actions import (
-    check_message,
-    check_send_stream_message,
-    do_deactivate_user,
-    do_set_realm_property,
-    extract_recipients,
-    do_create_user,
-    get_client,
-    do_add_alert_words,
-)
 
 from zerver.lib.upload import create_attachment
 

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -2,8 +2,6 @@
 from typing import Any, Callable, Dict, List, Mapping, Optional, cast
 
 import signal
-import sys
-import os
 from functools import wraps
 
 import smtplib
@@ -55,7 +53,6 @@ import time
 import datetime
 import logging
 import requests
-import ujson
 from io import StringIO
 import re
 import importlib


### PR DESCRIPTION
I wrote a script to find duplicate imports, and I think I've removed all of them (although I'm not certain). If there's a particular reason why some of the imports are split apart please tell me.