### PR TITLE
integrations/rss: Recommend integrating RSS via Zapier.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -1612,6 +1612,7 @@ input.new-organization-button {
     box-shadow: none;
 }
 
+.integration-instructions .tip,
 .markdown .warn,
 .markdown .tip {
     position: relative;
@@ -1623,16 +1624,19 @@ input.new-organization-button {
     margin: 5px 0px;
 }
 
+.integration-instructions .tip,
 .markdown .tip {
     background-color: hsl(46, 63%, 95%);
     border: 1px solid hsl(46, 63%, 84%);
 }
 
+.integration-instructions .tip,
 .markdown .warn p,
 .markdown .tip p {
     margin-bottom: 0;
 }
 
+.integration-instructions .tip::before,
 .markdown .tip::before {
     display: inline;
     content: "\f0eb   Tip:  ";
@@ -1640,6 +1644,7 @@ input.new-organization-button {
     font-weight: 600;
 }
 
+.integration-instructions .tip p:first-of-type,
 .markdown .tip p:first-of-type {
     display: inline;
 }

--- a/templates/zerver/integrations/rss.md
+++ b/templates/zerver/integrations/rss.md
@@ -1,6 +1,12 @@
 Get service alerts, news, and new blog posts right in Zulip with our
 RSS integration!
 
+!!! tip ""
+    Note that [the Zapier integration][1] is usually a simpler way to
+    integrate RSS with Zulip.
+
+[1]: ./zapier
+
 {!create-stream.md!}
 
 Next, on your {{ settings_html|safe }}, create an RSS bot.


### PR DESCRIPTION
An integration with RSS can be much easier to set up with Zapier.
Since the current RSS integration predates Zapier, we should at
least mention that there is an easier way to set it up via
Zapier!

@timabbott: FYI