### PR TITLE
Webpack: Move the styles consumed by 5xx.html to webpack.

### DIFF
--- a/static/html/5xx.html
+++ b/static/html/5xx.html
@@ -5,10 +5,7 @@
         <title>Zulip - 500 internal server error</title>
         <link href="/static/third/bootstrap/css/bootstrap.css" rel="stylesheet">
         <link href="/static/third/bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-        <!-- NB: Relies on the fact that PipelineCachedStorage also includes
-        a copy of the file with no hash in the name.
-        This file will not load in dev unless you run `manage.py collectstatic`. -->
-        <link href="/static/min/portico.css" rel="stylesheet">
+        <link href="/static/webpack-bundles/error-styles.css" rel="stylesheet">
 
         <meta http-equiv="refresh" content="60;URL='/'">
 

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -4,6 +4,9 @@
         "./static/js/portico/header.js",
         "./static/styles/scss/portico.scss"
     ],
+    "error-styles": [
+        "./static/styles/scss/portico.scss"
+    ],
     "common": [
                "string.prototype.endswith",
                "string.prototype.startswith",

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -144,7 +144,15 @@ export default (env?: string) : webpack.Configuration => {
             new BundleTracker({filename: 'webpack-stats-production.json'}),
             // Extract CSS from files
             new MiniCssExtractPlugin({
-                filename: "[name].[contenthash].css",
+                filename: (data) => {
+                    // This is a special case in order to produce
+                    // a static CSS file to be consumed by
+                    // static/html/5xx.html
+                    if(data.chunk.name === 'error-styles') {
+                        return 'error-styles.css';
+                    }
+                    return '[name].[contenthash].css';
+                },
                 chunkFilename: "[id].css"
             })
         ];

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -871,25 +871,6 @@ PIPELINE = {
             'source_filenames': ('styles/stats.css',),
             'output_filename': 'min/stats.css'
         },
-        # Although this is being handled by webpack already it seems
-        # portico.css would still need to be generated for 5xx.html
-        # (the error page for when Django is down) which can't be
-        # rendered as a template.  This block could be removed after
-        # we add another way for that template. to find `portico.css`.
-        # (Or maybe use premailer to generate it?)
-        'portico': {
-            'source_filenames': (
-                'third/zocial/zocial.css',
-                'styles/components.css',
-                'styles/portico.css',
-                'styles/portico-signin.css',
-                'styles/pygments.css',
-                'third/thirdparty-fonts.css',
-                'generated/icons/style.css',
-                'styles/fonts.css',
-            ),
-            'output_filename': 'min/portico.css'
-        },
         'landing-page': {
             'source_filenames': (
                 'styles/landing-page.css',


### PR DESCRIPTION
This commit removes the need for portico.css to be generated
by the Django pipeline and makes the error page use the css
file compiled by webpack instead.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Tested the 500 page is styled correctly.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
