### PR TITLE
 decorators: Fix email check in access_user_by_api_key should be case insensitive. 

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -250,7 +250,7 @@ def access_user_by_api_key(request: HttpRequest, api_key: Text, email: Optional[
         user_profile = get_user_profile_by_api_key(api_key)
     except UserProfile.DoesNotExist:
         raise JsonableError(_("Invalid API key"))
-    if email is not None and email != user_profile.email:
+    if email is not None and email.lower() != user_profile.email.lower():
         # This covers the case that the API key is correct, but for a
         # different user.  We may end up wanting to relaxing this
         # constraint or give a different error message in the future.

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -889,6 +889,10 @@ class TestValidateApiKey(ZulipTestCase):
                                    is_webhook=True)
         self.assertEqual(profile.id, self.webhook_bot.id)
 
+    def test_validate_api_key_if_email_is_case_insensitive(self) -> None:
+        profile = validate_api_key(HostRequestMock(host="zulip.testserver"), self.default_bot.email.upper(), self.default_bot.api_key)
+        self.assertEqual(profile.id, self.default_bot.id)
+
     def test_valid_api_key_if_user_is_on_wrong_subdomain(self) -> None:
         with self.settings(RUNNING_INSIDE_TORNADO=False):
             with mock.patch('logging.warning') as mock_warning:


### PR DESCRIPTION
The issue was discussed in stream:issues topic:Mobile+Apps:+Sometimes+don't+load+data. Includes fix + test case. 