### PR TITLE
compose: Eliminate the json/subscriptions/exists synchronous check.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -90,6 +90,7 @@ people.add(alice);
 people.add(bob);
 
 (function test_validate_stream_message_address_info() {
+    // User is subscribed.
     var sub = {
         stream_id: 101,
         name: 'social',
@@ -98,10 +99,12 @@ people.add(bob);
     stream_data.add_sub('social', sub);
     assert(compose.validate_stream_message_address_info('social'));
 
+    // User is not subscribed, stream does not exist.
     $('#stream').select(noop);
     assert(!compose.validate_stream_message_address_info('foobar'));
     assert.equal($('#compose-error-msg').html(), "translated: <p>The stream <b>foobar</b> does not exist.</p><p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>");
 
+    // User is not subscribed, autosubscribe=false.
     sub.subscribed = false;
     stream_data.add_sub('social', sub);
     templates.render = function (template_name) {
@@ -111,6 +114,7 @@ people.add(bob);
     assert(!compose.validate_stream_message_address_info('social'));
     assert.equal($('#compose-error-msg').html(), 'compose_not_subscribed_stub');
 
+    // User is not subscribed, autosubscribe=true.
     global.page_params.narrow_stream = false;
     channel.post = function (payload) {
         assert.equal(payload.data.stream, 'social');
@@ -118,31 +122,6 @@ people.add(bob);
         payload.success(payload.data);
     };
     assert(compose.validate_stream_message_address_info('social'));
-
-    sub.name = 'Frontend';
-    sub.stream_id = 102;
-    stream_data.add_sub('Frontend', sub);
-    channel.post = function (payload) {
-        assert.equal(payload.data.stream, 'Frontend');
-        payload.data.subscribed = false;
-        payload.success(payload.data);
-    };
-    assert(!compose.validate_stream_message_address_info('Frontend'));
-    assert.equal($('#compose-error-msg').html(), 'compose_not_subscribed_stub');
-
-    channel.post = function (payload) {
-        assert.equal(payload.data.stream, 'Frontend');
-        payload.error({status: 404});
-    };
-    assert(!compose.validate_stream_message_address_info('Frontend'));
-    assert.equal($('#compose-error-msg').html(), "translated: <p>The stream <b>Frontend</b> does not exist.</p><p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>");
-
-    channel.post = function (payload) {
-        assert.equal(payload.data.stream, 'social');
-        payload.error({status: 500});
-    };
-    assert(!compose.validate_stream_message_address_info('social'));
-    assert.equal($('#compose-error-msg').html(), i18n.t("Error checking subscription"));
 }());
 
 (function test_validate() {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -483,7 +483,7 @@ function validate_stream_message_announce(stream_name) {
     return true;
 }
 
-exports.validation_error = function (error_type, stream_name) {
+exports.report_validation_error = function (error_type, stream_name) {
     var response;
 
     var context = {};
@@ -511,12 +511,12 @@ exports.validate_stream_message_address_info = function (stream_name) {
     }
     var stream_obj = stream_data.get_sub(stream_name);
     if (!stream_obj) {
-        exports.validation_error("does-not-exist", stream_name);
+        exports.report_validation_error("does-not-exist", stream_name);
         return false;
     }
     var autosubscribe = page_params.narrow_stream !== undefined;
     if (!autosubscribe) {
-        exports.validation_error("not-subscribed", stream_name);
+        exports.report_validation_error("not-subscribed", stream_name);
         return false;
     }
     return true;

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -427,15 +427,8 @@ exports.get_invalid_recipient_emails = function () {
     return invalid_recipients;
 };
 
-function check_unsubscribed_stream_for_send(stream_name, autosubscribe) {
-    var stream_obj = stream_data.get_sub(stream_name);
+function check_unsubscribed_stream_for_send(stream_name) {
     var result;
-    if (!stream_obj) {
-        return "does-not-exist";
-    }
-    if (!autosubscribe) {
-        return "not-subscribed";
-    }
 
     // In the rare circumstance of the autosubscribe option, we
     // *Synchronously* try to subscribe to the stream before sending
@@ -537,8 +530,15 @@ exports.validate_stream_message_address_info = function (stream_name) {
     if (stream_data.is_subscribed(stream_name)) {
         return true;
     }
+    var stream_obj = stream_data.get_sub(stream_name);
+    if (!stream_obj) {
+        return exports.validation_error("does-not-exist", stream_name);
+    }
     var autosubscribe = page_params.narrow_stream !== undefined;
-    var error_type = check_unsubscribed_stream_for_send(stream_name, autosubscribe);
+    if (!autosubscribe) {
+        return exports.validation_error("not-subscribed", stream_name);
+    }
+    var error_type = check_unsubscribed_stream_for_send(stream_name);
     return exports.validation_error(error_type, stream_name);
 };
 

--- a/static/js/transmit.js
+++ b/static/js/transmit.js
@@ -17,7 +17,7 @@ function send_message_socket(request, success, error) {
     request.socket_user_agent = navigator.userAgent;
     socket.send(request, success, function (type, resp) {
         if (request.autosubscribe) {
-            exports.validation_error(resp.error_type, request.stream);
+            exports.report_validation_error(resp.error_type, request.stream);
             return;
         }
         var err_msg = "Error sending message";
@@ -45,7 +45,7 @@ function send_message_ajax(request, success, error) {
             }
             if (request.autosubscribe) {
                 error_type = xhr.responseJSON.error_type;
-                exports.validation_error(error_type, request.stream);
+                exports.report_validation_error(error_type, request.stream);
                 return;
             }
             var response = channel.xhr_error_message("Error sending message", xhr);

--- a/static/js/transmit.js
+++ b/static/js/transmit.js
@@ -16,6 +16,10 @@ $(function () {
 function send_message_socket(request, success, error) {
     request.socket_user_agent = navigator.userAgent;
     socket.send(request, success, function (type, resp) {
+        if (request.autosubscribe) {
+            exports.validation_error(resp.error_type, request.stream);
+            return;
+        }
         var err_msg = "Error sending message";
         if (type === 'response') {
             err_msg += ": " + resp.msg;
@@ -39,7 +43,11 @@ function send_message_ajax(request, success, error) {
                                  send_after_reload: true});
                 return;
             }
-
+            if (request.autosubscribe) {
+                error_type = xhr.responseJSON.error_type;
+                exports.validation_error(error_type, request.stream);
+                return;
+            }
             var response = channel.xhr_error_message("Error sending message", xhr);
             error(response);
         },

--- a/templates/zerver/api/fixtures.json
+++ b/templates/zerver/api/fixtures.json
@@ -312,12 +312,6 @@
         "result": "error",
         "var_name": "content"
     },
-    "nonexistent-stream-error": {
-        "code": "STREAM_DOES_NOT_EXIST",
-        "msg": "Stream 'nonexistent_stream' does not exist",
-        "result": "error",
-        "stream": "nonexistent_stream"
-    },
     "private-message": {
         "id": 134,
         "msg": "",

--- a/templates/zerver/api/remove-subscriptions.md
+++ b/templates/zerver/api/remove-subscriptions.md
@@ -89,6 +89,6 @@ A typical successful JSON response may look like:
 
 {generate_code_example|remove-subscriptions|fixture}
 
-A typical failed JSON response for when the target stream does not exist:
+A typical failed JSON response for when the target stream is invalid:
 
-{generate_code_example|nonexistent-stream-error|fixture}
+{generate_code_example|invalid-stream-error|fixture}

--- a/templates/zerver/api/stream-message.md
+++ b/templates/zerver/api/stream-message.md
@@ -102,6 +102,6 @@ A typical successful JSON response may look like:
 
 {generate_code_example|stream-message|fixture}
 
-A typical failed JSON response for when the target stream does not exist:
+A typical failed JSON response for when the target stream is invalid:
 
-{generate_code_example|nonexistent-stream-error|fixture}
+{generate_code_example|invalid-stream-error|fixture}

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -315,19 +315,6 @@ def stream_message(client):
 
     return message_id
 
-def test_nonexistent_stream_error(client):
-    # type: (Client) -> None
-    request = {
-        "type": "stream",
-        "to": "nonexistent_stream",
-        "subject": "Castle",
-        "content": "Something is rotten in the state of Denmark."
-    }
-    result = client.send_message(request)
-
-    fixture = FIXTURES['nonexistent-stream-error']
-    test_against_fixture(result, fixture)
-
 def private_message(client):
     # type: (Client) -> None
 
@@ -560,7 +547,7 @@ def test_messages(client):
     update_message(client, message_id)
     private_message(client)
 
-    test_nonexistent_stream_error(client)
+    test_invalid_stream_error(client)
     test_private_message_invalid_recipient(client)
 
 def test_users(client):

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1053,20 +1053,56 @@ class MessagePOSTTest(ZulipTestCase):
                                                      "client": "test suite",
                                                      "content": "Test message",
                                                      "subject": "Test subject"})
-        self.assert_json_error(result, "Stream 'nonexistent_stream' does not exist")
+        self.assert_json_error(result, "Invalid stream name 'nonexistent_stream'")
+        self.assertEqual(result.json().get("error_type"), "does-not-exist")
 
     def test_message_to_nonexistent_stream_with_bad_characters(self) -> None:
         """
         Nonexistent stream name with bad characters should be escaped properly.
         """
         self.login(self.example_email("hamlet"))
-        self.assertFalse(Stream.objects.filter(name="""&<"'><non-existent>"""))
+        name = """&<"'><non-existent>"""
+        self.assertFalse(Stream.objects.filter(name=name))
         result = self.client_post("/json/messages", {"type": "stream",
                                                      "to": """&<"'><non-existent>""",
                                                      "client": "test suite",
                                                      "content": "Test message",
                                                      "subject": "Test subject"})
-        self.assert_json_error(result, "Stream '&amp;&lt;&quot;&#39;&gt;&lt;non-existent&gt;' does not exist")
+        self.assert_json_error(result, "Invalid stream name '%s'" % (name,))
+        self.assertEqual(result.json().get("error_type"), "does-not-exist")
+
+    def test_message_user_is_not_subscribed_autosubscribe_is_false(self) -> None:
+        """
+        If user is not subscribed and autosubscribe=false, return an error.
+        """
+        user_profile = self.example_user("hamlet")
+        email = user_profile.email
+        stream_name = "Rome"
+        self.unsubscribe(user_profile, stream_name)
+        result = self.api_post(email, "/json/messages", {"type": "stream",
+                                                         "to": stream_name,
+                                                         "client": "test suite",
+                                                         "subject": "Test message",
+                                                         "content": "Test subject",
+                                                         "autosubscribe": "false"})
+        self.assert_json_error(result, "User not subscribed to this stream")
+        self.assertEqual(result.json().get("error_type"), "not-subscribed")
+
+    def test_message_user_is_not_subscribed_autosubscribe_is_true(self) -> None:
+        """
+        If user is not subscribed and autosubscribe=true, subscribe them.
+        """
+        user_profile = self.example_user("hamlet")
+        email = user_profile.email
+        stream_name = "Rome"
+        self.unsubscribe(user_profile, stream_name)
+        result = self.api_post(email, "/json/messages", {"type": "stream",
+                                                         "to": stream_name,
+                                                         "client": "test suite",
+                                                         "subject": "Test message",
+                                                         "content": "Test subject",
+                                                         "autosubscribe": "true"})
+        self.assert_json_success(result)
 
     def test_personal_message(self) -> None:
         """


### PR DESCRIPTION
The discussion of these changes can be found [here](https://chat.zulip.org/#narrow/stream/frontend/subject/autosubscribe/near/456551).

To sum it up, a user is not allowed to send a message to the stream they are not subscribed to, unless the request contains the `autosubscribe` variable set to `true`. In this case, the user will be automatically subscribed to the stream before sending a message.

To see this behavior though the web interface, you can narrow down to a stream using the link of the following form: https://chat.zulip.org/?stream=frontend. The messages sent after narrowing down to a stream the regular way (by clicking on its name) will be rejected by the backend.

Please let me know if anything can be changed or improved.

Fixes #4650.

@showell @timabbott FYI :)