### PR TITLE
Python dependency upgrade

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -76,7 +76,7 @@ httplib2==0.11.3
 -e git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 
 # Needed for inlining the CSS in emails
-premailer==3.1.1
+premailer==3.2.0
 
 # Needed for JWT-based auth
 PyJWT==1.6.1

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -17,7 +17,7 @@ MarkupSafe==1.0
 Pygments==2.2.0
 
 # Needed for manage.py
-ipython==6.2.1
+ipython==6.3.1
 
 # Needed for Image Processing
 Pillow==5.0.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -20,7 +20,7 @@ Pygments==2.2.0
 ipython==6.3.1
 
 # Needed for Image Processing
-Pillow==5.0.0
+Pillow==5.1.0
 
 # Needed for building complex DB queries
 SQLAlchemy==1.2.6

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -37,7 +37,7 @@ backports.ssl-match-hostname==3.5.0.1
 # Needed for S3 file uploads
 boto==2.48.0
 
-certifi==2018.1.18
+certifi==2018.4.16
 
 # Used for scrapy as well as argon2
 cffi==1.11.5

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -186,7 +186,7 @@ django-two-factor-auth==1.7.0
 twilio==6.13.0
 
 # Needed for processing payments (in zilencer)
-stripe==1.79.1
+stripe==1.80.0
 
 # Needed for serving uploaded files from nginx but perform auth checks in django.
 django-sendfile==0.3.11

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -183,7 +183,7 @@ lxml==4.2.1
 
 # Needed for 2-factor authentication
 django-two-factor-auth==1.7.0
-twilio==6.11.0
+twilio==6.13.0
 
 # Needed for processing payments (in zilencer)
 stripe==1.79.1

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -23,7 +23,7 @@ ipython==6.3.1
 Pillow==5.1.0
 
 # Needed for building complex DB queries
-SQLAlchemy==1.2.6
+SQLAlchemy==1.2.7
 
 # Needed for password hashing
 argon2-cffi==18.1.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -68,7 +68,7 @@ python-gcm==0.4
 gitdb==0.6.4
 
 # Needed for Google Apps mobile auth
-google-api-python-client==1.6.6
+google-api-python-client==1.6.7
 
 # Needed for the email mirror
 html2text==2018.1.9

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -92,7 +92,7 @@ oauthlib==2.0.7
 
 # Enhanced HTTPS support for httplib and urllib2 using PyOpenSSL
 # Needed by requests to send https request to some sites.
-ndg-httpsclient==0.4.4
+ndg-httpsclient==0.5.0
 
 # Needed to access rabbitmq
 # See #8466 for why we're not using the latest version.

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -192,4 +192,4 @@ stripe==1.79.1
 django-sendfile==0.3.11
 
 # For checking whether email of the user is from a disposable email provider.
-disposable-email-domains==0.0.23
+disposable-email-domains==0.0.26

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -44,6 +44,6 @@ transifex-client==0.12.5
 python-digitalocean==1.13.2
 
 # Needed for updating the locked pip dependencies
-pip-tools==1.11.0
+pip-tools==2.0.2
 
 -r mypy.in

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -32,7 +32,7 @@ pyflakes==1.6.0
 tblib==1.3.2
 
 # Needed to lint Git commit messages
-gitlint==0.9.0
+gitlint==0.10.0
 
 # Needed for visualising cprofile reports
 snakeviz==0.4.2

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,7 +5,7 @@
 -r docs.in
 
 # moto s3 mock
-moto==1.3.1
+moto==1.3.3
 
 # Needed for running tools/run-dev.py
 Twisted==17.9.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -8,7 +8,7 @@
 moto==1.3.3
 
 # Needed for running tools/run-dev.py
-Twisted==17.9.0
+Twisted==18.4.0
 
 # Needed for documentation links test
 Scrapy==1.5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -62,7 +62,7 @@ fakeldap==0.6.1
 first==2.0.1              # via pip-tools
 gitdb==0.6.4
 gitlint==0.10.0
-google-api-python-client==1.6.6
+google-api-python-client==1.6.7
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 html2text==2018.1.9

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,9 +26,9 @@ backcall==0.1.0           # via ipython
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.6.0
-boto3==1.4.7              # via moto
+boto3==1.7.11             # via moto
 boto==2.48.0
