### PR TITLE
i18n: Ignore var directory.

### DIFF
--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -133,6 +133,7 @@ class Command(makemessages.Command):
         try:
             ignore_patterns = options.get('ignore_patterns', [])
             ignore_patterns.append('docs/*')
+            ignore_patterns.append('var/*')
             options['ignore_patterns'] = ignore_patterns
             super().handle(*args, **options)
         finally:


### PR DESCRIPTION
Previously, makemessages command was also searching var directory for
translatable strings. This commit ignores that directory.

Fixes #8751

@timabbott, this is ready for review.