### PR TITLE
reactions: Add Reaction popover.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1121,6 +1121,12 @@ function render(template_name, args) {
     assert.equal(button_area.find(".no_propagate_notifications").text().trim(), 'translated: No');
 }());
 
+(function reaction_popover() {
+    var html = render('reaction_popover', {class: 'reaction-popover'});
+    global.write_handlebars_output("reaction_popover", html);
+    $(html).hasClass('popover reaction-popover');
+}());
+
 (function reminder_popover_content() {
     var args = {
         message: {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -171,9 +171,24 @@ $(function () {
 
     $("#main_div").on("click", ".message_reaction", function (e) {
         e.stopPropagation();
+        $(this).popover('hide');
         var local_id = $(this).attr('data-reaction-id');
         var message_id = rows.get_message_id(this);
         reactions.process_reaction_click(message_id, local_id);
+    });
+
+    $('#main_div').on('mouseenter', '.message_reaction', function (e) {
+        e.stopPropagation();
+        var elem = $(this);
+        var local_id = elem.attr('data-reaction-id');
+        var message_id = rows.get_message_id(this);
+        reactions.generate_popover(elem, message_id, local_id);
+        elem.data('popover').$tip.css('left', e.pageX + 3);
+    });
+
+    $('#main_div').on('mouseleave', '.message_reaction', function (e) {
+        e.stopPropagation();
+        $(this).popover('hide');
     });
 
     $("#main_div").on("click", "a.stream", function (e) {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2818,3 +2818,16 @@ div.topic_edit_spinner .loading_indicator_spinner {
 .hotkey-hint {
     opacity: 0.75;
 }
+
+.popover.reaction-popover {
+    background-color: #f5f5f5;
+    border-radius: 3px;
+    box-shadow: none;
+}
+
+.popover.reaction-popover .popover-content {
+    padding-top: 2px;
+    padding-bottom: 2px;
+    padding-left: 5px;
+    padding-right: 5px;
+}

--- a/static/templates/message_reaction.handlebars
+++ b/static/templates/message_reaction.handlebars
@@ -1,4 +1,4 @@
-<div class="{{this.class}}" title="{{this.title}}" data-reaction-id={{this.local_id}}>
+<div class="{{this.class}}" data-reaction-id={{this.local_id}}>
     {{#if this.emoji_alt_code}}
         <div class="emoji_alt_code">&nbsp:{{this.emoji_name}}:</div>
     {{else}}

--- a/static/templates/reaction_popover.handlebars
+++ b/static/templates/reaction_popover.handlebars
@@ -1,0 +1,8 @@
+<div class="popover {{class}}">
+    <div class="popover-inner">
+        <div class="popover-title"></div>
+        <div class="popover-content">
+            <div></div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This PR fixes #8679 and adds reaction popover to be used instead of html 'title' attribute.
See this for more discussion - https://chat.zulip.org/#narrow/stream/101-design/subject/reaction.20popover