### PR TITLE
Requirements: upgrade to mypy 0.590 & add assertion in timeout.py.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -88,7 +88,7 @@ markdown==2.6.11
 markupsafe==1.0
 mock==2.0.0
 moto==1.3.1
-mypy==0.580
+mypy==0.590
 mypy_extensions==0.3.0
 ndg-httpsclient==0.4.4
 oauth2client==4.1.2

--- a/requirements/mypy.in
+++ b/requirements/mypy.in
@@ -2,7 +2,7 @@
 # /tools/update-locked-requirements to update requirements/dev.txt
 # and requirements/mypy.txt.
 # See requirements/README.md for more detail.
-mypy==0.580
+mypy==0.590
 
 # Include typing explicitly, since it's needed on Python 3.4
 typing==3.6.4

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -7,6 +7,6 @@
 #
 # For details, see requirements/README.md .
 #
-mypy==0.580
+mypy==0.590
 typed-ast==1.1.0          # via mypy
 typing==3.6.4

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.0+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '19.0'
+PROVISION_VERSION = '19.1'

--- a/zerver/lib/timeout.py
+++ b/zerver/lib/timeout.py
@@ -52,6 +52,7 @@ def timeout(timeout: float, func: Callable[..., ResultT], *args: Any, **kwargs: 
         def raise_async_timeout(self) -> None:
             # Called from another thread.
             # Attempt to raise a TimeoutExpired in the thread represented by 'self'.
+            assert self.ident is not None  # Thread should be running; c_long expects int
             tid = ctypes.c_long(self.ident)
             result = ctypes.pythonapi.PyThreadState_SetAsyncExc(
                 tid, ctypes.py_object(TimeoutExpired))


### PR DESCRIPTION
Latest upgrade to mypy, with minor assertion fix.

I'm getting another provision issue, though I have followed the requirements upgrade process, and `run-mypy` is running fine with mypy 0.590 and this small fix. The error I have is as follows; happy to retest on my droplet if there is advice on resolving this:
```
error ts-loader@4.2.0: The engine "node" is incompatible with this module. Expected version ">=6.11.5".
```

With mypy 0.590, we can now add a `py.typed` file, to indicate that Zulip is typed in the packaging, though PEP 561 is still WIP as I understand it. We can also do so for the API repo, for which 0.590 otherwise doesn't make much of a change (from 0.560).