### PR TITLE
search: check 'pm-with' operands for validity

### DIFF
--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -148,7 +148,26 @@ function set_filter(operators) {
 
     set_filter([['pm-with', 'foo@bar.com']]);
     var pm_test = narrow_state.set_compose_defaults();
-    assert.equal(pm_test.private_message_recipient, 'foo@bar.com');
+    assert.equal(pm_test.private_message_recipient, null);
+
+    var jack = {
+        email: 'jack@foo.com',
+        user_id: 123,
+        full_name: 'Jack',
+    };
+
+    var jill = {
+        email: 'jill@foo.com',
+        user_id: 456,
+        full_name: 'Jill',
+    };
+
+    people.add(jack);
+    people.add(jill);
+
+    set_filter([['pm-with', 'jack@foo.com,jill@foo.com']]);
+    pm_test = narrow_state.set_compose_defaults();
+    assert.equal(pm_test.private_message_recipient, 'jack@foo.com,jill@foo.com');
 
     set_filter([['topic', 'duplicate'], ['topic', 'duplicate']]);
     assert.deepEqual(narrow_state.set_compose_defaults(), {});

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -191,6 +191,15 @@ exports.start = function (msg_type, opts) {
     exports.expand_compose_box();
 
     opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
+
+    // If we are invoked by search and the PM recipient is empty then
+    // cancel the compose
+    if (opts.trigger === "search" && opts.message_type === "private"
+        && ! opts.private_message_recipient) {
+        exports.cancel();
+        return;
+    }
+
     // If we are invoked by a compose hotkey (c or x) or new topic button
     // or sidebar stream actions (in stream popover), do not assume that we know what
     // the message's topic or PM recipient should be.
@@ -415,7 +424,7 @@ exports.on_narrow = function (opts) {
     }
 
     if (narrow_state.narrowed_by_pm_reply()) {
-        exports.start('private');
+        exports.start('private', opts);
         return;
     }
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -568,6 +568,18 @@ function pick_empty_narrow_banner() {
         // You are narrowed to empty search results.
         return $("#empty_search_narrow_message");
     } else if (first_operator === "pm-with") {
+        var valid_op = false;
+        first_operand.split(',').forEach(function (op) {
+            if (people.get_by_email(op)) {
+                valid_op = true;
+            }
+        });
+        if (!valid_op) {
+            if (first_operand.indexOf(',') === -1) {
+                return $("#non_existing_user");
+            }
+            return $("#non_existing_users");
+        }
         if (first_operand.indexOf(',') === -1) {
             // You have no private messages with this person
             return $("#empty_narrow_private_message");

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -89,7 +89,16 @@ exports.set_compose_defaults = function () {
     }
 
     if (single.has('pm-with')) {
-        opts.private_message_recipient = single.get('pm-with');
+        var private_message_recipient = single.get('pm-with');
+        var valid_op = false;
+        private_message_recipient.split(',').forEach(function (op) {
+            if (people.get_by_email(op)) {
+                valid_op = true;
+            }
+        });
+        if (valid_op) {
+            opts.private_message_recipient = private_message_recipient;
+        }
     }
     return opts;
 };

--- a/static/js/top_left_corner.js
+++ b/static/js/top_left_corner.js
@@ -75,7 +75,14 @@ exports.handle_narrow_activated = function (filter) {
 
     var op_is = filter.operands('is');
     var op_pm = filter.operands('pm-with');
-    if (((op_is.length >= 1) && _.contains(op_is, "private")) || op_pm.length >= 1) {
+    var valid_op = false;
+    op_pm.forEach(function (op) {
+        if (people.get_by_email(op)) {
+            valid_op = true;
+        }
+    });
+    if (((op_is.length >= 1) && _.contains(op_is, "private")) ||
+        (op_pm.length >= 1 && valid_op)) {
         pm_list.expand(op_pm);
     } else {
         pm_list.close();

--- a/templates/zerver/home.html
+++ b/templates/zerver/home.html
@@ -84,6 +84,9 @@
     <div id="non_existing_user" class="empty_feed_notice">
         <h4>{{ _("This user does not exist!") }}</h4>
     </div>
+    <div id="non_existing_users" class="empty_feed_notice">
+        <h4>{{ _("These users do not exist!") }}</h4>
+    </div>
     <div id="nonsubbed_stream_narrow_message" class="empty_feed_notice">
         <h4>{{ _("You aren't subscribed to this stream and nobody has talked about that yet!") }}</h4>
         <div class="sub_button_row new-style">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #3380

If the operands for 'pm-with' are all invalid then,
- do not update pm list
- cancel compose
- show non existent user message
