### PR TITLE
Clean function to update message-topic-edit-pencil.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -39,9 +39,12 @@ set_global('settings_account', {
 
 set_global('settings_org', {
     reset_realm_default_language: noop,
-    update_message_topic_editing_pencil: noop,
     update_message_retention_days: noop,
     update_realm_description: noop,
+});
+
+set_global('message_edit', {
+    update_message_topic_editing_pencil: noop,
 });
 
 // page_params is highly coupled to dispatching now

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -39,7 +39,7 @@ set_global('settings_account', {
 
 set_global('settings_org', {
     reset_realm_default_language: noop,
-    toggle_allow_message_editing_pencil: noop,
+    update_message_topic_editing_pencil: noop,
     update_message_retention_days: noop,
     update_realm_description: noop,
 });

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -37,7 +37,6 @@ set_global('templates', {
     settings_org.reset();
     settings_org.populate_realm_domains();
     settings_org.reset_realm_default_language();
-    settings_org.update_message_topic_editing_pencil();
     settings_org.update_realm_description();
     settings_org.update_message_retention_days();
     settings_org.populate_auth_methods();

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -37,7 +37,7 @@ set_global('templates', {
     settings_org.reset();
     settings_org.populate_realm_domains();
     settings_org.reset_realm_default_language();
-    settings_org.toggle_allow_message_editing_pencil();
+    settings_org.update_message_topic_editing_pencil();
     settings_org.update_realm_description();
     settings_org.update_message_retention_days();
     settings_org.populate_auth_methods();

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -129,6 +129,14 @@ exports.save = function (row, from_topic_edited_only) {
     // The message will automatically get replaced via message_list.update_message.
 };
 
+exports.update_message_topic_editing_pencil = function () {
+    if (page_params.realm_allow_message_editing) {
+        $(".on_hover_topic_edit, .always_visible_topic_edit").show();
+    } else {
+        $(".on_hover_topic_edit, .always_visible_topic_edit").hide();
+    }
+};
+
 function handle_edit_keydown(from_topic_edited_only, e) {
     var row;
     var code = e.keyCode || e.which;

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -79,11 +79,9 @@ function add_display_time(group, message_container, prev) {
 }
 
 function set_topic_edit_properties(group, message) {
+    group.realm_allow_message_editing = page_params.realm_allow_message_editing;
     group.always_visible_topic_edit = false;
     group.on_hover_topic_edit = false;
-    if (!page_params.realm_allow_message_editing) {
-        return;
-    }
 
     // Messages with no topics should always have an edit icon visible
     // to encourage updating them. Admins can also edit any topic.

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -94,7 +94,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             _.each(event.data, function (value, key) {
                 page_params['realm_' + key] = value;
                 if (key === 'allow_message_editing') {
-                    settings_org.toggle_allow_message_editing_pencil();
+                    settings_org.update_message_topic_editing_pencil();
                 }
             });
             if (event.data.authentication_methods !== undefined) {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -94,7 +94,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             _.each(event.data, function (value, key) {
                 page_params['realm_' + key] = value;
                 if (key === 'allow_message_editing') {
-                    settings_org.update_message_topic_editing_pencil();
+                    message_edit.update_message_topic_editing_pencil();
                 }
             });
             if (event.data.authentication_methods !== undefined) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -70,7 +70,7 @@ exports.reset_realm_default_language = function () {
     $("#id_realm_default_language").val(page_params.realm_default_language);
 };
 
-exports.toggle_allow_message_editing_pencil = function () {
+exports.update_message_topic_editing_pencil = function () {
     if (!meta.loaded) {
         return;
     }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -71,11 +71,11 @@ exports.reset_realm_default_language = function () {
 };
 
 exports.update_message_topic_editing_pencil = function () {
-    if (!meta.loaded) {
-        return;
+    if (page_params.realm_allow_message_editing) {
+        $(".on_hover_topic_edit, .always_visible_topic_edit").show();
+    } else {
+        $(".on_hover_topic_edit, .always_visible_topic_edit").hide();
     }
-
-    $(".on_hover_topic_edit").toggle();
 };
 
 exports.update_realm_description = function () {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -70,14 +70,6 @@ exports.reset_realm_default_language = function () {
     $("#id_realm_default_language").val(page_params.realm_default_language);
 };
 
-exports.update_message_topic_editing_pencil = function () {
-    if (page_params.realm_allow_message_editing) {
-        $(".on_hover_topic_edit, .always_visible_topic_edit").show();
-    } else {
-        $(".on_hover_topic_edit, .always_visible_topic_edit").hide();
-    }
-};
-
 exports.update_realm_description = function () {
     if (!meta.loaded) {
         return;

--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -33,15 +33,12 @@
             </span><span class="recipient_bar_controls no-select">
                 {{! edit subject pencil icon }}
                 {{#if always_visible_topic_edit}}
-                    <i class="icon-vector-pencil always_visible_topic_edit"></i>
+                    <i class="icon-vector-pencil always_visible_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>
                 {{else}}
                     {{#if on_hover_topic_edit}}
-                    <i class="icon-vector-pencil on_hover_topic_edit"></i>
-                    {{else}}
-                    <i class="icon-vector-pencil on_hover_topic_edit" style="display: none"></i>
+                    <i class="icon-vector-pencil on_hover_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>
                     {{/if}}
                 {{/if}}
-
                 {{! exterior links (e.g. to a trac ticket) }}
                 {{#each subject_links}}
                 <a href="{{this}}" target="_blank" class="no-underline">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR cleans the function to update message-topic-edit-icon in message row header. 
Following issues/tasks are addressed in PR:

**static/js/settings_org.js: Rename func which updates msg-topic-edit-pencil.**
    
    Rename `toggle_allow_message_editing_pencil` to
    `update_message_topic_editing_pencil` in `settings_org.js`.
    As this function update the pencil icon for updating message
    topic in message row header.

**message editing: Clean update msg-topic-edit-icon function.**
    
    `update_message_topic_editing_pencil` function update edit
    icon for message topic in message row header.
    
    - Remove erroneous `meta.loaded` check.
    - Add proper check of message editing permission in realm
      before updating message-topic-edit-icon in function.
    - Update `always-visible-topic-edit` element in function
      simultaneously.

 **message editing: Move update msg-topic-edit-icon func to `message_edit.js`.**
    
    Move function `update_message_topic_editing_pencil` to file
    `message_edit.js` from `settings_org.js`.

 **message editing: Fix bugs in `recipient-row` template rendering.**
    
    In `recipient-row` template, if conditions to add/hide/show edit
    icon for message topic is incorrect.
    In some cases, we only want to just hide the edit icon, but icon
    should be in DOM, cause in future if organization settings are
    changed we want to show edit icon in message row.
    
    If user can edit topic of message, surely add edit icon element to
    DOM regardless of user is allowed to edit or not. If user is
    allowed to edit then show edit icon otherwise hide edit icon element.


**Testing**
This is the ideal behavior, for message-topic-edit icon in message row header:
- Messages which doesn't have any topic should have "always visible edit icon", if message editing is allowed in org.
- Admins should have "on hover visible edit icon" for all messages, if message editing is allowed in org.
- All clients messages rows should get updated on change of org setting, without reloading browser.