### PR TITLE
embedded bots: Dispatch all config data on update event.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4443,11 +4443,12 @@ def do_update_bot_config_data(bot_profile: UserProfile,
                               config_data: Dict[Text, Text]) -> None:
     for key, value in config_data.items():
         set_bot_config(bot_profile, key, value)
+    updated_config_data = get_bot_config(bot_profile)
     send_event(dict(type='realm_bot',
                     op='update',
                     bot=dict(email=bot_profile.email,
                              user_id=bot_profile.id,
-                             services = [dict(config_data=config_data)],
+                             services = [dict(config_data=updated_config_data)],
                              ),
                     ),
                bot_owner_user_ids(bot_profile))


### PR DESCRIPTION
Previously, when a user updated the config data of an
embedded bot, only the updated fields were dispatched
back to the client. Dispatching all config data fields
makes the client updating code less brittle.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
