### PR TITLE
upload/jquery-filedrop: Fix progress bar for paste upload.

### DIFF
--- a/static/third/jquery-filedrop/jquery.filedrop.js
+++ b/static/third/jquery-filedrop/jquery.filedrop.js
@@ -151,11 +151,11 @@
 
     function sendRawImageData(event, image) {
       function finished_callback(serverResponse, timeDiff, xhr) {
-        return opts.uploadFinished(-1, undefined, serverResponse, timeDiff, xhr);
+        return opts.uploadFinished(-1, image.file, serverResponse, timeDiff, xhr);
       }
 
       var url_params = "?mimetype=" + encodeURIComponent(image.type);
-      do_xhr("pasted_image", image.data, image.type, {}, url_params, finished_callback, function () {});
+      do_xhr("pasted_image", image.data, image.type, {file: image.file}, url_params, finished_callback, function () {});
     }
 
     function uploadRawImageData(event, image) {
@@ -203,9 +203,10 @@
       var data = item.getAsFile();
       var reader = new FileReader();
       reader.onload = function(event) {
-        sendRawImageData(event, {type: data.type, data: event.target.result});
+        sendRawImageData(event, {type: data.type, data: event.target.result, file: data});
       };
       reader.readAsBinaryString(data);
+      opts.uploadStarted(undefined, data);
     }
 
     function getBuilder(filename, filedata, mime, boundary) {


### PR DESCRIPTION
This was a little complicated bug issue but these changes made this working. The problem here was that our custom paste option doesn't fit into new changes made in upload.js.
![wroking fine](https://user-images.githubusercontent.com/22238472/39652410-11aad6f0-500b-11e8-818c-eccc9b4f6dbf.gif)
