### PR TITLE
hotkeys: Add x for composing PM.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -164,7 +164,8 @@
         "hotspots": false,
         "compose_ui": false,
         "common": false,
-        "panels": false
+        "panels": false,
+        "deprecation_ui": false
     },
     "rules": {
         "array-callback-return": "error",

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -150,7 +150,7 @@ populated and where the focus is placed.
     - use R to reply to the author of a PM
     - use R to reply to the author of a PM stream
     - use c to compose a stream message
-    - use C to compose a new PM
+    - use x to compose a new PM
 
 - Buttons
     - Narrow to a stream and click on "New topic"

--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -216,7 +216,7 @@ exports.then_send_message = function (type, params) {
         if (type === "stream") {
             casper.page.sendEvent('keypress', "c");
         } else if (type === "private") {
-            casper.page.sendEvent('keypress', "C");
+            casper.page.sendEvent('keypress', "x");
         } else {
             casper.test.assertTrue(false, "send_message got valid message type");
         }

--- a/frontend_tests/casper_tests/04-compose.js
+++ b/frontend_tests/casper_tests/04-compose.js
@@ -44,7 +44,7 @@ casper.then(function () {
         casper.test.assertVisible('#stream-message', 'Stream input box visible');
         common.check_form('#send_message_form', {stream: '', subject: ''}, "Stream empty on new compose");
         casper.click('body');
-        casper.page.sendEvent('keypress', "C");
+        casper.page.sendEvent('keypress', "x");
     });
 });
 
