### PR TITLE
bots: Handle exception on changing bot owner to invalid user.

### DIFF
--- a/static/templates/bot_owner_select.handlebars
+++ b/static/templates/bot_owner_select.handlebars
@@ -1,5 +1,4 @@
 <select name="bot_owner_select">
-    <option value=''></option>
     {{#each users_list}}
     <option value='{{this.email}}'>{{this.full_name}}</option>
     {{/each}}

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -642,6 +642,27 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         bot = self.get_bot()
         self.assertEqual('The Bot of Hamlet', bot['full_name'])
 
+    def test_patch_bot_owner_bad_username(self) -> None:
+        self.login(self.example_email('hamlet'))
+        self.create_bot()
+        self.assert_num_bots_equal(1)
+
+        bot_info = {
+            'bot_owner': '',
+        }
+        result = self.client_patch("/json/bots/hambot-bot@zulip.testserver", bot_info)
+        self.assert_json_error(result, "Failed to change owner, no such user")
+        profile = get_user('hambot-bot@zulip.testserver', get_realm('zulip'))
+        self.assertEqual(profile.bot_owner, self.example_user("hamlet"))
+
+        bot_info = {
+            'bot_owner': 'Invalid name',
+        }
+        result = self.client_patch("/json/bots/hambot-bot@zulip.testserver", bot_info)
+        self.assert_json_error(result, "Failed to change owner, no such user")
+        profile = get_user('hambot-bot@zulip.testserver', get_realm('zulip'))
+        self.assertEqual(profile.bot_owner, self.example_user("hamlet"))
+
     @override_settings(LOCAL_UPLOADS_DIR='var/bot_avatar')
     def test_patch_bot_avatar(self) -> None:
         self.login(self.example_email('hamlet'))

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from mock import patch
 from typing import Any, Dict, List, Mapping
 
-from zerver.lib.actions import do_change_stream_invite_only
+from zerver.lib.actions import do_change_stream_invite_only, do_deactivate_user
 from zerver.lib.bot_config import get_bot_config
 from zerver.models import get_realm, get_stream, \
     Realm, Stream, UserProfile, get_user, get_bot_services, Service, \
@@ -660,6 +660,44 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         result = self.client_patch("/json/bots/hambot-bot@zulip.testserver", bot_info)
         self.assert_json_error(result, "Failed to change owner, no such user")
+        profile = get_user('hambot-bot@zulip.testserver', get_realm('zulip'))
+        self.assertEqual(profile.bot_owner, self.example_user("hamlet"))
+
+    def test_patch_bot_owner_deactivated(self) -> None:
+        self.login(self.example_email('hamlet'))
+        self.create_bot()
+        self.assert_num_bots_equal(1)
+
+        target_user_profile = self.example_user("othello")
+        do_deactivate_user(target_user_profile)
+        target_user_profile = self.example_user('othello')
+        self.assertFalse(target_user_profile.is_active)
+        bot_info = {
+            'bot_owner': self.example_email('othello'),
+        }
+
+        result = self.client_patch("/json/bots/hambot-bot@zulip.testserver", bot_info)
+        self.assert_json_error(result, "Failed to change owner, user is deactivated")
+        profile = get_user('hambot-bot@zulip.testserver', get_realm('zulip'))
+        self.assertEqual(profile.bot_owner, self.example_user("hamlet"))
+
+    def test_patch_bot_owner_a_bot(self) -> None:
+        self.login(self.example_email('hamlet'))
+        self.create_bot()
+        self.assert_num_bots_equal(1)
+
+        bot_info = {
+            'full_name': u'Another Bot of Hamlet',
+            'short_name': u'hamelbot',
+        }
+        result = self.client_post("/json/bots", bot_info)
+        self.assert_json_success(result)
+
+        bot_info = {
+            'bot_owner': 'hamelbot-bot@zulip.testserver',
+        }
+        result = self.client_patch("/json/bots/hambot-bot@zulip.testserver", bot_info)
+        self.assert_json_error(result, "Failed to change owner, bots can not be admin")
         profile = get_user('hambot-bot@zulip.testserver', get_realm('zulip'))
         self.assertEqual(profile.bot_owner, self.example_user("hamlet"))
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -173,8 +173,12 @@ def patch_bot_backend(
     if full_name is not None:
         check_change_full_name(bot, full_name, user_profile)
     if bot_owner is not None:
-        owner = get_user(bot_owner, user_profile.realm)
+        try:
+            owner = get_user(bot_owner, user_profile.realm)
+        except UserProfile.DoesNotExist:
+            return json_error(_('Failed to change owner, no such user'))
         do_change_bot_owner(bot, owner, user_profile)
+
     if default_sending_stream is not None:
         if default_sending_stream == "":
             stream = None  # type: Optional[Stream]

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -177,6 +177,10 @@ def patch_bot_backend(
             owner = get_user(bot_owner, user_profile.realm)
         except UserProfile.DoesNotExist:
             return json_error(_('Failed to change owner, no such user'))
+        if not owner.is_active:
+            return json_error(_('Failed to change owner, user is deactivated'))
+        if owner.is_bot:
+            return json_error(_('Failed to change owner, bots can not be admin'))
         do_change_bot_owner(bot, owner, user_profile)
 
     if default_sending_stream is not None:


### PR DESCRIPTION
It catches the `UserProfile.DoesNotExist` exception and
hence prevent internal server error.
Also remove option to select empty bot owner.
Fixes: #8334.