### PR TITLE
[WIP] stream settings: Add dropdown menu to allow sorting of streams.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -212,6 +212,15 @@ form#add_new_subscription {
     margin: 0;
 }
 
+.search_sort_bar #sort_menu {
+    float: left;
+    width: 50px;
+    margin-right: 5px;
+    border-radius: 5px;
+    box-shadow: none;
+    font-family: 'FontAwesome','Source Sans Pro';
+}
+
 .create_stream_button {
     margin: 0px 0px 0px 5px;
 
@@ -508,6 +517,11 @@ form#add_new_subscription {
 .subscriptions-container .left .search-container {
     padding: 6px 8px;
     border-bottom: 1px solid hsl(0, 0%, 86%);
+}
+
+.subscriptions-container .left .search-container .search_sort_bar {
+    float: right;
+    margin: 0;
 }
 
 .subscriptions-container .right .display-type {
@@ -959,6 +973,14 @@ form#add_new_subscription {
     margin-right: 5px;
 }
 
+@media (max-width: 1240px) {
+    #search_stream_name {
+        width: 100px;
+        margin-top: 2px;
+        margin-bottom: 0px;
+    }
+}
+
 @media (max-width: 1130px) {
     .subscriptions-container {
         max-width: 95%;
@@ -976,6 +998,10 @@ form#add_new_subscription {
         width: 100px;
         margin-top: 2px;
         margin-bottom: 0px;
+    }
+
+    #sort_menu {
+        display: none;
     }
 }
 

--- a/static/templates/subscription_table_body.handlebars
+++ b/static/templates/subscription_table_body.handlebars
@@ -10,16 +10,23 @@
             </div>
             <div class="left">
                 <div class="search-container">
-                    <form id="add_new_subscription" class="form-inline" action="">
-                        <input type="text" name="stream_name" id="search_stream_name"
-                          placeholder="{{t 'Filter streams' }}" value="" autocomplete="off" />
-                        {{#if can_create_streams}}
-                        <input type="submit" class="create_stream_button"
-                          value="+" title="{{t 'Create new stream' }} (n)"/>
-                        {{/if}}
-                        <div class="float-clear"></div>
-                    </form>
-                    <div class="clear-float"></div>
+                    <div class="search_sort_bar">
+                        <form id="add_new_subscription" class="form-inline" action="">
+                            <input type="text" name="stream_name" id="search_stream_name"
+                              placeholder="{{t 'Filter streams' }}" value="" autocomplete="off" />
+                            {{#if can_create_streams}}
+                            <input type="submit" class="create_stream_button"
+                              value="+" title="{{t 'Create new stream' }} (n)"/>
+                            {{/if}}
+                            <div class="float-clear"></div>
+                        </form>
+                        <select id="sort_menu">
+                            <option value="">&#xf160 Sort By</option>   # Sorting icon
+                            <option value="subscriber_count">&#xf2c0 Subscriber count</option>
+                            <option value="weekly_messages">&#xf080 Weekly traffic</option>
+                        </select>
+                        <div class="clear-float"></div>
+                    </div>
                 </div>
                 <div class="streams-list">
                     {{#each subscriptions}}

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -4,6 +4,7 @@ from zerver.lib.initial_password import initial_password
 from zerver.models import Realm, Stream, UserProfile, Huddle, \
     Subscription, Recipient, Client, RealmAuditLog, get_huddle_hash
 from zerver.lib.create_user import create_user_profile
+from django.utils.timezone import now as timezone_now
 
 def bulk_create_users(realm: Realm,
                       users_raw: Set[Tuple[Text, Text, Text, bool]],
@@ -66,10 +67,15 @@ def bulk_create_streams(realm: Realm,
     streams_to_create = []  # type: List[Stream]
     for name, options in stream_dict.items():
         if name.lower() not in existing_streams:
+            if "date_created" in options:
+                date_created = options["date_created"]
+            else:
+                date_created = timezone_now()
             streams_to_create.append(
                 Stream(
                     realm=realm, name=name, description=options["description"],
                     invite_only=options["invite_only"],
+                    date_created=date_created,
                     is_in_zephyr_realm=realm.is_zephyr_mirror_realm,
                 )
             )


### PR DESCRIPTION
Fixes #8659 
I have tried one possible way to implement the UI for sorting of streams. Once we finalize that, I would work on sorting the list based on the selected option.

**Testing Plan:**
Currently, manually tested.

**GIFs or Screenshots:**
![1](https://user-images.githubusercontent.com/14962324/37864597-55b69b16-2f97-11e8-8431-c427b238fe7b.gif)

![2](https://user-images.githubusercontent.com/14962324/37864685-4bf0932e-2f98-11e8-93e6-71c7288c7083.png)

I am unable to test the sorting of streams by average weekly traffic since all streams are New.
![sorting](https://user-images.githubusercontent.com/14962324/37880143-a2df6476-30a1-11e8-8da8-22f329505e5c.gif)


