### PR TITLE
Replace shortcut key Ctrl+L with Ctrl+L+Shift for link insertion.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -670,7 +670,7 @@ exports.handle_keydown = function (event) {
             }
         }
         if (isLink) {
-            // ctrl + l: Insert a link to selected text
+            // ctrl + l + shift: Insert a link to selected text
             add_markdown("[" + range.text + "](url)");
             var position = textarea.caret();
             var txt = document.getElementById("compose-textarea");

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -631,7 +631,30 @@ exports.handle_keydown = function (event) {
             }
             event.preventDefault();
         }
+        function get_text_for_markdown(cursor_position, compose_msg) {
+            var start_pos = cursor_position - 1;
+            var end_pos = cursor_position;
+            var txt = document.getElementById("compose-textarea");
+            var next_char = compose_msg.charAt(start_pos);
 
+            while ((next_char !== " " && next_char !== "\n") && start_pos >= 0) {
+                start_pos -= 1;
+                next_char = compose_msg.charAt(start_pos);
+            }
+            next_char = compose_msg.charAt(end_pos);
+            while ((next_char !== " " && next_char !== "\n") && end_pos <= compose_msg.length) {
+                end_pos += 1;
+                next_char = compose_msg.charAt(end_pos);
+            }
+            txt.selectionStart = start_pos + 1;
+            txt.selectionEnd = end_pos;
+        }
+
+        if (!range.length) {
+            get_text_for_markdown(textarea.caret(), textarea.val());
+        }
+
+        range = textarea.range();
         if (isBold) {
             // ctrl + b: Convert selected text to bold text
             add_markdown("**" + range.text + "**");


### PR DESCRIPTION
As Ctrl-L was interfering with browsers's Ctrl-L, the shortcut key
for link insertion is changed to Ctrl+L+Shift.