### PR TITLE
i18n: Improvements in various translation-related areas.

### DIFF
--- a/docs/translating/spanish.md
+++ b/docs/translating/spanish.md
@@ -49,6 +49,8 @@ Zulip friendly and usable.
   *channel limited by invitation*)
 * Public stream - **Canal público**
 * Bot - **Bot**
+* Embedded bot - **Bot integrado**
+* Interactive bot - **Bot interactivo**
 * Integration - **Integración**
 * Notification - **Notificación**
 * Alert word - **Alerta**: this is only *alert*. Nonetheless, adding *word* may
@@ -58,6 +60,9 @@ Zulip friendly and usable.
 * Filter - **Filtro**: as used with narrowing (see below).
 * Home - **Inicio**: we never use the term "Hogar" (literally home) in Spanish.
 * Emoji - **Emoticono** (plural: **emoticonos**)
+* Slash command - **/comando**
+* Webhook - **Webhook**
+* Endpoint - **Endpoint**
 
 ## Frases
 * Subscribe/Unsubscribe to a stream - **Suscribir a/Desuscribir de un canal**

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -201,7 +201,7 @@
             {{/if}}
             <i class="icon-vector-question-sign signup_notification_stream_tooltip" data-toggle="tooltip"
                 {{#if new_user_bot_configured}}style="display:none" {{/if}}
-                title="{{t 'You must configured new user bot before setting a stream.' }}"/>
+                title="{{t 'You must configure a "new user" bot before setting a stream for signup notifications.' }}"/>
         </div>
 
     </form>

--- a/templates/zerver/home.html
+++ b/templates/zerver/home.html
@@ -100,8 +100,8 @@
 
         <p>
             {% trans %}
-            Learn more about starring messages at <a href="/help/star-a-message">
-            {{ realm_uri }}/help/star-a-message</a>.
+            Learn more about starring messages <a href="/help/star-a-message">
+            here</a>.
             {% endtrans %}
         </p>
     </div>
@@ -113,8 +113,8 @@
 
         <p>
             {% trans %}
-            Learn more about mentions at <a href="/help/at-mention-a-team-member">
-            {{ realm_uri }}/help/at-mention-a-team-member</a>.
+            Learn more about mentions <a href="/help/at-mention-a-team-member">
+            here</a>.
             {% endtrans %}
         </p>
     </div>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3070,12 +3070,12 @@ def do_add_streams_to_default_stream_group(realm: Realm, group: DefaultStreamGro
     for stream in streams:
         if stream in default_streams:
             raise JsonableError(_(
-                "'%(stream_name)s' is a default stream and cannot be added to '%(group.name)s'")
-                % {'stream_name': stream.name, 'group.name': group.name})
+                "'%(stream_name)s' is a default stream and cannot be added to '%(group_name)s'")
+                % {'stream_name': stream.name, 'group_name': group.name})
         if stream in group.streams.all():
             raise JsonableError(_(
-                "Stream '%(stream_name)s' is already present in default stream group '%(group.name)s'")
-                % {'stream_name': stream.name, 'group.name': group.name})
+                "Stream '%(stream_name)s' is already present in default stream group '%(group_name)s'")
+                % {'stream_name': stream.name, 'group_name': group.name})
         group.streams.add(stream)
 
     group.save()
@@ -3086,8 +3086,8 @@ def do_remove_streams_from_default_stream_group(realm: Realm, group: DefaultStre
     for stream in streams:
         if stream not in group.streams.all():
             raise JsonableError(_(
-                "Stream '%(stream_name)s' is not present in default stream group '%(group.name)s'")
-                % {'stream_name': stream.name, 'group.name': group.name})
+                "Stream '%(stream_name)s' is not present in default stream group '%(group_name)s'")
+                % {'stream_name': stream.name, 'group_name': group.name})
         group.streams.remove(stream)
 
     group.save()


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Various fixes related to i18n and user-facing strings.

Regarding 9528cf5, I haven't been able if the strings were being misinterpolated before the fix. However, Transifex didn't recognize them and I thought it could be of use anyways from a code formatting perspective (to make `group.name` look like `stream_name` references). Feel free to drop it if you feel like it's not necessary.

About URLs in translation tags (see [this](https://chat.zulip.org/#narrow/stream/58-translation/subject/urls.20in.20translation.20strings) for some context), I considered adding a linter check for `<a>` tags containing anything similar to a path. However, I think it would be a source of many fake positives (e.g. `<a>Do this/that</a>` looks like a path too), so it may be just worth keeping in mind for future reviews.

**Testing Plan:** <!-- How have you tested? -->
Full test suite passed in my Travis CI instance.