### PR TITLE
notifications: Restore a comment explaining `received_messages`.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -496,6 +496,7 @@ exports.received_messages = function (messages) {
             return;
         }
         if (!unread.message_unread(message)) {
+            // The message is already read; Zulip is currently in focus.
             return;
         }
 


### PR DESCRIPTION
A comment like this was removed in
  fa44d2ea6 "settings: Remove autoscroll_forever setting."
The comment went on to say something about autoscroll, but this
part still seems relevant.  While here, adjust grammar and caps.