### PR TITLE
tests: Increase test coverage for check_message.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1814,11 +1814,6 @@ def check_message(sender: UserProfile, client: Client, addressee: Addressee,
         check_stream_name(stream_name)
 
         topic_name = addressee.topic()
-        if topic_name is None:
-            raise JsonableError(_("Missing topic"))
-        topic_name = topic_name.strip()
-        if topic_name == "":
-            raise JsonableError(_("Topic can't be empty"))
         topic_name = truncate_topic(topic_name)
 
         try:

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -111,6 +111,11 @@ class Addressee:
 
     @staticmethod
     def for_stream(stream_name: Text, topic: Text) -> 'Addressee':
+        if topic is None:
+            raise JsonableError(_("Missing topic"))
+        topic = topic.strip()
+        if topic == "":
+            raise JsonableError(_("Topic can't be empty"))
         return Addressee(
             msg_type='stream',
             stream_name=stream_name,

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1049,6 +1049,52 @@ class MessagePOSTTest(ZulipTestCase):
                                                      "to": self.example_email("othello")})
         self.assert_json_error(result, "Message must not be empty")
 
+    def test_empty_string_topic(self) -> None:
+        """
+        Sending a message that has empty string topic should fail
+        """
+        self.login(self.example_email("hamlet"))
+        result = self.client_post("/json/messages", {"type": "stream",
+                                                     "to": "Verona",
+                                                     "client": "test suite",
+                                                     "content": "Test message",
+                                                     "subject": ""})
+        self.assert_json_error(result, "Topic can't be empty")
+
+    def test_missing_topic(self) -> None:
+        """
+        Sending a message without topic should fail
+        """
+        self.login(self.example_email("hamlet"))
+        result = self.client_post("/json/messages", {"type": "stream",
+                                                     "to": "Verona",
+                                                     "client": "test suite",
+                                                     "content": "Test message"})
+        self.assert_json_error(result, "Missing topic")
+
+    def test_invalid_message_type(self) -> None:
+        """
+        Messages other than the type of "private" or "stream" are considered as invalid
+        """
+        self.login(self.example_email("hamlet"))
+        result = self.client_post("/json/messages", {"type": "invalid",
+                                                     "to": "Verona",
+                                                     "client": "test suite",
+                                                     "content": "Test message",
+                                                     "subject": "Test subject"})
+        self.assert_json_error(result, "Invalid message type")
+
+    def test_private_message_without_recipients(self) -> None:
+        """
+        Sending private message without recipients should fail
+        """
+        self.login(self.example_email("hamlet"))
+        result = self.client_post("/json/messages", {"type": "private",
+                                                     "content": "Test content",
+                                                     "client": "test suite",
+                                                     "to": ""})
+        self.assert_json_error(result, "Message must have recipients")
+
     def test_mirrored_huddle(self) -> None:
         """
         Sending a mirrored huddle message works


### PR DESCRIPTION
Also makes a little refactoring of "missing topic" assertion.
I was trying to cover this function completely but "It was difficult to cover that `forged_timestamp` case as its updated by time in `request` and tried it mock it but my approach was making it complicated if there is any better to cover them then please do tell me.