### PR TITLE
user-groups: Achieve 100% node-test coverage of user_groups.js

### DIFF
--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -17,6 +17,7 @@ zrequire('user_groups');
 
     var admins = {
         name: 'Admins',
+        description: 'foo',
         id: 1,
         members: [3],
     };
@@ -29,14 +30,23 @@ zrequire('user_groups');
     user_groups.add(admins);
     assert.equal(user_groups.get_user_group_from_id(admins.id), admins);
 
-    var update_event = {
+    var update_name_event = {
         group_id: admins.id,
         data: {
             name: "new admins",
         },
     };
-    user_groups.update(update_event);
+    user_groups.update(update_name_event);
     assert.equal(user_groups.get_user_group_from_id(admins.id).name, "new admins");
+
+    var update_des_event = {
+        group_id: admins.id,
+        data: {
+            description: "administer",
+        },
+    };
+    user_groups.update(update_des_event);
+    assert.equal(user_groups.get_user_group_from_id(admins.id).description, "administer");
 
     var called = false;
     global.blueslip.error = function (msg) {
@@ -52,4 +62,34 @@ zrequire('user_groups');
         assert.equal(msg, "Unknown group_id in get_user_group_from_id: " + students.id);
     };
     assert.equal(user_groups.get_user_group_from_id(students.id), undefined);
+
+    assert.equal(user_groups.get_user_group_from_name(all.name), undefined);
+    assert.equal(user_groups.get_user_group_from_name(admins.name).id, 1);
+
+    user_groups.add(all);
+    var user_groups_array = user_groups.get_realm_user_groups();
+    assert.equal(user_groups_array.length, 2);
+    assert.equal(user_groups_array[1].name, 'Everyone');
+    assert.equal(user_groups_array[0].name, 'new admins');
+
+    assert(!user_groups.is_member_of(admins.id, 4));
+    assert(user_groups.is_member_of(admins.id, 3));
+
+    user_groups.add_members(all.id, [5, 4]);
+    assert.deepEqual(user_groups.get_user_group_from_id(all.id).members,
+                        Dict.from_array([1, 2, 3, 5, 4]));
+
+    user_groups.remove_members(all.id, [1, 4]);
+    assert.deepEqual(user_groups.get_user_group_from_id(all.id).members,
+                        Dict.from_array([2, 3, 5]));
+
+    assert(user_groups.is_user_group(admins));
+    var object = {
+        name: 'core',
+        id: 3,
+    };
+    assert(!user_groups.is_user_group(object));
+
+    user_groups.init();
+    assert.equal(user_groups.get_realm_user_groups().length, 0);
 }());

--- a/static/js/user_groups.js
+++ b/static/js/user_groups.js
@@ -39,9 +39,13 @@ exports.update = function (event) {
     var group = exports.get_user_group_from_id(event.group_id);
     if (event.data.name !== undefined) {
         group.name = event.data.name;
+        user_group_name_dict.del(group.name);
+        user_group_name_dict.set(group.name, group);
     }
     if (event.data.description !== undefined) {
         group.description = event.data.description;
+        user_group_name_dict.del(group.name);
+        user_group_name_dict.set(group.name, group);
     }
 };
 

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -64,6 +64,7 @@ enforce_fully_covered = {
     'static/js/typing_status.js',
     'static/js/unread.js',
     'static/js/user_events.js',
+    'static/js/user_groups.js',
     'static/js/user_pill.js',
     'static/js/util.js',
 }


### PR DESCRIPTION
This PR fixes #8704. Also, I have added a commit for updating user_group_name_dict also, when update event for name/description is triggered, so that when get_user_group_from_name is called, it doesn't return undefined.