### PR TITLE
compose: Remove draft older than 30 days.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -145,3 +145,29 @@ var draft_2 = {
 
     drafts.initialize();
 }());
+
+(function test_remove_old_drafts() {
+    var draft_3 = {
+        stream: "stream",
+        subject: "topic",
+        type: "stream",
+        content: "Test Stream Message",
+        updatedAt: Date.now(),
+    };
+    var draft_4 = {
+        private_message_recipient: "aaron@zulip.com",
+        reply_to: "aaron@zulip.com",
+        type: "private",
+        content: "Test Private Message",
+        updatedAt: new Date().setDate(-30),
+    };
+    var draft_model = drafts.draft_model;
+    var ls = localstorage();
+    localStorage.clear();
+    var data = {id3: draft_3, id4: draft_4};
+    ls.set("drafts", data);
+    assert.deepEqual(draft_model.get(), data);
+
+    drafts.remove_old_drafts();
+    assert.deepEqual(draft_model.get(), {id3: draft_3});
+}());

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -1,10 +1,17 @@
-zrequire('localstorage');
-zrequire('drafts');
-
 set_global('$', global.make_zjquery());
+set_global('i18n', global.stub_i18n);
 set_global('window', {});
 
+zrequire('localstorage');
+zrequire('drafts');
+zrequire('XDate', 'xdate');
+zrequire('timerender');
+zrequire('Handlebars', 'handlebars');
+zrequire('util');
+
 var ls_container = {};
