### PR TITLE
portico: Add contact info to FAQ.

### DIFF
--- a/templates/zerver/faq.html
+++ b/templates/zerver/faq.html
@@ -78,6 +78,17 @@
                     support@zulipchat.com and we'll get you started!
                 </p>
             </div>
+            <div class="faq">
+                <div class="question">
+                    Who can I contact if I have further questions?
+                </div>
+                <p class="answer">
+                    Stop by the
+                    <a href="http://zulip.readthedocs.io/en/latest/contributing/chat-zulip-org.html">Zulip
+                    community server</a> to say hi, or shoot us an email at
+                    sales@zulipchat.com!
+                </p>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Just the bottom half of this:

![image](https://user-images.githubusercontent.com/890911/39013293-c9e9ecf2-43cb-11e8-869e-2b42453ee099.png)
