### PR TITLE
Settings: Fix vertical spacing.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -209,7 +209,7 @@ td .button {
 .settings-section .settings-section-title {
     font-size: 1.4em;
     font-weight: 500;
-    margin: 0px 0px 10px 0px;
+    margin: 10px 0px 10px 0px;
 }
 
 .settings-section .settings-section-title.transparent {
@@ -322,7 +322,7 @@ td .button {
 
 .button,
 .input-group {
-    margin: 20px 0px;
+    margin: 0 0 20px 0;
 }
 
 .input-group.thinner {
@@ -348,7 +348,7 @@ input[type=checkbox] + .inline-block {
 }
 
 .admin-realm-form h3 {
-    margin-bottom: 0px;
+    margin-bottom: 10px;
 }
 
 #settings_page .icon-button {
@@ -443,6 +443,14 @@ input[type=checkbox] + .inline-block {
 
 .org-settings-form .organization-submission {
     margin-top: 0px;
+}
+
+.realm-icon-section {
+    margin-bottom: 20px;
+}
+
+.inline-block.organization-permissions-parent div:first-of-type {
+    margin-top: 10px;
 }
 
 .admin-realm-form .subsection-header h3 {
@@ -925,7 +933,6 @@ input[type=checkbox].inline-block {
 
 .emojiset_choices {
     width: 250px;
-    margin-top: 10px;
     padding: 0px 10px;
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2073,7 +2073,6 @@ div.floating_recipient {
 
 .settings-section #default_language {
     text-decoration: none;
-    vertical-align: bottom;
 }
 
 .settings-section #default_language_modal table {

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -38,7 +38,7 @@
             </form>
 
             <form class="form-horizontal full-name-change-form">
-                <div class="inline-block grid user-name-parent">
+                <div class="input-group inline-block grid user-name-parent">
                     <div class="user-name-section inline-block">
                         <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
                         <a id="change_full_name" {{#if page_params.is_admin}}href="#change_email"{{else}}{{#unless page_params.realm_name_changes_disabled}}href="#change_email"{{/unless}}{{/if}}>


### PR DESCRIPTION
For #8890
Removed the top margin of input-group css to prevent the double margins. Also fixed the default-language positioning. 

Looks like:
![new](https://user-images.githubusercontent.com/15152698/38158132-f88d59c8-345c-11e8-95ef-9232df017efa.png)

