### PR TITLE
compose: Improve error message for mentioning unsubscribed users.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -202,13 +202,18 @@ table.compose_table {
 }
 
 .compose_invite_user,
-.compose_private_stream_alert {
+.compose_private_stream_alert,
+.compose-all-everyone,
+.compose-announce {
     padding: 4px 0px 4px 0px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .compose_invite_close,
 .compose_private_stream_alert_close {
-    display: inline;
+    display: inline-block;
     margin-top: 4px;
 
     width: 10px;
@@ -219,10 +224,13 @@ table.compose_table {
 .compose_invite_user_controls,
 .compose_private_stream_alert_controls {
     float: right;
-    -webkit-transform: translateY(-13%);
-    -ms-transform: translateY(-13%);
-    -o-transform: translateY(-13%);
-    transform: translateY(-13%);
+    position: relative;
+}
+
+.compose_invite_user p {
+    margin: 0px;
+    display: inline-block;
+    max-width: calc(100% - 100px);
 }
 
 .compose_invite_user_error {

--- a/static/templates/compose-invite-users.handlebars
+++ b/static/templates/compose-invite-users.handlebars
@@ -1,5 +1,5 @@
 <div class="compose_invite_user" data-useremail="{{email}}">
-    {{#tr this}}<strong>__name__</strong> is not subscribed to this stream.{{/tr}}
+    {{#tr this}}<strong>__name__</strong> is not subscribed to this stream. They will not be notified if you mention them here.{{/tr}}
     <div class="compose_invite_user_controls">
         <span class="compose_invite_user_error alert alert-error" style="display: none;">{{t "Unable to subscribe user" }}</span>
         <button href="" class="btn btn-warning compose_invite_link" >{{t "Subscribe" }}</button><button type="button" class="compose_invite_close close">&times;</button>

--- a/static/templates/compose-invite-users.handlebars
+++ b/static/templates/compose-invite-users.handlebars
@@ -1,7 +1,7 @@
 <div class="compose_invite_user" data-useremail="{{email}}">
-    {{#tr this}}<strong>__name__</strong> is not subscribed to this stream. They will not be notified if you mention them here.{{/tr}}
+    <p>{{#tr this}}<strong>__name__</strong> is not subscribed to this stream. They will not be notified if you mention them here.{{/tr}}</p>
     <div class="compose_invite_user_controls">
         <span class="compose_invite_user_error alert alert-error" style="display: none;">{{t "Unable to subscribe user" }}</span>
-        <button href="" class="btn btn-warning compose_invite_link" >{{t "Subscribe" }}</button><button type="button" class="compose_invite_close close">&times;</button>
+        <button class="btn btn-warning compose_invite_link" >{{t "Subscribe" }}</button><button type="button" class="compose_invite_close close">&times;</button>
     </div>
 </div>

--- a/static/templates/compose_private_stream_alert.handlebars
+++ b/static/templates/compose_private_stream_alert.handlebars
@@ -1,5 +1,5 @@
 <div class="compose_private_stream_alert" data-stream_name="{{stream_name}}">
-    {{#tr this}}Warning: <strong>__stream_name__</strong> is a private stream.{{/tr}}
+    <span>{{#tr this}}Warning: <strong>__stream_name__</strong> is a private stream.{{/tr}}</span>
     <div class="compose_private_stream_alert_controls">
         <button type="button" class="compose_private_stream_alert_close close">&times;</button>
     </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #8550

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![screenshot at mar 05 20-48-15](https://user-images.githubusercontent.com/15116870/37045832-b47826fe-211b-11e8-8852-e3b0eb079a89.png)
![screenshot at mar 05 20-48-03](https://user-images.githubusercontent.com/15116870/37045833-b4996936-211b-11e8-81c5-3a8dde5d3eeb.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
