### PR TITLE
mypy: Final push to py3 annotations in core & enforce via linter

### DIFF
--- a/analytics/management/commands/check_analytics_state.py
+++ b/analytics/management/commands/check_analytics_state.py
@@ -29,8 +29,7 @@ class Command(BaseCommand):
 
     Run as a cron job that runs every hour."""
 
-    def handle(self, *args, **options):
-        # type: (*Any, **Any) -> None
+    def handle(self, *args: Any, **options: Any) -> None:
         fill_state = self.get_fill_state()
         status = fill_state['status']
         message = fill_state['message']
@@ -43,8 +42,7 @@ class Command(BaseCommand):
                 int(time.time()), status, states[status], message))
         subprocess.check_call(["mv", state_file_tmp, state_file_path])
 
-    def get_fill_state(self):
-        # type: () -> Dict[str, Any]
+    def get_fill_state(self) -> Dict[str, Any]:
         if not Realm.objects.exists():
             return {'status': 0, 'message': 'No realms exist, so not checking FillState.'}
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -465,6 +465,14 @@ def build_custom_checkers(by_lang):
          'description': "Use `id` instead of `pk`.",
          'good_lines': ['if my_django_model.id == 42', 'self.user_profile._meta.pk'],
          'bad_lines': ['if my_django_model.pk == 42']},
+        {'pattern': '^[ ]*# type: \(',
+         'exclude': set(['scripts/', 'tools/', 'puppet/', 'zerver/tests', 'zerver/lib/api_test_helpers.py',
+                         'zerver/lib/cache.py', 'zerver/models.py', 'zerver/lib/stream_subscription.py',
+                         'zerver/tornado/descriptors.py', 'zerver/views/streams.py',
+                         'zthumbor/'  # thumbor is (currently) python2 only
+                         ]),
+         'description': 'Python2 function type annotation. Use Python3-style annotation instead.',
+         },
     ]) + whitespace_rules + comma_whitespace_rule
     bash_rules = cast(RuleList, [
         {'pattern': '#!.*sh [-xe]',

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -280,8 +280,7 @@ class OurAuthenticationForm(AuthenticationForm):
 
         return self.cleaned_data
 
-    def add_prefix(self, field_name):
-        # type: (Text) -> Text
+    def add_prefix(self, field_name: Text) -> Text:
         """Disable prefix, since Zulip doesn't use this Django forms feature
         (and django-two-factor does use it), and we'd like both to be
         happy with this form.

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4517,8 +4517,9 @@ def do_update_user_group_description(user_group: UserGroup, description: Text) -
     user_group.save(update_fields=['description'])
     do_send_user_group_update_event(user_group, dict(description=description))
 
-def do_update_outgoing_webhook_service(bot_profile, service_interface, service_payload_url):
-    # type: (UserProfile, int, Text) -> None
+def do_update_outgoing_webhook_service(bot_profile: UserProfile,
+                                       service_interface: int,
+                                       service_payload_url: Text) -> None:
     # TODO: First service is chosen because currently one bot can only have one service.
     # Update this once multiple services are supported.
     service = get_bot_services(bot_profile.id)[0]

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -440,14 +440,12 @@ class InlineHttpsProcessor(markdown.treeprocessors.Treeprocessor):
 
 class BacktickPattern(markdown.inlinepatterns.Pattern):
     """ Return a `<code>` element containing the matching text. """
-    def __init__(self, pattern):
-        # type: (Text) -> None
+    def __init__(self, pattern: Text) -> None:
         markdown.inlinepatterns.Pattern.__init__(self, pattern)
         self.ESCAPED_BSLASH = '%s%s%s' % (markdown.util.STX, ord('\\'), markdown.util.ETX)
         self.tag = 'code'
 
-    def handleMatch(self, m):
-        # type: (Match[Text]) -> Union[Text, Element]
+    def handleMatch(self, m: Match[Text]) -> Union[Text, Element]:
         if m.group(4):
             el = markdown.util.etree.Element(self.tag)
             # Modified to not strip whitespace
