### PR TITLE
settings: Clean up repeating code in error callback.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -494,20 +494,6 @@ $(function () {
         stream_list.toggle_filter_displayed(e);
     });
 
-    $("body").on("click", ".default_stream_row .remove-default-stream", function (e) {
-        var row = $(this).closest(".default_stream_row");
-        var stream_name = row.attr("id");
-
-        channel.del({
-            url: "/json/default_streams" + "?" + $.param({ stream_name: stream_name }),
-            error: function (xhr) {
-                ui_report.generic_row_button_error(xhr, $(e.target));
-            },
-            success: function () {
-                row.remove();
-            },
-        });
-    });
 
     // FEEDBACK
 

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -168,6 +168,21 @@ exports.set_up = function () {
         default_stream_input[0].value = "";
     });
 
+    $("body").on("click", ".default_stream_row .remove-default-stream", function (e) {
+        var row = $(this).closest(".default_stream_row");
+        var stream_name = row.attr("id");
+
+        channel.del({
+            url: "/json/default_streams" + "?" + $.param({ stream_name: stream_name }),
+            error: function (xhr) {
+                ui_report.generic_row_button_error(xhr, $(e.target));
+            },
+            success: function () {
+                row.remove();
+            },
+        });
+    });
+
     $("#settings_content").on("click", "#do_deactivate_stream_button", function () {
         if ($("#deactivation_stream_modal .stream_name").text() !== $(".active_stream_row").find('.stream_name').text()) {
             blueslip.error("Stream deactivation canceled due to non-matching fields.");


### PR DESCRIPTION
This cleans repeating code in error callback in settings.
We made a generic function in `ui_report.js` which require two
arguments `xhr` and `btn`; we preferred btn over row because a
row make have more than one buttons.

Fixes: #8788.

NO UI change