### PR TITLE
i18n: Flag server-side strings for translation.

### DIFF
--- a/static/js/translations.js
+++ b/static/js/translations.js
@@ -8,6 +8,13 @@ import localstorage from './localstorage';
 
 window.i18n = i18next;
 
+// Add those keys in this list which are received from the backend
+// and are translated by calling i18n.t function on variables. For example,
+// i18n.t(receivedFromBackend);
+var toBeTranslated = [  // eslint-disable-line no-unused-vars
+    i18n.t('Plain text'),
+];
+
 function loadPath(languages) {
     var language = languages[0];
     if (language.indexOf('-') >= 0) {


### PR DESCRIPTION
Fixes #7970.

**Testing Plan:**
1. Run `./manage.py makemessages --locale en.
2. Change value of 'Plain text' in 'static/locale/en/translations.json' to something else.
3. Run the application.
4. Clear the i18n cache from browser console using `localStorage.clear()`.
5. Go to http://localhost:9991/#settings/display-settings.
6. Check that the value of 'Plain text' emojiset matches with what you added in the translations.json.