### PR TITLE
docs: Added documentation for init.d starting nginx

### DIFF
--- a/docs/production/troubleshooting.md
+++ b/docs/production/troubleshooting.md
@@ -118,6 +118,10 @@ problems and how to resolve them:
   ```
   service nginx restart
   ```
+  Note: Zulip uses nginx, therefore if a new set of certificates are
+  being generated and to replace the old certificates, the server
+  will still run the old certificates until the nginx is restarted.
+  **Restarting the Zulip server doesn't restart the nginx server.**
 
 * If your host is being port scanned by unauthorized users, you may see
   messages in `/var/log/zulip/server.log` like


### PR DESCRIPTION
Improved documentation regarding troubleshooting the Nginx server.

<!-- What's this PR for?  (https://github.com/zulip/zulip/issues/4849) -->


**Testing Plan:** <!-- It is a documentation and I have post it under the #documentation section in zulip chat -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
