### PR TITLE
settings: Focus "Add a new bot" tab when there is no active bot.

### DIFF
--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -9,6 +9,7 @@ set_global("page_params", {
 set_global("avatar", {});
 
 set_global('$', global.make_zjquery());
+set_global('i18n', global.stub_i18n);
 set_global('document', 'document-stub');
 
 zrequire('bot_data');
@@ -112,6 +113,7 @@ function test_create_bot_type_input_box_toggle(f) {
     global.compile_template('embedded_bot_config_item');
     avatar.build_bot_create_widget = function () {};
     avatar.build_bot_edit_widget = function () {};
+    settings_bots.setup_bot_creation_policy_values();
 
     settings_bots.set_up();
 }());

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -164,12 +164,10 @@ exports.update_bot_permissions_ui = function () {
         !page_params.is_admin) {
         $('#create_bot_form').hide();
         $('.add-a-new-bot-tab').hide();
-        $('.account-api-key-section').hide();
         focus_tab.active_bots_tab();
     } else {
         $('#create_bot_form').show();
         $('.add-a-new-bot-tab').show();
-        $('.account-api-key-section').show();
     }
 };
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -55,7 +55,10 @@ function render_bots() {
     $('#active_bots_list').empty();
     $('#inactive_bots_list').empty();
 
-    _.each(bot_data.get_all_bots_for_current_user(), function (elem) {
+    var all_bots_for_current_user = bot_data.get_all_bots_for_current_user();
+    var user_owns_an_active_bot = false;
+
+    _.each(all_bots_for_current_user, function (elem) {
         add_bot_row({
             name: elem.full_name,
             email: elem.email,
@@ -66,7 +69,16 @@ function render_bots() {
             is_active: elem.is_active,
             zuliprc: 'zuliprc', // Most browsers do not allow filename starting with `.`
         });
+        user_owns_an_active_bot = user_owns_an_active_bot || elem.is_active;
     });
+
+    if (page_params.is_admin || page_params.realm_bot_creation_policy !==
+        exports.bot_creation_policy_values.admins_only.code) {
+        if (!user_owns_an_active_bot) {
+            focus_tab.add_a_new_bot_tab();
+            return;
+        }
+    }
 
     if ($("#bots_lists_navbar .add-a-new-bot-tab").hasClass("active")) {
         $("#add-a-new-bot-form").show();

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -2,6 +2,33 @@ var settings_bots = (function () {
 
 var exports = {};
 
+var focus_tab = {
+    add_a_new_bot_tab: function () {
+        $("#bots_lists_navbar .active").removeClass("active");
+        $("#bots_lists_navbar .add-a-new-bot-tab").addClass("active");
+        $("#add-a-new-bot-form").show();
+        $("#active_bots_list").hide();
+        $("#inactive_bots_list").hide();
+        $('#bot_table_error').hide();
+    },
+    active_bots_tab: function () {
+        $("#bots_lists_navbar .active").removeClass("active");
+        $("#bots_lists_navbar .active-bots-tab").addClass("active");
+        $("#add-a-new-bot-form").hide();
+        $("#active_bots_list").show();
+        $("#inactive_bots_list").hide();
+        $('#bot_table_error').hide();
+    },
+    inactive_bots_tab: function () {
+        $("#bots_lists_navbar .active").removeClass("active");
+        $("#bots_lists_navbar .inactive-bots-tab").addClass("active");
+        $("#add-a-new-bot-form").hide();
+        $("#active_bots_list").hide();
+        $("#inactive_bots_list").show();
+        $('#bot_table_error').hide();
+    },
+};
+
 function add_bot_row(info) {
     info.id_suffix = _.uniqueId('_bot_');
     var row = $(templates.render('bot_avatar_row', info));
@@ -126,7 +153,7 @@ exports.update_bot_permissions_ui = function () {
         $('#create_bot_form').hide();
         $('.add-a-new-bot-tab').hide();
         $('.account-api-key-section').hide();
-        $("#bots_lists_navbar .active-bots-tab").click();
+        focus_tab.active_bots_tab();
     } else {
         $('#create_bot_form').show();
         $('.add-a-new-bot-tab').show();
@@ -424,40 +451,19 @@ exports.set_up = function () {
     $("#bots_lists_navbar .add-a-new-bot-tab").click(function (e) {
         e.preventDefault();
         e.stopPropagation();
-
-        $("#bots_lists_navbar .add-a-new-bot-tab").addClass("active");
-        $("#bots_lists_navbar .active-bots-tab").removeClass("active");
-        $("#bots_lists_navbar .inactive-bots-tab").removeClass("active");
-        $("#add-a-new-bot-form").show();
-        $("#active_bots_list").hide();
-        $("#inactive_bots_list").hide();
-        $('#bot_table_error').hide();
+        focus_tab.add_a_new_bot_tab();
     });
 
     $("#bots_lists_navbar .active-bots-tab").click(function (e) {
         e.preventDefault();
         e.stopPropagation();
-
-        $("#bots_lists_navbar .add-a-new-bot-tab").removeClass("active");
-        $("#bots_lists_navbar .active-bots-tab").addClass("active");
-        $("#bots_lists_navbar .inactive-bots-tab").removeClass("active");
-        $("#add-a-new-bot-form").hide();
-        $("#active_bots_list").show();
-        $("#inactive_bots_list").hide();
-        $('#bot_table_error').hide();
+        focus_tab.active_bots_tab();
     });
 
     $("#bots_lists_navbar .inactive-bots-tab").click(function (e) {
         e.preventDefault();
         e.stopPropagation();
-
-        $("#bots_lists_navbar .add-a-new-bot-tab").removeClass("active");
-        $("#bots_lists_navbar .active-bots-tab").removeClass("active");
-        $("#bots_lists_navbar .inactive-bots-tab").addClass("active");
-        $("#add-a-new-bot-form").hide();
-        $("#active_bots_list").hide();
-        $("#inactive_bots_list").show();
-        $('#bot_table_error').hide();
+        focus_tab.inactive_bots_tab();
     });
 
 };


### PR DESCRIPTION
Fixes: #8872.
Some manual testing is needed to see if everything is working as expected.
GIFs+Manual Tests: 
1 bot active 1 inactive
![oneinactiveoneactive](https://user-images.githubusercontent.com/22238472/38111547-d9ac361e-33bc-11e8-9c99-694b95d3e6bf.gif)
No bots at all:
![nobots](https://user-images.githubusercontent.com/22238472/38111548-d9f91b64-33bc-11e8-9d93-59ca8295da50.gif)
No active bots but have inactive bots
![inactivebotspresent](https://user-images.githubusercontent.com/22238472/38111550-da69e93e-33bc-11e8-8e88-c85ad4a5647f.gif)

To determine whether we have any inactive bot or not I can do directly something like this but I kept myself away from another separate traversing:
```
    var has_all_inactive_bots = _.all(all_bots_for_current_user, function (elem) {

        return !elem.is_active;

    });
```

