### PR TITLE
search: Sanitize input when using PGroonga.

### DIFF
--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -249,13 +249,13 @@ class NarrowBuilderTest(ZulipTestCase):
     @override_settings(USING_PGROONGA=True)
     def test_add_term_using_search_operator_pgroonga(self) -> None:
         term = dict(operator='search', operand='"french fries"')
-        self._do_add_term_test(term, 'WHERE search_pgroonga @@ :search_pgroonga_1')
+        self._do_add_term_test(term, 'WHERE search_pgroonga @@ pgroonga.query_escape(:query_escape_1)')
 
     @override_settings(USING_PGROONGA=True)
     def test_add_term_using_search_operator_and_negated_pgroonga(
             self) -> None:  # NEGATED
         term = dict(operator='search', operand='"french fries"', negated=True)
-        self._do_add_term_test(term, 'WHERE NOT (search_pgroonga @@ :search_pgroonga_1)')
+        self._do_add_term_test(term, 'WHERE NOT (search_pgroonga @@ pgroonga.query_escape(:query_escape_1))')
 
     def test_add_term_using_has_operator_and_attachment_operand(self) -> None:
         term = dict(operator='has', operand='attachment')

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -358,13 +358,15 @@ class NarrowBuilder:
     def _by_search_pgroonga(self, query: Query, operand: str,
                             maybe_negate: ConditionTransform) -> Query:
         match_positions_character = func.pgroonga.match_positions_character
+        query_escape = func.pgroonga.query_escape
         query_extract_keywords = func.pgroonga.query_extract_keywords
-        keywords = query_extract_keywords(operand)
+        escaped = query_escape(operand)
+        keywords = query_extract_keywords(escaped)
         query = query.column(match_positions_character(column("rendered_content"),
                                                        keywords).label("content_matches"))
         query = query.column(match_positions_character(column("subject"),
                                                        keywords).label("subject_matches"))
-        condition = column("search_pgroonga").op("@@")(operand)
+        condition = column("search_pgroonga").op("@@")(escaped)
         return query.where(maybe_negate(condition))
 
     def _by_search_tsearch(self, query: Query, operand: str,


### PR DESCRIPTION
PGroonga's function query_split_keywords expects valid query as
input. In order to prevent it from crashing we escape all special
characters before passing it further.

The behavior would be changed in some cases (e.g. `A - B` used to
split into {`A`}, now it's {`A`,`-`,`B`}) due to the fact that our input is
no longer treated as a query string.

Fixes #8054.