### PR TITLE
webhooks/gitlab: Stop filtering comments when description is null.

### DIFF
--- a/zerver/webhooks/gitlab/fixtures/issue_opened_with_null_description.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_opened_with_null_description.json
@@ -1,0 +1,71 @@
+{
+    "object_kind":"issue",
+    "user":{
+        "name":"Eeshan Garg",
+        "username":"eeshangarg",
+        "avatar_url":"https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80\u0026d=identicon"
+    },
+    "project":{
+        "id":3319043,
+        "name":"my-awesome-project",
+        "description":"",
+        "web_url":"https://gitlab.com/eeshangarg/my-awesome-project",
+        "avatar_url":null,
+        "git_ssh_url":"git@gitlab.com:eeshangarg/my-awesome-project.git",
+        "git_http_url":"https://gitlab.com/eeshangarg/my-awesome-project.git",
+        "namespace":"eeshangarg",
+        "visibility_level":20,
+        "path_with_namespace":"eeshangarg/my-awesome-project",
+        "default_branch":"feature",
+        "ci_config_path":null,
+        "homepage":"https://gitlab.com/eeshangarg/my-awesome-project",
+        "url":"git@gitlab.com:eeshangarg/my-awesome-project.git",
+        "ssh_url":"git@gitlab.com:eeshangarg/my-awesome-project.git",
+        "http_url":"https://gitlab.com/eeshangarg/my-awesome-project.git"
+    },
+    "object_attributes":{
+        "author_id":1129123,
+        "closed_at":null,
+        "confidential":false,
+        "created_at":"2018-03-23 17:35:53 UTC",
+        "description":null,
+        "due_date":null,
+        "id":9892394,
+        "iid":7,
+        "last_edited_at":null,
+        "last_edited_by_id":null,
+        "milestone_id":null,
+        "moved_to_id":null,
+        "project_id":3319043,
+        "relative_position":1073745323,
+        "state":"opened",
+        "time_estimate":0,
+        "title":"Issue without description",
+        "updated_at":"2018-03-23 17:35:53 UTC",
+        "updated_by_id":null,
+        "url":"https://gitlab.com/eeshangarg/my-awesome-project/issues/7",
+        "total_time_spent":0,
+        "human_total_time_spent":null,
+        "human_time_estimate":null,
+        "assignee_ids":[
+
+        ],
+        "assignee_id":null,
+        "action":"open"
+    },
+    "labels":[
+
+    ],
+    "changes":{
+        "total_time_spent":{
+            "previous":null,
+            "current":0
+        }
+    },
+    "repository":{
+        "name":"my-awesome-project",
+        "url":"git@gitlab.com:eeshangarg/my-awesome-project.git",
+        "description":"",
+        "homepage":"https://gitlab.com/eeshangarg/my-awesome-project"
+    }
+}

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -124,6 +124,16 @@ class GitlabHookTests(WebhookTestCase):
             HTTP_X_GITLAB_EVENT="Issue Hook"
         )
 
+    def test_create_issue_with_null_description(self) -> None:
+        expected_subject = u"my-awesome-project / Issue #7 Issue without description"
+        expected_message = u"Eeshan Garg created [Issue #7](https://gitlab.com/eeshangarg/my-awesome-project/issues/7)"
+        self.send_and_test_stream_message(
+            'issue_opened_with_null_description',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Issue Hook"
+        )
+
     def test_update_issue_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
         expected_message = u"Tomasz Kolek updated [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -64,8 +64,9 @@ def get_tag_push_event_body(payload: Dict[str, Any]) -> Text:
 def get_issue_created_event_body(payload: Dict[str, Any]) -> Text:
     description = payload['object_attributes'].get('description')
     # Filter out multiline hidden comments
-    description = re.sub('<!--.*?-->', '', description, 0, re.DOTALL)
-    description = description.rstrip()
+    if description is not None:
+        description = re.sub('<!--.*?-->', '', description, 0, re.DOTALL)
+        description = description.rstrip()
     return get_issue_event_message(
         get_issue_user_name(payload),
         'created',


### PR DESCRIPTION
We filter out hidden comments out of Issue descriptions but this
breaks when description is null (which is unusual). So this commit
just checks to see if the description is None and if so, not to
filter anything out.

@timabbott: FYI :)