### PR TITLE
mypy/linting: null=true implies optional

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -73,6 +73,8 @@ strict_optional = False
 strict_optional = False
 [mypy-zerver.lib.bugdown.api_arguments_table_generator]  #18: error: Item "None" of "Optional[Dict[str, Any]]" has no attribute "items"
 strict_optional = False
+[mypy-zerver.lib.message]  #868: error: Unsupported operand types for - ("Optional[int]" and "int")
+strict_optional = False
 
 [mypy-zerver.migrations.0077_add_file_name_field_to_realm_emoji]  #73: error: Argument 2 to "upload_files" of "Uploader" has incompatible type "Optional[bytes]"; expected "bytes"
 strict_optional = False

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -494,6 +494,17 @@ def build_custom_checkers(by_lang):
          'bad_lines': ['desc = models.CharField(null=True)  # type: Text',
                        'stream = models.ForeignKey(Stream, null=True, on_delete=CASCADE)  # type: Stream'],
          },
+        {'pattern': ' = models[.](?!NullBoolean).*\)  # type: Optional',  # Optional tag, except NullBoolean(Field)
+         'exclude_pattern': 'null=True',
+         'include_only': {"zerver/models.py"},
+         'description': 'Model variable annotated with Optional but variable does not have null=true.',
+         'good_lines': ['desc = models.TextField(null=True)  # type: Optional[Text]',
+                        'stream = models.ForeignKey(Stream, null=True, on_delete=CASCADE)  # type: Optional[Stream]',
+                        'desc = models.TextField()  # type: Text',
+                        'stream = models.ForeignKey(Stream, on_delete=CASCADE)  # type: Stream'],
+         'bad_lines': ['desc = models.TextField()  # type: Optional[Text]',
+                       'stream = models.ForeignKey(Stream, on_delete=CASCADE)  # type: Optional[Stream]'],
+         },
     ]) + whitespace_rules + comma_whitespace_rule
     bash_rules = cast(RuleList, [
         {'pattern': '#!.*sh [-xe]',

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -484,6 +484,16 @@ def build_custom_checkers(by_lang):
          ]),
          'description': 'Comment-style function type annotation. Use Python3 style annotations instead.',
          },
