### PR TITLE
Fix: broken link zulip/zulipbot

### DIFF
--- a/docs/contributing/zulipbot-usage.md
+++ b/docs/contributing/zulipbot-usage.md
@@ -94,7 +94,7 @@ label "travis updates"`, and **@zulipbot** will let you know the build status
 ### Contributing
 
 If you wish to help develop and contribute to **@zulipbot**, check out the
-[zulip/zulipbot](https:/github.com/zulip/zulipbot) repository on GitHub and read
+[zulip/zulipbot](https://github.com/zulip/zulipbot) repository on GitHub and read
 the project's [contributing
 guidelines](https://github.com/zulip/zulipbot/blob/master/.github/CONTRIBUTING.md) for
 more information.


### PR DESCRIPTION
The broken link for zulipbot repo fixed in contributing section of [Using Zulipbot](https://zulip.readthedocs.io/en/latest/contributing/zulipbot-usage.html#usage) page.