### PR TITLE
Improve error message for mentioning a user who isn't subscribed

### DIFF
--- a/static/templates/compose-invite-users.handlebars
+++ b/static/templates/compose-invite-users.handlebars
@@ -1,5 +1,5 @@
 <div class="compose_invite_user" data-useremail="{{email}}">
-    {{#tr this}}<strong>__name__</strong> is not subscribed to this stream.{{/tr}}
+    {{#tr this}}<strong>__name__</strong> is not subscribed to this stream. They will not be notified if you mention them here.{{/tr}}
     <div class="compose_invite_user_controls">
         <span class="compose_invite_user_error alert alert-error" style="display: none;">{{t "Unable to subscribe user" }}</span>
         <button href="" class="btn btn-warning compose_invite_link" >{{t "Subscribe" }}</button><button type="button" class="compose_invite_close close">&times;</button>


### PR DESCRIPTION
New error message:
![screenshot from 2018-03-02 11-50-27](https://user-images.githubusercontent.com/22816171/36885968-056aeb82-1e10-11e8-840b-86fe386d9eb9.png)
