### PR TITLE
user groups: Prevent user not in user group to edit/delete group name/members.

### DIFF
--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -10,6 +10,9 @@ var noop = function () {};
 var pills = {
     pill: {},
 };
+
+var create_item_handler;
+
 set_global('channel', {});
 set_global('templates', {});
 set_global('blueslip', {});
@@ -23,6 +26,33 @@ set_global('ui_report', {});
 set_global('people', {
     my_current_user_id: noop,
 });
+function reset_test_setup(pill_container_stub) {
+    function input_pill_stub(opts) {
+        assert.equal(opts.container, pill_container_stub);
+        create_item_handler = opts.create_item_from_text;
+        assert(create_item_handler);
+        return pills;
+    }
+    set_global('input_pill', {
+        create: input_pill_stub,
+    });
+}
+
+(function test_can_edit() {
+    var me = {
+        is_admin: false,
+    };
+    people.get_person_from_user_id = function (id) {
+        assert.equal(id, undefined);
+        return me;
+    };
+    user_groups.is_member_of = function (group_id, user_id) {
+        assert.equal(group_id, 1);
+        assert.equal(user_id, undefined);
+        return false;
+    };
+    settings_user_groups.can_edit(1);
+}());
 
 var user_group_selector = "#user-groups #1";
 var cancel_selector = "#user-groups #1 .cancel";
@@ -61,6 +91,7 @@ var instructions_selector = "#user-groups #1 .save-instructions";
     user_groups.get_realm_user_groups = function () {
         return [realm_user_group];
     };
+
     var templates_render_called = false;
     var fake_rendered_temp = $.create('fake_admin_user_group_list_template_rendered');
     templates.render = function (template, args) {
@@ -84,12 +115,19 @@ var instructions_selector = "#user-groups #1 .save-instructions";
         if (user_id === iago.user_id) {
             return iago;
         }
+        if (user_id === undefined) {
+            return noop;
+        }
         assert.equal(user_id, 4);
         blueslip.warn = function (err_msg) {
             assert.equal(err_msg, 'Unknown user ID 4 in members of user group Mobile');
             blueslip_warn_called = true;
         };
         get_person_from_user_id_called = true;
+    };
+
+    settings_user_groups.can_edit = function () {
+        return true;
     };
 
     var all_pills = {};
@@ -109,14 +147,6 @@ var instructions_selector = "#user-groups #1 .save-instructions";
         text_cleared = true;
     };
 
-    var create_item_handler;
-
-    function input_pill_stub(opts) {
-        assert.equal(opts.container, pill_container_stub);
-        create_item_handler = opts.create_item_from_text;
-        assert(create_item_handler);
-        return pills;
-    }
     var input_field_stub = $.create('fake-input-field');
     pill_container_stub.children = function () {
         return input_field_stub;
@@ -261,9 +291,7 @@ var instructions_selector = "#user-groups #1 .save-instructions";
         handler();
     };
 
-    set_global('input_pill', {
-        create: input_pill_stub,
-    });
+    reset_test_setup(pill_container_stub);
     settings_user_groups.set_up();
     assert(templates_render_called);
     assert(user_groups_list_append_called);
@@ -276,6 +304,173 @@ var instructions_selector = "#user-groups #1 .save-instructions";
     assert.equal(typeof($('.organization').get_on_handler("submit", "form.admin-user-group-form")), 'function');
     assert.equal(typeof($('#user-groups').get_on_handler('click', '.delete')), 'function');
     assert.equal(typeof($('#user-groups').get_on_handler('keypress', '.user-group h4 > span')), 'function');
