### PR TITLE
emoji: Do selective local echo of emoticon conversions.

### DIFF
--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -78,15 +78,36 @@ zrequire('util');
 }());
 
 (function test_translate_emoticons_to_names() {
-  global.emoji_codes = {
-      codepoint_to_name: {
-          '1f603': 'smiley',
-      },
-  };
+    // Simple test
+    var test_text = 'Testing :)';
+    var expected = 'Testing :smiley:';
+    var result = emoji.translate_emoticons_to_names(test_text);
+    assert.equal(expected, result);
 
-  var test_text = 'Testing :)';
-  var expected = 'Testing :smiley:';
-  var result = emoji.translate_emoticons_to_names(test_text);
-
-  assert.equal(expected, result);
+    // Extensive tests.
+    // The following code loops over the test cases and each emoticon conversion
+    // to generate multiple test cases.
+    var testcases = [
+        {name: 'only emoticon', original: '<original>', expected: '<converted>'},
+        {name: 'space at start', original: ' <original>', expected: ' <converted>'},
+        {name: 'space at end', original: '<original> ', expected: '<converted> '},
+        {name: 'symbol at end', original: '<original>!', expected: '<converted>!'},
+        {name: 'symbol at start', original: 'Hello,<original>', expected: 'Hello,<converted>'},
+        {name: 'after a word', original: 'Hello<original>', expected: 'Hello<original>'},
+        {name: 'between words', original: 'Hello<original>World', expected: 'Hello<original>World'},
+        {name: 'end of sentence', original: 'End of sentence. <original>', expected: 'End of sentence. <converted>'},
+        {name: 'between symbols', original: 'Hello.<original>! World.', expected: 'Hello.<converted>! World.'},
+        {name: 'before end of sentence', original: 'Hello <original>!', expected: 'Hello <converted>!'},
+    ];
+    Object.keys(emoji.EMOTICON_CONVERSIONS).forEach(key => {
+        testcases.forEach(t => {
+            var converted_value = `:${emoji.EMOTICON_CONVERSIONS[key]}:`;
+            t = Object.assign({}, t); // circumvent copy by reference.
+            t.original = t.original.replace(/(<original>)/g, key);
+            t.expected = t.expected.replace(/(<original>)/g, key);
+            t.expected = t.expected.replace(/(<converted>)/g, converted_value);
+            var result = emoji.translate_emoticons_to_names(t.original);
+            assert.equal(result, t.expected);
+        });
+    });
 }());

--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -96,7 +96,7 @@ zrequire('util');
         {name: 'after a word', original: 'Hello<original>', expected: 'Hello<original>'},
         {name: 'between words', original: 'Hello<original>World', expected: 'Hello<original>World'},
         {name: 'end of sentence', original: 'End of sentence. <original>', expected: 'End of sentence. <converted>'},
