### PR TITLE
popovers: Show hotkey reminder for sender info popovers only.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -120,6 +120,7 @@ function show_user_info_popover(element, user, message) {
             is_me: people.is_current_user(user.email),
             is_active: people.is_active_user_for_popover(user.user_id),
             is_bot: people.get_person_from_user_id(user.user_id).is_bot,
+            is_sender: message.sender_id === user.user_id,
         };
 
 
@@ -637,6 +638,7 @@ exports.register_click_handlers = function () {
             private_message_class: "compose_private_message",
             is_active: people.is_active_user_for_popover(user_id),
             is_bot: user.is_bot,
+            is_sender: false,
         };
 
         target.popover({

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -32,7 +32,7 @@
         {{#unless is_me}}
         <li>
             <a href="#" class="{{ private_message_class }}">
-                <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr this}}Send private message{{/tr}} (R)
+                <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr this}}Send private message{{/tr}} {{#if is_sender}}(R){{/if}}
             </a>
         </li>
         {{/unless}}
@@ -47,7 +47,7 @@
     {{#unless is_me}}
     <li>
         <a class="mention_user">
-            <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}} (@)
+            <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}} {{#if is_sender}}(@){{/if}}
         </a>
     </li>
     {{/unless}}


### PR DESCRIPTION
Hotkey reminders in user popovers( i.e. `@` and `R`) should be present
only for sender info popovers, hence for user-mention and user-presence
popovers it will show no such reminders.

Fixes: #8313.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
**MANUAL TESTING**

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![popover](https://user-images.githubusercontent.com/22238472/36340856-ec134b48-140a-11e8-8966-bd9a801343a4.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
When sender mentions himself in a message it shows these reminders(which I think is okay).