### PR TITLE
yarn: Revert back to v0.27.5.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,7 @@ jobs:
               dirs=(/srv/zulip-{npm,venv}-cache)
               sudo mkdir -p "${dirs[@]}"
               sudo chown -R circleci "${dirs[@]}"
-              
-              # circleci has some sort of permission
-              # issues when installing new yarn verions
-              # so we just create and chown it to circleci
-              mkdir -p ~/.config
-              sudo chown -R circleci ~/.config
+
       - restore_cache:
           keys:
           - v1-npm-base.trusty.1
@@ -106,8 +101,6 @@ jobs:
               sudo mkdir -p "${dirs[@]}"
               sudo chown -R circleci "${dirs[@]}"
 
-              mkdir -p ~/.config
-              sudo chown -R circleci ~/.config
       - restore_cache:
           keys:
           - v1-npm-base.xenial.1

--- a/scripts/lib/install-node
+++ b/scripts/lib/install-node
@@ -8,7 +8,7 @@ if [ "$TRAVIS" ] ; then
 fi
 YARN_BIN="$ZULIP_SRV/zulip-yarn/bin/yarn"
 node_version=8.11.1
-yarn_version=1.5.1
+yarn_version=0.27.5
 
 current_node_version="none"
 if hash node 2>/dev/null; then

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.7.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '18.2'
+PROVISION_VERSION = '19.0'


### PR DESCRIPTION
Revert yarn version back due to some issue with new version that causes
permission issues in ~/.config/yarn directory.

Related discussion: https://chat.zulip.org/#narrow/stream/21-provision-help/topic/EACCES.3A.20permission.20denied.2C.20scandir.20'.2Fhome.2Fvagrant.2F.2Econfig.2Fya