### PR TITLE
portico: Hide realm details when registering new realm.

### DIFF
--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -27,7 +27,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
             {{ csrf_input }}
 
             <section class="user-registration">
-                {% if realm_name %}
+                {% if realm_name and not creating_new_team %}
                 <img class="avatar inline-block" src="{{ realm_icon }}" alt="" />
                 <div class="info-box inline-block">
                     <div class="organization-name">{{ realm_name }}</div>


### PR DESCRIPTION
If there was a realm on the base URL, its logo and name were being
displayed when registering a new realm (i.e. the page where realm details
are entered, after confirming email). This commit prevents the realm
details from being displayed.

Fixes #8186