### PR TITLE
markdown-tests: Two minor changes for ease of development.

### DIFF
--- a/docs/subsystems/markdown.md
+++ b/docs/subsystems/markdown.md
@@ -73,6 +73,14 @@ This procedure prevents any server-side rendering.  If you don't do
 this, backend will likely render the Markdown you're testing and swap
 it in before you can see the frontend's rendering.
 
+If you are working on a feature that breaks multiple testcases, and want
+to debug the testcases one by one, you can add `"ignore": true` to any
+testcases in `markdown_test_cases.json` that you want to ignore. This
+is a workaround due to lack of comments support in JSON. Revert your
+"ignore" changes before committing. After this, you can run the frontend
+tests with `tools/test-js-with-node markdown` and backend tests with
+`tools/test-backend zerver.tests.test_bugdown.BugdownTest.test_bugdown_fixtures`.
+
 ## Changing Zulip's markdown processor
 
 First, you will likely find these third-party resources helpful:

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -184,14 +184,14 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
         page_params.translate_emoticons = test.translate_emoticons || false;
         markdown.apply_markdown(message);
         var output = message.content;
-
+        var error_message = `Failure in test: ${test.name}`;
         if (test.marked_expected_output) {
-            global.bugdown_assert.notEqual(test.expected_output, output);
-            global.bugdown_assert.equal(test.marked_expected_output, output);
+            global.bugdown_assert.notEqual(test.expected_output, output, error_message);
+            global.bugdown_assert.equal(test.marked_expected_output, output, error_message);
         } else if (test.backend_only_rendering) {
             assert.equal(markdown.contains_backend_only_syntax(test.input), true);
         } else {
-            global.bugdown_assert.equal(test.expected_output, output);
+            global.bugdown_assert.equal(test.expected_output, output, error_message);
         }
     });
 }());

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -180,6 +180,12 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
     var tests = bugdown_data.regular_tests;
 
     tests.forEach(function (test) {
+
+        // Ignore tests if specified
+        if (test.ignore === true) {
+            return;
+        }
+
         var message = {raw_content: test.input};
         page_params.translate_emoticons = test.translate_emoticons || false;
         markdown.apply_markdown(message);

--- a/frontend_tests/zjsunit/bugdown_assert.js
+++ b/frontend_tests/zjsunit/bugdown_assert.js
@@ -131,9 +131,12 @@ class MarkdownComparer {
     assertEqual(actual, expected, message) {
         const comparison_results = this._compare(actual, expected);
 
+        message = message || '';
+        message += '\n';
+
         if (comparison_results.are_equivalent === false) {
             throw new assert.AssertionError({
-                message : message || this._output_formatter(
+                message : message + this._output_formatter(
                     comparison_results.html.actual,
                     comparison_results.html.expected
                 ),
@@ -144,9 +147,12 @@ class MarkdownComparer {
     assertNotEqual(actual, expected, message) {
         const comparison_results = this._compare(actual, expected);
 
+        message = message || '';
+        message += '\n';
+
         if (comparison_results.are_equivalent) {
             throw new assert.AssertionError({
-                message : message || [
+                message : message + [
                     "actual and expected output produce semantially identical HTML",
                     actual,
                     "==",

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -242,17 +242,29 @@ class BugdownTest(ZulipTestCase):
 
         return test_fixtures, data['linkify_tests']
 
+    def test_bugdown_no_ignores(self) -> None:
+        # We do not want any ignored tests to be committed and merged.
+        format_tests, linkify_tests = self.load_bugdown_tests()
+        for name, test in format_tests.items():
+            message = 'Test "%s" shouldn\'t be ignored.' % (name,)
+            is_ignored = test.get('ignore', False)
+            self.assertFalse(is_ignored, message)
+
     @slow("Aggregate of runs dozens of individual markdown tests")
     def test_bugdown_fixtures(self) -> None:
         format_tests, linkify_tests = self.load_bugdown_tests()
         valid_keys = set(["name", "input", "expected_output",
                           "backend_only_rendering",
                           "marked_expected_output", "text_content",
-                          "translate_emoticons"])
+                          "translate_emoticons", "ignore"])
 
         for name, test in format_tests.items():
             # Check that there aren't any unexpected keys as those are often typos
             self.assertEqual(len(set(test.keys()) - valid_keys), 0)
+
+            # Ignore tests if specified
+            if test.get('ignore', False):
+                return  # nocoverage
 
             if test.get('translate_emoticons', False):
                 # Create a userprofile and send message with it.


### PR DESCRIPTION
## Commit 1

Show the testcase name for easy debugging. Sample output:

```
AssertionError: Failure in test: safe_html_unclosed_tag_and_quotes
Actual and expected output do not match.  Showing diff
```

## Commit 2

Allow ignoring certain tests while debugging when you just want to test against one test at a time, or similar usecases, where you'd be tempted to remove the whole testcase from the JSON file. Both the approaches carry similar risk: forgetting to add that testcase back/removing the `ignore: true` part. This approach, however, can be tested for using another test added here.