### PR TITLE
Change permission of basic stream management operations

### DIFF
--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -203,9 +203,8 @@ exports.update_calculated_fields = function (sub) {
     sub.can_make_public = page_params.is_admin && sub.invite_only && sub.subscribed;
     sub.can_make_private = page_params.is_admin && !sub.invite_only;
     sub.can_change_subscription_type = sub.can_make_public || sub.can_make_private;
-    // User can access subscribers as well as add other users to stream
-    // if sub.can_add_subscribers is true.
-    sub.can_add_subscribers = !sub.invite_only || (sub.invite_only && sub.subscribed);
+    // User can add other users to stream if stream is public or user is subscribed to stream.
+    sub.can_access_subscribers = !sub.invite_only || sub.subscribed || page_params.is_admin;
     sub.preview_url = narrow.by_stream_uri(sub.name);
     exports.render_stream_description(sub);
     exports.update_subscribers_count(sub);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -194,10 +194,9 @@ exports.render_stream_description = function (sub) {
 
 exports.update_calculated_fields = function (sub) {
     sub.is_admin = page_params.is_admin;
-    // Admin can change stream name/description either stream is public or
-    // stream is private and admin is subscribed to private stream.
-    sub.can_change_name_description = page_params.is_admin &&
-                                     (!sub.invite_only || (sub.invite_only && sub.subscribed));
+    // Admin can change any stream's name & description either stream is public or
+    // private, subscribed or unsubscribed.
+    sub.can_change_name_description = page_params.is_admin;
     // If stream is public then any user can subscribe. If stream is private then only
     // subscribed users can unsubscribe.
     sub.should_display_subscription_button = !sub.invite_only || sub.subscribed;

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -24,7 +24,7 @@ function get_email_of_subscribers(subscribers) {
 }
 
 exports.rerender_subscribers_list = function (sub) {
-    if (!sub.can_add_subscribers) {
+    if (!sub.can_access_subscribers) {
         $(".subscriber_list_settings_container").hide();
     } else {
         var emails = get_email_of_subscribers(sub.subscribers);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -152,7 +152,7 @@ exports.set_color = function (stream_id, color) {
 exports.rerender_subscribers_count = function (sub, just_subscribed) {
     var stream_row = row_for_stream_id(sub.stream_id);
     stream_data.update_subscribers_count(sub);
-    if (!sub.can_add_subscribers || (just_subscribed && sub.invite_only)) {
+    if (!sub.can_access_subscribers || (just_subscribed && sub.invite_only)) {
         var sub_count = templates.render("subscription_count", sub);
         stream_row.find('.subscriber-count').expectOne().html(sub_count);
     } else {

--- a/static/templates/subscription.handlebars
+++ b/static/templates/subscription.handlebars
@@ -16,7 +16,7 @@
             <div class="stream-message-count">
                 {{#if is_old_stream}}
                     <i class="icon-vector-comments"></i>
-                    {{#if can_add_subscribers}}
+                    {{#if can_access_subscribers}}
                     <span class="stream-message-count-text">{{stream_weekly_traffic}}</span>
                     <div class="stream-message-hover-content">{{t "Average weekly traffic" }}</div>
                     {{/if}}

--- a/static/templates/subscription_count.handlebars
+++ b/static/templates/subscription_count.handlebars
@@ -1,4 +1,4 @@
-{{#if can_add_subscribers}}
+{{#if can_access_subscribers}}
 <span class="subscriber-count-text">{{subscriber_count}}</span>
 {{else}}
 <i class="subscriber-count-lock icon-vector-lock"></i>

--- a/static/templates/subscription_members.handlebars
+++ b/static/templates/subscription_members.handlebars
@@ -1,5 +1,5 @@
 {{#render_subscribers}}
-<div class="subscriber_list_settings_container" {{#unless can_add_subscribers}}style="display: none"{{/unless}}>
+<div class="subscriber_list_settings_container" {{#unless can_access_subscribers}}style="display: none"{{/unless}}>
     <div class="subscriber_list_settings">
         <div class="sub_settings_title float-left">
             {{t "Stream membership" }}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2241,7 +2241,13 @@ def get_peer_user_ids_for_stream_change(stream: Stream,
 
     if stream.invite_only:
         # PRIVATE STREAMS
-        return set(subscribed_user_ids) - set(altered_user_ids)
+        # Realm admins can access all private stream subscribers. Send them an
+        # event even if they aren't subscribed to stream.
+        realm_admin_ids = [user.id for user in stream.realm.get_admin_users()]
+        user_ids_to_notify = []
+        user_ids_to_notify.extend(realm_admin_ids)
+        user_ids_to_notify.extend(subscribed_user_ids)
+        return set(user_ids_to_notify) - set(altered_user_ids)
 
     else:
         # PUBLIC STREAMS

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -10,11 +10,11 @@ from zerver.models import UserProfile, Stream, Subscription, \
     Realm, Recipient, bulk_get_recipients, get_stream_recipient, get_stream, \
     bulk_get_streams, get_realm_stream, DefaultStreamGroup
 
-def access_stream_for_delete(user_profile: UserProfile, stream_id: int) -> Stream:
+def access_stream_for_delete_or_update(user_profile: UserProfile, stream_id: int) -> Stream:
 
     # We should only ever use this for realm admins, who are allowed
-    # to delete all streams on their realm, even private streams to
-    # which they are not subscribed.  We do an assert here, because
+    # to delete or update all streams on their realm, even private streams
+    # to which they are not subscribed.  We do an assert here, because
     # all callers should have the require_realm_admin decorator.
     assert(user_profile.is_realm_admin)
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -654,7 +654,7 @@ class StreamAdminTest(ZulipTestCase):
         are on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=21, is_admin=True, is_subbed=True, invite_only=True,
+            query_count=22, is_admin=True, is_subbed=True, invite_only=True,
             other_user_subbed=True)
         json = self.assert_json_success(result)
         self.assertEqual(len(json["removed"]), 1)
@@ -1880,9 +1880,10 @@ class SubscriptionAPITest(ZulipTestCase):
             set([user_profile.id, existing_user_profile.id])
         )
 
-        # We don't send a peer_add event to othello
+        # We don't send a peer_add event to othello, but we do send peer_add event to
+        # all realm admins.
         self.assertNotIn(user_profile.id, add_peer_event['users'])
-        self.assertEqual(len(add_peer_event['users']), 1)
+        self.assertEqual(len(add_peer_event['users']), 2)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
         self.assertEqual(add_peer_event['event']['user_id'], user_profile.id)
@@ -1931,6 +1932,7 @@ class SubscriptionAPITest(ZulipTestCase):
         user2 = self.example_user("cordelia")
         user3 = self.example_user("hamlet")
         user4 = self.example_user("iago")
+        user5 = self.example_user("AARON")
 
         stream1 = self.make_stream('stream1')
         stream2 = self.make_stream('stream2')
@@ -1977,6 +1979,9 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertIn((user3.id, user1.id, 'private_stream'), notifications)
         self.assertIn((user3.id, user2.id, 'private_stream'), notifications)
 
+        self.assertIn((user4.id, user1.id, 'private_stream'), notifications)
+        self.assertIn((user4.id, user2.id, 'private_stream'), notifications)
+
         # NEGATIVE
 
         # don't be notified if you are being removed yourself
@@ -1989,8 +1994,8 @@ class SubscriptionAPITest(ZulipTestCase):
         # don't send notifications for random people
         self.assertNotIn((user3.id, user4.id, 'stream2'), notifications)
 
-        # don't send notifications to unsubscribed people for private streams
-        self.assertNotIn((user4.id, user1.id, 'private_stream'), notifications)
+        # don't send notifications to unsubscribed non realm admin users for private streams
+        self.assertNotIn((user5.id, user1.id, 'private_stream'), notifications)
 
     def test_bulk_subscribe_MIT(self) -> None:
         realm = get_realm("zephyr")
@@ -2780,7 +2785,8 @@ class GetSubscribersTest(ZulipTestCase):
 
     def test_nonsubscriber_private_stream(self) -> None:
         """
-        A non-subscriber to a private stream can't query that stream's membership.
+        A non-subscriber non realm admin user to a private stream can't query that stream's membership.
+        But unsubscribed realm admin users can query private stream's membership.
         """
         # Create a private stream for which Hamlet is the only subscriber.
         stream_name = "NewStream"
@@ -2789,10 +2795,14 @@ class GetSubscribersTest(ZulipTestCase):
         user_profile = self.example_user('othello')
         other_email = user_profile.email
 
-        # Try to fetch the subscriber list as a non-member.
+        # Try to fetch the subscriber list as a non-member & non-realm-admin-user.
         stream_id = get_stream(stream_name, user_profile.realm).id
         result = self.make_subscriber_request(stream_id, email=other_email)
         self.assert_json_error(result, "Invalid stream id")
+
+        # Try to fetch the subscriber list as a non-member & realm-admin-user.
+        self.login(self.example_email("iago"))
+        self.make_successful_subscriber_request(stream_name)
 
 class AccessStreamTest(ZulipTestCase):
     def test_access_stream(self) -> None:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -415,7 +415,7 @@ def add_subscriptions_backend(
 @has_request_variables
 def get_subscribers_backend(request: HttpRequest, user_profile: UserProfile,
                             stream_id: int=REQ('stream', converter=to_non_negative_int)) -> HttpResponse:
-    (stream, recipient, sub) = access_stream_by_id(user_profile, stream_id)
+    (stream, recipient, sub) = access_stream_by_id(user_profile, stream_id, allow_realm_admin=True)
     subscribers = get_subscriber_emails(stream, user_profile)
 
     return json_success({'subscribers': subscribers})

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -220,6 +220,8 @@ def remove_subscriptions_backend(
 
     removing_someone_else = principals and \
         set(principals) != set((user_profile.email,))
+    # Realm admin can remove people from any stream, even if it's private
+    # stream and realm admin is not subscribed to it.
     if removing_someone_else and not user_profile.is_realm_admin:
         # You can only unsubscribe other people from a stream if you are a realm
         # admin.
@@ -230,13 +232,6 @@ def remove_subscriptions_backend(
         streams_as_dict.append({"name": stream_name.strip()})
 
     streams, __ = list_to_streams(streams_as_dict, user_profile)
-
-    for stream in streams:
-        if removing_someone_else and stream.invite_only and \
-                not subscribed_to_stream(user_profile, stream.id):
-            # Even as an admin, you can't remove other people from an
-            # invite-only stream you're not on.
-            return json_error(_("Cannot administer invite-only streams this way"))
 
     if principals:
         people_to_unsub = set(principal_to_user_profile(

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -25,7 +25,7 @@ from zerver.lib.actions import bulk_remove_subscriptions, \
 from zerver.lib.response import json_success, json_error, json_response
 from zerver.lib.streams import access_stream_by_id, access_stream_by_name, \
     check_stream_name, check_stream_name_available, filter_stream_authorization, \
-    list_to_streams, access_stream_for_delete, access_default_stream_group_by_id
+    list_to_streams, access_stream_for_delete_or_update, access_default_stream_group_by_id
 from zerver.lib.validator import check_string, check_int, check_list, check_dict, \
     check_bool, check_variable_type
 from zerver.models import UserProfile, Stream, Realm, Subscription, \
@@ -63,7 +63,7 @@ def principal_to_user_profile(agent, principal):
 @require_realm_admin
 def deactivate_stream_backend(request, user_profile, stream_id):
     # type: (HttpRequest, UserProfile, int) -> HttpResponse
-    stream = access_stream_for_delete(user_profile, stream_id)
+    stream = access_stream_for_delete_or_update(user_profile, stream_id)
     do_deactivate_stream(stream)
     return json_success()
 
@@ -148,8 +148,8 @@ def update_stream_backend(
         is_private: Optional[bool]=REQ(validator=check_bool, default=None),
         new_name: Optional[Text]=REQ(validator=check_string, default=None),
 ) -> HttpResponse:
-    (stream, recipient, sub) = access_stream_by_id(user_profile, stream_id)
 
+    stream = access_stream_for_delete_or_update(user_profile, stream_id)
     if description is not None:
         do_change_stream_description(stream, description)
     if new_name is not None:
@@ -161,7 +161,10 @@ def update_stream_backend(
             # are only changing the casing of the stream name).
             check_stream_name_available(user_profile.realm, new_name)
         do_rename_stream(stream, new_name)
+    # We allow realm admin to update unsubscribed private stream name and description.
+    # But can not change unsubscribed private stream type.
     if is_private is not None:
+        (stream, recipient, sub) = access_stream_by_id(user_profile, stream_id)
         do_change_stream_invite_only(stream, is_private)
     return json_success()
 


### PR DESCRIPTION
- [X] Allow realm admin to update unsubscribed private stream name & description

stream settings: Allow realm admin to update any stream name & description.
    
    Allow realm admin to change unsubscribed private stream's name and
    description.

- [X] Allow realm admin to access unsubscribe private stream  #subscribers.

- [X] Allow realm admin to remove other people from unsub private stream.


Solves issues mentioned in [this](https://github.com/zulip/zulip/issues/3783#issuecomment-364035154) comment. 