### PR TITLE
Responsive features page

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -400,7 +400,7 @@ nav ul li.active::after {
 /* -- features page css -- */
 .portico-landing.features-app {
     position: relative;
-
+    overflow-x: hidden;
     padding-top: 0px;
 
     z-index: 2;
@@ -408,6 +408,10 @@ nav ul li.active::after {
 
 .portico-landing.features-app section {
     max-width: 1440px;
+    display: flex;
+    flex: 1 1 auto;
+    flex-flow: row wrap;
+    justify-content: space-around;
     margin: 40px auto;
     padding: 0px 30px;
     color: #2a3241;
@@ -476,7 +480,6 @@ nav ul li.active::after {
     position: absolute;
     top: -169px;
     right: 0;
-
     width: 685px;
     height: 170px;
 
@@ -553,6 +556,7 @@ nav ul li.active::after {
     top: 0;
     left: 0;
     width: 100%;
+    max-height: 40vw;
 }
 
 .portico-landing.features-app section.notifications h2 {
@@ -648,13 +652,15 @@ nav ul li.active::after {
 
 .portico-landing.features-app section h2 {
     font-size: 2.5em;
+    text-align: center;
     margin: 0px 10px;
     line-height: 1.6;
+    flex: 1 0 100%;
 }
 
 .portico-landing.features-app section > .feature-block {
-    margin: 10px;
-    width: calc(33% - 20px);
+    margin: 10px 20px;
+    flex: 1 1 320px;
 }
 
 .portico-landing.features-app .feature-block h3 {
@@ -2892,6 +2898,14 @@ nav ul li.active::after {
     .portico-landing.why-page .hero p br {
         display: none;
     }
+
+    .portico-landing.features-app section.notifications {
+        padding: 50px 10px;
+    }
+
+    .portico-landing.features-app section.notifications .image-block {
+        display: none;
+    }
 }
 
 @media (max-width: 830px) {
@@ -3370,6 +3384,10 @@ nav ul li.active::after {
 
     .portico-landing.integrations .integration-lozenge {
         width: 120px;
+    }
+
+    .portico-landing.features-app section.keyboard-shortcuts::after {
+        left: 0;
     }
 }
 


### PR DESCRIPTION
Fixes #7925 

Note: This really only touches a couple of key points, but it does most of what's needed to collapse stuff down into columns or a single column when stuff is narrow. Here's some screenshots of the work.

Other note: the wave bit above keyboard notifications maybe should resize with the window, but it doesn't - it's relatively tall in narrow screens, but I'm living with it as a minimal-touch change, as the height needs to be static in order to get the offset right - to really fix this image to smoothly resize, I'd have to dig a bunch more into the guts of the page's HTML structure.

<img width="372" alt="notifications" src="https://user-images.githubusercontent.com/255715/36130187-3da91580-1020-11e8-83be-0504e16fe5e4.png">
<img width="377" alt="shortcuts" src="https://user-images.githubusercontent.com/255715/36129829-f8bc7e3c-101d-11e8-8b84-709eb296253b.png">
<img width="376" alt="features" src="https://user-images.githubusercontent.com/255715/36129830-f8d05722-101d-11e8-98bb-57b61132c8dd.png">