@@ -1280,8 +1278,7 @@ class AutoNumberOListPreprocessor(markdown.preprocessors.Preprocessor):
     RE = re.compile(r'^([ ]*)(\d+)\.[ ]+(.*)')
     TAB_LENGTH = 2
 
-    def run(self, lines):
-        # type: (List[Text]) -> List[Text]
+    def run(self, lines: List[Text]) -> List[Text]:
         new_lines = []  # type: List[Text]
         current_list = []  # type: List[Match[Text]]
         current_indent = 0
@@ -1313,8 +1310,7 @@ class AutoNumberOListPreprocessor(markdown.preprocessors.Preprocessor):
 
         return new_lines
 
-    def renumber(self, mlist):
-        # type: (List[Match[Text]]) -> List[Text]
+    def renumber(self, mlist: List[Match[Text]]) -> List[Text]:
         if not mlist:
             return []
 

--- a/zerver/lib/debug.py
+++ b/zerver/lib/debug.py
@@ -39,8 +39,7 @@ def interactive_debug_listen() -> None:
     signal.signal(signal.SIGUSR1, lambda sig, stack: traceback.print_stack(stack))
     signal.signal(signal.SIGUSR2, interactive_debug)
 
-def tracemalloc_dump():
-    # type: () -> None
+def tracemalloc_dump() -> None:
     if not tracemalloc.is_tracing():
         logger.warning("pid {}: tracemalloc off, nothing to dump"
                        .format(os.getpid()))
@@ -63,8 +62,7 @@ def tracemalloc_dump():
                         rss_pages // 256,
                         basename))
 
-def tracemalloc_listen_sock(sock):
-    # type: (socket.socket) -> None
+def tracemalloc_listen_sock(sock: socket.socket) -> None:
     logger.debug('pid {}: tracemalloc_listen_sock started!'.format(os.getpid()))
     while True:
         sock.recv(1)
@@ -72,8 +70,7 @@ def tracemalloc_listen_sock(sock):
 
 listener_pid = None  # Optional[int]
 
-def tracemalloc_listen():
-    # type: () -> None
+def tracemalloc_listen() -> None:
     global listener_pid
     if listener_pid == os.getpid():
         # Already set up -- and in this process, not just its parent.
@@ -90,8 +87,7 @@ def tracemalloc_listen():
     logger.debug('pid {}: tracemalloc_listen done: {}'.format(
         os.getpid(), path))
 
