### PR TITLE
mypy: Use mypy.ini to enforce strict optional where currently possible

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,132 @@
+[mypy]
+strict_optional = True
+
+# REQ returning None issue
+
+[mypy-zerver.decorator]
+strict_optional = False
+[mypy-zerver.views.zephyr]
+strict_optional = False
+[mypy-zerver.views.user_settings]
+strict_optional = False
+[mypy-zerver.views.streams]
+strict_optional = False
+[mypy-zerver.views.storage]
+strict_optional = False
+[mypy-zerver.views.report]
+strict_optional = False
+[mypy-zerver.views.integrations]
+strict_optional = False
+[mypy-zerver.tornado.views]
+strict_optional = False
+[mypy-zerver.views.events_register]
+strict_optional = False
+
+[mypy-zerver.lib.webhooks.common]
+strict_optional = False
+[mypy-zerver.webhooks.yo.view]
+strict_optional = False
+[mypy-zerver.webhooks.transifex.view]
+strict_optional = False
+[mypy-zerver.webhooks.newrelic.view]
+strict_optional = False
+[mypy-zerver.webhooks.gogs.view]
+strict_optional = False
+[mypy-zerver.webhooks.gitlab.view]
+strict_optional = False
+[mypy-zerver.webhooks.github_webhook.view]
+strict_optional = False
+[mypy-zerver.webhooks.bitbucket.view]
+strict_optional = False
+[mypy-zerver.webhooks.bitbucket2.view]
+strict_optional = False
+[mypy-zerver.webhooks.beanstalk.view]
+strict_optional = False
+
+[mypy-zerver.views.auth]  # Other issues in this file too
+strict_optional = False
+[mypy-zerver.views.realm]  # Other issues in this file too
+strict_optional = False
+[mypy-zerver.views.messages]  # Other issues in this file too
+strict_optional = False
+[mypy-zerver.views.users]  # Other issues in this file too
+strict_optional = False
+
+# One change required?
+
+[mypy-zerver.lib.notifications]  # line 122: Using group from regex, which might return None
+strict_optional = False
+[mypy-zerver.lib.avatar]  # str vs Optional[str]
+strict_optional = False
+[mypy-zerver.lib.soft_deactivation]
+strict_optional = False
+[mypy-zerver.lib.events]  # signup_notifications_stream is Optional, but accessing id property
+strict_optional = False
+[mypy-zerver.lib.exceptions]  #21: error: Return type of "__reduce_ex__" incompatible with supertype "object"
+strict_optional = False
+[mypy-zerver.lib.bugdown.api_arguments_table_generator]  #18: error: Item "None" of "Optional[Dict[str, Any]]" has no attribute "items"
+strict_optional = False
+
+[mypy-zerver.migrations.0077_add_file_name_field_to_realm_emoji]  #73: error: Argument 2 to "upload_files" of "Uploader" has incompatible type "Optional[bytes]"; expected "bytes"
+strict_optional = False
+
+[mypy-zerver/management/commands/purge_queue]  #24: error: Item "None" of "Optional[Any]" has no attribute "queue_purge"
+strict_optional = False
+[mypy-zerver/management/commands/check_redis]  #32: error: Incompatible types in assignment (expression has type "None", variable has type "UserProfile")
+strict_optional = False
+[mypy-zerver.management.commands.create_user]  #86: error: Item "None" of "Optional[str]" has no attribute "encode"
+strict_optional = False
+
+[mypy-zilencer.management.commands.calculate_first_visible_message_id]  #33: error: Argument 1 to "maybe_update_first_visible_message_id" has incompatible type "Optional[Realm]"; expected "Realm"
+strict_optional = False
+[mypy-zilencer.management.commands.add_new_realm]  #22: error: List item 0 has incompatible type "Optional[Stream]"; expected "Stream"
+strict_optional = False
+
+[mypy-analytics.management.commands.populate_analytics_db]  #148: error: Argument 2 to "insert_fixture_data" has incompatible type "Dict[str, List[int]]"; expected "Mapping[Optional[str], List[int]]"
+strict_optional = False
+
+[mypy-zthumbor.loaders.helpers]  #83: error: Argument 2 to "get_sign_hash" has incompatible type "Optional[str]"; expected "str"
+strict_optional = False
+
+# Re-architecting required?
+
+[mypy-zerver.lib.queue]  # Delayed setup of SimpleQueueClient.channel (Optional)
+strict_optional = False
+[mypy-zerver.tornado.handlers]  # Delayed setup of ASyncDjangoHandler._request_middleware (Optional), line 200 error
+strict_optional = False
+
+[mypy-zerver.tornado.descriptors]  # line 10: 'get' can return None; only used in zerver/tornado/handlers?
+strict_optional = False
+
+# General exclusions to work on
+
+[mypy-zerver.tests.*]
+strict_optional = False
+[mypy-zerver.lib.test_helpers]
+strict_optional = False
+[mypy-zerver.lib.test_classes]
+strict_optional = False
+
+[mypy-zerver.tornado.event_queue]
+strict_optional = False
+[mypy-zerver.lib.outgoing_webhook]
+strict_optional = False
+[mypy-zerver.lib.bugdown]  # for __init__.py
+strict_optional = False
+[mypy-zerver.lib.push_notifications]
+strict_optional = False
+[mypy-zerver.lib.actions]
+strict_optional = False
+[mypy-zproject.backends]
+strict_optional = False
+[mypy-zerver.worker.queue_processors]
+strict_optional = False
+[mypy-zerver.tornado.websocket_client]
+strict_optional = False
+[mypy-zerver.lib.slack_message_conversion]
+strict_optional = False
+[mypy-zerver.views.registration]
+strict_optional = False
+
+[mypy-tools.lib.html_branches]
+strict_optional = False

