### PR TITLE
[WIP] Custom filters

### DIFF
--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -159,11 +159,23 @@ function message_matches_search_term(message, operator, operand) {
     return true; // unknown operators return true (effectively ignored)
 }
 
-
-
 var canonical_operators = {from: "sender", subject: "topic"};
 
 Filter.custom_filters = new Dict();
+
+// Sample filters.
+Filter.custom_filters.set('test', function (msg) {
+    if (msg.subject.indexOf('1') !== -1) {
+        return true;
+    }
+    return false;
+});
+Filter.custom_filters.set('long', function (msg) {
+    if (msg.content.length > 300) {
+        return true;
+    }
+    return false;
+});
 
 Filter.canonicalize_operator = function (operator) {
     operator = operator.toLowerCase();


### PR DESCRIPTION
### Usage

1. Write a function that takes a Zulip message object and returns a boolean.
```js
var myfunction = function(msg) {
  if (msg.subject.length < 10) return true;
  return false;
};
```
2. Use `Filter.custom_filters.set('filter-name', myfunction);`
3. In the searchbar, use `filter:filter-name` either alone or with other filters.

### Testing

Requesting deployment on Playground.

### TODO

- [x] Basic implementation.
- [ ] Better wrapping (like `plugin.filters.set();`). Would help in further plugin features.
- [ ] Basic node tests.
- [ ] Remove sample filters from PR for merging.
- [ ] Documentation