### PR TITLE
typeahead: Fix typeahead ordering for user group mentions.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -78,6 +78,12 @@ stream_data.subscribed_streams = function () {
     return stream_list;
 };
 
+var hamlet = {
+    email: 'hamlet@zulip.com',
+    user_id: 100,
+    full_name: "King Hamlet",
+};
+
 var othello = {
     email: 'othello@zulip.com',
     user_id: 101,
@@ -580,9 +586,45 @@ global.user_groups.add(backend);
         expected_value = [cordelia, othello];
         assert.deepEqual(actual_value, expected_value);
 
+        var hamburger = {
+            email: 'coolham@zulip.com',
+            user_id: 200,
+            full_name: "Hamburger",
+        };
+        var hammer = {
+            email: 'hammer@zulip.com',
+            user_id: 202,
+            full_name: "Apollo",
+        };
+        var zeus = {
+            email: 'zeus@hamel.com',
+            user_id: 201,
+            full_name: "Zeus",
+        };
+
         fake_this = { completing: 'mention', token: 'ham' };
-        actual_value = options.sorter.call(fake_this, [backend, hamletcharacters]);
+        actual_value = options.sorter.call(fake_this, [hamletcharacters, hamburger]);
+        expected_value = [hamburger, hamletcharacters];
+        assert.deepEqual(actual_value, expected_value);
+
+        fake_this = { completing: 'mention', token: 'ham' };
+        actual_value = options.sorter.call(fake_this, [hamletcharacters, hamlet]);
+        expected_value = [hamletcharacters, hamlet];
+        assert.deepEqual(actual_value, expected_value);
+
+        fake_this = { completing: 'mention', token: 'ham' };
+        actual_value = options.sorter.call(fake_this, [hamletcharacters, backend]);
         expected_value = [hamletcharacters, backend];
+        assert.deepEqual(actual_value, expected_value);
+
+        fake_this = { completing: 'mention', token: 'ham' };
+        actual_value = options.sorter.call(fake_this, [hamletcharacters, zeus]);
+        expected_value = [hamletcharacters, zeus];
+        assert.deepEqual(actual_value, expected_value);
+
+        fake_this = { completing: 'mention', token: 'ham' };
+        actual_value = options.sorter.call(fake_this, [hamletcharacters, hammer]);
+        expected_value = [hamletcharacters, hammer];
         assert.deepEqual(actual_value, expected_value);
 
         fake_this = { completing: 'stream', token: 'de' };

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -493,21 +493,20 @@ exports.compose_matches_sorter = function (matches) {
     if (this.completing === 'emoji') {
         return typeahead_helper.sort_emojis(matches, this.token);
     } else if (this.completing === 'mention') {
-        var recipients = [];
+        var users = [];
         var groups = [];
         _.each(matches, function (match) {
             if (user_groups.is_user_group(match)) {
                 groups.push(match);
             } else {
-                recipients.push(match);
+                users.push(match);
             }
         });
 
-        recipients = typeahead_helper.sort_recipients(recipients, this.token,
+        var recipients = typeahead_helper.sort_recipients(users, this.token,
                                                       compose_state.stream_name(),
-                                                      compose_state.subject());
-        groups = typeahead_helper.sort_user_groups(groups, this.token);
-        return recipients.concat(groups);
+                                                      compose_state.subject(), groups);
+        return recipients;
     } else if (this.completing === 'stream') {
         return typeahead_helper.sort_streams(matches, this.token);
     } else if (this.completing === 'syntax') {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -263,27 +263,37 @@ exports.sort_languages = function (matches, query) {
     return results.matches.concat(results.rest);
 };
 
-exports.sort_recipients = function (matches, query, current_stream, current_subject) {
-    var name_results =  util.prefix_sort(query, matches, function (x) { return x.full_name; });
-    var email_results = util.prefix_sort(query, name_results.rest,
-        function (x) { return x.email; });
-
-    var matches_sorted = exports.sort_for_at_mentioning(
-        name_results.matches.concat(email_results.matches),
+exports.sort_recipients = function (users, query, current_stream, current_subject, groups) {
+    var users_name_results =  util.prefix_sort(query, users,
+        function (x) { return x.full_name; });
+    var result = exports.sort_for_at_mentioning(
+        users_name_results.matches,
         current_stream,
         current_subject
     );
+
+    var groups_results;
+    if (groups !== undefined) {
+        groups_results = util.prefix_sort(query, groups, function (x) { return x.name; });
+        result = result.concat(groups_results.matches);
+    }
+
+    var email_results = util.prefix_sort(query, users_name_results.rest,
+        function (x) { return x.email; });
+    result = result.concat(exports.sort_for_at_mentioning(
+        email_results.matches,
+        current_stream,
+        current_subject
+    ));
     var rest_sorted = exports.sort_for_at_mentioning(
         email_results.rest,
         current_stream,
         current_subject
     );
-    return matches_sorted.concat(rest_sorted);
-};
-
-exports.sort_user_groups = function (matches, query) {
-    var results = util.prefix_sort(query, matches, function (x) { return x.name; });
-    return results.matches.concat(results.rest);
+    if (groups !== undefined) {
+        rest_sorted = rest_sorted.concat(groups_results.rest);
+    }
+    return result.concat(rest_sorted);
 };
 
 exports.sort_emojis = function (matches, query) {


### PR DESCRIPTION
Priority change of mention typeahead can be summarized as:
`Matched User by name> Matched User group> Matched User by email > Rest unmatched user > Rest unmatched user group`
![screenshot from 2018-02-08 03-05-08](https://user-images.githubusercontent.com/22238472/35943824-55a2139c-0c80-11e8-993a-2242fdaa9d91.png)
![screenshot from 2018-02-08 02-45-40](https://user-images.githubusercontent.com/22238472/35943825-55e46d6e-0c80-11e8-8903-694436cee625.png)


Fixes: #8301.