-botocore==1.7.46          # via boto3, moto, s3transfer
+botocore==1.10.11         # via boto3, moto, s3transfer
 cchardet==2.1.1
 certifi==2018.4.16
 cffi==1.11.5
@@ -36,7 +36,7 @@ chardet==3.0.4
 click==6.6                # via gitlint, pip-tools
 commonmark==0.5.4
 constantly==15.1.0        # via twisted
-cookies==2.2.1            # via moto
+cookies==2.2.1            # via moto, responses
 coverage==4.5.1
 cryptography==2.2.2
 cssselect==1.0.1          # via parsel, premailer, scrapy
@@ -88,7 +88,7 @@ markdown-include==0.5.1
 markdown==2.6.11
 markupsafe==1.0
 mock==2.0.0
-moto==1.3.1
+moto==1.3.3
 mypy==0.590
 mypy_extensions==0.3.0
 ndg-httpsclient==0.4.4
@@ -140,7 +140,8 @@ recommonmark==0.4.0
 redis==2.10.6
 regex==2017.11.9
 requests-oauthlib==0.8.0
-requests==2.18.4          # via aws-xray-sdk, docker, moto, premailer, pyoembed, python-digitalocean, python-gcm, python-twitter, requests-oauthlib, social-auth-core, sphinx, stripe, twilio
+requests==2.18.4          # via aws-xray-sdk, docker, moto, premailer, pyoembed, python-digitalocean, python-gcm, python-twitter, requests-oauthlib, responses, social-auth-core, sphinx, stripe, twilio
+responses==0.9.0          # via moto
 rsa==3.4.2
 s3transfer==0.1.11        # via boto3
 scrapy==1.5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -157,7 +157,7 @@ social-auth-core==1.5.0   # via social-auth-app-django
 sockjs-tornado==1.0.3
 sourcemap==0.2.1
 sphinx-rtd-theme==0.2.4
-sphinx==1.7.2
+sphinx==1.7.4
 sphinxcontrib-websupport==1.0.1  # via sphinx
 sqlalchemy==1.2.6
 statsd==3.2.1             # via django-statsd-mozilla

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -103,7 +103,7 @@ phonenumberslite==8.8.6   # via django-phonenumber-field
 pickleshare==0.7.4        # via ipython
 pika==0.11.0
 pillow==5.1.0
-pip-tools==1.11.0
+pip-tools==2.0.2
 polib==1.1.0
 premailer==3.1.1
 prompt-toolkit==1.0.15    # via ipython

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -156,7 +156,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.5.0   # via social-auth-app-django
 sockjs-tornado==1.0.3
 sourcemap==0.2.1
-sphinx-rtd-theme==0.2.4
+sphinx-rtd-theme==0.3.1
 sphinx==1.7.4
 sphinxcontrib-websupport==1.0.1  # via sphinx
 sqlalchemy==1.2.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -91,7 +91,7 @@ mock==2.0.0
 moto==1.3.3
 mypy==0.590
 mypy_extensions==0.3.0
-ndg-httpsclient==0.4.4
+ndg-httpsclient==0.5.0
 oauth2client==4.1.2
 oauthlib==2.0.7
 packaging==16.8           # via sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -42,7 +42,7 @@ cssselect==1.0.1          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
-disposable-email-domains==0.0.23
+disposable-email-domains==0.0.26
 django-auth-ldap==1.3.0
 django-bitfield==1.9.3
 django-formtools==2.1     # via django-two-factor-auth

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,6 +22,7 @@ attrs==17.3.0             # via automat, service-identity
 automat==0.6.0            # via twisted
 aws-xray-sdk==0.94        # via moto
 babel==2.5.3
+backcall==0.1.0           # via ipython
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.6.0
@@ -75,7 +76,7 @@ ijson==2.3
 imagesize==1.0.0
 incremental==17.5.0       # via twisted
 ipython-genutils==0.2.0   # via traitlets
