### PR TITLE
messages: Make checking for status message consistent with backend.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1281,6 +1281,14 @@ function test_with_mock_socket(test_params) {
             };
         }
 
+        function setup_mock_markdown_is_status_message(msg_content, msg_rendered, return_val) {
+            markdown.is_status_message = function (content, rendered) {
+                assert.equal(content, msg_content);
+                assert.equal(rendered, msg_rendered);
+                return return_val;
+            };
+        }
+
         function test_post_success(success_callback) {
             var resp = {
                 rendered: 'Server: foobarfoobar',
@@ -1338,6 +1346,7 @@ function test_with_mock_socket(test_params) {
         $("#compose-textarea").val('```foobarfoobar```');
         setup_visibilities();
         setup_mock_markdown_contains_backend_only_syntax('```foobarfoobar```', true);
+        setup_mock_markdown_is_status_message('```foobarfoobar```', 'Server: foobarfoobar', false);
         loading.make_indicator = function (spinner) {
             assert.equal(spinner, $("#markdown_preview_spinner"));
             make_indicator_called = true;
@@ -1353,6 +1362,7 @@ function test_with_mock_socket(test_params) {
         $("#compose-textarea").val('foobarfoobar');
         setup_visibilities();
         setup_mock_markdown_contains_backend_only_syntax('foobarfoobar', false);
+        setup_mock_markdown_is_status_message('foobarfoobar', 'Server: foobarfoobar', false);
         mock_channel_post('foobarfoobar');
         markdown.apply_markdown = function (msg) {
             assert.equal(msg.raw_content, 'foobarfoobar');

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -351,6 +351,12 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
     assert.equal(message.is_me_message, true);
     assert(!message.unread);
 
+    input = "/me is testing\nthis";
+    message = {subject: "No links here", raw_content: input};
+    markdown.apply_markdown(message);
+
+    assert.equal(message.is_me_message, false);
+
     input = "testing this @**all** @**Cordelia Lear**";
     message = {subject: "No links here", raw_content: input};
     markdown.apply_markdown(message);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -927,9 +927,11 @@ exports.initialize = function () {
         $("#compose #file_input").trigger("click");
     });
 
-    function show_preview(rendered_content) {
+    // content is passed to check for status messages ("/me ...")
+    // and will be undefined in case of errors
+    function show_preview(rendered_content, content) {
         var preview_html;
-        if (rendered_content.indexOf("<p>/me ") === 0) {
+        if (content !== undefined && markdown.is_status_message(content, rendered_content)) {
             // Handle previews of /me messages
             preview_html = "<strong>" + page_params.full_name + "</strong> " + rendered_content.slice(4 + 3, -4);
         } else {
@@ -988,7 +990,7 @@ exports.initialize = function () {
                     if (markdown.contains_backend_only_syntax(content)) {
                         loading.destroy_indicator($("#markdown_preview_spinner"));
                     }
-                    show_preview(response_data.rendered);
+                    show_preview(response_data.rendered, content);
                 },
                 error: function () {
                     if (markdown.contains_backend_only_syntax(content)) {

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -79,9 +79,7 @@ exports.apply_markdown = function (message) {
         },
     };
     message.content = marked(message.raw_content + '\n\n', options).trim();
-    message.is_me_message = (message.raw_content.indexOf('/me ') === 0 &&
-                             message.content.indexOf('<p>') === 0 &&
-                             message.content.lastIndexOf('</p>') === message.content.length - 4);
+    message.is_me_message = exports.is_status_message(message.raw_content, message.content);
 };
 
 exports.add_subject_links = function (message) {
@@ -110,6 +108,13 @@ exports.add_subject_links = function (message) {
         }
     });
     message.subject_links = links;
+};
+
+exports.is_status_message = function (raw_content, content) {
+    return (raw_content.indexOf('/me ') === 0 &&
+            raw_content.indexOf('\n') === -1 &&
+            content.indexOf('<p>') === 0 &&
+            content.lastIndexOf('</p>') === content.length - 4);
 };
 
 function escape(html, encode) {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -104,7 +104,6 @@ exports.save = function (row, from_topic_edited_only) {
 
     if (new_content !== message.raw_content && !from_topic_edited_only) {
         request.content = new_content;
-        message.is_me_message = new_content.lastIndexOf('/me', 0) === 0;
         changed = true;
     }
     if (!changed) {

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -134,6 +134,10 @@ exports.update_messages = function update_messages(events) {
             msg.content = event.rendered_content;
         }
 
+        if (event.is_me_message !== undefined) {
+            msg.is_me_message = event.is_me_message;
+        }
+
         var row = current_msg_list.get_row(event.message_id);
         if (row.length > 0) {
             message_edit.end(row);

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3558,6 +3558,7 @@ def do_update_message(user_profile: UserProfile, message: Message, topic_name: O
         event["content"] = content
         event["rendered_content"] = rendered_content
         event['prev_rendered_content_version'] = message.rendered_content_version
+        event['is_me_message'] = Message.is_status_message(content, rendered_content)
 
         prev_content = edit_history_event['prev_content']
         if Message.content_has_attachment(prev_content) or Message.content_has_attachment(message.content):

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -738,6 +738,14 @@ class BugdownTest(ZulipTestCase):
         )
         self.assertTrue(Message.is_status_message(content, rendered_content))
 
+        content = '/me writes a second line\nline'
+        rendered_content = render_markdown(msg, content)
+        self.assertEqual(
+            rendered_content,
+            '<p>/me writes a second line<br>\nline</p>'
+        )
+        self.assertFalse(Message.is_status_message(content, rendered_content))
+
     def test_alert_words(self) -> None:
         user_profile = self.example_user('othello')
         do_set_alert_words(user_profile, ["ALERTWORD", "scaryword"])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -679,6 +679,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('subject', check_string),
             ('subject_links', check_list(None)),
             ('user_id', check_int),
+            ('is_me_message', check_bool),
         ])
 
         message = Message.objects.order_by('-id')[0]


### PR DESCRIPTION
Adds a check for newline that was present on backend, but missing in the
frontend markdown implementation. Updating messages uses is_me_message flag
received from server instead of its own partial test. Similarly, rendering
previews uses markdown code.

Fixes #6493.