### PR TITLE
nginx: Add cache-control headers for hashed static files.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -14,6 +14,12 @@ location /static/ {
     error_page 404 /django_static_404.html;
 }
 
+# Added cache control headers for hashed files
+# set them to cache for 1 year roughly
+location ~ /static/(js|min|css)/ {
+  add_header Cache-Control public, max-age=31536000;
+}
+
 # Send longpoll requests to Tornado
 location ~ /json/events {
     proxy_pass http://tornado;


### PR DESCRIPTION
This just sets cache control headers all the hashes files in static folder i.e. the min, js, CSS
directories. It sets the header so that those files will be cached for 1 year. In any case, if the
files change their has will change and therefore the cache will be invalidated. This will
provide faster load times and can potentially make it so the browser doesn't have to make a request for the static file if it has it in its cache.

Cache-Control header Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control