### PR TITLE
[WIP]Migrate away from six.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -98,7 +98,6 @@ from django.utils.timezone import now as timezone_now
 
 from confirmation.models import Confirmation, create_confirmation_link
 from confirmation import settings as confirmation_settings
-from six import unichr
 
 from zerver.lib.bulk_create import bulk_create_users
 from zerver.lib.create_user import random_api_key
@@ -3915,7 +3914,7 @@ def decode_email_address(email: Text) -> Optional[Tuple[Text, Text]]:
         encoded_stream_name, token = msg_string.split('.')
     else:
         encoded_stream_name, token = msg_string.split('+')
-    stream_name = re.sub("%\d{4}", lambda x: unichr(int(x.group(0)[1:])), encoded_stream_name)
+    stream_name = re.sub("%\d{4}", lambda x: chr(int(x.group(0)[1:])), encoded_stream_name)
     return stream_name, token
 
 SubHelperT = Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]

--- a/zerver/views/email_log.py
+++ b/zerver/views/email_log.py
@@ -12,7 +12,7 @@ from zproject.email_backends import (
     get_forward_address,
     set_forward_address,
 )
-from six.moves import urllib
+import urllib
 from confirmation.models import Confirmation, confirmation_url
 
 import os

--- a/zproject/email_backends.py
+++ b/zproject/email_backends.py
@@ -1,7 +1,7 @@
 import logging
 
 from typing import List
-from six.moves import configparser
+import configparser
 
 import smtplib
 from email.mime.multipart import MIMEMultipart


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #9327 
Migration from six to pure python3 API in the list of files below causes test failure:
`zerver/tests/test_i18n.py`
`zerver/lib/timeout.py`

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
