### PR TITLE
embedded bots: Log warning when bot quit()s.

### DIFF
--- a/zerver/lib/bot_lib.py
+++ b/zerver/lib/bot_lib.py
@@ -57,6 +57,9 @@ class StateHandler:
     def contains(self, key: Text) -> bool:
         return is_key_in_bot_storage(self.user_profile, key)
 
+class EmbeddedBotQuitException(Exception):
+    pass
+
 class EmbeddedBotHandler:
     def __init__(self, user_profile: UserProfile) -> None:
         # Only expose a subset of our UserProfile's functionality
@@ -113,3 +116,6 @@ class EmbeddedBotHandler:
             if optional:
                 return dict()
             raise
+
+    def quit(self, message: str= "") -> None:
+        raise EmbeddedBotQuitException(message)


### PR DESCRIPTION
External bots may call bot_handler.quit() when
they wish to terminate, e.g. due to a misconfiguration.
Currently, embedded bots ignore calls to quit(), even
though they signal a problem. This PR does the first
step in handling quit() calls by logging a warning.

Relevant discussion here: https://chat.zulip.org/#narrow/stream/integrations/subject/embedded.20bots/near/461189