### PR TITLE
Price swap and why link

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2522,6 +2522,17 @@ nav ul li.active::after {
     animation: box-shadow-pulse 2s infinite;
 }
 
+.pricing-model .pricing-container .text-content .premium-price-box {
+    display: flex;
+}
+
+.pricing-model .pricing-container .text-content .price .price-cents {
+    font-size: .4em;
+    vertical-align: top;
+    position: relative;
+    top: 6px;
+}
+
 /* while the overlay is showing, the transform properties should stay fixed
    for the container that sits inline in the page. */
 

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -264,6 +264,9 @@
                         Share content with drag-and-drop file uploads,
                         link previews, and inline images.
                     </p>
+                    <p>
+                        <a href="/why-zulip">Learn more about what makes Zulip unique &rarr;</a>
+                    </p>
                 </div>
             </div>
             <div class="col-2">

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -68,12 +68,12 @@
                             </div>
                             <div class="bottom">
                                 <div class="text-content">
-                                    <div class="">
-                                        <div class="price">8</div>
+                                    <div class="premium-price-box">
+                                        <div class="price">6<span class="price-cents">.67</span></div>
                                         <div class="details">
-                                            per active user, per month
+                                            per active user per month
                                             <br />
-                                            $80/year billed annually
+                                            $8/month billed monthly
                                         </div>
                                     </div>
                                     <a href="/new/">


### PR DESCRIPTION
This makes two small changes to portico:

- Swaps the location of the monthly and annual pricing on the plans page (with the 67 cents properly aligned)
![image](https://user-images.githubusercontent.com/2905696/39901590-58c6e9e4-547e-11e8-909a-3d0999668c9d.png)

- Adds a link (that behaves properly on hover) to the Why Zulip page at the bottom of the "Organized" column on the landing page
![image](https://user-images.githubusercontent.com/2905696/39901605-6d5f98a6-547e-11e8-8758-312517e6f9c0.png)
