### PR TITLE
 settings: Auto save user group members on blur.

### DIFF
--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -29,6 +29,7 @@ var cancel_selector = "#user-groups #1 .cancel";
 var saved_selector = "#user-groups #1 .saved";
 var name_selector = "#user-groups #1 .name";
 var description_selector = "#user-groups #1 .description";
+var instructions_selector = "#user-groups #1 .save-instructions";
 
 (function test_populate_user_groups() {
     var realm_user_group = {
@@ -178,6 +179,7 @@ var description_selector = "#user-groups #1 .description";
 
             var saved_fade_out_called = false;
             var cancel_fade_to_called = false;
+            var instructions_fade_to_called = false;
             $(saved_selector).fadeOut = function () {
                 saved_fade_out_called = true;
             };
@@ -193,12 +195,25 @@ var description_selector = "#user-groups #1 .description";
             $(cancel_selector).fadeTo = function () {
                 cancel_fade_to_called = true;
             };
+            $(instructions_selector).css = function (data) {
+                if (typeof(data) === 'string') {
+                    assert.equal(data, 'display');
+                }
+                assert.equal(typeof(data), 'object');
+                assert.equal(data.display, 'block');
+                assert.equal(data.opacity, '0');
+                return $(instructions_selector);
+            };
+            $(instructions_selector).fadeTo = function () {
+                instructions_fade_to_called = true;
+            };
 
             text_cleared = false;
             config.updater(alice);
             // update_cancel_button is called.
             assert(saved_fade_out_called);
             assert(cancel_fade_to_called);
+            assert(instructions_fade_to_called);
             assert.equal(text_cleared, true);
         }());
         input_typeahead_called = true;
@@ -458,20 +473,27 @@ var description_selector = "#user-groups #1 .description";
         };
 
         var cancel_fade_out_called = false;
+        var instructions_fade_out_called = false;
         $(cancel_selector).show();
         $(cancel_selector).fadeOut = function () {
             cancel_fade_out_called = true;
+        };
+        $(instructions_selector).fadeOut = function () {
+            instructions_fade_out_called = true;
         };
 
         // Cancel button removed if user group if user group has no changes.
         var fake_this = $.create('fake-#update_cancel_button');
         handler_name.call(fake_this);
         assert(cancel_fade_out_called);
+        assert(instructions_fade_out_called);
 
         // Check for handler_desc to achieve 100% coverage.
         cancel_fade_out_called = false;
+        instructions_fade_out_called = false;
         handler_desc.call(fake_this);
         assert(cancel_fade_out_called);
+        assert(instructions_fade_out_called);
     }());
 
     (function test_user_groups_save_group_changes_triggered() {
@@ -489,6 +511,10 @@ var description_selector = "#user-groups #1 .description";
         var api_endpoint_called = false;
         var cancel_fade_out_called = false;
         var saved_fade_to_called = false;
+        var instructions_fade_out_called = false;
+        $(instructions_selector).fadeOut = function () {
+            instructions_fade_out_called = true;
+        };
         $(cancel_selector).fadeOut = function () {
             cancel_fade_out_called = true;
         };
@@ -516,6 +542,7 @@ var description_selector = "#user-groups #1 .description";
                 });
                 opts.success();
                 assert(cancel_fade_out_called);
+                assert(instructions_fade_out_called);
                 assert(saved_fade_to_called);
             }());
         };
@@ -562,6 +589,10 @@ var description_selector = "#user-groups #1 .description";
 
         var cancel_fade_out_called = false;
         var saved_fade_to_called = false;
+        var instructions_fade_out_called = false;
+        $(instructions_selector).fadeOut = function () {
+            instructions_fade_out_called = true;
+        };
         $(cancel_selector).fadeOut = function () {
             cancel_fade_out_called = true;
         };
