### PR TITLE
Inhance dropdown settings

### DIFF
--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -84,6 +84,11 @@ body.dark-mode select {
     color: inherit;
 }
 
+body.dark-mode select option {
+    background-color: hsl(212, 28%, 18%);
+    color: hsl(236, 33%, 90%);
+}
+
 body.dark-mode .new-style .button.no-style {
     background-color: transparent;
 }

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -78,8 +78,8 @@
             <div class="inline-block create-stream-dropdown">
                 <label for="realm_create_stream_permission" class="dropdown-title">{{t "Who can create streams" }}</label>
                 <select name="realm_create_stream_permission" id="id_realm_create_stream_permission">
-                    <option value="by_admins_only">{{t "Admins only" }}</option>
                     <option value="by_anyone">{{t "Everyone" }}</option>
+                    <option value="by_admins_only">{{t "Admins only" }}</option>
                     <option value="by_admin_user_with_three_days_old">{{t "All admins, and users with accounts at least 3 days old." }}</option>
                     <option value="by_admin_user_with_custom_time">{{t "All admins, and users with accounts at least N days old." }}</option>
                 </select>
@@ -96,8 +96,8 @@
             <div class="inline-block">
                 <label for="realm_add_emoji_by_admins_only" class="dropdown-title">{{t "Who can add emoji" }}</label>
                 <select name="realm_add_emoji_by_admins_only" id="id_realm_add_emoji_by_admins_only">
-                    <option value="by_admins_only">{{t "Admins only" }}</option>
                     <option value="by_anyone">{{t "Everyone" }}</option>
+                    <option value="by_admins_only">{{t "Admins only" }}</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
`dark-mode: Fix background color of dropdown menus.`

The dropdown menu on mozilla-linux:
![mozilladropdown](https://user-images.githubusercontent.com/25907420/35399246-d58d3210-0219-11e8-820d-30d923059f15.gif)

Chrome-linx:
![dropdownsmenuchrome](https://user-images.githubusercontent.com/25907420/35398971-3575de3a-0219-11e8-8232-48f27b3044da.png)

If we create dropdown menus by using default elements `select` and `option` then we need jquery library to override that colors(backgroud color on hover in chrome or in mozilla).
Or we can change our dropdown to div elements(which do require some extra css styling then default).
@brockwhittaker and @rishig FYI.
The drodown problem is not dark mode specific problem.