### PR TITLE
Clean up bot edit menu.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1469,6 +1469,16 @@ function render(template_name, args) {
     render('edit_bot');
 }());
 
+(function edit_outgoing_webhook_service() {
+    var args = {
+        service: {base_url: "http://www.foo.bar",
+                  interface: "1"},
+    };
+    var html = render('edit-outgoing-webhook-service', args);
+    assert.equal($(html).find('#edit_service_base_url').attr('value'), args.service.base_url);
+    assert.equal($(html).find('#edit_service_interface').attr('value'), args.service.interface);
+}());
+
 // By the end of this test, we should have compiled all our templates.  Ideally,
 // we will also have exercised them to some degree, but that's a little trickier
 // to enforce.

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1465,6 +1465,10 @@ function render(template_name, args) {
     assert.equal($(html).find('input').attr('placeholder'), args.value);
 }());
 
+(function edit_bot() {
+    render('edit_bot');
+}());
+
 // By the end of this test, we should have compiled all our templates.  Ideally,
 // we will also have exercised them to some degree, but that's a little trickier
 // to enforce.

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -11,6 +11,7 @@ $("body").ready(function () {
 
     var close_sidebar = function () {
         $sidebar.removeClass("show");
+        $sidebar.find("#edit_bot").empty();
         is_open = false;
     };
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -281,25 +281,21 @@ exports.set_up = function () {
         var users_list = people.get_realm_persons().filter(function (person)  {
             return !person.is_bot;
         });
-        var edit_bot_form = templates.render('edit_bot', {bot: bot,
-                                                          users_list: users_list});
         $("#edit_bot").empty();
-        $("#edit_bot").append(edit_bot_form);
+        $("#edit_bot").append(templates.render('edit_bot', {bot: bot,
+                                                            users_list: users_list}));
         var avatar_widget = avatar.build_bot_edit_widget($("#settings_page"));
         var form = $('#settings_page .edit_bot_form');
         var image = li.find(".image");
-        $("#settings_page .edit_bot .edit-bot-owner select").val(bot.owner);
+        var errors = form.find('.bot_edit_errors');
 
+        $("#settings_page .edit_bot .edit-bot-owner select").val(bot.owner);
         if (bot.bot_type.toString() === OUTGOING_WEBHOOK_BOT_TYPE) {
             var services = bot_data.get_services(bot_id);
-            var outgoing_webhook_service_edit = templates.render("edit-outgoing-webhook-service",
-                                                                 {service: services[0]});
-            $("#service_data").append(outgoing_webhook_service_edit);
+            $("#service_data").append(templates.render("edit-outgoing-webhook-service",
+                                                       {service: services[0]}));
         }
-
         avatar_widget.clear();
-
-        var errors = form.find('.bot_edit_errors');
 
         form.validate({
             errorClass: 'text-error',
@@ -310,11 +306,13 @@ exports.set_up = function () {
                 var bot_id = form.attr('data-bot_id');
                 var email = form.attr('data-email');
                 var type = form.attr('data-type');
+
                 var full_name = form.find('.edit_bot_name').val();
                 var bot_owner = form.find('.edit-bot-owner select').val();
                 var file_input = $(".edit_bot").find('.edit_bot_avatar_file_input');
                 var spinner = form.find('.edit_bot_spinner');
                 var edit_button = form.find('.edit_bot_button');
+
                 var formData = new FormData();
                 formData.append('csrfmiddlewaretoken', csrf_token);
                 formData.append('full_name', full_name);
@@ -359,8 +357,6 @@ exports.set_up = function () {
                 });
             },
         });
-
-
     });
 
     $("#active_bots_list").on("click", "a.download_bot_zuliprc", function () {

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -278,17 +278,16 @@ exports.set_up = function () {
         var li = $(e.currentTarget).closest('li');
         var bot_id = li.find('.bot_info').attr('data-user_id').valueOf();
         var bot = bot_data.get(bot_id);
-        var edit_bot_form = templates.render('edit_bot', {bot: bot});
-        $("#edit_bot").empty();
-        $("#edit_bot").append(edit_bot_form);
         var users_list = people.get_realm_persons().filter(function (person)  {
             return !person.is_bot;
         });
+        var edit_bot_form = templates.render('edit_bot', {bot: bot,
+                                                          users_list: users_list});
+        $("#edit_bot").empty();
+        $("#edit_bot").append(edit_bot_form);
         var avatar_widget = avatar.build_bot_edit_widget($("#settings_page"));
         var form = $('#settings_page .edit_bot_form');
         var image = li.find(".image");
-        var owner_select = $(templates.render("bot_owner_select", {users_list:users_list}));
-        $("#settings_page .edit_bot .select-form").text("").append(owner_select);
         $("#settings_page .edit_bot .edit-bot-owner select").val(bot.owner);
 
         if (bot.bot_type.toString() === OUTGOING_WEBHOOK_BOT_TYPE) {

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -274,9 +274,11 @@ exports.set_up = function () {
 
     var image_version = 0;
 
-    var avatar_widget = avatar.build_bot_edit_widget($("#settings_page"));
-
     $("#active_bots_list").on("click", "button.open_edit_bot_form", function (e) {
+        var edit_bot_form = templates.render('edit_bot');
+        $(".edit_bot").empty();
+        $(".edit_bot").append(edit_bot_form);
+        var avatar_widget = avatar.build_bot_edit_widget($("#settings_page"));
         var users_list = people.get_realm_persons().filter(function (person)  {
             return !person.is_bot;
         });
@@ -286,7 +288,7 @@ exports.set_up = function () {
         var image = li.find(".image");
         var bot_info = li;
         var bot_id = bot_info.find('.bot_info').attr('data-user_id').valueOf();
-        var reset_edit_bot = li.find(".reset_edit_bot");
+        var reset_edit_bot = $("#edit_bot .reset_edit_bot");
         var owner_select = $(templates.render("bot_owner_select", {users_list:users_list}));
         var old_full_name = bot_info.find(".name").text();
         var old_owner = bot_data.get(bot_id).owner;

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -275,34 +275,24 @@ exports.set_up = function () {
     var image_version = 0;
 
     $("#active_bots_list").on("click", "button.open_edit_bot_form", function (e) {
-        var edit_bot_form = templates.render('edit_bot');
-        $(".edit_bot").empty();
-        $(".edit_bot").append(edit_bot_form);
-        var avatar_widget = avatar.build_bot_edit_widget($("#settings_page"));
+        var li = $(e.currentTarget).closest('li');
+        var bot_id = li.find('.bot_info').attr('data-user_id').valueOf();
+        var bot = bot_data.get(bot_id);
+        var edit_bot_form = templates.render('edit_bot', {bot: bot});
+        $("#edit_bot").empty();
+        $("#edit_bot").append(edit_bot_form);
         var users_list = people.get_realm_persons().filter(function (person)  {
             return !person.is_bot;
         });
-        var li = $(e.currentTarget).closest('li');
-        var edit_div = li.find('div.edit_bot');
+        var avatar_widget = avatar.build_bot_edit_widget($("#settings_page"));
         var form = $('#settings_page .edit_bot_form');
         var image = li.find(".image");
-        var bot_info = li;
-        var bot_id = bot_info.find('.bot_info').attr('data-user_id').valueOf();
         var reset_edit_bot = $("#edit_bot .reset_edit_bot");
         var owner_select = $(templates.render("bot_owner_select", {users_list:users_list}));
-        var old_full_name = bot_info.find(".name").text();
-        var old_owner = bot_data.get(bot_id).owner;
-        var bot_email = bot_data.get(bot_id).email;
-        var bot_type = bot_data.get(bot_id).bot_type;
-        $("#settings_page .edit_bot .edit_bot_name").val(old_full_name);
         $("#settings_page .edit_bot .select-form").text("").append(owner_select);
-        $("#settings_page .edit_bot .edit-bot-owner select").val(old_owner);
-        $("#settings_page .edit_bot_form").attr("data-bot_id", bot_id);
-        $("#settings_page .edit_bot_form").attr("data-email", bot_email);
-        $("#settings_page .edit_bot_form").attr("data-type", bot_type);
-        $(".edit_bot_email").text(bot_email);
+        $("#settings_page .edit_bot .edit-bot-owner select").val(bot.owner);
 
-        if (bot_type.toString() === OUTGOING_WEBHOOK_BOT_TYPE) {
+        if (bot.bot_type.toString() === OUTGOING_WEBHOOK_BOT_TYPE) {
             var services = bot_data.get_services(bot_id);
             $("#settings_page .edit_bot #service_data").show();
             // Currently, we only support one service per bot.
@@ -314,16 +304,9 @@ exports.set_up = function () {
 
         avatar_widget.clear();
 
-        function show_row_again() {
-            image.show();
-            bot_info.show();
-            edit_div.hide();
-        }
-
         reset_edit_bot.click(function (event) {
-            form.find(".edit_bot_name").val(old_full_name);
+            form.find(".edit_bot_name").val(bot.full_name);
             owner_select.remove();
-            show_row_again();
             $(this).off(event);
         });
 
@@ -347,6 +330,7 @@ exports.set_up = function () {
                 formData.append('csrfmiddlewaretoken', csrf_token);
                 formData.append('full_name', full_name);
                 formData.append('bot_owner', bot_owner);
+
                 if (type === OUTGOING_WEBHOOK_BOT_TYPE) {
                     var service_payload_url = $("#settings_page .edit_bot #edit_service_base_url").val();
                     var service_interface = $("#settings_page .edit_bot #edit_service_interface :selected").val();
@@ -368,11 +352,8 @@ exports.set_up = function () {
                         loading.destroy_indicator(spinner);
                         errors.hide();
                         edit_button.show();
-                        show_row_again();
                         avatar_widget.clear();
                         typeahead_helper.clear_rendered_person(bot_id);
-
-                        bot_info.find('.name').text(full_name);
                         if (data.avatar_url) {
                             // Note that the avatar_url won't actually change on the back end
                             // when the user had a previous uploaded avatar.  Only the content

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -287,7 +287,6 @@ exports.set_up = function () {
         var avatar_widget = avatar.build_bot_edit_widget($("#settings_page"));
         var form = $('#settings_page .edit_bot_form');
         var image = li.find(".image");
-        var reset_edit_bot = $("#edit_bot .reset_edit_bot");
         var owner_select = $(templates.render("bot_owner_select", {users_list:users_list}));
         $("#settings_page .edit_bot .select-form").text("").append(owner_select);
         $("#settings_page .edit_bot .edit-bot-owner select").val(bot.owner);
@@ -300,12 +299,6 @@ exports.set_up = function () {
         }
 
         avatar_widget.clear();
-
-        reset_edit_bot.click(function (event) {
-            form.find(".edit_bot_name").val(bot.full_name);
-            owner_select.remove();
-            $(this).off(event);
-        });
 
         var errors = form.find('.bot_edit_errors');
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -294,12 +294,9 @@ exports.set_up = function () {
 
         if (bot.bot_type.toString() === OUTGOING_WEBHOOK_BOT_TYPE) {
             var services = bot_data.get_services(bot_id);
-            $("#settings_page .edit_bot #service_data").show();
-            // Currently, we only support one service per bot.
-            $("#settings_page .edit_bot #edit_service_base_url").val(services[0].base_url);
-            $("#settings_page .edit_bot #edit_service_interface").val(services[0].interface);
-        } else {
-            $("#settings_page .edit_bot #service_data").hide();
+            var outgoing_webhook_service_edit = templates.render("edit-outgoing-webhook-service",
+                                                                 {service: services[0]});
+            $("#service_data").append(outgoing_webhook_service_edit);
         }
 
         avatar_widget.clear();
@@ -332,8 +329,8 @@ exports.set_up = function () {
                 formData.append('bot_owner', bot_owner);
 
                 if (type === OUTGOING_WEBHOOK_BOT_TYPE) {
-                    var service_payload_url = $("#settings_page .edit_bot #edit_service_base_url").val();
-                    var service_interface = $("#settings_page .edit_bot #edit_service_interface :selected").val();
+                    var service_payload_url = $("#edit_service_base_url").val();
+                    var service_interface = $("#edit_service_interface :selected").val();
                     formData.append('service_payload_url', JSON.stringify(service_payload_url));
                     formData.append('service_interface', service_interface);
                 }

--- a/static/templates/edit_bot.handlebars
+++ b/static/templates/edit_bot.handlebars
@@ -16,18 +16,6 @@
             <div class="select-form"></div>
         </div>
         <div id="service_data">
-            <div class="">
-                <label for="edit_service_base_url">{{t "Endoint URL" }}</label>
-                <input id="edit_service_base_url" type="text" name="service_payload_url" class="edit_service_base_url required" maxlength=50 />
-                <div><label for="edit_service_base_url" generated="true" class="text-error"></label></div>
-            </div>
-            <div class="">
-                <label for="edit_service_interface">{{t "Interface" }}</label>
-                <select id="edit_service_interface" name="service_interface" default="1">
-                    <option value="1">{{t "Generic" }}</option>
-                    <option value="2">{{t "Slack's outgoing webhooks" }}</option>
-                </select>
-            </div>
         </div>
         <div class="avatar-section">
             <label for="bot_avatar_file_input">Avatar</label>

--- a/static/templates/edit_bot.handlebars
+++ b/static/templates/edit_bot.handlebars
@@ -1,0 +1,45 @@
+<form class="edit_bot_form form-horizontal" data-target="edit-bot" data-title="{{t 'Edit bot' }}">
+    <div class="bot_edit_errors alert alert-error hide"></div>
+    <div class="">
+        <label>{{t "Bot email" }}</label>
+        <div class="edit_bot_email"></div>
+    </div>
+    <div class="edit-bot-form-box">
+        <div class="">
+            <label for="edit_bot_name">{{t "Full name" }}</label>
+            <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" maxlength=50 />
+            <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
+        </div>
+        <div class="edit-bot-owner">
+            <label for="bot_owner_select">{{t "Owner" }}</label>
+            <div class="select-form"></div>
+        </div>
+        <div id="service_data">
+            <div class="">
+                <label for="edit_service_base_url">{{t "Endoint URL" }}</label>
+                <input id="edit_service_base_url" type="text" name="service_payload_url" class="edit_service_base_url required" maxlength=50 />
+                <div><label for="edit_service_base_url" generated="true" class="text-error"></label></div>
+            </div>
+            <div class="">
+                <label for="edit_service_interface">{{t "Interface" }}</label>
+                <select id="edit_service_interface" name="service_interface" default="1">
+                    <option value="1">{{t "Generic" }}</option>
+                    <option value="2">{{t "Slack's outgoing webhooks" }}</option>
+                </select>
+            </div>
+        </div>
+        <div class="avatar-section">
+            <label for="bot_avatar_file_input">Avatar</label>
+            <input type="file" name="bot_avatar_file_input" class="notvisible edit_bot_avatar_file_input" value="{{t 'Upload avatar' }}" />
+            <div class="edit_bot_avatar_file"></div>
+            <button type="button" class="btn btn-default edit_bot_avatar_upload_button">{{t "Choose avatar" }}</button>
+            <button type="button" class="btn btn-default edit_bot_avatar_clear_button display-none">{{t "Clear avatar" }}</button>
+            <div><label for="edit_bot_avatar_file" generated="true" class="edit_bot_avatar_error text-error"></label></div>
+        </div>
+        <div class="buttons">
+            <input type="submit" class="btn btn-primary edit_bot_button" value="{{t 'Save' }}" />
+            <button type="button" class="btn btn-default reset_edit_bot" data-sidebar-form-close>{{t 'Cancel' }}</button>
+            <div class="edit_bot_spinner"></div>
+        </div>
+    </div>
+</form>

--- a/static/templates/edit_bot.handlebars
+++ b/static/templates/edit_bot.handlebars
@@ -13,7 +13,9 @@
         </div>
         <div class="edit-bot-owner">
             <label for="bot_owner_select">{{t "Owner" }}</label>
-            <div class="select-form"></div>
+            <div class="select-form">
+                {{partial "bot_owner_select" }}
+            </div>
         </div>
         <div id="service_data">
         </div>

--- a/static/templates/edit_bot.handlebars
+++ b/static/templates/edit_bot.handlebars
@@ -1,13 +1,14 @@
-<form class="edit_bot_form form-horizontal" data-target="edit-bot" data-title="{{t 'Edit bot' }}">
+<form class="edit_bot_form form-horizontal" data-target="edit-bot" data-title="{{t 'Edit bot' }}" data-bot_id="{{bot.bot_id}}"
+    data-email="{{bot.email}}" data-type="{{bot.bot_type}}">
     <div class="bot_edit_errors alert alert-error hide"></div>
     <div class="">
         <label>{{t "Bot email" }}</label>
-        <div class="edit_bot_email"></div>
+        <div class="edit_bot_email">{{bot.email}}</div>
     </div>
     <div class="edit-bot-form-box">
         <div class="">
             <label for="edit_bot_name">{{t "Full name" }}</label>
-            <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" maxlength=50 />
+            <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" value="{{bot.full_name}}" maxlength=50 />
             <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
         </div>
         <div class="edit-bot-owner">

--- a/static/templates/settings/edit-outgoing-webhook-service.handlebars
+++ b/static/templates/settings/edit-outgoing-webhook-service.handlebars
@@ -1,5 +1,5 @@
 <div class="">
-    <label for="edit_service_base_url">{{t "Endoint URL" }}</label>
+    <label for="edit_service_base_url">{{t "Endpoint URL" }}</label>
     <input id="edit_service_base_url" type="text" name="service_payload_url" class="edit_service_base_url required" value="{{service.base_url}}" maxlength=50 />
     <div><label for="edit_service_base_url" generated="true" class="text-error"></label></div>
 </div>

--- a/static/templates/settings/edit-outgoing-webhook-service.handlebars
+++ b/static/templates/settings/edit-outgoing-webhook-service.handlebars
@@ -1,0 +1,12 @@
+<div class="">
+    <label for="edit_service_base_url">{{t "Endoint URL" }}</label>
+    <input id="edit_service_base_url" type="text" name="service_payload_url" class="edit_service_base_url required" value="{{service.base_url}}" maxlength=50 />
+    <div><label for="edit_service_base_url" generated="true" class="text-error"></label></div>
+</div>
+<div class="">
+    <label for="edit_service_interface">{{t "Interface" }}</label>
+    <select id="edit_service_interface" name="service_interface" value="{{service.interface}}">
+        <option value="1">{{t "Generic" }}</option>
+        <option value="2">{{t "Slack's outgoing webhooks" }}</option>
+    </select>
+</div>

--- a/templates/zerver/settings_sidebar.html
+++ b/templates/zerver/settings_sidebar.html
@@ -5,52 +5,7 @@
     </div>
 
     <div class="content">
-        <div class='edit_bot'>
-            <form class="edit_bot_form form-horizontal" data-target="edit-bot" data-title="{{ _('Edit bot') }}">
-                <div class="bot_edit_errors alert alert-error hide"></div>
-                <div class="">
-                    <label>{{ _("Bot email") }}</label>
-                    <div class="edit_bot_email"></div>
-                </div>
-                <div class="edit-bot-form-box">
-                    <div class="">
-                        <label for="edit_bot_name">{{ _("Full name") }}</label>
-                        <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" maxlength=50 />
-                        <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
-                    </div>
-                    <div class="edit-bot-owner">
-                        <label for="bot_owner_select">{{ _("Owner") }}</label>
-                        <div class="select-form"></div>
-                    </div>
-                    <div id="service_data">
-                        <div class="">
-                            <label for="edit_service_base_url">{{ _("Endoint URL") }}</label>
-                            <input id="edit_service_base_url" type="text" name="service_payload_url" class="edit_service_base_url required" maxlength=50 />
-                            <div><label for="edit_service_base_url" generated="true" class="text-error"></label></div>
-                        </div>
-                        <div class="">
-                            <label for="edit_service_interface">{{ _("Interface") }}</label>
-                            <select id="edit_service_interface" name="service_interface" default="1">
-                                <option value="1">{{ _("Generic") }}</option>
-                                <option value="2">{{ _("Slack's outgoing webhooks") }}</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="avatar-section">
-                        <label for="bot_avatar_file_input">Avatar</label>
-                        <input type="file" name="bot_avatar_file_input" class="notvisible edit_bot_avatar_file_input" value="{{ _('Upload avatar') }}" />
-                        <div class="edit_bot_avatar_file"></div>
-                        <button type="button" class="btn btn-default edit_bot_avatar_upload_button">{{ _("Choose avatar") }}</button>
-                        <button type="button" class="btn btn-default edit_bot_avatar_clear_button display-none">{{ _("Clear avatar") }}</button>
-                        <div><label for="edit_bot_avatar_file" generated="true" class="edit_bot_avatar_error text-error"></label></div>
-                    </div>
-                    <div class="buttons">
-                        <input type="submit" class="btn btn-primary edit_bot_button" value="{{ _('Save') }}" />
-                        <button type="button" class="btn btn-default reset_edit_bot" data-sidebar-form-close>{{ _('Cancel') }}</button>
-                        <div class="edit_bot_spinner"></div>
-                    </div>
-                </div>
-            </form>
+        <div id="edit_bot" class='edit_bot'>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This refactors the bot edit menu code in two ways:
* Move from bot edit menu show()/hide() calls to dynamic HTML insertion into the DOM tree, while reducing `settings_sidebar.html` to the scaffold it should be.

* Simplify the edit bot code in settings_bots.js

The relevant Zulip discussion can be found here: https://playground.zulipdev.org/#narrow/stream/bot.20infrastructure/subject/edit.20bot.20config.20items/near/2742