### PR TITLE
Tab Navigation: Stage 1

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -165,6 +165,7 @@
         "emoji_picker": false,
         "hotspots": false,
         "compose_ui": false,
+        "tabs": false,
         "common": false,
         "panels": false
     },

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -149,7 +149,7 @@ function stubbing(func_name_to_stub, test_function) {
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
     assert_unmapped('abefhlmotxyz');
-    assert_unmapped('BEFHILNOQTUWXYZ');
+    assert_unmapped('BEFHILNOQUY');
 
     // We have to skip some checks due to the way the code is
     // currently organized for mapped keys.
@@ -267,6 +267,10 @@ function stubbing(func_name_to_stub, test_function) {
     assert_mapping('i', 'popovers.open_message_menu');
     assert_mapping(':', 'reactions.open_reactions_popover', true);
     assert_mapping('>', 'compose_actions.quote_and_reply');
+    assert_mapping('T', 'tabs.new');
+    assert_mapping('W', 'tabs.close');
+    assert_mapping('Z', 'tabs.previous');
+    assert_mapping('X', 'tabs.next');
 
     overlays.is_active = return_true;
     overlays.lightbox_open = return_true;

--- a/frontend_tests/node_tests/tabs.js
+++ b/frontend_tests/node_tests/tabs.js
@@ -1,0 +1,82 @@
+zrequire('tabs');
+
+var state;
+var narrow = {
+    activate: function (data) {
+        state = data;
+    },
+};
+
+tabs.update_indicator = function () {
+    return true;
+};
+
+set_global('narrow', narrow);
+
+// New Zulip web app instance started. Initial narrow:
+tabs.set_current_operators(['first location']);
+
+assert.deepEqual(tabs.get().length, 1);
+assert.deepEqual(tabs.get()[0].operators, ['first location']);
+
+// Create new tab.
+tabs.new();
+
+assert.deepEqual(tabs.get().length, 2);
+assert.deepEqual(tabs.get()[0].operators, ['first location']);
+assert.deepEqual(tabs.get()[1].operators, ['first location']);
+
+// Navigate somewhere. Narrows to:
+tabs.set_current_operators(['second location']);
+
+assert.deepEqual(tabs.get().length, 2);
+assert.deepEqual(tabs.get()[0].operators, ['first location']);
+assert.deepEqual(tabs.get()[1].operators, ['second location']);
+
+tabs.new();
+tabs.set_current_operators(['third location']);
+tabs.new();
+tabs.set_current_operators(['fourth location']);
+
+assert.deepEqual(tabs.get().length, 4);
+assert.deepEqual(tabs.get()[0].operators, ['first location']);
+assert.deepEqual(tabs.get()[1].operators, ['second location']);
+assert.deepEqual(tabs.get()[2].operators, ['third location']);
+assert.deepEqual(tabs.get()[3].operators, ['fourth location']);
+
+tabs.next();
+
+assert.deepEqual(state, ['first location']);
+
+tabs.next();
+tabs.next();
+assert.deepEqual(state, ['third location']);
+
+tabs.previous();
+
+assert.deepEqual(state, ['second location']);
+
+tabs.previous();
+tabs.previous();
+
+assert.deepEqual(state, ['fourth location']);
+
+tabs.activate(1);
+
+assert.deepEqual(state, ['second location']);
+
+tabs.next();
+tabs.close();
+
+assert.deepEqual(tabs.get().length, 3);
+assert.deepEqual(tabs.get()[0].operators, ['first location']);
+assert.deepEqual(tabs.get()[1].operators, ['second location']);
+assert.deepEqual(tabs.get()[2].operators, ['fourth location']);
+assert.deepEqual(state, ['second location']);
+
+tabs.close();
+tabs.close();
+
+assert.deepEqual(tabs.get().length, 1);
+assert.deepEqual(tabs.get()[0].operators, ['fourth location']);
+assert.deepEqual(state, ['fourth location']);

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -86,7 +86,11 @@ var keypress_mappings = {
     80: {name: 'narrow_private', message_view_only: true}, // 'P'
     82: {name: 'respond_to_author', message_view_only: true}, // 'R'
     83: {name: 'narrow_by_subject', message_view_only: true}, //'S'
+    84: {name: 'new_tab', message_view_only: true}, //'T'
     86: {name: 'view_selected_stream', message_view_only: false}, //'V'
+    87: {name: 'close_tab', message_view_only: true}, //'W'
+    88: {name: 'next_tab', message_view_only: true}, // 'X'
+    90: {name: 'previous_tab', message_view_only: true}, // 'Z'
     99: {name: 'compose', message_view_only: true}, // 'c'
     100: {name: 'open_drafts', message_view_only: true}, // 'd'
     103: {name: 'gear_menu', message_view_only: true}, // 'g'
@@ -674,6 +678,18 @@ exports.process_hotkey = function (e, hotkey) {
         case 'vim_page_down':
         case 'spacebar':
             navigate.page_down();
+            return true;
+        case 'new_tab':
+            tabs.new();
+            return true;
+        case 'close_tab':
+            tabs.close();
+            return true;
+        case 'previous_tab':
+            tabs.previous();
+            return true;
+        case 'next_tab':
+            tabs.next();
             return true;
     }
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -76,7 +76,7 @@ exports.activate = function (raw_operators, opts) {
     }
 
     notifications.redraw_title();
-
+    tabs.set_current_operators(operators);
     blueslip.debug("Narrowed", {operators: _.map(operators,
                                                  function (e) { return e.operator; }),
                                 trigger: opts ? opts.trigger : undefined,
@@ -440,6 +440,7 @@ exports.deactivate = function () {
         return;
     }
     unnarrow_times = {start_time: new Date()};
+    tabs.set_current_operators([]);
     blueslip.debug("Unnarrowed");
 
     if (ui.actively_scrolling()) {

--- a/static/js/tabs.js
+++ b/static/js/tabs.js
@@ -21,6 +21,7 @@ exports.activate = function (index) {
     }
     current_tab_index = index;
     narrow.activate(all_tabs[index].operators);
+    exports.update_indicator();
     return true;
 };
 
@@ -51,6 +52,7 @@ exports.new = function (from_index) {
     var new_tab = Object.assign({}, all_tabs[from_index]);
     all_tabs.splice(from_index + 1, 0, new_tab);
     current_tab_index = from_index + 1;
+    exports.update_indicator();
 };
 
 exports.close = function (index) {
@@ -59,20 +61,38 @@ exports.close = function (index) {
         return false;
     }
     if (all_tabs[current_tab_index-1]) {
-        current_tab_index--;
+        current_tab_index = current_tab_index - 1;
     } else {
         current_tab_index = 0;
     }
-    return all_tabs.splice(index, 1);
+    all_tabs.splice(index, 1);
+    exports.activate(current_tab_index);
+    return true;
 };
 
 exports.get = function () {
     return all_tabs;
 };
 
+exports.get_current_index = function () {
+    return current_tab_index;
+};
+
 exports._print = function () {
     blueslip.debug("All Tabs", all_tabs);
     blueslip.debug("Current Tab", all_tabs[current_tab_index]);
+};
+
+exports.update_indicator = function () {
+    var indicator = $('#tab-indicator');
+    if (all_tabs.length > 1) {
+        indicator.removeClass('notdisplayed');
+    } else {
+        indicator.addClass('notdisplayed');
+    }
+    var text = current_tab_index + 1;
+    text += "/" + all_tabs.length;
+    indicator.html(text);
 };
 
 return exports;

--- a/static/js/tabs.js
+++ b/static/js/tabs.js
@@ -1,0 +1,83 @@
+var tabs = (function () {
+
+// Implement tabs for multitasking in narrows.
+
+var exports = {};
+
+var all_tabs = [{
+        name: "Default",
+        operators: [],
+        locked: false,
+    }];
+var current_tab_index = 0;
+
+exports.set_current_operators = function (operators) {
+    all_tabs[current_tab_index].operators = operators;
+};
+
+exports.activate = function (index) {
+    if (!all_tabs[index]) {
+        return false;
+    }
+    current_tab_index = index;
+    narrow.activate(all_tabs[index].operators);
+    return true;
+};
+
+exports.next = function () {
+    if (all_tabs.length<2) {
+        return false;
+    }
+    var index = current_tab_index + 1;
+    if (index === all_tabs.length) {
+        index = 0;
+    }
+    return exports.activate(index);
+};
+
+exports.previous = function () {
+    if (all_tabs.length<2) {
+        return false;
+    }
+    var index = current_tab_index - 1;
+    if (index === -1) {
+        index = all_tabs.length - 1;
+    }
+    return exports.activate(index);
+};
+
+exports.new = function (from_index) {
+    from_index = from_index || current_tab_index;
+    var new_tab = Object.assign({}, all_tabs[from_index]);
+    all_tabs.splice(from_index + 1, 0, new_tab);
+    current_tab_index = from_index + 1;
+};
+
+exports.close = function (index) {
+    index = index || current_tab_index;
+    if (!all_tabs[index] || all_tabs.length === 1) {
+        return false;
+    }
+    if (all_tabs[current_tab_index-1]) {
+        current_tab_index--;
+    } else {
+        current_tab_index = 0;
+    }
+    return all_tabs.splice(index, 1);
+};
+
+exports.get = function () {
+    return all_tabs;
+};
+
+exports._print = function () {
+    blueslip.debug("All Tabs", all_tabs);
+    blueslip.debug("Current Tab", all_tabs[current_tab_index]);
+};
+
+return exports;
+
+}());
+if (typeof module !== 'undefined') {
+    module.exports = tabs;
+}

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1946,6 +1946,21 @@ nav a .no-style {
     letter-spacing: normal;
 }
 
+#tab-indicator {
+    z-index: 2;
+    padding-top: 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    float: right;
+    letter-spacing: normal;
+    height: 33px;
+    font-size: 20px;
+    padding-top: 7px;
+    padding-left: 4px;
+    padding-right: 4px;
+    border-right: 1px solid hsl(0, 0%, 87.8%);
+}
+
 div.floating_recipient {
     border-collapse: separate;
     width: 100%;

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -104,6 +104,22 @@
                     <td class="hotkey">Home</td>
                     <td class="definition">{% trans %}First message{% endtrans %}</td>
                 </tr>
+                <tr>
+                    <td class="hotkey">T</td>
+                    <td class="definition">{% trans %}Create new tab{% endtrans %}</td>
+                </tr>
+                <tr>
+                    <td class="hotkey">W</td>
+                    <td class="definition">{% trans %}Close current tab{% endtrans %}</td>
+                </tr>
+                <tr>
+                    <td class="hotkey">Z</td>
+                    <td class="definition">{% trans %}Previous tab{% endtrans %}</td>
+                </tr>
+                <tr>
+                    <td class="hotkey">X</td>
+                    <td class="definition">{% trans %}Next tab{% endtrans %}</td>
+                </tr>
             </table>
 
             <table class="hotkeys_table table table-striped table-bordered table-condensed">

--- a/templates/zerver/navbar.html
+++ b/templates/zerver/navbar.html
@@ -47,6 +47,8 @@
                 <div id="searchbox" class="searchbox-rightmargin">
                     <div id="tab_bar" class="notdisplayed">
                     </div>
+                    <div id="tab-indicator" class="notdisplayed" title="{% trans %}Tabs indicator{% endtrans %}">
+                    </div>
                     <form id="searchbox_form" class="form-search navbar-search">
                         <div id="search_arrows" class="input-append">
                             <input class="search-query input-block-level" id="search_query" type="text" placeholder="{{ _('Search') }}"

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1129,6 +1129,7 @@ JS_SPECS = {
             'js/typing_events.js',
             'js/ui_init.js',
             'js/emoji_picker.js',
+            'js/tabs.js',
             'js/compose_ui.js',
             'js/panels.js',
             'js/settings_ui.js'


### PR DESCRIPTION
This PR adds basic tab navigation, and is in its infancy as of now. The UI is almost non existent, but the features are fully functional.

1. Go to https://nightly.zulipdev.org
2. After logging in, use these key combos for tab management:

- 'T' - new tab
- 'W' - close current tab
- 'Z' - previous tab
- 'X' - next tab

Each of these tabs store the narrow you left them on, practically giving you access to multiple narrows simultaneously.
3. In the navbar, there is a small indicator that is displayed whenever the number of tabs is more than one: example: `2/5` - format: `current-tab/total-tabs`.
