### PR TITLE
settings: Fix label for message_content_in_email_notifications.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -75,7 +75,7 @@ function setup_settings_label() {
 
         // other_notification_settings
         enable_digest_emails: i18n.t("Send digest emails when I'm away"),
-        message_content_in_email_notifications: i18n.t("Include content of private messages"),
+        message_content_in_email_notifications: i18n.t("Include message content in missed message emails"),
         realm_name_in_notifications: i18n.t("Include organization name in subject of missed message emails"),
     };
 }


### PR DESCRIPTION
This was a regression introduced in deduplication of settings
template.
Fixes: #9021.
![notification](https://user-images.githubusercontent.com/22238472/38458752-6800af72-3abf-11e8-899c-4d4290ce19a5.png)
