### PR TITLE
org profile: Add new settings save method to org profile.

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -297,9 +297,12 @@ casper.then(function () {
     var selector = 'img#realm-settings-icon[src^="https://secure.gravatar.com/avatar/"]';
     casper.waitUntilVisible(selector, function () {
         casper.test.assertEqual(casper.visible('#realm_icon_delete_button'), false);
+        // A little hack is used her, rather than submitting the form we have just filled
+        // the form and then triggered click event by clicking the button.
         casper.fill('form.admin-realm-form', {
                 realm_icon_file_input: 'static/images/logo/zulip-icon-128x128.png',
-        }, true);
+        }, false);
+        casper.click("#realm_icon_upload_button");
         casper.waitWhileVisible("#upload_icon_spinner .loading_indicator_spinner", function () {
             casper.test.assertExists('img#realm-settings-icon[src^="/user_avatars/1/realm/icon.png?version=2"]');
             casper.test.assertEqual(casper.visible('#realm_icon_delete_button'), true);

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -140,42 +140,6 @@ function test_realms_domain_modal(add_realm_domain) {
     assert.equal(info.val(), 'translated: Failed');
 }
 
-function test_submit_profile_form(submit_form) {
-    var ev = {
-        preventDefault: noop,
-        stopPropagation: noop,
-    };
-
-    $('#id_realm_name').val('Acme');
-    $('#id_realm_description').val('makes widgets');
-
-    var patched;
-    var success_callback;
-
-    channel.patch = function (req) {
-        patched = true;
-        assert.equal(req.url, '/json/realm');
-
-        var data = req.data;
-
-        assert.equal(data.name, '"Acme"');
-        assert.equal(data.description, '"makes widgets"');
-
-        success_callback = req.success;
-    };
-
-    submit_form(ev);
-    assert(patched);
-
-    var response_data = {
-        name: 'Acme',
-    };
-    success_callback(response_data);
-
-    assert.equal($('#admin-realm-name-status').val(),
-                 'translated: Name changed!');
-}
-
 function test_submit_settings_form(submit_form) {
     var ev = {
         preventDefault: noop,
@@ -448,12 +412,6 @@ function test_extract_property_name() {
         }
     };
 
-    var submit_profile_form;
-    $('.organization form.org-profile-form').on = function (action, f) {
-        assert.equal(action, 'submit');
-        submit_profile_form = f;
-    };
-
     var change_allow_subdomains;
     $('#realm_domains_table').on = function (action, selector, f) {
         if (action === 'change') {
@@ -476,8 +434,6 @@ function test_extract_property_name() {
     verify_realm_domains();
 
     test_realms_domain_modal(callbacks.add_realm_domain);
-
-    test_submit_profile_form(submit_profile_form);
     test_submit_settings_form(submit_settings_form);
     test_upload_realm_icon(upload_realm_icon);
     test_change_invite_required(callbacks.change_invite_required);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -228,11 +228,9 @@ function _set_up() {
     var org_profile = {
         name: {
             type: 'text',
-            msg: i18n.t("Name changed!"),
         },
         description: {
             type: 'text',
-            msg: i18n.t("Description changed!"),
         },
     };
 
@@ -240,41 +238,28 @@ function _set_up() {
         msg_editing: {
             allow_message_deleting: {
                 type: 'bool',
-                checked_msg: i18n.t("Users can delete their messages!"),
-                unchecked_msg: i18n.t("Users can no longer delete their messages!"),
             },
             allow_edit_history: {
                 type: 'bool',
-                checked_msg: i18n.t("Users can view message edit history!"),
-                unchecked_msg: i18n.t("Users can no longer view message edit history!"),
             },
         },
         msg_feed: {
             inline_image_preview: {
                 type: 'bool',
-                checked_msg: i18n.t("Previews of uploaded and linked images will be shown!"),
-                unchecked_msg: i18n.t("Previews of uploaded and linked images will not be shown!"),
             },
             inline_url_embed_preview: {
                 type: 'bool',
-                checked_msg: i18n.t("Previews for linked websites will be shown!"),
-                unchecked_msg: i18n.t("Previews for linked websites will not be shown!"),
             },
             mandatory_topics: {
                 type: 'bool',
-                checked_msg: i18n.t("Topics are required in messages to streams!"),
-                unchecked_msg: i18n.t("Topics are not required in messages to streams!"),
             },
         },
         language_notify: {
             default_language: {
                 type: 'text',
-                msg: i18n.t("Default language changed!"),
             },
             send_welcome_emails: {
                 type: 'bool',
-                checked_msg: i18n.t("Send emails to new users explaining how to use Zulip!"),
-                unchecked_msg: i18n.t("Don't send emails to new users explaining how to use Zulip!"),
             },
         },
     };
@@ -283,46 +268,31 @@ function _set_up() {
         org_join: {
             restricted_to_domain: {
                 type: 'bool',
-                checked_msg: i18n.t("New user e-mails now restricted to certain domains!"),
-                unchecked_msg: i18n.t("New users may have arbitrary e-mails!"),
             },
             invite_required: {
                 type: 'bool',
-                checked_msg: i18n.t("New users must be invited by e-mail!"),
-                unchecked_msg: i18n.t("New users may sign up online!"),
             },
             disallow_disposable_email_addresses: {
                 type: 'bool',
-                checked_msg: i18n.t("Users cannot sign up using disposable email addresses!"),
-                unchecked_msg: i18n.t("Users can sign up using disposable email addresses!"),
             },
             invite_by_admins_only: {
                 type: 'bool',
-                checked_msg: i18n.t("New users must be invited by an admin!"),
-                unchecked_msg: i18n.t("Any user may now invite new users!"),
             },
         },
         user_identity: {
             name_changes_disabled: {
                 type: 'bool',
-                checked_msg: i18n.t("Users cannot change their name!"),
-                unchecked_msg: i18n.t("Users may now change their name!"),
             },
             email_changes_disabled: {
                 type: 'bool',
-                checked_msg: i18n.t("Users cannot change their email!"),
-                unchecked_msg: i18n.t("Users may now change their email!"),
             },
         },
         other_permissions: {
             add_emoji_by_admins_only: {
                 type: 'bool',
-                checked_msg: i18n.t("Only administrators may now add new emoji!"),
-                unchecked_msg: i18n.t("Any user may now add new emoji!"),
             },
             bot_creation_policy: {
                 type: 'integer',
-                msg: i18n.t("Permissions changed"),
             },
         },
     };

--- a/static/templates/settings/organization-profile-admin.handlebars
+++ b/static/templates/settings/organization-profile-admin.handlebars
@@ -1,12 +1,12 @@
 <div id="organization-profile" data-name="organization-profile" class="settings-section">
     <form class="form-horizontal admin-realm-form org-profile-form">
-        <div class="alert" id="admin-realm-name-status"></div>
-        <div class="alert" id="admin-realm-description-status"></div>
         <div class="alert" id="admin-realm-deactivation-status"></div>
+        <div class="alert admin-realm-failed-change-status"></div>
 
         <div id="org-org-profile" class="org-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Organization profile" }}</h3>
+                {{ partial "settings-save-discard-widget" "section_name" "org-profile" }}
             </div>
 
             <div class="organization-settings-parent">
@@ -20,14 +20,6 @@
                     <textarea id="id_realm_description" name="realm_description" class="admin-realm-description"
                         maxlength="1000">{{ realm_description }}</textarea>
                 </div>
-
-                {{#if is_admin }}
-                <div class="input-group organization-submission">
-                    <button type="submit" class="button rounded sea-green">
-                        {{t 'Save changes' }}
-                    </button>
-                </div>
-                {{/if}}
             </div>
         </div>
 

--- a/static/templates/settings/organization-profile-admin.handlebars
+++ b/static/templates/settings/organization-profile-admin.handlebars
@@ -1,30 +1,34 @@
 <div id="organization-profile" data-name="organization-profile" class="settings-section">
     <form class="form-horizontal admin-realm-form org-profile-form">
-        <h3>{{t "Organization profile" }}</h3>
-
         <div class="alert" id="admin-realm-name-status"></div>
         <div class="alert" id="admin-realm-description-status"></div>
         <div class="alert" id="admin-realm-deactivation-status"></div>
 
-        <div class="organization-settings-parent">
-            <div class="input-group admin-realm">
-                <label for="id_realm_name">{{t "Your organization's name" }}</label>
-                <input type="text" id="id_realm_name" name="realm_name" class="admin-realm-name"
-                       value="{{ realm_name }}" maxlength="40" />
-            </div>
-            <div class="input-group admin-realm">
-                <label for="realm_description">{{t "Your organization's description" }}</label>
-                <textarea id="id_realm_description" name="realm_description" class="admin-realm-description"
-                    maxlength="1000">{{ realm_description }}</textarea>
+        <div id="org-org-profile" class="org-subsection-parent">
+            <div class="subsection-header">
+                <h3>{{t "Organization profile" }}</h3>
             </div>
 
-            {{#if is_admin }}
-            <div class="input-group organization-submission">
-                <button type="submit" class="button rounded sea-green">
-                    {{t 'Save changes' }}
-                </button>
+            <div class="organization-settings-parent">
+                <div class="input-group admin-realm">
+                    <label for="id_realm_name">{{t "Your organization's name" }}</label>
+                    <input type="text" id="id_realm_name" name="realm_name" class="admin-realm-name"
+                        value="{{ realm_name }}" maxlength="40" />
+                </div>
+                <div class="input-group admin-realm">
+                    <label for="realm_description">{{t "Your organization's description" }}</label>
+                    <textarea id="id_realm_description" name="realm_description" class="admin-realm-description"
+                        maxlength="1000">{{ realm_description }}</textarea>
+                </div>
+
+                {{#if is_admin }}
+                <div class="input-group organization-submission">
+                    <button type="submit" class="button rounded sea-green">
+                        {{t 'Save changes' }}
+                    </button>
+                </div>
+                {{/if}}
             </div>
-            {{/if}}
         </div>
 
         <h3>{{t "Organization avatar" }}</h3>


### PR DESCRIPTION
I've implemented the new org settings saving method to organization profile page.
Also after implementing the new saving method to org profile, there is so much obsolete code, which is removed here as well.

But I'm getting one problem in Casper test, tests fail while uploading files, I found that no POST request is being sent to the server but after adding these lines back make tests pass.
```
    $(".organization form.org-profile-form").off('submit').on('submit', function (e) {
            e.preventDefault();
            e.stopPropagation();
    });
```
I guess this have something to do with `casper.fill` but I'm not sure what?
@timabbott FYI.