### PR TITLE
markdown: Update bugdown emoticon translation logic to match frontend.

### DIFF
--- a/zerver/fixtures/markdown_test_cases.json
+++ b/zerver/fixtures/markdown_test_cases.json
@@ -382,6 +382,21 @@
       "translate_emoticons": true
     },
     {
+      "name": "translate_emoticons_at_sentence_end",
+      "input": "Translate this :).",
+      "expected_output": "<p>Translate this <span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span>.</p>",
+      "text_content": "Translate this \ud83d\ude03.",
+      "translate_emoticons": true
+    },
+    {
+      "name": "translate_emoticons_between_symbols",
+      "input": "Translate this !:)?",
+      "expected_output": "<p>Translate this !<span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span>?</p>",
+      "marked_expected_output": "<p>Translate this !:)?</p>",
+      "text_content": "Translate this !\ud83d\ude03?",
+      "translate_emoticons": true
+    },
+    {
       "name": "random_emoji_1",
       "input": ":airplane:",
       "expected_output": "<p><span class=\"emoji emoji-2708\" title=\"airplane\">:airplane:</span></p>"

--- a/zerver/lib/emoji.py
+++ b/zerver/lib/emoji.py
@@ -28,7 +28,10 @@ EMOTICON_CONVERSIONS = {
 
 possible_emoticons = EMOTICON_CONVERSIONS.keys()
 possible_emoticon_regexes = map(re.escape, possible_emoticons)  # type: ignore # AnyStr/str issues
-emoticon_regex = '(?<![^\s])(?P<emoticon>(' + ')|('.join(possible_emoticon_regexes) + '))(?![\S])'  # type: ignore # annoying
+terminal_symbols = ',.;?!()\\[\\] "\'\\n\\t'  # type: str # from composebox_typeahead.js
+emoticon_regex = ('(?<![^{0}])(?P<emoticon>('.format(terminal_symbols)
+                  + ')|('.join(possible_emoticon_regexes)  # type: ignore # AnyStr/str issues
+                  + '))(?![^{0}])'.format(terminal_symbols))
 
 # Translates emoticons to their colon syntax, e.g. `:smiley:`.
 def translate_emoticons(text: Text) -> Text:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This PR solves some of the parity issues in the emoticon translation logic. I was unable to find a way of matching only one of the lookaround groups, so we still have some inconsistency (see testcase). The approach of having another check while converting just for this seemed like an inefficient way, so I've left that last change as it is.

Updated regex: `(?<![^,.;?!()\[\] "'\n\t])(?P<emoticon>(\:\()|(\<3)|(\(\:)|(\:\))|(\:\/)|(\:\|))(?![^,.;?!()\[\] "'\n\t])`

**Testing Plan:** <!-- How have you tested? -->

Added two tests.
