### PR TITLE
compose: Don't warn if mentioned stream members form a superset.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1135,10 +1135,14 @@ function test_raw_file_drop(raw_drop_func) {
 
     (function test_stream_name_completed_triggered() {
         var handler = $(document).get_on_handler('streamname_completed.zulip');
+        stream_data.add_sub(compose_state.stream_name(), {
+            subscribers: Dict.from_array([1, 2]),
+        });
 
         var data = {
             stream: {
                 name: 'Denmark',
+                subscribers: Dict.from_array([1, 2, 3]),
             },
         };
 
@@ -1150,6 +1154,9 @@ function test_raw_file_drop(raw_drop_func) {
         }
 
         test_noop_case(false);
+        // invite_only=true and current compose stream subscribers are a subset
+        // of mentioned_stream subscribers.
+        test_noop_case(true);
 
         $("#compose_private").hide();
         compose_state.set_message_type('stream');
@@ -1180,6 +1187,7 @@ function test_raw_file_drop(raw_drop_func) {
            stream: {
                invite_only: true,
                name: 'Denmark',
+               subscribers: Dict.from_array([1]),
            },
         };
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -834,6 +834,17 @@ exports.initialize = function () {
             return;
         }
 
+        var compose_stream = stream_data.get_sub(compose_state.stream_name());
+        if (compose_stream.subscribers && data.stream.subscribers) {
+            var compose_stream_sub = compose_stream.subscribers.keys();
+            var mentioned_stream_sub = data.stream.subscribers.keys();
+            // Don't warn if subscribers list of current compose_stream is a subset of
+            // mentioned_stream subscribers list.
+            if (_.difference(compose_stream_sub, mentioned_stream_sub).length === 0) {
+                return;
+            }
+        }
+
         // data.stream refers to the stream we're linking to in
         // typeahead.  If it's not invite-only, then it's public, and
         // there is no need to warn about it, since all users can already


### PR DESCRIPTION
Fixes #8634.
Suppress private stream warning if you're to a stream whose
membership is a subset of #mentioned-stream-name.

![demo](https://user-images.githubusercontent.com/13910561/37212782-0ceddcf4-23d6-11e8-85e6-129639605c39.gif)

