### PR TITLE
stats: Fix anchor links and add sidebar on /stats.

### DIFF
--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -499,8 +499,11 @@ function populate_messages_sent_by_client(data) {
         draw_plot();
     });
 
-    // handle links with @href started with '#' only
-    $(document).on('click', 'a[href^="#"]', function (e) {
+}
+
+$(document).on('click', 'a[href^="#"]', function (e) {
+        // prevent standard hash navigation (avoid blinking in IE)
+        e.preventDefault();
         // target element id
         var id = $(this).attr('href');
         // target element
@@ -508,12 +511,9 @@ function populate_messages_sent_by_client(data) {
         if ($id.length === 0) {
             return;
         }
-        // prevent standard hash navigation (avoid blinking in IE)
-        e.preventDefault();
         var pos = $id.offset().top+$('.page-content')[0].scrollTop-50;
-        $('.page-content').animate({scrollTop: pos + "px"}, 500);
+        $('html, body').animate({scrollTop: pos}, 500);
     });
-}
 
 $.get({
     url: '/json/analytics/chart_data',

--- a/static/styles/stats.css
+++ b/static/styles/stats.css
@@ -1,7 +1,8 @@
-.app-main {
+.app {
     padding: 0;
     width: auto;
     max-width: none;
+    position: relative;
 }
 
 body {
@@ -13,6 +14,53 @@ body {
 
 p {
     margin-bottom: 0px;
+}
+
+.page-content {
+    width: calc(100% - 270px - 10px);
+    overflow: auto;
+    display: inline-block;
+    vertical-align: top;
+    position: relative;
+    margin-left: 275px;
+}
+
+.sidebar {
+    width: 270px;
+    height: 100%;
+    z-index: 2;
+    display: inline-block;
+    vertical-align: top;
+    border-right: 1px solid #eee;
+    position: fixed;
+}
+
+.nav {
+    margin-left: 20px;
+}
+
+.nav-subtitle {
+    font-size: 20px;
+    font-weight: 300;
+    margin-top: 40px;
+    margin-bottom: 7px;
+}
+
+.nav-link {
+    display: block;
+    font-size: 16px;
+    margin-left: 25px;
+}
+
+@media (max-width: 1100px) {
+    .sidebar {
+        display: none;
+    }
+
+    .page-content {
+        width: 100%;
+        margin: auto;
+    }
 }
 
 .svg-container {

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -11,6 +11,17 @@
     {{ render_bundle('stats') }}
     {% stylesheet 'stats' %}
 
+    <div class="sidebar">
+        <nav class="nav">
+            <p class="nav-subtitle">Messages Sent</p>
+            <a href="#div_messages_sent_over_time" class="nav-link">Messages Sent Over Time</a>
+            <a href="#pie_messages_sent_by_client" class="nav-link">Messages Sent by Client</a>
+            <a href="#pie_messages_sent_by_type" class="nav-link">Messages Sent by Recipient Type</a>
+            <p class="nav-subtitle">Users</p>
+            <a href="#id_number_of_users" class="nav-link">Number of Users</a>
+        </nav>
+    </div>
+
     <div class="page-content">
         <div id="id_stats_errors" class="alert alert-error"></div>
         <div class="center-charts">
@@ -18,26 +29,28 @@
 
             <div class="left">
                 <div class="chart-container">
-                    <h1>{{ _("Messages sent over time") }}</h1>
-                    <div class="button-container">
-                        <label>{{ _("Aggregation") }}</label>
-                        <div class="buttons">
-                            <button class="button" type="button" id='daily_button'>{{ _("Daily") }} </button>
-                            <button class="button" type="button" id='weekly_button'>{{ _("Weekly") }} </button>
-                            <button class="button" type="button" id='cumulative_button'>{{ _("Cumulative") }} </button>
+                    <div id="div_messages_sent_over_time">
+                        <h1>{{ _("Messages sent over time") }}</h1>
+                        <div class="button-container">
+                            <label>{{ _("Aggregation") }}</label>
+                            <div class="buttons">
+                                <button class="button" type="button" id='daily_button'>{{ _("Daily") }} </button>
+                                <button class="button" type="button" id='weekly_button'>{{ _("Weekly") }} </button>
+                                <button class="button" type="button" id='cumulative_button'>{{ _("Cumulative") }} </button>
+                            </div>
                         </div>
-                    </div>
-                    <div id="id_messages_sent_over_time">
-                        <div class="spinner"></div>
-                    </div>
-                    <div id="hoverinfo">
-                        <span id="hover_date"></span>
-                        <span id="hover_me">{{ _("Me") }}:</span>
-                        <span id="hover_me_value"></span>
-                        <b id="hover_human">{{ _("Humans") }}:</b>
-                        <span id="hover_human_value"></span>
-                        <b id="hover_bot">{{ _("Bots") }}:</b>
-                        <span id="hover_bot_value"></span>
+                        <div id="id_messages_sent_over_time">
+                            <div class="spinner"></div>
+                        </div>
+                        <div id="hoverinfo">
+                            <span id="hover_date"></span>
+                            <span id="hover_me">{{ _("Me") }}:</span>
+                            <span id="hover_me_value"></span>
+                            <b id="hover_human">{{ _("Humans") }}:</b>
+                            <span id="hover_human_value"></span>
+                            <b id="hover_bot">{{ _("Bots") }}:</b>
+                            <span id="hover_bot_value"></span>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
In this fix, the sidebar on the /stats page is reintroduced.
The anchor links on this sidebar are now able to scroll to the
appropriate chart when clicked.

Fixes #3713.