### PR TITLE
Fix pika errors on upgrade

### DIFF
--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -182,10 +182,8 @@ class TornadoQueueClient(SimpleQueueClient):
         self.rabbitmq_heartbeat = None
         self._on_open_cbs = []  # type: List[Callable[[], None]]
 
-    def _connect(self, on_open_cb: Optional[Callable[[], None]]=None) -> None:
+    def _connect(self) -> None:
         self.log.info("Beginning TornadoQueueClient connection")
-        if on_open_cb is not None:
-            self._on_open_cbs.append(on_open_cb)
         self.connection = ExceptionFreeTornadoConnection(
             self._get_parameters(),
             on_open_callback = self._on_open,

--- a/zerver/tests/test_queue.py
+++ b/zerver/tests/test_queue.py
@@ -1,0 +1,18 @@
+import mock
+import os
+from typing import Any
+import ujson
+
+from pika.exceptions import ConnectionClosed
+
+from zerver.lib.queue import TornadoQueueClient
+from zerver.lib.test_classes import ZulipTestCase
+
+class TestTornadoQueueClient(ZulipTestCase):
+    @mock.patch('zerver.lib.queue.logging.getLogger', autospec=True)
+    @mock.patch('zerver.lib.queue.ExceptionFreeTornadoConnection', autospec=True)
+    def test_on_open_closed(self, mock_cxn: mock.MagicMock,
+                            mock_get_logger: mock.MagicMock) -> None:
+        connection = TornadoQueueClient()
+        connection.connection.channel.side_effect = ConnectionClosed
+        connection._on_open(mock.MagicMock())

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1446,8 +1446,19 @@ LOGGING = {
         # },
 
         # other libraries, alphabetized
-        'pika.adapters': {  # This library is super chatty on INFO.
+        'pika.adapters': {
+            # pika is super chatty on INFO.
             'level': 'WARNING',
+            # pika spews a lot of ERROR logs when a connection fails.
+            # We reconnect automatically, so those should be treated as WARNING --
+            # write to the log for use in debugging, but no error emails/Zulips.
+            'handlers': ['console', 'file', 'errors_file'],
+            'propagate': False,
+        },
+        'pika.connection': {
+            # Leave `zulip_admins` out of the handlers.  See pika.adapters above.
+            'handlers': ['console', 'file', 'errors_file'],
+            'propagate': False,
         },
         'requests': {
             'level': 'WARNING',


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This still leaves one error when a connection fails, which is the one we directly control. We'll want to dial that back so it's only a warning until e.g. a few retries fail.

**Testing Plan:** <!-- How have you tested? -->

Manual testing in a `test-install` container. Also gave this file its first ever unit tests, for one of the cleanups earlier in the branch.

