### PR TITLE
mypy: Centralize ViewFuncT definition & simplify decorator.py

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -16,6 +16,7 @@ from zerver.lib.subdomains import get_subdomain, user_matches_subdomain
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
 from zerver.lib.utils import statsd, is_remote_server
 from zerver.lib.exceptions import RateLimited, JsonableError, ErrorCode
+from zerver.lib.types import ViewFuncT
 
 from zerver.lib.rate_limiter import incr_ratelimit, is_ratelimited, \
     api_calls_left, RateLimitedUser
@@ -42,7 +43,6 @@ else:
     get_remote_server_by_uuid = Mock()
     RemoteZulipServer = Mock()  # type: ignore # https://github.com/JukkaL/mypy/issues/1188
 
-ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
 ReturnT = TypeVar('ReturnT')
 
 webhook_logger = logging.getLogger("zulip.zerver.webhooks")

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -531,7 +531,7 @@ def process_as_post(view_func: ViewFuncT) -> ViewFuncT:
     return _wrapped_view_func  # type: ignore # https://github.com/python/mypy/issues/1927
 
 def authenticate_log_and_execute_json(request: HttpRequest,
-                                      view_func: Callable[..., HttpResponse],
+                                      view_func: ViewFuncT,
                                       *args: Any, **kwargs: Any) -> HttpResponse:
     if not request.user.is_authenticated:
         return json_error(_("Not logged in"), status=401)
@@ -669,12 +669,12 @@ def rate_limit_user(request: HttpRequest, user: UserProfile, domain: Text) -> No
     request._ratelimit_remaining = calls_remaining
     request._ratelimit_secs_to_freedom = time_reset
 
-def rate_limit(domain: Text='all') -> Callable[[Callable[..., HttpResponse]], Callable[..., HttpResponse]]:
+def rate_limit(domain: Text='all') -> Callable[[ViewFuncT], ViewFuncT]:
     """Rate-limits a view. Takes an optional 'domain' param if you wish to
     rate limit different types of API calls independently.
 
     Returns a decorator"""
