### PR TITLE
Added scroll for overflow

### DIFF
--- a/static/styles/hotspots.css
+++ b/static/styles/hotspots.css
@@ -125,6 +125,7 @@
     right: 15px;
     max-width: 125px;
     max-height: 70px;
+    overflow:auto;
 
     border: none;
 

--- a/static/styles/hotspots.css
+++ b/static/styles/hotspots.css
@@ -125,7 +125,7 @@
     right: 15px;
     max-width: 125px;
     max-height: 70px;
-    overflow:auto;
+    overflow: auto;
 
     border: none;
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#8837 
I added overflow: auto
This adds a scroll to the container when there there is overflow.
**Testing Plan:** <!-- How have you tested? -->
I tested on development with longer sentences to verifty.

**GIFs or Screenshots:** <!-- If a UI change.  See:

  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![screen shot 2018-04-11 at 5 41 29 pm](https://user-images.githubusercontent.com/22230038/38644841-fbf7dae6-3daf-11e8-80a8-77890cfefe94.png)
![screen shot 2018-04-11 at 5 41 01 pm](https://user-images.githubusercontent.com/22230038/38644845-00d4a580-3db0-11e8-8dce-98971f52f442.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
