### PR TITLE
settings: template de-duplication

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -57,6 +57,28 @@ $("body").ready(function () {
     });
 });
 
+function setup_settings_label() {
+    exports.settings_label = {
+        // settings_notification
+        // stream_notification_settings
+        enable_stream_desktop_notifications: i18n.t("Visual desktop notifications"),
+        enable_stream_sounds: i18n.t("Audible desktop notifications"),
+        enable_stream_push_notifications: i18n.t("Mobile notifications"),
+
+        // pm_mention_notification_settings
+        enable_desktop_notifications: i18n.t("Visual desktop notifications"),
+        enable_offline_email_notifications: i18n.t("Email notifications when offline"),
+        enable_offline_push_notifications: i18n.t("Mobile notifications when offline"),
+        enable_online_push_notifications: i18n.t("Mobile notifications always (even when online)"),
+        enable_sounds: i18n.t("Audible desktop notifications"),
+        pm_content_in_desktop_notifications: i18n.t("Include content of private messages"),
+
+        // other_notification_settings
+        enable_digest_emails: i18n.t("Send digest emails when I'm away"),
+        message_content_in_email_notifications: i18n.t("Include content of private messages"),
+        realm_name_in_notifications: i18n.t("Include organization name in subject of missed message emails"),
+    };
+}
 
 function _setup_page() {
     ui.set_up_scrollbar($("#settings_page .sidebar.left"));
@@ -99,6 +121,7 @@ function _setup_page() {
         return tab;
     }());
 
