### PR TITLE
Add Content-Disposition header to S3 uploads and migrate existing uploaded files in S3

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -179,10 +179,19 @@ def upload_image_to_s3(
     key.set_metadata("user_profile_id", str(user_profile.id))
     key.set_metadata("realm_id", str(user_profile.realm_id))
 
+    attachment = True
+    if content_type is not None and (content_type.startswith("image/") or
+                                     content_type == "application/pdf"):
+        attachment = False
+
+    headers = {}  # type: Dict[Text, Text]
     if content_type is not None:
-        headers = {'Content-Type': content_type}  # type: Optional[Dict[Text, Text]]
-    else:
-        headers = None
+        headers['Content-Type'] = content_type
+    if attachment:
+        parts = ["attachment"]
+        quoted_filename = urllib.parse.quote(os.path.basename(file_name))
+        parts.append("filename*=UTF-8''%s" % (quoted_filename))
+        headers['Content-Disposition'] = '; '.join(parts)
 
     key.set_contents_from_string(contents, headers=headers)  # type: ignore # https://github.com/python/typeshed/issues/1552
 

--- a/zerver/migrations/0156_add_content_disposition_to_s3_uploads.py
+++ b/zerver/migrations/0156_add_content_disposition_to_s3_uploads.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from typing import Text, Dict
+
+from boto.s3.bucket import Bucket
+from boto.s3.connection import S3Connection
+from boto.s3.key import Key
+from django.conf import settings
+from django.db import migrations
+from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+import os
+import urllib
+
+def add_content_disposition_to_s3_uploads(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    if settings.LOCAL_UPLOADS_DIR is None:
+        conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
+        bucket_name = settings.S3_AUTH_UPLOADS_BUCKET
+        bucket = conn.get_bucket(bucket_name, validate=False)
+
+        all_keys = map(lambda key: key.name, bucket.get_all_keys())
+        for key_name in all_keys:
+            key = bucket.get_key(key_name)
+            content_type = key.content_type
+            content_disposition = key.content_disposition
+
+            if content_disposition is not None:
+                continue
+
+            attachment = True
+            if content_type.startswith("image/") or content_type == "application/pdf":
+                attachment = False
+
+            headers = {}  # type: Dict[Text, Text]
+            headers['Content-Type'] = content_type
+            if attachment:
+                parts = ["attachment"]
+                quoted_filename = urllib.parse.quote(os.path.basename(key_name))
+                parts.append("filename*=UTF-8''%s" % (quoted_filename))
+                headers['Content-Disposition'] = '; '.join(parts)
+
+            bucket.copy_key(key_name,
+                            bucket_name,
+                            key_name,
+                            preserve_acl=True,
+                            headers=headers)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0155_change_default_realm_description'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_content_disposition_to_s3_uploads,
+                             reverse_code=migrations.RunPython.noop)
+    ]

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -52,7 +52,7 @@ from django.http import HttpRequest
 from django.utils.timezone import now as timezone_now
 from sendfile import _get_sendfile
 
-from typing import Any, Callable, Text
+from typing import Any, Callable, Text, Optional
 
 def destroy_uploads() -> None:
     if os.path.exists(settings.LOCAL_UPLOADS_DIR):
@@ -1127,6 +1127,38 @@ class S3Test(ZulipTestCase):
         uri = upload_message_file(u'dummy.txt', len(b'zulip!'), u'text/plain', b'zulip!', user_profile)
         path_id = re.sub('/user_uploads/', '', uri)
         self.assertEqual(user_profile.realm_id, get_realm_for_filename(path_id))
+
+    @use_s3_backend
+    def test_file_upload_headers_s3(self) -> None:
+        conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
+        bucket = conn.create_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
+        user_profile = self.example_user('hamlet')
+
+        def check_upload_file_headers(uploaded_file_name: str,
+                                      content_type: Optional[str],
+                                      content_disposition: str='') -> None:
+            uri = upload_message_file(uploaded_file_name, len(b'zulip!'), content_type, b'zulip!', user_profile)
+            path_id = re.sub('/user_uploads/', '', uri)
+            key = bucket.get_key(path_id)
+
+            if content_type is not None:
+                self.assertEqual(content_type, key.content_type)
+            else:
+                self.assertEqual('application/octet-stream', key.content_type)
+
+            if content_disposition != '':
+                self.assertEqual(content_disposition, key.content_disposition)
+            else:
+                self.assertEqual(key.content_disposition, None)
+
+        check_upload_file_headers('dummy.txt', 'text/plain', "attachment; filename*=UTF-8''dummy.txt")
+        check_upload_file_headers('áéБД.txt', 'text/plain', "attachment; filename*=UTF-8''%C3%A1%C3%A9%D0%91%D0%94.txt")
+        check_upload_file_headers('zulip.html', 'text/html', "attachment; filename*=UTF-8''zulip.html")
+        check_upload_file_headers('zulip.sh', 'text/x-sh', "attachment; filename*=UTF-8''zulip.sh")
+        check_upload_file_headers('dummy.jpeg', 'image/jpeg')
+        check_upload_file_headers('dummy.pdf', 'application/pdf')
+        check_upload_file_headers('áéБД.pdf', 'application/pdf')
+        check_upload_file_headers('zulip', None, "attachment; filename*=UTF-8''zulip")
 
 class UploadTitleTests(TestCase):
     def test_upload_titles(self) -> None:


### PR DESCRIPTION
In this PR we are adding Content-Disposition header to S3 upload code path. This will work much the same way it works for local uploads which are served by django sendfile (Xenial only thing).

Some important stuff about migration which might make sense to re iterate here apart from the commit message is:
We work on the assumption that not passing in any metadata in params will copy the metadata field from the original S3 key as said in the docs here: http://boto.cloudhackers.com/en/latest/ref/s3.html#boto.s3.bucket.Bucket.copy_key