### PR TITLE
provision: Add virtualenv as an apt dependency to Ubuntu Xenial.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -150,6 +150,9 @@ APT_DEPENDENCIES = {
         "postgresql-9.5",
         "postgresql-9.5-tsearch-extras",
         "postgresql-9.5-pgroonga",
+        # Since Ubuntu Xenial there is a new package, virtualenv, which has to
+        # be installed additionally to avoid having 'command not found' error
+        "virtualenv"
     ],
     "zesty": UBUNTU_COMMON_APT_DEPENDENCIES + [
         "postgresql-9.6",


### PR DESCRIPTION
Since Ubuntu Xenial there is a new package, virtualenv, which has to
be installed additionally to avoid having 'command not found' error
when running `virtualenv`.

Observed in #8125 and when I was debugging https://chat.zulip.org/#narrow/stream/development.20help/topic/prompt.20started.20with.20vagrant.40 (16.04).