### PR TITLE
stream-settings: Remove redundant actually_filter_streams function call.

### DIFF
--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -156,7 +156,6 @@ stream_data.add_sub('Frontend', frontend);
     // Test unread count update
     with_overrides(function (override) {
         global.with_stub(function (stub) {
-            override('subs.actually_filter_streams', noop);
             override('message_util.do_unread_count_updates', stub.f);
             stream_events.mark_subscribed(frontend, [], '');
             var args = stub.get_args('messages');
@@ -167,19 +166,15 @@ stream_data.add_sub('Frontend', frontend);
     set_global('message_util', { do_unread_count_updates: noop });
 
     // Test jQuery event
-    with_overrides(function (override) {
         global.with_stub(function (stub) {
-            override('subs.actually_filter_streams', noop);
             $(document).on('subscription_add_done.zulip', stub.f);
             stream_events.mark_subscribed(frontend, [], '');
             var args = stub.get_args('event');
             assert.equal(args.event.sub.stream_id, 1);
         });
-    });
 
     // Test bookend update
     with_overrides(function (override) {
-        override('subs.actually_filter_streams', noop);
         override('narrow_state.is_for_stream_id', function () {
             return true;
         });
@@ -194,12 +189,9 @@ stream_data.add_sub('Frontend', frontend);
     // reset overridden value
     set_global('narrow_state', { is_for_stream_id: noop });
 
-    with_overrides(function (override) {
-        override('subs.actually_filter_streams', noop);
-        // Test setting color
-        stream_events.mark_subscribed(frontend, [], 'blue');
-        assert.equal(frontend.color, 'blue');
-    });
+    // Test setting color
+    stream_events.mark_subscribed(frontend, [], 'blue');
+    assert.equal(frontend.color, 'blue');
 
     // Test assigning generated color
     with_overrides(function (override) {
@@ -213,7 +205,6 @@ stream_data.add_sub('Frontend', frontend);
         });
 
         global.with_stub(function (stub) {
-            override('subs.actually_filter_streams', noop);
             override('subs.set_color', stub.f);
             stream_events.mark_subscribed(frontend, [], undefined);
             var args = stub.get_args('id', 'color');
@@ -227,7 +218,6 @@ stream_data.add_sub('Frontend', frontend);
     with_overrides(function (override) {
         global.with_stub(function (stub) {
             override('stream_data.set_subscribers', stub.f);
-            override('subs.actually_filter_streams', noop);
             var user_ids = [15, 20, 25];
             stream_events.mark_subscribed(frontend, user_ids, '');
             var args = stub.get_args('sub', 'subscribers');

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -109,7 +109,6 @@ exports.mark_subscribed = function (sub, subscribers, color) {
 
     if (overlays.streams_open()) {
         subs.update_settings_for_subscribed(sub);
-        subs.actually_filter_streams();
     }
 
     if (narrow_state.is_for_stream_id(sub.stream_id)) {


### PR DESCRIPTION
Fixes #9033.
After adding a newly created stream to the top of the stream list,
call to actually_filter_streams in stream_events.mark_subscribed
rerendered the filter_table and the stream list was refreshed.
Actually_filter streams was introduced to rerender the subscriber
list but stream_edit.rerender_subscribers_list takes care of it rn.

`actually_filter_streams` was added in https://github.com/zulip/zulip/commit/20af49b2bb503f9eb2b76250c5a75c277ced803b to solve #6797.
`rerender_subscribers_list` was added in https://github.com/zulip/zulip/commit/9090d6b12f1e7f0c8e45a3f0b6e273cc8ca0fe72 to solve #6955.

Although no visual change was noticed, this change may break things if `actually_filter_streams` was also used here for any other purpose, cc'ing @brockwhittaker for that.


