### PR TITLE
Add frontend for custom user profile fields

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -191,6 +191,16 @@ initialize();
 
 initialize();
 
+(function test_set_custom_profile_field_data() {
+    var person = people.get_by_email(me.email);
+    me.profile_data = {};
+    var field = {id: 3, name: 'Custom long field', type: 'text', value: 'Field value'};
+    people.set_custom_profile_field_data(person.user_id, {});
+    assert.deepEqual(person.profile_data, {});
+    people.set_custom_profile_field_data(person.user_id, field);
+    assert.equal(person.profile_data[field.id], 'Field value');
+}());
+
 (function test_get_rest_of_realm() {
     var alice1 = {
         email: 'alice1@example.com',

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -123,6 +123,14 @@ initialize();
     assert.equal(people.get_recipients('30,32'), 'Isaac Newton');
 }());
 
+(function test_my_custom_profile_data() {
+    var person = people.get_by_email(me.email);
+    person.profile_data = {3: 'My address', 4: 'My phone number'};
+    assert.equal(people.my_custom_profile_data(3), 'My address');
+    assert.equal(people.my_custom_profile_data(4), 'My phone number');
+    assert.equal(people.my_custom_profile_data(undefined), undefined);
+}());
+
 (function test_user_timezone() {
     var expected_pref = {
         timezone: 'US/Pacific',

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -579,6 +579,14 @@ function render(template_name, args) {
     global.write_handlebars_output("compose_stream_alert", html);
 }());
 
+(function custom_user_profile_field() {
+    var args = {field_name: "GitHub user name", field_id: 2, field_value: "@GitHub", field_type: "text"};
+    var html = render('custom-user-profile-field', args);
+    assert.equal($(html).find('input').attr('id'), 2);
+    assert.equal($(html).find('input').val(), "@GitHub");
+    global.write_handlebars_output("custom-user-profile-field", html);
+}());
+
 (function deactivate_stream_modal() {
     var args = {
         stream_name: "Public stream",

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -137,4 +137,8 @@ initialize();
     assert(!user_events.update_person({user_id: 29, full_name: 'Sir Isaac Newton'}));
     assert.equal(error_msg, "Got update_person event for unexpected user 29");
 
+    me.profile_data = {};
+    user_events.update_person({user_id: me.user_id, custom_profile_field: {id: 3, value: 'Value'}});
+    person = people.get_by_email(me.email);
+    assert.equal(person.profile_data[3], 'Value');
 }());

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -843,6 +843,14 @@ exports.my_current_user_id = function () {
     return my_user_id;
 };
 
+exports.my_custom_profile_data = function (field_id) {
+    if (field_id === undefined) {
+        blueslip.error("Undefined field id");
+        return;
+    }
+    return people_by_user_id_dict.get(my_user_id).profile_data[field_id];
+};
+
 exports.is_my_user_id = function (user_id) {
     if (!user_id) {
         return false;

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -819,6 +819,14 @@ exports.set_full_name = function (person_obj, new_full_name) {
     person_obj.full_name = new_full_name;
 };
 
+exports.set_custom_profile_field_data = function (user_id, field) {
+    if (field.id === undefined) {
+        blueslip.error("Unknown field id " + field.id);
+        return;
+    }
+    people_by_user_id_dict.get(user_id).profile_data[field.id] = field.value;
+};
+
 exports.is_current_user = function (email) {
     if (email === null || email === undefined) {
         return false;

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -310,6 +310,20 @@ exports.set_up = function () {
         $("#deactivate_self_modal").modal("show");
     });
 
+    $(".custom_user_field input, .custom_user_field textarea").on('change', function () {
+        var fields = [];
+        var value = $(this).val();
+        var spinner = $("#custom-field-status").expectOne();
+        loading.make_indicator(spinner, {text: 'Saving ...'});
+        if ($(this).attr("type") === "number") {
+            value = parseInt(value, 10);
+        }
+        fields.push({id: parseInt($(this).attr("id"), 10), value: value});
+
+        settings_ui.do_settings_change(channel.patch, "/json/users/me/profile_data",
+                                       {data: JSON.stringify(fields)}, spinner);
+    });
+
     $("#do_deactivate_self_button").on('click',function () {
         $("#do_deactivate_self_button .loader").css('display', 'inline-block');
         $("#do_deactivate_self_button span").hide();

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -53,8 +53,40 @@ function settings_change_success(message) {
     ui_report.success(message, $('#account-settings-status').expectOne());
 }
 
+function add_custom_profile_fields_to_settings() {
+    var all_custom_fields = page_params.custom_profile_fields;
+
+    all_custom_fields.forEach(function (field) {
+        var type;
+        var value = people.my_custom_profile_data(field.id);
+        var is_long_text = field.type === 4;
+
+        // 1 & 2 type represent numeric data and 3 & 4 type represent textual data.
+        if (field.type === 1 || field.type === 2) {
+            type = "number";
+        } else if (field.type === 3 || field.type === 4) {
+            type = "text";
+        } else {
+            blueslip.error("Undefined field type.");
+        }
+        if (value === undefined) {
+            // If user has not set value for field.
+            value = "";
+        }
+
+        var html = templates.render("custom-user-profile-field", {field_name: field.name,
+                                                                  field_id: field.id,
+                                                                  field_type: type,
+                                                                  field_value: value,
+                                                                  is_long_text_field: is_long_text,
+                                                                  });
+        $("#account-settings .custom-profile-fields-form").append(html);
+    });
+}
 
 exports.set_up = function () {
+    // Add custom profile fields elements to user account settings.
+    add_custom_profile_fields_to_settings();
     $("#account-settings-status").hide();
     $("#api_key_value").text("");
     $("#get_api_key_box").hide();

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -64,6 +64,10 @@ exports.update_person = function update(person) {
         message_live_update.update_avatar(person_obj.user_id, person.avatar_url);
     }
 
+    if (_.has(person, 'custom_profile_field')) {
+        people.set_custom_profile_field_data(person.user_id, person.custom_profile_field);
+    }
+
      if (_.has(person, 'timezone')) {
          person_obj.timezone = person.timezone;
     }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1212,10 +1212,20 @@ input[type=checkbox].inline-block {
     width: auto;
 }
 
+#settings_page .custom_user_field {
+    padding-bottom: 20px;
+}
+
 #settings_page #change_password_modal .change_password_info,
 #settings_page #change_email_modal .change_email_info,
 #settings_page #change_full_name_modal .change_full_name_info {
     margin: 10px;
+}
+
+#account-settings .custom_user_field input::placeholder,
+#account-settings .custom_user_field textarea::placeholder {
+    font-style: italic;
+    color: hsl(0, 0%, 66%);
 }
 
 #deactivation_user_modal.fade.in {

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -116,6 +116,11 @@
                     </div>
                 </div>
             </form>
+
+            <h3 class="inline-block" {{#unless page_params.custom_profile_fields}}style="display: none"{{/unless}}>{{t "Profile" }}</h3>
+            <div class="alert-notification" id="custom-field-status"></div>
+            <form class="form-horizontal custom-profile-fields-form grid"></form>
+
         </div>
 
         <div class="inline-block user-avatar-section">

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -116,15 +116,6 @@
                     </div>
                 </div>
             </form>
-
-            <form class="deactivate_account grid">
-                <div class="input-group">
-                    <label for="" class="inline-block"></label>
-                    <button type="submit" class="button rounded w-200 btn-danger input-size" id="user_deactivate_account_button">
-                        {{t 'Deactivate account' }}
-                    </button>
-                </div>
-            </form>
         </div>
 
         <div class="inline-block user-avatar-section">
@@ -216,6 +207,15 @@
             <div id="user_api_key_error text-error">
             </div>
         </div>
-
+        <div class="inline-block">
+            <h3>{{t "Deactivate account" }}</h3>
+            <form class="deactivate_account grid">
+                <div class="input-group">
+                    <button type="submit" class="button rounded w-200 btn-danger input-size" id="user_deactivate_account_button">
+                        {{t 'Deactivate account' }}
+                    </button>
+                </div>
+            </form>
+        </div>
     </div>
 </div>

--- a/static/templates/settings/custom-user-profile-field.handlebars
+++ b/static/templates/settings/custom-user-profile-field.handlebars
@@ -1,0 +1,8 @@
+<div class="user-name-section custom_user_field">
+    <label for="{{ field_name }}" class="title">{{ field_name }}</label>
+    {{#if is_long_text_field}}
+    <textarea name="{{ field_name }}" id="{{ field_id }}" placeholder="{{t 'No value.' }}">{{ field_value }}</textarea>
+    {{else}}
+    <input type="{{ field_type }}" name="{{ field_name }}" id="{{ field_id }}" placeholder="{{t 'No value.' }}" value="{{ field_value }}" />
+    {{/if}}
+</div>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4530,6 +4530,10 @@ def do_update_user_custom_profile_data(user_profile: UserProfile,
             update_or_create(user_profile=user_profile,
                              field_id=field['id'],
                              defaults={'value': field['value']})
+            payload = dict(user_id=user_profile.id, custom_profile_field=dict(id=field['id'],
+                                                                              value=field['value']))
+            event = dict(type="realm_user", op="update", person=payload)
+            send_event(event, active_user_ids(user_profile.realm.id))
 
 def do_send_create_user_group_event(user_group: UserGroup, members: List[UserProfile]) -> None:
     event = dict(type="user_group",

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -15,14 +15,11 @@ class CustomProfileFieldTest(ZulipTestCase):
 
     def test_list(self) -> None:
         self.login(self.example_email("iago"))
-        realm = get_realm('zulip')
-        try_add_realm_custom_profile_field(realm, u"Phone",
-                                           CustomProfileField.SHORT_TEXT)
         result = self.client_get("/json/realm/profile_fields")
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
         content = result.json()
-        self.assertEqual(len(content["custom_fields"]), 1)
+        self.assertEqual(len(content["custom_fields"]), 3)
 
     def test_create(self) -> None:
         self.login(self.example_email("iago"))
@@ -58,19 +55,15 @@ class CustomProfileFieldTest(ZulipTestCase):
     def test_delete(self) -> None:
         self.login(self.example_email("iago"))
         realm = get_realm('zulip')
-        field = try_add_realm_custom_profile_field(
-            realm,
-            "Phone",
-            CustomProfileField.SHORT_TEXT
-        )
+        field = CustomProfileField.objects.get(name="Phone number", realm=realm)
         result = self.client_delete("/json/realm/profile_fields/100")
         self.assert_json_error(result, 'Field id 100 not found.')
 
-        self.assertEqual(CustomProfileField.objects.count(), 1)
+        self.assertEqual(CustomProfileField.objects.count(), 3)
         result = self.client_delete(
             "/json/realm/profile_fields/{}".format(field.id))
         self.assert_json_success(result)
-        self.assertEqual(CustomProfileField.objects.count(), 0)
+        self.assertEqual(CustomProfileField.objects.count(), 2)
 
     def test_update(self) -> None:
         self.login(self.example_email("iago"))
@@ -89,21 +82,18 @@ class CustomProfileFieldTest(ZulipTestCase):
         )
         self.assert_json_error(result, u'Field id 100 not found.')
 
-        field = try_add_realm_custom_profile_field(
-            realm,
-            u"Phone",
-            CustomProfileField.SHORT_TEXT
-        )
+        field = CustomProfileField.objects.get(name="Phone number", realm=realm)
 
-        self.assertEqual(CustomProfileField.objects.count(), 1)
+        self.assertEqual(CustomProfileField.objects.count(), 3)
         result = self.client_patch(
             "/json/realm/profile_fields/{}".format(field.id),
-            info={'name': 'Phone Number',
+            info={'name': 'New phone number',
                   'field_type': CustomProfileField.SHORT_TEXT})
         self.assert_json_success(result)
-        self.assertEqual(CustomProfileField.objects.count(), 1)
-        field = CustomProfileField.objects.first()
-        self.assertEqual(field.name, 'Phone Number')
+
+        field = CustomProfileField.objects.get(id=field.id, realm=realm)
+        self.assertEqual(CustomProfileField.objects.count(), 3)
+        self.assertEqual(field.name, 'New phone number')
         self.assertEqual(field.field_type, CustomProfileField.SHORT_TEXT)
 
     def test_update_is_aware_of_uniqueness(self) -> None:
@@ -118,7 +108,7 @@ class CustomProfileFieldTest(ZulipTestCase):
             CustomProfileField.SHORT_TEXT
         )
 
-        self.assertEqual(CustomProfileField.objects.count(), 2)
+        self.assertEqual(CustomProfileField.objects.count(), 5)
         result = self.client_patch(
             "/json/realm/profile_fields/{}".format(field.id),
             info={'name': 'Phone', 'field_type': CustomProfileField.SHORT_TEXT})
@@ -191,21 +181,21 @@ class CustomProfileDataTest(ZulipTestCase):
         self.login(self.example_email("iago"))
         realm = get_realm('zulip')
         fields = [
-            (CustomProfileField.SHORT_TEXT, 'name 1', 'short text data'),
-            (CustomProfileField.LONG_TEXT, 'name 2', 'long text data'),
-            (CustomProfileField.INTEGER, 'name 3', 1),
-            (CustomProfileField.FLOAT, 'name 4', 2.0),
+            ('Phone number', 'short text data'),
+            ('Biography', 'long text data'),
+            ('Favorite integer', 1),
         ]
 
         data = []
         for i, field_value in enumerate(fields):
-            field_type, name, value = field_value
-            field = try_add_realm_custom_profile_field(realm, name, field_type)
+            name, value = field_value
+            field = CustomProfileField.objects.get(name=name, realm=realm)
             data.append({
                 'id': field.id,
                 'value': value,
             })
 
+        # Update value of field
         result = self.client_patch("/json/users/me/profile_data",
                                    {'data': ujson.dumps(data)})
         self.assert_json_success(result)
@@ -218,10 +208,10 @@ class CustomProfileDataTest(ZulipTestCase):
             for k in ['id', 'type', 'name']:
                 self.assertIn(k, field_dict)
 
-            self.assertEqual(len(iago.profile_data), 4)
+            self.assertEqual(len(iago.profile_data), 3)
 
-        # Update value of field
-        field = CustomProfileField.objects.get(name='name 1', realm=realm)
+        # Update value of one field.
+        field = CustomProfileField.objects.get(name='Biography', realm=realm)
         data = [{
             'id': field.id,
             'value': 'foobar',
@@ -237,18 +227,14 @@ class CustomProfileDataTest(ZulipTestCase):
     def test_delete(self) -> None:
         user_profile = self.example_user('iago')
         realm = user_profile.realm
-        field = try_add_realm_custom_profile_field(
-            realm,
-            u"Phone",
-            CustomProfileField.SHORT_TEXT
-        )
+        field = CustomProfileField.objects.get(name="Phone number", realm=realm)
         data = [{'id': field.id, 'value': u'123456'}]  # type: List[Dict[str, Union[int, Text]]]
         do_update_user_custom_profile_data(user_profile, data)
 
-        self.assertEqual(len(custom_profile_fields_for_realm(realm.id)), 1)
-        self.assertEqual(user_profile.customprofilefieldvalue_set.count(), 1)
+        self.assertEqual(len(custom_profile_fields_for_realm(realm.id)), 3)
+        self.assertEqual(user_profile.customprofilefieldvalue_set.count(), 3)
 
         do_remove_realm_custom_profile_field(realm, field)
 
-        self.assertEqual(len(custom_profile_fields_for_realm(realm.id)), 0)
-        self.assertEqual(user_profile.customprofilefieldvalue_set.count(), 0)
+        self.assertEqual(len(custom_profile_fields_for_realm(realm.id)), 2)
+        self.assertEqual(user_profile.customprofilefieldvalue_set.count(), 2)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -911,6 +911,7 @@ class EventsRegisterTest(ZulipTestCase):
         schema_checker = self.check_events_dict([
             ('type', equals('custom_profile_fields')),
             ('fields', check_list(check_dict_only([
+                ('id', check_int),
                 ('type', check_int),
                 ('name', check_string),
             ]))),

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -249,27 +249,26 @@ class Command(BaseCommand):
             Subscription.objects.bulk_create(subscriptions_to_add)
             RealmAuditLog.objects.bulk_create(all_subscription_logs)
 
-            if not options['test_suite']:
-                # Create custom profile field data
-                phone_number = try_add_realm_custom_profile_field(zulip_realm, "Phone number",
-                                                                  CustomProfileField.SHORT_TEXT)
-                biography = try_add_realm_custom_profile_field(zulip_realm, "Biography",
-                                                               CustomProfileField.LONG_TEXT)
-                favorite_integer = try_add_realm_custom_profile_field(zulip_realm, "Favorite integer",
-                                                                      CustomProfileField.INTEGER)
+            # Create custom profile field data
+            phone_number = try_add_realm_custom_profile_field(zulip_realm, "Phone number",
+                                                              CustomProfileField.SHORT_TEXT)
+            biography = try_add_realm_custom_profile_field(zulip_realm, "Biography",
+                                                           CustomProfileField.LONG_TEXT)
+            favorite_integer = try_add_realm_custom_profile_field(zulip_realm, "Favorite integer",
+                                                                  CustomProfileField.INTEGER)
 
-                # Fill in values for Iago and Hamlet
-                hamlet = get_user("hamlet@zulip.com", zulip_realm)
-                do_update_user_custom_profile_data(iago, [
-                    {"id": phone_number.id, "value": "+1-234-567-8901"},
-                    {"id": biography.id, "value": "Betrayer of Othello."},
-                    {"id": favorite_integer.id, "value": 17},
-                ])
-                do_update_user_custom_profile_data(hamlet, [
-                    {"id": phone_number.id, "value": "+0-11-23-456-7890"},
-                    {"id": biography.id, "value": "Prince of Denmark, and other things!"},
-                    {"id": favorite_integer.id, "value": 12},
-                ])
+            # Fill in values for Iago and Hamlet
+            hamlet = get_user("hamlet@zulip.com", zulip_realm)
+            do_update_user_custom_profile_data(iago, [
+                {"id": phone_number.id, "value": "+1-234-567-8901"},
+                {"id": biography.id, "value": "Betrayer of Othello."},
+                {"id": favorite_integer.id, "value": 17},
+            ])
+            do_update_user_custom_profile_data(hamlet, [
+                {"id": phone_number.id, "value": "+0-11-23-456-7890"},
+                {"id": biography.id, "value": "Prince of Denmark, and other things!"},
+                {"id": favorite_integer.id, "value": 12},
+            ])
         else:
             zulip_realm = get_realm("zulip")
             recipient_streams = [klass.type_id for klass in


### PR DESCRIPTION
It add frontend for custom user profile fields. Backend code is added in [this commit](https://github.com/zulip/zulip/commit/cf3b6c6ca95d4450f303271a4494c34d4851d591). 

Tested it locally, this is how custom fields looks like in user settings page.
![customuserprofilefields](https://user-images.githubusercontent.com/25907420/36746323-0e202ffc-1c18-11e8-8831-52080d08a3d9.png)

Will be working on commit messages, improving code quality. Already tested it locally, but will try to test with other corner cases. 

To test it with database: 
```
realm = get_realm('zulip')
iago = get_user("iago@zulip.com", realm)
long_field = try_add_realm_custom_profile_field(realm, "GitHub username", 4)
short_field = try_add_realm_custom_profile_field(realm, "GitHub username", 3)
hamlet = get_user("hamlet@zulip.com", realm)
do_update_user_custom_profile_data(hamlet, [{"id": short_field.id, "value":"Hamlet@GitHub"}])
```
You can create as many fields as you need. 