### PR TITLE
[#5312] Render the whole message list on resize

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -277,6 +277,9 @@ exports.handler = function () {
     popovers.hide_all();
     exports.resize_page_components();
 
+    // Re-compute and display/remove [More] links to messages
+    condense.condense_and_collapse($("div.message_row"));
+
     // This function might run onReady (if we're in a narrow window),
     // but before we've loaded in the messages; in that case, don't
     // try to scroll to one.


### PR DESCRIPTION
A big hammer fix for #5312

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

1. Open Zulip in a browser window
2. Resize the window to be tiny - shrink both height and width
3. Reload the page. 
4. Resize the window to a "normal size" - More tags shouldn't appear on messages which are fully displayed already. 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
