### PR TITLE
mypy: Migrate queue_processors.py to python3 annotations & simplify

### DIFF
--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -75,7 +75,7 @@ def assign_queue(
         return clazz
     return decorate
 
-worker_classes = {}  # type: Dict[str, Any] # Any here should be QueueProcessingWorker type
+worker_classes = {}  # type: Dict[str, Type[QueueProcessingWorker]]
 queues = {}  # type: Dict[str, Dict[str, Type[QueueProcessingWorker]]]
 def register_worker(queue_name: str, clazz: Type['QueueProcessingWorker'], queue_type: str) -> None:
     if queue_type not in queues:

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -101,14 +101,11 @@ def check_and_send_restart_signal() -> None:
         pass
 
 def retry_send_email_failures(
-        func: Callable[[Any, Dict[str, Any]], None]
+        func: Callable[[ConcreteQueueWorker, Dict[str, Any]], None]
 ) -> Callable[['QueueProcessingWorker', Dict[str, Any]], None]:
-    # If we don't use cast() and use QueueProcessingWorker instead of Any in
-    # function type annotation then mypy complains.
-    func = cast(Callable[[QueueProcessingWorker, Dict[str, Any]], None], func)
 
     @wraps(func)
-    def wrapper(worker: 'QueueProcessingWorker', data: Dict[str, Any]) -> None:
+    def wrapper(worker: ConcreteQueueWorker, data: Dict[str, Any]) -> None:
         try:
             func(worker, data)
         except (smtplib.SMTPServerDisconnected, socket.gaierror, EmailNotDeliveredException):


### PR DESCRIPTION
While adding mypy 0.570 support, I noticed this file used python2 annotations; this PR converts them to python3 form and simplifies them.

This passed travis, but recently my branches have failed `mypy` with `requests` issues, though I think this is unrelated.