### PR TITLE
settings: Update last active time text.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -153,7 +153,7 @@ function populate_users(realm_people_data) {
                     activity_rendered = $("<span></span>").text(i18n.t("Never"));
                 }
             } else {
-                activity_rendered = $("<span></span>").text(i18n.t("Unknown"));
+                activity_rendered = $("<span></span>").text("*");
             }
 
             var $row = $(templates.render("admin_user_list", {user: item, can_modify: page_params.is_admin}));

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1380,6 +1380,13 @@ thead .actions {
     width: 100%;
 }
 
+.inactive-users-text {
+    font-style: italic;
+    color: hsl(0, 0%, 66%);
+    position: fixed;
+    bottom: 0;
+}
+
 #payload_url_inputbox input[type=text] {
     width: 340px;
 }

--- a/static/templates/settings/user-list-admin.handlebars
+++ b/static/templates/settings/user-list-admin.handlebars
@@ -19,4 +19,9 @@
         </table>
     </div>
     <div id="admin_page_users_loading_indicator"></div>
+    <div>
+        <p class="inactive-users-text">
+            {{t '* not active in the last 3 weeks'}}
+        </p>
+    </div>
 </div>


### PR DESCRIPTION
Currently, we use "Unknown" text to denote a last active time.
This PR simplifies the last active status.

Fixes - #8432.

<img width="1101" alt="screen shot 2018-02-18 at 4 50 25 am" src="https://user-images.githubusercontent.com/2263909/36346781-af5f9ef2-146b-11e8-97fa-bff32b4f1cff.png">

<img width="1085" alt="screen shot 2018-02-18 at 4 49 52 am" src="https://user-images.githubusercontent.com/2263909/36346782-b8956664-146b-11e8-84e9-37e67b4aec29.png">

FYI, @rishig. 