### PR TITLE
setting: Fix password label is even shown when email auth is disabled.

### DIFF
--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -73,17 +73,17 @@
             </form>
 
             <form class="password-change-form grid">
+                {{#if page_params.realm_email_auth_enabled}}
                 <div class="user-name-section">
                     <label class="inline-block title">{{t "Password" }}</label>
                     <a id="change_password" {{#if page_params.realm_email_auth_enabled}}href="#change_password"{{/if}}>
-                        {{#if page_params.realm_email_auth_enabled}}
                         <div class="input-group inline-block" id="pw_change_link">
                             <button type="button" class="change_password_button small button rounded inline-block" data-dismiss="modal">{{t "********" }}<i class="fa fa-pencil"></i>
                             </button>
                         </div>
-                        {{/if}}
                     </a>
                 </div>
+                {{/if}}
 
                 <div id="change_password_modal" class="modal modal-bg hide" tabindex="-1" role="dialog"
                     aria-labelledby="change_password_modal_label" aria-hidden="true">


### PR DESCRIPTION
This PR
<img width="369" alt="screen shot 2018-02-10 at 6 57 10 pm" src="https://user-images.githubusercontent.com/18511177/36062596-ba3a934e-0e95-11e8-9925-b8e166a26256.png">

on [master](https://github.com/zulip/zulip/tree/7925e258a2f56ddfcd3c37b4fbbb2f0a69038c50)
<img width="380" alt="screen shot 2018-02-10 at 7 03 08 pm" src="https://user-images.githubusercontent.com/18511177/36062597-ba8493ea-0e95-11e8-8773-dbb76a089dc5.png">