+}());
+(function test_with_external_user() {
+
+    var realm_user_group = {
+        id: 1,
+        name: 'Mobile',
+        description: 'All mobile people',
+        members: Dict.from_array([2, 4]),
+    };
+
+    user_groups.get_realm_user_groups = function () {
+        return [realm_user_group];
+    };
+
+    // We return noop because these are already tested, so we skip them
+    people.get_realm_persons = function () {
+        return noop;
+    };
+
+    templates.render = function () {
+        return noop;
+    };
+
+    people.get_person_from_user_id = function () {
+        return noop;
+    };
+
+    user_pill.append_person = function () {
+        return noop;
+    };
+
+    var can_edit_called = 0;
+    settings_user_groups.can_edit = function () {
+        can_edit_called += 1;
+        return false;
+    };
+
+    // Reset zjquery to test stuff with user who cannot edit
+    set_global('$', global.make_zjquery());
+
+    var user_group_find_called = 0;
+    var user_group_stub = $('div.user-group[id="1"]');
+    var name_field_stub = $.create('fake-name-field');
+    var description_field_stub = $.create('fake-description-field');
+    var input_stub = $.create('fake-input');
+    user_group_stub.find = function (elem) {
+        if (elem === '.name') {
+            user_group_find_called += 1;
+            return name_field_stub;
+        }
+        if (elem === '.description') {
+            user_group_find_called += 1;
+            return description_field_stub;
+        }
+    };
+
+    var pill_container_stub = $('.pill-container[data-group-pills="Mobile"]');
+    var pill_stub = $.create('fake-pill');
+    var pill_container_find_called = 0;
+    pill_container_stub.find = function (elem) {
+        if (elem === '.input') {
+            pill_container_find_called += 1;
+            return input_stub;
+        }
+        if (elem === '.pill') {
+            pill_container_find_called += 1;
+            return pill_stub;
+        }
+    };
+
+    input_stub.css = function (property, val) {
+        assert.equal(property, 'display');
+        assert.equal(val, 'none');
+    };
+
+    // Test the 'off' handlers on the pill-container
+    var turned_off = {};
+    pill_container_stub.off = function (event_name, sel) {
+        if (sel === undefined) {
+           sel = 'whole';
+        }
+        turned_off[event_name + '/' + sel] = true;
+    };
+
+    var pill_hover_called = false;
+    var callback;
+    var empty_fn;
+    pill_stub.hover = function (one, two) {
+        callback = one;
+        empty_fn = two;
+        pill_hover_called = true;
+        assert.equal(typeof(one), 'function');
+        assert.equal(typeof(two), 'function');
+    };
+
+    var exit_button = $.create('fake-pill-exit');
+    pill_stub.set_find_results('.exit', exit_button);
+    var exit_button_called=false;
+    exit_button.css = function (property, value) {
+        exit_button_called = true;
+        assert.equal(property, 'opacity');
+        assert.equal(value, '0.5');
+    };
+
+    // We return noop because these are already tested, so we skip them
+    pill_container_stub.children = function () {
+        return noop;
+    };
+
+    $('#user-groups').append = function () {
+        return noop;
+    };
+
+    reset_test_setup(pill_container_stub);
+
+    settings_user_groups.set_up();
+
+    var set_parents_result_called = 0;
+    var set_attributes_called = 0;
+
+    // Test different handlers with an external user
+    var delete_handler = $('#user-groups').get_on_handler('click', '.delete');
+    var fake_delete = $.create('fk-#user-groups.delete_btn');
+    fake_delete.set_parents_result('.user-group', $('.user-group'));
+    set_parents_result_called += 1;
+    $('.user-group').attr('id', '1');
+    set_attributes_called += 1;
+
+    var name_update_handler = $(user_group_selector).get_on_handler("input", ".name");
+
+    var des_update_handler = $(user_group_selector).get_on_handler("input", ".description");
+
+    var member_change_handler = $(user_group_selector).get_on_handler("blur", ".input");
+
+    var name_change_handler = $(user_group_selector).get_on_handler("blur", ".name");
+
+    var des_change_handler = $(user_group_selector).get_on_handler("blur", ".description");
+
+    var event = {
+        stopPropagation: noop,
+    };
+    var pill_click_called = false;
+    var pill_click_handler = pill_container_stub.get_on_handler('click');
+    pill_click_called = true;
+
+    assert(callback);
+    assert(empty_fn);
+    callback();
+    empty_fn();
+    pill_click_handler(event);
+    assert.equal(delete_handler.call(fake_delete), undefined);
+    assert.equal(name_update_handler(), undefined);
+    assert.equal(des_update_handler(), undefined);
+    assert.equal(member_change_handler(), undefined);
+    assert.equal(name_change_handler(), undefined);
+    assert.equal(des_change_handler(), undefined);
+    assert.equal(set_parents_result_called, 1);
+    assert.equal(set_attributes_called, 1);
+    assert.equal(can_edit_called, 9);
+    assert(exit_button_called);
+    assert(pill_click_called);
+    assert(pill_hover_called);
+    assert.equal(user_group_find_called, 2);
+    assert.equal(pill_container_find_called, 4);
+    assert.equal(turned_off['keydown/.pill'], true);
+    assert.equal(turned_off['keydown/.input'], true);
+    assert.equal(turned_off['click/whole'], true);
 }());
 
 (function test_reload() {
@@ -296,6 +491,11 @@ var instructions_selector = "#user-groups #1 .save-instructions";
 }());
 
 (function test_on_events() {
+
+    settings_user_groups.can_edit = function () {
+        return true;
+    };
+
     (function test_admin_user_group_form_submit_triggered() {
         var handler = $('.organization').get_on_handler("submit", "form.admin-user-group-form");
         var event = {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -110,6 +110,7 @@ exports.populate_auth_methods = function (auth_methods) {
         // Don't prepend a tip to custom emoji settings page. We handle it separately.
         $(".organization-box").find(".settings-section:not(.can-edit)")
             .not("#emoji-settings")
+            .not("#user-groups-admin")
             .prepend(tip_box);
     }
 };

--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -32,6 +32,26 @@
     outline: none;
 }
 
+.pill-container.notmem {
+    cursor: not-allowed;
+    border: none;
+}
+
+.pill-container.notmem .pill {
+    padding-right: 4px;
+    cursor: not-allowed;
+}
+
+.pill-container.notmem .pill:focus {
+    color: inherit;
+    border: 1px solid hsla(0, 0%, 0%, 0.15);
+    background: hsla(0, 0%, 0%, 0.07);
+}
+
+.pill-container.notmem .pill .exit {
+    display: none;
+}
+
 .pill-container .input {
     display: inline-block;
     padding: 2px 4px;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -942,6 +942,10 @@ input[type=checkbox].inline-block {
     word-break: break-all;
 }
 
+#user-groups .ntm {
+    cursor: not-allowed;
+}
+
 #user-groups .user-group span[contenteditable]:empty::before {
     opacity: 0.5;
     display: inline-block;
@@ -949,7 +953,7 @@ input[type=checkbox].inline-block {
 }
 
 #user-groups .user-group span[contenteditable]:focus,
-#user-groups .user-group span[contenteditable]:hover {
+#user-groups .user-group span[contenteditable="true"]:hover {
     border-bottom: 1px solid hsl(0, 0%, 80%);
     outline: none;
 }
@@ -961,6 +965,15 @@ input[type=checkbox].inline-block {
 
 #user-groups .user-group h4 > .button {
     vertical-align: 1px;
+}
+
+#user-groups .ntm h4 > .button {
+    cursor: not-allowed;
+    display: none;
+}
+
+#user-groups .ntm h4 > .button:hover {
+    border-color: hsl(4, 56%, 82%);
 }
 
 #user-groups .save-status {

