### PR TITLE
***text*** will apply both bold and italic. Fixes #8155

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -213,6 +213,7 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
         {input: 'hello', expected: '<p>hello</p>'},
         {input: 'hello there', expected: '<p>hello there</p>'},
         {input: 'hello **bold** for you', expected: '<p>hello <strong>bold</strong> for you</p>'},
+        {input: 'hello ***foo*** for you', expected: '<p>hello <strong><em>foo</em></strong> for you</p>'},
         {input: '__hello__', expected: '<p>__hello__</p>'},
         {input: '\n```\nfenced code\n```\n\nand then after\n',
          expected: '<div class="codehilite"><pre><span></span>fenced code\n</pre></div>\n\n\n<p>and then after</p>'},

--- a/zerver/fixtures/markdown_test_cases.json
+++ b/zerver/fixtures/markdown_test_cases.json
@@ -228,6 +228,12 @@
       "text_content": "foo"
     },
     {
+      "name": "star_strong_em",
+      "input": "***foo***",
+      "expected_output": "<p><strong><em>foo</em></strong></p>",
+      "text_content": "foo"
+    },
+    {
       "name": "numbered_list",
       "input": "1. A\n 2. B",
       "expected_output": "<p>1. A<br>\n 2. B</p>",

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1526,6 +1526,12 @@ class Bugdown(markdown.Extension):
             BacktickPattern(r'(?:(?<!\\)((?:\\{2})+)(?=`+)|(?<!\\)(`+)(.+?)(?<!`)\3(?!`))'),
             "_begin")
 
+        md.inlinePatterns.add(
+            'strong_em',
+            markdown.inlinepatterns.DoubleTagPattern(
+                r'(\*\*\*)(?!\s+)([^\*^\n]+)(?<!\s)\*\*\*', 'strong,em'),
+            '>backtick')
+
         # Custom bold syntax: **foo** but not __foo__
         md.inlinePatterns.add('strong',
                               markdown.inlinepatterns.SimpleTagPattern(r'(\*\*)([^\n]+?)\2', 'strong'),


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
*** will now apply both bold and italic formatting. Fixes #8155 

Before:
![capture](https://user-images.githubusercontent.com/4214851/36338420-b599e8e6-13d4-11e8-998c-6945b6198eb1.PNG)
After:
![capture2](https://user-images.githubusercontent.com/4214851/36338422-b5cfbc0a-13d4-11e8-8e4e-ccd82f5469db.PNG)
