### PR TITLE
Check for OS before patching the lxc-config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,8 +31,8 @@ end
 # have the box (e.g. on first setup), Vagrant would download it but too
 # late for us to patch it like this; so we prompt them to explicitly add it
 # first and then rerun.
-if Vagrant::Util::Platform.linux?
-  if ['up', 'provision'].include? ARGV[0]
+if ['up', 'provision'].include? ARGV[0]
+  if command? "lxc-ls"
     LXC_VERSION = `lxc-ls --version`.strip unless defined? LXC_VERSION
     if LXC_VERSION == "2.1.0"
       lxc_config_file = ENV['HOME'] + "/.vagrant.d/boxes/fgrehm-VAGRANTSLASH-trusty64-lxc/1.2.0/lxc/lxc-config"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,25 +31,27 @@ end
 # have the box (e.g. on first setup), Vagrant would download it but too
 # late for us to patch it like this; so we prompt them to explicitly add it
 # first and then rerun.
-if ['up', 'provision'].include? ARGV[0]
-  LXC_VERSION = `lxc-ls --version`.strip unless defined? LXC_VERSION
-  if LXC_VERSION == "2.1.0"
-    lxc_config_file = ENV['HOME'] + "/.vagrant.d/boxes/fgrehm-VAGRANTSLASH-trusty64-lxc/1.2.0/lxc/lxc-config"
-    if File.file?(lxc_config_file)
-      lines = File.readlines(lxc_config_file)
-      deprecated_line = "lxc.pivotdir = lxc_putold\n"
-      if lines[1] == deprecated_line
-        lines[1] = "# #{deprecated_line}"
-        File.open(lxc_config_file, 'w') do |f|
-          f.puts(lines)
+if Vagrant::Util::Platform.linux?
+  if ['up', 'provision'].include? ARGV[0]
+    LXC_VERSION = `lxc-ls --version`.strip unless defined? LXC_VERSION
+    if LXC_VERSION == "2.1.0"
+      lxc_config_file = ENV['HOME'] + "/.vagrant.d/boxes/fgrehm-VAGRANTSLASH-trusty64-lxc/1.2.0/lxc/lxc-config"
+      if File.file?(lxc_config_file)
+        lines = File.readlines(lxc_config_file)
+        deprecated_line = "lxc.pivotdir = lxc_putold\n"
+        if lines[1] == deprecated_line
+          lines[1] = "# #{deprecated_line}"
+          File.open(lxc_config_file, 'w') do |f|
+            f.puts(lines)
+          end
         end
+      else
+        puts 'You are running LXC 2.1.0, and fgrehm/trusty64-lxc box is incompatible '\
+            "with it by default. First add the box by doing:\n"\
+            "  vagrant box add  https://vagrantcloud.com/fgrehm/trusty64-lxc\n"\
+            'Once this command succeeds, do "vagrant up" again.'
+        exit
       end
-    else
-      puts 'You are running LXC 2.1.0, and fgrehm/trusty64-lxc box is incompatible '\
-           "with it by default. First add the box by doing:\n"\
-           "  vagrant box add  https://vagrantcloud.com/fgrehm/trusty64-lxc\n"\
-           'Once this command succeeds, do "vagrant up" again.'
-      exit
     end
   end
 end


### PR DESCRIPTION
Followup of e68b45d08948622000608bce97e5672955415895
Without this vagrant up will fail on Windows.
https://chat.zulip.org/#narrow/stream/development.20help/topic/Vagrant.20up.20error

**Testing Plan:** <!-- How have you tested? -->
Run `vagrant up` from  a windows machine

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
