### PR TITLE
portico: Highlight active page's title in navbar on why-zulip page.

### DIFF
--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -26,7 +26,7 @@
             <li on-page="integrations">
                 <a href="/integrations/">Integrations</a>
             </li>
-            <li>
+            <li on-page="why-zulip">
                 <a href="/why-zulip/">Why Zulip</a>
             </li>
             {% if user_is_authenticated %}


### PR DESCRIPTION
This PR adds the **active state to Why Zulip link on the navbar** when the respective page is active.


**Screenshot** 
![Before and After](https://i.imgur.com/2KRKr2S.png)

