### PR TITLE
analytics: Eliminate slider-focused text selection in Firefox.

### DIFF
--- a/static/styles/stats.css
+++ b/static/styles/stats.css
@@ -43,6 +43,13 @@ hr {
     border-width: 2px;
 }
 
+.rangeslider-container {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
 .rangeselector text {
     font-weight: 400;
 }


### PR DESCRIPTION
Fixes #9151.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
[![https://gyazo.com/739f68f11052169ff2c566f28e9e5994](https://i.gyazo.com/739f68f11052169ff2c566f28e9e5994.gif)](https://gyazo.com/739f68f11052169ff2c566f28e9e5994)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
