### PR TITLE
browser-support: Add startswith and codepointat polyfills.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "script-loader": "0.7.2",
     "source-map-loader": "0.2.3",
     "string.prototype.codepointat": "0.2.0",
+    "string.prototype.startswith": "0.2.0",
     "to-markdown": "3.1.0",
     "ts-loader": "2.1.0",
     "ts-node": "3.3.0",

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -5,6 +5,7 @@
     ],
     "common": [
                "string.prototype.startswith",
+               "string.prototype.codepointat",
                "./node_modules/jquery/dist/jquery.js",
                "./node_modules/underscore/underscore.js",
                "./static/js/blueslip.js",

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -4,6 +4,7 @@
         "./static/js/portico/header.js"
     ],
     "common": [
+               "string.prototype.startswith",
                "./node_modules/jquery/dist/jquery.js",
                "./node_modules/underscore/underscore.js",
                "./static/js/blueslip.js",

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '17.11'
+PROVISION_VERSION = '17.12'

--- a/yarn.lock
+++ b/yarn.lock
@@ -5980,6 +5980,10 @@ string.prototype.codepointat@0.2.0, string.prototype.codepointat@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz#6b26e9bd3afcaa7be3b4269b526de1b82000ac78"
 
+string.prototype.startswith@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz#da68982e353a4e9ac4a43b450a2045d1c445ae7b"
+
 string.prototype.trim@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"


### PR DESCRIPTION
Fixes #8944.
~~Adds `pollyfill.js` which will contain imports to all polyfills in
order to avoid adding a new polyfill to each entry point in
webpack.assets.json . This `pollyfill.js` is placed at each entry point
in webpack.assets.json instead.~~

I implemented the code mentioned in the [comment on the original issue](https://github.com/zulip/zulip/issues/8944#issuecomment-379043205) but when writing tests for the same, it did not fulfil many of the test cases used in [a robust implentation of the same]( https://github.com/mathiasbynens/String.prototype.startsWith/blob/master/tests/tests.js)  recommended by the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#Polyfill).

`pollyfill.js` is added to ~~each~~ entry point in the webpack(refer [here](https://babeljs.io/docs/usage/polyfill/))

I've also added an extra commit adding `string.prototype.codepointat` which was added earlier on in the project but was not added at ~~each~~ entry point. Do let me know if this wasn't needed/should be part of another PR.