### PR TITLE
organization-settings: Fix organization description textarea style.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -116,7 +116,9 @@ label {
 
 .admin-realm-description {
     height: 16em;
-    width: 36em;
+    width: 100%;
+    max-width: 500px;
+    box-sizing: border-box;
 }
 
 .padded-container {

--- a/static/templates/settings/organization-profile-admin.handlebars
+++ b/static/templates/settings/organization-profile-admin.handlebars
@@ -6,7 +6,7 @@
         <div class="alert" id="admin-realm-description-status"></div>
         <div class="alert" id="admin-realm-deactivation-status"></div>
 
-        <div class="inline-block organization-settings-parent">
+        <div class="organization-settings-parent">
             <div class="input-group admin-realm">
                 <label for="id_realm_name">{{t "Your organization's name" }}</label>
                 <input type="text" id="id_realm_name" name="realm_name" class="admin-realm-name"


### PR DESCRIPTION
This makes the textarea responsive by making the width 100% and
the max-width 500px so that it doesn't get *too* wide.

Please close #8511 when this is merged.

Fixes: #8504.
