### PR TITLE
install-node: Upgrade node, yarn, and nvm.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,12 @@ jobs:
               dirs=(/srv/zulip-{npm,venv}-cache)
               sudo mkdir -p "${dirs[@]}"
               sudo chown -R circleci "${dirs[@]}"
+              
+              # circleci has some sort of permission
+              # issues when installing new yarn verions
+              # so we just create and chown it to circleci
+              mkdir -p ~/.config
+              sudo chown -R circleci ~/.config
       - restore_cache:
           keys:
           - v1-npm-base.trusty.1
@@ -99,6 +105,9 @@ jobs:
               dirs=(/srv/zulip-{npm,venv}-cache)
               sudo mkdir -p "${dirs[@]}"
               sudo chown -R circleci "${dirs[@]}"
+
+              mkdir -p ~/.config
+              sudo chown -R circleci ~/.config
       - restore_cache:
           keys:
           - v1-npm-base.xenial.1

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -197,7 +197,7 @@ zrequire('timerender');
 
 (function test_set_full_datetime() {
     var message = {
-        timestamp: 1495091573, // 5/18/2017 7:12:53 AM (UTC+0)
+        timestamp: 1495091573, // 2017-5-18 07:12:53 AM (UTC+0)
     };
     var time_element = $('<span/>');
     var attrs = new Dict();
@@ -207,7 +207,14 @@ zrequire('timerender');
         return time_element;
     };
 
-    var expected = '5/18/2017 7:12:53 AM (UTC+0)';
+    // since node >= 8 date.toLocaleDateString and
+    // date.toLocaleTimeString have been changed, instead of
+    // returning 5/18/2017 7:12:53 AM (UTC+0) they now return
+    // 2017-5-18 07:12:53 (UTC+0) - This change does not affect browsers
+    // since browsers have their own way of returning string that is
+    // or maybe inconsistenc with node's way.
+    var time = new Date(message.timestamp * 1000);
+    var expected = `${time.toLocaleDateString()} 07:12:53 (UTC+0)`;
     timerender.set_full_datetime(message, time_element);
     var actual = attrs.get('title');
     assert.equal(expected, actual);

--- a/scripts/lib/install-node
+++ b/scripts/lib/install-node
@@ -7,8 +7,8 @@ if [ "$TRAVIS" ] ; then
     ZULIP_SRV="/home/travis"
 fi
 YARN_BIN="$ZULIP_SRV/zulip-yarn/bin/yarn"
-node_version=6.6.0
-yarn_version=0.27.5
+node_version=8.11.1
+yarn_version=1.5.1
 
 current_node_version="none"
 if hash node 2>/dev/null; then
@@ -23,7 +23,7 @@ fi
 if [ "$current_node_version" != "v$node_version" ]; then
     export NVM_DIR=/usr/local/nvm
     if ! [ -e "$NVM_DIR/nvm.sh" ]; then
-        wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash
+        wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
     fi
 
     source "$NVM_DIR/nvm.sh"

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '17.12'
+PROVISION_VERSION = '17.13'


### PR DESCRIPTION
This upgrades:
node -> v8.9.4
yarn -> 1.5.1
nvm -> 0.33.8

Also updates a test in timerender.js which depends on time
provided by the node which is now changed in the newer release.

Some changes have been made in circleci script, we just create ~/.config
directory and `chown` it to `circleci` user so installing new version of yarn
does not cause any ci failure on circleci during provision.

**Testing Plan:** CI<!-- How have you tested? -->
