### PR TITLE
portico: Prevent Firefox from bfcaching the page.

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -253,3 +253,11 @@ $(function () {
         render_tabs();
     }
 });
+
+// Prevent Firefox from bfcaching the page.
+// According to https://developer.mozilla.org/en-US/docs/DOM/window.onunload
+// Using this event handler in your page prevents Firefox from caching the
+// page in the in-memory bfcache (backward/forward cache).
+$(window).on('unload', function () {
+    $(window).unbind('unload');
+});


### PR DESCRIPTION
Firefox stores the last state of the page in its back/forward cache
in memory and uses that for quickly rendering the page. Since our page's
last state was 'faded-out', the content wasn't visible when the browser
rendered the page from it's bfcache.

Fixes #7907.

Deployed a version with some console.logs at https://nightly.zulipdev.org/hello/
