### PR TITLE
requirements: Upgrade mypy to 0.580.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -88,7 +88,7 @@ markdown==2.6.11
 markupsafe==1.0
 mock==2.0.0
 moto==1.2.0
-mypy==0.570
+mypy==0.580
 mypy_extensions==0.3.0
 ndg-httpsclient==0.4.4
 oauth2client==4.1.2

--- a/requirements/mypy.in
+++ b/requirements/mypy.in
@@ -2,7 +2,7 @@
 # /tools/update-locked-requirements to update requirements/dev.txt
 # and requirements/mypy.txt.
 # See requirements/README.md for more detail.
-mypy==0.570
+mypy==0.580
 
 # Include typing explicitly, since it's needed on Python 3.4
 typing==3.6.4

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -7,6 +7,6 @@
 #
 # For details, see requirements/README.md .
 #
-mypy==0.570
+mypy==0.580
 typed-ast==1.1.0          # via mypy
 typing==3.6.4

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '17.5'
+PROVISION_VERSION = '17.6'


### PR DESCRIPTION
mypy 0.580 was released yesterday (March 23 2018).

No changes appear necessary to pass 0.580 as-is.