### PR TITLE
Removing User Doc Macros

### DIFF
--- a/docs/subsystems/user-docs.md
+++ b/docs/subsystems/user-docs.md
@@ -249,9 +249,9 @@ always create a new macro by adding a new file to that folder.
 
 ### **Organization settings** `{!admin.md!}` macro
 
-* **About:** Links to the **Organization settings** documentation.
-Usually preceded by the [**Go to the** macro](#go-to-the-go-to-the-md-macro)
-and a link to a particular section on the **Organization settings** page.
+* **About:** Links to the **Organization settings** documentation. Usually
+preceded by a link to a particular section on the **Organization settings**
+page.
 
 * **Contents:**
     ```md
@@ -260,7 +260,7 @@ and a link to a particular section on the **Organization settings** page.
 
 * **Example usage and rendering:**
     ```md
-    {!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+    1. Go to theOrganization settings](/#organization/organization-settings)
     {!admin.md!}
     ```
     ```md
@@ -346,27 +346,6 @@ macro](#message-actions-message-actions-md-macro).
     1. Hover over a message to replace the message's timestamp with its message
     actions, represented by three icons. From the icons that appear, select the
     down chevron (<i class="fa fa-chevron-down"></i>) icon to reveal an actions dropdown.
-    ```
-
-### **Go to the** `{!go-to-the.md}` macro
-
-* **About:** Usually precedes the [**Settings** macro](#settings-settings-md-macro)
-or the [**Organization settings** macro](#organization-settings-admin-md-macro). Transforms
-following content into a step.
-
-* **Contents:**
-    ```md
-    1. Go to the
-    ```
-
-* **Example usage and rendering:**
-    ```md
-    {!go-to-the.md!} [Notifications](/#settings/notifications)
-    {!settings.md!}
-    ```
-    ```md
-    1. Go to the [Notifications](/#settings/notifications) tab on the
-    [Settings](/help/edit-settings) page.
     ```
 
 ### **Filter streams** `{!filter-streams.md!}` macro
@@ -456,8 +435,7 @@ describing the settings they modified.
 ### **Settings** `{!settings.md!}` macro
 
 * **About:** Links to the **Edit Settings** documentation. Usually preceded by
-the [**Go to the** macro](#go-to-the-go-to-the-md-macro) and a link to a
-particular section on the **Settings** page.
+a link to a particular section on the **Settings** page.
 
 * **Contents:**
     ```md
@@ -466,7 +444,7 @@ particular section on the **Settings** page.
 
 * **Example usage and rendering:**
     ```md
-    {!go-to-the.md!} [Notifications](/#settings/notifications)
+    1. Go to the [Notifications](/#settings/notifications)
     {!settings.md!}
     ```
     ```md

--- a/docs/subsystems/user-docs.md
+++ b/docs/subsystems/user-docs.md
@@ -284,7 +284,7 @@ immediately after the title.
     ```md
     {!admin-only.md!}
 
-    {!follow-steps.md!} change who can join your stream by changing the stream's
+    Follow the following steps to change who can join your stream by changing the stream's
     accessibility.
     ```
     ```md
@@ -369,24 +369,6 @@ macro](#message-actions-message-actions-md-macro).
     1. [Find the relevant stream](/help/browse-and-join-streams#browse-streams) on the
     [Streams](/#streams) page. You can search for specific streams by entering the
     name of the stream in the **Filter streams** input.
-    ```
-
-### **Follow steps** `{!follow-steps.md!}` macro
-
-* **About:** Prepends phrases with instructions to follow the following steps.
-
-* **Contents:**
-    ```md
-    Follow the following steps to
-    ```
-
-* **Example usage and rendering:**
-    ```md
-    {!follow-steps.md!}  change your mobile notification settings.
-    ```
-    ```md
-    Follow the following steps to change your mobile notification
-    settings.
     ```
 
 ### **Message actions** `{!message-actions.md!}` macro

--- a/templates/zerver/help/add-a-bot-or-integration.md
+++ b/templates/zerver/help/add-a-bot-or-integration.md
@@ -4,7 +4,7 @@ Bots and integrations are features that are accessible to all members of an orga
 
 ## Add a bot
 
-{!go-to-the.md!} [Your bots](/#settings/your-bots)
+1. Go to the [Your bots](/#settings/your-bots)
 {!settings.md!}
 
 2. On this page, under the **Add a new bot** view, enter the bot type,

--- a/templates/zerver/help/add-a-custom-linkification-filter.md
+++ b/templates/zerver/help/add-a-custom-linkification-filter.md
@@ -9,7 +9,7 @@ define a filter to automatically linkify #1234 to
 https://github.com/zulip/zulip/pulls/1234, Z1234 to link to that
 Zendesk ticket ID, or anything similar.
 
-{!go-to-the.md!} [Filter settings](/#organization/filter-settings)
+1. Go to the [Filter settings](/#organization/filter-settings)
 {!admin.md!}
 
 5. In the green section labeled **Add a new filter**, find the **Regular expression**

--- a/templates/zerver/help/add-an-alert-word.md
+++ b/templates/zerver/help/add-an-alert-word.md
@@ -9,7 +9,7 @@ alert word is included in a message sent to a stream that you are subscribed to.
 Alert words will be highlighted within messages, and you will be alerted in
 accordance with your [notification settings](/#settings/notifications).
 
-{!go-to-the.md!} [Alert words](/#settings/alert-words)
+1. Go to the [Alert words](/#settings/alert-words)
 {!settings.md!}
 
 2. In the section labeled **Add a new alert word**, input the word/phrase you

--- a/templates/zerver/help/add-custom-emoji.md
+++ b/templates/zerver/help/add-custom-emoji.md
@@ -3,7 +3,7 @@
 If enabled by your Zulip organization administrator, you can add custom
 emojis to your organization for other members to use.
 
-{!go-to-the.md!} [Emoji Settings](/#organization/emoji-settings)
+1. Go to the [Emoji Settings](/#organization/emoji-settings)
 {!admin.md!}
 
 5. In the green section labeled **Add a new emoji**, find the **Emoji name** and

--- a/templates/zerver/help/allow-anyone-to-join-without-an-invitation.md
+++ b/templates/zerver/help/allow-anyone-to-join-without-an-invitation.md
@@ -11,7 +11,7 @@ members to those with email invitations.
 
 ## Limiting new membership to users invited by organization members
 
-{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
+1. Go to the [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 4. Locate the **Users need an invitation to join** checkbox under the

--- a/templates/zerver/help/allow-image-link-previews.md
+++ b/templates/zerver/help/allow-image-link-previews.md
@@ -6,7 +6,7 @@ By default, when a user uploads or links to an image or links to a website, a
 preview of the content will be shown. You can choose to disable previews of
 images and links separately.
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+1. Go to the [Organization settings](/#organization/organization-settings)
 {!admin.md!}
 
 2. Select the **Show previews of uploaded and linked images** or the

--- a/templates/zerver/help/change-a-users-name.md
+++ b/templates/zerver/help/change-a-users-name.md
@@ -4,7 +4,7 @@
 
 Ordinary users can [change their own names](/help/change-your-name), but
 administrators can change users' names when users are
-unavailable. {!follow-steps.md!} change the name of a user.
+unavailable. Follow the following steps to change the name of a user.
 
 1. Go to the [Users](/#organization/user-list-admin)
 {!admin.md!}

--- a/templates/zerver/help/change-a-users-name.md
+++ b/templates/zerver/help/change-a-users-name.md
@@ -6,7 +6,7 @@ Ordinary users can [change their own names](/help/change-your-name), but
 administrators can change users' names when users are
 unavailable. {!follow-steps.md!} change the name of a user.
 
-{!go-to-the.md!} [Users](/#organization/user-list-admin)
+1. Go to the [Users](/#organization/user-list-admin)
 {!admin.md!}
 
 2. Click on the pencil (<i class="icon-vector-pencil"></i>) icon next to

--- a/templates/zerver/help/change-the-date-and-time-format.md
+++ b/templates/zerver/help/change-the-date-and-time-format.md
@@ -4,7 +4,7 @@ By default, messages in Zulip are displayed with a 12-hour timestamp
 (e.g. 3:00 PM, not 15:00). If you prefer to see the time displayed in
 a 24-hour format, you can do so easily using the following procedure:
 
-{!go-to-the.md!} [Display settings](/#settings/display-settings)
+1. Go to the [Display settings](/#settings/display-settings)
 {!settings.md!}
 
 2. Select the option labeled **24-hour time (17:00

--- a/templates/zerver/help/change-the-default-language-for-your-organization.md
+++ b/templates/zerver/help/change-the-default-language-for-your-organization.md
@@ -4,7 +4,7 @@
 
 {!follow-steps.md!} change the default language of your organization.
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+1. Go to the [Organization settings](/#organization/organization-settings)
 {!admin.md!}
 
 2. Find and click on the **Default language** option under the

--- a/templates/zerver/help/change-the-default-language-for-your-organization.md
+++ b/templates/zerver/help/change-the-default-language-for-your-organization.md
@@ -2,7 +2,7 @@
 
 {!admin-only.md!}
 
-{!follow-steps.md!} change the default language of your organization.
+Follow the following steps to change the default language of your organization.
 
 1. Go to the [Organization settings](/#organization/organization-settings)
 {!admin.md!}

--- a/templates/zerver/help/change-the-privacy-of-a-stream.md
+++ b/templates/zerver/help/change-the-privacy-of-a-stream.md
@@ -2,7 +2,7 @@
 
 {!admin-only.md!}
 
-{!follow-steps.md!} change who can join your stream by changing the stream's
+Follow the following steps to change who can join your stream by changing the stream's
 privacy.
 
 Please note that any users that were previously subscribed to the stream will

--- a/templates/zerver/help/change-the-stream-description.md
+++ b/templates/zerver/help/change-the-stream-description.md
@@ -2,7 +2,7 @@
 
 {!admin-only.md!}
 
-{!follow-steps.md!} change the description of any stream in your
+Follow the following steps to change the description of any stream in your
 organization.
 
 {!subscriptions.md!}

--- a/templates/zerver/help/change-your-avatar.md
+++ b/templates/zerver/help/change-your-avatar.md
@@ -6,7 +6,7 @@ simply use your existing gravatar.
 
 You can also upload a custom avatar to Zulip.
 
-{!go-to-the.md!} [Your account](/#settings/your-account)
+1. Go to the [Your account](/#settings/your-account)
 {!settings.md!}
 
 2. Click the **Upload new avatar** button and choose an image to upload

--- a/templates/zerver/help/change-your-email-address.md
+++ b/templates/zerver/help/change-your-email-address.md
@@ -3,7 +3,7 @@
 If enabled by Zulip organization administrator, you can change your email address
 using the following steps.
 
-{!go-to-the.md!} [Your account](/#settings/your-account)
+1. Go to the [Your account](/#settings/your-account)
 {!settings.md!}
 
 2. Click on the **[Change]** link beside your email address.

--- a/templates/zerver/help/change-your-language.md
+++ b/templates/zerver/help/change-your-language.md
@@ -14,7 +14,7 @@ your Zulip account using the following procedure.
     the Zulip UI have been translated, you may still see English words
     interspersed throughout Zulip.
 
-{!go-to-the.md!} [Display settings](/#settings/display-settings)
+1. Go to the [Display settings](/#settings/display-settings)
 {!settings.md!}
 
 2. Next to the **Default language** heading, select the **[Change]** link.

--- a/templates/zerver/help/change-your-password.md
+++ b/templates/zerver/help/change-your-password.md
@@ -2,7 +2,7 @@
 
 ## If you know your current password
 
-{!go-to-the.md!} [Your account](/#settings/your-account)
+1. Go to the [Your account](/#settings/your-account)
 {!settings.md!}
 2. Click the **Change password** button located underneath your name.
 3. You will first be asked to enter your old password, and then to

--- a/templates/zerver/help/configure-authentication-methods.md
+++ b/templates/zerver/help/configure-authentication-methods.md
@@ -10,7 +10,7 @@ only), and/or various other SSO methods (also currently on premise only).
     If you are unsure about what these mean, don't worry! Zulip
     allows logging in via email and password by default.
 
-{!go-to-the.md!} [Authentication methods](/#organization/auth-methods)
+1. Go to the [Authentication methods](/#organization/auth-methods)
 {!admin.md!}
 
 2. Toggle the checkboxes next to the following options to configure your organization's authentication methods:

--- a/templates/zerver/help/configure-desktop-notifications.md
+++ b/templates/zerver/help/configure-desktop-notifications.md
@@ -3,7 +3,7 @@
 You can configure your settings to receive desktop notifications for messages
 sent while Zulip is offscreen.
 
-{!go-to-the.md!} [Notifications](/#settings/notifications)
+1. Go to the [Notifications](/#settings/notifications)
 {!settings.md!}
 
     * If you want desktop notifications for each new message from a stream,

--- a/templates/zerver/help/configure-email-digest-notifications.md
+++ b/templates/zerver/help/configure-email-digest-notifications.md
@@ -4,7 +4,7 @@
 with a summary of the activity on your Zulip organization, such as popular
 conversations and new users, while you were away.
 
-{!go-to-the.md!} [Notifications](/#settings/notifications)
+1. Go to the [Notifications](/#settings/notifications)
 {!settings.md!}
 
 2. Select the **Send digest emails when I'm away** option under the

--- a/templates/zerver/help/configure-email-digest-notifications.md
+++ b/templates/zerver/help/configure-email-digest-notifications.md
@@ -1,6 +1,6 @@
 # Configure email digest notifications
 
-{!follow-steps.md!} configure your settings to receive a weekly digest email
+Follow the following steps to configure your settings to receive a weekly digest email
 with a summary of the activity on your Zulip organization, such as popular
 conversations and new users, while you were away.
 

--- a/templates/zerver/help/configure-email-notifications.md
+++ b/templates/zerver/help/configure-email-notifications.md
@@ -3,7 +3,7 @@
 {!follow-steps.md!} configure your settings to receive email notifications
 for private messages and @-mentions sent while you are offline.
 
-{!go-to-the.md!} [Notifications](/#settings/notifications)
+1. Go to the [Notifications](/#settings/notifications)
 {!settings.md!}
 
 2. Select the **Email notifications** option under the

--- a/templates/zerver/help/configure-email-notifications.md
+++ b/templates/zerver/help/configure-email-notifications.md
@@ -1,6 +1,6 @@
 # Configure email notifications
 
-{!follow-steps.md!} configure your settings to receive email notifications
+Follow the following steps to configure your settings to receive email notifications
 for private messages and @-mentions sent while you are offline.
 
 1. Go to the [Notifications](/#settings/notifications)

--- a/templates/zerver/help/configure-mobile-notifications.md
+++ b/templates/zerver/help/configure-mobile-notifications.md
@@ -2,7 +2,7 @@
 
 {!follow-steps.md!} change your mobile notification settings.
 
-{!go-to-the.md!} [Notifications](/#settings/notifications)
+1. Go to the [Notifications](/#settings/notifications)
 {!settings.md!}
 
 2. Under the **Private messages and @-mentions** section, check the

--- a/templates/zerver/help/configure-mobile-notifications.md
+++ b/templates/zerver/help/configure-mobile-notifications.md
@@ -1,6 +1,6 @@
 # Configure mobile push notifications
 
-{!follow-steps.md!} change your mobile notification settings.
+Follow the following steps to change your mobile notification settings.
 
 1. Go to the [Notifications](/#settings/notifications)
 {!settings.md!}

--- a/templates/zerver/help/create-your-organization-profile.md
+++ b/templates/zerver/help/create-your-organization-profile.md
@@ -6,7 +6,7 @@ There are several aspects to your organization's profile that can be
 configured to customize how your organization appears to users and people
 searching for your organization.
 
-{!go-to-the.md!} [Organization profile](/#organization/organization-profile)
+1. Go to the [Organization profile](/#organization/organization-profile)
 {!admin.md!}
 
 ## Change your organization's name

--- a/templates/zerver/help/create-your-organization-profile.md
+++ b/templates/zerver/help/create-your-organization-profile.md
@@ -11,7 +11,7 @@ searching for your organization.
 
 ## Change your organization's name
 
-{!follow-steps.md!} change the name of your organization.
+Follow the following steps to change the name of your organization.
 
 2. Edit your organization's name in the **Your organization's name** textbox.
 You can choose any name of up to 40 characters for your organization.
@@ -20,7 +20,7 @@ You can choose any name of up to 40 characters for your organization.
 
 ## Change your organization's description
 
-{!follow-steps.md!} change the description of your organization.
+Follow the following steps to change the description of your organization.
 
 2. Edit your organization's description in the **Your organization's description**
 textbox. Markdown syntax is supported.
@@ -29,7 +29,7 @@ textbox. Markdown syntax is supported.
 
 ## Change your organization's avatar
 
-{!follow-steps.md!} change the avatar your organization uses.
+Follow the following steps to change the avatar your organization uses.
 
 2. Under the **Organization avatar** section, click the **Upload new icon**
 button and select the image you would like to use from your computer.

--- a/templates/zerver/help/deactivate-or-reactivate-a-bot.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-bot.md
@@ -11,7 +11,7 @@ in your organization.
 
 ## Deactivate a bot
 
-{!go-to-the.md!} [Bots](/#organization/bot-list-admin)
+1. Go to the [Bots](/#organization/bot-list-admin)
 {!admin.md!}
 
 4. Click the **Deactivate** button to the right of the bot that you want to
@@ -26,7 +26,7 @@ stricken through, confirming the success of the bot's deactivation.
 Zulip organization administrators can choose to reactivate a deactivated bot by
 following the following steps.
 
-{!go-to-the.md!} [Bots](/#organization/bot-list-admin)
+1. Go to the [Bots](/#organization/bot-list-admin)
 {!admin.md!}
 
 4. In the **Bots** section, click the **Reactivate** button to the right of the

--- a/templates/zerver/help/deactivate-or-reactivate-a-bot.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-bot.md
@@ -2,7 +2,7 @@
 
 {!admin-only.md!}
 
-{!follow-steps.md!} deactivate or reactivate any bots
+Follow the following steps to deactivate or reactivate any bots
 in your organization.
 
 !!! tip ""

--- a/templates/zerver/help/deactivate-or-reactivate-a-user.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-user.md
@@ -2,7 +2,7 @@
 
 {!admin-only.md!}
 
-{!follow-steps.md!} deactivate or reactivate any user's account in your
+Follow the following steps to deactivate or reactivate any user's account in your
 organization.
 
 ## Deactivate a user

--- a/templates/zerver/help/deactivate-or-reactivate-a-user.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-user.md
@@ -17,7 +17,7 @@ Instead, you should deactivate the user’s account using the Zulip
 **[organization administration interface](/help/change-your-organization-settings)**;
 this will also automatically deactivate any bots the user has created.
 
-{!go-to-the.md!} [Users](/#organization/user-list-admin)
+1. Go to the [Users](/#organization/user-list-admin)
 {!admin.md!}
 
  4. Click the **Deactivate** button to the right of the user account that you
@@ -42,7 +42,7 @@ disappear, confirming the success of the account's deactivation.
 Zulip organization administrators can choose to reactivate a user's deactivated account
 by following the following steps.
 
-{!go-to-the.md!} [Deactivated users](/#organization/deactivated-users-admin)
+1. Go to the [Deactivated users](/#organization/deactivated-users-admin)
 {!admin.md!}
 
 4. Click the **Reactivate** button to the right of the user account that you

--- a/templates/zerver/help/deactivate-your-account.md
+++ b/templates/zerver/help/deactivate-your-account.md
@@ -3,7 +3,7 @@
 We'd be sorry to see you go, but you can follow the following steps to
 deactivate your Zulip account.
 
-{!go-to-the.md!} [Your account](/#settings/your-account)
+1. Go to the [Your account](/#settings/your-account)
 {!settings.md!}
 
 2. Click the **Deactivate account** button on the bottom of the

--- a/templates/zerver/help/delete-a-stream.md
+++ b/templates/zerver/help/delete-a-stream.md
@@ -7,7 +7,7 @@ However, Zulip organization administrators must use the Zulip
 **[organization administration interface](/help/change-your-organization-settings)**
 to delete streams.
 
-{!go-to-the.md!} [Delete streams](/#organization/streams-list-admin)
+1. Go to the [Delete streams](/#organization/streams-list-admin)
 {!admin.md!}
 
 2. Find the stream you want to delete, and click the **Delete stream** button to

--- a/templates/zerver/help/disable-message-edit-history.md
+++ b/templates/zerver/help/disable-message-edit-history.md
@@ -14,7 +14,7 @@ If in your organization, you'd prefer that users not have access to
 message edit history, you can disable message edit history for your
 organization using the following steps:
 
-{!go-to-the.md!} [Organization settings](/#organization/settings)
+1. Go to the [Organization settings](/#organization/settings)
 {!admin.md!}
 
 2. Disable the the **Enable message edit history** checkbox under the

--- a/templates/zerver/help/enable-emoticon-translations.md
+++ b/templates/zerver/help/enable-emoticon-translations.md
@@ -15,7 +15,7 @@ or
 />
 automatically by Zulip.
 
-{!go-to-the.md!} [Display settings](/#settings/display-settings)
+1. Go to the [Display settings](/#settings/display-settings)
 {!settings.md!}
 
 2. Select the option labeled

--- a/templates/zerver/help/enable-high-contrast-mode.md
+++ b/templates/zerver/help/enable-high-contrast-mode.md
@@ -10,7 +10,7 @@ buttons, links and unread counts) are intentionally light in order to
 avoid having too much emphasis. However, you can choose to increase
 the contrast of the user interface by using the following procedure:
 
-{!go-to-the.md!} [Display settings](/#settings/display-settings)
+1. Go to the [Display settings](/#settings/display-settings)
 {!settings.md!}
 
 2. Select the option labeled **Enable high contrast mode**.
@@ -21,7 +21,7 @@ You might also wish to change the way emoji reactions to messages are
 displayed to increase readability. With this setting, a heart emoji
 will instead be displayed as `:heart:`.
 
-{!go-to-the.md!} [Display settings](/#settings/display-settings)
+1. Go to the [Display settings](/#settings/display-settings)
 {!settings.md!}
 
 2. Select the option labeled **Display emoji reactions as text**.

--- a/templates/zerver/help/enable-night-mode.md
+++ b/templates/zerver/help/enable-night-mode.md
@@ -5,7 +5,7 @@ for most environments.  However, Zulip also provides a "night mode"
 theme, which is great for working in a dark space.  You can switch to
 night mode as follows:
 
-{!go-to-the.md!} [Display settings](/#settings/display-settings)
+1. Go to the [Display settings](/#settings/display-settings)
 {!settings.md!}
 
 2. Select the option labeled **Night mode**.

--- a/templates/zerver/help/include/follow-steps.md
+++ b/templates/zerver/help/include/follow-steps.md
@@ -1,1 +1,0 @@
-Follow the following steps to

--- a/templates/zerver/help/include/go-to-the.md
+++ b/templates/zerver/help/include/go-to-the.md
@@ -1,1 +1,0 @@
-1. Go to the

--- a/templates/zerver/help/invite-a-friend-to-zulip.md
+++ b/templates/zerver/help/invite-a-friend-to-zulip.md
@@ -1,7 +1,7 @@
 # Invite a friend to Zulip
 
 By default, all users in a Zulip organization can invite users to
-their Zulip organization. {!follow-steps.md!}  invite a friend to Zulip.
+their Zulip organization. Follow the following steps to  invite a friend to Zulip.
 
 1. Click the cog (<i class="icon-vector-cog"></i>) in the top right corner of
    the right sidebar.

--- a/templates/zerver/help/make-a-user-an-administrator.md
+++ b/templates/zerver/help/make-a-user-an-administrator.md
@@ -4,7 +4,7 @@
 
 By default, everyone in an organization is a user; this limits them from
 modifying organization-wide settings, such as changing the organization name,
-activating or deactivating users, deleting streams, etc. {!follow-steps.md!}
+activating or deactivating users, deleting streams, etc. Follow the following steps to
 give any user in your organization administrative rights.
 
 1. Go to the [Users](/#organization/user-list-admin)

--- a/templates/zerver/help/make-a-user-an-administrator.md
+++ b/templates/zerver/help/make-a-user-an-administrator.md
@@ -7,7 +7,7 @@ modifying organization-wide settings, such as changing the organization name,
 activating or deactivating users, deleting streams, etc. {!follow-steps.md!}
 give any user in your organization administrative rights.
 
-{!go-to-the.md!} [Users](/#organization/user-list-admin)
+1. Go to the [Users](/#organization/user-list-admin)
 {!admin.md!}
 
 4. Click on the **Make admin** button for the user that you wish to make an
@@ -20,7 +20,7 @@ reload and the user will gain administrative privileges immediately.
 
 Administrators can also revoke the administrative rights given to a user.
 
-{!go-to-the.md!} [Users](/#organization/user-list-admin)
+1. Go to the [Users](/#organization/user-list-admin)
 {!admin.md!}
 
 2. Click on the **Remove admin** button.

--- a/templates/zerver/help/manage-your-uploaded-files.md
+++ b/templates/zerver/help/manage-your-uploaded-files.md
@@ -42,7 +42,7 @@ You can delete any of your uploaded files from your organization; however, doing
 so may confuse some of the other users in your organization since they can no
 longer view the file, so please be careful!
 
-{!go-to-the.md!} [Uploaded files](/#settings/uploaded-files)
+1. Go to the [Uploaded files](/#settings/uploaded-files)
 {!settings.md!}
 
 2. Locate the file you want to delete in the **Uploaded files** section; the

--- a/templates/zerver/help/manage-your-uploaded-files.md
+++ b/templates/zerver/help/manage-your-uploaded-files.md
@@ -1,6 +1,6 @@
 # Manage your uploaded files
 
-{!follow-steps.md!} view and manage the uploaded files to your organization.
+Follow the following steps to view and manage the uploaded files to your organization.
 
 ## View your uploaded files
 

--- a/templates/zerver/help/move-the-users-list-to-the-left-sidebar.md
+++ b/templates/zerver/help/move-the-users-list-to-the-left-sidebar.md
@@ -9,7 +9,7 @@ the left side of the screen under the **Streams** section in the left sidebar.
 You can easily change the location of the **Users** list by following a few
 steps.
 
-{!go-to-the.md!} [Display settings](/#settings/display-settings)
+1. Go to the [Display settings](/#settings/display-settings)
 {!settings.md!}
 
 2. Select the option labeled

--- a/templates/zerver/help/mute-a-topic.md
+++ b/templates/zerver/help/mute-a-topic.md
@@ -75,7 +75,7 @@ topic.
 
 ## Unmute a topic through the Settings page
 
-{!go-to-the.md!} [Muted topics](/#settings/muted-topics)
+1. Go to the [Muted topics](/#settings/muted-topics)
 {!settings.md!}
 
 2. Locate the topic you want to unmute in the **Muted topics** section; the

--- a/templates/zerver/help/only-allow-admins-to-add-emoji.md
+++ b/templates/zerver/help/only-allow-admins-to-add-emoji.md
@@ -6,7 +6,7 @@ By default, any user in your Zulip organization can add custom emoji to the
 organization. You can change your organization's settings to only allow
 administrators to add new emoji.
 
-{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
+1. Go to the [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 2. Select the **Prevent users from adding custom emoji** checkbox under the

--- a/templates/zerver/help/only-allow-admins-to-create-new-streams-feature.md
+++ b/templates/zerver/help/only-allow-admins-to-create-new-streams-feature.md
@@ -5,7 +5,7 @@
 By default, any user can create new streams. You can enable a setting that
 only allows administrators to create new streams in the organization.
 
-{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
+1. Go to the [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 2. Select the **Prevent users from creating streams** checkbox under the

--- a/templates/zerver/help/only-allow-admins-to-invite-new-users.md
+++ b/templates/zerver/help/only-allow-admins-to-invite-new-users.md
@@ -6,7 +6,7 @@ By default, any user in your Zulip organization can invite new users. You
 can change your organization's settings to only allow administrators to
 invite new users.
 
-{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
+1. Go to the [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 2. Select the **Users need an invitation to join** and **Only admins can invite new users**

--- a/templates/zerver/help/rename-a-stream.md
+++ b/templates/zerver/help/rename-a-stream.md
@@ -2,7 +2,7 @@
 
 {!admin-only.md!}
 
-{!follow-steps.md!} rename existing streams in your organization.
+Follow the following steps to rename existing streams in your organization.
 
 {!subscriptions.md!}
 {!filter-streams.md!}

--- a/templates/zerver/help/require-users-to-include-topics-in-stream-messages.md
+++ b/templates/zerver/help/require-users-to-include-topics-in-stream-messages.md
@@ -11,7 +11,7 @@ Some organizations prefer to require that every message to a stream
 includes a topic.  Organization administrators can choose to enforce
 the use of topics in new messages to streams:
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+1. Go to the [Organization settings](/#organization/organization-settings)
 {!admin.md!}
 
 2. Select the **Require topics in messages to streams** checkbox under the

--- a/templates/zerver/help/restrict-editing-of-old-messages-and-topics.md
+++ b/templates/zerver/help/restrict-editing-of-old-messages-and-topics.md
@@ -6,7 +6,7 @@ You can easily change the time limit that your organization's users have to
 change their messages after sending them. Alternatively, you can choose to
 disable message editing for your organization users.
 
-{!go-to-the.md!} [Organization settings](/#organization/organization-settings)
+1. Go to the [Organization settings](/#organization/organization-settings)
 {!admin.md!}
 
 4. Under the **Message editing** section, find the **Users can edit their messages**

--- a/templates/zerver/help/restrict-name-and-email-changes.md
+++ b/templates/zerver/help/restrict-name-and-email-changes.md
@@ -3,7 +3,7 @@
 {!admin-only.md!}
 
 
-{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
+1. Go to the [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 # Prevent users from changing their email address

--- a/templates/zerver/help/restrict-user-email-addresses-to-certain-domains.md
+++ b/templates/zerver/help/restrict-user-email-addresses-to-certain-domains.md
@@ -7,7 +7,7 @@ who are not in their organization. The administrator can accomplish this by
 restricting users to have email addresses only from the organization's
 domains.
 
-{!go-to-the.md!} [Organization permissions](/#organization/organization-permissions)
+1. Go to the [Organization permissions](/#organization/organization-permissions)
 {!admin.md!}
 
 2. Restricting user email addresses to certain domains can be enabled or disabled

--- a/templates/zerver/help/send-a-message-in-a-different-language.md
+++ b/templates/zerver/help/send-a-message-in-a-different-language.md
@@ -5,9 +5,9 @@ through your operating system.
 
 ## Change keyboard language on Linux
 
-{!go-to-the.md!} **System Settings** via the application launcher.
+1. Go to the **System Settings** via the application launcher.
 
-{!go-to-the.md!} **Text Entry** page.
+1. Go to the **Text Entry** page.
 
 3. Add a language by clicking on the plus
 (<i class="icon-vector-plus"></i>) icon.
@@ -28,7 +28,7 @@ This sets your current keyboard language to the selected language.
 
 2. Type "intl.cpl" in the **Start Search** box, and then press **ENTER**.
 
-{!go-to-the.md!} the **Keyboards and Language** tab.
+1. Go to the the **Keyboards and Language** tab.
 
 4. Click **Change keyboards** and then click **Add**.
 

--- a/templates/zerver/help/send-a-private-message.md
+++ b/templates/zerver/help/send-a-private-message.md
@@ -1,6 +1,6 @@
 # Send a private message
 
-{!follow-steps.md!} send a new private message.
+Follow the following steps to send a new private message.
 
 ## Open a new compose box for private messaging
 

--- a/templates/zerver/help/send-a-stream-message.md
+++ b/templates/zerver/help/send-a-stream-message.md
@@ -1,6 +1,6 @@
 # Send a new stream message
 
-{!follow-steps.md!} send a new stream message.
+Follow the following steps to send a new stream message.
 
 1. Click the **New topic** button located in the compose box
 at the bottom of your screen.  The compose box will open, showing the

--- a/templates/zerver/help/set-default-streams-for-new-users.md
+++ b/templates/zerver/help/set-default-streams-for-new-users.md
@@ -2,7 +2,7 @@
 
 {!admin-only.md!}
 
-{!follow-steps.md!} set the default streams that new users are automatically
+Follow the following steps to set the default streams that new users are automatically
 subscribed to.
 
 1. Go to the [Default streams](/#organization/default-streams-list)

--- a/templates/zerver/help/set-default-streams-for-new-users.md
+++ b/templates/zerver/help/set-default-streams-for-new-users.md
@@ -5,7 +5,7 @@
 {!follow-steps.md!} set the default streams that new users are automatically
 subscribed to.
 
-{!go-to-the.md!} [Default streams](/#organization/default-streams-list)
+1. Go to the [Default streams](/#organization/default-streams-list)
 {!admin.md!}
 
 2. To add a new stream to **Default streams**, enter the name of the stream in the

--- a/templates/zerver/help/verify-that-your-message-has-been-successfully-sent.md
+++ b/templates/zerver/help/verify-that-your-message-has-been-successfully-sent.md
@@ -20,7 +20,7 @@ rerenders the message to display the timestamp, so you can look for
 the timestamp to determine whether a message has been successfully
 received by the server.
 
-{!follow-steps.md!} to see this in action.
+Follow the following steps to to see this in action.
 
 1. Disconnect your computer from the Internet.
 


### PR DESCRIPTION
related to https://github.com/zulip/zulip/issues/8889 in that it involves the standardization of user docs, which is part of the point of doing all this in one batch. 