### PR TITLE
[#7549] YouTube link replaced by title of the video

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1084,6 +1084,22 @@ def url_filename(url: Text) -> Text:
     else:
         return url
 
+def youtube_title(id: Text) -> Text:
+    page = requests.get("https://www.youtube.com/watch?v="+id).text
+    title = str(page).split('<title>')[1].split('</title>')[0]
+    return title
+
+def url_youtubetitle(url: Text) -> Text:
+    """Extract the title if a URL is a youtube video, or return the original URL"""
+    youtube_re = r'^((?:https?://)?(?:youtu\.be/|(?:\w+\.)?youtube(?:-nocookie)?\.com/)' + \
+                 r'(?:(?:(?:v|embed)/)|(?:(?:watch(?:_popup)?(?:\.php)?)?(?:\?|#!?)(?:.+&)?v=)))' + \
+                 r'?([0-9A-Za-z_-]+)(?(1).+)?$'
+    match = re.match(youtube_re, url)
+    if match:
+        return youtube_title(match.group(2))
+    else:
+        return url
+
 def fixup_link(link: markdown.util.etree.Element, target_blank: bool=True) -> None:
     """Set certain attributes we want on every link."""
     if target_blank:
@@ -1161,6 +1177,7 @@ def url_to_a(url: Text, text: Optional[Text]=None) -> Union[Element, Text]:
 
     a.set('href', href)
     a.text = text
+    a.text = url_youtubetitle(a.text)
     fixup_link(a, target_blank)
     return a
 

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -285,16 +285,20 @@ class BugdownTest(ZulipTestCase):
         converted = bugdown_convert(msg)
         self.assertEqual(converted, '<p>To <a href="bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa" target="_blank" title="bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa">bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa</a> or not to bitcoin</p>')
 
-    def test_inline_youtube(self) -> None:
+    @mock.patch('requests.get')
+    def test_inline_youtube(self, get: Any) -> None:
+        get.return_value = response = mock.Mock()
+        response.text = "<title>Final Presidential Debate 2012 Complete - Mitt Romney, Barack Obama on Foreign Policy - YouTube</title>"
+
         msg = 'Check out the debate: http://www.youtube.com/watch?v=hx1mjT73xYE'
         converted = bugdown_convert(msg)
 
-        self.assertEqual(converted, '<p>Check out the debate: <a href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE">http://www.youtube.com/watch?v=hx1mjT73xYE</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE"><img src="https://i.ytimg.com/vi/hx1mjT73xYE/default.jpg"></a></div>')
+        self.assertEqual(converted, '<p>Check out the debate: <a href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE">Final Presidential Debate 2012 Complete - Mitt Romney, Barack Obama on Foreign Policy - YouTube</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE"><img src="https://i.ytimg.com/vi/hx1mjT73xYE/default.jpg"></a></div>')
 
         msg = 'http://www.youtube.com/watch?v=hx1mjT73xYE'
         converted = bugdown_convert(msg)
 
-        self.assertEqual(converted, '<p><a href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE">http://www.youtube.com/watch?v=hx1mjT73xYE</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE"><img src="https://i.ytimg.com/vi/hx1mjT73xYE/default.jpg"></a></div>')
+        self.assertEqual(converted, '<p><a href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE">Final Presidential Debate 2012 Complete - Mitt Romney, Barack Obama on Foreign Policy - YouTube</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="http://www.youtube.com/watch?v=hx1mjT73xYE" target="_blank" title="http://www.youtube.com/watch?v=hx1mjT73xYE"><img src="https://i.ytimg.com/vi/hx1mjT73xYE/default.jpg"></a></div>')
 
     def test_inline_vimeo(self) -> None:
         msg = 'Check out the debate: https://vimeo.com/246979354'


### PR DESCRIPTION
![capture](https://user-images.githubusercontent.com/4214851/36223489-950d21f6-11ea-11e8-8ca7-03d5e88c94f1.PNG)

Replaces the link of YouTube videos with their title. Fixes #7549