### PR TITLE
refactor: Extract transmit.js from compose.js.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,6 +65,7 @@
         "typing_data": false,
         "typing_status": false,
         "sent_messages": false,
+        "transmit": false,
         "compose": false,
         "compose_actions": false,
         "compose_state": false,

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -1,0 +1,169 @@
+var noop = function () {};
+
+set_global('page_params', {
+    use_websockets: true,
+});
+
+set_global('channel', {});
+set_global('navigator', {});
+set_global('reload', {});
+set_global('socket', {});
+set_global('Socket', function () {
+    return global.socket;
+});
+set_global('sent_messages', {
+    start_tracking_message: noop,
+    report_server_ack: noop,
+});
+
+zrequire('transmit');
+
+function test_with_mock_socket(test_params) {
+    var socket_send_called;
+    var send_args = {};
+
+    global.socket.send = function (request, success, error) {
+        global.socket.send = undefined;
+        socket_send_called = true;
+
+        // Save off args for check_send_args callback.
+        send_args.request = request;
+        send_args.success = success;
+        send_args.error = error;
+    };
+
+    // Run the actual code here.
+    test_params.run_code();
+
+    assert(socket_send_called);
+    test_params.check_send_args(send_args);
+}
+
+(function test_transmit_message_sockets() {
+    page_params.use_websockets = true;
+    global.navigator.userAgent = 'unittest_transmit_message';
+
+    // Our request is mostly unimportant, except that the
+    // socket_user_agent field will be added.
+    var request = {foo: 'bar'};
+
+    var success_func_checked = false;
+    var success = function () {
+        success_func_checked = true;
+    };
+
+    // Our error function gets wrapped, so we set up a real
+    // function to test the wrapping mechanism.
+    var error_func_checked = false;
+    var error = function (error_msg) {
+        assert.equal(error_msg, 'Error sending message: simulated_error');
+        error_func_checked = true;
+    };
+
+    test_with_mock_socket({
+        run_code: function () {
+            transmit.send_message(request, success, error);
+        },
+        check_send_args: function (send_args) {
+            // The real code patches new data on the request, rather
+            // than making a copy, so we test both that it didn't
+            // clone the object and that it did add a field.
+            assert.equal(send_args.request, request);
+            assert.deepEqual(send_args.request, {
+                foo: 'bar',
+                socket_user_agent: 'unittest_transmit_message',
+            });
+
+            send_args.success({});
+            assert(success_func_checked);
+
+            // Our error function does get wrapped, so we test by
+            // using socket.send's error callback, which should
+            // invoke our test error function via a wrapper
+            // function in the real code.
+            send_args.error('response', {msg: 'simulated_error'});
+            assert(error_func_checked);
+        },
+    });
+}());
+
+page_params.use_websockets = false;
+
+(function test_transmit_message_ajax() {
+
+    var success_func_called;
+    var success = function () {
+        success_func_called = true;
+    };
+
+    var request = {foo: 'bar'};
+
+    channel.post = function (opts) {
+        assert.equal(opts.url, '/json/messages');
+        assert.equal(opts.data.foo, 'bar');
+        opts.success();
+    };
+
+    transmit.send_message(request, success);
+
+    assert(success_func_called);
+
+    channel.xhr_error_message = function (msg) {
+        assert.equal(msg, 'Error sending message');
+        return msg;
+    };
+
+    channel.post = function (opts) {
+        assert.equal(opts.url, '/json/messages');
+        assert.equal(opts.data.foo, 'bar');
+        var xhr = 'whatever';
+        opts.error(xhr, 'timeout');
+    };
+
+    var error_func_called;
+    var error = function (response) {
+        assert.equal(response, 'Error sending message');
+        error_func_called = true;
+    };
+    transmit.send_message(request, success, error);
+    assert(error_func_called);
+}());
+
+(function test_transmit_message_ajax_reload_pending() {
+    var success = function () { throw 'unexpected success'; };
+
+    reload.is_pending = function () {
+        return true;
+    };
+
+    var reload_initiated;
+    reload.initiate = function (opts) {
+        reload_initiated = true;
+        assert.deepEqual(opts, {
+           immediate: true,
+           save_pointer: true,
+           save_narrow: true,
+           save_compose: true,
+           send_after_reload: true,
+        });
+    };
+
+    var request = {foo: 'bar'};
+
+    var error_func_called;
+    var error = function (response) {
+        assert.equal(response, 'Error sending message');
+        error_func_called = true;
+    };
+
+    error_func_called = false;
+    channel.post = function (opts) {
+        assert.equal(opts.url, '/json/messages');
+        assert.equal(opts.data.foo, 'bar');
+        var xhr = 'whatever';
+        opts.error(xhr, 'bad request');
+    };
+    transmit.send_message(request, success, error);
+    assert(!error_func_called);
+    assert(reload_initiated);
+}());

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -188,46 +188,6 @@ function nonexistent_stream_reply_error() {
 
 exports.nonexistent_stream_reply_error = nonexistent_stream_reply_error;
 
-function send_message_ajax(request, success, error) {
-    channel.post({
-        url: '/json/messages',
-        data: request,
-        success: success,
-        error: function (xhr, error_type) {
-            if (error_type !== 'timeout' && reload.is_pending()) {
-                // The error might be due to the server changing
-                reload.initiate({immediate: true,
-                                 save_pointer: true,
-                                 save_narrow: true,
-                                 save_compose: true,
-                                 send_after_reload: true});
-                return;
-            }
-
-            var response = channel.xhr_error_message("Error sending message", xhr);
-            error(response);
-        },
-    });
-}
-
-var socket;
-if (page_params.use_websockets) {
-    socket = new Socket("/sockjs");
-}
-// For debugging.  The socket will eventually move out of this file anyway.
-exports._socket = socket;
-
-function send_message_socket(request, success, error) {
-    request.socket_user_agent = navigator.userAgent;
-    socket.send(request, success, function (type, resp) {
-        var err_msg = "Error sending message";
-        if (type === 'response') {
-            err_msg += ": " + resp.msg;
-        }
-        error(err_msg);
-    });
-}
-
 function clear_compose_box() {
     $("#compose-textarea").val('').focus();
     drafts.delete_draft_after_send();
@@ -244,24 +204,6 @@ exports.send_message_success = function (local_id, message_id, locally_echoed) {
     }
 
     echo.reify_message_id(local_id, message_id);
-};
-
-exports.transmit_message = function (request, on_success, error) {
-
-    function success(data) {
-        // Call back to our callers to do things like closing the compose
-        // box and turning off spinners and reifying locally echoed messages.
-        on_success(data);
-
-        // Once everything is done, get ready to report times to the server.
-        sent_messages.report_server_ack(request.local_id);
-    }
-
-    if (page_params.use_websockets) {
-        send_message_socket(request, success, error);
-    } else {
-        send_message_ajax(request, success, error);
-    }
 };
 
 exports.send_message = function send_message(request) {
@@ -317,7 +259,7 @@ exports.send_message = function send_message(request) {
         echo.message_send_error(local_id, response);
     }
 
-    exports.transmit_message(request, success, error);
+    transmit.send_message(request, success, error);
     server_events.assert_get_events_running("Restarting get_events because it was not running during send");
 
     if (locally_echoed) {
@@ -418,7 +360,7 @@ exports.schedule_message = function schedule_message(request, success, error) {
        return;
     }
 
-    exports.transmit_message(request, success, error);
+    transmit.send_message(request, success, error);
 };
 
 exports.enter_with_preview_open = function () {

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -36,7 +36,7 @@ function resend_message(message, row) {
     }
 
     sent_messages.start_resend(local_id);
-    compose.transmit_message(message, on_success, on_error);
+    transmit.send_message(message, on_success, on_error);
 }
 
 function truncate_precision(float) {

--- a/static/js/transmit.js
+++ b/static/js/transmit.js
@@ -1,0 +1,67 @@
+var transmit = (function () {
+
+var exports = {};
+
+var socket;
+if (page_params.use_websockets) {
+    socket = new Socket("/sockjs");
+}
+// For debugging.  The socket will eventually move out of this file anyway.
+exports._socket = socket;
+
+function send_message_socket(request, success, error) {
+    request.socket_user_agent = navigator.userAgent;
+    socket.send(request, success, function (type, resp) {
+        var err_msg = "Error sending message";
+        if (type === 'response') {
+            err_msg += ": " + resp.msg;
+        }
+        error(err_msg);
+    });
+}
+
+function send_message_ajax(request, success, error) {
+    channel.post({
+        url: '/json/messages',
+        data: request,
+        success: success,
+        error: function (xhr, error_type) {
+            if (error_type !== 'timeout' && reload.is_pending()) {
+                // The error might be due to the server changing
+                reload.initiate({immediate: true,
+                                 save_pointer: true,
+                                 save_narrow: true,
+                                 save_compose: true,
+                                 send_after_reload: true});
+                return;
+            }
+
+            var response = channel.xhr_error_message("Error sending message", xhr);
+            error(response);
+        },
+    });
+}
+
+exports.send_message = function (request, on_success, error) {
+    function success(data) {
+        // Call back to our callers to do things like closing the compose
+        // box and turning off spinners and reifying locally echoed messages.
+        on_success(data);
+
+        // Once everything is done, get ready to report times to the server.
+        sent_messages.report_server_ack(request.local_id);
+    }
+
+    if (page_params.use_websockets) {
+        send_message_socket(request, success, error);
+    } else {
+        send_message_ajax(request, success, error);
+    }
+};
+
+return exports;
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = transmit;
+}

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -55,6 +55,7 @@ enforce_fully_covered = {
     'static/js/stream_sort.js',
     'static/js/topic_data.js',
     'static/js/topic_generator.js',
+    'static/js/transmit.js',
     'static/js/typeahead_helper.js',
     'static/js/typing_data.js',
     'static/js/typing_status.js',

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1033,6 +1033,7 @@ JS_SPECS = {
             'js/sent_messages.js',
             'js/compose_state.js',
             'js/compose_actions.js',
+            'js/transmit.js',
             'js/compose.js',
             'js/upload.js',
             'js/stream_color.js',


### PR DESCRIPTION
We now isolate the code to transmit messages into transmit.js.
It is stable code that most folks doing UI work in compose.js don't
care about the details of, so it's just clutter there.  Also, we may
soon have other widgets than the compose box that send messages.

This change mostly preserves test coverage, although in some cases
we stub at a higher level for the compose path (this is a good thing).
Extracting out transmit.js allows us to lock down 100% coverage on that
file.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
