### PR TITLE
[WIP] Basic template for testing migrations

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -14,6 +14,7 @@ from django.test.client import (
 from django.template import loader
 from django.http import HttpResponse, HttpResponseRedirect
 from django.db.utils import IntegrityError
+from django.db.migrations.state import StateApps
 
 import zerver.lib.upload
 from zerver.lib.upload import S3UploadBackend, LocalUploadBackend
@@ -48,7 +49,7 @@ from zerver.models import (
 from zerver.lib.request import JsonableError
 
 if False:
-    from zerver.lib.test_case import ZulipTestCase
+    from zerver.lib.test_case import ZulipTestCase, MigrationsTestCase
 
 import collections
 import base64
@@ -460,3 +461,115 @@ def use_s3_backend(method: FuncT) -> FuncT:
         finally:
             zerver.lib.upload.upload_backend = LocalUploadBackend()
     return new_method
+
+def use_db_models(method: Callable[..., None]) -> Callable[..., None]:
+    def method_patched_with_mock(self: 'MigrationsTestCase', apps: StateApps) -> None:
+        ArchivedAttachment = apps.get_model('zerver', 'ArchivedAttachment')
+        ArchivedMessage = apps.get_model('zerver', 'ArchivedMessage')
+        ArchivedUserMessage = apps.get_model('zerver', 'ArchivedUserMessage')
+        Attachment = apps.get_model('zerver', 'Attachment')
+        BotConfigData = apps.get_model('zerver', 'BotConfigData')
+        BotStorageData = apps.get_model('zerver', 'BotStorageData')
+        Client = apps.get_model('zerver', 'Client')
+        CustomProfileField = apps.get_model('zerver', 'CustomProfileField')
+        CustomProfileFieldValue = apps.get_model('zerver', 'CustomProfileFieldValue')
+        DefaultStream = apps.get_model('zerver', 'DefaultStream')
+        DefaultStreamGroup = apps.get_model('zerver', 'DefaultStreamGroup')
+        EmailChangeStatus = apps.get_model('zerver', 'EmailChangeStatus')
+        Huddle = apps.get_model('zerver', 'Huddle')
+        Message = apps.get_model('zerver', 'Message')
+        MultiuseInvite = apps.get_model('zerver', 'MultiuseInvite')
+        MutedTopic = apps.get_model('zerver', 'MutedTopic')
+        PreregistrationUser = apps.get_model('zerver', 'PreregistrationUser')
+        PushDeviceToken = apps.get_model('zerver', 'PushDeviceToken')
+        Reaction = apps.get_model('zerver', 'Reaction')
+        Realm = apps.get_model('zerver', 'Realm')
+        RealmAuditLog = apps.get_model('zerver', 'RealmAuditLog')
+        RealmDomain = apps.get_model('zerver', 'RealmDomain')
+        RealmEmoji = apps.get_model('zerver', 'RealmEmoji')
+        RealmFilter = apps.get_model('zerver', 'RealmFilter')
+        Recipient = apps.get_model('zerver', 'Recipient')
+        ScheduledEmail = apps.get_model('zerver', 'ScheduledEmail')
+        ScheduledMessage = apps.get_model('zerver', 'ScheduledMessage')
+        Service = apps.get_model('zerver', 'Service')
+        Stream = apps.get_model('zerver', 'Stream')
+        Subscription = apps.get_model('zerver', 'Subscription')
+        UserActivity = apps.get_model('zerver', 'UserActivity')
+        UserActivityInterval = apps.get_model('zerver', 'UserActivityInterval')
+        UserGroup = apps.get_model('zerver', 'UserGroup')
+        UserGroupMembership = apps.get_model('zerver', 'UserGroupMembership')
+        UserHotspot = apps.get_model('zerver', 'UserHotspot')
+        UserMessage = apps.get_model('zerver', 'UserMessage')
+        UserPresence = apps.get_model('zerver', 'UserPresence')
+        UserProfile = apps.get_model('zerver', 'UserProfile')
+
+        zerver_models_patch = mock.patch.multiple(
+            'zerver.models',
+            ArchivedAttachment=ArchivedAttachment,
+            ArchivedMessage=ArchivedMessage,
+            ArchivedUserMessage=ArchivedUserMessage,
+            Attachment=Attachment,
+            BotConfigData=BotConfigData,
+            BotStorageData=BotStorageData,
+            Client=Client,
+            CustomProfileField=CustomProfileField,
+            CustomProfileFieldValue=CustomProfileFieldValue,
+            DefaultStream=DefaultStream,
+            DefaultStreamGroup=DefaultStreamGroup,
+            EmailChangeStatus=EmailChangeStatus,
+            Huddle=Huddle,
+            Message=Message,
+            MultiuseInvite=MultiuseInvite,
+            MutedTopic=MutedTopic,
+            PreregistrationUser=PreregistrationUser,
+            PushDeviceToken=PushDeviceToken,
+            Reaction=Reaction,
+            Realm=Realm,
+            RealmAuditLog=RealmAuditLog,
+            RealmDomain=RealmDomain,
+            RealmEmoji=RealmEmoji,
+            RealmFilter=RealmFilter,
+            Recipient=Recipient,
+            ScheduledEmail=ScheduledEmail,
+            ScheduledMessage=ScheduledMessage,
+            Service=Service,
+            Stream=Stream,
+            Subscription=Subscription,
+            UserActivity=UserActivity,
+            UserActivityInterval=UserActivityInterval,
+            UserGroup=UserGroup,
+            UserGroupMembership=UserGroupMembership,
+            UserHotspot=UserHotspot,
+            UserMessage=UserMessage,
+            UserPresence=UserPresence,
+            UserProfile=UserProfile
+        )
+        zerver_test_helpers_patch = mock.patch.multiple(
+            'zerver.lib.test_helpers',
+            Client=Client,
+            Message=Message,
+            Realm=Realm,
+            Recipient=Recipient,
+            Stream=Stream,
+            Subscription=Subscription,
+            UserMessage=UserMessage,
+            UserProfile=UserProfile,
+        )
+
+        zerver_test_classes_patch = mock.patch.multiple(
+            'zerver.lib.test_classes',
+            Client=Client,
+            Message=Message,
+            Realm=Realm,
+            Recipient=Recipient,
+            Service=Service,
+            Stream=Stream,
+            Subscription=Subscription,
+            UserProfile=UserProfile,
+        )
+
+        with zerver_models_patch,\
+                zerver_test_helpers_patch,\
+                zerver_test_classes_patch:
+            method(self, apps)
+    return method_patched_with_mock

--- a/zerver/tests/test_migrations_0145.py
+++ b/zerver/tests/test_migrations_0145.py
@@ -1,0 +1,55 @@
+from zerver.lib.test_classes import (
+    MigrationsTestCase,
+)
+from django.utils.timezone import now as timezone_now
+from django.db.migrations.state import StateApps
+from django.db.models.base import ModelBase
+
+class EmojiName2IdTestCase(MigrationsTestCase):
+
+    migrate_from = '0144_remove_realm_create_generic_bot_by_admins_only'
+    migrate_to = '0145_reactions_realm_emoji_name_to_id'
+
+    def setUpBeforeMigration(self, apps: StateApps) -> None:
+        UserProfile = apps.get_model('zerver', 'UserProfile')
+        Reaction = apps.get_model('zerver', 'Reaction')
+        RealmEmoji = apps.get_model('zerver', 'RealmEmoji')
+        Stream = apps.get_model('zerver', 'Stream')
+        Message = apps.get_model('zerver', 'Message')
+        Recipient = apps.get_model('zerver', 'Recipient')
+        Realm = apps.get_model('zerver', 'Realm')
+        Client = apps.get_model('zerver', 'Client')
+
+        realm = Realm.objects.get(string_id='zulip')
+        sender = UserProfile.objects.select_related().get(email__iexact='iago@zulip.com'.strip(), realm=realm)
+        sending_client, _ = Client.objects.get_or_create(name="test suite")
+        stream_name = 'Denmark'
+        stream = Stream.objects.select_related("realm").get(
+            name__iexact=stream_name.strip(), realm_id=realm.id)
+        subject = 'foo'
+
+        def send_fake_message(message_content: str, stream: ModelBase) -> ModelBase:
+            recipient = Recipient.objects.get(type_id=stream.id, type=2)
+            return Message.objects.create(sender = sender,
+                                          recipient = recipient,
+                                          subject = subject,
+                                          content = message_content,
+                                          pub_date = timezone_now(),
+                                          sending_client = sending_client)
+
+        message = send_fake_message('Test 1', stream)
+
+        for realm_emoji in RealmEmoji.objects.all():
+            reaction = Reaction(user_profile=sender, message=message,
+                                emoji_name=realm_emoji.name, emoji_code=realm_emoji.name,
+                                reaction_type='realm_emoji')
+            reaction.save()
+
+    def test_tags_migrated(self) -> None:
+        Reaction = self.apps.get_model('zerver', 'Reaction')
+        RealmEmoji = self.apps.get_model('zerver', 'RealmEmoji')
+        for reaction in Reaction.objects.filter(reaction_type='realm_emoji'):
+            realm_emoji = RealmEmoji.objects.get(
+                realm_id=reaction.user_profile.realm_id,
+                name=reaction.emoji_name)
+            self.assertEqual(reaction.emoji_code, str(realm_emoji.id))

--- a/zerver/tests/test_migrations_0145.py
+++ b/zerver/tests/test_migrations_0145.py
@@ -1,31 +1,28 @@
-from zerver.lib.test_classes import (
-    MigrationsTestCase,
-)
+from zerver.lib.test_classes import MigrationsTestCase
+from zerver.lib.test_helpers import use_db_models, make_client
 from django.utils.timezone import now as timezone_now
 from django.db.migrations.state import StateApps
 from django.db.models.base import ModelBase
+
+from zerver.models import get_stream
 
 class EmojiName2IdTestCase(MigrationsTestCase):
 
     migrate_from = '0144_remove_realm_create_generic_bot_by_admins_only'
     migrate_to = '0145_reactions_realm_emoji_name_to_id'
 
+    @use_db_models
     def setUpBeforeMigration(self, apps: StateApps) -> None:
-        UserProfile = apps.get_model('zerver', 'UserProfile')
         Reaction = apps.get_model('zerver', 'Reaction')
         RealmEmoji = apps.get_model('zerver', 'RealmEmoji')
-        Stream = apps.get_model('zerver', 'Stream')
         Message = apps.get_model('zerver', 'Message')
         Recipient = apps.get_model('zerver', 'Recipient')
-        Realm = apps.get_model('zerver', 'Realm')
-        Client = apps.get_model('zerver', 'Client')
 
-        realm = Realm.objects.get(string_id='zulip')
-        sender = UserProfile.objects.select_related().get(email__iexact='iago@zulip.com'.strip(), realm=realm)
-        sending_client, _ = Client.objects.get_or_create(name="test suite")
+        sender = self.example_user('iago')
+        realm = sender.realm
+        sending_client = make_client(name="test suite")
         stream_name = 'Denmark'
-        stream = Stream.objects.select_related("realm").get(
-            name__iexact=stream_name.strip(), realm_id=realm.id)
+        stream = get_stream(stream_name, realm)
         subject = 'foo'
 
         def send_fake_message(message_content: str, stream: ModelBase) -> ModelBase:
@@ -36,19 +33,25 @@ class EmojiName2IdTestCase(MigrationsTestCase):
                                           content = message_content,
                                           pub_date = timezone_now(),
                                           sending_client = sending_client)
-
         message = send_fake_message('Test 1', stream)
 
+        # Create reactions for all the realm emoji's on the message we faked.
         for realm_emoji in RealmEmoji.objects.all():
             reaction = Reaction(user_profile=sender, message=message,
                                 emoji_name=realm_emoji.name, emoji_code=realm_emoji.name,
                                 reaction_type='realm_emoji')
             reaction.save()
+        realm_emoji_reactions_count = Reaction.objects.filter(reaction_type='realm_emoji').count()
+        self.assertEqual(realm_emoji_reactions_count, 1)
 
     def test_tags_migrated(self) -> None:
         Reaction = self.apps.get_model('zerver', 'Reaction')
         RealmEmoji = self.apps.get_model('zerver', 'RealmEmoji')
-        for reaction in Reaction.objects.filter(reaction_type='realm_emoji'):
+
+        realm_emoji_reactions = Reaction.objects.filter(reaction_type='realm_emoji')
+        realm_emoji_reactions_count = realm_emoji_reactions.count()
+        self.assertEqual(realm_emoji_reactions_count, 1)
+        for reaction in realm_emoji_reactions:
             realm_emoji = RealmEmoji.objects.get(
                 realm_id=reaction.user_profile.realm_id,
                 name=reaction.emoji_name)


### PR DESCRIPTION
In this PR we introduce a new class in test_classes called MigrationsTestCase which is aimed to provide a wire frame for writing unit tests for migrations. Entire idea of the PR is based off the this blog post: https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/

To test out migrations we are essentially going to revert the DB to the state before the migration happened, Add some new data to the DB at that point, and then let the migration run and later assert if data looked as it was supposed to after the migration.