### PR TITLE
 settings: Make saving spinner visible in night mode.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -115,7 +115,7 @@ function get_property_value(property_name) {
         }
         return "by_anyone";
     }
-    return;
+    return page_params[property_name];
 }
 
 exports.extract_property_name = function (elem) {
@@ -286,12 +286,7 @@ function update_dependent_subsettings(property_name) {
 function discard_property_element_changes(elem) {
     elem = $(elem);
     var property_name = exports.extract_property_name(elem);
-    // Check whether the id refers to a property whose name we can't
-    // extract from element's id.
     var property_value = get_property_value(property_name);
-    if (property_value === undefined) {
-        property_value = page_params[property_name];
-    }
 
     if (typeof property_value === 'boolean') {
         elem.prop('checked', property_value);
@@ -420,12 +415,7 @@ function _set_up() {
         elem = $(elem);
         var property_name = exports.extract_property_name(elem);
         var changed_val;
-        // Check whether the id refers to a property whose name we can't
-        // extract from element's id.
         var current_val = get_property_value(property_name);
-        if (current_val === undefined) {
-            current_val = page_params[property_name];
-        }
 
         if (typeof current_val === 'boolean') {
             changed_val = elem.prop('checked');

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -583,7 +583,11 @@ input[type=checkbox].inline-block {
     width: 13px;
     height: 20px;
     margin: 0;
-    margin-right: 3px;
+}
+
+/* make the spinner green like the text and box. */
+#settings_page .alert-notification .loading_indicator_spinner svg path {
+    fill: hsl(178, 100%, 40%);
 }
 
 #settings_page .alert-notification .loading_indicator_text {


### PR DESCRIPTION
settings: Make saving spinner visible in night mode.
Fixes: #9154.

Here I've added another unrelated commit:
org settings: Refactor code for get_property_value.
@timabbott FYI.
![lightmode](https://user-images.githubusercontent.com/22238472/39030799-f68d0b98-4481-11e8-94a6-02b6661909aa.gif)
![darkmode](https://user-images.githubusercontent.com/22238472/39030800-f6d4025a-4481-11e8-8e33-49df7d5dc25e.gif)
