### PR TITLE
user-groups: Fix disappearing of group when name/description is edited.

### DIFF
--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -43,4 +43,9 @@ zrequire('user_groups');
         assert.equal(msg, "Unknown group_id in get_user_group_from_id: " + students.id);
     };
     assert.equal(user_groups.get_user_group_from_id(students.id), undefined);
+    user_groups.add(students);
+    assert.deepEqual([user_groups.get_realm_user_groups()[0].id,
+                        user_groups.get_realm_user_groups()[1].id], [0, 1]);
+    assert.equal(user_groups.get_realm_user_groups()[1].name, 'Admins');
+    assert.deepEqual(user_groups.get_realm_user_groups()[0].members, Dict.from_array([1, 2]));
 }());

--- a/static/js/user_groups.js
+++ b/static/js/user_groups.js
@@ -17,8 +17,9 @@ exports.init();
 
 exports.add = function (user_group) {
     // Reformat the user group members structure to be a dict.
-    user_group.members = Dict.from_array(user_group.members);
-
+    if (user_group.members instanceof Array) {
+        user_group.members = Dict.from_array(user_group.members);
+    }
     user_group_name_dict.set(user_group.name, user_group);
     user_group_by_id_dict.set(user_group.id, user_group);
 };
@@ -41,7 +42,9 @@ exports.get_user_group_from_name = function (name) {
 };
 
 exports.get_realm_user_groups = function () {
-    return user_group_name_dict.values();
+    return user_group_by_id_dict.values().sort(function (a, b) {
+        return (a.id - b.id);
+    });
 };
 
 exports.is_member_of = function (user_group_id, user_id) {


### PR DESCRIPTION
This PR fixes #8692.
When we edit a user group's name or description, it is disappearing due to the fact that 'members' is already a dict when user_groups.add is called from the editing function, so the add function fails and it does not get added to list when groups are populated. We fix by checking if 'members' is an Array, if yes, then we convert it to dict, otherwise not. Also, when we fix this issue, the edited group is going to the bottom, it is not staying at its position, so to fix this we sort by ids of the groups to maintain proper relative order.
