### PR TITLE
compose: Fix "compose fade" not working when private message focused.

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -250,7 +250,10 @@ function initialize_stream_data() {
 
     assert(!$('<devel sidebar row html>').hasClass('active-filter'));
 
+    stream_data.get_streams_for_settings_page = noop;
+
     stream_list.initialize();
+
 
     var filter;
 

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -31,8 +31,7 @@ exports.set_focused_recipient = function (msg_type) {
     } else {
         // Normalize the recipient list so it matches the one used when
         // adding the message (see message_store.add_message_metadata()).
-        var reply_to = util.normalize_recipients(
-                $('#private_message_recipient').val());
+        var reply_to = util.normalize_recipients(compose_state.recipient());
         focused_recipient.reply_to = reply_to;
         focused_recipient.to_user_ids = people.reply_to_to_user_ids_string(reply_to);
     }

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -457,6 +457,10 @@ exports.initialize = function () {
         zoom_out: zoom_out,
     });
 
+    // Indirectly calling `stream_data.update_calculated_fields` for each stream
+    // to update attributes like `sub.can_access_subscribers`.
+    stream_data.get_streams_for_settings_page();
+
     $(document).on('subscription_add_done.zulip', function (event) {
         exports.create_sidebar_row(event.sub);
         exports.build_stream_list();


### PR DESCRIPTION
The problem was that we now have pills instead of emails.
Fixes: #8755.


![private message focus](https://user-images.githubusercontent.com/22238472/37666309-4741d9de-2c85-11e8-83c4-d593c8ccf571.gif)
