### PR TITLE
slack importer: Prevent id clashes for import in an active db.

### DIFF
--- a/tools/test-slack-importer
+++ b/tools/test-slack-importer
@@ -8,7 +8,16 @@ DROP DATABASE IF EXISTS zulip_slack_importer_test;
 CREATE DATABASE zulip_slack_importer_test TEMPLATE zulip_test_template;
 EOF
 
+sudo apt-get install unzip zip
+
 ./manage.py migrate --noinput
+pwd=$(pwd)
 wget https://github.com/houstondatavis/slack-export/archive/master.zip -O /tmp/slack-export-master.zip
-./manage.py convert_slack_data /tmp/slack-export-master.zip "slack-importer-test-realm" --output /tmp/slack_importer_test_data
-./manage.py import --destroy-rebuild-database /tmp/slack_importer_test_data
+cd /tmp
+unzip -q /tmp/slack-export-master.zip
+cd /tmp/slack-export-master/
+zip -r -q slack-export-master.zip .
+cd $pwd
+./manage.py convert_slack_data /tmp/slack-export-master/slack-export-master.zip "slack-importer-test-realm" --output /tmp/slack_importer_test_data
+rm -rf /tmp/slack-export-master
+./manage.py import --import-into-nonempty /tmp/slack_importer_test_data

--- a/zerver/fixtures/slack_message_conversion.json
+++ b/zerver/fixtures/slack_message_conversion.json
@@ -16,6 +16,16 @@
       "conversion_output": "http://datausa.io/ this is a good website."
     },
     {
+      "name": "mailto_format1",
+      "input": "email me at <mailto:random@gmail.com|random@gmail.com>",
+      "conversion_output": "email me at mailto:random@gmail.com"
+    },
+    {
+      "name": "mailto_format2",
+      "input": "email me at <mailto:random@gmail.com>",
+      "conversion_output": "email me at mailto:random@gmail.com"
+    },
+    {
       "name": "valid_strikethrough_test",
       "input": "(~str ike!~, text. ~Also ~)",
       "conversion_output": "(~~str ike!~~, text. ~~Also ~~)"

--- a/zerver/fixtures/slack_message_conversion.json
+++ b/zerver/fixtures/slack_message_conversion.json
@@ -1,7 +1,7 @@
 {
   "regular_tests": [
     {
-      "name": "slack_link",
+      "name": "slack_link1",
       "input": ">Google logo today:\n><https://www.google.com/images/srpr/logo4w.png>\n>Kinda boring",
       "conversion_output": ">Google logo today:\n>https://www.google.com/images/srpr/logo4w.png\n>Kinda boring"
     },
@@ -9,6 +9,11 @@
       "name": "slack_link_with_pipe",
       "input": ">Google logo today:\n><https://foo.com|foo>\n>Kinda boring",
       "conversion_output": ">Google logo today:\n>https://foo.com|foo\n>Kinda boring"
+    },
+    {
+      "name": "slack_link2",
+      "input": "<http://datausa.io/> this is a good website.",
+      "conversion_output": "http://datausa.io/ this is a good website."
     },
     {
       "name": "valid_strikethrough_test",

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -405,8 +405,9 @@ def channel_message_to_zerver_message(constants: List[Any], channel: str,
 def do_convert_data(slack_zip_file: str, realm_subdomain: str, output_dir: str) -> None:
     check_subdomain_available(realm_subdomain)
     slack_data_dir = slack_zip_file.replace('.zip', '')
-    zip_file_dir = os.path.dirname(slack_data_dir)
-    subprocess.check_call(['unzip', '-q', slack_zip_file, '-d', zip_file_dir])
+    if not os.path.exists(slack_data_dir):
+        os.makedirs(slack_data_dir)
+    subprocess.check_call(['unzip', '-q', slack_zip_file, '-d', slack_data_dir])
     # with zipfile.ZipFile(slack_zip_file, 'r') as zip_ref:
     #     zip_ref.extractall(slack_data_dir)
 

--- a/zerver/lib/slack_message_conversion.py
+++ b/zerver/lib/slack_message_conversion.py
@@ -7,11 +7,12 @@ AddedUsersT = Dict[str, int]
 
 # Slack link can be in the format <http://www.foo.com|www.foo.com> and <http://foo.com/>
 LINK_REGEX = r"""
-              (<)                                                     # match '>'
-              (http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?
-                  ([a-z0-9]+([\-\.]{1}[a-z0-9]+)*)(\.)                # subdomain
-                  ([a-z]{3,63}(:[0-9]{1,5})?)(\/[^>]*)?               # domain name has chars in range {3,63}
-              (\|)?(?:\|([^>]+))?                                     # char after pipe (for slack links)
+              (<)                                                              # match '>'
+              (http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/|ftp:\/\/)?  # protocol and www
+                  ([a-z0-9]+([\-\.]{1}[a-z0-9]+)*)(\.)                         # domain name
+                      ([a-z]{2,63}(:[0-9]{1,5})?)                              # domain
+                  (\/[^>]*)?                                                   # path
+              (\|)?(?:\|([^>]+))?                                # char after pipe (for slack links)
               (>)
               """
 SLACK_USERMENTION_REGEX = r"""


### PR DESCRIPTION
Commit 1: Previously we had a problem of id clashes while importing converted
slack data into an existing zulip instance with realms which are actively
populating the database.

This counts the total objects to be imported and does a db transaction
to increase the SEQUENCE number for that table by that number,
and hence allocates a range of ids for the to be converted slack data
objects.

Commit 2: Slack data file unzips into the same folder(tested with an actual file), unlike the dataset we have [here](https://github.com/houstondatavis/slack-export). This is a temporary method for testing, which I will later change by adding the unit tests.

Commit 3 : Fix link regex.

Commit 4: Add regex for `mailto:` mapping