### PR TITLE
org settings: Fix word-wrapping CSS in "users" section.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -135,7 +135,7 @@ label {
 
 .wrapped-table {
     table-layout: fixed;
-    word-break: break-all;
+    word-break: break-word;
     word-wrap: break-word;
     white-space: -moz-pre-wrap !important;
     white-space: -webkit-pre-wrap;


### PR DESCRIPTION
Fixes: #9225.
I think this is the desirable behavior (here is `IagoIago...` is a very large name and only it gets split)
![users](https://user-images.githubusercontent.com/22238472/39312812-08db6d56-498e-11e8-9eed-aefacb9cdc8a.png)
