### PR TITLE
pills: Improve style of placeholder texts in pills. 

### DIFF
--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -96,7 +96,7 @@
     opacity: 0.5;
 }
 
-.pm_recipient .pill-container .pill + .input:empty::before {
+.pm_recipient .pill-container .pill + .input:focus:empty::before {
     content: attr(data-some-recipients-text);
     opacity: 0.5;
 }

--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -91,7 +91,7 @@
     height: 20px;
 }
 
-.pm_recipient .pill-container .input:empty::before {
+.pm_recipient .pill-container .input:first-child:empty::before {
     content: attr(data-no-recipients-text);
     opacity: 0.5;
 }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR improves placeholder text styles, fixes #8622 

**pills: Show data-some-recipients placeholder text only on focus.**
    
    Show data-some-recipients placeholder text only when input
    element to add recipients is focused.
    
    Fixes #8622

**pills: Show data-no-recipients text only if no recipients selected.**
    
    Currently, we shows data-no-recipients placeholder text even if
    there are recipients selected. It's not visible cause it's value
    is override by data-some-recipients helper text in case if there
    are recipients selected.
    
    Show data-no-recipients placeholder text only when `input` element
    is first child of `pill-container`, which means there are no `pills`
    selected by user yet.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![pillsplaceholder](https://user-images.githubusercontent.com/25907420/37169411-d077ee98-232d-11e8-8e17-a7746543e8d5.gif)
