### PR TITLE
Mypy: "no implicit optional"

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,8 @@
 check_untyped_defs = True
 disallow_any_generics = True
 strict_optional = True
+# This is a more explicit supporting form of strict-optional:
+no_implicit_optional = True
 
 scripts_are_modules = True
 show_traceback = True

--- a/puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness
+++ b/puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness
@@ -26,7 +26,7 @@ django.setup()
 from zerver.models import UserActivity
 
 if False:
-    from typing import Any, Dict, Set
+    from typing import Any, Dict, Set, Optional
 
 states = {
     "OK": 0,
@@ -36,7 +36,7 @@ states = {
 }  # type: Dict[str, int]
 
 def report(state, short_msg, too_old=None):
-    # type: (str, str, Set[Any]) -> None
+    # type: (str, str, Optional[Set[Any]]) -> None
     too_old_data = ""
     if too_old:
         too_old_data = "\nLast call to get_message for recently out of date mirrors:\n" + "\n".join(

--- a/tools/lib/css_parser.py
+++ b/tools/lib/css_parser.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Tuple, Union
+from typing import Callable, List, Tuple, Union, Optional
 
 ####### Helpers
 
@@ -50,7 +50,7 @@ def get_whitespace(tokens, i, end):
     return i, text
 
 def get_whitespace_and_comments(tokens, i, end, line=None):
-    # type: (List[Token], int, int, int) -> Tuple[int, str]
+    # type: (List[Token], int, int, Optional[int]) -> Tuple[int, str]
 
     def is_fluff_token(token):
         # type: (Token) -> bool

--- a/tools/lib/template_parser.py
+++ b/tools/lib/template_parser.py
@@ -11,7 +11,7 @@ class TemplateParserException(Exception):
 
 class TokenizationException(Exception):
     def __init__(self, message, line_content=None):
-        # type: (str, str) -> None
+        # type: (str, Optional[str]) -> None
         self.message = message
         self.line_content = line_content
 

--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -49,7 +49,7 @@ def server_is_up(server, log_file):
 
 @contextmanager
 def test_server_running(force: bool=False, external_host: str='testserver',
-                        log_file: str=None, dots: bool=False, use_db: bool=True
+                        log_file: Optional[str]=None, dots: bool=False, use_db: bool=True
                         ) -> Iterator[None]:
     log = sys.stdout
     if log_file:

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -143,7 +143,7 @@ def write_data_to_file(output_file: Path, data: Any) -> None:
     with open(output_file, "w") as f:
         f.write(ujson.dumps(data, indent=4))
 
-def make_raw(query: Any, exclude: List[Field]=None) -> List[Record]:
+def make_raw(query: Any, exclude: Optional[List[Field]]=None) -> List[Record]:
     '''
     Takes a Django query and returns a JSONable list
     of dictionaries corresponding to the database rows.
@@ -194,13 +194,21 @@ class Config:
 
     '''
 
-    def __init__(self, table: str=None, model: Any=None,
-                 normal_parent: 'Config'=None, virtual_parent: 'Config'=None,
-                 filter_args: FilterArgs=None, custom_fetch: CustomFetch=None,
-                 custom_tables: List[TableName]=None, post_process_data: PostProcessData=None,
-                 concat_and_destroy: List[TableName]=None, id_source: IdSource=None,
-                 source_filter: SourceFilter=None, parent_key: Field=None,
-                 use_all: bool=False, is_seeded: bool=False, exclude: List[Field]=None) -> None:
+    def __init__(self, table: Optional[str]=None,
+                 model: Optional[Any]=None,
+                 normal_parent: Optional['Config']=None,
+                 virtual_parent: Optional['Config']=None,
+                 filter_args: Optional[FilterArgs]=None,
+                 custom_fetch: Optional[CustomFetch]=None,
+                 custom_tables: Optional[List[TableName]]=None,
+                 post_process_data: Optional[PostProcessData]=None,
+                 concat_and_destroy: Optional[List[TableName]]=None,
+                 id_source: Optional[IdSource]=None,
+                 source_filter: Optional[SourceFilter]=None,
+                 parent_key: Optional[Field]=None,
+                 use_all: bool=False,
+                 is_seeded: bool=False,
+                 exclude: Optional[List[Field]]=None) -> None:
         assert table or custom_tables
         self.table = table
         self.model = model
@@ -259,8 +267,8 @@ class Config:
                     self.virtual_parent.table))
 
 