+var noop = function () { return; };
+
 set_global('localStorage', {
     getItem: function (key) {
         return ls_container[key];
@@ -21,6 +28,28 @@ set_global('localStorage', {
 });
 set_global('compose', {});
 set_global('compose_state', {});
+set_global('stream_data', {
+    get_color: function () {
+        return '#FFFFFF';
+    },
+});
+set_global('blueslip', {});
+set_global('people', {
+    // Mocking get_by_email function, here we are
+    // just returning string before `@` in email
+    get_by_email: function (email) {
+        return {
+            full_name: email.split('@')[0],
+        };
+    },
+});
+set_global('templates', {});
+set_global('markdown', {
+    apply_markdown: noop,
+});
+set_global('page_params', {
+    twenty_four_hour_time: false,
+});
 
 function stub_timestamp(timestamp, func) {
     var original_func = Date.prototype.getTime;
@@ -170,4 +199,97 @@ var draft_2 = {
 
     drafts.remove_old_drafts();
     assert.deepEqual(draft_model.get(), {id3: draft_3});
+}());
+
+(function test_format_drafts() {
+    draft_1.updatedAt = new Date(1549958107000).getTime();      // 2/12/2019 07:55:07 AM (UTC+0)
+    draft_2.updatedAt = new Date(1549958107000).setDate(-1);
+    var draft_3 = {
+        stream: "stream 2",
+        subject: "topic",
+        type: "stream",
+        content: "Test Stream Message 2",
+        updatedAt: new Date(1549958107000).setDate(-10),
+    };
+    var draft_4 = {
+        private_message_recipient: "aaron@zulip.com",
+        reply_to: "iago@zulip.com",
+        type: "private",
+        content: "Test Private Message 2",
+        updatedAt: new Date(1549958107000).setDate(-5),
+    };
+    var draft_5 = {
+        private_message_recipient: "aaron@zulip.com",
+        reply_to: "zoe@zulip.com",
+        type: "private",
+        content: "Test Private Message 3",
+        updatedAt: new Date(1549958107000).setDate(-2),
+    };
+
+    var expected = {
+        id3: {
+            draft_id: 'id3',
+            is_stream: true,
+            stream: 'stream 2',
+            stream_color: '#FFFFFF',
+            topic: 'topic',
+            raw_content: 'Test Stream Message 2',
+            time_stamp: 'Jan 21',
+        },
+        id4: {
+            draft_id: 'id4',
+            is_stream: false,
+            recipients: 'aaron',
+            raw_content: 'Test Private Message 2',
+            time_stamp: 'Jan 26',
+        },
+        id5: {
+            draft_id: 'id5',
+            is_stream: false,
+            recipients: 'aaron',
+            raw_content: 'Test Private Message 3',
+            time_stamp: 'Jan 29',
+        },
+        id2: {
+            draft_id: 'id2',
+            is_stream: false,
+            recipients: 'aaron',
+            raw_content: 'Test Private Message',
+            time_stamp: 'Jan 30',
+        },
+        id1: {
+            draft_id: 'id1',
+            is_stream: true,
+            stream: 'stream',
+            stream_color: '#FFFFFF',
+            topic: 'topic',
+            raw_content: 'Test Stream Message',
+            time_stamp: '7:55 AM',
+        },
+    };
+
+    blueslip.error = noop;
+    $('#drafts_table').append = noop;
+
+    var draft_model = drafts.draft_model;
+    var ls = localstorage();
+    localStorage.clear();
+    var data = { id1: draft_1, id2: draft_2, id3: draft_3, id4: draft_4, id5: draft_5 };
+    ls.set("drafts", data);
+    assert.deepEqual(draft_model.get(), data);
+
+    var stub_render_now = timerender.render_now;
+    timerender.render_now = function (time) {
+        return stub_render_now(time, new XDate(1549958107000));
+    };
+
+    global.templates.render = function (template_name, data) {
+        assert.equal(template_name, 'draft_table_body');
+        // Tests formatting and sorting of drafts
+        assert.deepEqual(data.drafts, expected);
+        return '<draft table stub>';
+    };
+
+    drafts.setup_page();
+    timerender.render_now = stub_render_now;
 }());

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -212,7 +212,7 @@ exports.setup_page = function (callback) {
             var formatted;
             var time = new XDate(draft.updatedAt);
             var time_stamp = timerender.render_now(time).time_str;
-            if (time_stamp === "Today") {
+            if (time_stamp === i18n.t("Today")) {
                 time_stamp = timerender.stringify_time(time);
             }
             if (draft.type === "stream") {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -160,6 +160,20 @@ exports.restore_draft = function (draft_id) {
     $("#compose-textarea").data("draft-id", draft_id);
 };
 
+var DRAFT_LIFETIME = 30;
+
+function remove_old_drafts() {
+    var old_date  = new Date().setDate(new Date().getDate() - DRAFT_LIFETIME);
+    var drafts = draft_model.get();
+    _.each(drafts, function (draft, id) {
+        if (draft.updatedAt < old_date) {
+            draft_model.deleteDraft(id);
+        }
+    });
+}
+// Exporting for testing purpose
+exports.remove_old_drafts = remove_old_drafts;
+
 exports.setup_page = function (callback) {
     function setup_event_handlers() {
         $(".restore-draft").on("click", function (e) {
@@ -262,7 +276,10 @@ exports.setup_page = function (callback) {
     function _populate_and_fill() {
         $('#drafts_table').empty();
         var drafts = format_drafts(draft_model.get());
-        var rendered = templates.render('draft_table_body', { drafts: drafts });
+        var rendered = templates.render('draft_table_body',{
+                drafts: drafts,
+                draft_lifetime: DRAFT_LIFETIME,
+        });
         $('#drafts_table').append(rendered);
         if ($("#drafts_table .draft-row").length > 0) {
             $('#drafts_table .no-drafts').hide();
@@ -280,6 +297,8 @@ exports.setup_page = function (callback) {
             _populate_and_fill();
         });
     }
+
+    remove_old_drafts();
     populate_and_fill();
 };
 

--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -61,6 +61,15 @@
     -webkit-font-smoothing: antialiased;
 }
 
+.drafts-list .removed-drafts {
+    display: block;
+    text-align: center;
+    font-size: 1em;
+    color: hsl(0, 0%, 66%);
+    pointer-events: none;
+    -webkit-font-smoothing: antialiased;
+}
+
 .draft-row {
     padding: 5px 10px;
 }

--- a/static/templates/draft_table_body.handlebars
+++ b/static/templates/draft_table_body.handlebars
@@ -8,6 +8,9 @@
                 </div>
             </div>
             <div class="drafts-list">
+                <div class="removed-drafts">
+                    {{#tr this}} Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed {{/tr}}
+                </div>
                 <div class="no-drafts">
                     {{t 'No drafts.'}}
                 </div>


### PR DESCRIPTION
This removes drafts older than 30 days as they become irrelevant
for the user. Those drafts are removed before populating them.

It's difficult to test manually drafts older than 30 days, so I have only one chance to test drafts older than 30 days and it worked. [This](https://chat.zulip.org/user_uploads/2/3c/d73Ug4GRXZpNcjSteETX4CVU/drAFT.png) is the screenshot of object from dev tools (and  [GIF](https://user-images.githubusercontent.com/22238472/34405647-72928e94-ebda-11e7-96cb-9d874ac0ea78.gif)  of that draft from my another PR) of the drafts that date backs to `12 June 2017` which get removed after implementation.

Here's after is how it looks after getting removed [older.png](https://chat.zulip.org/user_uploads/2/3/1cMXTYJkwb3_sVruoibXXqoR/older.png) 

And this is how it looks when we don't have any draft. [NoDraft.png](https://chat.zulip.org/user_uploads/2/f/X-MXZBmTVa4jycTLPFrQK0k5/NoDraft.png)

Fixes: #7602.

Also, it might worth taking look into #7903, my another PR, in which I've also added timestamps and sorted them according to their timestamp.
