### PR TITLE
Compose: prevent autoselecting input text from Stream/Topic while composing new message on tab change

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -780,21 +780,6 @@ global.user_groups.add(backend);
     event.keyCode = 42;
     $('form#send_message_form').keyup(event);
 
-    // select_on_focus()
-    var focus_handler_called = false;
-    var stream_one_called = false;
-    $('#stream').focus = function (f) {
-        // This .one() function emulates the possible infinite recursion that
-        // in_handler tries to avoid.
-        $('#stream').one = function (event, handler) {
-            handler({ preventDefault: noop });
-            f();  // This time in_handler will already be true.
-            stream_one_called = true;
-        };
-        f();  // Here in_handler is false.
-        focus_handler_called = true;
-    };
-
     $("#compose-send-button").fadeOut = noop;
     $("#compose-send-button").fadeIn = noop;
     var channel_post_called = false;
@@ -822,8 +807,7 @@ global.user_groups.add(backend);
     assert(pm_recipient_blur_called);
     assert(channel_post_called);
     assert(compose_textarea_typeahead_called);
-    assert(focus_handler_called);
-    assert(stream_one_called);
+
 }());
 
 (function test_begins_typeahead() {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -210,24 +210,6 @@ function handle_keyup(e) {
     }
 }
 
-// http://stackoverflow.com/questions/3380458/looking-for-a-better-workaround-to-chrome-select-on-focus-bug
-function select_on_focus(field_id) {
-    // A select event appears to trigger a focus event under certain
-    // conditions in Chrome so we need to protect against infinite
-    // recursion.
-    var in_handler = false;
-    $("#" + field_id).focus(function () {
-        if (in_handler) {
-            return;
-        }
-        in_handler = true;
-        $("#" + field_id).select().one('mouseup', function (e) {
-            e.preventDefault();
-        });
-        in_handler = false;
-    });
-}
-
 exports.split_at_cursor = function (query, input) {
     var cursor = input.caret();
     return [query.slice(0, cursor), query.slice(cursor)];
@@ -537,10 +519,6 @@ exports.initialize_compose_typeahead = function (selector) {
 };
 
 exports.initialize = function () {
-    select_on_focus("stream");
-    select_on_focus("subject");
-    select_on_focus("private_message_recipient");
-
     // These handlers are at the "form" level so that they are called after typeahead
     $("form#send_message_form").keydown(handle_keydown);
     $("form#send_message_form").keyup(handle_keyup);


### PR DESCRIPTION
This selecting_on_element_focus feature was implemented very early as a part of user compose experience but is now causing buggy user interaction therefore is required to be removed.

This feature initially was facing a bug that caused infinite triggering of focus->select->focus events as a part of a google chrome specific webkit issue. Luckily this bug was fixed in final implementation. Thus It's hoped that this would not appear if this function is itself completely removed.

Fixes #8414 . now the topic/stream text is not autoselected if tab change is done.