+        {'pattern': ' = models[.].*null=True.*\)  # type: (?!Optional)',
+         'include_only': {"zerver/models.py"},
+         'description': 'Model variable with null=true not annotated as Optional.',
+         'good_lines': ['desc = models.TextField(null=True)  # type: Optional[Text]',
+                        'stream = models.ForeignKey(Stream, null=True, on_delete=CASCADE)  # type: Optional[Stream]',
+                        'desc = models.TextField()  # type: Text',
+                        'stream = models.ForeignKey(Stream, on_delete=CASCADE)  # type: Stream'],
+         'bad_lines': ['desc = models.CharField(null=True)  # type: Text',
+                       'stream = models.ForeignKey(Stream, null=True, on_delete=CASCADE)  # type: Stream'],
+         },
     ]) + whitespace_rules + comma_whitespace_rule
     bash_rules = cast(RuleList, [
         {'pattern': '#!.*sh [-xe]',

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -187,7 +187,7 @@ class Realm(models.Model):
     authentication_methods = BitField(flags=AUTHENTICATION_FLAGS,
                                       default=2**31 - 1)  # type: BitHandler
     waiting_period_threshold = models.PositiveIntegerField(default=0)  # type: int
-    _max_invites = models.IntegerField(null=True, db_column='max_invites')  # type: int
+    _max_invites = models.IntegerField(null=True, db_column='max_invites')  # type: Optional[int]
     message_visibility_limit = models.IntegerField(null=True)  # type: int
     # See upload_quota_bytes; don't interpret upload_quota_gb directly.
     upload_quota_gb = models.IntegerField(null=True)  # type: Optional[int]
@@ -608,7 +608,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
     api_key = models.CharField(max_length=API_KEY_LENGTH)  # type: Text
     tos_version = models.CharField(null=True, max_length=10)  # type: Optional[Text]
-    last_active_message_id = models.IntegerField(null=True)  # type: int
+    last_active_message_id = models.IntegerField(null=True)  # type: Optional[int]
 
     ### Notifications settings. ###
 
@@ -1786,9 +1786,9 @@ class AbstractScheduledJob(models.Model):
 class ScheduledEmail(AbstractScheduledJob):
     # Exactly one of user or address should be set. These are used to
     # filter the set of ScheduledEmails.
-    user = models.ForeignKey(UserProfile, null=True, on_delete=CASCADE)  # type: UserProfile
+    user = models.ForeignKey(UserProfile, null=True, on_delete=CASCADE)  # type: Optional[UserProfile]
     # Just the address part of a full "name <address>" email address
-    address = models.EmailField(null=True, db_index=True)  # type: Text
+    address = models.EmailField(null=True, db_index=True)  # type: Optional[Text]
 
     # Valid types are below
     WELCOME = 1
@@ -1806,7 +1806,7 @@ class ScheduledMessage(models.Model):
     subject = models.CharField(max_length=MAX_SUBJECT_LENGTH)  # type: Text
     content = models.TextField()  # type: Text
     sending_client = models.ForeignKey(Client, on_delete=CASCADE)  # type: Client
-    stream = models.ForeignKey(Stream, null=True, on_delete=CASCADE)  # type: Stream
+    stream = models.ForeignKey(Stream, null=True, on_delete=CASCADE)  # type: Optional[Stream]
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
     scheduled_timestamp = models.DateTimeField(db_index=True)  # type: datetime.datetime
     delivered = models.BooleanField(default=False)  # type: bool

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -870,7 +870,7 @@ class PreregistrationUser(models.Model):
 
     realm = models.ForeignKey(Realm, null=True, on_delete=CASCADE)  # type: Optional[Realm]
 
-    invited_as_admin = models.BooleanField(default=False)  # type: Optional[bool]
+    invited_as_admin = models.BooleanField(default=False)  # type: bool
 
 class MultiuseInvite(models.Model):
     referred_by = models.ForeignKey(UserProfile, on_delete=CASCADE)  # Optional[UserProfile]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -413,7 +413,7 @@ def get_realm_domains(realm: Realm) -> List[Dict[str, Text]]:
     return list(realm.realmdomain_set.values('domain', 'allow_subdomains'))
 
 class RealmEmoji(models.Model):
-    author = models.ForeignKey('UserProfile', blank=True, null=True, on_delete=CASCADE)
+    author = models.ForeignKey('UserProfile', blank=True, null=True, on_delete=CASCADE)  # type: Optional[UserProfile]
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
     # Second part of the regex (negative lookbehind) disallows names ending with
     # one of the punctuation characters
@@ -856,7 +856,7 @@ post_save.connect(flush_user_profile, sender=UserProfile)
 
 class PreregistrationUser(models.Model):
     email = models.EmailField()  # type: Text
-    referred_by = models.ForeignKey(UserProfile, null=True, on_delete=CASCADE)  # Optional[UserProfile]
+    referred_by = models.ForeignKey(UserProfile, null=True, on_delete=CASCADE)  # type: Optional[UserProfile]
     streams = models.ManyToManyField('Stream')  # type: Manager
     invited_at = models.DateTimeField(auto_now=True)  # type: datetime.datetime
     realm_creation = models.BooleanField(default=False)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -188,7 +188,7 @@ class Realm(models.Model):
                                       default=2**31 - 1)  # type: BitHandler
     waiting_period_threshold = models.PositiveIntegerField(default=0)  # type: int
     _max_invites = models.IntegerField(null=True, db_column='max_invites')  # type: Optional[int]
-    message_visibility_limit = models.IntegerField(null=True)  # type: int
+    message_visibility_limit = models.IntegerField(null=True)  # type: Optional[int]
     # See upload_quota_bytes; don't interpret upload_quota_gb directly.
     upload_quota_gb = models.IntegerField(null=True)  # type: Optional[int]
 


### PR DESCRIPTION
After reading many annotations in `models.py` (and exmaining one test case, whose exclusions are modified in one of these commits), I noticed that typically 'null=true' implies an Optional.

Assuming this is a reasonable assumption, this PR makes this connection explicit, adding a linter check and modifying annotations accordingly. One strict-optional exclusion is modified, since the test now passes but another file does not, and is left for later to resolve.

One associated issue is whether a linter rule should be added for the inverse, namely presence of Optional should also imply null=true.