### PR TITLE
lint: Replace 'return undefined;' with 'return;'.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -172,6 +172,9 @@
         "common": false,
         "panels": false
     },
+    "plugins": [
+        "eslint-plugin-empty-returns"
+    ],
     "rules": {
         "array-callback-return": "error",
         "array-bracket-spacing": "error",
@@ -191,6 +194,7 @@
         "complexity": [ 0, 4 ],
         "curly": 2,
         "dot-notation": [ "error", { "allowKeywords": true } ],
+        "empty-returns/main": "error",
         "eol-last": [ "error", "always" ],
         "eqeqeq": 2,
         "func-style": [ "off", "expression" ],

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -2,7 +2,7 @@ zrequire('util');
 zrequire('people');
 
 set_global('blueslip', {
-    error: function () { return undefined; },
+    error: function () { return; },
 });
 set_global('page_params', {});
 set_global('md5', function (s) {
@@ -555,7 +555,7 @@ initialize();
     assert.equal(email, 'debbie71@example.com');
 
     // Test undefined slug
-    people.emails_strings_to_user_ids_string = function () { return undefined; };
+    people.emails_strings_to_user_ids_string = function () { return; };
     assert.equal(people.emails_to_slug(), undefined);
 }());
 

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -107,7 +107,7 @@ people.initialize_current_user(me.user_id);
     assert(reply_to.indexOf('?') > -1);
 
     people.pm_with_user_ids = function () { return [42]; };
-    people.get_person_from_user_id = function () { return undefined; };
+    people.get_person_from_user_id = function () { return; };
     global.blueslip.error = function (msg) {
         assert.equal(msg, 'Unknown people in message');
     };

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -53,7 +53,7 @@ topic_data.reset();
     };
 
     global.narrow_state.stream = function () {
-        return undefined;
+        return;
     };
 
     var suggestions = search.get_suggestions(query);
@@ -73,7 +73,7 @@ topic_data.reset();
     };
 
     global.narrow_state.stream = function () {
-        return undefined;
+        return;
     };
 
     var ted =
