### PR TITLE
messagebox-css: Fixes time-stamp and message control icons location

### DIFF
--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -261,14 +261,14 @@
     }
 
     .message_time {
-        right: auto;
-        left: -3px;
+        right: -5px;
+        left: auto;
     }
 
     .message_controls {
         width: 56px;
-        right: -10px;
-        top: 0px;
+        right: 40px;
+        top: 1px;
     }
 
     .message_hovered .message_controls {
@@ -276,7 +276,7 @@
     }
 
     .selected_message .message_controls {
-        right: -10px;
+        right: 40px;
     }
 
     .include-sender .message_controls {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2699,3 +2699,9 @@ button.topic_edit_cancel {
     visibility: visible;
     opacity: 1;
 }
+@media (max-width: 500px) {
+    .messagebox p {
+        margin: 3px 45px 10px 0px;
+    }
+}
+    

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2703,5 +2703,4 @@ button.topic_edit_cancel {
     .messagebox p {
         margin: 3px 45px 10px 0px;
     }
-}
-    
+}  

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2703,4 +2703,4 @@ button.topic_edit_cancel {
     .messagebox p {
         margin: 3px 45px 10px 0px;
     }
-}  
+}


### PR DESCRIPTION
This PR fixes the incorrect time-stamp location, message control icons location and also increases margin for message-box so that nothing overlaps on smaller screen sizes. Fixes #8110.