### PR TITLE
[WIP] Make support multiple groups of default streams 

### DIFF
--- a/zerver/migrations/0139_make_default_group_in_default_stream_groups.py
+++ b/zerver/migrations/0139_make_default_group_in_default_stream_groups.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from django.db import migrations
+from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+def add_existing_default_streams_to_default_group(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    DefaultStreamGroup = apps.get_model('zerver', 'DefaultStreamGroup')
+    DefaultStream = apps.get_model('zerver', 'DefaultStream')
+    Realm = apps.get_model('zerver', 'Realm')
+
+    for realm in Realm.objects.all():
+        if not DefaultStreamGroup.objects.filter(realm=realm, name="default").exists():
+            default_stream_objects = DefaultStream.objects.filter(realm=realm)
+            default_streams = [default_stream_object.stream for default_stream_object in default_stream_objects]
+            group = DefaultStreamGroup.objects.create(realm=realm,  name="default")
+            group.streams = default_streams
+            group.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+         ('zerver', '0137_realm_upload_quota_gb'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_existing_default_streams_to_default_group)
+]


### PR DESCRIPTION
This Pull Request aims at solving issue #6693 allowing easily adding multiple groups for default streams and an carry forward to the work of @hackerkid in the pr #6973. Using the roadmap provided by @timabbott , we have now been able to reach these checkpoints.

- [X] Add a DefaultStreamGroup table with name and ID columns.
Thanks to @hackerkid  for #6973 most of the work important work has been done. 😃 
- [X] Change DefaultStream to have an additional DefaultStreamGroup column. 
I have successfully written a migration that creates a default group that contains all the default streams 
 now present.
- [ ] And we'd need to move the unique_together to be on DefaultStreamGroup, Stream, not Realm, Stream).
- [ ] Modify the registration process to, if the realm has a non-null DefaultStreamGroup, offer a page like the above in the signup process. 
Though Presently there are options shown on time of registration, but this thing is not implemented correctly yet. 
- [ ] Expand the default stream API endpoints to support adding/removing these.
- [ ] Expand the UI for default streams to support these.