### PR TITLE
Mypy.ini: Extract commands into mypy.ini, remove strict-optional parameter, enable option

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,8 @@ strict_optional = True
 scripts_are_modules = True
 show_traceback = True
 
+warn_no_return = True
+
 # REQ returning None issue
 
 [mypy-zerver.decorator]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,10 @@
 [mypy]
+check_untyped_defs = True
+disallow_any_generics = True
 strict_optional = True
+
+scripts_are_modules = True
+show_traceback = True
 
 # REQ returning None issue
 

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -41,8 +41,6 @@ parser.add_argument('--linecoverage-report', action='store_true',
 parser.add_argument('--no-disallow-untyped-defs',
                     dest='disallow_untyped_defs', action='store_false',
                     help="don't pass --disallow-untyped-defs to mypy")
-parser.add_argument('--strict-optional', action='store_true',
-                    help="pass --strict-optional to mypy")
 parser.add_argument('--warn-unused-ignores', action='store_true',
                     help="pass --warn-unused-ignores to mypy")
 parser.add_argument('--no-ignore-missing-imports',
@@ -98,8 +96,6 @@ if args.disallow_untyped_defs:
     extra_args.append("--disallow-untyped-defs")
 if args.warn_unused_ignores:
     extra_args.append("--warn-unused-ignores")
-if args.strict_optional:
-    extra_args.append("--strict-optional")
 if args.ignore_missing_imports:
     extra_args.append("--ignore-missing-imports")
 if args.quick:

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -83,12 +83,8 @@ if not python_files and not pyi_files:
     print("There are no files to run mypy on.")
     sys.exit(0)
 
-extra_args = ["--check-untyped-defs",
-              "--follow-imports=silent",
-              "--scripts-are-modules",
-              "--show-traceback",
-              "-i", "--cache-dir=var/mypy-cache",
-              "--disallow-any-generics"]
+extra_args = ["--follow-imports=silent",
+              "-i", "--cache-dir=var/mypy-cache"]
 if args.linecoverage_report:
     extra_args.append("--linecoverage-report")
     extra_args.append("var/linecoverage-report")


### PR DESCRIPTION
* Now that we use the `mypy.ini` file, extra options can be migrated. One commit does this.
* Now that strict-optional is handled in `mypy.ini`, it feels useful to remove the option from `run-mypy` 
* Another mypy option is added in a third commit, which does not appear to need additional changes, which checks some return values.