### PR TITLE
Enhance the bot type selection in the create-bot menu.

### DIFF
--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -113,6 +113,14 @@ function test_create_bot_type_input_box_toggle(f) {
         };
         return mock_children;
     };
+    $('#bot_type_2_radio').closest = function () {
+        var mock_label = {
+            prop: function () {
+                return;
+            },
+        };
+        return mock_label;
+    };
     global.compile_template('embedded_bot_config_item');
     avatar.build_bot_create_widget = function () {};
     avatar.build_bot_edit_widget = function () {};

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -3,6 +3,7 @@ var settings_bots = (function () {
 var exports = {};
 
 var BOT_TYPES = Object.freeze({GENERIC: '1',
+                               INCOMING_WEBHOOK: '2',
                                OUTGOING_WEBHOOK: '3',
                                EMBEDDED: '4'});
 
@@ -104,6 +105,8 @@ exports.set_up = function () {
     $("[name*='"+selected_embedded_bot+"']").show();
 
     $('#bot_type_'+BOT_TYPES.GENERIC+'_radio').prop('checked', true);
+    $('#bot_type_'+BOT_TYPES.INCOMING_WEBHOOK+'_radio').closest('label')
+        .prop('title', "Incoming webhooks can only send messages.");
 
     $('#download_flaskbotrc').click(function () {
         var OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -2,6 +2,10 @@ var settings_bots = (function () {
 
 var exports = {};
 
+var BOT_TYPES = Object.freeze({GENERIC: '1',
+                               OUTGOING_WEBHOOK: '3',
+                               EMBEDDED: '4'});
+
 function add_bot_row(info) {
     info.id_suffix = _.uniqueId('_bot_');
     var row = $(templates.render('bot_avatar_row', info));
@@ -122,9 +126,6 @@ exports.set_up = function () {
 
 
     var create_avatar_widget = avatar.build_bot_create_widget();
-    var OUTGOING_WEBHOOK_BOT_TYPE = '3';
-    var GENERIC_BOT_TYPE = '1';
-    var EMBEDDED_BOT_TYPE = '4';
 
     var GENERIC_INTERFACE = '1';
 
@@ -148,10 +149,10 @@ exports.set_up = function () {
             formData.append('short_name', short_name);
 
             // If the selected bot_type is Outgoing webhook
-            if (bot_type === OUTGOING_WEBHOOK_BOT_TYPE) {
+            if (bot_type === BOT_TYPES.OUTGOING_WEBHOOK) {
                 formData.append('payload_url', JSON.stringify(payload_url));
                 formData.append('interface_type', interface_type);
-            } else if (bot_type === EMBEDDED_BOT_TYPE) {
+            } else if (bot_type === BOT_TYPES.EMBEDDED) {
                 formData.append('service_name', service_name);
                 var config_data = {};
                 $("#config_inputbox [name*='"+service_name+"'] input").each(function () {
@@ -179,7 +180,7 @@ exports.set_up = function () {
                     $("[name*='"+service_name+"'] input").each(function () {
                         $(this).val('');
                     });
-                    $('#create_bot_type').val(GENERIC_BOT_TYPE);
+                    $('#create_bot_type').val(BOT_TYPES.GENERIC);
                     $('#select_service_name').val('converter'); // TODO: Later we can change this to hello bot or similar
                     $('#service_name_list').hide();
                     $('#create_bot_button').show();
@@ -207,11 +208,11 @@ exports.set_up = function () {
 
         $('#payload_url_inputbox').hide();
         $('#create_payload_url').removeClass('required');
-        if (bot_type === OUTGOING_WEBHOOK_BOT_TYPE) {
+        if (bot_type === BOT_TYPES.OUTGOING_WEBHOOK) {
             $('#payload_url_inputbox').show();
             $('#create_payload_url').addClass('required');
 
-        } else if (bot_type === EMBEDDED_BOT_TYPE) {
+        } else if (bot_type === BOT_TYPES.EMBEDDED) {
             $('#service_name_list').show();
             $('#select_service_name').addClass('required');
             $("#select_service_name").trigger('change');
@@ -285,7 +286,7 @@ exports.set_up = function () {
         var errors = form.find('.bot_edit_errors');
 
         $("#settings_page .edit_bot .edit-bot-owner select").val(bot.owner);
-        if (bot.bot_type.toString() === OUTGOING_WEBHOOK_BOT_TYPE) {
+        if (bot.bot_type.toString() === BOT_TYPES.OUTGOING_WEBHOOK) {
             var services = bot_data.get_services(bot_id);
             $("#service_data").append(templates.render("edit-outgoing-webhook-service",
                                                        {service: services[0]}));
@@ -313,7 +314,7 @@ exports.set_up = function () {
                 formData.append('full_name', full_name);
                 formData.append('bot_owner', bot_owner);
 
-                if (type === OUTGOING_WEBHOOK_BOT_TYPE) {
+                if (type === BOT_TYPES.OUTGOING_WEBHOOK) {
                     var service_payload_url = $("#edit_service_base_url").val();
                     var service_interface = $("#edit_service_interface :selected").val();
                     formData.append('service_payload_url', JSON.stringify(service_payload_url));

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -103,6 +103,8 @@ exports.set_up = function () {
     $('#config_inputbox').children().hide();
     $("[name*='"+selected_embedded_bot+"']").show();
 
+    $('#bot_type_'+BOT_TYPES.GENERIC+'_radio').prop('checked', true);
+
     $('#download_flaskbotrc').click(function () {
         var OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
         var content = "";
@@ -135,7 +137,7 @@ exports.set_up = function () {
             $('#bot_table_error').hide();
         },
         submitHandler: function () {
-            var bot_type = $('#create_bot_type :selected').val();
+            var bot_type = $('input[type=radio][name=bot_type]:checked').val();
             var full_name = $('#create_bot_name').val();
             var short_name = $('#create_bot_short_name').val() || $('#create_bot_short_name').text();
             var payload_url = $('#create_payload_url').val();
@@ -199,8 +201,8 @@ exports.set_up = function () {
         },
     });
 
-    $("#create_bot_type").on("change", function () {
-        var bot_type = $('#create_bot_type :selected').val();
+    $("input[type=radio][name=bot_type]").on("change", function () {
+        var bot_type = $('input[type=radio][name=bot_type]:checked').val();
         // For "generic bot" or "incoming webhook" both these fields need not be displayed.
         $('#service_name_list').hide();
         $('#select_service_name').removeClass('required');

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -34,13 +34,14 @@
                             <i class="icon-vector-question-sign settings-info-icon bot_type_tooltip" data-toggle="tooltip"
                              title='{{t "Incoming webhooks can only send messages." }}'></i>
                         </label>
-                        <select name="bot_type" id="create_bot_type">
-                            {{#each page_params.bot_types}}
-                                {{#if this.allowed}}
-                                <option value="{{this.type_id}}">{{this.name}}</option>
-                                {{/if}}
-                            {{/each}}
-                        </select>
+                        {{#each page_params.bot_types}}
+                            {{#if this.allowed}}
+                            <label class="radio">
+                                <input type="radio" id="bot_type_{{this.type_id}}_radio" name="bot_type" value="{{this.type_id}}" />
+                                {{this.name}}
+                            </label>
+                            {{/if}}
+                        {{/each}}
                     </div>
                     <div class="input-group">
                         <label for="create_bot_name">{{t "Full name" }}</label>

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -31,8 +31,6 @@
                     <div class="input-group">
                         <label for="bot_type">
                             {{t "Bot type" }}
-                            <i class="icon-vector-question-sign settings-info-icon bot_type_tooltip" data-toggle="tooltip"
-                             title='{{t "Incoming webhooks can only send messages." }}'></i>
                         </label>
                         {{#each page_params.bot_types}}
                             {{#if this.allowed}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Note that this "fixes" #5273 only partially: The radio buttons make the bot type selection easier, and the info for incoming webhooks is now displayed in a tooltip. The whole thing does, however, not look fancy.

**Testing Plan:** Manual.

**Screenshots:**
![bot_type_radio_selection](https://user-images.githubusercontent.com/7950151/36254126-2394e6de-124a-11e8-89e0-9442142a6191.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

I figure we can also remove the "Bot type" heading entirely.
