### PR TITLE
compose: Prevent inputs from being automatically selected after changing tabs.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -822,21 +822,6 @@ user_pill.get_user_ids = function () {
     event.keyCode = 42;
     $('form#send_message_form').keyup(event);
 
-    // select_on_focus()
-    var focus_handler_called = false;
-    var stream_one_called = false;
-    $('#stream').focus = function (f) {
-        // This .one() function emulates the possible infinite recursion that
-        // in_handler tries to avoid.
-        $('#stream').one = function (event, handler) {
-            handler({ preventDefault: noop });
-            f();  // This time in_handler will already be true.
-            stream_one_called = true;
-        };
-        f();  // Here in_handler is false.
-        focus_handler_called = true;
-    };
-
     $("#compose-send-button").fadeOut = noop;
     $("#compose-send-button").fadeIn = noop;
     var channel_post_called = false;
@@ -864,8 +849,6 @@ user_pill.get_user_ids = function () {
     assert(pm_recipient_blur_called);
     assert(channel_post_called);
     assert(compose_textarea_typeahead_called);
-    assert(focus_handler_called);
-    assert(stream_one_called);
 }());
 
 (function test_begins_typeahead() {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -236,24 +236,6 @@ function handle_keyup(e) {
     }
 }
 
-// http://stackoverflow.com/questions/3380458/looking-for-a-better-workaround-to-chrome-select-on-focus-bug
-function select_on_focus(field_id) {
-    // A select event appears to trigger a focus event under certain
-    // conditions in Chrome so we need to protect against infinite
-    // recursion.
-    var in_handler = false;
-    $("#" + field_id).focus(function () {
-        if (in_handler) {
-            return;
-        }
-        in_handler = true;
-        $("#" + field_id).select().one('mouseup', function (e) {
-            e.preventDefault();
-        });
-        in_handler = false;
-    });
-}
-
 exports.split_at_cursor = function (query, input) {
     var cursor = input.caret();
     return [query.slice(0, cursor), query.slice(cursor)];
@@ -563,10 +545,6 @@ exports.initialize_compose_typeahead = function (selector) {
 };
 
 exports.initialize = function () {
-    select_on_focus("stream");
-    select_on_focus("subject");
-    select_on_focus("private_message_recipient");
-
     // These handlers are at the "form" level so that they are called after typeahead
     $("form#send_message_form").keydown(handle_keydown);
     $("form#send_message_form").keyup(handle_keyup);


### PR DESCRIPTION
The stream and topic inputs are sometimes fully selected after the user changes tabs and then switches back. To fix this, remove the jQuery `focus` listener on the inputs so that the same amount of text (or no text) is selected before and after a user switches tabs. Also, completely remove `select_on_focus` because it is not used anywhere else.

See [discussion on this issue](https://chat.zulip.org/#narrow/stream/9-issues/subject/Topic.20autoselect.20on.20tab.20change/near/503595).

Fix #8414.

**Testing Plan:** <!-- How have you tested? -->

 - This removes the original `select_on_focus` tests because `select_on_focus` is deleted.

**GIFs:**

*Before:*

![before](https://user-images.githubusercontent.com/17259768/38068779-d04763aa-32c7-11e8-93be-a926b5b02fb3.gif)

*After:*

![after](https://user-images.githubusercontent.com/17259768/38068812-fca96cb8-32c7-11e8-8617-6713bd31e2bc.gif)

