### PR TITLE
Frontend: Show privately messaged user name in private narrows.

### DIFF
--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -70,7 +70,7 @@ exports.activate = function (raw_operators, opts) {
     } else if (filter.has_operator("is")) {
         exports.narrow_title = filter.operands("is")[0];
     } else if (filter.has_operator("pm-with")) {
-        exports.narrow_title = "private";
+        exports.narrow_title = "(Private) " + people.get_by_email(filter._operators[0].operand).full_name;
     } else if (filter.has_operator("group-pm-with")) {
         exports.narrow_title = "private group";
     }


### PR DESCRIPTION
This pr fixes issue #5876 and shows privately messaged user's name on narrowing to him/her.


**Testing Plan:** Tested locally with ./tools/test-all

![screenshot](https://user-images.githubusercontent.com/24868887/36754573-638347f6-1c2f-11e8-8f14-054964b91ecc.png)




