### PR TITLE
left sidebar: Clicking on a stream clears the stream search.

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -365,6 +365,23 @@ casper.waitForSelector('.input-append.notdisplayed', function () {
     casper.test.assertExists('.input-append.notdisplayed', 'Stream filter box not visible after second click');
 });
 
+// We search for the beginning of "Verona", not case sensitive
+casper.then(function () {
+    casper.evaluate(function () {
+        $('.stream-list-filter').expectOne()
+            .focus()
+            .val('ver')
+            .trigger($.Event('input'));
+    });
+});
+
+casper.waitWhileVisible('#stream_filters [data-stream-name="Denmark"]', function () {
+    // Clicking the narrowed list should clear the search
+    casper.click('#stream_filters [data-stream-name="Verona"] a');
+    expect_stream();
+    casper.test.assertEquals(casper.fetchText('.stream-list-filter'), '', 'Clicking on a stream clears the search');
+});
+
 un_narrow();
 
 common.then_log_out();

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -472,6 +472,8 @@ exports.initialize = function () {
         popovers.hide_all();
         narrow.by('stream', sub.name, {select_first_unread: true, trigger: 'sidebar'});
 
+        exports.clear_and_hide_search();
+
         e.preventDefault();
         e.stopPropagation();
     });


### PR DESCRIPTION
Clears and hides the search bar when a stream is selected from the
filtered stream list.

Fixes: #7909.