### PR TITLE
[WIP] tests: Move soft_deactivation.py to 100% coverage

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -62,7 +62,6 @@ not_yet_fully_covered = {
     'zerver/lib/message.py',
     'zerver/lib/notifications.py',
     'zerver/lib/send_email.py',
-    'zerver/lib/soft_deactivation.py',
     'zerver/lib/upload.py',
     # Other lib files that ideally would coverage, but aren't sorted
     'zerver/__init__.py',

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -119,7 +119,7 @@ def add_missing_messages(user_profile: UserProfile) -> None:
     for sub in all_stream_subs:
         stream_subscription_logs = all_stream_subscription_logs[sub['recipient__type_id']]
         if (stream_subscription_logs[-1].event_type == 'subscription_deactivated' and
-                stream_subscription_logs[-1].event_last_message_id < user_profile.last_active_message_id):
+                stream_subscription_logs[-1].event_last_message_id <= user_profile.last_active_message_id):
             # We are going to short circuit this iteration as its no use
             # iterating since user unsubscribed before soft-deactivation
             continue

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -50,8 +50,12 @@ from zerver.lib.test_classes import (
     ZulipTestCase,
 )
 
-from zerver.lib.soft_deactivation import add_missing_messages, do_soft_deactivate_users, \
+from zerver.lib.soft_deactivation import (
+    add_missing_messages,
+    do_soft_activate_users,
+    do_soft_deactivate_users,
     maybe_catch_up_soft_deactivated_user
+)
 
 from zerver.models import (
     MAX_MESSAGE_LENGTH, MAX_SUBJECT_LENGTH,
@@ -2801,6 +2805,37 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         self.assertEqual(len(idle_user_msg_list), idle_user_msg_count + 2)
         for sent_message in sent_message_list:
             self.assertEqual(idle_user_msg_list.pop(), sent_message)
+
+        # Test for when user unsubscribes before soft deactivation
+        # (must reactivate them in order to do this).
+
+        do_soft_activate_users([long_term_idle_user])
+        self.subscribe(long_term_idle_user, stream_name)
+        self.unsubscribe(long_term_idle_user, stream_name)
+        send_fake_message('Test Message 9', stream)
+        # Send a (not fake) message to another stream that the user is
+        # subscribed to so that their last_active_message_id field will
+        # be greater than the event_last_message_id of the unsubscription.
+        other_stream_name = 'Verona'
+        self.subscribe(long_term_idle_user, other_stream_name)
+        sent_message_id = self.send_stream_message(
+            sender.email, other_stream_name, 'Test Message 10')
+        # Soft deactivate and send another message to the unsubscribed stream.
+        do_soft_deactivate_users([long_term_idle_user])
+        send_fake_message('Test Message 11', stream)
+
+        idle_user_msg_list = get_user_messages(long_term_idle_user)
+        idle_user_msg_count = len(idle_user_msg_list)
+        self.assertEqual(idle_user_msg_list[-1].id, sent_message_id)
+        with queries_captured() as queries:
+            add_missing_messages(long_term_idle_user)
+        # There are no streams to fetch missing messages from, so
+        # the Message.objects query will be avoided.
+        self.assert_length(queries, 4)
+        idle_user_msg_list = get_user_messages(long_term_idle_user)
+        # No new UserMessage rows should have been created.
+        self.assertEqual(len(idle_user_msg_list), idle_user_msg_count)
+
         # Note: At this point in this test we have long_term_idle_user
         # unsubscribed from the 'Denmark' stream.
 
@@ -2809,13 +2844,13 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         private_stream = self.make_stream('Core', invite_only=True)
         self.subscribe(self.example_user("iago"), stream_name)
         sent_message_list = []
-        send_fake_message('Test Message 9', private_stream)
+        send_fake_message('Test Message 12', private_stream)
         self.subscribe(self.example_user("hamlet"), stream_name)
-        sent_message_list.append(send_fake_message('Test Message 10', private_stream))
+        sent_message_list.append(send_fake_message('Test Message 13', private_stream))
         self.unsubscribe(long_term_idle_user, stream_name)
-        send_fake_message('Test Message 11', private_stream)
+        send_fake_message('Test Message 14', private_stream)
         self.subscribe(long_term_idle_user, stream_name)
-        sent_message_list.append(send_fake_message('Test Message 12', private_stream))
+        sent_message_list.append(send_fake_message('Test Message 15', private_stream))
         sent_message_list.reverse()
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         idle_user_msg_count = len(idle_user_msg_list)

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -2811,18 +2811,13 @@ class SoftDeactivationMessageTest(ZulipTestCase):
 
         do_soft_activate_users([long_term_idle_user])
         self.subscribe(long_term_idle_user, stream_name)
-        self.unsubscribe(long_term_idle_user, stream_name)
-        send_fake_message('Test Message 9', stream)
-        # Send a (not fake) message to another stream that the user is
-        # subscribed to so that their last_active_message_id field will
-        # be greater than the event_last_message_id of the unsubscription.
-        other_stream_name = 'Verona'
-        self.subscribe(long_term_idle_user, other_stream_name)
+        # Send a real message to update last_active_message_id
         sent_message_id = self.send_stream_message(
-            sender.email, other_stream_name, 'Test Message 10')
+            sender.email, stream_name, 'Test Message 9')
+        self.unsubscribe(long_term_idle_user, stream_name)
         # Soft deactivate and send another message to the unsubscribed stream.
         do_soft_deactivate_users([long_term_idle_user])
-        send_fake_message('Test Message 11', stream)
+        send_fake_message('Test Message 10', stream)
 
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         idle_user_msg_count = len(idle_user_msg_list)
@@ -2844,13 +2839,13 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         private_stream = self.make_stream('Core', invite_only=True)
         self.subscribe(self.example_user("iago"), stream_name)
         sent_message_list = []
-        send_fake_message('Test Message 12', private_stream)
+        send_fake_message('Test Message 11', private_stream)
         self.subscribe(self.example_user("hamlet"), stream_name)
-        sent_message_list.append(send_fake_message('Test Message 13', private_stream))
+        sent_message_list.append(send_fake_message('Test Message 12', private_stream))
         self.unsubscribe(long_term_idle_user, stream_name)
-        send_fake_message('Test Message 14', private_stream)
+        send_fake_message('Test Message 13', private_stream)
         self.subscribe(long_term_idle_user, stream_name)
-        sent_message_list.append(send_fake_message('Test Message 15', private_stream))
+        sent_message_list.append(send_fake_message('Test Message 14', private_stream))
         sent_message_list.reverse()
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         idle_user_msg_count = len(idle_user_msg_list)


### PR DESCRIPTION
Brings lib/soft_deactivation.py up to 100% test coverage.

We (@BGR360  and I) added the test Tim suggested in #7089 to test_soft_deactivation.py (adding coverage to [this line](https://github.com/zulip/zulip/blob/master/zerver/lib/soft_deactivation.py#L125)). However, we noticed that test_messages.py contains more detailed tests for soft deactivation that appear to more thoroughly test correctness. Would it be preferable to test this in test_messages.py instead?


