### PR TITLE
Hotspot sync

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -646,12 +646,7 @@ $(function () {
     // open
     $('body').on('click', '.hotspot-icon', function (e) {
         // hide icon
-        $(this).animate({ opacity: 0 }, {
-            duration: 300,
-            done: function () {
-                $(this).css({ display: 'none' });
-            }.bind(this),
-        });
+        hotspots.close_hotspot_icon(this);
 
         // show popover
         var hotspot_name = $(e.target).closest('.hotspot-icon')

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -216,7 +216,15 @@ exports.close_hotspot_icon = function (elem) {
     });
 };
 
+function close_read_hotspots(new_hotspots) {
+    var unwanted_hotspots = _.difference(_.keys(HOTSPOT_LOCATIONS), _.pluck(new_hotspots, 'name'));
+    _.each(unwanted_hotspots, function (hotspot_name) {
+        exports.close_hotspot_icon($('#hotspot_' + hotspot_name + '_icon'));
+    });
+}
+
 exports.load_new = function (new_hotspots) {
+    close_read_hotspots(new_hotspots);
     new_hotspots.forEach(function (hotspot) {
         hotspot.location = HOTSPOT_LOCATIONS[hotspot.name];
     });

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -207,6 +207,15 @@ exports.is_open = function () {
     return $('.hotspot.overlay').hasClass('show');
 };
 
+exports.close_hotspot_icon = function (elem) {
+    $(elem).animate({ opacity: 0 }, {
+        duration: 300,
+        done: function () {
+            $(elem).css({ display: 'none' });
+        }.bind(elem),
+    });
+};
+
 exports.load_new = function (new_hotspots) {
     new_hotspots.forEach(function (hotspot) {
         hotspot.location = HOTSPOT_LOCATIONS[hotspot.name];


### PR DESCRIPTION

**hotspots: Fix real-time sync for dismissing hotspots.**
This closes all the hotspots which aren't included in the event.hotspots.
This means we treat all the hotspots in event.hotspots as the hotspot
which need to be shown.

Fixes: #8690.
Is this is what you're referring @timabbott .
**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
**[GIF LINK](https://i.imgur.com/QHj9FT6.gifv)**


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
