### PR TITLE
Show dark background in popover while avatar loads

### DIFF
--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -158,7 +158,8 @@ body.dark-mode .informational-overlays .overlay-content {
 }
 
 body.dark-mode .dropdown .dropdown-menu,
-body.dark-mode .popover {
+body.dark-mode .popover,
+body.dark-mode .popover-title {
     background: hsl(212, 32%, 14%);
 }
 


### PR DESCRIPTION
Currently, the user popover looks like `1` in the dark mode while the avatar is being fetched. Also, even after loading, there is a small white strip below the avatar as seen in `2`. Thus, changed to the common dark background here as shown with a transparent avatar in `3`

![screenshot-2018-2-14 private - zulip community - zulip](https://user-images.githubusercontent.com/8033238/36191078-8f8225ce-1181-11e8-81ca-3039db5e72ae.png)
![screenshot-2018-2-14 private - zulip community - zulip 1](https://user-images.githubusercontent.com/8033238/36191092-9d107c04-1181-11e8-87a6-b53892d5dc19.png)
![screenshot-2018-2-14 private - zulip community - zulip 2](https://user-images.githubusercontent.com/8033238/36191091-9ce13af2-1181-11e8-80f0-73a9c96c8411.png)
