### PR TITLE
Fix clipping of stream and topic name in left sidebar

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -319,11 +319,10 @@ ul.filters li.out_of_home_view li.muted_topic {
 
     text-overflow: ellipsis;
     white-space: nowrap;
-    overflow: hidden;
+    overflow: visible;
 
     line-height: 1.1;
     position: relative;
-    top: 3px;
 }
 
 #stream_filters .subscription_block.stream-with-count {


### PR DESCRIPTION
Changed the rule for text overflow, that clipped stream and topic name in the left sidebar.

I changed the rule of text overflowing and deleted "top" property to align it properly.  

Fixes #8209.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Three conditions that trigger this issue:

1. Using Chrome and zoomed in at 125%
2. Using Chrome and zoomed out at 90%
3. Using Firefox, with not zoomed in or out (100%)

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Was:
![screenshot from 2018-03-06 14-51-08](https://user-images.githubusercontent.com/10120566/37033267-0f347f84-214e-11e8-8bd7-395641970ba6.png)

Now:
![screenshot from 2018-03-06 14-51-31](https://user-images.githubusercontent.com/10120566/37033273-1407e28a-214e-11e8-8f68-ed557c99529f.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
