### PR TITLE
user docs: Fix double scrollbar on navigation on /help.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -1784,7 +1784,6 @@ input.new-organization-button {
     .app.help .sidebar.show {
         padding-right: 20px;
         transform: translateX(280px);
-        overflow: auto !important;
     }
 
     .app.help .sidebar.show + .hamburger {


### PR DESCRIPTION
Only one scrollbar now appears on the navigation
on /help page, for smaller screen sizes.

Fixes #8470.