@@ -582,6 +613,7 @@ var description_selector = "#user-groups #1 .description";
             (function test_post_success() {
                 opts.success();
                 assert(cancel_fade_out_called);
+                assert(instructions_fade_out_called);
                 assert(saved_fade_to_called);
             }());
         };

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -300,12 +300,14 @@ function render(template_name, args) {
     global.write_handlebars_output('admin_user_group_list', html);
 
     var group_id = $(html).find('.user-group:first').prop('id');
-    var group_name = $(html).find('.user-group:first .pill-container').attr('data-group-pills');
-    var group_description = $(html).find('.user-group:first h4').text().trim().replace(/\s+/g, ' ');
+    var group_name_pills = $(html).find('.user-group:first .pill-container').attr('data-group-pills');
+    var group_name_display = $(html).find('.user-group:first .name').text().trim().replace(/\s+/g, ' ');
+    var group_description = $(html).find('.user-group:first .description').text().trim().replace(/\s+/g, ' ');
 
     assert.equal(group_id, '9');
-    assert.equal(group_name, 'uranohoshi');
-    assert.equal(group_description, 'uranohoshi — Students at Uranohoshi Academy');
+    assert.equal(group_name_pills, 'uranohoshi');
+    assert.equal(group_name_display, 'uranohoshi');
+    assert.equal(group_description, 'Students at Uranohoshi Academy');
 }());
 
 (function admin_user_list() {

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -126,6 +126,12 @@ exports.make_zjquery = function () {
                 }
                 return html;
             },
+            is: function (arg) {
+                if (arg === ':visible') {
+                    return shown;
+                }
+                return self;
+            },
             is_focused: function () {
                 // is_focused is not a jQuery thing; this is
                 // for our testing

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -51,7 +51,7 @@ exports.populate_user_groups = function () {
             });
         }
 
-            data.members.keys().forEach(function (user_id) {
+        data.members.keys().forEach(function (user_id) {
             var user = people.get_person_from_user_id(user_id);
 
             if (user) {
@@ -79,21 +79,28 @@ exports.populate_user_groups = function () {
         function update_cancel_button() {
             var cancel_button = $('#user-groups #' + data.id + ' .cancel');
             var saved_button = $('#user-groups #' + data.id + ' .saved');
+            var save_instructions = $('#user-groups #' + data.id + ' .save-instructions');
+
             if (is_user_group_changed() &&
                !cancel_button.is(':visible')) {
                 saved_button.fadeOut(0);
                 cancel_button.css({display: 'inline-block', opacity: 0}).fadeTo(400, 1);
+                save_instructions.css({display: 'block', opacity: 0}).fadeTo(400, 1);
             } else if (!is_user_group_changed() &&
                 cancel_button.is(':visible')) {
                     cancel_button.fadeOut();
+                    save_instructions.fadeOut();
                 }
         }
 
         function show_saved_button() {
             var cancel_button = $('#user-groups #' + data.id + ' .cancel');
             var saved_button = $('#user-groups #' + data.id + ' .saved');
+            var save_instructions = $('#user-groups #' + data.id + ' .save-instructions');
+
             if (!saved_button.is(':visible')) {
                 cancel_button.fadeOut(0);
+                save_instructions.fadeOut(0);
                 saved_button.css({display: 'inline-block', opacity: 0}).fadeTo(400, 1);
             }
         }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -947,10 +947,32 @@ input[type=checkbox].inline-block {
     vertical-align: 1px;
 }
 
-#user-groups .save-group-changes,
-#user-groups .save-member-changes {
+#user-groups .save-status {
+    vertical-align: middle;
+    height: auto;
+    width: auto;
+    background: transparent;
+    padding: 2px 5px;
+    border-radius: 4px;
+    margin-left: 10px;
+}
+
+#user-groups .save-status.saved {
     display: none;
     opacity: 0;
+    border: 1px solid hsl(178, 100%, 40%);
+    color: hsl(178, 100%, 40%);
+}
+
+#user-groups .save-status.cancel {
+    display: none;
+    opacity: 0;
+    border: 1px solid #333;
+    color: #333;
+}
+
+#user-groups .checkmark {
+    width: 13px;
 }
 
 #user-groups .delete {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -953,6 +953,10 @@ input[type=checkbox].inline-block {
     opacity: 0;
 }
 
+#user-groups .delete {
+    float: right;
+}
+
 /* -- new settings overlay -- */
 #settings_page {
     height: 95vh;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -979,6 +979,13 @@ input[type=checkbox].inline-block {
     float: right;
 }
 
