### PR TITLE
settings: Add generic func to disable settings elements in UI.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,7 @@
         "settings_sections": false,
         "settings_emoji": false,
         "settings_org": false,
+        "settings_ui": false,
         "settings_users": false,
         "settings_streams": false,
         "settings_filters": false,

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -3,6 +3,7 @@ set_global('i18n', global.stub_i18n);
 
 zrequire('stream_data');
 zrequire('settings_org');
+zrequire('settings_ui');
 
 var noop = function () {};
 
@@ -329,11 +330,11 @@ function test_change_message_editing(change_message_editing) {
 
     change_message_editing.apply({checked: false});
     assert(parent_elem.hasClass('control-label-disabled'));
-    assert.equal($('#id_realm_message_content_edit_limit_minutes').attr('disabled'), true);
+    assert.equal($('#id_realm_message_content_edit_limit_minutes').attr('disabled'), 'disabled');
 
     change_message_editing.apply({checked: true});
     assert(!parent_elem.hasClass('control-label-disabled'));
-    assert.equal($('#id_realm_message_content_edit_limit_minutes').prop('disabled'), false);
+    assert.equal($('#id_realm_message_content_edit_limit_minutes').attr('disabled'), false);
 }
 
 function test_change_invite_required(change_invite_required) {
@@ -343,11 +344,11 @@ function test_change_invite_required(change_invite_required) {
 
     change_invite_required.apply({checked: false});
     assert(parent_elem.hasClass('control-label-disabled'));
-    assert.equal($('#id_realm_invite_by_admins_only').attr('disabled'), true);
+    assert.equal($('#id_realm_invite_by_admins_only').attr('disabled'), 'disabled');
 
     change_invite_required.apply({checked: true});
     assert(!parent_elem.hasClass('control-label-disabled'));
-    assert.equal($('#id_realm_invite_by_admins_only').prop('disabled'), false);
+    assert.equal($('#id_realm_invite_by_admins_only').attr('disabled'), false);
 }
 
 function test_disable_notifications_stream(disable_notifications_stream) {

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -82,23 +82,11 @@ exports.set_up = function () {
     });
 
     $("#enable_desktop_notifications").change(function () {
-        if (this.checked) {
-            $("#pm_content_in_desktop_notifications").prop("disabled", false);
-            $("#pm_content_in_desktop_notifications_label").parent().removeClass("control-label-disabled");
-        } else {
-            $("#pm_content_in_desktop_notifications").prop("disabled", true);
-            $("#pm_content_in_desktop_notifications_label").parent().addClass("control-label-disabled");
-        }
+        settings_ui.disable_sub_setting_onchange(this.checked, "pm_content_in_desktop_notifications", true);
     });
 
     $("#enable_offline_push_notifications").change(function () {
-        if (this.checked) {
-            $("#enable_online_push_notifications").prop("disabled", false);
-            $("#enable_online_push_notifications_label").parent().removeClass("control-label-disabled");
-        } else {
-            $("#enable_online_push_notifications").prop("disabled", true);
-            $("#enable_online_push_notifications_label").parent().addClass("control-label-disabled");
-        }
+        settings_ui.disable_sub_setting_onchange(this.checked, "enable_online_push_notifications", true);
     });
 };
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -408,23 +408,11 @@ function _set_up() {
     exports.set_add_emoji_permission_dropdown();
 
     $("#id_realm_invite_required").change(function () {
-        if (this.checked) {
-            $("#id_realm_invite_by_admins_only").prop("disabled", false);
-            $("#id_realm_invite_by_admins_only_label").parent().removeClass("control-label-disabled");
-        } else {
-            $("#id_realm_invite_by_admins_only").attr("disabled", true);
-            $("#id_realm_invite_by_admins_only_label").parent().addClass("control-label-disabled");
-        }
+        settings_ui.disable_sub_setting_onchange(this.checked, "id_realm_invite_by_admins_only", true);
     });
 
     $("#id_realm_allow_message_editing").change(function () {
-        if (this.checked) {
-            $("#id_realm_message_content_edit_limit_minutes").prop("disabled", false);
-            $("#id_realm_message_content_edit_limit_minutes_label").parent().removeClass("control-label-disabled");
-        } else {
-            $("#id_realm_message_content_edit_limit_minutes").attr("disabled", true);
-            $("#id_realm_message_content_edit_limit_minutes_label").parent().addClass("control-label-disabled");
-        }
+        settings_ui.disable_sub_setting_onchange(this.checked, "id_realm_message_content_edit_limit_minutes", true);
     });
 
     exports.save_organization_settings = function () {

--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -2,6 +2,23 @@ var settings_ui = (function () {
 
 var exports = {};
 
+// This function is used to disable sub-setting when main setting is checked or unchecked
+// or two settings are inter-dependent on their values values.
+// * is_checked is boolean, shows if the main setting is checked or not.
+// * sub_setting_id is sub setting or setting which depend on main setting,
+//   string id of setting.
+// * disable_on_uncheck is boolean, true if sub setting should be disabled
+//   when main setting unchecked.
+exports.disable_sub_setting_onchange = function (is_checked, sub_setting_id, disable_on_uncheck) {
+    if ((is_checked && disable_on_uncheck) || (!is_checked && !disable_on_uncheck)) {
+        $("#" + sub_setting_id).attr("disabled", false);
+        $("#" + sub_setting_id + "_label").parent().removeClass("control-label-disabled");
+    } else if ((is_checked && !disable_on_uncheck) || (!is_checked && disable_on_uncheck)) {
+        $("#" + sub_setting_id).attr("disabled", "disabled");
+        $("#" + sub_setting_id + "_label").parent().addClass("control-label-disabled");
+    }
+};
+
 return exports;
 }());
 

--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -1,0 +1,10 @@
+var settings_ui = (function () {
+
+var exports = {};
+
+return exports;
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = settings_ui;
+}

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -49,6 +49,7 @@ enforce_fully_covered = {
     'static/js/recent_senders.js',
     'static/js/rtl.js',
     'static/js/search_suggestion.js',
+    'static/js/settings_ui.js',
     'static/js/settings_user_groups.js',
     'static/js/stream_data.js',
     'static/js/stream_events.js',

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1130,7 +1130,8 @@ JS_SPECS = {
             'js/ui_init.js',
             'js/emoji_picker.js',
             'js/compose_ui.js',
-            'js/panels.js'
+            'js/panels.js',
+            'js/settings_ui.js'
         ],
         'output_filename': 'min/app.js'
     },


### PR DESCRIPTION
We have some settings which are inter dependent. If one setting
is checked or unchecked, it's dependent-sub-setting get disabled
or enabled. i.e. If user unchecked setting allow-message-editing
then message-editing-time-limit setting should get disabled in UI.

Add generic function to change `disable` attribute of sub-settings
on checked or unchecked event of main-setting.
