### PR TITLE
clean-venv-cache: Handle cleaning up zulip-thumbor-venv properly.

### DIFF
--- a/scripts/lib/clean-venv-cache
+++ b/scripts/lib/clean-venv-cache
@@ -3,8 +3,7 @@ import argparse
 import os
 import sys
 
-if False:
-    from typing import Set, Text
+from typing import Set, Text
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(ZULIP_PATH)
@@ -23,12 +22,16 @@ def get_caches_in_use(threshold_days):
     setups_to_check = set([ZULIP_PATH, ])
     caches_in_use = set()
 
+    def add_current_venv_cache(venv_name: Text) -> None:
+        CACHE_SYMLINK = os.path.join(os.path.dirname(ZULIP_PATH), venv_name)
+        CURRENT_CACHE = os.path.dirname(os.path.realpath(CACHE_SYMLINK))
+        caches_in_use.add(CURRENT_CACHE)
+
     if ENV == "prod":
         setups_to_check |= get_recent_deployments(threshold_days)
     if ENV == "dev":
-        CACHE_SYMLINK = os.path.join(os.path.dirname(ZULIP_PATH), "zulip-py3-venv")
-        CURRENT_CACHE = os.path.dirname(os.path.realpath(CACHE_SYMLINK))
-        caches_in_use.add(CURRENT_CACHE)
+        add_current_venv_cache("zulip-py3-venv")
+        add_current_venv_cache("zulip-thumbor-venv")
 
     for path in setups_to_check:
         reqs_dir = os.path.join(path, "requirements")


### PR DESCRIPTION
We make clean-venv-cache aware of zulip-thumbor-venv so that its cache clean up is handled properly and cache isn't deleted when it wasn't supposed to.