+#user-groups .save-instructions {
+    display: none;
+    opacity: 0;
+    color: #333;
+    font-size: 0.9em;
+}
+
 /* -- new settings overlay -- */
 #settings_page {
     height: 95vh;

--- a/static/templates/admin_user_group_list.handlebars
+++ b/static/templates/admin_user_group_list.handlebars
@@ -4,8 +4,12 @@
         <span class="name" data-placeholder="{{t 'Name' }}" contenteditable="true" spellcheck="false">{{name}}</span>
         —
         <span class="description" data-placeholder="{{t 'Description' }}" contenteditable="true">{{description}}</span>
-        <button class="button rounded small save-group-changes sea-green">
-            <i class="fa fa-check" aria-hidden="true"></i>
+        <button class="save-status saved">
+            <img class="checkmark" src="/static/images/checkbox-green.svg" />
+            {{t 'Saved' }}
+        </button>
+        <button class="save-status cancel">
+            {{t 'Cancel' }}
         </button>
         <button class="button rounded small delete btn-danger">
             {{t 'Delete' }}
@@ -16,9 +20,6 @@
         <div class="pill-container" data-group-pills="{{name}}">
             <div class="input" contenteditable="true" data-placeholder="{{t 'Add member...' }}"></div>
         </div>
-        <button class="button rounded small save-member-changes sea-green">
-            <i class="fa fa-check" aria-hidden="true"></i>
-        </button>
     </p>
 </div>
 {{/with}}

--- a/static/templates/admin_user_group_list.handlebars
+++ b/static/templates/admin_user_group_list.handlebars
@@ -9,7 +9,7 @@
             {{t 'Saved' }}
         </button>
         <button class="save-status cancel">
-            {{t 'Cancel' }}
+            {{t 'Discard changes' }}
         </button>
         <button class="button rounded small delete btn-danger">
             {{t 'Delete' }}
@@ -19,6 +19,9 @@
         {{t 'Subscribers' }}
         <div class="pill-container" data-group-pills="{{name}}">
             <div class="input" contenteditable="true" data-placeholder="{{t 'Add member...' }}"></div>
+        </div>
+        <div class="save-instructions">
+            {{t 'Click outside the input box to save. We\'ll automatically notify anyone that was added or removed.'}}
         </div>
     </p>
 </div>

--- a/static/templates/admin_user_group_list.handlebars
+++ b/static/templates/admin_user_group_list.handlebars
@@ -8,7 +8,7 @@
             <i class="fa fa-check" aria-hidden="true"></i>
         </button>
         <button class="button rounded small delete btn-danger">
-            <i class="fa fa-trash-o" aria-hidden="true"></i>
+            {{t 'Delete' }}
         </button>
     </h4>
     <p>


### PR DESCRIPTION
Fixes #8088.
- Cancel button fades out if user removes the changes manually i.e without clicking the cancel button.
- Clicking on cancel button discards the changes and the user group returns to its original state.
- Suppose you've made a change to the name, clicking on the description edit or pill input of the same group does not save that name, but if you click 
any input that is not present in the current group, then that change is saved before allowing the user to edit the second group.
- Solved: If user has added 1 user and tries to add another user (the 1st user is unsaved), then as typeahead is outside the input box, blur event is triggered resulting in the saving of 1st member which wasn't the intention.

![saveonblur1](https://user-images.githubusercontent.com/13910561/37492839-dd55fa38-28c8-11e8-9a4e-0de996681cab.gif)

Changes saved if any other user group input clicked:
![saveonblur2](https://user-images.githubusercontent.com/13910561/37492870-f7ba75d4-28c8-11e8-93b0-e5585eef7463.gif)
