### PR TITLE
#2088: `create_stream_if_needed` wrapper 

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1950,7 +1950,7 @@ def _internal_prep_message(realm: Realm,
         raise RuntimeError("None is not a valid realm for internal_prep_message!")
 
     if addressee.is_stream():
-        stream = ensure_stream(realm, addressee.stream_name())
+        ensure_stream(realm, addressee.stream_name())
 
     try:
         return check_message(sender, get_client("Internal"), addressee,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1950,7 +1950,7 @@ def _internal_prep_message(realm: Realm,
         raise RuntimeError("None is not a valid realm for internal_prep_message!")
 
     if addressee.is_stream():
-        stream, _ = create_stream_if_needed(realm, addressee.stream_name())
+        stream = ensure_stream(realm, addressee.stream_name())
 
     try:
         return check_message(sender, get_client("Internal"), addressee,
@@ -2981,10 +2981,10 @@ def do_create_realm(string_id: Text, name: Text, restricted_to_domain: Optional[
     realm.save()
 
     # Create stream once Realm object has been saved
-    notifications_stream, _ = create_stream_if_needed(realm, Realm.DEFAULT_NOTIFICATION_STREAM_NAME)
+    notifications_stream = ensure_stream(realm, Realm.DEFAULT_NOTIFICATION_STREAM_NAME)
     realm.notifications_stream = notifications_stream
 
-    signup_notifications_stream, _ = create_stream_if_needed(
+    signup_notifications_stream = ensure_stream(
         realm, Realm.INITIAL_PRIVATE_STREAM_NAME, invite_only=True,
         stream_description="A private stream for core team members.")
     realm.signup_notifications_stream = signup_notifications_stream
@@ -3083,10 +3083,10 @@ def set_default_streams(realm: Realm, stream_dict: Dict[Text, Dict[Text, Any]]) 
     stream_names = []
     for name, options in stream_dict.items():
         stream_names.append(name)
-        stream, _ = create_stream_if_needed(realm,
-                                            name,
-                                            invite_only = options.get("invite_only", False),
-                                            stream_description = options.get("description", ''))
+        stream = ensure_stream(realm,
+                               name,
+                               invite_only = options.get("invite_only", False),
+                               stream_description = options.get("description", ''))
         DefaultStream.objects.create(stream=stream, realm=realm)
 
     # Always include the realm's default notifications streams, if it exists

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1561,6 +1561,12 @@ def create_stream_if_needed(realm: Realm,
             send_stream_creation_event(stream, realm_admin_ids)
     return stream, created
 
+def ensure_stream(realm: Realm,
+                  stream_name: Text,
+                  invite_only: bool=False,
+                  stream_description: Text="") -> Stream:
+    return create_stream_if_needed(realm, stream_name, invite_only, stream_description)[0]
+
 def create_streams_if_needed(realm: Realm,
                              stream_dicts: List[Mapping[str, Any]]) -> Tuple[List[Stream], List[Stream]]:
     """Note that stream_dict["name"] is assumed to already be stripped of

--- a/zerver/management/commands/add_users_to_streams.py
+++ b/zerver/management/commands/add_users_to_streams.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from django.core.management.base import CommandParser
 
-from zerver.lib.actions import bulk_add_subscriptions, create_stream_if_needed
+from zerver.lib.actions import bulk_add_subscriptions, ensure_stream
 from zerver.lib.management import ZulipBaseCommand
 
 class Command(ZulipBaseCommand):
@@ -29,7 +29,7 @@ class Command(ZulipBaseCommand):
 
         for stream_name in set(stream_names):
             for user_profile in user_profiles:
-                stream, _ = create_stream_if_needed(realm, stream_name)
+                stream = ensure_stream(realm, stream_name)
                 _ignore, already_subscribed = bulk_add_subscriptions([stream], [user_profile])
                 was_there_already = user_profile.id in {tup[0].id for tup in already_subscribed}
                 print("%s %s to %s" % (

--- a/zerver/management/commands/create_default_stream_groups.py
+++ b/zerver/management/commands/create_default_stream_groups.py
@@ -2,7 +2,7 @@
 from argparse import ArgumentParser
 from typing import Any
 
-from zerver.lib.actions import create_stream_if_needed
+from zerver.lib.actions import ensure_stream
 from zerver.lib.management import ZulipBaseCommand
 from zerver.models import DefaultStreamGroup
 
@@ -46,7 +46,7 @@ Create default stream groups which the users can choose during sign up.
         streams = []
         stream_names = set([stream.strip() for stream in options["streams"].split(",")])
         for stream_name in set(stream_names):
-            stream, _ = create_stream_if_needed(realm, stream_name)
+            stream = ensure_stream(realm, stream_name)
             streams.append(stream)
 
         try:

--- a/zerver/management/commands/generate_multiuse_invite_link.py
+++ b/zerver/management/commands/generate_multiuse_invite_link.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 from typing import Any, List, Text
 
 from confirmation.models import Confirmation, create_confirmation_link
-from zerver.lib.actions import create_stream_if_needed, do_create_multiuse_invite_link
+from zerver.lib.actions import ensure_stream, do_create_multiuse_invite_link
 from zerver.lib.management import ZulipBaseCommand
 from zerver.models import Stream
 
@@ -35,7 +35,7 @@ class Command(ZulipBaseCommand):
         if options["streams"]:
             stream_names = set([stream.strip() for stream in options["streams"].split(",")])
             for stream_name in set(stream_names):
-                stream, _ = create_stream_if_needed(realm, stream_name)
+                stream = ensure_stream(realm, stream_name)
                 streams.append(stream)
 
         referred_by = self.get_user(options['referred_by'], realm)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -24,7 +24,7 @@ from zerver.lib.actions import (
     do_reactivate_realm,
     do_reactivate_user,
     do_set_realm_authentication_methods,
-    create_stream_if_needed,
+    ensure_stream,
 )
 from zerver.lib.mobile_auth_otp import otp_decrypt_api_key
 from zerver.lib.validator import validate_login_email, \
@@ -931,7 +931,7 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         stream_names = ["new_stream_1", "new_stream_2"]
         streams = []
         for stream_name in set(stream_names):
-            stream, _ = create_stream_if_needed(realm, stream_name)
+            stream = ensure_stream(realm, stream_name)
             streams.append(stream)
 
         # Without the invite link, we can't create an account due to invite_required

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -849,7 +849,7 @@ class DefaultStreamTest(ZulipTestCase):
         user_profile = self.example_user('hamlet')
         do_change_is_admin(user_profile, True)
         stream_name = 'stream ADDED via api'
-        stream = ensure_stream(user_profile.realm, stream_name)
+        ensure_stream(user_profile.realm, stream_name)
         result = self.client_post('/json/default_streams', dict(stream_name=stream_name))
         self.assert_json_success(result)
         self.assertTrue(stream_name in self.get_default_stream_names(user_profile.realm))

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -51,6 +51,7 @@ from zerver.lib.actions import (
     gather_subscriptions, get_default_streams_for_realm, get_realm, get_stream,
     get_user, set_default_streams, check_stream_name,
     create_stream_if_needed, create_streams_if_needed,
+    ensure_stream,
     do_deactivate_stream,
     stream_welcome_message,
     do_create_default_stream_group,
@@ -85,7 +86,7 @@ class TestCreateStreams(ZulipTestCase):
         # Test stream creation events.
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
-            create_stream_if_needed(realm, "Public stream", invite_only=False)
+            ensure_stream(realm, "Public stream", invite_only=False)
         self.assert_length(events, 1)
 
         self.assertEqual(events[0]['event']['type'], 'stream')
@@ -96,7 +97,7 @@ class TestCreateStreams(ZulipTestCase):
 
         events = []
         with tornado_redirected_to_list(events):
-            create_stream_if_needed(realm, "Private stream", invite_only=True)
+            ensure_stream(realm, "Private stream", invite_only=True)
         self.assert_length(events, 1)
 
         self.assertEqual(events[0]['event']['type'], 'stream')
@@ -143,7 +144,7 @@ class TestCreateStreams(ZulipTestCase):
         realm = get_realm('zulip')
         name = u'New Stream'
 
-        new_stream, _ = create_stream_if_needed(
+        new_stream = ensure_stream(
             realm=realm,
             stream_name=name
         )
@@ -826,7 +827,7 @@ class DefaultStreamTest(ZulipTestCase):
 
     def test_add_and_remove_default_stream(self) -> None:
         realm = get_realm("zulip")
-        (stream, _) = create_stream_if_needed(realm, "Added Stream")
+        stream = ensure_stream(realm, "Added Stream")
         orig_stream_names = self.get_default_stream_names(realm)
         do_add_default_stream(stream)
         new_stream_names = self.get_default_stream_names(realm)
@@ -848,7 +849,7 @@ class DefaultStreamTest(ZulipTestCase):
         user_profile = self.example_user('hamlet')
         do_change_is_admin(user_profile, True)
         stream_name = 'stream ADDED via api'
-        (stream, _) = create_stream_if_needed(user_profile.realm, stream_name)
+        stream = ensure_stream(user_profile.realm, stream_name)
         result = self.client_post('/json/default_streams', dict(stream_name=stream_name))
         self.assert_json_success(result)
         self.assertTrue(stream_name in self.get_default_stream_names(user_profile.realm))
@@ -868,7 +869,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
 
         streams = []
         for stream_name in ["stream1", "stream2", "stream3"]:
-            (stream, _) = create_stream_if_needed(realm, stream_name)
+            stream = ensure_stream(realm, stream_name)
             streams.append(stream)
 
         def get_streams(group: DefaultStreamGroup) -> List[Stream]:
@@ -888,7 +889,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
         new_stream_names = ["stream4", "stream5"]
         new_streams = []
         for new_stream_name in new_stream_names:
-            (new_stream, _) = create_stream_if_needed(realm, new_stream_name)
+            new_stream = ensure_stream(realm, new_stream_name)
             new_streams.append(new_stream)
             streams.append(new_stream)
 
@@ -947,7 +948,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
         self.assert_length(default_stream_groups, 0)
 
         for stream_name in stream_names:
-            (stream, _) = create_stream_if_needed(realm, stream_name)
+            stream = ensure_stream(realm, stream_name)
             streams.append(stream)
 
         result = self.client_post('/json/default_stream_groups/create',
@@ -965,7 +966,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
         new_stream_names = ["stream4", "stream5"]
         new_streams = []
         for new_stream_name in new_stream_names:
-            (new_stream, _) = create_stream_if_needed(realm, new_stream_name)
+            new_stream = ensure_stream(realm, new_stream_name)
             new_streams.append(new_stream)
             streams.append(new_stream)
 
@@ -1086,7 +1087,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
         streams = []
 
         for stream_name in stream_names:
-            (stream, _) = create_stream_if_needed(realm, stream_name)
+            stream = ensure_stream(realm, stream_name)
             streams.append(stream)
 
         result = self.client_post('/json/default_stream_groups/create',
@@ -1882,7 +1883,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         # Create a private stream with Hamlet subscribed
         stream_name = "private"
-        (stream, _) = create_stream_if_needed(realm, stream_name, invite_only=True)
+        stream = ensure_stream(realm, stream_name, invite_only=True)
 
         existing_user_profile = self.example_user('hamlet')
         bulk_add_subscriptions([stream], [existing_user_profile])
@@ -1921,7 +1922,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # Do not send stream creation event to realm admin users
         # even if realm admin is subscribed to stream cause realm admin already get
         # private stream creation event on stream creation.
-        (new_stream, _) = create_stream_if_needed(realm, "private stream", invite_only=True)
+        new_stream = ensure_stream(realm, "private stream", invite_only=True)
         events = []
         with tornado_redirected_to_list(events):
             bulk_add_subscriptions([new_stream], [self.example_user("iago")])
@@ -2351,9 +2352,9 @@ class SubscriptionAPITest(ZulipTestCase):
         realm = get_realm("zulip")
         user = self.example_user("iago")
         random_user = self.example_user("hamlet")
-        (stream1, _) = create_stream_if_needed(realm, "stream1", invite_only=False)
-        (stream2, _) = create_stream_if_needed(realm, "stream2", invite_only=False)
-        (private, _) = create_stream_if_needed(realm, "private_stream", invite_only=True)
+        stream1 = ensure_stream(realm, "stream1", invite_only=False)
+        stream2 = ensure_stream(realm, "stream2", invite_only=False)
+        private = ensure_stream(realm, "private_stream", invite_only=True)
 
         self.subscribe(user, "stream1")
         self.subscribe(user, "stream2")
@@ -2938,7 +2939,7 @@ class AccessStreamTest(ZulipTestCase):
 
         # Nobody can access a public stream in another realm
         mit_realm = get_realm("zephyr")
-        mit_stream, _ = create_stream_if_needed(mit_realm, "mit_stream", invite_only=False)
+        mit_stream = ensure_stream(mit_realm, "mit_stream", invite_only=False)
         sipbtest = self.mit_user("sipbtest")
         with self.assertRaisesRegex(JsonableError, "Invalid stream id"):
             access_stream_by_id(hamlet, mit_stream.id)

--- a/zilencer/management/commands/add_mock_conversation.py
+++ b/zilencer/management/commands/add_mock_conversation.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 from django.core.management.base import BaseCommand
 
 from zerver.lib.actions import bulk_add_subscriptions, \
-    create_stream_if_needed, do_add_reaction_legacy, do_change_avatar_fields, \
+    ensure_stream, do_add_reaction_legacy, do_change_avatar_fields, \
     do_create_user, do_send_messages, internal_prep_stream_message
 from zerver.lib.upload import upload_avatar_image
 from zerver.models import Message, UserProfile, get_realm
@@ -36,7 +36,7 @@ From image editing program:
 
     def add_message_formatting_conversation(self) -> None:
         realm = get_realm('zulip')
-        stream, _ = create_stream_if_needed(realm, 'zulip features')
+        stream = ensure_stream(realm, 'zulip features')
 
         UserProfile.objects.filter(email__contains='stage').delete()
         starr = do_create_user('1@stage.example.com', 'password', realm, 'Ada Starr', '')


### PR DESCRIPTION
Creates `ensure_stream` wrapper for `created_stream_if_needed`. (https://github.com/zulip/zulip/issues/2088)

Previous tests passed. Changes weren't significant enough to warrant any new tests.

Refactoring mentioned in #2088.