### PR TITLE
Change red buttons to black.

### DIFF
--- a/static/templates/admin_filter_list.handlebars
+++ b/static/templates/admin_filter_list.handlebars
@@ -8,7 +8,7 @@
     </td>
     {{#if ../can_modify}}
     <td>
-        <button class="button small delete btn-danger" data-filter-id="{{id}}">
+        <button class="button small delete" data-filter-id="{{id}}">
             <i class="icon-vector-trash" aria-hidden="true"></i>
         </button>
     </td>

--- a/static/templates/admin_invites_list.handlebars
+++ b/static/templates/admin_invites_list.handlebars
@@ -13,10 +13,10 @@
         <span class="invited_at">{{invited}}</span>
     </td>
     <td>
-        <button class="button rounded small revoke btn-danger" data-invite-id="{{id}}">
+        <button class="button rounded small revoke" data-invite-id="{{id}}">
             {{t "Revoke" }}
         </button>
-        <button class="button rounded small resend btn-warning" data-invite-id="{{id}}">
+        <button class="button rounded small resend" data-invite-id="{{id}}">
             {{t "Resend" }}
         </button>
     </td>

--- a/static/templates/admin_profile_field_list.handlebars
+++ b/static/templates/admin_profile_field_list.handlebars
@@ -11,10 +11,10 @@
     </td>
     {{#if ../can_modify}}
     <td>
-        <button class="button rounded small delete btn-danger" title="{{t 'Delete' }}" data-profile-field-id="{{id}}">
+        <button class="button rounded small delete" title="{{t 'Delete' }}" data-profile-field-id="{{id}}">
             <i class="icon-vector-trash"></i>
         </button>
-        <button class="button rounded small btn-warning open-edit-form" title="{{t 'Edit' }}" data-profile-field-id="{{id}}">
+        <button class="button rounded small open-edit-form" title="{{t 'Edit' }}" data-profile-field-id="{{id}}">
             <i class="icon-vector-pencil"></i>
         </button>
     </td>
@@ -35,7 +35,7 @@
                 <button type="button" class="button rounded sea-green submit">
                     {{t 'Save changes' }}
                 </button>
-                <button type="button" class="button rounded btn-danger reset">
+                <button type="button" class="button rounded reset">
                     {{t 'Cancel' }}
                 </button>
             </div>

--- a/static/templates/alert_word_settings_item.handlebars
+++ b/static/templates/alert_word_settings_item.handlebars
@@ -24,7 +24,7 @@
             <span class="value">{{word}}</span>
         </div>
         <div class="edit-alert-word-buttons">
-            <button type="submit" class="button small btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
+            <button type="submit" class="button small remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
                 <i class="icon-vector-trash"></i>
             </button>
         </div>

--- a/static/templates/settings/organization-profile-admin.handlebars
+++ b/static/templates/settings/organization-profile-admin.handlebars
@@ -36,7 +36,7 @@
                 <button class="button rounded sea-green w-200 block input-size"
                   id="realm_icon_upload_button">{{t 'Upload new icon' }}</button>
                 <div id="realm_icon_file_input_error" class="text-error"></div>
-                <button class="button rounded btn-danger w-200 m-t-10 block input-size"
+                <button class="button rounded w-200 m-t-10 block input-size"
                   id="realm_icon_delete_button">{{t 'Delete icon' }}</button>
             </div>
         </div>

--- a/static/templates/settings/resend-invite-modal.handlebars
+++ b/static/templates/settings/resend-invite-modal.handlebars
@@ -8,6 +8,6 @@
     </div>
     <div class="modal-footer">
         <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-        <button class="button rounded btn-danger" id="do_resend_invite_button" data-invite-id="{{invite_id}}">{{t "Resend now" }}</button>
+        <button class="button rounded" id="do_resend_invite_button" data-invite-id="{{invite_id}}">{{t "Resend now" }}</button>
     </div>
 </div>

--- a/static/templates/settings/revoke-invite-modal.handlebars
+++ b/static/templates/settings/revoke-invite-modal.handlebars
@@ -8,6 +8,6 @@
     </div>
     <div class="modal-footer">
         <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-        <button class="button rounded btn-danger" id="do_revoke_invite_button">{{t "Revoke now" }}</button>
+        <button class="button rounded" id="do_revoke_invite_button">{{t "Revoke now" }}</button>
     </div>
 </div>

--- a/static/templates/stream_member_list_entry.handlebars
+++ b/static/templates/stream_member_list_entry.handlebars
@@ -5,7 +5,7 @@
     <td class="unsubscribe">
         <div class="subscriber_list_remove">
             <form class="form-inline remove-subscriber-form">
-                <button type="submit" name="unsubscribe" class="remove-subscriber-button button small rounded btn-danger">
+                <button type="submit" name="unsubscribe" class="remove-subscriber-button button small rounded">
                     {{t 'Unsubscribe' }}
                 </button>
             </form>

--- a/templates/zerver/delete_message.html
+++ b/templates/zerver/delete_message.html
@@ -11,6 +11,6 @@
     </div>
     <div class="modal-footer">
         <button class="button rounded" data-dismiss="modal">{{ _("Cancel") }}</button>
-        <button class="button rounded btn-danger" id="do_delete_message_button">{{ _("Yes, delete this message") }}</button>
+        <button class="button rounded" id="do_delete_message_button">{{ _("Yes, delete this message") }}</button>
     </div>
 </div>


### PR DESCRIPTION
Remove unwanted 'btn-danger' class in buttons.

**Read the discussion in PR #8556.**

Tested on local development server successfully.

@timabbott I've removed almost all instances of 'btn-danger'. I went through the docs looking some kind of a coloring scheme for various kinds of buttons but couldn't find anything. So I felt using red for any button isn't appropriate unless we decide on some sort of a coloring scheme, and I'm unaware of any existing coloring scheme which is currently being used by zulip, so please do let me know if there is any.