### PR TITLE
[WIP] stream settings: Clean 500 errors on stream creation, update

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -420,7 +420,8 @@ exports.change_stream_name = function (e) {
         },
         error: function (xhr) {
             new_name_box.text(stream_data.maybe_get_stream_name(stream_id));
-            ui_report.error(i18n.t("Error renaming stream"), xhr, $(".stream_change_property_info"));
+            ui_report.error(i18n.t("Error"), xhr, $(".stream_change_property_info"));
+            ui.update_scrollbar($("#subscription_overlay .settings"));
         },
     });
 };
@@ -451,8 +452,9 @@ exports.change_stream_description = function (e) {
                              $(".stream_change_property_info"));
         },
         error: function (xhr) {
-            ui_report.error(i18n.t("Error updating the stream description"), xhr,
-                            $(".stream_change_property_info"));
+            sub_settings.find('.stream-description-editable').html(sub.rendered_description);
+            ui_report.error(i18n.t("Error"), xhr, $(".stream_change_property_info"));
+            ui.update_scrollbar($("#subscription_overlay .settings"));
         },
     });
 };

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -486,6 +486,8 @@ exports.setup_page = function (callback) {
             can_create_streams: page_params.can_create_streams,
             subscriptions: sub_rows,
             hide_all_streams: !should_list_all_streams(),
+            max_name_length: page_params.stream_name_max_length,
+            max_description_length: page_params.stream_description_max_length,
         };
 
         var rendered = templates.render('subscription_table_body', template_data);

--- a/static/templates/subscription_creation_form.handlebars
+++ b/static/templates/subscription_creation_form.handlebars
@@ -9,7 +9,7 @@
                     {{t "Stream name" }}
                 </div>
                 <input type="text" name="stream_name" id="create_stream_name"
-                  placeholder="{{t 'Stream name' }}" value="" autocomplete="off" />
+                  placeholder="{{t 'Stream name' }}" value="" autocomplete="off" maxlength="{{ max_name_length }}" />
                 <div id="stream_name_error" class="stream_creation_error"></div>
             </section>
             <section class="block">
@@ -17,7 +17,7 @@
                     {{t "Stream description (optional)"}}
                 </div>
                 <textarea name="stream_description" id="create_stream_description"
-                  placeholder="{{t 'Stream description' }}" value="" autocomplete="off"></textarea>
+                  placeholder="{{t 'Stream description' }}" value="" autocomplete="off" maxlength="{{ max_description_length }}"></textarea>
             </section>
             <section class="block" id="make-invite-only">
                 <div class="stream-title">

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1813,6 +1813,11 @@ def check_stream_name(stream_name: Text) -> None:
         if ord(i) == 0:
             raise JsonableError(_("Stream name '%s' contains NULL (0x00) characters." % (stream_name)))
 
+def check_stream_description(stream_description: Text) -> None:
+    if len(stream_description) > Stream.MAX_DESCRIPTION_LENGTH:
+        raise JsonableError(_("Stream description too long (limit: %s characters)."
+                            % (Stream.MAX_DESCRIPTION_LENGTH)))
+
 def check_default_stream_group_name(group_name: Text) -> None:
     if group_name.strip() == "":
         raise JsonableError(_("Invalid default stream group name '%s'" % (group_name)))

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -44,7 +44,7 @@ from zerver.models import Client, Message, Realm, UserPresence, UserProfile, Cus
     get_user_profile_by_id, \
     get_realm_user_dicts, realm_filters_for_realm, get_user,\
     custom_profile_fields_for_realm, get_realm_domains, \
-    get_default_stream_groups, CustomProfileField
+    get_default_stream_groups, CustomProfileField, Stream
 from zproject.backends import email_auth_enabled, password_auth_enabled
 from version import ZULIP_VERSION
 
