### PR TITLE
Eliminate annoying frontend race conditions involving i18next

### DIFF
--- a/static/js/translations.js
+++ b/static/js/translations.js
@@ -1,97 +1,25 @@
 // commonjs code goes here
-
 import i18next from 'i18next';
-import XHR from 'i18next-xhr-backend';
-import LngDetector from 'i18next-browser-languagedetector';
-import Cache from 'i18next-localstorage-cache';
-import localstorage from './localstorage';
 
 window.i18n = i18next;
 
-// Add those keys in this list which are received from the backend
-// and are translated by calling i18n.t function on variables. For example,
-// i18n.t(receivedFromBackend);
-var toBeTranslated = [  // eslint-disable-line no-unused-vars
-    // The Emoji type name for the "text" emojiset choice
-    i18n.t('Plain text'),
-];
-
-function loadPath(languages) {
-    var language = languages[0];
-    if (language.indexOf('-') >= 0) {
-        language = language.replace('-', '_');  // Change zh-Hans to zh_Hans.
-    }
-
-    return '/static/locale/' + language + '/translations.json';
-}
-
-var backendOptions = {
-    loadPath: loadPath,
-};
-var callbacks = [];
-var initialized = false;
-
-var detectionOptions = {
-    order: ['htmlTag'],
-    htmlTag: document.documentElement,
-};
-
-var cacheOptions = {
-    enabled: !page_params.development,
-    prefix: 'i18next:' + page_params.server_generation + ':',
-    expirationTime: 2*24*60*60*1000,  // 2 days
-};
-
-i18next.use(XHR)
-    .use(LngDetector)
-    .use(Cache)
+i18next
     .init({
+        lng: 'lang',
+        resources: {
+            lang: {
+                translation: page_params.translation_data,
+            },
+        },
         nsSeparator: false,
         keySeparator: false,
         interpolation: {
             prefix: "__",
             suffix: "__",
         },
-        backend: backendOptions,
-        detection: detectionOptions,
-        cache: cacheOptions,
-        fallbackLng: 'en',
         returnEmptyString: false,  // Empty string is not a valid translation.
-    }, function () {
-        var i;
-        initialized = true;
-        for (i=0; i<callbacks.length; i += 1) {
-            callbacks[i]();
-        }
     });
 
 i18next.ensure_i18n = function (callback) {
-    if (initialized) {
-        callback();
-    } else {
-        callbacks.push(callback);
-    }
+    callback();
 };
-
-// garbage collect all old i18n translation maps in localStorage.
-$(function () {
-    if (!localstorage.supported()) {
-        return;
-    }
-
-    // this collects all localStorage keys that match the format of:
-    //   i18next:dddddddddd:w+ => 1484902202:en
-    // these are all language translation strings.
-    var translations = Object.keys(localStorage).filter(function (key) {
-        return /^i18next:\d{10}:\w+$/.test(key);
-    });
-
-    var current_generation_key = 'i18next:' + page_params.server_generation;
-    // remove cached translations of older versions.
-    translations.forEach(function (translation_key) {
-        if (translation_key.indexOf(current_generation_key) !== 0) {
-            localStorage.removeItem(translation_key);
-        }
-    });
-    return this;
-});

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -77,3 +77,18 @@ def get_available_language_codes() -> List[str]:
     language_list = get_language_list()
     codes = [language['code'] for language in language_list]
     return codes
+
+def get_language_translation_data(language: str) -> Dict[str, str]:
+    if language == 'zh-hans':
+        language = 'zh_Hans'
+    elif language == 'zh-hant':
+        language = 'zh_Hant'
+    elif language == 'id-id':
+        language = 'id_ID'
+    path = os.path.join(settings.STATIC_ROOT, 'locale', language, 'translations.json')
+    try:
+        with open(path, 'r') as reader:
+            return ujson.load(reader)
+    except FileNotFoundError:
+        print('Translation for {} not found at {}'.format(language, path))
+        return {}

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -170,6 +170,7 @@ class HomeTest(ZulipTestCase):
             "test_suite",
             "timezone",
             "translate_emoticons",
+            "translation_data",
             "twenty_four_hour_time",
             "two_fa_enabled",
             "two_fa_enabled_user",
@@ -752,3 +753,15 @@ class HomeTest(ZulipTestCase):
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assertEqual(idle_user_msg_list[-1].content, message)
         self.logout()
+
+    def test_translation_data(self) -> None:
+        user = self.example_user("hamlet")
+        user.default_language = 'es'
+        user.save()
+        self.login(user.email)
+        result = self._get_home_page()
+        self.assertEqual(result.status_code, 200)
+
+        # TODO: Ideally, this should validate something about the translation
+        # data, but that requires parsing page_param from the HTML or doing
+        # more complex interception, which we haven't found worth doing.

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -21,7 +21,7 @@ from zerver.lib.actions import update_user_presence, do_change_tos_version, \
     do_update_pointer, realm_user_count
 from zerver.lib.avatar import avatar_url
 from zerver.lib.i18n import get_language_list, get_language_name, \
-    get_language_list_for_templates
+    get_language_list_for_templates, get_language_translation_data
 from zerver.lib.json_encoder_for_html import JSONEncoderForHTML
 from zerver.lib.push_notifications import num_push_devices_for_user
 from zerver.lib.streams import access_stream_by_name
@@ -243,6 +243,10 @@ def home_real(request: HttpRequest) -> HttpResponse:
         show_invites = False
 
     request._log_data['extra'] = "[%s]" % (register_ret["queue_id"],)
+
+    page_params['translation_data'] = {}
+    if not default_language == 'en':
+        page_params['translation_data'] = get_language_translation_data(translation.get_language())
 
     csp_nonce = generate_random_token(48)
     response = render(request, 'zerver/app/index.html',


### PR DESCRIPTION
* Currently it just: `i18n: Pass translation data as context to index.html.`

There are more steps to accomplish as mentioned in #9087.