-def export_from_config(response: TableData, config: Config, seed_object: Any=None,
-                       context: Context=None) -> None:
+def export_from_config(response: TableData, config: Config, seed_object: Optional[Any]=None,
+                       context: Optional[Context]=None) -> None:
     table = config.table
     parent = config.parent
     model = config.model
@@ -701,7 +709,7 @@ def write_message_export(message_filename: Path, output: MessageOutput) -> None:
 def export_partial_message_files(realm: Realm,
                                  response: TableData,
                                  chunk_size: int=1000,
-                                 output_dir: Path=None) -> Set[int]:
+                                 output_dir: Optional[Path]=None) -> Set[int]:
     if output_dir is None:
         output_dir = tempfile.mkdtemp(prefix="zulip-export")
 
@@ -1022,7 +1030,7 @@ def do_write_stats_file_for_realm_export(output_dir: Path) -> None:
             f.write('\n')
 
 def do_export_realm(realm: Realm, output_dir: Path, threads: int,
-                    exportable_user_ids: Set[int]=None) -> None:
+                    exportable_user_ids: Optional[Set[int]]=None) -> None:
     response = {}  # type: TableData
 
     # We need at least one thread running to export
@@ -1281,7 +1289,8 @@ def fix_realm_authentication_bitfield(data: TableData, table: TableName, field_n
         values_as_int = int(values_as_bitstring, 2)
         item[field_name] = values_as_int
 
-def bulk_import_model(data: TableData, model: Any, table: TableName, dump_file_id: str=None) -> None:
+def bulk_import_model(data: TableData, model: Any, table: TableName,
+                      dump_file_id: Optional[str]=None) -> None:
     # TODO, deprecate dump_file_id
     model.objects.bulk_create(model(**item) for item in data[table])
     if dump_file_id is None:
@@ -1532,7 +1541,8 @@ def do_import_system_bots(realm: Any) -> None:
     create_users(realm, names, bot_type=UserProfile.DEFAULT_BOT)
     print("Finished importing system bots.")
 
-def create_users(realm: Realm, name_list: Iterable[Tuple[Text, Text]], bot_type: int=None) -> None:
+def create_users(realm: Realm, name_list: Iterable[Tuple[Text, Text]],
+                 bot_type: Optional[int]=None) -> None:
     user_set = set()
     for full_name, email in name_list:
         short_name = email_to_username(email)

--- a/zerver/lib/request.pyi
+++ b/zerver/lib/request.pyi
@@ -21,7 +21,7 @@ NotSpecified = _NotSpecified()
 
 def REQ(whence: Optional[str] = None,
         *,
-        type: Type[ResultT] = None,
+        type: Type[ResultT] = Type[None],
         converter: Optional[Callable[[str], ResultT]] = None,
         default: Union[_NotSpecified, ResultT] = NotSpecified,
         validator: Optional[Validator] = None,

--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -95,9 +95,9 @@ def _check_hash(target_hash_file: str, status_dir: str) -> bool:
 
 def is_template_database_current(
         database_name: str='zulip_test_template',
-        migration_status: str=None,
+        migration_status: Optional[str]=None,
         settings: str='zproject.test_settings',
-        status_dir: str=None,
+        status_dir: Optional[str]=None,
         check_files: Optional[List[str]]=None) -> bool:
     # Using str type for check_files because re.split doesn't accept unicode
     if check_files is None:

--- a/zerver/lib/utils.py
+++ b/zerver/lib/utils.py
@@ -113,9 +113,9 @@ def generate_random_token(length: int) -> str:
     return str(base64.b16encode(os.urandom(length // 2)).decode('utf-8').lower())
 
 def query_chunker(queries: List[Any],
-                  id_collector: Set[int]=None,
+                  id_collector: Optional[Set[int]]=None,
                   chunk_size: int=1000,
-                  db_chunk_size: int=None) -> Iterable[Any]:
+                  db_chunk_size: Optional[int]=None) -> Iterable[Any]:
     '''
     This merges one or more Django ascending-id queries into
     a generator that returns chunks of chunk_size row objects

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -90,7 +90,7 @@ def check_list(sub_validator: Optional[Validator], length: Optional[int]=None) -
     return f
 
 def check_dict(required_keys: Iterable[Tuple[str, Validator]]=[],
-               value_validator: Validator=None,
+               value_validator: Optional[Validator]=None,
                _allow_only_listed_keys: bool=False) -> Validator:
     def f(var_name: str, val: object) -> Optional[str]:
         if not isinstance(val, dict):

--- a/zerver/management/commands/initialize_voyager_db.py
+++ b/zerver/management/commands/initialize_voyager_db.py
@@ -1,6 +1,6 @@
 
 from argparse import ArgumentParser
-from typing import Any, Iterable, Text, Tuple
+from typing import Any, Iterable, Text, Tuple, Optional
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -12,7 +12,7 @@ from zerver.models import Realm, UserProfile, \
 
 settings.TORNADO_SERVER = None
 
-def create_users(realm: Realm, name_list: Iterable[Tuple[Text, Text]], bot_type: int=None) -> None:
+def create_users(realm: Realm, name_list: Iterable[Tuple[Text, Text]], bot_type: Optional[int]=None) -> None:
     user_set = set()
     for full_name, email in name_list:
         short_name = email_to_username(email)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -45,7 +45,7 @@ import sys
 from io import StringIO
 from django.conf import settings
 
-from typing import Any, Callable, Dict, Mapping, Union, Text
+from typing import Any, Callable, Dict, Mapping, Union, Text, Optional
 
 class TestEmailMirrorLibrary(ZulipTestCase):
     def test_get_missed_message_token(self) -> None:
@@ -406,7 +406,7 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
 
         def check_queue_json_publish(queue_name: str,
                                      event: Union[Mapping[str, Any], str],
-                                     processor: Callable[[Any], None]=None) -> None:
+                                     processor: Optional[Callable[[Any], None]]=None) -> None:
             self.assertEqual(queue_name, "email_mirror")
             self.assertEqual(event, {"rcpt_to": to_address, "message": mail})
 

--- a/zerver/tests/test_export.py
+++ b/zerver/tests/test_export.py
@@ -8,7 +8,7 @@ import shutil
 import ujson
 
 from mock import patch, MagicMock
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Set, Optional
 
 from zerver.lib.actions import (
     do_claim_attachments,
@@ -181,7 +181,7 @@ class ExportTest(ZulipTestCase):
         os.makedirs(output_dir, exist_ok=True)
         return output_dir
 
-    def _export_realm(self, realm: Realm, exportable_user_ids: Set[int]=None) -> Dict[str, Any]:
+    def _export_realm(self, realm: Realm, exportable_user_ids: Optional[Set[int]]=None) -> Dict[str, Any]:
         output_dir = self._make_output_dir()
         with patch('logging.info'), patch('zerver.lib.export.create_soft_link'):
             do_export_realm(

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -10,7 +10,7 @@ from django.http import HttpResponse
 from django.test import override_settings
 from email.utils import formataddr
 from mock import patch, MagicMock
-from typing import Any, Dict, List, Text
+from typing import Any, Dict, List, Text, Optional
 
 from zerver.lib.notifications import fix_emojis, \
     handle_missedmessage_emails, relative_to_full_url
@@ -39,7 +39,7 @@ class TestMissedMessages(ZulipTestCase):
     def _test_cases(self, tokens: List[str], msg_id: int, body: str, subject: str,
                     send_as_user: bool, verify_html_body: bool=False,
                     show_message_content: bool=True,
-                    verify_body_does_not_include: List[str]=None) -> None:
+                    verify_body_does_not_include: Optional[List[str]]=None) -> None:
         othello = self.example_user('othello')
         hamlet = self.example_user('hamlet')
         handle_missedmessage_emails(hamlet.id, [{'message_id': msg_id}])

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -95,7 +95,7 @@ def get_in(payload: Dict[str, Any], keys: List[str], default: Text='') -> Any:
         return default
     return payload
 
-def get_issue_string(payload: Dict[str, Any], issue_id: Text=None) -> Text:
+def get_issue_string(payload: Dict[str, Any], issue_id: Optional[Text]=None) -> Text:
     # Guess the URL as it is not specified in the payload
     # We assume that there is a /browse/BUG-### page
     # from the REST url of the issue itself


### PR DESCRIPTION
Without this option, something like the following is accepted, ie. without `Optional` being necessary:
```python
def f(x: int=None) -> None:
    pass
```

While mypy presumably expands the type based on the default value, this feels consistent with other annotations and follows from the strict-optional work.

The associated changes are fairly straightforward annotation adjustments.