### PR TITLE
compose: Prepend space when text added at the end of textarea.

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -67,39 +67,39 @@ function make_textbox(s) {
     };
     compose_ui.insert_syntax_and_focus(':octopus:');
     assert.equal($('#compose-textarea').caret(), 4);
-    assert.equal($('#compose-textarea').val(), 'xyz :octopus:');
+    assert.equal($('#compose-textarea').val(), 'xyz :octopus: ');
     assert($("#compose-textarea").is_focused());
 
 }());
 
 (function test_smart_insert() {
-    var textbox = make_textbox('abc ');
+    var textbox = make_textbox('abc');
     textbox.caret(4);
 
     compose_ui.smart_insert(textbox, ':smile:');
     assert.equal(textbox.insert_pos, 4);
-    assert.equal(textbox.insert_text, ':smile:');
-    assert.equal(textbox.val(), 'abc :smile:');
+    assert.equal(textbox.insert_text, ' :smile: ');
+    assert.equal(textbox.val(), 'abc :smile: ');
     assert(textbox.focused);
 
     textbox.blur();
     compose_ui.smart_insert(textbox, ':airplane:');
-    assert.equal(textbox.insert_text, ' :airplane:');
-    assert.equal(textbox.val(), 'abc :smile: :airplane:');
+    assert.equal(textbox.insert_text, ':airplane: ');
+    assert.equal(textbox.val(), 'abc :smile: :airplane: ');
     assert(textbox.focused);
 
     textbox.caret(0);
     textbox.blur();
     compose_ui.smart_insert(textbox, ':octopus:');
     assert.equal(textbox.insert_text, ':octopus: ');
-    assert.equal(textbox.val(), ':octopus: abc :smile: :airplane:');
+    assert.equal(textbox.val(), ':octopus: abc :smile: :airplane: ');
     assert(textbox.focused);
 
     textbox.caret(textbox.val().length);
     textbox.blur();
     compose_ui.smart_insert(textbox, ':heart:');
-    assert.equal(textbox.insert_text, ' :heart:');
-    assert.equal(textbox.val(), ':octopus: abc :smile: :airplane: :heart:');
+    assert.equal(textbox.insert_text, ':heart: ');
+    assert.equal(textbox.val(), ':octopus: abc :smile: :airplane: :heart: ');
     assert(textbox.focused);
 
     // Note that we don't have any special logic for strings that are

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -21,11 +21,9 @@ exports.smart_insert = function (textarea, syntax) {
         }
     }
 
-    if (after_str.length > 0) {
-        if (!is_space(after_str[0])) {
+    if (!(after_str.length > 0 && is_space(after_str[0]))) {
             syntax += ' ';
         }
-    }
 
     textarea.focus();
 


### PR DESCRIPTION
This prepends a space when a text is inserted at the end using
`compose_ui.insert_syntax_and_focus`.

Fixes: #8569.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Updated node tests.
And manual testing for
* Emoji text
* Reply with hotkeys
* Reply with user popovers.
* Upload


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
