### PR TITLE
refactor: Rename mark_message(s)_as_read to notify_server_message(s)_read

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -71,7 +71,7 @@ set_global('narrow_state', {
 });
 
 set_global('unread_ops', {
-    mark_message_as_read: noop,
+    notify_server_message_read: noop,
 });
 
 set_global('common', {

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -935,7 +935,7 @@ with_overrides(function (override) {
     });
 });
 
-// mark_message_as_read requires message_store and these dependencies.
+// notify_server_message_read requires message_store and these dependencies.
 zrequire('unread_ops');
 zrequire('unread');
 zrequire('topic_data');

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -288,7 +288,7 @@ exports.respond_to_message = function (opts) {
         return;
     }
 
-    unread_ops.mark_message_as_read(message);
+    unread_ops.notify_server_message_read(message);
 
     var stream = '';
     var subject = '';

--- a/static/js/message_flags.js
+++ b/static/js/message_flags.js
@@ -88,7 +88,7 @@ exports.toggle_starred = function (message) {
 
     message.starred = !message.starred;
 
-    unread_ops.mark_message_as_read(message);
+    unread_ops.notify_server_message_read(message);
     ui.update_starred(message);
 
     if (message.starred) {

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -399,7 +399,7 @@ exports.by_subject = function (target_id, opts) {
         exports.by_recipient(target_id, opts);
         return;
     }
-    unread_ops.mark_message_as_read(original);
+    unread_ops.notify_server_message_read(original);
     var search_terms = [
         {operator: 'stream', operand: original.stream},
         {operator: 'topic', operand: original.subject},
@@ -413,7 +413,7 @@ exports.by_recipient = function (target_id, opts) {
     opts = _.defaults({}, opts, {then_select_id: target_id});
     // don't use current_msg_list as it won't work for muted messages or for out-of-narrow links
     var message = message_store.get(target_id);
-    unread_ops.mark_message_as_read(message);
+    unread_ops.notify_server_message_read(message);
     switch (message.type) {
     case 'private':
         exports.by('pm-with', message.reply_to, opts);

--- a/static/js/pointer.js
+++ b/static/js/pointer.js
@@ -112,7 +112,7 @@ exports.initialize = function initialize() {
             } else {
                 messages = event.msg_list.message_range(event.previously_selected, event.id);
             }
-            unread_ops.mark_messages_as_read(messages, {from: 'pointer'});
+            unread_ops.notify_server_messages_read(messages, {from: 'pointer'});
         }
     });
 };

--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -23,7 +23,7 @@ function process_newly_read_message(message, options) {
 
 exports.process_read_messages_event = function (message_ids) {
     /*
-        This code has a lot in common with mark_messages_as_read,
+        This code has a lot in common with notify_server_messages_read,
         but there are subtle differences due to the fact that the
         server can tell us about unread messages that we didn't
         actually read locally (and which we may not have even
@@ -58,7 +58,7 @@ exports.process_read_messages_event = function (message_ids) {
 
 // Takes a list of messages and marks them as read.
 // Skips any messages that are already marked as read.
-exports.mark_messages_as_read = function (messages, options) {
+exports.notify_server_messages_read = function (messages, options) {
     options = options || {};
 
     messages = unread.get_unread_messages(messages);
@@ -80,8 +80,8 @@ exports.mark_messages_as_read = function (messages, options) {
     unread_ui.update_unread_counts();
 };
 
-exports.mark_message_as_read = function (message, options) {
-    exports.mark_messages_as_read([message], options);
+exports.notify_server_message_read = function (message, options) {
+    exports.notify_server_messages_read([message], options);
 };
 
 // If we ever materially change the algorithm for this function, we
@@ -96,12 +96,12 @@ exports.process_visible = function () {
             exports.mark_current_list_as_read();
         }
     } else {
-        exports.mark_messages_as_read(message_viewport.visible_messages(true));
+        exports.notify_server_messages_read(message_viewport.visible_messages(true));
     }
 };
 
 exports.mark_current_list_as_read = function (options) {
-    exports.mark_messages_as_read(current_msg_list.all_messages(), options);
+    exports.notify_server_messages_read(current_msg_list.all_messages(), options);
 };
 
 exports.mark_stream_as_read = function (stream_id, cont) {


### PR DESCRIPTION
Fixes #8965.
Mark_message(s)_as_read is used in marking a message as having been
read by the browser, rename it to notify_server_message(s)_read to
avoid any confusion.