### PR TITLE
Improve email hint widget in stream subscription

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -172,7 +172,8 @@ function add_email_hint(row, email_address_hint_content) {
         $(hint_id).popover({placement: "right",
                 title: "Email integration",
                 content: email_address_hint_content,
-                trigger: "manual"});
+                trigger: "manual",
+                animation: false});
         $(hint_id).popover('show');
         e.stopPropagation();
     });

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -10,10 +10,15 @@
     margin: 0;
 }
 
+.email_address_hint {
+    max-width: 430px;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
 .subscription-email-hint-image {
     float: right;
     width: 80px;
-    padding-right: 60px;
 }
 
 .subscription_header.collapsed {

--- a/static/templates/email_address_hint.handlebars
+++ b/static/templates/email_address_hint.handlebars
@@ -1,14 +1,10 @@
 {{! Explanation of the stream email address }}
-<div>
-
+<div class="email_address_hint">
     <p>{{#tr this}}You can send emails to Zulip! Just copy and use this address as an email recipient, and:{{/tr}}</p>
-
     <img class="subscription-email-hint-image" src="/static/images/integrations/zulip_mail.png" />
-
     <ul>
         <li>{{t "The email will be forwarded to this stream" }}</li>
         <li>{{#tr this}}The email subject will become the Zulip topic{{/tr}}</li>
         <li>{{#tr this}}The email body will become the Zulip message{{/tr}}</li>
     </ul>
-
 </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR fixes both issues mentioned in #8743 
* Style of email hint widget
* Bug in email hint popover display



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![emailhint](https://user-images.githubusercontent.com/25907420/37840252-903943e8-2ee2-11e8-95d7-32dbe4f119b0.gif)
