### PR TITLE
stream settings: Fix quick bugs in stream subscription settings.

### DIFF
--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -237,8 +237,8 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         } else if (event.op === 'delete') {
             _.each(event.streams, function (stream) {
                 var was_subscribed = stream_data.get_sub_by_id(stream.stream_id).subscribed;
-                stream_data.delete_sub(stream.stream_id);
                 subs.remove_stream(stream.stream_id);
+                stream_data.delete_sub(stream.stream_id);
                 if (was_subscribed) {
                     stream_list.remove_sidebar_row(stream.stream_id);
                 }

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -668,8 +668,6 @@ exports.initialize = function () {
         }
         var row = $(".stream-row.active");
         exports.delete_stream(stream_id, $(".stream_change_property_info"), row);
-        $(".settings").hide();
-        $(".nothing-selected").show();
     });
 
     $("#subscriptions_table").on("hide.bs.modal", "#deactivation_stream_modal", function () {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -250,6 +250,10 @@ exports.remove_stream = function (stream_id) {
     // stream, but we let jQuery silently handle that.
     var row = row_for_stream_id(stream_id);
     row.remove();
+    var sub = stream_data.get_sub_by_id(stream_id);
+    if (stream_edit.is_sub_settings_active(sub)) {
+        exports.show_subs_pane.nothing_selected();
+    }
 };
 
 exports.update_settings_for_subscribed = function (sub) {

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2170,7 +2170,7 @@ class EventsRegisterTest(ZulipTestCase):
         events = self.do_test(action,
                               include_subscribers=include_subscribers,
                               num_events=3)
-        error = remove_schema_checker('events[1]', events[1])
+        error = remove_schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
         # Now resubscribe a user, to make sure that works on a vacated stream


### PR DESCRIPTION
This fixes issue #9028, #9029 and one bug which I found while testing this changes.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Preview button on private stream creation:
![prieviewbutton](https://user-images.githubusercontent.com/25907420/39430250-f5757ff2-4caa-11e8-8342-a3b84cb8b82b.gif)

Unsubscribing themselves from stream:
![scrollbarunsubscribethemselves](https://user-images.githubusercontent.com/25907420/39430247-f514b1ae-4caa-11e8-9d6b-49ec8b1704ec.gif)

To reproduce the last bug:
* Create private stream to only one admin is subscribed
* Unsubscribe admin from created private stream
The stream page will not get updated and it still shows admin in subscriber list.