### PR TITLE
webhooks/gitlab: Replace "Build Hook" with "Job Hook".

### DIFF
--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -316,7 +316,7 @@ class GitlabHookTests(WebhookTestCase):
             'build_created',
             expected_subject,
             expected_message,
-            HTTP_X_GITLAB_EVENT="Build Hook"
+            HTTP_X_GITLAB_EVENT="Job Hook"
         )
 
     def test_build_started_event_message(self) -> None:
@@ -327,7 +327,7 @@ class GitlabHookTests(WebhookTestCase):
             'build_started',
             expected_subject,
             expected_message,
-            HTTP_X_GITLAB_EVENT="Build Hook"
+            HTTP_X_GITLAB_EVENT="Job Hook"
         )
 
     def test_build_succeeded_event_message(self) -> None:
@@ -338,7 +338,7 @@ class GitlabHookTests(WebhookTestCase):
             'build_succeeded',
             expected_subject,
             expected_message,
-            HTTP_X_GITLAB_EVENT="Build Hook"
+            HTTP_X_GITLAB_EVENT="Job Hook"
         )
 
     def test_pipeline_succeeded_event_message(self) -> None:

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -261,7 +261,7 @@ EVENT_FUNCTION_MAPPER = {
     'Merge Request Hook reopen': partial(get_merge_request_event_body, action='reopened'),
     'Wiki Page Hook create': partial(get_wiki_page_event_body, action='created'),
     'Wiki Page Hook update': partial(get_wiki_page_event_body, action='updated'),
-    'Build Hook': get_build_hook_event_body,
+    'Job Hook': get_build_hook_event_body,
     'Pipeline Hook': get_pipeline_event_body,
 }
 
@@ -286,7 +286,7 @@ def get_body_based_on_event(event: str) -> Any:
 def get_subject_based_on_event(event: str, payload: Dict[str, Any]) -> Text:
     if event == 'Push Hook':
         return u"{} / {}".format(get_repo_name(payload), get_branch_name(payload))
-    elif event == 'Build Hook':
+    elif event == 'Job Hook':
         return u"{} / {}".format(payload['repository'].get('name'), get_branch_name(payload))
     elif event == 'Pipeline Hook':
         return u"{} / {}".format(


### PR DESCRIPTION
At some point, GitLab decided to change the name of the event for
CI notifications from "Build Hook" to "Job Hook" and we started
running into errors in webhook-logger.log.

@timabbott: FYI :)
