### PR TITLE
dev_login: Include realm uri in /dev_get_emails endpoint.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1345,14 +1345,14 @@ class DevFetchAPIKeyTest(ZulipTestCase):
 
 class DevGetEmailsTest(ZulipTestCase):
     def test_success(self) -> None:
-        result = self.client_get("/api/v1/dev_get_emails")
+        result = self.client_get("/api/v1/dev_list_users")
         self.assert_json_success(result)
         self.assert_in_response("direct_admins", result)
         self.assert_in_response("direct_users", result)
 
     def test_dev_auth_disabled(self) -> None:
         with mock.patch('zerver.views.auth.dev_auth_enabled', return_value=False):
-            result = self.client_get("/api/v1/dev_get_emails")
+            result = self.client_get("/api/v1/dev_list_users")
             self.assert_json_error_contains(result, "Dev environment not enabled.", 400)
 
 class FetchAuthBackends(ZulipTestCase):

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -655,7 +655,7 @@ def api_dev_fetch_api_key(request: HttpRequest, username: str=REQ()) -> HttpResp
     return json_success({"api_key": user_profile.api_key, "email": user_profile.email})
 
 @csrf_exempt
-def api_dev_get_emails(request: HttpRequest) -> HttpResponse:
+def api_dev_get_accounts(request: HttpRequest) -> HttpResponse:
     if not dev_auth_enabled() or settings.PRODUCTION:
         return json_error(_("Dev environment not enabled."))
     users = get_dev_users()

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -659,8 +659,10 @@ def api_dev_get_emails(request: HttpRequest) -> HttpResponse:
     if not dev_auth_enabled() or settings.PRODUCTION:
         return json_error(_("Dev environment not enabled."))
     users = get_dev_users()
-    return json_success(dict(direct_admins=[u.email for u in users if u.is_realm_admin],
-                             direct_users=[u.email for u in users if not u.is_realm_admin]))
+    return json_success(dict(direct_admins=[dict(email=u.email, realm_uri=u.realm.uri)
+                                            for u in users if u.is_realm_admin],
+                             direct_users=[dict(email=u.email, realm_uri=u.realm.uri)
+                                           for u in users if not u.is_realm_admin]))
 
 @csrf_exempt
 @require_post

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -560,7 +560,7 @@ urls += [
     url(r'^api/v1/dev_fetch_api_key$', zerver.views.auth.api_dev_fetch_api_key,
         name='zerver.views.auth.api_dev_fetch_api_key'),
     # This is for fetching the emails of the admins and the users.
-    url(r'^api/v1/dev_get_emails$', zerver.views.auth.api_dev_get_accounts,
+    url(r'^api/v1/dev_list_users$', zerver.views.auth.api_dev_get_accounts,
         name='zerver.views.auth.api_dev_get_accounts'),
 
     # Used to present the GOOGLE_CLIENT_ID to mobile apps

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -560,8 +560,8 @@ urls += [
     url(r'^api/v1/dev_fetch_api_key$', zerver.views.auth.api_dev_fetch_api_key,
         name='zerver.views.auth.api_dev_fetch_api_key'),
     # This is for fetching the emails of the admins and the users.
-    url(r'^api/v1/dev_get_emails$', zerver.views.auth.api_dev_get_emails,
-        name='zerver.views.auth.api_dev_get_emails'),
+    url(r'^api/v1/dev_get_emails$', zerver.views.auth.api_dev_get_accounts,
+        name='zerver.views.auth.api_dev_get_accounts'),
 
     # Used to present the GOOGLE_CLIENT_ID to mobile apps
     url(r'^api/v1/fetch_google_client_id$',


### PR DESCRIPTION
This is mobile specific endpoint. On mobile without this
realm uri it's impossible to send a login request to
corresponding realm on localhost and proceed further.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Send a request to `/api/v1/dev_get_emails`, on this PR: realm uri is also included with each user, to which it is registered.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->