### PR TITLE
org settings: Clear input fields of filter settings on success and disable button.

### DIFF
--- a/static/js/settings_filters.js
+++ b/static/js/settings_filters.js
@@ -72,6 +72,8 @@ exports.set_up = function () {
         var filter_status = $('#admin-filter-status');
         var pattern_status = $('#admin-filter-pattern-status');
         var format_status = $('#admin-filter-format-status');
+        var add_filter_button = $('.new-filter-form button');
+        add_filter_button.attr("disabled", "disabled");
         filter_status.hide();
         pattern_status.hide();
         format_status.hide();
@@ -86,11 +88,13 @@ exports.set_up = function () {
             success: function (data) {
                 $('#filter_pattern').val('');
                 $('#filter_format_string').val('');
+                add_filter_button.removeAttr("disabled");
                 filter.id = data.id;
                 ui_report.success(i18n.t("Custom filter added!"), filter_status);
             },
             error: function (xhr) {
                 var errors = JSON.parse(xhr.responseText).errors;
+                add_filter_button.removeAttr("disabled");
                 if (errors.pattern !== undefined) {
                     xhr.responseText = JSON.stringify({msg: errors.pattern});
                     ui_report.error(i18n.t("Failed"), xhr, pattern_status);

--- a/static/js/settings_filters.js
+++ b/static/js/settings_filters.js
@@ -84,6 +84,8 @@ exports.set_up = function () {
             url: "/json/realm/filters",
             data: $(this).serialize(),
             success: function (data) {
+                $('#filter_pattern').val('');
+                $('#filter_format_string').val('');
                 filter.id = data.id;
                 ui_report.success(i18n.t("Custom filter added!"), filter_status);
             },


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**org settings: Clear input fields of filter settings on success.**

**org settings: Disable "Add filter" button when a request is in transit.**
This prevents accidental multiple click requests due to which we get
some errors like "This field cannot be blank."(though we have successfully
added the desired filter).

**Testing Plan:** <!-- How have you tested? -->
Manual Testing

Fixes: #8699.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
