### PR TITLE
org settings: Move function out of setup function. 

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -10,6 +10,78 @@ exports.reset = function () {
     meta.loaded = false;
 };
 
+var org_profile = {
+    name: {
+        type: 'text',
+    },
+    description: {
+        type: 'text',
+    },
+};
+
+var org_settings = {
+    msg_editing: {
+        allow_message_deleting: {
+            type: 'bool',
+        },
+        allow_edit_history: {
+            type: 'bool',
+        },
+    },
+    msg_feed: {
+        inline_image_preview: {
+            type: 'bool',
+        },
+        inline_url_embed_preview: {
+            type: 'bool',
+        },
+        mandatory_topics: {
+            type: 'bool',
+        },
+    },
+    language_notify: {
+        default_language: {
+            type: 'text',
+        },
+        send_welcome_emails: {
+            type: 'bool',
+        },
+    },
+};
+
+var org_permissions = {
+    org_join: {
+        restricted_to_domain: {
+            type: 'bool',
+        },
+        invite_required: {
+            type: 'bool',
+        },
+        disallow_disposable_email_addresses: {
+            type: 'bool',
+        },
+        invite_by_admins_only: {
+            type: 'bool',
+        },
+    },
+    user_identity: {
+        name_changes_disabled: {
+            type: 'bool',
+        },
+        email_changes_disabled: {
+            type: 'bool',
+        },
+    },
+    other_permissions: {
+        add_emoji_by_admins_only: {
+            type: 'bool',
+        },
+        bot_creation_policy: {
+            type: 'integer',
+        },
+    },
+};
+
 exports.set_create_stream_permission_dropdwon = function () {
     var menu = "id_realm_create_stream_permission";
     $("#id_realm_waiting_period_threshold").parent().hide();
@@ -224,78 +296,6 @@ function _set_up() {
 
     // Populate authentication methods table
     exports.populate_auth_methods(page_params.realm_authentication_methods);
-
-    var org_profile = {
-        name: {
-            type: 'text',
-        },
-        description: {
-            type: 'text',
-        },
-    };
-
-    var org_settings = {
-        msg_editing: {
-            allow_message_deleting: {
-                type: 'bool',
-            },
-            allow_edit_history: {
-                type: 'bool',
-            },
-        },
-        msg_feed: {
-            inline_image_preview: {
-                type: 'bool',
-            },
-            inline_url_embed_preview: {
-                type: 'bool',
-            },
-            mandatory_topics: {
-                type: 'bool',
-            },
-        },
-        language_notify: {
-            default_language: {
-                type: 'text',
-            },
-            send_welcome_emails: {
-                type: 'bool',
-            },
-        },
-    };
-
-    var org_permissions = {
-        org_join: {
-            restricted_to_domain: {
-                type: 'bool',
-            },
-            invite_required: {
-                type: 'bool',
-            },
-            disallow_disposable_email_addresses: {
-                type: 'bool',
-            },
-            invite_by_admins_only: {
-                type: 'bool',
-            },
-        },
-        user_identity: {
-            name_changes_disabled: {
-                type: 'bool',
-            },
-            email_changes_disabled: {
-                type: 'bool',
-            },
-        },
-        other_permissions: {
-            add_emoji_by_admins_only: {
-                type: 'bool',
-            },
-            bot_creation_policy: {
-                type: 'integer',
-            },
-        },
-    };
 
     function populate_data_for_request(data, changing_property_types) {
         _.each(changing_property_types, function (v, k) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -316,7 +316,7 @@ exports.populate_signup_notifications_stream_dropdown = function (stream_list) {
 };
 
 exports.handle_dependent_subsettings = function (property_name) {
-    if (property_name === 'realm_create_stream_permission') {
+    if (property_name === 'realm_create_stream_permission' || property_name === 'realm_waiting_period_threshold') {
         exports.set_create_stream_permission_dropdwon();
     } else if (property_name === 'realm_allow_message_editing') {
         settings_ui.disable_sub_setting_onchange(page_params.realm_allow_message_editing,
@@ -358,10 +358,7 @@ exports.sync_realm_settings = function (property) {
 
     if (property === 'message_content_edit_limit_seconds') {
         property = 'message_content_edit_limit_minutes';
-    } else if (property === 'create_stream_by_admins_only' || property === 'waiting_period_threshold') {
-        // We use this path for `waiting_period_threshold` property because we
-        // don't get both 'create_stream_by_admins_only' and 'waiting_period_threshold'
-        // in the same event to determine the value of dropdown.
+    } else if (property === 'create_stream_by_admins_only') {
         property = 'create_stream_permission';
     }
     var element =  $('#id_realm_'+property);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -351,6 +351,25 @@ function discard_property_element_changes(elem) {
     exports.handle_dependent_subsettings(property_name);
 }
 
+exports.sync_realm_settings = function (property) {
+    if (!overlays.settings_open()) {
+        return;
+    }
+
+    if (property === 'message_content_edit_limit_seconds') {
+        property = 'message_content_edit_limit_minutes';
+    } else if (property === 'create_stream_by_admins_only' || property === 'waiting_period_threshold') {
+        // We use this path for `waiting_period_threshold` property because we
+        // don't get both 'create_stream_by_admins_only' and 'waiting_period_threshold'
+        // in the same event to determine the value of dropdown.
+        property = 'create_stream_permission';
+    }
+    var element =  $('#id_realm_'+property);
+    if (element.length) {
+        discard_property_element_changes(element);
+    }
+};
+
 function _set_up() {
     meta.loaded = true;
 
@@ -599,25 +618,6 @@ function _set_up() {
             node.hide();
         }
     });
-
-    exports.sync_realm_settings = function (property) {
-        if (!overlays.settings_open()) {
-            return;
-        }
-
-        if (property === 'message_content_edit_limit_seconds') {
-            property = 'message_content_edit_limit_minutes';
-        } else if (property === 'create_stream_by_admins_only' || property === 'waiting_period_threshold') {
-            // We use this path for `waiting_period_threshold` property because we
-            // don't get both 'create_stream_by_admins_only' and 'waiting_period_threshold'
-            // in the same event to determine the value of dropdown.
-            property = 'create_stream_permission';
-        }
-        var element =  $('#id_realm_'+property);
-        if (element.length) {
-            discard_property_element_changes(element);
-        }
-    };
 
     $(".organization form.org-authentications-form").off('submit').on('submit', function (e) {
         var authentication_methods_status = $("#admin-realm-authentication-methods-status").expectOne();

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -330,6 +330,27 @@ exports.handle_dependent_subsettings = function (property_name) {
     }
 };
 
+function discard_property_element_changes(elem) {
+    elem = $(elem);
+    var property_name = exports.extract_property_name(elem);
+    // Check whether the id refers to a property whose name we can't
+    // extract from element's id.
+    var property_value = property_value_element_refers(property_name);
+    if (property_value === undefined) {
+        property_value = page_params[property_name];
+    }
+
+    if (typeof property_value === 'boolean') {
+        elem.prop('checked', property_value);
+    } else if (typeof property_value === 'string' || typeof property_value === 'number') {
+        elem.val(property_value);
+    } else {
+        blueslip.error('Element refers to unknown property ' + property_name);
+    }
+
+    exports.handle_dependent_subsettings(property_name);
+}
+
 function _set_up() {
     meta.loaded = true;
 
@@ -435,27 +456,6 @@ function _set_up() {
             change_process_button.removeClass('show').addClass('hide');
         }
     });
-
-    function discard_property_element_changes(elem) {
-        elem = $(elem);
-        var property_name = exports.extract_property_name(elem);
-        // Check whether the id refers to a property whose name we can't
-        // extract from element's id.
-        var property_value = property_value_element_refers(property_name);
-        if (property_value === undefined) {
-            property_value = page_params[property_name];
-        }
-
-        if (typeof property_value === 'boolean') {
-            elem.prop('checked', property_value);
-        } else if (typeof property_value === 'string' || typeof property_value === 'number') {
-            elem.val(property_value);
-        } else {
-            blueslip.error('Element refers to unknown property ' + property_name);
-        }
-
-        exports.handle_dependent_subsettings(property_name);
-    }
 
     $('.organization').on('click', '.subsection-header .subsection-changes-discard button', function (e) {
         e.preventDefault();

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -83,16 +83,16 @@ var org_permissions = {
 };
 
 exports.set_create_stream_permission_dropdwon = function () {
-    var menu = "id_realm_create_stream_permission";
+    var menu = $("#id_realm_create_stream_permission");
     $("#id_realm_waiting_period_threshold").parent().hide();
     if (page_params.realm_create_stream_by_admins_only) {
-        $("#" + menu + " option[value=by_admins_only]").attr("selected", "selected");
+        menu.val("by_admins_only");
     } else if (page_params.realm_waiting_period_threshold === 0) {
-        $("#" + menu + " option[value=by_anyone]").attr("selected", "selected");
+        menu.val("by_anyone");
     } else if (page_params.realm_waiting_period_threshold === 3) {
-        $("#" + menu + " option[value=by_admin_user_with_three_days_old]").attr("selected", "selected");
+        menu.val("by_admin_user_with_three_days_old");
     } else {
-        $("#" + menu + " option[value=by_admin_user_with_custom_time]").attr("selected", "selected");
+        menu.val("by_admin_user_with_custom_time");
         $("#id_realm_waiting_period_threshold").parent().show();
     }
 };


### PR DESCRIPTION
This just moves some functions out of `_setup` function because they are unnecessarily initialized at the setup time.  These functions were inside `_setup` function because in past we have `property_types` inside `_setup` which contains some translation string but those strings are removed so we don't have these function and JS objects inside `_setup`.  

Also, there are some minor fixes for bugs in commits,
**org settings: Make sync_realm_settings to be available at load time.**

This moves `sync_realm_settings` function out of `_setup` so that
we can call `settings_org.sync_realm_settings` without opening
settings page atleast once.

This also fixes a minor bug in which if we have two tabs opened and
in one we haven't opened settings page at least once and in
another we change an org setting, then we get an exception in
the former tab because of the event as `sync_realm_settings`
isn't defined yet.

**org settings: Fix real-time sync for realm_waiting_period_threshold.**
This fixes a minor bug in which the value of `input` element of
`realm_waiting_period_threshold` don't get updated because in
`set_create_stream_permission_dropdwon` we don't change the
value of the input.
So, this minor refactor handles this more carefully.