### PR TITLE
portico: navigation side menu made more wide

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -3176,7 +3176,7 @@ nav ul li.active::after {
         top: 0;
         left: 0;
         height: 100vh;
-        width: 300px;
+        width: calc(100% - 50px);
         padding-left: 30px;
 
         background-color: #fff;


### PR DESCRIPTION
This PR fixes #8019. Now only the the cross (exit button) of the menu is visible, instead of showing both cross and the original button (which opens the menu).