### PR TITLE
Fix exception when updating bot permissions.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -122,7 +122,6 @@ function _setup_page() {
     }());
 
     setup_settings_label();
-    settings_bots.setup_bot_creation_policy_values();
 
     var settings_tab = templates.render('settings_tab', {
         full_name: people.my_full_name(),

--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -16,6 +16,8 @@ function _initialize() {
         failure: i18n.t("Save failed"),
         saving: i18n.t("Saving"),
     };
+
+    settings_bots.setup_bot_creation_policy_values();
 }
 
 exports.initialize = function () {


### PR DESCRIPTION
**settings: Fix exception on updating bot_creation_policy.**
This initializes the bot_creation_policy_values after the page
is loaded.

Previously we initialize these values in `settings.js` when settings page
is loaded at least once, so if we open two tabs, one(1) in which we
haven't opened the settings page yet and if in another tab (2) we
update the `bot_creation_policy` value, then because of the event
which calls `settings_bots.update_bot_permissions_ui` causes exception
in (1) because `bot_creation_policy_values` isn't initialized yet.

Fixes: #8852.

**org settings: Sync only when settings page is opened once.**

This fixes a minor bug in which if we have two tabs opened and
in one we haven't opened settings page at least once and in
another we change an org setting, then we get an exception in
the former tab because of the event as `sync_realm_settings`
isn't defined yet.

Another approach to fix this can be to check whether settings overlay is opened or not. Which(if any) is fine?