### PR TITLE
markdown: Increase rendered_content length limit.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1970,8 +1970,8 @@ def do_convert(content: Text,
         # Throw an exception if the content is huge; this protects the
         # rest of the codebase from any bugs where we end up rendering
         # something huge.
-        if len(rendered_content) > MAX_MESSAGE_LENGTH * 2:
-            raise BugdownRenderingException()
+        if len(rendered_content) > MAX_MESSAGE_LENGTH * 10:
+            raise BugdownRenderingException('Rendered Content Length Exceeded')
         return rendered_content
     except Exception:
         cleaned = privacy_clean_markdown(content)

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -1261,7 +1261,7 @@ class BugdownErrorTests(ZulipTestCase):
 
     def test_ultra_long_rendering(self) -> None:
         """A message with an ultra-long rendering throws an exception"""
-        msg = u'* a\n' * (MAX_MESSAGE_LENGTH // 5)  # Rendering is >20K characters
+        msg = u'* a\n' * MAX_MESSAGE_LENGTH  # Rendering is >100K characters
 
         with self.simulated_markdown_failure():
             with self.assertRaises(bugdown.BugdownRenderingException):


### PR DESCRIPTION
This commit increases the rendered_content limit from 2x to 10x of the
original message length.

Earlier, we had placed a limit of MAX_MESSAGE_LENGTH * 2 for the rendered
content (explained in commit 77addc5456c3e61062bd3615d1ec0d33bb105a90).
That limit was based on the assumption that in most cases, the rendered
content wouldn't cause an exponential increase in message length. However,
quite prominently in syntax highlighted codeblocks, that wasn't true and
this caused the limit condition to be hit for messages composed primarily
of code blocks.

Example: The following message would render close to 10x it's original size.

```py
if:
def:
print("x", var)
x = y
```
