### PR TITLE
compose: Prepend space if needed for attachments.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -190,12 +190,17 @@ function assert_hidden(sel) {
     };
     stub_selected_message(msg);
 
+    var syntax_to_insert;
+    compose_ui.insert_syntax_and_focus = function (syntax) {
+        syntax_to_insert = syntax;
+    };
+
     var opts = {
     };
 
     reply_with_mention(opts);
     assert.equal($('#stream').val(), 'devel');
-    assert.equal($('#compose-textarea').val(), '@**Bob Roberts** ');
+    assert.equal(syntax_to_insert, '@**Bob Roberts**');
     assert(compose_state.has_message_content());
 }());
 

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -93,11 +93,15 @@ var upload_opts = upload.options({ mode: "compose" });
     function test(i, response, textbox_val) {
         var compose_ui_autosize_textarea_checked = false;
         var compose_actions_start_checked = false;
+        var syntax_to_insert;
 
         function setup() {
             $("#compose-textarea").val('');
             compose_ui.autosize_textarea = function () {
                 compose_ui_autosize_textarea_checked = true;
+            };
+            compose_ui.insert_syntax_and_focus = function (syntax) {
+                syntax_to_insert = syntax;
             };
             compose_state.set_message_type();
             global.compose_actions = {
@@ -116,8 +120,8 @@ var upload_opts = upload.options({ mode: "compose" });
         }
 
         function assert_side_effects() {
-            assert.equal($("#compose-textarea").val(), textbox_val);
             if (response.uri) {
+                assert.equal(syntax_to_insert, textbox_val);
                 assert(compose_actions_start_checked);
                 assert(compose_ui_autosize_textarea_checked);
                 assert.equal($("#compose-send-button").prop('disabled'), false);
@@ -131,8 +135,8 @@ var upload_opts = upload.options({ mode: "compose" });
         assert_side_effects();
     }
 
-    var msg_1 = '[pasted image](https://foo.com/uploads/122456) ';
-    var msg_2 = '[foobar.jpeg](https://foo.com/user_uploads/foobar.jpeg) ';
+    var msg_1 = '[pasted image](https://foo.com/uploads/122456)';
+    var msg_2 = '[foobar.jpeg](https://foo.com/user_uploads/foobar.jpeg)';
 
     test(-1, {}, '');
     test(-1, {uri: 'https://foo.com/uploads/122456'}, msg_1);

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -320,7 +320,7 @@ exports.reply_with_mention = function (opts) {
     exports.respond_to_message(opts);
     var message = current_msg_list.selected_message();
     var mention = '@**' + message.sender_full_name + '**';
-    $('#compose-textarea').val(mention + ' ');
+    compose_ui.insert_syntax_and_focus(mention);
 };
 
 exports.on_topic_narrow = function () {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -564,8 +564,7 @@ exports.register_click_handlers = function () {
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         compose_actions.start('stream', {trigger: 'sidebar user actions'});
         var name = people.get_person_from_user_id(user_id).full_name;
-        var textarea = $("#compose-textarea");
-        textarea.val('@**' + name + '** ');
+        compose_ui.insert_syntax_and_focus('@**' + name + '**');
         popovers.hide_user_sidebar_popover();
         e.stopPropagation();
         e.preventDefault();
@@ -593,8 +592,7 @@ exports.register_click_handlers = function () {
         compose_actions.respond_to_message({trigger: 'user sidebar popover'});
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var name = people.get_person_from_user_id(user_id).full_name;
-        var textarea = $("#compose-textarea");
-        textarea.val('@**' + name + '** ');
+        compose_ui.insert_syntax_and_focus('@**' + name + '**');
         popovers.hide_message_info_popover();
         e.stopPropagation();
         e.preventDefault();

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -114,10 +114,12 @@ exports.options = function (config) {
 
         if (i === -1) {
             // This is a paste, so there's no filename. Show the image directly
-            textarea.val(textarea.val() + "[pasted image](" + uri + ") ");
+            var pasted_image_uri = "[pasted image](" + uri + ")";
+            compose_ui.insert_syntax_and_focus(pasted_image_uri);
         } else {
             // This is a dropped file, so make the filename a link to the image
-            textarea.val(textarea.val() + "[" + filename + "](" + uri + ")" + " ");
+            var filename_uri = "[" + filename + "](" + uri + ")";
+            compose_ui.insert_syntax_and_focus(filename_uri);
         }
         compose_ui.autosize_textarea();
         send_button.prop("disabled", false);


### PR DESCRIPTION
Fixes: #7212.
This completes Elena's PR #7273.

I think it's difficult to test whether space is appended on pasting the link or not, but function insert_syntax_and_focus is tested itself so I think we don't need to test in upload again. So I've stubbed out the function insert_syntax_and_focus.

(Other changes are Elena's commit message and another interesting thing I found that Elena's commit don't have right author I changed it as well from elena to elenaoat [edit- more info [here](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/)])

I've changed some `textarea.val` to use `insert_syntax_and_focus` as described in commit message:
Use compose_ui.insert_syntax_and_focus() when we need to insert text
inline-ly followed by focus to compose textarea because it does
this job more smartly(it take cares of spaces).