### PR TITLE
design: Give topic bars the proper background color in night mode.

### DIFF
--- a/static/styles/dark.css
+++ b/static/styles/dark.css
@@ -35,6 +35,10 @@ body.dark-mode .stream_label {
     color: hsl(212, 28%, 18%);
 }
 
+body.dark-mode .column-middle.column-overlay.recipient-bar-main {
+    background-color: hsl(212, 28%, 18%) !important;
+}
+
 body.dark-mode .new-style label.checkbox input[type=checkbox] ~ span {
     border-color: hsla(0, 0%, 100%, 0.4);
 }


### PR DESCRIPTION
**Give topic bars the proper background color in night mode.**

Use color `hsl(212, 28%, 18%)`, which is the same color used by various other night-mode elements. (Opacity is also already added by the `message-fade` class.)

Fix #8823.

---

**Screenshots**:

*Before (with white bar over "Denmark2"):*

<img width="904" alt="before" src="https://user-images.githubusercontent.com/17259768/37931558-eaa01e50-30fa-11e8-977a-a5592e11622a.png">

*After (without white bar over "Denmark2"):*

<img width="904" alt="after" src="https://user-images.githubusercontent.com/17259768/37931571-f42ef428-30fa-11e8-8029-de9802193ab3.png">

