### PR TITLE
Slack importer: Fix user mappings.

### DIFF
--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -142,7 +142,7 @@ def users_to_zerver_userprofile(slack_data_dir: str, realm_id: int, timestamp: A
 
         userprofile = dict(
             enable_desktop_notifications=DESKTOP_NOTIFICATION,
-            is_staff=user.get('is_admin', False),
+            is_staff=False,  # 'staff' is for server administrators, which does't exist in Slack.
             avatar_source=avatar_source,
             is_bot=user.get('is_bot', False),
             avatar_version=1,

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -133,6 +133,9 @@ def users_to_zerver_userprofile(slack_data_dir: str, realm_id: int, timestamp: A
         # email
         email = get_user_email(user, domain_name)
 
+        # check if user is the admin
+        realm_admin = get_admin(user)
+
         # avatar
         # ref: https://chat.zulip.org/help/change-your-avatar
         avatar_source = get_user_avatar_source(profile['image_32'])
@@ -154,7 +157,7 @@ def users_to_zerver_userprofile(slack_data_dir: str, realm_id: int, timestamp: A
             is_mirror_dummy=False,
             pointer=-1,
             default_events_register_stream=None,
-            is_realm_admin=user.get('is_owner', False),
+            is_realm_admin=realm_admin,
             # invites_granted=0,  # TODO
             enter_sends=True,
             bot_type=1 if user.get('is_bot', False) else None,
@@ -210,6 +213,15 @@ def get_user_email(user: ZerverFieldsT, domain_name: str) -> str:
     else:
         email = user['profile']['email']
     return email
+
+def get_admin(user: ZerverFieldsT) -> bool:
+    admin = user.get('is_admin', False)
+    owner = user.get('is_owner', False)
+    primary_owner = user.get('is_primary_owner', False)
+
+    if admin or owner or primary_owner:
+        return True
+    return False
 
 def get_user_avatar_source(image_url: str) -> str:
     if 'gravatar.com' in image_url:

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -6,6 +6,7 @@ from zerver.lib.slack_data_to_zulip_data import (
     get_model_id,
     build_zerver_realm,
     get_user_email,
+    get_admin,
     get_user_avatar_source,
     get_user_timezone,
     users_to_zerver_userprofile,
@@ -56,6 +57,16 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(test_zerver_realm_dict['string_id'], realm_subdomain)
         self.assertEqual(test_zerver_realm_dict['name'], realm_subdomain)
         self.assertEqual(test_zerver_realm_dict['date_created'], time)
+
+    def test_get_admin(self) -> None:
+        user_data = [{'is_admin': True, 'is_owner': False, 'is_primary_owner': False},
+                     {'is_admin': True, 'is_owner': True, 'is_primary_owner': False},
+                     {'is_admin': True, 'is_owner': True, 'is_primary_owner': True},
+                     {'is_admin': False, 'is_owner': False, 'is_primary_owner': False}]
+        self.assertEqual(get_admin(user_data[0]), True)
+        self.assertEqual(get_admin(user_data[1]), True)
+        self.assertEqual(get_admin(user_data[2]), True)
+        self.assertEqual(get_admin(user_data[3]), False)
 
     def test_get_avatar_source(self) -> None:
         gravatar_image_url = "https:\/\/secure.gravatar.com\/avatar\/78dc7b2e1bf423df8c82fb2a62c8917d.jpg?s=24&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0016-24.png"

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -111,6 +111,7 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(len(zerver_userprofile), 3)
         self.assertEqual(zerver_userprofile[0]['id'], 1)
         self.assertEqual(zerver_userprofile[0]['is_realm_admin'], True)
+        self.assertEqual(zerver_userprofile[0]['is_staff'], False)
         self.assertEqual(zerver_userprofile[0]['is_active'], True)
         self.assertEqual(zerver_userprofile[1]['is_staff'], False)
         self.assertEqual(zerver_userprofile[1]['is_bot'], False)


### PR DESCRIPTION
Description of the PR in short:

**Always map 'is_staff' to false in user data**:
`staff` is only for server administrators, which doesn't exist in Slack.
Hence, this should always be false.

**Change organization admin mappings**:
Map 'Primary owner', 'owner' and 'admin' to 'organization admin'.
Added tests for the same.

**Import primary owner user first**:
According to https://get.slack.help/hc/en-us/articles/201912948-Owners-and-Administrators,
only one Primary owner of a slack organsation exists. This allocates the first id
to the Primary owner and hence makes sure that the primary owner is imported first.
Added tests for the same.

