### PR TITLE
Python dependency upgrade

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -149,7 +149,7 @@ django-webpack-loader==0.6.0
 # Needed for iOS push notifications
 apns2==0.3.0
 
-python-twitter==3.3
+python-twitter==3.4.1
 
 # To parse po files
 polib==1.1.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -3,7 +3,7 @@
 # and requirements/prod.txt.
 # See requirements/README.md for more detail.
 # Django itself
-Django==1.11.6
+Django==1.11.11
 
 # needed for mypy TypedDict
 mypy_extensions==0.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -53,7 +53,7 @@ django-sendfile==0.3.11
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.7.0
 django-webpack-loader==0.6.0
-django==1.11.6
+django==1.11.11
 docker-pycreds==0.2.1     # via docker
 docker==2.6.1             # via moto
 docopt==0.6.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -129,7 +129,7 @@ pysocks==1.6.7            # via twilio
 python-dateutil==2.6.1
 python-digitalocean==1.13.2
 python-gcm==0.4
-python-twitter==3.3
+python-twitter==3.4.1
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.3
 pyyaml==3.12              # via pyaml

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -92,7 +92,7 @@ pyopenssl==17.3.0         # via ndg-httpsclient
 pysocks==1.6.7            # via twilio
 python-dateutil==2.6.1
 python-gcm==0.4
-python-twitter==3.3
+python-twitter==3.4.1
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.3
 qrcode==4.0.4             # via django-two-factor-auth

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -41,7 +41,7 @@ django-sendfile==0.3.11
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.7.0
 django-webpack-loader==0.6.0
-django==1.11.6
+django==1.11.11
 docopt==0.6.2
 gitdb==0.6.4
 google-api-python-client==1.6.6


### PR DESCRIPTION
### Upgraded Packages

|Package|Old|New|Status|
|---------|----|----|---|
disposable-email-domains |0.0.20| 0.0.23| :+1:
django-auth-ldap |1.3.0| 1.4.0| :+1:
django-webpack-loader |0.5.0| 0.6.0| :+1:
google-api-python-client |1.6.5| 1.6.6| :+1:
httplib2 |0.10.3| 0.11.3 | :+1:
imagesize |0.7.1| 1.0.0| :+1:
moto |1.2.0| 1.3.1| :+1:
oauthlib |2.0.6| 2.0.7| :+1:
pika |0.11.0| 0.11.2| :+1:
pip |9.0.1| 9.0.3| :+1:
PyJWT |1.5.3| 1.6.1| :+1:
python-twitter |3.3| 3.4.1| :+1:
setuptools |38.5.1| 39.0.1| :+1:
Sphinx |1.7.0| 1.7.2| :+1:
SQLAlchemy |1.2.4| 1.2.6| :+1:
twilio |6.10.3| 6.11.0| :+1:
cffi |1.11.4| 1.11.5| :+1:
cryptography |2.1.4| 2.2.2| :+1:
lxml |4.1.1| 4.2.1| :+1:
stripe |1.77.2| 1.79.1| :+1:

### Not Upgraded packages due to issues
|Package|Old|New|Status|
|---------|----|----|---|
pyldap |2.4.37| 3.0.0| See #8912
tornado |4.5.3| 5.0.1| See #8913
transifex-client|0.12.5| 0.13.1| See #8914
python-dateutil |2.6.1| 2.7.2| Lower version used by a botocore and tc-aws
regex |2017.11.9| 2018.2.21| Present only in dev.txt and prod.txt
Django |1.11.6| 2.0.3| Umair has a PR open
talon |1.2.11| 1.4.4| Known issue- Will break the build
CommonMark |0.5.4| 0.7.5|Known issue- Will break the build

### Packages not upgraded as they are dependencies of other packages
|Package|Old|New|Parent|
|---------|----|----|---|
hyperlink |17.3.1| 18.0.0| via twisted
Werkzeug |0.12.2| 0.14.1| via moto
queuelib |1.4.2| 1.5.0| via scrapy
pbr |3.1.1| 4.0.0| via mock
packaging |16.8| 17.1| via sphinx
docker-pycreds |0.2.1| 0.2.2| via docker
arrow |0.10.0| 0.12.1| via gitlint
attrs |17.3.0| 17.4.0| via automat
aws-xray-sdk |0.94| 0.97| via moto
boto3 |1.4.7| 1.6.21| via moto 
botocore |1.7.46| 1.9.21| via boto3
click |6.6| 6.7| via gitlint
cssselect |1.0.1| 1.0.3| via parsel
decorator |4.1.2| 4.2.1| via ipython
django-otp |0.4.1.1| 0.4.3| via django-two-factor-auth
django-phonenumber-field |1.3.0| 2.0.0| via django-two-factor-auth
docker |2.6.1| 3.2.1| via moto
h2 |2.6.2| 3.0.1| via hyper
hyperframe |3.2.0| 5.1.0| via h2
jedi |0.11.0| 0.11.1| via ipython
jsonpickle |0.9.5| 0.9.6| via aws-xray
parsel |1.2.0| 1.4.0| via scrapy
parso |0.1.0| 0.1.1| via jedi
pexpect |4.3.0| 4.4.0| via ipython
phonenumberslite |8.8.6| 8.9.2| via django-phonenumber-field
pyaml |17.10.0| 17.12.1| via moto
PySocks |1.6.7| 1.6.8| via Twilio
qrcode |4.0.4| 6.0| via django-two-factor-auth
s3transfer |0.1.11| 0.1.13| via boto3
sh |1.11| 1.12.14| via gitlint
social-auth-core |1.5.0| 1.7.0| via social-auth-app-django
statsd |3.2.1| 3.2.2| via thumbor
w3lib |1.18.0| 1.19.0| via parsel
websocket-client |0.44.0| 0.47.0| via docker
asn1crypto |0.23.0| 0.24.0| via cryptography
decorator |4.1.2| 4.2.1| via ipython, traitlets
hyperlink |17.3.1| 18.0.0| via twisted
packaging |16.8| 17.1| via sphinx
pyOpenSSL |17.3.0| 17.5.0| via ndg-httpsclient, scrapy, service-identity