### PR TITLE
Fix: #5827 - minimize references to the home view in /help/

### DIFF
--- a/templates/zerver/help/reading-messages-by-stream-or-topic.md
+++ b/templates/zerver/help/reading-messages-by-stream-or-topic.md
@@ -3,6 +3,13 @@
 You can view all messages from a specific stream by following the following
 steps.
 
+1. Find the **Streams** section in the left sidebar.
+
+2. Click on the name of stream to view all messages sent to that particular stream.
+
+If you're on the home view, you can view all messages from a specific stream by following the following
+steps.
+
 1. In your view, find a message sent to the stream.
 
 2. Click on the message's stream to narrow your view to all messages sent to
@@ -10,8 +17,7 @@ that particular stream.
 
 !!! tip ""
     You can also view your all messages from a specific stream by entering
-    the search operator `stream:(stream name)` in the search bar or
-    selecting the stream from the **Streams** section in the left sidebar.
+    the search operator `stream:(stream name)` in the search bar.
 
 # View messages from a topic
 


### PR DESCRIPTION
Fix : [#5827](https://github.com/zulip/zulip/issues/5827) . Emphasize left sidebar instead of the home view.

