### PR TITLE
webpack: Combine both js and css into one portico bundle.

### DIFF
--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block customhead %}
-{{ render_bundle('portico-styles') }}
+{{ render_bundle('portico') }}
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/portico-help.html
+++ b/templates/zerver/portico-help.html
@@ -7,7 +7,6 @@
 #}
 
 {% block porticocustomhead %}
-{{ render_bundle('portico-styles') }}
 {{ render_bundle('translations') }}
 {{ render_bundle('portico') }}
 {% endblock %}

--- a/templates/zerver/portico.html
+++ b/templates/zerver/portico.html
@@ -7,7 +7,6 @@
 #}
 
 {% block porticocustomhead %}
-{{ render_bundle('portico-styles') }}
 {{ render_bundle('translations') }}
 {{ render_bundle('portico') }}
 {% endblock %}

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -1,7 +1,8 @@
 {
     "activity": "./static/third/sorttable/sorttable.js",
     "portico": [
-        "./static/js/portico/header.js"
+        "./static/js/portico/header.js",
+        "./static/styles/scss/portico.scss"
     ],
     "common": [
                "string.prototype.endswith",
@@ -31,6 +32,5 @@
               "./node_modules/plotly.js/dist/plotly-basic.min.js"
              ],
     "translations": "./static/js/translations.js",
-    "zxcvbn": "./node_modules/zxcvbn/dist/zxcvbn.js",
-    "portico-styles": "./static/styles/scss/portico.scss"
+    "zxcvbn": "./node_modules/zxcvbn/dist/zxcvbn.js"
 }


### PR DESCRIPTION
Combines, both portico js and css into one bundle. This for now
solve the issue of an empty js bundle being generated by webpack.

**Testing Plan:** <!-- How have you tested? -->
Manually verified both css and js bundles are rendered correctly, at:
* localhost:9991/stats.html
* localhost:9991/help/
* localhost:9991/api/

