### PR TITLE
Slack importer: Migrate attachments. 

### DIFF
--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -754,6 +754,9 @@ def do_convert_data(slack_zip_file: str, realm_subdomain: str, output_dir: str, 
     os.makedirs(avatar_realm_folder, exist_ok=True)
     avatar_records = process_avatars(avatar_list, avatar_folder, realm_id)
 
+    uploads_folder = os.path.join(output_dir, 'uploads')
+    os.makedirs(os.path.join(uploads_folder, str(realm_id)), exist_ok=True)
+    uploads_records = process_uploads(uploads_list, uploads_folder)
     attachment = {"zerver_attachment": zerver_attachment}
 
     # IO realm.json
@@ -763,7 +766,7 @@ def do_convert_data(slack_zip_file: str, realm_subdomain: str, output_dir: str, 
     # IO avatar records
     create_converted_data_files(avatar_records, output_dir, '/avatars/records.json', False)
     # IO uploads TODO
-    create_converted_data_files([], output_dir, '/uploads/records.json', True)
+    create_converted_data_files(uploads_records, output_dir, '/uploads/records.json', False)
     # IO attachments
     create_converted_data_files(attachment, output_dir, '/attachment.json', False)
 
@@ -812,6 +815,25 @@ def get_avatar(slack_avatar_url: str, image_path: str, original_image_path: str)
     with open(image_path, 'wb') as image_file:
         shutil.copyfileobj(response.raw, image_file)
     shutil.copy(image_path, original_image_path)
+
+def process_uploads(upload_list: List[ZerverFieldsT], upload_dir: str) -> List[ZerverFieldsT]:
+    """
+    This function gets the uploads and saves it in the realm's upload directory
+    """
+    logging.info('######### GETTING ATTACHMENTS #########\n')
+    for upload in upload_list:
+        upload_url = upload['path']
+        upload_s3_path = upload['s3_path']
+
+        upload_path = os.path.join(upload_dir, upload_s3_path)
+        response = requests.get(upload_url, stream=True)
+        os.makedirs(os.path.dirname(upload_path), exist_ok=True)
+        with open(upload_path, 'wb') as upload_file:
+            shutil.copyfileobj(response.raw, upload_file)
+
+        upload['path'] = upload_s3_path
+    logging.info('######### GETTING ATTACHMENTS FINISHED #########\n')
+    return upload_list
 
 def get_data_file(path: str) -> Any:
     data = json.load(open(path))

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -760,15 +760,15 @@ def do_convert_data(slack_zip_file: str, realm_subdomain: str, output_dir: str, 
     attachment = {"zerver_attachment": zerver_attachment}
 
     # IO realm.json
-    create_converted_data_files(realm, output_dir, '/realm.json', False)
+    create_converted_data_files(realm, output_dir, '/realm.json')
     # IO message.json
-    create_converted_data_files(message_json, output_dir, '/messages-000001.json', False)
+    create_converted_data_files(message_json, output_dir, '/messages-000001.json')
     # IO avatar records
-    create_converted_data_files(avatar_records, output_dir, '/avatars/records.json', False)
+    create_converted_data_files(avatar_records, output_dir, '/avatars/records.json')
     # IO uploads TODO
-    create_converted_data_files(uploads_records, output_dir, '/uploads/records.json', False)
+    create_converted_data_files(uploads_records, output_dir, '/uploads/records.json')
     # IO attachments
-    create_converted_data_files(attachment, output_dir, '/attachment.json', False)
+    create_converted_data_files(attachment, output_dir, '/attachment.json')
 
     # remove slack dir
     rm_tree(slack_data_dir)
@@ -848,10 +848,6 @@ def get_user_data(token: str) -> List[ZerverFieldsT]:
     else:
         raise Exception('Enter a valid token!')
 
-def create_converted_data_files(data: Any, output_dir: str, file_path: str,
-                                make_new_dir: bool) -> None:
+def create_converted_data_files(data: Any, output_dir: str, file_path: str) -> None:
     output_file = output_dir + file_path
-    if make_new_dir:
-        new_directory = os.path.dirname(file_path)
-        os.makedirs(output_dir + new_directory, exist_ok=True)
     json.dump(data, open(output_file, 'w'))

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -467,11 +467,13 @@ def convert_slack_workspace_messages(slack_data_dir: str, users: List[ZerverFiel
                                      added_users: AddedUsersT, added_recipient: AddedRecipientsT,
                                      added_channels: AddedChannelsT, realm: ZerverFieldsT,
                                      domain_name: str) -> Tuple[ZerverFieldsT,
+                                                                List[ZerverFieldsT],
                                                                 List[ZerverFieldsT]]:
     """
     Returns:
     1. message.json, Converted messages
     2. uploads, which is a list of uploads to be mapped in uploads records.json
+    3. attachment, which is a list of the attachments
     """
     # now for message.json
     message_json = {}
@@ -494,7 +496,7 @@ def convert_slack_workspace_messages(slack_data_dir: str, users: List[ZerverFiel
     attachment_id_list = allocate_ids(UserMessage, total_attachments)
 
     id_list = [message_id_list, usermessage_id_list, attachment_id_list]
-    zerver_message, zerver_usermessage, uploads = channel_message_to_zerver_message(
+    zerver_message, zerver_usermessage, attachment, uploads = channel_message_to_zerver_message(
         realm_id, users, added_users, added_recipient, all_messages,
         realm['zerver_subscription'], domain_name, id_list)
 
@@ -503,7 +505,7 @@ def convert_slack_workspace_messages(slack_data_dir: str, users: List[ZerverFiel
     message_json['zerver_message'] = zerver_message
     message_json['zerver_usermessage'] = zerver_usermessage
 
-    return message_json, uploads
+    return message_json, uploads, attachment
 
 def get_all_messages(slack_data_dir: str, added_channels: AddedChannelsT) -> List[ZerverFieldsT]:
     all_messages = []  # type: List[ZerverFieldsT]
@@ -554,12 +556,14 @@ def channel_message_to_zerver_message(realm_id: int, users: List[ZerverFieldsT],
                                       domain_name: str,
                                       ids: List[Any]) -> Tuple[List[ZerverFieldsT],
                                                                List[ZerverFieldsT],
+                                                               List[ZerverFieldsT],
                                                                List[ZerverFieldsT]]:
     """
     Returns:
     1. zerver_message, which is a list of the messages
     2. zerver_usermessage, which is a list of the usermessages
-    3. uploads_list, which is a list of uploads to be mapped in uploads records.json
+    3. zerver_attachment, which is a list of the attachments
+    4. uploads_list, which is a list of uploads to be mapped in uploads records.json
     """
     message_id_count = usermessage_id_count = attachment_id_count = 0
     message_id_list, usermessage_id_list, attachment_id_list = ids
@@ -635,7 +639,7 @@ def channel_message_to_zerver_message(realm_id: int, users: List[ZerverFieldsT],
             zerver_subscription, recipient_id, mentioned_users_id, message_id)
 
         message_id_count += 1
-    return zerver_message, zerver_usermessage, uploads_list
+    return zerver_message, zerver_usermessage, zerver_attachment, uploads_list
 
 def get_attachment_path_and_content(fileinfo: ZerverFieldsT, realm_id: int) -> Tuple[str,
                                                                                      str]:
@@ -740,7 +744,7 @@ def do_convert_data(slack_zip_file: str, realm_subdomain: str, output_dir: str, 
     realm, added_users, added_recipient, added_channels, avatar_list = slack_workspace_to_realm(
         domain_name, realm_id, user_list, realm_subdomain, fixtures_path, slack_data_dir)
 
-    message_json, uploads_list = convert_slack_workspace_messages(
+    message_json, uploads_list, zerver_attachment = convert_slack_workspace_messages(
         slack_data_dir, user_list, realm_id, added_users, added_recipient, added_channels,
         realm, domain_name)
 
@@ -750,7 +754,6 @@ def do_convert_data(slack_zip_file: str, realm_subdomain: str, output_dir: str, 
     os.makedirs(avatar_realm_folder, exist_ok=True)
     avatar_records = process_avatars(avatar_list, avatar_folder, realm_id)
 
-    zerver_attachment = []  # type: List[ZerverFieldsT]
     attachment = {"zerver_attachment": zerver_attachment}
 
     # IO realm.json

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -15,7 +15,7 @@ from django.db import connection
 from django.utils.timezone import now as timezone_now
 from typing import Any, Dict, List, Tuple
 from zerver.models import UserProfile, Realm, Stream, UserMessage, \
-    Subscription, Message, Recipient, DefaultStream
+    Subscription, Message, Recipient, DefaultStream, Attachment
 from zerver.forms import check_subdomain_available
 from zerver.lib.slack_message_conversion import convert_to_zulip_markdown, \
     get_user_full_name
@@ -484,13 +484,14 @@ def convert_slack_workspace_messages(slack_data_dir: str, users: List[ZerverFiel
     logging.info('######### IMPORTING MESSAGES STARTED #########\n')
 
     # To pre-compute the total number of messages and usermessages
-    total_messages, total_usermessages = get_total_messages_and_usermessages(
+    total_messages, total_usermessages, total_attachments = get_total_messages_and_attachments(
         realm['zerver_subscription'], added_recipient, all_messages)
 
     message_id_list = allocate_ids(Message, total_messages)
     usermessage_id_list = allocate_ids(UserMessage, total_usermessages)
+    attachment_id_list = allocate_ids(UserMessage, total_attachments)
 
-    id_list = [message_id_list, usermessage_id_list]
+    id_list = [message_id_list, usermessage_id_list, attachment_id_list]
     zerver_message, zerver_usermessage = channel_message_to_zerver_message(
         realm_id, users, added_users, added_recipient, all_messages,
         realm['zerver_subscription'], domain_name, id_list)
@@ -516,29 +517,32 @@ def get_all_messages(slack_data_dir: str, added_channels: AddedChannelsT) -> Lis
             all_messages += messages
     return all_messages
 
-def get_total_messages_and_usermessages(zerver_subscription: List[ZerverFieldsT],
-                                        added_recipient: AddedRecipientsT,
-                                        all_messages: List[ZerverFieldsT]) -> Tuple[int, int]:
+def get_total_messages_and_attachments(zerver_subscription: List[ZerverFieldsT],
+                                       added_recipient: AddedRecipientsT,
+                                       all_messages: List[ZerverFieldsT]) -> Tuple[int, int,
+                                                                                   int]:
     """
     Returns:
     1. message_id, which is total number of messages
     2. usermessage_id, which is total number of usermessages
+    3. attachment_id, which is total number of attachments
     """
-    total_messages = 0
-    total_usermessages = 0
+    total_messages = total_usermessages = total_attachments = 0
 
     for message in all_messages:
         if 'subtype' in message.keys():
             subtype = message['subtype']
             if subtype in ["channel_join", "channel_leave", "channel_name"]:
                 continue
+            elif subtype  == "file_share":
+                total_attachments += 1
 
         for subscription in zerver_subscription:
             if subscription['recipient'] == added_recipient[message['channel_name']]:
                 total_usermessages += 1
         total_messages += 1
 
-    return total_messages, total_usermessages
+    return total_messages, total_usermessages, total_attachments
 
 def channel_message_to_zerver_message(realm_id: int, users: List[ZerverFieldsT],
                                       added_users: AddedUsersT,
@@ -553,11 +557,12 @@ def channel_message_to_zerver_message(realm_id: int, users: List[ZerverFieldsT],
     1. zerver_message, which is a list of the messages
     2. zerver_usermessage, which is a list of the usermessages
     """
-    message_id_count = usermessage_id_count = 0
-    message_id_list, usermessage_id_list = ids
+    message_id_count = usermessage_id_count = attachment_id_count = 0
+    message_id_list, usermessage_id_list, attachment_id_list = ids
     zerver_message = []
     zerver_usermessage = []  # type: List[ZerverFieldsT]
     uploads_list = []  # type: List[ZerverFieldsT]
+    zerver_attachment = []  # type: List[ZerverFieldsT]
 
     for message in all_messages:
         user = get_message_sending_user(message)
@@ -571,6 +576,10 @@ def channel_message_to_zerver_message(realm_id: int, users: List[ZerverFieldsT],
                                                                           users,
                                                                           added_users)
         rendered_content = None
+
+        recipient_id = added_recipient[message['channel_name']]
+        message_id = message_id_list[message_id_count]
+
         if 'subtype' in message.keys():
             subtype = message['subtype']
             if subtype in ["channel_join", "channel_leave", "channel_name"]:
@@ -592,8 +601,11 @@ def channel_message_to_zerver_message(realm_id: int, users: List[ZerverFieldsT],
                 build_uploads(added_users[user], realm_id, file_user_email, fileinfo, s3_path,
                               uploads_list)
 
-        recipient_id = added_recipient[message['channel_name']]
-        message_id = message_id_list[message_id_count]
+                attachment_id = attachment_id_list[attachment_id_count]
+                build_zerver_attachment(realm_id, message_id, attachment_id, added_users[user],
+                                        fileinfo, s3_path, zerver_attachment)
+                attachment_id_count += 1
+
         # construct message
         zulip_message = dict(
             sending_client=1,
@@ -655,6 +667,21 @@ def build_uploads(user_id: int, realm_id: int, email: str, fileinfo: ZerverField
         s3_path=s3_path,
         size=fileinfo['size'])
     uploads_list.append(upload)
+
+def build_zerver_attachment(realm_id: int, message_id: int, attachment_id: int,
+                            user_id: int, fileinfo: ZerverFieldsT, s3_path: str,
+                            zerver_attachment: List[ZerverFieldsT]) -> None:
+    attachment = dict(
+        owner=user_id,
+        messages=[message_id],
+        id=attachment_id,
+        size=fileinfo['size'],
+        create_time=fileinfo['created'],
+        is_realm_public=True,  # is always true for stream message
+        path_id=s3_path,
+        realm=realm_id,
+        file_name=fileinfo['name'])
+    zerver_attachment.append(attachment)
 
 def get_message_sending_user(message: ZerverFieldsT) -> str:
     try:

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -593,8 +593,8 @@ def channel_message_to_zerver_message(realm_id: int, users: List[ZerverFieldsT],
             if subtype in ["channel_join", "channel_leave", "channel_name"]:
                 continue
 
-            # For attachments
-            elif subtype == "file_share":
+            # For attachments with slack download link
+            elif subtype == "file_share" and 'files.slack.com' in message['file']['url_private']:
                 fileinfo = message['file']
 
                 has_attachment = has_link = True
@@ -613,6 +613,17 @@ def channel_message_to_zerver_message(realm_id: int, users: List[ZerverFieldsT],
                 build_zerver_attachment(realm_id, message_id, attachment_id, added_users[user],
                                         fileinfo, s3_path, zerver_attachment)
                 attachment_id_count += 1
+
+            # For attachments with link not from slack
+            # Example: Google drive integration
+            elif subtype == "file_share":
+                fileinfo = message['file']
+                has_link = True
+                if 'title' in fileinfo:
+                    file_name = fileinfo['title']
+                else:
+                    file_name = fileinfo['name']
+                content = '[%s](%s)' % (file_name, fileinfo['url_private'])
 
         # construct message
         zulip_message = dict(

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -487,12 +487,14 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(message_json['zerver_message'], zerver_message)
         self.assertEqual(message_json['zerver_usermessage'], zerver_usermessage)
 
+    @mock.patch("zerver.lib.slack_data_to_zulip_data.process_uploads", return_value = [])
     @mock.patch("zerver.lib.slack_data_to_zulip_data.build_avatar_url")
     @mock.patch("zerver.lib.slack_data_to_zulip_data.build_avatar")
     @mock.patch("zerver.lib.slack_data_to_zulip_data.get_user_data")
     def test_slack_import_to_existing_database(self, mock_get_user_data: mock.Mock,
                                                mock_build_avatar_url: mock.Mock,
-                                               mock_build_avatar: mock.Mock) -> None:
+                                               mock_build_avatar: mock.Mock,
+                                               mock_process_uploads: mock.Mock) -> None:
         test_slack_dir = os.path.join(settings.DEPLOY_ROOT, "zerver", "fixtures",
                                       "slack_fixtures")
         test_slack_zip_file = os.path.join(test_slack_dir, "test_slack_importer.zip")

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -501,7 +501,7 @@ class SlackImporter(ZulipTestCase):
         test_slack_unzipped_file = os.path.join(test_slack_dir, "test_slack_importer")
 
         test_realm_subdomain = 'test-slack-import'
-        output_dir = '/tmp/test-slack-importer-data'
+        output_dir = os.path.join(settings.DEPLOY_ROOT, "var", "test-slack-importer-data")
         token = 'valid-token'
 
         # If the test fails, the 'output_dir' would not be deleted and hence it would give an

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -18,7 +18,7 @@ from zerver.lib.slack_data_to_zulip_data import (
     build_subscription,
     channels_to_zerver_stream,
     slack_workspace_to_realm,
-    get_total_messages_and_usermessages,
+    get_total_messages_and_attachments,
     get_message_sending_user,
     build_zerver_usermessage,
     channel_message_to_zerver_message,
@@ -347,10 +347,10 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(realm['zerver_userprofile'], [])
         self.assertEqual(realm['zerver_realm'], [{}])
 
-    def test_get_total_messages_and_usermessages(self) -> None:
+    def test_get_total_messages_and_attachments(self) -> None:
         messages = [{"text": "<@U8VAHEVUY> has joined the channel", "subtype": "channel_join",
                      "channel_name": "random"},
-                    {"text": "message", "channel_name": "random"},
+                    {"text": "message", "channel_name": "random", "subtype": "file_share"},
                     {"text": "random", "channel_name": "random"},
                     {"text": "test messsage", "channel_name": "general"},
                     {"text": "test message 2", "subtype": "channel_leave", "channel_name": "general"},
@@ -360,11 +360,11 @@ class SlackImporter(ZulipTestCase):
         added_recipient = {'random': 2, 'general': 4}
         zerver_subscription = [{'recipient': 2}, {'recipient': 4}, {'recipient': 2}]
 
-        total_messages, total_usermessages = get_total_messages_and_usermessages(zerver_subscription,
-                                                                                 added_recipient,
-                                                                                 messages)
+        total_messages, total_usermessages, total_attachments = get_total_messages_and_attachments(
+            zerver_subscription, added_recipient, messages)
         # subtype: channel_join, channel_leave are filtered out
         self.assertEqual(total_messages, 4)
+        self.assertEqual(total_attachments, 1)
         self.assertEqual(total_usermessages, 6)
 
     def test_get_message_sending_user(self) -> None:
@@ -429,7 +429,7 @@ class SlackImporter(ZulipTestCase):
                          "ts": "1433868669.000012", "channel_name": "general"}]  # type: List[Dict[str, Any]]
 
         added_recipient = {'random': 2, 'general': 1}
-        ids = [[3, 4, 5, 6, 7], []]
+        ids = [[3, 4, 5, 6, 7], [], []]
 
         zerver_usermessage = []  # type: List[Dict[str, Any]]
         zerver_subscription = []  # type: List[Dict[str, Any]]
@@ -468,8 +468,8 @@ class SlackImporter(ZulipTestCase):
     @mock.patch("zerver.lib.slack_data_to_zulip_data.channel_message_to_zerver_message")
     @mock.patch("zerver.lib.slack_data_to_zulip_data.allocate_ids")
     @mock.patch("zerver.lib.slack_data_to_zulip_data.get_all_messages")
-    @mock.patch("zerver.lib.slack_data_to_zulip_data.get_total_messages_and_usermessages", return_value=[2, 4])
-    def test_convert_slack_workspace_messages(self, mock_get_total_messages_and_usermessages: mock.Mock,
+    @mock.patch("zerver.lib.slack_data_to_zulip_data.get_total_messages_and_attachments", return_value=[2, 4, 1])
+    def test_convert_slack_workspace_messages(self, mock_get_total_messages_and_attachments: mock.Mock,
                                               mock_get_all_messages: mock.Mock, mock_allocate_ids: mock.Mock,
                                               mock_message: mock.Mock) -> None:
         added_channels = {'random': 1, 'general': 2}

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -436,7 +436,8 @@ class SlackImporter(ZulipTestCase):
         zerver_message, zerver_usermessage = channel_message_to_zerver_message(1, user_data, added_users,
                                                                                added_recipient,
                                                                                all_messages,
-                                                                               zerver_subscription, ids)
+                                                                               zerver_subscription,
+                                                                               'domain', ids)
         # functioning already tested in helper function
         self.assertEqual(zerver_usermessage, [])
         # subtype: channel_join is filtered
@@ -457,7 +458,7 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(zerver_message[4]['id'], 7)
 
         self.assertIsNone(zerver_message[3]['rendered_content'])
-        self.assertEqual(zerver_message[0]['has_image'], all_messages[1]['has_image'])
+        self.assertEqual(zerver_message[0]['has_image'], False)
         self.assertEqual(zerver_message[0]['pub_date'], float(all_messages[1]['ts']))
         self.assertEqual(zerver_message[2]['rendered_content_version'], 1)
 
@@ -482,7 +483,7 @@ class SlackImporter(ZulipTestCase):
         mock_message.side_effect = [[zerver_message, zerver_usermessage]]
         message_json = convert_slack_workspace_messages('./random_path', user_list, 2, {},
                                                         {}, added_channels,
-                                                        realm)
+                                                        realm, 'domain')
         self.assertEqual(message_json['zerver_message'], zerver_message)
         self.assertEqual(message_json['zerver_usermessage'], zerver_usermessage)
 

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -330,9 +330,8 @@ class SlackImporter(ZulipTestCase):
 
         realm_id = 1
         user_list = []  # type: List[Dict[str, Any]]
-        with self.settings(EXTERNAL_HOST='testdomain'):
-            realm, added_users, added_recipient, added_channels, avatar_list = slack_workspace_to_realm(
-                realm_id, user_list, 'test-realm', './fixtures', './random_path')
+        realm, added_users, added_recipient, added_channels, avatar_list = slack_workspace_to_realm(
+            'testdomain', realm_id, user_list, 'test-realm', './fixtures', './random_path')
         test_zerver_realmdomain = [{'realm': realm_id, 'allow_subdomains': False,
                                     'domain': 'testdomain', 'id': realm_id}]
         # Functioning already tests in helper functions

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -433,7 +433,7 @@ class SlackImporter(ZulipTestCase):
 
         zerver_usermessage = []  # type: List[Dict[str, Any]]
         zerver_subscription = []  # type: List[Dict[str, Any]]
-        zerver_message, zerver_usermessage, uploads = channel_message_to_zerver_message(
+        zerver_message, zerver_usermessage, attachment, uploads = channel_message_to_zerver_message(
             1, user_data, added_users, added_recipient, all_messages, zerver_subscription,
             'domain', ids)
         # functioning already tested in helper function
@@ -442,6 +442,7 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(len(zerver_message), 5)
 
         self.assertEqual(uploads, [])
+        self.assertEqual(attachment, [])
 
         # Message conversion already tested in tests.test_slack_message_conversion
         self.assertEqual(zerver_message[0]['content'], '@**Jane**: hey!')
@@ -480,8 +481,8 @@ class SlackImporter(ZulipTestCase):
 
         zerver_usermessage = [{'id': 3}, {'id': 5}, {'id': 6}, {'id': 9}]
 
-        mock_message.side_effect = [[zerver_message, zerver_usermessage, []]]
-        message_json, uploads = convert_slack_workspace_messages(
+        mock_message.side_effect = [[zerver_message, zerver_usermessage, [], []]]
+        message_json, uploads, zerver_attachment = convert_slack_workspace_messages(
             './random_path', user_list, 2, {}, {}, added_channels, realm, 'domain')
         self.assertEqual(message_json['zerver_message'], zerver_message)
         self.assertEqual(message_json['zerver_usermessage'], zerver_usermessage)

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -433,15 +433,15 @@ class SlackImporter(ZulipTestCase):
 
         zerver_usermessage = []  # type: List[Dict[str, Any]]
         zerver_subscription = []  # type: List[Dict[str, Any]]
-        zerver_message, zerver_usermessage = channel_message_to_zerver_message(1, user_data, added_users,
-                                                                               added_recipient,
-                                                                               all_messages,
-                                                                               zerver_subscription,
-                                                                               'domain', ids)
+        zerver_message, zerver_usermessage, uploads = channel_message_to_zerver_message(
+            1, user_data, added_users, added_recipient, all_messages, zerver_subscription,
+            'domain', ids)
         # functioning already tested in helper function
         self.assertEqual(zerver_usermessage, [])
         # subtype: channel_join is filtered
         self.assertEqual(len(zerver_message), 5)
+
+        self.assertEqual(uploads, [])
 
         # Message conversion already tested in tests.test_slack_message_conversion
         self.assertEqual(zerver_message[0]['content'], '@**Jane**: hey!')
@@ -480,10 +480,9 @@ class SlackImporter(ZulipTestCase):
 
         zerver_usermessage = [{'id': 3}, {'id': 5}, {'id': 6}, {'id': 9}]
 
-        mock_message.side_effect = [[zerver_message, zerver_usermessage]]
-        message_json = convert_slack_workspace_messages('./random_path', user_list, 2, {},
-                                                        {}, added_channels,
-                                                        realm, 'domain')
+        mock_message.side_effect = [[zerver_message, zerver_usermessage, []]]
+        message_json, uploads = convert_slack_workspace_messages(
+            './random_path', user_list, 2, {}, {}, added_channels, realm, 'domain')
         self.assertEqual(message_json['zerver_message'], zerver_message)
         self.assertEqual(message_json['zerver_usermessage'], zerver_usermessage)
 


### PR DESCRIPTION
Overview:

We have create both `records.json` for upload dir and `zerver_attachment` for the uploads.

Screenshot of attachment:
![screen shot 2018-03-08 at 5 25 34 pm](https://user-images.githubusercontent.com/25330892/37220251-11df8f1c-23ec-11e8-84a3-c1d9bb355a18.png)
