### PR TITLE
local-uploads: Start running authentication checks on file requests.

### DIFF
--- a/puppet/zulip/files/nginx/sites-available/zulip-enterprise
+++ b/puppet/zulip/files/nginx/sites-available/zulip-enterprise
@@ -12,12 +12,6 @@ server {
     ssl_certificate /etc/ssl/certs/zulip.combined-chain.crt;
     ssl_certificate_key /etc/ssl/private/zulip.key;
 
-    location /user_uploads {
-        add_header X-Content-Type-Options nosniff;
-        include /etc/nginx/zulip-include/uploads.types;
-        alias /home/zulip/uploads/files;
-    }
-
     location /user_avatars {
         add_header X-Content-Type-Options nosniff;
         include /etc/nginx/zulip-include/uploads.types;
@@ -30,4 +24,5 @@ server {
 
     include /etc/nginx/zulip-include/certbot;
     include /etc/nginx/zulip-include/app;
+    include /etc/nginx/zulip-include/uploads.route;
 }

--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.direct
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.direct
@@ -1,0 +1,5 @@
+location /user_uploads {
+    add_header X-Content-Type-Options nosniff;
+    include /etc/nginx/zulip-include/uploads.types;
+    alias /home/zulip/uploads/files;
+}

--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.internal
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.internal
@@ -1,0 +1,6 @@
+location /serve_uploads {
+    internal;
+    add_header X-Content-Type-Options nosniff;
+    include /etc/nginx/zulip-include/uploads.types;
+    alias /home/zulip/uploads/files;
+}

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -188,3 +188,6 @@ twilio==6.10.3
 
 # Needed for processing payments (in zilencer)
 stripe==1.77.2
+
+# Needed for serving uploaded files from nginx but perform auth checks in django.
+django-sendfile==0.3.11

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -47,6 +47,7 @@ django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.4.1.1       # via django-two-factor-auth
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-pipeline==1.6.14
+django-sendfile==0.3.11
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.7.0
 django-webpack-loader==0.5.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -35,6 +35,7 @@ django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.4.1.1       # via django-two-factor-auth
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-pipeline==1.6.14
+django-sendfile==0.3.11
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.7.0
 django-webpack-loader==0.5.0

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -78,4 +78,3 @@ TWO_FACTOR_SMS_GATEWAY = 'two_factor.gateways.fake.Fake'
 
 # Make sendfile use django to serve files in development
 SENDFILE_BACKEND = 'sendfile.backends.development'
-SENDFILE_ROOT = os.path.join(LOCAL_UPLOADS_DIR, 'files')

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -75,3 +75,7 @@ EMAIL_HOST_USER = ""
 # Two factor authentication: Use the fake backend for development.
 TWO_FACTOR_CALL_GATEWAY = 'two_factor.gateways.fake.Fake'
 TWO_FACTOR_SMS_GATEWAY = 'two_factor.gateways.fake.Fake'
+
+# Make sendfile use django to serve files in development
+SENDFILE_BACKEND = 'sendfile.backends.development'
+SENDFILE_ROOT = os.path.join(LOCAL_UPLOADS_DIR, 'files')

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -180,9 +180,7 @@ DEFAULT_SETTINGS = {
     'REMOTE_POSTGRES_HOST': '',
     'REMOTE_POSTGRES_SSLMODE': '',
     'THUMBOR_HOST': '',
-    'SENDFILE_BACKEND': 'sendfile.backends.nginx',
-    'SENDFILE_ROOT': '/home/zulip/uploads/files',
-    'SENDFILE_URL': '/serve_uploads',
+    'SENDFILE_BACKEND': None,
 
     # ToS/Privacy templates
     'PRIVACY_POLICY': None,
@@ -672,6 +670,12 @@ if "NAGIOS_BOT_HOST" not in vars():
 
 S3_KEY = get_secret("s3_key")
 S3_SECRET_KEY = get_secret("s3_secret_key")
+
+if LOCAL_UPLOADS_DIR is not None:
+    if SENDFILE_BACKEND is None:
+        SENDFILE_BACKEND = 'sendfile.backends.nginx'
+    SENDFILE_ROOT = os.path.join(LOCAL_UPLOADS_DIR, "files")
+    SENDFILE_URL = '/serve_uploads'
 
 # GCM tokens are IP-whitelisted; if we deploy to additional
 # servers you will need to explicitly add their IPs here:

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -180,6 +180,9 @@ DEFAULT_SETTINGS = {
     'REMOTE_POSTGRES_HOST': '',
     'REMOTE_POSTGRES_SSLMODE': '',
     'THUMBOR_HOST': '',
+    'SENDFILE_BACKEND': 'sendfile.backends.nginx',
+    'SENDFILE_ROOT': '/home/zulip/uploads/files',
+    'SENDFILE_URL': '/serve_uploads',
 
     # ToS/Privacy templates
     'PRIVACY_POLICY': None,


### PR DESCRIPTION
From here on we start to authenticate uploaded file request before
serving this files in production. This involves allowing NGINX to
pass on these file requests to Django for authentication and then
serve these files by making use on internal redirect requests having
x-accel-redirect field. The redirection on requests and loading
of x-accel-redirect param is handled by django-sendfile.

NOTE: This commit starts to authenticate these requests for Zulip
servers running platforms either Ubuntu Xenial (16.04) or above.

Fixes: #320 and #291 partially.