-ipython==6.2.1
+ipython==6.3.1
 isort==4.3.4
 jedi==0.11.0              # via ipython
 jinja2==2.10

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -102,7 +102,7 @@ pexpect==4.3.0            # via ipython
 phonenumberslite==8.8.6   # via django-phonenumber-field
 pickleshare==0.7.4        # via ipython
 pika==0.11.0
-pillow==5.0.0
+pillow==5.1.0
 pip-tools==1.11.0
 polib==1.1.0
 premailer==3.1.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -161,7 +161,7 @@ sphinx==1.7.4
 sphinxcontrib-websupport==1.0.1  # via sphinx
 sqlalchemy==1.2.7
 statsd==3.2.1             # via django-statsd-mozilla
-stripe==1.79.1
+stripe==1.80.0
 tblib==1.3.2
 tornado==4.5.3
 traitlets==4.3.2          # via ipython

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -61,7 +61,7 @@ docutils==0.14
 fakeldap==0.6.1
 first==2.0.1              # via pip-tools
 gitdb==0.6.4
-gitlint==0.9.0
+gitlint==0.10.0
 google-api-python-client==1.6.6
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
@@ -93,7 +93,6 @@ mypy_extensions==0.3.0
 ndg-httpsclient==0.4.4
 oauth2client==4.1.2
 oauthlib==2.0.7
-ordereddict==1.1          # via gitlint
 packaging==16.8           # via sphinx
 parsel==1.2.0             # via scrapy
 parso==0.1.0              # via jedi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -167,7 +167,7 @@ tornado==4.5.3
 traitlets==4.3.2          # via ipython
 transifex-client==0.12.5
 twilio==6.13.0
-twisted==17.9.0
+twisted==18.4.0
 typed-ast==1.1.0          # via mypy
 typing==3.6.4
 uritemplate==3.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -166,7 +166,7 @@ tblib==1.3.2
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 transifex-client==0.12.5
-twilio==6.11.0
+twilio==6.13.0
 twisted==17.9.0
 typed-ast==1.1.0          # via mypy
 typing==3.6.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -105,7 +105,7 @@ pika==0.11.0
 pillow==5.1.0
 pip-tools==2.0.2
 polib==1.1.0
-premailer==3.1.1
+premailer==3.2.0
 prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.4
 ptyprocess==0.5.2         # via pexpect

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,7 +29,7 @@ boto3==1.4.7              # via moto
 boto==2.48.0
 botocore==1.7.46          # via boto3, moto, s3transfer
 cchardet==2.1.1
-certifi==2018.1.18
+certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
 click==6.6                # via gitlint, pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -159,7 +159,7 @@ sourcemap==0.2.1
 sphinx-rtd-theme==0.2.4
 sphinx==1.7.4
 sphinxcontrib-websupport==1.0.1  # via sphinx
-sqlalchemy==1.2.6
+sqlalchemy==1.2.7
 statsd==3.2.1             # via django-statsd-mozilla
 stripe==1.79.1
 tblib==1.3.2

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -8,7 +8,7 @@
 # See requirements/README.md for more detail.
 
 # Needed to build RTD docs
-sphinx==1.7.2
+sphinx==1.7.4
 sphinx-rtd-theme==0.2.4
 
 # Needed to build markdown docs

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -9,7 +9,7 @@
 
 # Needed to build RTD docs
 sphinx==1.7.4
-sphinx-rtd-theme==0.2.4
+sphinx-rtd-theme==0.3.1
 
 # Needed to build markdown docs
 recommonmark==0.4.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -25,7 +25,7 @@ recommonmark==0.4.0
 requests==2.18.4          # via sphinx
 six==1.11.0               # via packaging, sphinx
 snowballstemmer==1.2.1
-sphinx-rtd-theme==0.2.4
+sphinx-rtd-theme==0.3.1
 sphinx==1.7.4
 sphinxcontrib-websupport==1.0.1  # via sphinx
 typing==3.6.4

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -26,7 +26,7 @@ requests==2.18.4          # via sphinx
 six==1.11.0               # via packaging, sphinx
 snowballstemmer==1.2.1
 sphinx-rtd-theme==0.2.4
-sphinx==1.7.2
+sphinx==1.7.4
 sphinxcontrib-websupport==1.0.1  # via sphinx
 typing==3.6.4
 urllib3==1.22             # via requests

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
-setuptools==39.0.1
 pip==9.0.3
