### PR TITLE
i18n: Add missing strings for custom profile fields.

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -203,7 +203,7 @@ casper.then(function () {
     });
     casper.waitUntilVisible('.profile-field-row span.profile_field_name', function () {
         casper.test.assertSelectorHasText('.profile-field-row span.profile_field_name', 'Teams');
-        casper.test.assertSelectorHasText('.profile-field-row span.profile_field_type', 'Short Text');
+        casper.test.assertSelectorHasText('.profile-field-row span.profile_field_type', 'Short text');
         casper.click('.profile-field-row button.open-edit-form');
     });
 });
@@ -223,7 +223,7 @@ casper.then(function () {
     });
     casper.waitForSelectorTextChange('.profile-field-row span.profile_field_name', function () {
         casper.test.assertSelectorHasText('.profile-field-row span.profile_field_name', 'team');
-        casper.test.assertSelectorHasText('.profile-field-row span.profile_field_type', 'Short Text');
+        casper.test.assertSelectorHasText('.profile-field-row span.profile_field_type', 'Short text');
         casper.click('.profile-field-row button.delete');
     });
 });

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -192,7 +192,7 @@ function render(template_name, args) {
     var args = {
         profile_field: {
             name: "teams",
-            type: "Long Text",
+            type: "Long text",
         },
         can_modify: true,
     };
@@ -207,14 +207,14 @@ function render(template_name, args) {
     var td = $(html).find('tr.profile-field-row:first td');
 
     assert.equal(field_name.text(), 'teams');
-    assert.equal(field_type.text(), 'Long Text');
+    assert.equal(field_type.text(), 'Long text');
     assert.equal(td.length, 4);
 
     // When the logged in user is not admin
     args = {
         profile_field: {
             name: "teams",
-            type: "Long Text",
+            type: "Long text",
         },
         can_modify: false,
     };
@@ -229,7 +229,7 @@ function render(template_name, args) {
     td = $(html).find('tr.profile-field-row:first td');
 
     assert.equal(field_name.text(), 'teams');
-    assert.equal(field_type.text(), 'Long Text');
+    assert.equal(field_type.text(), 'Long text');
     assert.equal(td.length, 3);
 }());
 

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -60,11 +60,11 @@ exports.add_custom_profile_fields_to_settings = function () {
         var field_type = settings_profile_fields.field_type_id_to_string(field.type);
         var type;
         var value = people.my_custom_profile_data(field.id);
-        var is_long_text = field_type === "Long Text";
+        var is_long_text = field_type === "Long text";
         var is_choice_field = field_type === "Choice";
         var field_choices = [];
 
-        if (field_type === "Long Text" || field_type === "Short Text") {
+        if (field_type === "Long text" || field_type === "Short text") {
             type = "text";
         } else if (field_type === "Choice") {
             type = "choice";

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -280,7 +280,7 @@ def process_customprofilefields(customprofilefield: List[ZerverFieldsT],
     for field in customprofilefield:
         for field_value in customprofilefield_value:
             if field_value['field'] == field['id'] and len(field_value['value']) > 50:
-                field['field_type'] = 2  # corresponding to Long Text
+                field['field_type'] = 2  # corresponding to Long text
                 break
 
 def get_user_email(user: ZerverFieldsT, domain_name: str) -> str:

--- a/zerver/migrations/0073_custom_profile_fields.py
+++ b/zerver/migrations/0073_custom_profile_fields.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=100)),
-                ('field_type', models.PositiveSmallIntegerField(choices=[(1, 'Integer'), (2, 'Float'), (3, 'Short Text'), (4, 'Long Text')], default=3)),
+                ('field_type', models.PositiveSmallIntegerField(choices=[(1, 'Integer'), (2, 'Float'), (3, 'Short text'), (4, 'Long text')], default=3)),
                 ('realm', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='zerver.Realm')),
             ],
         ),

--- a/zerver/migrations/0153_remove_int_float_custom_fields.py
+++ b/zerver/migrations/0153_remove_int_float_custom_fields.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='customprofilefield',
             name='field_type',
-            field=models.PositiveSmallIntegerField(choices=[(1, 'Short Text'), (2, 'Long Text')], default=1),
+            field=models.PositiveSmallIntegerField(choices=[(1, 'Short text'), (2, 'Long text')], default=1),
         ),
     ]

--- a/zerver/migrations/0160_add_choice_field.py
+++ b/zerver/migrations/0160_add_choice_field.py
@@ -20,6 +20,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='customprofilefield',
             name='field_type',
