### PR TITLE
Fix empty notifications for messages containing an image and no text.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -255,7 +255,13 @@ function process_notification(notification) {
     // Convert the content to plain text, replacing emoji with their alt text
     content = $('<div/>').html(message.content);
     ui.replace_emoji_with_text(content);
-    content = content.text();
+
+    // Prevent empty notification when message contains only an image
+    if (content.text() === '' && content.children().first().hasClass("message_inline_image")) {
+        content = title + " sent you an image";
+    } else {
+        content = content.text();
+    }
 
     if (message.is_me_message) {
         content = message.sender_full_name + content.slice(3);

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -257,11 +257,9 @@ function process_notification(notification) {
     ui.replace_emoji_with_text(content);
 
     // Prevent empty notification when message contains only an image
-    if (content.text() === '' && content.children().first().hasClass("message_inline_image")) {
-        content = title + " sent you an image";
-    } else {
-        content = content.text();
-    }
+    content = (content.text() === '' && content.children().first().hasClass("message_inline_image"))
+            ? title + " sent you an image"
+            : content.text();
 
     if (message.is_me_message) {
         content = message.sender_full_name + content.slice(3);

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -257,9 +257,11 @@ function process_notification(notification) {
     ui.replace_emoji_with_text(content);
 
     // Prevent empty notification when message contains only an image
-    content = (content.text() === '' && content.children().first().hasClass("message_inline_image"))
-            ? title + " sent you an image"
-            : content.text();
+    if (content.text() === '' && content.children().first().hasClass("message_inline_image")) {
+        content = i18n.t("__title__ sent you an image", {title: title})
+    } else {
+        content = content.text();
+    }
 
     if (message.is_me_message) {
         content = message.sender_full_name + content.slice(3);


### PR DESCRIPTION
solves issue #8087
Before:
<img width="345" alt="screen shot 2018-02-17 at 01 23 03" src="https://user-images.githubusercontent.com/25613521/36335554-27e12d8c-1381-11e8-884d-0bf0ce2327c5.png">
<img width="349" alt="screen shot 2018-02-17 at 01 22 43" src="https://user-images.githubusercontent.com/25613521/36335559-2edda75a-1381-11e8-8d64-73d8e5980a08.png">

After fix:
<img width="358" alt="screen shot 2018-02-17 at 01 11 56" src="https://user-images.githubusercontent.com/25613521/36335485-ad9c87ec-1380-11e8-99fc-55aac3ef8200.png">
<img width="352" alt="screen shot 2018-02-17 at 01 13 04" src="https://user-images.githubusercontent.com/25613521/36335493-b3aaba28-1380-11e8-8459-c6ad74aea307.png">

