### PR TITLE
webhooks: Send error as PM to bot owner if stream doesn't exist.

### DIFF
--- a/templates/zerver/api/fixtures.json
+++ b/templates/zerver/api/fixtures.json
@@ -313,9 +313,10 @@
         "var_name": "content"
     },
     "nonexistent-stream-error": {
-        "code": "BAD_REQUEST",
+        "code": "STREAM_DOES_NOT_EXIST",
         "msg": "Stream 'nonexistent_stream' does not exist",
-        "result": "error"
+        "result": "error",
+        "stream": "nonexistent_stream"
     },
     "private-message": {
         "id": 134,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -36,6 +36,7 @@ from zerver.lib.cache import (
 )
 from zerver.lib.context_managers import lockfile
 from zerver.lib.emoji import emoji_name_to_emoji_code, get_emoji_file_name
+from zerver.lib.exceptions import StreamDoesNotExistError
 from zerver.lib.hotspots import get_next_hotspots
 from zerver.lib.message import (
     access_message,
@@ -1869,8 +1870,7 @@ def check_message(sender: UserProfile, client: Client, addressee: Addressee,
 
         except Stream.DoesNotExist:
             send_pm_if_empty_stream(sender, None, stream_name, realm)
-            raise JsonableError(_("Stream '%(stream_name)s' "
-                                  "does not exist") % {'stream_name': escape(stream_name)})
+            raise StreamDoesNotExistError(escape(stream_name))
         recipient = get_stream_recipient(stream.id)
 
         if not stream.invite_only:

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Text, Type
 
 from django.core.exceptions import PermissionDenied
+from django.utils.translation import ugettext as _
 
 class AbstractEnum(Enum):
     '''An enumeration whose members are used strictly for their names.'''
@@ -29,6 +30,7 @@ class ErrorCode(AbstractEnum):
     BAD_IMAGE = ()
     REALM_UPLOAD_QUOTA = ()
     BAD_NARROW = ()
+    STREAM_DOES_NOT_EXIST = ()
     UNAUTHORIZED_PRINCIPAL = ()
     BAD_EVENT_QUEUE_ID = ()
     CSRF_FAILED = ()
@@ -133,6 +135,17 @@ class JsonableError(Exception):
 
     def __str__(self) -> str:
         return self.msg
+
+class StreamDoesNotExistError(JsonableError):
+    code = ErrorCode.STREAM_DOES_NOT_EXIST
+    data_fields = ['stream']
+
+    def __init__(self, stream: str) -> None:
+        self.stream = stream
+
+    @staticmethod
+    def msg_format() -> str:
+        return _("Stream '{stream}' does not exist")
 
 class RateLimited(PermissionDenied):
     def __init__(self, msg: str="") -> None:

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -652,7 +652,8 @@ class WebhookTestCase(ZulipTestCase):
         if content_type is not None:
             kwargs['content_type'] = content_type
 
-        msg = self.send_json_payload(self.test_user, self.url, payload,
+        sender = kwargs.get('sender', self.test_user)
+        msg = self.send_json_payload(sender, self.url, payload,
                                      stream_name=None, **kwargs)
         self.do_test_message(msg, expected_message)
 

--- a/zerver/webhooks/helloworld/tests.py
+++ b/zerver/webhooks/helloworld/tests.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from typing import Text
 
 from zerver.lib.test_classes import WebhookTestCase
+from zerver.models import get_system_bot
 
 class HelloWorldHookTests(WebhookTestCase):
     STREAM_NAME = 'test'
@@ -34,6 +36,16 @@ class HelloWorldHookTests(WebhookTestCase):
 
         self.send_and_test_private_message('goodbye', expected_message=expected_message,
                                            content_type="application/x-www-form-urlencoded")
+
+    def test_stream_error_pm_to_bot_owner(self) -> None:
+        # Note taht this is really just a test for check_send_webhook_message
+        self.STREAM_NAME = 'nonexistent'
+        self.url = self.build_webhook_url()
+        notification_bot = get_system_bot(settings.NOTIFICATION_BOT)
+        expected_message = "Hi there! We thought you'd like to know that your bot **Zulip Webhook Bot** just tried to send a message to stream `nonexistent`, but that stream does not yet exist. To create it, click the gear in the left-side stream list."
+        self.send_and_test_private_message('goodbye', expected_message=expected_message,
+                                           content_type='application/x-www-form-urlencoded',
+                                           sender=notification_bot)
 
     def test_custom_topic(self) -> None:
         # Note that this is really just a test for check_send_webhook_message


### PR DESCRIPTION
@timabbott: So, I figured out what was happening. Apparently, if a stream does
not exist `check_message` [uses `send_pm_if_empty_stream` to send a PM](https://github.com/zulip/zulip/blob/master/zerver/lib/actions.py#L1864)
to the sender. However, in the case of a webhook bot sending a message to a
non-existent stream, it will send a PM to the webhook bot, not to the bot's
owner.

Since `Stream.DoesNotExist` has already been caught, it isn't raised again
but instead, `JsonableError` is raised, which is why `Stream.DoesNotExist` is
never caught in `check_send_webhook_message` when I tried to catch it.

We have a couple of options:
* In the case of a *bot* (with type `INCOMING_WEBHOOK`) sending a message to
  a nonexistent stream, we could simply modify `check_message` to send the PM
  to the bot's owner, and not to the bot itself.
* Or, we could simply re-raise `Stream.DoesNotExist` in `check_message`.

I didn't touch `check_message` because I thought I should have a discussion with
you before doing that. What do you think? Are there any more options?

Of course, this PR is a very "hacky" solution, so I am not expecting this to be merged.

Thanks,

\-Eeshan
