### PR TITLE
#8838 Service bot code leads to database queries in loop for organization administrators

### DIFF
--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -192,7 +192,7 @@ class HomeTest(ZulipTestCase):
                 result = self._get_home_page(stream='Denmark')
 
         self.assert_length(queries, 43)
-        self.assert_length(cache_mock.call_args_list, 8)
+        self.assert_length(cache_mock.call_args_list, 7)
 
         html = result.content.decode('utf-8')
 
@@ -234,8 +234,8 @@ class HomeTest(ZulipTestCase):
             with patch('zerver.lib.cache.cache_set') as cache_mock:
                 result = self._get_home_page()
                 self.assertEqual(result.status_code, 200)
-                self.assert_length(cache_mock.call_args_list, 17)
-            self.assert_length(queries, 59)
+                self.assert_length(cache_mock.call_args_list, 6)
+            self.assert_length(queries, 39)
 
     @slow("Creates and subscribes 10 users in a loop.  Should use bulk queries.")
     def test_num_queries_with_streams(self) -> None:


### PR DESCRIPTION
Fixes #8838 

Implement `get_service_dicts_for_bots()` for reading bots dicts by constant number of queries from database and use it in `get_owned_bot_dicts()`:
- add `models.get_user_profiles_by_ids()` for reading bots profiles by single query from database
- add `models.get_services_for_bots()` for reading services for bots by single query from database
- add `bot_config.get_bot_configs()` for reading config data for bots by single query from database