### PR TITLE
 Increment provision version to install stripe package

### DIFF
--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '14.4'
+PROVISION_VERSION = '14.5'


### PR DESCRIPTION
Stripe package got included in 167a71292283f37cdd821856c7db95cf82fea419 but the provision version was not incremented.