### PR TITLE
katex: Update the `require` path to point to the new one.

### DIFF
--- a/static/third/katex/cli.js
+++ b/static/third/katex/cli.js
@@ -36,7 +36,15 @@ SOFTWARE.
 let katex;
 try {
     // Attempt to import KaTeX from the production bundle
-    katex = require("/home/zulip/prod-static/min/katex.js");
+    const paths = require('/home/zulip/deployments/current/staticfiles.json').paths.values();
+    var katexPath = paths[paths.lastIndexOf('webpack-bundles/katex-')];
+    if (!katexPath.endsWith('js')) {
+      // This is to anticipate that the webpack staticfiles ordering may not be
+      // deterministic, that katex-somehash.js.map gets selected instead of
+      // katex-somehash.js
+      katexPath = paths[paths.indexOf('webpack-bundles/katex-')];
+    }
+    katex = require('/home/zulip/prod-static/' + katexPath);
 } catch (ex) {
     // Import KaTeX from node_modules (development environment) otherwise
     katex = require("../../node_modules/katex/dist/katex.js");


### PR DESCRIPTION
This fixes #7620.