### PR TITLE
Allow embedded bots for recurse.zulipchat.com.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -730,7 +730,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
             UserProfile.INCOMING_WEBHOOK_BOT,
             UserProfile.OUTGOING_WEBHOOK_BOT,
         ]
-        if settings.EMBEDDED_BOTS_ENABLED:
+        if settings.EMBEDDED_BOTS_ENABLED or self.realm.subdomain == 'recurse':
             allowed_bot_types.append(UserProfile.EMBEDDED_BOT)
         return allowed_bot_types
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -286,7 +286,7 @@ def add_bot_backend(
     form = CreateUserForm({'full_name': full_name, 'email': email})
 
     if bot_type == UserProfile.EMBEDDED_BOT:
-        if not settings.EMBEDDED_BOTS_ENABLED:
+        if not (settings.EMBEDDED_BOTS_ENABLED or user_profile.realm.subdomain == 'recurse'):
             return json_error(_("Embedded bots are not enabled."))
         if service_name not in [bot.name for bot in EMBEDDED_BOTS]:
             return json_error(_("Invalid embedded bot name."))


### PR DESCRIPTION
I tested this by verifying that it doesn't break in the dev server. However, I cannot verify if this will actually enable embedded bots on Recurse.