### PR TITLE
user settings: Directly send password reset email to current user.

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -28,10 +28,11 @@ casper.then(function () {
     casper.waitUntilVisible("#settings_content .account-settings-form", function () {
         casper.test.assertUrlMatch(/^http:\/\/[^/]+\/#settings/, 'URL suggests we are on settings page');
         casper.test.assertVisible('.account-settings-form', 'Settings page is active');
-
         casper.test.assertNotVisible("#pw_change_controls");
-
-        // casper.click(".change_password_button");
+        casper.click(".change_password_button");
+        casper.test.assertVisible('#forgot_password', 'Forgot password is visible');
+        casper.click("#forgot_password");
+        casper.test.assertVisible('#reset_password', 'Reset password is visible');
         casper.click('#api_key_button');
     });
 });
@@ -63,7 +64,6 @@ casper.then(function () {
     });
 });
 */
-
 casper.then(function () {
     casper.waitUntilVisible('#get_api_key_password', function () {
         casper.fill('form[action^="/json/fetch_api_key"]', {password:test_credentials.default_user.password});

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -166,6 +166,8 @@ exports.set_up = function () {
         // Clear the password boxes so that passwords don't linger in the DOM
         // for an XSS attacker to find.
         $('#old_password, #new_password').val('');
+        $(".reset_password_container").hide();
+        $("#forgot_password").show();
         common.password_quality('', $('#pw_strength .bar'), $('#new_password'));
     }
 
@@ -252,6 +254,51 @@ exports.set_up = function () {
                 ui_report.error(i18n.t("Failed"), xhr, change_password_info);
             },
         });
+    });
+
+    function show_reset_email_loader() {
+        loading.make_indicator($(".loading_indicator_spinner"), {text: 'Sending...'});
+    }
+
+    function hide_reset_email_loader() {
+        loading.destroy_indicator($(".loading_indicator_spinner"));
+    }
+
+    function send_password_reset() {
+        var email = people.my_current_email();
+        var data = {};
+
+        data.email = email;
+        channel.post({
+            url: '/accounts/password/reset/',
+            data: data,
+            success: function () {
+                $('#reset_sent, #resend_link').show();
+            },
+            error: function () {
+                $('#reset_failed, #resend_link').show();
+            },
+            complete: function () {
+                hide_reset_email_loader();
+            },
+        });
+    }
+
+    $('#forgot_password').on('click', function () {
+        $('#forgot_password').hide();
+        $('#reset_password').show();
+    });
+
+    $('#reset_password').on('click', function () {
+        $('#reset_password').hide();
+        show_reset_email_loader();
+        send_password_reset();
+    });
+
+    $('#resend_link').on('click', function () {
+        $('#resend_link, #reset_sent, #reset_failed').hide();
+        show_reset_email_loader();
+        send_password_reset();
     });
 
     $('#new_password').on('change keyup', function () {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -56,11 +56,17 @@ label {
 .new-style .grid .warning {
     display: inline-block;
     vertical-align: top;
-
     width: 150px;
     padding: 5px 10px;
-
     text-align: left;
+}
+
+.new-style #account-settings .loading_indicator_spinner {
+    display: inline-block;
+    width: 32px;
+    height: 15px;
+    float: none;
+    margin-top: 0;
 }
 
 .new-style .warning #pw_strength {
@@ -1354,6 +1360,15 @@ input[type=checkbox].inline-block {
 #settings_page #change_email_modal .change_email_info,
 #settings_page #change_full_name_modal .change_full_name_info {
     margin: 10px;
+}
+
+#account-settings #change_password_modal .reset_password_container {
+    display: none;
+}
+
+#account-settings #change_password_modal #reset_sent,
+#account-settings #change_password_modal #reset_failed {
+    padding-right: 3px;
 }
 
 #deactivation_user_modal.fade.in {

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -96,9 +96,13 @@
                             <label for="old_password" class="title">{{t "Old password" }}</label>
                             <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block" value="" />
                             <div class="info">
-                                <a href="/accounts/password/reset/" class="sea-green" target="_blank">{{t "Forgotten it?" }}</a>
+                                <a class="sea-green" id="forgot_password">{{t "Forgotten it?" }}</a>
+                                <a class="sea-green reset_password_container" id="reset_password">{{t "Reset password" }}</a>
+                                <div class="loading_indicator_spinner"></div>
+                                <span id="reset_sent" class="reset_password_container">{{t "Check your email!" }}</span>
+                                <span id="reset_failed" class="reset_password_container">{{t "Reset failed to send" }}</span>
+                                <a class="sea-green reset_password_container" id="resend_link">{{t "Resend" }}</a>
                             </div>
-
                         </div>
                         <div class="field">
                             <label for="new_password" class="title">{{t "New password" }}</label>


### PR DESCRIPTION
Directly send password reset email on forgot password link to
current user in user setting page, rather than redirecting them
to another page to enter their email.
An option to resend the link is also added.

Fixes: #6342.

Updated version of #7725 

