### PR TITLE
frontend: Make hotkey popovers less saturated.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2739,3 +2739,7 @@ button.topic_edit_cancel {
     visibility: visible;
     opacity: 1;
 }
+
+.hotkey-hint {
+    opacity: 0.5;
+}

--- a/static/templates/actions_popover_content.handlebars
+++ b/static/templates/actions_popover_content.handlebars
@@ -25,7 +25,7 @@
     <li>
         <a href="#" class="popover_toggle_collapse" data-message-id="{{message.id}}">
             <i class="fa fa-minus" aria-hidden="true"></i>
-            {{t "Collapse" }} (–)
+            {{t "Collapse" }} <span class="hotkey-hint">(–)</span>
         </a>
     </li>
     {{/if}}
@@ -34,7 +34,7 @@
     <li>
         <a href="#" class="popover_toggle_collapse" data-message-id="{{message.id}}">
             <i class="fa fa-plus" aria-hidden="true"></i>
-            {{t "Un-collapse" }} (–)
+            {{t "Un-collapse" }} <span class="hotkey-hint">(–)</span>
         </a>
     </li>
     {{/if}}
@@ -59,7 +59,7 @@
     <li>
         <a href="#" class="popover_mute_topic" data-msg-stream="{{message.stream}}" data-msg-topic="{{message.subject}}">
             <i class="fa fa-eye-slash" aria-hidden="true"></i>
-            {{#tr message}}Mute the topic <b>__subject__</b>{{/tr}} (M)
+            {{#tr message}}Mute the topic <b>__subject__</b>{{/tr}} <span class="hotkey-hint">(M)</span>
         </a>
     </li>
     {{/if}}

--- a/static/templates/actions_popover_content.handlebars
+++ b/static/templates/actions_popover_content.handlebars
@@ -25,7 +25,7 @@
     <li>
         <a href="#" class="popover_toggle_collapse" data-message-id="{{message.id}}">
             <i class="fa fa-minus" aria-hidden="true"></i>
-            {{t "Collapse" }} (-)
+            {{t "Collapse" }} (–)
         </a>
     </li>
     {{/if}}
@@ -34,7 +34,7 @@
     <li>
         <a href="#" class="popover_toggle_collapse" data-message-id="{{message.id}}">
             <i class="fa fa-plus" aria-hidden="true"></i>
-            {{t "Un-collapse" }} (-)
+            {{t "Un-collapse" }} (–)
         </a>
     </li>
     {{/if}}

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -32,7 +32,7 @@
         {{#unless is_me}}
         <li>
             <a href="#" class="{{ private_message_class }}">
-                <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr this}}Send private message{{/tr}} (R)
+                <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr this}}Send private message{{/tr}} <span class="hotkey-hint">(R)</span>
             </a>
         </li>
         {{/unless}}
@@ -47,7 +47,7 @@
     {{#unless is_me}}
     <li>
         <a class="mention_user">
-            <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}} (@)
+            <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}} <span class="hotkey-hint">(@)</span>
         </a>
     </li>
     {{/unless}}

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -102,7 +102,7 @@
                             </li>
                             <li role="presentation">
                                 <a tabindex="0" role="menuitem" data-overlay-trigger="keyboard-shortcuts">
-                                    <i class="icon-vector-keyboard"></i> {{ _('Keyboard shortcuts') }} (?)
+                                    <i class="icon-vector-keyboard"></i> {{ _('Keyboard shortcuts') }} <span class="hotkey-hint">(?)</span>
                                 </a>
                             </li>
                             <li role="presentation">


### PR DESCRIPTION
This is what the slightly faded-out popovers look like:
![image](https://user-images.githubusercontent.com/13666710/35979284-df0c2e42-0cdf-11e8-94be-c57283ba7632.png)
