### PR TITLE
Portico:Rename sign in to log in.

### DIFF
--- a/static/locale/bg/LC_MESSAGES/django.po
+++ b/static/locale/bg/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Boris Yankov <borisyankov@gmail.com>, 2017
 msgid ""
@@ -1015,11 +1015,11 @@ msgid "Download"
 msgstr ""
 
 #: templates/zerver/login.html:27
-msgid "Sign in to Zulip"
+msgid "Log in to Zulip"
 msgstr ""
 
 #: templates/zerver/login.html:35
-msgid "Sign in with SSO"
+msgid "Log in with SSO"
 msgstr ""
 
 #: templates/zerver/login.html:82
@@ -1037,19 +1037,19 @@ msgstr "Парола"
 
 #: templates/zerver/login.html:106
 msgid ""
-"You've already registered with this email address. Please sign in below."
+"You've already registered with this email address. Please log in below."
 msgstr ""
 
 #: templates/zerver/login.html:116
-msgid "Sign in"
+msgid "Log in"
 msgstr "Вход"
 
 #: templates/zerver/login.html:128
-msgid "Sign in with Google"
+msgid "Log in with Google"
 msgstr "Вход с Google"
 
 #: templates/zerver/login.html:136
-msgid "Sign in with GitHub"
+msgid "Log in with GitHub"
 msgstr ""
 
 #: templates/zerver/markdown_help.html:2 templates/zerver/navbar.html:101
@@ -1268,7 +1268,7 @@ msgid "Use %(external_host)s"
 msgstr ""
 
 #: templates/zerver/register.html:145
-msgid "The address you'll use to sign in to your organization."
+msgid "The address you'll use to log in to your organization."
 msgstr ""
 
 #: templates/zerver/register.html:166

--- a/templates/zerver/help/signing-in.md
+++ b/templates/zerver/help/signing-in.md
@@ -1,6 +1,6 @@
 # Signing in
 
-Zulip offers three ways to sign in: e-mail and password, Google
+Zulip offers three ways to log in: e-mail and password, Google
 credentials, and GitHub credentials. Your organization's administrator
 may choose to enable or disable any of these options. So don't worry
 if your login page doesn't have some of the options described here!
@@ -28,12 +28,12 @@ following a few simple steps.
         [Change your password](/help/change-your-password) page for
         instructions on how to reset it.
 
-## Signing in with your Google account
+## Logging in with your Google account
 
 If your organization has enabled Google authentication, you can sign
 into Zulip using your Google account by following a few simple steps.
 
-1. Click the **Sign in with Google** button located under the
+1. Click the **Log in with Google** button located under the
    **Login** button and **Forgot your password?** link.
 
     ![Zulip sign in Google](/static/images/help/signin-google.png)
@@ -57,12 +57,12 @@ into Zulip using your Google account by following a few simple steps.
     If you click the **Deny** button, Zulip cannot finish logging you
     in, and you will be redirected to the Zulip login page.
 
-## Signing in with your GitHub account
+## Logging in with your GitHub account
 
 If your organization has enabled GitHub authentication, you can sign into
 Zulip using your GitHub account by following a few simple steps.
 
-1. Click the **Sign in with GitHub** button located under the **Sign in with Google** button.
+1. Click the **Log in with GitHub** button located under the **Log in with Google** button.
 
     ![Zulip sign in GitHub](/static/images/help/signin-github.png)
 
@@ -71,7 +71,7 @@ Zulip using your GitHub account by following a few simple steps.
 
     ![Zulip sign in GitHub login](/static/images/help/github-login.png)
 
-3. If you're signing into Zulip with a GitHub account for the first
+3. If you're logging into Zulip with a GitHub account for the first
    time, you will be taken to a page titled **Authorize application**.
 
     ![Zulip sign in GitHub Request Permission](/static/images/help/github-request.png)

--- a/templates/zerver/help/zulip-on-android.md
+++ b/templates/zerver/help/zulip-on-android.md
@@ -31,7 +31,7 @@ then press **Log in**.
 
     ![Login form](/static/images/help/android-log-in.png)
 
-* If you prefer to log in with your Google account, press the **Sign in with Google** button.
+* If you prefer to log in with your Google account, press the **Log in with Google** button.
 
     ![Google button](/static/images/help/android-google-sign-in-button.png)
 

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -24,7 +24,7 @@
     <div class="app login-page split-view new-style flex full-page">
         <div class="inline-block">
             <div class="lead">
-                <h1 class="get-started">{{ _("Sign in to Zulip") }}</h1>
+                <h1 class="get-started">{{ _("Log in to Zulip") }}</h1>
             </div>
 
             <div class="app-main login-page-container white-box inline-block">
@@ -32,7 +32,7 @@
                     {# SSO users don't have a password. #}
 
                     <div class="login-sso">
-                        <a href="/accounts/login/sso" class="btn btn-large btn-primary">{{ _('Sign in with SSO') }}</a>
+                        <a href="/accounts/login/sso" class="btn btn-large btn-primary">{{ _('Log in with SSO') }}</a>
                     </div>
 
                 {% else %}
@@ -101,7 +101,7 @@
 
                                     {% if already_registered %}
                                     <div class="alert">
-                                        {{ _("You've already registered with this email address. Please sign in below.") }}
+                                        {{ _("You've already registered with this email address. Please log in below.") }}
                                     </div>
                                     {% endif %}
 
@@ -113,8 +113,9 @@
 
                                     <button type="submit" name="button" class="full-width">
                                         <img class="loader" src="/static/images/loader.svg" />
-                                        <span class="text">{{ _("Sign in") }}</span>
+                                        <span class="text">{{ _("Log in") }}</span>
                                     </button>
+
                                 </form>
 
                                 {% if any_oauth_backend_enabled %}
@@ -126,7 +127,7 @@
                             {% if google_auth_enabled %}
                             <div class="login-google">
                                 <form class="form-inline" action="{{ url('zerver.views.auth.start_google_oauth2') }}" method="get">
-                                    <button class="login-social-button login-google-button full-width">{{ _('Sign in with Google') }}</button>
+                                    <button class="login-social-button login-google-button full-width">{{ _('Log in with Google') }}</button>
                                 </form>
                             </div>
                             {% endif %}
@@ -134,7 +135,7 @@
                             {% if github_auth_enabled %}
                             <div class="login-github">
                                 <form class="form-inline github-wrapper" action="{{ url('login-social', args=('github',)) }}" method="get">
-                                    <button class="login-social-button login-github-button github">{{ _('Sign in with GitHub') }}</button>
+                                    <button class="login-social-button login-github-button github">{{ _('Log in with GitHub') }}</button>
                                 </form>
                             </div>
                             {% endif %}


### PR DESCRIPTION
Renamed sign in to log in to the login.html.
Fixes #7884.
![screen shot 2018-01-31 at 6 20 43 pm 2](https://user-images.githubusercontent.com/29195786/35631638-65160f1a-06ca-11e8-9ef7-0c55329c1d16.png)
