### PR TITLE
casper: Avoid nesting wait statements to avoid flakes.

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -124,19 +124,20 @@ casper.then(function create_bot() {
 });
 
 var bot_email = '1-bot@zulip.zulipdev.com';
+var button_sel = '.download_bot_zuliprc[data-email="' + bot_email + '"]';
 
 casper.then(function () {
-    var button_sel = '.download_bot_zuliprc[data-email="' + bot_email + '"]';
-
     casper.waitUntilVisible(button_sel, function () {
         casper.click(button_sel);
+    });
+});
 
-        casper.waitUntilVisible(button_sel + '[href^="data:application"]', function () {
-            casper.test.assertMatch(
-                decodeURIComponent(casper.getElementsAttribute(button_sel, 'href')),
-                regex_zuliprc,
-                'Looks like a bot ~/.zuliprc file');
-        });
+casper.then(function () {
+    casper.waitUntilVisible(button_sel + '[href^="data:application"]', function () {
+        casper.test.assertMatch(
+            decodeURIComponent(casper.getElementsAttribute(button_sel, 'href')),
+            regex_zuliprc,
+            'Looks like a bot ~/.zuliprc file');
     });
 });
 


### PR DESCRIPTION
This test had flaked before. Nesting waitUntilVisible
statements is generally discouraged in casper tests.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
