### PR TITLE
stream settings: Fix subscriber count display.

### DIFF
--- a/static/templates/subscription_count.handlebars
+++ b/static/templates/subscription_count.handlebars
@@ -1,6 +1,6 @@
 {{#if can_add_subscribers}}
-<i class="icon-vector-user"></i>
 <span class="subscriber-count-text">{{subscriber_count}}</span>
 {{else}}
 <i class="subscriber-count-lock icon-vector-lock"></i>
 {{/if}}
+<i class="icon-vector-user"></i>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fix subscriber count not displaying correctly. It's introduced in several commits back because of merge conflicts. 

![subscribercount](https://user-images.githubusercontent.com/25907420/37244895-e2a84cc8-24b5-11e8-9eb1-8d8a6981cec0.png)