### PR TITLE
[WIP] New User Invite Through Github

### DIFF
--- a/templates/zerver/invite_user.html
+++ b/templates/zerver/invite_user.html
@@ -1,18 +1,18 @@
 <div id="invite-user" class="overlay flex new-style" tabindex="-1" role="dialog" data-overlay="invite"
-  aria-labelledby="invite-user-label" aria-hidden="true">
+    aria-labelledby="invite-user-label" aria-hidden="true">
     <div class="overlay-content modal-bg">
         <div class="modal-header">
             <button type="button" class="exit" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
             <h3 id="invite-user-label">{% trans %}Invite users to Zulip{% endtrans %}</h3>
         </div>
         <form id="invite_user_form" class="form-horizontal"
-          action="/json/invites" method="POST">{{ csrf_input }}
+            action="/json/invites" method="POST">{{ csrf_input }}
             <div class="modal-body">
                 <div class="control-group">
                     <div id="invite-result"></div>
                     <label class="control-label" for="invitee_emails">{{ _('Emails (one on each line or comma-separated)') }}</label>
                     <div class="controls">
-                        <textarea rows="2" id="invitee_emails" name="invitee_emails" placeholder="{{ _('One or more email addresses...') }}"></textarea>
+                        <textarea rows="3" id="invitee_emails" name="invitee_emails" placeholder="{{ _('One or more email addresses or github usernames (formatted like: git<user>)...') }}"></textarea>
                     </div>
                     {% if is_admin %}
                     <label class="control-label" id="invite_as_admin" for"invite_as_admin">{{ _('User(s) join as') }}</label>
@@ -38,7 +38,7 @@
             <div class="modal-footer">
                 <button class="button exit small rounded" data-dismiss="modal">{{ _('Cancel') }}</button>
                 <button id="submit-invitation" class="button small rounded sea-green"
-                  data-loading-text="{{ _('Inviting...') }}" type="submit">{{ _('Invite') }}</button>
+                data-loading-text="{{ _('Inviting...') }}" type="submit">{{ _('Invite') }}</button>
             </div>
         </form>
     </div>

--- a/zerver/tests/test_invite_github.py
+++ b/zerver/tests/test_invite_github.py
@@ -1,0 +1,36 @@
+from zerver.lib.test_classes import ZulipTestCase
+
+from zerver.views.invite import get_invitee_emails_set
+
+class GithubInviteTest(ZulipTestCase):
+    def test_github_invite_empty(self) -> None:
+        # Empty test case 
+        empty_string = ""
+        empty_set = set()
+        empty_set.add('')
+        return_set = get_invitee_emails_set(empty_string)
+        self.assertEqual(empty_set,return_set)
+    def test_github_invite_with_email(self) -> None:
+        # github mixed with emails
+        goal_set = set()
+        goal_set.add("foo@bar.com")
+        goal_set.add("zulip-devel@googlegroups.com")
+        input_string = "foo@bar.com,git<zulip>"
+        output_set = get_invitee_emails_set(input_string)
+        self.assertEqual(goal_set,output_set)
+    def test_github_invite_invalid_entry(self) -> None:
+        # invalid input
+        goal_set = set()
+        input_string = "git<invaliduserentry_raiseHTTPError>"
+        output_set = get_invitee_emails_set(input_string)
+        self.assertEqual(goal_set,output_set)
+    def test_github_invite_stress(self) -> None:
+        # Stress test
+        input_string = ""
+        for i in range(25):
+            input_string += "zulip-devel@googlegroups.com,"
+        input_string += "git<zulip>"
+        output_set = get_invitee_emails_set(input_string)
+        #print(len(output_set))
+        for email in output_set:
+            self.assertEqual(email,"zulip-devel@googlegroups.com")


### PR DESCRIPTION
#8700: Invite a new user through github account

Offering possible feature that will enable users to invite Github users using a "git<username>" flag in the emails textbox.

Added backend Django test test_invite_github.py to test the modified zerver/views/invite.py file.  Made small modifications to invite_user.html to support git usernames:

![image](https://user-images.githubusercontent.com/34328245/38788970-1da92d04-4105-11e8-990c-cb642c50f999.png)