### PR TITLE
Add coloring improvements to tools/provision.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -14,7 +14,7 @@ ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 
 sys.path.append(ZULIP_PATH)
 from scripts.lib.zulip_tools import run, subprocess_text_output, OKBLUE, ENDC, WARNING, \
-    get_dev_uuid_var_path
+    get_dev_uuid_var_path, FAIL
 from scripts.lib.setup_venv import (
     setup_virtualenv, VENV_DEPENDENCIES, THUMBOR_VENV_DEPENDENCIES
 )
@@ -54,7 +54,7 @@ if is_travis:
     EMOJI_CACHE_PATH = "/home/travis/zulip-emoji-cache"
 
 if not os.path.exists(os.path.join(ZULIP_PATH, ".git")):
-    print("Error: No Zulip git repository present!")
+    print(FAIL + "Error: No Zulip git repository present!" + ENDC)
     print("To setup the Zulip development environment, you should clone the code")
     print("from GitHub, rather than using a Zulip production release tarball.")
     sys.exit(1)
@@ -82,7 +82,8 @@ try:
     )
     os.remove(os.path.join(VAR_DIR_PATH, 'zulip-test-symlink'))
 except OSError as err:
-    print("Error: Unable to create symlinks. Make sure you have permission to create symbolic links.")
+    print(FAIL + "Error: Unable to create symlinks."
+          "Make sure you have permission to create symbolic links." + ENDC)
     print("See this page for more information:")
     print("  https://zulip.readthedocs.io/en/latest/development/setup-vagrant.html#os-symlink-error")
     sys.exit(1)

--- a/tools/provision
+++ b/tools/provision
@@ -10,6 +10,9 @@ if [ "$EUID" -eq 0 ]; then
     exit 1
 fi
 
+RED="\033[0;31m"
+ENDC="\033[0m"
+
 #Make the script independent of the location from where it is
 #executed
 PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
@@ -26,23 +29,23 @@ export PYTHONUNBUFFERED=1
 failed=${PIPESTATUS[0]}
 
 if [ $failed = 1 ]; then
-    echo -e "\033[0;31m"
+    echo -e "$RED"
     echo "Provisioning failed!"
     echo
     echo "* Look at the traceback(s) above to find more about the errors."
     echo "* Resolve the errors or get help on chat."
     echo "* If you can fix this yourself, you can re-run tools/provision at any time."
     echo "* Logs are here: zulip/var/log/provision.log"
-    echo -e "\033[0m"
+    echo -e "$ENDC"
     exit 1
 elif [ "$VIRTUAL_ENV" != "/srv/zulip-py3-venv" ] && [ -z "${TRAVIS}${SKIP_VENV_SHELL_WARNING}" ]; then
-    echo -e "\033[0;31m"
+    echo -e "$RED"
     echo "WARNING: This shell does not have the Python 3 virtualenv activated."
     echo "Zulip commands will fail."
     echo
     echo "To update the shell, run:"
     echo "    source /srv/zulip-py3-venv/bin/activate"
     echo "or just close this shell and start a new one."
-    echo -en "\033[0m"
+    echo -en "$ENDC"
 fi
 exit 0

--- a/tools/provision
+++ b/tools/provision
@@ -10,6 +10,7 @@ if [ "$EUID" -eq 0 ]; then
     exit 1
 fi
 
+FAIL="\033[91m"
 RED="\033[0;31m"
 ENDC="\033[0m"
 
@@ -29,7 +30,7 @@ export PYTHONUNBUFFERED=1
 failed=${PIPESTATUS[0]}
 
 if [ $failed = 1 ]; then
-    echo -e "$RED"
+    echo -e "$FAIL"
     echo "Provisioning failed!"
     echo
     echo "* Look at the traceback(s) above to find more about the errors."
@@ -39,7 +40,7 @@ if [ $failed = 1 ]; then
     echo -e "$ENDC"
     exit 1
 elif [ "$VIRTUAL_ENV" != "/srv/zulip-py3-venv" ] && [ -z "${TRAVIS}${SKIP_VENV_SHELL_WARNING}" ]; then
-    echo -e "$RED"
+    echo -e "$WARN"
     echo "WARNING: This shell does not have the Python 3 virtualenv activated."
     echo "Zulip commands will fail."
     echo


### PR DESCRIPTION
I noticed that some of the fail error messages are done by `logging.critical`. Is this supposed to be the newer way to display the error messages?