### PR TITLE
left-sidebar: Remove non-clickable vertical space between topics.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -68,7 +68,7 @@
 }
 
 #stream_filters li ul.topic-list li {
-    padding: 2px 0px 2px 29px;
+    padding: 0px 0px 0px 29px;
 }
 
 #stream-filters-container {
@@ -208,7 +208,7 @@ li.active-sub-filter {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding-right: 2px;
+    padding: 3px 2px 2px 0px;
 }
 
 .topic-name {
@@ -383,7 +383,6 @@ li.expanded_private_message a {
 .topic-box {
     display: flex;
     justify-content: center;
-    padding-top: 1px;
     cursor: pointer;
 }
 


### PR DESCRIPTION
Fixes #8952.
Tested on local development server.