### PR TITLE
#7217 copy-paste: Copy the recipient bar if and only if selecting from more than one recipient block.

### DIFF
--- a/frontend_tests/casper_tests/16-copy-and-paste.js
+++ b/frontend_tests/casper_tests/16-copy-and-paste.js
@@ -1,0 +1,167 @@
+var common = require('../casper_lib/common.js').common;
+
+common.start_and_log_in();
+
+casper.then(function () {
+    casper.test.info('Sending messages');
+});
+
+// setup environment: several messages to different topics
+common.then_send_many([
+    { stream:  'Verona', subject: 'copy-paste-subject #1',
+      content: 'copy paste test A' },
+
+    { stream:  'Verona', subject: 'copy-paste-subject #1',
+      content: 'copy paste test B' },
+
+    { stream:  'Verona', subject: 'copy-paste-subject #2',
+      content: 'copy paste test C' },
+
+    { stream:  'Verona', subject: 'copy-paste-subject #2',
+      content: 'copy paste test D' },
+
+    { stream:  'Verona', subject: 'copy-paste-subject #2',
+      content: 'copy paste test E' },
+
+    { stream:  'Verona', subject: 'copy-paste-subject #3',
+      content: 'copy paste test F' },
+
+    { stream:  'Verona', subject: 'copy-paste-subject #3',
+      content: 'copy paste test G' },
+]);
+
+common.wait_for_receive(function () {
+    common.expected_messages('zhome', [
+        'Verona > copy-paste-subject #1',
+        'Verona > copy-paste-subject #2',
+        'Verona > copy-paste-subject #3',
+    ], [
+        '<p>copy paste test A</p>',
+        '<p>copy paste test B</p>',
+        '<p>copy paste test C</p>',
+        '<p>copy paste test D</p>',
+        '<p>copy paste test E</p>',
+        '<p>copy paste test F</p>',
+        '<p>copy paste test G</p>',
+    ]);
+});
+
+casper.then(function () {
+    casper.test.info('Messages were sent successfully');
+});
+
+function get_message_node(message) {
+    return $('.message_row .message_content:contains("' + message + '")').get(0);
+}
+
+function copy_messages(start_message, end_message) {
+    return casper.evaluate(function (get_message_node, start_message, end_message) {
+        // select messages from start_message to end_message
+        var selectedRange = document.createRange();
+        selectedRange.setStart(get_message_node(start_message));
+        selectedRange.setEnd(get_message_node(end_message));
+        window.getSelection().removeAllRanges();
+        window.getSelection().addRange(selectedRange);
+
+        // emulate copy event
+        var event = document.createEvent('Event');
+        event.initEvent('copy', true, true);
+        document.dispatchEvent(event);
+
+        // find temp div with copied text
+        var temp_div = $('#copytempdiv');
+        return temp_div.children('p').get().map(function (p) { return p.textContent; });
+    }, {
+        get_message_node: get_message_node,
+        start_message: start_message,
+        end_message: end_message,
+    });
+}
+
+// test copying first message from topic
+casper.then(function () {
+    var actual_copied_lines = copy_messages('copy paste test C', 'copy paste test C');
+    var expected_copied_lines = [];
+    casper.test.assertEquals(actual_copied_lines, expected_copied_lines, 'Copying was handled by browser');
+});
+
+// test copying last message from topic
+casper.then(function () {
+    var actual_copied_lines = copy_messages('copy paste test E', 'copy paste test E');
+    var expected_copied_lines = [];
+    casper.test.assertEquals(actual_copied_lines, expected_copied_lines, 'Copying was handled by browser');
+});
+
+// test copying two first messages from topic
+casper.then(function () {
+    var actual_copied_lines = copy_messages('copy paste test C', 'copy paste test D');
+    var expected_copied_lines = ['Iago: copy paste test C', 'Iago: copy paste test D'];
+    casper.test.assertEquals(actual_copied_lines, expected_copied_lines, 'Copying was handled by custom handler');
+});
+
+// test copying all messages from topic
+casper.then(function () {
+    var actual_copied_lines = copy_messages('copy paste test C', 'copy paste test E');
+    var expected_copied_lines = ['Iago: copy paste test C', 'Iago: copy paste test D', 'Iago: copy paste test E'];
+    casper.test.assertEquals(actual_copied_lines, expected_copied_lines, 'Copying was handled by custom handler');
+});
+
+// test copying last message from previous topic and first message from next topic
+casper.then(function () {
+    var actual_copied_lines = copy_messages('copy paste test B', 'copy paste test C');
+    var expected_copied_lines = [
+        'Verona > copy-paste-subject #1 Today',
+        'Iago: copy paste test B',
+        'Verona > copy-paste-subject #2 Today',
+        'Iago: copy paste test C',
+    ];
+    casper.test.assertEquals(actual_copied_lines, expected_copied_lines, 'Copying was handled by custom handler');
+});
+
+// test copying last message from previous topic and all messages from next topic
+casper.then(function () {
+    var actual_copied_lines = copy_messages('copy paste test B', 'copy paste test E');
+    var expected_copied_lines = [
+        'Verona > copy-paste-subject #1 Today',
+        'Iago: copy paste test B',
+        'Verona > copy-paste-subject #2 Today',
+        'Iago: copy paste test C',
+        'Iago: copy paste test D',
+        'Iago: copy paste test E',
+    ];
+    casper.test.assertEquals(actual_copied_lines, expected_copied_lines, 'Copying was handled by custom handler');
+});
+
+// test copying all messages from previous topic and first message from next topic
+casper.then(function () {
+    var actual_copied_lines = copy_messages('copy paste test A', 'copy paste test C');
+    var expected_copied_lines = [
+        'Verona > copy-paste-subject #1 Today',
+        'Iago: copy paste test A',
+        'Iago: copy paste test B',
+        'Verona > copy-paste-subject #2 Today',
+        'Iago: copy paste test C',
+    ];
+    casper.test.assertEquals(actual_copied_lines, expected_copied_lines, 'Copying was handled by custom handler');
+});
+
+// test copying message from several topics
+casper.then(function () {
+    var actual_copied_lines = copy_messages('copy paste test B', 'copy paste test F');
+    var expected_copied_lines = [
+        'Verona > copy-paste-subject #1 Today',
+        'Iago: copy paste test B',
+        'Verona > copy-paste-subject #2 Today',
+        'Iago: copy paste test C',
+        'Iago: copy paste test D',
+        'Iago: copy paste test E',
+        'Verona > copy-paste-subject #3 Today',
+        'Iago: copy paste test F',
+    ];
+    casper.test.assertEquals(actual_copied_lines, expected_copied_lines, 'Copying was handled by custom handler');
+});
+
+// Run the above queued actions.
+casper.run(function () {
+  casper.test.done();
+});

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -35,15 +35,20 @@ function find_boundary_tr(initial_tr, iterate_row) {
     return [rows.id(tr), skip_same_td_check];
 }
 