@@ -102,7 +102,7 @@ casper.then(function () {
 casper.then(function () {
     casper.waitWhileVisible('#stream-message', function () {
         casper.test.assertNotVisible('#stream-message', 'Close stream compose box');
-        casper.page.sendEvent('keypress', "C");
+        casper.page.sendEvent('keypress', "x");
         casper.click('body');
     });
 });

--- a/frontend_tests/casper_tests/14-drafts.js
+++ b/frontend_tests/casper_tests/14-drafts.js
@@ -60,7 +60,7 @@ casper.then(function () {
 casper.then(function () {
     casper.test.info('Creating Private Message Draft');
     casper.click('body');
-    casper.page.sendEvent('keypress', "C");
+    casper.page.sendEvent('keypress', "x");
     casper.waitUntilVisible('#private-message', function () {
         casper.fill('form#send_message_form', {
             recipient: 'cordelia@zulip.com, hamlet@zulip.com',
@@ -171,7 +171,7 @@ casper.then(function () {
     casper.click('#draft_overlay .exit');
     waitWhileDraftsVisible(function () {
         casper.click('body');
-        casper.page.sendEvent('keypress', "C");
+        casper.page.sendEvent('keypress', "x");
     });
 });
 

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -148,7 +148,7 @@ function stubbing(func_name_to_stub, test_function) {
 
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
-    assert_unmapped('abefhlmoptxyz');
+    assert_unmapped('abefhlmoptyz');
     assert_unmapped('BEFHILNOQTUWXYZ');
 
     // We have to skip some checks due to the way the code is
@@ -223,7 +223,7 @@ function stubbing(func_name_to_stub, test_function) {
     assert_mapping('D', 'narrow.stream_cycle_forward');
 
     assert_mapping('c', 'compose_actions.start');
-    assert_mapping('C', 'compose_actions.start');
+    assert_mapping('x', 'compose_actions.start');
     assert_mapping('P', 'narrow.by');
     assert_mapping('g', 'gear_menu.open');
 

--- a/static/js/deprecation_ui.js
+++ b/static/js/deprecation_ui.js
@@ -1,0 +1,42 @@
+var deprecation_ui = (function () {
+
+var exports = {};
+
+function get_deprecation_message_display_status() {
+    var deprecation_message_display_status = localStorage.getItem('deprecation_message_display_status');
+    if (deprecation_message_display_status === null) {
+        deprecation_message_display_status = JSON.parse('{}');
+    } else {
+        deprecation_message_display_status = JSON.parse(deprecation_message_display_status);
+    }
+    return deprecation_message_display_status;
+}
+
+function update_deprecation_message_display_status(deprecation_message_display_status) {
+    localStorage.setItem('deprecation_message_display_status', JSON.stringify(deprecation_message_display_status));
+}
+
+exports.display_deprecation_modal = function (opts) {
+    var trigger_key = opts.trigger_key;
+    var deprecation_message_display_status = get_deprecation_message_display_status();
+
+    if (!deprecation_message_display_status[trigger_key]) {
+        var deprecation_modal = $('#deprecation-modal');
+        var deprecation_modal_message = $('#deprecation-modal-message');
+        var deprecation_modal_message_text = opts.message;
+
+        deprecation_modal.modal('show');
+        deprecation_modal_message.text(i18n.t(deprecation_modal_message_text));
+
+        deprecation_message_display_status[trigger_key] = true;
+        update_deprecation_message_display_status(deprecation_message_display_status);
+    }
+
+};
+
+return exports;
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = deprecation_ui;
+}

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -70,7 +70,7 @@ var keypress_mappings = {
     63: {name: 'show_shortcuts', message_view_only: false}, // '?'
     64: {name: 'compose_reply_with_mention', message_view_only: true}, // '@'
     65: {name: 'stream_cycle_backward', message_view_only: true}, // 'A'
-    67: {name: 'compose_private_message', message_view_only: true}, // 'C'
+    67: {name: 'display_deprecation_message', message_view_only: false}, // 'C'
     68: {name: 'stream_cycle_forward', message_view_only: true}, // 'D'
     71: {name: 'G_end', message_view_only: true}, // 'G'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
@@ -93,6 +93,7 @@ var keypress_mappings = {
     117: {name: 'show_sender_info', message_view_only: true}, // 'u'
     118: {name: 'show_lightbox', message_view_only: true}, // 'v'
     119: {name: 'query_users', message_view_only: false}, // 'w'
+    120: {name: 'compose_private_message', message_view_only: true}, // 'x'
 };
 
 exports.get_keydown_hotkey = function (e) {
@@ -630,6 +631,10 @@ exports.process_hotkey = function (e, hotkey) {
             // Note that you can "enter" to respond to messages as well,
             // but that is handled in process_enter_key().
             compose_actions.respond_to_message({trigger: 'hotkey'});
+            return true;
+        case 'display_deprecation_message':
+            var message = i18n.t('Use the \'x\' key to compose private messages. The \'C\' key previously used for this purpose is deprecated.');
+            deprecation_ui.display_deprecation_modal({trigger_key: 'C', message: message});
             return true;
     }
 

--- a/templates/zerver/deprecation_ui.html
+++ b/templates/zerver/deprecation_ui.html
@@ -1,0 +1,16 @@
+<div id="deprecation-modal" class="modal fade" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <h4 id="deprecation-modal-title" class="modal-title">Deprecation Notice</h4>
+            </div>
+            <div class="modal-body">
+                <p id="deprecation-modal-message"></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -89,7 +89,7 @@ below, and add more to your repertoire as needed.
 
 * **New stream message**: `c` — For starting a new topic in a stream.
 
-* **New private message**: `C`
+* **New private message**: `x`
 
 ### In the compose box
 

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -153,6 +153,7 @@
     {% include "zerver/invite_user.html" %}
     {% include "zerver/bankruptcy.html" %}
     {% include "zerver/logout.html" %}
+    {% include "zerver/deprecation_ui.html" %}
     <div class='notifications top-right'></div>
 </div>
 {% endblock %}

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -116,6 +116,7 @@ class TemplateTestCase(ZulipTestCase):
             'zerver/api_content.json',
             'zerver/handlebars_compilation_failed.html',
             'zerver/portico-header.html',
+            'zerver/deprecation_ui.html',
         ]
 
         integrations_regexp = re.compile('zerver/integrations/.*.html')

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1115,7 +1115,8 @@ JS_SPECS = {
             'js/ui_init.js',
             'js/emoji_picker.js',
             'js/compose_ui.js',
-            'js/panels.js'
+            'js/panels.js',
+            'js/deprecation_ui.js'
         ],
         'output_filename': 'min/app.js'
     },


### PR DESCRIPTION
Pressing the 'x' key can now be used to compose a PM.
Pressing the 'C' key displays a modal that shows a deprecation notice.

Fixes #6548.