### PR TITLE
Centralize Validator definition in types.py

### DIFF
--- a/zerver/lib/request.pyi
+++ b/zerver/lib/request.pyi
@@ -7,11 +7,9 @@
 # types.
 
 from typing import Any, Callable, Text, TypeVar, Optional, Union, Type
-from zerver.lib.types import ViewFuncT
+from zerver.lib.types import ViewFuncT, Validator
 
 from zerver.lib.exceptions import JsonableError as JsonableError
-
-Validator = Callable[[str, Any], Optional[str]]
 
 ResultT = TypeVar('ResultT')
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -1153,7 +1153,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         # invalid URL test case.
         bot_info['payload_url'] = ujson.dumps('http://127.0.0.:5002/bots/followup')
         result = self.client_post("/json/bots", bot_info)
-        self.assert_json_error(result, "Enter a valid URL.")
+        self.assert_json_error(result, "payload_url is not a URL")
 
     def test_get_bot_handler(self) -> None:
         # Test for valid service.

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -634,14 +634,16 @@ class ValidatorTestCase(TestCase):
 
     def test_check_url(self) -> None:
         url = "http://127.0.0.1:5002/"  # type: Any
-        check_url('url', url)
+        self.assertEqual(check_url('url', url), None)
 
         url = "http://zulip-bots.example.com/"
-        check_url('url', url)
+        self.assertEqual(check_url('url', url), None)
 
         url = "http://127.0.0"
-        with self.assertRaises(JsonableError):
-            check_url('url', url)
+        self.assertEqual(check_url('url', url), 'url is not a URL')
+
+        url = 99.3
+        self.assertEqual(check_url('url', url), 'url is not a string')
 
 class DeactivatedRealmTest(ZulipTestCase):
     def test_send_deactivated_realm(self) -> None:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1553,12 +1553,12 @@ class EventsRegisterTest(ZulipTestCase):
             if bot_type == "GENERIC_BOT":
                 check_services = check_list(sub_validator=None, length=0)
             elif bot_type == "OUTGOING_WEBHOOK_BOT":
-                check_services = check_list(check_dict_only([  # type: ignore  # check_url doesn't completely fit the default validator spec, but is de facto working here.
+                check_services = check_list(check_dict_only([
                     ('base_url', check_url),
                     ('interface', check_int),
                 ]), length=1)
             elif bot_type == "EMBEDDED_BOT":
-                check_services = check_list(check_dict_only([  # type: ignore  # See above.
+                check_services = check_list(check_dict_only([
                     ('service_name', check_string),
                     ('config_data', check_dict(value_validator=check_string)),
                 ]), length=1)
@@ -1745,7 +1745,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('bot', check_dict_only([
                 ('email', check_string),
                 ('user_id', check_int),
-                ('services', check_list(check_dict_only([  # type: ignore  # check_url doesn't completely fit the default validator spec, but is de facto working here.
+                ('services', check_list(check_dict_only([
                     ('base_url', check_url),
                     ('interface', check_int),
                 ]))),
@@ -1795,7 +1795,7 @@ class EventsRegisterTest(ZulipTestCase):
                 ('default_all_public_streams', check_bool),
                 ('avatar_url', check_string),
                 ('owner', check_none_or(check_string)),
-                ('services', check_list(check_dict_only([  # type: ignore  # check_url doesn't completely fit the default validator spec, but is de facto working here.
+                ('services', check_list(check_dict_only([
                     ('base_url', check_url),
                     ('interface', check_int),
                 ]))),


### PR DESCRIPTION
Following #8708, which introduced type.py to hold the widely used `ViewFuncT` type, this PR uses the same file to centralize the definition of `Validator`.

Implementations matching the `Validator` type are generally in `validator.py`, but it is currently also defined separately in `request.pyi` (since the REQ pattern uses it). After some digging, an equivalent type is also used in `models.py`, though no type alias is used here. The definition varies slightly as the PR diff shows, notably between `Any` and `object` in the second parameter, though `check_url` has `Text`, which satisfies the former but not the latter, requiring adjustment in this PR but also allowing removal of some `type: ignore` comments.

Commits all together pass `test-all` on my droplet; untested individually, but look fairly safe.

**Points for reviewers to consider**
* I don't believe any strictness is lost in the second parameter of `check_url` moving to `object` from `Text`, since there is no information about what is passed in here that is different than any other `check_*` function?
* Should `check_url` be adjusted to return a true `Optional[str]` in future, rather than returning `None` or throwing an exception, as at present? That would fit with the standard `check_*` behavior.

**Other queries**
* Is it worth/possible to move types.py into types.pyi, since it is by intended to just hold type definitions?