### PR TITLE
 portico: Fix broken mobile responsive design on Plans page.

### DIFF
--- a/static/styles/landing-page.css
+++ b/static/styles/landing-page.css
@@ -2612,14 +2612,13 @@ nav ul li.active::after {
 }
 
 @media (max-width: 1390px) {
-    .portico-landing.plans .pricing-container .block .responsive-title {
+    .portico-landing.plans .pricing-container .block:not(:first-child) .responsive-title {
         color: inherit;
     }
 }
 
 @media (max-width: 1376px) {
     .portico-landing.plans .price-box {
-        height: 500px !important;
         margin: 20px;
     }
 
@@ -3318,7 +3317,26 @@ nav ul li.active::after {
     }
 }
 
-@media (max-device-width: 450px) {
+@media (max-width: 450px) {
+    .portico-landing.plans .price-box {
+        display: inline-flex;
+        flex-direction: column;
+        min-height: 500px;
+        height: auto;
+        max-width: 300px;
+        width: auto;
+        margin: 10px 0px;
+    }
+
+    .pricing-model .pricing-container .text-content {
+        flex: 1;
+    }
+
+    .pricing-model .pricing-container .bottom {
+        position: static;
+        height: auto;
+    }
+
     nav {
         padding-bottom: 105px;
     }

--- a/static/styles/lightbox.css
+++ b/static/styles/lightbox.css
@@ -290,7 +290,7 @@
     clear: both;
 }
 
-@media only screen and (min-device-width : 320px) and (max-device-width : 736px) {
+@media only screen and (min-width: 320px) and (max-width: 736px) {
     #lightbox_overlay .image-actions {
         float: left;
         margin-top: 0;

--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -345,7 +345,7 @@
     }
 }
 
-@media only screen and (min-device-width: 300px) and (max-device-width: 700px) {
+@media only screen and (min-width: 300px) and (max-width: 700px) {
     #unmute_muted_topic_notification {
         width: calc(90% - 30px);
         left: 5%;

--- a/static/third/spectrum/spectrum.css
+++ b/static/third/spectrum/spectrum.css
@@ -209,7 +209,7 @@ License: MIT
 .sp-cf { *zoom: 1; }
 
 /* Mobile devices, make hue slider bigger so it is easier to slide */
-@media (max-device-width: 480px) {
+@media (max-width: 480px) {
     .sp-color { right: 40%; }
     .sp-hue { left: 63%; }
     .sp-fill { padding-top: 60%; }


### PR DESCRIPTION
Before:

![screenshot at apr 21 14-37-37](https://user-images.githubusercontent.com/15116870/39089033-716d17fe-4572-11e8-8545-d5435af43b5e.png)

After:

![screenshot at apr 21 14-46-18](https://user-images.githubusercontent.com/15116870/39089051-cdfe8066-4572-11e8-9345-77e2afd19fe1.png)

