### PR TITLE
Remove popover memory leak.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -790,6 +790,7 @@ exports.hide_all = function () {
             $o.$tip.remove();
         }
     });
+    list_of_popovers = [];
 };
 
 exports.set_userlist_placement = function (placement) {


### PR DESCRIPTION
Fixes #8416

This change resets the list_of_popovers array to a new empty array after
hide_all has been called. Prior behavior kept it around, and it kept
pointers to orphaned DOM nodes.

**Testing Plan:**
For now - it's passing travis tests.

There should probably be some tests here, to make sure there's not other leaking DOM elements. Ideally, we could figure out a way to automate this a bit more, but it would be optimal if the testing regime could make assertions about the state of the heap at various points. I'll investigate casper (and puppeteer, for that matter, which is pretty fancy) and see if I can do that. But for now, it seems that this didn't *break* anything new (or at least anything that's tested for).



