### PR TITLE
Fix errors in stream descriptions

### DIFF
--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -159,7 +159,7 @@ exports.get_subscriber_count = function (stream_name) {
 };
 
 exports.render_stream_description = function (sub) {
-    if (sub.description) {
+    if (sub.description !== undefined) {
         sub.rendered_description = marked(sub.description).replace('<p>', '').replace('</p>', '');
     }
 };

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -717,7 +717,7 @@ form#add_new_subscription {
     line-height: 1.5;
 }
 
-#subscription_overlay .stream-description:empty:after,
+#subscription_overlay .stream-description .stream-description-editable:empty:after,
 .stream-row .sub-info-box .description:empty:after {
     content: attr(data-no-description);
     font-style: italic;

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -25,8 +25,8 @@
                 <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button" title="{{t 'View stream'}} (V)">{{t "View stream"}}</a>
             </div>
         </div>
-        <div class="stream-description" data-no-description="{{t 'No description.' }}">
-            <span class="stream-description-editable editable-section">{{{rendered_description}}}</span>
+        <div class="stream-description">
+            <span class="stream-description-editable editable-section description" data-no-description="{{t 'No description.' }}">{{{rendered_description}}}</span>
             {{#if can_change_name_description}}
             <span class="editable" data-make-editable=".stream-description-editable"></span>
             <span class="checkmark" data-finish-editing=".stream-description-editable">✓</span>


### PR DESCRIPTION
**stream settings: Fix error in updates of stream description.**
    
    Stream description is not getting update in UI, if we remove
    stream description, mean pass "" as description. Cause the
    condition for checking description is undefined or not is
    not correctly set.
    Fix the error, by setting correct condition in function.

To reproduce the issue:
* On creating stream, set any stream description
* After stream creation, set `""` for stream description

**stream settings: Show message in case of no stream description.**
    
    Show "No description." message if stream doesn't have any

![streamdescription](https://user-images.githubusercontent.com/25907420/36041159-af1910f6-0ded-11e8-893b-57c819210b70.png)
