### PR TITLE
setup-vagrant.md: Fixes broken link to zulip community server

### DIFF
--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -604,7 +604,7 @@ If these solutions aren't working for you or you encounter an issue not
 documented below, there are a few ways to get further help:
 
 * Ask in [#provision help](https://chat.zulip.org/#narrow/stream/provision.20help)
-  in the [Zulip development community server](../contributing/chat-zulip-org.html),
+  in the [Zulip development community server](https://chat.zulip.org),
 * send a note to the [Zulip-devel Google
   group](https://groups.google.com/forum/#!forum/zulip-devel), or
 * [File an issue](https://github.com/zulip/zulip/issues).


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#9159   - [Broken Link in Markdown File](https://github.com/zulip/zulip/issues/9159)

**Testing Plan:** <!-- How have you tested? -->
I Made and pushed the changes to my local fork. Once submitted to my local fork, I went to my fork on GitHub, found the markdown file I made a change to, and I clicked the link I fixed to make sure that the link works and links to the proper page.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![fix](https://user-images.githubusercontent.com/22033861/39031751-14c216e8-4438-11e8-87fc-0cda306e79af.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->