### PR TITLE
[WIP] tests: improve test coverage of zerver/lib files

### DIFF
--- a/zerver/lib/hotspots.py
+++ b/zerver/lib/hotspots.py
@@ -28,9 +28,8 @@ ALL_HOTSPOTS = {
 }  # type: Dict[str, Dict[str, Text]]
 
 def get_next_hotspots(user: UserProfile) -> List[Dict[str, object]]:
-    # For manual testing, it can be convenient to set
-    # ALWAYS_SEND_ALL_HOTSPOTS=True in `zproject/dev_settings.py` to
-    # make it easy to click on all of the hotspots.
+    # Only used for manual testing
+    # set this value True in zproject/dev_settings.py
     if settings.ALWAYS_SEND_ALL_HOTSPOTS:
         return [{
             'name': hotspot,

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -219,6 +219,10 @@ FEEDBACK_EMAIL = ZULIP_ADMINISTRATOR
 # "file:///" as a hyperlink (useful if you have e.g. an NFS share).
 ENABLE_FILE_LINKS = False
 
+# This is used to send all hotspots for manual testing in
+# development mode. Always set it False in Production.
+ALWAYS_SEND_ALL_HOTSPOTS = False
+
 # By default, files uploaded by users and user avatars are stored
 # directly on the Zulip server.  If file storage in Amazon S3 is
 # desired, you can configure that as follows:


### PR DESCRIPTION
#7089  
 - [x] zerver/lib/management.py: Add a few corner cases to test suite in zerver/tests/test_management_commands.py.
- [x] zerver/lib/message.py: get_raw_unread_data needs a test with 2 messages to the same group PM thread ("huddle"), and the Message is None case in render_markdown is probably dead code, since render_message_backend seems to actually pass a fake Message object now. Which suggest a pretty nice cleanup.
 - [x] zerver/lib/tex.py render_text probably just needs a small unit test that features with self.settings(STATIC_ROOT="/invalid/path") and confirms the error appears.
  - [x] zerver/lib/hotspots.py: Add a test for the SEND_ALL feature (used primarily in development)
 - [x]  zerver/lib/initial_password.py: Just needs a unit test using with self.settings(INITIAL_PASSWORD_SALT='').
  - [x] zerver/lib/url_preview/preview.py | 40 | 1 | 0 | 98%
  - [ ] zerver/lib/user_agent.py: Add a test passing in something totally invalid as a user agent.
 - [ ]  zerver/lib/soft_deactivation.py: Just need a test in zerver/tests/test_soft_deactivation.py to cover the case that the user unsubscribed early.