### PR TITLE
settings: Change wordings of a few notification settings.

### DIFF
--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -139,7 +139,7 @@
 
         <div id="other_notifications">
 
-            <h3>{{t "Other notifications I want:" }}</h3>
+            <h3>{{t "Other notification settings" }}</h3>
 
             <div class="input-group no-margin" id="digest_container">
                 <label class="checkbox">
@@ -150,7 +150,7 @@
                     <span></span>
                 </label>
                 <label for="enable_digest_emails" class="inline-block">
-                    {{t "Digest emails when I'm away" }}
+                    {{t "Send digest emails when I'm away" }}
                 </label>
             </div>
 


### PR DESCRIPTION
The last bit of #8059 (merged as b875fe07) didn't get merged, so just adding
it as a followup.

The "Other notification settings" section will also eventually house the
"pick your notification sound" setting, which is why it isn't called "Other
email settings" or similar.