### PR TITLE
translations: Improve Polish style guide.

### DIFF
--- a/docs/translating/polish.md
+++ b/docs/translating/polish.md
@@ -5,6 +5,9 @@ Use semi-formal Polish for translation, some specifics:
 * Informal "you" (*ty*) instead of more formal approaches (e.g. plural
   "you" (*wy*), using any formal titles like *Państwo*, *Pan/Pani*).
 
+* Gender-neutral forms of verbs, e.g. *unsubscribed* - *odsubskrybowano*,
+  not *odsubskrybowałeś".
+
 * Imperative, active and continuous verbs, e.g. *manage streams* -
   *zarządzaj kanałami*, not *zarządź kanałami*.
 
@@ -36,48 +39,217 @@ Zulip friendly and usable.
 
 ## Special terms used in Zulip
 
+**alert word**: powiadomienie, "ostrzeżenie" could mean something negative
+  and alert words in Zulip are used to help users find relevant content
+
+example:
+
+You can set your own alert words for Zulip messages.
+> Możesz ustawić powiadomienia dla wybranych fraz w Zulipie.
+
+**All messages**: wszystkie wiadomości
+
+example:
+
+You can see all messages in unmuted streams and topics with "All messages".
+> Możesz zobaczyć pełną listę wiadomości poprzez widok "Wszystkie wiadomości".
+
+**bot**: bot
+
+example:
+
+You can add bots to your Zulip.
+> Możesz dodać boty do swojego Zulipa.
+
 **customization**: personalizacja, *kastomizacja* could be too awkward
   and *dostosowanie do potrzeb klienta* is too long
 
+example:
+
+You can personalize Zulip in many ways, e.g. by pinning certain streams.
+> Możesz spersonalizować Zulipa na wiele sposobów, np. przypinając niektóre kanały.
+
 **emoji**: emoji, both in singular and plural, *ikona emoji* is a pleonasm
 
+example:
+
+Zulip supports emoji both in messages and as reactions.
+> Zulip wspiera używanie emoji w wiadomościach i jako reakcje.
+
 **filter**: filtr (noun) and filtrowanie (verb)
+
+example:
+
+You can filter the messages by searching for relevant terms.
+> Możesz przefiltrować wiadomości poprzez wyszukiwanie.
 
 **group PM**: czat grupowy, different from *wiadomość* since the usage
   of *czat grupowy* seems more common
 
-**home**: strona główna
+example:
+
+You can start a group PM with users in your organization.
+> Możesz rozpocząć czat grupowy z użytkownikami w Twojej organizacji.
+
+**integration**: integracja
+
+example:
+
+Zulip supports multiple third-party integrations.
+> Zulip wspiera wiele zewnętrznych integracji.
+
+**I want**: chcę
+
+example:
+
+I want to change my password.
+> Chcę zmienić hasło.
+
+**invalid**: niepoprawny/a
+
+example:
+
+Invalid command.
+> Niepoprawna instrukcja.
 
 **me**: me, no translation since it's used as `/me`
 
-**mention**: mention, translation as *wzmianka* or *wskazanie* wouldn't convey the meaning
+example:
+
+You can use `/me` to write a reaction message.
+> Możesz napisać wiadomość w formie komentarza poprzez użycie `me`.
+
+**mention**: oznaczenie (noun) and oznaczyć (verb)
+
+example:
+
+You can mention other Zulip users by using @.
+> Możesz oznaczyć innych użytkowników Zulipa używając @.
+
+**message**: wiadomość
+
+example:
+
+You got a new message.
+> Masz nową wiadomość.
 
 **message table**: lista wiadomości
 
-**muting a stream**: wyciszenie wątku
+example:
 
