### PR TITLE
compose: Improve error message for mentioning a user who isn't subscr…

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -469,6 +469,13 @@ a#undo_markdown_preview {
     margin: auto;
 }
 
+@media (max-width: 1300px) {
+    .compose_invite_user_controls {
+        float: none;
+        margin-top: 10px;
+    }
+}
+
 @media (max-width: 700px) {
     #compose_buttons .compose_reply_button {
         display: none;

--- a/static/templates/compose-invite-users.handlebars
+++ b/static/templates/compose-invite-users.handlebars
@@ -1,7 +1,8 @@
 <div class="compose_invite_user" data-useremail="{{email}}">
-    {{#tr this}}<strong>__name__</strong> is not subscribed to this stream.{{/tr}}
+    <span class="compose_invite_close close">&times;</span>
+    {{#tr this}}<strong>__name__</strong> is not subscribed to this stream. They will not be notified if you mention them here.{{/tr}}
     <div class="compose_invite_user_controls">
         <span class="compose_invite_user_error alert alert-error" style="display: none;">{{t "Unable to subscribe user" }}</span>
-        <button href="" class="btn btn-warning compose_invite_link" >{{t "Subscribe" }}</button><button type="button" class="compose_invite_close close">&times;</button>
+        <button href="" class="btn btn-warning compose_invite_link" >{{t "Subscribe" }}</button>
     </div>
 </div>


### PR DESCRIPTION
Fixes: #8550  Changed error message and styled it according to different screen sizes
![screenshot from 2018-03-06 16-21-27](https://user-images.githubusercontent.com/22816171/37029123-49ff33d0-215c-11e8-8bba-6c3f0c4ab403.png)
![screenshot from 2018-03-06 16-21-46](https://user-images.githubusercontent.com/22816171/37029125-4dedf940-215c-11e8-93fa-5963e27d3f65.png)
![screenshot from 2018-03-06 16-22-18](https://user-images.githubusercontent.com/22816171/37029130-505f92d8-215c-11e8-8042-dd7f156f1436.png)
