### PR TITLE
left sidebar: Fix "Compose" in stream actions popover prefills topic.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -191,9 +191,12 @@ exports.start = function (msg_type, opts) {
     exports.expand_compose_box();
 
     opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
-    // If we are invoked by a compose hotkey (c or C), do not assume that we know
-    // what the message's topic or PM recipient should be.
-    if ((opts.trigger === "compose_hotkey") || (opts.trigger === "new topic button")) {
+    // If we are invoked by a compose hotkey (c or C) or new topic button
+    // or sidebar stream actions (in stream popover), do not assume that we know what
+    // the message's topic or PM recipient should be.
+    if ((opts.trigger === "compose_hotkey") ||
+        (opts.trigger === "new topic button") ||
+        (opts.trigger === "sidebar stream actions")) {
         opts.subject = '';
         opts.private_message_recipient = '';
     }


### PR DESCRIPTION
Fixes #8824.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!--**Testing Plan:** How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![stream_topic](https://user-images.githubusercontent.com/22166422/38126177-798e21fc-340c-11e8-827e-da3b6be20543.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