+function construct_recipient_header(message_row) {
+    var message_header_content = rows.get_message_recipient_header(message_row)
+                                     .text()
+                                     .replace(/\s+/g, " ")
+                                     .replace(/^\s/, "").replace(/\s$/, "");
+    return $('<p>').append($('<strong>').text(message_header_content));
+}
+
 function construct_copy_div(div, start_id, end_id) {
     for (var row = current_msg_list.get_row(start_id);
          rows.id(row) <= end_id;
          row = rows.next_visible(row)) {
         if (row.prev().hasClass("message_header")) {
-            var content = $('<div>').text(row.prev().text()
-                                        .replace(/\s+/g, " ")
-                                        .replace(/^\s/, "").replace(/\s$/, ""));
-            div.append($('<p>').append($('<strong>').text(content.text())));
+            div.append(construct_recipient_header(row));
         }
         var message = current_msg_list.get(rows.id(row));
         var message_firstp = $(message.content).slice(0, 1);

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -35,6 +35,23 @@ function find_boundary_tr(initial_tr, iterate_row) {
     return [rows.id(tr), skip_same_td_check];
 }
 
+function construct_copy_div(div, start_id, end_id) {
+    for (var row = current_msg_list.get_row(start_id);
+         rows.id(row) <= end_id;
+         row = rows.next_visible(row)) {
+        if (row.prev().hasClass("message_header")) {
+            var content = $('<div>').text(row.prev().text()
+                                        .replace(/\s+/g, " ")
+                                        .replace(/^\s/, "").replace(/\s$/, ""));
+            div.append($('<p>').append($('<strong>').text(content.text())));
+        }
+        var message = current_msg_list.get(rows.id(row));
+        var message_firstp = $(message.content).slice(0, 1);
+        message_firstp.prepend(message.sender_full_name + ": ");
+        div.append(message_firstp);
+        div.append($(message.content).slice(1));
+    }
+}
 
 function copy_handler() {
     var selection = window.getSelection();
@@ -46,13 +63,10 @@ function copy_handler() {
     var initial_end_tr;
     var start_id;
     var end_id;
-    var row;
-    var message;
     var start_data;
     var end_data;
     var skip_same_td_check = false;
     var div = $('<div>');
-    var content;
     for (i = 0; i < selection.rangeCount; i += 1) {
         range = selection.getRangeAt(i);
         ranges.push(range);
@@ -96,22 +110,8 @@ function copy_handler() {
             return;
         }
 
-            // Construct a div for what we want to copy (div)
-        for (row = current_msg_list.get_row(start_id);
-             rows.id(row) <= end_id;
-             row = rows.next_visible(row)) {
-             if (row.prev().hasClass("message_header")) {
-                content = $('<div>').text(row.prev().text()
-                                            .replace(/\s+/g, " ")
-                                            .replace(/^\s/, "").replace(/\s$/, ""));
-                div.append($('<p>').append($('<strong>').text(content.text())));
-            }
-            message = current_msg_list.get(rows.id(row));
-            var message_firstp = $(message.content).slice(0, 1);
-            message_firstp.prepend(message.sender_full_name + ": ");
-            div.append(message_firstp);
-            div.append($(message.content).slice(1));
-        }
+        // Construct a div for what we want to copy (div)
+        construct_copy_div(div, start_id, end_id);
     }
 
     if (window.bridge !== undefined) {

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -44,17 +44,34 @@ function construct_recipient_header(message_row) {
 }
 
 function construct_copy_div(div, start_id, end_id) {
-    for (var row = current_msg_list.get_row(start_id);
+    var start_row = current_msg_list.get_row(start_id);
+    var start_recipient_row = rows.get_message_recipient_row(start_row);
+    var start_recipient_row_id = rows.id_for_recipient_row(start_recipient_row);
+    var should_include_start_recipient_header = false;
+
+    var last_recipient_row_id = start_recipient_row_id;
+    for (var row = start_row;
          rows.id(row) <= end_id;
          row = rows.next_visible(row)) {
-        if (row.prev().hasClass("message_header")) {
+        var recipient_row_id = rows.id_for_recipient_row(rows.get_message_recipient_row(row));
+        // if we found a message from another recipient,
+        // it means that we have messages from several recipients,
+        // so we have to add new recipient's bar to final copied message
+        // and wouldn't forget to add start_recipient's bar at the beginning of final message
+        if (recipient_row_id !== last_recipient_row_id) {
             div.append(construct_recipient_header(row));
+            last_recipient_row_id = recipient_row_id;
+            should_include_start_recipient_header = true;
         }
         var message = current_msg_list.get(rows.id(row));
         var message_firstp = $(message.content).slice(0, 1);
         message_firstp.prepend(message.sender_full_name + ": ");
         div.append(message_firstp);
         div.append($(message.content).slice(1));
+    }
+
+    if (should_include_start_recipient_header) {
+        div.prepend(construct_recipient_header(start_row));
     }
 }
 


### PR DESCRIPTION
#7217  
Changed algorithm of including recipient bars to the following: the recipient bar header is copied if there are selected messages from more than 1 recipient block. If there are multiple messages from only one recipient block then recipient bar is not copied

P.S. At the moment I write tests for changed functionality