### PR TITLE
settings: Add modal fade.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1217,6 +1217,14 @@ input[type=checkbox].inline-block {
     transition: opacity 100ms ease-out;
 }
 
+.modal.fade {
+    -webkit-transition: opacity 0.3s linear;
+    -moz-transition: opacity 0.3s linear;
+    -o-transition: opacity 0.3s linear;
+    transition: opacity 0.3s linear;
+    transform: translateY(-50%);
+}
+
 #settings_page .table-striped thead th.active:after {
     content: " \f0d8";
     white-space: pre;
@@ -1366,7 +1374,6 @@ input[type=checkbox].inline-block {
 
 .modal.fade.in {
     top: 50%;
-    transform: translateY(-50%);
 }
 
 #id_realm_create_stream_permission,
@@ -1380,6 +1387,10 @@ input[type=checkbox].inline-block {
     margin-top: 10px;
 }
 
+#change_email_modal,
+#change_full_name_modal,
+#change_password_modal,
+#default_language_modal,
 #deactivate_self_modal,
 #deactivate-realm-modal {
     box-shadow: 0px 0px 75px hsla(0, 0%, 0%, 0.5);

--- a/static/templates/default_language_modal.handlebars
+++ b/static/templates/default_language_modal.handlebars
@@ -1,4 +1,4 @@
-<div id="default_language_modal" class="modal hide modal-bg" tabindex="-1" role="dialog"
+<div id="default_language_modal" class="modal hide modal-bg fade" tabindex="-1" role="dialog"
   aria-labelledby="default_language_modal_label" aria-hidden="true">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -17,7 +17,7 @@
                       title="{{t 'Changing email addresses has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"></i>
                 </div>
 
-                <div id="change_email_modal" class="modal modal-bg hide" tabindex="-1" role="dialog"
+                <div id="change_email_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
                   aria-labelledby="change_email_modal_label" aria-hidden="true">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
@@ -51,7 +51,7 @@
                           {{#if page_params.is_admin}}style="display:none"{{else}}{{#unless page_params.realm_name_changes_disabled}}style="display:none"{{/unless}}{{/if}}
                           title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
                     </div>
-                    <div id="change_full_name_modal" class="modal modal-bg hide" tabindex="-1" role="dialog"
+                    <div id="change_full_name_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
                       aria-labelledby="change_full_name_modal_label" aria-hidden="true">
                         <div class="modal-header">
                             <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
@@ -85,7 +85,7 @@
                 </div>
                 {{/if}}
 
-                <div id="change_password_modal" class="modal modal-bg hide" tabindex="-1" role="dialog"
+                <div id="change_password_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
                   aria-labelledby="change_password_modal_label" aria-hidden="true">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>


### PR DESCRIPTION
Implemented the modal fade, one of the first suggestions on here goo.gl/HXzb66

Only thing that could be an issue is the modal was originally at the top of the screen, but is now at the middle of the screen due to the preexisting positioning on the fade class.
![screenshot from 2018-04-19 01-15-03](https://user-images.githubusercontent.com/15152698/38972555-4855f62e-436f-11e8-8818-4431a6233848.png)

Additionally, the width of the different modals vary greatly, I think we should choose a width for all the modals for consistency (This change isn't implemented yet in this PR), maybe the same width as the deactivate-account modal, I think it looks the best.
![image](https://user-images.githubusercontent.com/15152698/38972660-f905c77e-436f-11e8-8f21-24bfab5c2f00.png) 

 
