### PR TITLE
default stream: Fix default stream suggestion do not include private stream.

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -417,7 +417,7 @@ zrequire('marked', 'third/marked/lib/marked');
     stream_data.add_sub('private_stream', private_stream);
 
     var names = stream_data.get_non_default_stream_names();
-    assert.deepEqual(names, ['public']);
+    assert.deepEqual(names, ['public', 'private']);
 }());
 
 (function test_delete_sub() {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -143,9 +143,6 @@ exports.get_non_default_stream_names = function () {
     subs = _.reject(subs, function (sub) {
         return exports.is_default_stream_id(sub.stream_id);
     });
-    subs = _.reject(subs, function (sub) {
-        return sub.invite_only;
-    });
     var names = _.pluck(subs, 'name');
     return names;
 };


### PR DESCRIPTION
**Issue:**
Private streams were not included in stream suggestions for default streams
in org settings.

Remove function, which exclude private streams from stream suggestions
for default streams.
[chat discussion](https://chat.zulip.org/#narrow/stream/9-issues/subject/default.20private.20stream).

NOTE: Private streams, to which org admin doesn't have access(isn't subscribed to), can not be added to default stream.