### PR TITLE
Refactor popover and use insert_syntax_and_focus if needed.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -190,12 +190,17 @@ function assert_hidden(sel) {
     };
     stub_selected_message(msg);
 
+    var syntax_to_insert;
+    compose_ui.insert_syntax_and_focus = function (syntax) {
+        syntax_to_insert = syntax;
+    };
+
     var opts = {
     };
 
     reply_with_mention(opts);
     assert.equal($('#stream').val(), 'devel');
-    assert.equal($('#compose-textarea').val(), '@**Bob Roberts** ');
+    assert.equal(syntax_to_insert, '@**Bob Roberts**');
     assert(compose_state.has_message_content());
 }());
 

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -320,7 +320,7 @@ exports.reply_with_mention = function (opts) {
     exports.respond_to_message(opts);
     var message = current_msg_list.selected_message();
     var mention = '@**' + message.sender_full_name + '**';
-    $('#compose-textarea').val(mention + ' ');
+    compose_ui.insert_syntax_and_focus(mention);
 };
 
 exports.on_topic_narrow = function () {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -532,37 +532,28 @@ exports.register_click_handlers = function () {
         }
     });
 
-    $('body').on('click', '.user_popover .narrow_to_private_messages', function (e) {
+
+    $('body').on('click', '.info_popover_actions .narrow_to_private_messages', function (e) {
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var email = people.get_person_from_user_id(user_id).email;
-
-        popovers.hide_user_sidebar_popover();
+        popovers.hide_message_info_popover();
         narrow.by('pm-with', email, {select_first_unread: true, trigger: 'user sidebar popover'});
         e.stopPropagation();
+        e.preventDefault();
     });
 
-    $('body').on('click', '.user_popover .narrow_to_messages_sent', function (e) {
+    $('body').on('click', '.info_popover_actions .narrow_to_messages_sent', function (e) {
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var email = people.get_person_from_user_id(user_id).email;
-
-        popovers.hide_user_sidebar_popover();
+        popovers.hide_message_info_popover();
         narrow.by('sender', email, {select_first_unread: true, trigger: 'user sidebar popover'});
-        e.stopPropagation();
-    });
-
-    $('body').on('click', '.user_popover .compose_private_message', function (e) {
-        var user_id = $(e.target).parents('ul').attr('data-user-id');
-        var email = people.get_person_from_user_id(user_id).email;
-        popovers.hide_user_sidebar_popover();
-
-        compose_actions.start('private', {private_message_recipient: email, trigger: 'sidebar user actions'});
         e.stopPropagation();
         e.preventDefault();
     });
 
     $('body').on('click', '.user_popover .mention_user', function (e) {
-        var user_id = $(e.target).parents('ul').attr('data-user-id');
         compose_actions.start('stream', {trigger: 'sidebar user actions'});
+        var user_id = $(e.target).parents('ul').attr('data-user-id');
         var name = people.get_person_from_user_id(user_id).full_name;
         var textarea = $("#compose-textarea");
         textarea.val('@**' + name + '** ');
@@ -571,25 +562,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.sender_info_popover .narrow_to_private_messages', function (e) {
-        var user_id = $(e.target).parents('ul').attr('data-user-id');
-        var email = people.get_person_from_user_id(user_id).email;
-        narrow.by('pm-with', email, {select_first_unread: true, trigger: 'user sidebar popover'});
-        popovers.hide_message_info_popover();
-        e.stopPropagation();
-        e.preventDefault();
-    });
-
-    $('body').on('click', '.sender_info_popover .narrow_to_messages_sent', function (e) {
-        var user_id = $(e.target).parents('ul').attr('data-user-id');
-        var email = people.get_person_from_user_id(user_id).email;
-        narrow.by('sender', email, {select_first_unread: true, trigger: 'user sidebar popover'});
-        popovers.hide_message_info_popover();
-        e.stopPropagation();
-        e.preventDefault();
-    });
-
-    $('body').on('click', '.sender_info_popover .mention_user', function (e) {
+    $('body').on('click', '.message-info-popover .mention_user', function (e) {
         compose_actions.respond_to_message({trigger: 'user sidebar popover'});
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var name = people.get_person_from_user_id(user_id).full_name;
@@ -731,7 +704,7 @@ exports.register_click_handlers = function () {
         reminder_click_handler(datestr, e);
     });
 
-    $('body').on('click', '.respond_personal_button', function (e) {
+    $('body').on('click', '.respond_personal_button, .compose_private_message', function (e) {
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var email = people.get_person_from_user_id(user_id).email;
         compose_actions.start('private', {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -552,7 +552,9 @@ exports.register_click_handlers = function () {
     });
 
     $('body').on('click', '.user_popover .mention_user', function (e) {
-        compose_actions.start('stream', {trigger: 'sidebar user actions'});
+        if (!compose_state.composing()) {
+            compose_actions.start('stream', {trigger: 'sidebar user actions'});
+        }
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var name = people.get_person_from_user_id(user_id).full_name;
         compose_ui.insert_syntax_and_focus('@**' + name + '**');
@@ -562,7 +564,9 @@ exports.register_click_handlers = function () {
     });
 
     $('body').on('click', '.message-info-popover .mention_user', function (e) {
-        compose_actions.respond_to_message({trigger: 'user sidebar popover'});
+        if (!compose_state.composing()) {
+            compose_actions.respond_to_message({trigger: 'user sidebar popover'});
+        }
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var name = people.get_person_from_user_id(user_id).full_name;
         compose_ui.insert_syntax_and_focus('@**' + name + '**');

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -555,8 +555,7 @@ exports.register_click_handlers = function () {
         compose_actions.start('stream', {trigger: 'sidebar user actions'});
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var name = people.get_person_from_user_id(user_id).full_name;
-        var textarea = $("#compose-textarea");
-        textarea.val('@**' + name + '** ');
+        compose_ui.insert_syntax_and_focus('@**' + name + '**');
         popovers.hide_user_sidebar_popover();
         e.stopPropagation();
         e.preventDefault();
@@ -566,8 +565,7 @@ exports.register_click_handlers = function () {
         compose_actions.respond_to_message({trigger: 'user sidebar popover'});
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var name = people.get_person_from_user_id(user_id).full_name;
-        var textarea = $("#compose-textarea");
-        textarea.val('@**' + name + '** ');
+        compose_ui.insert_syntax_and_focus('@**' + name + '**');
         popovers.hide_message_info_popover();
         e.stopPropagation();
         e.preventDefault();

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -66,7 +66,7 @@
     float: none;
 }
 
-ul.sender_info_popover i {
+ul.info_popover_actions i {
     display: inline-block;
     width: 14px;
     text-align: center;

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -1,5 +1,5 @@
 {{! Contents of the "message info" popup }}
-<ul class="nav nav-list actions_popover sender_info_popover" data-user-id="{{user_id}}">
+<ul class="nav nav-list actions_popover info_popover_actions" data-user-id="{{user_id}}">
     <div class="popover_info">
         <li class="user_{{presence_status}}">
             <b>{{user_full_name}}</b>


### PR DESCRIPTION
Commit messages are self explainatory:
**popovers: Fix two click handler attached to (rightbar) user_popovers**
No need to have separate click handler for user_popovers and
message_info_popovers as the same user-id can be extracted similarly
from the target of both the click events.

Another refactor, `sender_info_popover` was confusing as it doesn't
fix into the context of rightbar user popovers so changed it to
`info_popover_actions` since that section of popovers contains popover
actions.

**compose: Use insert_syntax_and_focus to insert text in compose textarea.**
Use compose_ui.insert_syntax_and_focus() when we need to insert text
inline-ly followed by the focus to compose textarea because it does
this job more smartly(it take cares of spaces).

**compose: Fix clearing of existing text on replying from popovers.**
compose_action.respond_to_message and compose_action.start starts new
compose box so we should check whether we are already composing
or not. So, behavior, when we are composing, is that the user we want
to mention is added to the same compose-text without the changing stream
and topic name.