### PR TITLE
user settings: Display avatar source.

### DIFF
--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -51,7 +51,11 @@ exports.build_user_avatar_widget = function (upload_function) {
 
     if (page_params.avatar_source === 'G') {
         $("#user_avatar_delete_button").hide();
+        $("#user-avatar-source").show();
+    } else {
+        $("#user-avatar-source").hide();
     }
+
     $("#user_avatar_delete_button").on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
@@ -60,6 +64,7 @@ exports.build_user_avatar_widget = function (upload_function) {
             success: function (data) {
               $("#user-settings-avatar").expectOne().attr("src", data.avatar_url);
               $("#user_avatar_delete_button").hide();
+              $("#user-avatar-source").show();
               // Need to clear input because of a small edge case
               // where you try to upload the same image you just deleted.
               get_file_input().val('');

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -291,6 +291,8 @@ exports.set_up = function () {
             form_data.append('file-'+i, file);
         });
 
+        $("#user-avatar-source").hide();
+
         var spinner = $("#upload_avatar_spinner").expectOne();
         loading.make_indicator(spinner, {text: 'Uploading avatar.'});
 
@@ -304,6 +306,12 @@ exports.set_up = function () {
                 loading.destroy_indicator($("#upload_avatar_spinner"));
                 $("#user-settings-avatar").expectOne().attr("src", data.avatar_url);
                 $("#user_avatar_delete_button").show();
+                $("#user-avatar-source").hide();
+            },
+            error: function () {
+                if (page_params.avatar_source === 'G') {
+                    $("#user-avatar-source").show();
+                }
             },
         });
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -820,8 +820,27 @@ input[type=checkbox].inline-block {
     transition: all 0.3s ease;
 }
 
-#user-settings-avatar:hover {
-    -webkit-filter: brightness(0.5);
+#user-settings-avatar:hover #user-avatar-block {
+    -webkit-filter: brightness(0.4);
+}
+
+#user-settings-avatar:hover #user-avatar-source {
+    visibility: visible;
+}
+
+#user-avatar-source {
+    margin-left: 10px;
+    width: 200px;
+    height: 20px;
+    position: absolute;
+    bottom: 19%;
+    left: 0%;
+    font-size: 0.9em;
+    visibility: hidden;
+}
+
+.white-color {
+    color: white;
 }
 
 #realm-settings-icon {

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -131,7 +131,12 @@
             <h3>{{t "User avatar" }}</h3>
 
             <div class="inline-block">
-                <img id="user-settings-avatar" src="{{ page_params.avatar_url_medium }}" />
+                <div id="user-settings-avatar">
+                    <img id="user-avatar-block" src="{{ page_params.avatar_url_medium }}" />
+                    <div id="user-avatar-source">
+                        <a href="https://en.gravatar.com/" target="_blank" class="white-color">{{t "Avatar from gravatar" }}</a>
+                    </div>
+                </div>
                 <div id="user_avatar_file_input_error" class="text-error"></div>
                 <input type="file" name="user_avatar_file_input" class="notvisible" id="user_avatar_file_input" value="{{t 'Upload avatar' }}" />
                 <div id="upload_avatar_spinner"></div>


### PR DESCRIPTION
For issue  #8225:

Approach: To see if the Gravtar is custom or generated, the method is  to add the get parameter `d=404` to the url gravatar. If it returns a 404 status instead of a generated image if the user does not have an image on gravatar set, and it is displaying the custom avatar.

I have done a quick implementation of this by writing this [function](https://github.com/zulip/zulip/commit/62fbb50b7280521c65f22378409e30b563a582cc) and I am unsure about a few things mentioned below which I require thoughts on (and hence I haven't added the tests.)

1. I have implemented this by calling the function mentioned about (`check_custom_gravatar`) every time an avatar related event occurs (fetching initial state, upload), Hence a request is send everytime to the gravatar url to check if it returns 404. We have to do this every time while fetching the initial state to detect if the user hasn't updated their gravatar and the gravatar is not custom anymore. (Hence a request goes out everytime, which is not good practice.) The two solutions I am confused with are below:

**solution 1** : Add `custom_gravatar` as a field in UserProfile model, and only check if the gravatar is custom when the events upload and delete occur. ( Hence a request won't go out everytime the initial state is fetched and only when the mentioned  events occur.)

**solution 2**: Avoid the entire thing by displaying `Sourced from Gravatar` everytime without checking if it is custom.

Also need thoughts about the UI:
Current implementation: (only for a uploaded gravatar, for a custom gravatar, there would be no `Sourced from Gravatar` text. (This also shows solution 1: Displaying text only when avatar is not custom)
![ezgif com-gif-maker 4](https://user-images.githubusercontent.com/25330892/36780191-4430edf4-1c98-11e8-9332-94858ba896cd.gif)
 Here, always displaying the text below, looks kinda ugly. So we can add it only on image hover, like below.  (This also shows solution 2: Always displaying the text)

![ezgif com-gif-maker 3](https://user-images.githubusercontent.com/25330892/36780362-cbcc0c12-1c98-11e8-83c1-43d83dc49faf.gif)

@rishig FYI