### PR TITLE
org settings: Fix loading spinner size.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -202,9 +202,9 @@ function populate_users(realm_people_data) {
 }
 
 exports.set_up = function () {
-    loading.make_indicator($('#admin_page_users_loading_indicator'));
-    loading.make_indicator($('#admin_page_bots_loading_indicator'));
-    loading.make_indicator($('#admin_page_deactivated_users_loading_indicator'));
+    loading.make_indicator($('#admin_page_users_loading_indicator'), {text: 'Loading...'});
+    loading.make_indicator($('#admin_page_bots_loading_indicator'), {text: 'Loading...'});
+    loading.make_indicator($('#admin_page_deactivated_users_loading_indicator'), {text: 'Loading...'});
 
     // Populate users and bots tables
     channel.get({

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -199,12 +199,18 @@ function populate_users(realm_people_data) {
     loading.destroy_indicator($('#admin_page_users_loading_indicator'));
     loading.destroy_indicator($('#admin_page_bots_loading_indicator'));
     loading.destroy_indicator($('#admin_page_deactivated_users_loading_indicator'));
+    $("#admin_deactivated_users_table").show();
+    $("#admin_users_table").show();
+    $("#admin_bots_table").show();
 }
 
 exports.set_up = function () {
     loading.make_indicator($('#admin_page_users_loading_indicator'), {text: 'Loading...'});
     loading.make_indicator($('#admin_page_bots_loading_indicator'), {text: 'Loading...'});
     loading.make_indicator($('#admin_page_deactivated_users_loading_indicator'), {text: 'Loading...'});
+    $("#admin_deactivated_users_table").hide();
+    $("#admin_users_table").hide();
+    $("#admin_bots_table").hide();
 
     // Populate users and bots tables
     channel.get({

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2022,8 +2022,8 @@ div.floating_recipient {
 }
 
 .settings-section .loading_indicator_spinner {
-    width: 20%;
-    height: 20px;
+    width: 30%;
+    height: 30px;
     margin-top: 7px;
     vertical-align: middle;
     display: inline-block;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR fixes, issue #8502. It fixes bug in spinner in org settings. 

org settings: Fix issue, loading spinners are not visible.
    
    In org settings, loading spinners are not visible, currently
    because their size is very small.
    
    Fix this, by increasing width and height of spinners and
    adding spinner text, to make spinners more visible.
    Fixes #8502

**Testing Plan:** <!-- How have you tested? -->
If you do not have many users/bots listed, you will not be able to see loading animations. In that case, you can comment out the code of destroying spinner(in `static/js/settings_users.js` function `populate_users` last lines). 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
This is how spinner looks, 
![loadingspinner](https://user-images.githubusercontent.com/25907420/36809018-c6df5ed0-1cec-11e8-9159-a2f371a39a18.gif)

**PR will cover**:

- [X] Fix visibility issue of loading spinners in org setting sections.
- [ ] Loading spinners are not visible even after increasing size of spinners in `Bots` and `Deactivated users` section. Fix this issue. 