### PR TITLE
org settings: Fix real time sync.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -49,6 +49,7 @@ set_global('settings_org', {
     reset_realm_default_language: noop,
     update_message_retention_days: noop,
     update_realm_description: noop,
+    sync_realm_settings: noop,
 });
 
 set_global('message_edit', {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -67,6 +67,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             invite_by_admins_only: noop,
             invite_required: noop,
             mandatory_topics: noop,
+            message_content_edit_limit_seconds: noop,
             message_retention_days: settings_org.update_message_retention_days,
             name: notifications.redraw_title,
             name_changes_disabled: settings_account.update_name_change_display,
@@ -79,6 +80,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         if (event.op === 'update' && _.has(realm_settings, event.property)) {
             page_params['realm_' + event.property] = event.value;
             realm_settings[event.property]();
+            settings_org.sync_realm_settings(event.property);
             if (event.property === 'create_stream_by_admins_only') {
                 if (!page_params.is_admin) {
                     page_params.can_create_streams = (!page_params.
@@ -100,6 +102,9 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 page_params['realm_' + key] = value;
                 if (key === 'allow_message_editing') {
                     message_edit.update_message_topic_editing_pencil();
+                }
+                if (_.has(realm_settings, key)) {
+                    settings_org.sync_realm_settings(key);
                 }
             });
             if (event.data.authentication_methods !== undefined) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -423,7 +423,7 @@ function _set_up() {
         if (property_name === 'realm_message_content_edit_limit_minutes') {
             return Math.ceil(page_params.realm_message_content_edit_limit_seconds / 60).toString();
         } else if (property_name === 'realm_create_stream_permission') {
-            if (page_params.create_stream_by_admins_only) {
+            if (page_params.realm_create_stream_by_admins_only) {
                 return "by_admins_only";
             }
             if (page_params.realm_waiting_period_threshold === 0) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -492,6 +492,21 @@ function _set_up() {
         }
     });
 
+    exports.handle_dependent_subsettings = function (property_name) {
+        if (property_name === 'realm_create_stream_permission') {
+            exports.set_create_stream_permission_dropdwon();
+        } else if (property_name === 'realm_allow_message_editing') {
+            settings_ui.disable_sub_setting_onchange(page_params.realm_allow_message_editing,
+                "id_realm_message_content_edit_limit_minutes", true);
+        } else if (property_name === 'realm_invite_required') {
+            settings_ui.disable_sub_setting_onchange(page_params.realm_invite_required,
+                "id_realm_invite_by_admins_only", true);
+        } else if (property_name === 'realm_restricted_to_domain') {
+            settings_ui.disable_sub_setting_onchange(page_params.realm_restricted_to_domain,
+                "id_realm_disallow_disposable_email_addresses", false);
+        }
+    };
+
     function discard_property_element_changes(elem) {
         elem = $(elem);
         var property_name = exports.extract_property_name(elem);
@@ -509,9 +524,8 @@ function _set_up() {
         } else {
             blueslip.error('Element refers to unknown property ' + property_name);
         }
-        // Triggering a change event to handle fading and showing of
-        // dependent sub-settings correctly
-        elem.change();
+
+        exports.handle_dependent_subsettings(property_name);
     }
 
     $('.organization').on('click', '.subsection-header .subsection-changes-discard button', function (e) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -402,13 +402,7 @@ function _set_up() {
     exports.set_add_emoji_permission_dropdown();
 
     $("#id_realm_restricted_to_domain").change(function () {
-        if (this.checked) {
-            $("#id_realm_disallow_disposable_email_addresses").attr("disabled", true);
-            $("#id_realm_disallow_disposable_email_addresses_label").parent().addClass("control-label-disabled");
-        } else {
-            $("#id_realm_disallow_disposable_email_addresses").prop("disabled", false);
-            $("#id_realm_disallow_disposable_email_addresses_label").parent().removeClass("control-label-disabled");
-        }
+        settings_ui.disable_sub_setting_onchange(this.checked, "id_realm_disallow_disposable_email_addresses", false);
     });
 
     $("#id_realm_invite_required").change(function () {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -679,6 +679,25 @@ function _set_up() {
         }
     });
 
+    exports.sync_realm_settings = function (property) {
+        if (!overlays.settings_open()) {
+            return;
+        }
+
+        if (property === 'message_content_edit_limit_seconds') {
+            property = 'message_content_edit_limit_minutes';
+        } else if (property === 'create_stream_by_admins_only' || property === 'waiting_period_threshold') {
+            // We use this path for `waiting_period_threshold` property because we
+            // don't get both 'create_stream_by_admins_only' and 'waiting_period_threshold'
+            // in the same event to determine the value of dropdown.
+            property = 'create_stream_permission';
+        }
+        var element =  $('#id_realm_'+property);
+        if (element.length) {
+            discard_property_element_changes(element);
+        }
+    };
+
     $(".organization form.org-profile-form").off('submit').on('submit', function (e) {
         e.preventDefault();
         e.stopPropagation();

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -492,34 +492,32 @@ function _set_up() {
         }
     });
 
-    function discard_subsection_changes(target) {
-        _.each(get_subsection_property_elements(target), function (elem) {
-            elem = $(elem);
-            var property_name = exports.extract_property_name(elem);
-            // Check whether the id refers to a property whose name we can't
-            // extract from element's id.
-            var property_value = property_value_element_refers(property_name);
-            if (property_value === undefined) {
-                property_value = page_params[property_name];
-            }
+    function discard_property_element_changes(elem) {
+        elem = $(elem);
+        var property_name = exports.extract_property_name(elem);
+        // Check whether the id refers to a property whose name we can't
+        // extract from element's id.
+        var property_value = property_value_element_refers(property_name);
+        if (property_value === undefined) {
+            property_value = page_params[property_name];
+        }
 
-            if (typeof property_value === 'boolean') {
-                elem.prop('checked', property_value);
-            } else if (typeof property_value === 'string' || typeof property_value === 'number') {
-                elem.val(property_value);
-            } else {
-                blueslip.error('Element refers to unknown property ' + property_name);
-            }
-            // Triggering a change event to handle fading and showing of
-            // dependent sub-settings correctly
-            elem.change();
-        });
+        if (typeof property_value === 'boolean') {
+            elem.prop('checked', property_value);
+        } else if (typeof property_value === 'string' || typeof property_value === 'number') {
+            elem.val(property_value);
+        } else {
+            blueslip.error('Element refers to unknown property ' + property_name);
+        }
+        // Triggering a change event to handle fading and showing of
+        // dependent sub-settings correctly
+        elem.change();
     }
 
     $('.organization').on('click', '.subsection-header .subsection-changes-discard button', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        discard_subsection_changes(e.target);
+        _.each(get_subsection_property_elements(e.target), discard_property_element_changes);
         var subsection = $(e.target).closest('.org-subsection-parent');
         var change_process_buttons = subsection.find('.subsection-header .button');
         change_process_buttons.removeClass('show').addClass('hide');

--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -26,41 +26,36 @@ exports.initialize = function () {
 // UI.  Intended to replace the old system that was built around
 // direct calls to `ui_report`.
 exports.do_settings_change = function (request_method, url, data, status_element, opts) {
-    var success;
+    var spinner = $(status_element).expectOne();
+    loading.make_indicator(spinner, {text: exports.strings.saving});
     var success_msg;
     var success_continuation;
-    var error;
-    var spinner = $(status_element).expectOne();
+    var error_continuation;
     if (opts !== undefined) {
-        success = opts.success;
         success_msg = opts.success_msg;
         success_continuation = opts.success_continuation;
-        error = opts.error;
+        error_continuation = opts.error_continuation;
     }
     if (success_msg === undefined) {
         success_msg = exports.strings.success;
-    }
-    if (success === undefined) {
-        loading.make_indicator(spinner, {text: exports.strings.saving});
-        success = function (reponse_data) {
-            ui_report.success(success_msg, $(status_element).expectOne());
-            settings_ui.display_checkmark(spinner);
-            if (success_continuation !== undefined) {
-                success_continuation(reponse_data);
-            }
-        };
-    }
-    if (error === undefined) {
-        error = function (xhr) {
-            ui_report.error(exports.strings.failure, xhr, $(status_element).expectOne());
-        };
     }
 
     request_method({
         url: url,
         data: data,
-        success: success,
-        error: error,
+        success: function (reponse_data) {
+            ui_report.success(success_msg, spinner);
+            settings_ui.display_checkmark(spinner);
+            if (success_continuation !== undefined) {
+                success_continuation(reponse_data);
+            }
+        },
+        error: function (xhr) {
+            ui_report.error(exports.strings.failure, xhr, spinner);
+            if (error_continuation !== undefined) {
+                error_continuation(xhr);
+            }
+        },
     });
 };
 


### PR DESCRIPTION
*Commits for real-time syncing:*
**org settings: Refactor the discard changes function.**
This extract the logic of resetting the value of a single property element
at a time so that we can reuse this for real-time-syncing.

**org settings: Handle dependent sub settings manually.**
This replaces the previous logic of triggering change() event.
(Also, when we trigger the change() event whole path for detecting
changes in a subsection are triggered which isn't good.)

**org settings: Add real-time syncing for property changes.**

*Minor bug found during changes:*
**org settings: Fix discard changes for realm_create_stream_permission.**
On discarding changes made for `realm_create_stream_permission` always
"by_admin_user_with_custom_time" get selected because
`create_stream_by_admins_only` isn't a valid page_param.

*Small refactor:*

**org settings: Use disable_sub_setting_onchange for dependent checkbox.**
This makes use of `settings_ui.disable_sub_setting_onchange` for
handling dependent `id_realm_disallow_disposable_email_addresses`
checkbox when `id_realm_restricted_to_domain` is changed.

*I want to know how does this below commit sounds to you because when I found that this function should be extended I can only figure out the cases for success_continuation. So my point is rather than using this function for custom `success` function I think one will directly make a call using `channel.post` to prevent complexity in providing arguments.*

**settings_ui: Revert extension for success callback in do_settings_change**

This reverts success callback extension for `do_settings_change` function
because it seems it is better to make the request directly rather
than calling `do_settings_change`.
And hence `error` callback extension is also removed  for the same
reason, but a error_continuation is added to do additional tasks when
errors happened.