### PR TITLE
landing-page: Change "Help Center" => "Why Zulip".

### DIFF
--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -26,8 +26,8 @@
             <li on-page="integrations">
                 <a href="/integrations/">Integrations</a>
             </li>
-            <li on-page="help">
-                <a href="/help/">Help Center</a>
+            <li>
+                <a href="/why-zulip/">Why Zulip</a>
             </li>
             {% if user_is_authenticated %}
                 {% include 'zerver/portico-header-dropdown.html' %}


### PR DESCRIPTION
We have a good "Help Center" section in the footer, where a user
may already expect to look for help/support related requests, so
we can replace the navbar spot there with the "Why Zulip" page link.