### PR TITLE
Clean up user settings

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -525,6 +525,7 @@ function test_change_allow_subdomains(change_allow_subdomains) {
     settings_org.reset_realm_default_language();
     assert.equal($('#id_realm_default_language').val(), 'es');
 
+    page_params.is_admin = false;
     var name_toggled;
     $('.change_name_tooltip').toggle = function () {
         name_toggled = true;
@@ -550,6 +551,20 @@ function test_change_allow_subdomains(change_allow_subdomains) {
     settings_org.toggle_email_change_display();
     assert.equal($("#change_email .button").attr('disabled'), 'disabled');
     assert(email_tooltip_toggled);
+
+    // Test should't toggle name display or email display for org admins.
+    page_params.is_admin = true;
+    name_toggled = false;
+    $('#full_name').attr('disabled', false);
+    settings_org.toggle_name_change_display();
+    assert.equal($('#full_name').prop('disabled'), false);
+    assert(!name_toggled);
+
+    email_tooltip_toggled = false;
+    $('#change_email .button').attr('disabled', false);
+    settings_org.toggle_email_change_display();
+    assert.equal($("#change_email .button").attr('disabled'), false);
+    assert(!email_tooltip_toggled);
 
     page_params.realm_description = 'realm description';
     settings_org.update_realm_description();

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -104,7 +104,7 @@ exports.set_up = function () {
     $("#change_full_name").on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        if (!page_params.realm_name_changes_disabled) {
+        if (!page_params.realm_name_changes_disabled || page_params.is_admin) {
             overlays.open_modal('change_full_name_modal');
         }
     });
@@ -245,7 +245,7 @@ exports.set_up = function () {
     $('#change_email').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        if (!page_params.realm_email_changes_disabled) {
+        if (!page_params.realm_email_changes_disabled || page_params.is_admin) {
             overlays.open_modal('change_email_modal');
             var email = $('#email_value').text().trim();
             $('.email_change_container').find("input[name='email']").val(email);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -72,7 +72,9 @@ exports.reset_realm_default_language = function () {
 
 
 exports.toggle_name_change_display = function () {
-    if (!meta.loaded) {
+    // If user is an org admin, return. Cause org admin can change
+    // name or email even name changes or email changes are disabled in org.
+    if (!meta.loaded || page_params.is_admin) {
         return;
     }
 
@@ -85,7 +87,7 @@ exports.toggle_name_change_display = function () {
 };
 
 exports.toggle_email_change_display = function () {
-    if (!meta.loaded) {
+    if (!meta.loaded || page_params.is_admin) {
         return;
     }
 

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -6,14 +6,14 @@
                 <h3>{{t "User settings" }}</h3>
                 <div class="input-group user-name-section">
                     <label class="inline-block title">{{t "Email" }}</label>
-                    <a id="change_email" {{#unless page_params.realm_email_changes_disabled}}href="#change_email"{{/unless}}>
+                    <a id="change_email" {{#if page_params.is_admin}}href="#change_email"{{else}}{{#unless page_params.realm_email_changes_disabled}}href="#change_email"{{/unless}}{{/if}}>
                         <button type="button" class="button small rounded inline-block" id='email_value'
-                            {{#if page_params.realm_email_changes_disabled}} disabled="disabled" {{/if}}>
+                            {{#unless page_params.is_admin}}{{#if page_params.realm_email_changes_disabled}}disabled="disabled"{{/if}}{{/unless}}>
                             {{page_params.email}}
                             <i class="fa fa-pencil"></i>
                         </button>
                     </a>
-                    <i class="icon-vector-question-sign change_email_tooltip settings-info-icon" {{#unless page_params.realm_email_changes_disabled}}style="display:none" {{/unless}} data-toggle="tooltip"
+                    <i class="icon-vector-question-sign change_email_tooltip settings-info-icon" {{#if page_params.is_admin}}style="display:none"{{else}}{{#unless page_params.realm_email_changes_disabled}}style="display:none"{{/unless}}{{/if}}  data-toggle="tooltip"
                     title="{{t 'Changing email addresses has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"></i>
                 </div>
 
@@ -41,14 +41,14 @@
                 <div class="inline-block grid user-name-parent">
                     <div class="user-name-section inline-block">
                         <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
-                        <a id="change_full_name" {{#if page_params.realm_name_changes_disabled}}href="#change_name" {{/if}}>
-                            <button type="button" class="button small white rounded inline-block" id="full_name"{{#if page_params.realm_name_changes_disabled}} disabled="disabled"{{/if}}>
+                        <a id="change_full_name" {{#if page_params.is_admin}}href="#change_email"{{else}}{{#unless page_params.realm_name_changes_disabled}}href="#change_email"{{/unless}}{{/if}}>
+                            <button type="button" class="button small white rounded inline-block" id="full_name"{{#unless page_params.is_admin}}{{#if page_params.realm_name_changes_disabled}}disabled="disabled"{{/if}}{{/unless}}>
                                 <span id="full_name_value">{{page_params.full_name}}</span>
                                 <i class="fa fa-pencil"></i>
                             </button>
                         </a>
                         <i class="icon-vector-question-sign change_name_tooltip settings-info-icon" data-toggle="tooltip"
-                        {{#unless page_params.realm_name_changes_disabled}}style="display:none" {{/unless}}
+                        {{#if page_params.is_admin}}style="display:none"{{else}}{{#unless page_params.realm_name_changes_disabled}}style="display:none"{{/unless}}{{/if}}
                         title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
                     </div>
                     <div id="change_full_name_modal" class="modal modal-bg hide" tabindex="-1" role="dialog"

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -127,6 +127,12 @@ class EmailChangeTestCase(ZulipTestCase):
         self.assertEqual(result.status_code, 400)
         self.assert_in_response("Email address changes are disabled in this organization.",
                                 result)
+        # Realm admins can change their email address even setting is disabled.
+        data = {'email': 'iago-new@zulip.com'}
+        self.login(self.example_email("iago"))
+        url = '/json/settings'
+        result = self.client_patch(url, data)
+        self.assert_in_success_response(['Check your email for a confirmation link.'], result)
 
     def test_email_change_already_taken(self) -> None:
         data = {'email': 'cordelia@zulip.com'}

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -133,6 +133,12 @@ class RealmTest(ZulipTestCase):
         self.assertEqual(result.status_code, 200)
         # Since the setting fails silently, no message is returned
         self.assert_in_response("", result)
+        # Realm admins can change their name even setting is disabled.
+        data = {'full_name': 'New Iago'}
+        self.login(self.example_email("iago"))
+        url = '/json/settings'
+        result = self.client_patch(url, data)
+        self.assert_in_success_response(['"full_name":"New Iago"'], result)
 
     def test_do_deactivate_realm_clears_user_realm_cache(self) -> None:
         """The main complicated thing about deactivating realm names is

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -37,7 +37,7 @@ def confirm_email_change(request: HttpRequest, confirmation_key: str) -> HttpRes
     old_email = email_change_object.old_email
     user_profile = email_change_object.user_profile
 
-    if user_profile.realm.email_changes_disabled:
+    if user_profile.realm.email_changes_disabled and not user_profile.is_realm_admin:
         raise JsonableError(_("Email address changes are disabled in this organization."))
     do_change_user_email(user_profile, new_email)
 
@@ -100,7 +100,7 @@ def json_change_settings(request: HttpRequest, user_profile: UserProfile,
     result = {}  # type: Dict[str, Any]
     new_email = email.strip()
     if user_profile.email != email and new_email != '':
-        if user_profile.realm.email_changes_disabled:
+        if user_profile.realm.email_changes_disabled and not user_profile.is_realm_admin:
             return json_error(_("Email address changes are disabled in this organization."))
         error, skipped = validate_email(user_profile, new_email)
         if error:
@@ -112,7 +112,7 @@ def json_change_settings(request: HttpRequest, user_profile: UserProfile,
         result['account_email'] = _("Check your email for a confirmation link. ")
 
     if user_profile.full_name != full_name and full_name.strip() != "":
-        if name_changes_disabled(user_profile.realm):
+        if name_changes_disabled(user_profile.realm) and not user_profile.is_realm_admin:
             # Failingly silently is fine -- they can't do it through the UI, so
             # they'd have to be trying to break the rules.
             pass


### PR DESCRIPTION
settings: Allow admin to change email/name even not allowed in realm.
    
    Allow realm admin users to change their email or name even,
    changing name or email is disabled in realm.

This will allow realm admin user to change their name or email even if `realm_name_changes_disabled` is `True` or `realm_email_changes_disabled` is `True`.

settings: Restrict opening full name and email change overlay modal.
    
    Set condition before opening full name and email change overlay modal,
    to check whether changing full name or email is allowed in realm.

settings: Remove data-dismiss property of submit-btn in password modal.
    
    In password modal, submit button's data-dismiss property should be
    removed, as on data-dismiss we flush all data of form fields,
    which results in passing empty string to json request.
    
    We already flush all data of fields after compeletion of request.