### PR TITLE
notify electron app when realm icon, profile is changed

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -173,6 +173,7 @@ exports.redraw_title = function () {
     // Notify the current desktop app's UI about the new unread count.
     if (window.electron_bridge !== undefined) {
         window.electron_bridge.send_event('total_unread_count', new_message_count);
+        window.electron_bridge.send_event('unread_count_data', unread.get_counts());
     }
 };
 

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -91,6 +91,10 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 settings_org.render_signup_notifications_stream_ui(
                     page_params.realm_signup_notifications_stream_id);
             }
+
+            if (event.property === 'name' && window.electron_bridge !== undefined) {
+                window.electron_bridge.send_event('realm_name_updated', event.value);
+            }
         } else if (event.op === 'update_dict' && event.property === 'default') {
             _.each(event.data, function (value, key) {
                 page_params['realm_' + key] = value;
@@ -105,7 +109,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             page_params.realm_icon_url = event.data.icon_url;
             page_params.realm_icon_source = event.data.icon_source;
             realm_icon.rerender();
-            
+
             var electron_bridge = window.electron_bridge;
             if (electron_bridge !== undefined) {
                 electron_bridge.send_event('org_avatar_updated', event.data.icon_url);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -105,6 +105,11 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             page_params.realm_icon_url = event.data.icon_url;
             page_params.realm_icon_source = event.data.icon_source;
             realm_icon.rerender();
+            
+            var electron_bridge = window.electron_bridge;
+            if (electron_bridge !== undefined) {
+                electron_bridge.send_event('org_avatar_updated', event.data.icon_url);
+            }
         } else if (event.op === 'deactivated') {
             window.location.href = "/accounts/deactivated/";
         }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Notify electron app about changed realm icon, org profile through `electron_bridge`. Also, send unread count data to electron app.

**Testing Plan**:
* Add this to the console of devtools:
```javascript
electron_bridge = {
  send_event: console.log
}
```
* Open up a new tab and edit the realm name and icon, you should see the event name and data in your console.
