### PR TITLE
Fixes #4513: show name if single user has reacted

### DIFF
--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -168,6 +168,7 @@ set_global('current_msg_list', {
          title: 'Cali reacted with :frown:',
          emoji_alt_code: false,
          class: 'message_reaction',
+         label: 1,
       },
       {
          emoji_name: 'inactive_realm_emoji',
@@ -181,6 +182,7 @@ set_global('current_msg_list', {
          is_realm_emoji: true,
          url: 'TBD',
          class: 'message_reaction reacted',
+         label: 1,
       },
       {
          emoji_name: 'smile',
@@ -192,6 +194,7 @@ set_global('current_msg_list', {
          title: 'You (click to remove) and Bob van Roberts reacted with :smile:',
          emoji_alt_code: false,
          class: 'message_reaction reacted',
+         label: 2,
       },
    ];
    assert.deepEqual(result, expected_result);
@@ -276,15 +279,14 @@ set_global('current_msg_list', {
     reactions.remove_reaction = orig_remove_reaction;
 }());
 
-(function test_set_reaction_count() {
-    var count_element = $.create('count-stub');
+(function test_set_label() {
+    var label_element = $.create('label-stub');
     var reaction_element = $.create('reaction-stub');
 
-    reaction_element.set_find_results('.message_reaction_count', count_element);
+    reaction_element.set_find_results('.message_reaction_label', label_element);
 
-    reactions.set_reaction_count(reaction_element, 5);
-
-    assert.equal(count_element.html(), '5');
+    reactions.set_label(reaction_element, [5]);
+    assert.equal(label_element.html(), 1);
 }());
 
 (function test_get_reaction_section() {
@@ -364,9 +366,9 @@ set_global('current_msg_list', {
         },
     };
 
-    var count_element = $.create('count-element');
+    var label_element = $.create('label-element');
     var reaction_element = $.create('reaction-element');
-    reaction_element.set_find_results('.message_reaction_count', count_element);
+    reaction_element.set_find_results('.message_reaction_label', label_element);
 
     var title_set;
     reaction_element.prop = function (prop_name, value) {
@@ -384,7 +386,7 @@ set_global('current_msg_list', {
 
     reactions.add_reaction(bob_event);
     assert(title_set);
-    assert.equal(count_element.html(), '2');
+    assert.equal(label_element.html(), '2');
 
     // Now, remove Bob's 8ball emoji.  The event has the same exact
     // structure as the add event.
@@ -398,7 +400,7 @@ set_global('current_msg_list', {
 
     reactions.remove_reaction(bob_event);
     assert(title_set);
-    assert.equal(count_element.html(), '1');
+    assert.equal(label_element.html(), 1);
 
     var current_emojis = reactions.get_emojis_used_by_user_for_message_id(1001);
     assert.deepEqual(current_emojis, ['smile', 'inactive_realm_emoji', '8ball']);

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -1,5 +1,6 @@
 set_global('document', 'document-stub');
 set_global('$', global.make_zjquery());
+set_global('i18n', global.stub_i18n);
 
 zrequire('people');
 zrequire('reactions');
@@ -168,7 +169,7 @@ set_global('current_msg_list', {
          title: 'Cali reacted with :frown:',
          emoji_alt_code: false,
          class: 'message_reaction',
-         label: 1,
+         label: 'Cali',
       },
       {
          emoji_name: 'inactive_realm_emoji',
@@ -182,7 +183,7 @@ set_global('current_msg_list', {
          is_realm_emoji: true,
          url: 'TBD',
          class: 'message_reaction reacted',
-         label: 1,
+         label: i18n.t("You"),
       },
       {
          emoji_name: 'smile',
@@ -285,8 +286,14 @@ set_global('current_msg_list', {
 
     reaction_element.set_find_results('.message_reaction_label', label_element);
 
+    reactions.set_label(reaction_element, [5, 6]);
+    assert.equal(label_element.html(), '2');
+
     reactions.set_label(reaction_element, [5]);
-    assert.equal(label_element.html(), 1);
+    assert.equal(label_element.html(), i18n.t("You"));
+
+    reactions.set_label(reaction_element, [7]);
+    assert.equal(label_element.html(), 'Cali');
 }());
 
 (function test_get_reaction_section() {
@@ -400,7 +407,7 @@ set_global('current_msg_list', {
 
     reactions.remove_reaction(bob_event);
     assert(title_set);
-    assert.equal(label_element.html(), 1);
+    assert.equal(label_element.html(), i18n.t("You"));
 
     var current_emojis = reactions.get_emojis_used_by_user_for_message_id(1001);
     assert.deepEqual(current_emojis, ['smile', 'inactive_realm_emoji', '8ball']);

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -150,7 +150,12 @@ function full_name(user_id) {
 
 function get_label(user_list) {
     var count = user_list.length;
-    return count;
+    if (count > 1) {
+        return count;
+    } else if (user_list.indexOf(page_params.user_id) !== -1) {
+        return i18n.t("You");
+    }
+    return people.get_person_from_user_id(user_list[0]).full_name;
 }
 
 function generate_title(emoji_name, user_ids) {

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -148,6 +148,11 @@ function full_name(user_id) {
     return people.get_person_from_user_id(user_id).full_name;
 }
 
+function get_label(user_list) {
+    var count = user_list.length;
+    return count;
+}
+
 function generate_title(emoji_name, user_ids) {
     var i = user_ids.indexOf(page_params.user_id);
     if (i !== -1) {
@@ -181,9 +186,9 @@ exports.get_add_reaction_button = function (message_id) {
     return add_button;
 };
 
-exports.set_reaction_count = function (reaction, count) {
-    var count_element = reaction.find('.message_reaction_count');
-    count_element.html(count);
+exports.set_label = function (reaction, user_list) {
+    var label_element = reaction.find('.message_reaction_label');
+    label_element.html(get_label(user_list));
 };
 
 exports.add_reaction = function (event) {
@@ -238,7 +243,7 @@ exports.view.update_existing_reaction = function (opts) {
     var local_id = exports.get_local_reaction_id(opts);
     var reaction = exports.find_reaction(message_id, local_id);
 
-    exports.set_reaction_count(reaction, user_list.length);
+    exports.set_label(reaction, user_list);
 
     var new_title = generate_title(emoji_name, user_list);
     reaction.prop('title', new_title);
@@ -277,6 +282,7 @@ exports.view.insert_new_reaction = function (opts) {
     context.title = new_title;
     context.local_id = exports.get_local_reaction_id(opts);
     context.emoji_alt_code = (page_params.emojiset === 'text');
+    context.label = get_label(user_list);
 
     if (opts.user_id === page_params.user_id) {
         context.class = "message_reaction reacted";
@@ -363,7 +369,7 @@ exports.view.remove_reaction = function (opts) {
     var new_title = generate_title(emoji_name, user_list);
     reaction.prop('title', new_title);
 
-    exports.set_reaction_count(reaction, user_list.length);
+    exports.set_label(reaction, user_list);
 
     if (user_id === page_params.user_id) {
         reaction.removeClass("reacted");
@@ -407,6 +413,7 @@ exports.get_message_reactions = function (message) {
         reaction.count = reaction.user_ids.length;
         reaction.title = generate_title(reaction.emoji_name, reaction.user_ids);
         reaction.emoji_alt_code = (page_params.emojiset === 'text');
+        reaction.label = get_label(reaction.user_ids);
 
         if (reaction.reaction_type !== 'unicode_emoji') {
             reaction.is_realm_emoji = true;

--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -55,7 +55,7 @@ body.dark-mode .popover a {
 body.dark-mode .dark_background a,
 body.dark-mode a.dark_background:hover,
 body.dark-mode .dark_background,
-body.dark-mode .message_reactions .message_reaction_count,
+body.dark-mode .message_reactions .message_reaction_label,
 body.dark-mode .message_reactions .reaction_button i,
 body.dark-mode .message_reactions:hover .message_reaction + .reaction_button {
     color: inherit !important;

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -48,7 +48,7 @@
     position: relative;
 }
 
-.message_reactions .message_reaction_count {
+.message_reactions .message_reaction_label {
     position: relative;
     top: 4px;
     font-size: 0.8em;
@@ -59,7 +59,7 @@
     line-height: 1em;
 }
 
-.message_reactions .reaction_button .message_reaction_count {
+.message_reactions .reaction_button .message_reaction_label {
     top: 0.5px;
 }
 
@@ -124,13 +124,13 @@
     color: hsl(200, 100%, 40%);
 }
 
-.message_reactions .reaction_button .message_reaction_count {
+.message_reactions .reaction_button .message_reaction_label {
     font-size: 1.1em;
     color: hsl(0, 0%, 33%);
     margin-left: 3px;
 }
 
-.message_reactions .reaction_button:hover .message_reaction_count {
+.message_reactions .reaction_button:hover .message_reaction_label {
     color: hsl(200, 100%, 40%);
 }
 

--- a/static/templates/message_reaction.handlebars
+++ b/static/templates/message_reaction.handlebars
@@ -8,5 +8,5 @@
         <div class="emoji emoji-{{this.emoji_code}}" />
         {{/if}}
     {{/if}}
-    <div class="message_reaction_count">{{this.count}}</div>
+    <div class="message_reaction_label">{{this.label}}</div>
 </div>

--- a/static/templates/message_reactions.handlebars
+++ b/static/templates/message_reactions.handlebars
@@ -3,5 +3,5 @@
 {{/each}}
 <div class="reaction_button" title="{{t 'Add emoji reaction' }} (:)">
     <i class="fa fa-smile-o" aria-hidden="true"></i>
-    <div class="message_reaction_count">+</div>
+    <div class="message_reaction_label">+</div>
 </div>


### PR DESCRIPTION
fixes #4513.
Name is shown if both of the below conditions are fulfilled:
- Only single user has reacted
- The current user is not in the user_list of that reaction

`label` has been used instead of `count` because if the name is being displayed, calling it count isn't appropriate.

![selection_032](https://user-images.githubusercontent.com/13910561/36072730-b99a2b38-0f4a-11e8-983c-c863cb503135.png)
