### PR TITLE
portico: Fix Text Overflow on Zulip Features Page

### DIFF
--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -135,6 +135,9 @@
             <p>Prefer Zulip in its own window and rich, OS-level
             notifications? Enjoy Zulip on your desktop.</p>
         </div>
+        <!--Adding 2 pseudo elements so as to not disturb the flex arrangment-->
+        <div class="feature-block"></div>
+        <div class="feature-block"></div>
     </section>
 
     <section>


### PR DESCRIPTION
This PR fixes the **overflowing text on the Features page** under the App, Integrations, and API section.

Screenshot
![Changes Done](https://i.imgur.com/8eymA6S.png)