### PR TITLE
hotkey: Add a comment to document 'message_view_only' used in hotkeys.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -19,6 +19,9 @@ var actions_dropdown_hotkeys = [
 // we'll do in cases where they have the exact same semantics.
 // DON'T FORGET: update keyboard_shortcuts.html
 
+// message_view_only is a boolean which is true if the keyboard 
+// shortcut works only when the message view is in focus
+
 var keydown_shift_mappings = {
     // these can be triggered by shift + key only
     9: {name: 'shift_tab', message_view_only: false}, // tab


### PR DESCRIPTION
The file `static/js/hotkey.js` while describing various keydown mappings, makes use of a property called message_view_only, which can be a tad bit overwhelming to figure out for new developers. Adding a comment documenting the same.

fixes: #8323