### PR TITLE
Extract find_first_unread_anchor().

### DIFF
--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -4,7 +4,7 @@
 from django.db import connection
 from django.test import override_settings
 from sqlalchemy.sql import (
-    and_, select, column, table,
+    and_, select, column, table, literal, join, literal_column,
 )
 from sqlalchemy.sql import compiler
 
@@ -38,6 +38,7 @@ from zerver.views.messages import (
     get_messages_backend, ok_to_include_history,
     NarrowBuilder, BadNarrowOperator, Query,
     post_process_limited_query,
+    find_first_unread_anchor,
     LARGER_THAN_MAX_MESSAGE_ID,
 )
 
@@ -1726,6 +1727,56 @@ class GetOldMessagesTest(ZulipTestCase):
                 self.assertEqual(sql, expected)
                 return
         raise AssertionError("get_messages query not found")
+
+    def test_find_first_unread_anchor(self) -> None:
+        hamlet = self.example_user('hamlet')
+        cordelia = self.example_user('cordelia')
+        othello = self.example_user('othello')
+
+        self.make_stream('England')
+
+        # Send a few messages that Hamlet won't have UserMessage rows for.
+        self.send_stream_message(cordelia.email, 'England')
+        self.send_personal_message(cordelia.email, othello.email)
+
+        self.subscribe(hamlet, 'England')
+
+        muted_topics = [
+            ['England', 'muted'],
+        ]
+        set_topic_mutes(hamlet, muted_topics)
+
+        # send a muted message
+        self.send_stream_message(cordelia.email, 'England', topic_name='muted')
+
+        # finally send Hamlet a "normal" message
+        first_message_id = self.send_stream_message(cordelia.email, 'England')
+
+        # send a few more messages
+        self.send_stream_message(cordelia.email, 'England')
+        self.send_personal_message(cordelia.email, hamlet.email)
+
+        sa_conn = get_sqlalchemy_connection()
+
+        user_profile = hamlet
+
+        # TODO: Make it so that find_first_unread_anchor() does not require
+        #       the incoming query to join to zerver_usermessage.
+        query = select([column("message_id"), column("flags")],
+                       column("user_profile_id") == literal(user_profile.id),
+                       join(table("zerver_usermessage"), table("zerver_message"),
+                            literal_column("zerver_usermessage.message_id") ==
+                            literal_column("zerver_message.id")))
+        inner_msg_id_col = column("message_id")
+
+        anchor = find_first_unread_anchor(
+            sa_conn=sa_conn,
+            inner_msg_id_col=inner_msg_id_col,
+            user_profile=user_profile,
+            narrow=[],
+            query=query,
+        )
+        self.assertEqual(anchor, first_message_id)
 
     def test_use_first_unread_anchor_with_some_unread_messages(self) -> None:
         user_profile = self.example_user('hamlet')

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -557,6 +557,43 @@ def exclude_muting_conditions(user_profile: UserProfile,
 
     return conditions
 
+def find_first_unread_anchor(sa_conn: Any,
+                             inner_msg_id_col: ColumnElement,
+                             user_profile: UserProfile,
+                             narrow: List[Dict[str, Any]],
+                             query: Query) -> int:
+    condition = column("flags").op("&")(UserMessage.flags.read.mask) == 0
+
+    # We exclude messages on muted topics when finding the first unread
+    # message in this narrow
+    muting_conditions = exclude_muting_conditions(user_profile, narrow)
+    if muting_conditions:
+        condition = and_(condition, *muting_conditions)
+
+    # The mobile app uses narrow=[] and use_first_unread_anchor=True to
+    # determine what messages to show when you first load the app.
+    # Unfortunately, this means that if you have a years-old unread
+    # message, the mobile app could get stuck in the past.
+    #
+    # To fix this, we enforce that the "first unread anchor" must be on or
+    # after the user's current pointer location. Since the pointer
+    # location refers to the latest the user has read in the home view,
+    # we'll only apply this logic in the home view (ie, when narrow is
+    # empty).
+    if not narrow:
+        pointer_condition = inner_msg_id_col >= user_profile.pointer
+        condition = and_(condition, pointer_condition)
+
+    first_unread_query = query.where(condition)
+    first_unread_query = first_unread_query.order_by(inner_msg_id_col.asc()).limit(1)
+    first_unread_result = list(sa_conn.execute(first_unread_query).fetchall())
+    if len(first_unread_result) > 0:
+        anchor = first_unread_result[0][0]
+    else:
+        anchor = LARGER_THAN_MAX_MESSAGE_ID
+
+    return anchor
+
 @has_request_variables
 def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
                          anchor: int=REQ(converter=int),
@@ -628,43 +665,6 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
             query = builder.add_term(query, search_term)
 
     sa_conn = get_sqlalchemy_connection()
-
-    def find_first_unread_anchor(sa_conn: Any,
-                                 inner_msg_id_col: ColumnElement,
-                                 user_profile: UserProfile,
-                                 narrow: List[Dict[str, Any]],
-                                 query: Query) -> int:
-        condition = column("flags").op("&")(UserMessage.flags.read.mask) == 0
-
-        # We exclude messages on muted topics when finding the first unread
-        # message in this narrow
-        muting_conditions = exclude_muting_conditions(user_profile, narrow)
-        if muting_conditions:
-            condition = and_(condition, *muting_conditions)
-
-        # The mobile app uses narrow=[] and use_first_unread_anchor=True to
-        # determine what messages to show when you first load the app.
-        # Unfortunately, this means that if you have a years-old unread
-        # message, the mobile app could get stuck in the past.
-        #
-        # To fix this, we enforce that the "first unread anchor" must be on or
-        # after the user's current pointer location. Since the pointer
-        # location refers to the latest the user has read in the home view,
-        # we'll only apply this logic in the home view (ie, when narrow is
-        # empty).
-        if not narrow:
-            pointer_condition = inner_msg_id_col >= user_profile.pointer
-            condition = and_(condition, pointer_condition)
-
-        first_unread_query = query.where(condition)
-        first_unread_query = first_unread_query.order_by(inner_msg_id_col.asc()).limit(1)
-        first_unread_result = list(sa_conn.execute(first_unread_query).fetchall())
-        if len(first_unread_result) > 0:
-            anchor = first_unread_result[0][0]
-        else:
-            anchor = LARGER_THAN_MAX_MESSAGE_ID
-
-        return anchor
 
     if use_first_unread_anchor:
         anchor = find_first_unread_anchor(


### PR DESCRIPTION
@timabbott should review this.

So far this is just a pure refactoring.  When we make it so that the main function uses only Message for the mobile case, we have a couple options for joining to UserMessage in find_first_unread_anchor:

* just build the first_unread query from scratch, which would require extracting some of the NarrowBuilder code and running it twice
* try to splice the UserMessage join into our copy of the main query somehow

