### PR TITLE
mypy: Identification of further/last Validator functions (#8729 followup)

### DIFF
--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -26,6 +26,7 @@ from zerver.lib.queue import queue_json_publish
 from zerver.lib.response import json_error, json_response_from_error
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.utils import statsd
+from zerver.lib.types import ViewFuncT
 from zerver.models import Realm, flush_per_request_caches, get_realm
 
 logger = logging.getLogger('zulip.requests')
@@ -231,7 +232,7 @@ class LogRequests(MiddlewareMixin):
         if connection.connection is not None:
             connection.connection.queries = []
 
-    def process_view(self, request: HttpRequest, view_func: Callable[..., HttpResponse],
+    def process_view(self, request: HttpRequest, view_func: ViewFuncT,
                      args: List[str], kwargs: Dict[str, Any]) -> None:
         # process_request was already run; we save the initialization
         # time (i.e. the time between receiving the request and
@@ -283,7 +284,7 @@ class JsonErrorHandler(MiddlewareMixin):
         return None
 
 class TagRequests(MiddlewareMixin):
-    def process_view(self, request: HttpRequest, view_func: Callable[..., HttpResponse],
+    def process_view(self, request: HttpRequest, view_func: ViewFuncT,
                      args: List[str], kwargs: Dict[str, Any]) -> None:
         self.process_request(request)
 

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -14,6 +14,7 @@ from mypy_extensions import NoReturn
 from typing import Any, Callable, Dict, Mapping, Optional, Text, Iterator
 
 from zerver.lib.request import JsonableError
+from zerver.lib.types import ViewFuncT
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.logging_handlers import AdminNotifyHandler
 from zerver.middleware import JsonErrorHandler
@@ -22,9 +23,8 @@ from zerver.worker.queue_processors import QueueProcessingWorker
 
 captured_request = None  # type: Optional[HttpRequest]
 captured_exc_info = None
-def capture_and_throw(
-        domain: Optional[Text]=None) -> Callable[[Callable[..., HttpResponse]], Callable[..., HttpResponse]]:
-    def wrapper(view_func: Callable[..., HttpResponse]) -> Callable[..., HttpResponse]:
+def capture_and_throw(domain: Optional[Text]=None) -> Callable[[ViewFuncT], ViewFuncT]:
+    def wrapper(view_func: ViewFuncT) -> ViewFuncT:
         @wraps(view_func)
         def wrapped_view(request: HttpRequest, *args: Any, **kwargs: Any) -> NoReturn:
             global captured_request
@@ -35,7 +35,7 @@ def capture_and_throw(
                 global captured_exc_info
                 captured_exc_info = sys.exc_info()
                 raise e
-        return wrapped_view
+        return wrapped_view  # type: ignore # https://github.com/python/mypy/issues/1927
     return wrapper
 
 class AdminNotifyHandlerTest(ZulipTestCase):

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -21,6 +21,7 @@ from tornado.wsgi import WSGIContainer
 
 from zerver.decorator import RespondAsynchronously
 from zerver.lib.response import json_response
+from zerver.lib.types import ViewFuncT
 from zerver.middleware import async_request_restart, async_request_stop
 from zerver.tornado.descriptors import get_descriptor_by_handler_id
 
@@ -109,7 +110,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         system code doesn't change.
         """
         self._request_middleware = []  # type: Optional[List[Callable[[HttpRequest], HttpResponse]]]
-        self._view_middleware = []  # type: List[Callable[[HttpRequest, Callable[..., HttpResponse], List[str], Dict[str, Any]], Optional[HttpResponse]]]
+        self._view_middleware = []  # type: List[Callable[[HttpRequest, ViewFuncT, List[str], Dict[str, Any]], Optional[HttpResponse]]]
         self._template_response_middleware = []  # type: List[Callable[[HttpRequest, HttpResponse], HttpResponse]]
         self._response_middleware = []  # type: List[Callable[[HttpRequest, HttpResponse], HttpResponse]]
         self._exception_middleware = []  # type: List[Callable[[HttpRequest, Exception], Optional[HttpResponse]]]


### PR DESCRIPTION
In #8729 `Validator` was centralized into `types.py`. Some extra instances of that `Callable` type were identified and referred to that central definition there; this PR includes some other instances found subsequently.

Both changes combined pass `test-all` on my droplet.