### PR TITLE
docs: Add /keyboard-shorcuts to /help/

### DIFF
--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -99,7 +99,7 @@
             <p>Communicate as efficiently as you use your favorite
                 text editor.  Anything you can do with a mouse, you
                 can do even faster from the keyboard.
-                <a class="cta" href="/help/">
+                <a class="cta" href="/help/keyboard-shortcuts">
                 Learn more about keyboard shortcuts.</a>
             </p>
         </div>


### PR DESCRIPTION
Add /keyboard-shorcuts to /help/ in Keyboard shorcuts section.

It changes the link [Learn more about keyboard shortcuts](https://zulipchat.com/help/) to [this](https://zulipchat.com/help/keyboard-shortcuts) link.