### PR TITLE
Revise SMTP setup docs

### DIFF
--- a/docs/production/email.md
+++ b/docs/production/email.md
@@ -1,9 +1,25 @@
 # Outgoing email
 
-This page documents everything you need to know about setting up
-outgoing email in a Zulip production environment.  It's pretty simple
-if you already have an outgoing SMTP provider; just start reading from
-[the configuration section](#configuration).
+Zulip needs to be able to send email so it can confirm new users'
+email addresses and send notifications.
+
+## How to configure
+
+1. Identify an outgoing email (SMTP) account where you can have Zulip
+   send mail.  If you don't already have one you want to use, see
+   [Email services](#email-services) below.
+
+2. Fill out the section of `/etc/zulip/settings.py` headed "Outgoing
+   email (SMTP) settings".  This includes the hostname and typically
+   the port to reach your SMTP provider, and the username to log into
+   it as.
+
+3. Put the password for the SMTP user account in
+   `/etc/zulip/zulip-secrets.conf` by setting `email_password`. For
+   example: `email_password = abcd1234`.
+
+
+## Email services
 
 ### Free outgoing email services
 
@@ -63,19 +79,7 @@ initial user registration without an SMTP provider.
 Remember to delete this configuration and restart the server if you
 later setup a real SMTP provider!
 
-### Configuration
-
-To configure outgoing SMTP, you will need to complete the following steps:
-
-1. Fill out the outgoing email sending configuration block in
-`/etc/zulip/settings.py`, including `EMAIL_HOST`, and
-`EMAIL_HOST_USER`.  You may also need to set `EMAIL_PORT` if your
-provider doesn't use the standard SMTP submission port (587).
-
-2. Put the SMTP password for `EMAIL_HOST_USER` in
-`/etc/zulip/zulip-secrets.conf` as `email_password = yourPassword`.
-
-#### Testing and troubleshooting
+## Troubleshooting
 
 You can quickly test your outgoing email configuration using:
 
@@ -101,7 +105,7 @@ restart your Zulip server using
 `/home/zulip/deployments/current/scripts/restart-server` so that the running
 server is using the latest configuration.
 
-#### Advanced troubleshooting
+### Advanced troubleshooting
 
 Here are a few final notes on what to look at when debugging why you
 aren't receiving emails from Zulip:

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -1,13 +1,17 @@
 from typing import Optional
 
-# Zulip server-level Settings (to be set by the system administrator).
+################################################################
+# Zulip Server settings.
 #
-# Remember to restart the server after changes here!  Documentation at:
-#
+# This file controls settings that affect the whole Zulip server.
+# See our documentation at:
 #   https://zulip.readthedocs.io/en/latest/production/settings.html
 #
-# Developer documentation on the Zulip settings system is available at:
+# For developer documentation on the Zulip settings system, see:
 #   https://zulip.readthedocs.io/en/latest/subsystems/settings.html
+#
+# Remember to restart the server after making changes here!
+#   su zulip -c /home/zulip/deployments/current/scripts/restart-server
 
 ## MANDATORY SETTINGS
 #

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -8,8 +8,8 @@ from typing import Optional
 #
 # Developer documentation on the Zulip settings system is available at:
 #   https://zulip.readthedocs.io/en/latest/subsystems/settings.html
-#
-### MANDATORY SETTINGS
+
+## MANDATORY SETTINGS
 #
 # These settings MUST be set in production. In a development environment,
 # sensible default values will be used.
@@ -32,34 +32,31 @@ EXTERNAL_HOST = 'zulip.example.com'
 # 'Zulip Support <support@example.com>'.
 ZULIP_ADMINISTRATOR = 'zulip-admin@example.com'
 
-# Configure the outgoing Email (aka SMTP) server below. You will need
-# working SMTP to complete the installation process, in addition to
-# sending email address confirmations, missed message notifications,
-# onboarding follow-ups, and other user needs. If you do not have an
-# SMTP server already, we recommend services intended for developers
-# such as Mailgun.  Detailed documentation is available at:
+
+### OUTGOING EMAIL (SMTP) SETTINGS
 #
+# Zulip needs to be able to send email (that is, use SMTP) so it can
+# confirm new users' email addresses and send notifications.
+#
+# If you don't already have an SMTP provider, free ones are available.
+#
+# For more details, including a list of free SMTP providers and
+# advice for troubleshooting, see the Zulip documentation:
 #   https://zulip.readthedocs.io/en/latest/production/email.html
-#
-# To configure SMTP, you will need to complete the following steps:
-#
-# (1) Fill out the outgoing email sending configuration below.
-#
-# (2) Put the SMTP password for EMAIL_HOST_USER in
-# /etc/zulip/zulip-secrets.conf as e.g.:
-#
-#    email_password = abcd1234
-#
-# You can quickly test your sending email configuration using:
-#   su zulip
-#   /home/zulip/deployments/current/manage.py send_test_email username@example.com
-#
-# A common problem is hosting provider firewalls that block outgoing SMTP traffic.
-#
+
+# EMAIL_HOST and EMAIL_HOST_USER are generally required.
 #EMAIL_HOST = 'smtp.example.com'
 #EMAIL_HOST_USER = ''
-#EMAIL_PORT = 587
+
+# Passwords and secrets are not stored in this file.  The password
+# for user EMAIL_HOST_USER goes in `/etc/zulip/zulip-secrets.conf`.
+# In that file, set `email_password`.  For example:
+#   email_password = abcd1234
+
+# EMAIL_USE_TLS and EMAIL_PORT are required for most SMTP providers.
 #EMAIL_USE_TLS = True
+#EMAIL_PORT = 587
+
 
 ## OPTIONAL SETTINGS
 

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -113,7 +113,9 @@ AUTHENTICATION_BACKENDS = (
     # 'zproject.backends.ZulipRemoteUserBackend',  # Local SSO, setup docs on readthedocs
 )
 
-
+########
+# Google OAuth.
+#
 # To set up Google authentication, you'll need to do the following:
 #
 # (1) Visit https://console.developers.google.com/ , navigate to
@@ -134,7 +136,9 @@ AUTHENTICATION_BACKENDS = (
 # client secret in zulip-secrets.conf as `google_oauth2_client_secret`.
 #GOOGLE_OAUTH2_CLIENT_ID = <your client ID from Google>
 
-
+########
+# GitHub OAuth.
+#
 # To set up GitHub authentication, you'll need to do the following:
 #
 # (1) Register an OAuth2 application with GitHub at one of:
@@ -157,7 +161,9 @@ AUTHENTICATION_BACKENDS = (
 #SOCIAL_AUTH_GITHUB_TEAM_ID = <your team id>
 #SOCIAL_AUTH_GITHUB_ORG_NAME = <your org name>
 
-
+########
+# SSO via REMOTE_USER.
+#
 # If you are using the ZulipRemoteUserBackend authentication backend,
 # set this to your domain (e.g. if REMOTE_USER is "username" and the
 # corresponding email address is "username@example.com", set
@@ -166,6 +172,7 @@ SSO_APPEND_DOMAIN = None  # type: Optional[str]
 
 
 ################
+# Miscellaneous settings.
 
 # Support for mobile push notifications.  Setting controls whether
 # push notifications will be forwarded through a Zulip push
@@ -357,7 +364,7 @@ EMAIL_GATEWAY_IMAP_FOLDER = "INBOX"
 
 
 ################
-# LDAP integration configuration.
+# LDAP integration.
 #
 # Zulip supports retrieving information about users via LDAP, and
 # optionally using LDAP as an authentication mechanism.
@@ -438,6 +445,7 @@ AUTH_LDAP_USER_ATTR_MAP = {
 
 
 ################
+# Miscellaneous settings.
 
 # The default CAMO_URI of '/external_content/' is served by the camo
 # setup in the default Voyager nginx configuration.  Setting CAMO_URI

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -13,7 +13,9 @@ from typing import Optional
 # Remember to restart the server after making changes here!
 #   su zulip -c /home/zulip/deployments/current/scripts/restart-server
 
-## MANDATORY SETTINGS
+
+################################
+# Mandatory settings.
 #
 # These settings MUST be set in production. In a development environment,
 # sensible default values will be used.
@@ -37,7 +39,8 @@ EXTERNAL_HOST = 'zulip.example.com'
 ZULIP_ADMINISTRATOR = 'zulip-admin@example.com'
 
 
-### OUTGOING EMAIL (SMTP) SETTINGS
+################
+# Outgoing email (SMTP) settings.
 #
 # Zulip needs to be able to send email (that is, use SMTP) so it can
 # confirm new users' email addresses and send notifications.
@@ -62,7 +65,8 @@ ZULIP_ADMINISTRATOR = 'zulip-admin@example.com'
 #EMAIL_PORT = 587
 
 
-## OPTIONAL SETTINGS
+################################
+# Optional settings.
 
 # The noreply address to be used as the sender for certain generated
 # emails.  Messages sent to this address could contain sensitive user
@@ -90,8 +94,10 @@ ZULIP_ADMINISTRATOR = 'zulip-admin@example.com'
 # Note that these should just be hostnames, without port numbers.
 #ALLOWED_HOSTS = ['zulip-alias.example.com', '192.0.2.1']
 
-### AUTHENTICATION SETTINGS
-#
+
+################
+# Authentication settings.
+
 # Enable at least one of the following authentication backends.
 # See https://zulip.readthedocs.io/en/latest/production/authentication-methods.html
 # for documentation on our authentication backends.
@@ -106,6 +112,7 @@ AUTHENTICATION_BACKENDS = (
     # 'zproject.backends.ZulipLDAPAuthBackend',  # LDAP, setup below
     # 'zproject.backends.ZulipRemoteUserBackend',  # Local SSO, setup docs on readthedocs
 )
+
 
 # To set up Google authentication, you'll need to do the following:
 #
@@ -126,6 +133,7 @@ AUTHENTICATION_BACKENDS = (
 # Use the client ID as `GOOGLE_OAUTH2_CLIENT_ID` here, and put the
 # client secret in zulip-secrets.conf as `google_oauth2_client_secret`.
 #GOOGLE_OAUTH2_CLIENT_ID = <your client ID from Google>
+
 
 # To set up GitHub authentication, you'll need to do the following:
 #
@@ -156,6 +164,8 @@ AUTHENTICATION_BACKENDS = (
 # SSO_APPEND_DOMAIN = "example.com")
 SSO_APPEND_DOMAIN = None  # type: Optional[str]
 
+
+################
 
 # Support for mobile push notifications.  Setting controls whether
 # push notifications will be forwarded through a Zulip push
@@ -273,7 +283,9 @@ ENABLE_GRAVATAR = True
 # Similarly if you want to set a Privacy Policy.
 #PRIVACY_POLICY = '/etc/zulip/privacy.md'
 
-### TWITTER INTEGRATION
+
+################
+# Twitter integration.
 
 # Zulip supports showing inline Tweet previews when a tweet is linked
 # to in a message.  To support this, Zulip must have access to the
@@ -287,8 +299,10 @@ ENABLE_GRAVATAR = True
 # 4. Fill in the values for twitter_consumer_key, twitter_consumer_secret, twitter_access_token_key,
 #    and twitter_access_token_secret in /etc/zulip/zulip-secrets.conf.
 
-### EMAIL GATEWAY INTEGRATION
 
+################
+# Email gateway integration.
+#
 # The Email gateway integration supports sending messages into Zulip
 # by sending an email.  This is useful for receiving notifications
 # from third-party services that only send outgoing notifications via
@@ -341,7 +355,10 @@ EMAIL_GATEWAY_IMAP_PORT = 993
 # must be delivered to this folder
 EMAIL_GATEWAY_IMAP_FOLDER = "INBOX"
 
-### LDAP integration configuration
+
+################
+# LDAP integration configuration.
+#
 # Zulip supports retrieving information about users via LDAP, and
 # optionally using LDAP as an authentication mechanism.
 #
@@ -418,6 +435,9 @@ AUTH_LDAP_USER_ATTR_MAP = {
     # full_name is required; common values include "cn" or "displayName".
     "full_name": "cn",
 }
+
+
+################
 
 # The default CAMO_URI of '/external_content/' is served by the camo
 # setup in the default Voyager nginx configuration.  Setting CAMO_URI


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Revise and streamline our docs on setting up SMTP, as one of the main remaining hurdles after the simplified installer.

The last few commits go on to make some light revisions to the comments in the template settings file, while I'm there and because I've found it kind of hard to navigate for some time now.

**Testing Plan:** <!-- How have you tested? -->

Built the doc locally and looked at it.