-**narrow**: zawężenie (noun) and zawęzić (verb)
+The middle column in Zulip is a message table of all messages in current narrow.
+> Środkowa kolumna w Zulipie zawiera listę wiadomości w wybranym widoku.
+
+**muting a stream/topic**: wyciszenie kanału/wątku
+**unmuting a stream/topic**: wyłącz wyciszenie kanału/wątku
+
+example:
+
+You can mute any topic in Zulip through the left-side panel.
+> Możesz wyciszyć dowolny wątek w Zulipie używając menu kontekstowego po lewej.
+
+**narrow**: widok (noun) and zawęzić (verb)
+
+example:
+
+You can narrow the messages to any stream, topic or search results.
+> Możesz zawęzić wiadomości do wybranego kanału, wątku lub wyników wyszukiwania.
+
+**notification**: powiadomienie
+
+example:
+
+Turn on notifications.
+> Włącz powiadomienia.
+
+**person**: osoba, najczęściej użytkownik
+**people**: osoby, najczęściej użytkownicy
 
 **pinning**: przypięcie (noun) and przypiąć (verb)
 
+example:
+
+You can pin streams in the left-side panel.
+> Możesz przypiąć wybrane kanały w menu kontekstowym po lewej.
+
 **private message**: prywatna wiadomość
+
+example:
+
+You can send a private message to other users in your organization.
+> Możesz wysłać prywatną wiadomość do innych użytkowników w Twojej organizacji.
 
 **PM**: PM, translation could be confusing
 
-**private stream**: prywatny kanał
+example:
 
-**realm**: domena
+Private messages are often abbreviated to PM.
+> Prywatne wiadomości są też nazywane PMami, od angielskiego "private message".
+
+**private stream**: prywatny kanał
+**public stream**: publiczny kanał
+
+example:
+
+Join a private stream.
+> Dołącz do prywatnego kanału.
+
+**search**: wyszukiwanie (noun) and wyszukaj (verb)
+
+example:
+
+Zulip allows you to search messages in all streams and topics you are
+subscribed to.
+> Zulip pozwala na wyszukiwanie wiadomości we wszystkich subskrybowanych kanałach
+  i wątkach.
+
+**starred message**: oznaczona wiadomość (noun)
+**star**: oznaczyć
+
+example:
+
+You starred this message.
+> Ta wiadomość została oznaczona.
 
 **stream**: kanał, similar to a tv channel - *strumień* sounds a bit artificial
+
+example:
+
+You can create new streams in Zulip.
+> Możesz tworzyć nowe kanały w Zulipie.
 
 **subscribing to a stream**: (za)subskrybowanie kanału (noun) and
   (za)subskrybować kanał (verb), perfective form depending on the
   context
 
+examples:
+
+Subscribe to a stream.
+> Zasubskrybuj kanał.
+
+You are not subscribed to this stream.
+> Nie subskrybujesz tego kanału.
+
 **topic**: wątek
 
-**unsubscribing from a stream**: odsubskrybowanie kanału (noun) and odsubskrybować kanał (verb)
+example:
 
-**view**: widok
+Add a new topic.
+> Dodaj nowy wątek.
 
-**starred message**: oznaczona wiadomość
+**unsubscribing from a stream**: odsubskrybowanie kanału (noun) and
+  odsubskrybować kanał (verb)
+
+example:
+
+You have unsubscribed from this stream.
+> Odsubskrybowano kanał.
+
+**user**: użytkownik
+
+example:
+
+Zulip supports an unlimited number of users in an organization.
+> Zulip nie limituje liczby użytkowników w organizacji.
+
+**view**: widok, see: **narrow**


### PR DESCRIPTION
Reviewed and reworked #7800, main changes:
- squashed commits, rebased
- used @AjgorXD's idea for adding examples to the style guide
- removed or reworked some obsolete phrases (e.g. "Home")
- added a remark for gender-neutral verb forms (it's a bit tricky in Polish)
- put the terms in an alphabetical order

I also added @AjgorXD as co-author, seems to be working in GH (squashing makes it tricky to do the co-authoring the other way round).

Up for review :)
