### PR TITLE
Add outgoing webhook config entries to the "edit bot" menu.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -214,6 +214,7 @@ var event_fixtures = {
         op: 'remove',
         bot: {
             email: 'the-bot@example.com',
+            user_id: '42',
             full_name: 'The Bot',
         },
     },
@@ -585,8 +586,8 @@ with_overrides(function (override) {
             override('bot_data.deactivate', bot_stub.f);
             override('settings_users.update_user_data', admin_stub.f);
             dispatch(event);
-            var args = bot_stub.get_args('email');
-            assert_same(args.email, event.bot.email);
+            var args = bot_stub.get_args('user_id');
+            assert_same(args.user_id, event.bot.user_id);
 
             admin_stub.get_args('update_user_id', 'update_bot_data');
         });
@@ -600,8 +601,8 @@ with_overrides(function (override) {
 
             dispatch(event);
 
-            var args = bot_stub.get_args('email', 'bot');
-            assert_same(args.email, event.bot.email);
+            var args = bot_stub.get_args('user_id', 'bot');
+            assert_same(args.user_id, event.bot.user_id);
             assert_same(args.bot, event.bot);
 
             args = admin_stub.get_args('update_user_id', 'update_bot_data');

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -4,7 +4,7 @@ var bot_data = (function () {
     var bots = {};
     var bot_fields = ['api_key', 'avatar_url', 'default_all_public_streams',
                       'default_events_register_stream', 'default_sending_stream',
-                      'email', 'full_name', 'is_active', 'owner', 'bot_type'];
+                      'email', 'full_name', 'is_active', 'owner', 'bot_type', 'user_id'];
     var services = {};
     var services_fields = ['base_url', 'interface'];
 
@@ -24,28 +24,28 @@ var bot_data = (function () {
 
     exports.add = function bot_data__add(bot) {
         var clean_bot = _.pick(bot, bot_fields);
-        bots[bot.email] = clean_bot;
+        bots[bot.user_id] = clean_bot;
         set_can_admin(clean_bot);
         var clean_services = _.map(bot.services, function (service) {
             return _.pick(service, services_fields);
         });
-        services[bot.email] = clean_services;
+        services[bot.user_id] = clean_services;
 
         send_change_event();
     };
 
-    exports.deactivate = function bot_data__deactivate(email) {
-        bots[email].is_active = false;
+    exports.deactivate = function bot_data__deactivate(bot_id) {
+        bots[bot_id].is_active = false;
         send_change_event();
     };
 
-    exports.update = function bot_data__update(email, bot_update) {
-        var bot = bots[email];
+    exports.update = function bot_data__update(bot_id, bot_update) {
+        var bot = bots[bot_id];
         _.extend(bot, _.pick(bot_update, bot_fields));
         set_can_admin(bot);
 
         // We currently only support one service per bot.
-        var service = services[email][0];
+        var service = services[bot_id][0];
         if (typeof bot_update.services !== 'undefined' && bot_update.services.length > 0) {
             _.extend(service, _.pick(bot_update.services[0], services_fields));
         }
@@ -64,12 +64,12 @@ var bot_data = (function () {
         });
     };
 
-    exports.get = function bot_data__get(email) {
-        return bots[email];
+    exports.get = function bot_data__get(bot_id) {
+        return bots[bot_id];
     };
 
-    exports.get_services = function bot_data__get_services(email) {
-        return services[email];
+    exports.get_services = function bot_data__get_services(bot_id) {
+        return services[bot_id];
     };
 
     exports.initialize = function () {

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -5,6 +5,8 @@ var bot_data = (function () {
     var bot_fields = ['api_key', 'avatar_url', 'default_all_public_streams',
                       'default_events_register_stream', 'default_sending_stream',
                       'email', 'full_name', 'is_active', 'owner', 'bot_type'];
+    var services = {};
+    var services_fields = ['base_url', 'interface'];
 
     var send_change_event = _.debounce(function () {
         $(document).trigger('zulip.bot_data_changed');
@@ -24,6 +26,11 @@ var bot_data = (function () {
         var clean_bot = _.pick(bot, bot_fields);
         bots[bot.email] = clean_bot;
         set_can_admin(clean_bot);
+        var clean_services = _.map(bot.services, function (service) {
+            return _.pick(service, services_fields);
+        });
+        services[bot.email] = clean_services;
+
         send_change_event();
     };
 
@@ -36,6 +43,12 @@ var bot_data = (function () {
         var bot = bots[email];
         _.extend(bot, _.pick(bot_update, bot_fields));
         set_can_admin(bot);
+
+        // We currently only support one service per bot.
+        var service = services[email][0];
+        if (typeof bot_update.services !== 'undefined' && bot_update.services.length > 0) {
+            _.extend(service, _.pick(bot_update.services[0], services_fields));
+        }
         send_change_event();
     };
 
@@ -53,6 +66,10 @@ var bot_data = (function () {
 
     exports.get = function bot_data__get(email) {
         return bots[email];
+    };
+
+    exports.get_services = function bot_data__get_services(email) {
+        return services[email];
     };
 
     exports.initialize = function () {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -112,14 +112,14 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             bot_data.add(event.bot);
             settings_users.update_user_data(event.bot.user_id, event.bot);
         } else if (event.op === 'remove') {
-            bot_data.deactivate(event.bot.email);
+            bot_data.deactivate(event.bot.user_id);
             event.bot.is_active = false;
             settings_users.update_user_data(event.bot.user_id, event.bot);
         } else if (event.op === 'update') {
             if (_.has(event.bot, 'owner_id')) {
                 event.bot.owner = people.get_person_from_user_id(event.bot.owner_id).email;
             }
-            bot_data.update(event.bot.email, event.bot);
+            bot_data.update(event.bot.user_id, event.bot);
             settings_users.update_user_data(event.bot.user_id, event.bot);
         }
         break;

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -294,6 +294,7 @@ exports.set_up = function () {
         var old_full_name = bot_info.find(".name").text();
         var old_owner = bot_data.get(bot_info.find(".email .value").text()).owner;
         var bot_email = bot_info.find(".email .value").text();
+        var bot_type = bot_info.find(".type .value").text();
 
         $("#settings_page .edit_bot .edit_bot_name").val(old_full_name);
         $("#settings_page .edit_bot .select-form").text("").append(owner_select);
@@ -301,8 +302,17 @@ exports.set_up = function () {
         $("#settings_page .edit_bot_form").attr("data-email", bot_email);
         $(".edit_bot_email").text(bot_email);
 
-        avatar_widget.clear();
+        if (bot_type === "Outgoing webhook") {
+            var services = bot_data.get_services(bot_email);
+            $("#settings_page .edit_bot #service_data").show();
+            // Currently, we only support one service per bot.
+            $("#settings_page .edit_bot #edit_service_base_url").val(services[0].base_url);
+            $("#settings_page .edit_bot #edit_service_interface").val(services[0].interface);
+        } else {
+            $("#settings_page .edit_bot #service_data").hide();
+        }
 
+        avatar_widget.clear();
 
         function show_row_again() {
             image.show();
@@ -336,6 +346,12 @@ exports.set_up = function () {
                 formData.append('csrfmiddlewaretoken', csrf_token);
                 formData.append('full_name', full_name);
                 formData.append('bot_owner', bot_owner);
+                if (bot_type === "Outgoing webhook") {
+                    var service_payload_url = $("#settings_page .edit_bot #edit_service_base_url").val();
+                    var service_interface = $("#settings_page .edit_bot #edit_service_interface :selected").val();
+                    formData.append('service_payload_url', JSON.stringify(service_payload_url));
+                    formData.append('service_interface', service_interface);
+                }
                 jQuery.each(file_input[0].files, function (i, file) {
                     formData.append('file-'+i, file);
                 });

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -403,7 +403,7 @@ exports.on_load_success = function (realm_people_data) {
         } else if (person.is_bot) {
             // Dynamically add the owner select control in order to
             // avoid performance issues in case of large number of users.
-            owner_select.val(bot_data.get(person.email).owner || "");
+            owner_select.val(bot_data.get(user_id).owner || "");
             form_row.find(".edit_bot_owner_container").append(owner_select);
         }
 

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -18,7 +18,7 @@
             {{/if}}
         </div>
     </div>
-    <div class="bot_info">
+    <div class="bot_info" data-user_id="{{user_id}}">
         <div class="email">
             <div class="field">{{t "Username" }}</div>
             <div class="value">{{email}}</div>

--- a/templates/zerver/settings_sidebar.html
+++ b/templates/zerver/settings_sidebar.html
@@ -22,6 +22,20 @@
                         <label for="bot_owner_select">{{ _("Owner") }}</label>
                         <div class="select-form"></div>
                     </div>
+                    <div id="service_data">
+                        <div class="">
+                            <label for="edit_service_base_url">{{ _("Endoint URL") }}</label>
+                            <input id="edit_service_base_url" type="text" name="service_payload_url" class="edit_service_base_url required" maxlength=50 />
+                            <div><label for="edit_service_base_url" generated="true" class="text-error"></label></div>
+                        </div>
+                        <div class="">
+                            <label for="edit_service_interface">{{ _("Interface") }}</label>
+                            <select id="edit_service_interface" name="service_interface" default="1">
+                                <option value="1">{{ _("Generic") }}</option>
+                                <option value="2">{{ _("Slack's outgoing webhooks") }}</option>
+                            </select>
+                        </div>
+                    </div>
                     <div class="avatar-section">
                         <label for="bot_avatar_file_input">Avatar</label>
                         <input type="file" name="bot_avatar_file_input" class="notvisible edit_bot_avatar_file_input" value="{{ _('Upload avatar') }}" />

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -71,7 +71,8 @@ from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, 
     custom_profile_fields_for_realm, get_huddle_user_ids, \
     CustomProfileFieldValue, validate_attachment_request, get_system_bot, \
     get_display_recipient_by_id, query_for_ids, get_huddle_recipient, \
-    UserGroup, UserGroupMembership, get_default_stream_groups
+    UserGroup, UserGroupMembership, get_default_stream_groups, \
+    get_service_dicts_for_bots, get_bot_services
 
 from zerver.lib.alert_words import alert_words_in_realm
 from zerver.lib.avatar import avatar_url
@@ -415,6 +416,7 @@ def notify_created_bot(user_profile: UserProfile) -> None:
                default_events_register_stream=default_events_register_stream_name,
                default_all_public_streams=user_profile.default_all_public_streams,
                avatar_url=avatar_url(user_profile),
+               services = get_service_dicts_for_bots(user_profile.id),
                )
 
     # Set the owner key only when the bot has an owner.
@@ -4379,6 +4381,24 @@ def do_update_user_group_description(user_group: UserGroup, description: Text) -
     user_group.description = description
     user_group.save(update_fields=['description'])
     do_send_user_group_update_event(user_group, dict(description=description))
+
+def do_update_outgoing_webhook_service(bot_profile, service_interface, service_payload_url):
+    # type: (UserProfile, int, Text) -> None
+    # TODO: First service is chosen because currently one bot can only have one service.
+    # Update this once multiple services are supported.
+    service = get_bot_services(bot_profile.id)[0]
+    service.base_url = service_payload_url
+    service.interface = service_interface
+    service.save()
+    send_event(dict(type='realm_bot',
+                    op='update',
+                    bot=dict(email=bot_profile.email,
+                             user_id=bot_profile.id,
+                             services = [dict(base_url=service.base_url,
+                                              interface=service.interface)],
+                             ),
+                    ),
+               bot_owner_user_ids(bot_profile))
 
 def do_send_user_group_members_update_event(event_name: Text,
                                             user_group: UserGroup,

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1460,6 +1460,7 @@ def get_owned_bot_dicts(user_profile: UserProfile,
              'default_all_public_streams': botdict['default_all_public_streams'],
              'owner': botdict['bot_owner__email'],
              'avatar_url': avatar_url_from_dict(botdict),
+             'services': get_service_dicts_for_bots(botdict['id']),
              }
             for botdict in result]
 
@@ -1908,6 +1909,14 @@ def get_realm_outgoing_webhook_services_name(realm: Realm) -> List[Any]:
 
 def get_bot_services(user_profile_id: str) -> List[Service]:
     return list(Service.objects.filter(user_profile__id=user_profile_id))
+
+def get_service_dicts_for_bots(user_profile_id: str) -> List[Dict[str, Any]]:
+    services = get_bot_services(user_profile_id)
+    service_dicts = [{'base_url': service.base_url,
+                      'interface': service.interface,
+                      }
+                     for service in services]
+    return service_dicts
 
 def get_service_profile(user_profile_id: str, service_name: str) -> Service:
     return Service.objects.get(user_profile__id=user_profile_id, name=service_name)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -73,6 +73,7 @@ from zerver.lib.actions import (
     do_update_embedded_data,
     do_update_message,
     do_update_message_flags,
+    do_update_outgoing_webhook_service,
     do_update_pointer,
     do_update_user_presence,
     log_event,
@@ -106,10 +107,11 @@ from zerver.lib.topic_mutes import (
 )
 from zerver.lib.validator import (
     check_bool, check_dict, check_dict_only, check_float, check_int, check_list, check_string,
-    equals, check_none_or, Validator
+    equals, check_none_or, Validator, check_url
 )
 
 from zerver.views.events_register import _default_all_public_streams, _default_narrow
+from zerver.views.users import add_service
 
 from zerver.tornado.event_queue import (
     allocate_client_descriptor,
@@ -1534,6 +1536,10 @@ class EventsRegisterTest(ZulipTestCase):
                 ('default_all_public_streams', check_bool),
                 ('avatar_url', check_string),
                 ('owner', check_string),
+                ('services', check_list(check_dict_only([  # type: ignore  # check_url doesn't completely fit the default validator spec, but is de facto working here.
+                    ('base_url', check_url),
+                    ('interface', check_int),
+                ]))),
             ])),
         ])
         action = lambda: self.create_bot('test-bot@zulip.com')
@@ -1632,6 +1638,30 @@ class EventsRegisterTest(ZulipTestCase):
         error = change_bot_owner_checker('events[0]', events[0])
         self.assert_on_error(error)
 
+    def test_do_update_outgoing_webhook_service(self):
+        # type: () -> None
+        update_outgoing_webhook_service_checker = self.check_events_dict([
+            ('type', equals('realm_bot')),
+            ('op', equals('update')),
+            ('bot', check_dict_only([
+                ('email', check_string),
+                ('user_id', check_int),
+                ('services', check_list(check_dict_only([  # type: ignore  # check_url doesn't completely fit the default validator spec, but is de facto working here.
+                    ('base_url', check_url),
+                    ('interface', check_int),
+                ]))),
+            ])),
+        ])
+        self.user_profile = self.example_user('iago')
+        bot = do_create_user('test-bot@zulip.com', '123', get_realm('zulip'), 'Test Bot', 'test',
+                             bot_type=UserProfile.OUTGOING_WEBHOOK_BOT, bot_owner=self.user_profile)
+        add_service(user_profile=bot, name="test", base_url="http://hostname.domain1.com",
+                    interface=1, token="abced")
+        action = lambda: do_update_outgoing_webhook_service(bot, 2, 'http://hostname.domain2.com')
+        events = self.do_test(action)
+        error = update_outgoing_webhook_service_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
     def test_do_deactivate_user(self) -> None:
         bot_deactivate_checker = self.check_events_dict([
             ('type', equals('realm_bot')),
@@ -1664,6 +1694,10 @@ class EventsRegisterTest(ZulipTestCase):
                 ('default_all_public_streams', check_bool),
                 ('avatar_url', check_string),
                 ('owner', check_none_or(check_string)),
+                ('services', check_list(check_dict_only([  # type: ignore  # check_url doesn't completely fit the default validator spec, but is de facto working here.
+                    ('base_url', check_url),
+                    ('interface', check_int),
+                ]))),
             ])),
         ])
         bot = self.create_bot('foo-bot@zulip.com')

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -183,7 +183,7 @@ class HomeTest(ZulipTestCase):
             with patch('zerver.lib.cache.cache_set') as cache_mock:
                 result = self._get_home_page(stream='Denmark')
 
-        self.assert_length(queries, 41)
+        self.assert_length(queries, 42)
         self.assert_length(cache_mock.call_args_list, 7)
 
         html = result.content.decode('utf-8')
@@ -211,6 +211,7 @@ class HomeTest(ZulipTestCase):
             'full_name',
             'is_active',
             'owner',
+            'services',
             'user_id',
         ]
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -15,7 +15,7 @@ from zerver.lib.actions import do_change_avatar_fields, do_change_bot_owner, \
     do_change_is_admin, do_change_default_all_public_streams, \
     do_change_default_events_register_stream, do_change_default_sending_stream, \
     do_create_user, do_deactivate_user, do_reactivate_user, do_regenerate_api_key, \
-    check_change_full_name
+    check_change_full_name, notify_created_bot
 from zerver.lib.avatar import avatar_url, get_gravatar_url, get_avatar_field
 from zerver.lib.bot_config import set_bot_config
 from zerver.lib.exceptions import JsonableError
@@ -319,6 +319,8 @@ def add_bot_backend(
     if bot_type == UserProfile.EMBEDDED_BOT:
         for key, value in config_data.items():
             set_bot_config(bot_profile, key, value)
+
+    notify_created_bot(bot_profile)
 
     json_result = dict(
         api_key=bot_profile.api_key,


### PR DESCRIPTION
This partially reuses code from #5665 (thanks again @vabs22!).

This PR incorporates @timabbott's suggestion from #5665 to put all service data into `page_params.realm_bots`.