### PR TITLE
Fix clipping of stream and topic name in left sidebar

### DIFF
--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -321,9 +321,9 @@ ul.filters li.out_of_home_view li.muted_topic {
     white-space: nowrap;
     overflow: hidden;
 
-    line-height: 1.1;
+    line-height: 1.2;
     position: relative;
-    top: 3px;
+    top: 4px;
 }
 
 #stream_filters .subscription_block.stream-with-count {


### PR DESCRIPTION
Changed a little bit the rule for line-height and top, so now it does not clip "g" letter in of stream and topic name in the left sidebar. 

Fixes #8209.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Three conditions that trigger this issue:

Using Chrome and zoomed in at 125%
Using Chrome and zoomed out at 90%
Using Firefox, with not zoomed in or out (100%)

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Was:
![37033267-0f347f84-214e-11e8-8bd7-395641970ba6](https://user-images.githubusercontent.com/10120566/37084732-f5b4356e-21fb-11e8-8c1f-800ffdec8de1.png)

Now:
![37033273-1407e28a-214e-11e8-8f68-ed557c99529f](https://user-images.githubusercontent.com/10120566/37084739-fa72bdaa-21fb-11e8-85ee-4fcf49e9dd28.png)
![screenshot from 2018-03-07 11-28-06](https://user-images.githubusercontent.com/10120566/37084748-fee42ff4-21fb-11e8-8646-741fbc978a16.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
