### PR TITLE
vagrant: replace run-dev vagrant check from username to file based

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -156,6 +156,9 @@ set -o pipefail
 # something that we don't want to happen when running provision in a
 # development environment not using Vagrant.
 
+# Empty file for run-dev to identify it's running inside vagrant
+touch /srv/zulip/var/vagrant-placeholder
+
 # Set the MOTD on the system to have Zulip instructions
 sudo rm -f /etc/update-motd.d/*
 sudo bash -c 'cat << EndOfMessage > /etc/motd

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -78,7 +78,9 @@ if not options.force:
 if options.interface is None:
     user_id = os.getuid()
     user_name = pwd.getpwuid(user_id).pw_name
-    if user_name in ["vagrant", "zulipdev"]:
+    # Check if vagrant-placeholder exists, a file created when the machine is provisioned by vagrant
+    vagrant = True if os.path.isfile("/srv/zulip/var/vagrant-placeholder") else False
+    if vagrant is True or user_name == "zulipdev":
         # In the Vagrant development environment, we need to listen on
         # all ports, and it's safe to do so, because Vagrant is only
         # exposing certain guest ports (by default just 9991) to the


### PR DESCRIPTION
A new file /srv/zulip/var/vagrant-placeholder is created when
vagrant provision is run.

tools/run-dev.py now checks if running inside vagrant by checking
the existence of the vagrant-placeholder file instead of checking
if the username is "vagrant"

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #2429 

**Testing Plan:** <!-- How have you tested? -->
Check /srv/zulip/var/vagrant-placeholder is created successfully by running "vagrant provision"
Check script is running properly on vagrant via tools/run-dev.py

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
