### PR TITLE
message view: Fix hiding of connection-error message on narrowing streams.

### DIFF
--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -3,7 +3,7 @@ set_global('document', 'document-stub');
 
 zrequire('message_fetch');
 
-var noop = function () {};
+var noop = () => {};
 
 set_global('MessageListView', function () { return {}; });
 
@@ -17,7 +17,9 @@ set_global('page_params', {
     have_initial_messages: true,
     pointer: 444,
 });
-
+set_global('ui_report', {
+    hide_error: noop,
+});
 set_global('activity', {});
 set_global('channel', {});
 set_global('document', 'document-stub');

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -18,7 +18,9 @@ var consts = {
 function process_result(data, opts) {
     var messages = data.messages;
 
-    $('#connection-error').removeClass("show");
+    if (!($('#connection-error').hasClass('get-events-error'))) {
+        ui_report.hide_error($("#connection-error"));
+    }
 
     if ((messages.length === 0) && (current_msg_list === message_list.narrowed) &&
         message_list.narrowed.empty()) {

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -170,6 +170,7 @@ function get_events(options) {
                 get_events_xhr = undefined;
                 get_events_failures = 0;
                 ui_report.hide_error($("#connection-error"));
+                $("#connection-error").removeClass('get-events-error');
 
                 get_events_success(data.events);
             } catch (ex) {
@@ -201,14 +202,17 @@ function get_events(options) {
                     // Retry indefinitely on timeout.
                     get_events_failures = 0;
                     ui_report.hide_error($("#connection-error"));
+                    $("#connection-error").removeClass('get-events-error');
                 } else {
                     get_events_failures += 1;
                 }
 
                 if (get_events_failures >= 5) {
                     ui_report.show_error($("#connection-error"));
+                    $("#connection-error").addClass('get-events-error');
                 } else {
                     ui_report.hide_error($("#connection-error"));
+                    $("#connection-error").removeClass('get-events-error');
                 }
             } catch (ex) {
                 blueslip.error('Failed to handle get_events error\n' +


### PR DESCRIPTION
When there is some error in connecting to server(more specifically to the
tornado server) the "Unable to connect to Zulip" connection error message
gets cleared as Django server could send the response of "get" request of
old messages and hence get_old_messages_success hides the error message
even though the connection is not properly established.

Fixes: #5599.

Is my understanding of issue and event system is correct?
@timabbott FYI.