### PR TITLE
Made organization's description box responsive.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -116,7 +116,7 @@ label {
 
 .admin-realm-description {
     height: 16em;
-    width: 36em;
+    width: 100%;
 }
 
 .padded-container {
@@ -342,6 +342,10 @@ input[type=checkbox] + .inline-block {
 
 .organization-settings-parent div:first-of-type {
     margin-top: 10px;
+}
+
+.organization-settings-parent{
+  width:98%;
 }
 
 .organization-submission {


### PR DESCRIPTION
Fixed issue #8504  with the organization description textarea not being responsive.

![full window](https://user-images.githubusercontent.com/32234630/36640839-67130260-1a4c-11e8-9e6f-346f04cc4b14.jpeg)
![after_shrinking _window](https://user-images.githubusercontent.com/32234630/36640840-6751bbd6-1a4c-11e8-8018-9401667e56cb.jpeg)

