### PR TITLE
User Settings: Enforces unique display names per realm.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -141,6 +141,7 @@ import os
 import platform
 import logging
 import itertools
+import unicodedata
 from collections import defaultdict
 from operator import itemgetter
 
@@ -2853,6 +2854,9 @@ def check_change_full_name(user_profile: UserProfile, full_name_raw: str,
     full name, which may differ from what was passed in (because this
     function strips whitespace)."""
     new_full_name = check_full_name(full_name_raw)
+    unique_full_name = make_unique_display_name(user_profile.realm, new_full_name)
+    if new_full_name != unique_full_name:
+        raise JsonableError(_('%s name has already been taken' % (new_full_name,)))
     do_change_full_name(user_profile, new_full_name, acting_user)
     return new_full_name
 
@@ -4338,6 +4342,16 @@ def do_send_confirmation_email(invitee: PreregistrationUser,
 def email_not_system_bot(email: str) -> None:
     if is_cross_realm_bot_email(email):
         raise ValidationError('%s is an email address reserved for system bots' % (email,))
+
+def make_unique_display_name(target_realm: Realm, full_name: str) -> str:
+    full_name_counter = 1
+    full_name_initial = full_name
+    realm_users = UserProfile.objects.filter(realm=target_realm)
+    normalized_full_names = {unicodedata.normalize('NFKC', user.full_name) for user in realm_users}
+    while unicodedata.normalize('NFKC', full_name) in normalized_full_names:
+            full_name = '{0}#{1}'.format(full_name_initial, full_name_counter)
+            full_name_counter += 1
+    return full_name
 
 def validate_email_for_realm(target_realm: Realm, email: str) -> None:
     email_not_system_bot(email)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -184,7 +184,7 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
                 name_validated = True
             except KeyError:
                 pass
-        form = RegistrationForm(postdata, realm_creation=realm_creation)
+        form = RegistrationForm(postdata, realm_creation=realm_creation, realm=realm)
         if not (password_auth_enabled(realm) and password_required):
             form['password'].field.required = False
 

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -18,7 +18,7 @@ from social_core.exceptions import AuthFailed, SocialAuthBaseException
 from social_django.models import DjangoStorage
 from social_django.strategy import DjangoStrategy
 
-from zerver.lib.actions import do_create_user
+from zerver.lib.actions import do_create_user, make_unique_display_name
 from zerver.lib.request import JsonableError
 from zerver.lib.subdomains import user_matches_subdomain, get_subdomain
 from zerver.lib.users import check_full_name
@@ -396,6 +396,7 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
             full_name = check_full_name(full_name)
         except JsonableError as e:
             raise ZulipLDAPException(e.msg)
+        full_name = make_unique_display_name(self._realm, full_name)
         if "short_name" in settings.AUTH_LDAP_USER_ATTR_MAP:
             short_name_attr = settings.AUTH_LDAP_USER_ATTR_MAP["short_name"]
             short_name = ldap_user.attrs[short_name_attr][0]


### PR DESCRIPTION
Added check for name uniqueness per realm to actions.py
Also updates the UI.
This check works when manualy changing the name in
settings or during signup.

Fixes #7830