### PR TITLE
Fix double hashing of file, and broken npm/yarn script

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "xmlhttprequest": "1.5.0"
   },
   "scripts": {
-    "lint": "eslint --quiet --cache",
-    "lint-fix": "eslint --quiet --fix",
+    "lint": "eslint static/js frontend_tests --quiet --cache",
+    "lint-fix": "eslint static/js frontend_tests --quiet --fix",
     "lint-loud": "eslint static/js frontend_tests --cache"
   },
   "repository": {

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -82,7 +82,7 @@ export default (env?: string) : Config => {
         },
         output: {
             path: resolve(__dirname, '../static/webpack-bundles'),
-            filename: production ? '[name]-[hash].js' : '[name].js',
+            filename: '[name].js',
         },
         resolve: {
             extensions: [".tsx", ".ts", ".js", ".json"],


### PR DESCRIPTION
File hashing required to be done in webpack, this is already
done by `tools/update-prod-static` through Django's static management
system, `./manage.py collectstatic` which will add hashes for js files too.

This will fix a double hashing issue ie `file-3uisdas.dakldsadads.js` -> `file.dakldsadads.js`

And then this also fixes broken npm scripts for lint and lint-fix.

