### PR TITLE
team page: Add contributions for Zulip Terminal.

### DIFF
--- a/static/js/portico/team.js
+++ b/static/js/portico/team.js
@@ -2,7 +2,7 @@
 // eslint's error.
 /* global contributors_list */
 
-var repos = ['server', 'desktop', 'mobile', 'python-zulip-api', 'zulip-js', 'zulipbot'];
+var repos = ['server', 'desktop', 'mobile', 'python-zulip-api', 'zulip-js', 'zulipbot', 'terminal'];
 
 function contrib_total_commits(contrib) {
     var commits = 0;

--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -950,7 +950,8 @@ input#desktop:checked ~ #tab-desktop,
 input#mobile:checked ~ #tab-mobile,
 input#python-zulip-api:checked ~ #tab-python-zulip-api,
 input#zulip-js:checked ~ #tab-zulip-js,
-input#zulipbot:checked ~ #tab-zulipbot {
+input#zulipbot:checked ~ #tab-zulipbot,
+input#terminal:checked ~ #tab-terminal {
     border-top: 1px solid #eee;
     padding-top: 20px;
     display: grid;

--- a/templates/zerver/team.html
+++ b/templates/zerver/team.html
@@ -151,6 +151,9 @@
                 <input id="zulipbot" type="radio" name="tabs">
                 <label for="zulipbot"><i class="fa fa-at" aria-hidden="true"></i>&nbsp; Zulipbot</label>
 
+                <input id="terminal" type="radio" name="tabs">
+                <label for="terminal"><i class="fa fa-terminal" aria-hidden="true"></i>&nbsp; Terminal</label>
+
                 <div id="tab-total" class="contributors"></div>
                 <div id="tab-server" class="contributors"></div>
                 <div id="tab-desktop" class="contributors"></div>
@@ -158,6 +161,7 @@
                 <div id="tab-python-zulip-api" class="contributors"></div>
                 <div id="tab-zulip-js" class="contributors"></div>
                 <div id="tab-zulipbot" class="contributors"></div>
+                <div id="tab-terminal" class="contributors"></div>
 
                 <!-- Compiled using underscore -->
                 <script type="text/template" id="contributors-template">

--- a/templates/zerver/team.html
+++ b/templates/zerver/team.html
@@ -134,7 +134,7 @@
                 <label for="total"><i class="fa fa-globe" aria-hidden="true"></i>&nbsp; Total</label>
 
                 <input id="server" type="radio" name="tabs">
-                <label for="server"><i class="fa fa-server" aria-hidden="true"></i>&nbsp; Zulip server</label>
+                <label for="server"><i class="fa fa-server" aria-hidden="true"></i>&nbsp; Server</label>
 
                 <input id="desktop" type="radio" name="tabs">
                 <label for="desktop"><i class="fa fa-desktop" aria-hidden="true"></i>&nbsp; Desktop</label>
@@ -146,7 +146,7 @@
                 <label for="python-zulip-api"><i class="fa fa-code" aria-hidden="true"></i>&nbsp; Python API</label>
 
                 <input id="zulip-js" type="radio" name="tabs">
-                <label for="zulip-js"><i class="fa fa-code" aria-hidden="true"></i>&nbsp; JavaScript API</label>
+                <label for="zulip-js"><i class="fa fa-code" aria-hidden="true"></i>&nbsp; JS API</label>
 
                 <input id="zulipbot" type="radio" name="tabs">
                 <label for="zulipbot"><i class="fa fa-at" aria-hidden="true"></i>&nbsp; Zulipbot</label>

--- a/tools/update-authors-json
+++ b/tools/update-authors-json
@@ -73,6 +73,7 @@ def run_production() -> None:
         'python-zulip-api': 'https://api.github.com/repos/zulip/python-zulip-api/stats/contributors',
         'zulip-js': 'https://api.github.com/repos/zulip/zulip-js/stats/contributors',
         'zulipbot': 'https://api.github.com/repos/zulip/zulipbot/stats/contributors',
+        'terminal': 'https://api.github.com/repos/zulip/zulip-terminal/stats/contributors',
     }
 
     data = dict(date=str(date.today()), contrib=[])  # type: ContributorsJSON


### PR DESCRIPTION
It adds contributions of the Zulip-terminal on team page as follows -
![image](https://user-images.githubusercontent.com/9110208/37804499-9342e50e-2e5a-11e8-9626-b346e503e633.png)
