### PR TITLE
Fix thumbor deps issue

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -19,7 +19,7 @@ VENV_DEPENDENCIES = [
     "build-essential",
     "libffi-dev",
     "libfreetype6-dev",     # Needed for image types with Pillow
-    "libz-dev",             # Needed to handle compressed PNGs with Pillow
+    "zlib1g-dev",             # Needed to handle compressed PNGs with Pillow
     "libjpeg-dev",          # Needed to handle JPEGs with Pillow
     "libldap2-dev",
     "libmemcached-dev",

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -40,7 +40,8 @@ VENV_DEPENDENCIES = [
 THUMBOR_VENV_DEPENDENCIES = [
     "libcurl4-openssl-dev",
     "libjpeg-dev",
-    "libjasper-dev",
+    "zlib1g-dev",
+    "libfreetype6-dev",
     "libpng-dev",
     "gifsicle",
 ]

--- a/tools/circleci/Dockerfile.template
+++ b/tools/circleci/Dockerfile.template
@@ -91,7 +91,7 @@ RUN apt-get update \
   && apt-get install --no-install-recommends \
     closure-compiler memcached rabbitmq-server redis-server \
     hunspell-en-us supervisor libssl-dev yui-compressor puppet \
-    gettext libffi-dev libfreetype6-dev libz-dev libjpeg-dev \
+    gettext libffi-dev libfreetype6-dev zlib1g-dev libjpeg-dev \
     libldap2-dev libmemcached-dev python-dev python-pip \
     python-six libxml2-dev libxslt1-dev libpq-dev \
     {extra_packages}

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -200,7 +200,9 @@ def install_apt_deps():
     # type: () -> None
     # setup-apt-repo does an `apt-get update`
     run(["sudo", "./scripts/lib/setup-apt-repo"])
-    run(["sudo", "apt-get", "-y", "install", "--no-install-recommends"] + APT_DEPENDENCIES[codename])
+    # By doing list -> set -> list conversion we remove duplicates.
+    deps_to_install = list(set(APT_DEPENDENCIES[codename]))
+    run(["sudo", "apt-get", "-y", "install", "--no-install-recommends"] + deps_to_install)
 
 def main(options):
     # type: (Any) -> int

--- a/tools/test-install/prepare-base
+++ b/tools/test-install/prepare-base
@@ -49,7 +49,7 @@ run apt-get install -y --no-install-recommends \
   build-essential python3-dev \
   closure-compiler memcached rabbitmq-server redis-server \
   hunspell-en-us supervisor libssl-dev yui-compressor puppet \
-  gettext libffi-dev libfreetype6-dev libz-dev libjpeg-dev \
+  gettext libffi-dev libfreetype6-dev zlib1g-dev libjpeg-dev \
   libldap2-dev libmemcached-dev python-dev python-pip \
   python-six libxml2-dev libxslt1-dev libpq-dev \
   "${extra_packages[@]}"

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '14.8'
+PROVISION_VERSION = '14.9'

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '14.9'
+PROVISION_VERSION = '14.10'


### PR DESCRIPTION
We do the following here:
* Remove libjasper-dev from THUMBOR_VENV_DEPENDENCIES.
Reason: This dependancy wasn't really needed by us for using
thumbor. It was a dependancy for using open-cv as Imaging Engine
in thumbor but we use PIL (Pillow now) as Imaging Engine.
* Add zlib1g-dev, libfreetype6-dev to THUMBOR_VENV_DEPENDENCIES.
Reason: These are dependancies of Pillow which are required for it
Pillow to function. Since we use Pillow in thumbor as Imaging Engine
we need these. Stuff before this didn't break because we also use
Pillow in development Environment and have these dependancies
installed from VENV_DEPENDENCIES as well.

Relevant conversation about this happened in:
https://chat.zulip.org/#narrow/stream/development.20help/subject/zulip-thumbor-venv/near/487981
https://chat.zulip.org/#narrow/stream/backend/subject/thumbor/near/490169