### PR TITLE
clipboard: Update clipboard to v2.0.0 to avoid variable name conflict.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -168,7 +168,7 @@
         "emoji_codes": false,
         "drafts": false,
         "katex": false,
-        "Clipboard": false,
+        "ClipboardJS": false,
         "emoji_picker": false,
         "hotspots": false,
         "compose_ui": false,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@types/node": "8.0.34",
     "@types/webpack": "3.0.13",
     "blueimp-md5": "2.10.0",
-    "clipboard": "1.5.16",
+    "clipboard": "2.0.0",
     "emoji-datasource-apple": "3.0.0",
     "emoji-datasource-emojione": "3.0.0",
     "emoji-datasource-google": "3.0.0",

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -232,7 +232,7 @@ function edit_message(row, raw_content) {
     if (editability === editability_types.NO) {
         message_edit_content.prop("readonly", "readonly");
         message_edit_topic.prop("readonly", "readonly");
-        new Clipboard(copy_message[0]);
+        new ClipboardJS(copy_message[0]);
     } else if (editability === editability_types.NO_LONGER) {
         // You can currently only reach this state in non-streams. If that
         // changes (e.g. if we stop allowing topics to be modified forever
@@ -240,12 +240,12 @@ function edit_message(row, raw_content) {
         // row.find('input.message_edit_topic') as well.
         message_edit_content.prop("readonly", "readonly");
         message_edit_countdown_timer.text(i18n.t("View source"));
-        new Clipboard(copy_message[0]);
+        new ClipboardJS(copy_message[0]);
     } else if (editability === editability_types.TOPIC_ONLY) {
         message_edit_content.prop("readonly", "readonly");
         // Hint why you can edit the topic but not the message content
         message_edit_countdown_timer.text(i18n.t("Topic editing only"));
-        new Clipboard(copy_message[0]);
+        new ClipboardJS(copy_message[0]);
     } else if (editability === editability_types.FULL) {
         copy_message.remove();
         var edit_id = "#message_edit_content_" + rows.id(row);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -59,7 +59,7 @@ function init_email_clipboard() {
             var copy_email_icon = email_el.find('i');
             copy_email_icon.removeClass('hide_copy_icon');
 
-            var copy_email_clipboard = new Clipboard(copy_email_icon[0]);
+            var copy_email_clipboard = new ClipboardJS(copy_email_icon[0]);
             copy_email_clipboard.on('success', copy_email_handler);
         }
     });
@@ -830,7 +830,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    new Clipboard('.copy_link');
+    new ClipboardJS('.copy_link');
 
     $('body').on('click', '.copy_link', function (e) {
         popovers.hide_actions_popover();

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,13 +883,13 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
-clipboard@1.5.16:
-  version "1.5.16"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.5.16.tgz#916d5e739b0064be61b0b48a535731ecaef3d367"
+clipboard@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.0.tgz#4661dc972fb72a4c4770b8db78aa9b1caef52b50"
   dependencies:
-    good-listener "^1.2.0"
-    select "^1.0.6"
-    tiny-emitter "^1.0.0"
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -2861,7 +2861,7 @@ glslify@^6.0.2, glslify@^6.1.0:
     through2 "^2.0.1"
     xtend "^4.0.0"
 
-good-listener@^1.2.0:
+good-listener@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
   dependencies:
@@ -5545,7 +5545,7 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
-select@^1.0.6:
+select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
 
@@ -5814,7 +5814,7 @@ source-list-map@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-1.1.2.tgz#9889019d1024cce55cdc069498337ef6186a11a1"
 
-source-map-loader@^0.2.3:
+source-map-loader@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.2.3.tgz#d4b0c8cd47d54edce3e6bfa0f523f452b5b0e521"
   dependencies:
@@ -6341,9 +6341,9 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-emitter@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-1.2.0.tgz#6dc845052cb08ebefc1874723b58f24a648c3b6f"
+tiny-emitter@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
 
 tinycolor2@^1.3.0:
   version "1.4.1"


### PR DESCRIPTION
It turns out, now we have a new standard way to access clipboard by
`Clipboard` method and currently this conflict with the constructor
exported by clipboard package. The new update v2.0.0 was released to address
this issue. The new version just exports the constructor as `ClipboardJS`.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
Ref: zenorocha/clipboard.js#468