### PR TITLE
user docs: Add styling for keyboard_tip admonition.

### DIFF
--- a/static/styles/portico.css
+++ b/static/styles/portico.css
@@ -1634,7 +1634,8 @@ input.new-organization-button {
 
 .integration-instructions .tip,
 .markdown .warn,
-.markdown .tip {
+.markdown .tip,
+.markdown .keyboard_tip {
     position: relative;
     display: block;
     background-color: hsl(210, 22%, 96%);
@@ -1645,14 +1646,16 @@ input.new-organization-button {
 }
 
 .integration-instructions .tip,
-.markdown .tip {
+.markdown .tip,
+.markdown .keyboard_tip {
     background-color: hsl(46, 63%, 95%);
     border: 1px solid hsl(46, 63%, 84%);
 }
 
 .integration-instructions .tip,
 .markdown .warn p,
-.markdown .tip p {
+.markdown .tip p,
+.markdown .keyboard_tip p {
     margin-bottom: 0;
 }
 
@@ -1664,8 +1667,16 @@ input.new-organization-button {
     font-weight: 600;
 }
 
+.markdown .keyboard_tip::before {
+    display: inline;
+    content: "\f11c   Keyboard Shortcut:  ";
+    font-family: FontAwesome, "Yantramanav", Source Sans Pro;
+    font-weight: 600;
+}
+
 .integration-instructions .tip p:first-of-type,
-.markdown .tip p:first-of-type {
+.markdown .tip p:first-of-type,
+.markdown .keyboard_tip p:first-of-type {
     display: inline;
 }
 
@@ -1673,6 +1684,7 @@ input.new-organization-button {
     margin: 20px 0;
 }
 
+.markdown ol > li > div.keyboard_tip,
 .markdown ol > li > div.tip,
 .markdown ol > li > div.warn {
     margin: 5px 25px 5px;

--- a/templates/zerver/help/send-a-private-message.md
+++ b/templates/zerver/help/send-a-private-message.md
@@ -42,13 +42,9 @@ Once you have the user card displayed, select the **Send private message**
 option from the actions dropdown.  This will open the compose box with the
 target user as the recipient.
 
-### Use a keyboard shortcut
-
-You can open a compose box with the addressee autopopulated if you press `R`
-while a message is highlighted, but the compose box is not open. You can close
-the compose box by pressing `Esc` or by clicking the x (<i class="icon-vector-
-remove"></i>) icon located at the top right corner of the compose box. Look
-[here](/help/keyboard-shortcuts) for more keyboard shortcuts.
+!!! keyboard_tip ""
+    You can open a compose box with the addressee autopopulated if you press `R`
+    while a message is highlighted, but the compose box is not open.
 
 ## View your private message history with a user and compose
 
@@ -85,4 +81,7 @@ key or clicking the **Send** button, depending on your settings.
 
 You can always cancel your message by clicking the x (<i
 class="icon-vector-remove"></i>) icon located at the top right corner of
-your compose box or pressing the `Esc` key.
+your compose box
+
+!!! keyboard_tip ""
+    You can close the compose box by pressing the `Esc` key.


### PR DESCRIPTION
Adds keyboard_tip admonition with the syntax 
`!!! keyboard_tip ""`
![screenshot from 2018-05-02 16-35-33](https://user-images.githubusercontent.com/549661/39548003-41324e0c-4e27-11e8-83a5-33134680454c.png)

