### PR TITLE
Bump provision after clipboard package update.

### DIFF
--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '17.10'
+PROVISION_VERSION = '17.11'


### PR DESCRIPTION
It wasn't bumped in https://github.com/zulip/zulip/pull/8984 which caused some js exceptions.
