### PR TITLE
message-box css: Fixes time-stamp and message control icons location.

### DIFF
--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -261,14 +261,14 @@
     }
 
     .message_time {
-        right: auto;
-        left: -3px;
+        right: -5px;
+        left: auto;
     }
 
     .message_controls {
         width: 56px;
-        right: -10px;
-        top: 0px;
+        right: 40px;
+        top: 1px;
     }
 
     .message_hovered .message_controls {
@@ -276,7 +276,7 @@
     }
 
     .selected_message .message_controls {
-        right: -10px;
+        right: 40px;
     }
 
     .include-sender .message_controls {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2699,3 +2699,8 @@ button.topic_edit_cancel {
     visibility: visible;
     opacity: 1;
 }
+@media (max-width: 500px) {
+    .messagebox p {
+        margin: 3px 45px 10px 0px;
+    }
+}

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2699,6 +2699,7 @@ button.topic_edit_cancel {
     visibility: visible;
     opacity: 1;
 }
+
 @media (max-width: 500px) {
     .messagebox p {
         margin: 3px 45px 10px 0px;


### PR DESCRIPTION
Fixes #8110. This PR fixes the time-stamp location (from left to right) and message control icons location so that they do not overlap, also increases margin of message-box to avoid overlap between text and message control icons. 