### PR TITLE
org settings: Hide "disable" option when setting already disabled.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -422,6 +422,8 @@ function test_extract_property_name() {
         upload_realm_icon = f;
     };
 
+    var stub_render_notifications_stream_ui = settings_org.render_notifications_stream_ui;
+    settings_org.render_notifications_stream_ui = noop;
     var parent_elem = $.create('waiting-period-parent-stub');
     $('#id_realm_waiting_period_threshold').set_parent(parent_elem);
     // TEST set_up() here, but this mostly just allows us to
@@ -439,10 +441,16 @@ function test_extract_property_name() {
     test_disable_signup_notifications_stream(callbacks.disable_signup_notifications_stream);
     test_change_allow_subdomains(change_allow_subdomains);
     test_extract_property_name();
+
+    settings_org.render_notifications_stream_ui = stub_render_notifications_stream_ui;
 }());
 
 (function test_misc() {
     page_params.is_admin = false;
+
+    var stub_notification_disable_parent = $.create('<stub notification_disable parent');
+    stub_notification_disable_parent.set_find_results('.notification-disable',
+        $.create('<disable link>'));
 
     page_params.realm_name_changes_disabled = false;
     settings_account.update_name_change_display();
@@ -469,6 +477,9 @@ function test_extract_property_name() {
     assert.equal($("#change_email .button").attr('disabled'), false);
 
     var elem = $('#realm_notifications_stream_name');
+    elem.closest = function () {
+        return stub_notification_disable_parent;
+    };
     stream_data.get_sub_by_id = function (stream_id) {
         assert.equal(stream_id, 42);
         return { name: 'some_stream' };
@@ -483,6 +494,9 @@ function test_extract_property_name() {
     assert(elem.hasClass('text-warning'));
 
     elem = $('#realm_signup_notifications_stream_name');
+    elem.closest = function () {
+        return stub_notification_disable_parent;
+    };
     stream_data.get_sub_by_id = function (stream_id) {
         assert.equal(stream_id, 75);
         return { name: 'some_stream' };

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -204,12 +204,14 @@ exports.render_notifications_stream_ui = function (stream_id, elem) {
     if (!name) {
         elem.text(i18n.t("Disabled"));
         elem.addClass("text-warning");
+        elem.closest('.input-group').find('.notification-disable').hide();
         return;
     }
 
     // Happy path
     elem.text('#' + name);
     elem.removeClass('text-warning');
+    elem.closest('.input-group').find('.notification-disable').show();
 };
 
 exports.populate_notifications_stream_dropdown = function (stream_list) {

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -146,7 +146,7 @@
                     </span>
                 </label>
                 {{#if is_admin }}
-                <a class="notifications-stream-disable">{{t "[Disable]" }}</a>
+                <a class="notifications-stream-disable notification-disable">{{t "[Disable]" }}</a>
                 {{/if}}
             </div>
 
@@ -169,7 +169,7 @@
                     </span>
                 </label>
                 {{#if is_admin }}
-                <a class="signup-notifications-stream-disable">{{t "[Disable]" }}</a>
+                <a class="signup-notifications-stream-disable notification-disable">{{t "[Disable]" }}</a>
                 {{/if}}
             </div>
         </div>


### PR DESCRIPTION
Fixes: #8942.

In these type of change, I try to make code concise and use available jQuery APIs rather than using simple `if...else` conditions(more LOC), like to find which disable link I've to hide. So, with which approach I should go, `if...else` or using jQuery APIs like `closest` and `find` to find the element in the DOM tree. One drawback of using such of jQuery APIs can be if we change classes or do a restructure of HTML/template, there is a great possibility of regressions. 