### PR TITLE
portico: Temporarily fix CSS compilation bug with `calc` property.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -229,7 +229,9 @@ body {
     background-color: hsl(152, 40%, 42%);
 
     /* Extend highlight to entire width of sidebar, not just link area */
-    width: calc(100% + 20px);
+    /* This has been changed from "+" to "- -" because of issue #8403.
+       If the issue has been fixed, please change this back to "+" again. */
+    width: calc(100% - -20px);
     margin-left: -40px;
     padding-left: 40px;
 }


### PR DESCRIPTION
This temporarily fixes a CSS compilation bug with `calc`, that is
outlined in Issue #8403 in the Zulip project.

**Screenshots:**

Before: 
<img width="339" alt="screen shot 2018-02-15 at 4 00 35 pm" src="https://user-images.githubusercontent.com/10321399/36287669-1c90f60e-126b-11e8-876b-10fe81d50ec4.png">

After:
<img width="340" alt="screen shot 2018-02-15 at 4 13 20 pm" src="https://user-images.githubusercontent.com/10321399/36287681-2ea7e730-126b-11e8-89fb-80394063386c.png">
