### PR TITLE
Refactor org permission settings page.

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -81,7 +81,8 @@ casper.then(function () {
 });
 
 function submit_permissions_change() {
-    casper.click('form.org-permissions-form button.button');
+    casper.test.assertSelectorHasText('#org-submit-other-permissions', "Save");
+    casper.click('#org-submit-other-permissions');
 }
 
 // Test setting limiting stream creation to administrators
@@ -97,9 +98,9 @@ casper.then(function () {
 
 casper.then(function () {
     // Test setting was activated
-    casper.waitUntilVisible('#admin-realm-create-stream-by-admins-only-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-create-stream-by-admins-only-status',
-                                          'Stream creation permission changed!');
+    casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-other-permissions',
+                                          'Saved');
     });
 });
 
@@ -115,9 +116,9 @@ casper.then(function () {
 
 casper.then(function () {
     // Test setting was activated
-    casper.waitUntilVisible('#admin-realm-create-stream-by-admins-only-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-create-stream-by-admins-only-status',
-            'Stream creation permission changed!');
+    casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-other-permissions',
+                                          'Saved');
     });
 });
 
@@ -145,12 +146,12 @@ casper.waitUntilVisible('#id_realm_create_stream_permission', function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('#admin-realm-create-stream-by-admins-only-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-create-stream-by-admins-only-status',
-                                          'Stream creation permission changed!');
+    // Test setting was activated
+    casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-other-permissions',
+                                          'Saved');
     });
 });
