### PR TITLE
docs: Replace SEND_ALL with ALWAYS_SEND_ALL_HOTSPOTS in hotspots.

### DIFF
--- a/docs/subsystems/hotspots.md
+++ b/docs/subsystems/hotspots.md
@@ -45,8 +45,9 @@ However, if you would like to fix the orientation of a hotspot popover, a
 
 ### Step 3: Test manually
 
-To test your hotspot in the development environment, set `SEND_ALL = True` in
-`zerver/lib/hotspots.py`, and invoke `hotspots.initialize()` in your browser
+To test your hotspot in the development environment, set
+`ALWAYS_SEND_ALL_HOTSPOTS = True` in `zproject/dev_settings.py`,
+and invoke `hotspots.initialize()` in your browser
 console. Every hotspot should be displayed.
 
 Here are some visual characteristics to confirm:


### PR DESCRIPTION
In this [commit](https://github.com/zulip/zulip/commit/f29a1918f3cd3795f6ded3dc174472ef0fde3973) `SEND_ALL` is replaced with `ALWAYS_SEND_ALL_HOTSPOTS`. The docs are outdated for this.