+    setup_settings_label();
     settings_bots.setup_bot_creation_policy_values();
 
     var settings_tab = templates.render('settings_tab', {
@@ -110,6 +133,7 @@ function _setup_page() {
         admin_only_bot_creation: page_params.is_admin ||
             page_params.realm_bot_creation_policy !==
             settings_bots.bot_creation_policy_values.admins_only.code,
+        settings_label: settings.settings_label,
     });
 
     $(".settings-box").html(settings_tab);

--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -7,48 +7,24 @@
             <div class="alert-notification" id="stream-notify-settings-status"></div>
             <p>{{t "Unless I say otherwise for a particular stream, I want:" }}</p>
 
-            <div class="input-group">
-                <label class="checkbox">
-                    <input type="checkbox" class="inline-block" name="enable_stream_desktop_notifications"
-                        id="enable_stream_desktop_notifications"
-                        {{#if page_params.enable_stream_desktop_notifications}}
-                        checked="checked"
-                        {{/if}} />
-                    <span></span>
-                </label>
-                <label for="enable_stream_desktop_notifications" class="inline-block">
-                    {{t "Visual desktop notifications" }}
-                </label>
-                <div class="propagate_stream_notifications_change"></div>
-            </div>
+            {{partial "settings_checkbox"
+            "setting_name" "enable_stream_desktop_notifications"
+            "is_checked" page_params.enable_stream_desktop_notifications
+            "label" settings_label.enable_stream_desktop_notifications
+            "end_content" '<div class="propagate_stream_notifications_change"></div>'}}
 
-            <div class="input-group">
-                <label class="checkbox">
-                    <input type="checkbox" class="inline-block" name="enable_stream_sounds" id="enable_stream_sounds"
-                        {{#if page_params.enable_stream_sounds}}
-                        checked="checked"
-                        {{/if}} />
-                    <span></span>
-                </label>
-                <label for="enable_stream_sounds" class="inline-block no-border">
-                    {{t "Audible desktop notifications" }}
-                </label>
-                <div class="propagate_stream_notifications_change"></div>
-            </div>
 
-            <div class="input-group">
-                <label class="checkbox">
-                    <input type="checkbox" class="inline-block" name="enable_stream_push_notifications" id="enable_stream_push_notifications"
-                        {{#if page_params.enable_stream_push_notifications}}
-                        checked="checked"
-                        {{/if}} />
-                    <span></span>
-                </label>
-                <label for="enable_stream_push_notifications" class="inline-block no-border">
-                    {{t "Mobile notifications" }}
-                </label>
-                <div class="propagate_stream_notifications_change"></div>
-            </div>
+            {{partial "settings_checkbox"
+            "setting_name" "enable_stream_sounds"
+            "is_checked" page_params.enable_stream_sounds
+            "label" settings_label.enable_stream_sounds
+            "end_content" '<div class="propagate_stream_notifications_change"></div>'}}
+
+            {{partial "settings_checkbox"
+            "setting_name" "enable_stream_push_notifications"
+            "is_checked" page_params.enable_stream_push_notifications
+            "label" settings_label.enable_stream_push_notifications
+            "end_content" '<div class="propagate_stream_notifications_change"></div>'}}
 
             <p class="notification-settings-note">
                 {{#tr this}}Change notification settings for individual streams on your <a href="/#streams">Streams page</a>.{{/tr}}
@@ -60,18 +36,10 @@
             <div class="alert-notification" id="pm-mention-notify-settings-status"></div>
             <p>{{t "I want:" }}</p>
 
-            <div class="input-group">
-                <label class="checkbox">
-                    <input type="checkbox" name="enable_desktop_notifications" id="enable_desktop_notifications"
-                        {{#if page_params.enable_desktop_notifications}}
-                        checked="checked"
-                        {{/if}} />
-                    <span></span>
-                </label>
-                <label for="enable_desktop_notifications" class="inline-block">
-                    {{t "Visual desktop notifications" }}
-                </label>
-            </div>
+            {{partial "settings_checkbox"
+            "setting_name" "enable_desktop_notifications"
+            "is_checked" page_params.enable_desktop_notifications
+            "label" settings_label.enable_desktop_notifications}}
 
             <div class="input-group disableable {{#unless page_params.enable_desktop_notifications}}control-label-disabled{{/unless}}">
                 <label class="checkbox">
@@ -84,48 +52,24 @@
                     <span></span>
                 </label>
                 <label for="pm_content_in_desktop_notifications" id="pm_content_in_desktop_notifications_label" class="inline-block">
-                    {{t "Include content of private messages" }}
+                    {{settings_label.pm_content_in_desktop_notifications}}
                 </label>
             </div>
 
-            <div class="input-group">
-                <label class="checkbox">
-                    <input type="checkbox" name="enable_sounds" id="enable_sounds"
-                        {{#if page_params.enable_sounds}}
-                        checked="checked"
-                        {{/if}} />
-                    <span></span>
-                </label>
-                <label for="enable_sounds" class="inline-block">
-                    {{t "Audible desktop notifications" }}
-                </label>
-            </div>
+            {{partial "settings_checkbox"
+            "setting_name" "enable_sounds"
+            "is_checked" page_params.enable_sounds
+            "label" settings_label.enable_sounds}}
 
-            <div class="input-group">
-                <label class="checkbox">
-                    <input type="checkbox" name="enable_offline_email_notifications" id="enable_offline_email_notifications"
-                        {{#if page_params.enable_offline_email_notifications}}
-                        checked="checked"
-                        {{/if}} />
-                    <span></span>
-                </label>
-                <label for="enable_offline_email_notifications" class="inline-block">
-                    {{t "Email notifications when offline" }}
-                </label>
-            </div>
+            {{partial "settings_checkbox"
+            "setting_name" "enable_offline_email_notifications"
+            "is_checked" page_params.enable_offline_email_notifications
+            "label" settings_label.enable_offline_email_notifications}}
 
-            <div class="input-group">
-                <label class="checkbox">
-                    <input type="checkbox" name="enable_offline_push_notifications" id="enable_offline_push_notifications"
-                        {{#if page_params.enable_offline_push_notifications}}
-                        checked="checked"
-                        {{/if}} />
-                    <span></span>
-                </label>
-                <label for="enable_offline_push_notifications" class="inline-block">
-                    {{t "Mobile notifications when offline" }}
-                </label>
-            </div>
+            {{partial "settings_checkbox"
+            "setting_name" "enable_offline_push_notifications"
+            "is_checked" page_params.enable_offline_push_notifications
+            "label" settings_label.enable_offline_push_notifications}}
 
             <div class="input-group disableable {{#unless page_params.enable_offline_push_notifications}}control-label-disabled{{/unless}}">
                 <label class="checkbox">
@@ -137,7 +81,7 @@
                     <span></span>
                 </label>
                 <label for="enable_online_push_notifications" id="enable_online_push_notifications_label" class="inline-block">
-                    {{t "Mobile notifications always (even when online)" }}
+                    {{settings_label.enable_online_push_notifications}}
                 </label>
             </div>
         </div>
@@ -146,18 +90,12 @@
 
             <h3 class="inline-block">{{t "Other notification settings" }}</h3>
             <div class="alert-notification" id="other-notify-settings-status"></div>
-            <div class="input-group no-margin" id="digest_container">
-                <label class="checkbox">
-                    <input type="checkbox" name="enable_digest_emails" id="enable_digest_emails"
-                           {{#if page_params.enable_digest_emails}}
-                           checked="checked"
-                           {{/if}} />
-                    <span></span>
-                </label>
-                <label for="enable_digest_emails" class="inline-block">
-                    {{t "Send digest emails when I'm away" }}
-                </label>
-            </div>
+
+            {{partial "settings_checkbox"
+            "setting_name" "enable_digest_emails"
+            "is_checked" page_params.enable_digest_emails
+            "label" settings_label.enable_digest_emails}}
+
             <div class="input-group {{#unless page_params.enable_offline_email_notifications}}control-label-disabled{{/unless}}">
                 <label class="checkbox">
                     <input type="checkbox" name="message_content_in_email_notifications"
@@ -169,26 +107,14 @@
                     <span></span>
                 </label>
                 <label for="message_content_in_email_notifications" id="message_content_in_email_notifications_label" class="inline-block">
-                    {{t "Include message content in missed message emails" }}
-                </label>
-            </div>
-            <div class="input-group" id="realm_name_in_notifications_container">
-                <label class="checkbox">
-                    <input type="checkbox" name="realm_name_in_notifications" id="realm_name_in_notifications"
-                           {{#if page_params.realm_name_in_notifications}}
-                           checked="checked"
-                           {{/if}} />
-                    <span></span>
-                </label>
-                <label for="realm_name_in_notifications" class="inline-block">
-                    {{t "Include organization name in subject of missed message emails" }}
+                    {{settings_label.message_content_in_email_notifications}}
                 </label>
             </div>
 
-            {{!-- If we end up removing the last control group, make sure to change
-            $("#digest_container").hide(); in settings_notifications.js to
-            $("#other_notifications").hide();
-            --}}
+            {{partial "settings_checkbox"
+            "setting_name" "realm_name_in_notifications"
+            "is_checked" page_params.realm_name_in_notifications
+            "label" settings_label.realm_name_in_notifications}}
         </div>
     </form>
 

--- a/static/templates/settings/settings_checkbox.handlebars
+++ b/static/templates/settings/settings_checkbox.handlebars
@@ -1,0 +1,14 @@
+<div class="input-group">
+    <label class="checkbox">
+        <input type="checkbox" class="inline-block" name="{{setting_name}}"
+                  id="{{setting_name}}"
+               {{#if is_checked}}
+               checked="checked"
+               {{/if}} />
+        <span></span>
+    </label>
+    <label for="{{setting_name}}" class="inline-block">
+        {{t label}}
+    </label>
+    {{{end_content}}}
+</div>


### PR DESCRIPTION
**settings notification: De-duplicate template content for checkboxes.**
Created a new template `settings_checkbox.handlebars` to deduplicate
the checkboxes in notification settings page.

There is also a commit for small followup of organization permission refactor.

There is no UI change.
![deduplicate](https://user-images.githubusercontent.com/22238472/37847338-89fa18e0-2ef6-11e8-805e-7d298261903d.gif)

I'm not sure that this should merge or not because I want to see if this checkbox template can be made generic to other checkboxes or not.(if not I've to rename checkbox template to notification-settings-checkbox.handlebars)

Now my biggest doubt here is this line: `{{t label}}` in checkbox template, this made translation work for labels but I'm not sure whether this will cause any problem in translation. 
@timabbott FYI.