### PR TITLE
test_bugdown: Fix ignore-testcase feature for markdown_test_cases.

### DIFF
--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -264,7 +264,7 @@ class BugdownTest(ZulipTestCase):
 
             # Ignore tests if specified
             if test.get('ignore', False):
-                return  # nocoverage
+                continue  # nocoverage
 
             if test.get('translate_emoticons', False):
                 # Create a userprofile and send message with it.


### PR DESCRIPTION
We accidentally were 'return'ing on encountering an ignored case, and thus
exiting the loop, not running further testcases.

Since the particular tests I wanted to see passing passed after ignoring some of them, I must have missed this error while writing the original code here. :/

**Testing Plan:** <!-- How have you tested? -->
Manual Testing