-        {name: 'between symbols', original: 'Hello.<original>! World.', expected: 'Hello.<converted>! World.'},
+        {name: 'between symbols', original: 'Hello.<original>! World.', expected: 'Hello.<original>! World.'},
         {name: 'before end of sentence', original: 'Hello <original>!', expected: 'Hello <converted>!'},
     ];
     Object.keys(emoji.EMOTICON_CONVERSIONS).forEach(key => {

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -181,6 +181,7 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
 
     tests.forEach(function (test) {
         var message = {raw_content: test.input};
+        page_params.translate_emoticons = test.translate_emoticons || false;
         markdown.apply_markdown(message);
         var output = message.content;
 

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -291,6 +291,12 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
          expected: '<p>@*notagroup*</p>'},
         {input: 'This is a realm filter `hello` with text after it',
          expected: '<p>This is a realm filter <code>hello</code> with text after it</p>'},
+        // Test the emoticon conversion
+        {input: ':)',
+         expected: '<p>:)</p>'},
+        {input: ':)',
+         expected: '<p><span class="emoji emoji-1f603" title="smiley">:smiley:</span></p>',
+         translate_emoticons: true},
     ];
 
     // We remove one of the unicode emoji we put as input in one of the test
@@ -299,6 +305,9 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
     delete emoji_codes.codepoint_to_name['1f6b2'];
 
     test_cases.forEach(function (test_case) {
+        // Disable emoji conversion by default.
+        page_params.translate_emoticons = test_case.translate_emoticons || false;
+
         var input = test_case.input;
         var expected = test_case.expected;
 
@@ -308,17 +317,6 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
 
         assert.equal(expected, output);
     });
-
-    // Here to arrange 100% test coverage for the new emoticons code
-    // path.  TODO: Have a better way to test this setting in both
-    // states, once we implement the local echo feature properly.
-    // Probably a good technique would be to support toggling the
-    // page_params setting inside the `test_cases.forEach` loop above.
-    page_params.translate_emoticons = true;
-    var message = {raw_content: ":)"};
-    markdown.apply_markdown(message);
-    assert.equal('<p><span class="emoji emoji-1f603" title="smiley">:smiley:</span></p>', message.content);
-    page_params.translate_emoticons = false;
 }());
 
 (function test_subject_links() {

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -126,12 +126,22 @@ exports.translate_emoticons_to_names = function translate_emoticons_to_names(tex
     var translated = text;
     var replacement_text;
     var terminal_symbols = ',.;?!()[] "\'\n\t'; // From composebox_typeahead
+    var symbols_except_space = terminal_symbols.replace(' ', '');
+
     var emoticon_replacer = function (match, g1, offset, str) {
-        var symbol_at_start = terminal_symbols.indexOf(str[offset - 1]) !== -1;
-        var symbol_at_end = terminal_symbols.indexOf(str[offset + match.length]) !== -1;
+        var prev_char = str[offset - 1];
+        var next_char = str[offset + match.length];
+
+        var symbol_at_start = terminal_symbols.indexOf(prev_char) !== -1;
+        var symbol_at_end = terminal_symbols.indexOf(next_char) !== -1;
+        var non_space_at_start = symbols_except_space.indexOf(prev_char) !== -1;
+        var non_space_at_end = symbols_except_space.indexOf(next_char) !== -1;
         var valid_start = symbol_at_start || offset === 0;
         var valid_end = symbol_at_end || offset === str.length - match.length;
 
+        if (non_space_at_start && non_space_at_end) { // Hello!:)?
+            return match;
+        }
         if (valid_start && valid_end) {
             return replacement_text;
         }

--- a/zerver/fixtures/markdown_test_cases.json
+++ b/zerver/fixtures/markdown_test_cases.json
@@ -341,23 +341,39 @@
       "text_content": "test \ud83d\ude04 again \ud83d\udca9\n foobar x::y::z :wasted waste: :fakeemojithisshouldnotrender:"
     },
     {
+      "name": "translate_emoticons_not_enabled",
+      "input": ":)",
+      "expected_output": "<p>:)</p>",
+      "text_content": ":)",
+      "translate_emoticons": false
+    },
+    {
+      "name": "translate_emoticons_enabled",
+      "input": ":)",
+      "expected_output": "<p><span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span></p>",
+      "text_content": "\ud83d\ude03",
+      "translate_emoticons": true
+    },
+    {
       "name": "translate_emoticons",
       "input":  ":) foo :( bar <3 with space : ) real emoji :smiley:",
       "expected_output": "<p><span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span> foo <span class=\"emoji emoji-1f641\" title=\"slightly frowning face\">:slightly_frowning_face:</span> bar <span class=\"emoji emoji-2764\" title=\"heart\">:heart:</span> with space : ) real emoji <span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span></p>",
-      "marked_expected_output": "<p>:) foo :( bar &lt;3 with space : ) real emoji <span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span></p>",
-      "text_content": "\ud83d\ude03 foo \ud83d\ude41 bar \u2764 with space : ) real emoji \ud83d\ude03"
+      "text_content": "\ud83d\ude03 foo \ud83d\ude41 bar \u2764 with space : ) real emoji \ud83d\ude03",
+      "translate_emoticons": true
     },
     {
       "name": "translate_emoticons_whitepsace",
       "input":  "a:) ;)b",
       "expected_output": "<p>a:) ;)b</p>",
-      "text_content": "a:) ;)b"
+      "text_content": "a:) ;)b",
+      "translate_emoticons": true
     },
     {
       "name": "translate_emoticons_in_code",
       "input":  "`:)`",
       "expected_output": "<p><code>:)</code></p>",
-      "text_content": ":)"
+      "text_content": ":)",
+      "translate_emoticons": true
     },
     {
       "name": "random_emoji_1",

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1013,9 +1013,8 @@ def unicode_emoji_to_codepoint(unicode_emoji: Text) -> Text:
 class EmoticonTranslation(markdown.inlinepatterns.Pattern):
     """ Translates emoticons like `:)` into emoji like `:smile:`. """
     def handleMatch(self, match: Match[Text]) -> Optional[Element]:
-        # If there is `db_data` and it is false, then don't do translating.
-        # If there is no `db_data`, such as during tests, translate.
-        if db_data is not None and not db_data['translate_emoticons']:
+        # If there is `db_data` and it is True, proceed with translating.
+        if db_data is None or not db_data['translate_emoticons']:
             return None
 
         emoticon = match.group('emoticon')


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Earlier, we used to convert all occurrences of an emoticon on the
frontend. That behavior has been altered to do conversions only
when the emoticon has some terminal symbols around them, and not
any alphabet or number. Also adds tests for emoji conversions for
the above logic.

markdown: Test the translate_emoticons flag.

The main testing of the translate emoticons code is in the
node_tests/emoji.js file. This code just checks if the setting
to enable/disable the emoticon translation is being honored.

Fixes #8585 .