### PR TITLE
uploads: Change Content-Security-Policy to fix issue with pdf's.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.direct
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.direct
@@ -1,6 +1,6 @@
 location /user_uploads {
     add_header X-Content-Type-Options nosniff;
-    add_header Content-Security-Policy "default-src 'none' img-src 'self'";
+    add_header Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self';";
     include /etc/nginx/zulip-include/uploads.types;
     alias /home/zulip/uploads/files;
 }

--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.internal
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.internal
@@ -1,7 +1,7 @@
 location /serve_uploads {
     internal;
     add_header X-Content-Type-Options nosniff;
-    add_header Content-Security-Policy "default-src 'none' img-src 'self'";
+    add_header Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self';";
     include /etc/nginx/zulip-include/uploads.types;
     alias /home/zulip/uploads/files;
 }


### PR DESCRIPTION
We change the Content-Security-Policy to include object-src 'self'
which was earlier using the default-src 'none' and essentially
interfering with the browser plugins which are responsible for
inline rendering of the pdf's.
This issue behaved differently for Trusty and Xenial. On Xenial,
pdf's rendered inline but inside a separate frame inside of the
normal browser tab. On Trusty, the pdf's didn't render at all and
just get downloaded. I suspect this difference in behaviour due to
the fact that we are able to set Content-Disposition for the Xenial
based system downloads through the attachment=True param to the
django-sendfile.