### PR TITLE
left-sidebar: Make topic name narrower.

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -205,7 +205,7 @@ li.active-sub-filter {
 .topic-name {
     display: block;
     line-height: 1.1;
-    width: calc(100% - 5px);
+    width: calc(100% - 10px);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
To prevent the topic name from running into the unread count or options chevron, reduce the width of the element.

Fixes #7492.

**Testing Plan:**

Visually inspected in the browser and on mobile.

**GIFs or Screenshots:**

<img width="250" alt="screen shot 2018-02-21 at 12 51 37 pm" src="https://user-images.githubusercontent.com/3302817/36505502-9aea0cce-1708-11e8-8ef8-34350bf149ad.png">
