### PR TITLE
Changes in user settings

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -81,6 +81,7 @@ exports.set_up = function () {
         // Clear the password boxes so that passwords don't linger in the DOM
         // for an XSS attacker to find.
         $('#old_password, #new_password').val('');
+        common.password_quality('', $('#pw_strength .bar'), $('#new_password'));
     }
 
     clear_password_change();
@@ -103,6 +104,10 @@ exports.set_up = function () {
                 $('#pw_strength .bar').removeClass("fade");
             });
         }
+    });
+
+    $('#change_password_modal').find('[data-dismiss=modal]').on('click', function () {
+        clear_password_change();
     });
 
     $('#change_password_button').on('click', function (e) {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -86,6 +86,12 @@ exports.set_up = function () {
 
     clear_password_change();
 
+    $("#change_full_name").on('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        overlays.open_modal('change_full_name_modal');
+    });
+
     $('#change_password').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
@@ -166,14 +172,30 @@ exports.set_up = function () {
         common.password_quality(field.val(), $('#pw_strength .bar'), field);
     });
 
-    $("form.your-account-settings").ajaxForm({
-        dataType: 'json', // This seems to be ignored. We still get back an xhr.
-        success: function () {
-            settings_change_success(i18n.t("Updated settings!"));
-        },
-        error: function (xhr) {
-            settings_change_error(i18n.t("Error changing settings"), xhr);
-        },
+    $("#change_full_name_button").on('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var change_full_name_info = $('#change_full_name_modal').find(".change_full_name_info").expectOne();
+        var data = {};
+        var full_name_field = $("#change_full_name button #full_name_value").expectOne();
+
+        data.full_name = $('.full_name_change_container').find("input[name='full_name']").val();
+        channel.patch({
+            url: '/json/settings',
+            data: data,
+            success: function (data) {
+                if ('full_name' in data) {
+                    settings_change_success(i18n.t("Updated settings!"));
+                    full_name_field.html(data.full_name);
+                } else {
+                    settings_change_success(i18n.t("No changes made."));
+                }
+                overlays.close_modal('change_full_name_modal');
+            },
+            error: function (xhr) {
+                ui_report.error(i18n.t("Failed"), xhr, change_full_name_info);
+            },
+        });
     });
 
     $('#change_email_button').on('click', function (e) {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -179,7 +179,7 @@ exports.set_up = function () {
     $('#change_email_button').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        overlays.close_modal('change_email_modal');
+        var change_email_info = $('#change_email_modal').find(".change_email_info").expectOne();
 
         var data = {};
         data.email = $('.email_change_container').find("input[name='email']").val();
@@ -197,9 +197,10 @@ exports.set_up = function () {
                 } else {
                     settings_change_success(i18n.t("No changes made."));
                 }
+                overlays.close_modal('change_email_modal');
             },
             error: function (xhr) {
-                settings_change_error(i18n.t("Error changing settings"), xhr);
+                ui_report.error(i18n.t("Failed"), xhr, change_email_info);
             },
         });
     });

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1096,7 +1096,8 @@ input[type=checkbox].inline-block {
     width: auto;
 }
 
-#settings_page #change_password_modal .change_password_info {
+#settings_page #change_password_modal .change_password_info,
+#settings_page #change_email_modal .change_email_info {
     margin: 10px;
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -109,7 +109,8 @@ label {
     box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);
 }
 
-#change_email_modal {
+#change_email_modal,
+#change_full_name_modal {
     width: 460px;
 }
 
@@ -1097,7 +1098,8 @@ input[type=checkbox].inline-block {
 }
 
 #settings_page #change_password_modal .change_password_info,
-#settings_page #change_email_modal .change_email_info {
+#settings_page #change_email_modal .change_email_info,
+#settings_page #change_full_name_modal .change_full_name_info {
     margin: 10px;
 }
 

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -32,9 +32,10 @@
                             <input type="text" name="email" value="{{ page_params.email }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
                         </div>
                     </div>
+                    <div class="alert change_email_info"></div>
                     <div class="modal-footer">
+                        <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
                         <button id='change_email_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
-                        <button class="button white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
                     </div>
                 </div>
             </form>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -83,7 +83,7 @@
                 </div>
             </form>
 
-            <form class="form-horizontal your-account-settings">
+            <form class="form-horizontal your-account-settings" action="/json/settings" method="patch">
                 <div class="inline-block grid user-name-parent">
                     <div class="user-name-section inline-block">
                         <div class="input-group" id="name_change_container">

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -13,12 +13,9 @@
                             <i class="fa fa-pencil"></i>
                         </button>
                     </a>
