### PR TITLE
[draft] Show bot presence status in buddy list.

### DIFF
--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -26,6 +26,10 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         muting_ui.handle_updates(event.muted_topics);
         break;
 
+    case 'bot_presence':
+        activity.set_bot_status(event.user_id, event.is_present)
+        break;
+
     case 'presence':
         activity.set_user_status(event.email, event.presence, event.server_timestamp);
         break;

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -244,6 +244,7 @@ $(function () {
 
     if (page_params.realm_presence_disabled) {
         $("#user-list").hide();
+        $("#bot-list").hide();
         $("#group-pm-list").hide();
     }
 

--- a/static/styles/right-sidebar.css
+++ b/static/styles/right-sidebar.css
@@ -66,6 +66,20 @@
     top: 5px;
 }
 
+.bot-status-indicator {
+    display: block;
+    width: 8px;
+    height: 8px;
+    margin: 0px 5px;
+    border-radius: 50%;
+    border: 1px solid;
+    float: left;
+    position: relative;
+    top: 5px;
+    background-color: hsl(106, 74%, 44%);
+    border-color: hsl(106, 74%, 44%);
+}
+
 .user_active .user-status-indicator,
 .group-pm-status-indicator {
     background-color: hsl(106, 74%, 44%);

--- a/static/templates/bot_presence_row.handlebars
+++ b/static/templates/bot_presence_row.handlebars
@@ -1,0 +1,9 @@
+<li data-bot-id="{{bot_id}}">
+    <span class="selectable_sidebar_block">
+	    <span class="bot-status-indicator"></span>
+	    <a href="{{href}}"
+	        data-bot-id="{{bot_id}}"
+	        data-name="{{name}}"
+	        title="{{name}}">{{name}}</a>
+    </span>
+</li>

--- a/static/templates/bot_presence_rows.handlebars
+++ b/static/templates/bot_presence_rows.handlebars
@@ -1,0 +1,4 @@
+{{! Bot Presence rows }}
+{{#each bots}}
+{{partial "bot_presence_row"}}
+{{/each}}

--- a/templates/zerver/right_sidebar.html
+++ b/templates/zerver/right_sidebar.html
@@ -23,6 +23,13 @@
             <a id="invite-user-link" href="#invite"><i class="icon-vector-plus-sign"></i>{{ _('Invite more users') }}</a>
             {% endif %}
         </div>
+        <div id="bot-list">
+            <div id="botlist-header">
+                <h4 class='sidebar-title' id='botlist-title'>{{ _('BOTS') }}</h4>
+            </div>
+            <ul id="bot_presences" class="filters scrolling_list">
+            </ul>
+        </div>
         <div id="group-pm-list">
             <div id="group-pm-header">
                 <h4 class='sidebar-title' id='group-pm-title'>{{ _('GROUP PMs') }}</h4>

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -604,7 +604,7 @@ def do_events_register(user_profile: UserProfile, user_client: Client,
 
     # Note that we pass event_types, not fetch_event_types here, since
     # that's what controls which future events are sent.
-    queue_id = request_event_queue(user_profile, user_client, apply_markdown, client_gravatar,
+    queue_id, bot_presence_data = request_event_queue(user_profile, user_client, apply_markdown, client_gravatar,
                                    queue_lifespan_secs, event_types, all_public_streams,
                                    narrow=narrow)
 
@@ -624,6 +624,9 @@ def do_events_register(user_profile: UserProfile, user_client: Client,
     ret = fetch_initial_state_data(user_profile, event_types_set, queue_id,
                                    client_gravatar=client_gravatar,
                                    include_subscribers=include_subscribers)
+
+    if event_types_set is None:
+        ret['bot_presence'] = bot_presence_data
 
     # Apply events that came in while we were fetching initial data
     events = get_user_events(user_profile, queue_id, -1)

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -54,6 +54,7 @@ def get_events_backend(request: HttpRequest, user_profile: UserProfile, handler:
     events_query = dict(
         user_profile_id = user_profile.id,
         user_profile_email = user_profile.email,
+        user_profile_is_bot = user_profile.is_bot,
         queue_id = queue_id,
         last_event_id = last_event_id,
         event_types = event_types,
@@ -69,6 +70,7 @@ def get_events_backend(request: HttpRequest, user_profile: UserProfile, handler:
             user_profile_id = user_profile.id,
             realm_id = user_profile.realm_id,
             user_profile_email = user_profile.email,
+            user_profile_is_bot = user_profile.is_bot,
             event_types = event_types,
             client_type_name = user_client.name,
             apply_markdown = apply_markdown,


### PR DESCRIPTION
This is an initial implementation for showing active bots in the buddy list. Both the code and the commits are a little rough around the edges.

### What does this do?
In specific, this displays all active external generic bots in the right sidebar under the title "BOTS" (see live on playground.zulipdev.org).

### What load is added to Tornado?
Afaik, Tornado needs to handle three additional things:
* a user connects: Tornado sends 1 event with size O(|active external generic bots|)
* a bot connects/disconnects: Tornado sends |user| events each with size O(1)
* one callback loop with O(|active external generic bots|) operations per 30 sec.

For big realms, |active external generic bots| will probably max at ~20.

### Known issues
* There is too little space between the BOTS and USERS lists in the right sidebar.
* If for some reason a bot misses a heartbeat, but is still connected, it'll get marked as disconnected. However, if a new heartbeat arrives, it doesn't get marked as connected again. This can be fixed with a few additional lines in maybe_send_bot_presence_udpate_event().

@showell @timabbott FYI.

Fixes #8090.