### PR TITLE
Document how to setup dev instance on cloud9

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -4,6 +4,7 @@ Contents:
 
 * [Installing directly on Ubuntu](#installing-directly-on-ubuntu)
 * [Installing manually on Linux](#installing-manually-on-linux)
+* [Installing directly on cloud9](#installing-directly-on-cloud9)
 * [Using Docker (experimental)](#using-docker-experimental)
 
 ## Installing directly on Ubuntu
@@ -372,6 +373,34 @@ proxy in the environment as follows:
  yarn config set proxy http://proxy_host:port
  yarn config set https-proxy http://proxy_host:port
  ```
+
+## Installing directly on cloud9
+This section documents how to setup zulip dev environment on cloud9 workspace.
+If you don't have a cloud9 account signup [here](https://aws.amazon.com/cloud9/)
+although new AWS cloud9 is not free. And the zulip dev env may work with zulip-cloud9 package.
+
+* Create a Workspace, and select the blank template.
+* Resize the workspace to be 1GB of memory and 4GB of disk space. (This is under free limit)
+* Clone the zulip repo `git clone --config pull.rebase https://github.com/<your-username>/zulip.git`
+* Restart rabbitmq-server since its broken on cloud9 `sudo service rabbitmq-server restart`.
+* And run provison `cd zulip && ./tools/provision`, once this is done.
+* Activate virtual environment by `source /srv/zulip-py3-venv/bin/activate` or by opening a new terminal.
+
+#### Install zulip-cloud9
+Note: `npm i -g zulip-cloud9` does not work in zulip's virtual enviorment.
+Although by default any package installed in workspace folder (i.e. the top level folder) are added to `$PATH`.
+
+```bash
+cd .. # switch to workspace folder if you are in zulip directory
+npm i zulip-cloud9
+zulip-dev start # to start the devlopment server
+```
+If you get error like `bash: cannot find command zulip-dev` start a new terminal.
+
+Your devlopment server would be running at `https://<workspace-name>-<username>.c9users.io` on port 8080.
+You dont need to add `:8080` to your url since cloud9 proxy don't require you to. You might want to visit
+[zulip-cloud9 repo](https://github.com/cPhost/zulip-cloud9) and it's
+[wiki](https://github.com/cPhost/zulip-cloud9/wiki) for more info on how to use zulip-cloud9 package.
 
 ## Using Docker (experimental)
 

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -375,6 +375,13 @@ proxy in the environment as follows:
  ```
 
 ## Installing directly on cloud9
+AWS Cloud9 is a cloud-based integrated development environment (IDE) that lets you write,
+run, and debug your code with just a browser. It includes a code editor, debugger, and terminal.
+Cloud9 comes prepackaged with essential tools for popular programming languages,
+including JavaScript, Python, PHP, and more, so you don’t need to install files or
+configure your development machine to start new projects. Since your Cloud9 IDE is cloud-based,
+you can work on your projects from your office, home, or anywhere using an internet-connected machine.
+
 This section documents how to setup zulip dev environment on cloud9 workspace.
 If you don't have a cloud9 account signup [here](https://aws.amazon.com/cloud9/)
 although new AWS cloud9 is not free. And the zulip dev env may work with zulip-cloud9 package.
@@ -383,7 +390,7 @@ although new AWS cloud9 is not free. And the zulip dev env may work with zulip-c
 * Resize the workspace to be 1GB of memory and 4GB of disk space. (This is under free limit)
 * Clone the zulip repo `git clone --config pull.rebase https://github.com/<your-username>/zulip.git`
 * Restart rabbitmq-server since its broken on cloud9 `sudo service rabbitmq-server restart`.
-* And run provison `cd zulip && ./tools/provision`, once this is done.
+* And run provision `cd zulip && ./tools/provision`, once this is done.
 * Activate virtual environment by `source /srv/zulip-py3-venv/bin/activate` or by opening a new terminal.
 
 #### Install zulip-cloud9
@@ -393,11 +400,11 @@ Although by default any package installed in workspace folder (i.e. the top leve
 ```bash
 cd .. # switch to workspace folder if you are in zulip directory
 npm i zulip-cloud9
-zulip-dev start # to start the devlopment server
+zulip-dev start # to start the development server
 ```
 If you get error like `bash: cannot find command zulip-dev` start a new terminal.
 
-Your devlopment server would be running at `https://<workspace-name>-<username>.c9users.io` on port 8080.
+Your development server would be running at `https://<workspace-name>-<username>.c9users.io` on port 8080.
 You dont need to add `:8080` to your url since cloud9 proxy don't require you to. You might want to visit
 [zulip-cloud9 repo](https://github.com/cPhost/zulip-cloud9) and it's
 [wiki](https://github.com/cPhost/zulip-cloud9/wiki) for more info on how to use zulip-cloud9 package.


### PR DESCRIPTION
Somebody could have zulip dev instance on cloud9 easily with the help of [zulip-cloud9](https://github.com/cPhost/zulip-cloud9) package. This could be helpful for people who currently use cloud9, unfortunately cloud9 no longer accepts signup and moved into aws which is bit tricky to setup and not free after 12 months.