### PR TITLE
settings: Allow selecting "restrict to domain" even if no domains selected.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -47,7 +47,11 @@ exports.populate_realm_domains = function (realm_domains) {
     $("#id_realm_restricted_to_domain").prop("checked", page_params.realm_restricted_to_domain);
     if (domains.length === 0) {
         domains = i18n.t("None");
-        $("#id_realm_restricted_to_domain").prop("disabled", true);
+        $("#id_realm_restricted_to_domain").attr("data-toggle", "modal");
+        $("#id_realm_restricted_to_domain").attr("href", "#realm_domains_modal");
+    }
+    if (domains !== "None") {
+        $("#id_realm_restricted_to_domain").attr("data-toggle", "none");
     }
     $("#realm_restricted_to_domains_label").text(i18n.t("Restrict new users to the following email domains: __domains__", {domains: domains}));
 
@@ -714,7 +718,6 @@ function _set_up() {
             success: function () {
                 $("#add-realm-domain-widget .new-realm-domain").val("");
                 $("#add-realm-domain-widget .new-realm-domain-allow-subdomains").prop("checked", false);
-                $("#id_realm_restricted_to_domain").prop("disabled", false);
                 ui_report.success(i18n.t("Added successfully!"), realm_domains_info);
             },
             error: function (xhr) {


### PR DESCRIPTION
Allow a user to click anywhere on the "restrict to domain" line to open the modal.

Fixes: #7626.