### PR TITLE
Use /new endpoint for creating new realm.

### DIFF
--- a/docs/subsystems/realms.md
+++ b/docs/subsystems/realms.md
@@ -33,7 +33,7 @@ within 7 days. The expiration period can be changed by modifying
 If you want anyone to be able to create new realms on your server, you
 can enable Open Realm Creation.  This will add a **Create new
 organization** link to your Zulip homepage footer, and anyone can
-create a new realm by visiting this link (**/create_realm**).  This
+create a new realm by visiting this link (**/new**).  This
 feature is disabled by default in production instances, and can be
 enabled by setting `OPEN_REALM_CREATION = True` in settings.py.
 

--- a/frontend_tests/casper_tests/00-realm-creation.js
+++ b/frontend_tests/casper_tests/00-realm-creation.js
@@ -6,17 +6,17 @@ var organization_name = 'Awesome Organization';
 var host = "zulipdev.com:9981";
 var realm_host = "testsubdomain" + '.' + host;
 
-casper.start('http://' + host + '/create_realm/');
+casper.start('http://' + host + '/new/');
 
 casper.then(function () {
     // Submit the email for realm creation
-    this.waitUntilVisible('form[action^="/create_realm/"]', function () {
-        this.fill('form[action^="/create_realm/"]', {
+    this.waitUntilVisible('form[action^="/new/"]', function () {
+        this.fill('form[action^="/new/"]', {
             email: email,
         }, true);
     });
     // Make sure confirmation email is send
-    this.waitWhileVisible('form[action^="/create_realm/"]', function () {
+    this.waitWhileVisible('form[action^="/new/"]', function () {
          var regex = new RegExp('^http://[^/]+/accounts/send_confirm/' + email);
          this.test.assertUrlMatch(regex, 'Confirmation mail send');
     });

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -27,7 +27,7 @@
             <li><a href="{{ root_domain_uri }}/accounts/find">{{ _("Find account") }}</a></li>
             {% endif %}
             {% if open_realm_creation %}
-            <li><a href="{{ root_domain_uri }}/create_realm/">{{ _("New organization") }}</a></li>
+            <li><a href="{{ root_domain_uri }}/new/">{{ _("New organization") }}</a></li>
             {% endif %}
             {% if login_link_disabled %}
             {% else %}

--- a/templates/zerver/for/mystery-hunt.md
+++ b/templates/zerver/for/mystery-hunt.md
@@ -41,7 +41,7 @@ it's easy to write bots that send things into or out of Zulip.
 
 **Where can I test it out?**
 
-[Click here](https://zulipchat.com/create_realm) to create an organization; it
+[Click here](https://zulipchat.com/new) to create an organization; it
 only takes only about 30 seconds. If you decide to continue using it, just email
 support@zulipchat.com to tell us you're a mystery hunt team.
 

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -44,7 +44,7 @@
                                     <div class="pricing-details">
                                         Free
                                     </div>
-                                    <a href="/create_realm/">
+                                    <a href="/new/">
                                         <button class="green" type="button">
                                             Sign up now
                                         </button>
@@ -79,7 +79,7 @@
                                             $80/year billed annually
                                         </div>
                                     </div>
-                                    <a href="/create_realm/">
+                                    <a href="/new/">
                                         <button class="green" type="button">
                                             Try it free
                                         </button>

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -218,7 +218,7 @@ class TestGenerateRealmCreationLink(ZulipTestCase):
     @override_settings(OPEN_REALM_CREATION=False)
     def test_realm_creation_with_random_link(self) -> None:
         # Realm creation attempt with an invalid link should fail
-        random_link = "/create_realm/5e89081eb13984e0f3b130bf7a4121d153f1614b"
+        random_link = "/new/5e89081eb13984e0f3b130bf7a4121d153f1614b"
         result = self.client_get(random_link)
         self.assert_in_success_response(["The organization creation link has expired or is not valid."], result)
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1204,7 +1204,7 @@ class RealmCreationTest(ZulipTestCase):
         self.assertIsNone(realm)
 
         # Create new realm with the email
-        result = self.client_post('/create_realm/', {'email': email})
+        result = self.client_post('/new/', {'email': email})
         self.assertEqual(result.status_code, 302)
         self.assertTrue(result["Location"].endswith(
             "/accounts/send_confirm/%s" % (email,)))
@@ -1251,7 +1251,7 @@ class RealmCreationTest(ZulipTestCase):
         self.check_able_to_create_realm("hamlet@zulip.com")
 
     def test_create_realm_as_system_bot(self) -> None:
-        result = self.client_post('/create_realm/', {'email': 'notification-bot@zulip.com'})
+        result = self.client_post('/new/', {'email': 'notification-bot@zulip.com'})
         self.assertEqual(result.status_code, 200)
         self.assert_in_response('notification-bot@zulip.com is an email address reserved', result)
 
@@ -1264,7 +1264,7 @@ class RealmCreationTest(ZulipTestCase):
 
         with self.settings(OPEN_REALM_CREATION=False):
             # Create new realm with the email, but no creation key.
-            result = self.client_post('/create_realm/', {'email': email})
+            result = self.client_post('/new/', {'email': email})
             self.assertEqual(result.status_code, 200)
             self.assert_in_response('New organization creation disabled.', result)
 
@@ -1279,7 +1279,7 @@ class RealmCreationTest(ZulipTestCase):
         self.assertIsNone(get_realm(string_id))
 
         # Create new realm with the email
-        result = self.client_post('/create_realm/', {'email': email})
+        result = self.client_post('/new/', {'email': email})
         self.assertEqual(result.status_code, 302)
         self.assertTrue(result["Location"].endswith(
             "/accounts/send_confirm/%s" % (email,)))
@@ -1309,7 +1309,7 @@ class RealmCreationTest(ZulipTestCase):
 
     @override_settings(OPEN_REALM_CREATION=True)
     def test_mailinator_signup(self) -> None:
-        result = self.client_post('/create_realm/', {'email': "hi@mailinator.com"})
+        result = self.client_post('/new/', {'email': "hi@mailinator.com"})
         self.assert_in_response('Please use your real email address.', result)
 
     @override_settings(OPEN_REALM_CREATION=True)
@@ -1318,7 +1318,7 @@ class RealmCreationTest(ZulipTestCase):
         email = "user1@test.com"
         realm_name = "Test"
 
-        result = self.client_post('/create_realm/', {'email': email})
+        result = self.client_post('/new/', {'email': email})
         self.client_get(result["Location"])
         confirmation_url = self.get_confirmation_url_from_outbox(email)
         self.client_get(confirmation_url)
@@ -1351,7 +1351,7 @@ class RealmCreationTest(ZulipTestCase):
         email = "user1@test.com"
         realm_name = "Test"
 
-        result = self.client_post('/create_realm/', {'email': email})
+        result = self.client_post('/new/', {'email': email})
         self.client_get(result["Location"])
         confirmation_url = self.get_confirmation_url_from_outbox(email)
         self.client_get(confirmation_url)
@@ -1376,7 +1376,7 @@ class RealmCreationTest(ZulipTestCase):
         email = "user1@test.com"
         realm_name = "Test"
 
-        result = self.client_post('/create_realm/', {'email': email})
+        result = self.client_post('/new/', {'email': email})
         self.client_get(result["Location"])
         confirmation_url = self.get_confirmation_url_from_outbox(email)
         self.client_get(confirmation_url)
@@ -1460,7 +1460,7 @@ class UserSignUpTest(ZulipTestCase):
         error_mock = patch('logging.error')
 
         with smtp_mock, error_mock as err:
-            result = self.client_post('/create_realm/', {'email': email})
+            result = self.client_post('/new/', {'email': email})
 
         self._assert_redirected_to(result, '/config-error/smtp')
 

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -440,9 +440,9 @@ i18n_urls = [
         name='zerver.views.registration.find_account'),
 
     # Realm Creation
-    url(r'^create_realm/$', zerver.views.registration.create_realm,
+    url(r'^new/$', zerver.views.registration.create_realm,
         name='zerver.views.create_realm'),
-    url(r'^create_realm/(?P<creation_key>[\w]+)$',
+    url(r'^new/(?P<creation_key>[\w]+)$',
         zerver.views.registration.create_realm, name='zerver.views.create_realm'),
 
     # Login/registration


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Use /new instead of /create_realm for creating a new realm.

