### PR TITLE
scripts: Disable deb-src PPA lines for now.

### DIFF
--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -17,15 +17,15 @@ if [ "$release" = "trusty" ] || [ "$release" = "xenial" ] || [ "$release" = "zes
     cat >/etc/apt/sources.list.d/zulip.list <<EOF
 deb http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 deb http://ppa.launchpad.net/tabbott/zulip/ubuntu $release main
-deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
-deb-src http://ppa.launchpad.net/tabbott/zulip/ubuntu $release main
+# deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
+# deb-src http://ppa.launchpad.net/tabbott/zulip/ubuntu $release main
 EOF
 elif [ "$release" = "stretch" ]; then
     apt-get install -y -V apt-transport-https
     apt-key add "$SCRIPTS_PATH"/setup/pgroonga-debian.asc
     cat >/etc/apt/sources.list.d/zulip.list <<EOF
 deb https://packages.groonga.org/debian/ stretch main
-deb-src https://packages.groonga.org/debian/ stretch main
+# deb-src https://packages.groonga.org/debian/ stretch main
 EOF
 else
     echo "Unsupported release $release."


### PR DESCRIPTION
Apparently, including the deb-src package lines in setup-apt-repo was
resulting in some users getting this error from the Ubuntu PPAs on
Trusty:

==> default: W: Failed to fetch http://ppa.launchpad.net/groonga/ppa/ubuntu/dists/trusty/main/source/Sources  Hash Sum mismatch
==> default:
==> default: W: Failed to fetch http://ppa.launchpad.net/tabbott/zulip/ubuntu/dists/trusty/main/source/Sources  Hash Sum mismatch
==> default:
==> default: W: Failed to fetch http://ppa.launchpad.net/tabbott/zulip/ubuntu/dists/trusty/main/i18n/Translation-en  Hash Sum mismatch
==> default:
==> default: E: Some index files failed to download. They have been ignored, or old ones used instead.

Since we don't strictly require the source packages to provision
Zulip, it seems better to just not include the deb-src lines in order
to avoid problems provisioning Zulip.