-def maybe_tracemalloc_listen():
-    # type: () -> None
+def maybe_tracemalloc_listen() -> None:
     '''If tracemalloc tracing enabled, listen for requests to dump a snapshot.
 
     To trigger once this is listening:

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -264,24 +264,23 @@ class MessageDict:
 
     @staticmethod
     def build_message_dict(
-            message,
-            message_id,
-            last_edit_time,
-            edit_history,
-            content,
-            subject,
-            pub_date,
-            rendered_content,
-            rendered_content_version,
-            sender_id,
-            sender_realm_id,
-            sending_client_name,
-            recipient_id,
-            recipient_type,
-            recipient_type_id,
-            reactions
-    ):
-        # type: (Optional[Message], int, Optional[datetime.datetime], Optional[Text], Text, Text, datetime.datetime, Optional[Text], Optional[int], int, int, Text, int, int, int, List[Dict[str, Any]]) -> Dict[str, Any]
+            message: Optional[Message],
+            message_id: int,
+            last_edit_time: Optional[datetime.datetime],
+            edit_history: Optional[Text],
+            content: Text,
+            subject: Text,
+            pub_date: datetime.datetime,
+            rendered_content: Optional[Text],
+            rendered_content_version: Optional[int],
+            sender_id: int,
+            sender_realm_id: int,
+            sending_client_name: Text,
+            recipient_id: int,
+            recipient_type: int,
+            recipient_type_id: int,
+            reactions: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
 
         obj = dict(
             id                = message_id,

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -14,7 +14,7 @@ from zerver.lib.exceptions import JsonableError, ErrorCode
 
 from django.http import HttpRequest, HttpResponse
 
-from typing import Any, Callable, Type
+from typing import Any, Callable, Type, TypeVar
 
 class RequestVariableMissingError(JsonableError):
     code = ErrorCode.REQUEST_VARIABLE_MISSING
@@ -101,8 +101,10 @@ class REQ:
 # Note that this can't be used in helper functions which are not
 # expected to call json_error or json_success, as it uses json_error
 # internally when it encounters an error
-def has_request_variables(view_func):
-    # type: (Callable[[HttpRequest, Any, Any], HttpResponse]) -> Callable[[HttpRequest, *Any, **Any], HttpResponse]
+
+ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
+
+def has_request_variables(view_func: ViewFuncT) -> ViewFuncT:
     num_params = view_func.__code__.co_argcount
     if view_func.__defaults__ is None:
         num_default_params = 0

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -116,8 +116,7 @@ class ZulipTestCase(TestCase):
         return django_client.patch(url, encoded, **kwargs)
 
     @instrument_url
-    def client_patch_multipart(self, url, info={}, **kwargs):
-        # type: (Text, Dict[str, Any], **Any) -> HttpResponse
+    def client_patch_multipart(self, url: Text, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         """
         Use this for patch requests that have file uploads or
         that need some sort of multi-part content.  In the future

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -115,8 +115,7 @@ def simulated_empty_cache() -> Generator[
         cache_queries.append(('get', key, cache_name))
         return None
 
-    def my_cache_get_many(keys, cache_name=None):  # nocoverage -- simulated code doesn't use this
-        # type: (List[Text], Optional[str]) -> Dict[Text, Any]
+    def my_cache_get_many(keys: List[Text], cache_name: Optional[str]=None) -> Dict[Text, Any]:  # nocoverage -- simulated code doesn't use this
         cache_queries.append(('getmany', keys, cache_name))
         return {}
 

--- a/zerver/management/commands/create_default_stream_groups.py
+++ b/zerver/management/commands/create_default_stream_groups.py
@@ -13,8 +13,7 @@ Create default stream groups which the users can choose during sign up.
 ./manage.py create_default_stream_groups -s gsoc-1,gsoc-2,gsoc-3 -d "Google summer of code"  -r zulip
 """
 
-    def add_arguments(self, parser):
-        # type: (ArgumentParser) -> None
+    def add_arguments(self, parser: ArgumentParser) -> None:
         self.add_realm_args(parser, True)
 
         parser.add_argument(
@@ -40,8 +39,7 @@ Create default stream groups which the users can choose during sign up.
             required=True,
             help='A comma-separated list of stream names.')
 
-    def handle(self, *args, **options):
-        # type: (*Any, **Any) -> None
+    def handle(self, *args: Any, **options: Any) -> None:
         realm = self.get_realm(options)
         assert realm is not None  # Should be ensured by parser
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -768,8 +768,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         return self.is_bot and self.bot_type in UserProfile.SERVICE_BOT_TYPES
 
     @property
-    def allowed_bot_types(self):
-        # type: () -> List[int]
+    def allowed_bot_types(self) -> List[int]:
         allowed_bot_types = []
         if self.is_realm_admin or \
                 not self.realm.bot_creation_policy == Realm.BOT_CREATION_LIMIT_GENERIC_BOTS:

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -18,16 +18,14 @@ from zerver.lib.cache import ignore_unhashable_lru_cache
 
 register = Library()
 
-def and_n_others(values, limit):
-    # type: (List[str], int) -> str
+def and_n_others(values: List[str], limit: int) -> str:
     # A helper for the commonly appended "and N other(s)" string, with
     # the appropriate pluralization.
     return " and %d other%s" % (len(values) - limit,
                                 "" if len(values) == limit + 1 else "s")
 
 @register.filter(name='display_list', is_safe=True)
-def display_list(values, display_limit):
-    # type: (List[str], int) -> str
+def display_list(values: List[str], display_limit: int) -> str:
     """
     Given a list of values, return a string nicely formatting those values,
     summarizing when you have more than `display_limit`. Eg, for a
@@ -70,8 +68,7 @@ docs_without_macros = [
 # the results when called if none of the arguments are unhashable.
 @ignore_unhashable_lru_cache(512)
 @register.filter(name='render_markdown_path', is_safe=True)
-def render_markdown_path(markdown_file_path, context=None):
-    # type: (str, Optional[Dict[Any, Any]]) -> str
+def render_markdown_path(markdown_file_path: str, context: Optional[Dict[Any, Any]]=None) -> str:
     """Given a path to a markdown file, return the rendered html.
 
     Note that this assumes that any HTML in the markdown file is

--- a/zerver/templatetags/minified_js.py
+++ b/zerver/templatetags/minified_js.py
@@ -4,19 +4,15 @@ from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.template import Library, Node, TemplateSyntaxError
 
-if False:
-    # no need to add dependency
-    from django.template.base import Parser, Token
+from django.template.base import Parser, Token
 
 register = Library()
 
 class MinifiedJSNode(Node):
-    def __init__(self, sourcefile):
-        # type: (str) -> None
+    def __init__(self, sourcefile: str) -> None:
         self.sourcefile = sourcefile
 
-    def render(self, context):
-        # type: (Dict[str, Any]) -> str
+    def render(self, context: Dict[str, Any]) -> str:
         if settings.DEBUG:
             source_files = settings.JS_SPECS[self.sourcefile]
             normal_source = source_files['source_filenames']
@@ -34,8 +30,7 @@ class MinifiedJSNode(Node):
 
 
 @register.tag
-def minified_js(parser, token):
-    # type: (Parser, Token) -> MinifiedJSNode
+def minified_js(parser: Parser, token: Token) -> MinifiedJSNode:
     try:
         tag_name, sourcefile = token.split_contents()
     except ValueError:

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -64,8 +64,7 @@ def sent_time_in_epoch_seconds(user_message: Optional[UserMessage]) -> Optional[
     # Return the epoch seconds in UTC.
     return calendar.timegm(user_message.message.pub_date.utctimetuple())
 
-def get_bot_types(user_profile):
-    # type: (UserProfile) -> List[Dict[Text, object]]
+def get_bot_types(user_profile: UserProfile) -> List[Dict[Text, object]]:
     bot_types = []
     for type_id, name in UserProfile.BOT_TYPES.items():
         bot_types.append({

--- a/zerver/views/storage.py
+++ b/zerver/views/storage.py
@@ -16,8 +16,8 @@ from zerver.models import UserProfile
 from typing import Dict, List, Optional
 
 @has_request_variables
-def update_storage(request, user_profile, storage=REQ(validator=check_dict([]))):
-    # type: (HttpRequest, UserProfile, Dict[str, str]) -> HttpResponse
+def update_storage(request: HttpRequest, user_profile: UserProfile,
+                   storage: Dict[str, str]=REQ(validator=check_dict([]))) -> HttpResponse:
     try:
         set_bot_storage(user_profile, list(storage.items()))
     except StateError as e:
@@ -25,8 +25,11 @@ def update_storage(request, user_profile, storage=REQ(validator=check_dict([])))
     return json_success()
 
 @has_request_variables
-def get_storage(request, user_profile, keys=REQ(validator=check_list(check_string), default=None)):
-    # type: (HttpRequest, UserProfile, Optional[List[str]]) -> HttpResponse
+def get_storage(
+        request: HttpRequest,
+        user_profile: UserProfile,
+        keys: Optional[List[str]]=REQ(validator=check_list(check_string), default=None)
+) -> HttpResponse:
     keys = keys or get_keys_in_bot_storage(user_profile)
     try:
         storage = {key: get_bot_storage(user_profile, key) for key in keys}
@@ -35,8 +38,11 @@ def get_storage(request, user_profile, keys=REQ(validator=check_list(check_strin
     return json_success({'storage': storage})
 
 @has_request_variables
-def remove_storage(request, user_profile, keys=REQ(validator=check_list(check_string), default=None)):
-    # type: (HttpRequest, UserProfile, Optional[List[str]]) -> HttpResponse
+def remove_storage(
+        request: HttpRequest,
+        user_profile: UserProfile,
+        keys: Optional[List[str]]=REQ(validator=check_list(check_string), default=None)
+) -> HttpResponse:
     keys = keys or get_keys_in_bot_storage(user_profile)
     try:
         remove_bot_storage(user_profile, keys)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -40,17 +40,14 @@ class PrincipalError(JsonableError):
     data_fields = ['principal']
     http_status_code = 403
 
-    def __init__(self, principal):
-        # type: (Text) -> None
+    def __init__(self, principal: Text) -> None:
         self.principal = principal  # type: Text
 
     @staticmethod
-    def msg_format():
-        # type: () -> Text
+    def msg_format() -> Text:
         return _("User not authorized to execute queries on behalf of '{principal}'")
 
-def principal_to_user_profile(agent, principal):
-    # type: (UserProfile, Text) -> UserProfile
+def principal_to_user_profile(agent: UserProfile, principal: Text) -> UserProfile:
     try:
         return get_user(principal, agent.realm)
     except UserProfile.DoesNotExist:
@@ -61,16 +58,18 @@ def principal_to_user_profile(agent, principal):
         raise PrincipalError(principal)
 
 @require_realm_admin
-def deactivate_stream_backend(request, user_profile, stream_id):
-    # type: (HttpRequest, UserProfile, int) -> HttpResponse
+def deactivate_stream_backend(request: HttpRequest,
+                              user_profile: UserProfile,
+                              stream_id: int) -> HttpResponse:
     stream = access_stream_for_delete(user_profile, stream_id)
     do_deactivate_stream(stream)
     return json_success()
 
 @require_realm_admin
 @has_request_variables
-def add_default_stream(request, user_profile, stream_name=REQ()):
-    # type: (HttpRequest, UserProfile, Text) -> HttpResponse
+def add_default_stream(request: HttpRequest,
+                       user_profile: UserProfile,
+                       stream_name: Text=REQ()) -> HttpResponse:
     (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name)
     do_add_default_stream(stream)
     return json_success()
@@ -133,8 +132,9 @@ def remove_default_stream_group(request: HttpRequest, user_profile: UserProfile,
 
 @require_realm_admin
 @has_request_variables
-def remove_default_stream(request, user_profile, stream_name=REQ()):
-    # type: (HttpRequest, UserProfile, Text) -> HttpResponse
+def remove_default_stream(request: HttpRequest,
+                          user_profile: UserProfile,
+                          stream_name: Text=REQ()) -> HttpResponse:
     (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name)
     do_remove_default_stream(stream)
     return json_success()
@@ -165,8 +165,7 @@ def update_stream_backend(
         do_change_stream_invite_only(stream, is_private)
     return json_success()
 
-def list_subscriptions_backend(request, user_profile):
-    # type: (HttpRequest, UserProfile) -> HttpResponse
+def list_subscriptions_backend(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     return json_success({"subscriptions": gather_subscriptions(user_profile)[0]})
 
 FuncKwargPair = Tuple[Callable[..., HttpResponse], Dict[str, Union[int, Iterable[Any]]]]
@@ -252,8 +251,9 @@ def remove_subscriptions_backend(
 
     return json_success(result)
 
-def you_were_just_subscribed_message(acting_user, stream_names, private_stream_names):
-    # type: (UserProfile, Set[Text], Set[Text]) -> Text
+def you_were_just_subscribed_message(acting_user: UserProfile,
+                                     stream_names: Set[Text],
+                                     private_stream_names: Set[Text]) -> Text:
 
     # stream_names is the list of streams for which we should send notifications.
     #
@@ -469,14 +469,18 @@ def json_stream_exists(request: HttpRequest, user_profile: UserProfile, stream_n
     return json_success(result)  # results are ignored for HEAD requests
 
 @has_request_variables
-def json_get_stream_id(request, user_profile, stream_name=REQ('stream')):
-    # type: (HttpRequest, UserProfile, Text) -> HttpResponse
+def json_get_stream_id(request: HttpRequest,
+                       user_profile: UserProfile,
+                       stream_name: Text=REQ('stream')) -> HttpResponse:
     (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name)
     return json_success({'stream_id': stream.id})
 
 @has_request_variables
-def update_subscriptions_property(request, user_profile, stream_id=REQ(), property=REQ(), value=REQ()):
-    # type: (HttpRequest, UserProfile, int, str, str) -> HttpResponse
+def update_subscriptions_property(request: HttpRequest,
+                                  user_profile: UserProfile,
+                                  stream_id: int=REQ(),
+                                  property: str=REQ(),
+                                  value: str=REQ()) -> HttpResponse:
     subscription_data = [{"property": property,
                           "stream_id": stream_id,
                           "value": value}]

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -270,8 +270,8 @@ class Bitbucket2HookTests(WebhookTestCase):
         self.assert_json_success(result)
 
     @patch('zerver.webhooks.bitbucket2.view.check_send_stream_message')
-    def test_bitbucket2_on_push_without_changes_ignore(self, check_send_stream_message_mock):
-        # type: (MagicMock) -> None
+    def test_bitbucket2_on_push_without_changes_ignore(
+            self, check_send_stream_message_mock: MagicMock) -> None:
         payload = self.get_body('push_without_changes')
         result = self.client_post(self.url, payload, content_type="application/json")
         self.assertFalse(check_send_stream_message_mock.called)

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -407,8 +407,7 @@ class GitlabHookTests(WebhookTestCase):
             HTTP_X_GITLAB_EVENT="Pipeline Hook"
         )
 
-    def test_issue_type_test_payload(self):
-        # type: () -> None
+    def test_issue_type_test_payload(self) -> None:
         expected_subject = u'public-repo'
         expected_message = u"Webhook for **public-repo** has been configured successfully! :tada:"
 

--- a/zthumbor/loaders/helpers.py
+++ b/zthumbor/loaders/helpers.py
@@ -35,7 +35,7 @@ else:
     secrets_file.read(os.path.join(DEPLOY_ROOT, "zproject/dev-secrets.conf"))
 
 def get_secret(key):
-    # type: (str) -> Any
+    # type: (str) -> Text
     if secrets_file.has_option('secrets', key):
         return secrets_file.get('secrets', key)
     return None

--- a/zthumbor/loaders/zloader.py
+++ b/zthumbor/loaders/zloader.py
@@ -19,9 +19,9 @@ def get_not_found_result():
     result.successful = False
     return result
 
-@return_future  # type: ignore # This was giving mypy error for missing generic datatype?
+@return_future
 def load(context, url, callback):
-    # type: (Context, str, Callable) -> None
+    # type: (Context, str, Callable[..., Any]) -> None
     url = urllib.parse.unquote(url)
     url_params = get_url_params(url)
     source_type = url_params.get('source_type')


### PR DESCRIPTION
This concludes (almost) all the final changes from py2 to py3 annotation of functions, enforcing them through a linter addition.

One outstanding set of changes are to `cache.py` due to the comments in that file which suggest potential issues with such a transition; I thought it best to get what is there out so the linter can be enabled, if the changes as they are look good.

Otherwise, the linting is also currently disabled for scripts, tools, puppet and zerver/tests.

This passes `run-mypy` and `lint --backend` on my droplet.