### PR TITLE
Auto-numbered lists in messages: add documentation and ignore code blocks

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -497,3 +497,46 @@ run_test('katex_throws_unexpected_exceptions', () => {
     assert(blueslip.get_test_logs('error').length, 1);
     blueslip.clear_test_data();
 });
+
+run_test('auto_renumber_lists', () => {
+    var test_cases = [{
+        input: [
+            { type: 'paragraph', text: '1. A\n1. B' },
+            { type: 'blockquote_start' },
+            { type: 'paragraph', text: '1. A\n1. B' },
+            { type: 'blockquote_end' },
+            { type: 'paragraph', text: '1. A\n1. B' },
+        ],
+        expected: [
+            { type: 'paragraph', text: '1. A\n2. B' },
+            { type: 'blockquote_start' },
+            { type: 'paragraph', text: '1. A\n1. B' },
+            { type: 'blockquote_end' },
+            { type: 'paragraph', text: '1. A\n2. B' },
+        ],
+    }, {
+        input: [
+            { type: 'blockquote_start' },
+            { type: 'blockquote_start' },
+            { type: 'paragraph', text: 'A' },
+            { type: 'blockquote_end' },
+            { type: 'paragraph', text: '1. A\n1. B' },
+            { type: 'blockquote_end' },
+            { type: 'paragraph', text: '1. A\n1. B' },
+        ],
+        expected: [
+            { type: 'blockquote_start' },
+            { type: 'blockquote_start' },
+            { type: 'paragraph', text: 'A' },
+            { type: 'blockquote_end' },
+            { type: 'paragraph', text: '1. A\n1. B' },
+            { type: 'blockquote_end' },
+            { type: 'paragraph', text: '1. A\n2. B' },
+        ],
+    }];
+
+    test_cases.forEach(function (test_case) {
+        marked.autoRenumberLists(test_case.input);
+        assert.deepEqual(test_case.input, test_case.expected);
+    });
+});

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -264,65 +264,6 @@ exports.set_realm_filters = function (realm_filters) {
     marked.InlineLexer.rules.zulip.realm_filters = marked_rules;
 };
 
