### PR TITLE
compose: Reply button becomes inactive when there are no messages.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -388,6 +388,10 @@ exports.on_narrow = function (opts) {
     // We use force_close when jumping between PM narrows with the "p" key,
     // so that we don't have an open compose box that makes it difficult
     // to cycle quickly through unread messages.
+
+    $("#left_bar_compose_reply_button_big").attr('disabled', false);
+    $("#left_bar_compose_reply_button_big").attr('title', 'Reply (r)');
+
     if (opts.force_close) {
         // This closes the compose box if it was already open, and it is
         // basically a noop otherwise.

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -442,6 +442,9 @@ exports.deactivate = function () {
     unnarrow_times = {start_time: new Date()};
     blueslip.debug("Unnarrowed");
 
+    $("#left_bar_compose_reply_button_big").attr('disabled', false);
+    $("#left_bar_compose_reply_button_big").attr('title', 'Reply (r)');
+
     if (ui.actively_scrolling()) {
         // There is no way to intercept in-flight scroll events, and they will
         // cause you to end up in the wrong place if you are actively scrolling
@@ -532,6 +535,9 @@ exports.restore_home_state = function () {
 };
 
 function pick_empty_narrow_banner() {
+    $("#left_bar_compose_reply_button_big").attr('disabled', 'disabled');
+    $("#left_bar_compose_reply_button_big").attr('title', 'There are no messages to reply to yet.');
+
     var default_banner = $('#empty_narrow_message');
 
     var current_filter = narrow_state.get_current_filter();


### PR DESCRIPTION
Fixes #8547 

**Testing Plan:** I used the developer tool and git grep to find area of the relevant code. Then, I used js to test different cases.
I disabled the `Reply` button when the `stream` or `topic` or `pm` is not having any message, which restores its normal behaviour when it encounters the same with messages or when we go to `Home`,

**GIFs or Screenshots:** 
![ezgif com-video-to-gif 9](https://user-images.githubusercontent.com/25428397/36937887-ee401bae-1f3f-11e8-81d0-f388668f7697.gif)

