### PR TITLE
dark-mode: Fix bug with open graph previews.

### DIFF
--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -19,7 +19,7 @@ body.dark-mode #settings_page .right {
     background-color: hsl(212, 28%, 18%);
 }
 
-.message_embed .data-container::after {
+body.dark-mode .message_embed .data-container::after {
     background: linear-gradient(0deg, hsl(212, 28%, 18%), transparent 10%);
 }
 


### PR DESCRIPTION
This fixes a bug where the open graph preview bottom fade is dark
rather than white when not in dark mode, which results in a heavy
dark faded line at the bottom of the description.

This is good to be merged and should be done immediately @rishig.