### PR TITLE
slack importer: Change 'total_users' to 'total_channels'.

### DIFF
--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -294,7 +294,7 @@ def channels_to_zerver_stream(slack_data_dir: str, realm_id: int, added_users: A
         for member in channel['members']:
             total_subscription += 1
 
-    stream_id_list = allocate_ids(Stream, total_users)
+    stream_id_list = allocate_ids(Stream, total_channels)
     subscription_id_list = allocate_ids(Subscription, total_subscription)
     recipient_id_list = allocate_ids(Recipient, total_recipients)
     # corresponding to channels 'general' and 'random'


### PR DESCRIPTION
The total number of stream objects are allocated to total_users. They should be allocated to the total_channels. This passed the tests as the total number of users in the test where greater than the total number of channels.

@timabbott This one is my bad! I'll be more careful with more atomic commits so that it would be easier to spot an error.