--- a/static/templates/user-groups-admin.handlebars
+++ b/static/templates/user-groups-admin.handlebars
@@ -1,5 +1,7 @@
 <div id="user-groups-admin" class="settings-section" data-name="user-groups-admin">
-    <div class="tip">Anyone in this organization can add user groups.</div>
+    {{#unless is_admin}}
+    <div class="tip">Only group members and organization administrators can modify a group.</div>
+    {{/unless}}
     <form class="form-horizontal admin-user-group-form">
         <div class="add-new-user-group-box grey-box">
             <div class="new-user-group-form">

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4687,7 +4687,7 @@ def do_send_delete_user_group_event(user_group_id: int, realm_id: int) -> None:
                  group_id=user_group_id)
     send_event(event, active_user_ids(realm_id))
 
-def check_delete_user_group(user_group_id: int, realm: Realm) -> None:
-    user_group = access_user_group_by_id(user_group_id, realm)
+def check_delete_user_group(user_group_id: int, user_profile: UserProfile) -> None:
+    user_group = access_user_group_by_id(user_group_id, user_profile)
     user_group.delete()
-    do_send_delete_user_group_event(user_group_id, realm.id)
+    do_send_delete_user_group_event(user_group_id, user_profile.realm.id)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1086,7 +1086,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('op', equals('remove')),
             ('group_id', check_int),
         ])
