### PR TITLE
org settings: Refactor the `render_notifications_stream_ui` function.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -488,12 +488,12 @@ function test_extract_property_name() {
         assert.equal(stream_id, 42);
         return { name: 'some_stream' };
     };
-    settings_org.render_notifications_stream_ui(42);
+    settings_org.render_notifications_stream_ui(42, elem);
     assert.equal(elem.text(), '#some_stream');
     assert(!elem.hasClass('text-warning'));
 
     stream_data.get_sub_by_id = noop;
-    settings_org.render_notifications_stream_ui();
+    settings_org.render_notifications_stream_ui(undefined, elem);
     assert.equal(elem.text(), 'translated: Disabled');
     assert(elem.hasClass('text-warning'));
 

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -502,12 +502,12 @@ function test_extract_property_name() {
         assert.equal(stream_id, 75);
         return { name: 'some_stream' };
     };
-    settings_org.render_signup_notifications_stream_ui(75);
+    settings_org.render_notifications_stream_ui(75, elem);
     assert.equal(elem.text(), '#some_stream');
     assert(!elem.hasClass('text-warning'));
 
     stream_data.get_sub_by_id = noop;
-    settings_org.render_signup_notifications_stream_ui();
+    settings_org.render_notifications_stream_ui(undefined, elem);
     assert.equal(elem.text(), 'translated: Disabled');
     assert(elem.hasClass('text-warning'));
 

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -91,8 +91,9 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                     page_params.realm_notifications_stream_id,
                     $('#realm_notifications_stream_name'));
             } else if (event.property === 'signup_notifications_stream_id') {
-                settings_org.render_signup_notifications_stream_ui(
-                    page_params.realm_signup_notifications_stream_id);
+                settings_org.render_notifications_stream_ui(
+                    page_params.realm_signup_notifications_stream_id,
+                    $('#realm_signup_notifications_stream_name'));
             }
 
             if (event.property === 'name' && window.electron_bridge !== undefined) {
@@ -234,8 +235,9 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 }
                 if (page_params.realm_signup_notifications_stream_id === stream.stream_id) {
                     page_params.realm_signup_notifications_stream_id = -1;
-                    settings_org.render_signup_notifications_stream_ui(
-                        page_params.realm_signup_notifications_stream_id);
+                    settings_org.render_notifications_stream_ui(
+                        page_params.realm_signup_notifications_stream_id,
+                        $('#realm_signup_notifications_stream_name'));
                 }
             });
         }

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -88,7 +88,8 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 }
             } else if (event.property === 'notifications_stream_id') {
                 settings_org.render_notifications_stream_ui(
-                    page_params.realm_notifications_stream_id);
+                    page_params.realm_notifications_stream_id,
+                    $('#realm_notifications_stream_name'));
             } else if (event.property === 'signup_notifications_stream_id') {
                 settings_org.render_signup_notifications_stream_ui(
                     page_params.realm_signup_notifications_stream_id);
@@ -228,7 +229,8 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 if (page_params.realm_notifications_stream_id === stream.stream_id) {
                     page_params.realm_notifications_stream_id = -1;
                     settings_org.render_notifications_stream_ui(
-                        page_params.realm_notifications_stream_id);
+                        page_params.realm_notifications_stream_id,
+                        $('#realm_notifications_stream_name'));
                 }
                 if (page_params.realm_signup_notifications_stream_id === stream.stream_id) {
                     page_params.realm_signup_notifications_stream_id = -1;

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -272,22 +272,6 @@ exports.populate_notifications_stream_dropdown = function (stream_list) {
     });
 };
 
-exports.render_signup_notifications_stream_ui = function (stream_id) {
-    var elem = $('#realm_signup_notifications_stream_name');
-
-    var name = stream_data.maybe_get_stream_name(stream_id);
-
-    if (!name) {
-        elem.text(i18n.t("Disabled"));
-        elem.addClass("text-warning");
-        return;
-    }
-
-    // Happy path
-    elem.text('#' + name);
-    elem.removeClass('text-warning');
-};
-
 exports.populate_signup_notifications_stream_dropdown = function (stream_list) {
     var dropdown_list_body = $("#id_realm_signup_notifications_stream .dropdown-list-body").expectOne();
     var search_input = $("#id_realm_signup_notifications_stream .dropdown-search > input[type=text]");
@@ -379,7 +363,8 @@ function _set_up() {
     }
     exports.render_notifications_stream_ui(page_params.realm_notifications_stream_id,
                                            $('#realm_notifications_stream_name'));
-    exports.render_signup_notifications_stream_ui(page_params.realm_signup_notifications_stream_id);
+    exports.render_notifications_stream_ui(page_params.realm_signup_notifications_stream_id,
+                                           $('#realm_signup_notifications_stream_name'));
 
     // Populate realm domains
     exports.populate_realm_domains(page_params.realm_domains);
@@ -777,7 +762,8 @@ function _set_up() {
 
     var signup_notifications_stream_status = $("#admin-realm-signup-notifications-stream-status").expectOne();
     function update_signup_notifications_stream(new_signup_notifications_stream_id) {
-        exports.render_signup_notifications_stream_ui(new_signup_notifications_stream_id);
+        exports.render_notifications_stream_ui(new_signup_notifications_stream_id,
+                                               $('#realm_signup_notifications_stream_name'));
         signup_notifications_stream_status.hide();
         var stringified_id = JSON.stringify(parseInt(new_signup_notifications_stream_id, 10));
         var url = "/json/realm";

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -226,8 +226,7 @@ exports.populate_auth_methods = function (auth_methods) {
 };
 
 
-exports.render_notifications_stream_ui = function (stream_id) {
-    var elem = $('#realm_notifications_stream_name');
+exports.render_notifications_stream_ui = function (stream_id, elem) {
 
     var name = stream_data.maybe_get_stream_name(stream_id);
 
@@ -378,7 +377,8 @@ function _set_up() {
         exports.populate_notifications_stream_dropdown(streams);
         exports.populate_signup_notifications_stream_dropdown(streams);
     }
-    exports.render_notifications_stream_ui(page_params.realm_notifications_stream_id);
+    exports.render_notifications_stream_ui(page_params.realm_notifications_stream_id,
+                                           $('#realm_notifications_stream_name'));
     exports.render_signup_notifications_stream_ui(page_params.realm_signup_notifications_stream_id);
 
     // Populate realm domains
@@ -730,7 +730,8 @@ function _set_up() {
 
     var notifications_stream_status = $("#admin-realm-notifications-stream-status").expectOne();
     function update_notifications_stream(new_notifications_stream_id) {
-        exports.render_notifications_stream_ui(new_notifications_stream_id);
+        exports.render_notifications_stream_ui(new_notifications_stream_id,
+                                               $('#realm_notifications_stream_name'));
         notifications_stream_status.hide();
 
         var url = "/json/realm";


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
**First commit:**

org settings: Add elem param to the render_notifications_stream_ui. 

**Second commit:**
We are having the same code in `render_notifications_stream_ui`
    and `render_signup_notifications_stream_ui` functions aside from
    the HTML element. So this commit will remove the duplicate code in
    `render_signup_notifications_stream_ui` and make use of
    `render_notifications_stream_ui`.
Fixes #8886.
 <!-- **Testing Plan:**How have you tested? -->

 <!--**GIFs or Screenshots:** If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
