### PR TITLE
slack import: Use less strict checks in `check_subdomain_available`.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -55,7 +55,7 @@ def email_is_not_mit_mailing_list(email: Text) -> None:
             else:
                 raise AssertionError("Unexpected DNS error")
 
-def check_subdomain_available(subdomain: str) -> None:
+def check_subdomain_available(subdomain: str, from_management_command: bool=False) -> None:
     error_strings = {
         'too short': _("Subdomain needs to have length 3 or greater."),
         'extremal dash': _("Subdomain cannot start or end with a '-'."),
@@ -70,6 +70,8 @@ def check_subdomain_available(subdomain: str) -> None:
         raise ValidationError(error_strings['extremal dash'])
     if not re.match('^[a-z0-9-]*$', subdomain):
         raise ValidationError(error_strings['bad character'])
+    if from_management_command:
+        return
     if len(subdomain) < 3:
         raise ValidationError(error_strings['too short'])
     if is_reserved_subdomain(subdomain) or \

--- a/zerver/management/commands/import.py
+++ b/zerver/management/commands/import.py
@@ -74,7 +74,7 @@ import a database dump from one or more JSON files."""
             for model in models_to_import:
                 self.new_instance_check(model)
 
-        check_subdomain_available(subdomain)
+        check_subdomain_available(subdomain, from_management_command=True)
 
         for path in options['export_files']:
             if not os.path.exists(path):


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #9166.

**Testing Plan:** <!-- How have you tested? -->
Manual testing of management command. Not sure if unit tests are desired here since the logic for this function is pretty simple.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
N/A


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
