### PR TITLE
settings: Fix escaping of HTML in checkbox labels.

### DIFF
--- a/static/templates/settings/settings_checkbox.handlebars
+++ b/static/templates/settings/settings_checkbox.handlebars
@@ -8,7 +8,7 @@
         <span></span>
     </label>
     <label for="{{prefix}}{{setting_name}}" class="inline-block" id="{{prefix}}{{setting_name}}_label">
-        {{label}}
+        {{{label}}}
     </label>
     {{{end_content}}}
 </div>


### PR DESCRIPTION
Some labels like one for `translate_emoticons` which contains HTML
get escaped because of use of `{{ label }}` syntax, which escapes
the string for XSS security purpose but since labels aren't any
threat to any such security cases, we can use triple curly brackets
`{{{ label }}}` syntax.

Fixes: #9231.
![fixed](https://user-images.githubusercontent.com/22238472/39288676-95c1f43a-4946-11e8-84ca-f13504c0bc53.png)
