### PR TITLE
vagrant: Get vagrant up and running with lxc 3.0.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,10 +126,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "lxc" do |lxc|
     if command? "lxc-ls"
       LXC_VERSION = `lxc-ls --version`.strip unless defined? LXC_VERSION
-      if LXC_VERSION >= "1.1.0"
+      if LXC_VERSION >= "1.1.0" and LXC_VERSION < "3.0.0"
         # Allow start without AppArmor, otherwise Box will not Start on Ubuntu 14.10
         # see https://github.com/fgrehm/vagrant-lxc/issues/333
         lxc.customize 'aa_allow_incomplete', 1
+      end
+      if LXC_VERSION >= "3.0.0"
+        lxc.customize 'apparmor.allow_incomplete', 1
       end
       if LXC_VERSION >= "2.0.0"
         lxc.backingstore = 'dir'


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Vagrant doesn't start when `lxc>=3.0.0`.  Release `2.1.0` of `lxc` had [deprecated some configuration keys](https://discuss.linuxcontainers.org/t/lxc-2-1-has-been-released/487) (which also caused #7838) and they are now unsupported in `lxc 3.0.0`.

**Testing Plan:** <!-- How have you tested? -->
Got `vagrant up` working again with the newer version of `lxc` after it was crashing mysteriously. 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
