### PR TITLE
Mypy: Fully migrate to py3 function annotations in cache.py

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -477,7 +477,6 @@ def build_custom_checkers(by_lang):
              # Zerver files that we should just clean.
              'zerver/tests',
              'zerver/lib/api_test_helpers.py',
-             'zerver/lib/cache.py',
              'zerver/lib/request.py',
              'zerver/views/streams.py',
              # thumbor is (currently) python2 only

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -303,12 +303,10 @@ def user_profile_by_email_cache_key(email: Text) -> Text:
     # with high likelihood be ASCII-only for the foreseeable future.
     return 'user_profile_by_email:%s' % (make_safe_digest(email.strip()),)
 
-def user_profile_cache_key_id(email, realm_id):
-    # type: (Text, int) -> Text
+def user_profile_cache_key_id(email: Text, realm_id: int) -> Text:
     return u"user_profile:%s:%s" % (make_safe_digest(email.strip()), realm_id,)
 
-def user_profile_cache_key(email, realm):
-    # type: (Text, Realm) -> Text
+def user_profile_cache_key(email: Text, realm: 'Realm') -> Text:
     return user_profile_cache_key_id(email, realm.id)
 
 def bot_profile_cache_key(email: Text) -> Text:
@@ -342,16 +340,14 @@ bot_dict_fields = ['id', 'full_name', 'short_name', 'bot_type', 'email',
                    'bot_owner__email', 'avatar_source',
                    'avatar_version']  # type: List[str]
 
-def bot_dicts_in_realm_cache_key(realm):
-    # type: (Realm) -> Text
+def bot_dicts_in_realm_cache_key(realm: 'Realm') -> Text:
     return "bot_dicts_in_realm:%s" % (realm.id,)
 
 def get_stream_cache_key(stream_name: Text, realm_id: int) -> Text:
     return "stream_by_realm_and_name:%s:%s" % (
         realm_id, make_safe_digest(stream_name.strip().lower()))
 
-def delete_user_profile_caches(user_profiles):
-    # type: (Iterable[UserProfile]) -> None
+def delete_user_profile_caches(user_profiles: Iterable['UserProfile']) -> None:
     keys = []
     for user_profile in user_profiles:
         keys.append(user_profile_by_email_cache_key(user_profile.email))
@@ -361,8 +357,7 @@ def delete_user_profile_caches(user_profiles):
 
     cache_delete_many(keys)
 
-def delete_display_recipient_cache(user_profile):
-    # type: (UserProfile) -> None
+def delete_display_recipient_cache(user_profile: 'UserProfile') -> None:
     from zerver.models import Subscription  # We need to import here to avoid cyclic dependency.
     recipient_ids = Subscription.objects.filter(user_profile=user_profile)
     recipient_ids = recipient_ids.values_list('recipient_id', flat=True)
@@ -427,12 +422,10 @@ def flush_realm(sender: Any, **kwargs: Any) -> None:
         cache_delete(bot_dicts_in_realm_cache_key(realm))
         cache_delete(realm_alert_words_cache_key(realm))
 
-def realm_alert_words_cache_key(realm):
-    # type: (Realm) -> Text
+def realm_alert_words_cache_key(realm: 'Realm') -> Text:
     return "realm_alert_words:%s" % (realm.string_id,)
 
-def realm_first_visible_message_id_cache_key(realm):
-    # type: (Realm) -> Text
+def realm_first_visible_message_id_cache_key(realm: 'Realm') -> Text:
     return u"realm_first_visible_message_id:%s" % (realm.string_id,)
 
 # Called by models.py to flush the stream cache whenever we save a stream
@@ -453,8 +446,7 @@ def flush_stream(sender: Any, **kwargs: Any) -> None:
 def to_dict_cache_key_id(message_id: int) -> Text:
     return 'message_dict:%d' % (message_id,)
 
-def to_dict_cache_key(message):
-    # type: (Message) -> Text
+def to_dict_cache_key(message: 'Message') -> Text:
     return to_dict_cache_key_id(message.id)
 
 def flush_message(sender: Any, **kwargs: Any) -> None:

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -107,15 +107,18 @@ def get_cache_backend(cache_name: Optional[str]) -> BaseCache:
         return djcache
     return caches[cache_name]
 
-def get_cache_with_key(keyfunc: Any, cache_name: Optional[str]=None) -> Any:
+def get_cache_with_key(
+        keyfunc: Callable[..., Text],
+        cache_name: Optional[str]=None
+) -> Callable[[Callable[..., ReturnT]], Callable[..., ReturnT]]:
     """
     The main goal of this function getting value from the cache like in the "cache_with_key".
     A cache value can contain any data including the "None", so
     here used exception for case if value isn't found in the cache.
     """
-    def decorator(func: Callable[..., Any]) -> (Callable[..., Any]):
+    def decorator(func: Callable[..., ReturnT]) -> (Callable[..., ReturnT]):
         @wraps(func)
-        def func_with_caching(*args: Any, **kwargs: Any) -> Callable[..., Any]:
+        def func_with_caching(*args: Any, **kwargs: Any) -> Callable[..., ReturnT]:
             key = keyfunc(*args, **kwargs)
             val = cache_get(key, cache_name=cache_name)
             if val is not None:
@@ -126,8 +129,10 @@ def get_cache_with_key(keyfunc: Any, cache_name: Optional[str]=None) -> Any:
 
     return decorator
 
-def cache_with_key(keyfunc, cache_name=None, timeout=None, with_statsd_key=None):
-    # type: (Callable[..., Text], Optional[str], Optional[int], Optional[str]) -> Callable[[Callable[..., ReturnT]], Callable[..., ReturnT]]
+def cache_with_key(
+        keyfunc: Callable[..., Text], cache_name: Optional[str]=None,
+        timeout: Optional[int]=None, with_statsd_key: Optional[str]=None
+) -> Callable[[Callable[..., ReturnT]], Callable[..., ReturnT]]:
     """Decorator which applies Django caching to a function.
 
        Decorator argument is a function which computes a cache key


### PR DESCRIPTION
Migrate one more of the outstanding files previously excluded from the python3 function annotation lint check introduced in #8662 - `cache.py`.

The first commit generally improves upon some use of `Any` by matching `ReturnT` in the `[get_]cache_with_key` functions, and removing one use of python2 comment annotation in `cache_with_key`.

The second commit makes the remaining simple annotation changes to `cache.py` and removes the exclusion from the lint check in `custom_check.py`. This uses forward declaration style typing for `Realm`, `UserProfile` and `Message`; see the query below.

Both commits individually pass `test-all` on my droplet.

**Query for reviewers**
* A `TODO` on line 321 suggests a reformulation of imports is necessary for this transition to be possible, yet it passes `test-all` since this uses forward declaration of types instead; is this style ok? if so, should these two lines of text be removed in the final commit?