### PR TITLE
custom fields: Add UI for custom field hint.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -79,6 +79,7 @@ function add_custom_profile_fields_to_settings() {
                                                                   field_type: type,
                                                                   field_value: value,
                                                                   is_long_text_field: is_long_text,
+                                                                  field_hint: field.hint,
                                                                   });
         $("#account-settings .custom-profile-fields-form").append(html);
     });

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1358,6 +1358,10 @@ input[type=checkbox].inline-block {
     width: auto;
 }
 
+#account-settings .custom_user_field .field_hint {
+    color: hsl(0, 0%, 66%);
+}
+
 #settings_page .custom_user_field {
     padding-bottom: 20px;
 }

--- a/static/templates/settings/custom-user-profile-field.handlebars
+++ b/static/templates/settings/custom-user-profile-field.handlebars
@@ -5,4 +5,5 @@
     {{else}}
     <input type="{{ field_type }}" name="{{ field_name }}" id="{{ field_id }}" value="{{ field_value }}" />
     {{/if}}
+    <div class="field_hint">{{ field_hint }}</div>
 </div>


### PR DESCRIPTION
Fixes #8876

Current UI is:
![customfieldhint](https://user-images.githubusercontent.com/25907420/39415806-30b8509e-4c65-11e8-9326-8700cfb6b475.png)

@rishig Does this UI make sense for custom field's hint?