### PR TITLE
Add LoggingCountStat for the Client string (replaces #8224)

### DIFF
--- a/analytics/lib/counts.py
+++ b/analytics/lib/counts.py
@@ -488,6 +488,10 @@ count_stats_ = [
               sql_data_collector(StreamCount, count_message_by_stream_query, (UserProfile, 'is_bot')),
               CountStat.DAY),
 
+    # Messages Read Stats
+    # Messages Read by client
+    LoggingCountStat('messages_read_log:client:day', UserCount, CountStat.DAY),
+
     # Number of Users stats
     # Stats that count the number of active users in the UserProfile.is_active sense.
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -852,7 +852,7 @@ class StreamAdminTest(ZulipTestCase):
         those you aren't on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=22, is_admin=True, is_subbed=True, invite_only=False,
+            query_count=24, is_admin=True, is_subbed=True, invite_only=False,
             other_user_subbed=True)
         json = self.assert_json_success(result)
         self.assertEqual(len(json["removed"]), 1)
@@ -864,7 +864,7 @@ class StreamAdminTest(ZulipTestCase):
         are on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=22, is_admin=True, is_subbed=True, invite_only=True,
+            query_count=24, is_admin=True, is_subbed=True, invite_only=True,
             other_user_subbed=True)
         json = self.assert_json_success(result)
         self.assertEqual(len(json["removed"]), 1)
@@ -876,7 +876,7 @@ class StreamAdminTest(ZulipTestCase):
         streams you aren't on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=22, is_admin=True, is_subbed=False, invite_only=True,
+            query_count=24, is_admin=True, is_subbed=False, invite_only=True,
             other_user_subbed=True, other_sub_users=[self.example_user("othello")])
         json = self.assert_json_success(result)
         self.assertEqual(len(json["removed"]), 1)


### PR DESCRIPTION
This should correctly implement logging the number of messages read in every case where a message is marked as read, with pretty clean tests, tracked by Client.  It's based on #8224, but redoes a lot of things to use nicer APIs and actually keep track of the client involved.

The main thing that I think deserves some further thinking is that this implementation doesn't distinguish the bankruptcy cases from the rest (which are in the webapp client, but feel like they will throw everything off by being huge).  It might be a good idea to use a special client string, e.g. ZulipBankruptcy, for that feature (and equivalently, the `end` key in the home narrow).

@rishig what are your thoughts on that question?  And can you check the last commit uses the LoggingCountStat API correctly?

(And maybe another is whether we want to actually be counting number of messages read, or just counts of times messages were read).  

@showell can you review this?  I'm specifically interested in whether I missed anything in the preparatory refactors, or any code paths that mark messages as read (for the last commit).

