### PR TITLE
webhooks/gitlab: Filter out hidden comments from issue descriptions.

### DIFF
--- a/zerver/webhooks/gitlab/fixtures/issue_created_with_hidden_comment_in_description.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_created_with_hidden_comment_in_description.json
@@ -1,0 +1,67 @@
+{
+    "object_kind": "issue",
+    "user": {
+        "name": "Eeshan Garg",
+        "username": "eeshangarg",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+    },
+    "project": {
+        "id": 3319013,
+        "name": "public-repo",
+        "description": null,
+        "web_url": "https://gitlab.com/eeshangarg/public-repo",
+        "avatar_url": null,
+        "git_ssh_url": "git@gitlab.com:eeshangarg/public-repo.git",
+        "git_http_url": "https://gitlab.com/eeshangarg/public-repo.git",
+        "namespace": "eeshangarg",
+        "visibility_level": 0,
+        "path_with_namespace": "eeshangarg/public-repo",
+        "default_branch": "changes",
+        "ci_config_path": null,
+        "homepage": "https://gitlab.com/eeshangarg/public-repo",
+        "url": "git@gitlab.com:eeshangarg/public-repo.git",
+        "ssh_url": "git@gitlab.com:eeshangarg/public-repo.git",
+        "http_url": "https://gitlab.com/eeshangarg/public-repo.git"
+    },
+    "object_attributes": {
+        "author_id": 1129123,
+        "closed_at": null,
+        "confidential": false,
+        "created_at": "2018-01-24 00:47:44 UTC",
+        "description": "This description actually has a hidden comment in it!\n\n<!-- This is\na multiline\ncomment -->\n\n<!-- one line comment -->\n\n<!--\nanother\nmultiline\ncomment\n-->",
+        "due_date": null,
+        "id": 8816601,
+        "iid": 3,
+        "last_edited_at": null,
+        "last_edited_by_id": null,
+        "milestone_id": null,
+        "moved_to_id": null,
+        "project_id": 3319013,
+        "relative_position": 1073743323,
+        "state": "opened",
+        "time_estimate": 0,
+        "title": "New Issue with hidden comment",
+        "updated_at": "2018-01-24 00:47:44 UTC",
+        "updated_by_id": null,
+        "url": "https://gitlab.com/eeshangarg/public-repo/issues/3",
+        "total_time_spent": 0,
+        "human_total_time_spent": null,
+        "human_time_estimate": null,
+        "assignee_ids": [],
+        "assignee_id": null,
+        "action": "open"
+    },
+    "labels": [],
+    "changes": {
+        "total_time_spent": {
+            "previous": null,
+            "current": 0
+        }
+    },
+    "repository": {
+        "name": "public-repo",
+        "url": "git@gitlab.com:eeshangarg/public-repo.git",
+        "description": null,
+        "homepage": "https://gitlab.com/eeshangarg/public-repo"
+    }
+}

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -113,6 +113,17 @@ class GitlabHookTests(WebhookTestCase):
             HTTP_X_GITLAB_EVENT="Issue Hook"
         )
 
+    def test_create_issue_with_hidden_comment_in_description(self) -> None:
+        expected_subject = u"public-repo / Issue #3 New Issue with hidden comment"
+        expected_message = u"Eeshan Garg created [Issue #3](https://gitlab.com/eeshangarg/public-repo/issues/3)\n\n~~~ quote\nThis description actually has a hidden comment in it!\n~~~"
+
+        self.send_and_test_stream_message(
+            'issue_created_with_hidden_comment_in_description',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Issue Hook"
+        )
+
     def test_update_issue_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
         expected_message = u"Tomasz Kolek updated [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -1,5 +1,6 @@
 from functools import partial
 from typing import Any, Dict, Iterable, Optional, Text
+import re
 
 from django.http import HttpRequest, HttpResponse
 
@@ -61,12 +62,16 @@ def get_tag_push_event_body(payload: Dict[str, Any]) -> Text:
     )
 
 def get_issue_created_event_body(payload: Dict[str, Any]) -> Text:
+    description = payload['object_attributes'].get('description')
+    # Filter out multiline hidden comments
+    description = re.sub('<!--.*?-->', '', description, 0, re.DOTALL)
+    description = description.rstrip()
     return get_issue_event_message(
         get_issue_user_name(payload),
         'created',
         get_object_url(payload),
         payload['object_attributes'].get('iid'),
-        payload['object_attributes'].get('description'),
+        description,
         get_objects_assignee(payload)
     )
 


### PR DESCRIPTION
Hidden comments of the form `<!-- comment -->` were previously
rendered as is when a new Issue was created. Now, we strip those
out completely!

@timabbott: FYI :)