### PR TITLE
compose: Fix "New Topic" button behaviour auto-populates the current …

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -193,7 +193,7 @@ exports.start = function (msg_type, opts) {
     opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
     // If we are invoked by a compose hotkey (c or C), do not assume that we know
     // what the message's topic or PM recipient should be.
-    if (opts.trigger === "compose_hotkey") {
+    if ((opts.trigger === "compose_hotkey") || (opts.trigger === "new topic button")) {
         opts.subject = '';
         opts.private_message_recipient = '';
     }


### PR DESCRIPTION
…topic.

Previously, Clicking a "New Topic" in a topic narrow auto-populates
the current topic.

Fixes #8608.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Test it by clicking a Clicking a "New Topic" button in a topic narrow

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![new-topic](https://user-images.githubusercontent.com/22166422/37074125-25660ff4-21f1-11e8-9a47-e7e6419cddbd.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
