### PR TITLE
org settings: Fix casper failing due to check_property_changed.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -459,7 +459,7 @@ function _set_up() {
         return subsection.find("input[id^='id_realm_'], select[id^='id_realm_']");
     }
 
-    $('.organization').on('change input', 'input, select', function (e) {
+    $('.org-settings-form').on('change input', 'input, select', function (e) {
         e.preventDefault();
         e.stopPropagation();
 


### PR DESCRIPTION
The bug was that 
` $('.organization').on('change input', 'input, select', function (e) {` detects input change on all organization sections and that commit far we haven't defined properties of org-permissions in  `property_value_element_refers` and hence on changing value of stream permission dropdown we get bluesip error .