### PR TITLE
Fix Marked JS emoticon translation and simplify testing.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -292,6 +292,21 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
          expected: '<p>@*notagroup*</p>'},
         {input: 'This is a realm filter `hello` with text after it',
          expected: '<p>This is a realm filter <code>hello</code> with text after it</p>'},
+        {input: ':)',
+         expected: '<p>:)</p>'},
+        {input: 'a:)b',
+         expected: '<p>a:)b</p>'},
+        {input: 'a :) b',
+         expected: '<p>a :) b</p>'},
+        {input: ':)',
+         expected: '<p><span class="emoji emoji-1f603" title="smiley">:smiley:</span></p>',
+         translate_emoticons: true},
+        {input: 'a:)b',
+         expected: '<p>a:)b</p>',
+         translate_emoticons: true},
+        {input: 'a :) b',
+         expected: '<p>a <span class="emoji emoji-1f603" title="smiley">:smiley:</span> b</p>',
+         translate_emoticons: true},
     ];
 
     // We remove one of the unicode emoji we put as input in one of the test
@@ -300,6 +315,12 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
     delete emoji_codes.codepoint_to_name['1f6b2'];
 
     test_cases.forEach(function (test_case) {
+        if (test_case.translate_emoticons) {
+            page_params.translate_emoticons = false;
+        } else {
+            page_params.translate_emoticons = false;
+        }
+
         var input = test_case.input;
         var expected = test_case.expected;
 
@@ -309,17 +330,6 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
 
         assert.equal(expected, output);
     });
-
-    // Here to arrange 100% test coverage for the new emoticons code
-    // path.  TODO: Have a better way to test this setting in both
-    // states, once we implement the local echo feature properly.
-    // Probably a good technique would be to support toggling the
-    // page_params setting inside the `test_cases.forEach` loop above.
-    page_params.translate_emoticons = true;
-    var message = {raw_content: ":)"};
-    markdown.apply_markdown(message);
-    assert.equal('<p><span class="emoji emoji-1f603" title="smiley">:smiley:</span></p>', message.content);
-    page_params.translate_emoticons = false;
 }());
 
 (function test_subject_links() {

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -127,7 +127,10 @@ exports.translate_emoticons_to_names = function translate_emoticons_to_names(tex
 
     for (var emoticon in EMOTICON_CONVERSIONS) {
         if (EMOTICON_CONVERSIONS.hasOwnProperty(emoticon)) {
-            var emoticon_reg_ex = new RegExp(util.escape_regexp(emoticon), "g");
+            var emoticon_reg_ex = new RegExp(
+                "\\B" + util.escape_regexp(emoticon) + "\\B",
+                "g"
+            );
             translated = translated.replace(
                 emoticon_reg_ex,
                 ':' + EMOTICON_CONVERSIONS[emoticon] + ':');


### PR DESCRIPTION
This PR works on and possibly closes #8585.

 1. It fixes whitespace handling in the frontend emoticon translation function [`translate_emoticons_to_names`](https://github.com/skunkmb/zulip/blob/2a18a504260d7c3e7388053e37e5d46a7554de14/static/js/emoji.js), so that `a :) b` will translate to `a 😃 b` but `a:)b` will stay as `a:)b`. (See https://github.com/zulip/zulip/issues/8585#issue-302134796.) 
 2. It simplifies testing by adding a new, optional field to the test cases in the [`markdown.js` frontend tests](https://github.com/skunkmb/zulip/blob/2a18a504260d7c3e7388053e37e5d46a7554de14/frontend_tests/node_tests/markdown.js), `translate_emoticons`, which is used to determine if emoticon translation should be on or off for that test case.
    a. Also, it adds some new test cases for `:)`, `a:)b`, and `a :) b`.
 
**Testing Plan:** <!-- How have you tested? -->

This PR adds tests to the already-existing JS implementation of emoticon translation.