### PR TITLE
Add support for Debian stretch

### DIFF
--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -19,6 +19,7 @@ class zulip::base {
     # Debian releases
     /7.[0-9]*/ => 'wheezy',
     /8.[0-9]*/ => 'jessie',
+    /9.[0-9]*/ => 'stretch',
     # Ubuntu releases
     '12.04' => 'precise',
     '14.04' => 'trusty',
@@ -30,6 +31,7 @@ class zulip::base {
   $postgres_version = $release_name ? {
     'wheezy'  => '9.1',
     'jessie'  => '9.4',
+    'stretch'  => '9.6',
     'precise' => '9.1',
     'trusty'  => '9.3',
     'vivid'   => '9.4',

--- a/puppet/zulip/manifests/static_asset_compiler.pp
+++ b/puppet/zulip/manifests/static_asset_compiler.pp
@@ -3,6 +3,8 @@ class zulip::static_asset_compiler {
     $closure_compiler_package = "libclosure-compiler-java"
   } elsif $zulip::base::release_name == "xenial" {
     $closure_compiler_package = "closure-compiler"
+  } elsif $zulip::base::release_name == "stretch" {
+    $closure_compiler_package = "closure-compiler"
   }
   $static_asset_compiler_packages = [
                                      # Needed for minify-js

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -77,7 +77,7 @@ export LC_ALL="en_US.UTF-8"
 apt-get install -y lsb-release
 os_release="$(lsb_release -sc)"
 case "$os_release" in
-    trusty|xenial) ;;
+    trusty|xenial|stretch) ;;
     *)
         set +x
         cat <<EOF
@@ -87,6 +87,7 @@ Unsupported OS release: $os_release
 Zulip in production is supported only on:
  - Ubuntu 14.04 LTS "trusty"
  - Ubuntu 16.04 LTS "xenial"
+ - Debian 9 "stretch"
 
 For more information, see:
   https://zulip.readthedocs.io/en/latest/production/requirements.html


### PR DESCRIPTION
This PR updates the `zulip` scripts to enable its installation on Debian 9 "stretch".

It needs to be completed with an additional PR to address the compatibility issues with the version of Puppet shipped with Debian 9 and Ubuntu 18.04 (version 4.x).
