### PR TITLE
Mypy: Fully migrate to py3 function annotations in 3 more core files

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -479,7 +479,6 @@ def build_custom_checkers(by_lang):
              'zerver/lib/api_test_helpers.py',
              'zerver/lib/cache.py',
              'zerver/lib/request.py',
-             'zerver/lib/stream_subscription.py',
              'zerver/tornado/descriptors.py',
              'zerver/views/streams.py',
              # thumbor is (currently) python2 only

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -480,7 +480,6 @@ def build_custom_checkers(by_lang):
              'zerver/lib/cache.py',
              'zerver/lib/request.py',
              'zerver/lib/stream_subscription.py',
-             'zerver/models.py',
              'zerver/tornado/descriptors.py',
              'zerver/views/streams.py',
              # thumbor is (currently) python2 only

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -479,7 +479,6 @@ def build_custom_checkers(by_lang):
              'zerver/lib/api_test_helpers.py',
              'zerver/lib/cache.py',
              'zerver/lib/request.py',
-             'zerver/tornado/descriptors.py',
              'zerver/views/streams.py',
              # thumbor is (currently) python2 only
              'zthumbor/',

--- a/zerver/lib/stream_subscription.py
+++ b/zerver/lib/stream_subscription.py
@@ -9,31 +9,31 @@ from zerver.models import (
     UserProfile,
 )
 
-def get_active_subscriptions_for_stream_id(stream_id):
-    # type: (int) -> QuerySet[Subscription]
+def get_active_subscriptions_for_stream_id(stream_id: int) -> QuerySet:
+    # TODO: Change return type to QuerySet[Subscription]
     return Subscription.objects.filter(
         recipient__type=Recipient.STREAM,
         recipient__type_id=stream_id,
         active=True,
     )
 
-def get_active_subscriptions_for_stream_ids(stream_ids):
-    # type: (List[int]) -> QuerySet[Subscription]
+def get_active_subscriptions_for_stream_ids(stream_ids: List[int]) -> QuerySet:
+    # TODO: Change return type to QuerySet[Subscription]
     return Subscription.objects.filter(
         recipient__type=Recipient.STREAM,
         recipient__type_id__in=stream_ids,
         active=True
     )
 
-def get_stream_subscriptions_for_user(user_profile):
-    # type: (UserProfile) -> QuerySet[Subscription]
+def get_stream_subscriptions_for_user(user_profile: UserProfile) -> QuerySet:
+    # TODO: Change return type to QuerySet[Subscription]
     return Subscription.objects.filter(
         user_profile=user_profile,
         recipient__type=Recipient.STREAM,
     )
 
-def get_stream_subscriptions_for_users(user_profiles):
-    # type: (List[UserProfile]) -> QuerySet[Subscription]
+def get_stream_subscriptions_for_users(user_profiles: List[UserProfile]) -> QuerySet:
+    # TODO: Change return type to QuerySet[Subscription]
     return Subscription.objects.filter(
         user_profile__in=user_profiles,
         recipient__type=Recipient.STREAM,

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1036,6 +1036,8 @@ def stream_name_in_use(stream_name: Text, realm_id: int) -> bool:
     ).exists()
 
 def get_active_streams(realm: Optional[Realm]) -> QuerySet:
+    # TODO: Change return type to QuerySet[Stream]
+    # NOTE: Return value is used as a QuerySet, so cannot currently be Sequence[QuerySet]
     """
     Return all streams (including invite-only streams) that have not been deactivated.
     """
@@ -1249,8 +1251,7 @@ def pre_save_message(sender: Any, **kwargs: Any) -> None:
         message = kwargs['instance']
         message.update_calculated_fields()
 
-def get_context_for_message(message):
-    # type: (Message) -> QuerySet[Message]
+def get_context_for_message(message: Message) -> Sequence[Message]:
     # TODO: Change return type to QuerySet[Message]
     return Message.objects.filter(
         recipient_id=message.recipient_id,

--- a/zerver/tornado/descriptors.py
+++ b/zerver/tornado/descriptors.py
@@ -2,18 +2,17 @@
 from typing import Any, Dict, Optional
 
 if False:
-    import zerver.tornado.event_queue
+    from zerver.tornado.event_queue import ClientDescriptor
 
-descriptors_by_handler_id = {}  # type: Dict[int, zerver.tornado.event_queue.ClientDescriptor]
+descriptors_by_handler_id = {}  # type: Dict[int, ClientDescriptor]
 
-def get_descriptor_by_handler_id(handler_id):
-    # type: (int) -> zerver.tornado.event_queue.ClientDescriptor
+def get_descriptor_by_handler_id(handler_id: int) -> 'ClientDescriptor':
     return descriptors_by_handler_id.get(handler_id)
 
-def set_descriptor_by_handler_id(handler_id, client_descriptor):
-    # type: (int, zerver.tornado.event_queue.ClientDescriptor) -> None
+def set_descriptor_by_handler_id(handler_id: int,
+                                 client_descriptor: 'ClientDescriptor') -> None:
     descriptors_by_handler_id[handler_id] = client_descriptor
 
-def clear_descriptor_by_handler_id(handler_id, client_descriptor):
-    # type: (int, Optional[zerver.tornado.event_queue.ClientDescriptor]) -> None
+def clear_descriptor_by_handler_id(handler_id: int,
+                                   client_descriptor: 'ClientDescriptor') -> None:
     del descriptors_by_handler_id[handler_id]


### PR DESCRIPTION
This reduces the list of files which are excluded from linting for python2 annotations:
* models.py: using approach already taken elsewhere in the file (`QuerySet` without subscript, or `Sequence[T]`);
* stream_subscription.py: same approach as above, except only the former option is possible;
* descriptors.py: use quotes for types, presumably bypassing a circular dependency.

Passes `test-all` on droplet.