### PR TITLE
uploads: Make web app more XSS safe from user uploaded files.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.direct
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.direct
@@ -1,5 +1,6 @@
 location /user_uploads {
     add_header X-Content-Type-Options nosniff;
+    add_header Content-Security-Policy "default-src 'none' img-src 'self'";
     include /etc/nginx/zulip-include/uploads.types;
     alias /home/zulip/uploads/files;
 }

--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.internal
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.internal
@@ -1,6 +1,7 @@
 location /serve_uploads {
     internal;
     add_header X-Content-Type-Options nosniff;
+    add_header Content-Security-Policy "default-src 'none' img-src 'self'";
     include /etc/nginx/zulip-include/uploads.types;
     alias /home/zulip/uploads/files;
 }


### PR DESCRIPTION
In this PR we make sure that the user_uploads/ files which are served should have a Content Security Policy (CSP) header. Using the CSP header we make our web app more XSS tolerant in the sense that now no inline JS buried in images could be executed and no external scripts can be requested other than those which have origin same as the web server.

To test this out we can use the file located at: https://html5sec.org/test.svg
More testing files could be found at https://github.com/cure53/H5SC but most of them aren't of use to us since we only allow browser to render a file in browser in case a image or a PDF. So it is only these files which need extra attention.
More about CSP:
https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
https://www.owasp.org/index.php/Content_Security_Policy_Cheat_Sheet