### PR TITLE
puppet: Allow manual configuration of postfix_mailname.

### DIFF
--- a/puppet/zulip/manifests/postfix_localmail.pp
+++ b/puppet/zulip/manifests/postfix_localmail.pp
@@ -4,6 +4,7 @@ class zulip::postfix_localmail {
   if $fqdn == '' {
     fail("Your system does not have a fully-qualified domain name defined. See hostname(1).")
   }
+  $postfix_mailname = zulipconf("postfix", "mailname", $fqdn)
   package { $postfix_packages:
     ensure => "installed",
     require => File['/etc/mailname'],

--- a/puppet/zulip/templates/postfix/main.cf.erb
+++ b/puppet/zulip/templates/postfix/main.cf.erb
@@ -15,12 +15,12 @@ smtpd_use_tls=yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
-myhostname = <%= @fqdn %>
+myhostname = <%= @postfix_mailname %>
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 transport_maps = hash:/etc/postfix/transport
 myorigin = /etc/mailname
-mydestination = localhost, <%= @fqdn %>
+mydestination = localhost, <%= @postfix_mailname %>
 relayhost =
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0


### PR DESCRIPTION
This allows users to configure a mailname for postfix in
/etc/zulip/zulip.conf

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
