### PR TITLE
Tools: Upgrade to Mypy 0.570

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -87,7 +87,7 @@ markdown==2.6.11
 markupsafe==1.0
 mock==2.0.0
 moto==1.2.0
-mypy==0.560
+mypy==0.570
 mypy_extensions==0.3.0
 ndg-httpsclient==0.4.4
 oauth2client==4.1.2
@@ -106,7 +106,6 @@ pip-tools==1.11.0
 polib==1.1.0
 premailer==3.1.1
 prompt-toolkit==1.0.15    # via ipython
-psutil==5.4.1             # via mypy
 psycopg2==2.7.4
 ptyprocess==0.5.2         # via pexpect
 py3dns==3.1.0

--- a/requirements/mypy.in
+++ b/requirements/mypy.in
@@ -2,7 +2,7 @@
 # /tools/update-locked-requirements to update requirements/dev.txt
 # and requirements/mypy.txt.
 # See requirements/README.md for more detail.
-mypy==0.560
+mypy==0.570
 
 # Include typing explicitly, since it's needed on Python 3.4
 typing==3.6.4

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -7,7 +7,6 @@
 #
 # For details, see requirements/README.md .
 #
-mypy==0.560
-psutil==5.4.1             # via mypy
+mypy==0.570
 typed-ast==1.1.0          # via mypy
 typing==3.6.4

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '15.7'
+PROVISION_VERSION = '15.8'

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1,7 +1,7 @@
 # Zulip's main markdown implementation.  See docs/subsystems/markdown.md for
 # detailed documentation on our markdown syntax.
 from typing import (Any, Callable, Dict, Iterable, List, NamedTuple,
-                    Optional, Set, Text, Tuple, TypeVar, Union)
+                    Optional, Set, Text, Tuple, TypeVar, Union, cast)
 from mypy_extensions import TypedDict
 from typing.re import Match
 
@@ -172,7 +172,9 @@ def walk_tree_with_family(root: Element,
             result = processor(child)
             if result is not None:
                 if currElementPair['parent']:
-                    grandparent = currElementPair['parent']['value']
+                    grandparent_element = cast(Dict[str, Optional[Element]],
+                                               currElementPair['parent'])
+                    grandparent = grandparent_element['value']
                 else:
                     grandparent = None
                 family = ElementFamily(

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -103,7 +103,7 @@ class TestMissedMessages(ZulipTestCase):
         if show_message_content:
             body = 'Denmark > test Othello, the Moor of Venice 1 2 3 4 5 6 7 8 9 10 @**King Hamlet**'
             subject = 'Othello, the Moor of Venice mentioned you'
-            verify_body_does_not_include = []
+            verify_body_does_not_include = []  # type: List[str]
         else:
             # Test in case if message content in missed email message are disabled.
             body = 'While you were away you received 1 new message in which you were mentioned!'
@@ -146,7 +146,7 @@ class TestMissedMessages(ZulipTestCase):
         if show_message_content:
             body = 'You and Othello, the Moor of Venice Extremely personal message!'
             subject = 'Othello, the Moor of Venice sent you a message'
-            verify_body_does_not_include = []
+            verify_body_does_not_include = []  # type: List[str]
         else:
             body = 'While you were away you received 1 new private message!'
             subject = 'New missed message'
@@ -206,7 +206,7 @@ class TestMissedMessages(ZulipTestCase):
             body = ('You and Iago, Othello, the Moor of Venice Othello,'
                     ' the Moor of Venice Group personal message')
             subject = 'Group PMs with Iago and Othello, the Moor of Venice'
-            verify_body_does_not_include = []
+            verify_body_does_not_include = []  # type: List[str]
         else:
             body = 'While you were away you received 1 new group private message!'
             subject = 'New missed message'


### PR DESCRIPTION
Fixes #8582.

- First two commits correct some annotations, which also pass previous mypy version;
- Third commit was exposed while writing the PR and rebasing (simple list annotations);
- Last commit updates mypy, with all code then passing the new version with no errors.

[This passed a travis build on my local branch; rebuilding now due to pushing a commit text adjustment]