### PR TITLE
Webhooks: Prefer topic as alternative to subject in ifttt & zapier

### DIFF
--- a/zerver/webhooks/ifttt/doc.md
+++ b/zerver/webhooks/ifttt/doc.md
@@ -10,11 +10,11 @@ Get notifications from every event supported by IFTTT!
 
 1. Set **URL** to the URL constructed above. Set **Method** to `POST`,
    and set **Content Type** to `application/json`. Set **Body** to a
-   JSON object with two parameters: `content` and `subject`, like so:
+   JSON object with two parameters: `content` and `topic`, like so:
 
-    `{"content": "message body", "subject": "message topic"}`
+    `{"content": "message body", "topic": "message topic"}`
 
     You will most likely want to specify some IFTTT **Ingredients** to
-    customize the subject and content of your messages. Click **Add ingredient**
-    to see the available options and customize the `content` and `subject`
+    customize the topic and content of your messages. Click **Add ingredient**
+    to see the available options and customize the `content` and `topic`
     parameters as necessary. Click **Create action**, and click **Finish**.

--- a/zerver/webhooks/ifttt/fixtures/correct_topic_and_body.json
+++ b/zerver/webhooks/ifttt/fixtures/correct_topic_and_body.json
@@ -1,0 +1,4 @@
+{
+  "topic": "Email sent from email@email.com",
+  "content": "Email subject: Subject"
+}

--- a/zerver/webhooks/ifttt/tests.py
+++ b/zerver/webhooks/ifttt/tests.py
@@ -10,3 +10,8 @@ class IFTTTHookTests(WebhookTestCase):
         expected_subject = u"Email sent from email@email.com"
         expected_message = u"Email subject: Subject"
         self.send_and_test_stream_message('correct_subject_and_body', expected_subject, expected_message)
+
+    def test_ifttt_when_topic_and_body_are_correct(self) -> None:
+        expected_subject = u"Email sent from email@email.com"
+        expected_message = u"Email subject: Subject"
+        self.send_and_test_stream_message('correct_topic_and_body', expected_subject, expected_message)

--- a/zerver/webhooks/ifttt/view.py
+++ b/zerver/webhooks/ifttt/view.py
@@ -13,11 +13,16 @@ from zerver.models import UserProfile
 @has_request_variables
 def api_iftt_app_webhook(request: HttpRequest, user_profile: UserProfile,
                          payload: Dict[str, Any]=REQ(argument_type='body')) -> HttpResponse:
-    subject = payload.get('subject')
+    topic = payload.get('topic')
     content = payload.get('content')
-    if subject is None:
-        return json_error(_("Subject can't be empty"))
+
+    if topic is None:
+        topic = payload.get('subject')  # Backwards-compatibility
+        if topic is None:
+            return json_error(_("Topic can't be empty"))
+
     if content is None:
         return json_error(_("Content can't be empty"))
-    check_send_webhook_message(request, user_profile, subject, content)
+
+    check_send_webhook_message(request, user_profile, topic, content)
     return json_success()

--- a/zerver/webhooks/zapier/doc.md
+++ b/zerver/webhooks/zapier/doc.md
@@ -12,8 +12,8 @@ Get notifications from every event supported by Zapier.
 1. Set **URL** to the URL constructed above. Set **Payload Type** to `JSON`.
    Add the following two fields to **Data**:
 
-    * `subject` corresponds to the topic of a message
+    * `topic` corresponds to the topic of a message
     * `content` corresponds to the content of a message
 
-    Customize the `subject` and `content` fields as necessary. Click
+    Customize the `topic` and `content` fields as necessary. Click
     **Continue**.

--- a/zerver/webhooks/zapier/fixtures/correct_topic_and_body.json
+++ b/zerver/webhooks/zapier/fixtures/correct_topic_and_body.json
@@ -1,0 +1,4 @@
+{
+  "content": "Your email content is: \nMy Email content.\n",
+  "topic": "New email from zulip@zulip.com"
+}

--- a/zerver/webhooks/zapier/tests.py
+++ b/zerver/webhooks/zapier/tests.py
@@ -11,6 +11,11 @@ class ZapierHookTests(WebhookTestCase):
         expected_message = u"Your email content is: \nMy Email content."
         self.send_and_test_stream_message('correct_subject_and_body', expected_subject, expected_message)
 
+    def test_zapier_when_topic_and_body_are_correct(self) -> None:
+        expected_subject = u"New email from zulip@zulip.com"
+        expected_message = u"Your email content is: \nMy Email content."
+        self.send_and_test_stream_message('correct_topic_and_body', expected_subject, expected_message)
+
     def test_zapier_weather_update(self) -> None:
         expected_subject = u"Here is your weather update for the day:"
         expected_message = u"Foggy in the morning.\nMaximum temperature to be 24.\nMinimum temperature to be 12"

--- a/zerver/webhooks/zapier/view.py
+++ b/zerver/webhooks/zapier/view.py
@@ -13,11 +13,16 @@ from zerver.models import UserProfile
 @has_request_variables
 def api_zapier_webhook(request: HttpRequest, user_profile: UserProfile,
                        payload: Dict[str, Any]=REQ(argument_type='body')) -> HttpResponse:
-    subject = payload.get('subject')
+    topic = payload.get('topic')
     content = payload.get('content')
-    if subject is None:
-        return json_error(_("Subject can't be empty"))
+
+    if topic is None:
+        topic = payload.get('subject')  # Backwards-compatibility
+        if topic is None:
+            return json_error(_("Topic can't be empty"))
+
     if content is None:
         return json_error(_("Content can't be empty"))
-    check_send_webhook_message(request, user_profile, subject, content)
+
+    check_send_webhook_message(request, user_profile, topic, content)
     return json_success()


### PR DESCRIPTION
Fixes #8698.
Updates docs, test, code.

First commit for Zapier only, pending comments on correct approach.

Copied simple subject-based fixture to topic-based fixture, for new test.