### PR TITLE
Fixes message which appears when restoring drafts (issue #9093)

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -321,13 +321,6 @@ exports.process_enter_key = function (e) {
         return false;
     }
 
-    // This handles when pressing enter while looking at drafts.
-    // It restores draft that is focused.
-    if (overlays.drafts_open()) {
-        drafts.drafts_handle_events(e, "enter");
-        return true;
-    }
-
     // If we're on a button or a link and have pressed enter, let the
     // browser handle the keypress
     //

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -321,6 +321,14 @@ exports.process_enter_key = function (e) {
         return false;
     }
 
+    // This handles when pressing enter while looking at drafts.
+    // It restores draft that is focused.
+
+    if (overlays.drafts_open()) {
+        drafts.drafts_handle_events(e, "enter");
+        return true;
+    }
+
     // If we're on a button or a link and have pressed enter, let the
     // browser handle the keypress
     //

--- a/static/templates/draft.handlebars
+++ b/static/templates/draft.handlebars
@@ -33,11 +33,11 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="draft_controls">
-                            <i class="icon-vector-large icon-vector-pencil restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }} (Enter)"></i>
+                            <i class="icon-vector-large icon-vector-pencil restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }} (Click)"></i>
                             <i class="icon-vector-large icon-vector-trash delete-draft" data-toggle="tooltip" title="{{t 'Delete draft' }} (Backspace)"></i>
                         </div>
                     </div>
-                    <div class="message_content restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }} (Enter)">{{{content}}}</div>
+                    <div class="message_content restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }} (Click)">{{{content}}}</div>
                 </div>
             </div>
         </div>

--- a/static/templates/draft.handlebars
+++ b/static/templates/draft.handlebars
@@ -33,11 +33,11 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="draft_controls">
-                            <i class="icon-vector-large icon-vector-pencil restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }} (Click)"></i>
+                            <i class="icon-vector-large icon-vector-pencil restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }}"></i>
                             <i class="icon-vector-large icon-vector-trash delete-draft" data-toggle="tooltip" title="{{t 'Delete draft' }} (Backspace)"></i>
                         </div>
                     </div>
-                    <div class="message_content restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }} (Click)">{{{content}}}</div>
+                    <div class="message_content restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }}">{{{content}}}</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/9093

**Testing Plan:** <!-- How have you tested? -->
Tested on local environment

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="1240" alt="screen shot 2018-04-19 at 11 31 35 am" src="https://user-images.githubusercontent.com/27150975/39003037-f31b653c-43c7-11e8-9a47-e3da89e91401.png">
<img width="1249" alt="screen shot 2018-04-19 at 11 31 49 am" src="https://user-images.githubusercontent.com/27150975/39003038-f49f9022-43c7-11e8-8e1e-4d3a5183c4fe.png">
<img width="1248" alt="screen shot 2018-04-19 at 11 31 59 am" src="https://user-images.githubusercontent.com/27150975/39003042-f6da4a3a-43c7-11e8-8405-255e13a70808.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->