### PR TITLE
portico: Minor UI fix in plans page.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -2612,7 +2612,7 @@ nav ul li.active::after {
 }
 
 @media (max-width: 1390px) {
-    .portico-landing.plans .pricing-container .block .zulip-cloud {
+    .portico-landing.plans .pricing-container .block .responsive-title {
         color: inherit;
     }
 }

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -21,7 +21,7 @@
 
                 <div class="pricing-container">
                     <div class="block">
-                        <div class="plan-title zulip-cloud">
+                        <div class="plan-title responsive-title">
                             Zulip Cloud
                         </div>
 
@@ -90,7 +90,7 @@
                     </div>
 
                     <div class="block">
-                        <div class="plan-title">
+                        <div class="plan-title responsive-title">
                             Zulip On-Premise
                         </div>
 

--- a/templates/zilencer/billing.html
+++ b/templates/zilencer/billing.html
@@ -24,7 +24,7 @@
             <div class="padded-content">
                 <div class="pricing-container">
                     <div class="block">
-                        <div class="plan-title zulip-cloud">
+                        <div class="plan-title responsive-title">
                             Zulip Cloud subscription for {{ realm_name }}
                         </div>
                         {% if payment_method_added %}


### PR DESCRIPTION
Renamed `zulip-cloud` class to `responsive-title` so that we can re-use this class in other sections also.

Fixes: #9133.

Before - 

![image](https://user-images.githubusercontent.com/2263909/38959642-058f1ac2-437f-11e8-92a7-d9e871eb0c85.png)


After - 

![image](https://user-images.githubusercontent.com/2263909/38959623-f38b75f0-437e-11e8-9ab3-90d1f0bdd195.png)



