### PR TITLE
slack import: Support Custom profile fields.

### DIFF
--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -145,7 +145,8 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(get_user_timezone(user_timezone_none), "America/New_York")
         self.assertEqual(get_user_timezone(user_no_timezone), "America/New_York")
 
-    def test_users_to_zerver_userprofile(self) -> None:
+    @mock.patch("zerver.lib.slack_data_to_zulip_data.get_data_file")
+    def test_users_to_zerver_userprofile(self, mock_get_data_file: mock.Mock) -> None:
         user_data = [{"id": "U08RGD1RD",
                       "team_id": "T5YFFM2QY",
                       "name": "john",
@@ -179,6 +180,8 @@ class SlackImporter(ZulipTestCase):
                             'U09TYF5Sk': 2}
         slack_data_dir = './random_path'
         timestamp = int(timezone_now().timestamp())
+        mock_get_data_file.return_value = user_data
+
         zerver_userprofile, avatar_list, added_users = users_to_zerver_userprofile(
             slack_data_dir, user_data, 1, timestamp, 'test_domain')
 


### PR DESCRIPTION
This support the import of Custom profile fields from slack converted data.

@timabbott  I didn't have access to a data of any slack organization with custom profile fields, So using the slack [documentation](https://api.slack.com/methods/users.profile.set) I manually added the custom field data in my slack data set to test this.
It would be amazing if you could test this out with a dataset containing custom profile fields and let me of any errors/border cases to be handled so that I can correct it here.

Screenshot:
![screen shot 2018-04-09 at 5 54 25 pm](https://user-images.githubusercontent.com/25330892/38497513-fa733086-3c1e-11e8-99d4-a442bf2ebb89.png)

![screen shot 2018-04-09 at 5 58 19 pm](https://user-images.githubusercontent.com/25330892/38497574-365dbc56-3c1f-11e8-87e5-393717ac01e7.png)


 