### PR TITLE
invitations: Improve error message displayed on inviting deactivated …

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2248,6 +2248,10 @@ button.topic_edit_cancel {
     display: none;
 }
 
+#invite_status_message {
+    margin-top: 6px;
+}
+
 #invite-user #invite-user-label {
     font-size: 1em;
     font-weight: 700;

--- a/templates/zerver/invite_user.html
+++ b/templates/zerver/invite_user.html
@@ -26,7 +26,12 @@
                     </div>
                     {% endif %}
                 </div>
-                <div class="alert" id="invite_status"></div>
+                <div class="alert" id="invite_status">
+                    <p id="invite_status_message"></p>
+                    <ul id="invite_error_list"></ul>
+                    <p id="reactivation_message_non_admin">{{ _('Organization administrators can reactivate deactivated users from organization settings.') }}</p>
+                    <p id="reactivation_message_admin">You can reactivate deactivated users from <a href="#organization/deactivated-users-admin">organization settings</a>.</p>
+                </div>
                 {% if development_environment %}
                 <div class="alert" id="dev_env_msg"></div>
                 {% endif %}


### PR DESCRIPTION
…users.

The following are achieved:

Upon inviting a user whose account was deactivated,
the error message reads 'Has an account that has been deactivated.'
instead of 'Already has an account.'

Furthermore, if the inviting user is a realm admin, it also adds,
'You can reactivate a deactivated user in organization settings.'
If the inviting user is a non-admin for the realm, it adds
'Organization administrators can reactivate a
deactivated user in organization settings.'

Fixes #8144.