### PR TITLE
queue: Remove missedmessage_email_senders code.

### DIFF
--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -46,7 +46,6 @@ class zulip::base {
              'error_reports',
              'feedback_messages',
              'invites',
-             'missedmessage_email_senders',
              'email_senders',
              'missedmessage_emails',
              'missedmessage_mobile_notifications',

--- a/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
+++ b/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
@@ -548,15 +548,6 @@ define service {
 
 define service {
         use                             generic-service
-        service_description             Check missedmessage_email_senders queue processor
-        check_command                   check_remote_arg_string!manage.py process_queue --queue_name=missedmessage_email_senders!1:1!1:1
-        max_check_attempts              3
-        hostgroup_name                  frontends
-        contact_groups                  admins
-}
-
-define service {
-        use                             generic-service
         service_description             Check email_senders queue processor
         check_command                   check_remote_arg_string!manage.py process_queue --queue_name=email_senders!1:1!1:1
         max_check_attempts              3

--- a/scripts/nagios/check-rabbitmq-consumers
+++ b/scripts/nagios/check-rabbitmq-consumers
@@ -50,7 +50,6 @@ queues = {
     'invites',
     'message_sender',
     'missedmessage_emails',
-    'missedmessage_email_senders',
     'email_senders',
     'missedmessage_mobile_notifications',
     'outgoing_webhooks',

--- a/tools/test-queue-worker-reload
+++ b/tools/test-queue-worker-reload
@@ -17,7 +17,7 @@ from typing import IO, Text
 # TODO: Convert this to use scripts/lib/queue_workers.py
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 successful_worker_launches = [
-    '[process_queue] 20 queue worker threads were launched',
+    '[process_queue] 19 queue worker threads were launched',
 ]
 
 def check_worker_launch(logfile_name):

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -308,19 +308,6 @@ class EmailSendingWorker(QueueProcessingWorker):
             del copied_event['failed_tries']
         send_email_from_dict(copied_event)
 
-@assign_queue('missedmessage_email_senders')
-class MissedMessageSendingWorker(EmailSendingWorker):
-    """
-    Note: Class decorators are not inherited.
-
-    The `missedmessage_email_senders` queue was used up through 1.7.1, so we
-    keep consuming from it in case we've just upgraded from an old version.
-    After the 1.8 release, we can delete it and tell admins to upgrade to 1.8
-    first.
-    """
-    # TODO: zulip-1.8: Delete code related to missedmessage_email_senders queue.
-    pass
-
 @assign_queue('missedmessage_mobile_notifications')
 class PushNotificationsWorker(QueueProcessingWorker):
     def consume(self, data):


### PR DESCRIPTION
@timabbott, after 68513952fbb4, all emails are sent through email_senders queue.
This commit removes code related to the legacy queue.