### PR TITLE
vagrant: Fix link to testing docs in motd

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -167,7 +167,7 @@ Welcome to the Zulip development environment!  Popular commands:
 * tools/lint - Run the linter (quick and catches many problmes)
 * tools/test-* - Run tests (use --help to learn about options)
 
-Read https://zulip.readthedocs.io/en/latest/testing.html to learn
+Read https://zulip.readthedocs.io/en/latest/testing/testing.html to learn
 how to run individual test suites so that you can get a fast debug cycle.
 
 EndOfMessage'


### PR DESCRIPTION
Fixes #8982

Change https://zulip.readthedocs.io/en/latest/testing.html to https://zulip.readthedocs.io/en/latest/testing/testing.html

Previous link does not exist.

TODO:
- [x] Fix Vagrantfile
- [ ] Add a test case to the documentation tests to test this link?

**Tested:**
```
(zulip-py3-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$ exit
Ben$ vagrant halt
Ben$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Checking if box 'ubuntu/trusty64' is up to date...
==> default: A newer version of the box 'ubuntu/trusty64' is available! You currently
==> default: have version '20180328.0.0'. The latest is version '20180330.0.0'. Run
==> default: `vagrant box update` to update.
==> default: Clearing any previously set forwarded ports...
==> default: Fixed port collision for 22 => 2222. Now on port 2200.
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 9991 (guest) => 9991 (host) (adapter 1)
    default: 22 (guest) => 2200 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2200
    default: SSH username: vagrant
    default: SSH auth method: private key
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: The guest additions on this VM do not match the installed version of
    default: VirtualBox! In most cases this is fine, but in rare cases it can
    default: prevent things such as shared folders from working properly. If you see
    default: shared folder errors, please make sure the guest additions within the
    default: virtual machine match the version of VirtualBox you have installed on
    default: your host and reload your VM.
    default: 
    default: Guest Additions Version: 4.3.36
    default: VirtualBox Version: 5.1
==> default: Configuring and enabling network interfaces...
==> default: Exporting NFS shared folders...
==> default: Preparing to edit /etc/exports. Administrator privileges will be required...
Password:
==> default: Mounting NFS shared folders...
==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> default: flag to force provisioning. Provisioners marked to run always will still run.

Ben$ vagrant ssh
Welcome to the Zulip development environment!  Popular commands:
* tools/provision - Update the development environment
* tools/run-dev.py - Run the development server
* tools/lint - Run the linter (quick and catches many problmes)
* tools/test-* - Run tests (use --help to learn about options)

Read https://zulip.readthedocs.io/en/latest/testing/testing.html to learn
how to run individual test suites so that you can get a fast debug cycle.

Last login: Thu Apr  5 21:29:27 2018 from 10.0.2.2

(zulip-py3-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$ ./tools/run-dev.py 
rm: cannot remove ‘./scripts/__pycache__/__init__.cpython-34.pyc’: Permission denied
rm: cannot remove ‘./tools/setup/__pycache__/__init__.cpython-34.pyc’: Permission denied
rm: cannot remove ‘./tools/setup/__pycache__/setup_venvs.cpython-34.pyc’: Permission denied
rm: cannot remove ‘./scripts/__pycache__/__init__.cpython-34.pyc’: Permission denied
rm: cannot remove ‘./tools/setup/__pycache__/__init__.cpython-34.pyc’: Permission denied
rm: cannot remove ‘./tools/setup/__pycache__/setup_venvs.cpython-34.pyc’: Permission denied
Clearing memcached ...
Flushing memcached...
OK
Starting Zulip services on ports: web proxy: 9991, Django: 9992, Tornado: 9993, Thumbor: 9995, webpack: 9994
Note: only port 9991 is exposed to the host in a Vagrant environment.
2018-04-05 21:30:06,079 INFO: process_fts_updates starting
2018-04-05 21:30:06,690 INFO: Not in recovery; listening for FTS updates
Recompiling templates
done
Project is running at http://0.0.0.0:9994/webpack-dev-server/
webpack output is served from /webpack/
Performing system checks...

Validating Django models.py...
System check identified no issues (1 silenced).

Django version 1.11.6
Tornado server is running at http://127.0.0.1:9993/
Quit the server with CTRL-C.
2018-04-05 21:30:15.924 INFO [] Tornado loaded 0 event queues in 0.005s
System check identified no issues (1 silenced).

webpack: Compiled successfully.
April 05, 2018 - 21:30:19
Django version 1.11.6, using settings 'zproject.settings'
Starting development server at http://127.0.0.1:9992/
Quit the server with CONTROL-C.
2018-04-05 21:30:21.004 INFO [process_queue] 20 queue worker threads were launched

```
