### PR TITLE
Slack importer: Sort messages in the order of their dates in the precomputation.

### DIFF
--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -481,6 +481,10 @@ def convert_slack_workspace_messages(slack_data_dir: str, users: List[ZerverFiel
     zerver_usermessage = []  # type: List[ZerverFieldsT]
     all_messages = get_all_messages(slack_data_dir, added_channels)
 
+    # we sort the messages according to the timestamp to show messages with
+    # the proper date order
+    all_messages = sorted(all_messages, key=lambda message: message['ts'])
+
     logging.info('######### IMPORTING MESSAGES STARTED #########\n')
 
     # To pre-compute the total number of messages and usermessages

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -365,11 +365,13 @@ class SlackImporter(ZulipTestCase):
 
         added_recipient = {'random': 2}
         zerver_subscription = [{'recipient': 2}, {'recipient': 4}, {'recipient': 2}]
+        all_messages = []  # type: List[Dict[str, Any]]
 
         total_messages, total_usermessages = get_total_messages_and_usermessages('./path',
                                                                                  'random',
                                                                                  zerver_subscription,
-                                                                                 added_recipient)
+                                                                                 added_recipient,
+                                                                                 all_messages)
         # subtype: channel_join, channel_leave are filtered out
         self.assertEqual(total_messages, 4)
         self.assertEqual(total_usermessages, 8)
@@ -451,9 +453,11 @@ class SlackImporter(ZulipTestCase):
 
         zerver_usermessage = []  # type: List[Dict[str, Any]]
         zerver_subscription = []  # type: List[Dict[str, Any]]
+        all_messages = []  # type: List[Dict[str,Any]]
         zerver_message, zerver_usermessage = channel_message_to_zerver_message(constants, channel_name,
                                                                                user_data, added_users,
                                                                                added_recipient,
+                                                                               all_messages,
                                                                                zerver_subscription, ids)
         # functioning already tested in helper function
         self.assertEqual(zerver_usermessage, [])
@@ -484,9 +488,11 @@ class SlackImporter(ZulipTestCase):
 
     @mock.patch("zerver.lib.slack_data_to_zulip_data.channel_message_to_zerver_message")
     @mock.patch("zerver.lib.slack_data_to_zulip_data.allocate_ids")
+    @mock.patch("zerver.lib.slack_data_to_zulip_data.get_all_messages")
     @mock.patch("zerver.lib.slack_data_to_zulip_data.get_total_messages_and_usermessages", return_value=[1, 2])
     def test_convert_slack_workspace_messages(self, mock_get_total_messages_and_usermessages: mock.Mock,
-                                              mock_allocate_ids: mock.Mock, mock_message: mock.Mock) -> None:
+                                              mock_get_all_messages: mock.Mock, mock_allocate_ids: mock.Mock,
+                                              mock_message: mock.Mock) -> None:
         added_channels = {'random': 1, 'general': 2}
 
         zerver_message1 = [{'id': 1}]

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -349,32 +349,25 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(realm['zerver_userprofile'], [])
         self.assertEqual(realm['zerver_realm'], [{}])
 
-    @mock.patch("os.listdir", return_value = ['2015-08-08.json', '2016-01-15.json'])
-    @mock.patch("zerver.lib.slack_data_to_zulip_data.get_data_file")
-    def test_get_total_messages_and_usermessages(self, mock_get_data_file: mock.Mock,
-                                                 mock_list_dir: mock.Mock) -> None:
+    def test_get_total_messages_and_usermessages(self) -> None:
+        messages = [{"text": "<@U8VAHEVUY> has joined the channel", "subtype": "channel_join",
+                     "channel_name": "random"},
+                    {"text": "message", "channel_name": "random"},
+                    {"text": "random", "channel_name": "random"},
+                    {"text": "test messsage", "channel_name": "general"},
+                    {"text": "test message 2", "subtype": "channel_leave", "channel_name": "general"},
+                    {"text": "random test", "channel_name": "general"},
+                    {"text": "message", "subtype": "channel_name", "channel_name": "general"}]
 
-        date1 = [{"text": "<@U8VAHEVUY> has joined the channel", "subtype": "channel_join"},
-                 {"text": "message"},
-                 {"text": "random"},
-                 {"text": "test messsage"}]
-        date2 = [{"text": "test message 2", "subtype": "channel_leave"},
-                 {"text": "random test"},
-                 {"text": "message", "subtype": "channel_name"}]
-        mock_get_data_file.side_effect = [date1, date2]
-
-        added_recipient = {'random': 2}
+        added_recipient = {'random': 2, 'general': 4}
         zerver_subscription = [{'recipient': 2}, {'recipient': 4}, {'recipient': 2}]
-        all_messages = []  # type: List[Dict[str, Any]]
 
-        total_messages, total_usermessages = get_total_messages_and_usermessages('./path',
-                                                                                 'random',
-                                                                                 zerver_subscription,
+        total_messages, total_usermessages = get_total_messages_and_usermessages(zerver_subscription,
                                                                                  added_recipient,
-                                                                                 all_messages)
+                                                                                 messages)
         # subtype: channel_join, channel_leave are filtered out
         self.assertEqual(total_messages, 4)
-        self.assertEqual(total_usermessages, 8)
+        self.assertEqual(total_usermessages, 6)
 
     def test_get_message_sending_user(self) -> None:
         message_with_file = {'subtype': 'file', 'type': 'message',


### PR DESCRIPTION
Updated:

**Problem**: For sorting of the messages in the order of date (As reported here: https://chat.zulip.org/#narrow/stream/2-general/topic/slack-import)
The problem being faced was that as the messages were being processed corresponding to the streams together( Process all messages in the stream and then move to another stream), the messages in the stream where ordered by date, but in 'All messages' the messages were not ordered by date.

**solution approach**: Precompute all messages in every stream by ordering them by date and then use this for the import.


**commit 1**:
 We make a list `all_messages` which is the list of all messages from the all the channels (For this we have the function `get_all_messages`) and we pass this list to the functions `get_total_messages_and_usermessages` and `channel_message_to_zerver_message` where the messages are being processed. Added and changed tests for the same.

**commit 2**: 
Instead of getting messages channel-wise in the function `get_total_messages_and_usermessages`, we now use the list `all_messages`. (Hence the extra loops to the channel-wise messages are removed.)

**commit 3**: 
Same procedure used above but for the function `channel_message_to_zerver_message`.

**commit 4**: 
Sort the list `all_messages` according to the timestamp.