### PR TITLE
user settings: Fix user avatar not updated in settings page.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -324,7 +324,7 @@ exports.set_up = function () {
             contentType: false,
             success: function (data) {
                 loading.destroy_indicator($("#upload_avatar_spinner"));
-                $("#user-settings-avatar").expectOne().attr("src", data.avatar_url);
+                $("#user-avatar-block").expectOne().attr("src", data.avatar_url);
                 $("#user_avatar_delete_button").show();
                 $("#user-avatar-source").hide();
             },

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -58,7 +58,7 @@ exports.update_person = function update(person) {
             page_params.avatar_source = person.avatar_source;
             page_params.avatar_url = url;
             page_params.avatar_url_medium = person.avatar_url_medium;
-            $("#user-settings-avatar").attr("src", person.avatar_url_medium);
+            $("#user-avatar-block").attr("src", person.avatar_url_medium);
         }
 
         message_live_update.update_avatar(person_obj.user_id, person.avatar_url);


### PR DESCRIPTION
On uploading new avatar, user avatar in settings page doesn't
get updated. Cause we have set `src` attribute of wrong html
element instead of image element in user settings page.

Fixes #8680

![useravatar](https://user-images.githubusercontent.com/25907420/37359496-c160489e-2713-11e8-9211-38d0c9c1ac2e.gif)