-        events = self.do_test(lambda: check_delete_user_group(backend.id, backend.realm))
+        events = self.do_test(lambda: check_delete_user_group(backend.id, othello))
         error = user_group_remove_checker('events[0]', events[0])
         self.assert_on_error(error)
 

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -13,7 +13,7 @@ from zerver.lib.response import json_success, json_error
 from zerver.lib.users import user_ids_to_users
 from zerver.lib.validator import check_list, check_string, check_int, \
     check_short_string
-from zerver.lib.user_groups import access_user_group_by_id, get_memberships_of_users
+from zerver.lib.user_groups import access_user_group_by_id, get_memberships_of_users, get_user_group_members
 from zerver.models import UserProfile, UserGroup, UserGroupMembership
 from zerver.views.streams import compose_views, FuncKwargPair
 
@@ -34,7 +34,7 @@ def edit_user_group(request: HttpRequest, user_profile: UserProfile,
     if not (name or description):
         return json_error(_("No new data supplied"))
 
-    user_group = access_user_group_by_id(user_group_id, realm=user_profile.realm)
+    user_group = access_user_group_by_id(user_group_id, user_profile)
 
     result = {}
     if name != user_group.name:
@@ -50,7 +50,8 @@ def edit_user_group(request: HttpRequest, user_profile: UserProfile,
 @has_request_variables
 def delete_user_group(request: HttpRequest, user_profile: UserProfile,
                       user_group_id: int=REQ(validator=check_int)) -> HttpResponse:
-    check_delete_user_group(user_group_id, user_profile.realm)
+
+    check_delete_user_group(user_group_id, user_profile)
     return json_success()
 
 @has_request_variables
@@ -75,10 +76,10 @@ def add_members_to_group_backend(request: HttpRequest, user_profile: UserProfile
     if not members:
         return json_success()
 
-    user_group = access_user_group_by_id(user_group_id, user_profile.realm)
+    user_group = access_user_group_by_id(user_group_id, user_profile)
     user_profiles = user_ids_to_users(members, user_profile.realm)
-
     existing_member_ids = set(get_memberships_of_users(user_group, user_profiles))
+
     for user_profile in user_profiles:
         if user_profile.id in existing_member_ids:
             raise JsonableError(_("User %s is already a member of this group" % (user_profile.id,)))
@@ -92,6 +93,11 @@ def remove_members_from_group_backend(request: HttpRequest, user_profile: UserPr
         return json_success()
 
     user_profiles = user_ids_to_users(members, user_profile.realm)
-    user_group = access_user_group_by_id(user_group_id, user_profile.realm)
+    user_group = access_user_group_by_id(user_group_id, user_profile)
+    group_member_ids = get_user_group_members(user_group)
+    for member in members:
+        if (member not in group_member_ids):
+            raise JsonableError(_("There is no member '%s' in this user group" % (member,)))
+
     remove_members_from_user_group(user_group, user_profiles)
     return json_success()


### PR DESCRIPTION
This PR fixes #8315. It prevents users who are not a part of user group to edit/delete user group name/members. Realm admins and user group members can continue to do the above operations. 
I'm attaching two gifs showing the behavior of user group UI after changes, also if a user creates a group, adds some members in it, then removes himself/herself, he/she cannot further edit/delete the user group, the code prevents doing that.
The following picture has Cordelia as current user.
![user groups](https://user-images.githubusercontent.com/23361315/36146710-88e5acd2-10db-11e8-8bb6-bfc29577a9c3.gif)
The following picture has iago as current user (admin).
![1](https://user-images.githubusercontent.com/23361315/36146709-87dcf17e-10db-11e8-99ba-dcdd0a9bc14f.gif)

