### PR TITLE
mypy: Add type parameters to webhooks, enabling type inference.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -31,27 +31,6 @@ strict_optional = False
 [mypy-zerver.views.events_register]
 strict_optional = False
 
-[mypy-zerver.lib.webhooks.common]
-strict_optional = False
-[mypy-zerver.webhooks.yo.view]
-strict_optional = False
-[mypy-zerver.webhooks.transifex.view]
-strict_optional = False
-[mypy-zerver.webhooks.newrelic.view]
-strict_optional = False
-[mypy-zerver.webhooks.gogs.view]
-strict_optional = False
-[mypy-zerver.webhooks.gitlab.view]
-strict_optional = False
-[mypy-zerver.webhooks.github.view]
-strict_optional = False
-[mypy-zerver.webhooks.bitbucket.view]
-strict_optional = False
-[mypy-zerver.webhooks.bitbucket2.view]
-strict_optional = False
-[mypy-zerver.webhooks.beanstalk.view]
-strict_optional = False
-
 [mypy-zerver.views.auth]  # Other issues in this file too
 strict_optional = False
 [mypy-zerver.views.realm]  # Other issues in this file too

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -11,8 +11,8 @@ from zerver.models import UserProfile
 @has_request_variables
 def check_send_webhook_message(
         request: HttpRequest, user_profile: UserProfile,
-        topic: Text, body: Text, stream: Optional[Text]=REQ(default=None),
-        user_specified_topic: Optional[Text]=REQ("topic", default=None)
+        topic: Text, body: Text, stream: Optional[Text]=REQ(default=None, type=str),
+        user_specified_topic: Optional[Text]=REQ("topic", default=None, type=str)
 ) -> None:
 
     if stream is None:

--- a/zerver/webhooks/beanstalk/view.py
+++ b/zerver/webhooks/beanstalk/view.py
@@ -41,7 +41,7 @@ def beanstalk_decoder(view_func: ViewFuncT) -> ViewFuncT:
 @has_request_variables
 def api_beanstalk_webhook(request: HttpRequest, user_profile: UserProfile,
                           payload: Dict[str, Any]=REQ(validator=check_dict([])),
-                          branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
+                          branches: Optional[Text]=REQ(default=None, type=str)) -> HttpResponse:
     # Beanstalk supports both SVN and git repositories
     # We distinguish between the two by checking for a
     # 'uri' key that is only present for git repos

