### PR TITLE
Improve Vagrant troubleshooting.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,11 +5,8 @@ VAGRANTFILE_API_VERSION = "2"
 if Vagrant::VERSION == "1.8.7"
   path = `command -v curl`
   if path.include?("/opt/vagrant/embedded/bin/curl")
-    puts "In Vagrant 1.8.7, curl is broken. Please use Vagrant 2.0.2 " \
-         "or run 'sudo rm -f /opt/vagrant/embedded/bin/curl' to fix the " \
-         "issue before provisioning. See " \
-         "https://github.com/mitchellh/vagrant/issues/7997 " \
-         "for reference."
+    puts "In Vagrant 1.8.7, curl is broken. Please the latest Vagrant."
+    puts "See https://github.com/mitchellh/vagrant/issues/7997 for details."
     exit
   end
 end


### PR DESCRIPTION
Since I don't have a Windows machine available, I can't test if the `curl` path is always `/cygdrive/c/HashiCorp/Vagrant/embedded/bin/curl.exe`.