### PR TITLE
settings: Make bot-settings tabs look better in dark mode.

### DIFF
--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -485,3 +485,10 @@ body.night-mode .ps__rail-y {
         background-color: hsla(0, 0%, 0%, 0.2);
     }
 }
+
+body.night-mode #bots_lists_navbar .active a {
+    color: #ddd;
+    background-color: hsl(212, 28%, 18%);
+    border-color: #ddd;
+    border-bottom-color: transparent;
+}


### PR DESCRIPTION
Fixes: #9230.
Here are two prototype one with the complete white border and one with a blue border for active tab. Which one looks better?
![whitebackground](https://user-images.githubusercontent.com/22238472/39298825-ded80c0e-4964-11e8-8a0c-360cdf6f1ab0.gif)
![blueborder](https://user-images.githubusercontent.com/22238472/39298826-df3ad564-4964-11e8-8a47-19db599ca48a.gif)
Currently, PR has the "complete white border" changes.