### PR TITLE
Add endpoint to log CSP Reports sent by clients

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -4,6 +4,9 @@ error_log /var/log/nginx/error.log;
 # Enable HSTS: tell browsers to always use HTTPS
 add_header Strict-Transport-Security max-age=15768000;
 
+# Add CSP header to add security against XSS
+add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src https:; media-src https:; report-uri /report/csp_violations";
+
 # Serve a custom error page when the app is down
 error_page 502 503 504 /static/html/5xx.html;
 

--- a/tools/travis/success-http-headers.txt
+++ b/tools/travis/success-http-headers.txt
@@ -8,6 +8,7 @@ WARNING: no certificate subject alternative name matches
   Connection: keep-alive
   Location: /login
   Strict-Transport-Security: max-age=15768000
+  Content-Security-Policy-Report-Only: default-src 'self'; img-src https:; media-src https:; report-uri /report/csp_violations
 Location: /login [following]
 Reusing existing connection to localhost:443.
   HTTP/1.1 301 Moved Permanently
@@ -17,6 +18,7 @@ Reusing existing connection to localhost:443.
   Connection: keep-alive
   Location: /login/
   Strict-Transport-Security: max-age=15768000
+  Content-Security-Policy-Report-Only: default-src 'self'; img-src https:; media-src https:; report-uri /report/csp_violations
 Location: /login/ [following]
 Reusing existing connection to localhost:443.
   HTTP/1.1 200 OK
@@ -25,6 +27,7 @@ Reusing existing connection to localhost:443.
   Content-Length: 6361
   Connection: keep-alive
   Strict-Transport-Security: max-age=15768000
+  Content-Security-Policy-Report-Only: default-src 'self'; img-src https:; media-src https:; report-uri /report/csp_violations
 Length: 6361 (6.2K) [text/html]
 Saving to: ‘/tmp/index.html’
 

--- a/zerver/fixtures/csp_report.json
+++ b/zerver/fixtures/csp_report.json
@@ -1,0 +1,16 @@
+{
+    "csp-report": {
+        "document-uri": "http://localhost:9991/",
+        "referrer": "http://zulipdev.com:9991/devlogin/",
+        "violated-directive": "script-src",
+        "effective-directive": "script-src",
+        "original-policy": "default-src 'self'; report-uri /report/csp_violations",
+        "disposition": "report",
+        "blocked-uri": "eval",
+        "line-number": 1256,
+        "column-number": 1,
+        "source-file": "http://localhost:9991/webpack/common.js",
+        "status-code": 200,
+        "script-sample": ""
+    }
+}

--- a/zerver/tests/test_report.py
+++ b/zerver/tests/test_report.py
@@ -10,6 +10,7 @@ from zerver.lib.utils import statsd
 
 import mock
 import ujson
+import os
 
 def fix_params(raw_params: Dict[str, Any]) -> Dict[str, str]:
     # A few of our few legacy endpoints need their
@@ -150,3 +151,11 @@ class TestReport(ZulipTestCase):
         self.assert_json_success(result)
         # fix_params (see above) adds quotes when JSON encoding.
         annotate.assert_called_once_with('"trace"')
+
+    def test_report_csp_violations(self) -> None:
+        fixture_data_file = open(os.path.join(os.path.dirname(__file__),
+                                 '../fixtures/csp_report.json'), 'r')
+        fixture_data = ujson.load(fixture_data_file)
+        params = ujson.dumps(fixture_data)
+        result = self.client_post("/report/csp_violations", params, content_type="application/json")
+        self.assert_json_success(result)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -523,6 +523,10 @@ urls += url(r'^user_uploads/(?P<realm_id_str>(\d*|unk))/(?P<filename>.*)',
             {'GET': ('zerver.views.upload.serve_file_backend',
                      {'override_api_url_scheme'})}),
 
+# This url serves as a way to recieve CSP violation reports from the users.
+# We use this endpoint to just log these reports.
+urls += url(r'^report/csp_violations$', zerver.views.report.report_csp_violations,
+            name='zerver.views.report.report_csp_violations'),
 # Incoming webhook URLs
 # We don't create urls for particular git integrations here
 # because of generic one below


### PR DESCRIPTION
We add a new endpoint to log CSP reports sent by clients. This PR currently has the endpoint and a commit which tries to introduce a Report only CSP header into our main app via NGINX.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only

