### PR TITLE
narrow: Fix narrowing behavior when loading a new tab.

### DIFF
--- a/docs/subsystems/pointer.md
+++ b/docs/subsystems/pointer.md
@@ -36,7 +36,7 @@ what you clicked on, and in fact the message you clicked on stays at
 exactly the same scroll position in the window after the narrowing as
 it was at before.
 
-### Search or sidebar click: unread/recent matching narrow
+### Search, sidebar click, or new narrowed tab: unread/recent matching narrow
 
 If you instead narrow by clicking on something in the left sidebar or
 typing some terms into the search box, Zulip will instead select
@@ -70,16 +70,6 @@ streams in your All messages view, this can lag.
 
 We plan to change this to automatically advance the pointer in a way
 similar to the unnarrow logic.
-
-### Narrow in a new tab: closest to pointer
-
-When you load a new browser tab or window to a narrowed view, Zulip
-will select the message closest to your pointer, which is what you
-would have got had you loaded the browser window to your All messages view and
-then clicked on the nearest message matching your narrow (which might
-have been offscreen).
-
-We plan to change this to match the Search/sidebar behavior.
 
 ### Forced reload: state preservation
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -101,16 +101,6 @@ exports.activate = function (raw_operators, opts) {
         opts.select_first_unread = false;
     }
 
-    // This block is for a case of loading a browser window for the
-    // first time in a narrow.
-    // According to old comments, this shouldn't happen anymore;
-    // more investigation is needed.
-    if (opts.then_select_id === -1 && !opts.use_initial_narrow_pointer) {
-        blueslip.warn("Setting then_select_id to page_params.pointer.");
-        opts.then_select_id = page_params.pointer;
-        opts.select_first_unread = false;
-    }
-
     var then_select_id = opts.then_select_id;
     var then_select_offset;
 


### PR DESCRIPTION
In the very early days of Zulip, we didn't have unread counts; just
the pointer, and the correct behavior when opening a new tab was to
place you near the pointer.  That doesn't make any sense now that we
do have unread counts, and this corner case has been a wart for a long
time.

This commit does the main behavior change here.  However, there's a
bug we need to fix, where we might end up trying to pre-render a view
of the narrow based on the `all_msg_list` data before `all_msg_list`
is caught up).  We need to fix that bug before we can merge this; it
should be possible to determine that using `FetchStatus` on
`all_msg_list`, or with better performance by using the `unread_msgs`
structure to determine whether the message we should be selecting is
present locally.

Fixes #789.

----------------------------

For testing this and working on the outstanding bug, the test procedure is this:
* `manage.py populate_db -n2000` 
* `manage.py mark_all_messages_unread`
* Login as Iago, pick a stream/topic pair, narrow and hit end in that narrow to mark as read.
* Reload.

Before this change, you'd be placed at the first message to that topic ever.  With this change, you get placed somewhere random that appears to be the bottom, and then a fetch from the server adds a few more messages below where you're placed.  Correct would be to be placed at the very bottom.

I made some notes on fixing the remaining issue above.  I believe what we need to do is as follows:
* For the on-reload case, first (correct but potentially not optimized version), just unconditionally do a fetch from the server when doing rendering.  I have an idea for how to do this that I'll try in a commit after getting home.  
