### PR TITLE
emails: Fix link to org-admin help docs.

### DIFF
--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -449,7 +449,7 @@ def enqueue_welcome_emails(user: UserProfile) -> None:
     context.update({
         'unsubscribe_link': unsubscribe_link,
         'organization_setup_advice_link':
-        user.realm.uri + '%s/help/getting-your-organization-started-with-zulip',
+        user.realm.uri + '/help/getting-your-organization-started-with-zulip',
         'is_realm_admin': user.is_realm_admin,
     })
     send_future_email(


### PR DESCRIPTION
Relevant discussion: https://chat.zulip.org/#narrow/stream/general/topic/Guide.20for.20admins

I haven't created a new realm to test this, but this was the only place where we link to the doc in the email code, so the fix should work.