### PR TITLE
attachments_ui: Removed exporting of bytes_to_size function

### DIFF
--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -16,7 +16,7 @@ function delete_attachments(attachment) {
     });
 }
 
-exports.bytes_to_size = function (bytes, kb_with_1024_bytes) {
+function bytes_to_size(bytes, kb_with_1024_bytes) {
     if (kb_with_1024_bytes === undefined) {
         kb_with_1024_bytes = false;
     }
@@ -40,7 +40,7 @@ exports.set_up_attachments = function () {
     _.each(attachments, function (attachment) {
         var time = new XDate(attachment.create_time);
         attachment.create_time_str = timerender.render_now(time).time_str;
-        attachment.size_str = exports.bytes_to_size(attachment.size);
+        attachment.size_str = bytes_to_size(attachment.size);
     });
 
     var uploaded_files_table = $("#uploaded_files_table").expectOne();

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -31,7 +31,7 @@ function bytes_to_size(bytes, kb_with_1024_bytes) {
         size = Math.round((bytes / Math.pow(kb_size, i)) * 10) / 10;
     }
     return size + ' ' + sizes[i];
- };
+ }
 
 exports.set_up_attachments = function () {
     // The settings page must be rendered before this function gets called.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

https://github.com/zulip/zulip/issues/8667

> probably better would be to stop exporting the function (since we don't use it in other modules) or do nothing. 

Since the function is not used anywhere else, I removed the exporting. 