-var preprocess_auto_olists = (function () {
-    var TAB_LENGTH = 2;
-    var re = /^( *)(\d+)\. +(.*)/;
-
-    function getIndent(match) {
-        return Math.floor(match[1].length / TAB_LENGTH);
-    }
-
-    function extendArray(arr, arr2) {
-        Array.prototype.push.apply(arr, arr2);
-    }
-
-    function renumber(mlist) {
-        if (!mlist.length) {
-            return [];
-        }
-
-        var startNumber = parseInt(mlist[0][2], 10);
-        var changeNumbers = _.every(mlist, function (m) {
-            return startNumber === parseInt(m[2], 10);
-        });
-
-        var counter = startNumber;
-        return _.map(mlist, function (m) {
-            var number = changeNumbers ? counter.toString() : m[2];
-            counter += 1;
-            return m[1] + number + '. ' + m[3];
-        });
-    }
-
-    return function (src) {
-        var newLines = [];
-        var currentList = [];
-        var currentIndent = 0;
-
-        _.each(src.split('\n'), function (line) {
-            var m = line.match(re);
-            var isNextItem = m && currentList.length && currentIndent === getIndent(m);
-            if (!isNextItem) {
-                extendArray(newLines, renumber(currentList));
-                currentList = [];
-            }
-
-            if (!m) {
-                newLines.push(line);
-            } else if (isNextItem) {
-                currentList.push(m);
-            } else {
-                currentList = [m];
-                currentIndent = getIndent(m);
-            }
-        });
-
-        extendArray(newLines, renumber(currentList));
-
-        return newLines.join('\n');
-    };
-}());
-
 exports.initialize = function () {
 
     function disable_markdown_regex(rules, name) {
@@ -419,7 +360,6 @@ exports.initialize = function () {
         renderer: r,
         preprocessors: [
             preprocess_code_blocks,
-            preprocess_auto_olists,
             preprocess_translate_emoticons,
         ],
     });

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -268,6 +268,50 @@
       "text_content": "1. A\n3. B\n 2. C\n1. D"
     },
     {
+      "name": "auto_renumbered_list_paragraphs",
+      "input": "1. A\n1. B\n\n1. A\n1. B",
+      "expected_output": "<p>1. A<br>\n2. B</p>\n<p>3. A<br>\n4. B</p>",
+      "text_content": "1. A\n2. B\n3. A\n4. B"
+    },
+    {
+      "name": "auto_renumbered_list_separate",
+      "input": "1. A\n1. B\nC\n1. A\n1. B",
+      "expected_output": "<p>1. A<br>\n2. B<br>\nC<br>\n1. A<br>\n2. B</p>",
+      "text_content": "1. A\n2. B\nC\n1. A\n2. B"
+    },
+    {
+      "name": "auto_renumbered_list_code",
+      "input": "1. A\n1. B\n\n```\n1. A\n1. B\n```\n\n1. A\n1. B",
+      "expected_output": "<p>1. A<br>\n2. B</p>\n<div class=\"codehilite\"><pre><span></span>1. A\n1. B\n</pre></div>\n\n\n<p>1. A<br>\n2. B</p>",
+      "text_content": "1. A\n2. B\n1. A\n1. B\n\n\n\n1. A\n2. B"
+    },
+    {
+      "name": "auto_renumbered_list_blockquote",
+      "input": "1. A\n1. B\n\n> 1. A\n> 1. B\n\n1. A\n1. B",
+      "expected_output": "<p>1. A<br>\n2. B</p>\n<blockquote>\n<p>1. A<br>\n1. B</p>\n</blockquote>\n<p>1. A<br>\n2. B</p>",
+      "text_content": "1. A\n2. B\n> 1. A\n> 1. B\n\n1. A\n2. B"
+    },
+    {
+      "name": "auto_renumbered_list_nested_blockquote",
+      "input": "> > A\n>\n> 1. A\n> 1. B\n\n1. A\n1. B",
+      "expected_output": "<blockquote>\n<blockquote>\n<p>A</p>\n</blockquote>\n<p>1. A<br>\n1. B</p>\n</blockquote>\n<p>1. A<br>\n2. B</p>",
+      "text_content": "> > A\n> 1. A\n> 1. B\n\n1. A\n2. B"
+    },
+    {
+      "name": "auto_renumbered_list_inside_ulist",
+      "input": "* 1. A\n  1. B",
+      "expected_output": "<ul>\n<li>1. A<p>2. B</p>\n</li>\n</ul>",
+      "marked_expected_output": "<ul>\n<li>1. A<br>\n2. B</li>\n</ul>",
+      "text_content": "\n1. A2. B\n\n"
+    },
+    {
+      "name": "auto_renumbered_list_inside_ulist_separate",
+      "input": "* 1. A\n  1. B\n\n  1. C\n1. D",
+      "expected_output": "<ul>\n<li>\n<p>1. A</p>\n<p>2. B</p>\n<p>3. C<br>\n4. D</p>\n</li>\n</ul>",
+      "marked_expected_output": "<ul>\n<li><p>1. A<br>\n2. B</p>\n<p>3. C<br>\n4. D</p>\n</li>\n</ul>",
+      "text_content": "\n\n1. A\n2. B\n3. C\n4. D\n\n"
+    },
+    {
       "name": "linkify_interference",
       "input": "link: xx, x xxxxx xx xxxx xx\n\n[xxxxx #xx](http://xxxxxxxxx:xxxx/xxx/xxxxxx%xxxxxx/xx/):**xxxxxxx**\n\nxxxxxxx xxxxx xxxx xxxxx:\n`xxxxxx`: xxxxxxx\n`xxxxxx`: xxxxx\n`xxxxxx`: xxxxx xxxxx",
       "expected_output": "<p>link: xx, x xxxxx xx xxxx xx</p>\n<p><a href=\"http://xxxxxxxxx:xxxx/xxx/xxxxxx%xxxxxx/xx/\" target=\"_blank\" title=\"http://xxxxxxxxx:xxxx/xxx/xxxxxx%xxxxxx/xx/\">xxxxx #xx</a>:<strong>xxxxxxx</strong></p>\n<p>xxxxxxx xxxxx xxxx xxxxx:<br>\n<code>xxxxxx</code>: xxxxxxx<br>\n<code>xxxxxx</code>: xxxxx<br>\n<code>xxxxxx</code>: xxxxx xxxxx</p>",


### PR DESCRIPTION
~~Uses a way of checking if a line is inside a code block similar to the preprocessor that handles hanging lists (bulleted lists directly after a paragraph with no blank line between them), so those that are don't get changed.~~

(edit): Renumbering is moved to paragraph blockprocessor (Bugdown) and after block-level lexer (marked.js) so that it runs only on paragraphs. This also means processed text doesn't have indentation, so iterating over lines is simplified.

Adds a mention of the feature and a screenshot in user docs and an example in the "Message formating" help window.

Fixes #8246 