### PR TITLE
buddy list: Refactor and fix two glitches

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -146,6 +146,7 @@
         "user_search": false,
         "buddy_data": false,
         "buddy_list": false,
+        "list_cursor": false,
         "activity": false,
         "invite": false,
         "colorspace": false,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -143,6 +143,7 @@
         "tab_bar": false,
         "emoji": false,
         "presence": false,
+        "user_search": false,
         "buddy_data": false,
         "buddy_list": false,
         "activity": false,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -108,6 +108,7 @@
         "Socket": false,
         "channel": false,
         "components": false,
+        "scroll_util": false,
         "message_viewport": false,
         "upload_widget": false,
         "avatar": false,

--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -337,30 +337,36 @@ casper.waitForSelector('#stream_filters .highlighted_stream', function () {
 
 // Use arrow keys to navigate through suggestions
 casper.then(function () {
-    // Down: Denmark -> Scotland
-    casper.sendKeys('.stream-list-filter', casper.page.event.key.Down, {keepFocus: true});
-    // Up: Scotland -> Denmark
-    casper.sendKeys('.stream-list-filter', casper.page.event.key.Up, {keepFocus: true});
-    // Up: Denmark -> Verona
-    casper.sendKeys('.stream-list-filter', casper.page.event.key.Up, {keepFocus: true});
+    function arrow(key) {
+        casper.sendKeys('.stream-list-filter',
+                        casper.page.event.key[key],
+                        {keepFocus: true});
+    }
+    arrow('Down'); // Denmark -> Scotland
+    arrow('Up'); // Scotland -> Denmark
+    arrow('Up'); // Denmark -> Denmark
+    arrow('Down'); // Denmark -> Scotland
 });
 
-casper.waitForSelector('#stream_filters [data-stream-name="Verona"].highlighted_stream', function () {
+casper.waitForSelector('#stream_filters [data-stream-name="Scotland"].highlighted_stream', function () {
     casper.test.info('Suggestion highlighting - after arrow key navigation');
-    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Denmark"].highlighted_stream',
-                                  'Stream Denmark is not highlighted');
-    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Scotland"].highlighted_stream',
-                                  'Stream Scotland is not highlighted');
-    casper.test.assertExist('#stream_filters [data-stream-name="Verona"].highlighted_stream',
-                            'Stream Verona is highlighted');
+    casper.test.assertDoesntExist(
+            '#stream_filters [data-stream-name="Denmark"].highlighted_stream',
+            'Stream Denmark is not highlighted');
+    casper.test.assertExist(
+            '#stream_filters [data-stream-name="Scotland"].highlighted_stream',
+            'Stream Scotland is  highlighted');
+    casper.test.assertDoesntExist(
+            '#stream_filters [data-stream-name="Verona"].highlighted_stream',
+            'Stream Verona is not highlighted');
 });
 
-// We search for the beginning of "Verona", not case sensitive
+// We search for the beginning of "Scotland", not case sensitive
 casper.then(function () {
     casper.evaluate(function () {
         $('.stream-list-filter').expectOne()
             .focus()
-            .val('ver')
+            .val('sCoT')
             .trigger($.Event('input'))
             .trigger($.Event('click'));
     });
@@ -373,16 +379,16 @@ casper.waitWhileVisible('#stream_filters [data-stream-name="Denmark"]', function
     casper.test.assertDoesntExist('#stream_filters [data-stream-name="Denmark"]',
                                   'Filtered stream list does not contain Denmark');
 });
-casper.waitWhileVisible('#stream_filters [data-stream-name="Scotland"]', function () {
-    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Scotland"]',
-                                  'Filtered stream list does not contain Scotland');
+casper.waitWhileVisible('#stream_filters [data-stream-name="Verona"]', function () {
+    casper.test.assertDoesntExist('#stream_filters [data-stream-name="Verona"]',
+                                  'Filtered stream list does not contain Verona');
 });
 
 casper.then(function () {
-    casper.test.assertExists('#stream_filters [data-stream-name="Verona"]',
-                             'Filtered stream list does contain Verona');
-    casper.test.assertExists('#stream_filters [data-stream-name="Verona"].highlighted_stream',
-                             'Stream Verona is highlighted');
+    casper.test.assertExists('#stream_filters [data-stream-name="Scotland"]',
+                             'Filtered stream list does contain Scotland');
+    casper.test.assertExists('#stream_filters [data-stream-name="Scotland"].highlighted_stream',
+                             'Stream Scotland is highlighted');
 });
 
 // Clearing the list should give us back all the streams in the list

--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -470,22 +470,23 @@ casper.waitForSelector('#user_presences .highlighted_user', function () {
 
 // Use arrow keys to navigate through suggestions
 casper.then(function () {
-    // Down: Cordelia -> Hamlet
-    casper.sendKeys('.user-list-filter', casper.page.event.key.Down, {keepFocus: true});
-    // Up: Hamlet -> Cordelia
-    casper.sendKeys('.user-list-filter', casper.page.event.key.Up, {keepFocus: true});
-    // Up: Cordelia -> aaron
-    casper.sendKeys('.user-list-filter', casper.page.event.key.Up, {keepFocus: true});
+    function arrow(key) {
+        casper.sendKeys('.user-list-filter',
+                        casper.page.event.key[key],
+                        {keepFocus: true});
+    }
+    arrow('Down'); // Cordelia -> Hamlet
+    arrow('Up'); // Hamlet -> Cordelia
+    arrow('Up'); // already at top
+    arrow('Down'); // Cordelia -> Hamlet
 });
 
-casper.waitForSelector('#user_presences li.highlighted_user [data-name="aaron"]', function () {
+casper.waitForSelector('#user_presences li.highlighted_user [data-name="King Hamlet"]', function () {
     casper.test.info('Suggestion highlighting - after arrow key navigation');
     casper.test.assertDoesntExist('#user_presences li.highlighted_user [data-name="Cordelia Lear"]',
         'User Cordelia Lear not is selected');
-    casper.test.assertDoesntExist('#user_presences li.highlighted_user [data-name="King Hamlet"]',
-        'User King Hamlet is not selected');
-    casper.test.assertExist('#user_presences li.highlighted_user [data-name="aaron"]',
-        'User aaron is selected');
+    casper.test.assertExist('#user_presences li.highlighted_user [data-name="King Hamlet"]',
+        'User King Hamlet is selected');
 });
 
 common.then_log_out();

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -55,7 +55,7 @@ set_global('keydown_util', {
 
 set_global('compose_state', {});
 
-set_global('stream_list', {
+set_global('scroll_util', {
     scroll_element_into_container: () => {},
 });
 

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -53,6 +53,8 @@ set_global('keydown_util', {
     },
 });
 
+set_global('compose_state', {});
+
 set_global('stream_list', {
     scroll_element_into_container: () => {},
 });
@@ -127,8 +129,6 @@ people.add_in_realm(norbert);
 people.add_in_realm(zoe);
 people.add_in_realm(me);
 people.initialize_current_user(me.user_id);
-
-compose_fade.update_faded_users = () => {};
 
 const real_update_huddles = activity.update_huddles;
 activity.update_huddles = () => {};
@@ -298,6 +298,9 @@ reset_setup();
 
 (function test_presence_list_full_update() {
     $('.user-list-filter').focus();
+    compose_state.recipient = () => fred.email;
+    compose_fade.set_focused_recipient("private");
+
     const users = activity.build_user_sidebar();
     assert.deepEqual(users, [{
             name: 'Fred Flintstone',
@@ -306,6 +309,7 @@ reset_setup();
             num_unread: 0,
             type: 'active',
             type_desc: 'is active',
+            faded: false,
         },
         {
             name: 'Jill Hill',
@@ -314,6 +318,7 @@ reset_setup();
             num_unread: 0,
             type: 'active',
             type_desc: 'is active',
+            faded: true,
         },
         {
             name: 'Norbert Oswald',
@@ -322,6 +327,7 @@ reset_setup();
             num_unread: 0,
             type: 'active',
             type_desc: 'is active',
+            faded: true,
         },
         {
             name: 'Zoe Yang',
@@ -330,6 +336,7 @@ reset_setup();
             num_unread: 0,
             type: 'active',
             type_desc: 'is active',
+            faded: true,
         },
         {
             name: 'Alice Smith',
@@ -338,6 +345,7 @@ reset_setup();
             num_unread: 0,
             type: 'idle',
             type_desc: 'is not active',
+            faded: true,
         },
         {
             name: 'Marky Mark',
@@ -346,6 +354,7 @@ reset_setup();
             num_unread: 0,
             type: 'idle',
             type_desc: 'is not active',
+            faded: true,
         },
     ]);
 }());

--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -1,7 +1,3 @@
-const patched_underscore = _.clone(_);
-patched_underscore.debounce = function (f) { return f; };
-global.patch_builtin('_', patched_underscore);
-
 zrequire('people');
 zrequire('bot_data');
 

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -14,7 +14,7 @@ set_global('page_params', {});
     _.each(_.range(1000, 2000), (i) => {
         const person = {
             user_id: i,
-            full_name: `Person ${i}`,
+            full_name: `Human ${i}`,
             email: `person${i}@example.com`,
         };
         people.add_in_realm(person);
@@ -42,9 +42,35 @@ set_global('page_params', {});
 }());
 
 (function test_user_ids() {
-    const user_ids = buddy_data.get_filtered_and_sorted_user_ids();
+    var user_ids;
 
-    // Even though we have 900 users, we only get the 400 active
+    // Even though we have 1000 users, we only get the 400 active
     // users.  This is a consequence of buddy_data.maybe_shrink_list.
+    user_ids = buddy_data.get_filtered_and_sorted_user_ids();
     assert.equal(user_ids.length, 400);
+
+    user_ids = buddy_data.get_filtered_and_sorted_user_ids('');
+    assert.equal(user_ids.length, 400);
+
+    // We don't match on "s", because it's not at the start of a
+    // word in the name/email.
+    user_ids = buddy_data.get_filtered_and_sorted_user_ids('s');
+    assert.equal(user_ids.length, 0);
+
+    // We match on "h" for the first name, and the result limit
+    // is relaxed for searches.
+    user_ids = buddy_data.get_filtered_and_sorted_user_ids('h');
+    assert.equal(user_ids.length, 1000);
+
+    // We match on "p" for the email.
+    user_ids = buddy_data.get_filtered_and_sorted_user_ids('p');
+    assert.equal(user_ids.length, 1000);
+
+
+    // Make our shrink limit higher, and go back to an empty search.
+    // We won't get all 1000 users, just the present ones.
+    buddy_data.max_size_before_shrinking = 50000;
+
+    user_ids = buddy_data.get_filtered_and_sorted_user_ids('');
+    assert.equal(user_ids.length, 700);
 }());

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -1,0 +1,14 @@
+set_global('$', global.make_zjquery());
+zrequire('buddy_list');
+
+(function test_get_items() {
+    const alice_li = $.create('alice stub');
+    const sel = 'li.user_sidebar_entry';
+
+    buddy_list.container.set_find_results(sel, {
+        map: (f) => [f(0, alice_li)],
+    });
+    const items = buddy_list.get_items();
+
+    assert.deepEqual(items, [alice_li]);
+}());

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -944,10 +944,10 @@ function test_raw_file_drop(raw_drop_func) {
         var checks = [
             (function () {
                 var called;
-                compose_fade.would_receive_message = function (email) {
+                compose.needs_subscribe_warning = function (email) {
                     called = true;
                     assert.equal(email, 'foo@bar.com');
-                    return false;
+                    return true;
                 };
                 return function () { assert(called); };
             }()),

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -868,27 +868,27 @@ function test_raw_file_drop(raw_drop_func) {
     var keyup_handler_func = $(selector).get_on_handler('keyup');
 
     var set_focused_recipient_checked = false;
-    var update_faded_messages_checked = false;
+    var update_all_called = false;
 
     global.compose_fade = {
         set_focused_recipient: function (msg_type) {
             assert.equal(msg_type, 'private');
             set_focused_recipient_checked = true;
         },
-        update_faded_messages: function () {
-            update_faded_messages_checked = true;
+        update_all: function () {
+            update_all_called = true;
         },
     };
 
     compose_state.set_message_type(false);
     keyup_handler_func();
     assert(!set_focused_recipient_checked);
-    assert(!update_faded_messages_checked);
+    assert(!update_all_called);
 
     compose_state.set_message_type('private');
     keyup_handler_func();
     assert(set_focused_recipient_checked);
-    assert(update_faded_messages_checked);
+    assert(update_all_called);
 }());
 
 (function test_trigger_submit_compose_form() {

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -60,10 +60,10 @@ people.add_in_realm(bob);
 
     compose_fade.set_focused_recipient('stream');
 
-    assert(compose_fade.would_receive_message('me@example.com'));
-    assert(compose_fade.would_receive_message('alice@example.com'));
-    assert(!compose_fade.would_receive_message('bob@example.com'));
-    assert.equal(compose_fade.would_receive_message('nonrealmuser@example.com'), undefined);
+    assert.equal(compose_fade.would_receive_message('me@example.com'), true);
+    assert.equal(compose_fade.would_receive_message('alice@example.com'), true);
+    assert.equal(compose_fade.would_receive_message('bob@example.com'), false);
+    assert.equal(compose_fade.would_receive_message('nonrealmuser@example.com'), true);
 
     var good_msg = {
         type: 'stream',

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -495,16 +495,6 @@ zrequire('message_events');
 
 */
 
-// We have a little bit of housekeeping to make the tests run
-// faster.  Server requests get throttled, but we don't care
-// about the timing issues for now in the tests, so we re-implement
-// throttle to just call a function immediately.
-_.throttle = (f) => {
-    return () => {
-        return f();
-    };
-};
-
 set_global('channel', {});
 set_global('feature_flags', {});
 set_global('home_msg_list', {});

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -694,6 +694,9 @@ function make_sidebar_helper() {
     }
 
     stream_list.stream_sidebar.set_row(social_stream.stream_id, row_widget());
+    stream_list.stream_cursor = {
+        redraw: noop,
+    };
 
     return {
         verify_actions: () => {

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -1,0 +1,55 @@
+zrequire('scroll_util');
+
+(function test_scroll_delta() {
+    // If we are entirely on-screen, don't scroll
+    assert.equal(0, scroll_util.scroll_delta({
+        elem_top: 1,
+        elem_bottom: 9,
+        container_height: 10,
+    }));
+
+    assert.equal(0, scroll_util.scroll_delta({
+        elem_top: -5,
+        elem_bottom: 15,
+        container_height: 10,
+    }));
+
+    // The top is offscreen.
+    assert.equal(-3, scroll_util.scroll_delta({
+        elem_top: -3,
+        elem_bottom: 5,
+        container_height: 10,
+    }));
+
+    assert.equal(-3, scroll_util.scroll_delta({
+        elem_top: -3,
+        elem_bottom: -1,
+        container_height: 10,
+    }));
+
+    assert.equal(-11, scroll_util.scroll_delta({
+        elem_top: -150,
+        elem_bottom: -1,
+        container_height: 10,
+    }));
+
+    // The bottom is offscreen.
+    assert.equal(3, scroll_util.scroll_delta({
+        elem_top: 7,
+        elem_bottom: 13,
+        container_height: 10,
+    }));
+
+    assert.equal(3, scroll_util.scroll_delta({
+        elem_top: 11,
+        elem_bottom: 13,
+        container_height: 10,
+    }));
+
+    assert.equal(11, scroll_util.scroll_delta({
+        elem_top: 11,
+        elem_bottom: 99,
+        container_height: 10,
+    }));
+
+}());

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -53,3 +53,41 @@ zrequire('scroll_util');
     }));
 
 }());
+
+(function test_scroll_element_into_container() {
+    const container = (function () {
+        var top = 3;
+        return {
+            height: () => 100,
+            scrollTop: (arg) => {
+                if (arg === undefined) {
+                    return top;
+                }
+                top = arg;
+            },
+        };
+    }());
+
+    const elem1 = {
+        height: () => 25,
+        position: () => {
+            return {
+                top: 0,
+            };
+        },
+    };
+    scroll_util.scroll_element_into_container(elem1, container);
+    assert.equal(container.scrollTop(), 3);
+
+    const elem2 = {
+        height: () => 15,
+        position: () => {
+            return {
+                top: 250,
+            };
+        },
+    };
+    scroll_util.scroll_element_into_container(elem2, container);
+    assert.equal(container.scrollTop(), 250 - 100 + 3 + 15);
+}());
+

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -651,6 +651,44 @@ set_global('$', global.make_zjquery());
     });
 }());
 
+narrow_state.active = () => false;
+
+(function test_rename_stream() {
+    const old_stream_id = stream_data.get_stream_id('devel');
+    const renamed_devel = {
+        name: 'Development',
+        stream_id: old_stream_id,
+        color: 'blue',
+        subscribed: true,
+        pin_to_top: true,
+    };
+
+    const li_stub = $.create('li stub');
+    templates.render = (name, payload) => {
+        assert.equal(name, 'stream_sidebar_row');
+        assert.deepEqual(payload, {
+            name: 'Development',
+            id: 1000,
+            uri: '#narrow/stream/Development',
+            not_in_home_view: false,
+            invite_only: undefined,
+            color: payload.color,
+            pin_to_top: true,
+            dark_background: payload.dark_background,
+        });
+        return {to_$: () => li_stub};
+    };
+
+    var count_updated;
+    stream_list.update_count_in_dom = (li) => {
+        assert.equal(li, li_stub);
+        count_updated = true;
+    };
+
+    stream_list.rename_stream(renamed_devel);
+    assert(count_updated);
+}());
+
 (function test_create_initial_sidebar_rows() {
     initialize_stream_data();
 

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -13,6 +13,7 @@ zrequire('hash_util');
 zrequire('narrow');
 zrequire('unread');
 zrequire('stream_data');
+zrequire('scroll_util');
 zrequire('stream_list');
 
 var noop = function () {};
@@ -237,7 +238,7 @@ function initialize_stream_data() {
     topic_list.rebuild = noop;
     topic_list.active_stream_id = noop;
     stream_list.show_all_streams = noop;
-    stream_list.scroll_element_into_container = noop;
+    scroll_util.scroll_element_into_container = noop;
 
     var scrollbar_updated = false;
 
@@ -670,58 +671,4 @@ var keydown_handler = $('.stream-list-filter').get_on_handler('keydown');
 
     assert.equal(html_dict.get(1000), '<div>stub-html-devel');
     assert.equal(html_dict.get(5000), '<div>stub-html-Denmark');
-}());
-
-(function test_scroll_delta() {
-    // If we are entirely on-screen, don't scroll
-    assert.equal(0, stream_list.scroll_delta({
-        elem_top: 1,
-        elem_bottom: 9,
-        container_height: 10,
-    }));
-
-    assert.equal(0, stream_list.scroll_delta({
-        elem_top: -5,
-        elem_bottom: 15,
-        container_height: 10,
-    }));
-
-    // The top is offscreen.
-    assert.equal(-3, stream_list.scroll_delta({
-        elem_top: -3,
-        elem_bottom: 5,
-        container_height: 10,
-    }));
-
-    assert.equal(-3, stream_list.scroll_delta({
-        elem_top: -3,
-        elem_bottom: -1,
-        container_height: 10,
-    }));
-
-    assert.equal(-11, stream_list.scroll_delta({
-        elem_top: -150,
-        elem_bottom: -1,
-        container_height: 10,
-    }));
-
-    // The bottom is offscreen.
-    assert.equal(3, stream_list.scroll_delta({
-        elem_top: 7,
-        elem_bottom: 13,
-        container_height: 10,
-    }));
-
-    assert.equal(3, stream_list.scroll_delta({
-        elem_top: 11,
-        elem_bottom: 13,
-        container_height: 10,
-    }));
-
-    assert.equal(11, stream_list.scroll_delta({
-        elem_top: 11,
-        elem_bottom: 99,
-        container_height: 10,
-    }));
-
 }());

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -14,6 +14,7 @@ zrequire('narrow');
 zrequire('unread');
 zrequire('stream_data');
 zrequire('scroll_util');
+zrequire('list_cursor');
 zrequire('stream_list');
 
 var noop = function () {};
@@ -22,6 +23,10 @@ var return_true = function () { return true; };
 
 set_global('topic_list', {});
 set_global('overlays', {});
+
+set_global('keydown_util', {
+    handle: noop,
+});
 
 (function test_create_sidebar_row() {
     // Make a couple calls to create_sidebar_row() and make sure they
@@ -278,127 +283,6 @@ function initialize_stream_data() {
     stream_list.handle_narrow_activated(filter);
     assert(!$("ul.filters li").hasClass('active-filter'));
     assert($('<cars sidebar row html>').hasClass('active-filter'));
-}());
-
-var keydown_handler = $('.stream-list-filter').get_on_handler('keydown');
-
-(function test_arrow_navigation() {
-
-    stream_list.build_stream_list();
-    initialize_stream_data();
-
-    var stream_order = ['devel', 'Rome', 'test',
-                        '-divider-', 'announce','Denmark',
-                        '-divider-','cars'];
-    var stream_count = 8;
-
-    // Mock the jquery is func
-    $('.stream-list-filter').is = function (sel) {
-        if (sel === ':focus') {
-            return $('.stream-list-filter').is_focused();
-        }
-    };
-
-    // Mock the jquery first func
-    $('#stream_filters li.narrow-filter').first = function () {
-        return $('#stream_filters li[data-stream-name="' + stream_order[0] + '"]');
-    };
-    $('#stream_filters li.narrow-filter').last = function () {
-        return $('#stream_filters li[data-stream-name="' + stream_order[stream_count - 1] + '"]');
-    };
-
-    var sel_index = 0;
-    // Returns which element is highlighted
-    $('#stream_filters li.narrow-filter.highlighted_stream')
-        .expectOne().data = function () {
-            // Return random id (is further not used)
-            return 1;
-        };
-
-    // Returns element before highlighted one
-    $('#stream_filters li.narrow-filter.highlighted_stream')
-        .expectOne().prev = function () {
-            if (sel_index === 0) {
-                // Top, no prev element
-                return $('div.no_stream');
-            } else if (sel_index === 3 || sel_index === 6) {
-                return $('div.divider');
-            }
-            return $('#stream_filters li[data-stream-name="'
-                        + stream_order[sel_index-1] + '"]');
-        };
-
-    // Returns element after highlighted one
-    $('#stream_filters li.narrow-filter.highlighted_stream')
-        .expectOne().next = function () {
-            if (sel_index === stream_count - 1) {
-                // Bottom, no next element
-                return $('div.no_stream');
-            } else if (sel_index === 3 || sel_index === 6) {
-                return $('div.divider');
-            }
-            return $('#stream_filters li[data-stream-name="'
-                        + stream_order[sel_index + 1] + '"]');
-        };
-
-    for (var i = 0; i < stream_count; i = i + 1) {
-        if (i === 3 || i === 6) {
-            $('#stream_filters li[data-stream-name="' + stream_order[i] + '"]')
-                .is = return_false;
-        } else {
-            $('#stream_filters li[data-stream-name="' + stream_order[i] + '"]')
-                .is = return_true;
-        }
-    }
-
-    $('div.no_stream').is = return_false;
-    $('div.divider').is = return_false;
-
-    $('#stream_filters li.narrow-filter').length = stream_count;
-
-    // up
-    var e = {
-        keyCode: 38,
-        stopPropagation: function () {},
-        preventDefault: function () {},
-    };
-
-    keydown_handler(e);
-    // Now the last element is highlighted
-    sel_index = stream_count - 1;
-    keydown_handler(e);
-    sel_index = sel_index - 1;
-
-    // down
-    e = {
-        keyCode: 40,
-        stopPropagation: function () {},
-        preventDefault: function () {},
-    };
-    keydown_handler(e);
-    sel_index = sel_index + 1;
-    keydown_handler(e);
-}());
-
-(function test_enter_press() {
-    var e = {
-        keyCode: 13,
-        stopPropagation: function () {},
-        preventDefault: function () {},
-    };
-
-    overlays.is_active = return_false;
-    narrow_state.active = return_false;
-    stream_data.get_sub_by_id = function () {
-        return 'name';
-    };
-    narrow.by = noop;
-    stream_list.clear_and_hide_search = noop;
-
-    // Enter text and narrow users
-    $(".stream-list-filter").expectOne().val('');
-
-    keydown_handler(e);
 }());
 
 (function test_focusout_user_filter() {

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -689,6 +689,42 @@ narrow_state.active = () => false;
     assert(count_updated);
 }());
 
+set_global('$', global.make_zjquery());
+
+(function test_refresh_pin() {
+    initialize_stream_data();
+
+    const sub = {
+        name: 'maybe_pin',
+        stream_id: 100,
+        color: 'blue',
+        pin_to_top: false,
+    };
+
+    stream_data.add_sub(sub.name, sub);
+
+    const pinned_sub = _.extend(sub, {
+        pin_to_top: true,
+    });
+
+    const li_stub = $.create('li stub');
+    templates.render = () => {
+        return {to_$: () => li_stub};
+    };
+
+    stream_list.update_count_in_dom = noop;
+    $('#stream_filters').append = noop;
+
+    var scrolled;
+    stream_list.scroll_stream_into_view = (li) => {
+        assert.equal(li, li_stub);
+        scrolled = true;
+    };
+
+    stream_list.refresh_pinned_or_unpinned_stream(pinned_sub);
+    assert(scrolled);
+}());
+
 (function test_create_initial_sidebar_rows() {
     initialize_stream_data();
 

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -403,6 +403,20 @@ set_global('$', global.make_zjquery());
     stream_list.handle_narrow_activated(filter);
     assert(!$("ul.filters li").hasClass('active-filter'));
     assert($('<cars sidebar row html>').hasClass('active-filter'));
+
+    var removed_classes;
+    $("ul#stream_filters li").removeClass = (classes) => {
+        removed_classes = classes;
+    };
+
+    var topics_closed;
+    topic_list.close = () => {
+        topics_closed = true;
+    };
+
+    stream_list.handle_narrow_deactivated();
+    assert.equal(removed_classes, 'active-filter active-sub-filter');
+    assert(topics_closed);
 }());
 
 (function test_focusout_user_filter() {

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -1,0 +1,184 @@
+// This tests the stream searching functionality which currently
+// lives in stream_list.js.
+
+set_global('$', global.make_zjquery());
+zrequire('stream_list');
+
+const noop = () => {};
+
+set_global('resize', {
+    resize_page_components: noop,
+});
+
+set_global('popovers', {});
+set_global('stream_popover', {});
+
+function expand_sidebar() {
+    $('.app-main .column-left').addClass('expanded');
+}
+
+function make_cursor_helper() {
+    const events = [];
+
+    stream_list.stream_cursor = {
+        reset: () => {
+            events.push('reset');
+        },
+        clear: () => {
+            events.push('clear');
+        },
+    };
+
+    return {
+        events: events,
+    };
+}
+
+function simulate_search_expanded() {
+    // The way we check if the search widget is expanded
+    // is kind of awkward.
+
+    $('#stream-filters-container .input-append.notdisplayed').length = 0;
+}
+
+function simulate_search_collapsed() {
+    $('#stream-filters-container .input-append.notdisplayed').length = 1;
+}
+
+function toggle_filter() {
+    stream_list.toggle_filter_displayed({preventDefault: noop});
+}
+
+(function test_basics() {
+    var cursor_helper;
+    const input = $('.stream-list-filter');
+    const header = $.create('header stub');
+
+    input.parent = () => header;
+
+    expand_sidebar();
+    header.addClass('notdisplayed');
+
+    cursor_helper = make_cursor_helper();
+
+    function verify_expanded() {
+        assert(!header.hasClass('notdisplayed'));
+        simulate_search_expanded();
+    }
+
+    function verify_focused() {
+        assert(stream_list.searching());
+        assert(input.is_focused());
+    }
+
+    function verify_blurred() {
+        assert(stream_list.searching());
+        assert(input.is_focused());
+    }
+
+    function verify_collapsed() {
+        assert(header.hasClass('notdisplayed'));
+        assert(!input.is_focused());
+        assert(!stream_list.searching());
+        simulate_search_collapsed();
+    }
+
+    function verify_list_updated(f) {
+        var updated;
+        stream_list.update_streams_sidebar = () => {
+            updated = true;
+        };
+
+        f();
+        assert(updated);
+    }
+
+    // Initiate search (so expand widget).
+    stream_list.initiate_search();
+    verify_expanded();
+    verify_focused();
+
+    assert.deepEqual(cursor_helper.events, ['reset']);
+
+    // Collapse the widget.
+    cursor_helper = make_cursor_helper();
+
+    toggle_filter();
+    verify_collapsed();
+
+    assert.deepEqual(cursor_helper.events, ['clear']);
+
+    // Expand the widget.
+    toggle_filter();
+    verify_expanded();
+    verify_focused();
+
+    (function add_some_text_and_collapse() {
+        cursor_helper = make_cursor_helper();
+        input.val('foo');
+        verify_list_updated(() => {
+            toggle_filter();
+        });
+
+        verify_collapsed();
+        assert.deepEqual(cursor_helper.events, ['reset', 'clear']);
+    }());
+
+    // Expand the widget.
+    toggle_filter();
+    verify_expanded();
+    verify_focused();
+
+    // Clear an empty search.
+    stream_list.clear_search();
+    verify_collapsed();
+
+    // Expand the widget.
+    toggle_filter();
+    stream_list.initiate_search();
+
+    // Clear a non-empty search.
+    input.val('foo');
+    verify_list_updated(() => {
+        stream_list.clear_search();
+    });
+    verify_expanded();
+
+    // Expand the widget.
+    toggle_filter();
+    stream_list.initiate_search();
+
+    // Escape a non-empty search.
+    input.val('foo');
+    stream_list.escape_search();
+    verify_blurred();
+
+    // Expand the widget.
+    toggle_filter();
+    stream_list.initiate_search();
+
+    // Escape an empty search.
+    input.val('');
+    stream_list.escape_search();
+    verify_collapsed();
+
+}());
+
+(function test_expanding_sidebar() {
+    $('.app-main .column-left').removeClass('expanded');
+
+    const events = [];
+    popovers.hide_all = () => {
+        events.push('popovers.hide_all');
+    };
+    stream_popover.show_streamlist_sidebar  = () => {
+        events.push('stream_popover.show_streamlist_sidebar');
+    };
+
+    stream_list.initiate_search();
+
+    assert.deepEqual(events, [
+        'popovers.hide_all',
+        'stream_popover.show_streamlist_sidebar',
+    ]);
+}());

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -3,9 +3,9 @@ zrequire('stream_data');
 zrequire('stream_sort');
 var with_overrides = global.with_overrides;
 
-// Test no subscribed streams
 (function test_no_subscribed_streams() {
     assert.equal(stream_sort.sort_groups(''), undefined);
+    assert.equal(stream_sort.first_stream_id(), undefined);
 }());
 
 const scalene = {
@@ -56,11 +56,24 @@ with_overrides(function (override) {
     assert.deepEqual(sorted.normal_streams, ['clarinet', 'fast tortoise']);
     assert.deepEqual(sorted.dormant_streams, ['pneumonia']);
 
+    // Test cursor helpers.
+    assert.equal(stream_sort.first_stream_id(), scalene.stream_id);
+
+    assert.equal(stream_sort.prev_stream_id(scalene.stream_id), undefined);
+    assert.equal(stream_sort.prev_stream_id(clarinet.stream_id), scalene.stream_id);
+
+    assert.equal(stream_sort.next_stream_id(fast_tortoise.stream_id), pneumonia.stream_id);
+    assert.equal(stream_sort.next_stream_id(pneumonia.stream_id), undefined);
+
     // Test filtering
     sorted = stream_sort.sort_groups("s");
     assert.deepEqual(sorted.pinned_streams, ['scalene']);
     assert.deepEqual(sorted.normal_streams, []);
     assert.deepEqual(sorted.dormant_streams, []);
+
+    assert.equal(stream_sort.prev_stream_id(clarinet.stream_id), undefined);
+
+    assert.equal(stream_sort.next_stream_id(clarinet.stream_id), undefined);
 
     // Test searching entire word, case-insensitive
     sorted = stream_sort.sort_groups("PnEuMoNiA");

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -8,36 +8,42 @@ var with_overrides = global.with_overrides;
     assert.equal(stream_sort.sort_groups(''), undefined);
 }());
 
-stream_data.add_sub('scalene', {
+const scalene = {
     subscribed: true,
     name: 'scalene',
     stream_id: 1,
     pin_to_top: true,
-});
-stream_data.add_sub('fast tortoise', {
+};
+const fast_tortoise = {
     subscribed: true,
     name: 'fast tortoise',
     stream_id: 2,
     pin_to_top: false,
-});
-stream_data.add_sub('pneumonia', {
+};
+const pneumonia = {
     subscribed: true,
     name: 'pneumonia',
     stream_id: 3,
     pin_to_top: false,
-});
-stream_data.add_sub('clarinet', {
+};
+const clarinet = {
     subscribed: true,
     name: 'clarinet',
     stream_id: 4,
     pin_to_top: false,
-});
-stream_data.add_sub('weaving', {
+};
+const weaving = {
     subscribed: false,
     name: 'weaving',
     stream_id: 5,
     pin_to_top: false,
-});
+};
+
+stream_data.add_sub(scalene.name, scalene);
+stream_data.add_sub(fast_tortoise.name, fast_tortoise);
+stream_data.add_sub(pneumonia.name, pneumonia);
+stream_data.add_sub(clarinet.name, clarinet);
+stream_data.add_sub(weaving.name, weaving);
 
 with_overrides(function (override) {
     override('stream_data.is_active', function (sub) {

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -8,6 +8,13 @@ global.Dict = require('js/dict');
 global._ = require('node_modules/underscore/underscore.js');
 var _ = global._;
 
+// Create a helper function to avoid sneaky delays in tests.
+function immediate(f) {
+    return () => {
+        return f();
+    };
+}
+
 // Find the files we need to run.
 var finder = require('./finder.js');
 var files = finder.find_files_to_run(); // may write to console
@@ -67,6 +74,8 @@ global.bugdown_assert = require('./bugdown_assert.js');
 files.forEach(function (file) {
     global.patch_builtin('setTimeout', noop);
     global.patch_builtin('setInterval', noop);
+    _.throttle = immediate;
+    _.debounce = immediate;
 
     console.info('running tests for ' + file.name);
     render.init();

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -35,7 +35,12 @@ exports.make_event_store = (selector) => {
 
         get_on_handler: function (name, child_selector) {
             var funcs = self.get_on_handlers(name, child_selector);
-            assert.equal(funcs.length, 1, 'We expected to have exactly one handler here.');
+            if (funcs.length === 0) {
+                throw Error('Could not find handler for ' + name);
+            }
+            if (funcs.length > 1) {
+                throw Error('Found too many handlers for ' + name);
+            }
             return funcs[0];
         },
 

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -224,6 +224,9 @@ exports.make_new_elem = function (selector, opts) {
             if (arg === ':visible') {
                 return shown;
             }
+            if (arg === ':focus') {
+                return focused;
+            }
             return self;
         },
         is_focused: function () {

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -210,7 +210,7 @@ exports.insert_user_into_list = function (user_id) {
         return;
     }
 
-    var info = buddy_data.info_for(user_id);
+    var info = buddy_data.get_item(user_id);
 
     buddy_list.insert_or_move({
         key: user_id,
@@ -219,9 +219,6 @@ exports.insert_user_into_list = function (user_id) {
     });
 
     exports.update_scrollbar.users();
-
-    var elt = get_pm_list_item(user_id);
-    compose_fade.update_one_user_row(elt);
 };
 
 exports.searching = function () {
@@ -240,9 +237,6 @@ exports.build_user_sidebar = function () {
     buddy_list.populate({
         items: user_info,
     });
-
-    // Update user fading, if necessary.
-    compose_fade.update_faded_users();
 
     resize.resize_page_components();
 

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -11,7 +11,7 @@ var exports = {};
 
 */
 
-var max_size_before_shrinking = 600;
+exports.max_size_before_shrinking = 600;
 
 var presence_descriptions = {
     active: 'is active',
@@ -108,8 +108,18 @@ function user_is_recently_active(user_id) {
     return level(presence.get_status(user_id)) <= 2;
 }
 
-function maybe_shrink_list(user_ids) {
-    if (user_ids.length <= max_size_before_shrinking) {
+function maybe_shrink_list(user_ids, filter_text) {
+    if (user_ids.length <= exports.max_size_before_shrinking) {
+        return user_ids;
+    }
+
+    if (filter_text) {
+        // If the user types something, we want to show all
+        // users matching the text, even if they have not been
+        // online recently.
+        // For super common letters like "s", we may
+        // eventually want to filter down to only users that
+        // are in presence.get_user_ids().
         return user_ids;
     }
 
@@ -132,7 +142,7 @@ exports.get_filtered_and_sorted_user_ids = function (filter_text) {
         user_ids = presence.get_user_ids();
     }
 
-    user_ids = maybe_shrink_list(user_ids);
+    user_ids = maybe_shrink_list(user_ids, filter_text);
 
     return exports.sort_users(user_ids);
 };

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -18,6 +18,18 @@ var presence_descriptions = {
     idle:   'is not active',
 };
 
+var fade_config = {
+    get_user_id: function (item) {
+        return item.user_id;
+    },
+    fade: function (item) {
+        item.faded = true;
+    },
+    unfade: function (item) {
+        item.faded = false;
+    },
+};
+
 function level(status) {
     switch (status) {
         case 'active':
@@ -103,6 +115,12 @@ exports.info_for = function (user_id) {
     };
 };
 
+exports.get_item = function (user_id) {
+    var info = exports.info_for(user_id);
+    compose_fade.update_user_info([info], fade_config);
+    return info;
+};
+
 function user_is_recently_active(user_id) {
     // return true if the user has a green/orange cirle
     return level(presence.get_status(user_id)) <= 2;
@@ -155,6 +173,8 @@ exports.get_items = function (filter_text) {
         // function.
         return typeof person !== "undefined";
     });
+
+    compose_fade.update_user_info(user_info, fade_config);
 
     return user_info;
 };

--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -35,6 +35,13 @@ var buddy_list = (function () {
         self.container.html(html);
     };
 
+    self.get_items = function () {
+        var obj = self.container.find(self.item_sel);
+        return obj.map(function (i, elem) {
+            return $(elem);
+        });
+    };
+
     self.first_key = function () {
         var list_items = self.container.find(self.item_sel);
         var li = list_items.first();

--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -35,6 +35,36 @@ var buddy_list = (function () {
         self.container.html(html);
     };
 
+    self.first_key = function () {
+        var list_items = self.container.find(self.item_sel);
+        var li = list_items.first();
+        if (li.length === 0) {
+            return;
+        }
+        var key = self.get_key_from_li({li: li});
+        return key;
+    };
+
+    self.prev_key = function (key) {
+        var li = self.find_li({key: key});
+        var prev_li = li.prev();
+        if (prev_li.length === 0) {
+            return;
+        }
+        var prev_key = self.get_key_from_li({li: prev_li});
+        return prev_key;
+    };
+
+    self.next_key = function (key) {
+        var li = self.find_li({key: key});
+        var next_li = li.next();
+        if (next_li.length === 0) {
+            return;
+        }
+        var next_key = self.get_key_from_li({li: next_li});
+        return next_key;
+    };
+
     self.maybe_remove_key = function (opts) {
         var li = self.find_li({key: opts.key});
         li.remove();

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -107,7 +107,7 @@ function update_fade() {
 
     var msg_type = compose_state.get_message_type();
     compose_fade.set_focused_recipient(msg_type);
-    compose_fade.update_faded_messages();
+    compose_fade.update_all();
 }
 
 exports.abort_xhr = function () {

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -37,7 +37,7 @@ exports.set_focused_recipient = function (msg_type) {
     }
 };
 
-function _display_messages_normally() {
+function display_messages_normally() {
     var table = rows.get_table(current_msg_list.table_name);
     table.find('.recipient_row').removeClass("message-fade");
 
@@ -53,7 +53,7 @@ function change_fade_state(elt, should_fade_group) {
     }
 }
 
-function _fade_messages() {
+function fade_messages() {
     var i;
     var first_message;
     var first_row;
@@ -170,7 +170,7 @@ function fade_users(items, conf) {
     });
 }
 
-function _want_normal_display() {
+function want_normal_display() {
     // If we're not composing show a normal display.
     if (focused_recipient === undefined) {
         return true;
@@ -199,7 +199,7 @@ function _want_normal_display() {
 exports.update_one_user_row = function (item) {
     var conf = user_fade_config;
 
-    if (_want_normal_display()) {
+    if (want_normal_display()) {
         conf.unfade(item);
     } else {
         update_user_row_when_fading(item, conf);
@@ -209,13 +209,13 @@ exports.update_one_user_row = function (item) {
 function do_update_all() {
     var user_items = buddy_list.get_items();
 
-    if (_want_normal_display()) {
+    if (want_normal_display()) {
         if (!normal_display) {
-            _display_messages_normally();
+            display_messages_normally();
             display_users_normally(user_items, user_fade_config);
         }
     } else {
-        _fade_messages();
+        fade_messages();
         fade_users(user_items, user_fade_config);
     }
 }
@@ -226,7 +226,7 @@ function do_update_all() {
 exports.update_faded_users = function () {
     var user_items = buddy_list.get_items();
 
-    if (_want_normal_display()) {
+    if (want_normal_display()) {
         display_users_normally(user_items, user_fade_config);
     } else {
         fade_users(user_items, user_fade_config);
@@ -243,24 +243,24 @@ exports.start_compose = function (msg_type) {
 
 exports.clear_compose = function () {
     focused_recipient = undefined;
-    _display_messages_normally();
+    display_messages_normally();
     exports.update_faded_users();
 };
 
 exports.update_message_list = function () {
-    if (_want_normal_display()) {
-       _display_messages_normally();
+    if (want_normal_display()) {
+       display_messages_normally();
     } else {
-        _fade_messages();
+        fade_messages();
     }
 };
 
 exports.update_rendered_message_groups = function (message_groups, get_element) {
-    if (_want_normal_display()) {
+    if (want_normal_display()) {
         return;
     }
 
-    // This loop is superficially similar to some code in _fade_messages, but an
+    // This loop is superficially similar to some code in fade_messages, but an
     // important difference here is that we look at each message individually, whereas
     // the other code takes advantage of blocks beneath recipient bars.
     _.each(message_groups, function (message_group) {

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -96,22 +96,14 @@ function fade_messages() {
 }
 
 exports.would_receive_message = function (email) {
-    // Given the current focused_recipient, this function returns true if
-    // the user in question would definitely receive this message, false if
-    // they would definitely not receive this message, and undefined if we
-    // don't know (e.g. the recipient is a stream we're not subscribed to).
-    //
-    // The distinction between undefined and true is historical.  We really
-    // only ever fade stuff if would_receive_message() returns false; i.e.
-    // we are **sure** that you would **not** receive the message.
-
     if (focused_recipient.type === 'stream') {
         var user = people.get_active_user_for_email(email);
         var sub = stream_data.get_sub(focused_recipient.stream);
         if (!sub || !user) {
             // If the stream or user isn't valid, there is no risk of a mix
-            // yet, so don't fade.
-            return;
+            // yet, so we sort of "lie" and say they would receive a
+            // message.
+            return true;
         }
 
         return stream_data.is_user_subscribed(focused_recipient.stream, user.user_id);
@@ -138,12 +130,10 @@ function update_user_row_when_fading(li, conf) {
     var email = people.get_person_from_user_id(user_id).email;
     var would_receive = exports.would_receive_message(email);
 
-    if (would_receive === false) {
-        conf.fade(li);
-    } else {
-        // would_receive is either true (so definitely don't fade) or
-        // undefined (in which case we don't presume to fade)
+    if (would_receive) {
         conf.unfade(li);
+    } else {
+        conf.fade(li);
     }
 }
 

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -196,16 +196,6 @@ function want_normal_display() {
     return focused_recipient.type === "private" && focused_recipient.reply_to === "";
 }
 
-exports.update_one_user_row = function (item) {
-    var conf = user_fade_config;
-
-    if (want_normal_display()) {
-        conf.unfade(item);
-    } else {
-        update_user_row_when_fading(item, conf);
-    }
-};
-
 function do_update_all() {
     var user_items = buddy_list.get_items();
 
@@ -226,10 +216,14 @@ function do_update_all() {
 exports.update_faded_users = function () {
     var user_items = buddy_list.get_items();
 
+    exports.update_user_info(user_items, user_fade_config);
+};
+
+exports.update_user_info = function (items, conf) {
     if (want_normal_display()) {
-        display_users_normally(user_items, user_fade_config);
+        display_users_normally(items, conf);
     } else {
-        fade_users(user_items, user_fade_config);
+        fade_users(items, conf);
     }
 };
 

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -105,12 +105,6 @@ exports.would_receive_message = function (email) {
     // only ever fade stuff if would_receive_message() returns false; i.e.
     // we are **sure** that you would **not** receive the message.
 
-    if (people.is_current_user(email)) {
-        // We never want to fade you yourself, so pretend it's true even if
-        // it's not.
-        return true;
-    }
-
     if (focused_recipient.type === 'stream') {
         var user = people.get_active_user_for_email(email);
         var sub = stream_data.get_sub(focused_recipient.stream);
@@ -120,11 +114,6 @@ exports.would_receive_message = function (email) {
             return;
         }
 
-        if (user && user.is_bot && !sub.invite_only) {
-            // Bots may receive messages on public streams even if they are
-            // not subscribed.
-            return;
-        }
         return stream_data.is_user_subscribed(focused_recipient.stream, user.user_id);
     }
 

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -206,11 +206,7 @@ exports.update_one_user_row = function (item) {
     }
 };
 
-function _update_faded_messages() {
-    // See also update_faded_messages(), which just wraps this with a debounce.
-    // FIXME: This fades users too now, as well as messages, so should have
-    // a better name.
-
+function do_update_all() {
     var user_items = buddy_list.get_items();
 
     if (_want_normal_display()) {
@@ -237,13 +233,12 @@ exports.update_faded_users = function () {
     }
 };
 
-// See trac #1633.  For fast typists, calls to _update_faded_messages can
-// cause typing sluggishness.
-exports.update_faded_messages = _.debounce(_update_faded_messages, 50);
+// This gets called on keyup events, hence the throttling.
+exports.update_all = _.debounce(do_update_all, 50);
 
 exports.start_compose = function (msg_type) {
     exports.set_focused_recipient(msg_type);
-    _update_faded_messages();
+    do_update_all();
 };
 
 exports.clear_compose = function () {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -305,11 +305,6 @@ exports.process_enter_key = function (e) {
     }
 
     if (exports.processing_text()) {
-        if (activity.searching()) {
-            activity.blur_search();
-            return true;
-        }
-
         if (stream_list.searching()) {
             // This is sort of funny behavior, but I think
             // the intention is that we want it super easy

--- a/static/js/keydown_util.js
+++ b/static/js/keydown_util.js
@@ -7,6 +7,7 @@ var exports = {};
 */
 
 var keys = {
+    13: 'enter_key',
     37: 'left_arrow',
     38: 'up_arrow',
     39: 'right_arrow',

--- a/static/js/list_cursor.js
+++ b/static/js/list_cursor.js
@@ -61,9 +61,7 @@ var list_cursor = function (opts) {
     };
 
     self.adjust_scroll = function (li) {
-        // TODO: move scroll_element_into_container out of
-        //       stream_list.js
-        stream_list.scroll_element_into_container(li, opts.list.container);
+        scroll_util.scroll_element_into_container(li, opts.list.container);
     };
 
     self.redraw = function () {

--- a/static/js/list_cursor.js
+++ b/static/js/list_cursor.js
@@ -1,0 +1,142 @@
+var list_cursor = function (opts) {
+    var self = {};
+
+    var config_ok = (
+        opts.highlight_class &&
+        opts.list &&
+        opts.list.container &&
+        opts.list.find_li &&
+        opts.list.first_key &&
+        opts.list.prev_key &&
+        opts.list.next_key
+    );
+
+    if (!config_ok) {
+        blueslip.error('Programming error');
+        return;
+    }
+
+    self.clear = function () {
+        if (self.curr_key === undefined) {
+            return;
+        }
+        var row = self.get_row(self.curr_key);
+        if (row) {
+            row.clear();
+        }
+        self.curr_key = undefined;
+    };
+
+    self.get_key = function () {
+        return self.curr_key;
+    };
+
+    self.get_row = function (key) {
+        // TODO: The list class should probably do more of the work
+        //       here, so we're not so coupled to jQuery, and
+        //       so we instead just get back a widget we can say
+        //       something like widget.select() on.  This will
+        //       be especially important if we do lazy rendering.
+        //       It would also give the caller more flexibility on
+        //       the actual styling.
+        if (key === undefined) {
+            return;
+        }
+
+        var li = opts.list.find_li({key: key});
+
+        if (li.length === 0) {
+            return;
+        }
+
+        return {
+            highlight: function () {
+                li.addClass(opts.highlight_class);
+                self.adjust_scroll(li);
+            },
+            clear: function () {
+                li.removeClass(opts.highlight_class);
+            },
+        };
+    };
+
+    self.adjust_scroll = function (li) {
+        // TODO: move scroll_element_into_container out of
+        //       stream_list.js
+        stream_list.scroll_element_into_container(li, opts.list.container);
+    };
+
+    self.redraw = function () {
+        // We should only call this for situations like the buddy
+        // list where we redraw the whole list without necessarily
+        // changing it, so we just want to re-highlight the current
+        // row in the new DOM.  If you are filtering, for now you
+        // should call the 'reset()' method.
+        var row = self.get_row(self.curr_key);
+
+        if (row === undefined) {
+            return;
+        }
+        row.highlight();
+    };
+
+    self.go_to = function (key) {
+        if (key === self.curr_key) {
+            return;
+        }
+        if (key === undefined) {
+            blueslip.error('Caller is not checking keys for list_cursor.go_to');
+            return;
+        }
+        self.clear();
+        self.curr_key = key;
+        var row = self.get_row(key);
+        if (row === undefined) {
+            blueslip.error('Cannot highlight key for list_cursor: ' + key);
+            return;
+        }
+        row.highlight();
+    };
+
+    self.reset = function () {
+        self.clear();
+        var key = opts.list.first_key();
+        if (key === undefined) {
+            self.curr_key = undefined;
+            return;
+        }
+        self.go_to(key);
+    };
+
+    self.prev = function () {
+        if (self.curr_key === undefined) {
+            return;
+        }
+        var key = opts.list.prev_key(self.curr_key);
+        if (key === undefined) {
+            // leave the current key
+            return;
+        }
+        self.go_to(key);
+    };
+
+    self.next = function () {
+        if (self.curr_key === undefined) {
+            // This is sort of a special case where we went from
+            // an empty filter to having data.
+            self.reset();
+            return;
+        }
+        var key = opts.list.next_key(self.curr_key);
+        if (key === undefined) {
+            // leave the current key
+            return;
+        }
+        self.go_to(key);
+    };
+
+    return self;
+};
+if (typeof module !== 'undefined') {
+    module.exports = list_cursor;
+}

--- a/static/js/scroll_util.js
+++ b/static/js/scroll_util.js
@@ -1,0 +1,59 @@
+var scroll_util = (function () {
+
+var exports = {};
+
+exports.scroll_delta = function (opts) {
+    var elem_top = opts.elem_top;
+    var container_height = opts.container_height;
+    var elem_bottom = opts.elem_bottom;
+
+    var delta = 0;
+
+    if (elem_top < 0) {
+        delta = Math.max(
+            elem_top,
+            elem_bottom - container_height
+        );
+        delta = Math.min(0, delta);
+    } else {
+        if (elem_bottom > container_height) {
+            delta = Math.min(
+                elem_top,
+                elem_bottom - container_height
+            );
+            delta = Math.max(0, delta);
+        }
+    }
+
+    return delta;
+};
+
+exports.scroll_element_into_container = function (elem, container) {
+    // This does the minimum amount of scrolling that is needed to make
+    // the element visible.  It doesn't try to center the element, so
+    // this will be non-intrusive to users when they already have
+    // the element visible.
+
+    var elem_top = elem.position().top;
+    var elem_bottom = elem_top + elem.height();
+
+    var opts = {
+        elem_top: elem_top,
+        elem_bottom: elem_bottom,
+        container_height: container.height(),
+    };
+
+    var delta = exports.scroll_delta(opts);
+
+    if (delta === 0) {
+        return;
+    }
+
+    container.scrollTop(container.scrollTop() + delta);
+};
+
+return exports;
+}());
+if (typeof module !== 'undefined') {
+    module.exports = scroll_util;
+}

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -306,7 +306,7 @@ exports.update_streams_sidebar = function () {
     $('#stream_filters li.highlighted_stream').removeClass('highlighted_stream');
     if (exports.searching()) {
         var all_streams = $('#stream_filters li.narrow-filter');
-        exports.highlight_first(all_streams, 'highlighted_stream');
+        exports.highlight_first(all_streams);
     }
 
     if (! narrow_state.active()) {
@@ -452,7 +452,7 @@ function focus_stream_filter(e) {
     if ($('#stream_filters li.narrow-filter.highlighted_stream').length === 0) {
         // Highlight
         var all_streams = $('#stream_filters li.narrow-filter');
-        exports.highlight_first(all_streams, 'highlighted_stream');
+        exports.highlight_first(all_streams);
     }
     e.stopPropagation();
 }
@@ -480,7 +480,7 @@ function keydown_enter_key() {
 
 function keydown_stream_filter(e) {
     exports.keydown_filter(e, '#stream_filters li.narrow-filter',
-     $('#stream-filters-container'), 'highlighted_stream', keydown_enter_key);
+     $('#stream-filters-container'), keydown_enter_key);
 }
 
 function actually_update_streams_for_search() {
@@ -575,7 +575,7 @@ exports.initiate_search = function () {
 
     // Highlight first result
     var all_streams = $('#stream_filters li.narrow-filter');
-    exports.highlight_first(all_streams, 'highlighted_stream');
+    exports.highlight_first(all_streams);
 };
 
 exports.clear_and_hide_search = function () {
@@ -595,16 +595,13 @@ function next_sibing_in_dir(elm, dir_up) {
     return elm.next();
 }
 
-function keydown_arrow_key(dir_up, all_streams_selector,
-                           scroll_container, highlighting_class) {
+function keydown_arrow_key(dir_up, all_streams_selector, scroll_container) {
     // Are there streams to cyle through?
     if ($(all_streams_selector).length > 0) {
-        var current_sel = $(all_streams_selector + '.' + highlighting_class).expectOne();
+        var current_sel = $(all_streams_selector + '.highlighted_stream').expectOne();
         var next_sibling = next_sibing_in_dir(current_sel, dir_up);
 
-        if (highlighting_class === 'highlighted_stream'
-            && next_sibling.is('hr.stream-split')) {
-            // Only for the left sidebar
+        if (next_sibling.is('hr.stream-split')) {
             // Skip separator
             next_sibling = next_sibing_in_dir(next_sibling, dir_up);
         }
@@ -622,20 +619,15 @@ function keydown_arrow_key(dir_up, all_streams_selector,
         }
 
         // Classes must be explicitly named
-        if (highlighting_class === 'highlighted_stream') {
-            current_sel.removeClass('highlighted_stream');
-            next_sibling.addClass('highlighted_stream');
-        } else if (highlighting_class === 'highlighted_user') {
-            current_sel.removeClass('highlighted_user');
-            next_sibling.addClass('highlighted_user');
-        }
+        current_sel.removeClass('highlighted_stream');
+        next_sibling.addClass('highlighted_stream');
 
         exports.scroll_element_into_container(next_sibling, scroll_container);
     }
 }
 
 exports.keydown_filter = function (e, all_streams_selector, scroll_container,
-                                   highlighting_class, enter_press_function) {
+                                   enter_press_function) {
     // Function for left and right sidebar
     // Could be placed somewhere else but ui.js is already very full
 
@@ -651,15 +643,13 @@ exports.keydown_filter = function (e, all_streams_selector, scroll_container,
         }
         case 38: {
             // Up-arrow key was pressed
-            keydown_arrow_key(true, all_streams_selector,
-                              scroll_container, highlighting_class);
+            keydown_arrow_key(true, all_streams_selector, scroll_container);
             handled = true;
             break;
         }
         case 40: {
             // Down-arrow key was pressed
-            keydown_arrow_key(false, all_streams_selector,
-                              scroll_container, highlighting_class);
+            keydown_arrow_key(false, all_streams_selector, scroll_container);
             handled = true;
             break;
         }
@@ -675,14 +665,10 @@ exports.keydown_filter = function (e, all_streams_selector, scroll_container,
     }
 };
 
-exports.highlight_first = function (all_streams, highlighting_class) {
+exports.highlight_first = function (all_streams) {
     if (all_streams.length > 0) {
         // Classes must be explicitly named
-        if (highlighting_class === 'highlighted_stream') {
-            all_streams.first().addClass('highlighted_stream');
-        } else if (highlighting_class === 'highlighted_user') {
-            all_streams.first().addClass('highlighted_user');
-        }
+        all_streams.first().addClass('highlighted_stream');
     }
 };
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -622,7 +622,7 @@ function keydown_arrow_key(dir_up, all_streams_selector, scroll_container) {
         current_sel.removeClass('highlighted_stream');
         next_sibling.addClass('highlighted_stream');
 
-        exports.scroll_element_into_container(next_sibling, scroll_container);
+        scroll_util.scroll_element_into_container(next_sibling, scroll_container);
     }
 }
 
@@ -692,64 +692,7 @@ exports.scroll_stream_into_view = function (stream_li) {
         return;
     }
 
-    exports.scroll_element_into_container(stream_li, container);
-};
-
-exports.scroll_delta = function (opts) {
-    var elem_top = opts.elem_top;
-    var container_height = opts.container_height;
-    var elem_bottom = opts.elem_bottom;
-
-    var delta = 0;
-
-    if (elem_top < 0) {
-        delta = Math.max(
-            elem_top,
-            elem_bottom - container_height
-        );
-        delta = Math.min(0, delta);
-    } else {
-        if (elem_bottom > container_height) {
-            delta = Math.min(
-                elem_top,
-                elem_bottom - container_height
-            );
-            delta = Math.max(0, delta);
-        }
-    }
-
-    return delta;
-};
-
-exports.scroll_element_into_container = function (elem, container) {
-    // This is a generic function to make elem visible in
-    // container by scrolling container appropriately.  We may want to
-    // eventually move this into another module, but I couldn't find
-    // an ideal landing space for this.  I considered a few modules, but
-    // some are already kind of bloated (ui.js), some may be deprecated
-    // (scroll_bar.js), and some just aren't exact fits (resize.js).
-    //
-    // This does the minimum amount of scrolling that is needed to make
-    // the element visible.  It doesn't try to center the element, so
-    // this will be non-intrusive to users when they already have
-    // the element visible.
-
-    var elem_top = elem.position().top;
-    var elem_bottom = elem_top + elem.height();
-
-    var opts = {
-        elem_top: elem_top,
-        elem_bottom: elem_bottom,
-        container_height: container.height(),
-    };
-
-    var delta = exports.scroll_delta(opts);
-
-    if (delta === 0) {
-        return;
-    }
-
-    container.scrollTop(container.scrollTop() + delta);
+    scroll_util.scroll_element_into_container(stream_li, container);
 };
 
 return exports;

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -611,9 +611,6 @@ exports.clear_and_hide_search = function () {
 };
 
 exports.toggle_filter_displayed = function (e) {
-    if (e.target.id === 'streams_inline_cog') {
-        return;
-    }
     if ($('#stream-filters-container .input-append.notdisplayed').length === 0) {
         exports.clear_and_hide_search();
     } else {

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -91,6 +91,52 @@ exports.sort_groups = function (search_term) {
     };
 };
 
+function pos(stream_id) {
+    var sub = stream_data.get_sub_by_id(stream_id);
+    var name = sub.name;
+    var i = all_streams.indexOf(name);
+
+    if (i < 0) {
+        return;
+    }
+
+    return i;
+}
+
+function maybe_get_stream_id(i) {
+    if (i < 0 || i >= all_streams.length) {
+        return;
+    }
+
+    var name = all_streams[i];
+    var stream_id = stream_data.get_stream_id(name);
+    return stream_id;
+}
+
+exports.first_stream_id = function () {
+    return maybe_get_stream_id(0);
+};
+
+exports.prev_stream_id = function (stream_id) {
+    var i = pos(stream_id);
+
+    if (i === undefined) {
+        return;
+    }
+
+    return maybe_get_stream_id(i - 1);
+};
+
+exports.next_stream_id = function (stream_id) {
+    var i = pos(stream_id);
+
+    if (i === undefined) {
+        return;
+    }
+
+    return maybe_get_stream_id(i + 1);
+};
+
 return exports;
 }());
 if (typeof module !== 'undefined') {

--- a/static/js/user_search.js
+++ b/static/js/user_search.js
@@ -1,0 +1,117 @@
+var user_search = function (opts) {
+    // This is mostly view code to manage the user search widget
+    // above the buddy list.  We rely on other code to manage the
+    // details of populating the list when we change.
+
+    var self = {};
+
+    var $widget = $('#user-list .input-append').expectOne();
+    var $input = $('.user-list-filter').expectOne();
+
+    self.input_field = function () {
+        return $input;
+    };
+
+    self.text = function () {
+        return $input.val().trim();
+    };
+
+    self.searching = function () {
+        return $input.is(':focus');
+    };
+
+    self.empty = function () {
+        return self.text() === '';
+    };
+
+    self.clear_search = function () {
+        if (self.empty()) {
+            self.close_widget();
+            return;
+        }
+
+        $input.val('');
+        $input.blur();
+        opts.update_list();
+    };
+
+    self.escape_search = function () {
+        if (self.empty()) {
+            self.close_widget();
+            return;
+        }
+
+        $input.val('');
+        opts.update_list();
+    };
+
+    self.hide_widget = function () {
+        $widget.addClass('notdisplayed');
+    };
+
+    self.show_widget = function () {
+        $widget.removeClass('notdisplayed');
+    };
+
+    self.widget_shown = function () {
+        return $widget.hasClass('notdisplayed');
+    };
+
+    self.clear_and_hide_search = function () {
+        if (!self.empty()) {
+            $input.val('');
+            opts.update_list();
+        }
+        self.close_widget();
+    };
+
+    self.close_widget = function () {
+        $input.blur();
+        self.hide_widget();
+        opts.reset_items();
+    };
+
+    self.expand_column = function () {
+        var column = $input.closest(".app-main [class^='column-']");
+        if (!column.hasClass("expanded")) {
+            popovers.hide_all();
+            if (column.hasClass('column-left')) {
+                stream_popover.show_streamlist_sidebar();
+            } else if (column.hasClass('column-right')) {
+                popovers.show_userlist_sidebar();
+            }
+        }
+    };
+
+    self.initiate_search = function () {
+        self.expand_column();
+        self.show_widget();
+        $input.focus();
+        opts.initialize_list_for_search();
+    };
+
+    self.toggle_filter_displayed = function () {
+        if (self.widget_shown()) {
+            self.initiate_search();
+        } else {
+            self.clear_and_hide_search();
+        }
+    };
+
+    function on_focus(e) {
+        opts.initialize_list_for_search();
+        e.stopPropagation();
+    }
+
+    $('#clear_search_people_button').on('click', self.clear_search);
+    $('#userlist-header').on('click', self.toggle_filter_displayed);
+
+    $input.on('input', opts.update_list);
+    $input.on('click', on_focus);
+
+    return self;
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = user_search;
+}

--- a/static/js/user_search.js
+++ b/static/js/user_search.js
@@ -32,7 +32,7 @@ var user_search = function (opts) {
 
         $input.val('');
         $input.blur();
-        opts.update_list();
+        opts.reset_items();
     };
 
     self.escape_search = function () {
@@ -87,7 +87,6 @@ var user_search = function (opts) {
         self.expand_column();
         self.show_widget();
         $input.focus();
-        opts.initialize_list_for_search();
     };
 
     self.toggle_filter_displayed = function () {
@@ -99,7 +98,7 @@ var user_search = function (opts) {
     };
 
     function on_focus(e) {
-        opts.initialize_list_for_search();
+        opts.on_focus();
         e.stopPropagation();
     }
 
@@ -107,7 +106,7 @@ var user_search = function (opts) {
     $('#userlist-header').on('click', self.toggle_filter_displayed);
 
     $input.on('input', opts.update_list);
-    $input.on('click', on_focus);
+    $input.on('focus', on_focus);
 
     return self;
 };

--- a/static/templates/user_presence_row.handlebars
+++ b/static/templates/user_presence_row.handlebars
@@ -1,4 +1,4 @@
-<li data-user-id="{{user_id}}" class="user_sidebar_entry {{#if num_unread}}user-with-count {{/if}}narrow-filter user_{{type}}">
+<li data-user-id="{{user_id}}" class="user_sidebar_entry {{#if num_unread}} user-with-count {{/if}} narrow-filter user_{{type}} {{#if faded}} user-fade {{/if}}">
     <span class="selectable_sidebar_block">
         <span class="user-status-indicator"></span>
         <a href="{{href}}"

--- a/tools/lib/find_add_class.py
+++ b/tools/lib/find_add_class.py
@@ -93,6 +93,8 @@ def find(fns):
                         continue
                     elif 'stream_dark' in line:
                         continue
+                    elif 'opts.' in line:
+                        continue
                     elif fn == 'signup.js' and 'class_to_add' in line:
                         html_classes = ['error', 'success']
                     elif fn == 'ui_report.js' and 'status_classes' in line:

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -73,6 +73,7 @@ enforce_fully_covered = {
     'static/js/user_events.js',
     'static/js/user_groups.js',
     'static/js/user_pill.js',
+    'static/js/user_search.js',
     'static/js/util.js',
 }
 

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -54,6 +54,7 @@ enforce_fully_covered = {
     'static/js/reactions.js',
     'static/js/recent_senders.js',
     'static/js/rtl.js',
+    'static/js/scroll_util.js',
     'static/js/search_suggestion.js',
     # Removed because we're migrating code from uncovered other settings pages to here.
     # 'static/js/settings_ui.js',

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1032,6 +1032,7 @@ JS_SPECS = {
             'js/lightbox_canvas.js',
             'js/rtl.js',
             'js/dict.js',
+            'js/scroll_util.js',
             'js/components.js',
             'js/localstorage.js',
             'js/drafts.js',

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1132,6 +1132,7 @@ JS_SPECS = {
             'js/user_search.js',
             'js/buddy_data.js',
             'js/buddy_list.js',
+            'js/list_cursor.js',
             'js/activity.js',
             'js/user_events.js',
             'js/colorspace.js',

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1129,6 +1129,7 @@ JS_SPECS = {
             'js/server_events_dispatch.js',
             'js/zulip.js',
             'js/presence.js',
+            'js/user_search.js',
             'js/buddy_data.js',
             'js/buddy_list.js',
             'js/activity.js',


### PR DESCRIPTION
So far this fixes one glitch, which is that we have slow performance on czo where there are 1000+ offline users.  This suppresses offline users when the widget would otherwise show 600+ items.

It also starts breaking up the beast that is activity.js, pulling out these components:

* buddy_list
* buddy_data
* user_search

I tested this manually, and we also had 100% node coverage on activity.js, which I've preserved (without cheating--the new files are also 100%).