### PR TITLE
compose_actions.js: Scroll if message is short than viewport.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -148,10 +148,14 @@ exports.maybe_scroll_up_selected_message = function () {
         return;
     }
     var selected_row = current_msg_list.selected_row();
-    var cover = selected_row.offset().top + selected_row.height()
-        - $("#compose").offset().top;
-    if (cover > 0) {
-        message_viewport.user_initiated_animate_scroll(cover+5);
+
+    if (selected_row.height() < message_viewport.height()) {
+        // If the height of the selected message is less than the height of the viewport
+        // Then we initiate a scroll to the bottom of the screen
+        // we calculate the amount of scroll in var cover
+         var cover = selected_row.offset().top + selected_row.height()
+             - $("#compose").offset().top;
+        message_viewport.user_initiated_animate_scroll(cover);
     }
 
 };


### PR DESCRIPTION

![scrolling-wrt-viewport-height](https://user-images.githubusercontent.com/22795943/39382576-90e8c25c-4a83-11e8-8c4d-2ab03b1c22ca.gif)
Resolves #8941 

Earlier, the messages scrolled on click only if it was long enough but now I've changed it to scroll for the message whose height < height of the viewport. Upon clicking, the message scrolls to the bottom of the screen.

Please see the above gif for further reference.