### PR TITLE
Add translation tags for email templates

### DIFF
--- a/templates/zerver/emails/confirm_registration.source.html
+++ b/templates/zerver/emails/confirm_registration.source.html
@@ -5,20 +5,27 @@
 {% endblock %}
 
 {% block content %}
-<p>Hello there.
+<p>
+    {{ _('Hello there.') }}
 </p>
 <p>
-    You recently signed up for Zulip. Awesome!
+    {{ _('You recently signed up for Zulip. Awesome!') }}
 </p>
 <p>
-    To complete signup, please click here:
-    <a class="button" href="{{ activate_url }}">Complete registration</a>
+    {{ _('To complete signup, please click here:') }}
+    <a class="button" href="{{ activate_url }}">{{ _('Complete registration') }}</a>
 </p>
 <p>
-    Feel free to give us a shout at <a href="mailto:{{ support_email }}">{{ support_email }}</a>, if you have any questions.
+    {% trans %}
+    Feel free to give us a shout at
+    <a href="mailto:{{ support_email }}">{{ support_email }}</a>,
+    if you have any questions.
+    {% endtrans %}
 </p>
 <p>
+    {% trans %}
     Cheers,<br />
     Team Zulip
+    {% endtrans %}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/confirm_registration.txt
+++ b/templates/zerver/emails/confirm_registration.txt
@@ -1,11 +1,11 @@
-Hello there.
+{{ _('Hello there.') }}
 
-You recently signed up for Zulip. Awesome!
+{{ _('You recently signed up for Zulip. Awesome!') }}
 
-To complete signup, visit this link below:
+{{ _('To complete signup, please click here:') }}
     <{{ activate_url }}>
 
-Feel free to give us a shout at <{{ support_email }}> if you have any questions.
+{% trans %}Feel free to give us a shout at <{{ support_email }}> if you have any questions.{% endtrans %}
 
-Cheers,
-Team Zulip
+{% trans %}Cheers,
+Team Zulip{% endtrans %}

--- a/templates/zerver/emails/password_reset.source.html
+++ b/templates/zerver/emails/password_reset.source.html
@@ -24,9 +24,9 @@
             {% endif %}
         {% endif %}
     {% else %}
-        Psst. Word on the street is that you need a new password, {{ email }}.<br />
-        It's all good. Click here and we'll take care of the rest:<br />
-        <a class="button" href="{{ reset_url }}">Reset password</a>
+        {% trans %}Psst. Word on the street is that you need a new password, {{ email }}.{% endtrans %}<br />
+        {% trans %}It's all good. Click here and we'll take care of the rest:{% endtrans %}<br />
+        <a class="button" href="{{ reset_url }}">{{ _('Reset password') }}</a>
     {% endif %}
 </p>
 <p>

--- a/templates/zerver/emails/password_reset.txt
+++ b/templates/zerver/emails/password_reset.txt
@@ -16,9 +16,9 @@ organization; you can try logging in or resetting your password there.
 {% endif %}
 {% endif %}
 {% else %}
-Psst. Word on the street is that you need a new password, {{ email }}.
+{{ _('Psst. Word on the street is that you need a new password, {{ email }}.') }}
 
-It's all good. Follow the link below and we'll take care of the rest:
+{{ _('It's all good. Follow the link below and we'll take care of the rest:') }}
 
 {{ reset_url }}
 


### PR DESCRIPTION
Read the documentation commit carefully for how this works; I also did what I think is the correct translation for 2 of the templates.  I'd love it if someone picked up doing this for the rest of the email templates using the strategy described.

I think it's likely we may need a third commit in here, which is to modify `zerver/lib/send_email.py` to use the user's language (when we have a user) in the context for the email so that the right language gets used; I'm not really sure how this works in Django though (needs research).  Otherwise, seems very possible everything will end up in English even with translation data.