### PR TITLE
popovers: Fix issue with user-info-popover in legacy mention messages.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -509,13 +509,21 @@ exports.register_click_handlers = function () {
 
     $("#main_div").on("click", ".user-mention", function (e) {
         var id = $(this).attr('data-user-id');
-        if (id === '*') {
+        // We fallback to email to handle legacy markdown that was rendered
+        // before we cut over to using data-user-id
+        var email = $(this).attr('data-user-email');
+        if (id === '*' || email === '*') {
             return;
         }
         var row = $(this).closest(".message_row");
         e.stopPropagation();
         var message = current_msg_list.get(rows.id(row));
-        var user = people.get_person_from_user_id(id);
+        var user;
+        if (id) {
+            user = people.get_person_from_user_id(id);
+        } else {
+            user = people.get_by_email(email);
+        }
         show_user_info_popover(this, user, message);
     });
 


### PR DESCRIPTION
We fallback to using data-user-email attrib for mention messages
from the times when we use to expose user emails to frontend.
This is only required for cases where we are dealing with anything
that isn't rendered dynamically (like the messages that were already
sent and stored long time ago). Hopefully we won't be needing this
kind of fallback logic in more places so I am putting off efforts
to try to extract fallback logic for common use. Also this is like
this because it will probably be tricky to extract out a common
fallback logic in this case because of different situations involved.

Fixes: #8588.