### PR TITLE
portico: Add noindex tags for non root realms

### DIFF
--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -10,11 +10,13 @@
             <title>{{user_profile.realm.name}} - Zulip</title>
             {% else %}
             <title>Zulip</title>
-            {% include 'zerver/meta_tags.html' %}
             {% endif %}
         {% endblock %}
         <link href="/static/favicon.ico?v=2" rel="shortcut icon">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+        {% if not user_profile %}
+        {% include 'zerver/meta_tags.html' %}
+        {% endif %}
 
         {# We need to import jQuery before Bootstrap #}
         {% stylesheet 'common' %}

--- a/templates/zerver/meta_tags.html
+++ b/templates/zerver/meta_tags.html
@@ -1,6 +1,9 @@
 <!-- Google / Search Engine Tags -->
+{% if allow_search_engine_indexing %}
 <meta name="description" content="Zulip combines the immediacy of real-time chat with an email threading model. With Zulip, you can catch up on important conversations while ignoring irrelevant ones.">
-
+{% else %}
+<meta name="robots" content="noindex,nofollow">
+{% endif %}
 <!-- Facebook Meta Tags -->
 <meta property="og:url" content="{{ realm_uri }}">
 <meta property="og:type" content="website">

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -67,12 +67,14 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
     register_link_disabled = settings.REGISTER_LINK_DISABLED
     login_link_disabled = settings.LOGIN_LINK_DISABLED
     find_team_link_disabled = settings.FIND_TEAM_LINK_DISABLED
+    allow_search_engine_indexing = False
 
     if (settings.ROOT_DOMAIN_LANDING_PAGE
             and get_subdomain(request) == Realm.SUBDOMAIN_FOR_ROOT_DOMAIN):
         register_link_disabled = True
         login_link_disabled = True
         find_team_link_disabled = False
+        allow_search_engine_indexing = True
 
     apps_page_url = 'https://zulipchat.com/apps/'
     if settings.ZILENCER_ENABLED:
@@ -135,4 +137,5 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         'secrets_path': secrets_path,
         'settings_comments_path': settings_comments_path,
         'platform': platform,
+        'allow_search_engine_indexing': allow_search_engine_indexing,
     }

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -21,19 +21,25 @@ from zerver.views.integrations import (
 
 class DocPageTest(ZulipTestCase):
     def _test(self, url: str, expected_content: str, extra_strings: List[str]=[],
-              landing_missing_strings: List[str]=[], landing_page: bool=True) -> None:
+              landing_missing_strings: List[str]=[], landing_page: bool=True,
+              check_search_engine_meta_tags: bool=True) -> None:
 
-        # Test the URL on the "zulip" subdomain
-        result = self.client_get(url, subdomain="zulip")
+        # Test the URL on the "zephyr" subdomain
+        result = self.client_get(url, subdomain="zephyr")
         self.assertEqual(result.status_code, 200)
         self.assertIn(expected_content, str(result.content))
         for s in extra_strings:
             self.assertIn(s, str(result.content))
+        if check_search_engine_meta_tags:
+            self.assert_in_success_response(['<meta name="robots" content="noindex,nofollow">'], result)
 
         # Test the URL on the root subdomain
         result = self.client_get(url, subdomain="")
         self.assertEqual(result.status_code, 200)
         self.assertIn(expected_content, str(result.content))
+        if check_search_engine_meta_tags:
+            self.assert_in_success_response(['<meta name="robots" content="noindex,nofollow">'], result)
+
         for s in extra_strings:
             self.assertIn(s, str(result.content))
 
@@ -48,6 +54,8 @@ class DocPageTest(ZulipTestCase):
                 self.assertIn(s, str(result.content))
             for s in landing_missing_strings:
                 self.assertNotIn(s, str(result.content))
+            if check_search_engine_meta_tags:
+                self.assert_in_success_response(['<meta name="description" content="Zulip combines'], result)
 
     @slow("Tests dozens of endpoints, including generating lots of emails")
     def test_doc_endpoints(self) -> None:
@@ -107,22 +115,23 @@ class DocPageTest(ZulipTestCase):
                        'Hubot',
                        'Zapier',
                        'IFTTT'
-                   ])
+                   ],
+                   check_search_engine_meta_tags=False)
 
         for integration in INTEGRATIONS.keys():
             url = '/integrations/doc-html/{}'.format(integration)
-            self._test(url, '')
+            self._test(url, '', check_search_engine_meta_tags=False)
 
     def test_email_integration(self) -> None:
         self._test('/integrations/doc-html/email',
-                   'support+abcdefg@testserver')
+                   'support+abcdefg@testserver', check_search_engine_meta_tags=False)
 
         with self.settings(EMAIL_GATEWAY_PATTERN=''):
             result = self.client_get('integrations/doc-html/email', subdomain='zulip')
             self.assertNotIn('support+abcdefg@testserver', str(result.content))
             # if EMAIL_GATEWAY_PATTERN is empty, the main /integrations page should
             # be rendered instead
-            self._test('/integrations/', 'native integrations.')
+            self._test('/integrations/', 'native integrations.', check_search_engine_meta_tags=False)
 
 class HelpTest(ZulipTestCase):
     def test_html_settings_links(self) -> None:


### PR DESCRIPTION
Meta tags was used instead of robots.txt due to this.

> While Google won't crawl or index the content blocked by robots.txt, we might still find and index a disallowed URL if it is linked from other places on the web. As a result, the URL address and, potentially, other publicly available information such as anchor text in links to the page can still appear in Google search results. To properly prevent your URL from appearing in Google Search results, you should password-protect the files on your server or use the noindex meta tag or response header 

https://support.google.com/webmasters/answer/6062608?hl=en

> In general, the meta tag is used to disallow indexing, whereas robots.txt is used to disallow crawling.

https://stackoverflow.com/questions/3348226/meta-tag-vs-robots-txt#comment39039961_18316292

Slack also use meta tags instead of robots.tx for organizations. We still need to remove the already indexed urls through Google webmaster.

As far as the testing is concerned one case is not tested (ROOT_DOMAIN_LANDING_PAGE == True and subdomain != ""). Should I add a test for that as well in DocPageTest? (Since it's already slow I am not 100% what to do)

