### PR TITLE
subscription: Add real time sync for user-just-deactivated case.

### DIFF
--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -26,11 +26,11 @@ var bob = {
     full_name: 'Bob',
 };
 
-people.add(me);
+people.add_in_realm(me);
 people.initialize_current_user(me.user_id);
 
-people.add(alice);
-people.add(bob);
+people.add_in_realm(alice);
+people.add_in_realm(bob);
 
 
 (function test_set_focused_recipient() {
@@ -65,6 +65,7 @@ people.add(bob);
     assert(compose_fade.would_receive_message('me@example.com'));
     assert(compose_fade.would_receive_message('alice@example.com'));
     assert(!compose_fade.would_receive_message('bob@example.com'));
+    assert.equal(compose_fade.would_receive_message('nonrealmuser@example.com'), undefined);
 
     var good_msg = {
         type: 'stream',

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -750,6 +750,7 @@ with_overrides(function (override) {
     event = event_fixtures.realm_user__remove;
     global.with_stub(function (stub) {
         override('people.deactivate', stub.f);
+        override('stream_data.remove_deactivated_user_from_all_streams', noop);
         dispatch(event);
         var args = stub.get_args('person');
         assert_same(args.person, event.person);

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -209,6 +209,12 @@ zrequire('marked', 'third/marked/lib/marked');
     stream_data.update_subscribers_count(sub);
     assert.equal(sub.subscriber_count, 0);
 
+    // verify that deactivating user should unsubscribe user from all streams
+    assert(stream_data.add_subscriber('Rome', george.user_id));
+    set_global('subs', { rerender_subscriptions_settings: function () {} });
+    stream_data.remove_deactivated_user_from_all_streams(george.user_id);
+    assert(!stream_data.is_user_subscribed('Rome', george.user_id));
+
     // verify that checking subscription with undefined user id
     global.blueslip.warn = function (msg) {
         assert.equal(msg, "Undefined user_id passed to function is_user_subscribed");

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -118,8 +118,8 @@ exports.would_receive_message = function (email) {
     if (focused_recipient.type === 'stream') {
         var user = people.get_active_user_for_email(email);
         var sub = stream_data.get_sub(focused_recipient.stream);
-        if (!sub) {
-            // If the stream isn't valid, there is no risk of a mix
+        if (!sub || !user) {
+            // If the stream or user isn't valid, there is no risk of a mix
             // yet, so don't fade.
             return;
         }
@@ -129,7 +129,7 @@ exports.would_receive_message = function (email) {
             // not subscribed.
             return;
         }
-        return stream_data.user_is_subscribed(focused_recipient.stream, email);
+        return stream_data.is_user_subscribed(focused_recipient.stream, user.user_id);
     }
 
     // PM, so check if the given email is in the recipients list.

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -197,6 +197,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             people.add_in_realm(event.person);
         } else if (event.op === 'remove') {
             people.deactivate(event.person);
+            stream_data.remove_deactivated_user_from_all_streams(event.person.user_id);
         } else if (event.op === 'update') {
             user_events.update_person(event.person);
         }

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -246,9 +246,6 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         break;
 
     case 'subscription':
-        var person;
-        var email;
-
         if (event.op === 'add') {
             _.each(event.subscriptions, function (rec) {
                 var sub = stream_data.get_sub_by_id(rec.stream_id);
@@ -260,29 +257,17 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 }
             });
         } else if (event.op === 'peer_add') {
-            // TODO: remove email shim here and fix called functions
-            //       to use user_ids
-            person = people.get_person_from_user_id(event.user_id);
-            email = person.email;
             _.each(event.subscriptions, function (sub) {
                 if (stream_data.add_subscriber(sub, event.user_id)) {
-                    $(document).trigger(
-                        'peer_subscribe.zulip',
-                        {stream_name: sub, user_email: email});
+                    $(document).trigger('peer_subscribe.zulip', {stream_name: sub});
                 } else {
                     blueslip.warn('Cannot process peer_add event');
                 }
             });
         } else if (event.op === 'peer_remove') {
-            // TODO: remove email shim here and fix called functions
-            //       to use user_ids
-            person = people.get_person_from_user_id(event.user_id);
-            email = person.email;
             _.each(event.subscriptions, function (sub) {
                 if (stream_data.remove_subscriber(sub, event.user_id)) {
-                    $(document).trigger(
-                        'peer_unsubscribe.zulip',
-                        {stream_name: sub, user_email: email});
+                    $(document).trigger('peer_unsubscribe.zulip', {stream_name: sub});
                 } else {
                     blueslip.warn('Cannot process peer_remove event.');
                 }

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -365,18 +365,17 @@ exports.remove_subscriber = function (stream_name, user_id) {
     return true;
 };
 
-exports.user_is_subscribed = function (stream_name, user_email) {
+exports.is_user_subscribed = function (stream_name, user_id) {
     var sub = exports.get_sub(stream_name);
     if (typeof sub === 'undefined' || !sub.can_access_subscribers) {
         // If we don't know about the stream, or we ourselves cannot access subscriber list,
         // so we return undefined (treated as falsy if not explicitly handled).
-        blueslip.warn("We got a user_is_subscribed call for a non-existent or inaccessible stream.");
+        blueslip.warn("We got a is_user_subscribed call for a non-existent or inaccessible stream.");
         return;
     }
-    var user_id = people.get_user_id(user_email);
-    if (!user_id) {
-        blueslip.warn("Bad email passed to user_is_subscribed: " + user_email);
-        return false;
+    if (typeof user_id === "undefined") {
+        blueslip.warn("Undefined user_id passed to function is_user_subscribed");
+        return;
     }
 
     return sub.subscribers.has(user_id);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -349,6 +349,16 @@ exports.add_subscriber = function (stream_name, user_id) {
     return true;
 };
 
+exports.remove_deactivated_user_from_all_streams = function (user_id) {
+    (stream_info.values()).forEach(function (stream) {
+        if (exports.is_user_subscribed(stream.name, user_id)) {
+            exports.remove_subscriber(stream.name, user_id);
+            var sub = exports.get_sub(stream.name);
+            subs.rerender_subscriptions_settings(sub);
+        }
+    });
+};
+
 exports.remove_subscriber = function (stream_name, user_id) {
     var sub = exports.get_sub(stream_name);
     if (typeof sub === 'undefined') {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -213,7 +213,7 @@ function show_subscription_settings(sub_row) {
             // Case-insensitive.
             var item_matches = (item.email.toLowerCase().indexOf(query) !== -1) ||
                                (item.full_name.toLowerCase().indexOf(query) !== -1);
-            var is_subscribed = stream_data.user_is_subscribed(sub.name, item.email);
+            var is_subscribed = stream_data.is_user_subscribed(sub.name, item.user_id);
             return item_matches && !is_subscribed;
         },
         sorter: function (matches) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -632,12 +632,12 @@ $(function () {
 
     $(document).on('peer_subscribe.zulip', function (e, data) {
         var sub = stream_data.get_sub(data.stream_name);
-        exports.rerender_subscribers_list(sub);
+        subs.rerender_subscriptions_settings(sub);
     });
 
     $(document).on('peer_unsubscribe.zulip', function (e, data) {
         var sub = stream_data.get_sub(data.stream_name);
-        exports.rerender_subscribers_list(sub);
+        subs.rerender_subscriptions_settings(sub);
     });
 
 });

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -58,6 +58,9 @@ exports.hide_sub_settings = function (sub) {
 };
 
 exports.show_sub_settings = function (sub) {
+    if (!exports.is_sub_settings_active(sub)) {
+        return;
+    }
     var $settings = $(".subscription_settings[data-stream-id='" + sub.stream_id + "']");
     if ($settings.find(".email-address").val().length === 0) {
         // Rerender stream email address, if not.

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -74,10 +74,8 @@ exports.add_me_to_member_list = function (sub) {
     // Add the user to the member list if they're currently
     // viewing the members of this stream
     var stream_settings = settings_for_sub(sub);
-    if (sub.render_subscribers && stream_settings.hasClass('in')) {
-        exports.prepend_subscriber(
-            stream_settings,
-            people.my_current_email());
+    if (sub.render_subscribers && overlays.streams_open()) {
+        exports.prepend_subscriber(stream_settings, people.my_current_email());
     }
 };
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -14,6 +14,14 @@ function settings_for_sub(sub) {
     return $("#subscription_overlay .subscription_settings[data-stream-id='" + id + "']");
 }
 
+exports.is_sub_settings_active = function (sub) {
+    var active_stream = subs.active_stream();
+    if (active_stream !== undefined && active_stream.id === sub.stream_id) {
+        return true;
+    }
+    return false;
+};
+
 function get_email_of_subscribers(subscribers) {
     var emails = [];
     subscribers.each(function (o, i) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -231,8 +231,7 @@ exports.update_settings_for_subscribed = function (sub) {
         exports.add_sub_to_table(sub);
     }
 
-    var active_stream = exports.active_stream();
-    if (active_stream !== undefined && active_stream.id === sub.stream_id) {
+    if (stream_edit.is_sub_settings_active(sub)) {
         stream_edit.rerender_subscribers_list(sub);
     }
 
@@ -251,9 +250,8 @@ exports.update_settings_for_unsubscribed = function (sub) {
 
     stream_edit.hide_sub_settings(sub);
 
-    var active_stream = exports.active_stream();
     stream_data.update_stream_email_address(sub, "");
-    if (active_stream !== undefined && active_stream.id === sub.stream_id) {
+    if (stream_edit.is_sub_settings_active(sub)) {
         stream_edit.rerender_subscribers_list(sub);
 
         // If user unsubscribed from private stream then user cannot subscribe to

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -814,17 +814,6 @@ $(function () {
         sub_arrow.removeClass('icon-vector-chevron-up');
         sub_arrow.addClass('icon-vector-chevron-down');
     });
-
-    $(document).on('peer_subscribe.zulip', function (e, data) {
-        var sub = stream_data.get_sub(data.stream_name);
-        exports.rerender_subscribers_count(sub);
-    });
-
-    $(document).on('peer_unsubscribe.zulip', function (e, data) {
-        var sub = stream_data.get_sub(data.stream_name);
-        exports.rerender_subscribers_count(sub);
-    });
-
 });
 
 function focus_on_narrowed_stream() {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -16,7 +16,7 @@ exports.show_subs_pane = {
     },
 };
 
-function button_for_sub(sub) {
+function check_button_for_sub(sub) {
     var id = parseInt(sub.stream_id, 10);
     return $(".stream-row[data-stream-id='" + id + "'] .check");
 }
@@ -229,7 +229,7 @@ exports.add_sub_to_table = function (sub) {
 };
 
 exports.is_sub_already_present = function (sub) {
-    var button = button_for_sub(sub);
+    var button = check_button_for_sub(sub);
     if (button.length !== 0) {
         return true;
     }
@@ -244,7 +244,7 @@ exports.remove_stream = function (stream_id) {
 };
 
 exports.update_settings_for_subscribed = function (sub) {
-    var button = button_for_sub(sub);
+    var button = check_button_for_sub(sub);
     var settings_button = settings_button_for_sub(sub).removeClass("unsubscribed").show();
     $('.add_subscribers_container').show();
 
@@ -268,7 +268,7 @@ exports.update_settings_for_subscribed = function (sub) {
 };
 
 exports.update_settings_for_unsubscribed = function (sub) {
-    var button = button_for_sub(sub);
+    var button = check_button_for_sub(sub);
     var settings_button = settings_button_for_sub(sub).addClass("unsubscribed").show();
 
     button.toggleClass("checked");

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -166,6 +166,22 @@ exports.rerender_subscribers_count = function (sub, just_subscribed) {
     }
 };
 
+exports.rerender_subscriptions_settings = function (sub) {
+    if (typeof sub === "undefined") {
+        blueslip.error('Undefined sub passed to function rerender_subscriptions_settings');
+        return;
+    }
+
+    if (overlays.streams_open()) {
+        // Render subscriptions templates only if subscription tab is open
+        exports.rerender_subscribers_count(sub);
+        if (stream_edit.is_sub_settings_active(sub)) {
+            // Render subscriptions only if stream settings is open
+            stream_edit.rerender_subscribers_list(sub);
+        }
+    }
+};
+
 function add_email_hint_handler() {
     // Add a popover explaining stream e-mail addresses on hover.
 
@@ -245,15 +261,11 @@ exports.update_settings_for_unsubscribed = function (sub) {
 
     button.toggleClass("checked");
     settings_button.text(i18n.t("Subscribe"));
-
-    exports.rerender_subscribers_count(sub);
-
     stream_edit.hide_sub_settings(sub);
+    exports.rerender_subscriptions_settings(sub);
 
     stream_data.update_stream_email_address(sub, "");
     if (stream_edit.is_sub_settings_active(sub)) {
-        stream_edit.rerender_subscribers_list(sub);
-
         // If user unsubscribed from private stream then user cannot subscribe to
         // stream without invitation and cannot add subscribers to stream.
         if (!sub.should_display_subscription_button) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -203,6 +203,10 @@ function add_email_hint_handler() {
 }
 
 exports.add_sub_to_table = function (sub) {
+    if (exports.is_sub_already_present(sub)) {
+        return;
+    }
+
     var html = templates.render('subscription', sub);
     var settings_html = templates.render('subscription_settings', sub);
     if (stream_create.get_name() === sub.name) {
@@ -222,6 +226,14 @@ exports.add_sub_to_table = function (sub) {
         row_for_stream_id(sub.stream_id).click();
         stream_create.reset_created_stream();
     }
+};
+
+exports.is_sub_already_present = function (sub) {
+    var button = button_for_sub(sub);
+    if (button.length !== 0) {
+        return true;
+    }
+    return false;
 };
 
 exports.remove_stream = function (stream_id) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -259,7 +259,7 @@ exports.update_settings_for_subscribed = function (sub) {
         exports.add_sub_to_table(sub);
     }
 
-    if (stream_edit.is_sub_settings_active(sub)) {
+    if (stream_edit.is_sub_settings_active(sub) && sub.invite_only) {
         stream_edit.rerender_subscribers_list(sub);
     }
 

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -186,8 +186,8 @@ function compare_for_at_mentioning(person_a, person_b, tertiary_compare, current
 
     // give preference to subscribed users first
     if (current_stream !== undefined) {
-        var a_is_sub = stream_data.user_is_subscribed(current_stream, person_a.email);
-        var b_is_sub = stream_data.user_is_subscribed(current_stream, person_b.email);
+        var a_is_sub = stream_data.is_user_subscribed(current_stream, person_a.user_id);
+        var b_is_sub = stream_data.is_user_subscribed(current_stream, person_b.user_id);
 
         if (a_is_sub && !b_is_sub) {
             return -1;


### PR DESCRIPTION
Currently, stream subscriptions aren't getting updated without
hard reload when user is deactivated in realm.

Fix this issue by updating stream subscription widgets on user
deactivation event.

Fixes #5623

**Testing Plan:** <!-- How have you tested? -->
Manual testing:
* Open any stream subscription(say X) in incognito window
* Login as realm admin in another window
* Deactivate any user subscribed to stream X
* Check if user is removed from stream subscribers in another window or not
* You can also check in admin window, by opening stream subscribers tab