### PR TITLE
Python dependency upgrade

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -98,7 +98,7 @@ ndg-httpsclient==0.4.4
 pika==0.11.0
 
 # Needed to access our database
-psycopg2==2.7.3.2
+psycopg2==2.7.4 --no-binary psycopg2
 
 pyasn1==0.4.2
 pyasn1-modules==0.2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,6 +7,8 @@
 #
 # For details, see requirements/README.md .
 #
+--no-binary psycopg2
+
 git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 git+https://github.com/zulip/virtualenv-clone.git@44e831da39ffb6b9bb5c7d103d98babccdca0456#egg=virtualenv-clone==0.2.6.zulip1
@@ -106,7 +108,7 @@ polib==1.1.0
 premailer==3.1.1
 prompt-toolkit==1.0.15    # via ipython
 psutil==5.4.1             # via mypy
-psycopg2==2.7.3.2
+psycopg2==2.7.4
 ptyprocess==0.5.2         # via pexpect
 py3dns==3.1.0
 pyaml==17.10.0            # via moto

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -7,6 +7,8 @@
 #
 # For details, see requirements/README.md .
 #
+--no-binary psycopg2
+
 git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 git+https://github.com/zulip/virtualenv-clone.git@44e831da39ffb6b9bb5c7d103d98babccdca0456#egg=virtualenv-clone==0.2.6.zulip1
@@ -74,7 +76,7 @@ pillow==5.0.0
 polib==1.1.0
 premailer==3.1.1
 prompt-toolkit==1.0.15    # via ipython
-psycopg2==2.7.3.2
+psycopg2==2.7.4
 ptyprocess==0.5.2         # via pexpect
 py3dns==3.1.0
 pyasn1-modules==0.2.1

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '15.0'
+PROVISION_VERSION = '15.1'


### PR DESCRIPTION
A couple of dependencies left to upgrade. 

|package|Old version| New Version|Status|
|---------|--------------|------------------|----------|
argon2-cffi |16.3.0 |18.1.0 |:+1:
arrow |0.10.0 |0.12.1 |via gitlint 
attrs |17.3.0 |17.4.0 |via automat
aws-xray-sdk |0.94 |0.95 |via moto
Babel |2.5.1 |2.5.3 |:+1: 
boto3 |1.4.7 |1.5.27 |via moto
botocore |1.7.46 |1.8.41 |via boto3
cffi |1.11.2 |1.11.4 |:+1: 
click |6.6 |6.7 |via gitlint
CommonMark |0.5.4 |0.7.4 |:warning: Breaks
coverage |4.4.1 |4.5.1 |:+1: 
cryptography |2.1.2 |2.1.4 |:+1: 
cssselect |1.0.1 |1.0.3 |via parsel
decorator |4.1.2 |4.2.1 |via ipython
Django |1.11.6 |2.0.2 |Umair
django-auth-ldap |1.2.16 |1.3.0 |:warning:  #8380 https://circleci.com/gh/hackerkid/zulip/370
django-otp |0.4.1.1 |0.4.2 |via django-two-factor-auth
django-phonenumber-field |1.3.0 |2.0.0 |via django-two-factor-auth
django-pipeline |1.6.13 |1.6.14 |:+1: 
django-two-factor-auth |1.6.2 |1.7.0 |:+1: 
docker |2.6.1 |3.0.1 |via moto
gitlint |0.8.2 |0.9.0 |:+1: 
google-api-python-client |1.6.4 |1.6.5 [wheel]|:+1:
h2 |2.6.2 |3.0.1 |via hyper
hyperframe |3.2.0 |5.1.0 |via h2
jedi |0.11.0 |0.11.1 |via ipython
Jinja2 |2.9.6 |2.10 |:+1: 
jsonpickle |0.9.5 |0.9.6 |via aws-xray
lxml |4.1.0 |4.1.1 |:+1: 
Markdown |2.6.9 |2.6.11 |:+1: 
moto |1.1.24 |1.2.0 |:+1: 
ndg-httpsclient |0.4.3 |0.4.4 [wheel]|:+1:
parsel |1.2.0 |1.4.0 |via scrapy
parso |0.1.0 |0.1.1 |via jedi
pexpect |4.3.0 |4.4.0 | via ipython
phonenumberslite |8.8.6 |8.8.11 |via django-phonenumber-field
pika |0.11.0 |0.11.2 |:+1: 
Pillow |4.3.0 |5.0.0 |:+1: 
pip-tools |1.10.1 |1.11.0 |:+1: 
polib |1.0.8 |1.1.0 |:+1: 
psutil |5.4.1 |5.4.3 |via mypy
psycopg2 |2.7.3.2 |2.7.4 |:+1:
pyaml |17.10.0 |17.12.1 |via moto
pyasn1 |0.3.7 |0.4.2 |:+1:
pyasn1-modules |0.1.5 |0.2.1 |:+1:
pyldap |2.4.37 |2.4.45 |:+1:
PySocks |1.6.7 |1.6.8 |via twilio
python-digitalocean |1.12 |1.13.2 |:+1:
pytz |2017.2 |2018.3 |:+1:
qrcode |4.0.4 |5.3 |via django-two-factor-auth
s3transfer |0.1.11 |0.1.12 |via boto3
Scrapy |1.4.0 |1.5.0 |:+1:
setuptools |36.6.0 |38.5.1 |:+1:
sh |1.11 |1.12.14 |via gitlint
social-auth-core |1.5.0 |1.6.0 |via social-auth-app-django
Sphinx |1.6.5 |1.7.0 |:+1:
SQLAlchemy |1.1.14 |1.2.2 |:warning: #8381 https://circleci.com/gh/hackerkid/zulip/385
statsd |3.2.1 |3.2.2 |via thumbor
stripe |1.77.0 |1.77.2 |:+1:
talon |1.2.11 |1.4.4 |:warning: Breaks
tornado |4.5.2 |4.5.3 |:+1:
typing |3.6.2 |3.6.4 |:+1:
transifex-client |0.12.4 |0.12.5 |:+1:
twilio |6.9.0 |6.10.3 |:+1:
w3lib |1.18.0 |1.19.0 |via parsel
websocket-client |0.44.0 |0.46.0 |via docker
certifi |2017.7.27.1 |2018.1.18 |:+1:
