### PR TITLE
Clean active user setting in org setting

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -739,6 +739,7 @@ $(function () {
         $settings_overlay_container.find(".settings-header.mobile").addClass("slide-left");
 
         settings.set_settings_header($(this).attr("data-section"));
+        $("#organization-status").hide();
     });
 
     $(".settings-header.mobile .icon-vector-chevron-left").on("click", function () {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -436,8 +436,8 @@ exports.on_load_success = function (realm_people_data) {
                 success: function () {
                     ui_report.success(i18n.t('Updated successfully!'), admin_status);
                 },
-                error: function () {
-                    ui_report.error(i18n.t('Failed'), admin_status);
+                error: function (xhr) {
+                    ui_report.error(i18n.t('Failed'), xhr, admin_status);
                 },
             });
         });

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -404,7 +404,8 @@ exports.on_load_success = function (realm_people_data) {
             form_row.find(".edit_bot_owner_container").append(owner_select);
         }
 
-        // Show user form.
+        // Show user form and set the full name value in input field.
+        full_name.val(person.full_name);
         user_row.hide();
         form_row.show();
 

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -251,13 +251,10 @@ exports.on_load_success = function (realm_people_data) {
         channel.del({
             url: '/json/users/' + encodeURIComponent(email),
             error: function (xhr) {
-                if (xhr.status.toString().charAt(0) === "4") {
-                    meta.current_deactivate_user_modal_row.find("button").closest("td").html(
-                        $("<p>").addClass("text-error").text(JSON.parse(xhr.responseText).msg)
-                    );
-                } else {
-                    meta.current_deactivate_user_modal_row.find("button").text(i18n.t("Failed!"));
-                }
+                var status = $("#organization-status").expectOne();
+                ui_report.error(i18n.t("Failed"), xhr, status);
+                var button = meta.current_deactivate_user_modal_row.find("button.deactivate");
+                button.text(i18n.t("Deactivate"));
             },
             success: function () {
                 var button = meta.current_deactivate_user_modal_row.find("button.deactivate");
@@ -347,7 +344,7 @@ exports.on_load_success = function (realm_people_data) {
                 button.text(i18n.t("Remove admin"));
             },
             error: function (xhr) {
-                var status = row.find(".admin-user-status");
+                var status = $("#organization-status").expectOne();
                 ui_report.error(i18n.t("Failed"), xhr, status);
             },
         });
@@ -378,7 +375,7 @@ exports.on_load_success = function (realm_people_data) {
                 button.text(i18n.t("Make admin"));
             },
             error: function (xhr) {
-                var status = row.find(".admin-user-status");
+                var status = $("#organization-status").expectOne();
                 ui_report.error(i18n.t("Failed"), xhr, status);
             },
         });

--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -65,7 +65,7 @@
             </div>
             {{/if}}
             <div class="input-group">
-                <button type="button" class="button rounded sea-green submit_name_changes">
+                <button type="submit" class="button rounded sea-green submit_name_changes">
                     {{t 'Save changes' }}
                 </button>
                 <button type="button" class="button rounded btn-danger reset_edit_user">{{t 'Cancel' }}</button>


### PR DESCRIPTION
**org settings: Fix bug in edit user-name-form in active user setting.**
    
    In active user settings, when user click on user-name-form to edit
    user's full name, we don't set any default value for full-name
    input field, which results in garbage or falsy value in input field.
    
    Set true value of selected user's full name in input field by default
    in user-name-form.

To reproduce this issue: 
- click on edit-btn to edit user
- change full name
- click on Cancel
- again click on edit-btn, it will display old value rather than correct value of full name

**org settings: Fix bug of reloading page on Enter in active user setting.**
    
    In active user section, while editing user's full name,
    if we press enter it reloads the whole page, rather than
    submitting the form.
    Change button type of user-name-form to submit.

To reproduce this issue: 
- click on edit-btn to edit user
- change full name
- Press **Enter** key

**org settings: Clear alert messages when user click on other setting tab.**
    
    Currently, if user get an error message in one setting tab of
    organization setting and go to other tab of organization setting,
    previous error message still shows up on top of setting page.
    Cause organization-settings div element, which is used for error
    reporting, is common to all settings tab in org settings section.
    
    So hide this error element when user click to other section/tab of org
    settings, cause we don't want to display alert messages of previous
    setting tab.

**org settings: Display error message on top of active user setting page.**
    
    Currently, an error message on active user setting is showing at
    the row of edited user profile in user-profiles-list-table.
    Instead, show error message on top of setting page.

Before:
![errormessage](https://user-images.githubusercontent.com/25907420/35774527-2370334e-0998-11e8-88d7-37f75949d03a.png)

![errormessagesecond](https://user-images.githubusercontent.com/25907420/35774536-5265ddfc-0998-11e8-95e0-0d8186431c98.png)

After:
![activeuserpage](https://user-images.githubusercontent.com/25907420/36473077-84570e24-1719-11e8-977d-0961122b9082.png)

**org settings: Fix bug in error reporting on active users setting.**
    
    In active users setting, an errors occurred on editing user
    profiles, are not reported correctly because there is missing
    argument in call of ui_report.error() function.
    Fix the issue by passing proper arguments in ui_report.error()
    function call.

To reproduce this issue: 
- click on edit-btn to edit user
- change full name with special character
- click on save-btn