### PR TITLE
search refactor: Make num_after/num_before logic more encapsulated.

### DIFF
--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1744,11 +1744,11 @@ class GetOldMessagesTest(ZulipTestCase):
     def test_get_messages_queries(self) -> None:
         query_ids = self.get_query_ids()
 
-        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage \nWHERE user_profile_id = {hamlet_id} AND message_id <= 0 ORDER BY message_id DESC \n LIMIT 1) AS anon_1 ORDER BY message_id ASC'
+        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage \nWHERE user_profile_id = {hamlet_id} AND message_id = 0) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 0}, sql)
 
-        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage \nWHERE user_profile_id = {hamlet_id} AND message_id <= 0 ORDER BY message_id DESC \n LIMIT 2) AS anon_1 ORDER BY message_id ASC'
+        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage \nWHERE user_profile_id = {hamlet_id} AND message_id = 0) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 1, 'num_after': 0}, sql)
 
@@ -1777,7 +1777,7 @@ class GetOldMessagesTest(ZulipTestCase):
                                               'narrow': '[["pm-with", "%s"]]' % (self.example_email("othello"),)},
                                              sql)
 
-        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id <= 0 ORDER BY message_id DESC \n LIMIT 1) AS anon_1 ORDER BY message_id ASC'
+        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id = 0) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 1, 'num_after': 0,
                                               'narrow': '[["pm-with", "%s"]]' % (self.example_email("othello"),)},

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1736,6 +1736,18 @@ class GetOldMessagesTest(ZulipTestCase):
     def test_get_messages_queries(self) -> None:
         query_ids = self.get_query_ids()
 
+        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage \nWHERE user_profile_id = {hamlet_id} AND message_id >= 0 AND message_id <= 0 ORDER BY message_id DESC \n LIMIT 1) AS anon_1 ORDER BY message_id ASC'
+        sql = sql_template.format(**query_ids)
+        self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 0}, sql)
+
+        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage \nWHERE user_profile_id = {hamlet_id} AND message_id >= 0 AND message_id <= 0 ORDER BY message_id DESC \n LIMIT 2) AS anon_1 ORDER BY message_id ASC'
+        sql = sql_template.format(**query_ids)
+        self.common_check_get_messages_query({'anchor': 0, 'num_before': 1, 'num_after': 0}, sql)
+
+        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage \nWHERE user_profile_id = {hamlet_id} AND message_id >= 0 AND message_id >= 0 ORDER BY message_id ASC \n LIMIT 2) AS anon_1 ORDER BY message_id ASC'
+        sql = sql_template.format(**query_ids)
+        self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 1}, sql)
+
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage \nWHERE user_profile_id = {hamlet_id} AND message_id >= 0 AND message_id >= 0 ORDER BY message_id ASC \n LIMIT 11) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 10}, sql)
@@ -1750,6 +1762,18 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def test_get_messages_with_narrow_queries(self) -> None:
         query_ids = self.get_query_ids()
+
+        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND message_id >= 0 AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id = 0) AS anon_1 ORDER BY message_id ASC'
+        sql = sql_template.format(**query_ids)
+        self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 0,
+                                              'narrow': '[["pm-with", "%s"]]' % (self.example_email("othello"),)},
+                                             sql)
+
+        sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND message_id >= 0 AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id <= 0 ORDER BY message_id DESC \n LIMIT 1) AS anon_1 ORDER BY message_id ASC'
+        sql = sql_template.format(**query_ids)
+        self.common_check_get_messages_query({'anchor': 0, 'num_before': 1, 'num_after': 0,
+                                              'narrow': '[["pm-with", "%s"]]' % (self.example_email("othello"),)},
+                                             sql)
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND message_id >= 0 AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id >= 0 ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -596,7 +596,8 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
         inner_msg_id_col = column("message_id")
 
     first_visible_message_id = get_first_visible_message_id(user_profile.realm)
-    query = query.where(inner_msg_id_col >= first_visible_message_id)
+    if first_visible_message_id > 0:
+        query = query.where(inner_msg_id_col >= first_visible_message_id)
 
     num_extra_messages = 1
     is_search = False
@@ -675,6 +676,7 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
 
     before_query = None
     after_query = None
+
     if num_before > 0:
         before_query = query
 
@@ -686,9 +688,14 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
             before_query = before_query.where(inner_msg_id_col <= before_anchor)
 
         before_query = before_query.order_by(inner_msg_id_col.desc()).limit(num_before)
+
     if num_after > 0:
-        after_query = query.where(inner_msg_id_col >= anchor) \
-                           .order_by(inner_msg_id_col.asc()).limit(num_after)
+        after_query = query
+
+        if anchor > 0:
+            after_query = after_query.where(inner_msg_id_col >= anchor)
+
+        after_query = after_query.order_by(inner_msg_id_col.asc()).limit(num_after)
 
     if before_query is not None:
         if after_query is not None:

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -633,7 +633,7 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
     # specified to ensure that the resulting list always contains the
     # anchor message.  If a narrow was specified, the anchor message
     # might not match the narrow anyway.
-    if num_after != 0:
+    if num_after > 0:
         num_after += num_extra_messages
     else:
         num_before += num_extra_messages
@@ -672,14 +672,14 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
 
     before_query = None
     after_query = None
-    if num_before != 0:
+    if num_before > 0:
         before_anchor = anchor
-        if num_after != 0:
+        if num_after > 0:
             # Don't include the anchor in both the before query and the after query
             before_anchor = anchor - 1
         before_query = query.where(inner_msg_id_col <= before_anchor) \
                             .order_by(inner_msg_id_col.desc()).limit(num_before)
-    if num_after != 0:
+    if num_after > 0:
         after_query = query.where(inner_msg_id_col >= anchor) \
                            .order_by(inner_msg_id_col.asc()).limit(num_after)
 


### PR DESCRIPTION
This also simplifies some of the SQL we generate for searches.