-            field=models.PositiveSmallIntegerField(choices=[(1, 'Short Text'), (2, 'Long Text'), (3, 'Choice')], default=1),
+            field=models.PositiveSmallIntegerField(choices=[(1, 'Short text'), (2, 'Long text'), (3, 'Choice')], default=1),
         ),
     ]

--- a/zerver/migrations/0165_add_date_to_profile_field.py
+++ b/zerver/migrations/0165_add_date_to_profile_field.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='customprofilefield',
             name='field_type',
-            field=models.PositiveSmallIntegerField(choices=[(1, 'Short Text'), (2, 'Long Text'), (4, 'Date'), (3, 'Choice')], default=1),
+            field=models.PositiveSmallIntegerField(choices=[(1, 'Short text'), (2, 'Long text'), (4, 'Date'), (3, 'Choice')], default=1),
         ),
     ]

--- a/zerver/migrations/0166_add_url_to_profile_field.py
+++ b/zerver/migrations/0166_add_url_to_profile_field.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='customprofilefield',
             name='field_type',
-            field=models.PositiveSmallIntegerField(choices=[(1, 'Short Text'), (2, 'Long Text'), (4, 'Date'), (5, 'URL'), (3, 'Choice')], default=1),
+            field=models.PositiveSmallIntegerField(choices=[(1, 'Short text'), (2, 'Long text'), (4, 'Date'), (5, 'URL'), (3, 'Choice')], default=1),
         ),
     ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1905,7 +1905,7 @@ class CustomProfileField(models.Model):
     # These are the fields whose validators require field_data
     # argument as well.
     EXTENDED_FIELD_TYPE_DATA = [
-        (CHOICE, 'Choice', validate_choice_field, str),
+        (CHOICE, str(_('Choice')), validate_choice_field, str),
     ]  # type: FieldTypeData
 
     EXTENDED_FIELD_VALIDATORS = {
@@ -1914,10 +1914,10 @@ class CustomProfileField(models.Model):
 
     FIELD_TYPE_DATA = [
         # Type, Name, Validator, Converter
-        (SHORT_TEXT, u'Short Text', check_short_string, str),
-        (LONG_TEXT, u'Long Text', check_long_string, str),
-        (DATE, u'Date', check_date, str),
-        (URL, u'URL', check_url, str),
+        (SHORT_TEXT, str(_('Short Text')), check_short_string, str),
+        (LONG_TEXT, str(_('Long Text')), check_long_string, str),
+        (DATE, str(_('Date')), check_date, str),
+        (URL, str(_('URL')), check_url, str),
     ]  # type: FieldTypeData
 
     ALL_FIELD_TYPES = FIELD_TYPE_DATA + EXTENDED_FIELD_TYPE_DATA

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1914,8 +1914,8 @@ class CustomProfileField(models.Model):
 
     FIELD_TYPE_DATA = [
         # Type, Name, Validator, Converter
-        (SHORT_TEXT, str(_('Short Text')), check_short_string, str),
-        (LONG_TEXT, str(_('Long Text')), check_long_string, str),
+        (SHORT_TEXT, str(_('Short text')), check_short_string, str),
+        (LONG_TEXT, str(_('Long text')), check_long_string, str),
         (DATE, str(_('Date')), check_date, str),
         (URL, str(_('URL')), check_url, str),
     ]  # type: FieldTypeData


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR tags for translation the different types of custom profile fields.

**Testing Plan:**

I generated the old strings and checked for differences before and after my commit. The new strings appear as expected:

```diff
diff --git a/static/locale/es/LC_MESSAGES/django.po b/static/locale/es/LC_MESSAGES/django.po
index 0b761c339..d1e73f12e 100644
--- a/static/locale/es/LC_MESSAGES/django.po
+++ b/static/locale/es/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-06 09:46+0000\n"
+"POT-Creation-Date: 2018-05-06 09:47+0000\n"
 "PO-Revision-Date: 2018-04-16 20:46+0000\n"
 "Last-Translator: Yago González <yagogonzalezg@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/zulip/zulip/language/es/)\n"
@@ -3036,6 +3036,26 @@ msgstr "Emoticonos unicode"
 msgid "Zulip extra emoji"
 msgstr "Emoticonos extra de Zulip"
 
+#: zerver/models.py:1908
+msgid "Choice"
+msgstr ""
+
+#: zerver/models.py:1917
+msgid "Short Text"
+msgstr ""
+
+#: zerver/models.py:1918
+msgid "Long Text"
+msgstr ""
+
+#: zerver/models.py:1919
+msgid "Date"
+msgstr ""
+
+#: zerver/models.py:1920
+msgid "URL"
+msgstr ""
+
 #: zerver/signals.py:77
 #, fuzzy
 #| msgid "Unknown chart name: %s"
```