+setuptools==39.1.0
 wheel==0.30.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -73,7 +73,7 @@ pexpect==4.3.0            # via ipython
 phonenumberslite==8.8.6   # via django-phonenumber-field
 pickleshare==0.7.4        # via ipython
 pika==0.11.0
-pillow==5.0.0
+pillow==5.1.0
 polib==1.1.0
 premailer==3.1.1
 prompt-toolkit==1.0.15    # via ipython

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -112,7 +112,7 @@ sockjs-tornado==1.0.3
 sourcemap==0.2.1
 sqlalchemy==1.2.7
 statsd==3.2.1             # via django-statsd-mozilla
-stripe==1.79.1
+stripe==1.80.0
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 twilio==6.13.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -17,6 +17,7 @@ apns2==0.3.0
 argon2-cffi==18.1.0
 asn1crypto==0.23.0        # via cryptography
 babel==2.5.1              # via django-phonenumber-field
+backcall==0.1.0           # via ipython
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.6.0
@@ -54,7 +55,7 @@ hyperframe==3.2.0         # via h2, hyper
 idna==2.6                 # via cryptography, requests
 ijson==2.3
 ipython-genutils==0.2.0   # via traitlets
-ipython==6.2.1
+ipython==6.3.1
 jedi==0.11.0              # via ipython
 jinja2==2.10
 lxml==4.2.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -30,7 +30,7 @@ cssselect==1.0.1          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
-disposable-email-domains==0.0.23
+disposable-email-domains==0.0.26
 django-auth-ldap==1.3.0
 django-bitfield==1.9.3
 django-formtools==2.1     # via django-two-factor-auth

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -110,7 +110,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.5.0   # via social-auth-app-django
 sockjs-tornado==1.0.3
 sourcemap==0.2.1
-sqlalchemy==1.2.6
+sqlalchemy==1.2.7
 statsd==3.2.1             # via django-statsd-mozilla
 stripe==1.79.1
 tornado==4.5.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -75,7 +75,7 @@ pickleshare==0.7.4        # via ipython
 pika==0.11.0
 pillow==5.1.0
 polib==1.1.0
-premailer==3.1.1
+premailer==3.2.0
 prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.4
 ptyprocess==0.5.2         # via pexpect

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -64,7 +64,7 @@ markdown==2.6.11
 markupsafe==1.0
 mock==2.0.0
 mypy_extensions==0.3.0
-ndg-httpsclient==0.4.4
+ndg-httpsclient==0.5.0
 oauth2client==4.1.2
 oauthlib==2.0.7
 parso==0.1.0              # via jedi

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -44,7 +44,7 @@ django-webpack-loader==0.6.0
 django==1.11.11
 docopt==0.6.2
 gitdb==0.6.4
-google-api-python-client==1.6.6
+google-api-python-client==1.6.7
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 html2text==2018.1.9

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -22,7 +22,7 @@ backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.6.0
 boto==2.48.0
 cchardet==2.1.1
-certifi==2018.1.18
+certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
 cryptography==2.2.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -115,7 +115,7 @@ statsd==3.2.1             # via django-statsd-mozilla
 stripe==1.79.1
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
-twilio==6.11.0
+twilio==6.13.0
 typing==3.6.4
 uritemplate==3.0.0
 urllib3==1.22             # via requests

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.0+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '19.4'
+PROVISION_VERSION = '19.5'


### PR DESCRIPTION
## Upgraded packages

|Package|Old|New|Status|
|---------|----|----|---|
certifi |2018.1.18| 2018.4.16| :+1:
disposable-email-domains |0.0.23| 0.0.26| :+1:
gitlint |0.9.0| 0.10.0| :+1:
google-api-python-client |1.6.6| 1.6.7| :+1:
ipython |6.2.1| 6.3.1| :+1:
moto |1.3.1| 1.3.3| :+1:
ndg-httpsclient |0.4.4| 0.5.0| :+1:
Pillow |5.0.0| 5.1.0| :+1:
pip-tools |1.11.0| 2.0.2| :+1:
premailer |3.1.1| 3.2.0| :+1:
Sphinx |1.7.2| 1.7.4| :+1:
sphinx-rtd-theme |0.2.4| 0.3.0| :+1:
SQLAlchemy |1.2.6| 1.2.7 | :+1:
twilio |6.11.0| 6.13.0| :+1:
Twisted |17.9.0| 18.4.0 | :+1:
sphinx-rtd-theme |0.3.0| 0.3.1| :+1:
stripe |1.79.1| 1.80.0| :+1: 
setuptools |39.0.1| 39.1.0| :+1:

