### PR TITLE
custom fields: Don't ask org admin to enter "value" for choice.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -328,7 +328,7 @@ exports.set_up = function () {
         $("#deactivate_self_modal").modal("show");
     });
 
-    $(".custom_user_field_value").on('change', function (e) {
+    $('#settings_page').on('change', '.custom_user_field_value', function (e) {
         var fields = [];
         var value = $(this).val();
         fields.push({id: parseInt($(e.target).closest('.custom_user_field').attr("data-field-id"), 10),

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -27,11 +27,13 @@ function delete_profile_field(e) {
 
 function read_field_data_from_form(selector) {
     var field_data = {};
+    var i = 0;
     selector.each(function (ind, row) {
-        var value = row.children[0].value;
-        var text = row.children[1].value;
-        var order = row.children[2].value;
+        var value = i;
+        var text = row.children[0].value;
+        var order = row.children[1].value;
         field_data[value] = {text: text, order: order};
+        i += 1;
     });
     return field_data;
 }

--- a/static/templates/admin_profile_field_list.handlebars
+++ b/static/templates/admin_profile_field_list.handlebars
@@ -42,7 +42,6 @@
                 <label for="profile_field_choices_edit">{{t "Field choices" }}</label>
                 <div class="profile-field-choices" name="profile_field_choices_edit">
                     <div class='choices-header'>
-                        <div class='choice-field'>Value</div>
                         <div class='choice-field'>Text</div>
                         <div class='choice-field'>Order</div>
                     </div>

--- a/static/templates/settings/profile-field-choice.handlebars
+++ b/static/templates/settings/profile-field-choice.handlebars
@@ -1,5 +1,4 @@
 <div class='choice-row'>
-    <input type='text' data-toggle='tooltip' title='{{t "Value" }}' placeholder='{{t "Value" }}' value="{{ value }}" />
     <input type='text' data-toggle='tooltip' title='{{t "Text" }}' placeholder='{{t "Text" }}' value="{{ text }}" />
     <input type='text' data-toggle='tooltip' title='{{t "Order" }}' placeholder='{{t "Order" }}' value="{{ order }}" />
     {{#if add_delete_button }}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Followup of #9322


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![choicecustomfield](https://user-images.githubusercontent.com/25907420/39872580-14983d60-5486-11e8-80fc-cbfecf84d982.gif)


@timabbott Can you more elaborate on changes required in "+" and "trash icon" behavior. I also think that asking choice order is also annoying. User can enter choices in order, from first to last, no need to define order separately. 