### PR TITLE
message view: Hide "view source" and "quote" for deleted messages.

### DIFF
--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -29,6 +29,7 @@ i18n.init({
             subject: "testing",
             sender_full_name: "King Lear",
         },
+        should_display_quote_and_reply: true,
         can_edit_message: true,
         can_mute_topic: true,
         narrowed: true,

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -61,6 +61,7 @@ function render(template_name, args) {
             subject: "testing",
             sender_full_name: "King Lear",
         },
+        should_display_quote_and_reply: true,
         can_edit_message: true,
         can_mute_topic: true,
         narrowed: true,
@@ -72,6 +73,27 @@ function render(template_name, args) {
     var link = $(html).find("a.respond_button");
     assert.equal(link.text().trim(), 'translated: Quote and reply');
     global.write_handlebars_output("actions_popover_content", html);
+
+    var deletedArgs = {
+        message: {
+            is_stream: true,
+            id: "100",
+            stream: "devel",
+            subject: "testing",
+            sender_full_name: "King Lear",
+        },
+        should_display_edit_and_view_source: false,
+        should_display_quote_and_reply: false,
+        narrowed: true,
+    };
+
+    var deletedHtml = '<div style="height: 250px">';
+    deletedHtml += render('actions_popover_content', deletedArgs);
+    deletedHtml += "</div>";
+    var viewSourceLink = $(deletedHtml).find("a.popover_edit_message");
+    assert.equal(viewSourceLink.length, 0);
+    var quoteLink = $(deletedHtml).find("a.respond_button");
+    assert.equal(quoteLink.length, 0);
 }());
 
 (function admin_realm_domains_list() {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -281,6 +281,12 @@ exports.toggle_actions_popover = function (element, id) {
         var should_display_collapse = !message.locally_echoed && !message.collapsed;
         var should_display_uncollapse = !message.locally_echoed && message.collapsed;
 
+        var should_display_edit_and_view_source =
+                message.content !== '<p>(deleted)</p>' ||
+                editability === message_edit.editability_types.FULL ||
+                editability === message_edit.editability_types.TOPIC_ONLY;
+        var should_display_quote_and_reply = message.content !== '<p>(deleted)</p>';
+
         var args = {
             message: message,
             use_edit_icon: use_edit_icon,
@@ -295,6 +301,8 @@ exports.toggle_actions_popover = function (element, id) {
             narrowed: narrow_state.active(),
             should_display_delete_option: should_display_delete_option,
             should_display_reminder_option: feature_flags.reminders_in_message_action_menu,
+            should_display_edit_and_view_source: should_display_edit_and_view_source,
+            should_display_quote_and_reply: should_display_quote_and_reply,
         };
 
         var ypos = elt.offset().top;

--- a/static/templates/actions_popover_content.handlebars
+++ b/static/templates/actions_popover_content.handlebars
@@ -1,17 +1,21 @@
 {{! Contents of the "message actions" popup }}
 <ul class="nav nav-list actions_popover">
+    {{#if should_display_edit_and_view_source}}
     <li>
         <a href="#" class="popover_edit_message" data-message-id="{{message.id}}">
             {{! Can consider http://fontawesome.io/icon/file-code-o/ when we upgrade to font awesome 4.}}
             <i class="{{#if use_edit_icon}}fa fa-pencil{{else}}fa fa-file-text-o{{/if}}" aria-hidden="true"></i> {{editability_menu_item}}
         </a>
     </li>
+    {{/if}}
 
+    {{#if should_display_quote_and_reply}}
     <li>
         <a href="#" class="respond_button" data-message-id="{{message.id}}">
             <i class="fa fa-reply" aria-hidden="true"></i> {{t "Quote and reply" }}
         </a>
     </li>
+    {{/if}}
 
     {{#if should_display_reminder_option}}
     <li>


### PR DESCRIPTION
Fix #8839.

**Testing Plan:**

 - There is a test in `frontend_tests/node_tests/templates.js` for verifying that the *"Quote and reply"* and *"View source"* buttons are not shown when `should_display_quote_and_reply` and `should_display_edit_and_view_source` are off.
 - I also had to add `should_display_quote_and_reply: true` to some arguments in two other tests in order for them to pass.

**Screenshots:**

*Before*:

<img width="686" alt="before" src="https://user-images.githubusercontent.com/17259768/37998699-7fe8430a-31d4-11e8-8699-ddd1c496d4eb.png">


*After*:

<img width="685" alt="after" src="https://user-images.githubusercontent.com/17259768/37998698-7fce4806-31d4-11e8-886d-f6b1715ad0b5.png">