### PR TITLE
profile menu: Show profile-edit option when a user clicks on self-profile.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -100,6 +100,7 @@ function show_user_info_popover(element, user, message) {
             sent_by_uri: narrow.by_sender_uri(user.email),
             narrowed: narrow_state.active(),
             private_message_class: "respond_personal_button",
+            is_me: people.is_current_user(user.email),
             is_active: people.is_active_user_for_popover(user.user_id),
             is_bot: people.get_person_from_user_id(user.user_id).is_bot,
         };

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -28,24 +28,37 @@
         {{/if}}
     </div>
     <hr />
-    {{#if is_active }}
+    {{#if is_active}}
+        {{#unless is_me}}
+        <li>
+            <a href="#" class="{{ private_message_class }}">
+                <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr this}}Send private message{{/tr}} (R)
+            </a>
+        </li>
+        {{/unless}}
+    {{/if}}
+    {{#if is_me}}
     <li>
-        <a href="#" class="{{ private_message_class }}">
-            <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr this}}Send private message{{/tr}} (R)
+        <a href="/#settings/your-account">
+            <i class="icon-vector-user" aria-hidden="true"></i> {{#tr this}}Edit profile{{/tr}}
         </a>
     </li>
     {{/if}}
+    {{#unless is_me}}
     <li>
         <a class="mention_user">
             <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}} (@)
         </a>
     </li>
+    {{/unless}}
     <hr />
+    {{#unless is_me}}
     <li>
         <a href="{{ pm_with_uri }}" class="narrow_to_private_messages">
             <i class="icon-vector-user"></i> {{#tr this}}View private messages{{/tr}}
         </a>
     </li>
+    {{/unless}}
     <li>
         <a href="{{ sent_by_uri }}" class="narrow_to_messages_sent">
             <i class="icon-vector-bullhorn"></i> {{#tr this}}View messages sent{{/tr}}


### PR DESCRIPTION
This removes some options when a user clicks on their own profile. And add
a link to edit their own profile settings.
Front end test adjusted because it was testing an option that does not
appear if a user clicks on their own profile.

Fixes #5075

@ryanle42 FYI
