### PR TITLE
emoji-picker: Add minimum scrollbar length.

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -19,6 +19,7 @@ exports.set_up_scrollbar = function (element) {
         useKeyboard: false,
         wheelSpeed: 0.68,
         scrollingThreshold: 50,
+        minScrollbarLength: 40,
     });
     element[0].perfectScrollbar = perfectScrollbar;
 };


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/2-general/topic/Zulip.20poll

@rishig This is what a `minScrollbarLength` of 40 looks like 
![minscroll](https://user-images.githubusercontent.com/15152698/38169530-54c2b2f0-353a-11e8-9c7c-b6bc8fb146a0.png)

Additionally, this change is currently only for the emoji-picker scrollbar. If we want this change to be for all scrollbars, I can update the initalization of set_up_scrollbar in ui.js to include minScrollbarLength.