### PR TITLE
Add embedded bot config data editing.

### DIFF
--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -44,6 +44,15 @@ assert.equal(bot_data.get(314).full_name, 'Outgoing webhook');
         extra: 'Not in data',
     };
 
+    var test_embedded_bot = {
+        email: 'embedded-bot@zulip.com',
+        user_id: 143,
+        avatar_url: '',
+        full_name: 'Embedded bot 1',
+        services: [{config_data: {key: '12345678'},
+                    service_name: "giphy"}],
+    };
+
     (function test_add() {
         bot_data.add(test_bot);
 
@@ -71,6 +80,15 @@ assert.equal(bot_data.get(314).full_name, 'Outgoing webhook');
         assert.equal('New Bot 1', bot.full_name);
         assert.equal(2, services[0].interface);
         assert.equal('http://baz.com', services[0].base_url);
+    }());
+
+    (function test_embedded_bot_update() {
+        bot_data.add(test_embedded_bot);
+        var bot_id = 143;
+        var services = bot_data.get_services(bot_id);
+        assert.equal('12345678', services[0].config_data.key);
+        bot_data.update(bot_id, {services: [{config_data: {key: '87654321'}}]});
+        assert.equal('87654321', services[0].config_data.key);
     }());
 
     (function test_remove() {

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -101,10 +101,6 @@ function test_create_bot_type_input_box_toggle(f) {
         }
     };
 
-    var embedded_bots_added = 0;
-    $('#select_service_name').append = function () {
-        embedded_bots_added += 1;
-    };
     $('#config_inputbox').children = function () {
         var mock_children = {
             hide: function () {
@@ -118,6 +114,5 @@ function test_create_bot_type_input_box_toggle(f) {
     avatar.build_bot_edit_widget = function () {};
 
     settings_bots.set_up();
-    assert(embedded_bots_added === page_params.realm_embedded_bots.length);
 }());
 

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1479,6 +1479,16 @@ function render(template_name, args) {
     assert.equal($(html).find('#edit_service_interface').attr('value'), args.service.interface);
 }());
 
+(function edit_embedded_bot_service() {
+    var args = {
+        service: {service_name: "giphy",
+                  config_data: {key: "abcd1234"}},
+    };
+    var html = render('edit-embedded-bot-service', args);
+    assert.equal($(html).find('#embedded_bot_key_edit').attr('name'), 'key');
+    assert.equal($(html).find('#embedded_bot_key_edit').val(), 'abcd1234');
+}());
+
 // By the end of this test, we should have compiled all our templates.  Ideally,
 // we will also have exercised them to some degree, but that's a little trickier
 // to enforce.

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -6,7 +6,8 @@ var bot_data = (function () {
                       'default_events_register_stream', 'default_sending_stream',
                       'email', 'full_name', 'is_active', 'owner', 'bot_type', 'user_id'];
     var services = {};
-    var services_fields = ['base_url', 'interface'];
+    var services_fields = ['base_url', 'interface',
+                           'config_data', 'service_name'];
 
     var send_change_event = _.debounce(function () {
         $(document).trigger('zulip.bot_data_changed');

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -279,11 +279,16 @@ exports.set_up = function () {
         var errors = form.find('.bot_edit_errors');
 
         $("#settings_page .edit_bot .edit-bot-owner select").val(bot.owner);
+        var service = bot_data.get_services(bot_id)[0];
         if (bot.bot_type.toString() === OUTGOING_WEBHOOK_BOT_TYPE) {
-            var services = bot_data.get_services(bot_id);
             $("#service_data").append(templates.render("edit-outgoing-webhook-service",
-                                                       {service: services[0]}));
+                                                       {service: service}));
         }
+        if (bot.bot_type.toString() === EMBEDDED_BOT_TYPE) {
+            $("#service_data").append(templates.render("edit-embedded-bot-service",
+                                                       {service: service}));
+        }
+
         avatar_widget.clear();
 
         form.validate({
@@ -312,6 +317,12 @@ exports.set_up = function () {
                     var service_interface = $("#edit_service_interface :selected").val();
                     formData.append('service_payload_url', JSON.stringify(service_payload_url));
                     formData.append('service_interface', service_interface);
+                } else if (type === EMBEDDED_BOT_TYPE) {
+                    var config_data = {};
+                    $("#config_edit_inputbox input").each(function () {
+                        config_data[$(this).attr('name')] = $(this).val();
+                    });
+                    formData.append('config_data', JSON.stringify(config_data));
                 }
                 jQuery.each(file_input[0].files, function (i, file) {
                     formData.append('file-'+i, file);

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -88,12 +88,6 @@ exports.set_up = function () {
     $('#create_payload_url').val('');
     $('#service_name_list').hide();
     $('#config_inputbox').hide();
-    page_params.realm_embedded_bots.forEach(function (bot) {
-        $('#select_service_name').append($('<option>', {
-            value: bot.name,
-            text: bot.name,
-        }));
-    });
     var selected_embedded_bot = 'converter';
     $('#select_service_name').val(selected_embedded_bot); // TODO: Use 'select a bot'.
     $('#config_inputbox').children().hide();

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -76,6 +76,9 @@
                     <div class="input-group" id="service_name_list">
                         <label for="select_service_name">{{t "Bot"}}</label>
                         <select name="service_name" id="select_service_name">
+                            {{#each page_params.realm_embedded_bots}}
+                            <option value="{{this.name}}">{{this.name}}</option>
+                            {{/each}}
                         </select>
                     </div>
                     <div id="config_inputbox">

--- a/static/templates/settings/edit-embedded-bot-service.handlebars
+++ b/static/templates/settings/edit-embedded-bot-service.handlebars
@@ -1,0 +1,9 @@
+<div id="config_edit_inputbox">
+    {{#each service.config_data}}
+    <div class="input-group">
+        <label for="embedded_bot_{{@key}}_edit">{{@key}}</label>
+        <input type="text" name="{{@key}}" id="embedded_bot_{{@key}}_edit"
+            maxlength=1000 value="{{this}}" />
+    </div>
+    {{/each}}
+</div>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -24,6 +24,7 @@ from zerver.lib.addressee import (
 from zerver.lib.bot_config import (
     ConfigError,
     get_bot_config,
+    set_bot_config,
 )
 from zerver.lib.cache import (
     bot_dict_fields,
@@ -4406,6 +4407,19 @@ def do_update_outgoing_webhook_service(bot_profile, service_interface, service_p
                              user_id=bot_profile.id,
                              services = [dict(base_url=service.base_url,
                                               interface=service.interface)],
+                             ),
+                    ),
+               bot_owner_user_ids(bot_profile))
+
+def do_update_bot_config_data(bot_profile: UserProfile,
+                              config_data: Dict[Text, Text]) -> None:
+    for key, value in config_data.items():
+        set_bot_config(bot_profile, key, value)
+    send_event(dict(type='realm_bot',
+                    op='update',
+                    bot=dict(email=bot_profile.email,
+                             user_id=bot_profile.id,
+                             services = [dict(config_data=config_data)],
                              ),
                     ),
                bot_owner_user_ids(bot_profile))

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -21,7 +21,12 @@ from zerver.lib.addressee import (
     Addressee,
     user_profiles_from_unvalidated_emails,
 )
+from zerver.lib.bot_config import (
+    ConfigError,
+    get_bot_config,
+)
 from zerver.lib.cache import (
+    bot_dict_fields,
     delete_user_profile_caches,
     to_dict_cache_key_id,
 )
@@ -64,18 +69,17 @@ from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, 
     email_allowed_for_realm, email_to_username, display_recipient_cache_key, \
     get_user, get_stream_cache_key, \
     UserActivityInterval, active_user_ids, get_active_streams, \
-    realm_filters_for_realm, RealmFilter, \
-    get_owned_bot_dicts, stream_name_in_use, \
+    realm_filters_for_realm, RealmFilter, stream_name_in_use, \
     get_old_unclaimed_attachments, is_cross_realm_bot_email, \
     Reaction, EmailChangeStatus, CustomProfileField, \
     custom_profile_fields_for_realm, get_huddle_user_ids, \
     CustomProfileFieldValue, validate_attachment_request, get_system_bot, \
     get_display_recipient_by_id, query_for_ids, get_huddle_recipient, \
     UserGroup, UserGroupMembership, get_default_stream_groups, \
-    get_service_dicts_for_bots, get_bot_services
+    get_bot_services, get_bot_dicts_in_realm
 
 from zerver.lib.alert_words import alert_words_in_realm
-from zerver.lib.avatar import avatar_url
+from zerver.lib.avatar import avatar_url, avatar_url_from_dict
 from zerver.lib.stream_recipient import StreamRecipientMap
 
 from django.db import transaction, IntegrityError, connection
@@ -4405,6 +4409,47 @@ def do_update_outgoing_webhook_service(bot_profile, service_interface, service_p
                              ),
                     ),
                bot_owner_user_ids(bot_profile))
+
+def get_service_dicts_for_bots(user_profile_id: str) -> List[Dict[str, Any]]:
+    user_profile = get_user_profile_by_id(user_profile_id)
+    services = get_bot_services(user_profile_id)
+    service_dicts = []  # type: List[Dict[Text, Any]]
+    if user_profile.bot_type == UserProfile.OUTGOING_WEBHOOK_BOT:
+        service_dicts = [{'base_url': service.base_url,
+                          'interface': service.interface,
+                          }
+                         for service in services]
+    elif user_profile.bot_type == UserProfile.EMBEDDED_BOT:
+        try:
+            service_dicts = [{'config_data': get_bot_config(user_profile),
+                              'service_name': services[0].name
+                              }]
+        # A ConfigError just means that there are no config entries for user_profile.
+        except ConfigError:
+            pass
+    return service_dicts
+
+def get_owned_bot_dicts(user_profile: UserProfile,
+                        include_all_realm_bots_if_admin: bool=True) -> List[Dict[str, Any]]:
+    if user_profile.is_realm_admin and include_all_realm_bots_if_admin:
+        result = get_bot_dicts_in_realm(user_profile.realm)
+    else:
+        result = UserProfile.objects.filter(realm=user_profile.realm, is_bot=True,
+                                            bot_owner=user_profile).values(*bot_dict_fields)
+    return [{'email': botdict['email'],
+             'user_id': botdict['id'],
+             'full_name': botdict['full_name'],
+             'bot_type': botdict['bot_type'],
+             'is_active': botdict['is_active'],
+             'api_key': botdict['api_key'],
+             'default_sending_stream': botdict['default_sending_stream__name'],
+             'default_events_register_stream': botdict['default_events_register_stream__name'],
+             'default_all_public_streams': botdict['default_all_public_streams'],
+             'owner': botdict['bot_owner__email'],
+             'avatar_url': avatar_url_from_dict(botdict),
+             'services': get_service_dicts_for_bots(botdict['id']),
+             }
+            for botdict in result]
 
 def do_send_user_group_members_update_event(event_name: Text,
                                             user_group: UserGroup,

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -34,14 +34,15 @@ from zerver.lib.actions import (
     do_get_streams, get_default_streams_for_realm,
     gather_subscriptions_helper, get_cross_realm_dicts,
     get_status_dict, streams_to_dicts_sorted,
-    default_stream_groups_to_dicts_sorted
+    default_stream_groups_to_dicts_sorted,
+    get_owned_bot_dicts,
 )
 from zerver.lib.user_groups import user_groups_in_realm_serialized
 from zerver.tornado.event_queue import request_event_queue, get_user_events
 from zerver.models import Client, Message, Realm, UserPresence, UserProfile, \
     get_user_profile_by_id, \
     get_realm_user_dicts, realm_filters_for_realm, get_user,\
-    get_owned_bot_dicts, custom_profile_fields_for_realm, get_realm_domains, \
+    custom_profile_fields_for_realm, get_realm_domains, \
     get_default_stream_groups
 from zproject.backends import email_auth_enabled, password_auth_enabled
 from version import ZULIP_VERSION

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -260,7 +260,7 @@ class ZulipTestCase(TestCase):
         else:
             self.assert_json_success(result)
             bot_email = '{}-bot@zulip.testserver'.format(short_name)
-            bot_profile = get_user(bot_email, self.user_profile.realm)
+            bot_profile = get_user(bot_email, user_profile.realm)
             return bot_profile
 
     def login_with_return(self, email: Text, password: Optional[Text]=None,

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1445,31 +1445,6 @@ def active_user_ids(realm_id: int) -> List[int]:
 def get_bot_dicts_in_realm(realm: Realm) -> List[Dict[str, Any]]:
     return UserProfile.objects.filter(realm=realm, is_bot=True).values(*bot_dict_fields)
 
-def get_owned_bot_dicts(user_profile: UserProfile,
-                        include_all_realm_bots_if_admin: bool=True) -> List[Dict[str, Any]]:
-    if user_profile.is_realm_admin and include_all_realm_bots_if_admin:
-        result = get_bot_dicts_in_realm(user_profile.realm)
-    else:
-        result = UserProfile.objects.filter(realm=user_profile.realm, is_bot=True,
-                                            bot_owner=user_profile).values(*bot_dict_fields)
-    # TODO: Remove this import cycle
-    from zerver.lib.avatar import avatar_url_from_dict
-
-    return [{'email': botdict['email'],
-             'user_id': botdict['id'],
-             'full_name': botdict['full_name'],
-             'bot_type': botdict['bot_type'],
-             'is_active': botdict['is_active'],
-             'api_key': botdict['api_key'],
-             'default_sending_stream': botdict['default_sending_stream__name'],
-             'default_events_register_stream': botdict['default_events_register_stream__name'],
-             'default_all_public_streams': botdict['default_all_public_streams'],
-             'owner': botdict['bot_owner__email'],
-             'avatar_url': avatar_url_from_dict(botdict),
-             'services': get_service_dicts_for_bots(botdict['id']),
-             }
-            for botdict in result]
-
 def is_cross_realm_bot_email(email: Text) -> bool:
     return email.lower() in settings.CROSS_REALM_BOT_EMAILS
 
@@ -1925,26 +1900,6 @@ def get_realm_outgoing_webhook_services_name(realm: Realm) -> List[Any]:
 
 def get_bot_services(user_profile_id: str) -> List[Service]:
     return list(Service.objects.filter(user_profile__id=user_profile_id))
-
-def get_service_dicts_for_bots(user_profile_id: str) -> List[Dict[str, Any]]:
-    user_profile = get_user_profile_by_id(user_profile_id)
-    services = get_bot_services(user_profile_id)
-    service_dicts = []  # type: List[Dict[Text, Any]]
-    if user_profile.bot_type == UserProfile.OUTGOING_WEBHOOK_BOT:
-        service_dicts = [{'base_url': service.base_url,
-                          'interface': service.interface,
-                          }
-                         for service in services]
-    elif user_profile.bot_type == UserProfile.EMBEDDED_BOT:
-        from zerver.lib.bot_config import get_bot_config, ConfigError
-        try:
-            service_dicts = [{'config_data': get_bot_config(user_profile),
-                              'service_name': services[0].name
-                              }]
-        # A ConfigError just means that there are no config entries for user_profile.
-        except ConfigError:
-            pass
-    return service_dicts
 
 def get_service_profile(user_profile_id: str, service_name: str) -> Service:
     return Service.objects.get(user_profile__id=user_profile_id, name=service_name)

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -992,6 +992,19 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         service_payload_url = ujson.loads(result.content)['service_payload_url']
         self.assertEqual(service_payload_url, "http://foo.bar2.com")
 
+    def test_patch_bot_config_data(self) -> None:
+        self.create_test_bot('test', self.example_user("hamlet"),
+                             full_name=u'Bot with config data',
+                             bot_type=UserProfile.EMBEDDED_BOT,
+                             service_name='giphy',
+                             config_data=ujson.dumps({'key': '12345678'}))
+        bot_info = {'config_data': ujson.dumps({'key': '87654321'})}
+        result = self.client_patch("/json/bots/test-bot@zulip.testserver", bot_info)
+        self.assert_json_success(result)
+
+        config_data = ujson.loads(result.content)['config_data']
+        self.assertEqual(config_data, ujson.loads(bot_info['config_data']))
+
     def test_outgoing_webhook_invalid_interface(self):
         # type: () -> None
         self.login(self.example_email('hamlet'))

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -185,8 +185,8 @@ class HomeTest(ZulipTestCase):
             with patch('zerver.lib.cache.cache_set') as cache_mock:
                 result = self._get_home_page(stream='Denmark')
 
-        self.assert_length(queries, 41)
-        self.assert_length(cache_mock.call_args_list, 7)
+        self.assert_length(queries, 42)
+        self.assert_length(cache_mock.call_args_list, 8)
 
         html = result.content.decode('utf-8')
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -15,7 +15,8 @@ from zerver.lib.actions import do_change_avatar_fields, do_change_bot_owner, \
     do_change_is_admin, do_change_default_all_public_streams, \
     do_change_default_events_register_stream, do_change_default_sending_stream, \
     do_create_user, do_deactivate_user, do_reactivate_user, do_regenerate_api_key, \
-    check_change_full_name, notify_created_bot, do_update_outgoing_webhook_service
+    check_change_full_name, notify_created_bot, do_update_outgoing_webhook_service, \
+    do_update_bot_config_data
 from zerver.lib.avatar import avatar_url, get_gravatar_url, get_avatar_field
 from zerver.lib.bot_config import set_bot_config
 from zerver.lib.exceptions import JsonableError
@@ -156,6 +157,8 @@ def patch_bot_backend(
         request: HttpRequest, user_profile: UserProfile, email: Text,
         full_name: Optional[Text]=REQ(default=None),
         bot_owner: Optional[Text]=REQ(default=None),
+        config_data: Optional[Dict[Text, Text]]=REQ(default=None,
+                                                    validator=check_dict(value_validator=check_string)),
         service_payload_url: Optional[Text]=REQ(validator=check_url, default=None),
         service_interface: Optional[int]=REQ(validator=check_int, default=1),
         default_sending_stream: Optional[Text]=REQ(default=None),
@@ -196,6 +199,9 @@ def patch_bot_backend(
         check_valid_interface_type(service_interface)
         do_update_outgoing_webhook_service(bot, service_interface, service_payload_url)
 
+    if config_data is not None:
+        do_update_bot_config_data(bot, config_data)
+
     if len(request.FILES) == 0:
         pass
     elif len(request.FILES) == 1:
@@ -211,6 +217,7 @@ def patch_bot_backend(
         avatar_url=avatar_url(bot),
         service_interface = service_interface,
         service_payload_url = service_payload_url,
+        config_data = config_data,
         default_sending_stream=get_stream_name(bot.default_sending_stream),
         default_events_register_stream=get_stream_name(bot.default_events_register_stream),
         default_all_public_streams=bot.default_all_public_streams,


### PR DESCRIPTION
plus various cleanup commits in the first 7 commits.

This should be the final step towards making our bots fully editable (assuming that we don't want users to be able to change a bot's type).