### PR TITLE
Add live updates in stream setting page on subscription removal event

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -24,16 +24,24 @@ function get_email_of_subscribers(subscribers) {
 }
 
 exports.rerender_subscribers_list = function (sub) {
-    var emails = get_email_of_subscribers(sub.subscribers);
-    var subscribers_list = list_render.get("stream_subscribers/" + sub.stream_id);
+    if (!sub.can_add_subscribers) {
+        // It is also possible that user don't have rights to access subscribers.
+        // If user can't add subscribers, user can't access subscribers.
+        var html = templates.render('subscription_members', sub);
+        var stream_settings = settings_for_sub(sub);
+        stream_settings.find('.subscription-members-setting').expectOne().html(html);
+    } else {
+        var emails = get_email_of_subscribers(sub.subscribers);
+        var subscribers_list = list_render.get("stream_subscribers/" + sub.stream_id);
 
-    // Changing the data clears the rendered list and the list needs to be re-rendered.
-    // Perform re-rendering only when the stream settings form of the corresponding
-    // stream is open.
-    if (subscribers_list) {
-        subscribers_list.data(emails);
-        subscribers_list.render();
-        ui.update_scrollbar($(".subscriber_list_container"));
+        // Changing the data clears the rendered list and the list needs to be re-rendered.
+        // Perform re-rendering only when the stream settings form of the corresponding
+        // stream is open.
+        if (subscribers_list) {
+            subscribers_list.data(emails);
+            subscribers_list.render();
+            ui.update_scrollbar($(".subscriber_list_container"));
+        }
     }
 };
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -249,13 +249,21 @@ exports.update_settings_for_unsubscribed = function (sub) {
     var active_stream = exports.active_stream();
     if (active_stream !== undefined && active_stream.id === sub.stream_id) {
         stream_edit.rerender_subscribers_list(sub);
+
+        // Remove private streams from subscribed streams list.
+        if ($("#subscriptions_table .search-container .tab-switcher .first").hasClass("selected")
+            && sub.invite_only) {
+            var sub_row = $('#subscriptions_table .stream-row[data-stream-id=' + sub.stream_id + ']');
+            sub_row.addClass("notdisplayed");
+        }
+
+        // If user unsubscribed from private stream then user can not subscribe to
+        // stream without invitation. So hide subscribe button.
+        if (!sub.should_display_subscription_button) {
+            settings_button.hide();
+        }
     }
 
-    // If user unsubscribed from private stream then user can not subscribe to
-    // stream without invitation. So hide subscribe button.
-    if (!sub.should_display_subscription_button) {
-        settings_button.hide();
-    }
     row_for_stream_id(subs.stream_id).attr("data-temp-view", true);
 };
 

--- a/static/templates/subscription_members.handlebars
+++ b/static/templates/subscription_members.handlebars
@@ -1,0 +1,32 @@
+{{#render_subscribers}}
+<div class="subscriber_list_settings">
+    <div class="sub_settings_title float-left">
+        {{t "Stream membership" }}
+        <div class="stream_subscription_info small"></div>
+    </div>
+    <div class="subscriber_list_add float-right">
+        <form class="form-inline">
+            {{#if can_add_subscribers}}
+            <input type="text" class="search" placeholder="{{t 'Search subscribers' }}" />
+            <input type="text" name="principal" placeholder="{{t 'Email address' }}" value="" class="input-block" autocomplete="off" tabindex="-1" />
+            <button type="submit" name="add_subscriber" class="button add-subscriber-button small rounded" tabindex="-1 ">
+                {{t 'Add' }}
+            </button>
+            {{/if}}
+        </form>
+    </div>
+    <div class="clear-float"></div>
+</div>
+<div class="subscriber-list-box">
+    <div class="subscriber_list_container">
+        <div class="subscriber_list_loading_indicator"></div>
+        {{#if can_add_subscribers}}
+        <table class="subscriber-list"></table>
+        {{else}}
+        <div class="hide-subscriber-list">
+            {{t "This stream is private, so you can't see who is subscribed." }}
+        </div>
+        {{/if}}
+    </div>
+</div>
+{{/render_subscribers}}

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -107,33 +107,9 @@
             </div>
             {{/if}}
         </div>
-
-        {{#render_subscribers}}
-            {{#if can_add_subscribers}}
-            <div class="subscriber_list_settings">
-                <div class="sub_settings_title float-left">
-                    {{t "Stream membership" }}
-                    <div class="stream_subscription_info small"></div>
-                </div>
-                <div class="subscriber_list_add float-right">
-                    <form class="form-inline">
-                        <input type="text" class="search" placeholder="{{t 'Search subscribers' }}" />
-                        <input type="text" name="principal" placeholder="{{t 'Email address' }}" value="" class="input-block" autocomplete="off" tabindex="-1" />
-                        <button type="submit" name="add_subscriber" class="button add-subscriber-button small rounded" tabindex="-1 ">
-                            {{t 'Add' }}
-                        </button>
-                    </form>
-                </div>
-                <div class="clear-float"></div>
-            </div>
-            <div class="subscriber-list-box">
-                <div class="subscriber_list_container">
-                    <div class="subscriber_list_loading_indicator"></div>
-                    <table class="subscriber-list"></table>
-                </div>
-            </div>
-            {{/if}}
-        {{/render_subscribers}}
+        <div class="subscription-members-setting">
+            {{partial "subscription_members"}}
+        </div>
     </div>
 </div>
 {{/with}}


### PR DESCRIPTION
**stream settings: Update subscription count on subscription event.**
    
    On subscription add or removal event, render subscription count
    template in case of user can't access subscribers.

This will immediately change subscription count to lock icon if user is unsubscribing from private stream.

**stream settings: Hide stream members immediately on unsub, if can't access.**
    
    If user unsubscribe from private stream, then user can't
    access unsubscribed stream members.
    After subscription removal, immediately render subscription members
    template in case of user can't access stream subscriber.

This will immediately change subscribers list to a message "You can't access subscriber" if user is subscribing from private stream.

**stream settings: Remove stream from subscribed list immediately on unsub.**
    
    When user click on unsubscribe button, to unsubscribe from stream
    immediately remove unsubscribed stream from subscribed list.

This will remove stream from **Subscribed** stream list immediately, as user unsubscribe from stream.
NOTE: It will remove stream only and only from **Subscribed** list, **All stream** tab is active and user unsubscribe from stream, then stream shouldn't removed from list, cause it's **All stream** list. 

**stream settings: Fix error in rendering stream members in UI.**
    
    To re-render stream members on subscription add or remove event,
    we are accessing undefined value "active_stream.stream_id" rather
    than "active_stream.id", which resulted in falsey value and our
    stream members aren't get updated.

Our stream members aren't getting updated when user subscribe or unsubscribe from stream, cause this condition was not satisfied due to comparing undefined value of `active_stream` variable.

Fixes #8295 