### PR TITLE
desktop-notifications: Add warning if email is not set up to admins.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -164,7 +164,7 @@
         "hotspots": false,
         "compose_ui": false,
         "common": false,
-        "desktop_notifications_panel": false
+        "panels": false
     },
     "rules": {
         "array-callback-return": "error",

--- a/static/js/panels.js
+++ b/static/js/panels.js
@@ -12,16 +12,28 @@ var resize_app = function () {
 
 exports.resize_app = resize_app;
 
-var show_step = function (step) {
-    $("#panels [data-step]").hide().filter("[data-step=" + step + "]").show();
+var show_step = function ($process, step) {
+    $process.find("[data-step]").hide().filter("[data-step=" + step + "]").show();
 };
 
-var get_step = function () {
-    return $("#panels [data-step]").filter(":visible").data("step");
+var get_step = function ($process) {
+    return $process.find("[data-step]").filter(":visible").data("step");
 };
 
 exports.initialize = function () {
+    // if email has not been set up and the user is the admin, display a warning
+    // to tell them to set up an email server.
+    if (page_params.warn_no_email === true && page_params.is_admin) {
+        panels.open($("[data-process='email-server']"));
+    } else {
+        panels.open($("[data-process='notifications']"));
+    }
+};
+
+exports.open = function ($process) {
     var ls = localstorage();
+
+    $("[data-process]").hide();
 
     var should_show_notifications = (
         // notifications *basically* don't work on any mobile platforms, so don't
@@ -38,7 +50,14 @@ exports.initialize = function () {
     );
 
     if (should_show_notifications) {
-        $("#desktop-notifications-panel").show();
+        $process.show();
+        resize_app();
+    }
+
+    // if it is not the notifications prompt, show the error if it has been
+    // initialized here.
+    if ($process.is(":not([data-process='notifications'])")) {
+        $process.show();
         resize_app();
     }
 
@@ -57,8 +76,8 @@ exports.initialize = function () {
 
     $("#panels").on("click", ".alert .close, .alert .exit", function (e) {
         e.stopPropagation();
-        if (get_step() === 1) {
-            show_step(2);
+        if (get_step($process) === 1 && $process.data("process") === "notifications") {
+            show_step($process, 2);
         } else {
             $(this).closest(".alert").hide();
         }

--- a/static/js/panels.js
+++ b/static/js/panels.js
@@ -1,4 +1,4 @@
-var desktop_notifications_panel = (function () {
+var panels = (function () {
 
 var exports = {};
 
@@ -71,5 +71,5 @@ return exports;
 }());
 
 if (typeof module !== 'undefined') {
-    module.exports = desktop_notifications_panel;
+    module.exports = panels;
 }

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -263,7 +263,7 @@ exports.resize_page_components = function () {
     activity.update_scrollbar.users();
     activity.update_scrollbar.group_pms();
 
-    desktop_notifications_panel.resize_app();
+    panels.resize_app();
 };
 
 var _old_width = $(window).width();

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -280,7 +280,7 @@ $(function () {
     compose.initialize();
     hotspots.initialize();
     ui.initialize();
-    desktop_notifications_panel.initialize();
+    panels.initialize();
 });
 
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -203,6 +203,10 @@ p.n-margin {
     background: hsl(170, 46%, 54%);
 }
 
+#panels .alert.alert-info.red {
+    background: hsl(0, 46%, 54%);
+}
+
 #panels .alert .close {
     line-height: 24px;
 }
@@ -210,6 +214,10 @@ p.n-margin {
 #panels .alert .alert-link {
     color: hsl(169, 100%, 88%);
     font-weight: 600;
+}
+
+#panels .alert.red .alert-link {
+    color: hsl(0, 100%, 88%);
 }
 
 #panels .alert .buttons .alert-link {

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -1,5 +1,5 @@
 <div id="panels">
-    <div id="desktop-notifications-panel" class="alert alert-info">
+    <div data-process="notifications" class="alert alert-info">
         <span class="close" data-dismiss="alert" aria-label="{{ _('Close') }}">&times;</span>
         <div data-step="1">
             {% trans %}Zulip needs your permission to
@@ -15,6 +15,15 @@
                 &bull;
                 <a class="alert-link reject-notifications">{{ _('Never ask on this computer') }}</a>
             </span>
+        </div>
+    </div>
+    <div data-process="email-server" class="alert alert-info red">
+        <span class="close" data-dismiss="alert" aria-label="{{ _('Close') }}">&times;</span>
+        <div data-step="1">
+            {% trans %}Zulip needs to send email to confirm users' addresses and send notifications.{% endtrans %}
+            <a class="alert-link" href="https://zulip.readthedocs.io/en/latest/production/email.html" target="_blank">
+                {% trans %}See how to configure email.{% endtrans %}
+            </a>
         </div>
     </div>
 </div>

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -159,6 +159,7 @@ class HomeTest(ZulipTestCase):
             "unsubscribed",
             "use_websockets",
             "user_id",
+            "warn_no_email",
             "zulip_version",
         ]
 

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -185,6 +185,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
         server_generation     = settings.SERVER_GENERATION,
         use_websockets        = settings.USE_WEBSOCKETS,
         save_stacktraces      = settings.SAVE_FRONTEND_STACKTRACES,
+        warn_no_email         = settings.WARN_NO_EMAIL,
         server_inline_image_preview = settings.INLINE_IMAGE_PREVIEW,
         server_inline_url_embed_preview = settings.INLINE_URL_EMBED_PREVIEW,
         password_min_length = settings.PASSWORD_MIN_LENGTH,

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1115,7 +1115,7 @@ JS_SPECS = {
             'js/ui_init.js',
             'js/emoji_picker.js',
             'js/compose_ui.js',
-            'js/desktop_notifications_panel.js'
+            'js/panels.js'
         ],
         'output_filename': 'min/app.js'
     },


### PR DESCRIPTION
This PR adds a warning at the top of the screen if the outgoing email server is not configured.

Fixes: #8166.