### PR TITLE
Spoofs message post-date in development

### DIFF
--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -67,6 +67,19 @@ if you're working on new database migrations.  To do this, run:
   above. Afterwards, re-run the `init*-db` and the
   `do-destroy-rebuild*-database` scripts.
 
+- Or, when running the test suite, if you get an error involving Git that looks like this:
+
+  ```
+      commit_messages| An error occurred while executing '/usr/bin/git rev-list --max-count=-1 upstream/master..HEAD': b"fatal: ambiguous argument 'upstream/master..HEAD': unknown revision or path not in the working tree.\nUse '--' to separate paths from revisions, like this:\n'git <command> [<revision>...] -- [<file>...]'"
+  ```
+
+  ... then you need to connect your fork to Zulip upstream with the following commands.
+
+  ```
+    git remote add upstream https://github.com/zulip/zulip.git
+    git fetch upstream
+  ```
+
 - When building the development environment using Vagrant and the LXC
   provider, if you encounter permissions errors, you may need to
   `chown -R 1000:$(whoami) /path/to/zulip` on the host before running


### PR DESCRIPTION
The spoofed message dates looks like this https://jpst.it/1aXd9 (with the num_message to the left of the date). 
Two things to notice is there is a 24+ hour gap between num_message 79 and 80, as well as the distribution for the past 5 days has a more spread hour distribution with 2x the hours skipped as well as a randomly added hour. The distribution for the past 15 hours is less spread in comparison, not having the 2x hours skipped nor the randomly added hour.

#8277 