### PR TITLE
Efficiently clear typeahead when renaming a bot.

### DIFF
--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -399,7 +399,7 @@ _.each(matches, function (person) {
     assert(rendered);
 }());
 
-(function test_clear_rendered_persons() {
+(function test_clear_rendered_person() {
     var rendered = false;
     global.templates.render = function (template_name, args) {
         assert.equal(template_name, 'typeahead_list_item');
@@ -419,7 +419,7 @@ _.each(matches, function (person) {
     assert.equal(rendered, false);
 
     // Here rendered will be true as it is being rendered again.
-    th.clear_rendered_persons();
+    th.clear_rendered_person(matches[5].user_id);
     assert.equal(th.render_person(matches[5]), 'typeahead-item-stub');
     assert(rendered);
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -295,6 +295,7 @@ exports.set_up = function () {
         $("#settings_page .edit_bot .edit_bot_name").val(old_full_name);
         $("#settings_page .edit_bot .select-form").text("").append(owner_select);
         $("#settings_page .edit_bot .edit-bot-owner select").val(old_owner);
+        $("#settings_page .edit_bot_form").attr("data-bot_id", bot_id);
         $("#settings_page .edit_bot_form").attr("data-email", bot_email);
         $("#settings_page .edit_bot_form").attr("data-type", bot_type);
         $(".edit_bot_email").text(bot_email);
@@ -332,6 +333,7 @@ exports.set_up = function () {
                 errors.hide();
             },
             submitHandler: function () {
+                var bot_id = form.attr('data-bot_id');
                 var email = form.attr('data-email');
                 var type = form.attr('data-type');
                 var full_name = form.find('.edit_bot_name').val();
@@ -366,7 +368,7 @@ exports.set_up = function () {
                         edit_button.show();
                         show_row_again();
                         avatar_widget.clear();
-                        typeahead_helper.clear_rendered_persons();
+                        typeahead_helper.clear_rendered_person(bot_id);
 
                         bot_info.find('.name').text(full_name);
                         if (data.avatar_url) {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -94,8 +94,8 @@ exports.render_person = function (person) {
     return html;
 };
 
-exports.clear_rendered_persons = function () {
-    rendered.persons.clear();
+exports.clear_rendered_person = function (user_id) {
+    rendered.persons.del(user_id);
 };
 
 exports.render_user_group = function (user_group) {


### PR DESCRIPTION
This amends 1df3e04.