### PR TITLE
Uniform color styling for all 'Cancel' buttons.

### DIFF
--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -66,7 +66,7 @@
                 <button type="submit" class="button rounded sea-green submit_name_changes">
                     {{t 'Save changes' }}
                 </button>
-                <button type="button" class="button rounded btn-danger reset_edit_user">{{t 'Cancel' }}</button>
+                <button type="button" class="button rounded reset_edit_user">{{t 'Cancel' }}</button>
             </div>
         </form>
     </td>

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -27,7 +27,7 @@
         <div class="controls edit-controls">
             {{#if is_editable}}
             <button type="button" class="button small rounded sea-green message_edit_save">{{t "Save" }}</button>
-            <button type="button" class="button small rounded btn-danger message_edit_cancel">{{t "Cancel" }}</button>
+            <button type="button" class="button small rounded message_edit_cancel">{{t "Cancel" }}</button>
             {{else}}
             <button type="button" class="button small rounded btn-danger message_edit_close">{{t "Close" }}</button>
             {{/if}}

--- a/templates/zerver/invite_user.html
+++ b/templates/zerver/invite_user.html
@@ -36,7 +36,7 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="button exit btn-danger small rounded" data-dismiss="modal">{{ _('Cancel') }}</button>
+                <button class="button exit small rounded" data-dismiss="modal">{{ _('Cancel') }}</button>
                 <button id="submit-invitation" class="button small rounded sea-green"
                 data-loading-text="{{ _('Inviting...') }}" type="submit">{{ _('Invite') }}</button>
             </div>


### PR DESCRIPTION
![ss](https://user-images.githubusercontent.com/12075549/36901574-ac512e1a-1e4d-11e8-9346-830dc4dc1d33.png)

Change the colour of all red Cancel buttons to black **(standard colour for all Cancel buttons)** in the following:
1. `admin_user_list.handlebars`
2. `message_edit_form.handlebars`
3. `invite_user.html`

In this PR, commit [56eea6a](https://github.com/zulip/zulip/commit/56eea6a0b319c9bfe8347f172cdc549677895b89) resolves issue https://github.com/zulip/zulip/issues/8548.