## New breaking packages

|Package|Old|New|Status|
|---------|----|----|---|
pycodestyle| 2.3.1| 2.4.0| #9306
django-auth-ldap| 1.3.0| 1.5.0| #9307
pip|9.0.3|10.0.1|#9308

## Dependencies or known issues

|Package|Old|New|Status|
|---------|----|----|---|
tornado| 4.5.3| 5.0.2 |   #8913
transifex-client| 0.13.1| 0.13.3 |  #8914
pika| 0.11.0| 0.11.2|  #8466
asn1crypto| 0.23.0| 0.24.0| #  via cryptography
arrow| 0.10.0| 0.12.1 |  # via gitlint
attrs| 17.3.0| 17.4.0|  # via automat, service-identity
CommonMark| 0.5.4| 0.7.5| Known issue- Will break the build
django-otp| 0.4.1.1| 0.4.3|  # via django-two-factor-auth
django-phonenumber-field| 1.3.0| 2.0.0 |  # via django-two-factor-auth
h2| 2.6.2| 3.0.1|  # via hyper
pbr| 3.1.1| 4.0.2|  # via mock
pyldap| 2.4.37| 3.0.0.post1|  # via django-auth-ldap, fakeldap
qrcode| 4.0.4| 6.0|  # via django-two-factor-auth
queuelib| 1.4.2| 1.5.0|  # via scrapy
social-auth-core| 1.5.0| 1.7.0|   # via social-auth-app-django
statsd| 3.2.1| 3.2.2|  # via django-statsd-mozilla
talon| 1.2.11| 1.4.4 | Known issue- Will break the build
aws-xray-sdk| 0.94| 1.0|   # via moto
boto3| 1.7.11| 1.7.12|  # via moto
click| 6.6| 6.7|  # via gitlint
decorator| 4.1.2| 4.3.0|  # via ipython
docker| 2.6.1| 3.3.0|  # via moto
hyperlink| 17.3.1| 18.0.0|  # via twisted
jedi| 0.11.0| 0.12.0|  # ipython
packaging| 16.8| 17.1|  # via sphinx
parsel| 1.2.0| 1.4.0|  # via scrapy
pbr| 3.1.1| 4.0.2|  # via mock
pexpect| 4.3.0| 4.5.0|  # via ipython
pyaml| 17.10.0| 17.12.1|  # via moto
pyOpenSSL| 17.3.0| 17.5.0|   # via ndg-httpsclient
PySocks| 1.6.7| 1.6.8 |  # via twilio
sh| 1.11| 1.12.14|   # via gitlint
Werkzeug| 0.12.2| 0.14.1|  # via moto
zope.interface| 4.4.3| 4.5.0 |  # via twisted
botocore| 1.10.11| 1.10.12|  # via boto3
cssselect| 1.0.1| 1.0.3|  # via premailer
Django| 1.11.11| 2.0.5|  PR open
docker-pycreds| 0.2.1| 0.2.3|  # via docker
hyperframe| 3.2.0| 5.1.0|  # via h2, hyper
jsonpickle| 0.9.5| 0.9.6 |  # via aws-xray-sdk, python-digitalocean
parso| 0.1.0| 0.2.0|  # via jedi
phonenumberslite| 8.8.6| 8.9.4|  # via django-phonenumber-field
pytz| 2018.3| 2018.4|  # via thumbor
s3transfer| 0.1.11| 0.1.13|  # via boto3
python-dateutil| 2.6.1| 2.7.2|  # via botocore, tc-aws
w3lib| 1.18.0| 1.19.0|  # via parsel, scrapy
websocket-client| 0.44.0| 0.47.0|  # via docker