### PR TITLE
notifications: Clean and automate global notifications update handler.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -658,28 +658,8 @@ exports.handle_global_notification_updates = function (notification_name, settin
     // Update the global settings checked when determining if we should notify
     // for a given message. These settings do not affect whether or not a
     // particular stream should receive notifications.
-    if (notification_name === "enable_stream_desktop_notifications") {
-        page_params.enable_stream_desktop_notifications = setting;
-    } else if (notification_name === "enable_stream_push_notifications") {
-        page_params.enable_stream_push_notifications = setting;
-    } else if (notification_name === "enable_stream_sounds") {
-        page_params.enable_stream_sounds = setting;
-    } else if (notification_name === "enable_desktop_notifications") {
-        page_params.enable_desktop_notifications = setting;
-    } else if (notification_name === "enable_sounds") {
-        page_params.enable_sounds = setting;
-    } else if (notification_name === "enable_offline_email_notifications") {
-        page_params.enable_offline_email_notifications = setting;
-    } else if (notification_name === "enable_offline_push_notifications") {
-        page_params.enable_offline_push_notifications = setting;
-    } else if (notification_name === "enable_online_push_notifications") {
-        page_params.enable_online_push_notifications = setting;
-    } else if (notification_name === "enable_digest_emails") {
-        page_params.enable_digest_emails = setting;
-    } else if (notification_name === "pm_content_in_desktop_notifications") {
-        page_params.pm_content_in_desktop_notifications = setting;
-    } else if (notification_name === "realm_name_in_notifications") {
-        page_params.realm_name_in_notifications = setting;
+    if (settings_notifications.notification_settings.indexOf(notification_name) !== -1) {
+        page_params[notification_name] = setting;
     }
 };
 

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -22,7 +22,7 @@ var other_notification_settings = [
     "realm_name_in_notifications",
 ];
 
-var notification_settings = other_notification_settings.concat(
+exports.notification_settings = other_notification_settings.concat(
     pm_mention_notification_settings,
     _.map(stream_notification_settings, function (item) {
         return item.setting;
@@ -91,7 +91,7 @@ exports.set_up = function () {
 };
 
 function _update_page() {
-    _.each(notification_settings, function (setting) {
+    _.each(exports.notification_settings, function (setting) {
         $("#" + setting).prop('checked', page_params[setting]);
     });
 }


### PR DESCRIPTION
To prevent specifying notifications individually for global
updates, automate handle_global_notification_updates using
settings_notifications.notification_settings where we have
the keys of all the types of notifications.

Manual testing: If the previous state of a notification setting is disabled and then we enable it, so checkbox input should remain enabled if this isn't working then it will get uncheck again because page_params aren't updated and we called `settings_notifications.update_page();` in "server_event_dispatch.js" because of an event for it.
