### PR TITLE
browser-support: Add string.prototype.endswith polyfill.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "script-loader": "0.7.2",
     "source-map-loader": "0.2.3",
     "string.prototype.codepointat": "0.2.0",
+    "string.prototype.endswith": "0.2.0",
     "string.prototype.startswith": "0.2.0",
     "to-markdown": "3.1.0",
     "ts-loader": "2.1.0",

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -4,6 +4,7 @@
         "./static/js/portico/header.js"
     ],
     "common": [
+               "string.prototype.endswith",
                "string.prototype.startswith",
                "string.prototype.codepointat",
                "./node_modules/jquery/dist/jquery.js",

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '18.1'
+PROVISION_VERSION = '18.2'

--- a/yarn.lock
+++ b/yarn.lock
@@ -5980,6 +5980,10 @@ string.prototype.codepointat@0.2.0, string.prototype.codepointat@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz#6b26e9bd3afcaa7be3b4269b526de1b82000ac78"
 
+string.prototype.endswith@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz#a19c20dee51a98777e9a47e10f09be393b9bba75"
+
 string.prototype.startswith@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz#da68982e353a4e9ac4a43b450a2045d1c445ae7b"


### PR DESCRIPTION
String.prototype.endsWith is not supported in ie11.
Adds string.prototype.endswith package to dependencies and places
it at `common` entry point in webpack.assets.json.

https://github.com/mathiasbynens/String.prototype.endsWith

cc: @timabbott 