### PR TITLE
message-editing: Update unread count when message is deleted in stream.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -848,13 +848,28 @@ with_overrides(function (override) {
     });
 });
 
+// mark_message_as_read requires message_store and these dependencies.
+zrequire('unread_ops');
+zrequire('unread');
+set_global('message_store', {});
+
 with_overrides(function (override) {
     // delete_message
     var event = event_fixtures.delete_message;
+    message_store.get = function (msg_id) {
+        return {id: msg_id, reactions: []};
+    };
+
     global.with_stub(function (stub) {
         override('ui.remove_message', stub.f);
         dispatch(event);
         var args = stub.get_args('message_id');
         assert_same(args.message_id, 1337);
+    });
+    global.with_stub(function (stub) {
+        override('unread_ops.mark_message_as_read', stub.f);
+        dispatch(event);
+        var args = stub.get_args('message');
+        assert_same(args.message.id, 1337);
     });
 });

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -356,6 +356,11 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
 
     case 'delete_message':
         var msg_id = event.message_id;
+        var message = message_store.get(msg_id);
+        // message is passed to unread.get_unread_messages,
+        // which returns all the unread messages out of a given list.
+        // So double marking something as read would not occur
+        unread_ops.mark_message_as_read(message);
         ui.remove_message(msg_id);
         break;
 


### PR DESCRIPTION
fixes #8411 first issue
Testing instructions:
Send multiple messages to a stream, while the other user is offline. Note the unread count on the second user's sidebar. Start deleting those messages one by one. Note that the unread count is decreasing with the deletion. 
