### PR TITLE
Webpack/Tooling: Quieten webpack output for tests.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -161,7 +161,7 @@ if options.test:
     # in order to support running the Casper tests while a Zulip
     # development server is running, we use webpack in production mode
     # for the Casper tests.
-    subprocess.check_call('./tools/webpack')
+    subprocess.check_call(['./tools/webpack', '--quiet'])
 else:
     webpack_cmd = ['./tools/webpack', '--watch', '--port', str(webpack_port)]
     if options.minify:

--- a/tools/webpack
+++ b/tools/webpack
@@ -18,12 +18,16 @@ os.chdir(settings.DEPLOY_ROOT)
 STATIC_PATH = 'static/'
 
 
-def run():
-    # type: () -> None
+def run(quiet):
+    # type: (bool) -> None
     """Builds for production, writing the output to disk"""
-    subprocess.check_call(['node', 'node_modules/.bin/webpack-cli'] +
-                          ['--config', 'tools/webpack.config.ts', '-p'] +
-                          ['--env', 'production'])
+    webpack_args = ['node', 'node_modules/.bin/webpack-cli']
+    webpack_args += ['--config', 'tools/webpack.config.ts', '-p']
+    webpack_args += ['--env', 'production']
+    if quiet:
+        webpack_args += ['--display', 'errors-only']
+        print('starting webpack compilation')
+    subprocess.check_call(webpack_args)
 
 def run_watch(host, port, minify, disable_host_check):
     # type: (str, str, bool, bool) -> None
@@ -71,6 +75,9 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--test',
                     action='store_true', dest='test', default=False,
                     help='generate a stub webpack-stats.json file (for backend testing)')
+parser.add_argument('--quiet',
+                    action='store_true', dest='quiet', default=False,
+                    help='Minimizes webpack output while running')
 parser.add_argument('--watch',
                     action='store_true', dest='watch', default=False,
                     help='watch for changes to source files (for development)')
@@ -93,4 +100,4 @@ if args.test:
 elif args.watch:
     run_watch(args.host, args.port, args.minify, args.disable_host_check)
 else:
-    run()
+    run(args.quiet)


### PR DESCRIPTION
This commit adds a --quiet argument to tools/webpack which removes
the verbose output from webpack and replaces it with showing only
errors. It also makes tools/run-dev --tests use this argument while
running webpack for testing.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Make sure tests are running.
Make sure dev server is running.
Make sure production is building correctly.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
