### PR TITLE
[WIP] Make login URL's with next param `/login?next=some_path` work.

### DIFF
--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -17,7 +17,7 @@
                         <h2>{{ _('Administrators') }}</h2>
                         {% if direct_admins %}
                             {% for direct_admin in direct_admins %}
-                            <p><input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}"
+                            <p><input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}?next={{ next }}"
                                       name="direct_email" class="btn-direct btn-admin" value="{{ direct_admin.email }}" /></p>
                             {% endfor %}
                         {% else %}
@@ -29,7 +29,7 @@
                         <h2>{{ _('Normal users') }}</h2>
                         {% if direct_users %}
                             {% for direct_user in direct_users %}
-                            <p><input type="submit" formaction="{{ direct_user.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}"
+                            <p><input type="submit" formaction="{{ direct_user.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}?next={{ next }}"
                                       name="direct_email" class="btn-direct btn-admin" value="{{ direct_user.email }}" /></p>
                             {% endfor %}
                         {% else %}

--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -57,7 +57,13 @@
 
 <script type="text/javascript">
 if (window.location.hash.substring(0, 1) === "#") {
-    document.login_form.action += window.location.hash;
+    /* We append the location.hash to the formaction so that URL can be
+    preserved after user is logged in. See this:
+    https://stackoverflow.com/questions/5283395/url-hash-is-persisting-between-redirects */
+    $("input[name='direct_email']").each(function () {
+        var new_formaction = $(this).attr('formaction') + '/' + window.location.hash;
+        $(this).attr('formaction', new_formaction);
+    });
 }
 </script>
 {% endblock %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -32,7 +32,7 @@
                     {# SSO users don't have a password. #}
 
                     <div class="login-sso">
-                        <a href="/accounts/login/sso" class="btn btn-large btn-primary">{{ _('Log in with SSO') }}</a>
+                        <a id="sso-login" href="/accounts/login/sso/?next={{ next }}" class="btn btn-large btn-primary">{{ _('Log in with SSO') }}</a>
                     </div>
 
                 {% else %}
@@ -164,6 +164,7 @@
         $("#login_form").attr('action', email_formaction + '/' + window.location.hash);
         $("#google_login_form input[name='next']").attr('value', '/' + window.location.hash);
         $("#social_login_form input[name='next']").attr('value', '/' + window.location.hash);
+        $("#sso-login").attr('href', $("#sso-login").attr('href') + window.location.hash.slice(1));
     }
     </script>
 

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -164,7 +164,9 @@
         $("#login_form").attr('action', email_formaction + '/' + window.location.hash);
         $("#google_login_form input[name='next']").attr('value', '/' + window.location.hash);
         $("#social_login_form input[name='next']").attr('value', '/' + window.location.hash);
-        $("#sso-login").attr('href', $("#sso-login").attr('href') + window.location.hash.slice(1));
+
+        var sso_address = $("#sso-login").attr('href');
+        $("#sso-login").attr('href', sso_address + window.location.hash);
     }
     </script>
 

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -125,7 +125,7 @@
 
                             {% if google_auth_enabled %}
                             <div class="login-google">
-                                <form class="form-inline" action="{{ url('zerver.views.auth.start_google_oauth2') }}" method="get">
+                                <form id='google_login_form' class="form-inline" action="{{ url('zerver.views.auth.start_google_oauth2') }}" method="get">
                                     <input type="hidden" name="next" value="{{ next }}">
                                     <button class="login-social-button login-google-button full-width">{{ _('Log in with Google') }}</button>
                                 </form>
@@ -134,7 +134,7 @@
 
                             {% if github_auth_enabled %}
                             <div class="login-github">
-                                <form class="form-inline github-wrapper" action="{{ url('login-social', args=('github',)) }}" method="get">
+                                <form id='social_login_form' class="form-inline github-wrapper" action="{{ url('login-social', args=('github',)) }}" method="get">
                                     <input type="hidden" name="next" value="{{ next }}">
                                     <button class="login-social-button login-github-button github">{{ _('Log in with GitHub') }}</button>
                                 </form>
