### PR TITLE
Don't allow zero subscriber to private stream subscription

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -99,9 +99,9 @@ function ajaxSubscribeForCreation(stream_name, description, principals, invite_o
                announce: JSON.stringify(announce),
         },
         success: function () {
-            $(".stream_change_property_info").hide();
             $("#create_stream_name").val("");
             $("#create_stream_description").val("");
+            ui_report.success(i18n.t("Stream successfully created!"), $(".stream_create_info"));
             loading.destroy_indicator($('#stream_creating_indicator'));
             // The rest of the work is done via the subscribe event we will get
         },
@@ -114,7 +114,7 @@ function ajaxSubscribeForCreation(stream_name, description, principals, invite_o
                 stream_name_error.select();
             }
 
-            ui_report.error(i18n.t("Error creating stream"), xhr, $(".stream_change_property_info"));
+            ui_report.error(i18n.t("Error creating stream"), xhr, $(".stream_create_info"));
             loading.destroy_indicator($('#stream_creating_indicator'));
         },
     });
@@ -235,6 +235,7 @@ exports.show_new_stream_modal = function () {
     }
 
     stream_name_error.clear_errors();
+    $(".stream_create_info").hide();
 
     $("#stream-checkboxes label.checkbox").on('change', function (e) {
         var elem = $(this);

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -24,6 +24,11 @@ var stream_subscription_error = (function () {
         $("#stream_subscription_error").show();
     };
 
+    self.cant_create_stream_without_susbscribing = function () {
+        $("#stream_subscription_error").text(i18n.t("You must be a realm administrator to create a stream without subscribing."));
+        $("#stream_subscription_error").show();
+    };
+
     self.clear_errors = function () {
         $("#stream_subscription_error").hide();
     };
@@ -236,6 +241,7 @@ exports.show_new_stream_modal = function () {
     $('#people_to_add').html(templates.render('new_stream_users', {
         users: all_users,
         streams: stream_data.get_streams_for_settings_page(),
+        is_admin: page_params.is_admin,
     }));
 
     // Make the options default to the same each time:
@@ -291,6 +297,9 @@ $(function () {
     $(document).on('click', '.subs_unset_all_users', function (e) {
         $('#user-checkboxes .checkbox').each(function (idx, li) {
             if  (li.style.display !== "none") {
+                if (idx === 0 && !page_params.is_admin) {
+                    return;
+                }
                 $(li.firstElementChild).prop('checked', false);
             }
         });
@@ -357,6 +366,10 @@ $(function () {
         var principals = get_principals();
         if (principals.length === 0) {
             stream_subscription_error.report_no_subs_to_stream();
+            return;
+        }
+        if (principals.indexOf(people.my_current_email()) < 0 && !page_params.is_admin) {
+            stream_subscription_error.cant_create_stream_without_susbscribing();
             return;
         }
 

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -16,6 +16,22 @@ exports.get_name = function () {
     return created_stream;
 };
 
+var stream_subscription_error = (function () {
+    var self = {};
+
+    self.report_no_subs_to_stream = function () {
+        $("#stream_subscription_error").text(i18n.t("You cannot create a stream with no subscribers!"));
+        $("#stream_subscription_error").show();
+    };
+
+    self.clear_errors = function () {
+        $("#stream_subscription_error").hide();
+    };
+
+    return self;
+
+}());
+
 var stream_name_error = (function () {
     var self = {};
 
@@ -236,6 +252,7 @@ exports.show_new_stream_modal = function () {
 
     stream_name_error.clear_errors();
     $(".stream_create_info").hide();
+    stream_subscription_error.clear_errors();
 
     $("#stream-checkboxes label.checkbox").on('change', function (e) {
         var elem = $(this);
@@ -338,6 +355,11 @@ $(function () {
         }
 
         var principals = get_principals();
+        if (principals.length === 0) {
+            stream_subscription_error.report_no_subs_to_stream();
+            return;
+        }
+
         if (principals.length >= 50) {
             var invites_warning_modal = templates.render('subscription_invites_warning_modal',
                                                          {stream_name: stream_name,

--- a/static/styles/alerts.css
+++ b/static/styles/alerts.css
@@ -11,6 +11,10 @@
     margin: 20px;
 }
 
+.alert.stream_create_info {
+    margin: 10px 10px 0px 10px;
+}
+
 /* alert box compoent changes */
 .alert-box {
     position: absolute;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -241,7 +241,7 @@ form#add_new_subscription {
     width: calc(100% - 15px);
 }
 
-#stream_name_error {
+.stream_creation_error {
     display: none;
     margin-left: 2px;
     color: hsl(0, 100%, 50%);

--- a/static/templates/new_stream_users.handlebars
+++ b/static/templates/new_stream_users.handlebars
@@ -30,7 +30,7 @@
 <div id="user-checkboxes">
     {{#each users}}
     <label class="checkbox add-user-label" data-user-id="{{this.user_id}}" data-email="{{this.email}}">
-        <input type="checkbox" name="user" value="{{this.email}}" {{#if @first}}checked="checked"{{/if}}/>
+        <input type="checkbox" name="user" value="{{this.email}}" {{#if @first}}checked="checked"{{#unless is_admin}} disabled="disabled"{{/unless}}{{/if}}/>
         <span></span>
         {{this.full_name}} ({{this.email}})
     </label>

--- a/static/templates/subscription_creation_form.handlebars
+++ b/static/templates/subscription_creation_form.handlebars
@@ -10,7 +10,7 @@
                 </div>
                 <input type="text" name="stream_name" id="create_stream_name"
                      placeholder="{{t 'Stream name' }}" value="" autocomplete="off" />
-                <div id="stream_name_error"></div>
+                <div id="stream_name_error" class="stream_creation_error"></div>
             </section>
             <section class="block">
                 <div class="stream-title">
@@ -60,6 +60,7 @@
                 <label class="stream-title" for="people_to_add">
                     {{t "People to add" }}
                 </label>
+                <div id="stream_subscription_error" class="stream_creation_error"></div>
                 <div class="controls" id="people_to_add"></div>
             </section>
         </div>

--- a/static/templates/subscription_creation_form.handlebars
+++ b/static/templates/subscription_creation_form.handlebars
@@ -1,6 +1,7 @@
 <div class="hide" id="stream-creation" tabindex="-1" role="dialog"
     aria-label="{{t 'Stream creation' }}">
     <form id="stream_creation_form" class="form-inline">
+        <div class="alert stream_create_info"></div>
         <div id="stream_creating_indicator"></div>
         <div class="stream-creation-body">
             <section class="block">


### PR DESCRIPTION
**create stream: Do not subscribe current user automatically to stream.**
    
    In frontend we are providing option, whether current user wants to
    subscribe to stream or not.
    Previously, if there are zero subscriber to stream we automatically
    subscribe current user to stream.
    This feels like bug to user as they are subscribed to stream, even they
    have manually deselect themselves from subscription while creating stream.
