### PR TITLE
hotkeys: Replace C with x for composing PM.

### DIFF
--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -150,7 +150,7 @@ populated and where the focus is placed.
     - use R to reply to the author of a PM
     - use R to reply to the author of a PM stream
     - use c to compose a stream message
-    - use C to compose a new PM
+    - use x to compose a new PM
 
 - Buttons
     - Narrow to a stream and click on "New topic"

--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -232,7 +232,7 @@ exports.then_send_message = function (type, params) {
         if (type === "stream") {
             casper.page.sendEvent('keypress', "c");
         } else if (type === "private") {
-            casper.page.sendEvent('keypress', "C");
+            casper.page.sendEvent('keypress', "x");
         } else {
             casper.test.assertTrue(false, "send_message got valid message type");
         }

--- a/frontend_tests/casper_tests/04-compose.js
+++ b/frontend_tests/casper_tests/04-compose.js
@@ -44,7 +44,7 @@ casper.then(function () {
         casper.test.assertVisible('#stream-message', 'Stream input box visible');
         common.check_form('#send_message_form', {stream: '', subject: ''}, "Stream empty on new compose");
         casper.click('body');
-        casper.page.sendEvent('keypress', "C");
+        casper.page.sendEvent('keypress', "x");
     });
 });
 
@@ -102,7 +102,7 @@ casper.then(function () {
 casper.then(function () {
     casper.waitWhileVisible('#stream-message', function () {
         casper.test.assertNotVisible('#stream-message', 'Close stream compose box');
-        casper.page.sendEvent('keypress', "C");
+        casper.page.sendEvent('keypress', "x");
         casper.click('body');
     });
 });

--- a/frontend_tests/casper_tests/14-drafts.js
+++ b/frontend_tests/casper_tests/14-drafts.js
@@ -60,7 +60,7 @@ casper.then(function () {
 casper.then(function () {
     casper.test.info('Creating Private Message Draft');
     casper.click('body');
-    casper.page.sendEvent('keypress', "C");
+    casper.page.sendEvent('keypress', "x");
     casper.waitUntilVisible('#private-message', function () {
         casper.fill('form#send_message_form', {
             content: 'Test Private Message',
@@ -171,7 +171,7 @@ casper.then(function () {
     casper.click('#draft_overlay .exit');
     waitWhileDraftsVisible(function () {
         casper.click('body');
-        casper.page.sendEvent('keypress', "C");
+        casper.page.sendEvent('keypress', "x");
     });
 });
 

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -149,7 +149,7 @@ function stubbing(func_name_to_stub, test_function) {
 
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
-    assert_unmapped('abefhlmotxyz');
+    assert_unmapped('abefhlmotyz');
     assert_unmapped('BEFHILNOQTUWXYZ');
 
     // We have to skip some checks due to the way the code is
@@ -224,7 +224,7 @@ function stubbing(func_name_to_stub, test_function) {
     assert_mapping('D', 'narrow.stream_cycle_forward');
 
     assert_mapping('c', 'compose_actions.start');
-    assert_mapping('C', 'compose_actions.start');
+    assert_mapping('x', 'compose_actions.start');
     assert_mapping('P', 'narrow.by');
     assert_mapping('g', 'gear_menu.open');
 

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -191,7 +191,7 @@ exports.start = function (msg_type, opts) {
     exports.expand_compose_box();
 
     opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
-    // If we are invoked by a compose hotkey (c or C), do not assume that we know
+    // If we are invoked by a compose hotkey (c or x), do not assume that we know
     // what the message's topic or PM recipient should be.
     if ((opts.trigger === "compose_hotkey") || (opts.trigger === "new topic button")) {
         opts.subject = '';

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -78,7 +78,7 @@ var keypress_mappings = {
     63: {name: 'show_shortcuts', message_view_only: false}, // '?'
     64: {name: 'compose_reply_with_mention', message_view_only: true}, // '@'
     65: {name: 'stream_cycle_backward', message_view_only: true}, // 'A'
-    67: {name: 'compose_private_message', message_view_only: true}, // 'C'
+    67: {name: 'C_deprecated', message_view_only: true}, // 'C'
     68: {name: 'stream_cycle_forward', message_view_only: true}, // 'D'
     71: {name: 'G_end', message_view_only: true}, // 'G'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
@@ -102,6 +102,7 @@ var keypress_mappings = {
     117: {name: 'show_sender_info', message_view_only: true}, // 'u'
     118: {name: 'show_lightbox', message_view_only: true}, // 'v'
     119: {name: 'query_users', message_view_only: false}, // 'w'
+    120: {name: 'compose_private_message', message_view_only: true}, // 'x'
 };
 
 exports.get_keydown_hotkey = function (e) {
@@ -643,6 +644,9 @@ exports.process_hotkey = function (e, hotkey) {
             // Note that you can "enter" to respond to messages as well,
             // but that is handled in process_enter_key().
             compose_actions.respond_to_message({trigger: 'hotkey'});
+            return true;
+        case 'C_deprecated':
+            ui.maybe_show_deprecation_notice('C');
             return true;
     }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -193,6 +193,27 @@ exports.maybe_show_keyboard_shortcuts = function () {
     ui.show_info_overlay("keyboard-shortcuts");
 };
 
+exports.maybe_show_deprecation_notice = function (key) {
+    var message;
+    if (key === 'C') {
+        message = i18n.t('We\'ve replaced the "C" hotkey with "x" to make this common shortcut easier to trigger.');
+    } else {
+        // should never get here
+        return;
+    }
+
+    var shown_deprecation_notices = JSON.parse(localStorage.getItem('shown_deprecation_notices'));
+    if (shown_deprecation_notices === null) {
+        shown_deprecation_notices = [];
+    }
+    if (shown_deprecation_notices.indexOf(key) === -1) {
+        $('#deprecation-notice-modal').modal('show');
+        $('#deprecation-notice-message').text(message);
+        shown_deprecation_notices.push(key);
+        localStorage.setItem('shown_deprecation_notices', JSON.stringify(shown_deprecation_notices));
+    }
+};
+
 /* EXPERIMENTS */
 
 /* This method allows an advanced user to use the console

--- a/templates/zerver/compose.html
+++ b/templates/zerver/compose.html
@@ -27,7 +27,7 @@
                 <span class="new_message_button">
                     <button type="button" class="button small rounded compose_private_button"
                         id="left_bar_compose_private_button_big"
-                        title="{{ _('New private message') }} (C)">
+                        title="{{ _('New private message') }} (x)">
                         <span class="compose_private_button_label">{{ _('New private message') }}</span>
                     </button>
                 </span>

--- a/templates/zerver/deprecation_notice.html
+++ b/templates/zerver/deprecation_notice.html
@@ -1,0 +1,16 @@
+<div class="modal hide modal-bg new-style" id="deprecation-notice-modal" role="dialog"
+    aria-labelledby="deprecation-notice-label" aria-hidden="true">
+
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
+        <h3 id="deprecation-notice-label">{{ _('Deprecation notice') }}</h3>
+    </div>
+
+    <div class="modal-body">
+        <p id="deprecation-notice-message"></p>
+    </div>
+
+    <div class="modal-footer">
+        <button type="button" class="button rounded" data-dismiss="modal">{{ _("Got it") }}</button>
+    </div>
+</div>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -20,7 +20,7 @@ below, and add more to your repertoire as needed.
 
 * **New stream message**: `c` — Start a new topic in the current stream.
 
-* **New private message**: `C`
+* **New private message**: `x`
 
 * **Cancel compose**: `Esc` or `Ctrl + [` — Close the compose box and save
   the unsent message as a draft.
@@ -93,7 +93,7 @@ below, and add more to your repertoire as needed.
 
 * **New stream message**: `c` — For starting a new topic in a stream.
 
-* **New private message**: `C`
+* **New private message**: `x`
 
 ### In the compose box
 

--- a/templates/zerver/index.html
+++ b/templates/zerver/index.html
@@ -153,6 +153,7 @@
     {% include "zerver/invite_user.html" %}
     {% include "zerver/bankruptcy.html" %}
     {% include "zerver/logout.html" %}
+    {% include "zerver/deprecation_notice.html" %}
     <div class='notifications top-right'></div>
 </div>
 {% endblock %}

--- a/templates/zerver/keyboard_shortcuts.html
+++ b/templates/zerver/keyboard_shortcuts.html
@@ -17,7 +17,7 @@
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">C</td>
+                    <td class="hotkey">x</td>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -129,7 +129,7 @@
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">C</td>
+                    <td class="hotkey">x</td>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
                 </tr>
                 <tr>

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -116,6 +116,7 @@ class TemplateTestCase(ZulipTestCase):
             'zerver/api_content.json',
             'zerver/handlebars_compilation_failed.html',
             'zerver/portico-header.html',
+            'zerver/deprecation_notice.html',
         ]
 
         integrations_regexp = re.compile('zerver/integrations/.*.html')


### PR DESCRIPTION
Update of #8308. 
@aedorado, could you review?

I think `maybe_show_deprecation_notice` should most naturally take a key and a message, but didn't want to clutter hotkey.js with the message text.