@@ -157,7 +157,13 @@
     </div>
     <script type="text/javascript">
     if (window.location.hash.substring(0, 1) === "#") {
-        document.login_form.action += window.location.hash;
+        /* We append the location.hash to the formaction so that URL can be
+        preserved after user is logged in. See this:
+        https://stackoverflow.com/questions/5283395/url-hash-is-persisting-between-redirects */
+        var email_formaction = $("#login_form").attr('action');
+        $("#login_form").attr('action', email_formaction + '/' + window.location.hash);
+        $("#google_login_form input[name='next']").attr('value', '/' + window.location.hash);
+        $("#social_login_form input[name='next']").attr('value', '/' + window.location.hash);
     }
     </script>
 

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -126,6 +126,7 @@
                             {% if google_auth_enabled %}
                             <div class="login-google">
                                 <form class="form-inline" action="{{ url('zerver.views.auth.start_google_oauth2') }}" method="get">
+                                    <input type="hidden" name="next" value="{{ next }}">
                                     <button class="login-social-button login-google-button full-width">{{ _('Log in with Google') }}</button>
                                 </form>
                             </div>
@@ -134,6 +135,7 @@
                             {% if github_auth_enabled %}
                             <div class="login-github">
                                 <form class="form-inline github-wrapper" action="{{ url('login-social', args=('github',)) }}" method="get">
+                                    <input type="hidden" name="next" value="{{ next }}">
                                     <button class="login-social-button login-github-button github">{{ _('Log in with GitHub') }}</button>
                                 </form>
                             </div>

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -800,7 +800,8 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         data = {'name': 'Full Name',
                 'email': self.example_email("hamlet"),
                 'subdomain': 'zulip',
-                'is_signup': False}
+                'is_signup': False,
+                'next': ''}
         result = self.get_log_into_subdomain(data)
         self.assertEqual(result.status_code, 302)
         user_profile = self.example_user('hamlet')
@@ -817,7 +818,8 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         data = {'name': 'Full Name',
                 'email': self.example_email("hamlet"),
                 'subdomain': 'zulip',
-                'is_signup': False}
+                'is_signup': False,
+                'next': ''}
         with mock.patch('logging.warning') as mock_warning:
             result = self.get_log_into_subdomain(data, key='nonsense')
             mock_warning.assert_called_with("Subdomain cookie: Bad signature.")
@@ -827,7 +829,8 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         data = {'name': 'Full Name',
                 'email': self.example_email("hamlet"),
                 'subdomain': 'zulip',
-                'is_signup': False}
+                'is_signup': False,
+                'next': ''}
         with mock.patch('django.core.signing.time.time', return_value=time.time() - 45):
             token = signing.dumps(data, salt=_subdomain_token_salt)
         url_path = reverse('zerver.views.auth.log_into_subdomain', args=[token])
@@ -840,7 +843,8 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         data = {'name': 'Full Name',
                 'email': self.example_email("hamlet"),
                 'subdomain': 'zulip',
-                'is_signup': True}
+                'is_signup': True,
+                'next': ''}
         result = self.get_log_into_subdomain(data)
         self.assertEqual(result.status_code, 200)
         self.assert_in_response('hamlet@zulip.com already has an account', result)
@@ -850,7 +854,8 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         data = {'name': 'New User Name',
                 'email': 'new@zulip.com',
                 'subdomain': 'zulip',
-                'is_signup': True}
+                'is_signup': True,
+                'next': ''}
         result = self.get_log_into_subdomain(data)
         self.assertEqual(result.status_code, 302)
         confirmation = Confirmation.objects.all().first()
@@ -872,7 +877,8 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         data = {'name': 'New User Name',
                 'email': 'new@zulip.com',
                 'subdomain': 'zulip',
-                'is_signup': True}
+                'is_signup': True,
+                'next': ''}
 
         realm = get_realm("zulip")
         realm.invite_required = True
