### PR TITLE
Search suggestions for @'username' mentions

### DIFF
--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -25,6 +25,7 @@ set_global('recent_senders', {
 set_global('page_params', {
     realm_allow_message_editing: true,
     is_admin: true,
+    user_id : 101,
 });
 
 set_global('blueslip', {});
@@ -254,5 +255,29 @@ global.people.initialize_current_user(me.user_id);
         assert.equal(msg_id.old, 401);
         assert.equal(msg_id.new, 402);
     });
+
+}());
+
+(function test_is_user_mentioned() {
+    var message = {
+        sender_id: me.user_id,
+        content:"<p><span class=\"user-mention\" data-user-email=\"bob@example.com\" data-user-id=\"103\">@Bob</span>  is mentioned.</p>",
+    };
+    var check_case_one = message_store.is_user_mentioned(message,bob);
+    assert.equal(check_case_one,true);
+
+    var message_two = {
+        sender_id:1000,
+    };
+
+    var check_case_two = message_store.is_user_mentioned(message_two,bob);
+    assert.equal(check_case_two,false);
+
+    var message_three = {
+        sender_id:101,
+        content:"abcdefg",
+    };
+    var check_case_three = message_store.is_user_mentioned(message_three,alice);
+    assert.equal(check_case_three,false);
 
 }());

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -220,6 +220,28 @@ exports.reify_message_id = function (opts) {
     });
 };
 
+exports.is_user_mentioned = function is_user_mentioned(message,user) {
+
+    if (message.sender_id !== page_params.user_id) {
+        return false;
+    }
+
+    var regExp = /data\-user\-id\=\"([0-9]+)\"/ig;
+    var matches = message.content.match(regExp);
+
+    if (matches === null || matches.length === 0) {
+    return false;
+    }
+    for (var i = 0; i < matches.length; i+=1) {
+    var str = matches[i];
+    matches[i] = parseInt(str.substring(14 , str.length -1),10);
+
+    if (matches.includes(user.user_id)) {
+        return true;
+    }
+    }
+};
+
 return exports;
 
 }());

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -631,6 +631,20 @@ exports.by_conversation_and_time_uri = function (message, is_absolute_url) {
         "/near/" + hash_util.encodeHashComponent(message.id);
 };
 
+exports.by_operator_conversation_and_time_uri = function (message) {
+
+    var absolute_url = "";
+    if (message.type === "stream") {
+        return absolute_url + "stream:" +
+            hash_util.encodeHashComponent(message.stream) + " " +
+            "subject:" + hash_util.encodeHashComponent(message.subject) + " " +
+            "near:" + hash_util.encodeHashComponent(message.id);
+    }
+
+    return absolute_url + "pm-with:" +
+        message.reply_to + " near:" + hash_util.encodeHashComponent(message.id);
+};
+
 return exports;
 
 }());


### PR DESCRIPTION
Fixes the Issue #6902 . 

a quick video of this feature in working is given here: [updated_search.mp4](https://drive.google.com/open?id=1jkEaegWoNJ-44pR-MYEGnsSB0G74vqjN)

There are some extra suggestions provided when you start searching with '@' which are suggested out of currently narrowed messages. The suggestions then take you to that particular suggested message. The problem of message having @<username> styling has also been taken care of and @** My_UserName ** is simply displayed as "@My_UserName " in suggestion description as can be seen in above video.

As displayed above the rendered mentioned message suggestions include :
- Date when conversation took place
- a small description of message string (26 characters long as of now)
- and the mentioned user name and email id.

The current_msg_list is filtered using the ids only to check if user is present.The ids here include sender_id, message_id and the to_be_checked_user_id and if message's data-user-id[] includes the to_be_checked_user_id and sender_id is equal to user_id , the message is suggested.

There a couple of adjustments required.:

- As of now this method is unable to search when you are narrowed to a private-message with a particular user.
- Also this search fails as of now when mentioned user is searched in a particular topic messages of a stream.



