### PR TITLE
Made organization's description box responsive #8504

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -116,7 +116,7 @@ label {
 
 .admin-realm-description {
     height: 16em;
-    width: 36em;
+    width: 100%;
 }
 
 .padded-container {
@@ -342,6 +342,10 @@ input[type=checkbox] + .inline-block {
 
 .organization-settings-parent div:first-of-type {
     margin-top: 10px;
+}
+
+.organization-settings-parent {
+    width: 98%;
 }
 
 .organization-submission {


### PR DESCRIPTION
Fixed issue #8504 with the organization description textarea not being responsive.

![full window](https://user-images.githubusercontent.com/32234630/36642201-ff9f0c94-1a61-11e8-97ec-fe571b1d7533.jpeg)
![after_shrinking _window](https://user-images.githubusercontent.com/32234630/36642207-051350fe-1a62-11e8-94b3-05dd0c3b594e.jpeg)
