### PR TITLE
compose: Show avatars for people in typeahead autocompletes.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -11,6 +11,9 @@ zrequire('stream_data');
 zrequire('user_pill');
 zrequire('compose_pm_pill');
 zrequire('composebox_typeahead');
+set_global('md5', function (s) {
+    return 'md5-' + s;
+});
 
 var ct = composebox_typeahead;
 var noop = function () {};
@@ -446,17 +449,17 @@ user_pill.get_user_ids = function () {
         // corresponding parts in bold.
         options.query = 'oth';
         actual_value = options.highlighter(othello);
-        expected_value = '<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">othello@zulip.com</small>\n';
+        expected_value = '        <img class="typeahead-image" src="https://secure.gravatar.com/avatar/md5-othello@zulip.com?d&#x3D;identicon&amp;s&#x3D;50" />\n<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">othello@zulip.com</small>\n';
         assert.equal(actual_value, expected_value);
 
         options.query = 'Lear';
         actual_value = options.highlighter(cordelia);
-        expected_value = '<strong>Cordelia Lear</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">cordelia@zulip.com</small>\n';
+        expected_value = '        <img class="typeahead-image" src="https://secure.gravatar.com/avatar/md5-cordelia@zulip.com?d&#x3D;identicon&amp;s&#x3D;50" />\n<strong>Cordelia Lear</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">cordelia@zulip.com</small>\n';
         assert.equal(actual_value, expected_value);
 
         options.query = 'othello@zulip.com, co';
         actual_value = options.highlighter(cordelia);
-        expected_value = '<strong>Cordelia Lear</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">cordelia@zulip.com</small>\n';
+        expected_value = '        <img class="typeahead-image" src="https://secure.gravatar.com/avatar/md5-cordelia@zulip.com?d&#x3D;identicon&amp;s&#x3D;50" />\n<strong>Cordelia Lear</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">cordelia@zulip.com</small>\n';
         assert.equal(actual_value, expected_value);
 
         // options.matcher()
@@ -561,12 +564,12 @@ user_pill.get_user_ids = function () {
         // content_highlighter.
         fake_this = { completing: 'mention', token: 'othello' };
         actual_value = options.highlighter.call(fake_this, othello);
-        expected_value = '<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">othello@zulip.com</small>\n';
+        expected_value = '        <img class="typeahead-image" src="https://secure.gravatar.com/avatar/md5-othello@zulip.com?d&#x3D;identicon&amp;s&#x3D;50" />\n<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">othello@zulip.com</small>\n';
         assert.equal(actual_value, expected_value);
 
         fake_this = { completing: 'mention', token: 'hamletcharacters' };
         actual_value = options.highlighter.call(fake_this, hamletcharacters);
-        expected_value = '<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
+        expected_value = '        <i class="typeahead-image icon icon-vector-group"></i>\n<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
         assert.equal(actual_value, expected_value);
 
         // options.matcher()

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -366,6 +366,31 @@ people.init();
 
 initialize();
 
+(function test_small_avatar_url_for_person() {
+    var charles = {
+        email: 'charles@example.com',
+        user_id: 451,
+        full_name: 'Charles Dickens',
+        avatar_url: 'charles.com/foo.png',
+    };
+    var maria = {
+        email: 'athens@example.com',
+        user_id: 452,
+        full_name: 'Maria Athens',
+    };
+    people.add(charles);
+    people.add(maria);
+
+    assert.equal(
+        people.small_avatar_url_for_person(charles),
+        'charles.com/foo.png&s=50'
+    );
+    assert.equal(
+        people.small_avatar_url_for_person(maria),
+        'https://secure.gravatar.com/avatar/md5-athens@example.com?d=identicon&s=50'
+    );
+}());
+
 (function test_message_methods() {
     var charles = {
         email: 'charles@example.com',

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -1,5 +1,8 @@
 set_global('page_params', {realm_is_zephyr_mirror_realm: false});
 set_global('templates', {});
+set_global('md5', function (s) {
+    return 'md5-' + s;
+});
 
 zrequire('Handlebars', 'handlebars');
 zrequire('recent_senders');

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -489,6 +489,25 @@ exports.sender_is_bot = function (message) {
     return false;
 };
 
+function small_avatar_url_for_email(email) {
+    var hash = md5(email);
+    var avatar_url = 'https://secure.gravatar.com/avatar/' + hash + '?d=identicon';
+    var small_avatar_url = exports.format_small_avatar_url(avatar_url);
+    return small_avatar_url;
+}
+
+exports.small_avatar_url_for_person = function (person) {
+    var avatar_url = person.avatar_url;
+
+    if (!avatar_url) {
+        return small_avatar_url_for_email(person.email);
+    }
+
+    var small_avatar_url = exports.format_small_avatar_url(avatar_url);
+
+    return small_avatar_url;
+};
+
 exports.small_avatar_url = function (message) {
     // Try to call this function in all places where we need 25px
     // avatar images, so that the browser can help
@@ -508,33 +527,21 @@ exports.small_avatar_url = function (message) {
         person = exports.get_person_from_user_id(message.sender_id);
     }
 
-    var email;
-
     // The first time we encounter a sender in a message, we may
     // not have person.avatar_url set, but if we do, then use that.
     if (person) {
-        url = person.avatar_url;
-        email = person.email;
+        url = exports.small_avatar_url_for_person(person);
     }
 
     // Try to get info from the message if we didn't have a `person` object
     // or if the avatar was missing. We do this verbosely to avoid false
     // positives on line coverage (we don't do branch checking).
-    if (!url) {
-        url = message.avatar_url;
+    if (!url && message.avatar_url) {
+        url = exports.format_small_avatar_url(message.avatar_url);
     }
 
-    if (!email) {
-        email = message.sender_email;
-    }
-
-    if (!url) {
-        var hash = md5(email);
-        url = 'https://secure.gravatar.com/avatar/' + hash + '?d=identicon';
-    }
-
-    if (url) {
-        url = exports.format_small_avatar_url(url);
+    if (!url && message.sender_email) {
+        url = small_avatar_url_for_email(message.sender_email);
     }
 
     return url;

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -79,14 +79,21 @@ var rendered = { persons: new Dict(), streams: new Dict(), user_groups: new Dict
 
 exports.render_person = function (person) {
     if (person.special_item_text) {
-        return exports.render_typeahead_item({ primary: person.special_item_text });
+        return exports.render_typeahead_item({
+            primary: person.special_item_text,
+            is_person: true,
+        });
     }
 
     var html = rendered.persons.get(person.user_id);
     if (html === undefined) {
+        var avatar_url = people.small_avatar_url_for_person(person);
+
         html = exports.render_typeahead_item({
             primary: person.full_name,
             secondary: person.email,
+            img_src: avatar_url,
+            is_person: true,
         });
         rendered.persons.set(person.user_id, html);
     }
@@ -104,6 +111,7 @@ exports.render_user_group = function (user_group) {
         html = exports.render_typeahead_item({
             primary: user_group.name,
             secondary: user_group.description,
+            is_user_group: true,
         });
         rendered.user_groups.set(user_group.id, html);
     }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1775,6 +1775,27 @@ blockquote p {
     color: hsl(96, 7%, 73%);
 }
 
+.typeahead-image {
+    display: inline-block;
+    height: 21px;
+    width: 21px;
+    position: relative;
+    margin-top: -7px;
+    vertical-align: middle;
+    top: 2px;
+    right: 8px;
+    border-radius: 4px;
+
+    /* For FontAwesome icons used in place of images for some users. */
+    font-size: 19px;
+    text-align: center;
+}
+
+.typeahead-image.icon {
+    /* This aligns the icon vertically. */
+    top: 0px;
+}
+
 .nav .dropdown-menu:after {
     position: absolute;
     width: 0px;

--- a/static/templates/typeahead_list_item.handlebars
+++ b/static/templates/typeahead_list_item.handlebars
@@ -5,6 +5,18 @@
     <span class='emoji emoji-{{ codepoint }}' />
     {{/if}}
     &nbsp;&nbsp;
+{{else}}
+    {{#if is_person}}
+        {{#if has_image}}
+        <img class="typeahead-image" src="{{ img_src }}" />
+        {{else}}
+        <span class='typeahead-image fa fa-bullhorn'></span>
+        {{/if}}
+    {{else}}
+        {{#if is_user_group}}
+        <i class="typeahead-image icon icon-vector-group"></i>
+        {{/if}}
+    {{/if}}
 {{/if}}
 <strong>
     {{~ primary ~}}


### PR DESCRIPTION
This PR adds avatars in the typeahead autocompletes next to users. Users without avatars (e.g. `@all` and `@everyone`) have an empty placeholder instead so that they line up with the other names.

The `typeahead-image` class is similar to the `emoji` class also used by typeahead, but with a few differences in size, positioning, and its `border-radius`.

Fixes #6635.

**Screenshot:**

<img width="258" alt="screen shot 2018-03-31 at 11 01 54 am" src="https://user-images.githubusercontent.com/17259768/38166117-4b49fcb8-34d3-11e8-8e30-fa82245b4ff0.png">
