### PR TITLE
auth: Retain email value if login fails.

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -312,7 +312,9 @@ class LoginTest(ZulipTestCase):
         self.assertIsNone(get_session_dict_user(self.client.session))
 
     def test_login_bad_password(self) -> None:
-        self.login(self.example_email("hamlet"), password="wrongpassword", fails=True)
+        email = self.example_email("hamlet")
+        result = self.login_with_return(email, password="wrongpassword")
+        self.assert_in_success_response([email], result)
         self.assertIsNone(get_session_dict_user(self.client.session))
 
     def test_login_nonexist_user(self) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -546,6 +546,9 @@ def login_page(request: HttpRequest, **kwargs: Any) -> HttpResponse:
             # only if it actually exists.
             return HttpResponseRedirect(realm.uri)
 
+    if 'username' in request.POST:
+        extra_context['email'] = request.POST['username']
+
     try:
         template_response = django_login_page(
             request, authentication_form=OurAuthenticationForm,


### PR DESCRIPTION
Fixes #7795


**Testing Plan:**
1. Go to login page.
2. Enter invalid credentials.
3. Check if email field retains value.