@@ -244,7 +244,7 @@ topic_data.reset();
     };
 
     global.narrow_state.stream = function () {
-        return undefined;
+        return;
     };
 
     set_global('activity', {
@@ -430,7 +430,7 @@ init();
     };
 
     global.narrow_state.stream = function () {
-        return undefined;
+        return;
     };
 
     var suggestions = search.get_suggestions(query);
@@ -466,7 +466,7 @@ init();
     };
 
     global.narrow_state.stream = function () {
-        return undefined;
+        return;
     };
 
     var query = '';

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -174,7 +174,7 @@ function is_odd(i) { return i % 2 === 1; }
     assert.equal(gen.next(), undefined);
 
     var undef = function () {
-        return undefined;
+        return;
     };
 
     global.blueslip.error = function (msg) {
@@ -315,7 +315,7 @@ function is_odd(i) { return i % 2 === 1; }
 
     unread.num_unread_for_person = function (user_ids_string) {
         if (user_ids_string === 'unk') {
-            return undefined;
+            return;
         }
 
         if (user_ids_string === 'read') {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cssstyle": "0.2.29",
     "difflib": "0.2.4",
     "eslint": "3.9.1",
+    "eslint-plugin-empty-returns": "1.0.2",
     "htmlparser2": "3.8.3",
     "istanbul": "0.4.5",
     "jsdom": "9.4.1",

--- a/static/js/blueslip.js
+++ b/static/js/blueslip.js
@@ -71,7 +71,7 @@ Logger.prototype = (function () {
             if (console[name] !== undefined) {
                 return console[name].apply(console, arguments);
             }
-            return undefined;
+            return;
         };
     }
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -26,7 +26,7 @@ exports.autofocus = function (selector) {
 exports.password_quality = function (password, bar, password_field) {
     // We load zxcvbn.js asynchronously, so the variable might not be set.
     if (typeof zxcvbn === 'undefined') {
-        return undefined;
+        return;
     }
 
     var min_length = password_field.data('minLength');
@@ -58,7 +58,7 @@ exports.password_quality = function (password, bar, password_field) {
 
 exports.password_warning = function (password, password_field) {
     if (typeof zxcvbn === 'undefined') {
-        return undefined;
+        return;
     }
 
     var min_length = password_field.data('minLength');

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -122,13 +122,13 @@ exports.would_receive_message = function (email) {
         if (!sub) {
             // If the stream isn't valid, there is no risk of a mix
             // yet, so don't fade.
-            return undefined;
+            return;
         }
 
         if (user && user.is_bot && !sub.invite_only) {
             // Bots may receive messages on public streams even if they are
             // not subscribed.
-            return undefined;
+            return;
         }
         return stream_data.user_is_subscribed(focused_recipient.stream, email);
     }

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -11,7 +11,7 @@ function find_boundary_tr(initial_tr, iterate_row) {
     // parent tr, we should let the browser handle the copy-paste
     // entirely on its own
     if (tr.length === 0) {
-        return undefined;
+        return;
     }
 
     // If the selection boundary is on a table row that does not have an
@@ -24,7 +24,7 @@ function find_boundary_tr(initial_tr, iterate_row) {
         tr = iterate_row(tr);
     }
     if (j === 10) {
-        return undefined;
+        return;
     } else if (j !== 0) {
         // If we updated tr, then we are not dealing with a selection
         // that is entirely within one td, and we can skip the same td

--- a/static/js/dict.js
+++ b/static/js/dict.js
@@ -57,7 +57,7 @@ Dict.prototype = {
     _munge: function Dict__munge(k) {
         if (k === undefined) {
             blueslip.error("Tried to call a Dict method with an undefined key.");
-            return undefined;
+            return;
         }
         if (this._opts.fold_case) {
             k = k.toLowerCase();
@@ -74,7 +74,7 @@ Dict.prototype = {
     get: function Dict_get(key) {
         var mapping = this._items[this._munge(key)];
         if (mapping === undefined) {
-            return undefined;
+            return;
         }
         return mapping.v;
     },

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -60,19 +60,19 @@ var get_next_local_id = (function () {
             // If our id is already used, it is probably an edge case like we had
             // to abort a very recent message.
             blueslip.warn("We don't reuse ids for local echo.");
-            return undefined;
+            return;
         }
 
         if (next_local_id % 1 > local_id_increment * 5) {
             blueslip.warn("Turning off local echo for this message to let host catch up");
-            return undefined;
+            return;
         }
 
         if (next_local_id % 1 === 0) {
             // The logic to stop at 0.05 should prevent us from ever wrapping around
             // to the next integer.
             blueslip.error("Programming error");
-            return undefined;
+            return;
         }
 
         already_used[next_local_id] = true;
@@ -139,18 +139,18 @@ function insert_local_message(message_request, local_id) {
 
 exports.try_deliver_locally = function try_deliver_locally(message_request) {
     if (markdown.contains_backend_only_syntax(message_request.content)) {
-        return undefined;
+        return;
     }
 
     if (narrow_state.active() && !narrow_state.filter().can_apply_locally()) {
-        return undefined;
+        return;
     }
 
     var next_local_id = get_next_local_id();
 
     if (!next_local_id) {
         // This can happen for legit reasons.
-        return undefined;
+        return;
     }
 
     return insert_local_message(message_request, next_local_id);

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -85,7 +85,7 @@ exports.parse_narrow = function (hash) {
             }
             operators.push({negated: negated, operator: operator, operand: operand});
         } catch (err) {
-            return undefined;
+            return;
         }
     }
     return operators;

--- a/static/js/localstorage.js
+++ b/static/js/localstorage.js
@@ -6,7 +6,7 @@ var ls = {
         try {
             return JSON.parse(str);
         } catch (err) {
-            return undefined;
+            return;
         }
     },
 

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -63,7 +63,7 @@ exports.apply_markdown = function (message) {
                        '@' + name +
                        '</span>';
             }
-            return undefined;
+            return;
         },
         groupMentionHandler: function (name) {
             var group = user_groups.get_user_group_from_name(name);
@@ -75,7 +75,7 @@ exports.apply_markdown = function (message) {
                        '@' + group.name +
                        '</span>';
             }
-            return undefined;
+            return;
         },
     };
     message.content = marked(message.raw_content + '\n\n', options).trim();
@@ -165,7 +165,7 @@ function handleAvatar(email) {
 function handleStream(streamName) {
     var stream = stream_data.get_sub(streamName);
     if (stream === undefined) {
-        return undefined;
+        return;
     }
     var href = window.location.origin + '/#narrow/stream/' + hash_util.encode_stream_name(stream.name);
     return '<a class="stream" data-stream-id="' + stream.stream_id + '" ' +

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -100,7 +100,7 @@ exports.MessageList.prototype = {
     get: function MessageList_get(id) {
         id = parseFloat(id);
         if (isNaN(id)) {
-            return undefined;
+            return;
         }
         return this._hash[id];
     },

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -41,7 +41,7 @@ exports.update_email = function (user_id, new_email) {
 /* Operators we should send to the server. */
 exports.public_operators = function () {
     if (current_filter === undefined) {
-        return undefined;
+        return;
     }
     return current_filter.public_operators();
 };
@@ -96,7 +96,7 @@ exports.set_compose_defaults = function () {
 
 exports.stream = function () {
     if (current_filter === undefined) {
-        return undefined;
+        return;
     }
     var stream_operands = current_filter.operands("stream");
     if (stream_operands.length === 1) {
@@ -106,18 +106,18 @@ exports.stream = function () {
         // name (considering renames and capitalization).
         return stream_data.get_name(name);
     }
-    return undefined;
+    return;
 };
 
 exports.topic = function () {
     if (current_filter === undefined) {
-        return undefined;
+        return;
     }
     var operands = current_filter.operands("topic");
     if (operands.length === 1) {
         return operands[0];
     }
-    return undefined;
+    return;
 };
 
 exports.pm_string = function () {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -35,7 +35,7 @@ exports.init();
 exports.get_person_from_user_id = function (user_id) {
     if (!people_by_user_id_dict.has(user_id)) {
         blueslip.error('Unknown user_id in get_person_from_user_id: ' + user_id);
-        return undefined;
+        return;
     }
     return people_by_user_id_dict.get(user_id);
 };
@@ -44,7 +44,7 @@ exports.get_by_email = function (email) {
     var person = people_dict.get(email);
 
     if (!person) {
-        return undefined;
+        return;
     }
 
     if (person.email.toLowerCase() !== email.toLowerCase()) {
@@ -91,12 +91,12 @@ exports.get_user_id = function (email) {
     if (person === undefined) {
         var error_msg = 'Unknown email for get_user_id: ' + email;
         blueslip.error(error_msg);
-        return undefined;
+        return;
     }
     var user_id = person.user_id;
     if (!user_id) {
         blueslip.error('No user_id found for ' + email);
-        return undefined;
+        return;
     }
 
     return user_id;
@@ -555,7 +555,7 @@ exports.is_valid_email_for_compose = function (email) {
 exports.get_active_user_for_email = function (email) {
     var person = people.get_by_email(email);
     if (!person) {
-        return undefined;
+        return;
     }
     return active_user_dict.get(person.user_id);
 };
@@ -596,7 +596,7 @@ exports.get_active_user_ids = function () {
 exports.is_cross_realm_email = function (email) {
     var person = people.get_by_email(email);
     if (!person) {
-        return undefined;
+        return;
     }
     return cross_realm_dict.has(person.user_id);
 };

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -370,7 +370,7 @@ exports.user_is_subscribed = function (stream_name, user_email) {
         // subscribed, we can't keep track of the subscriber list in general,
         // so we return undefined (treated as falsy if not explicitly handled).
         blueslip.warn("We got a user_is_subscribed call for a non-existent or unsubscribed stream.");
-        return undefined;
+        return;
     }
     var user_id = people.get_user_id(user_email);
     if (!user_id) {
@@ -529,7 +529,7 @@ exports.get_newbie_stream = function () {
         return page_params.notifications_stream;
     }
 
-    return undefined;
+    return;
 };
 
 exports.remove_default_stream = function (stream_id) {

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -24,7 +24,7 @@ function send_typing_notification_ajax(recipients, operation) {
 function get_recipient() {
     var compose_recipient = compose_state.recipient();
     if (compose_recipient === "") {
-        return undefined;
+        return;
     }
     return compose_recipient;
 }

--- a/static/js/user_groups.js
+++ b/static/js/user_groups.js
@@ -31,7 +31,7 @@ exports.remove = function (user_group) {
 exports.get_user_group_from_id = function (group_id) {
     if (!user_group_by_id_dict.has(group_id)) {
         blueslip.error('Unknown group_id in get_user_group_from_id: ' + group_id);
-        return undefined;
+        return;
     }
     return user_group_by_id_dict.get(group_id);
 };

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '15.9'
+PROVISION_VERSION = '15.10'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,6 +1731,10 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-plugin-empty-returns@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-empty-returns/-/eslint-plugin-empty-returns-1.0.1.tgz#ca19faa501e114812577db68ec6882ea48c40a27"
+
 eslint@3.9.1:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.9.1.tgz#5a8597706fc6048bc6061ac754d4a211d28f4f5b"
@@ -3994,13 +3998,13 @@ mapbox-gl-function@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/mapbox-gl-function/-/mapbox-gl-function-1.3.0.tgz#cee3d95750c189d45e83ab41a0a57fc2a8a509bc"
 
-"mapbox-gl-shaders@github:mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747":
+mapbox-gl-shaders@mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747:
   version "1.0.0"
   resolved "https://codeload.github.com/mapbox/mapbox-gl-shaders/tar.gz/de2ab007455aa2587c552694c68583f94c9f2747"
   dependencies:
     brfs "^1.4.0"
 
-"mapbox-gl-style-spec@github:mapbox/mapbox-gl-style-spec#83b1a3e5837d785af582efd5ed1a212f2df6a4ae":
+mapbox-gl-style-spec@mapbox/mapbox-gl-style-spec#83b1a3e5837d785af582efd5ed1a212f2df6a4ae:
   version "8.8.0"
   resolved "https://codeload.github.com/mapbox/mapbox-gl-style-spec/tar.gz/83b1a3e5837d785af582efd5ed1a212f2df6a4ae"
   dependencies:


### PR DESCRIPTION
Also adds a custom rule to eslint. Since the recommended way of extending
eslint is to create plugins as standalone npm packages, the separate rule
is published as 'eslint-plugins-empty-returns'.

Fixes #8669.

**Testing Plan:** <!-- How have you tested? -->

Tests are in https://www.npmjs.com/package/eslint-plugin-empty-returns. In this repository, the code is a simple refactoring.