### PR TITLE
RealmAuditLog: Fill subscription events with event_last_message_id=None.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2300,6 +2300,8 @@ def bulk_add_subscriptions(streams: Iterable[Stream],
     # Log Subscription Activities in RealmAuditLog
     event_time = timezone_now()
     event_last_message_id = Message.objects.aggregate(Max('id'))['id__max']
+    if event_last_message_id is None:
+        event_last_message_id = -1
     all_subscription_logs = []  # type: (List[RealmAuditLog])
     for (sub, stream) in subs_to_add:
         all_subscription_logs.append(RealmAuditLog(realm=sub.user_profile.realm,

--- a/zerver/migrations/0139_fill_last_message_id_in_subscription_logs.py
+++ b/zerver/migrations/0139_fill_last_message_id_in_subscription_logs.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+def fill_last_message_id_in_subscription_logs(
+    apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    event_type = ['subscription_created', 'subscription_deactivated', 'subscription_activated']
+    RealmAuditLog = apps.get_model('zerver', 'RealmAuditLog')
+    subscription_logs = RealmAuditLog.objects.filter(
+        event_last_message_id__isnull=True, event_type__in=event_type)
+
+    for log in subscription_logs:
+        log.event_last_message_id = -1
+        log.save(update_fields=['event_last_message_id'])
+
+def reverse_code(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    pass
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0138_userprofile_realm_name_in_notifications'),
+    ]
+
+    operations = [
+        migrations.RunPython(fill_last_message_id_in_subscription_logs,
+                             reverse_code=reverse_code),
+    ]


### PR DESCRIPTION
RealmAuditLog: Fill subscription events with event_last_message_id=None.

This is in context to conversation which happened at https://chat.zulip.org/#narrow/stream/9-issues/subject/500.20error.20on.20login/near/511981 

Issue was that `event_last_message_id` was being assigned value `None` for subscription events when the realm was first created. Thing is realm administrator account was already created before initial onboarding messages were sent to streams. If administrator account was soft deactivated and reactivated that will lead to errors and admin account will not be logged in.