### PR TITLE
test-backend: Mock try_git_describe to speed up AdminNotifyHandlerTest.

### DIFF
--- a/zerver/logging_handlers.py
+++ b/zerver/logging_handlers.py
@@ -18,7 +18,7 @@ from zerver.lib.queue import queue_json_publish
 from version import ZULIP_VERSION
 
 def try_git_describe() -> Optional[str]:
-    try:
+    try:  # nocoverage
         return subprocess.check_output(
             ['git',
              '--git-dir', os.path.join(os.path.dirname(__file__), '../.git'),

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -61,7 +61,9 @@ class AdminNotifyHandlerTest(ZulipTestCase):
             if isinstance(h, AdminNotifyHandler)
         ][0]
 
-    def test_basic(self) -> None:
+    @patch('zerver.logging_handlers.try_git_describe')
+    def test_basic(self, mock_function: Any) -> None:
+        mock_function.return_value = None
         """A random exception passes happily through AdminNotifyHandler"""
         handler = self.get_admin_zulip_handler()
         try:
@@ -92,7 +94,9 @@ class AdminNotifyHandlerTest(ZulipTestCase):
             patched_notify.assert_called_once()
             return patched_notify.call_args[0][0]
 
-    def test_long_exception_request(self) -> None:
+    @patch('zerver.logging_handlers.try_git_describe')
+    def test_long_exception_request(self, mock_function: Any) -> None:
+        mock_function.return_value = None
         """A request with no stack and multi-line report.getMessage() is handled properly"""
         record = self.simulate_error()
         record.exc_info = None
@@ -105,7 +109,9 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         self.assertEqual(report['stack_trace'], 'message\nmoremesssage\nmore')
         self.assertEqual(report['message'], 'message')
 
-    def test_request(self) -> None:
+    @patch('zerver.logging_handlers.try_git_describe')
+    def test_request(self, mock_function: Any) -> None:
+        mock_function.return_value = None
         """A normal request is handled properly"""
         record = self.simulate_error()
 


### PR DESCRIPTION
By mocking the try_git_describe function in the AdminNotifyHandlerTest suite the execution time of ./tools/test-backend is reduced from 238 seconds in single-threaded mode to 189 seconds, a different of 49 seconds.

Mocks try_git_describe to speed up the following tests:
test_logging_handlers.AdminNotifyHandlerTest.test_basic
test_logging_handlers.AdminNotifyHandlerTest.test_long_exception_request
test_logging_handlers.AdminNotifyHandlerTest.test_request

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Run the following three commands:
./tools/test-backend zerver.tests.test_logging_handlers.AdminNotifyHandlerTest.test_basic
./tools/test-backend zerver.tests.test_logging_handlers.AdminNotifyHandlerTest.test_long_exception_request
./tools/test-backend zerver.tests.test_logging_handlers.AdminNotifyHandlerTest.test_request


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
test-backend output before: https://pastebin.com/9STD5Ndx
test-backend output after:    https://pastebin.com/zrJH41wB

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
