### PR TITLE
webhooks/bitbucket2: Detect pushes that remove branches correctly.

### DIFF
--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -145,7 +145,8 @@ def get_push_bodies(payload: Dict[str, Any]) -> List[Text]:
         potential_tag = (change['new'] or change['old'] or {}).get('type')
         if potential_tag == 'tag':
             messages_list.append(get_push_tag_body(payload, change))
-        elif change.get('closed'):
+        # if change['new'] is None, that means a branch was deleted
+        elif change.get('new') is None:
             messages_list.append(get_remove_branch_push_body(payload, change))
         elif change.get('forced'):
             messages_list.append(get_force_push_body(payload, change))


### PR DESCRIPTION
This was a user-reported bug and a very subtle and painful one
to track down.

Previously, if payload['push']['changes'][i]['closed'] was True,
we assumed that a branch was removed. Looking at whether `closed`
was set to True or not was our way to tell whether a push removed
a branch or not.

However, this is wrong! `closed` being set to True can also mean
that the pull request associated with the branch was approved but
the branch itself was not deleted. According to the BitBucket docs,
the correct way to see if a branch is deleted is to check if `new`
is null.

This bug was leading to KeyErrors about not being able to find
the `commits` key, which shouldn't happen anymore!

@timabbott: FYI! :)