### PR TITLE
#8857 outgoing webhooks: Improve error handling when non-JSON response returned

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -198,7 +198,6 @@ def notify_bot_owner(event: Dict[str, Any],
     send_response_message(bot_id, message_info, notification_message)
 
 def request_retry(event: Dict[str, Any],
-                  request_data: Dict[str, Any],
                   failure_message: str,
                   exception: Optional[Exception]=None) -> None:
     def failure_processor(event: Dict[str, Any]) -> None:
@@ -264,7 +263,7 @@ def do_rest_call(rest_operation: Dict[str, Any],
     except requests.exceptions.Timeout as e:
         logging.info("Trigger event %s on %s timed out. Retrying" % (
             event["command"], event['service_name']))
-        request_retry(event, request_data, 'Unable to connect with the third party.', exception=e)
+        request_retry(event, 'Unable to connect with the third party.', exception=e)
 
     except requests.exceptions.ConnectionError as e:
         response_message = ("The message `%s` resulted in a connection error when "
@@ -272,7 +271,7 @@ def do_rest_call(rest_operation: Dict[str, Any],
                             "webhook! See the Zulip server logs for more information." % (event["command"],))
         logging.info("Trigger event %s on %s resulted in a connection error. Retrying"
                      % (event["command"], event['service_name']))
-        request_retry(event, request_data, response_message, exception=e)
+        request_retry(event, response_message, exception=e)
 
     except requests.exceptions.RequestException as e:
         response_message = ("An exception of type *%s* occurred for message `%s`! "

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -173,7 +173,6 @@ def get_message_url(event: Dict[str, Any]) -> str:
     return message_url
 
 def notify_bot_owner(event: Dict[str, Any],
-                     request_data: Dict[str, Any],
                      status_code: Optional[int]=None,
                      response_content: Optional[AnyStr]=None,
                      exception: Optional[Exception]=None,
@@ -210,7 +209,7 @@ def request_retry(event: Dict[str, Any],
         """
         bot_user = get_user_profile_by_id(event['user_profile_id'])
         fail_with_message(event, "Maximum retries exceeded! " + failure_message)
-        notify_bot_owner(event, request_data, exception=exception)
+        notify_bot_owner(event, exception=exception)
         logging.warning("Maximum retries exceeded for trigger:%s event:%s" % (
             bot_user.email, event['command']))
 
@@ -223,7 +222,7 @@ def process_success_response(event: Dict[str, Any],
     success_message, failure_message = service_handler.process_success(response, event)
     if failure_message is not None:
         fail_with_message(event, failure_message)
-        notify_bot_owner(event, request_data, failure_message=failure_message)
+        notify_bot_owner(event, failure_message=failure_message)
     elif success_message is not None:
         succeed_with_message(event, success_message)
 
@@ -261,7 +260,7 @@ def do_rest_call(rest_operation: Dict[str, Any],
                                'response': response.content})
             failure_message = "Third party responded with %d" % (response.status_code)
             fail_with_message(event, failure_message)
-            notify_bot_owner(event, request_data, response.status_code, response.content)
+            notify_bot_owner(event, response.status_code, response.content)
 
     except requests.exceptions.Timeout as e:
         logging.info("Trigger event %s on %s timed out. Retrying" % (
@@ -282,4 +281,4 @@ def do_rest_call(rest_operation: Dict[str, Any],
                                 type(e).__name__, event["command"],))
         logging.exception("Outhook trigger failed:\n %s" % (e,))
         fail_with_message(event, response_message)
-        notify_bot_owner(event, request_data, exception=e)
+        notify_bot_owner(event, exception=e)

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -217,7 +217,6 @@ def request_retry(event: Dict[str, Any],
 
 def process_success_response(event: Dict[str, Any],
                              service_handler: Any,
-                             request_data: Optional[Dict[str, Any]],
                              response: Response) -> None:
     success_message, failure_message = service_handler.process_success(response, event)
     if failure_message is not None:
@@ -250,7 +249,7 @@ def do_rest_call(rest_operation: Dict[str, Any],
     try:
         response = requests.request(http_method, final_url, data=request_data, **request_kwargs)
         if str(response.status_code).startswith('2'):
-            process_success_response(event, service_handler, request_data, response)
+            process_success_response(event, service_handler, response)
         else:
             logging.warning("Message %(message_url)s triggered an outgoing webhook, returning status "
                             "code %(status_code)s.\n Content of response (in quotes): \""

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -153,7 +153,7 @@ def fail_with_message(event: Dict[str, Any], failure_message: str) -> None:
     failure_message = "Failure! " + failure_message
     send_response_message(event['user_profile_id'], event['message'], failure_message)
 
-def get_message_url(event: Dict[str, Any], request_data: Dict[str, Any]) -> str:
+def get_message_url(event: Dict[str, Any]) -> str:
     bot_user = get_user_profile_by_id(event['user_profile_id'])
     message = event['message']
     if message['type'] == 'stream':
@@ -178,7 +178,7 @@ def notify_bot_owner(event: Dict[str, Any],
                      response_content: Optional[AnyStr]=None,
                      exception: Optional[Exception]=None,
                      failure_message: Optional[str]=None) -> None:
-    message_url = get_message_url(event, request_data)
+    message_url = get_message_url(event)
     bot_id = event['user_profile_id']
     bot_owner = get_user_profile_by_id(bot_id).bot_owner
     message_info = {'display_recipient': [{'email': bot_owner.email}],
@@ -256,7 +256,7 @@ def do_rest_call(rest_operation: Dict[str, Any],
             logging.warning("Message %(message_url)s triggered an outgoing webhook, returning status "
                             "code %(status_code)s.\n Content of response (in quotes): \""
                             "%(response)s\""
-                            % {'message_url': get_message_url(event, request_data),
+                            % {'message_url': get_message_url(event),
                                'status_code': response.status_code,
                                'response': response.content})
             failure_message = "Third party responded with %d" % (response.status_code)

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -15,8 +15,13 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
     def setUp(self) -> None:
         self.event = {
             u'command': '@**test**',
+            u'user_profile_id': 12,
             u'message': {
+                'id': 100,
                 'content': '@**test**',
+                'type': 'stream',
+                'display_recipient': 'integrations',
+                'subject': 'test_subject',
             },
             u'trigger': 'mention',
         }
@@ -49,6 +54,18 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
         success_response, _ = self.handler.process_success(response, self.event)
         self.assertEqual(success_response, None)
 
+    @mock.patch('logging.warning')
+    def test_process_response_with_decode_error(self, mock_logger: mock.Mock) -> None:
+        response = mock.Mock(spec=Response)
+        response.text = "{"
+        success_message, failure_message = self.handler.process_success(response, self.event)
+        self.assertEqual(success_message, None)
+        self.assertEqual(failure_message, "Your outgoing webhook bot nagios-receive-bot@zulip.com "
+                                          "sent an outgoing HTTP request for "
+                                          "[this message](http://zulip.testserver/#narrow/stream/None-integrations/subject/test_subject/near/100), "
+                                          "but the HTTP was not in JSON format. Here's the content of the response:\n```\n{\n```")
+        mock_logger.assert_called_once()
+
 mock_service = Service()
 
 class TestSlackOutgoingWebhookService(ZulipTestCase):
@@ -60,6 +77,7 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
             u'service_name': 'test-service',
             u'trigger': 'mention',
             u'message': {
+                'id': 101,
                 'content': 'test_content',
                 'type': 'stream',
                 'sender_realm_str': 'zulip',
@@ -69,6 +87,7 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
                 'timestamp': 123456,
                 'sender_id': 21,
                 'sender_full_name': 'Sample User',
+                'subject': 'test_subject',
             }
         }
         self.handler = SlackOutgoingWebhookService(base_url='http://example.domain.com',
@@ -103,3 +122,15 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
         response.text = json.dumps({"text": 'test_content'})
         success_response, _ = self.handler.process_success(response, self.event)
         self.assertEqual(success_response, 'test_content')
+
+    @mock.patch('logging.warning')
+    def test_process_response_with_decode_error(self, mock_logger: mock.Mock) -> None:
+        response = mock.Mock(spec=Response)
+        response.text = "{"
+        success_message, failure_message = self.handler.process_success(response, self.event)
+        self.assertEqual(success_message, None)
+        self.assertEqual(failure_message, "Your Slack-format outgoing webhook bot "
+                                          "nagios-receive-bot@zulip.com sent an outgoing HTTP request for "
+                                          "[this message](http://zulip.testserver/#narrow/stream/123-integrations/subject/test_subject/near/101), "
+                                          "but the HTTP was not in JSON format. Here's the content of the response:\n```\n{\n```")
+        mock_logger.assert_called_once()

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -131,7 +131,7 @@ I'm a generic exception :(
             self.assertTrue(mock_fail_with_message.called)
             self.assertEqual(bot_owner_notification.content,
                              '''[A message](http://zulip.testserver/#narrow/stream/999-Verona/subject/Foo/near/) triggered an outgoing webhook.
-The error occurred during request to the webhook service:
+Your outgoing webhook bot outgoing-webhook@zulip.com sent an outgoing HTTP request for [this message](http://zulip.testserver/#narrow/stream/999-Verona/subject/Foo/near/), but received an error from the HTTP server:
 ```
 Fail!
 ```''')

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -10,6 +10,8 @@ from django.test import override_settings
 from requests import Response
 from typing import Any, Dict, Tuple, Optional
 
+from mock import MagicMock
+
 from zerver.lib.outgoing_webhook import do_rest_call, OutgoingWebhookServiceInterface
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import get_realm, get_user, UserProfile, get_display_recipient
@@ -117,6 +119,23 @@ When trying to send a request to the webhook service, an exception of type Reque
 I'm a generic exception :(
 ```''')
         self.assertEqual(bot_owner_notification.recipient_id, self.bot_user.bot_owner.id)
+
+    @mock.patch('zerver.lib.outgoing_webhook.fail_with_message')
+    def test_process_success_response_failed(self, mock_fail_with_message: mock.Mock) -> None:
+        response = ResponseMock(200)
+        service_handler = MagicMock()
+        service_handler.process_success = MagicMock(return_value=(None, "Fail!"))
+        with mock.patch('requests.request', return_value=response):
+            do_rest_call(self.rest_operation, None, self.mock_event, service_handler, None)
+            bot_owner_notification = self.get_last_message()
+            self.assertTrue(mock_fail_with_message.called)
+            self.assertEqual(bot_owner_notification.content,
+                             '''[A message](http://zulip.testserver/#narrow/stream/999-Verona/subject/Foo/near/) triggered an outgoing webhook.
+The error occurred during request to the webhook service:
+```
+Fail!
+```''')
+            self.assertEqual(bot_owner_notification.recipient_id, self.bot_user.bot_owner.id)
 
 class TestOutgoingWebhookMessaging(ZulipTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Fixes #8857.

I decided to put logic for notifying `bot_owner` about error during response parsing in `do_rest_call()` method, because it already notifies `bot_owner` about error during request execution to third-party service. That's why I change return type of  `OutgoingWebhookServiceInterface.process_success` to 2-elements tuple with `(success_message, failure_message)` structure. If `success_message` was returned in `do_rest_call()` method, then existing logic works. If `failure_message` was returned, then logic for notifying the `bot_owner` starts, similar to case when request to service was failed due to `RequestException`.