### PR TITLE
slack importer: migrate avatars.

### DIFF
--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -139,7 +139,6 @@ def users_to_zerver_userprofile(slack_data_dir: str, users: List[ZerverFieldsT],
 
     for user in users:
         slack_user_id = user['id']
-        profile = user['profile']
         DESKTOP_NOTIFICATION = True
 
         if user.get('is_primary_owner', False):
@@ -153,17 +152,13 @@ def users_to_zerver_userprofile(slack_data_dir: str, users: List[ZerverFieldsT],
         # check if user is the admin
         realm_admin = get_admin(user)
 
-        # avatar
-        # ref: https://chat.zulip.org/help/change-your-avatar
-        avatar_source = get_user_avatar_source(profile['image_32'])
-
         # timezone
         timezone = get_user_timezone(user)
 
         userprofile = dict(
             enable_desktop_notifications=DESKTOP_NOTIFICATION,
             is_staff=False,  # 'staff' is for server administrators, which don't exist in Slack.
-            avatar_source=avatar_source,
+            avatar_source='U',
             is_bot=user.get('is_bot', False),
             avatar_version=1,
             default_desktop_notifications=True,
@@ -242,14 +237,6 @@ def get_admin(user: ZerverFieldsT) -> bool:
     if admin or owner or primary_owner:
         return True
     return False
-
-def get_user_avatar_source(image_url: str) -> str:
-    if 'gravatar.com' in image_url:
-        # use the avatar from gravatar
-        avatar_source = 'G'
-    else:
-        avatar_source = 'U'
-    return avatar_source
 
 def get_user_timezone(user: ZerverFieldsT) -> str:
     _default_timezone = "America/New_York"

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -50,13 +50,15 @@ def allocate_ids(model_class: Any, count: int) -> List[int]:
 def slack_workspace_to_realm(REALM_ID: int, user_list: List[ZerverFieldsT],
                              realm_subdomain: str, fixtures_path: str,
                              slack_data_dir: str) -> Tuple[ZerverFieldsT, AddedUsersT,
-                                                           AddedRecipientsT, AddedChannelsT]:
+                                                           AddedRecipientsT, AddedChannelsT,
+                                                           List[ZerverFieldsT]]:
     """
     Returns:
     1. realm, Converted Realm data
     2. added_users, which is a dictionary to map from slack user id to zulip user id
     3. added_recipient, which is a dictionary to map from channel name to zulip recipient_id
     4. added_channels, which is a dictionary to map from channel name to zulip stream_id
+    5. avatars, which is list to map avatars to zulip avatard records.json
     """
     DOMAIN_NAME = settings.EXTERNAL_HOST
     NOW = float(timezone_now().timestamp())
@@ -80,11 +82,8 @@ def slack_workspace_to_realm(REALM_ID: int, user_list: List[ZerverFieldsT],
                  zerver_realmfilter=[],
                  zerver_realmemoji=[])
 
-    zerver_userprofile, added_users = users_to_zerver_userprofile(slack_data_dir,
-                                                                  user_list,
-                                                                  REALM_ID,
-                                                                  int(NOW),
-                                                                  DOMAIN_NAME)
+    zerver_userprofile, avatars, added_users = users_to_zerver_userprofile(
+        slack_data_dir, user_list, REALM_ID, int(NOW), DOMAIN_NAME)
     channels_to_zerver_stream_fields = channels_to_zerver_stream(slack_data_dir,
                                                                  REALM_ID,
                                                                  added_users,
@@ -100,7 +99,7 @@ def slack_workspace_to_realm(REALM_ID: int, user_list: List[ZerverFieldsT],
     added_channels = channels_to_zerver_stream_fields[2]
     added_recipient = channels_to_zerver_stream_fields[5]
 
-    return realm, added_users, added_recipient, added_channels
+    return realm, added_users, added_recipient, added_channels, avatars
 
 def build_zerver_realm(fixtures_path: str, REALM_ID: int, realm_subdomain: str,
                        time: float) -> List[ZerverFieldsT]:
@@ -116,11 +115,13 @@ def build_zerver_realm(fixtures_path: str, REALM_ID: int, realm_subdomain: str,
 
 def users_to_zerver_userprofile(slack_data_dir: str, users: List[ZerverFieldsT], realm_id: int,
                                 timestamp: Any, domain_name: str) -> Tuple[List[ZerverFieldsT],
+                                                                           List[ZerverFieldsT],
                                                                            AddedUsersT]:
     """
     Returns:
     1. zerver_userprofile, which is a list of user profile
-    2. added_users, which is a dictionary to map from slack user id to zulip
+    2. avatar_list, which is list to map avatars to zulip avatard records.json
+    3. added_users, which is a dictionary to map from slack user id to zulip
        user id
     """
     logging.info('######### IMPORTING USERS STARTED #########\n')
@@ -226,7 +227,7 @@ def users_to_zerver_userprofile(slack_data_dir: str, users: List[ZerverFieldsT],
 
         logging.info(u"{} -> {}".format(user['name'], userprofile['email']))
     logging.info('######### IMPORTING USERS FINISHED #########\n')
-    return zerver_userprofile, added_users
+    return zerver_userprofile, avatar_list, added_users
 
 def get_user_email(user: ZerverFieldsT, domain_name: str) -> str:
     if 'email' not in user['profile']:
@@ -652,11 +653,9 @@ def do_convert_data(slack_zip_file: str, realm_subdomain: str, output_dir: str, 
     REALM_ID = allocate_ids(Realm, 1)[0]
 
     user_list = get_user_data(token)
-    realm, added_users, added_recipient, added_channels = slack_workspace_to_realm(REALM_ID,
-                                                                                   user_list,
-                                                                                   realm_subdomain,
-                                                                                   fixtures_path,
-                                                                                   slack_data_dir)
+    realm, added_users, added_recipient, added_channels, avatar_list = slack_workspace_to_realm(
+        REALM_ID, user_list, realm_subdomain, fixtures_path, slack_data_dir)
+
     message_json = convert_slack_workspace_messages(slack_data_dir, user_list, REALM_ID,
                                                     added_users, added_recipient, added_channels,
                                                     realm)

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -8,7 +8,6 @@ from zerver.lib.slack_data_to_zulip_data import (
     build_zerver_realm,
     get_user_email,
     get_admin,
-    get_user_avatar_source,
     get_user_timezone,
     users_to_zerver_userprofile,
     build_defaultstream,
@@ -104,12 +103,6 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(get_admin(user_data[2]), True)
         self.assertEqual(get_admin(user_data[3]), False)
 
-    def test_get_avatar_source(self) -> None:
-        gravatar_image_url = "https:\/\/secure.gravatar.com\/avatar\/78dc7b2e1bf423df8c82fb2a62c8917d.jpg?s=24&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0016-24.png"
-        uploaded_avatar_url = "https:\/\/avatars.slack-edge.com\/2015-06-12\/6314338625_3c7c62301a2d61b4a756_24.jpg"
-        self.assertEqual(get_user_avatar_source(gravatar_image_url), 'G')
-        self.assertEqual(get_user_avatar_source(uploaded_avatar_url), 'U')
-
     def test_get_timezone(self) -> None:
         user_chicago_timezone = {"tz": "America\/Chicago"}
         user_timezone_none = {"tz": None}
@@ -168,6 +161,7 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(zerver_userprofile[0]['is_bot'], False)
         self.assertEqual(zerver_userprofile[0]['enable_desktop_notifications'], True)
         self.assertEqual(zerver_userprofile[2]['bot_type'], 1)
+        self.assertEqual(zerver_userprofile[2]['avatar_source'], 'U')
 
     def test_build_defaultstream(self) -> None:
         realm_id = 1


### PR DESCRIPTION
Summary:

**Remove function 'get_user_avatar_source':**
In the user profile data, we get the image url as `"image_512": "https:\/\/secure.gravatar.com\/avatar\/1260bbb9ad836a3122d081d49d083214.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0024-512.png"`

Another format of slack avatar url which I have used is:
Slack avatar urls have the format: `https://ca.slack-edge.com/<team_id>-<user_id>-<avatar_hash>-<size>`. For any url of this form, if the user hasn't uploaded an image, Slack uses default gravatar, but we don't have a way of knowing if Slack has used the uploaded image or the custom gravatar (eg: https://ca.slack-edge.com/T5YFFM2QY-U6006P1CN-gd41c3c33cbe-512)
Hence, `avatar_source` would always be mapped to `U`.


**Make sure medium avatars exist during import:**
The [import](https://github.com/zulip/zulip/blob/master/zerver/lib/export.py#L1303-L1345) script processes the correctly processes the avatars if they are stored in the hashed directory, however, it doesn't store the medium sized images( urls ending with `-medium.png`) neither are the avatars processed to creates the medium image. 



The below are the screenshots of the converted slack data: https://github.com/rheaparekh/slack2zulip-data-converter/tree/master/plan8team

![screen_shot1](https://user-images.githubusercontent.com/25330892/36336307-9b00b5b4-13ac-11e8-9584-3c661e309fe9.png)
![screen_shot2](https://user-images.githubusercontent.com/25330892/36336391-5a5e1500-13ad-11e8-8c78-4d2920e5d302.png)


