### PR TITLE
portico: Add export advertisement to FAQ.

### DIFF
--- a/templates/zerver/faq.html
+++ b/templates/zerver/faq.html
@@ -67,6 +67,17 @@
                     the future.
                 </p>
             </div>
+            <div class="faq">
+                <div class="question">
+                    Can I start on Zulip Cloud and later move to On-Premise?
+                </div>
+                <p class="answer">
+                    Yes! Our high quality export and import tools ensure you
+                    can always move from our hosting to yours (and back). If
+                    you'd like to do a migration, email
+                    support@zulipchat.com and we'll get you started!
+                </p>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Making a user docs page for this ended up being a bit complicated, since e.g. you'll want them to figure out their realm_id or subdomain, deactivate their realm before the export, there are a bunch of caveats (like bots), etc. 

![image](https://user-images.githubusercontent.com/890911/38964918-7e0b9d32-432e-11e8-9d64-d7b2b97cee96.png)
