### PR TITLE
Compose subscribe close

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -43,6 +43,7 @@ set_global('notifications', {
     notify_above_composebox: noop,
     clear_compose_notifications: noop,
 });
+set_global('subs', {});
 
 // Setting these up so that we can test that links to uploads within messages are
 // automatically converted to server relative links.
@@ -1144,6 +1145,51 @@ function test_raw_file_drop(raw_drop_func) {
         assert(container_removed);
         assert(all_invite_children_called);
         assert(!$("#compose_invite_users").visible());
+    }());
+
+    (function test_compose_not_subscribed_clicked() {
+        var handler = $("#compose-send-status")
+                      .get_on_handler('click', '.sub_unsub_button');
+        var subscription = {
+            stream_id: 102,
+            name: 'test',
+            subscribed: false,
+        };
+        var compose_not_subscribed_called = false;
+        subs.sub_or_unsub = function () {
+            compose_not_subscribed_called = true;
+        };
+
+        setup_parents_and_mock_remove('compose-send-status',
+                                      'sub_unsub_button',
+                                      '.compose_not_subscribed');
+
+        handler(event);
+
+        assert(compose_not_subscribed_called);
+
+        stream_data.add_sub('test', subscription);
+        $('#stream').val('test');
+        $("#compose-send-status").show();
+
+        handler(event);
+
+        assert(!$("#compose-send-status").visible());
+    }());
+
+    (function test_compose_not_subscribed_close_clicked() {
+        var handler = $("#compose-send-status")
+                      .get_on_handler('click', '#compose_not_subscribed_close');
+
+        setup_parents_and_mock_remove('compose_user_not_subscribed_close',
+                                      'compose_not_subscribed_close',
+                                      '.compose_not_subscribed');
+
+        $("#compose-send-status").show();
+
+        handler(event);
+
+        assert(!$("#compose-send-status").visible());
     }());
 
     event = {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -794,6 +794,12 @@ exports.initialize = function () {
         $("#compose-send-status").hide();
     });
 
+    $("#compose-send-status").on('click', '#compose_not_subscribed_close', function (event) {
+        event.preventDefault();
+
+        $("#compose-send-status").hide();
+    });
+
     $("#compose_invite_users").on('click', '.compose_invite_link', function (event) {
         event.preventDefault();
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- **Testing Plan:** How have you tested? -->


   <!--**GIFs or Screenshots:**If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
**First commit**:
compose: Close the compose error message box on clicking X. 

Not sure how I missed this function to add in the last PR.
![compose_error_clear](https://user-images.githubusercontent.com/22166422/38450850-e437c36e-3a42-11e8-8665-579a430633ba.gif)

**Second commit:**

node tests: Cover compose_not_subscribed in compose.js.

This commit covers the node tests to close(X) button and
subscribe button click handlers in compose.js.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