-                    <i class="icon-vector-question-sign change_email_tooltip" {{#unless page_params.realm_email_changes_disabled}}style="display:none" {{/unless}} data-toggle="tooltip"
+                    <i class="icon-vector-question-sign change_email_tooltip settings-info-icon" {{#unless page_params.realm_email_changes_disabled}}style="display:none" {{/unless}} data-toggle="tooltip"
                     title="{{t 'Changing email addresses has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"></i>
                 </div>
-
-                <i class="icon-vector-question-sign settings-info-icon change_email_tooltip" {{#unless page_params.realm_email_changes_disabled}}style="display:none" {{/unless}} data-toggle="tooltip"
-                title="{{t 'Changing email addresses has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"></i>
 
                 <div id="change_email_modal" class="modal hide" tabindex="-1" role="dialog"
                     aria-labelledby="change_email_modal_label" aria-hidden="true">
@@ -40,8 +37,43 @@
                 </div>
             </form>
 
+            <form class="form-horizontal full-name-change-form">
+                <div class="inline-block grid user-name-parent">
+                    <div class="user-name-section inline-block">
+                        <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
+                        <a id="change_full_name" {{#if page_params.realm_name_changes_disabled}}href="#change_name" {{/if}}>
+                            <button type="button" class="button small white rounded inline-block" id="full_name"{{#if page_params.realm_name_changes_disabled}} disabled="disabled"{{/if}}>
+                                <span id="full_name_value">{{page_params.full_name}}</span>
+                                <i class="fa fa-pencil"></i>
+                            </button>
+                        </a>
+                        <i class="icon-vector-question-sign change_name_tooltip settings-info-icon" data-toggle="tooltip"
+                        {{#unless page_params.realm_name_changes_disabled}}style="display:none" {{/unless}}
+                        title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
+                    </div>
+                    <div id="change_full_name_modal" class="modal hide" tabindex="-1" role="dialog"
+                        aria-labelledby="change_full_name_modal_label" aria-hidden="true">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+                            <h3 id="change_full_name_modal_label">{{t "Change full name" }}</h3>
+                        </div>
+                        <div class="modal-body">
+                            <div class="input-group full_name_change_container">
+                                <label for="email">{{t "New full name" }}</label>
+                                <input type="text" name="full_name" value="{{ page_params.full_name }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
+                            </div>
+                        </div>
+                        <div class="alert change_full_name_info"></div>
+                        <div class="modal-footer">
+                            <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
+                            <button id='change_full_name_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+
             <form class="password-change-form grid">
-                <div class="input-group user-name-section">
+                <div class="user-name-section">
                     <label class="inline-block title">{{t "Password" }}</label>
                     <a id="change_password" {{#if page_params.realm_email_auth_enabled}}href="#change_password"{{/if}}>
                         {{#if page_params.realm_email_auth_enabled}}
@@ -85,46 +117,12 @@
                 </div>
             </form>
 
-            <form class="form-horizontal full-name-change-form">
-                <div class="inline-block grid user-name-parent">
-                    <div class="user-name-section inline-block">
-                        <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
-                        <a id="change_full_name" {{#if page_params.realm_name_changes_disabled}}href="#change_name" {{/if}}>
-                            <button type="button" class="button small white rounded inline-block" id="full_name"{{#if page_params.realm_name_changes_disabled}} disabled="disabled"{{/if}}>
-                                <span id="full_name_value">{{page_params.full_name}}</span>
-                                <i class="fa fa-pencil"></i>
-                            </button>
-                        </a>
-                        <i class="icon-vector-question-sign change_name_tooltip" data-toggle="tooltip"
-                        {{#unless page_params.realm_name_changes_disabled}}style="display:none" {{/unless}}
-                        title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
-                    </div>
-                    <div id="change_full_name_modal" class="modal hide" tabindex="-1" role="dialog"
-                        aria-labelledby="change_full_name_modal_label" aria-hidden="true">
-                        <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-                            <h3 id="change_full_name_modal_label">{{t "Change full name" }}</h3>
-                        </div>
-                        <div class="modal-body">
-                            <div class="input-group full_name_change_container">
-                                <label for="email">{{t "New full name" }}</label>
-                                <input type="text" name="full_name" value="{{ page_params.full_name }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
-                            </div>
-                        </div>
-                        <div class="alert change_full_name_info"></div>
-                        <div class="modal-footer">
-                            <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
-                            <button id='change_full_name_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
-                        </div>
-                    </div>
-                    <div class="input-group">
-                        <div class="input-group">
-                            <label for="" class="inline-block"></label>
-                            <button type="submit" class="button rounded w-200 btn-danger input-size" id="user_deactivate_account_button">
-                                {{t 'Deactivate account' }}
-                            </button>
-                        </div>
-                    </div>
+            <form class="deactivate_account grid">
+                <div class="input-group">
+                    <label for="" class="inline-block"></label>
+                    <button type="submit" class="button rounded w-200 btn-danger input-size" id="user_deactivate_account_button">
+                        {{t 'Deactivate account' }}
+                    </button>
                 </div>
             </form>
         </div>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -45,7 +45,8 @@
                     <a id="change_password" {{#if page_params.realm_email_auth_enabled}}href="#change_password"{{/if}}>
                         {{#if page_params.realm_email_auth_enabled}}
                         <div class="input-group inline-block" id="pw_change_link">
-                            <button type="button" class="change_password_button button rounded inline-block input-size" data-dismiss="modal">{{t "Change password" }}</button>
+                            <button type="button" class="change_password_button small button rounded inline-block" data-dismiss="modal">{{t "********" }}<i class="fa fa-pencil"></i>
+                            </button>
                         </div>
                         {{/if}}
                     </a>
@@ -77,7 +78,7 @@
                     </div>
                     <div class="alert change_password_info"></div>
                     <div class="modal-footer">
-                        <button class="button white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+                        <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
                         <button id='change_password_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
                     </div>
                 </div>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -85,24 +85,39 @@
                 </div>
             </form>
 
-            <form class="form-horizontal your-account-settings" action="/json/settings" method="patch">
+            <form class="form-horizontal full-name-change-form">
                 <div class="inline-block grid user-name-parent">
                     <div class="user-name-section inline-block">
-                        <div class="input-group" id="name_change_container">
-                            <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
-                            <input type="text" name="full_name" id="full_name" class="w-200 inline-block" value="{{ page_params.full_name }}" {{#if page_params.realm_name_changes_disabled}}disabled="disabled" {{/if}}/>
-                            <i class="icon-vector-question-sign change_name_tooltip" data-toggle="tooltip"
-                            {{#unless page_params.realm_name_changes_disabled}}style="display:none" {{/unless}}
-                            title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
-                            <div class="warning"></div>
-                        </div>
-
-                        <div class="input-group no-border">
-                            <label for="" class="inline-block"></label>
-                            <button type="submit" class="button rounded w-200 sea-green input-size" name="change_settings">
-                                {{t 'Save changes'}}
+                        <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
+                        <a id="change_full_name" {{#if page_params.realm_name_changes_disabled}}href="#change_name" {{/if}}>
+                            <button type="button" class="button small white rounded inline-block" id="full_name"{{#if page_params.realm_name_changes_disabled}} disabled="disabled"{{/if}}>
+                                <span id="full_name_value">{{page_params.full_name}}</span>
+                                <i class="fa fa-pencil"></i>
                             </button>
+                        </a>
+                        <i class="icon-vector-question-sign change_name_tooltip" data-toggle="tooltip"
+                        {{#unless page_params.realm_name_changes_disabled}}style="display:none" {{/unless}}
+                        title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
+                    </div>
+                    <div id="change_full_name_modal" class="modal hide" tabindex="-1" role="dialog"
+                        aria-labelledby="change_full_name_modal_label" aria-hidden="true">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+                            <h3 id="change_full_name_modal_label">{{t "Change full name" }}</h3>
                         </div>
+                        <div class="modal-body">
+                            <div class="input-group full_name_change_container">
+                                <label for="email">{{t "New full name" }}</label>
+                                <input type="text" name="full_name" value="{{ page_params.full_name }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
+                            </div>
+                        </div>
+                        <div class="alert change_full_name_info"></div>
+                        <div class="modal-footer">
+                            <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
+                            <button id='change_full_name_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
+                        </div>
+                    </div>
+                    <div class="input-group">
                         <div class="input-group">
                             <label for="" class="inline-block"></label>
                             <button type="submit" class="button rounded w-200 btn-danger input-size" id="user_deactivate_account_button">


### PR DESCRIPTION
* `settings: Change design of your account page in user settings.`

The more changes here I can see, is that renaming `Save changes` btn to `Change name` to be more specific. I was not sure, so I hadn't included this.

* `settings: Exclude forgot-password div from focus in change pwd modal.`

I know, it's not the best solution to get focused on `New password` field after `Old password` field, but it's safest one. If we go with numbering all fields with tabindex it can generate more issues.
Reference: https://developer.paciellogroup.com/blog/2014/08/using-the-tabindex-attribute/

* `user settings: Add method and action in account setting ajax form.`

This seems to introduce after we merge Password UI modal PR.