@@ -258,6 +258,8 @@ def fetch_initial_state_data(user_profile: UserProfile,
 
     if want('stream'):
         state['streams'] = do_get_streams(user_profile)
+        state['stream_name_max_length'] = Stream.MAX_NAME_LENGTH
+        state['stream_description_max_length'] = Stream.MAX_DESCRIPTION_LENGTH
     if want('default_streams'):
         state['realm_default_streams'] = streams_to_dicts_sorted(
             get_default_streams_for_realm(user_profile.realm_id))

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -935,6 +935,7 @@ def generate_email_token_for_stream() -> str:
 
 class Stream(models.Model):
     MAX_NAME_LENGTH = 60
+    MAX_DESCRIPTION_LENGTH = 1024
     name = models.CharField(max_length=MAX_NAME_LENGTH, db_index=True)  # type: Text
     realm = models.ForeignKey(Realm, db_index=True, on_delete=CASCADE)  # type: Realm
     invite_only = models.NullBooleanField(default=False)  # type: Optional[bool]
@@ -955,7 +956,7 @@ class Stream(models.Model):
     # have plenty of room for the token.
     email_token = models.CharField(
         max_length=32, default=generate_email_token_for_stream)  # type: str
-    description = models.CharField(max_length=1024, default=u'')  # type: Text
+    description = models.CharField(max_length=MAX_DESCRIPTION_LENGTH, default=u'')  # type: Text
 
     date_created = models.DateTimeField(default=timezone_now)  # type: datetime.datetime
     deactivated = models.BooleanField(default=False)  # type: bool

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -161,6 +161,8 @@ class HomeTest(ZulipTestCase):
             "server_generation",
             "server_inline_image_preview",
             "server_inline_url_embed_preview",
+            "stream_description_max_length",
+            "stream_name_max_length",
             "subscriptions",
             "test_suite",
             "timezone",

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -610,12 +610,11 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_json_error(result, "Invalid stream id")
 
     def test_change_stream_description(self) -> None:
-        user_profile = self.example_user('hamlet')
+        user_profile = self.example_user('iago')
         email = user_profile.email
         self.login(email)
         realm = user_profile.realm
         self.subscribe(user_profile, 'stream_name1')
-        do_change_is_admin(user_profile, True)
 
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
@@ -643,6 +642,11 @@ class StreamAdminTest(ZulipTestCase):
                       notified_user_ids)
 
         self.assertEqual('Test description', stream.description)
+
+        result = self.client_patch('/json/streams/%d' % (stream_id,),
+                                   {'description': ujson.dumps('a' * 1025)})
+        self.assert_json_error(result, "Stream description too long (limit: %s characters)."
+                               % (Stream.MAX_DESCRIPTION_LENGTH))
 
     def test_change_stream_description_requires_realm_admin(self) -> None:
         user_profile = self.example_user('hamlet')

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -21,7 +21,7 @@ from zerver.lib.actions import bulk_remove_subscriptions, \
     do_create_default_stream_group, do_add_streams_to_default_stream_group, \
     do_remove_streams_from_default_stream_group, do_remove_default_stream_group, \
     do_change_default_stream_group_description, do_change_default_stream_group_name, \
-    prep_stream_welcome_message
+    prep_stream_welcome_message, check_stream_description
 from zerver.lib.response import json_success, json_error, json_response
 from zerver.lib.streams import access_stream_by_id, access_stream_by_name, \
     check_stream_name, check_stream_name_available, filter_stream_authorization, \
@@ -153,6 +153,7 @@ def update_stream_backend(
     # description even for private streams.
     stream = access_stream_for_delete_or_update(user_profile, stream_id)
     if description is not None:
+        check_stream_description(description)
         do_change_stream_description(stream, description)
     if new_name is not None:
         new_name = new_name.strip()


### PR DESCRIPTION
- [X] update stream: Add validation of stream description on backend (Fix returning 500 response)
- [X] create stream: Add frontend length validation on stream name & description 
- [ ] create stream: Add backend validation on stream description (currently, we only have length validation on stream name when stream is created)
- [ ] update stream: Add frontend length validation (limiting characters in the text input in the web UI to make it basically impossible to enter a too-long description.) 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![streamdescriptiontoolong](https://user-images.githubusercontent.com/25907420/39422629-d9ce94ba-4c8b-11e8-8a26-39dd402676a3.gif)
