### PR TITLE
recent senders: Use message ids instead of timestamps for sorting.

### DIFF
--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -16,13 +16,13 @@ var rs = zrequire('recent_senders');
     // New stream
     var message1 = {
         stream_id: stream1,
-        timestamp: _.uniqueId(),
+        id: _.uniqueId(),
         subject: topic1,
         sender_id: sender1,
     };
     var message2 = {
         stream_id: stream2,
-        timestamp: _.uniqueId(),
+        id: _.uniqueId(),
         subject: topic1,
         sender_id: sender2,
     };
@@ -45,7 +45,7 @@ var rs = zrequire('recent_senders');
     // New topic
     var message3 = {
         stream_id: stream1,
-        timestamp: _.uniqueId(),
+        id: _.uniqueId(),
         subject: topic2,
         sender_id: sender3,
     };
@@ -57,7 +57,7 @@ var rs = zrequire('recent_senders');
     // New sender
     var message4 = {
         stream_id: stream1,
-        timestamp: _.uniqueId(),
+        id: _.uniqueId(),
         subject: topic1,
         sender_id: sender2,
     };
@@ -69,7 +69,7 @@ var rs = zrequire('recent_senders');
     // More recent message
     var message5 = {
         stream_id: stream1,
-        timestamp: _.uniqueId(),
+        id: _.uniqueId(),
         subject: topic1,
         sender_id: sender1,
     };
@@ -81,19 +81,19 @@ var rs = zrequire('recent_senders');
     // Same stream, but different topics
     var message6 = {
         stream_id: stream3,
-        timestamp: _.uniqueId(),
+        id: _.uniqueId(),
         subject: topic1,
         sender_id: sender1,
     };
     var message7 = {
         stream_id: stream3,
-        timestamp: _.uniqueId(),
+        id: _.uniqueId(),
         subject: topic2,
         sender_id: sender2,
     };
     var message8 = {
         stream_id: stream3,
-        timestamp: _.uniqueId(),
+        id: _.uniqueId(),
         subject: topic3,
         sender_id: sender3,
     };

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -180,19 +180,19 @@ _.each(matches, function (person) {
         sender_id : 7,
         stream_id : 1,
         subject : "Dev Topic",
-        timestamp : _.uniqueId(),
+        id : _.uniqueId(),
     });
     global.recent_senders.process_message_for_senders({
         sender_id : 5,
         stream_id : 1,
         subject : "Dev Topic",
-        timestamp : _.uniqueId(),
+        id : _.uniqueId(),
     });
     global.recent_senders.process_message_for_senders({
         sender_id : 6,
         stream_id : 1,
         subject : "Dev Topic",
-        timestamp : _.uniqueId(),
+        id : _.uniqueId(),
     });
 
     // Typeahead for stream message [query, stream-name, topic-name]
@@ -210,13 +210,13 @@ _.each(matches, function (person) {
         sender_id : 5,
         stream_id : 2,
         subject : "Linux Topic",
-        timestamp : _.uniqueId(),
+        id : _.uniqueId(),
     });
     global.recent_senders.process_message_for_senders({
         sender_id : 7,
         stream_id : 2,
         subject : "Linux Topic",
-        timestamp : _.uniqueId(),
+        id : _.uniqueId(),
     });
 
     // No match

--- a/static/js/recent_senders.js
+++ b/static/js/recent_senders.js
@@ -10,42 +10,42 @@ exports.process_message_for_senders = function (message) {
 
     // Process most recent sender to topic
     var topic_dict = topic_senders.get(stream_id) || new Dict({fold_case: true});
-    var sender_timestamps = topic_dict.get(message.subject) || new Dict();
-    var old_timestamp = sender_timestamps.get(message.sender_id);
+    var sender_message_ids = topic_dict.get(message.subject) || new Dict();
+    var old_message_id = sender_message_ids.get(message.sender_id);
 
-    if (old_timestamp === undefined || old_timestamp < message.timestamp) {
-        sender_timestamps.set(message.sender_id, message.timestamp);
+    if (old_message_id === undefined || old_message_id < message.id) {
+        sender_message_ids.set(message.sender_id, message.id);
     }
 
-    topic_dict.set(message.subject, sender_timestamps);
+    topic_dict.set(message.subject, sender_message_ids);
     topic_senders.set(stream_id, topic_dict);
 
     // Process most recent sender to whole stream
-    sender_timestamps = stream_senders.get(stream_id) || new Dict();
-    old_timestamp = sender_timestamps.get(message.sender_id);
+    sender_message_ids = stream_senders.get(stream_id) || new Dict();
+    old_message_id = sender_message_ids.get(message.sender_id);
 
-    if (old_timestamp === undefined || old_timestamp < message.timestamp) {
-        sender_timestamps.set(message.sender_id, message.timestamp);
+    if (old_message_id === undefined || old_message_id < message.id) {
+        sender_message_ids.set(message.sender_id, message.id);
     }
 
-    stream_senders.set(stream_id, sender_timestamps);
+    stream_senders.set(stream_id, sender_message_ids);
 };
 
 exports.compare_by_recency = function (user_a, user_b, stream_id, topic) {
     stream_id = stream_id.toString();
 
-    var a_timestamp;
-    var b_timestamp;
+    var a_message_id;
+    var b_message_id;
 
     var topic_dict = topic_senders.get(stream_id);
     if (topic !== undefined && topic_dict !== undefined) {
-        var sender_timestamps = topic_dict.get(topic);
-        if (sender_timestamps !== undefined) {
-            b_timestamp = sender_timestamps.get(user_b.user_id) || Number.NEGATIVE_INFINITY;
-            a_timestamp = sender_timestamps.get(user_a.user_id) || Number.NEGATIVE_INFINITY;
+        var sender_message_ids = topic_dict.get(topic);
+        if (sender_message_ids !== undefined) {
+            b_message_id = sender_message_ids.get(user_b.user_id) || Number.NEGATIVE_INFINITY;
+            a_message_id = sender_message_ids.get(user_a.user_id) || Number.NEGATIVE_INFINITY;
 
-            if (a_timestamp !== b_timestamp) {
-                return b_timestamp - a_timestamp;
+            if (a_message_id !== b_message_id) {
+                return b_message_id - a_message_id;
             }
         }
     }
@@ -53,11 +53,11 @@ exports.compare_by_recency = function (user_a, user_b, stream_id, topic) {
     // Check recency for whole stream as tiebreaker
     var stream_dict = stream_senders.get(stream_id);
     if (stream_dict !== undefined) {
-        b_timestamp = stream_dict.get(user_b.user_id) || Number.NEGATIVE_INFINITY;
-        a_timestamp = stream_dict.get(user_a.user_id) || Number.NEGATIVE_INFINITY;
+        b_message_id = stream_dict.get(user_b.user_id) || Number.NEGATIVE_INFINITY;
+        a_message_id = stream_dict.get(user_a.user_id) || Number.NEGATIVE_INFINITY;
 
-        if (a_timestamp !== b_timestamp) {
-            return b_timestamp - a_timestamp;
+        if (a_message_id !== b_message_id) {
+            return b_message_id - a_message_id;
         }
     }
 


### PR DESCRIPTION
Fixes: 5956.