### PR TITLE
coverage: Add coverage to estimate_recent_messages.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -59,7 +59,6 @@ not_yet_fully_covered = {
     'zerver/lib/exceptions.py',
     'zerver/lib/i18n.py',
     'zerver/lib/management.py',
-    'zerver/lib/message.py',
     'zerver/lib/notifications.py',
     'zerver/lib/send_email.py',
     'zerver/lib/upload.py',


### PR DESCRIPTION
With this message.py is fully covered and can be removed from not_yet_fully_covered in test-backend.

