### PR TITLE
Clean up custom user settings frontend

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -483,6 +483,16 @@ input[type=checkbox].inline-block {
     height: 75px;
 }
 
+#settings_page .custom_user_field input[type=number]::-webkit-outer-spin-button,
+#settings_page .custom_user_field input[type=number]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+#settings_page .custom_user_field input[type=number] {
+    -moz-appearance: textfield;
+}
+
 #settings_page .alert-notification.alert-error {
     color: hsl(2, 46%, 68%);
     border-color: hsl(2, 46%, 68%);

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -478,6 +478,11 @@ input[type=checkbox].inline-block {
     margin-left: 10px;
 }
 
+#settings_page .custom_user_field textarea {
+    width: 303px;
+    height: 75px;
+}
+
 #settings_page .alert-notification.alert-error {
     color: hsl(2, 46%, 68%);
     border-color: hsl(2, 46%, 68%);

--- a/static/templates/settings/custom-user-profile-field.handlebars
+++ b/static/templates/settings/custom-user-profile-field.handlebars
@@ -1,8 +1,8 @@
 <div class="user-name-section custom_user_field">
     <label for="{{ field_name }}" class="title">{{ field_name }}</label>
     {{#if is_long_text_field}}
-    <textarea name="{{ field_name }}" id="{{ field_id }}" placeholder="{{t 'No value.' }}">{{ field_value }}</textarea>
+    <textarea name="{{ field_name }}" id="{{ field_id }}">{{ field_value }}</textarea>
     {{else}}
-    <input type="{{ field_type }}" name="{{ field_name }}" id="{{ field_id }}" placeholder="{{t 'No value.' }}" value="{{ field_value }}" />
+    <input type="{{ field_type }}" name="{{ field_name }}" id="{{ field_id }}" value="{{ field_value }}" />
     {{/if}}
 </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR cleans few frontend changes in custom user fields added in PR #8530.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![customprofile](https://user-images.githubusercontent.com/25907420/37830637-bc078364-2ec8-11e8-9918-c6b25758ac9d.png)

