### PR TITLE
css: Allow the bot API key to be selected on all browsers.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -59,6 +59,14 @@ a {
     user-select: auto;
 }
 
+.text-select {
+    -webkit-touch-callout: text;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
+}
+
 p.n-margin {
     margin: 10px 0px 0px 0px;
 }

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -31,8 +31,8 @@
         <div class="api_key">
             <span class="field">{{t "API key" }}</span>
             <span class="api-key-value-and-button no-select">
-                <!-- have the `.auto-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
-                <span class="value auto-select">{{api_key}}</span>
+                <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
+                <span class="value text-select">{{api_key}}</span>
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-email="{{email}}">
                     <i class="icon-vector-refresh"></i>
                 </button>


### PR DESCRIPTION
@XavierCooney: Thanks a lot for working on this! This is a feature I personally was looking forward to getting merged, so I just rebased this in favour of #8053. :)

@timabbott: Could you please merge this and close #8053? :) 