-
 
 casper.then(function () {
     // Test custom realm emoji

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -234,60 +234,6 @@ function test_submit_settings_form(submit_form) {
     assert(updated_value_from_response, 0);
 }
 
-function test_submit_permissions_form(submit_form) {
-    var ev = {
-        preventDefault: noop,
-        stopPropagation: noop,
-    };
-
-    $('#id_realm_add_emoji_by_admins_only').prop('checked', true);
-    $("#id_realm_create_stream_permission").val("by_admin_user_with_custom_time").change();
-    $("#id_realm_waiting_period_threshold").val("55");
-
-    var patched;
-    var success_callback;
-    var error_callback;
-    channel.patch = function (req) {
-        patched = true;
-        assert.equal(req.url, '/json/realm');
-
-        var data = req.data;
-        assert.equal(data.add_emoji_by_admins_only, 'true');
-        assert.equal(data.create_stream_by_admins_only, false);
-        assert.equal(data.waiting_period_threshold, '55');
-
-        success_callback = req.success;
-        error_callback = req.error;
-    };
-
-    submit_form(ev);
-    assert(patched);
-
-    var response_data = {
-        waiting_period_threshold: 55,
-        add_emoji_by_admins_only: true,
-        create_stream_by_admins_only: false,
-    };
-    success_callback(response_data);
-
-    assert.equal($('#admin-realm-add-emoji-by-admins-only-status').val(),
-                 'translated: Only administrators may now add new emoji!');
-    assert.equal($('#admin-realm-create-stream-by-admins-only-status').val(),
-                  'translated: Stream creation permission changed!');
-
-    // TODO: change the code to have a better place to report status.
-    var status_elem = $('#admin-realm-restricted-to-domain-status');
-
-    success_callback({});
-
-    assert.equal(status_elem.val(),
-                 'translated: No changes to save!');
-
-    error_callback({});
-    assert.equal(status_elem.val(),
-                 'translated: Failed');
-}
-
 function test_upload_realm_icon(upload_realm_icon) {
     var form_data = {
         append: function (field, val) {
@@ -492,7 +438,6 @@ function test_extract_property_name() {
     $('.signup-notifications-stream-disable').click = set_callback('disable_signup_notifications_stream');
 
     var submit_settings_form;
-    var submit_permissions_form;
     var submit_profile_form;
     $('.organization').on = function (action, selector, f) {
         if (selector === '.subsection-header .subsection-changes-save button') {
@@ -501,10 +446,6 @@ function test_extract_property_name() {
         }
         if (selector === 'button.save-language-org-settings') {
             assert.equal(action, 'click');
-        }
-        if (selector === 'form.org-permissions-form') {
-            assert.equal(action, 'submit');
-            submit_permissions_form = f;
         }
         if (selector === 'form.org-profile-form') {
             assert.equal(action, 'submit');
@@ -537,7 +478,6 @@ function test_extract_property_name() {
 
     test_submit_profile_form(submit_profile_form);
     test_submit_settings_form(submit_settings_form);
-    test_submit_permissions_form(submit_permissions_form);
     test_upload_realm_icon(upload_realm_icon);
     test_change_invite_required(callbacks.change_invite_required);
     test_change_message_editing(callbacks.change_message_editing);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -421,6 +421,22 @@ function _set_up() {
     function property_value_element_refers(property_name) {
         if (property_name === 'realm_message_content_edit_limit_minutes') {
             return Math.ceil(page_params.realm_message_content_edit_limit_seconds / 60).toString();
+        } else if (property_name === 'realm_create_stream_permission') {
+            if (page_params.create_stream_by_admins_only) {
+                return "by_admins_only";
+            }
+            if (page_params.realm_waiting_period_threshold === 0) {
+                return "by_anyone";
+            }
+            if (page_params.realm_waiting_period_threshold === 3) {
+                return "by_admin_user_with_three_days_old";
+            }
+            return "by_admin_user_with_custom_time";
+        } else if (property_name === 'realm_add_emoji_by_admins_only') {
+            if (page_params.realm_add_emoji_by_admins_only) {
+                return "by_admins_only";
+            }
+            return "by_anyone";
         }
         return;
     }
@@ -459,7 +475,7 @@ function _set_up() {
         return subsection.find("input[id^='id_realm_'], select[id^='id_realm_']");
     }
 
-    $('.org-settings-form').on('change input', 'input, select', function (e) {
+    $('.admin-realm-form').on('change input', 'input, select', function (e) {
         e.preventDefault();
         e.stopPropagation();
 
@@ -576,8 +592,51 @@ function _set_up() {
                    $("#id_realm_message_content_edit_limit_minutes").val(data_message_content_edit_limit_minutes);
                 }
             };
+        } else if (subsection === 'other_permissions') {
+            var create_stream_permission = $("#id_realm_create_stream_permission").val();
+            var add_emoji_permission = $("#id_realm_add_emoji_by_admins_only").val();
+            var new_message_retention_days = $("#id_realm_message_retention_days").val();
+
+            if (parseInt(new_message_retention_days, 10).toString() !==
+                new_message_retention_days && new_message_retention_days !== "") {
+                    new_message_retention_days = "";
+            }
+
+            var data = {
+                message_retention_days: new_message_retention_days !== "" ?
+                    JSON.stringify(parseInt(new_message_retention_days, 10)) : null,
+            };
+
+            if (add_emoji_permission === "by_admins_only") {
+                data.add_emoji_by_admins_only = true;
+            } else if (add_emoji_permission === "by_anyone") {
+                data.add_emoji_by_admins_only = false;
+            }
+
+            if (create_stream_permission === "by_admins_only") {
+                data.create_stream_by_admins_only = true;
+            } else if (create_stream_permission === "by_admin_user_with_three_days_old") {
+                data.create_stream_by_admins_only = false;
+                data.waiting_period_threshold = 3;
+            } else if (create_stream_permission === "by_admin_user_with_custom_time") {
+                data.create_stream_by_admins_only = false;
+                data.waiting_period_threshold = $("#id_realm_waiting_period_threshold").val();
+            } else if (create_stream_permission === "by_anyone") {
+                data.create_stream_by_admins_only = false;
+                data.waiting_period_threshold = 0;
+            }
+            opts.data = data;
         }
+
         return opts;
+    }
+
+    function get_subsection_property_types(subsection) {
+        if (_.has(org_settings, subsection)) {
+            return org_settings[subsection];
+        } else if (_.has(org_permissions, subsection)) {
+            return org_permissions[subsection];
+        }
     }
 
     $(".organization").on("click", ".subsection-header .subsection-changes-save button", function (e) {
@@ -587,11 +646,11 @@ function _set_up() {
         var subsection_id = save_button.attr('id').replace("org-submit-", "");
         var subsection = subsection_id.split('-').join('_');
 
+        var data = populate_data_for_request({}, get_subsection_property_types(subsection));
         var opts = get_complete_data_for_subsection(subsection);
-        var data = _.extend({}, opts.data);
+        data = _.extend(data, opts.data);
         var success_continuation = opts.success_continuation;
 
-        data = populate_data_for_request(data, org_settings[subsection]);
         exports.save_organization_settings(data, save_button, success_continuation);
     });
 
@@ -603,81 +662,6 @@ function _set_up() {
         } else {
             node.hide();
         }
-    });
-
-    $(".organization").on("submit", "form.org-permissions-form", function (e) {
-        var $alerts = $(".settings-section.show .alert").hide();
-        // grab the first alert available and use it for the status.
-        var status = $("#admin-realm-restricted-to-domain-status");
-
-        var create_stream_permission = $("#id_realm_create_stream_permission").val();
-        var create_stream_permission_status = $("#admin-realm-create-stream-by-admins-only-status").expectOne();
-        var add_emoji_permission = $("#id_realm_add_emoji_by_admins_only").val();
-        status.hide();
-
-        e.preventDefault();
-        e.stopPropagation();
-
-        var new_message_retention_days = $("#id_realm_message_retention_days").val();
-
-        if (parseInt(new_message_retention_days, 10).toString() !==
-            new_message_retention_days && new_message_retention_days !== "") {
-                new_message_retention_days = "";
-        }
-
-        // take the existing object and apply the rest of the properties.
-        var data = populate_data_for_request({
-            message_retention_days: new_message_retention_days !== "" ? JSON.stringify(parseInt(new_message_retention_days, 10)) : null,
-        }, property_types.permissions);
-
-        if (add_emoji_permission === "by_admins_only") {
-            data.add_emoji_by_admins_only = true;
-        } else if (add_emoji_permission === "by_anyone") {
-            data.add_emoji_by_admins_only = false;
-        }
-
-        if (create_stream_permission === "by_admins_only") {
-            data.create_stream_by_admins_only = true;
-        } else if (create_stream_permission === "by_admin_user_with_three_days_old") {
-            data.create_stream_by_admins_only = false;
-            data.waiting_period_threshold = 3;
-        } else if (create_stream_permission === "by_admin_user_with_custom_time") {
-            data.create_stream_by_admins_only = false;
-            data.waiting_period_threshold = $("#id_realm_waiting_period_threshold").val();
-        } else if (create_stream_permission === "by_anyone") {
-            data.create_stream_by_admins_only = false;
-            data.waiting_period_threshold = 0;
-        }
-
-        channel.patch({
-            url: "/json/realm",
-            data: data,
-            success: function (response_data) {
-                $alerts.hide();
-
-                if (response_data.create_stream_by_admins_only !== undefined ||
-                    response_data.waiting_period_threshold !== undefined) {
-                    ui_report.success(i18n.t("Stream creation permission changed!"), create_stream_permission_status);
-                }
-
-                process_response_data(response_data, 'permissions');
-
-                // Check if no changes made
-                var no_changes_made = true;
-                for (var key in response_data) {
-                    if (['msg', 'result'].indexOf(key) < 0) {
-                        no_changes_made = false;
-                    }
-                }
-                if (no_changes_made) {
-                    ui_report.success(i18n.t("No changes to save!"), status);
-                }
-            },
-            error: function (xhr) {
-                $alerts.hide();
-                ui_report.error(i18n.t("Failed"), xhr, status);
-            },
-        });
     });
 
     $(".organization").on("submit", "form.org-profile-form", function (e) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -654,6 +654,14 @@ function _set_up() {
         exports.save_organization_settings(data, save_button, success_continuation);
     });
 
+    $(".org-subsection-parent").on("keydown", "input", function (e) {
+        e.stopPropagation();
+        if (e.keyCode === 13) {
+            e.preventDefault();
+            $(e.target).closest('.org-subsection-parent').find('.subsection-changes-save button').click();
+        }
+    });
+
     $("#id_realm_create_stream_permission").change(function () {
         var create_stream_permission = this.value;
         var node = $("#id_realm_waiting_period_threshold").parent();

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -481,37 +481,35 @@ function _set_up() {
         }
     });
 
+    function discard_subsection_changes(target) {
+        _.each(get_subsection_property_elements(target), function (elem) {
+            elem = $(elem);
+            var property_name = exports.extract_property_name(elem);
+            // Check whether the id refers to a property whose name we can't
+            // extract from element's id.
+            var property_value = property_value_element_refers(property_name);
+            if (property_value === undefined) {
+                property_value = page_params[property_name];
+            }
+
+            if (typeof property_value === 'boolean') {
+                elem.prop('checked', property_value);
+            } else if (typeof property_value === 'string' || typeof property_value === 'number') {
+                elem.val(property_value);
+            } else {
+                blueslip.error('Element refers to unknown property ' + property_name);
+            }
+            // Triggering a change event to handle fading and showing of
+            // dependent sub-settings correctly
+            elem.change();
+        });
+    }
+
     $('.organization').on('click', '.subsection-header .subsection-changes-discard button', function (e) {
         e.preventDefault();
         e.stopPropagation();
-
-        var properties_elements = get_subsection_property_elements(this);
-        _.each(properties_elements, function (elem) {
-            elem = $(elem);
-            var property_name = exports.extract_property_name(elem);
-            if (typeof page_params[property_name] === 'boolean') {
-                // We trigger a click event rather than just changing
-                // the prop, because that handles dependent
-                // sub-settings correctly.
-                if (elem.prop('checked') !== page_params[property_name]) {
-                    elem.click();
-                }
-            } else if (typeof page_params[property_name] === 'string' || typeof page_params[property_name] === 'number') {
-                elem.val(page_params[property_name]);
-            } else {
-                // Check whether the id refers to a property whose name we can't
-                // extract from element's id.
-                var property_value = property_value_element_refers(property_name);
-
-                if (property_value !== undefined) {
-                    elem.val(property_value);
-                } else {
-                    blueslip.error('Element refers to unknown property ' + property_name);
-                }
-            }
-        });
-
-        var subsection = $(this).closest('.org-subsection-parent');
+        discard_subsection_changes(e.target);
+        var subsection = $(e.target).closest('.org-subsection-parent');
         var change_process_buttons = subsection.find('.subsection-header .button');
         change_process_buttons.removeClass('show').addClass('hide');
     });

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -17,12 +17,12 @@
                 <h3>{{t "Joining the organization" }}</h3>
                 {{#if is_admin }}
                 <div class="input-group organization-submission subsection-changes-save">
-                    <button id="org-submit-org-join" class="button rounded sea-green hide" data-status="save">
+                    <button type="button" id="org-submit-org-join" class="button rounded sea-green hide" data-status="save">
                         {{t 'Save' }}
                     </button>
                 </div>
                 <div class="input-group subsection-changes-discard">
-                    <button id="org-discard-org-join" class="button rounded hide">
+                    <button type="button" id="org-discard-org-join" class="button rounded hide">
                         {{t 'Discard changes' }}
                     </button>
                 </div>
@@ -84,12 +84,12 @@
                 <h3>{{t "User identity" }}</h3>
                 {{#if is_admin }}
                 <div class="input-group organization-submission subsection-changes-save">
-                    <button id="org-submit-user-identity" class="button rounded sea-green hide" data-status="save">
+                    <button type="button" id="org-submit-user-identity" class="button rounded sea-green hide" data-status="save">
                         {{t 'Save' }}
                     </button>
                 </div>
                 <div class="input-group subsection-changes-discard">
-                    <button id="org-discard-user-identity" class="button rounded hide">
+                    <button type="button" id="org-discard-user-identity" class="button rounded hide">
                         {{t 'Discard changes' }}
                     </button>
                 </div>
@@ -125,12 +125,12 @@
                 <h3>{{t "Other permissions" }}</h3>
                 {{#if is_admin }}
                 <div class="input-group organization-submission subsection-changes-save">
-                    <button id="org-submit-other-permissions" class="button rounded sea-green hide" data-status="save">
+                    <button type="button" id="org-submit-other-permissions" class="button rounded sea-green hide" data-status="save">
                         {{t 'Save' }}
                     </button>
                 </div>
                 <div class="input-group subsection-changes-discard">
-                    <button id="org-discard-other-permissions" class="button rounded hide">
+                    <button type="button" id="org-discard-other-permissions" class="button rounded hide">
                         {{t 'Discard changes' }}
                     </button>
                 </div>

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -10,10 +10,23 @@
         <div class="alert" id="admin-realm-add-emoji-by-admins-only-status"></div>
         <div class="alert" id="admin-realm-create-stream-by-admins-only-status"></div>
         <div class="alert" id="admin-realm-bot-creation-policy-status"></div>
+        <div class="alert admin-realm-failed-change-status"></div>
 
         <div id="org-org-join" class="org-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Joining the organization" }}</h3>
+                {{#if is_admin }}
+                <div class="input-group organization-submission subsection-changes-save">
+                    <button id="org-submit-org-join" class="button rounded sea-green hide" data-status="save">
+                        {{t 'Save' }}
+                    </button>
+                </div>
+                <div class="input-group subsection-changes-discard">
+                    <button id="org-discard-org-join" class="button rounded hide">
+                        {{t 'Discard changes' }}
+                    </button>
+                </div>
+                {{/if}}
             </div>
             <div class="inline-block organization-permissions-parent">
                 <div class="input-group admin-restricted-to-domain">
@@ -69,6 +82,18 @@
         <div id="org-user-identity" class="org-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "User identity" }}</h3>
+                {{#if is_admin }}
+                <div class="input-group organization-submission subsection-changes-save">
+                    <button id="org-submit-user-identity" class="button rounded sea-green hide" data-status="save">
+                        {{t 'Save' }}
+                    </button>
+                </div>
+                <div class="input-group subsection-changes-discard">
+                    <button id="org-discard-user-identity" class="button rounded hide">
+                        {{t 'Discard changes' }}
+                    </button>
+                </div>
+                {{/if}}
             </div>
             <div class="inline-block organization-permissions-parent">
                 <div class="input-group">
@@ -98,6 +123,18 @@
         <div id="org-other-permissions" class="org-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Other permissions" }}</h3>
+                {{#if is_admin }}
+                <div class="input-group organization-submission subsection-changes-save">
+                    <button id="org-submit-other-permissions" class="button rounded sea-green hide" data-status="save">
+                        {{t 'Save' }}
+                    </button>
+                </div>
+                <div class="input-group subsection-changes-discard">
+                    <button id="org-discard-other-permissions" class="button rounded hide">
+                        {{t 'Discard changes' }}
+                    </button>
+                </div>
+                {{/if}}
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
@@ -135,13 +172,5 @@
                 </div>
             </div>
         </div>
-
-        {{#if is_admin }}
-        <div class="input-group organization-submission">
-            <button type="submit" class="button rounded sea-green">
-                {{t 'Save changes' }}
-            </button>
-        </div>
-        {{/if}}
     </form>
 </div>

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -9,12 +9,12 @@
                 <h3>{{t "Message editing" }}</h3>
                 {{#if is_admin }}
                 <div class="input-group organization-submission subsection-changes-save">
-                    <button id="org-submit-msg-editing" class="button rounded sea-green hide" data-status="save">
+                    <button type="button" id="org-submit-msg-editing" class="button rounded sea-green hide" data-status="save">
                         {{t 'Save' }}
                     </button>
                 </div>
                 <div class="input-group subsection-changes-discard">
-                    <button id="org-discard-msg-editing" class="button rounded hide">
+                    <button type="button" id="org-discard-msg-editing" class="button rounded hide">
                         {{t 'Discard changes' }}
                     </button>
                 </div>
@@ -75,12 +75,12 @@
                 <h3>{{t "Message feed" }}</h3>
                 {{#if is_admin }}
                 <div class="input-group organization-submission subsection-changes-save">
-                    <button id="org-submit-msg-feed" class="button rounded sea-green hide" data-status="save">
+                    <button type="button" id="org-submit-msg-feed" class="button rounded sea-green hide" data-status="save">
                         {{t 'Save' }}
                     </button>
                 </div>
                 <div class="input-group subsection-changes-discard">
-                    <button id="org-discard-msg-feed" class="button rounded hide">
+                    <button type="button" id="org-discard-msg-feed" class="button rounded hide">
                         {{t 'Discard changes' }}
                     </button>
                 </div>
@@ -144,12 +144,12 @@
                 <h3>{{t "Language &amp; notifications" }}</h3>
                 {{#if is_admin }}
                 <div class="input-group organization-submission subsection-changes-save">
-                    <button id="org-submit-language-notify" class="button rounded sea-green hide" data-status="save">
+                    <button type="button" id="org-submit-language-notify" class="button rounded sea-green hide" data-status="save">
                         {{t 'Save' }}
                     </button>
                 </div>
                 <div class="input-group subsection-changes-discard">
-                    <button id="org-discard-language-notify" class="button rounded hide">
+                    <button type="button" id="org-discard-language-notify" class="button rounded hide">
                         {{t 'Discard changes' }}
                     </button>
                 </div>


### PR DESCRIPTION
Commit messages are mostly explanatory.
For node-tests I think we have to rewrite them because now we don't have two handlers for submissions. Also, the logic behind previous node tests doesn't do anything now as we're now dependent upon button for a response.
I'll discuss them with Steve.
Except for last two commits, most of the commits are either refactor or restructuring of code.
@timabbott FYI.