### PR TITLE
landing-page: Click anywhere to close sidebar.

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -201,14 +201,18 @@ var events = function () {
     $("body").click(function (e) {
         var $e = $(e.target);
 
-
         if ($e.is("nav ul .exit")) {
+            $("nav ul").removeClass("show");
+        }
+
+        if ($("nav ul.show") && !$e.closest("nav ul.show").length && !$e.is("nav ul.show")) {
             $("nav ul").removeClass("show");
         }
     });
 
-    $(".hamburger").click(function () {
+    $(".hamburger").click(function (e) {
         $("nav ul").addClass("show");
+        e.stopPropagation();
     });
 
     if (path_parts().includes("apps")) {


### PR DESCRIPTION
This makes it so you can click anywhere over the grey-ed out area
to close the sidebar.

Fixes: #8208.