### PR TITLE
compose: Changes to make "Sending..." appear on the right of "Drafts"

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -390,13 +390,10 @@ input.recipient_box {
 }
 
 #sending-indicator {
-    float: left;
+    top: 2px;
+    position: relative;
     font-weight: bold;
-    display: none;
-}
-
-#sending-indicator {
-    padding-top: 2px;
+    display: inline-block;
 }
 
 #compose a.message-control-button {


### PR DESCRIPTION

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
fixes: #8570

**Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![screenshot from 2018-03-05 14-08-26](https://user-images.githubusercontent.com/20434085/36965144-cc170c1e-207e-11e8-94f0-d90f1d0aac7c.png)

Removed `float:left` css property from "Sending..." and used `inline-block` to `display` instead of `block`.