### PR TITLE
requirements: Upgrade pyldap to latest version.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -174,7 +174,7 @@ pyoembed==0.1.2
 py3dns==3.1.0
 
 # Needed for LDAP integration
-pyldap==2.4.37
+python-ldap==3.0.0
 
 # Install Python Social Auth
 social-auth-app-django==2.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -120,7 +120,7 @@ pydispatcher==2.0.5       # via scrapy
 pyflakes==1.6.0
 pygments==2.2.0
 pyjwt==1.6.1
-pyldap==2.4.37
+pyldap==3.0.0.post1       # via django-auth-ldap, fakeldap
 pylibmc==1.5.2
 pyoembed==0.1.2
 pyopenssl==17.3.0         # via ndg-httpsclient, scrapy, service-identity
@@ -129,6 +129,7 @@ pysocks==1.6.7            # via twilio
 python-dateutil==2.6.1
 python-digitalocean==1.13.2
 python-gcm==0.4
+python-ldap==3.0.0
 python-twitter==3.4.1
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -85,13 +85,14 @@ pycparser==2.18           # via cffi
 pycrypto==2.6.1
 pygments==2.2.0
 pyjwt==1.6.1
-pyldap==2.4.37
+pyldap==3.0.0.post1       # via django-auth-ldap
 pylibmc==1.5.2
 pyoembed==0.1.2
 pyopenssl==17.3.0         # via ndg-httpsclient
 pysocks==1.6.7            # via twilio
 python-dateutil==2.6.1
 python-gcm==0.4
+python-ldap==3.0.0
 python-twitter==3.4.1
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.3

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '17.8'
+PROVISION_VERSION = '17.9'


### PR DESCRIPTION
The pyldap fork was merged back into
python-ldap, and released as python-ldap 3.0.0. 
useful links -  1) readme of https://github.com/pyldap/pyldap/
                       2) https://github.com/pyldap/pyldap/issues/148
Fixes #8912.

