### PR TITLE
components: Simplify toggle component.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,7 @@
         "user_groups": false,
         "navigate": false,
         "toMarkdown": false,
+        "settings_toggle": false,
         "settings_account": false,
         "settings_display": false,
         "settings_notifications": false,

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -125,7 +125,6 @@ var RIGHT_KEY = { which: 39, preventDefault: noop };
 
     var widget;
     widget = components.toggle({
-        name: "info-overlay-toggle",
         selected: 0,
         values: [
             { label: i18n.t("Keyboard shortcuts"), key: "keyboard-shortcuts" },
@@ -157,7 +156,7 @@ var RIGHT_KEY = { which: 39, preventDefault: noop };
 
     callback_args = undefined;
 
-    components.toggle.lookup("info-overlay-toggle").goto('markdown-help');
+    widget.goto('markdown-help');
     assert.equal(focused_tab, 1);
     assert.equal(tabs[0].class, 'first');
     assert.equal(tabs[1].class, 'middle selected');

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -118,7 +118,7 @@ exports.launch_page = function (tab) {
     var $active_tab = $("#settings_overlay_container li[data-section='" + tab + "']");
 
     if ($active_tab.hasClass("admin")) {
-        components.toggle.lookup("settings-toggle").goto("organization", { dont_switch_tab: true });
+        settings_toggle.highlight_toggle('organization');
     }
 
     overlays.open_settings();

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -762,34 +762,6 @@ $(function () {
 
         $(".settings-section" + sel + ", .settings-wrapper" + sel).addClass("show");
     });
-
-    (i18n.ensure_i18n(function () {
-        var settings_toggle = components.toggle({
-            name: "settings-toggle",
-            values: [
-                { label: i18n.t("Settings"), key: "settings" },
-                { label: i18n.t("Organization"), key: "organization" },
-            ],
-            callback: function (name, key, payload) {
-                $(".sidebar li").hide();
-
-                if (key === "organization") {
-                    $("li.admin").show();
-                    if (!payload.dont_switch_tab) {
-                        $("li[data-section='organization-profile']").click();
-                    }
-                } else {
-                    $(".settings-list li:not(.admin)").show();
-                    if (!payload.dont_switch_tab) {
-                        $("li[data-section='your-account']").click();
-                    }
-                }
-            },
-        }).get();
-
-        $("#settings_overlay_container .tab-container")
-            .append(settings_toggle);
-    }));
 });
 
 return exports;

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -4,7 +4,6 @@ var exports = {};
 
 /* USAGE:
     Toggle x = components.toggle({
-        name: String toggle_name,
         selected: Integer selected_index,
         values: Array<Object> [
             { label: i18n.t(String title) }
@@ -15,145 +14,124 @@ var exports = {};
     }).get();
 */
 
-exports.toggle = (function () {
-    var keys = {};
+exports.toggle = function (opts) {
+    var component = (function render_component(opts) {
+        var _component = $("<div class='tab-switcher'></div>");
+        opts.values.forEach(function (value, i) {
+            // create a tab with a tab-id so they don't have to be referenced
+            // by text value which can be inconsistent.
+            var tab = $("<div class='ind-tab' data-tab-key='" + value.key + "' data-tab-id='" + i + "' tabindex='0'>" + value.label + "</div>");
 
-    var __toggle = function (opts) {
-        var component = (function render_component(opts) {
-            var _component = $("<div class='tab-switcher'></div>");
-            opts.values.forEach(function (value, i) {
-                // create a tab with a tab-id so they don't have to be referenced
-                // by text value which can be inconsistent.
-                var tab = $("<div class='ind-tab' data-tab-key='" + value.key + "' data-tab-id='" + i + "' tabindex='0'>" + value.label + "</div>");
-
-                // add proper classes for styling in CSS.
-                if (i === 0) {
-                    // this should be default selected unless otherwise specified.
-                    tab.addClass("first selected");
-                } else if (i === opts.values.length - 1) {
-                    tab.addClass("last");
-                } else {
-                    tab.addClass("middle");
-                }
-                _component.append(tab);
-            });
-            return _component;
-        }(opts));
-
-        var meta = {
-            $ind_tab: component.find(".ind-tab"),
-            idx: -1,
-        };
-
-        function select_tab(idx, payload) {
-            meta.$ind_tab.removeClass("selected");
-
-            var elem = meta.$ind_tab.eq(idx);
-            elem.addClass("selected");
-
-            if (idx !== meta.idx) {
-                meta.idx = idx;
-                if (opts.callback) {
-                    opts.callback(
-                        opts.values[idx].label,
-                        opts.values[idx].key,
-                        payload || {}
-                    );
-                }
+            // add proper classes for styling in CSS.
+            if (i === 0) {
+                // this should be default selected unless otherwise specified.
+                tab.addClass("first selected");
+            } else if (i === opts.values.length - 1) {
+                tab.addClass("last");
+            } else {
+                tab.addClass("middle");
             }
+            _component.append(tab);
+        });
+        return _component;
+    }(opts));
 
-            if (!opts.child_wants_focus) {
-                elem.focus();
-            }
-        }
-
-        function maybe_go_left() {
-            if (meta.idx > 0) {
-                select_tab(meta.idx - 1);
-                return true;
-            }
-        }
-
-        function maybe_go_right() {
-            if (meta.idx < opts.values.length - 1) {
-                select_tab(meta.idx + 1);
-                return true;
-            }
-        }
-
-        (function () {
-            meta.$ind_tab.click(function () {
-                var idx = $(this).data("tab-id");
-                select_tab(idx);
-            });
-
-            keydown_util.handle({
-                elem: meta.$ind_tab,
-                handlers: {
-                    left_arrow: maybe_go_left,
-                    right_arrow: maybe_go_right,
-                },
-            });
-
-            // We should arguably default opts.selected to 0.
-            if (typeof opts.selected === "number") {
-                select_tab(opts.selected);
-            }
-        }());
-
-        var prototype = {
-            maybe_go_left: maybe_go_left,
-            maybe_go_right: maybe_go_right,
-
-            value: function () {
-                if (meta.idx >= 0) {
-                    return opts.values[meta.idx].label;
-                }
-            },
-
-            get: function () {
-                return component;
-            },
-            // go through the process of finding the correct tab for a given name,
-            // and when found, select that one and provide the proper callback.
-            // supply a payload of data; since this is a custom event, we'll pass
-            // the data through to the callback.
-            goto: function (name, payload) {
-                // there are cases in which you would want to set this tab, but
-                // not to run the content inside the callback because it doesn't
-                // need to be initialized.
-                var value = _.find(opts.values, function (o) {
-                    return o.label === name || o.key === name;
-                });
-
-                var idx = opts.values.indexOf(value);
-
-                if (idx >= 0) {
-                    select_tab(idx, payload);
-                }
-            },
-        };
-
-        if (opts.name) {
-            keys[opts.name] = {
-                opts: opts,
-                component: component,
-                value: prototype.value,
-                goto: prototype.goto,
-            };
-        }
-
-        return prototype;
+    var meta = {
+        $ind_tab: component.find(".ind-tab"),
+        idx: -1,
     };
 
-    // look up a toggle globally by the name you set it as and return
-    // the prototype.
-    __toggle.lookup = function (id) {
-        return keys[id];
+    function select_tab(idx, payload) {
+        meta.$ind_tab.removeClass("selected");
+
+        var elem = meta.$ind_tab.eq(idx);
+        elem.addClass("selected");
+
+        if (idx !== meta.idx) {
+            meta.idx = idx;
+            if (opts.callback) {
+                opts.callback(
+                    opts.values[idx].label,
+                    opts.values[idx].key,
+                    payload || {}
+                );
+            }
+        }
+
+        if (!opts.child_wants_focus) {
+            elem.focus();
+        }
+    }
+
+    function maybe_go_left() {
+        if (meta.idx > 0) {
+            select_tab(meta.idx - 1);
+            return true;
+        }
+    }
+
+    function maybe_go_right() {
+        if (meta.idx < opts.values.length - 1) {
+            select_tab(meta.idx + 1);
+            return true;
+        }
+    }
+
+    (function () {
+        meta.$ind_tab.click(function () {
+            var idx = $(this).data("tab-id");
+            select_tab(idx);
+        });
+
+        keydown_util.handle({
+            elem: meta.$ind_tab,
+            handlers: {
+                left_arrow: maybe_go_left,
+                right_arrow: maybe_go_right,
+            },
+        });
+
+        // We should arguably default opts.selected to 0.
+        if (typeof opts.selected === "number") {
+            select_tab(opts.selected);
+        }
+    }());
+
+    var prototype = {
+        maybe_go_left: maybe_go_left,
+        maybe_go_right: maybe_go_right,
+
+        value: function () {
+            if (meta.idx >= 0) {
+                return opts.values[meta.idx].label;
+            }
+        },
+
+        get: function () {
+            return component;
+        },
+        // go through the process of finding the correct tab for a given name,
+        // and when found, select that one and provide the proper callback.
+        // supply a payload of data; since this is a custom event, we'll pass
+        // the data through to the callback.
+        goto: function (name, payload) {
+            // there are cases in which you would want to set this tab, but
+            // not to run the content inside the callback because it doesn't
+            // need to be initialized.
+            var value = _.find(opts.values, function (o) {
+                return o.label === name || o.key === name;
+            });
+
+            var idx = opts.values.indexOf(value);
+
+            if (idx >= 0) {
+                select_tab(idx, payload);
+            }
+        },
     };
 
-    return __toggle;
-}());
+    return prototype;
+};
 
 return exports;
 }());

--- a/static/js/info_overlay.js
+++ b/static/js/info_overlay.js
@@ -27,7 +27,6 @@ exports.toggler = undefined;
 
 function _setup_info_overlay() {
     var opts = {
-        name: "info-overlay-toggle",
         selected: 0,
         child_wants_focus: true,
         values: [

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -155,7 +155,7 @@ exports.launch_page = function (tab) {
     var $active_tab = $("#settings_overlay_container li[data-section='" + tab + "']");
 
     if (!$active_tab.hasClass("admin")) {
-        components.toggle.lookup("settings-toggle").goto("settings", { dont_switch_tab: true });
+        settings_toggle.highlight_toggle('settings');
     }
 
     overlays.open_settings();

--- a/static/js/settings_toggle.js
+++ b/static/js/settings_toggle.js
@@ -1,0 +1,50 @@
+var settings_toggle = (function () {
+
+var exports = {};
+
+var toggler;
+
+exports.highlight_toggle = function (tab_name) {
+    if (toggler) {
+        toggler.goto(tab_name, { dont_switch_tab: true });
+    }
+};
+
+exports.create_toggler = function () {
+    toggler = components.toggle({
+        name: "settings-toggle",
+        values: [
+            { label: i18n.t("Settings"), key: "settings" },
+            { label: i18n.t("Organization"), key: "organization" },
+        ],
+        callback: function (name, key, payload) {
+            $(".sidebar li").hide();
+
+            if (key === "organization") {
+                $("li.admin").show();
+                if (!payload.dont_switch_tab) {
+                    $("li[data-section='organization-profile']").click();
+                }
+            } else {
+                $(".settings-list li:not(.admin)").show();
+                if (!payload.dont_switch_tab) {
+                    $("li[data-section='your-account']").click();
+                }
+            }
+        },
+    });
+
+    $("#settings_overlay_container .tab-container").append(toggler.get());
+};
+
+exports.initialize = function () {
+    i18n.ensure_i18n(exports.create_toggler);
+};
+
+return exports;
+
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = settings_toggle;
+}

--- a/static/js/settings_toggle.js
+++ b/static/js/settings_toggle.js
@@ -12,7 +12,6 @@ exports.highlight_toggle = function (tab_name) {
 
 exports.create_toggler = function () {
     toggler = components.toggle({
-        name: "settings-toggle",
         values: [
             { label: i18n.t("Settings"), key: "settings" },
             { label: i18n.t("Organization"), key: "organization" },

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -447,7 +447,6 @@ exports.setup_page = function (callback) {
     // Also, we'll always go back to the "Subscribed" tab.
     function initialize_components() {
         exports.toggler = components.toggle({
-            name: "stream-filter-toggle",
             values: [
                 { label: i18n.t("Subscribed"), key: "subscribed" },
                 { label: i18n.t("All streams"), key: "all-streams" },

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -270,6 +270,7 @@ $(function () {
     notifications.initialize();
     gear_menu.initialize();
     settings_sections.initialize();
+    settings_toggle.initialize();
     hashchange.initialize();
     pointer.initialize();
     unread_ui.initialize();

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1093,6 +1093,7 @@ JS_SPECS = {
             'js/ui_util.js',
             'js/pointer.js',
             'js/click_handlers.js',
+            'js/settings_toggle.js',
             'js/scroll_bar.js',
             'js/gear_menu.js',
             'js/copy_and_paste.js',


### PR DESCRIPTION
We now make sure our toggler exists before invoking its `goto`
method.  Usually a toggler exists pretty early during app
startup, but _setup_info_overlay is wrapped in i18n.ensure_i18n,
which asynchronously fetches translation data.

This commit also simplifies how we find the toggler, by just
storing it in the module where it gets created and consumed.

Fixes #9085.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
