### PR TITLE
analytics: Make stats of all realms accessible to server admins.

### DIFF
--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -11,6 +11,8 @@ i18n_urlpatterns = [
         name='analytics.views.get_realm_activity'),
     url(r'^user_activity/(?P<email>[\S]+)/$', analytics.views.get_user_activity,
         name='analytics.views.get_user_activity'),
+    url(r'^stats/realm/(?P<realm_str>[\S]+)/$', analytics.views.stats_for_realm,
+        name='analytics.views.stats_for_realm'),
 
     # User-visible stats page
     url(r'^stats$', analytics.views.stats,
@@ -29,6 +31,8 @@ v1_api_and_json_patterns = [
     # get data for the graphs at /stats
     url(r'^analytics/chart_data$', rest_dispatch,
         {'GET': 'analytics.views.get_chart_data'}),
+    url(r'^analytics/chart_data/realm/(?P<realm_str>[\S]+)$', rest_dispatch,
+        {'GET': 'analytics.views.get_chart_data_for_realm'}),
 ]
 
 i18n_urlpatterns += [

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -468,6 +468,7 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
 
     # formatting
     for row in rows:
+        row['stats_link'] = realm_stats_link(row['string_id'])
         row['string_id'] = realm_activity_link(row['string_id'])
 
     # Count active sites
@@ -489,6 +490,7 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
 
     rows.append(dict(
         string_id='Total',
+        stats_link = '',
         date_created_day='',
         realm_admin_email='',
         dau_count=total_dau_count,
@@ -933,6 +935,12 @@ def realm_activity_link(realm_str: str) -> mark_safe:
     url = reverse(url_name, kwargs=dict(realm_str=realm_str))
     realm_link = '<a href="%s">%s</a>' % (url, realm_str)
     return mark_safe(realm_link)
+
+def realm_stats_link(realm_str: str) -> mark_safe:
+    url_name = 'analytics.views.stats_for_realm'
+    url = reverse(url_name, kwargs=dict(realm_str=realm_str))
+    stats_link = '<a href="{}"><i class="fa fa-pie-chart"></i></a>'.format(url, realm_str)
+    return mark_safe(stats_link)
 
 def realm_client_table(user_summaries: Dict[str, Dict[str, Dict[str, Any]]]) -> str:
     exclude_keys = [

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -72,9 +72,17 @@ $(function () {
     });
 });
 
+
 function get_chart_data(data, callback) {
+    var url;
+    if (page_params.is_staff) {
+        url = '/json/analytics/chart_data/realm/' + page_params.stats_realm;
+    } else {
+        url = '/json/analytics/chart_data';
+    }
+
     $.get({
-        url: '/json/analytics/chart_data',
+        url: url,
         data: data,
         idempotent: true,
         success: function (data) {

--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -37,7 +37,7 @@
         <tr>
             <th>Realm</th>
             <th>Created (green if ≤12wk)</th>
-            <th><i class="fa fa-envelope"></i></th>
+            <th></th>
             <th>DAU</th>
             <th>WAU</th>
             <th>Total users</th>
@@ -63,12 +63,13 @@
                 {{ row.date_created_day }}
             </td>
 
-            <td class="envelope">
+            <td>
                 {% if not loop.last %}
                 <a class="envelope-link" data-value="{{ row.realm_admin_email }}">
                     <i class="fa fa-envelope"></i>
                 </a>
                 {% endif %}
+                {{ row.stats_link }}
             </td>
 
             <td class="number">

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -20,7 +20,7 @@
     <div class="page-content">
         <div id="id_stats_errors" class="alert alert-error"></div>
         <div class="center-charts">
-            <h1 class="analytics-page-header">{% trans %}Zulip analytics for {{ given_realm_name }}{% endtrans %}</h1>
+            <h1 class="analytics-page-header">{% trans %}Zulip analytics for {{ target_realm_name }}{% endtrans %}</h1>
 
             <div class="left">
                 <div class="chart-container">

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -1,5 +1,11 @@
 {% extends "zerver/base.html" %}
 
+{% block page_params %}
+<script type="text/javascript">
+    var page_params = {{ page_params|safe }};
+</script>
+{% endblock %}
+
 {% block customhead %}
 {% stylesheet 'portico' %}
 {% endblock %}
@@ -14,7 +20,7 @@
     <div class="page-content">
         <div id="id_stats_errors" class="alert alert-error"></div>
         <div class="center-charts">
-            <h1 class="analytics-page-header">{% trans %}Zulip analytics for {{ realm_name }}{% endtrans %}</h1>
+            <h1 class="analytics-page-header">{% trans %}Zulip analytics for {{ given_realm_name }}{% endtrans %}</h1>
 
             <div class="left">
                 <div class="chart-container">

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -452,7 +452,8 @@ def require_server_admin(view_func: ViewFuncT) -> ViewFuncT:
 def require_server_admin_api(view_func: ViewFuncT) -> ViewFuncT:
     @zulip_login_required
     @wraps(view_func)
-    def _wrapped_view_func(request: HttpRequest, user_profile: UserProfile, *args: Any, **kwargs: Any) -> HttpResponse:
+    def _wrapped_view_func(request: HttpRequest, user_profile: UserProfile, *args: Any,
+                           **kwargs: Any) -> HttpResponse:
         if not user_profile.is_staff:
             raise JsonableError(_("Must be an server administrator"))
         return view_func(request, user_profile, *args, **kwargs)

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -449,6 +449,15 @@ def require_server_admin(view_func: ViewFuncT) -> ViewFuncT:
         return add_logging_data(view_func)(request, *args, **kwargs)
     return _wrapped_view_func  # type: ignore # https://github.com/python/mypy/issues/1927
 
+def require_server_admin_api(view_func: ViewFuncT) -> ViewFuncT:
+    @zulip_login_required
+    @wraps(view_func)
+    def _wrapped_view_func(request: HttpRequest, user_profile: UserProfile, *args: Any, **kwargs: Any) -> HttpResponse:
+        if not user_profile.is_staff:
+            raise JsonableError(_("Must be an server administrator"))
+        return view_func(request, user_profile, *args, **kwargs)
+    return _wrapped_view_func  # type: ignore # https://github.com/python/mypy/issues/1927
+
 # authenticated_api_view will add the authenticated user's
 # user_profile to the view function's arguments list, since we have to
 # look it up anyway.  It is deprecated in favor on the REST API


### PR DESCRIPTION
* Currently, I've made things working.
@timabbott @rishig FYI.
![peek 2018-04-15 23-13](https://user-images.githubusercontent.com/22238472/38781462-fe220836-4102-11e8-955b-c8c14940449e.gif)
* ~Tests aren't updated/added yet.~ Added
* Sorry for the delay actually in this comment https://github.com/zulip/zulip/pull/7568#issuecomment-378648704 I've misunderstood that we want the data of `/stat` to be served in the tables of `/activity` page, ~indeed I'm not sure whether we want to do this also or not?~
* ~Currently we can access chart stats of any realm at URL `analytics/chart_data/realm/(?P<realm_str>[\S]+)`. Definitely, we need a page to direct to these links or we can have these links at `/activity` page(I think this clears my above confusion)~ Added link in /activity table