--- a/tools/update-authors-json
+++ b/tools/update-authors-json
@@ -86,13 +86,24 @@ def run_production() -> None:
             if contribs:
                 repos_done.append(name)
                 for contrib in contribs:
-                    if contrib.get('author') is None:
+                    assert contrib is not None  # TODO: To improve/clarify
+
+                    author = contrib.get('author')
+                    if author is None:
                         # This happens for users who've deleted their GitHub account.
                         continue
-                    username = contrib.get('author').get('login')
+
+                    username = author.get('login')
+                    assert username is not None  # TODO: To improve/clarify
+
+                    avatar = author.get('avatar_url')
+                    assert avatar is not None  # TODO: To improve/clarify
+                    total = contrib.get('total')
+                    assert total is not None  # TODO: To improve/clarify
+
                     contrib_data = {
-                        'avatar': contrib.get('author').get('avatar_url'),
-                        name: contrib.get('total'),
+                        'avatar': avatar,
+                        name: total,
                     }
                     if username in contribs_list:
                         contribs_list[username].update(contrib_data)

--- a/zerver/webhooks/appfollow/view.py
+++ b/zerver/webhooks/appfollow/view.py
@@ -16,7 +16,9 @@ from zerver.models import UserProfile
 def api_appfollow_webhook(request: HttpRequest, user_profile: UserProfile,
                           payload: Dict[str, Any]=REQ(argument_type="body")) -> HttpResponse:
     message = payload["text"]
-    app_name = re.search('\A(.+)', message).group(0)
+    app_name_search= re.search('\A(.+)', message)
+    assert app_name_search is not None
+    app_name = app_name_search.group(0)
     topic = app_name
 
     check_send_webhook_message(request, user_profile, topic,


### PR DESCRIPTION
This is a followup to #6017, which became unwieldy due to ongoing work, with other commits competing against it which limited completing it quick enough. This PR follows the advice of @gnprice, introducing `mypy.ini` and setting `strict-optional` to `True` by default, followed by a (relatively long, for now) list of exclusions.

The exclusions are split into commented sections, with some themselves also individually commented for reference purposes. The `REQ` list is particularly long. However, commits may be mergeable from #6017, if they are suitable, and can be discussed in another issue/PR.

This PR includes some other adjustments to mitigate additional exclusions being necessary, and in at least two cases (two prior to the mypy.ini addition) were specifically made since simple temporary exclusions did not appear to work correctly.

While some files may still lose strict-optional compliance, due to being in the excluded lists, other files will now require strict-optional compliance to pass `run-mypy` in future.

This passed Travis, and `run-mypy` passed on the commit prior to final commit.