### PR TITLE
doc tests: Add portico pages to tools/test-help-documentation.

### DIFF
--- a/tools/documentation_crawler/documentation_crawler/spiders/check_help_documentation.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/check_help_documentation.py
@@ -53,3 +53,13 @@ class APIDocumentationSpider(UnusedImagesLinterSpider):
     start_urls = ['http://localhost:9981/api']
     deny_domains = []  # type: List[str]
     images_path = "static/images/api"
+
+class PorticoDocumentationSpider(BaseDocumentationSpider):
+    name = 'portico_documentation_crawler'
+    start_urls = ['http://localhost:9981/hello',
+                  'http://localhost:9981/features',
+                  'http://localhost:9981/why-zulip',
+                  'http://localhost:9981/for/open-source',
+                  'http://localhost:9981/for/companies',
+                  'http://localhost:9981/for/working-groups-and-communities']
+    deny_domains = []  # type: List[str]

--- a/tools/test-help-documentation
+++ b/tools/test-help-documentation
@@ -31,8 +31,10 @@ with test_server_running(options.force, external_host, log_file=LOG_FILE,
                                    cwd='tools/documentation_crawler')
     ret_api_doc = subprocess.call(('scrapy', 'crawl_with_status', 'api_documentation_crawler'),
                                   cwd='tools/documentation_crawler')
+    ret_portico_doc = subprocess.call(('scrapy', 'crawl_with_status', 'portico_documentation_crawler'),
+                                      cwd='tools/documentation_crawler')
 
-if ret_help_doc != 0 or ret_api_doc != 0:
+if ret_help_doc != 0 or ret_api_doc != 0 or ret_portico_doc != 0:
     print("\033[0;91m")
     print("Failed")
     print("\033[0m")
@@ -42,4 +44,4 @@ else:
     print("\033[0m")
 
 
-sys.exit(ret_help_doc or ret_api_doc)
+sys.exit(ret_help_doc or ret_api_doc or ret_portico_doc)


### PR DESCRIPTION
Fixes #9117.

@timabbott: FYI! I tested this thoroughly by placing broken links inside all of the extra pages I added! Should be good to go! :)