### PR TITLE
puppet: Require rabbitmq to be running before starting supervisor.

### DIFF
--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -13,6 +13,7 @@ class zulip::supervisor {
       require    => [
         File["/var/log/zulip"],
         Package["supervisor"],
+        Service["rabbitmq-server"],
       ],
       hasstatus  => true,
       status     => "/bin/true",
@@ -25,6 +26,7 @@ class zulip::supervisor {
       require => [
         File["/var/log/zulip"],
         Package["supervisor"],
+        Service["rabbitmq-server"],
       ],
       hasstatus => true,
       status => "supervisorctl status",


### PR DESCRIPTION
This potentially fixes the "Connection to ::1:5672 failed" problem from https://chat.zulip.org/#narrow/stream/issues/topic/Connection.20to.20.3A.3A1.3A5672.20failed.
- [ ] need testing
