### PR TITLE
auth: Redirect to an error page instead of 500.

### DIFF
--- a/templates/zerver/config_error.html
+++ b/templates/zerver/config_error.html
@@ -44,6 +44,10 @@
                         {% endif %}
                     {% endif %}
 
+                    {% if dev_not_supported_error %}
+                    {{ render_markdown_path('zerver/dev-not-supported-error.md', {"settings_path": settings_path}) }}
+                    {% endif %}
+
                     {% if google_error %}
                     {{ render_markdown_path('zerver/google-error.md', {"root_domain_uri": root_domain_uri, "settings_path": settings_path, "secrets_path": secrets_path}) }}
                     {% endif %}

--- a/templates/zerver/dev-not-supported-error.md
+++ b/templates/zerver/dev-not-supported-error.md
@@ -1,0 +1,6 @@
+Login without password is not supported. Please check the following:
+
+* You are running under production environment. In this case, `DevAuthBackend`
+  will not be supported.
+* You have not added `DevAuthBackend` in `AUTHENTICATION_BACKENDS` in
+  `{{ settings_path }}`.

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1497,9 +1497,9 @@ class TestDevAuthBackend(ZulipTestCase):
         email = self.example_email("hamlet")
         data = {'direct_email': email}
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.EmailAuthBackend',)):
-            with self.assertRaisesRegex(Exception, 'Direct login not supported.'):
-                with mock.patch('django.core.handlers.exception.logger'):
-                    self.client_post('/accounts/login/local/', data)
+            with mock.patch('django.core.handlers.exception.logger'):
+                response = self.client_post('/accounts/login/local/', data)
+                self.assertRedirects(response, reverse('dev_not_supported'))
 
     def test_login_failure_due_to_nonexistent_user(self) -> None:
         email = 'nonexisting@zulip.com'

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -230,3 +230,8 @@ class ConfigErrorTest(ZulipTestCase):
         result = self.client_get("/config-error/smtp")
         self.assertEqual(result.status_code, 200)
         self.assert_in_success_response(["email configuration"], result)
+
+    def test_dev_direct_production_error(self) -> None:
+        result = self.client_get("/config-error/dev")
+        self.assertEqual(result.status_code, 200)
+        self.assert_in_success_response(["Login without password"], result)

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -568,7 +568,7 @@ def dev_direct_login(request: HttpRequest, **kwargs: Any) -> HttpResponse:
     if (not dev_auth_enabled()) or settings.PRODUCTION:
         # This check is probably not required, since authenticate would fail without
         # an enabled DevAuthBackend.
-        raise Exception('Direct login not supported.')
+        return HttpResponseRedirect(reverse('dev_not_supported'))
     email = request.POST['direct_email']
     subdomain = get_subdomain(request)
     realm = get_realm(subdomain)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -492,6 +492,10 @@ i18n_urls = [
         template_name='zerver/config_error.html',),
         {'ldap_error_realm_is_none': True},
         name='ldap_error_realm_is_none'),
+    url(r'^config-error/dev$', TemplateView.as_view(
+        template_name='zerver/config_error.html',),
+        {'dev_not_supported_error': True},
+        name='dev_not_supported'),
 ]
 
 # Make a copy of i18n_urls so that they appear without prefix for english


### PR DESCRIPTION
Previously, we used to raise an exception if direct dev login was attempted
when:

* we were running under production environment.
* dev. login was not enabled.

Now we redirect to an error page and give an explanatory message to the
user.

Fixes #8249

**Testing Plan:**
1. Set `PRODUCTION=True`
2. Go to http://localhost:9991/devlogin/
3. Click on any user.

@timabbott 
