### PR TITLE
bots: Introduce System bots in UserProfile and port realm_internal_bots.

### DIFF
--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -17,7 +17,7 @@ def setup_realm_internal_bots(realm: Realm) -> None:
     """
     internal_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
                      for bot in settings.REALM_INTERNAL_BOTS]
-    create_users(realm, internal_bots, bot_type=UserProfile.DEFAULT_BOT)
+    create_users(realm, internal_bots, bot_type=UserProfile.SYSTEM_BOT)
     bots = UserProfile.objects.filter(
         realm=realm,
         email__in=[bot_info[1] for bot_info in internal_bots],

--- a/zerver/migrations/0155_realm_internal_bots_to_system_bots.py
+++ b/zerver/migrations/0155_realm_internal_bots_to_system_bots.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+def convert_bots_to_system_bots(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    REALM_INTERNAL_BOTS = [
+        'reminder-bot@zulip.com',
+    ]
+    UserProfile = apps.get_model('zerver', 'UserProfile')
+    internal_bots = UserProfile.objects.filter(
+        email__in=REALM_INTERNAL_BOTS,
+        bot_type=1
+    )
+    for bot in internal_bots:
+        bot.bot_type = 5
+        bot.save(update_fields=['bot_type'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0154_fix_invalid_bot_owner'),
+    ]
+
+    operations = [
+        migrations.RunPython(convert_bots_to_system_bots),
+    ]

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -442,7 +442,7 @@ def get_members_backend(request: HttpRequest, user_profile: UserProfile,
 
         return result
 
-    members = [get_member(row) for row in query]
+    members = [get_member(row) for row in query if row['bot_type'] != UserProfile.SYSTEM_BOT]
 
     return json_success({'members': members})
 


### PR DESCRIPTION
We introduce System bots as a new kind of bots in UserProfile.
Following this we make realm_internal_bots use this new bot type
while migrating any already created realm_internal_bot to new
bot_type.

This is the first step towards moving from a world of cross_realm_bot to realm_internal_bots.
In future we can make cross realm bots use this new type of bot type and migrate them to be realm based.