### PR TITLE
 upload: Fix stacking of progress bar on canceling the upload.

### DIFF
--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -33,13 +33,14 @@ var upload_opts = upload.options({ mode: "compose" });
     };
     $("#compose-error-msg").html('');
     var test_html = '<div class="progress active">' +
-                    '<div class="bar" id="compose-upload-bar" style="width: 0"></div>' +
+                    '<div class="bar" id="compose-upload-bar-1549958107000" style="width: 0"></div>' +
                     '</div>';
     $("#compose-send-status").append = function (html) {
         assert.equal(html, test_html);
     };
 
     upload_opts.drop();
+    upload_opts.uploadStarted(0, {lastModified: 1549958107000}, 1);
 
     assert.equal($("#compose-send-button").attr("disabled"), '');
     assert($("#compose-send-status").hasClass("alert-info"));
@@ -49,11 +50,11 @@ var upload_opts = upload.options({ mode: "compose" });
 
 (function test_progress_updated() {
     var width_update_checked = false;
-    $("#compose-upload-bar").width = function (width_percent) {
+    $("#compose-upload-bar-1549958107000").width = function (width_percent) {
         assert.equal(width_percent, '39%');
         width_update_checked = true;
     };
-    upload_opts.progressUpdated(1, '', 39);
+    upload_opts.progressUpdated(1, {lastModified: 1549958107000}, 39);
     assert(width_update_checked);
 }());
 
@@ -64,7 +65,7 @@ var upload_opts = upload.options({ mode: "compose" });
         $("#compose-send-button").attr("disabled", 'disabled');
         $("#compose-error-msg").text('');
 
-        $("#compose-upload-bar").parent = function () {
+        $("#compose-upload-bar-1549958107000").parent = function () {
             return { remove: function () {} };
         };
     }
@@ -78,6 +79,7 @@ var upload_opts = upload.options({ mode: "compose" });
 
     function test(err, msg, server_response=null, file={}) {
         setup_test();
+        file.lastModified = 1549958107000;
         upload_opts.error(err, server_response, file);
         assert_side_effects(msg);
     }
@@ -132,6 +134,10 @@ var upload_opts = upload.options({ mode: "compose" });
                 assert.equal(elem, $('#file_input'));
                 file_input_clear = true;
             };
+
+            $("#compose-upload-bar-1549958107000").parent = function () {
+                return { remove: function () {$('div.progress.active').length = 0;} };
+            };
         }
 
         function assert_side_effects() {
@@ -150,13 +156,13 @@ var upload_opts = upload.options({ mode: "compose" });
             func();
         });
 
-        $("#compose-upload-bar").width = function (width_percent) {
+        $("#compose-upload-bar-1549958107000").width = function (width_percent) {
             assert.equal(width_percent, '100%');
         };
 
         setup();
-        upload_opts.uploadFinished(i, {}, response);
-        upload_opts.progressUpdated(1, '', 100);
+        upload_opts.uploadFinished(i, {lastModified: 1549958107000}, response);
+        upload_opts.progressUpdated(1, {lastModified: 1549958107000}, 100);
         assert_side_effects();
     }
 

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -24,7 +24,6 @@ exports.options = function (config) {
     var send_status_close;
     var error_msg;
     var upload_bar;
-    var should_hide_upload_status;
     var file_input;
 
     switch (config.mode) {
@@ -50,41 +49,29 @@ exports.options = function (config) {
         throw Error("Invalid upload mode!");
     }
 
-    var maybe_hide_upload_status = function () {
-        // The first time `maybe_hide_upload_status`, it will not hide the
-        // status; the second time it will. This guarantees that whether
-        // `progressUpdated` or `uploadFinished` is called first, the status
-        // is hidden only after the animation is finished.
-        if (should_hide_upload_status) {
-            setTimeout(function () {
-                send_button.prop("disabled", false);
-                send_status.removeClass("alert-info").hide();
-                $("#" + upload_bar).parent().remove();
-            }, 500);
-        } else {
-            should_hide_upload_status = true;
-        }
+    var hide_upload_status = function () {
+        setTimeout(function () {
+            send_button.prop("disabled", false);
+            send_status.removeClass("alert-info").hide();
+            $("#" + upload_bar).parent().remove();
+        }, 500);
     };
 
     var drop = function () {
         send_button.attr("disabled", "");
         send_status.addClass("alert-info").show();
         send_status_close.one('click', function () {
-            maybe_hide_upload_status();
+            hide_upload_status();
             compose.abort_xhr();
         });
         error_msg.html($("<p>").text(i18n.t("Uploading…")));
         send_status.append('<div class="progress active">' +
                            '<div class="bar" id="' + upload_bar + '" style="width: 0"></div>' +
                            '</div>');
-        should_hide_upload_status = false;
     };
 
     var progressUpdated = function (i, file, progress) {
         $("#" + upload_bar).width(progress + "%");
-        if (progress === 100) {
-            maybe_hide_upload_status();
-        }
     };
 
     var uploadError = function (error_code, server_response, file) {
@@ -146,7 +133,7 @@ exports.options = function (config) {
         }
         compose_ui.autosize_textarea();
 
-        maybe_hide_upload_status();
+        hide_upload_status();
 
         // In order to upload the same file twice in a row, we need to clear out
         // the file input element, so that the next time we use the file dialog,

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -50,10 +50,8 @@ exports.options = function (config) {
     }
 
     var hide_upload_status = function () {
-        setTimeout(function () {
-            send_button.prop("disabled", false);
-            send_status.removeClass("alert-info").hide();
-        }, 500);
+        send_button.prop("disabled", false);
+        send_status.removeClass("alert-info").hide();
         $('div.progress.active').remove();
     };
 
@@ -61,7 +59,9 @@ exports.options = function (config) {
         send_button.attr("disabled", "");
         send_status.addClass("alert-info").show();
         send_status_close.one('click', function () {
-            hide_upload_status();
+            setTimeout(function () {
+                hide_upload_status();
+            }, 500);
             compose.abort_xhr();
         });
     };
@@ -140,10 +140,12 @@ exports.options = function (config) {
         }
         compose_ui.autosize_textarea();
 
-        $("#" + upload_bar  + '-' + file.lastModified).parent().remove();
-        if ($('div.progress.active').length === 0) {
-            hide_upload_status();
-        }
+        setTimeout(function () {
+            $("#" + upload_bar  + '-' + file.lastModified).parent().remove();
+            if ($('div.progress.active').length === 0) {
+                hide_upload_status(file);
+            }
+        }, 500);
 
         // In order to upload the same file twice in a row, we need to clear out
         // the file input element, so that the next time we use the file dialog,

--- a/static/third/jquery-filedrop/jquery.filedrop.js
+++ b/static/third/jquery-filedrop/jquery.filedrop.js
@@ -546,7 +546,7 @@
                            index: e.target.index };
 
         do_xhr(fileName, fileData, file.type, extra_opts, "", finished_callback, on_error);
-
+        opts.uploadStarted(index, file, files_count);
       };
 
       // Initiate the processing loop


### PR DESCRIPTION
Here we can see on canceling first upload there is no stacking of progress bar while second upload. 
![gif fix upload](https://user-images.githubusercontent.com/22238472/38753328-9ca86e66-3f7b-11e8-89ad-153c9dc64717.gif)

I'll push second fix here soon.
