### PR TITLE
viewport: Hide right-sidebar buddy list below 1024px.

### DIFF
--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -250,9 +250,9 @@ exports.stop_auto_scrolling = function () {
 exports.is_narrow = function () {
     // This basically returns true when we hide the right sidebar for
     // the left_side_userlist skinny mode.  It would be nice to have a less brittle
-    // test for this.  See the "@media (max-width: 975px)" section in
+    // test for this.  See the "@media (max-width: 1025px)" section in
     // zulip.css.
-    return window.innerWidth <= 975;
+    return window.innerWidth <= 1025;
 };
 
 exports.system_initiated_animate_scroll = function (scroll_amount) {

--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -53,7 +53,7 @@ $(function () {
                                "margin-right": (250 + sbWidth) + "px"});
     $("#compose-container").css("max-width", (1400 + sbWidth) + "px");
 
-    $("head").append("<style> @media (max-width: 975px) { .compose-content, .header-main .column-middle { margin-right: " + (7 + sbWidth) + "px !important; } } " +
+    $("head").append("<style> @media (max-width: 1025px) { .compose-content, .header-main .column-middle { margin-right: " + (7 + sbWidth) + "px !important; } } " +
                      "@media (max-width: 775px) { .fixed-app .column-middle { margin-left: " + (7 + sbWidth) + "px !important; } } " +
                      "</style>");
    }

--- a/static/styles/media.css
+++ b/static/styles/media.css
@@ -4,7 +4,7 @@
 }
 
 /* This max-width must be synced with message_viewport.is_narrow */
-@media (max-width: 975px) {
+@media (max-width: 1025px) {
     .screen-full-show {
         display: none !important;
     }


### PR DESCRIPTION
This is a slight change in the responsive design, moving the 975px
cutoff to 1025px; the main effect is that for windows that just barely
had a right sidebar, we now hide the ride sidebar.  This is pretty
beneficial for the user experience specifically in the common size of
1024px, where that sidebar was making things feel a bit too
constrained.

@rishig can you review this?