--- a/zerver/webhooks/bitbucket/view.py
+++ b/zerver/webhooks/bitbucket/view.py
@@ -15,7 +15,7 @@ from zerver.models import UserProfile, get_client
 @has_request_variables
 def api_bitbucket_webhook(request: HttpRequest, user_profile: UserProfile,
                           payload: Mapping[Text, Any]=REQ(validator=check_dict([])),
-                          branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
+                          branches: Optional[Text]=REQ(default=None, type=str)) -> HttpResponse:
     repository = payload['repository']
 
     commits = [

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -46,7 +46,7 @@ class UnknownTriggerType(Exception):
 @has_request_variables
 def api_bitbucket2_webhook(request: HttpRequest, user_profile: UserProfile,
                            payload: Dict[str, Any]=REQ(argument_type='body'),
-                           branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
+                           branches: Optional[Text]=REQ(default=None, type=str)) -> HttpResponse:
     type = get_type(request, payload)
     if type != 'push':
         subject = get_subject_based_on_type(payload, type)

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -370,7 +370,7 @@ EVENT_FUNCTION_MAPPER = {
 def api_github_webhook(
         request: HttpRequest, user_profile: UserProfile,
         payload: Dict[str, Any]=REQ(argument_type='body'),
-        branches: Text=REQ(default=None)) -> HttpResponse:
+        branches: Optional[Text]=REQ(default=None, type=str)) -> HttpResponse:
     event = get_event(request, payload, branches)
     if event is not None:
         subject = get_subject_based_on_type(payload, event)
@@ -378,7 +378,7 @@ def api_github_webhook(
         check_send_webhook_message(request, user_profile, subject, body)
     return json_success()
 
-def get_event(request: HttpRequest, payload: Dict[str, Any], branches: Text) -> Optional[str]:
+def get_event(request: HttpRequest, payload: Dict[str, Any], branches: Optional[Text]) -> Optional[str]:
     event = request.META['HTTP_X_GITHUB_EVENT']
     if event == 'pull_request':
         action = payload['action']

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -271,7 +271,7 @@ EVENT_FUNCTION_MAPPER = {
 @has_request_variables
 def api_gitlab_webhook(request: HttpRequest, user_profile: UserProfile,
                        payload: Dict[str, Any]=REQ(argument_type='body'),
-                       branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
+                       branches: Optional[Text]=REQ(default=None, type=str)) -> HttpResponse:
     event = get_event(request, payload, branches)
     if event is not None:
         body = get_body_based_on_event(event)(payload)

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -63,7 +63,7 @@ def format_pull_request_event(payload: Dict[str, Any]) -> Text:
 @has_request_variables
 def api_gogs_webhook(request: HttpRequest, user_profile: UserProfile,
                      payload: Dict[str, Any]=REQ(argument_type='body'),
-                     branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
+                     branches: Optional[Text]=REQ(default=None, type=str)) -> HttpResponse:
 
     repo = payload['repository']['name']
     event = request.META['HTTP_X_GOGS_EVENT']

--- a/zerver/webhooks/newrelic/view.py
+++ b/zerver/webhooks/newrelic/view.py
@@ -13,10 +13,11 @@ from zerver.models import Stream, UserProfile
 
 @api_key_only_webhook_view("NewRelic")
 @has_request_variables
-def api_newrelic_webhook(request: HttpRequest, user_profile: UserProfile,
-                         alert: Optional[Dict[str, Any]]=REQ(validator=check_dict([]), default=None),
-                         deployment: Optional[Dict[str, Any]]=REQ(validator=check_dict([]), default=None)
-                         )-> HttpResponse:
+def api_newrelic_webhook(
+        request: HttpRequest, user_profile: UserProfile,
+        alert: Optional[Dict[str, Any]]=REQ(validator=check_dict([]), default=None, type=dict),
+        deployment: Optional[Dict[str, Any]]=REQ(validator=check_dict([]), default=None, type=dict)
+)-> HttpResponse:
     if alert:
         # Use the message as the subject because it stays the same for
         # "opened", "acknowledged", and "closed" messages that should be

--- a/zerver/webhooks/transifex/view.py
+++ b/zerver/webhooks/transifex/view.py
@@ -13,9 +13,11 @@ from zerver.models import UserProfile
 @api_key_only_webhook_view('Transifex')
 @has_request_variables
 def api_transifex_webhook(request: HttpRequest, user_profile: UserProfile,
-                          project: str=REQ(), resource: str=REQ(),
-                          language: str=REQ(), translated: Optional[int]=REQ(default=None),
-                          reviewed: Optional[int]=REQ(default=None)) -> HttpResponse:
+                          project: str=REQ(),
+                          resource: str=REQ(),
+                          language: str=REQ(),
+                          translated: Optional[int]=REQ(default=None, type=int),
+                          reviewed: Optional[int]=REQ(default=None, type=int)) -> HttpResponse:
     subject = "{} in {}".format(project, language)
     if translated:
         body = "Resource {} fully translated.".format(resource)

--- a/zerver/webhooks/yo/view.py
+++ b/zerver/webhooks/yo/view.py
@@ -15,8 +15,8 @@ from zerver.models import UserProfile, get_user
 def api_yo_app_webhook(request: HttpRequest, user_profile: UserProfile,
                        email: str = REQ(default=""),
                        username: str = REQ(default='Yo Bot'),
-                       topic: Optional[str] = REQ(default=None),
-                       user_ip: Optional[str] = REQ(default=None)) -> HttpResponse:
+                       topic: Optional[str] = REQ(default=None, type=str),
+                       user_ip: Optional[str] = REQ(default=None, type=str)) -> HttpResponse:
     body = ('Yo from %s') % (username,)
     receiving_user = get_user(email, user_profile.realm)
     check_send_private_message(user_profile, request.client, receiving_user, body)


### PR DESCRIPTION
Also remove exclusions of these files from mypy.ini, ensuring they are fully checked in future.

This is a followup to #8800, with some work originally in #6017.

The type parameters are currently necessary for code such as the following:
```python
def func(request: HttpRequest, x: Optional[sometype]=REQ(default=None))...
```
Using `REQ` from request.pyi, mypy infers the return type is `None` and complains. Using the `type` parameter mypy infers differently.

Addressing an issue @timabbott raised with the default type to return being `str`; if the idea is that `REQ` parameters default to str, and that if `sometype` above is `str`, then `type=str` need not be specified, then I agree that would be ideal. Currently I'm not sure how to resolve that.

If this PR is accepted, then I will migrate the other REQ work from #6017.

[the tests currently fail locally, but in the frontend; this doesn't happen in master, either; error is:
FAIL "input:checked[type="checkbox"][id="id_realm_allow_message_editing"] + span" never appeared in 5000ms]