### PR TITLE
 create stream: Send user to created stream page after stream creation

### DIFF
--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -183,6 +183,10 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             settings_streams.update_default_streams_table();
         } else if (event.op === 'create') {
             stream_data.create_streams(event.streams);
+            _.each(event.streams, function (stream) {
+                var sub = stream_data.get_sub_by_id(stream.stream_id);
+                subs.add_sub_to_table(sub);
+            });
         } else if (event.op === 'delete') {
             _.each(event.streams, function (stream) {
                 var was_subscribed = stream_data.get_sub_by_id(stream.stream_id).subscribed;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -178,7 +178,7 @@ function add_email_hint(row, email_address_hint_content) {
 // server_events code flow not having a good way to associate with
 // this request.  These should be appended to the top of the list so
 // they are more visible.
-function add_sub_to_table(sub) {
+exports.add_sub_to_table = function (sub) {
     stream_data.update_calculated_fields(sub);
     var html = templates.render('subscription', sub);
     var settings_html = templates.render('subscription_settings', sub);
@@ -197,7 +197,7 @@ function add_sub_to_table(sub) {
         $(".stream-row[data-stream-id='" + stream_data.get_sub(created_stream).stream_id + "']").click();
         stream_create.reset_created_stream();
     }
-}
+};
 
 exports.remove_stream = function (stream_id) {
     // It is possible that row is empty when we deactivate a
@@ -218,7 +218,7 @@ exports.update_settings_for_subscribed = function (sub) {
 
         stream_edit.add_me_to_member_list(sub);
     } else {
-        add_sub_to_table(sub);
+        exports.add_sub_to_table(sub);
     }
 
     var active_stream = exports.active_stream();

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2350,11 +2350,14 @@ def bulk_add_subscriptions(streams: Iterable[Stream],
     for stream in streams:
         new_users = [user for user in users if (user.id, stream.id) in new_streams]
 
-        # Users newly added to invite-only streams need a `create`
-        # notification, since they didn't have the invite-only stream
+        # Users newly added to invite-only streams and all relam admin users
+        # need a `create` notification, since they didn't have the invite-only stream
         # in their browser yet.
+        event_recievers = [user.id for user in new_users]
         if not stream.is_public():
-            send_stream_creation_event(stream, [user.id for user in new_users])
+            realm_admin_users = [user.id for user in user_profile.realm.get_admin_users()]
+            event_recievers.extend(realm_admin_users)
+            send_stream_creation_event(stream, list(set(event_recievers)))
 
     # The second batch is events for the users themselves that they
     # were subscribed to the new streams.

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1845,7 +1845,8 @@ class SubscriptionAPITest(ZulipTestCase):
 
         self.assertEqual(create_event['event']['type'], 'stream')
         self.assertEqual(create_event['event']['op'], 'create')
-        self.assertEqual(create_event['users'], [user_profile.id])
+        # Send stream creation event to subscribed users and all realm admin users.
+        self.assertEqual(create_event['users'], [user_profile.id, self.example_user('iago').id])
         self.assertEqual(create_event['event']['streams'][0]['name'], stream_name)
 
         self.assertEqual(add_event['event']['type'], 'subscription')


### PR DESCRIPTION
**server event: On stream create event, add sub to stream lists.**
```    
    Currently, our stream creation do not add stream list to all
    stream list. Only subscription-add event add stream list to
    stream list. If public stream is created without acting user
    subscribed to stream, then newly created stream is not listed
    to all stream list.
    
    On stream creation add sub to all stream list table.
```
To reproduce the issue:
* login with iago
* Create a stream public/private without subscribing iago to stream
Stream doesn't add to all stream list.

**create stream: Fix real time sync bug in private stream creation.**
```    
    If new private stream is created by realm admin without realm admin
    subscribed to it, then it doesn't automatically add created stream to
    realm admin's stream list. We have to reload the browser to get newly
    created stream in stream list. Cause private stream creation event is
    only sent to the subscribed users to private stream, so even if realm
    admin is acting user, they don't get creation event.
    
    We should send private stream creation event to realm admin users along
    with subscribed user to stream, as realm admins can access unsubscribed
    private streams.
```
To reproduce the issue:
* login with iago
* Create a stream private without subscribing iago to stream
Created private stream doesn't add to all stream list.

@rishig FYI

For issue #8230 
**Create public stream && not subscribed**
* For admin user or normal user after stream creation, they will be transferred to created stream page.

**Create private stream && not subscribed**
* Admin user will be transferred to created stream page, cause they can access the private stream, event if they are not subscribed
* Normal user can't access non subscribed private stream, so they will be not transferred to created stream page. But PR #8084  does cover the commit, which will notify current user in this kind of case whether stream is successfully created or not.