### PR TITLE
Add copy-to-clipboard button in popovers

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -34,6 +34,23 @@ var list_of_popovers = [];
     }
 }($.fn.popover));
 
+function init_email_clipboard() {
+  var copy_email_clipboard = new Clipboard($('.copy_email')[0]);
+  var copy_email_span = $('.copy_email span');
+
+  copy_email_clipboard.on('success', function (e) {
+      copy_email_span.text(i18n.t('Email copied'));
+      setTimeout(function () {
+        copy_email_span.text(i18n.t("Copy user's email"));
+      }, 3000);
+      e.clearSelection();
+  });
+
+  copy_email_clipboard.on('error', function () {
+      copy_email_span.text(i18n.t('Failed to copy email!'));
+  });
+}
+
 function load_medium_avatar(user, elt) {
     var user_avatar_url = "avatar/" + user.user_id + "/medium";
     var sender_avatar_medium = new Image();
@@ -126,6 +143,7 @@ function show_user_info_popover(element, user, message) {
             trigger: "manual",
         });
         elt.popover("show");
+        init_email_clipboard();
 
         load_medium_avatar(user, $(".popover-avatar"));
 
@@ -204,6 +222,7 @@ exports.toggle_actions_popover = function (element, id) {
             trigger:   "manual",
         });
         elt.popover("show");
+        init_email_clipboard();
         current_actions_popover_elem = elt;
     }
 };
@@ -267,6 +286,7 @@ exports.render_actions_remind_popover = function (element, id) {
             trigger:   "manual",
         });
         elt.popover("show");
+        init_email_clipboard();
         current_flatpickr_instance = $('.remind.custom[data-message-id="'+message.id+'"]').flatpickr({
             enableTime: true,
             clickOpens: false,
@@ -559,6 +579,7 @@ exports.register_click_handlers = function () {
             placement: userlist_placement === "left" ? "right" : "left",
         });
         target.popover("show");
+        init_email_clipboard();
 
         load_medium_avatar(user, $(".popover-avatar"));
 
@@ -767,7 +788,6 @@ exports.register_click_handlers = function () {
             last_scroll = date;
         });
     }());
-
 };
 
 exports.any_active = function () {

--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -159,7 +159,7 @@ body.dark-mode .popover {
 }
 
 body.dark-mode .dropdown-menu a {
-  color: inherit;
+    color: inherit;
 }
 
 body.dark-mode .dropdown .dropdown-menu li.divider,
@@ -228,7 +228,8 @@ body.dark-mode #settings_page .sidebar .tab-container,
 body.dark-mode .table-striped tbody tr:nth-child(odd) td,
 body.dark-mode .table-striped tbody tr:nth-child(odd) th,
 body.dark-mode .modal-footer,
-body.dark-mode .modal-bg .modal-header {
+body.dark-mode .modal-bg .modal-header,
+body.dark-mode .copy_email:hover {
     border-color: hsla(0, 0%, 0%, 0.2);
     background-color: hsla(0, 0%, 0%, 0.2);
 }
@@ -265,7 +266,8 @@ body.dark-mode .draft-row .message_header_private_message .message_label_clickab
 }
 
 body.dark-mode .nav-list > li > a,
-body.dark-mode .nav-list .nav-header {
+body.dark-mode .nav-list .nav-header,
+body.dark-mode .nav-list > li > .copy_email {
     text-shadow: none;
 }
 
@@ -376,6 +378,10 @@ body.dark-mode .empty-star:hover {
 
 body.dark-mode #out-of-view-notification {
     border: 1px solid 1px solid hsl(144, 45%, 62%);
+}
+
+body.dark-mode .copy_email {
+    color: inherit;
 }
 
 @-moz-document url-prefix() {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2679,3 +2679,20 @@ button.topic_edit_cancel {
     visibility: visible;
     opacity: 1;
 }
+
+.copy_email {
+    color: #3188cc;
+    cursor: pointer;
+    padding: 3px 0;
+    padding: 3px 15px;
+    margin-left: -15px;
+    margin-right: -15px;
+}
+
+.copy_email:hover {
+    background-color: #f1f1f1;
+}
+
+.fake_email_input {
+    display: none;
+}

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -28,6 +28,12 @@
         {{/if}}
     </div>
     <hr />
+    <li>
+        <div class="copy_email" data-clipboard-action="copy" data-clipboard-text="{{ user_email }}">
+            <i class="fa fa-clone" aria-hidden="true"></i>
+            <span>{{#tr this}}Copy user's email{{/tr}}</span>
+        </div>
+    </li>
     {{#if is_active }}
     <li>
         <a href="#" class="{{ private_message_class }}">


### PR DESCRIPTION
This makes it easy to copy emails.
![copy_email](https://user-images.githubusercontent.com/23620441/35756644-110d46ce-083a-11e8-8760-d01741c0b8e3.gif)
When coverting from .mov to gif the resolution got messed up  ^^^

Fixes: https://github.com/zulip/zulip/issues/8247