### PR TITLE
marketing: Update integration count.

### DIFF
--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -276,7 +276,7 @@
                     <p>
                         Zulip has everything you want in group
                         chat. Apps for the iPhone, Android and
-                        desktop.  More than 60 integrations (GitHub,
+                        desktop.  More than 80 integrations (GitHub,
                         Jira, Stripe, Zendesk, etc.). Keyboard
                         shortcuts. Emoji reactions.  Translated into a
                         dozen languages.

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -25,7 +25,7 @@
                 <div id="integration-main-text">
                     <header>
                         <h1 class="portico-page-heading">
-                            {% trans %}Over 60 native integrations.{% endtrans %}
+                            {% trans %}Over {{integrations_count_display}} native integrations.{% endtrans %}
                         </h1>
                     </header>
                     <h2 class="portico-page-subheading">

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -101,7 +101,7 @@ class DocPageTest(ZulipTestCase):
     @slow("Tests dozens of endpoints, including all our integrations docs")
     def test_integration_doc_endpoints(self) -> None:
         self._test('/integrations/',
-                   'Over 60 native integrations.',
+                   'Over 80 native integrations.',
                    extra_strings=[
                        'And hundreds more through',
                        'Hubot',
@@ -122,7 +122,7 @@ class DocPageTest(ZulipTestCase):
             self.assertNotIn('support+abcdefg@testserver', str(result.content))
             # if EMAIL_GATEWAY_PATTERN is empty, the main /integrations page should
             # be rendered instead
-            self._test('/integrations/', 'Over 60 native integrations.')
+            self._test('/integrations/', 'Over 80 native integrations.')
 
 
 class IntegrationTest(TestCase):

--- a/zerver/views/integrations.py
+++ b/zerver/views/integrations.py
@@ -93,8 +93,13 @@ class MarkdownDirectoryView(ApiURLView):
 def add_integrations_context(context: Dict[str, Any]) -> None:
     alphabetical_sorted_categories = OrderedDict(sorted(CATEGORIES.items()))
     alphabetical_sorted_integration = OrderedDict(sorted(INTEGRATIONS.items()))
+    enabled_integrations_count = len(list(filter(lambda v: v.is_enabled(), INTEGRATIONS.values())))
+    # Subtract 1 so saying "Over X integrations" is correct. Then,
+    # round down to the nearest multiple of 10.
+    integrations_count_display = ((enabled_integrations_count - 1) // 10) * 10
     context['categories_dict'] = alphabetical_sorted_categories
     context['integrations_dict'] = alphabetical_sorted_integration
+    context['integrations_count_display'] = integrations_count_display
 
     if "html_settings_links" in context and context["html_settings_links"]:
         settings_html = '<a href="../../#settings">Zulip settings page</a>'


### PR DESCRIPTION
https://zulip.com/integrations currently counts 91 integrations. This includes publicly featured bots in https://zulip.com/integrations/bots.