### PR TITLE
portico: Update text on confirm_continue_registration.

### DIFF
--- a/static/styles/portico-signin.css
+++ b/static/styles/portico-signin.css
@@ -138,7 +138,6 @@ html {
 
 .app-main.confirm-continue-page-container .form-inline {
     display: inline-block;
-    width: 180px;
 }
 
 .app-main.confirm-continue-page-container .form-inline .outline {
@@ -290,7 +289,7 @@ html {
 }
 
 .register-form button {
-    margin-top: 25px;
+    margin-top: 22px;
 }
 
 .new-style .alert:not(.alert-info) {

--- a/templates/zerver/confirm_continue_registration.html
+++ b/templates/zerver/confirm_continue_registration.html
@@ -12,10 +12,10 @@
                     <div class="white-box">
                         <p>
                             {% trans %}
-                            No account found for {{ email }}. Would you like to register instead?
+                            No account found for {{ email }}.
                             {% endtrans %}
                         </p>
-                        <div style="text-align: left;">
+                        <div style="text-align: center;">
                             <form class="form-inline" id="send_confirm" name="send_confirm"
                               action="/login/" method="get">
                                 <input type="hidden"
@@ -23,13 +23,14 @@
                                   name="email"
                                   value="{{ email }}" />
                                 <button>
-                                    {{ _("Go back to login") }}
+                                    {{ _("Log in with another account") }}
                                 </button>
                             </form>
+                            <br/>
                             <form class="form-inline" id="send_confirm" name="send_confirm"
                               action="{{ continue_link }}" method="get">
                                 <button class="outline">
-                                    {{ _("Sign up instead") }}
+                                    {{ _("Continue to registration") }}
                                 </button>
                             </form>
                         </div>

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -665,7 +665,7 @@ class GitHubAuthBackendTest(ZulipTestCase):
 
             result = self.client_get(result.url)
             self.assert_in_response('No account found for', result)
-            self.assert_in_response('new-user@zulip.com. Would you like to register instead?', result)
+            self.assert_in_response('new-user@zulip.com.', result)
             self.assert_in_response('action="http://zulip.testserver/accounts/do_confirm/', result)
 
             url = re.findall('action="(http://zulip.testserver/accounts/do_confirm[^"]*)"', result.content.decode('utf-8'))[0]
@@ -990,7 +990,7 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         result = self.get_log_into_subdomain(data)
         self.assertEqual(result.status_code, 200)
         self.assert_in_response('No account found for', result)
-        self.assert_in_response('new@zulip.com. Would you like to register instead?', result)
+        self.assert_in_response('new@zulip.com.', result)
         self.assert_in_response('action="http://zulip.testserver/accounts/do_confirm/', result)
 
         url = re.findall('action="(http://zulip.testserver/accounts/do_confirm[^"]*)"', result.content.decode('utf-8'))[0]


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/890911/39221045-b4c27c6e-47e9-11e8-8819-0d8339a5ba47.png)


Not very confident about the html or css, but tested having a long translation:
![image](https://user-images.githubusercontent.com/890911/39221033-a2d22e14-47e9-11e8-91e1-304a2655f597.png)
