### PR TITLE
webpack: Disable host check for webpack-dev-server.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -66,6 +66,9 @@ parser.add_argument('--force',
 parser.add_argument('--enable-tornado-logging',
                     action="store_true",
                     default=False, help='Enable access logs from tornado proxy server.')
+parser.add_argument('--disable-host-check',
+                    action="store_true",
+                    default=False, help='Disable host check for webpack-dev-server')
 options = parser.parse_args()
 
 if not options.force:
@@ -90,6 +93,7 @@ if options.interface is None:
         options.interface = "127.0.0.1"
 elif options.interface == "":
     options.interface = None
+    options.disable_host_check = True
 
 runserver_args = []  # type: List[str]
 base_port = 9991
@@ -166,6 +170,8 @@ else:
     webpack_cmd = ['./tools/webpack', '--watch', '--port', str(webpack_port)]
     if options.minify:
         webpack_cmd.append('--minify')
+    if options.disable_host_check:
+        webpack_cmd.append('--disable-host-check')
     if options.interface:
         webpack_cmd += ["--host", options.interface]
     else:

--- a/tools/webpack
+++ b/tools/webpack
@@ -25,13 +25,15 @@ def run():
                           ['--config', 'tools/webpack.config.ts', '-p'] +
                           ['--env', 'production'])
 
-def run_watch(host, port, minify):
-    # type: (str, str, bool) -> None
+def run_watch(host, port, minify, disable_host_check):
+    # type: (str, str, bool, bool) -> None
     """watches and rebuilds on changes, serving files from memory via webpack-dev-server"""
     webpack_args = ['node', 'node_modules/.bin/webpack-dev-server']
     webpack_args += ['--config', 'tools/webpack.config.ts', '--port', port, "--host", host]
     if minify:
         webpack_args.append('--optimize-minimize')
+    if disable_host_check:
+        webpack_args.append('--disable-host-check')
     subprocess.Popen(webpack_args)
 
 def run_test():
@@ -72,11 +74,14 @@ parser.add_argument('--port',
 parser.add_argument('--minify',
                     action='store_true', dest='minify', default=False,
                     help='Minify and optimize the assets (for development)')
+parser.add_argument('--disable-host-check',
+                    action='store_true', dest='disable_host_check', default=None,
+                    help='Disable host check for webpack-dev-server')
 
 args = parser.parse_args()
 if args.test:
     run_test()
 elif args.watch:
-    run_watch(args.host, args.port, args.minify)
+    run_watch(args.host, args.port, args.minify, args.disable_host_check)
 else:
     run()


### PR DESCRIPTION
Webpack dev server by default does host checking for requests. so
in dev environment, if the request came for zulipdev.com it would not
send js files which caused dev environment to not work.

