### PR TITLE
webhooks/gitlab: Support both "Build Hook" and "Job Hook" events.

### DIFF
--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -341,6 +341,39 @@ class GitlabHookTests(WebhookTestCase):
             HTTP_X_GITLAB_EVENT="Job Hook"
         )
 
+    def test_build_created_event_message_legacy_event_name(self) -> None:
+        expected_subject = u"my-awesome-project / master"
+        expected_message = u"Build job_name from test stage was created."
+
+        self.send_and_test_stream_message(
+            'build_created',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Build Hook"
+        )
+
+    def test_build_started_event_message_legacy_event_name(self) -> None:
+        expected_subject = u"my-awesome-project / master"
+        expected_message = u"Build job_name from test stage started."
+
+        self.send_and_test_stream_message(
+            'build_started',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Build Hook"
+        )
+
+    def test_build_succeeded_event_message_legacy_event_name(self) -> None:
+        expected_subject = u"my-awesome-project / master"
+        expected_message = u"Build job_name from test stage changed status to success."
+
+        self.send_and_test_stream_message(
+            'build_succeeded',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Build Hook"
+        )
+
     def test_pipeline_succeeded_event_message(self) -> None:
         expected_subject = u"my-awesome-project / master"
         expected_message = u"Pipeline changed status to success with build(s):\n* job_name2 - success\n* job_name - success."

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -262,6 +262,7 @@ EVENT_FUNCTION_MAPPER = {
     'Wiki Page Hook create': partial(get_wiki_page_event_body, action='created'),
     'Wiki Page Hook update': partial(get_wiki_page_event_body, action='updated'),
     'Job Hook': get_build_hook_event_body,
+    'Build Hook': get_build_hook_event_body,
     'Pipeline Hook': get_pipeline_event_body,
 }
 
@@ -286,7 +287,7 @@ def get_body_based_on_event(event: str) -> Any:
 def get_subject_based_on_event(event: str, payload: Dict[str, Any]) -> Text:
     if event == 'Push Hook':
         return u"{} / {}".format(get_repo_name(payload), get_branch_name(payload))
-    elif event == 'Job Hook':
+    elif event == 'Job Hook' or event == 'Build Hook':
         return u"{} / {}".format(payload['repository'].get('name'), get_branch_name(payload))
     elif event == 'Pipeline Hook':
         return u"{} / {}".format(


### PR DESCRIPTION
GitLab recently changed their event name for build notifications
from "Build Hook" to "Job Hook". Instead of just supporting the
latter, we should support both just in case people are running
older versions of GitLab.

@timabbott: Sorry, I didn't know GitLab was open source! :)