### PR TITLE
[DO NOT MERGE] decorators: Log eroneous payloads in authenticated_rest_api_view.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -504,8 +504,13 @@ def authenticated_rest_api_view(*, webhook_client_name: str=None,
                                            client_name=full_webhook_client_name(webhook_client_name))
             except JsonableError as e:
                 return json_unauthorized(e.msg)
-            # Apply rate limiting
-            return rate_limit()(view_func)(request, profile, *args, **kwargs)
+            try:
+                # Apply rate limiting
+                return rate_limit()(view_func)(request, profile, *args, **kwargs)
+            except Exception as err:
+                if is_webhook or webhook_client_name is not None:
+                    log_exception_to_webhook_logger(request, profile,
+                                                    request_body=request.POST.get('payload'))
         return _wrapped_func_arguments
     return _wrapped_view_func
 


### PR DESCRIPTION
@timabbott: Okay, so the reason freshdesk errors weren't getting logged were because `authenticated_rest_api_view` doesn't log bad payloads. So for the last few hours, I have been working on trying to get it to log a payload that caused an exception.

Testing manually, when I raise an exception in a webhook (such as beanstalk), the payload *does* get logged. However, when trying to write a unit test for this, it says `Exception not raised` and fails. I have tried print debugging every `try/except` clause in `authenticated_rest_api_view` and tried printing everything. Nothing seems amiss. What am I doing wrong?

It would mean a lot to me if you could please point me in the right direction! Thanks! :)