### PR TITLE
Set REALM_HOSTS based on EXTERNAL_HOST if it is available.

### DIFF
--- a/docs/development/remote.md
+++ b/docs/development/remote.md
@@ -41,6 +41,10 @@ the remote virtual machine, we recommend installing
 [Vagrant][install-vagrant] method so you can easily uninstall if you
 need to.
 
+For a direct install, also set `EXTERNAL_HOST=<REMOTE_IP>:9991` in your
+environment. This allows you to access Zulip running in your development
+environment using a browser on another host.
+
 ## Running the development server
 
 Once you have set up the development environment, you can start up the

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -26,6 +26,11 @@ if EXTERNAL_HOST is None:
         REALM_HOSTS = {
             'zulip': 'localhost:9991'
         }
+else:
+    REALM_HOSTS = {
+        'zulip': EXTERNAL_HOST,
+    }
+
 ALLOWED_HOSTS = ['*']
 
 # Uncomment extra backends if you want to test with them.  Note that


### PR DESCRIPTION
Code change based on @timabbott's diff as discussed in #8670.

Also update remote.md to recommend setting `EXTERNAL_HOST` in an environment
variable.

Fixes #8670
https://github.com/zulip/zulip/issues/8670

Note: this change is for remote direct install. It does not address the
trouble I had with a remote vagrant environment.

**Testing Plan:**
The change worked and I was able to connect to the remote dev Zulip
correctly. Local tests failed for unrelated reasons, hopefully they will run
correctly for this PR.