@@ -930,7 +936,8 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         data = {'name': None,
                 'email': None,
                 'subdomain': 'zulip',
-                'is_signup': False}
+                'is_signup': False,
+                'next': ''}
 
         with mock.patch('logging.warning'):
             result = self.get_log_into_subdomain(data)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1697,6 +1697,21 @@ class TestZulipRemoteUserBackend(ZulipTestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn('Zulip on Android', mail.outbox[0].body)
 
+    def test_redirect_to(self) -> None:
+        def test_with_redirect_to_param_set_as_next(next: Text='') -> HttpResponse:
+            user_profile = self.example_user('hamlet')
+            email = user_profile.email
+            with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
+                result = self.client_post('/accounts/login/sso/?next=' + next, REMOTE_USER=email)
+            return result
+
+        res = test_with_redirect_to_param_set_as_next()
+        self.assertEqual('http://zulip.testserver', res.url)
+        res = test_with_redirect_to_param_set_as_next('/user_uploads/image_path')
+        self.assertEqual('http://zulip.testserver/user_uploads/image_path', res.url)
+        res = test_with_redirect_to_param_set_as_next('narrow/stream/7-test-here')
+        self.assertEqual('http://zulip.testserver/#narrow/stream/7-test-here', res.url)
+
 class TestJWTLogin(ZulipTestCase):
     """
     JWT uses ZulipDummyBackend.

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1709,8 +1709,13 @@ class TestZulipRemoteUserBackend(ZulipTestCase):
         self.assertEqual('http://zulip.testserver', res.url)
         res = test_with_redirect_to_param_set_as_next('/user_uploads/image_path')
         self.assertEqual('http://zulip.testserver/user_uploads/image_path', res.url)
-        res = test_with_redirect_to_param_set_as_next('narrow/stream/7-test-here')
-        self.assertEqual('http://zulip.testserver/#narrow/stream/7-test-here', res.url)
+
+        # In SSO based auth we never make browser send the hash to the backend.
+        # Rather we depend upon the browser's behaviour of persisting hash anchors
+        # in between redirect requests. See below stackoverflow conversation
+        # https://stackoverflow.com/questions/5283395/url-hash-is-persisting-between-redirects
+        res = test_with_redirect_to_param_set_as_next('#narrow/stream/7-test-here')
+        self.assertEqual('http://zulip.testserver', res.url)
 
 class TestJWTLogin(ZulipTestCase):
     """

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1459,6 +1459,20 @@ class TestDevAuthBackend(ZulipTestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
 
+    def test_redirect_to_next_url(self) -> None:
+        def do_local_login(formaction: Text) -> HttpResponse:
+            user_email = self.example_email('hamlet')
+            data = {'direct_email': user_email}
+            return self.client_post(formaction, data)
+
+        res = do_local_login('/accounts/login/local/')
+        self.assertEqual(res.status_code, 302)
+        self.assertEqual(res.url, 'http://zulip.testserver')
+
+        res = do_local_login('/accounts/login/local/?next=/user_uploads/path_to_image')
+        self.assertEqual(res.status_code, 302)
+        self.assertEqual(res.url, 'http://zulip.testserver/user_uploads/path_to_image')
+
     def test_login_with_subdomain(self) -> None:
         user_profile = self.example_user('hamlet')
         email = user_profile.email

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -76,14 +76,16 @@ class RedirectAndLogIntoSubdomainTestCase(ZulipTestCase):
         email = self.example_email("hamlet")
         response = redirect_and_log_into_subdomain(realm, name, email)
         data = load_subdomain_token(response)
-        self.assertDictEqual(data, {'name': name, 'email': email,
+        self.assertDictEqual(data, {'name': name, 'next': '',
+                                    'email': email,
                                     'subdomain': realm.subdomain,
                                     'is_signup': False})
 
         response = redirect_and_log_into_subdomain(realm, name, email,
                                                    is_signup=True)
         data = load_subdomain_token(response)
-        self.assertDictEqual(data, {'name': name, 'email': email,
+        self.assertDictEqual(data, {'name': name, 'next': '',
+                                    'email': email,
                                     'subdomain': realm.subdomain,
                                     'is_signup': True})
 
@@ -2612,7 +2614,7 @@ class LoginOrAskForRegistrationTestCase(ZulipTestCase):
         user_id = get_session_dict_user(getattr(request, 'session'))
         self.assertEqual(user_id, user_profile.id)
         self.assertEqual(response.status_code, 302)
-        self.assertIn('http://zulip.testserver', response.url)
+        self.assertEqual('http://zulip.testserver', response.url)
 
 class FollowupEmailTest(ZulipTestCase):
     def test_followup_day2_email(self) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -218,12 +218,6 @@ def remote_user_sso(request: HttpRequest,
     user_profile = authenticate(remote_user=remote_user, realm=realm)
 
     redirect_to = request.GET.get('next', '')
-    # We decide whether the next link is a narrow or not based on the fact that
-    # either the path will be relative and hence begin with a '/' or be a narrow
-    # in which case it should have had a '#' in the start but we removed that
-    # using Js so that the narrow path could make it to the backend.
-    if not redirect_to.startswith('/') and redirect_to != '':
-        redirect_to = '/#' + redirect_to
 
     return login_or_register_remote_user(request, remote_user, user_profile,
                                          mobile_flow_otp=mobile_flow_otp,

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -216,8 +216,18 @@ def remote_user_sso(request: HttpRequest,
     # Since RemoteUserBackend will return None if Realm is None, we
     # don't need to check whether `get_realm` returned None.
     user_profile = authenticate(remote_user=remote_user, realm=realm)
+
+    redirect_to = request.GET.get('next', '')
+    # We decide whether the next link is a narrow or not based on the fact that
+    # either the path will be relative and hence begin with a '/' or be a narrow
+    # in which case it should have had a '#' in the start but we removed that
+    # using Js so that the narrow path could make it to the backend.
+    if not redirect_to.startswith('/') and redirect_to != '':
+        redirect_to = '/#' + redirect_to
+
     return login_or_register_remote_user(request, remote_user, user_profile,
-                                         mobile_flow_otp=mobile_flow_otp)
+                                         mobile_flow_otp=mobile_flow_otp,
+                                         redirect_to=redirect_to)
 
 @csrf_exempt
 @log_view_func

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -231,6 +231,7 @@ class SocialAuthMixin(ZulipAuthMixin):
         email_address = self.get_email_address(*args, **kwargs)
         full_name = self.get_full_name(*args, **kwargs)
         is_signup = strategy.session_get('is_signup') == '1'
+        redirect_to = strategy.session_get('next')
 
         mobile_flow_otp = strategy.session_get('mobile_flow_otp')
         subdomain = strategy.session_get('subdomain')
@@ -247,12 +248,14 @@ class SocialAuthMixin(ZulipAuthMixin):
                                                  user_profile, full_name,
                                                  invalid_subdomain=bool(invalid_subdomain),
                                                  mobile_flow_otp=mobile_flow_otp,
-                                                 is_signup=is_signup)
+                                                 is_signup=is_signup,
+                                                 redirect_to=redirect_to)
         realm = get_realm(subdomain)
         if realm is None:
             return redirect_to_subdomain_login_url()
         return redirect_and_log_into_subdomain(realm, full_name, email_address,
-                                               is_signup=is_signup)
+                                               is_signup=is_signup,
+                                               redirect_to=redirect_to)
 
     def auth_complete(self, *args: Any, **kwargs: Any) -> Optional[HttpResponse]:
         """


### PR DESCRIPTION
This PR contains commit to make urls with `/login?next=some_path` work as they would be expected to.
Currently when logged in the user is redirected to the home page of the web app rather than the link they were trying to open in the first place (during which they were asked to login).

To test this out follow these steps:
* Upload a image as part of a message in local environment.
* Use the direct link to this image to access the image in a new incognito browser window (so that you are asked to login again)
* Web app should ask you to login again. Login using any one of the specified methods.
* Observe yourself getting redirected to the web home page rather to the actual image.

* **Checkout the new branch now**
* Repeat the steps in previous phase of steps and you can observe that in final step you are redirected to the image you were trying to open.

I would recommend people to test out with other kind of files rather than images (I am tested with images so might be worthwhile checking out maybe PDF's)

I have tried to include some unit tests.

Currently I have covered three backends:
* Development Backend (Click user name to login one)
* GoogleOAuth2Backend
* GitHubAuthBackend

Fixes: #8476 