### PR TITLE
test-queue-worker-reload: Increase delay to 1.3s.

### DIFF
--- a/tools/test-queue-worker-reload
+++ b/tools/test-queue-worker-reload
@@ -70,16 +70,17 @@ if __name__ == '__main__':
         logfile.close()
         sys.exit(1)
 
-    # The autoreload code of Django works by looping over the files associated
-    # with all the loaded modules. This loop is run after every 1 second. If
-    # the file is found for the first time by the loop, it is assumed that the
+    # In dev. environment, queues are run through Django's autoreload code. The
+    # autoreload code of Django works by looping over the files associated with
+    # all the loaded modules. This loop is run after every 1 second. If the
+    # file is found for the first time by the loop, it is assumed that the
     # file is new and is not modified between the time it is loaded and is
     # checked by the loop. This assumption is the source of a race condition.
 
     # We can either implement a more sensitive version of the loop or we can
     # just allow enough time to the Django loop to touch every file at least
     # once.
-    time.sleep(1.1)
+    time.sleep(1.3)
     # Removing all data from the server log file.
     logfile.truncate(0)
     logfile.seek(0)


### PR DESCRIPTION
@timabbott,  see 625939 for more information. In short, the purpose of this delay is to give autoreload code enough time to touch every watched file at least once before the change is made.