### PR TITLE
subscription: Fix unexpected blueslip/js warnings.

### DIFF
--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -1,5 +1,7 @@
 set_global('$', function () {
 });
+set_global('blueslip', {});
+global.blueslip.warn = function () {};
 
 zrequire('util');
 zrequire('stream_data');
@@ -36,6 +38,7 @@ people.add(bob);
         stream_id: 101,
         name: 'social',
         subscribed: true,
+        can_access_subscribers: true,
     };
     stream_data.add_sub('social', sub);
     stream_data.set_subscribers(sub, [me.user_id, alice.user_id]);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -363,11 +363,10 @@ exports.remove_subscriber = function (stream_name, user_id) {
 
 exports.user_is_subscribed = function (stream_name, user_email) {
     var sub = exports.get_sub(stream_name);
-    if (typeof sub === 'undefined' || !sub.subscribed) {
-        // If we don't know about the stream, or we ourselves are not
-        // subscribed, we can't keep track of the subscriber list in general,
+    if (typeof sub === 'undefined' || !sub.can_access_subscribers) {
+        // If we don't know about the stream, or we ourselves can not access subscriber list,
         // so we return undefined (treated as falsy if not explicitly handled).
-        blueslip.warn("We got a user_is_subscribed call for a non-existent or unsubscribed stream.");
+        blueslip.warn("We got a user_is_subscribed call for a non-existent or inaccessible stream.");
         return;
     }
     var user_id = people.get_user_id(user_email);


### PR DESCRIPTION
- [ ] Fix issue #8720 
- [X] Fix blueslip warnings in add subscription option. 

In stream settings, if user add subscriber to unsubscribed public
stream from `Add` input widget it gives lots of blueslip warnings,
cause user isn't subscribed to public stream.

Fix this by changing condition to `sub.can_access_subscriber` from
`sub.subscribed` in blueslip warning, cause user can access
subscribers in such cases even if not subscribed to stream.