-    def wrapper(func: Callable[..., HttpResponse]) -> Callable[..., HttpResponse]:
+    def wrapper(func: ViewFuncT) -> ViewFuncT:
         @wraps(func)
         def wrapped_func(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
 
@@ -706,13 +706,13 @@ def rate_limit(domain: Text='all') -> Callable[[Callable[..., HttpResponse]], Ca
             rate_limit_user(request, user, domain)
 
             return func(request, *args, **kwargs)
-        return wrapped_func
+        return wrapped_func  # type: ignore # https://github.com/python/mypy/issues/1927
     return wrapper
 
-def return_success_on_head_request(view_func: Callable[..., HttpResponse]) -> Callable[..., HttpResponse]:
+def return_success_on_head_request(view_func: ViewFuncT) -> ViewFuncT:
     @wraps(view_func)
     def _wrapped_view_func(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         if request.method == 'HEAD':
             return json_success()
         return view_func(request, *args, **kwargs)
-    return _wrapped_view_func
+    return _wrapped_view_func  # type: ignore # https://github.com/python/mypy/issues/1927

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -632,7 +632,6 @@ def flexible_boolean(boolean: Text) -> bool:
 def to_utc_datetime(timestamp: Text) -> datetime.datetime:
     return timestamp_to_datetime(float(timestamp))
 
-WrapperT = Callable[[Callable[..., ReturnT]], Callable[..., ReturnT]]
 def statsd_increment(counter: Text, val: int=1,
                      ) -> Callable[[Callable[..., ReturnT]], Callable[..., ReturnT]]:
     """Increments a statsd counter on completion of the

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -406,11 +406,10 @@ def human_users_only(view_func: ViewFuncT) -> ViewFuncT:
 
 # Based on Django 1.8's @login_required
 def zulip_login_required(
-        function: Optional[Callable[..., HttpResponse]]=None,
+        function: Optional[ViewFuncT]=None,
         redirect_field_name: Text=REDIRECT_FIELD_NAME,
         login_url: Text=settings.HOME_NOT_LOGGED_IN,
-) -> Union[Callable[[Callable[..., HttpResponse]], Callable[..., HttpResponse]],
-           Callable[..., HttpResponse]]:
+) -> Union[Callable[[ViewFuncT], ViewFuncT], ViewFuncT]:
     actual_decorator = user_passes_test(
         logged_in_and_active,
         login_url=login_url,

--- a/zerver/lib/request.pyi
+++ b/zerver/lib/request.pyi
@@ -7,14 +7,13 @@
 # types.
 
 from typing import Any, Callable, Text, TypeVar, Optional, Union, Type
-from django.http import HttpResponse
+from zerver.lib.types import ViewFuncT
 
 from zerver.lib.exceptions import JsonableError as JsonableError
 
 Validator = Callable[[str, Any], Optional[str]]
 
 ResultT = TypeVar('ResultT')
-ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
 
 class RequestVariableMissingError(JsonableError): ...
 class RequestVariableConversionError(JsonableError): ...

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -1,0 +1,4 @@
+from typing import TypeVar, Callable
+from django.http import HttpResponse
+
+ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -225,7 +225,7 @@ class DecoratorTestCase(TestCase):
         request.POST['api_key'] = 'not_existing_api_key'
 
         with self.assertRaisesRegex(JsonableError, "Invalid API key"):
-            my_webhook(request)
+            my_webhook(request)  # type: ignore # mypy doesn't seem to apply the decorator
 
         # Start a valid request here
         request.POST['api_key'] = webhook_bot_api_key
@@ -233,7 +233,7 @@ class DecoratorTestCase(TestCase):
         with mock.patch('logging.warning') as mock_warning:
             with self.assertRaisesRegex(JsonableError,
                                         "Account is not associated with this subdomain"):
-                api_result = my_webhook(request)
+                api_result = my_webhook(request)  # type: ignore # mypy doesn't seem to apply the decorator
 
             mock_warning.assert_called_with(
                 "User {} ({}) attempted to access API on wrong "
@@ -243,7 +243,7 @@ class DecoratorTestCase(TestCase):
             with self.assertRaisesRegex(JsonableError,
                                         "Account is not associated with this subdomain"):
                 request.host = "acme." + settings.EXTERNAL_HOST
-                api_result = my_webhook(request)
+                api_result = my_webhook(request)  # type: ignore # mypy doesn't seem to apply the decorator
 
             mock_warning.assert_called_with(
                 "User {} ({}) attempted to access API on wrong "
@@ -257,7 +257,7 @@ class DecoratorTestCase(TestCase):
             with self.assertRaisesRegex(Exception, "raised by webhook function"):
                 request.body = "{}"
                 request.content_type = 'application/json'
-                my_webhook_raises_exception(request)
+                my_webhook_raises_exception(request)  # type: ignore # mypy doesn't seem to apply the decorator
 
         # Test when content_type is not application/json; exception raised
         # in the webhook function should be re-raised
@@ -265,7 +265,7 @@ class DecoratorTestCase(TestCase):
             with self.assertRaisesRegex(Exception, "raised by webhook function"):
                 request.body = "notjson"
                 request.content_type = 'text/plain'
-                my_webhook_raises_exception(request)
+                my_webhook_raises_exception(request)  # type: ignore # mypy doesn't seem to apply the decorator
 
         # Test when content_type is application/json but request.body
         # is not valid JSON; invalid JSON should be logged and the
@@ -274,7 +274,7 @@ class DecoratorTestCase(TestCase):
             with self.assertRaisesRegex(Exception, "raised by webhook function"):
                 request.body = "invalidjson"
                 request.content_type = 'application/json'
-                my_webhook_raises_exception(request)
+                my_webhook_raises_exception(request)  # type: ignore # mypy doesn't seem to apply the decorator
 
             message = """
 user: {email} ({realm})
@@ -297,7 +297,7 @@ body:
 
         with self.settings(RATE_LIMITING=True):
             with mock.patch('zerver.decorator.rate_limit_user') as rate_limit_mock:
-                api_result = my_webhook(request)
+                api_result = my_webhook(request)  # type: ignore # mypy doesn't seem to apply the decorator
 
         # Verify rate limiting was attempted.
         self.assertTrue(rate_limit_mock.called)
@@ -314,7 +314,7 @@ body:
         webhook_bot.is_active = False
         webhook_bot.save()
         with self.assertRaisesRegex(JsonableError, "Account not active"):
-            my_webhook(request)
+            my_webhook(request)  # type: ignore # mypy doesn't seem to apply the decorator
 
         # Reactive the user, but deactivate their realm.
         webhook_bot.is_active = True
@@ -322,7 +322,7 @@ body:
         webhook_bot.realm.deactivated = True
         webhook_bot.realm.save()
         with self.assertRaisesRegex(JsonableError, "Realm for account has been deactivated"):
-            my_webhook(request)
+            my_webhook(request)  # type: ignore # mypy doesn't seem to apply the decorator
 
     def test_authenticated_api_view_logging(self) -> None:
         @authenticated_api_view(is_webhook=True)
@@ -345,7 +345,7 @@ body:
                 request.body = '{}'
                 request.POST['payload'] = '{}'
                 request.content_type = 'text/plain'
-                my_webhook_raises_exception(request)
+                my_webhook_raises_exception(request)  # type: ignore # mypy doesn't seem to apply the decorator
 
             message = """
 user: {email} ({realm})

--- a/zerver/webhooks/beanstalk/view.py
+++ b/zerver/webhooks/beanstalk/view.py
@@ -8,13 +8,12 @@ from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import authenticated_rest_api_view
 from zerver.lib.actions import check_send_stream_message
+from zerver.lib.types import ViewFuncT
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.validator import check_dict
 from zerver.models import UserProfile, get_client
 from zerver.webhooks.github.view import build_message_from_gitlog
-
-ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
 
 # Beanstalk's web hook UI rejects url with a @ in the username section of a url
 # So we ask the user to replace them with %40

--- a/zerver/webhooks/github_dispatcher.py
+++ b/zerver/webhooks/github_dispatcher.py
@@ -9,6 +9,6 @@ from .github_webhook.view import api_github_webhook
 @csrf_exempt
 def api_github_webhook_dispatch(request: HttpRequest) -> HttpResponse:
     if request.META.get('HTTP_X_GITHUB_EVENT'):
-        return api_github_webhook(request)
+        return api_github_webhook(request)  # type: ignore # mypy doesn't seem to apply the decorator
     else:
-        return api_github_landing(request)
+        return api_github_landing(request)  # type: ignore # mypy doesn't seem to apply the decorator

--- a/zerver/webhooks/github_webhook/view.py
+++ b/zerver/webhooks/github_webhook/view.py
@@ -368,7 +368,7 @@ EVENT_FUNCTION_MAPPER = {
 @api_key_only_webhook_view('GitHub')
 @has_request_variables
 def api_github_webhook(
-        request: HttpResponse, user_profile: UserProfile, payload: Dict[str, Any]=REQ(argument_type='body'),
+        request: HttpRequest, user_profile: UserProfile, payload: Dict[str, Any]=REQ(argument_type='body'),
         stream: Text=REQ(default='github'), branches: Text=REQ(default=None)) -> HttpResponse:
     event = get_event(request, payload, branches)
     if event is not None:


### PR DESCRIPTION
* `ViewFuncT` was defined in 3 places (including a webhook); this is now in `zerver/lib/types.py`;
* Generally migrate use of `Callable[..., HttpResponse]` to `ViewFuncT`, removing the need for `WrappedViewFuncT` since `Callable[[ViewFuncT], ViewFuncT]` is clearer;
* Amend one webhook and decorator test code to include type ignores, to allow the previous;
* A few minor changes: `WrapperT` was previously no longer necessary, and `HttpResponse` was used for a `request` parameter.

Passes `test-all` on my droplet.

**Questions for reviewers**
* Would `types.py` be better named as `annotation_types.py` ?
* I've made the `ViewFuncT` substitution across `decorator.py`; are any cases going to be different - do they only match now due to `type: ignore` or use of the simplistic `ViewFuncT` definition? 
* Are the webhook/decorator-test type-ignores a correct resolution of the issue? (hence the `[?]` in the commit lines)

BTW gitlint seems to require commits be capitalized, hence here; is that new?