### PR TITLE
dark-mode: Fix text color of emoji_alt_code.

### DIFF
--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -241,7 +241,6 @@
     font-size: 0.8em;
     display: inline-block;
     vertical-align: top;
-    color: hsl(0, 0%, 20%);
     margin: 0px 1px 0px 0px;
     line-height: 1em;
 }

--- a/static/templates/settings/display-settings.handlebars
+++ b/static/templates/settings/display-settings.handlebars
@@ -91,7 +91,7 @@
                     <span>{{t this }}</span>
                     <span class="right">
                         {{#if @last}}
-                        <div class="emoji_alt_code">&nbsp:relaxed:</div>
+                        <div class="emoji_alt_code">&nbsp;:relaxed:</div>
                         {{else}}
                         <img class="emoji" src="/static/generated/emoji/images-{{@key}}-64/1f642.png" />
                         <img class="emoji" src="/static/generated/emoji/images-{{@key}}-64/1f44d.png" />


### PR DESCRIPTION
This PR
<img width="755" alt="screen shot 2018-01-17 at 7 16 21 pm" src="https://user-images.githubusercontent.com/18511177/35046110-193a883c-fbbc-11e7-901f-8b40734a143d.png">
<img width="345" alt="screen shot 2018-01-17 at 7 16 37 pm" src="https://user-images.githubusercontent.com/18511177/35046111-19b0400e-fbbc-11e7-8ca2-9b9ac33768b8.png">

current master (9fe284b44236cff79bb71bccba181d26f8aa1fb7)
<img width="332" alt="screen shot 2018-01-17 at 7 17 24 pm" src="https://user-images.githubusercontent.com/18511177/35046112-19f37842-fbbc-11e7-9d7c-fbb8ca454605.png">
<img width="709" alt="screen shot 2018-01-17 at 7 17 30 pm" src="https://user-images.githubusercontent.com/18511177/35046114-1b251f4a-fbbc-11e7-8317-322fa1f5f915.png">