### PR TITLE
compose typeahead: Add all public streams including unsubscribed streams.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -48,11 +48,13 @@ var sweden_stream = {
     name: 'Sweden',
     description: 'Cold, mountains and home decor.',
     stream_id: 1,
+    subscribed: true,
 };
 var denmark_stream = {
     name: 'Denmark',
-    description: 'Vikings and boats, in a cold weather.',
+    description: 'Vikings and boats, in a serene and cold weather.',
     stream_id: 2,
+    subscribed: true,
 };
 
 set_global('$', global.make_zjquery());
@@ -70,7 +72,7 @@ set_global('pygments_data', {langs:
 
 global.compile_template('typeahead_list_item');
 
-stream_data.subscribed_subs = function () {
+stream_data.get_streams_for_settings_page = function () {
     return stream_list;
 };
 
@@ -421,17 +423,17 @@ global.user_groups.add(backend);
         // corresponding parts in bold.
         options.query = 'oth';
         actual_value = options.highlighter(othello);
-        expected_value = '<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">othello@zulip.com</small>';
+        expected_value = '<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">othello@zulip.com</small>\n';
         assert.equal(actual_value, expected_value);
 
         options.query = 'Lear';
         actual_value = options.highlighter(cordelia);
-        expected_value = '<strong>Cordelia Lear</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">cordelia@zulip.com</small>';
+        expected_value = '<strong>Cordelia Lear</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">cordelia@zulip.com</small>\n';
         assert.equal(actual_value, expected_value);
 
         options.query = 'othello@zulip.com, co';
         actual_value = options.highlighter(cordelia);
-        expected_value = '<strong>Cordelia Lear</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">cordelia@zulip.com</small>';
+        expected_value = '<strong>Cordelia Lear</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">cordelia@zulip.com</small>\n';
         assert.equal(actual_value, expected_value);
 
         // options.matcher()
@@ -543,12 +545,12 @@ global.user_groups.add(backend);
         // content_highlighter.
         fake_this = { completing: 'mention', token: 'othello' };
         actual_value = options.highlighter.call(fake_this, othello);
-        expected_value = '<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">othello@zulip.com</small>';
+        expected_value = '<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">othello@zulip.com</small>\n';
         assert.equal(actual_value, expected_value);
 
         fake_this = { completing: 'mention', token: 'hamletcharacters' };
         actual_value = options.highlighter.call(fake_this, hamletcharacters);
-        expected_value = '<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>';
+        expected_value = '<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
         assert.equal(actual_value, expected_value);
 
         // options.matcher()
@@ -643,6 +645,33 @@ global.user_groups.add(backend);
         fake_this = { completing: 'syntax', token: 'ap' };
         actual_value = options.sorter.call(fake_this, ['abap', 'applescript']);
         expected_value = ['applescript', 'abap'];
+        assert.deepEqual(actual_value, expected_value);
+
+        var serbia_stream = {
+            name: 'Serbia',
+            description: 'Snow and cold',
+            stream_id: 3,
+            subscribed: false,
+        };
+        // Subscribed stream is active
+        stream_data.is_active = function () {
+            return false;
+        };
+        fake_this = { completing: 'stream', token: 's' };
+        actual_value = options.sorter.call(fake_this, [sweden_stream, serbia_stream]);
+        expected_value = [sweden_stream, serbia_stream];
+        assert.deepEqual(actual_value, expected_value);
+        // Subscribed stream is inactive
+        stream_data.is_active = function () {
+            return true;
+        };
+        actual_value = options.sorter.call(fake_this, [sweden_stream, serbia_stream]);
+        expected_value = [sweden_stream, serbia_stream];
+        assert.deepEqual(actual_value, expected_value);
+
+        fake_this = { completing: 'stream', token: 'ser' };
+        actual_value = options.sorter.call(fake_this, [denmark_stream, serbia_stream]);
+        expected_value = [serbia_stream, denmark_stream];
         assert.deepEqual(actual_value, expected_value);
 
         fake_this = { completing: 'non-existing-completion' };

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -24,11 +24,11 @@ stream_data.create_streams([
     }};
 
     var test_streams = [
-        {name: 'Dev', pin_to_top: false, subscribers: unpopular},
-        {name: 'Docs', pin_to_top: false, subscribers: popular},
-        {name: 'Derp', pin_to_top: false, subscribers: unpopular},
-        {name: 'Denmark', pin_to_top: true, subscribers: popular},
-        {name: 'dead', pin_to_top: false, subscribers: unpopular},
+        {name: 'Dev', pin_to_top: false, subscribers: unpopular, subscribed: true},
+        {name: 'Docs', pin_to_top: false, subscribers: popular, subscribed: true},
+        {name: 'Derp', pin_to_top: false, subscribers: unpopular, subscribed: true},
+        {name: 'Denmark', pin_to_top: true, subscribers: popular, subscribed: true},
+        {name: 'dead', pin_to_top: false, subscribers: unpopular, subscribed: true},
     ];
 
     global.stream_data.is_active = function (sub) {
@@ -44,11 +44,11 @@ stream_data.create_streams([
 
     // Test sort streams with description
     test_streams = [
-        {name: 'Dev', description: 'development help', subscribers: unpopular},
-        {name: 'Docs', description: 'writing docs', subscribers: popular},
-        {name: 'Derp', description: 'derping around', subscribers: unpopular},
-        {name: 'Denmark', description: 'visiting Denmark', subscribers: popular},
-        {name: 'dead', description: 'dead stream', subscribers: unpopular},
+        {name: 'Dev', description: 'development help', subscribers: unpopular, subscribed: true},
+        {name: 'Docs', description: 'writing docs', subscribers: popular, subscribed: true},
+        {name: 'Derp', description: 'derping around', subscribers: unpopular, subscribed: true},
+        {name: 'Denmark', description: 'visiting Denmark', subscribers: popular, subscribed: true},
+        {name: 'dead', description: 'dead stream', subscribers: unpopular, subscribed: true},
     ];
     test_streams = th.sort_streams(test_streams, 'wr');
     assert.deepEqual(test_streams[0].name, "Docs"); // Description match
@@ -56,6 +56,24 @@ stream_data.create_streams([
     assert.deepEqual(test_streams[2].name, "Derp"); // Less subscribers
     assert.deepEqual(test_streams[3].name, "Dev"); // Alphabetically last
     assert.deepEqual(test_streams[4].name, "dead"); // Inactive streams last
+
+    // Test sort both subscribed and unsubscribed streams.
+    test_streams = [
+        {name: 'Dev', description: 'Some devs', subscribed: true},
+        {name: 'East', description: 'Developing east', subscribed: true},
+        {name: 'New', description: 'No match', subscribed: true},
+        {name: 'Derp', description: 'Always Derping', subscribed: false},
+        {name: 'Ether', description: 'Destroying ether', subscribed: false},
+        {name: 'Mew', description: 'Cat mews', subscribed: false},
+    ];
+
+    test_streams = th.sort_streams(test_streams, 'd');
+    assert.deepEqual(test_streams[0].name, "Dev"); // Subscribed and stream name starts with query
+    assert.deepEqual(test_streams[1].name, "Derp"); // Unsubscribed and stream name starts with query
+    assert.deepEqual(test_streams[2].name, "East"); // Subscribed and description starts with query
+    assert.deepEqual(test_streams[3].name, "Ether"); // Unsubscribed and description starts with query
+    assert.deepEqual(test_streams[4].name, "New"); // Subscribed and no match
+    assert.deepEqual(test_streams[5].name, "Mew"); // Unsubscribed and no match
 }());
 
 (function test_sort_languages() {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -384,7 +384,7 @@ exports.compose_content_begins_typeahead = function (query) {
 
         this.completing = 'stream';
         this.token = current_token;
-        return stream_data.subscribed_subs();
+        return stream_data.get_streams_for_settings_page();
     }
     return false;
 };

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -124,6 +124,7 @@ exports.render_stream = function (stream) {
         html = exports.render_typeahead_item({
             primary: stream.name,
             secondary: desc,
+            is_unsubscribed: !stream.subscribed,
         });
         rendered.streams.set(stream.stream_id, html);
     }
@@ -305,12 +306,16 @@ exports.sort_emojis = function (matches, query) {
 // Gives stream a score from 0 to 3 based on its activity
 function activity_score(sub) {
     var stream_score = 0;
-    if (sub.pin_to_top) {
-        stream_score += 2;
-    }
-    // Note: A pinned stream may accumulate a 3rd point if it is active
-    if (stream_data.is_active(sub)) {
-        stream_score += 1;
+    if (!sub.subscribed) {
+        stream_score = -1;
+    } else {
+        if (sub.pin_to_top) {
+            stream_score += 2;
+        }
+        // Note: A pinned stream may accumulate a 3rd point if it is active
+        if (stream_data.is_active(sub)) {
+            stream_score += 1;
+        }
     }
     return stream_score;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1754,6 +1754,19 @@ blockquote p {
     color: #fff;
 }
 
+.typeahead.dropdown-menu .unsubscribed_icon {
+    display: none;
+}
+
+.typeahead.dropdown-menu .active .unsubscribed_icon {
+    display: block;
+    float: right;
+    margin-top: 5px;
+    margin-right: -12px;
+    font-size: 0.8em;
+    color: hsl(96, 7%, 73%);
+}
+
 .nav .dropdown-menu:after {
     position: absolute;
     width: 0px;

--- a/static/templates/typeahead_list_item.handlebars
+++ b/static/templates/typeahead_list_item.handlebars
@@ -14,4 +14,9 @@
 <small class="autocomplete_secondary">
     {{~ secondary ~}}
 </small>
+{{#if is_unsubscribed}}
+&nbsp;
+<span class="fa fa-exclamation-triangle unsubscribed_icon"
+title="{{t 'You are not subscribed to this stream, but can still mention it'}}"></span>
+{{/if}}
 {{~/if}}


### PR DESCRIPTION
Fixes: #5757.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This adds unsubscribed streams to typeahead with the basic logic of:
> Changed source of typeahead to all streams and activity_score to -1 of unsubscribed streams.
Which means unsubscribed stream has the lowest position in stream name comparison but above those whose description matches. And then for lowest among those matched on the basis of description.

Which means always show unsubscribed streams to bottom but keep exactness first.
**Testing Plan:** <!-- How have you tested? -->
- [x] node-tests

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![typeahead](https://user-images.githubusercontent.com/22238472/36847887-a874c072-1d85-11e8-9bbe-e1e32bdf9c10.gif)
