### PR TITLE
landing-page: Darken body when mobile sidebar is open.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -311,7 +311,11 @@ nav ul {
     margin: 0;
     padding: 0;
 
+    outline: 1000px solid;
+    outline-color: transparent;
+
     cursor: pointer;
+    transition: outline-color 0.2s ease;
 }
 
 nav ul .exit {
@@ -3190,6 +3194,10 @@ nav ul li.active::after {
 
     nav ul.show {
         transform: translate(0px, 0px);
+    }
+
+    nav .content > ul.show {
+        outline-color: rgba(32, 62, 80, 0.7);
     }
 
     nav ul .exit {

--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -3169,7 +3169,7 @@ nav ul li.active::after {
 
     .portico-header .dropdown ul {
         width: 100%;
-        height: 85px;
+        height: auto;
         margin: 42px 0 0 0;
         font-size: 0.8em;
     }


### PR DESCRIPTION
This signals that you should not access the body before trying to close the sidebar.

<img width="532" alt="screen shot 2018-01-26 at 10 03 01 am" src="https://user-images.githubusercontent.com/10321399/35453737-244c7148-0280-11e8-9c65-1219d12e98ea.png">

Fixes: #8019.