### PR TITLE
enhancement: Add a progress bar to uploads with a percentage.

### DIFF
--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -33,11 +33,12 @@ var upload_opts = upload.options({ mode: "compose" });
     };
     $("#compose-error-msg").html('');
     var test_html = '<div class="progress progress-striped active">' +
-                    '<div class="bar" id="compose-upload-bar" style="width: 00%;">' +
-                    '</div></div>';
-    $("<p>").after = function (html) {
+                    '<div class="bar" id="compose-upload-bar" style="width: 00%;"></div>' +
+                    '<p class="progress-bar-percent" id="compose-upload-bar-percent">' +
+                    '0%</p>' +
+                    '</div>';
+    $("#compose-send-status").append = function (html) {
         assert.equal(html, test_html);
-        return 'fake-html';
     };
 
     upload_opts.drop();
@@ -46,13 +47,12 @@ var upload_opts = upload.options({ mode: "compose" });
     assert($("#compose-send-status").hasClass("alert-info"));
     assert($("#compose-send-status").visible());
     assert.equal($("<p>").text(), 'translated: Uploading…');
-    assert.equal($("#compose-error-msg").html(), 'fake-html');
 }());
 
 (function test_progress_updated() {
     var width_update_checked = false;
-    $("#compose-upload-bar").width = function (width_percent) {
-        assert.equal(width_percent, '39%');
+    $("#compose-upload-bar").animate = function (css) {
+        assert.equal(css.width, '39%');
         width_update_checked = true;
     };
     upload_opts.progressUpdated(1, '', 39);
@@ -65,6 +65,10 @@ var upload_opts = upload.options({ mode: "compose" });
         $("#compose-send-status").addClass("alert-info");
         $("#compose-send-button").attr("disabled", 'disabled');
         $("#compose-error-msg").text('');
+
+        $("#compose-upload-bar").parent = function () {
+            return { remove: function () {} };
+        };
     }
 
     function assert_side_effects(msg) {
@@ -121,6 +125,10 @@ var upload_opts = upload.options({ mode: "compose" });
             $("#compose-send-status").addClass("alert-info");
             $("#compose-send-status").show();
 
+            $("#compose-upload-bar").animate = function (css, delay, type, callback) {
+                callback();
+            };
+
             $('#file_input').clone = function (param) {
                 assert(param);
                 return $('#file_input');
@@ -146,6 +154,7 @@ var upload_opts = upload.options({ mode: "compose" });
 
         setup();
         upload_opts.uploadFinished(i, {}, response);
+        upload_opts.progressUpdated(1, '', 100);
         assert_side_effects();
     }
 

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -152,6 +152,10 @@ var upload_opts = upload.options({ mode: "compose" });
             }
         }
 
+        global.patch_builtin('setTimeout', function (func) {
+            func();
+        });
+
         setup();
         upload_opts.uploadFinished(i, {}, response);
         upload_opts.progressUpdated(1, '', 100);

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -81,6 +81,7 @@ exports.options = function (config) {
     };
 
     var progressUpdated = function (i, file, progress) {
+        $("#" + upload_bar).stop();
         $("#" + upload_bar).animate({
             width: progress + "%",
         }, 500, "linear", function () {

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -24,6 +24,7 @@ exports.options = function (config) {
     var send_status_close;
     var error_msg;
     var upload_bar;
+    var upload_bar_percent;
     var should_hide_upload_status;
     var file_input;
 
@@ -35,6 +36,7 @@ exports.options = function (config) {
         send_status_close = $('.compose-send-status-close');
         error_msg = $('#compose-error-msg');
         upload_bar = 'compose-upload-bar';
+        upload_bar_percent = 'compose-upload-bar-percent';
         file_input = 'file_input';
         break;
     case 'edit':
@@ -44,6 +46,7 @@ exports.options = function (config) {
         send_status_close = send_status.find('.send-status-close');
         error_msg = send_status.find('.error-msg');
         upload_bar = 'message-edit-upload-bar-' + config.row;
+        upload_bar_percent = 'message-edit-upload-bar-percent-' + config.row;
         file_input = 'message_edit_file_input_' + config.row;
         break;
     default:
@@ -71,6 +74,8 @@ exports.options = function (config) {
         error_msg.html($("<p>").text(i18n.t("Uploading…")));
         send_status.append('<div class="progress progress-striped active">' +
                            '<div class="bar" id="' + upload_bar + '" style="width: 00%;"></div>' +
+                           '<p class="progress-bar-percent" id="' + upload_bar_percent + '">' +
+                           '0%</p>' +
                            '</div>');
         should_hide_upload_status = false;
     };
@@ -83,6 +88,7 @@ exports.options = function (config) {
                 maybe_hide_upload_status();
             }
         });
+        $("#" + upload_bar_percent).text(progress + "%");
     };
 
     var uploadError = function (error_code, server_response, file) {

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -59,9 +59,11 @@ exports.options = function (config) {
         // `progressUpdated` or `uploadFinished` is called first, the status
         // is hidden only after the animation is finished.
         if (should_hide_upload_status) {
-            send_button.prop("disabled", false);
-            send_status.removeClass("alert-info").hide();
-            $("#" + upload_bar).parent().remove();
+            setTimeout(function () {
+                send_button.prop("disabled", false);
+                send_status.removeClass("alert-info").hide();
+                $("#" + upload_bar).parent().remove();
+            }, 200);
         } else {
             should_hide_upload_status = true;
         }

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -360,6 +360,17 @@ body.night-mode .alert-box .alert.alert-error::before {
     color: 1px solid hsl(0, 75%, 65%);
 }
 
+body.night-mode .progress {
+    /* Setting `background-image` to none overrides Bootstrap and allows for
+    `background-color` to be used instead. */
+    background-image: none;
+    background-color: hsl(212, 28%, 18%);
+}
+
+body.night-mode .progress-bar-percent {
+    color: #fff;
+}
+
 /* Popover: */
 
 body.night-mode .hotspot.overlay .hotspot-popover {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2050,6 +2050,35 @@ div.floating_recipient {
     display: inline-block;
 }
 
+.progress {
+    /* Setting `background-image` to none overrides Bootstrap and allows for
+    `background-color` to be used instead. */
+    background-image: none;
+    background-color: #fff;
+
+    text-align: center;
+    margin-bottom: 8px;
+}
+
+.progress .bar {
+    background-image: none;
+    background-color: hsl(170, 47%, 54%);
+
+    /* Override Bootstrap's progress bar transitions. */
+    -webkit-transition: none;
+    -moz-transition: none;
+    -ms-transition: none;
+    -o-transition: none;
+    transition: none;
+}
+
+.progress-bar-percent {
+    position: absolute;
+    left: 0px;
+    right: 0px;
+    color: #333;
+}
+
 .settings-section #default_language {
     text-decoration: none;
     vertical-align: bottom;


### PR DESCRIPTION
enhancement: Add a progress bar to uploads with a percentage.

There was already a progress bar set up, but it became non-functional after refactoring (see discussion here: https://github.com/zulip/zulip/issues/8863#issuecomment-377706603). This PR fixes it and adds a percent indicator to the middle of it. There are also some related fixes including styles for night mode and setting up jQuery animations.

Fixes #8863.

**Testing Plan:** <!-- How have you tested? -->

Some edits were made to frontend tests in order to fix the templates and change the functions used.

**GIFs or Screenshots:** 

*Light mode:*

![light mode](https://user-images.githubusercontent.com/17259768/38288760-7910efec-3787-11e8-8c62-3735f10d6e02.gif)

*Night mode:*

![night mode](https://user-images.githubusercontent.com/17259768/38288763-7ddb8528-3787-11e8-97a6-70c7b358da5d.gif)
