### PR TITLE
stream settings: Fix subscribers not showing on private stream creation.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -25,11 +25,7 @@ function get_email_of_subscribers(subscribers) {
 
 exports.rerender_subscribers_list = function (sub) {
     if (!sub.can_add_subscribers) {
-        // It is also possible that user don't have rights to access subscribers.
-        // If user can't add subscribers, user can't access subscribers.
-        var html = templates.render('subscription_members', sub);
-        var stream_settings = settings_for_sub(sub);
-        stream_settings.find('.subscription-members-setting').expectOne().html(html);
+        $(".subscriber_list_settings_container").hide();
     } else {
         var emails = get_email_of_subscribers(sub.subscribers);
         var subscribers_list = list_render.get("stream_subscribers/" + sub.stream_id);
@@ -42,6 +38,7 @@ exports.rerender_subscribers_list = function (sub) {
             subscribers_list.render();
             ui.update_scrollbar($(".subscriber_list_container"));
         }
+        $(".subscriber_list_settings_container").show();
     }
 };
 
@@ -164,7 +161,7 @@ function show_subscription_settings(sub_row) {
     var color = stream_data.get_color(sub.name);
     stream_color.set_colorpicker_color(colorpicker, color);
 
-    if (!sub.render_subscribers || !sub.can_add_subscribers) {
+    if (!sub.render_subscribers) {
         return;
     }
     // fetch subscriber list from memory.

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -27,7 +27,7 @@ function row_for_stream_id(stream_id) {
 
 function settings_button_for_sub(sub) {
     var id = parseInt(sub.stream_id, 10);
-    return $(".subscription_settings[data-stream-id='" + id + "'] .subscribe-button");
+    return $(".subscription_settings[data-stream-id='" + id + "'] .subscribe-button").expectOne();
 }
 
 function get_row_data(row) {
@@ -212,7 +212,7 @@ exports.remove_stream = function (stream_id) {
 
 exports.update_settings_for_subscribed = function (sub) {
     var button = button_for_sub(sub);
-    var settings_button = settings_button_for_sub(sub).removeClass("unsubscribed");
+    var settings_button = settings_button_for_sub(sub).removeClass("unsubscribed").show();
 
     if (button.length !== 0) {
         exports.rerender_subscribers_count(sub, true);
@@ -236,7 +236,7 @@ exports.update_settings_for_subscribed = function (sub) {
 
 exports.update_settings_for_unsubscribed = function (sub) {
     var button = button_for_sub(sub);
-    var settings_button = settings_button_for_sub(sub).addClass("unsubscribed");
+    var settings_button = settings_button_for_sub(sub).addClass("unsubscribed").show();
 
     button.toggleClass("checked");
     settings_button.text(i18n.t("Subscribe"));

--- a/static/templates/subscription_count.handlebars
+++ b/static/templates/subscription_count.handlebars
@@ -1,6 +1,6 @@
 {{#if can_add_subscribers}}
-<i class="icon-vector-user"></i>
 <span class="subscriber-count-text">{{subscriber_count}}</span>
 {{else}}
 <i class="subscriber-count-lock icon-vector-lock"></i>
 {{/if}}
+<i class="icon-vector-user"></i>

--- a/static/templates/subscription_members.handlebars
+++ b/static/templates/subscription_members.handlebars
@@ -1,32 +1,26 @@
 {{#render_subscribers}}
-<div class="subscriber_list_settings">
-    <div class="sub_settings_title float-left">
-        {{t "Stream membership" }}
-        <div class="stream_subscription_info small"></div>
-    </div>
-    <div class="subscriber_list_add float-right">
-        <form class="form-inline">
-            {{#if can_add_subscribers}}
-            <input type="text" class="search" placeholder="{{t 'Search subscribers' }}" />
-            <input type="text" name="principal" placeholder="{{t 'Email address' }}" value="" class="input-block" autocomplete="off" tabindex="-1" />
-            <button type="submit" name="add_subscriber" class="button add-subscriber-button small rounded" tabindex="-1 ">
-                {{t 'Add' }}
-            </button>
-            {{/if}}
-        </form>
-    </div>
-    <div class="clear-float"></div>
-</div>
-<div class="subscriber-list-box">
-    <div class="subscriber_list_container">
-        <div class="subscriber_list_loading_indicator"></div>
-        {{#if can_add_subscribers}}
-        <table class="subscriber-list"></table>
-        {{else}}
-        <div class="hide-subscriber-list">
-            {{t "This stream is private, so you can't see who is subscribed." }}
+<div class="subscriber_list_settings_container" {{#unless can_add_subscribers}}style="display: none"{{/unless}}>
+    <div class="subscriber_list_settings">
+        <div class="sub_settings_title float-left">
+            {{t "Stream membership" }}
+            <div class="stream_subscription_info small"></div>
         </div>
-        {{/if}}
+        <div class="subscriber_list_add float-right">
+            <form class="form-inline">
+                <input type="text" class="search" placeholder="{{t 'Search subscribers' }}" />
+                <input type="text" name="principal" placeholder="{{t 'Email address' }}" value="" class="input-block" autocomplete="off" tabindex="-1" />
+                <button type="submit" name="add_subscriber" class="button add-subscriber-button small rounded" tabindex="-1 ">
+                    {{t 'Add' }}
+                </button>
+            </form>
+        </div>
+        <div class="clear-float"></div>
+    </div>
+    <div class="subscriber-list-box">
+        <div class="subscriber_list_container">
+            <div class="subscriber_list_loading_indicator"></div>
+            <table class="subscriber-list"></table>
+        </div>
     </div>
 </div>
 {{/render_subscribers}}

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -21,10 +21,8 @@
                 {{#if is_admin}}
                 <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Delete stream'}}">{{t 'Delete' }} <i class="icon-vector-trash" aria-hidden="true"></i></button>
                 {{/if}}
-                {{#if should_display_subscription_button}}
-                <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" title="{{t 'Toggle subscription'}} (S)">
+                <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" title="{{t 'Toggle subscription'}} (S)" {{#unless should_display_subscription_button}}style="display: none"{{/unless}}>
                     {{#if subscribed }}{{#tr oneself }}Unsubscribe{{/tr}}{{else}}{{#tr oneself }}Subscribe{{/tr}}{{/if}}</button>
-                {{/if}}
                 {{#if invite_only}}
                     {{#if subscribed}}
                         <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button" title="{{t 'View stream'}} (V)">{{t "View stream"}}</a>


### PR DESCRIPTION
Fixes:

- [X] Fix subscribers not showing on private stream creation.

Previously, stream subscribers were not rendering correctly. Due to
following reasons:
- Subscribers list didn't get initialized
- Subscriber members template add subscriber-list-table DOM element
  conditionally, which doesn't handle case if user have access to
  subscribers later.
- [X] Fix sub-unsub btn not showing on private stream creation.
- [X] Fix display of stream subscribers count


Fix this by cleaning subscriber member template to hide the
elements, instead of conditionally adding DOM elements and
initialize subscribers list even if user can't access subscribers.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![streamsubscriberrender](https://user-images.githubusercontent.com/25907420/37254562-82707596-2565-11e8-96ff-d3dbbf3f524b.gif)

This PR is still  WIP, cause it will cover subscriber count bug fix and subscribe/unsubscribe button not showing up in private stream creation. 