### PR TITLE
[WIP]Refactoring perfect-scrollbar: Calling ui instead of perfect-scrollbar

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -240,9 +240,13 @@ function initialize_stream_data() {
     stream_list.scroll_element_into_container = noop;
 
     var scrollbar_updated = false;
-    $.stub_selector("#stream-filters-container", {
-        perfectScrollbar: function () { scrollbar_updated = true; },
+
+    set_global('ui', {
+        update_scrollbar: function () {scrollbar_updated = true;},
     });
+    ui.update_scrollbar(
+        $.stub_selector("#stream-filters-container")
+    );
 
     assert(!$('<devel sidebar row html>').hasClass('active-filter'));
 

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -182,15 +182,6 @@ var generate_emoji_picker_content = function (id) {
     });
 };
 
-function add_scrollbar(element) {
-    $(element).perfectScrollbar({
-        suppressScrollX: true,
-        useKeyboard: false,
-        // Picked so that each mousewheel bump moves 1 emoji down.
-        wheelSpeed: 0.68,
-    });
-}
-
 function refill_section_head_offsets(popover) {
     section_head_offsets = [];
     popover.find('.emoji-popover-subheading').each(function () {
@@ -209,8 +200,8 @@ exports.hide_emoji_popover = function () {
     $('.has_popover').removeClass('has_popover has_emoji_popover');
     if (exports.reactions_popped()) {
         var orig_title = current_message_emoji_popover_elem.data("original-title");
-        $(".emoji-popover-emoji-map").perfectScrollbar("destroy");
-        $(".emoji-search-results-container").perfectScrollbar("destroy");
+        ui.destroy_scrollbar($(".emoji-popover-emoji-map"));
+        ui.destroy_scrollbar($(".emoji-search-results-container"));
         current_message_emoji_popover_elem.popover("destroy");
         current_message_emoji_popover_elem.prop("title", orig_title);
         current_message_emoji_popover_elem.removeClass("reaction_button_visible");
@@ -261,7 +252,7 @@ function filter_emojis() {
             message_id: message_id,
         });
         $('.emoji-search-results').html(search_results_rendered);
-        $(".emoji-search-results-container").perfectScrollbar("update");
+        ui.update_scrollbar($(".emoji-search-results-container"));
         if (!search_results_visible) {
             show_search_results();
         }
@@ -626,8 +617,8 @@ exports.render_emoji_popover = function (elt, id) {
     elt.popover("show");
     elt.prop("title", i18n.t("Add emoji reaction (:)"));
     $('.emoji-popover-filter').focus();
-    add_scrollbar($(".emoji-popover-emoji-map"));
-    add_scrollbar($(".emoji-search-results-container"));
+    ui.set_up_scrollbar($(".emoji-popover-emoji-map"));
+    ui.set_up_scrollbar($(".emoji-search-results-container"));
     current_message_emoji_popover_elem = elt;
 
     emoji_catalog_last_coordinates = {

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -1,4 +1,4 @@
-const Ps = require('perfect-scrollbar');
+const ui = require('../ui');
 
 function registerCodeSection($codeSection) {
     const $li = $codeSection.find("ul.nav li");
@@ -99,7 +99,7 @@ function scrollToHash(container) {
 
         if ($next.is("ul")) {
             $next.slideToggle("fast", "swing", function () {
-                Ps.update($(".markdown")[0]);
+                ui.update_scrollbar($(".markdown"));
             });
         }
     });
@@ -124,7 +124,7 @@ function scrollToHash(container) {
 
         if (html_map[path]) {
             $(".markdown .content").html(html_map[path]);
-            Ps.update(container);
+            ui.update_scrollbar(container);
             render_code_sections();
             scrollToHash(container);
         } else {
@@ -134,7 +134,7 @@ function scrollToHash(container) {
                 html_map[path] = res;
                 $(".markdown .content").html(html_map[path]);
                 loading.name = null;
-                Ps.update(container);
+                ui.update_scrollbar(container);
                 scrollToHash(container);
             });
         }
@@ -155,20 +155,11 @@ function scrollToHash(container) {
         window.location.href = window.location.href.replace(/#.*/, '') + '#' + $(this).attr("id");
     });
 
-    Ps.initialize($(".markdown")[0], {
-        suppressScrollX: true,
-        useKeyboard: false,
-        wheelSpeed: 0.68,
-    });
-
-    Ps.initialize($(".sidebar")[0], {
-        suppressScrollX: true,
-        useKeyboard: false,
-        wheelSpeed: 0.68,
-    });
+    ui.set_up_scrollbar($(".markdown"));
+    ui.set_up_scrollbar($(".sidebar"));
 
     window.onresize = function () {
-        Ps.update($(".markdown")[0]);
+        ui.update_scrollbar($(".markdown"));
     };
 
     window.addEventListener("popstate", function () {

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -212,7 +212,7 @@ exports.resize_stream_filters_container = function (h) {
     h = narrow_window ? left_userlist_get_new_heights() : get_new_heights();
     exports.resize_bottom_whitespace(h);
     $("#stream-filters-container").css('max-height', h.stream_filters_max_height);
-    $('#stream-filters-container').perfectScrollbar('update');
+    ui.update_scrollbar($("#stream-filters-container"));
 };
 
 exports.resize_page_components = function () {
@@ -255,10 +255,8 @@ exports.resize_page_components = function () {
     $("#user_presences").css('max-height', h.user_presences_max_height);
     $("#group-pms").css('max-height', h.group_pms_max_height);
 
-    $("#stream-filters-container")
-        .css('max-height', h.stream_filters_max_height)
-        // the `.css` method returns `$this`, so we can chain `perfectScrollbar`.
-        .perfectScrollbar('update');
+    $("#stream-filters-container").css('max-height', h.stream_filters_max_height);
+    ui.update_scrollbar($("#stream-filters-container"));
 
     activity.update_scrollbar.users();
     activity.update_scrollbar.group_pms();

--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -1,9 +1,5 @@
 $(function () {
-    $("#stream-filters-container").perfectScrollbar({
-        suppressScrollX: true,
-        useKeyboard: false,
-        wheelSpeed: 0.5,
-    });
+    ui.set_up_scrollbar($("#stream-filters-container"));
 });
 
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -440,7 +440,7 @@ exports.handle_narrow_activated = function (filter) {
         exports.scroll_stream_into_view(stream_li);
     }
     // Update scrollbar size.
-    $("#stream-filters-container").perfectScrollbar("update");
+    ui.update_scrollbar($("#stream-filters-container"));
 };
 
 exports.handle_narrow_deactivated = function () {

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -258,11 +258,11 @@ exports.zoom_in = function () {
             active_widget.show_no_more_topics();
         }
 
-        $('#stream-filters-container').perfectScrollbar('update');
+        ui.update_scrollbar($("#stream-filters-container"));
     }
 
     $('#stream-filters-container').scrollTop(0);
-    $('#stream-filters-container').perfectScrollbar('update');
+    ui.update_scrollbar($("#stream-filters-container"));
     active_widget.show_spinner();
     topic_data.get_server_history(stream_id, on_success);
 };

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -26,6 +26,10 @@ exports.update_scrollbar = function (element) {
     element.perfectScrollbar('update');
 };
 
+exports.destroy_scrollbar = function (element) {
+    element.perfectScrollbar('destroy');
+};
+
 function update_message_in_all_views(message_id, callback) {
     _.each([message_list.all, home_msg_list, message_list.narrowed], function (list) {
         if (list === undefined) {


### PR DESCRIPTION
@timabbott This is the refactor as mentioned in [#8544](https://github.com/zulip/zulip/issues/8544)

**Testing Plan:** 
So far I've manually tested ensuring that perfect-scrollbar is where it should be. Only concern is I'm not sure how to handle line 443 in stream_list.js, so far I've left it untouched
`$("#stream-filters-container").perfectScrollbar("update");` 
I am not entirely sure on the proper way to get ui.js in the stream_list file.
