### PR TITLE
Subscription: Fixed subscription bug.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -177,7 +177,7 @@ def can_access_stream_user_ids(stream: Stream) -> Set[int]:
     if stream.is_public():
         return set(active_user_ids(stream.realm_id))
     else:
-        return private_stream_user_ids(stream.id)
+        return private_stream_user_ids(stream.id) | {user.id for user in stream.realm.get_admin_users()}
 
 def private_stream_user_ids(stream_id: int) -> Set[int]:
     # TODO: Find similar queries elsewhere and de-duplicate this code.


### PR DESCRIPTION
![issue_9034](https://user-images.githubusercontent.com/15901908/38712259-13037a5a-3ed3-11e8-9192-f9ee239b22ad.gif)
Admin can now unsubscribe others from private stream after stream is renamed.

Fixes #9034.
