### PR TITLE
bots: Sync data on bot ownership change.

### DIFF
--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -104,6 +104,19 @@ assert.equal(bot_data.get(314).full_name, 'Outgoing webhook');
         assert.equal(bot.is_active, false);
     }());
 
+    (function test_delete() {
+        var bot;
+
+        bot_data.add(_.extend({}, test_bot, {is_active: true}));
+
+        bot = bot_data.get(43);
+        assert.equal('Bot 1', bot.full_name);
+        assert(bot.is_active);
+        bot_data.delete(43);
+        bot = bot_data.get(43);
+        assert.equal(bot, undefined);
+    }());
+
     (function test_owner_can_admin() {
         var bot;
 

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -225,6 +225,15 @@ var event_fixtures = {
         },
     },
 
+    realm_bot__delete: {
+        type: 'realm_bot',
+        op: 'delete',
+        bot: {
+            email: 'the-bot@example.com',
+            user_id: '42',
+        },
+    },
+
     realm_bot__update: {
         type: 'realm_bot',
         op: 'update',
@@ -601,6 +610,19 @@ with_overrides(function (override) {
             dispatch(event);
             var args = bot_stub.get_args('user_id');
             assert_same(args.user_id, event.bot.user_id);
+
+            admin_stub.get_args('update_user_id', 'update_bot_data');
+        });
+    });
+
+    event = event_fixtures.realm_bot__delete;
+    global.with_stub(function (bot_stub) {
+        global.with_stub(function (admin_stub) {
+            override('bot_data.delete', bot_stub.f);
+            override('settings_users.update_user_data', admin_stub.f);
+            dispatch(event);
+            var args = bot_stub.get_args('bot_id');
+            assert_same(args.bot_id, event.bot.user_id);
 
             admin_stub.get_args('update_user_id', 'update_bot_data');
         });

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -40,6 +40,12 @@ var bot_data = (function () {
         send_change_event();
     };
 
+    exports.delete = function bot_data__delete(bot_id) {
+        delete bots[bot_id];
+        delete services[bot_id];
+        send_change_event();
+    };
+
     exports.update = function bot_data__update(bot_id, bot_update) {
         var bot = bots[bot_id];
         _.extend(bot, _.pick(bot_update, bot_fields));

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -118,6 +118,9 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             bot_data.deactivate(event.bot.user_id);
             event.bot.is_active = false;
             settings_users.update_user_data(event.bot.user_id, event.bot);
+        } else if (event.op === 'delete') {
+            bot_data.delete(event.bot.user_id);
+            settings_users.update_user_data(event.bot.user_id, event.bot);
         } else if (event.op === 'update') {
             if (_.has(event.bot, 'owner_id')) {
                 event.bot.owner = people.get_person_from_user_id(event.bot.owner_id).email;

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -376,6 +376,10 @@ def apply_event(state: Dict[str, Any],
                 if bot['email'] == email:
                     bot['is_active'] = False
 
+        if event['op'] == 'delete':
+            state['realm_bots'] = [item for item
+                                   in state['realm_bots'] if item['email'] != event['bot']['email']]
+
         if event['op'] == 'update':
             for bot in state['realm_bots']:
                 if bot['email'] == event['bot']['email']:


### PR DESCRIPTION
Fixes #8577.

The issue mentioned above occurs in case of non-admin users as the bot hasn't been added to their bot_data. Also the bots for which ownership was changed were not being updated in real time for the non-admin users. For admin users, they already have the bot added, so everything works fine there.

**Approach taken:**
- Add event is sent to the new bot owner in order to add the bot. Delete event is sent to the previous bot owner to remove the bot.
- New event delete is added to remove the bot from data instead of deactivating it.
- The existing `remove` sets the bot status to inactive if the bot is deleted. A non-admin user's bot_data contains only those bots that the user owns. Using the existing `remove` would have just set the bot to inactive, which is not the case and the bot should be removed from bot data.
- In case of admins however, the bot data contains all the bots. Sending an add/delete event to admins would cause the same error being reported, but this time in case of admins.
