### PR TITLE
Migration: Move from the use of typing.Text to use str 

### DIFF
--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -22,7 +22,7 @@ from zerver.models import PreregistrationUser, EmailChangeStatus, MultiuseInvite
     UserProfile, Realm
 from random import SystemRandom
 import string
-from typing import Any, Dict, Optional, Text, Union
+from typing import Any, Dict, Optional, Union
 
 class ConfirmationKeyException(Exception):
     WRONG_LENGTH = 1
@@ -102,7 +102,7 @@ class Confirmation(models.Model):
     REALM_CREATION = 7
     type = models.PositiveSmallIntegerField()  # type: int
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return '<Confirmation: %s>' % (self.content_object,)
 
 class ConfirmationType:
@@ -145,7 +145,7 @@ def validate_key(creation_key: Optional[str]) -> Optional['RealmCreationKey']:
         raise RealmCreationKey.Invalid()
     return key_record
 
-def generate_realm_creation_url(by_admin: bool=False) -> Text:
+def generate_realm_creation_url(by_admin: bool=False) -> str:
     key = generate_key()
     RealmCreationKey.objects.create(creation_key=key,
                                     date_created=timezone_now(),

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -32,7 +32,7 @@ import logging
 import re
 import DNS
 
-from typing import Any, Callable, List, Optional, Text, Dict
+from typing import Any, Callable, List, Optional, Dict
 
 MIT_VALIDATION_ERROR = u'That user does not exist at MIT or is a ' + \
                        u'<a href="https://ist.mit.edu/email-lists">mailing list</a>. ' + \
@@ -42,7 +42,7 @@ WRONG_SUBDOMAIN_ERROR = "Your Zulip account is not a member of the " + \
                         "organization associated with this subdomain.  " + \
                         "Please contact %s with any questions!" % (FromAddress.SUPPORT,)
 
-def email_is_not_mit_mailing_list(email: Text) -> None:
+def email_is_not_mit_mailing_list(email: str) -> None:
     """Prevent MIT mailing lists from signing up for Zulip"""
     if "@mit.edu" in email:
         username = email.rsplit("@", 1)[0]
@@ -99,7 +99,7 @@ class RegistrationForm(forms.Form):
             max_length=Realm.MAX_REALM_NAME_LENGTH,
             required=self.realm_creation)
 
-    def clean_full_name(self) -> Text:
+    def clean_full_name(self) -> str:
         try:
             return check_full_name(self.cleaned_data['full_name'])
         except JsonableError as e:
@@ -164,7 +164,7 @@ class HomepageForm(forms.Form):
 
         return email
 
-def email_is_not_disposable(email: Text) -> None:
+def email_is_not_disposable(email: str) -> None:
     if is_disposable_domain(email_to_domain(email)):
         raise ValidationError(_("Please use your real email address."))
 
@@ -182,13 +182,13 @@ class LoggingSetPasswordForm(SetPasswordForm):
 class ZulipPasswordResetForm(PasswordResetForm):
     def save(self,
              domain_override: Optional[bool]=None,
-             subject_template_name: Text='registration/password_reset_subject.txt',
-             email_template_name: Text='registration/password_reset_email.html',
+             subject_template_name: str='registration/password_reset_subject.txt',
+             email_template_name: str='registration/password_reset_email.html',
              use_https: bool=False,
              token_generator: PasswordResetTokenGenerator=default_token_generator,
-             from_email: Optional[Text]=None,
+             from_email: Optional[str]=None,
              request: HttpRequest=None,
-             html_email_template_name: Optional[Text]=None,
+             html_email_template_name: Optional[str]=None,
              extra_email_context: Optional[Dict[str, Any]]=None
              ) -> None:
         """
@@ -286,7 +286,7 @@ class OurAuthenticationForm(AuthenticationForm):
 
         return self.cleaned_data
 
-    def add_prefix(self, field_name: Text) -> Text:
+    def add_prefix(self, field_name: str) -> str:
         """Disable prefix, since Zulip doesn't use this Django forms feature
         (and django-two-factor does use it), and we'd like both to be
         happy with this form.
@@ -294,14 +294,14 @@ class OurAuthenticationForm(AuthenticationForm):
         return field_name
 
 class MultiEmailField(forms.Field):
-    def to_python(self, emails: Text) -> List[Text]:
+    def to_python(self, emails: str) -> List[str]:
         """Normalize data to a list of strings."""
         if not emails:
             return []
 
         return [email.strip() for email in emails.split(',')]
 
-    def validate(self, emails: List[Text]) -> None:
+    def validate(self, emails: List[str]) -> None:
         """Check if value consists only of valid emails."""
         super().validate(emails)
         for email in emails:
@@ -311,7 +311,7 @@ class FindMyTeamForm(forms.Form):
     emails = MultiEmailField(
         help_text=_("Add up to 10 comma-separated email addresses."))
 
-    def clean_emails(self) -> List[Text]:
+    def clean_emails(self) -> List[str]:
         emails = self.cleaned_data['emails']
         if len(emails) > 10:
             raise forms.ValidationError(_("Please enter at most 10 emails."))

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1,6 +1,6 @@
 from typing import (
     AbstractSet, Any, AnyStr, Callable, Dict, Iterable, List, Mapping, MutableMapping,
-    Optional, Sequence, Set, Text, Tuple, TypeVar, Union, cast
+    Optional, Sequence, Set, Tuple, TypeVar, Union, cast
 )
 from mypy_extensions import TypedDict
 
@@ -142,7 +142,7 @@ from operator import itemgetter
 
 # This will be used to type annotate parameters in a function if the function
 # works on both str and unicode in python 2 but in python 3 it only works on str.
-SizedTextIterable = Union[Sequence[Text], AbstractSet[Text]]
+SizedTextIterable = Union[Sequence[str], AbstractSet[str]]
 
 STREAM_ASSIGNMENT_COLORS = [
     "#76ce90", "#fae589", "#a6c7e5", "#e79ab5",
@@ -257,7 +257,7 @@ def get_topic_history_for_stream(user_profile: UserProfile,
 
     return history
 
-def send_signup_message(sender: UserProfile, admin_realm_signup_notifications_stream: Text,
+def send_signup_message(sender: UserProfile, admin_realm_signup_notifications_stream: str,
                         user_profile: UserProfile, internal: bool=False,
                         realm: Optional[Realm]=None) -> None:
     if internal:
@@ -433,7 +433,7 @@ def notify_created_user(user_profile: UserProfile) -> None:
     send_event(event, active_user_ids(user_profile.realm_id))
 
 def created_bot_event(user_profile: UserProfile) -> Dict[str, Any]:
-    def stream_name(stream: Optional[Stream]) -> Optional[Text]:
+    def stream_name(stream: Optional[Stream]) -> Optional[str]:
         if not stream:
             return None
         return stream.name
@@ -466,17 +466,17 @@ def notify_created_bot(user_profile: UserProfile) -> None:
     event = created_bot_event(user_profile)
     send_event(event, bot_owner_user_ids(user_profile))
 
-def create_users(realm: Realm, name_list: Iterable[Tuple[Text, Text]], bot_type: int=None) -> None:
+def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]], bot_type: int=None) -> None:
     user_set = set()
     for full_name, email in name_list:
         short_name = email_to_username(email)
         user_set.add((email, full_name, short_name, True))
     bulk_create_users(realm, user_set, bot_type)
 
-def do_create_user(email: Text, password: Optional[Text], realm: Realm, full_name: Text,
-                   short_name: Text, is_realm_admin: bool=False, bot_type: Optional[int]=None,
-                   bot_owner: Optional[UserProfile]=None, tos_version: Optional[Text]=None,
-                   timezone: Text="", avatar_source: Text=UserProfile.AVATAR_FROM_GRAVATAR,
+def do_create_user(email: str, password: Optional[str], realm: Realm, full_name: str,
+                   short_name: str, is_realm_admin: bool=False, bot_type: Optional[int]=None,
+                   bot_owner: Optional[UserProfile]=None, tos_version: Optional[str]=None,
+                   timezone: str="", avatar_source: str=UserProfile.AVATAR_FROM_GRAVATAR,
                    default_sending_stream: Optional[Stream]=None,
                    default_events_register_stream: Optional[Stream]=None,
                    default_all_public_streams: bool=None,
@@ -756,7 +756,7 @@ def do_deactivate_stream(stream: Stream, log: bool=True) -> None:
                  streams=[stream_dict])
     send_event(event, affected_user_ids)
 
-def do_change_user_email(user_profile: UserProfile, new_email: Text) -> None:
+def do_change_user_email(user_profile: UserProfile, new_email: str) -> None:
     delete_user_profile_caches([user_profile])
 
     user_profile.email = new_email
@@ -771,7 +771,7 @@ def do_change_user_email(user_profile: UserProfile, new_email: Text) -> None:
                                  modified_user=user_profile, event_type='user_email_changed',
                                  event_time=event_time)
 
-def do_start_email_change_process(user_profile: UserProfile, new_email: Text) -> None:
+def do_start_email_change_process(user_profile: UserProfile, new_email: str) -> None:
     old_email = user_profile.email
     user_profile.email = new_email
     obj = EmailChangeStatus.objects.create(new_email=new_email, old_email=old_email,
@@ -817,8 +817,8 @@ def compute_mit_user_fullname(email: NonBinaryStr) -> NonBinaryStr:
 
 @cache_with_key(lambda realm, email, f: user_profile_by_email_cache_key(email),
                 timeout=3600*24*7)
-def create_mirror_user_if_needed(realm: Realm, email: Text,
-                                 email_to_fullname: Callable[[Text], Text]) -> UserProfile:
+def create_mirror_user_if_needed(realm: Realm, email: str,
+                                 email_to_fullname: Callable[[str], str]) -> UserProfile:
     try:
         return get_user(email, realm)
     except UserProfile.DoesNotExist:
@@ -841,11 +841,11 @@ def send_welcome_bot_response(message: MutableMapping[str, Any]) -> None:
             "skills. Or, try clicking on some of the stream names to your left!")
 
 def render_incoming_message(message: Message,
-                            content: Text,
+                            content: str,
                             user_ids: Set[int],
                             realm: Realm,
                             mention_data: Optional[bugdown.MentionData]=None,
-                            email_gateway: Optional[bool]=False) -> Text:
+                            email_gateway: Optional[bool]=False) -> str:
     realm_alert_words = alert_words_in_realm(realm)
     try:
         rendered_content = render_markdown(
@@ -1127,7 +1127,7 @@ def do_send_messages(messages_maybe_none: Sequence[Optional[MutableMapping[str, 
             new_messages.append(message)
     messages = new_messages
 
-    links_for_embed = set()  # type: Set[Text]
+    links_for_embed = set()  # type: Set[str]
     # For consistency, changes to the default values for these gets should also be applied
     # to the default args in do_send_message
     for message in messages:
@@ -1425,7 +1425,7 @@ def bulk_insert_ums(ums: List[UserMessageLite]) -> None:
         cursor.execute(query)
 
 def notify_reaction_update(user_profile: UserProfile, message: Message,
-                           reaction: Reaction, op: Text) -> None:
+                           reaction: Reaction, op: str) -> None:
     user_dict = {'user_id': user_profile.id,
                  'email': user_profile.email,
                  'full_name': user_profile.full_name}
@@ -1455,7 +1455,7 @@ def notify_reaction_update(user_profile: UserProfile, message: Message,
     ums = UserMessage.objects.filter(message=message.id)
     send_event(event, [um.user_profile_id for um in ums])
 
-def do_add_reaction_legacy(user_profile: UserProfile, message: Message, emoji_name: Text) -> None:
+def do_add_reaction_legacy(user_profile: UserProfile, message: Message, emoji_name: str) -> None:
     (emoji_code, reaction_type) = emoji_name_to_emoji_code(user_profile.realm, emoji_name)
     reaction = Reaction(user_profile=user_profile, message=message,
                         emoji_name=emoji_name, emoji_code=emoji_code,
@@ -1463,7 +1463,7 @@ def do_add_reaction_legacy(user_profile: UserProfile, message: Message, emoji_na
     reaction.save()
     notify_reaction_update(user_profile, message, reaction, "add")
 
-def do_remove_reaction_legacy(user_profile: UserProfile, message: Message, emoji_name: Text) -> None:
+def do_remove_reaction_legacy(user_profile: UserProfile, message: Message, emoji_name: str) -> None:
     reaction = Reaction.objects.filter(user_profile=user_profile,
                                        message=message,
                                        emoji_name=emoji_name).get()
@@ -1471,7 +1471,7 @@ def do_remove_reaction_legacy(user_profile: UserProfile, message: Message, emoji
     notify_reaction_update(user_profile, message, reaction, "remove")
 
 def do_add_reaction(user_profile: UserProfile, message: Message,
-                    emoji_name: Text, emoji_code: Text, reaction_type: Text) -> None:
+                    emoji_name: str, emoji_code: str, reaction_type: str) -> None:
     reaction = Reaction(user_profile=user_profile, message=message,
                         emoji_name=emoji_name, emoji_code=emoji_code,
                         reaction_type=reaction_type)
@@ -1479,7 +1479,7 @@ def do_add_reaction(user_profile: UserProfile, message: Message,
     notify_reaction_update(user_profile, message, reaction, "add")
 
 def do_remove_reaction(user_profile: UserProfile, message: Message,
-                       emoji_code: Text, reaction_type: Text) -> None:
+                       emoji_code: str, reaction_type: str) -> None:
     reaction = Reaction.objects.filter(user_profile=user_profile,
                                        message=message,
                                        emoji_code=emoji_code,
@@ -1506,16 +1506,16 @@ def do_send_typing_notification(notification: Dict[str, Any]) -> None:
 
 # check_send_typing_notification:
 # Checks the typing notification and sends it
-def check_send_typing_notification(sender: UserProfile, notification_to: Sequence[Text],
-                                   operator: Text) -> None:
+def check_send_typing_notification(sender: UserProfile, notification_to: Sequence[str],
+                                   operator: str) -> None:
     typing_notification = check_typing_notification(sender, notification_to, operator)
     do_send_typing_notification(typing_notification)
 
 # check_typing_notification:
 # Returns typing notification ready for sending with do_send_typing_notification on success
 # or the error message (string) on error.
-def check_typing_notification(sender: UserProfile, notification_to: Sequence[Text],
-                              operator: Text) -> Dict[str, Any]:
+def check_typing_notification(sender: UserProfile, notification_to: Sequence[str],
+                              operator: str) -> Dict[str, Any]:
     if len(notification_to) == 0:
         raise JsonableError(_('Missing parameter: \'to\' (recipient)'))
     elif operator not in ('start', 'stop'):
@@ -1531,7 +1531,7 @@ def check_typing_notification(sender: UserProfile, notification_to: Sequence[Tex
         raise ValueError('Forbidden recipient type')
     return {'sender': sender, 'recipient': recipient, 'op': operator}
 
-def stream_welcome_message(stream: Stream) -> Text:
+def stream_welcome_message(stream: Stream) -> str:
     content = _('Welcome to #**%s**.') % (stream.name,)
 
     if stream.description:
@@ -1584,11 +1584,11 @@ def get_default_value_for_history_public_to_subscribers(
     return history_public_to_subscribers
 
 def create_stream_if_needed(realm: Realm,
-                            stream_name: Text,
+                            stream_name: str,
                             *,
                             invite_only: bool=False,
                             history_public_to_subscribers: Optional[bool]=None,
-                            stream_description: Text="") -> Tuple[Stream, bool]:
+                            stream_description: str="") -> Tuple[Stream, bool]:
 
     history_public_to_subscribers = get_default_value_for_history_public_to_subscribers(
         realm, invite_only, history_public_to_subscribers)
@@ -1615,9 +1615,9 @@ def create_stream_if_needed(realm: Realm,
     return stream, created
 
 def ensure_stream(realm: Realm,
-                  stream_name: Text,
+                  stream_name: str,
                   invite_only: bool=False,
-                  stream_description: Text="") -> Stream:
+                  stream_description: str="") -> Stream:
     return create_stream_if_needed(realm, stream_name,
                                    invite_only=invite_only,
                                    stream_description=stream_description)[0]
@@ -1694,7 +1694,7 @@ def validate_recipient_user_profiles(user_profiles: List[UserProfile],
 
     return recipient_profile_ids
 
-def recipient_for_emails(emails: Iterable[Text], not_forged_mirror_message: bool,
+def recipient_for_emails(emails: Iterable[str], not_forged_mirror_message: bool,
                          forwarder_user_profile: Optional[UserProfile],
                          sender: UserProfile) -> Recipient:
 
@@ -1738,7 +1738,7 @@ def already_sent_mirrored_message_id(message: Message) -> Optional[int]:
         return messages[0].id
     return None
 
-def extract_recipients(s: Union[str, Iterable[Text]]) -> List[Text]:
+def extract_recipients(s: Union[str, Iterable[str]]) -> List[str]:
     # We try to accept multiple incoming formats for recipients.
     # See test_extract_recipients() for examples of what we allow.
     try:
@@ -1759,15 +1759,15 @@ def extract_recipients(s: Union[str, Iterable[Text]]) -> List[Text]:
     recipients = [recipient.strip() for recipient in recipients]
     return list(set(recipient for recipient in recipients if recipient))
 
-def check_send_stream_message(sender: UserProfile, client: Client, stream_name: Text,
-                              topic: Text, body: Text) -> int:
+def check_send_stream_message(sender: UserProfile, client: Client, stream_name: str,
+                              topic: str, body: str) -> int:
     addressee = Addressee.for_stream(stream_name, topic)
     message = check_message(sender, client, addressee, body)
 
     return do_send_messages([message])[0]
 
 def check_send_private_message(sender: UserProfile, client: Client,
-                               receiving_user: UserProfile, body: Text) -> int:
+                               receiving_user: UserProfile, body: str) -> int:
     addressee = Addressee.for_user_profile(receiving_user)
     message = check_message(sender, client, addressee, body)
 
@@ -1775,13 +1775,13 @@ def check_send_private_message(sender: UserProfile, client: Client,
 
 # check_send_message:
 # Returns the id of the sent message.  Has same argspec as check_message.
-def check_send_message(sender: UserProfile, client: Client, message_type_name: Text,
-                       message_to: Sequence[Text], topic_name: Optional[Text],
-                       message_content: Text, realm: Optional[Realm]=None,
+def check_send_message(sender: UserProfile, client: Client, message_type_name: str,
+                       message_to: Sequence[str], topic_name: Optional[str],
+                       message_content: str, realm: Optional[Realm]=None,
                        forged: bool=False, forged_timestamp: Optional[float]=None,
                        forwarder_user_profile: Optional[UserProfile]=None,
-                       local_id: Optional[Text]=None,
-                       sender_queue_id: Optional[Text]=None) -> int:
+                       local_id: Optional[str]=None,
+                       sender_queue_id: Optional[str]=None) -> int:
 
     addressee = Addressee.legacy_build(
         sender,
@@ -1795,9 +1795,9 @@ def check_send_message(sender: UserProfile, client: Client, message_type_name: T
     return do_send_messages([message])[0]
 
 def check_schedule_message(sender: UserProfile, client: Client,
-                           message_type_name: Text, message_to: Sequence[Text],
-                           topic_name: Optional[Text], message_content: Text,
-                           delivery_type: Text, deliver_at: datetime.datetime,
+                           message_type_name: str, message_to: Sequence[str],
+                           topic_name: Optional[str], message_content: str,
+                           delivery_type: str, deliver_at: datetime.datetime,
                            realm: Optional[Realm]=None,
                            forwarder_user_profile: Optional[UserProfile]=None
                            ) -> int:
@@ -1814,7 +1814,7 @@ def check_schedule_message(sender: UserProfile, client: Client,
     message['delivery_type'] = delivery_type
     return do_schedule_messages([message])[0]
 
-def check_stream_name(stream_name: Text) -> None:
+def check_stream_name(stream_name: str) -> None:
     if stream_name.strip() == "":
         raise JsonableError(_("Invalid stream name '%s'" % (stream_name)))
     if len(stream_name) > Stream.MAX_NAME_LENGTH:
@@ -1823,7 +1823,7 @@ def check_stream_name(stream_name: Text) -> None:
         if ord(i) == 0:
             raise JsonableError(_("Stream name '%s' contains NULL (0x00) characters." % (stream_name)))
 
-def check_default_stream_group_name(group_name: Text) -> None:
+def check_default_stream_group_name(group_name: str) -> None:
     if group_name.strip() == "":
         raise JsonableError(_("Invalid default stream group name '%s'" % (group_name)))
     if len(group_name) > DefaultStreamGroup.MAX_NAME_LENGTH:
@@ -1836,7 +1836,7 @@ def check_default_stream_group_name(group_name: Text) -> None:
 
 def send_rate_limited_pm_notification_to_bot_owner(sender: UserProfile,
                                                    realm: Realm,
-                                                   content: Text) -> None:
+                                                   content: str) -> None:
     """
     Sends a PM error notification to a bot's owner if one hasn't already
     been sent in the last 5 minutes.
@@ -1871,7 +1871,7 @@ def send_rate_limited_pm_notification_to_bot_owner(sender: UserProfile,
 
 def send_pm_if_empty_stream(sender: UserProfile,
                             stream: Optional[Stream],
-                            stream_name: Text,
+                            stream_name: str,
                             realm: Realm) -> None:
     """If a bot sends a message to a stream that doesn't exist or has no
     subscribers, sends a notification to the bot owner (if not a
@@ -1900,11 +1900,11 @@ def send_pm_if_empty_stream(sender: UserProfile,
 # check_message:
 # Returns message ready for sending with do_send_message on success or the error message (string) on error.
 def check_message(sender: UserProfile, client: Client, addressee: Addressee,
-                  message_content_raw: Text, realm: Optional[Realm]=None, forged: bool=False,
+                  message_content_raw: str, realm: Optional[Realm]=None, forged: bool=False,
                   forged_timestamp: Optional[float]=None,
                   forwarder_user_profile: Optional[UserProfile]=None,
-                  local_id: Optional[Text]=None,
-                  sender_queue_id: Optional[Text]=None) -> Dict[str, Any]:
+                  local_id: Optional[str]=None,
+                  sender_queue_id: Optional[str]=None) -> Dict[str, Any]:
     stream = None
 
     message_content = message_content_raw.rstrip()
@@ -2005,7 +2005,7 @@ def check_message(sender: UserProfile, client: Client, addressee: Addressee,
 def _internal_prep_message(realm: Realm,
                            sender: UserProfile,
                            addressee: Addressee,
-                           content: Text) -> Optional[Dict[str, Any]]:
+                           content: str) -> Optional[Dict[str, Any]]:
     """
     Create a message object and checks it, but doesn't send it or save it to the database.
     The internal function that calls this can therefore batch send a bunch of created
@@ -2031,8 +2031,8 @@ def _internal_prep_message(realm: Realm,
     return None
 
 def internal_prep_stream_message(realm: Realm, sender: UserProfile,
-                                 stream_name: Text, topic: Text,
-                                 content: Text) -> Optional[Dict[str, Any]]:
+                                 stream_name: str, topic: str,
+                                 content: str) -> Optional[Dict[str, Any]]:
     """
     See _internal_prep_message for details of how this works.
     """
@@ -2048,7 +2048,7 @@ def internal_prep_stream_message(realm: Realm, sender: UserProfile,
 def internal_prep_private_message(realm: Realm,
                                   sender: UserProfile,
                                   recipient_user: UserProfile,
-                                  content: Text) -> Optional[Dict[str, Any]]:
+                                  content: str) -> Optional[Dict[str, Any]]:
     """
     See _internal_prep_message for details of how this works.
     """
@@ -2061,8 +2061,8 @@ def internal_prep_private_message(realm: Realm,
         content=content,
     )
 
-def internal_send_message(realm: Realm, sender_email: Text, recipient_type_name: str,
-                          recipients: Text, topic_name: Text, content: Text,
+def internal_send_message(realm: Realm, sender_email: str, recipient_type_name: str,
+                          recipients: str, topic_name: str, content: str,
                           email_gateway: Optional[bool]=False) -> None:
     """internal_send_message should only be used where `sender_email` is a
     system bot."""
@@ -2094,7 +2094,7 @@ def internal_send_message(realm: Realm, sender_email: Text, recipient_type_name:
 def internal_send_private_message(realm: Realm,
                                   sender: UserProfile,
                                   recipient_user: UserProfile,
-                                  content: Text) -> None:
+                                  content: str) -> None:
     message = internal_prep_private_message(realm, sender, recipient_user, content)
     if message is None:
         return
@@ -2120,11 +2120,11 @@ def internal_send_huddle_message(realm: Realm, sender: UserProfile, emails: List
         return
     do_send_messages([message])
 
-def pick_color(user_profile: UserProfile) -> Text:
+def pick_color(user_profile: UserProfile) -> str:
     subs = get_stream_subscriptions_for_user(user_profile).filter(active=True)
     return pick_color_helper(user_profile, subs)
 
-def pick_color_helper(user_profile: UserProfile, subs: Iterable[Subscription]) -> Text:
+def pick_color_helper(user_profile: UserProfile, subs: Iterable[Subscription]) -> str:
     # These colors are shared with the palette in subs.js.
     used_colors = [sub.color for sub in subs if sub.active]
     available_colors = [s for s in STREAM_ASSIGNMENT_COLORS if s not in used_colors]
@@ -2266,12 +2266,12 @@ def get_subscribers(stream: Stream,
     return [subscription.user_profile for subscription in subscriptions]
 
 def get_subscriber_emails(stream: Stream,
-                          requesting_user: Optional[UserProfile]=None) -> List[Text]:
+                          requesting_user: Optional[UserProfile]=None) -> List[str]:
     subscriptions_query = get_subscribers_query(stream, requesting_user)
     subscriptions = subscriptions_query.values('user_profile__email')
     return [subscription['user_profile__email'] for subscription in subscriptions]
 
-def maybe_get_subscriber_emails(stream: Stream, user_profile: UserProfile) -> List[Text]:
+def maybe_get_subscriber_emails(stream: Stream, user_profile: UserProfile) -> List[str]:
     """ Alternate version of get_subscriber_emails that takes a Stream object only
     (not a name), and simply returns an empty list if unable to get a real
     subscriber list (because we're on the MIT realm). """
@@ -2675,7 +2675,7 @@ def bulk_remove_subscriptions(users: Iterable[UserProfile],
         not_subscribed,
     )
 
-def log_subscription_property_change(user_email: Text, stream_name: Text, property: Text,
+def log_subscription_property_change(user_email: str, stream_name: str, property: str,
                                      value: Any) -> None:
     event = {'type': 'subscription_property',
              'property': property,
@@ -2685,7 +2685,7 @@ def log_subscription_property_change(user_email: Text, stream_name: Text, proper
     log_event(event)
 
 def do_change_subscription_property(user_profile: UserProfile, sub: Subscription,
-                                    stream: Stream, property_name: Text, value: Any
+                                    stream: Stream, property_name: str, value: Any
                                     ) -> None:
     setattr(sub, property_name, value)
     sub.save(update_fields=[property_name])
@@ -2701,7 +2701,7 @@ def do_change_subscription_property(user_profile: UserProfile, sub: Subscription
                  name=stream.name)
     send_event(event, [user_profile.id])
 
-def do_change_password(user_profile: UserProfile, password: Text, commit: bool=True,
+def do_change_password(user_profile: UserProfile, password: str, commit: bool=True,
                        hashed_password: bool=False) -> None:
     if hashed_password:
         # This is a hashed password, not the password itself.
@@ -2715,7 +2715,7 @@ def do_change_password(user_profile: UserProfile, password: Text, commit: bool=T
                                  modified_user=user_profile, event_type='user_change_password',
                                  event_time=event_time)
 
-def do_change_full_name(user_profile: UserProfile, full_name: Text,
+def do_change_full_name(user_profile: UserProfile, full_name: str,
                         acting_user: Optional[UserProfile]) -> None:
     old_name = user_profile.full_name
     user_profile.full_name = full_name
@@ -2733,8 +2733,8 @@ def do_change_full_name(user_profile: UserProfile, full_name: Text,
         send_event(dict(type='realm_bot', op='update', bot=payload),
                    bot_owner_user_ids(user_profile))
 
-def check_change_full_name(user_profile: UserProfile, full_name_raw: Text,
-                           acting_user: UserProfile) -> Text:
+def check_change_full_name(user_profile: UserProfile, full_name_raw: str,
+                           acting_user: UserProfile) -> str:
     """Verifies that the user's proposed full name is valid.  The caller
     is responsible for checking check permissions.  Returns the new
     full name, which may differ from what was passed in (because this
@@ -2788,7 +2788,7 @@ def do_change_bot_owner(user_profile: UserProfile, bot_owner: UserProfile,
                              )),
                update_users)
 
-def do_change_tos_version(user_profile: UserProfile, tos_version: Text) -> None:
+def do_change_tos_version(user_profile: UserProfile, tos_version: str) -> None:
     user_profile.tos_version = tos_version
     user_profile.save(update_fields=["tos_version"])
     event_time = timezone_now()
@@ -2813,7 +2813,7 @@ def do_regenerate_api_key(user_profile: UserProfile, acting_user: UserProfile) -
                                  )),
                    bot_owner_user_ids(user_profile))
 
-def do_change_avatar_fields(user_profile: UserProfile, avatar_source: Text) -> None:
+def do_change_avatar_fields(user_profile: UserProfile, avatar_source: str) -> None:
     user_profile.avatar_source = avatar_source
     user_profile.avatar_version += 1
     user_profile.save(update_fields=["avatar_source", "avatar_version"])
@@ -2846,7 +2846,7 @@ def do_change_avatar_fields(user_profile: UserProfile, avatar_source: Text) -> N
                active_user_ids(user_profile.realm_id))
 
 
-def do_change_icon_source(realm: Realm, icon_source: Text, log: bool=True) -> None:
+def do_change_icon_source(realm: Realm, icon_source: str, log: bool=True) -> None:
     realm.icon_source = icon_source
     realm.icon_version += 1
     realm.save(update_fields=["icon_source", "icon_version"])
@@ -2885,7 +2885,7 @@ def do_change_default_sending_stream(user_profile: UserProfile, stream: Optional
                    'stream': str(stream)})
     if user_profile.is_bot:
         if stream:
-            stream_name = stream.name  # type: Optional[Text]
+            stream_name = stream.name  # type: Optional[str]
         else:
             stream_name = None
         send_event(dict(type='realm_bot',
@@ -2909,7 +2909,7 @@ def do_change_default_events_register_stream(user_profile: UserProfile,
                    'stream': str(stream)})
     if user_profile.is_bot:
         if stream:
-            stream_name = stream.name  # type: Optional[Text]
+            stream_name = stream.name  # type: Optional[str]
         else:
             stream_name = None
         send_event(dict(type='realm_bot',
@@ -2974,7 +2974,7 @@ def do_change_stream_web_public(stream: Stream, is_web_public: bool) -> None:
     stream.is_web_public = is_web_public
     stream.save(update_fields=['is_web_public'])
 
-def do_rename_stream(stream: Stream, new_name: Text, log: bool=True) -> Dict[str, Text]:
+def do_rename_stream(stream: Stream, new_name: str, log: bool=True) -> Dict[str, str]:
     old_name = stream.name
     stream.name = new_name
     stream.save(update_fields=["name"])
@@ -3030,7 +3030,7 @@ def do_rename_stream(stream: Stream, new_name: Text, log: bool=True) -> Dict[str
     # email forwarding address to display the correctly-escaped new name.
     return {"email_address": new_email}
 
-def do_change_stream_description(stream: Stream, new_description: Text) -> None:
+def do_change_stream_description(stream: Stream, new_description: str) -> None:
     stream.description = new_description
     stream.save(update_fields=['description'])
 
@@ -3044,7 +3044,7 @@ def do_change_stream_description(stream: Stream, new_description: Text) -> None:
     )
     send_event(event, can_access_stream_user_ids(stream))
 
-def do_create_realm(string_id: Text, name: Text, restricted_to_domain: Optional[bool]=None,
+def do_create_realm(string_id: str, name: str, restricted_to_domain: Optional[bool]=None,
                     invite_required: Optional[bool]=None, org_type: Optional[int]=None
                     ) -> Realm:
     existing_realm = get_realm(string_id)
@@ -3119,7 +3119,7 @@ def do_change_enter_sends(user_profile: UserProfile, enter_sends: bool) -> None:
 
 def do_set_user_display_setting(user_profile: UserProfile,
                                 setting_name: str,
-                                setting_value: Union[bool, Text]) -> None:
+                                setting_value: Union[bool, str]) -> None:
     property_type = UserProfile.property_types[setting_name]
     assert isinstance(setting_value, property_type)
     setattr(user_profile, setting_name, setting_value)
@@ -3154,7 +3154,7 @@ def lookup_default_stream_groups(default_stream_group_names: List[str],
         default_stream_groups.append(default_stream_group)
     return default_stream_groups
 
-def set_default_streams(realm: Realm, stream_dict: Dict[Text, Dict[Text, Any]]) -> None:
+def set_default_streams(realm: Realm, stream_dict: Dict[str, Dict[str, Any]]) -> None:
     DefaultStream.objects.filter(realm=realm).delete()
     stream_names = []
     for name, options in stream_dict.items():
@@ -3200,8 +3200,8 @@ def do_remove_default_stream(stream: Stream) -> None:
     DefaultStream.objects.filter(realm_id=realm_id, stream_id=stream_id).delete()
     notify_default_streams(realm_id)
 
-def do_create_default_stream_group(realm: Realm, group_name: Text,
-                                   description: Text, streams: List[Stream]) -> None:
+def do_create_default_stream_group(realm: Realm, group_name: str,
+                                   description: str, streams: List[Stream]) -> None:
     default_streams = get_default_streams_for_realm(realm.id)
     for stream in streams:
         if stream in default_streams:
@@ -3249,7 +3249,7 @@ def do_remove_streams_from_default_stream_group(realm: Realm, group: DefaultStre
     notify_default_stream_groups(realm)
 
 def do_change_default_stream_group_name(realm: Realm, group: DefaultStreamGroup,
-                                        new_group_name: Text) -> None:
+                                        new_group_name: str) -> None:
     if group.name == new_group_name:
         raise JsonableError(_("This default stream group is already named '%s'") % (new_group_name,))
 
@@ -3261,7 +3261,7 @@ def do_change_default_stream_group_name(realm: Realm, group: DefaultStreamGroup,
     notify_default_stream_groups(realm)
 
 def do_change_default_stream_group_description(realm: Realm, group: DefaultStreamGroup,
-                                               new_description: Text) -> None:
+                                               new_description: str) -> None:
     group.description = new_description
     group.save()
     notify_default_stream_groups(realm)
@@ -3315,7 +3315,7 @@ def do_update_user_activity_interval(user_profile: UserProfile,
 @statsd_increment('user_activity')
 def do_update_user_activity(user_profile: UserProfile,
                             client: Client,
-                            query: Text,
+                            query: str,
                             log_time: datetime.datetime) -> None:
     (activity, created) = UserActivity.objects.get_or_create(
         user_profile = user_profile,
@@ -3456,7 +3456,7 @@ def do_mark_all_as_read(user_profile: UserProfile) -> int:
 
 def do_mark_stream_messages_as_read(user_profile: UserProfile,
                                     stream: Optional[Stream],
-                                    topic_name: Optional[Text]=None) -> int:
+                                    topic_name: Optional[str]=None) -> int:
     log_statsd_event('mark_stream_as_read')
 
     msgs = UserMessage.objects.filter(
@@ -3492,8 +3492,8 @@ def do_mark_stream_messages_as_read(user_profile: UserProfile,
     return count
 
 def do_update_message_flags(user_profile: UserProfile,
-                            operation: Text,
-                            flag: Text,
+                            operation: str,
+                            flag: str,
                             messages: Optional[Sequence[int]]) -> int:
     flagattr = getattr(UserMessage.flags, flag)
 
@@ -3545,15 +3545,15 @@ def subscribed_to_stream(user_profile: UserProfile, stream_id: int) -> bool:
     except Subscription.DoesNotExist:
         return False
 
-def truncate_content(content: Text, max_length: int, truncation_message: Text) -> Text:
+def truncate_content(content: str, max_length: int, truncation_message: str) -> str:
     if len(content) > max_length:
         content = content[:max_length - len(truncation_message)] + truncation_message
     return content
 
-def truncate_body(body: Text) -> Text:
+def truncate_body(body: str) -> str:
     return truncate_content(body, MAX_MESSAGE_LENGTH, "...")
 
-def truncate_topic(topic: Text) -> Text:
+def truncate_topic(topic: str) -> str:
     return truncate_content(topic, MAX_SUBJECT_LENGTH, "...")
 
 MessageUpdateUserInfoResult = TypedDict('MessageUpdateUserInfoResult', {
@@ -3638,8 +3638,8 @@ def update_to_dict_cache(changed_messages: List[Message]) -> List[int]:
 @transaction.atomic
 def do_update_embedded_data(user_profile: UserProfile,
                             message: Message,
-                            content: Optional[Text],
-                            rendered_content: Optional[Text]) -> None:
+                            content: Optional[str],
+                            rendered_content: Optional[str]) -> None:
     event = {
         'type': 'update_message',
         'sender': user_profile.email,
@@ -3669,9 +3669,9 @@ def do_update_embedded_data(user_profile: UserProfile,
 
 # We use transaction.atomic to support select_for_update in the attachment codepath.
 @transaction.atomic
-def do_update_message(user_profile: UserProfile, message: Message, topic_name: Optional[Text],
-                      propagate_mode: str, content: Optional[Text],
-                      rendered_content: Optional[Text], prior_mention_user_ids: Set[int],
+def do_update_message(user_profile: UserProfile, message: Message, topic_name: Optional[str],
+                      propagate_mode: str, content: Optional[str],
+                      rendered_content: Optional[str], prior_mention_user_ids: Set[int],
                       mention_user_ids: Set[int]) -> int:
     event = {'type': 'update_message',
              # TODO: We probably want to remove the 'sender' field
@@ -3867,10 +3867,10 @@ def get_average_weekly_stream_traffic(stream_id: int, stream_date_created: datet
 def is_old_stream(stream_date_created: datetime.datetime) -> bool:
     return (datetime.date.today() - stream_date_created.date()).days >= 7
 
-def encode_email_address(stream: Stream) -> Text:
+def encode_email_address(stream: Stream) -> str:
     return encode_email_address_helper(stream.name, stream.email_token)
 
-def encode_email_address_helper(name: Text, email_token: Text) -> Text:
+def encode_email_address_helper(name: str, email_token: str) -> str:
     # Some deployments may not use the email gateway
     if settings.EMAIL_GATEWAY_PATTERN == '':
         return ''
@@ -3887,7 +3887,7 @@ def encode_email_address_helper(name: Text, email_token: Text) -> Text:
     encoded_token = "%s+%s" % (encoded_name, email_token)
     return settings.EMAIL_GATEWAY_PATTERN % (encoded_token,)
 
-def get_email_gateway_message_string_from_address(address: Text) -> Optional[Text]:
+def get_email_gateway_message_string_from_address(address: str) -> Optional[str]:
     pattern_parts = [re.escape(part) for part in settings.EMAIL_GATEWAY_PATTERN.split('%s')]
     if settings.EMAIL_GATEWAY_EXTRA_PATTERN_HACK:
         # Accept mails delivered to any Zulip server
@@ -3902,7 +3902,7 @@ def get_email_gateway_message_string_from_address(address: Text) -> Optional[Tex
 
     return msg_string
 
-def decode_email_address(email: Text) -> Optional[Tuple[Text, Text]]:
+def decode_email_address(email: str) -> Optional[Tuple[str, str]]:
     # Perform the reverse of encode_email_address. Returns a tuple of (streamname, email_token)
     msg_string = get_email_gateway_message_string_from_address(email)
 
@@ -4135,7 +4135,7 @@ def filter_presence_idle_user_ids(user_ids: Set[int]) -> List[int]:
     idle_user_ids = user_ids - active_user_ids
     return sorted(list(idle_user_ids))
 
-def get_status_dict(requesting_user_profile: UserProfile) -> Dict[Text, Dict[Text, Dict[str, Any]]]:
+def get_status_dict(requesting_user_profile: UserProfile) -> Dict[str, Dict[str, Dict[str, Any]]]:
     if requesting_user_profile.realm.presence_disabled:
         # Return an empty dict if presence is disabled in this realm
         return defaultdict(dict)
@@ -4169,11 +4169,11 @@ def do_send_confirmation_email(invitee: PreregistrationUser,
     send_email('zerver/emails/invitation', to_email=invitee.email, from_name=from_name,
                from_address=FromAddress.NOREPLY, context=context)
 
-def email_not_system_bot(email: Text) -> None:
+def email_not_system_bot(email: str) -> None:
     if is_cross_realm_bot_email(email):
         raise ValidationError('%s is an email address reserved for system bots' % (email,))
 
-def validate_email_for_realm(target_realm: Realm, email: Text) -> None:
+def validate_email_for_realm(target_realm: Realm, email: str) -> None:
     email_not_system_bot(email)
 
     try:
@@ -4189,7 +4189,7 @@ def validate_email_for_realm(target_realm: Realm, email: Text) -> None:
         # Other users should not already exist at all.
         raise ValidationError('%s already has an account' % (email,))
 
-def validate_email(user_profile: UserProfile, email: Text) -> Tuple[Optional[str], Optional[str]]:
+def validate_email(user_profile: UserProfile, email: str) -> Tuple[Optional[str], Optional[str]]:
     try:
         validators.validate_email(email)
     except ValidationError:
@@ -4213,9 +4213,9 @@ class InvitationError(JsonableError):
     code = ErrorCode.INVITATION_FAILED
     data_fields = ['errors', 'sent_invitations']
 
-    def __init__(self, msg: Text, errors: List[Tuple[Text, str]], sent_invitations: bool) -> None:
-        self._msg = msg  # type: Text
-        self.errors = errors  # type: List[Tuple[Text, str]]
+    def __init__(self, msg: str, errors: List[Tuple[str, str]], sent_invitations: bool) -> None:
+        self._msg = msg  # type: str
+        self.errors = errors  # type: List[Tuple[str, str]]
         self.sent_invitations = sent_invitations  # type: bool
 
 def estimate_recent_invites(realms: Iterable[Realm], *, days: int) -> int:
@@ -4270,9 +4270,9 @@ def do_invite_users(user_profile: UserProfile,
                   "Ask an organization admin, or a more experienced user."),
                 [], sent_invitations=False)
 
-    validated_emails = []  # type: List[Text]
-    errors = []  # type: List[Tuple[Text, str]]
-    skipped = []  # type: List[Tuple[Text, str]]
+    validated_emails = []  # type: List[str]
+    errors = []  # type: List[Tuple[str, str]]
+    skipped = []  # type: List[Tuple[str, str]]
     for email in invitee_emails:
         if email == '':
             continue
@@ -4383,7 +4383,7 @@ def notify_realm_emoji(realm: Realm) -> None:
     send_event(event, active_user_ids(realm.id))
 
 def check_add_realm_emoji(realm: Realm,
-                          name: Text,
+                          name: str,
                           author: UserProfile,
                           image_file: File) -> Optional[RealmEmoji]:
     realm_emoji = RealmEmoji(realm=realm, name=name, author=author)
@@ -4405,25 +4405,25 @@ def check_add_realm_emoji(realm: Realm,
             notify_realm_emoji(realm_emoji.realm)
     return realm_emoji
 
-def do_remove_realm_emoji(realm: Realm, name: Text) -> None:
+def do_remove_realm_emoji(realm: Realm, name: str) -> None:
     emoji = RealmEmoji.objects.get(realm=realm, name=name, deactivated=False)
     emoji.deactivated = True
     emoji.save(update_fields=['deactivated'])
     notify_realm_emoji(realm)
 
-def notify_alert_words(user_profile: UserProfile, words: Iterable[Text]) -> None:
+def notify_alert_words(user_profile: UserProfile, words: Iterable[str]) -> None:
     event = dict(type="alert_words", alert_words=words)
     send_event(event, [user_profile.id])
 
-def do_add_alert_words(user_profile: UserProfile, alert_words: Iterable[Text]) -> None:
+def do_add_alert_words(user_profile: UserProfile, alert_words: Iterable[str]) -> None:
     words = add_user_alert_words(user_profile, alert_words)
     notify_alert_words(user_profile, words)
 
-def do_remove_alert_words(user_profile: UserProfile, alert_words: Iterable[Text]) -> None:
+def do_remove_alert_words(user_profile: UserProfile, alert_words: Iterable[str]) -> None:
     words = remove_user_alert_words(user_profile, alert_words)
     notify_alert_words(user_profile, words)
 
-def do_set_alert_words(user_profile: UserProfile, alert_words: List[Text]) -> None:
+def do_set_alert_words(user_profile: UserProfile, alert_words: List[str]) -> None:
     set_user_alert_words(user_profile, alert_words)
     notify_alert_words(user_profile, alert_words)
 
@@ -4451,7 +4451,7 @@ def notify_realm_filters(realm: Realm) -> None:
 # RegExp syntax. In addition to JS-compatible syntax, the following features are available:
 #   * Named groups will be converted to numbered groups automatically
 #   * Inline-regex flags will be stripped, and where possible translated to RegExp-wide flags
-def do_add_realm_filter(realm: Realm, pattern: Text, url_format_string: Text) -> int:
+def do_add_realm_filter(realm: Realm, pattern: str, url_format_string: str) -> int:
     pattern = pattern.strip()
     url_format_string = url_format_string.strip()
     realm_filter = RealmFilter(
@@ -4463,7 +4463,7 @@ def do_add_realm_filter(realm: Realm, pattern: Text, url_format_string: Text) ->
 
     return realm_filter.id
 
-def do_remove_realm_filter(realm: Realm, pattern: Optional[Text]=None,
+def do_remove_realm_filter(realm: Realm, pattern: Optional[str]=None,
                            id: Optional[int]=None) -> None:
     if pattern is not None:
         RealmFilter.objects.get(realm=realm, pattern=pattern).delete()
@@ -4471,11 +4471,11 @@ def do_remove_realm_filter(realm: Realm, pattern: Optional[Text]=None,
         RealmFilter.objects.get(realm=realm, pk=id).delete()
     notify_realm_filters(realm)
 
-def get_emails_from_user_ids(user_ids: Sequence[int]) -> Dict[int, Text]:
+def get_emails_from_user_ids(user_ids: Sequence[int]) -> Dict[int, str]:
     # We may eventually use memcached to speed this up, but the DB is fast.
     return UserProfile.emails_from_ids(user_ids)
 
-def do_add_realm_domain(realm: Realm, domain: Text, allow_subdomains: bool) -> (RealmDomain):
+def do_add_realm_domain(realm: Realm, domain: str, allow_subdomains: bool) -> (RealmDomain):
     realm_domain = RealmDomain.objects.create(realm=realm, domain=domain,
                                               allow_subdomains=allow_subdomains)
     event = dict(type="realm_domains", op="add",
@@ -4605,7 +4605,7 @@ def do_delete_old_unclaimed_attachments(weeks_ago: int) -> None:
         delete_message_image(attachment.path_id)
         attachment.delete()
 
-def check_attachment_reference_change(prev_content: Text, message: Message) -> None:
+def check_attachment_reference_change(prev_content: str, message: Message) -> None:
     new_content = message.content
     prev_attachments = set(attachment_url_re.findall(prev_content))
     new_attachments = set(attachment_url_re.findall(new_content))
@@ -4630,8 +4630,8 @@ def notify_realm_custom_profile_fields(realm: Realm, operation: str) -> None:
                  fields=[f.as_dict() for f in fields])
     send_event(event, active_user_ids(realm.id))
 
-def try_add_realm_custom_profile_field(realm: Realm, name: Text, field_type: int,
-                                       hint: Text='',
+def try_add_realm_custom_profile_field(realm: Realm, name: str, field_type: int,
+                                       hint: str='',
                                        field_data: ProfileFieldData=None) -> CustomProfileField:
     field = CustomProfileField(realm=realm, name=name, field_type=field_type)
     field.hint = hint
@@ -4653,7 +4653,7 @@ def do_remove_realm_custom_profile_field(realm: Realm, field: CustomProfileField
     notify_realm_custom_profile_fields(realm, 'delete')
 
 def try_update_realm_custom_profile_field(realm: Realm, field: CustomProfileField,
-                                          name: Text, hint: Text='',
+                                          name: str, hint: str='',
                                           field_data: ProfileFieldData=None) -> None:
     field.name = name
     field.hint = hint
@@ -4674,7 +4674,7 @@ def try_reorder_realm_custom_profile_fields(realm: Realm, order: List[int]) -> N
     notify_realm_custom_profile_fields(realm, 'update')
 
 def do_update_user_custom_profile_data(user_profile: UserProfile,
-                                       data: List[Dict[str, Union[int, Text]]]) -> None:
+                                       data: List[Dict[str, Union[int, str]]]) -> None:
     with transaction.atomic():
         update_or_create = CustomProfileFieldValue.objects.update_or_create
         for field in data:
@@ -4697,8 +4697,8 @@ def do_send_create_user_group_event(user_group: UserGroup, members: List[UserPro
                  )
     send_event(event, active_user_ids(user_group.realm_id))
 
-def check_add_user_group(realm: Realm, name: Text, initial_members: List[UserProfile],
-                         description: Text) -> None:
+def check_add_user_group(realm: Realm, name: str, initial_members: List[UserProfile],
+                         description: str) -> None:
     try:
         user_group = create_user_group(name, initial_members, realm, description=description)
         do_send_create_user_group_event(user_group, initial_members)
@@ -4709,19 +4709,19 @@ def do_send_user_group_update_event(user_group: UserGroup, data: Dict[str, Any])
     event = dict(type="user_group", op='update', group_id=user_group.id, data=data)
     send_event(event, active_user_ids(user_group.realm_id))
 
-def do_update_user_group_name(user_group: UserGroup, name: Text) -> None:
+def do_update_user_group_name(user_group: UserGroup, name: str) -> None:
     user_group.name = name
     user_group.save(update_fields=['name'])
     do_send_user_group_update_event(user_group, dict(name=name))
 
-def do_update_user_group_description(user_group: UserGroup, description: Text) -> None:
+def do_update_user_group_description(user_group: UserGroup, description: str) -> None:
     user_group.description = description
     user_group.save(update_fields=['description'])
     do_send_user_group_update_event(user_group, dict(description=description))
 
 def do_update_outgoing_webhook_service(bot_profile: UserProfile,
                                        service_interface: int,
-                                       service_payload_url: Text) -> None:
+                                       service_payload_url: str) -> None:
     # TODO: First service is chosen because currently one bot can only have one service.
     # Update this once multiple services are supported.
     service = get_bot_services(bot_profile.id)[0]
@@ -4739,7 +4739,7 @@ def do_update_outgoing_webhook_service(bot_profile: UserProfile,
                bot_owner_user_ids(bot_profile))
 
 def do_update_bot_config_data(bot_profile: UserProfile,
-                              config_data: Dict[Text, Text]) -> None:
+                              config_data: Dict[str, str]) -> None:
     for key, value in config_data.items():
         set_bot_config(bot_profile, key, value)
     updated_config_data = get_bot_config(bot_profile)
@@ -4755,7 +4755,7 @@ def do_update_bot_config_data(bot_profile: UserProfile,
 def get_service_dicts_for_bot(user_profile_id: str) -> List[Dict[str, Any]]:
     user_profile = get_user_profile_by_id(user_profile_id)
     services = get_bot_services(user_profile_id)
-    service_dicts = []  # type: List[Dict[Text, Any]]
+    service_dicts = []  # type: List[Dict[str, Any]]
     if user_profile.bot_type == UserProfile.OUTGOING_WEBHOOK_BOT:
         service_dicts = [{'base_url': service.base_url,
                           'interface': service.interface,
@@ -4782,12 +4782,12 @@ def get_service_dicts_for_bots(bot_dicts: List[Dict[str, Any]],
                         if bot_dict['bot_type'] == UserProfile.EMBEDDED_BOT]
     embedded_bot_configs = get_bot_configs(embedded_bot_ids)
 
-    service_dicts_by_uid = {}  # type: Dict[int, List[Dict[Text, Any]]]
+    service_dicts_by_uid = {}  # type: Dict[int, List[Dict[str, Any]]]
     for bot_dict in bot_dicts:
         bot_profile_id = bot_dict["id"]
         bot_type = bot_dict["bot_type"]
         services = bot_services_by_uid[bot_profile_id]
-        service_dicts = []  # type: List[Dict[Text, Any]]
+        service_dicts = []  # type: List[Dict[str, Any]]
         if bot_type  == UserProfile.OUTGOING_WEBHOOK_BOT:
             service_dicts = [{'base_url': service.base_url,
                               'interface': service.interface,
@@ -4825,7 +4825,7 @@ def get_owned_bot_dicts(user_profile: UserProfile,
              }
             for botdict in result]
 
-def do_send_user_group_members_update_event(event_name: Text,
+def do_send_user_group_members_update_event(event_name: str,
                                             user_group: UserGroup,
                                             user_ids: List[int]) -> None:
     event = dict(type="user_group",

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Text
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple
 
 from zerver.lib.initial_password import initial_password
 from zerver.models import Realm, Stream, UserProfile, Huddle, \
@@ -6,11 +6,11 @@ from zerver.models import Realm, Stream, UserProfile, Huddle, \
 from zerver.lib.create_user import create_user_profile
 
 def bulk_create_users(realm: Realm,
-                      users_raw: Set[Tuple[Text, Text, Text, bool]],
+                      users_raw: Set[Tuple[str, str, str, bool]],
                       bot_type: Optional[int]=None,
                       bot_owner: Optional[UserProfile]=None,
-                      tos_version: Optional[Text]=None,
-                      timezone: Text="") -> None:
+                      tos_version: Optional[str]=None,
+                      timezone: str="") -> None:
     """
     Creates and saves a UserProfile with the given email.
     Has some code based off of UserManage.create_user, but doesn't .save()
@@ -35,7 +35,7 @@ def bulk_create_users(realm: Realm,
                        event_type='user_created', event_time=profile_.date_joined)
          for profile_ in profiles_to_create])
 
-    profiles_by_email = {}  # type: Dict[Text, UserProfile]
+    profiles_by_email = {}  # type: Dict[str, UserProfile]
     profiles_by_id = {}  # type: Dict[int, UserProfile]
     for profile in UserProfile.objects.select_related().filter(realm=realm):
         profiles_by_email[profile.email] = profile
@@ -47,7 +47,7 @@ def bulk_create_users(realm: Realm,
                                               type=Recipient.PERSONAL))
     Recipient.objects.bulk_create(recipients_to_create)
 
-    recipients_by_email = {}  # type: Dict[Text, Recipient]
+    recipients_by_email = {}  # type: Dict[str, Recipient]
     for recipient in recipients_to_create:
         recipients_by_email[profiles_by_id[recipient.type_id].email] = recipient
 
@@ -60,7 +60,7 @@ def bulk_create_users(realm: Realm,
 
 # This is only sed in populate_db, so doesn't realy need tests
 def bulk_create_streams(realm: Realm,
-                        stream_dict: Dict[Text, Dict[Text, Any]]) -> None:  # nocoverage
+                        stream_dict: Dict[str, Dict[str, Any]]) -> None:  # nocoverage
     existing_streams = frozenset([name.lower() for name in
                                   Stream.objects.filter(realm=realm)
                                   .values_list('name', flat=True)])

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -1,5 +1,5 @@
 
-from typing import Any, Callable, Dict, List, Tuple, Text
+from typing import Any, Callable, Dict, List, Tuple
 
 # This file needs to be different from cache.py because cache.py
 # cannot import anything from zerver.models or we'd have an import
@@ -30,7 +30,7 @@ def message_fetch_objects() -> List[Any]:
     return Message.objects.select_related().filter(~Q(sender__email='tabbott/extra@mit.edu'),
                                                    id__gt=max_id - MESSAGE_CACHE_SIZE)
 
-def message_cache_items(items_for_remote_cache: Dict[Text, Tuple[bytes]],
+def message_cache_items(items_for_remote_cache: Dict[str, Tuple[bytes]],
                         message: Message) -> None:
     '''
     Note: this code is untested, and the caller has been
@@ -40,31 +40,31 @@ def message_cache_items(items_for_remote_cache: Dict[Text, Tuple[bytes]],
     value = MessageDict.to_dict_uncached(message)
     items_for_remote_cache[key] = (value,)
 
-def user_cache_items(items_for_remote_cache: Dict[Text, Tuple[UserProfile]],
+def user_cache_items(items_for_remote_cache: Dict[str, Tuple[UserProfile]],
                      user_profile: UserProfile) -> None:
     items_for_remote_cache[user_profile_by_email_cache_key(user_profile.email)] = (user_profile,)
     items_for_remote_cache[user_profile_by_id_cache_key(user_profile.id)] = (user_profile,)
     items_for_remote_cache[user_profile_by_api_key_cache_key(user_profile.api_key)] = (user_profile,)
     items_for_remote_cache[user_profile_cache_key(user_profile.email, user_profile.realm)] = (user_profile,)
 
-def stream_cache_items(items_for_remote_cache: Dict[Text, Tuple[Stream]],
+def stream_cache_items(items_for_remote_cache: Dict[str, Tuple[Stream]],
                        stream: Stream) -> None:
     items_for_remote_cache[get_stream_cache_key(stream.name, stream.realm_id)] = (stream,)
 
-def client_cache_items(items_for_remote_cache: Dict[Text, Tuple[Client]],
+def client_cache_items(items_for_remote_cache: Dict[str, Tuple[Client]],
                        client: Client) -> None:
     items_for_remote_cache[get_client_cache_key(client.name)] = (client,)
 
-def huddle_cache_items(items_for_remote_cache: Dict[Text, Tuple[Huddle]],
+def huddle_cache_items(items_for_remote_cache: Dict[str, Tuple[Huddle]],
                        huddle: Huddle) -> None:
     items_for_remote_cache[huddle_hash_cache_key(huddle.huddle_hash)] = (huddle,)
 
-def recipient_cache_items(items_for_remote_cache: Dict[Text, Tuple[Recipient]],
+def recipient_cache_items(items_for_remote_cache: Dict[str, Tuple[Recipient]],
                           recipient: Recipient) -> None:
     items_for_remote_cache[get_recipient_cache_key(recipient.type, recipient.type_id)] = (recipient,)
 
 session_engine = import_module(settings.SESSION_ENGINE)
-def session_cache_items(items_for_remote_cache: Dict[Text, Text],
+def session_cache_items(items_for_remote_cache: Dict[str, str],
                         session: Session) -> None:
     store = session_engine.SessionStore(session_key=session.session_key)  # type: ignore # import_module
     items_for_remote_cache[store.cache_key] = store.decode(session.session_data)
@@ -86,12 +86,12 @@ cache_fillers = {
     #    'message': (message_fetch_objects, message_cache_items, 3600 * 24, 1000),
     'huddle': (lambda: Huddle.objects.select_related().all(), huddle_cache_items, 3600*24*7, 10000),
     'session': (lambda: Session.objects.all(), session_cache_items, 3600*24*7, 10000),
-}  # type: Dict[str, Tuple[Callable[[], List[Any]], Callable[[Dict[Text, Any], Any], None], int, int]]
+}  # type: Dict[str, Tuple[Callable[[], List[Any]], Callable[[Dict[str, Any], Any], None], int, int]]
 
 def fill_remote_cache(cache: str) -> None:
     remote_cache_time_start = get_remote_cache_time()
     remote_cache_requests_start = get_remote_cache_requests()
-    items_for_remote_cache = {}  # type: Dict[Text, Any]
+    items_for_remote_cache = {}  # type: Dict[str, Any]
     (objects, items_filler, timeout, batch_size) = cache_fillers[cache]
     count = 0
     for obj in objects():

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -7,9 +7,9 @@ import ujson
 import os
 import string
 
-from typing import Optional, Text
+from typing import Optional
 
-def random_api_key() -> Text:
+def random_api_key() -> str:
     choices = string.ascii_letters + string.digits
     altchars = ''.join([choices[ord(os.urandom(1)) % 62] for _ in range(2)]).encode("utf-8")
     return base64.b64encode(os.urandom(24), altchars=altchars).decode("utf-8")
@@ -21,12 +21,12 @@ def random_api_key() -> Text:
 # Only use this for bulk_create -- for normal usage one should use
 # create_user (below) which will also make the Subscription and
 # Recipient objects
-def create_user_profile(realm: Realm, email: Text, password: Optional[Text],
-                        active: bool, bot_type: Optional[int], full_name: Text,
-                        short_name: Text, bot_owner: Optional[UserProfile],
-                        is_mirror_dummy: bool, tos_version: Optional[Text],
-                        timezone: Optional[Text],
-                        tutorial_status: Optional[Text] = UserProfile.TUTORIAL_WAITING,
+def create_user_profile(realm: Realm, email: str, password: Optional[str],
+                        active: bool, bot_type: Optional[int], full_name: str,
+                        short_name: str, bot_owner: Optional[UserProfile],
+                        is_mirror_dummy: bool, tos_version: Optional[str],
+                        timezone: Optional[str],
+                        tutorial_status: Optional[str] = UserProfile.TUTORIAL_WAITING,
                         enter_sends: bool = False) -> UserProfile:
     now = timezone_now()
     email = UserManager.normalize_email(email)
@@ -51,12 +51,12 @@ def create_user_profile(realm: Realm, email: Text, password: Optional[Text],
     user_profile.api_key = random_api_key()
     return user_profile
 
-def create_user(email: Text, password: Optional[Text], realm: Realm,
-                full_name: Text, short_name: Text, active: bool = True,
+def create_user(email: str, password: Optional[str], realm: Realm,
+                full_name: str, short_name: str, active: bool = True,
                 is_realm_admin: bool = False, bot_type: Optional[int] = None,
                 bot_owner: Optional[UserProfile] = None,
-                tos_version: Optional[Text] = None, timezone: Text = "",
-                avatar_source: Text = UserProfile.AVATAR_FROM_GRAVATAR,
+                tos_version: Optional[str] = None, timezone: str = "",
+                avatar_source: str = UserProfile.AVATAR_FROM_GRAVATAR,
                 is_mirror_dummy: bool = False,
                 default_sending_stream: Optional[Stream] = None,
                 default_events_register_stream: Optional[Stream] = None,

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext as _
 from django.conf import settings
 from importlib import import_module
 from typing import (
-    cast, Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Text, Tuple, Union
+    cast, Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 )
 
 session_engine = import_module(settings.SESSION_ENGINE)
@@ -50,7 +50,7 @@ from zproject.backends import email_auth_enabled, password_auth_enabled
 from version import ZULIP_VERSION
 
 
-def get_raw_user_data(realm_id: int, client_gravatar: bool) -> Dict[int, Dict[str, Text]]:
+def get_raw_user_data(realm_id: int, client_gravatar: bool) -> Dict[int, Dict[str, str]]:
     user_dicts = get_realm_user_dicts(realm_id)
 
     # TODO: Consider optimizing this query away with caching.
@@ -476,7 +476,7 @@ def apply_event(state: Dict[str, Any],
                     event['subscriptions'][i] = copy.deepcopy(event['subscriptions'][i])
                     del event['subscriptions'][i]['subscribers']
 
-        def name(sub: Dict[str, Any]) -> Text:
+        def name(sub: Dict[str, Any]) -> str:
             return sub['name'].lower()
 
         if event['op'] == "add":
@@ -629,7 +629,7 @@ def do_events_register(user_profile: UserProfile, user_client: Client,
                        queue_lifespan_secs: int = 0,
                        all_public_streams: bool = False,
                        include_subscribers: bool = True,
-                       narrow: Iterable[Sequence[Text]] = [],
+                       narrow: Iterable[Sequence[str]] = [],
                        fetch_event_types: Optional[Iterable[str]] = None) -> Dict[str, Any]:
     # Technically we don't need to check this here because
     # build_narrow_filter will check it, but it's nicer from an error

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional, Text, Type
+from typing import Any, Dict, List, Optional, Type
 
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _
@@ -93,15 +93,15 @@ class JsonableError(Exception):
     # like 403 or 404.
     http_status_code = 400  # type: int
 
-    def __init__(self, msg: Text, code: Optional[ErrorCode]=None) -> None:
+    def __init__(self, msg: str, code: Optional[ErrorCode]=None) -> None:
         if code is not None:
             self.code = code
 
         # `_msg` is an implementation detail of `JsonableError` itself.
-        self._msg = msg  # type: Text
+        self._msg = msg  # type: str
 
     @staticmethod
-    def msg_format() -> Text:
+    def msg_format() -> str:
         '''Override in subclasses.  Gets the items in `data_fields` as format args.
 
         This should return (a translation of) a string literal.
@@ -119,7 +119,7 @@ class JsonableError(Exception):
     #
 
     @property
-    def msg(self) -> Text:
+    def msg(self) -> str:
         format_data = dict(((f, getattr(self, f)) for f in self.data_fields),
                            _msg=getattr(self, '_msg', None))
         return self.msg_format().format(**format_data)

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -19,7 +19,7 @@ from zerver.models import UserProfile, Realm, Client, Huddle, Stream, \
     get_display_recipient, Attachment, get_system_bot
 from zerver.lib.parallel import run_parallel
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, \
-    Iterable, Text
+    Iterable
 
 # Custom mypy types follow:
 Record = Dict[str, Any]

--- a/zerver/lib/feedback.py
+++ b/zerver/lib/feedback.py
@@ -1,7 +1,7 @@
 
 from django.conf import settings
 from django.core.mail import EmailMessage
-from typing import Any, Mapping, Optional, Text
+from typing import Any, Mapping, Optional
 
 from zerver.lib.actions import internal_send_message
 from zerver.lib.send_email import FromAddress
@@ -13,7 +13,7 @@ import time
 
 client = get_redis_client()
 
-def has_enough_time_expired_since_last_message(sender_email: Text, min_delay: float) -> bool:
+def has_enough_time_expired_since_last_message(sender_email: str, min_delay: float) -> bool:
     # This function returns a boolean, but it also has the side effect
     # of noting that a new message was received.
     key = 'zilencer:feedback:%s' % (sender_email,)

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -7,12 +7,12 @@ from django.utils.translation import ugettext as _
 from django.utils.lru_cache import lru_cache
 
 from itertools import zip_longest
-from typing import Any, List, Dict, Optional, Text
+from typing import Any, List, Dict, Optional
 
 import os
 import ujson
 
-def with_language(string: Text, language: Text) -> Text:
+def with_language(string: str, language: str) -> str:
     """
     This is an expensive function. If you are using it in a loop, it will
     make your code slow.
@@ -30,7 +30,7 @@ def get_language_list() -> List[Dict[str, Any]]:
         languages = ujson.load(reader)
         return languages['name_map']
 
-def get_language_list_for_templates(default_language: Text) -> List[Dict[str, Dict[str, str]]]:
+def get_language_list_for_templates(default_language: str) -> List[Dict[str, Dict[str, str]]]:
     language_list = [l for l in get_language_list()
                      if 'percent_translated' not in l or
                         l['percent_translated'] >= 5.]
@@ -67,13 +67,13 @@ def get_language_list_for_templates(default_language: Text) -> List[Dict[str, Di
 
     return formatted_list
 
-def get_language_name(code: str) -> Optional[Text]:
+def get_language_name(code: str) -> Optional[str]:
     for lang in get_language_list():
         if code in (lang['code'], lang['locale']):
             return lang['name']
     return None
 
-def get_available_language_codes() -> List[Text]:
+def get_available_language_codes() -> List[str]:
     language_list = get_language_list()
     codes = [language['code'] for language in language_list]
     return codes

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.db import connection
 from django.utils.timezone import utc as timezone_utc
 from typing import Any, Dict, List, Optional, Set, Tuple, \
-    Iterable, Text
+    Iterable
 
 from zerver.lib.avatar_hash import user_avatar_path_from_ids
 from zerver.lib.bulk_create import bulk_create_users
@@ -567,7 +567,7 @@ def do_import_system_bots(realm: Any) -> None:
     create_users(realm, names, bot_type=UserProfile.DEFAULT_BOT)
     print("Finished importing system bots.")
 
-def create_users(realm: Realm, name_list: Iterable[Tuple[Text, Text]],
+def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]],
                  bot_type: Optional[int]=None) -> None:
     user_set = set()
     for full_name, email in name_list:

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 
-from typing import Dict, List, Optional, TypeVar, Any, Text
+from typing import Dict, List, Optional, TypeVar, Any
 from django.conf import settings
 from django.conf.urls import url
 from django.urls.resolvers import LocaleRegexProvider

--- a/zerver/lib/management.py
+++ b/zerver/lib/management.py
@@ -6,7 +6,7 @@ from argparse import ArgumentParser
 from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned
 from django.core.management.base import BaseCommand, CommandError
-from typing import Any, Dict, Optional, Text, List
+from typing import Any, Dict, Optional, List
 
 from zerver.models import Realm, UserProfile
 
@@ -107,7 +107,7 @@ You can use the command list_realms to find ID of the realms in this server."""
             user_profiles.append(self.get_user(email, realm))
         return user_profiles
 
-    def get_user(self, email: Text, realm: Optional[Realm]) -> UserProfile:
+    def get_user(self, email: str, realm: Optional[Realm]) -> UserProfile:
 
         # If a realm is specified, try to find the user there, and
         # throw an error if they don't exist.

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -1,5 +1,5 @@
 
-from typing import Optional, Set, Text
+from typing import Optional, Set
 
 import re
 
@@ -10,10 +10,10 @@ user_group_mentions = r'(?<![^\s\'\"\(,:<])@(\*[^\*]+\*)'
 
 wildcards = ['all', 'everyone', 'stream']
 
-def user_mention_matches_wildcard(mention: Text) -> bool:
+def user_mention_matches_wildcard(mention: str) -> bool:
     return mention in wildcards
 
-def extract_name(s: Text) -> Optional[Text]:
+def extract_name(s: str) -> Optional[str]:
     if s.startswith("**") and s.endswith("**"):
         name = s[2:-2]
         if name in wildcards:
@@ -23,15 +23,15 @@ def extract_name(s: Text) -> Optional[Text]:
     # We don't care about @all, @everyone or @stream
     return None
 
-def possible_mentions(content: Text) -> Set[Text]:
+def possible_mentions(content: str) -> Set[str]:
     matches = re.findall(find_mentions, content)
     names_with_none = (extract_name(match) for match in matches)
     names = {name for name in names_with_none if name}
     return names
 
-def extract_user_group(matched_text: Text) -> Text:
+def extract_user_group(matched_text: str) -> str:
     return matched_text[1:-1]
 
-def possible_user_group_mentions(content: Text) -> Set[Text]:
+def possible_user_group_mentions(content: str) -> Set[str]:
     matches = re.findall(user_group_mentions, content)
     return {extract_user_group(match) for match in matches}

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -43,10 +43,10 @@ from zerver.models import (
     Reaction
 )
 
-from typing import Any, Dict, List, Optional, Set, Tuple, Text, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from mypy_extensions import TypedDict
 
-RealmAlertWords = Dict[int, List[Text]]
+RealmAlertWords = Dict[int, List[str]]
 
 RawUnreadMessagesResult = TypedDict('RawUnreadMessagesResult', {
     'pm_dict': Dict[int, Any],
@@ -69,7 +69,7 @@ MAX_UNREAD_MESSAGES = 5000
 
 def messages_for_ids(message_ids: List[int],
                      user_message_flags: Dict[int, List[str]],
-                     search_fields: Dict[int, Dict[str, Text]],
+                     search_fields: Dict[int, Dict[str, str]],
                      apply_markdown: bool,
                      client_gravatar: bool,
                      allow_edit_history: bool) -> List[Dict[str, Any]]:
@@ -267,15 +267,15 @@ class MessageDict:
             message: Optional[Message],
             message_id: int,
             last_edit_time: Optional[datetime.datetime],
-            edit_history: Optional[Text],
-            content: Text,
-            subject: Text,
+            edit_history: Optional[str],
+            content: str,
+            subject: str,
             pub_date: datetime.datetime,
-            rendered_content: Optional[Text],
+            rendered_content: Optional[str],
             rendered_content_version: Optional[int],
             sender_id: int,
             sender_realm_id: int,
-            sending_client_name: Text,
+            sending_client_name: str,
             recipient_id: int,
             recipient_type: int,
             recipient_type_id: int,
@@ -406,7 +406,7 @@ class MessageDict:
         if recipient_type == Recipient.STREAM:
             display_type = "stream"
         elif recipient_type in (Recipient.HUDDLE, Recipient.PERSONAL):
-            assert not isinstance(display_recipient, Text)
+            assert not isinstance(display_recipient, str)
             display_type = "private"
             if len(display_recipient) == 1:
                 # add the sender in if this isn't a message between
@@ -507,12 +507,12 @@ def access_message(user_profile: UserProfile, message_id: int) -> Tuple[Message,
     return (message, user_message)
 
 def render_markdown(message: Message,
-                    content: Text,
+                    content: str,
                     realm: Optional[Realm]=None,
                     realm_alert_words: Optional[RealmAlertWords]=None,
                     user_ids: Optional[Set[int]]=None,
                     mention_data: Optional[bugdown.MentionData]=None,
-                    email_gateway: Optional[bool]=False) -> Text:
+                    email_gateway: Optional[bool]=False) -> str:
     """Return HTML for given markdown. Bugdown may add properties to the
     message object such as `mentions_user_ids`, `mentions_user_group_ids`, and
     `mentions_wildcard`.  These are only on this Django object and are not
@@ -533,7 +533,7 @@ def render_markdown(message: Message,
     if realm is None:
         realm = message.get_realm()
 
-    possible_words = set()  # type: Set[Text]
+    possible_words = set()  # type: Set[str]
     if realm_alert_words is not None:
         for user_id, words in realm_alert_words.items():
             if user_id in message_user_ids:
@@ -566,10 +566,10 @@ def render_markdown(message: Message,
 def huddle_users(recipient_id: int) -> str:
     display_recipient = get_display_recipient_by_id(recipient_id,
                                                     Recipient.HUDDLE,
-                                                    None)  # type: Union[Text, List[Dict[str, Any]]]
+                                                    None)  # type: Union[str, List[Dict[str, Any]]]
 
-    # Text is for streams.
-    assert not isinstance(display_recipient, Text)
+    # str is for streams.
+    assert not isinstance(display_recipient, str)
 
     user_ids = [obj['id'] for obj in display_recipient]  # type: List[int]
     user_ids = sorted(user_ids)
@@ -689,7 +689,7 @@ def get_raw_unread_data(user_profile: UserProfile) -> RawUnreadMessagesResult:
 
     topic_mute_checker = build_topic_mute_checker(user_profile)
 
-    def is_row_muted(stream_id: int, recipient_id: int, topic: Text) -> bool:
+    def is_row_muted(stream_id: int, recipient_id: int, topic: str) -> bool:
         if stream_id in muted_stream_ids:
             return True
 

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -1,5 +1,5 @@
 
-from typing import cast, Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Text
+from typing import cast, Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from confirmation.models import Confirmation, create_confirmation_link
 from django.conf import settings
@@ -42,34 +42,34 @@ def one_click_unsubscribe_link(user_profile: UserProfile, email_type: str) -> st
                                     Confirmation.UNSUBSCRIBE,
                                     url_args = {'email_type': email_type})
 
-def hash_util_encode(string: Text) -> Text:
+def hash_util_encode(string: str) -> str:
     # Do the same encoding operation as hash_util.encodeHashComponent on the
     # frontend.
     # `safe` has a default value of "/", but we want those encoded, too.
     return urllib.parse.quote(
         string.encode("utf-8"), safe=b"").replace(".", "%2E").replace("%", ".")
 
-def encode_stream(stream_id: int, stream_name: Text) -> Text:
+def encode_stream(stream_id: int, stream_name: str) -> str:
     # We encode streams for urls as something like 99-Verona.
     stream_name = stream_name.replace(' ', '-')
     return str(stream_id) + '-' + hash_util_encode(stream_name)
 
-def pm_narrow_url(realm: Realm, participants: List[Text]) -> Text:
+def pm_narrow_url(realm: Realm, participants: List[str]) -> str:
     participants.sort()
     base_url = "%s/#narrow/pm-with/" % (realm.uri,)
     return base_url + hash_util_encode(",".join(participants))
 
-def stream_narrow_url(realm: Realm, stream: Stream) -> Text:
+def stream_narrow_url(realm: Realm, stream: Stream) -> str:
     base_url = "%s/#narrow/stream/" % (realm.uri,)
     return base_url + encode_stream(stream.id, stream.name)
 
-def topic_narrow_url(realm: Realm, stream: Stream, topic: Text) -> Text:
+def topic_narrow_url(realm: Realm, stream: Stream, topic: str) -> str:
     base_url = "%s/#narrow/stream/" % (realm.uri,)
     return "%s%s/topic/%s" % (base_url,
                               encode_stream(stream.id, stream.name),
                               hash_util_encode(topic))
 
-def relative_to_full_url(base_url: Text, content: Text) -> Text:
+def relative_to_full_url(base_url: str, content: str) -> str:
     # Convert relative URLs to absolute URLs.
     fragment = lxml.html.fromstring(content)
 
@@ -114,7 +114,7 @@ def relative_to_full_url(base_url: Text, content: Text) -> Text:
 
     return content
 
-def fix_emojis(content: Text, base_url: Text, emojiset: Text) -> Text:
+def fix_emojis(content: str, base_url: str, emojiset: str) -> str:
     def make_emoji_img_elem(emoji_span_elem: Any) -> Dict[str, Any]:
         # Convert the emoji spans to img tags.
         classes = emoji_span_elem.get('class')
@@ -157,19 +157,19 @@ def build_message_list(user_profile: UserProfile, messages: List[Message]) -> Li
     """
     messages_to_render = []  # type: List[Dict[str, Any]]
 
-    def sender_string(message: Message) -> Text:
+    def sender_string(message: Message) -> str:
         if message.recipient.type in (Recipient.STREAM, Recipient.HUDDLE):
             return message.sender.full_name
         else:
             return ''
 
-    def fix_plaintext_image_urls(content: Text) -> Text:
+    def fix_plaintext_image_urls(content: str) -> str:
         # Replace image URLs in plaintext content of the form
         #     [image name](image url)
         # with a simple hyperlink.
         return re.sub(r"\[(\S*)\]\((\S*)\)", r"\2", content)
 
-    def build_message_payload(message: Message) -> Dict[str, Text]:
+    def build_message_payload(message: Message) -> Dict[str, str]:
         plain = message.content
         plain = fix_plaintext_image_urls(plain)
         # There's a small chance of colliding with non-Zulip URLs containing
@@ -200,7 +200,7 @@ def build_message_list(user_profile: UserProfile, messages: List[Message]) -> Li
             header_html = "<a style='color: #ffffff;' href='%s'>%s</a>" % (html_link, header)
         elif message.recipient.type == Recipient.HUDDLE:
             disp_recipient = get_display_recipient(message.recipient)
-            assert not isinstance(disp_recipient, Text)
+            assert not isinstance(disp_recipient, str)
             other_recipients = [r['full_name'] for r in disp_recipient
                                 if r['email'] != user_profile.email]
             header = "You and %s" % (", ".join(other_recipients),)
@@ -332,7 +332,7 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile: UserProfile,
     if (missed_messages[0].recipient.type == Recipient.HUDDLE):
         display_recipient = get_display_recipient(missed_messages[0].recipient)
         # Make sure that this is a list of strings, not a string.
-        assert not isinstance(display_recipient, Text)
+        assert not isinstance(display_recipient, str)
         other_recipients = [r['full_name'] for r in display_recipient
                             if r['id'] != user_profile.id]
         context.update({'group_pm': True})
@@ -375,7 +375,7 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile: UserProfile,
             'realm_str': user_profile.realm.name,
         })
 
-    from_name = "Zulip missed messages"  # type: Text
+    from_name = "Zulip missed messages"  # type: str
     from_address = FromAddress.NOREPLY
     if len(senders) == 1 and settings.SEND_MISSED_MESSAGE_EMAILS_AS_USER:
         # If this setting is enabled, you can reply to the Zulip
@@ -420,7 +420,7 @@ def handle_missedmessage_emails(user_profile_id: int,
     if not messages:
         return
 
-    messages_by_recipient_subject = defaultdict(list)  # type: Dict[Tuple[int, Text], List[Message]]
+    messages_by_recipient_subject = defaultdict(list)  # type: Dict[Tuple[int, str], List[Message]]
     for msg in messages:
         if msg.recipient.type == Recipient.PERSONAL:
             # For PM's group using (recipient, sender).
@@ -460,7 +460,7 @@ def clear_scheduled_emails(user_id: int, email_type: Optional[int]=None) -> None
         items = items.filter(type=email_type)
     items.delete()
 
-def log_digest_event(msg: Text) -> None:
+def log_digest_event(msg: str) -> None:
     import logging
     logging.basicConfig(filename=settings.DIGEST_LOG_PATH, level=logging.INFO)
     logging.info(msg)
@@ -512,7 +512,7 @@ def enqueue_welcome_emails(user: UserProfile) -> None:
         "zerver/emails/followup_day2", user.realm, to_user_id=user.id, from_name=from_name,
         from_address=from_address, context=context, delay=followup_day2_email_delay(user))
 
-def convert_html_to_markdown(html: Text) -> Text:
+def convert_html_to_markdown(html: str) -> str:
     # On Linux, the tool installs as html2markdown, and there's a command called
     # html2text that does something totally different. On OSX, the tool installs
     # as html2text.

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -7,7 +7,7 @@ from zerver.lib.actions import set_default_streams, bulk_add_subscriptions, \
     do_add_reaction_legacy, create_users
 from zerver.models import Realm, UserProfile, Message, Reaction, get_system_bot
 
-from typing import Any, Dict, List, Mapping, Text
+from typing import Any, Dict, List, Mapping
 
 def setup_realm_internal_bots(realm: Realm) -> None:
     """Create this realm's internal bots.
@@ -96,7 +96,7 @@ def send_initial_realm_messages(realm: Realm) -> None:
          'content': "This is a message in a second topic.\n\nTopics are similar to email subjects, "
          "in that each conversation should get its own topic. Keep them short, though; one "
          "or two words will do it!"},
-    ]  # type: List[Dict[str, Text]]
+    ]  # type: List[Dict[str, str]]
     messages = [internal_prep_stream_message(
         realm, welcome_bot,
         message['stream'], message['topic'], message['content']) for message in welcome_messages]

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -10,7 +10,7 @@ import re
 import time
 import random
 
-from typing import Any, Dict, List, Optional, SupportsInt, Text, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, SupportsInt, Tuple, Type, Union
 
 from apns2.client import APNsClient
 from apns2.payload import Payload as APNsPayload
@@ -44,10 +44,10 @@ else:  # nocoverage  -- Not convenient to add test for this.
 DeviceToken = Union[PushDeviceToken, RemotePushDeviceToken]
 
 # We store the token as b64, but apns-client wants hex strings
-def b64_to_hex(data: bytes) -> Text:
+def b64_to_hex(data: bytes) -> str:
     return binascii.hexlify(base64.b64decode(data)).decode('utf-8')
 
-def hex_to_b64(data: Text) -> bytes:
+def hex_to_b64(data: str) -> bytes:
     return base64.b64encode(binascii.unhexlify(data.encode('utf-8')))
 
 #
@@ -255,7 +255,7 @@ class PushNotificationBouncerException(Exception):
 
 def send_to_push_bouncer(method: str,
                          endpoint: str,
-                         post_data: Union[Text, Dict[str, Any]],
+                         post_data: Union[str, Dict[str, Any]],
                          extra_headers: Optional[Dict[str, Any]]=None) -> None:
     """While it does actually send the notice, this function has a lot of
     code and comments around error handling for the push notifications
@@ -413,7 +413,7 @@ def push_notifications_enabled() -> bool:
         return True
     return False
 
-def get_alert_from_message(message: Message) -> Text:
+def get_alert_from_message(message: Message) -> str:
     """
     Determine what alert string to display based on the missed messages.
     """
@@ -430,8 +430,8 @@ def get_alert_from_message(message: Message) -> Text:
     else:
         return "New Zulip mentions and private messages from %s" % (sender_str,)
 
-def get_mobile_push_content(rendered_content: Text) -> Text:
-    def get_text(elem: LH.HtmlElement) -> Text:
+def get_mobile_push_content(rendered_content: str) -> str:
+    def get_text(elem: LH.HtmlElement) -> str:
         # Convert default emojis to their unicode equivalent.
         classes = elem.get("class", "")
         if "emoji" in classes:
@@ -449,13 +449,13 @@ def get_mobile_push_content(rendered_content: Text) -> Text:
             return ''  # To avoid empty line before quote text
         return elem.text or ''
 
-    def format_as_quote(quote_text: Text) -> Text:
+    def format_as_quote(quote_text: str) -> str:
         quote_text_list = filter(None, quote_text.split('\n'))  # Remove empty lines
         quote_text = '\n'.join(map(lambda x: "> "+x, quote_text_list))
         quote_text += '\n'
         return quote_text
 
-    def process(elem: LH.HtmlElement) -> Text:
+    def process(elem: LH.HtmlElement) -> str:
         plain_text = get_text(elem)
         sub_text = ''
         for child in elem:
@@ -473,7 +473,7 @@ def get_mobile_push_content(rendered_content: Text) -> Text:
         plain_text = process(elem)
         return plain_text
 
-def truncate_content(content: Text) -> Tuple[Text, bool]:
+def truncate_content(content: str) -> Tuple[str, bool]:
     # We use unicode character 'HORIZONTAL ELLIPSIS' (U+2026) instead
     # of three dots as this saves two extra characters for textual
     # content. This function will need to be updated to handle unicode

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -1,7 +1,7 @@
 
 import os
 
-from typing import Any, Iterator, List, Optional, Tuple, Text
+from typing import Any, Iterator, List, Optional, Tuple
 
 from django.conf import settings
 from zerver.lib.redis_utils import get_redis_client
@@ -21,23 +21,23 @@ rules = settings.RATE_LIMITING_RULES  # type: List[Tuple[int, int]]
 KEY_PREFIX = ''
 
 class RateLimitedObject:
-    def get_keys(self) -> List[Text]:
+    def get_keys(self) -> List[str]:
         key_fragment = self.key_fragment()
         return ["{}ratelimit:{}:{}".format(KEY_PREFIX, key_fragment, keytype)
                 for keytype in ['list', 'zset', 'block']]
 
-    def key_fragment(self) -> Text:
+    def key_fragment(self) -> str:
         raise NotImplementedError()
 
     def rules(self) -> List[Tuple[int, int]]:
         raise NotImplementedError()
 
 class RateLimitedUser(RateLimitedObject):
-    def __init__(self, user: UserProfile, domain: Text='all') -> None:
+    def __init__(self, user: UserProfile, domain: str='all') -> None:
         self.user = user
         self.domain = domain
 
-    def key_fragment(self) -> Text:
+    def key_fragment(self) -> str:
         return "{}:{}:{}".format(type(self.user), self.user.id, self.domain)
 
     def rules(self) -> List[Tuple[int, int]]:
@@ -49,9 +49,9 @@ class RateLimitedUser(RateLimitedObject):
             return result
         return rules
 
-def bounce_redis_key_prefix_for_testing(test_name: Text) -> None:
+def bounce_redis_key_prefix_for_testing(test_name: str) -> None:
     global KEY_PREFIX
-    KEY_PREFIX = test_name + ':' + Text(os.getpid()) + ':'
+    KEY_PREFIX = test_name + ':' + str(os.getpid()) + ':'
 
 def max_api_calls(entity: RateLimitedObject) -> int:
     "Returns the API rate limit for the highest limit"

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -12,7 +12,7 @@ import logging
 import ujson
 
 import os
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Text
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 from zerver.lib.logging_util import log_to_file
 
@@ -26,8 +26,8 @@ class FromAddress:
     NOREPLY = parseaddr(settings.NOREPLY_EMAIL_ADDRESS)[1]
 
 def build_email(template_prefix: str, to_user_id: Optional[int]=None,
-                to_email: Optional[Text]=None, from_name: Optional[Text]=None,
-                from_address: Optional[Text]=None, reply_to_email: Optional[Text]=None,
+                to_email: Optional[str]=None, from_name: Optional[str]=None,
+                from_address: Optional[str]=None, reply_to_email: Optional[str]=None,
                 context: Optional[Dict[str, Any]]=None) -> EmailMultiAlternatives:
     # Callers should pass exactly one of to_user_id and to_email.
     assert (to_user_id is None) ^ (to_email is None)
@@ -83,9 +83,9 @@ class EmailNotDeliveredException(Exception):
 
 # When changing the arguments to this function, you may need to write a
 # migration to change or remove any emails in ScheduledEmail.
-def send_email(template_prefix: str, to_user_id: Optional[int]=None, to_email: Optional[Text]=None,
-               from_name: Optional[Text]=None, from_address: Optional[Text]=None,
-               reply_to_email: Optional[Text]=None, context: Dict[str, Any]={}) -> None:
+def send_email(template_prefix: str, to_user_id: Optional[int]=None, to_email: Optional[str]=None,
+               from_name: Optional[str]=None, from_address: Optional[str]=None,
+               reply_to_email: Optional[str]=None, context: Dict[str, Any]={}) -> None:
     mail = build_email(template_prefix, to_user_id=to_user_id, to_email=to_email, from_name=from_name,
                        from_address=from_address, reply_to_email=reply_to_email, context=context)
     template = template_prefix.split("/")[-1]
@@ -99,8 +99,8 @@ def send_email_from_dict(email_dict: Mapping[str, Any]) -> None:
     send_email(**dict(email_dict))
 
 def send_future_email(template_prefix: str, realm: Realm, to_user_id: Optional[int]=None,
-                      to_email: Optional[Text]=None, from_name: Optional[Text]=None,
-                      from_address: Optional[Text]=None, context: Dict[str, Any]={},
+                      to_email: Optional[str]=None, from_name: Optional[str]=None,
+                      from_address: Optional[str]=None, context: Dict[str, Any]={},
                       delay: datetime.timedelta=datetime.timedelta(0)) -> None:
     template_name = template_prefix.split('/')[-1]
     email_fields = {'template_prefix': template_prefix, 'to_user_id': to_user_id, 'to_email': to_email,

--- a/zerver/lib/stream_topic.py
+++ b/zerver/lib/stream_topic.py
@@ -1,4 +1,4 @@
-from typing import (Dict, List, Text, Set)
+from typing import (Dict, List, Set)
 from django.db.models.query import QuerySet
 
 from zerver.lib.stream_subscription import (
@@ -16,7 +16,7 @@ class StreamTopicTarget:
     places where we are are still using `subject` or
     `topic_name` as a key into tables.
     '''
-    def __init__(self, stream_id: int, topic_name: Text) -> None:
+    def __init__(self, stream_id: int, topic_name: str) -> None:
         self.stream_id = stream_id
         self.topic_name = topic_name
 

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -1,5 +1,5 @@
 
-from typing import Any, Iterable, List, Mapping, Set, Text, Tuple, Optional
+from typing import Any, Iterable, List, Mapping, Set, Tuple, Optional
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
@@ -32,7 +32,7 @@ def access_stream_for_delete_or_update(user_profile: UserProfile, stream_id: int
 # Only set allow_realm_admin flag to True when you want to allow realm admin to
 # access unsubscribed private stream content.
 def access_stream_common(user_profile: UserProfile, stream: Stream,
-                         error: Text,
+                         error: str,
                          require_active: bool=True,
                          allow_realm_admin: bool=False) -> Tuple[Recipient, Optional[Subscription]]:
     """Common function for backend code where the target use attempts to
@@ -93,7 +93,7 @@ def get_stream_by_id(stream_id: int) -> Stream:
         raise JsonableError(error)
     return stream
 
-def check_stream_name_available(realm: Realm, name: Text) -> None:
+def check_stream_name_available(realm: Realm, name: str) -> None:
     check_stream_name(name)
     try:
         get_stream(name, realm)
@@ -102,7 +102,7 @@ def check_stream_name_available(realm: Realm, name: Text) -> None:
         pass
 
 def access_stream_by_name(user_profile: UserProfile,
-                          stream_name: Text) -> Tuple[Stream, Recipient, Optional[Subscription]]:
+                          stream_name: str) -> Tuple[Stream, Recipient, Optional[Subscription]]:
     error = _("Invalid stream name '%s'" % (stream_name,))
     try:
         stream = get_realm_stream(stream_name, user_profile.realm_id)
@@ -112,7 +112,7 @@ def access_stream_by_name(user_profile: UserProfile,
     (recipient, sub) = access_stream_common(user_profile, stream, error)
     return (stream, recipient, sub)
 
-def access_stream_for_unmute_topic(user_profile: UserProfile, stream_name: Text, error: Text) -> Stream:
+def access_stream_for_unmute_topic(user_profile: UserProfile, stream_name: str, error: str) -> Stream:
     """
     It may seem a little silly to have this helper function for unmuting
     topics, but it gets around a linter warning, and it helps to be able
@@ -132,7 +132,7 @@ def access_stream_for_unmute_topic(user_profile: UserProfile, stream_name: Text,
         raise JsonableError(error)
     return stream
 
-def can_access_stream_history_by_name(user_profile: UserProfile, stream_name: Text) -> bool:
+def can_access_stream_history_by_name(user_profile: UserProfile, stream_name: str) -> bool:
     """Determine whether the provided user is allowed to access the
     history of the target stream.  The stream is specified by name.
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from typing import (cast, Any, Callable, Dict, Iterable, Iterator, List, Mapping, Optional,
-                    Sized, Tuple, Union, Text)
+                    Sized, Tuple, Union)
 
 from django.urls import resolve
 from django.conf import settings
@@ -56,7 +56,7 @@ import re
 import ujson
 import urllib
 
-API_KEYS = {}  # type: Dict[Text, Text]
+API_KEYS = {}  # type: Dict[str, str]
 
 def flush_caches_for_testing() -> None:
     global API_KEYS
@@ -107,7 +107,7 @@ class ZulipTestCase(TestCase):
             kwargs['HTTP_HOST'] = Realm.host_for_subdomain(self.DEFAULT_SUBDOMAIN)
 
     @instrument_url
-    def client_patch(self, url: Text, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_patch(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         """
         We need to urlencode, since Django's function won't do it for us.
         """
@@ -117,7 +117,7 @@ class ZulipTestCase(TestCase):
         return django_client.patch(url, encoded, **kwargs)
 
     @instrument_url
-    def client_patch_multipart(self, url: Text, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_patch_multipart(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         """
         Use this for patch requests that have file uploads or
         that need some sort of multi-part content.  In the future
@@ -136,41 +136,41 @@ class ZulipTestCase(TestCase):
             **kwargs)
 
     @instrument_url
-    def client_put(self, url: Text, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_put(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_host(kwargs)
         return django_client.put(url, encoded, **kwargs)
 
     @instrument_url
-    def client_delete(self, url: Text, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_delete(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_host(kwargs)
         return django_client.delete(url, encoded, **kwargs)
 
     @instrument_url
-    def client_options(self, url: Text, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_options(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_host(kwargs)
         return django_client.options(url, encoded, **kwargs)
 
     @instrument_url
-    def client_head(self, url: Text, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_head(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_host(kwargs)
         return django_client.head(url, encoded, **kwargs)
 
     @instrument_url
-    def client_post(self, url: Text, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_post(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_host(kwargs)
         return django_client.post(url, info, **kwargs)
 
     @instrument_url
-    def client_post_request(self, url: Text, req: Any) -> HttpResponse:
+    def client_post_request(self, url: str, req: Any) -> HttpResponse:
         """
         We simulate hitting an endpoint here, although we
         actually resolve the URL manually and hit the view
@@ -184,7 +184,7 @@ class ZulipTestCase(TestCase):
         return match.func(req)
 
     @instrument_url
-    def client_get(self, url: Text, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_get(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_host(kwargs)
         return django_client.get(url, info, **kwargs)
@@ -234,20 +234,20 @@ class ZulipTestCase(TestCase):
         email = self.mit_user_map[name]
         return get_user(email, get_realm('zephyr'))
 
-    def nonreg_email(self, name: str) -> Text:
+    def nonreg_email(self, name: str) -> str:
         return self.nonreg_user_map[name]
 
-    def example_email(self, name: str) -> Text:
+    def example_email(self, name: str) -> str:
         return self.example_user_map[name]
 
-    def mit_email(self, name: str) -> Text:
+    def mit_email(self, name: str) -> str:
         return self.mit_user_map[name]
 
     def notification_bot(self) -> UserProfile:
         return get_user('notification-bot@zulip.com', get_realm('zulip'))
 
-    def create_test_bot(self, short_name: Text, user_profile: UserProfile,
-                        assert_json_error_msg: Text=None, **extras: Any) -> Optional[UserProfile]:
+    def create_test_bot(self, short_name: str, user_profile: UserProfile,
+                        assert_json_error_msg: str=None, **extras: Any) -> Optional[UserProfile]:
         self.login(user_profile.email)
         bot_info = {
             'short_name': short_name,
@@ -264,7 +264,7 @@ class ZulipTestCase(TestCase):
             bot_profile = get_user(bot_email, user_profile.realm)
             return bot_profile
 
-    def login_with_return(self, email: Text, password: Optional[Text]=None,
+    def login_with_return(self, email: str, password: Optional[str]=None,
                           **kwargs: Any) -> HttpResponse:
         if password is None:
             password = initial_password(email)
@@ -272,7 +272,7 @@ class ZulipTestCase(TestCase):
                                 {'username': email, 'password': password},
                                 **kwargs)
 
-    def login(self, email: Text, password: Optional[Text]=None, fails: bool=False,
+    def login(self, email: str, password: Optional[str]=None, fails: bool=False,
               realm: Optional[Realm]=None) -> HttpResponse:
         if realm is None:
             realm = get_realm("zulip")
@@ -288,18 +288,18 @@ class ZulipTestCase(TestCase):
     def logout(self) -> None:
         self.client.logout()
 
-    def register(self, email: Text, password: Text, **kwargs: Any) -> HttpResponse:
+    def register(self, email: str, password: str, **kwargs: Any) -> HttpResponse:
         self.client_post('/accounts/home/', {'email': email},
                          **kwargs)
         return self.submit_reg_form_for_user(email, password, **kwargs)
 
     def submit_reg_form_for_user(
-            self, email: Text, password: Text,
-            realm_name: Optional[Text]="Zulip Test",
-            realm_subdomain: Optional[Text]="zuliptest",
-            from_confirmation: Optional[Text]='', full_name: Optional[Text]=None,
-            timezone: Optional[Text]='', realm_in_root_domain: Optional[Text]=None,
-            default_stream_groups: Optional[List[Text]]=[], **kwargs: Any) -> HttpResponse:
+            self, email: str, password: str,
+            realm_name: Optional[str]="Zulip Test",
+            realm_subdomain: Optional[str]="zuliptest",
+            from_confirmation: Optional[str]='', full_name: Optional[str]=None,
+            timezone: Optional[str]='', realm_in_root_domain: Optional[str]=None,
+            default_stream_groups: Optional[List[str]]=[], **kwargs: Any) -> HttpResponse:
         """
         Stage two of the two-step registration process.
 
@@ -325,8 +325,8 @@ class ZulipTestCase(TestCase):
             payload['realm_in_root_domain'] = realm_in_root_domain
         return self.client_post('/accounts/register/', payload, **kwargs)
 
-    def get_confirmation_url_from_outbox(self, email_address: Text, *,
-                                         url_pattern: Text=None) -> Text:
+    def get_confirmation_url_from_outbox(self, email_address: str, *,
+                                         url_pattern: str=None) -> str:
         from django.core.mail import outbox
         if url_pattern is None:
             # This is a bit of a crude heuristic, but good enough for most tests.
@@ -337,7 +337,7 @@ class ZulipTestCase(TestCase):
         else:
             raise AssertionError("Couldn't find a confirmation email.")
 
-    def encode_credentials(self, identifier: Text, realm: Text="zulip") -> Text:
+    def encode_credentials(self, identifier: str, realm: str="zulip") -> str:
         """
         identifier: Can be an email or a remote server uuid.
         """
@@ -353,27 +353,27 @@ class ZulipTestCase(TestCase):
         credentials = "%s:%s" % (identifier, api_key)
         return 'Basic ' + base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
 
-    def api_get(self, email: Text, *args: Any, **kwargs: Any) -> HttpResponse:
+    def api_get(self, email: str, *args: Any, **kwargs: Any) -> HttpResponse:
         kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(email)
         return self.client_get(*args, **kwargs)
 
-    def api_post(self, identifier: Text, *args: Any, **kwargs: Any) -> HttpResponse:
+    def api_post(self, identifier: str, *args: Any, **kwargs: Any) -> HttpResponse:
         kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(identifier, kwargs.get('realm', 'zulip'))
         return self.client_post(*args, **kwargs)
 
-    def api_patch(self, email: Text, *args: Any, **kwargs: Any) -> HttpResponse:
+    def api_patch(self, email: str, *args: Any, **kwargs: Any) -> HttpResponse:
         kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(email)
         return self.client_patch(*args, **kwargs)
 
-    def api_put(self, email: Text, *args: Any, **kwargs: Any) -> HttpResponse:
+    def api_put(self, email: str, *args: Any, **kwargs: Any) -> HttpResponse:
         kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(email)
         return self.client_put(*args, **kwargs)
 
-    def api_delete(self, email: Text, *args: Any, **kwargs: Any) -> HttpResponse:
+    def api_delete(self, email: str, *args: Any, **kwargs: Any) -> HttpResponse:
         kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(email)
         return self.client_delete(*args, **kwargs)
 
-    def get_streams(self, email: Text, realm: Realm) -> List[Text]:
+    def get_streams(self, email: str, realm: Realm) -> List[str]:
         """
         Helper function to get the stream names for a user
         """
@@ -381,10 +381,10 @@ class ZulipTestCase(TestCase):
         subs = get_stream_subscriptions_for_user(user_profile).filter(
             active=True,
         )
-        return [cast(Text, get_display_recipient(sub.recipient)) for sub in subs]
+        return [cast(str, get_display_recipient(sub.recipient)) for sub in subs]
 
-    def send_personal_message(self, from_email: Text, to_email: Text, content: Text="test content",
-                              sender_realm: Text="zulip") -> int:
+    def send_personal_message(self, from_email: str, to_email: str, content: str="test content",
+                              sender_realm: str="zulip") -> int:
         sender = get_user(from_email, get_realm(sender_realm))
 
         recipient_list = [to_email]
@@ -395,8 +395,8 @@ class ZulipTestCase(TestCase):
             content
         )
 
-    def send_huddle_message(self, from_email: Text, to_emails: List[Text], content: Text="test content",
-                            sender_realm: Text="zulip") -> int:
+    def send_huddle_message(self, from_email: str, to_emails: List[str], content: str="test content",
+                            sender_realm: str="zulip") -> int:
         sender = get_user(from_email, get_realm(sender_realm))
 
         assert(len(to_emails) >= 2)
@@ -408,8 +408,8 @@ class ZulipTestCase(TestCase):
             content
         )
 
-    def send_stream_message(self, sender_email: Text, stream_name: Text, content: Text="test content",
-                            topic_name: Text="test", sender_realm: Text="zulip") -> int:
+    def send_stream_message(self, sender_email: str, stream_name: str, content: str="test content",
+                            topic_name: str="test", sender_realm: str="zulip") -> int:
         sender = get_user(sender_email, get_realm(sender_realm))
 
         (sending_client, _) = Client.objects.get_or_create(name="test suite")
@@ -436,7 +436,7 @@ class ZulipTestCase(TestCase):
         data = self.get_messages_response(anchor, num_before, num_after, use_first_unread_anchor)
         return data['messages']
 
-    def users_subscribed_to_stream(self, stream_name: Text, realm: Realm) -> List[UserProfile]:
+    def users_subscribed_to_stream(self, stream_name: str, realm: Realm) -> List[UserProfile]:
         stream = Stream.objects.get(name=stream_name, realm=realm)
         recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
         subscriptions = Subscription.objects.filter(recipient=recipient, active=True)
@@ -474,7 +474,7 @@ class ZulipTestCase(TestCase):
         self.assertEqual(json.get("result"), "error")
         return json['msg']
 
-    def assert_json_error(self, result: HttpResponse, msg: Text, status_code: int=400) -> None:
+    def assert_json_error(self, result: HttpResponse, msg: str, status_code: int=400) -> None:
         """
         Invalid POSTs return an error status code and JSON of the form
         {"result": "error", "msg": "reason"}.
@@ -490,42 +490,42 @@ class ZulipTestCase(TestCase):
             print("\nexpected length: %s\nactual length: %s" % (count, actual_count))
             raise AssertionError('List is unexpected size!')
 
-    def assert_json_error_contains(self, result: HttpResponse, msg_substring: Text,
+    def assert_json_error_contains(self, result: HttpResponse, msg_substring: str,
                                    status_code: int=400) -> None:
         self.assertIn(msg_substring, self.get_json_error(result, status_code=status_code))
 
-    def assert_in_response(self, substring: Text, response: HttpResponse) -> None:
+    def assert_in_response(self, substring: str, response: HttpResponse) -> None:
         self.assertIn(substring, response.content.decode('utf-8'))
 
-    def assert_in_success_response(self, substrings: List[Text],
+    def assert_in_success_response(self, substrings: List[str],
                                    response: HttpResponse) -> None:
         self.assertEqual(response.status_code, 200)
         decoded = response.content.decode('utf-8')
         for substring in substrings:
             self.assertIn(substring, decoded)
 
-    def assert_not_in_success_response(self, substrings: List[Text],
+    def assert_not_in_success_response(self, substrings: List[str],
                                        response: HttpResponse) -> None:
         self.assertEqual(response.status_code, 200)
         decoded = response.content.decode('utf-8')
         for substring in substrings:
             self.assertNotIn(substring, decoded)
 
-    def webhook_fixture_data(self, type: Text, action: Text, file_type: Text='json') -> Text:
+    def webhook_fixture_data(self, type: str, action: str, file_type: str='json') -> str:
         fn = os.path.join(
             os.path.dirname(__file__),
             "../webhooks/%s/fixtures/%s.%s" % (type, action, file_type)
         )
         return open(fn).read()
 
-    def fixture_data(self, file_name: Text, type: Text='') -> Text:
+    def fixture_data(self, file_name: str, type: str='') -> str:
         fn = os.path.join(
             os.path.dirname(__file__),
             "../tests/fixtures/%s/%s" % (type, file_name)
         )
         return open(fn).read()
 
-    def make_stream(self, stream_name: Text, realm: Optional[Realm]=None,
+    def make_stream(self, stream_name: str, realm: Optional[Realm]=None,
                     invite_only: Optional[bool]=False,
                     history_public_to_subscribers: Optional[bool]=None) -> Stream:
         if realm is None:
@@ -552,7 +552,7 @@ class ZulipTestCase(TestCase):
         return stream
 
     # Subscribe to a stream directly
-    def subscribe(self, user_profile: UserProfile, stream_name: Text) -> Stream:
+    def subscribe(self, user_profile: UserProfile, stream_name: str) -> Stream:
         try:
             stream = get_stream(stream_name, user_profile.realm)
             from_stream_creation = False
@@ -561,12 +561,12 @@ class ZulipTestCase(TestCase):
         bulk_add_subscriptions([stream], [user_profile], from_stream_creation=from_stream_creation)
         return stream
 
-    def unsubscribe(self, user_profile: UserProfile, stream_name: Text) -> None:
+    def unsubscribe(self, user_profile: UserProfile, stream_name: str) -> None:
         stream = get_stream(stream_name, user_profile.realm)
         bulk_remove_subscriptions([user_profile], [stream])
 
     # Subscribe to a stream by making an API request
-    def common_subscribe_to_streams(self, email: Text, streams: Iterable[Text],
+    def common_subscribe_to_streams(self, email: str, streams: Iterable[str],
                                     extra_post_data: Dict[str, Any]={}, invite_only: bool=False,
                                     **kwargs: Any) -> HttpResponse:
         post_data = {'subscriptions': ujson.dumps([{"name": stream} for stream in streams]),
@@ -576,7 +576,7 @@ class ZulipTestCase(TestCase):
         result = self.api_post(email, "/api/v1/users/me/subscriptions", post_data, **kwargs)
         return result
 
-    def check_user_subscribed_only_to_streams(self, user_name: Text,
+    def check_user_subscribed_only_to_streams(self, user_name: str,
                                               streams: List[Stream]) -> None:
         streams = sorted(streams, key=lambda x: x.name)
         subscribed_streams = gather_subscriptions(self.nonreg_user(user_name))[0]
@@ -586,9 +586,9 @@ class ZulipTestCase(TestCase):
         for x, y in zip(subscribed_streams, streams):
             self.assertEqual(x["name"], y.name)
 
-    def send_json_payload(self, user_profile: UserProfile, url: Text,
-                          payload: Union[Text, Dict[str, Any]],
-                          stream_name: Optional[Text]=None, **post_params: Any) -> Message:
+    def send_json_payload(self, user_profile: UserProfile, url: str,
+                          payload: Union[str, Dict[str, Any]],
+                          stream_name: Optional[str]=None, **post_params: Any) -> Message:
         if stream_name is not None:
             self.subscribe(user_profile, stream_name)
 
@@ -630,10 +630,10 @@ class WebhookTestCase(ZulipTestCase):
     If you create your url in uncommon way you can override build_webhook_url method
     In case that you need modify body or create it without using fixture you can also override get_body method
     """
-    STREAM_NAME = None  # type: Optional[Text]
+    STREAM_NAME = None  # type: Optional[str]
     TEST_USER_EMAIL = 'webhook-bot@zulip.com'
-    URL_TEMPLATE = None  # type: Optional[Text]
-    FIXTURE_DIR_NAME = None  # type: Optional[Text]
+    URL_TEMPLATE = None  # type: Optional[str]
+    FIXTURE_DIR_NAME = None  # type: Optional[str]
 
     @property
     def test_user(self) -> UserProfile:
@@ -642,13 +642,13 @@ class WebhookTestCase(ZulipTestCase):
     def setUp(self) -> None:
         self.url = self.build_webhook_url()
 
-    def api_stream_message(self, email: Text, *args: Any, **kwargs: Any) -> HttpResponse:
+    def api_stream_message(self, email: str, *args: Any, **kwargs: Any) -> HttpResponse:
         kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(email)
         return self.send_and_test_stream_message(*args, **kwargs)
 
-    def send_and_test_stream_message(self, fixture_name: Text, expected_subject: Optional[Text]=None,
-                                     expected_message: Optional[Text]=None,
-                                     content_type: Optional[Text]="application/json", **kwargs: Any) -> Message:
+    def send_and_test_stream_message(self, fixture_name: str, expected_subject: Optional[str]=None,
+                                     expected_message: Optional[str]=None,
+                                     content_type: Optional[str]="application/json", **kwargs: Any) -> Message:
         payload = self.get_body(fixture_name)
         if content_type is not None:
             kwargs['content_type'] = content_type
@@ -659,8 +659,8 @@ class WebhookTestCase(ZulipTestCase):
 
         return msg
 
-    def send_and_test_private_message(self, fixture_name: Text, expected_subject: Text=None,
-                                      expected_message: Text=None, content_type: str="application/json",
+    def send_and_test_private_message(self, fixture_name: str, expected_subject: str=None,
+                                      expected_message: str=None, content_type: str="application/json",
                                       **kwargs: Any)-> Message:
         payload = self.get_body(fixture_name)
         if content_type is not None:
@@ -673,7 +673,7 @@ class WebhookTestCase(ZulipTestCase):
 
         return msg
 
-    def build_webhook_url(self, *args: Any, **kwargs: Any) -> Text:
+    def build_webhook_url(self, *args: Any, **kwargs: Any) -> str:
         url = self.URL_TEMPLATE
         if url.find("api_key") >= 0:
             api_key = self.test_user.api_key
@@ -696,15 +696,15 @@ class WebhookTestCase(ZulipTestCase):
 
         return url[:-1] if has_arguments else url
 
-    def get_body(self, fixture_name: Text) -> Union[Text, Dict[str, Text]]:
+    def get_body(self, fixture_name: str) -> Union[str, Dict[str, str]]:
         """Can be implemented either as returning a dictionary containing the
         post parameters or as string containing the body of the request."""
         return ujson.dumps(ujson.loads(self.webhook_fixture_data(self.FIXTURE_DIR_NAME, fixture_name)))
 
-    def do_test_subject(self, msg: Message, expected_subject: Optional[Text]) -> None:
+    def do_test_subject(self, msg: Message, expected_subject: Optional[str]) -> None:
         if expected_subject is not None:
             self.assertEqual(msg.topic_name(), expected_subject)
 
-    def do_test_message(self, msg: Message, expected_message: Optional[Text]) -> None:
+    def do_test_message(self, msg: Message, expected_message: Optional[str]) -> None:
         if expected_message is not None:
             self.assertEqual(msg.content, expected_message)

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from typing import (
     cast, Any, Callable, Dict, Generator, Iterable, Iterator, List, Mapping,
-    Optional, Set, Sized, Tuple, Union, IO, Text, TypeVar
+    Optional, Set, Sized, Tuple, Union, IO, TypeVar
 )
 
 from django.core import signing
@@ -108,14 +108,14 @@ def tornado_redirected_to_list(lst: List[Mapping[str, Any]]) -> Iterator[None]:
 
 @contextmanager
 def simulated_empty_cache() -> Generator[
-        List[Tuple[str, Union[Text, List[Text]], Text]], None, None]:
-    cache_queries = []  # type: List[Tuple[str, Union[Text, List[Text]], Text]]
+        List[Tuple[str, Union[str, List[str]], str]], None, None]:
+    cache_queries = []  # type: List[Tuple[str, Union[str, List[str]], str]]
 
-    def my_cache_get(key: Text, cache_name: Optional[str]=None) -> Optional[Dict[Text, Any]]:
+    def my_cache_get(key: str, cache_name: Optional[str]=None) -> Optional[Dict[str, Any]]:
         cache_queries.append(('get', key, cache_name))
         return None
 
-    def my_cache_get_many(keys: List[Text], cache_name: Optional[str]=None) -> Dict[Text, Any]:  # nocoverage -- simulated code doesn't use this
+    def my_cache_get_many(keys: List[str], cache_name: Optional[str]=None) -> Dict[str, Any]:  # nocoverage -- simulated code doesn't use this
         cache_queries.append(('getmany', keys, cache_name))
         return {}
 
@@ -186,7 +186,7 @@ def get_test_image_file(filename: str) -> IO[Any]:
     test_avatar_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../tests/images'))
     return open(os.path.join(test_avatar_dir, filename), 'rb')
 
-def avatar_disk_path(user_profile: UserProfile, medium: bool=False) -> Text:
+def avatar_disk_path(user_profile: UserProfile, medium: bool=False) -> str:
     avatar_url_path = avatar_url(user_profile, medium)
     avatar_disk_path = os.path.join(settings.LOCAL_UPLOADS_DIR, "avatars",
                                     avatar_url_path.split("/")[-2],
@@ -197,7 +197,7 @@ def make_client(name: str) -> Client:
     client, _ = Client.objects.get_or_create(name=name)
     return client
 
-def find_key_by_email(address: Text) -> Optional[Text]:
+def find_key_by_email(address: str) -> Optional[str]:
     from django.core.mail import outbox
     key_regex = re.compile("accounts/do_confirm/([a-z0-9]{24})>")
     for message in reversed(outbox):
@@ -222,7 +222,7 @@ def most_recent_message(user_profile: UserProfile) -> Message:
     usermessage = most_recent_usermessage(user_profile)
     return usermessage.message
 
-def get_subscription(stream_name: Text, user_profile: UserProfile) -> Subscription:
+def get_subscription(stream_name: str, user_profile: UserProfile) -> Subscription:
     stream = get_stream(stream_name, user_profile.realm)
     recipient = get_stream_recipient(stream.id)
     return Subscription.objects.get(user_profile=user_profile,
@@ -255,7 +255,7 @@ class HostRequestMock:
     """A mock request object where get_host() works.  Useful for testing
     routes that use Zulip's subdomains feature"""
 
-    def __init__(self, user_profile: UserProfile=None, host: Text=settings.EXTERNAL_HOST) -> None:
+    def __init__(self, user_profile: UserProfile=None, host: str=settings.EXTERNAL_HOST) -> None:
         self.host = host
         self.GET = {}  # type: Dict[str, Any]
         self.POST = {}  # type: Dict[str, Any]
@@ -267,11 +267,11 @@ class HostRequestMock:
         self.content_type = ''
         self._email = ''
 
-    def get_host(self) -> Text:
+    def get_host(self) -> str:
         return self.host
 
 class MockPythonResponse:
-    def __init__(self, text: Text, status_code: int) -> None:
+    def __init__(self, text: str, status_code: int) -> None:
         self.text = text
         self.status_code = status_code
 
@@ -291,7 +291,7 @@ def instrument_url(f: UrlFuncT) -> UrlFuncT:
     if not INSTRUMENTING:  # nocoverage -- option is always enabled; should we remove?
         return f
     else:
-        def wrapper(self: 'ZulipTestCase', url: Text, info: Dict[str, Any]={},
+        def wrapper(self: 'ZulipTestCase', url: str, info: Dict[str, Any]={},
                     **kwargs: Any) -> HttpResponse:
             start = time.time()
             result = f(self, url, info, **kwargs)
@@ -420,7 +420,7 @@ def get_all_templates() -> List[str]:
     isfile = os.path.isfile
     path_exists = os.path.exists
 
-    def is_valid_template(p: Text, n: Text) -> bool:
+    def is_valid_template(p: str, n: str) -> bool:
         return 'webhooks' not in p \
                and not n.startswith('.') \
                and not n.startswith('__init__') \

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -3,7 +3,7 @@ from functools import partial
 import random
 
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, \
-    Text, Type, cast, Union, TypeVar
+    Type, cast, Union, TypeVar
 from unittest import loader, runner  # type: ignore  # Mypy cannot pick these up.
 from unittest.result import TestResult
 
@@ -140,7 +140,7 @@ class TextTestResult(runner.TextTestResult):
         super().__init__(*args, **kwargs)
         self.failed_tests = []  # type: List[str]
 
-    def addInfo(self, test: TestCase, msg: Text) -> None:
+    def addInfo(self, test: TestCase, msg: str) -> None:
         self.stream.write(msg)
         self.stream.flush()
 
@@ -165,7 +165,7 @@ class TextTestResult(runner.TextTestResult):
         test_name = full_test_name(args[0])
         self.failed_tests.append(test_name)
 
-    def addSkip(self, test: TestCase, reason: Text) -> None:
+    def addSkip(self, test: TestCase, reason: str) -> None:
         TestResult.addSkip(self, test, reason)
         self.stream.writeln("** Skipping {}: {}".format(full_test_name(test),
                                                         reason))
@@ -176,7 +176,7 @@ class RemoteTestResult(django_runner.RemoteTestResult):
     The class follows the unpythonic style of function names of the
     base class.
     """
-    def addInfo(self, test: TestCase, msg: Text) -> None:
+    def addInfo(self, test: TestCase, msg: str) -> None:
         self.events.append(('addInfo', self.test_index, msg))
 
     def addInstrumentation(self, test: TestCase, data: Dict[str, Any]) -> None:
@@ -353,7 +353,7 @@ class ParallelTestSuite(django_runner.ParallelTestSuite):
         # definitions.
         self.subsuites = SubSuiteList(self.subsuites)  # type: ignore # Type of self.subsuites changes.
 
-def check_import_error(test_name: Text) -> None:
+def check_import_error(test_name: str) -> None:
     try:
         # Directly using __import__ is not recommeded, but here it gives
         # clearer traceback as compared to importlib.import_module.

--- a/zerver/lib/topic_mutes.py
+++ b/zerver/lib/topic_mutes.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Text
+from typing import Any, Callable, Dict, List, Optional
 
 from zerver.models import (
     get_stream_recipient,
@@ -15,7 +15,7 @@ from sqlalchemy.sql import (
     Selectable
 )
 
-def get_topic_mutes(user_profile: UserProfile) -> List[List[Text]]:
+def get_topic_mutes(user_profile: UserProfile) -> List[List[str]]:
     rows = MutedTopic.objects.filter(
         user_profile=user_profile,
     ).values(
@@ -27,7 +27,7 @@ def get_topic_mutes(user_profile: UserProfile) -> List[List[Text]]:
         for row in rows
     ]
 
-def set_topic_mutes(user_profile: UserProfile, muted_topics: List[List[Text]]) -> None:
+def set_topic_mutes(user_profile: UserProfile, muted_topics: List[List[str]]) -> None:
 
     '''
     This is only used in tests.
@@ -64,7 +64,7 @@ def remove_topic_mute(user_profile: UserProfile, stream_id: int, topic_name: str
     )
     row.delete()
 
-def topic_is_muted(user_profile: UserProfile, stream_id: int, topic_name: Text) -> bool:
+def topic_is_muted(user_profile: UserProfile, stream_id: int, topic_name: str) -> bool:
     is_muted = MutedTopic.objects.filter(
         user_profile=user_profile,
         stream_id=stream_id,
@@ -103,7 +103,7 @@ def exclude_topic_mutes(conditions: List[Selectable],
     condition = not_(or_(*list(map(mute_cond, rows))))
     return conditions + [condition]
 
-def build_topic_mute_checker(user_profile: UserProfile) -> Callable[[int, Text], bool]:
+def build_topic_mute_checker(user_profile: UserProfile) -> Callable[[int, str], bool]:
     rows = MutedTopic.objects.filter(
         user_profile=user_profile,
     ).values(
@@ -118,7 +118,7 @@ def build_topic_mute_checker(user_profile: UserProfile) -> Callable[[int, Text],
         topic_name = row['topic_name']
         tups.add((recipient_id, topic_name.lower()))
 
-    def is_muted(recipient_id: int, topic: Text) -> bool:
+    def is_muted(recipient_id: int, topic: str) -> bool:
         return (recipient_id, topic.lower()) in tups
 
     return is_muted

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Text
+from typing import Dict, List, Optional
 
 from django.db.models.query import QuerySet
 from django.utils.translation import ugettext as _
@@ -11,7 +11,7 @@ from zerver.models import UserProfile, Service, Realm, \
 
 from zulip_bots.custom_exceptions import ConfigValidationError
 
-def check_full_name(full_name_raw: Text) -> Text:
+def check_full_name(full_name_raw: str) -> str:
     full_name = full_name_raw.strip()
     if len(full_name) > UserProfile.MAX_NAME_LENGTH:
         raise JsonableError(_("Name too long!"))
@@ -21,7 +21,7 @@ def check_full_name(full_name_raw: Text) -> Text:
         raise JsonableError(_("Invalid characters in name!"))
     return full_name
 
-def check_short_name(short_name_raw: Text) -> Text:
+def check_short_name(short_name_raw: str) -> str:
     short_name = short_name_raw.strip()
     if len(short_name) == 0:
         raise JsonableError(_("Bad name or username"))

--- a/zerver/lib/utils.py
+++ b/zerver/lib/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Any, Callable, List, Optional, Sequence, TypeVar, Iterable, Set, Tuple, Text
+from typing import Any, Callable, List, Optional, Sequence, TypeVar, Iterable, Set, Tuple
 import base64
 import errno
 import hashlib
@@ -85,8 +85,8 @@ def run_in_batches(all_list: Sequence[T],
         if i != limit - 1:
             sleep(sleep_time)
 
-def make_safe_digest(string: Text,
-                     hash_func: Callable[[bytes], Any]=hashlib.sha1) -> Text:
+def make_safe_digest(string: str,
+                     hash_func: Callable[[bytes], Any]=hashlib.sha1) -> str:
     """
     return a hex digest of `string`.
     """
@@ -178,7 +178,7 @@ def split_by(array: List[Any], group_size: int, filler: Any) -> List[List[Any]]:
     args = [iter(array)] * group_size
     return list(map(list, zip_longest(*args, fillvalue=filler)))
 
-def is_remote_server(identifier: Text) -> bool:
+def is_remote_server(identifier: str) -> bool:
     """
     This function can be used to identify the source of API auth
     request. We can have two types of sources, Remote Zulip Servers

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -29,7 +29,7 @@ import ujson
 from django.utils.translation import ugettext as _
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email, URLValidator
-from typing import Callable, Iterable, Optional, Tuple, TypeVar, Text, cast, \
+from typing import Callable, Iterable, Optional, Tuple, TypeVar, cast, \
     Dict
 
 from datetime import datetime
@@ -189,7 +189,7 @@ def equals(expected_val: object) -> Validator:
         return None
     return f
 
-def validate_login_email(email: Text) -> None:
+def validate_login_email(email: str) -> None:
     try:
         validate_email(email)
     except ValidationError as err:

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.http import HttpRequest
 from django.utils.translation import ugettext as _
-from typing import Optional, Text
+from typing import Optional
 
 from zerver.lib.actions import check_send_stream_message, \
     check_send_private_message, send_rate_limited_pm_notification_to_bot_owner
@@ -28,7 +28,7 @@ class MissingHTTPEventHeader(JsonableError):
     code = ErrorCode.MISSING_HTTP_EVENT_HEADER
     data_fields = ['header']
 
-    def __init__(self, header: Text) -> None:
+    def __init__(self, header: str) -> None:
         self.header = header
 
     @staticmethod
@@ -38,8 +38,8 @@ class MissingHTTPEventHeader(JsonableError):
 @has_request_variables
 def check_send_webhook_message(
         request: HttpRequest, user_profile: UserProfile,
-        topic: Text, body: Text, stream: Optional[Text]=REQ(default=None),
-        user_specified_topic: Optional[Text]=REQ("topic", default=None)
+        topic: str, body: str, stream: Optional[str]=REQ(default=None),
+        user_specified_topic: Optional[str]=REQ("topic", default=None)
 ) -> None:
 
     if stream is None:
@@ -60,8 +60,8 @@ def check_send_webhook_message(
             # webhook-errors.log
             pass
 
-def validate_extract_webhook_http_header(request: HttpRequest, header: Text,
-                                         integration_name: Text) -> Text:
+def validate_extract_webhook_http_header(request: HttpRequest, header: str,
+                                         integration_name: str) -> str:
     extracted_header = request.META.get(DJANGO_HTTP_PREFIX + header)
     if extracted_header is None:
         message_body = MISSING_EVENT_HEADER_MESSAGE.format(

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -4,7 +4,7 @@ import logging
 import time
 import traceback
 from typing import Any, AnyStr, Callable, Dict, \
-    Iterable, List, MutableMapping, Optional, Text
+    Iterable, List, MutableMapping, Optional
 
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -78,7 +78,7 @@ def format_timedelta(timedelta: float) -> str:
         return "%.1fs" % (timedelta)
     return "%.0fms" % (timedelta_ms(timedelta),)
 
-def is_slow_query(time_delta: float, path: Text) -> bool:
+def is_slow_query(time_delta: float, path: str) -> bool:
     if time_delta < 1.2:
         return False
     is_exempt = \
@@ -92,8 +92,8 @@ def is_slow_query(time_delta: float, path: Text) -> bool:
         return time_delta >= 10
     return True
 
-def write_log_line(log_data: MutableMapping[str, Any], path: Text, method: str, remote_ip: str, email: Text,
-                   client_name: Text, status_code: int=200, error_content: Optional[AnyStr]=None,
+def write_log_line(log_data: MutableMapping[str, Any], path: str, method: str, remote_ip: str, email: str,
+                   client_name: str, status_code: int=200, error_content: Optional[AnyStr]=None,
                    error_content_iter: Optional[Iterable[AnyStr]]=None) -> None:
     assert error_content is None or error_content_iter is None
     if error_content is not None:
@@ -213,7 +213,7 @@ def write_log_line(log_data: MutableMapping[str, Any], path: Text, method: str, 
         error_content_list = list(error_content_iter)
         if error_content_list:
             error_data = u''
-        elif isinstance(error_content_list[0], Text):
+        elif isinstance(error_content_list[0], str):
             error_data = u''.join(error_content_list)
         elif isinstance(error_content_list[0], bytes):
             error_data = repr(b''.join(error_content_list))
@@ -299,14 +299,14 @@ class CsrfFailureError(JsonableError):
     code = ErrorCode.CSRF_FAILED
     data_fields = ['reason']
 
-    def __init__(self, reason: Text) -> None:
-        self.reason = reason  # type: Text
+    def __init__(self, reason: str) -> None:
+        self.reason = reason  # type: str
 
     @staticmethod
-    def msg_format() -> Text:
+    def msg_format() -> str:
         return _("CSRF Error: {reason}")
 
-def csrf_failure(request: HttpRequest, reason: Text="") -> HttpResponse:
+def csrf_failure(request: HttpRequest, reason: str="") -> HttpResponse:
     if request.error_format == "JSON":
         return json_response_from_error(CsrfFailureError(reason))
     else:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1,4 +1,4 @@
-from typing import Any, DefaultDict, Dict, List, Set, Tuple, TypeVar, Text, \
+from typing import Any, DefaultDict, Dict, List, Set, Tuple, TypeVar, \
     Union, Optional, Sequence, AbstractSet, Pattern, AnyStr, Callable, Iterable
 from typing.re import Match
 from zerver.lib.str_utils import NonBinaryStr
@@ -56,7 +56,7 @@ MAX_SUBJECT_LENGTH = 60
 MAX_MESSAGE_LENGTH = 10000
 MAX_LANGUAGE_ID_LENGTH = 50  # type: int
 
-STREAM_NAMES = TypeVar('STREAM_NAMES', Sequence[Text], AbstractSet[Text])
+STREAM_NAMES = TypeVar('STREAM_NAMES', Sequence[str], AbstractSet[str])
 
 def query_for_ids(query: QuerySet, user_ids: List[int], field: str) -> QuerySet:
     '''
@@ -78,9 +78,9 @@ def query_for_ids(query: QuerySet, user_ids: List[int], field: str) -> QuerySet:
 
 # Doing 1000 remote cache requests to get_display_recipient is quite slow,
 # so add a local cache as well as the remote cache cache.
-per_request_display_recipient_cache = {}  # type: Dict[int, Union[Text, List[Dict[str, Any]]]]
+per_request_display_recipient_cache = {}  # type: Dict[int, Union[str, List[Dict[str, Any]]]]
 def get_display_recipient_by_id(recipient_id: int, recipient_type: int,
-                                recipient_type_id: Optional[int]) -> Union[Text, List[Dict[str, Any]]]:
+                                recipient_type_id: Optional[int]) -> Union[str, List[Dict[str, Any]]]:
     """
     returns: an object describing the recipient (using a cache).
     If the type is a stream, the type_id must be an int; a string is returned.
@@ -91,7 +91,7 @@ def get_display_recipient_by_id(recipient_id: int, recipient_type: int,
         per_request_display_recipient_cache[recipient_id] = result
     return per_request_display_recipient_cache[recipient_id]
 
-def get_display_recipient(recipient: 'Recipient') -> Union[Text, List[Dict[str, Any]]]:
+def get_display_recipient(recipient: 'Recipient') -> Union[str, List[Dict[str, Any]]]:
     return get_display_recipient_by_id(
         recipient.id,
         recipient.type,
@@ -104,7 +104,7 @@ def flush_per_request_caches() -> None:
     global per_request_realm_filters_cache
     per_request_realm_filters_cache = {}
 
-DisplayRecipientCacheT = Union[Text, List[Dict[str, Any]]]
+DisplayRecipientCacheT = Union[str, List[Dict[str, Any]]]
 @cache_with_key(lambda *args: display_recipient_cache_key(args[0]),
                 timeout=3600*24*7)
 def get_display_recipient_remote_cache(recipient_id: int, recipient_type: int,
@@ -131,7 +131,7 @@ def get_display_recipient_remote_cache(recipient_id: int, recipient_type: int,
              'id': user_profile.id,
              'is_mirror_dummy': user_profile.is_mirror_dummy} for user_profile in user_profile_list]
 
-def get_realm_emoji_cache_key(realm: 'Realm') -> Text:
+def get_realm_emoji_cache_key(realm: 'Realm') -> str:
     return u'realm_emoji:%s' % (realm.id,)
 
 def get_active_realm_emoji_cache_key(realm: 'Realm') -> str:
@@ -146,8 +146,8 @@ class Realm(models.Model):
     AUTHENTICATION_FLAGS = [u'Google', u'Email', u'GitHub', u'LDAP', u'Dev', u'RemoteUser']
     SUBDOMAIN_FOR_ROOT_DOMAIN = ''
 
-    name = models.CharField(max_length=MAX_REALM_NAME_LENGTH, null=True)  # type: Optional[Text]
-    string_id = models.CharField(max_length=MAX_REALM_SUBDOMAIN_LENGTH, unique=True)  # type: Text
+    name = models.CharField(max_length=MAX_REALM_NAME_LENGTH, null=True)  # type: Optional[str]
+    string_id = models.CharField(max_length=MAX_REALM_SUBDOMAIN_LENGTH, unique=True)  # type: str
     restricted_to_domain = models.BooleanField(default=False)  # type: bool
     invite_required = models.BooleanField(default=True)  # type: bool
     invite_by_admins_only = models.BooleanField(default=False)  # type: bool
@@ -160,7 +160,7 @@ class Realm(models.Model):
     name_changes_disabled = models.BooleanField(default=False)  # type: bool
     email_changes_disabled = models.BooleanField(default=False)  # type: bool
     disallow_disposable_email_addresses = models.BooleanField(default=True)  # type: bool
-    description = models.TextField(default=u"")  # type: Text
+    description = models.TextField(default=u"")  # type: str
     send_welcome_emails = models.BooleanField(default=True)  # type: bool
     allow_message_deleting = models.BooleanField(default=False)  # type: bool
     DEFAULT_MESSAGE_CONTENT_DELETE_LIMIT_SECONDS = 600  # if changed, also change in admin.js, setting_org.js
@@ -190,7 +190,7 @@ class Realm(models.Model):
     notifications_stream = models.ForeignKey('Stream', related_name='+', null=True, blank=True, on_delete=CASCADE)  # type: Optional[Stream]
     signup_notifications_stream = models.ForeignKey('Stream', related_name='+', null=True, blank=True, on_delete=CASCADE)  # type: Optional[Stream]
     deactivated = models.BooleanField(default=False)  # type: bool
-    default_language = models.CharField(default=u'en', max_length=MAX_LANGUAGE_ID_LENGTH)  # type: Text
+    default_language = models.CharField(default=u'en', max_length=MAX_LANGUAGE_ID_LENGTH)  # type: str
     authentication_methods = BitField(flags=AUTHENTICATION_FLAGS,
                                       default=2**31 - 1)  # type: BitHandler
     waiting_period_threshold = models.PositiveIntegerField(default=0)  # type: int
@@ -208,23 +208,23 @@ class Realm(models.Model):
         allow_message_deleting=bool,
         bot_creation_policy=int,
         create_stream_by_admins_only=bool,
-        default_language=Text,
+        default_language=str,
         default_twenty_four_hour_time = bool,
-        description=Text,
+        description=str,
         disallow_disposable_email_addresses=bool,
         email_changes_disabled=bool,
-        google_hangouts_domain=Text,
+        google_hangouts_domain=str,
         invite_required=bool,
         invite_by_admins_only=bool,
         inline_image_preview=bool,
         inline_url_embed_preview=bool,
         mandatory_topics=bool,
         message_retention_days=(int, type(None)),
-        name=Text,
+        name=str,
         name_changes_disabled=bool,
         restricted_to_domain=bool,
         send_welcome_emails=bool,
-        video_chat_provider=Text,
+        video_chat_provider=str,
         waiting_period_threshold=int,
     )  # type: Dict[str, Union[type, Tuple[type, ...]]]
 
@@ -235,7 +235,7 @@ class Realm(models.Model):
         (ICON_UPLOADED, 'Uploaded by administrator'),
     )
     icon_source = models.CharField(default=ICON_FROM_GRAVATAR, choices=ICON_SOURCES,
-                                   max_length=1)  # type: Text
+                                   max_length=1)  # type: str
     icon_version = models.PositiveSmallIntegerField(default=1)  # type: int
 
     DEFAULT_NOTIFICATION_STREAM_NAME = u'announce'
@@ -247,7 +247,7 @@ class Realm(models.Model):
         BOT_CREATION_ADMINS_ONLY,
     ]
 
-    def authentication_methods_dict(self) -> Dict[Text, bool]:
+    def authentication_methods_dict(self) -> Dict[str, bool]:
         """Returns the a mapping from authentication flags to their status,
         showing only those authentication flags that are supported on
         the current server (i.e. if EmailAuthBackend is not configured
@@ -256,7 +256,7 @@ class Realm(models.Model):
         # dependency.
         from zproject.backends import AUTH_BACKEND_NAME_MAP
 
-        ret = {}  # type: Dict[Text, bool]
+        ret = {}  # type: Dict[str, bool]
         supported_backends = {backend.__class__ for backend in django.contrib.auth.get_backends()}
         for k, v in self.authentication_methods.iteritems():
             backend = AUTH_BACKEND_NAME_MAP[k]
@@ -264,11 +264,11 @@ class Realm(models.Model):
                 ret[k] = v
         return ret
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return "<Realm: %s %s>" % (self.string_id, self.id)
 
     @cache_with_key(get_realm_emoji_cache_key, timeout=3600*24*7)
-    def get_emoji(self) -> Dict[Text, Dict[str, Iterable[Text]]]:
+    def get_emoji(self) -> Dict[str, Dict[str, Iterable[str]]]:
         return get_realm_emoji_uncached(self)
 
     @cache_with_key(get_active_realm_emoji_cache_key, timeout=3600*24*7)
@@ -316,11 +316,11 @@ class Realm(models.Model):
         return self.upload_quota_gb << 30
 
     @property
-    def subdomain(self) -> Text:
+    def subdomain(self) -> str:
         return self.string_id
 
     @property
-    def display_subdomain(self) -> Text:
+    def display_subdomain(self) -> str:
         """Likely to be temporary function to avoid signup messages being sent
         to an empty topic"""
         if self.string_id == "":
@@ -362,7 +362,7 @@ class Realm(models.Model):
 
 post_save.connect(flush_realm, sender=Realm)
 
-def get_realm(string_id: Text) -> Realm:
+def get_realm(string_id: str) -> Realm:
     return Realm.objects.filter(string_id=string_id).first()
 
 def name_changes_disabled(realm: Optional[Realm]) -> bool:
@@ -373,7 +373,7 @@ def name_changes_disabled(realm: Optional[Realm]) -> bool:
 class RealmDomain(models.Model):
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
     # should always be stored lowercase
-    domain = models.CharField(max_length=80, db_index=True)  # type: Text
+    domain = models.CharField(max_length=80, db_index=True)  # type: str
     allow_subdomains = models.BooleanField(default=False)
 
     class Meta:
@@ -385,11 +385,11 @@ class RealmDomain(models.Model):
 # Note that we need to use some care, since can you have multiple @-signs; e.g.
 # "tabbott@test"@zulip.com
 # is valid email address
-def email_to_username(email: Text) -> Text:
+def email_to_username(email: str) -> str:
     return "@".join(email.split("@")[:-1]).lower()
 
 # Returns the raw domain portion of the desired email address
-def email_to_domain(email: Text) -> Text:
+def email_to_domain(email: str) -> str:
     return email.split("@")[-1].lower()
 
 class DomainNotAllowedForRealmError(Exception):
@@ -402,7 +402,7 @@ class DisposableEmailError(Exception):
 # (This function does not check whether the user has been invited to the realm.
 # So for invite-only realms, this is the test for whether a user can be invited,
 # not whether the user can sign up currently.)
-def email_allowed_for_realm(email: Text, realm: Realm) -> None:
+def email_allowed_for_realm(email: str, realm: Realm) -> None:
     if not realm.restricted_to_domain:
         if realm.disallow_disposable_email_addresses and \
                 is_disposable_domain(email_to_domain(email)):
@@ -421,7 +421,7 @@ def email_allowed_for_realm(email: Text, realm: Realm) -> None:
                 return
     raise DomainNotAllowedForRealmError
 
-def get_realm_domains(realm: Realm) -> List[Dict[str, Text]]:
+def get_realm_domains(realm: Realm) -> List[Dict[str, str]]:
     return list(realm.realmdomain_set.values('domain', 'allow_subdomains'))
 
 class RealmEmoji(models.Model):
@@ -431,13 +431,13 @@ class RealmEmoji(models.Model):
     # one of the punctuation characters
     name = models.TextField(validators=[MinLengthValidator(1),
                                         RegexValidator(regex=r'^[0-9a-z.\-_]+(?<![.\-_])$',
-                                                       message=_("Invalid characters in emoji name"))])  # type: Text
-    file_name = models.TextField(db_index=True, null=True, blank=True)  # type: Optional[Text]
+                                                       message=_("Invalid characters in emoji name"))])  # type: str
+    file_name = models.TextField(db_index=True, null=True, blank=True)  # type: Optional[str]
     deactivated = models.BooleanField(default=False)  # type: bool
 
     PATH_ID_TEMPLATE = "{realm_id}/emoji/images/{emoji_file_name}"
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return "<RealmEmoji(%s): %s %s %s %s>" % (self.realm.string_id,
                                                   self.id,
                                                   self.name,
@@ -489,7 +489,7 @@ def flush_realm_emoji(sender: Any, **kwargs: Any) -> None:
 post_save.connect(flush_realm_emoji, sender=RealmEmoji)
 post_delete.connect(flush_realm_emoji, sender=RealmEmoji)
 
-def filter_pattern_validator(value: Text) -> None:
+def filter_pattern_validator(value: str) -> None:
     regex = re.compile(r'(?:[\w\-#]*)(\(\?P<\w+>.+\))')
     error_msg = 'Invalid filter pattern, you must use the following format OPTIONAL_PREFIX(?P<id>.+)'
 
@@ -511,39 +511,39 @@ def filter_format_validator(value: str) -> None:
 
 class RealmFilter(models.Model):
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
-    pattern = models.TextField(validators=[filter_pattern_validator])  # type: Text
-    url_format_string = models.TextField(validators=[URLValidator(), filter_format_validator])  # type: Text
+    pattern = models.TextField(validators=[filter_pattern_validator])  # type: str
+    url_format_string = models.TextField(validators=[URLValidator(), filter_format_validator])  # type: str
 
     class Meta:
         unique_together = ("realm", "pattern")
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return "<RealmFilter(%s): %s %s>" % (self.realm.string_id, self.pattern, self.url_format_string)
 
-def get_realm_filters_cache_key(realm_id: int) -> Text:
+def get_realm_filters_cache_key(realm_id: int) -> str:
     return u'%s:all_realm_filters:%s' % (cache.KEY_PREFIX, realm_id,)
 
 # We have a per-process cache to avoid doing 1000 remote cache queries during page load
-per_request_realm_filters_cache = {}  # type: Dict[int, List[Tuple[Text, Text, int]]]
+per_request_realm_filters_cache = {}  # type: Dict[int, List[Tuple[str, str, int]]]
 
 def realm_in_local_realm_filters_cache(realm_id: int) -> bool:
     return realm_id in per_request_realm_filters_cache
 
-def realm_filters_for_realm(realm_id: int) -> List[Tuple[Text, Text, int]]:
+def realm_filters_for_realm(realm_id: int) -> List[Tuple[str, str, int]]:
     if not realm_in_local_realm_filters_cache(realm_id):
         per_request_realm_filters_cache[realm_id] = realm_filters_for_realm_remote_cache(realm_id)
     return per_request_realm_filters_cache[realm_id]
 
 @cache_with_key(get_realm_filters_cache_key, timeout=3600*24*7)
-def realm_filters_for_realm_remote_cache(realm_id: int) -> List[Tuple[Text, Text, int]]:
+def realm_filters_for_realm_remote_cache(realm_id: int) -> List[Tuple[str, str, int]]:
     filters = []
     for realm_filter in RealmFilter.objects.filter(realm_id=realm_id):
         filters.append((realm_filter.pattern, realm_filter.url_format_string, realm_filter.id))
 
     return filters
 
-def all_realm_filters() -> Dict[int, List[Tuple[Text, Text, int]]]:
-    filters = defaultdict(list)  # type: DefaultDict[int, List[Tuple[Text, Text, int]]]
+def all_realm_filters() -> Dict[int, List[Tuple[str, str, int]]]:
+    filters = defaultdict(list)  # type: DefaultDict[int, List[Tuple[str, str, int]]]
     for realm_filter in RealmFilter.objects.all():
         filters[realm_filter.realm_id].append((realm_filter.pattern,
                                                realm_filter.url_format_string,
@@ -593,7 +593,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
 
     # Fields from models.AbstractUser minus last_name and first_name,
     # which we don't use; email is modified to make it indexed and unique.
-    email = models.EmailField(blank=False, db_index=True)  # type: Text
+    email = models.EmailField(blank=False, db_index=True)  # type: str
     is_staff = models.BooleanField(default=False)  # type: bool
     is_active = models.BooleanField(default=True, db_index=True)  # type: bool
     is_realm_admin = models.BooleanField(default=False, db_index=True)  # type: bool
@@ -613,14 +613,14 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     NAME_INVALID_CHARS = ['*', '`', '>', '"', '@']
 
     # Our custom site-specific fields
-    full_name = models.CharField(max_length=MAX_NAME_LENGTH)  # type: Text
-    short_name = models.CharField(max_length=MAX_NAME_LENGTH)  # type: Text
+    full_name = models.CharField(max_length=MAX_NAME_LENGTH)  # type: str
+    short_name = models.CharField(max_length=MAX_NAME_LENGTH)  # type: str
     # pointer points to Message.id, NOT UserMessage.id.
     pointer = models.IntegerField()  # type: int
-    last_pointer_updater = models.CharField(max_length=64)  # type: Text
+    last_pointer_updater = models.CharField(max_length=64)  # type: str
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
-    api_key = models.CharField(max_length=API_KEY_LENGTH)  # type: Text
-    tos_version = models.CharField(null=True, max_length=10)  # type: Optional[Text]
+    api_key = models.CharField(max_length=API_KEY_LENGTH)  # type: str
+    tos_version = models.CharField(null=True, max_length=10)  # type: Optional[str]
     last_active_message_id = models.IntegerField(null=True)  # type: Optional[int]
 
     ### Notifications settings. ###
@@ -646,7 +646,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     ###
 
     last_reminder = models.DateTimeField(default=None, null=True)  # type: Optional[datetime.datetime]
-    rate_limits = models.CharField(default=u"", max_length=100)  # type: Text # comma-separated list of range:max pairs
+    rate_limits = models.CharField(default=u"", max_length=100)  # type: str # comma-separated list of range:max pairs
 
     # Default streams
     default_sending_stream = models.ForeignKey('zerver.Stream', null=True, related_name='+', on_delete=CASCADE)  # type: Optional[Stream]
@@ -659,7 +659,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
 
     # display settings
     twenty_four_hour_time = models.BooleanField(default=False)  # type: bool
-    default_language = models.CharField(default=u'en', max_length=MAX_LANGUAGE_ID_LENGTH)  # type: Text
+    default_language = models.CharField(default=u'en', max_length=MAX_LANGUAGE_ID_LENGTH)  # type: str
     high_contrast_mode = models.BooleanField(default=False)  # type: bool
     night_mode = models.BooleanField(default=False)  # type: bool
     translate_emoticons = models.BooleanField(default=False)  # type: bool
@@ -676,7 +676,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         (AVATAR_FROM_GRAVATAR, 'Hosted by Gravatar'),
         (AVATAR_FROM_USER, 'Uploaded by user'),
     )
-    avatar_source = models.CharField(default=AVATAR_FROM_GRAVATAR, choices=AVATAR_SOURCES, max_length=1)  # type: Text
+    avatar_source = models.CharField(default=AVATAR_FROM_GRAVATAR, choices=AVATAR_SOURCES, max_length=1)  # type: str
     avatar_version = models.PositiveSmallIntegerField(default=1)  # type: int
 
     TUTORIAL_WAITING  = u'W'
@@ -686,14 +686,14 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
                          (TUTORIAL_STARTED, "Started"),
                          (TUTORIAL_FINISHED, "Finished"))
 
-    tutorial_status = models.CharField(default=TUTORIAL_WAITING, choices=TUTORIAL_STATES, max_length=1)  # type: Text
+    tutorial_status = models.CharField(default=TUTORIAL_WAITING, choices=TUTORIAL_STATES, max_length=1)  # type: str
     # Contains serialized JSON of the form:
     #    [("step 1", true), ("step 2", false)]
     # where the second element of each tuple is if the step has been
     # completed.
-    onboarding_steps = models.TextField(default=u'[]')  # type: Text
+    onboarding_steps = models.TextField(default=u'[]')  # type: str
 
-    alert_words = models.TextField(default=u'[]')  # type: Text # json-serialized list of strings
+    alert_words = models.TextField(default=u'[]')  # type: str # json-serialized list of strings
 
     objects = UserManager()  # type: UserManager
     # The maximum length of a timezone in pytz.all_timezones is 32.
@@ -701,7 +701,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     # In Django, the convention is to use empty string instead of Null
     # for text based fields. For more information, see
     # https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.Field.null.
-    timezone = models.CharField(max_length=40, default=u'')  # type: Text
+    timezone = models.CharField(max_length=40, default=u'')  # type: str
 
     # Emojisets
     APPLE_EMOJISET      = u'apple'
@@ -714,14 +714,14 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
                            (TWITTER_EMOJISET, "Twitter"),
                            (EMOJIONE_EMOJISET, "EmojiOne"),
                            (TEXT_EMOJISET, "Plain text"))
-    emojiset = models.CharField(default=GOOGLE_EMOJISET, choices=EMOJISET_CHOICES, max_length=20)  # type: Text
+    emojiset = models.CharField(default=GOOGLE_EMOJISET, choices=EMOJISET_CHOICES, max_length=20)  # type: str
 
     # Define the types of the various automatically managed properties
     property_types = dict(
-        default_language=Text,
-        emojiset=Text,
+        default_language=str,
+        emojiset=str,
         left_side_userlist=bool,
-        timezone=Text,
+        timezone=str,
         twenty_four_hour_time=bool,
         high_contrast_mode=bool,
         night_mode=bool,
@@ -776,7 +776,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         else:
             return False
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return "<UserProfile: %s %s>" % (self.email, self.realm)
 
     @property
@@ -798,11 +798,11 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         return allowed_bot_types
 
     @staticmethod
-    def emojiset_choices() -> Dict[Text, Text]:
+    def emojiset_choices() -> Dict[str, str]:
         return OrderedDict((emojiset[0], emojiset[1]) for emojiset in UserProfile.EMOJISET_CHOICES)
 
     @staticmethod
-    def emails_from_ids(user_ids: Sequence[int]) -> Dict[int, Text]:
+    def emails_from_ids(user_ids: Sequence[int]) -> Dict[int, str]:
         rows = UserProfile.objects.filter(id__in=user_ids).values('id', 'email')
         return {row['id']: row['email'] for row in rows}
 
@@ -831,7 +831,7 @@ class UserGroup(models.Model):
     name = models.CharField(max_length=100)
     members = models.ManyToManyField(UserProfile, through='UserGroupMembership')
     realm = models.ForeignKey(Realm, on_delete=CASCADE)
-    description = models.TextField(default=u'')  # type: Text
+    description = models.TextField(default=u'')  # type: str
 
     class Meta:
         unique_together = (('realm', 'name'),)
@@ -859,7 +859,7 @@ def receives_stream_notifications(user_profile: UserProfile) -> bool:
     return (user_profile.enable_stream_push_notifications and
             not user_profile.is_bot)
 
-def remote_user_to_email(remote_user: Text) -> Text:
+def remote_user_to_email(remote_user: str) -> str:
     if settings.SSO_APPEND_DOMAIN is not None:
         remote_user += "@" + settings.SSO_APPEND_DOMAIN
     return remote_user
@@ -869,7 +869,7 @@ def remote_user_to_email(remote_user: Text) -> Text:
 post_save.connect(flush_user_profile, sender=UserProfile)
 
 class PreregistrationUser(models.Model):
-    email = models.EmailField()  # type: Text
+    email = models.EmailField()  # type: str
     referred_by = models.ForeignKey(UserProfile, null=True, on_delete=CASCADE)  # type: Optional[UserProfile]
     streams = models.ManyToManyField('Stream')  # type: Manager
     invited_at = models.DateTimeField(auto_now=True)  # type: datetime.datetime
@@ -892,8 +892,8 @@ class MultiuseInvite(models.Model):
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
 
 class EmailChangeStatus(models.Model):
-    new_email = models.EmailField()  # type: Text
-    old_email = models.EmailField()  # type: Text
+    new_email = models.EmailField()  # type: str
+    old_email = models.EmailField()  # type: str
     updated_at = models.DateTimeField(auto_now=True)  # type: datetime.datetime
     user_profile = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
 
@@ -921,7 +921,7 @@ class AbstractPushDeviceToken(models.Model):
     last_updated = models.DateTimeField(auto_now=True)  # type: datetime.datetime
 
     # [optional] Contains the app id of the device if it is an iOS device
-    ios_app_id = models.TextField(null=True)  # type: Optional[Text]
+    ios_app_id = models.TextField(null=True)  # type: Optional[str]
 
     class Meta:
         abstract = True
@@ -937,7 +937,7 @@ def generate_email_token_for_stream() -> str:
 class Stream(models.Model):
     MAX_NAME_LENGTH = 60
     MAX_DESCRIPTION_LENGTH = 1024
-    name = models.CharField(max_length=MAX_NAME_LENGTH, db_index=True)  # type: Text
+    name = models.CharField(max_length=MAX_NAME_LENGTH, db_index=True)  # type: str
     realm = models.ForeignKey(Realm, db_index=True, on_delete=CASCADE)  # type: Realm
     invite_only = models.NullBooleanField(default=False)  # type: Optional[bool]
     history_public_to_subscribers = models.BooleanField(default=False)  # type: bool
@@ -958,12 +958,12 @@ class Stream(models.Model):
     # have plenty of room for the token.
     email_token = models.CharField(
         max_length=32, default=generate_email_token_for_stream)  # type: str
-    description = models.CharField(max_length=MAX_DESCRIPTION_LENGTH, default=u'')  # type: Text
+    description = models.CharField(max_length=MAX_DESCRIPTION_LENGTH, default=u'')  # type: str
 
     date_created = models.DateTimeField(default=timezone_now)  # type: datetime.datetime
     deactivated = models.BooleanField(default=False)  # type: bool
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return "<Stream: %s>" % (self.name,)
 
     def is_public(self) -> bool:
@@ -1017,7 +1017,7 @@ class Recipient(models.Model):
         # Raises KeyError if invalid
         return self._type_names[self.type]
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         display_recipient = get_display_recipient(self)
         return "<Recipient: %s (%d, %s)>" % (display_recipient, self.type_id, self.type)
 
@@ -1030,17 +1030,17 @@ class MutedTopic(models.Model):
     class Meta:
         unique_together = ('user_profile', 'stream', 'topic_name')
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return "<MutedTopic: (%s, %s, %s)>" % (self.user_profile.email, self.stream.name, self.topic_name)
 
 class Client(models.Model):
-    name = models.CharField(max_length=30, db_index=True, unique=True)  # type: Text
+    name = models.CharField(max_length=30, db_index=True, unique=True)  # type: str
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return "<Client: %s>" % (self.name,)
 
-get_client_cache = {}  # type: Dict[Text, Client]
-def get_client(name: Text) -> Client:
+get_client_cache = {}  # type: Dict[str, Client]
+def get_client(name: str) -> Client:
     # Accessing KEY_PREFIX through the module is necessary
     # because we need the updated value of the variable.
     cache_name = cache.KEY_PREFIX + name
@@ -1049,20 +1049,20 @@ def get_client(name: Text) -> Client:
         get_client_cache[cache_name] = result
     return get_client_cache[cache_name]
 
-def get_client_cache_key(name: Text) -> Text:
+def get_client_cache_key(name: str) -> str:
     return u'get_client:%s' % (make_safe_digest(name),)
 
 @cache_with_key(get_client_cache_key, timeout=3600*24*7)
-def get_client_remote_cache(name: Text) -> Client:
+def get_client_remote_cache(name: str) -> Client:
     (client, _) = Client.objects.get_or_create(name=name)
     return client
 
 @cache_with_key(get_stream_cache_key, timeout=3600*24*7)
-def get_realm_stream(stream_name: Text, realm_id: int) -> Stream:
+def get_realm_stream(stream_name: str, realm_id: int) -> Stream:
     return Stream.objects.select_related("realm").get(
         name__iexact=stream_name.strip(), realm_id=realm_id)
 
-def stream_name_in_use(stream_name: Text, realm_id: int) -> bool:
+def stream_name_in_use(stream_name: str, realm_id: int) -> bool:
     return Stream.objects.filter(
         name__iexact=stream_name.strip(),
         realm_id=realm_id
@@ -1076,7 +1076,7 @@ def get_active_streams(realm: Optional[Realm]) -> QuerySet:
     """
     return Stream.objects.filter(realm=realm, deactivated=False)
 
-def get_stream(stream_name: Text, realm: Realm) -> Stream:
+def get_stream(stream_name: str, realm: Realm) -> Stream:
     '''
     Callers that don't have a Realm object already available should use
     get_realm_stream directly, to avoid unnecessarily fetching the
@@ -1084,9 +1084,9 @@ def get_stream(stream_name: Text, realm: Realm) -> Stream:
     '''
     return get_realm_stream(stream_name, realm.id)
 
-def bulk_get_streams(realm: Realm, stream_names: STREAM_NAMES) -> Dict[Text, Any]:
+def bulk_get_streams(realm: Realm, stream_names: STREAM_NAMES) -> Dict[str, Any]:
 
-    def fetch_streams_by_name(stream_names: List[Text]) -> Sequence[Stream]:
+    def fetch_streams_by_name(stream_names: List[str]) -> Sequence[Stream]:
         #
         # This should be just
         #
@@ -1108,7 +1108,7 @@ def bulk_get_streams(realm: Realm, stream_names: STREAM_NAMES) -> Dict[Text, Any
                                      [stream_name.lower() for stream_name in stream_names],
                                      id_fetcher=lambda stream: stream.name.lower())
 
-def get_recipient_cache_key(type: int, type_id: int) -> Text:
+def get_recipient_cache_key(type: int, type_id: int) -> str:
     return u"%s:get_recipient:%s:%s" % (cache.KEY_PREFIX, type, type_id,)
 
 @cache_with_key(get_recipient_cache_key, timeout=3600*24*7)
@@ -1139,7 +1139,7 @@ def get_huddle_user_ids(recipient: Recipient) -> List[int]:
     ).order_by('user_profile_id').values_list('user_profile_id', flat=True)
 
 def bulk_get_recipients(type: int, type_ids: List[int]) -> Dict[int, Any]:
-    def cache_key_function(type_id: int) -> Text:
+    def cache_key_function(type_id: int) -> str:
         return get_recipient_cache_key(type, type_id)
 
     def query_function(type_ids: List[int]) -> Sequence[Recipient]:
@@ -1163,14 +1163,14 @@ def get_stream_recipients(stream_ids: List[int]) -> List[Recipient]:
 class AbstractMessage(models.Model):
     sender = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
     recipient = models.ForeignKey(Recipient, on_delete=CASCADE)  # type: Recipient
-    subject = models.CharField(max_length=MAX_SUBJECT_LENGTH, db_index=True)  # type: Text
-    content = models.TextField()  # type: Text
-    rendered_content = models.TextField(null=True)  # type: Optional[Text]
+    subject = models.CharField(max_length=MAX_SUBJECT_LENGTH, db_index=True)  # type: str
+    content = models.TextField()  # type: str
+    rendered_content = models.TextField(null=True)  # type: Optional[str]
     rendered_content_version = models.IntegerField(null=True)  # type: Optional[int]
     pub_date = models.DateTimeField('date published', db_index=True)  # type: datetime.datetime
     sending_client = models.ForeignKey(Client, on_delete=CASCADE)  # type: Client
     last_edit_time = models.DateTimeField(null=True)  # type: Optional[datetime.datetime]
-    edit_history = models.TextField(null=True)  # type: Optional[Text]
+    edit_history = models.TextField(null=True)  # type: Optional[str]
     has_attachment = models.BooleanField(default=False, db_index=True)  # type: bool
     has_image = models.BooleanField(default=False, db_index=True)  # type: bool
     has_link = models.BooleanField(default=False, db_index=True)  # type: bool
@@ -1178,7 +1178,7 @@ class AbstractMessage(models.Model):
     class Meta:
         abstract = True
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         display_recipient = get_display_recipient(self.recipient)
         return "<%s: %s / %s / %s>" % (self.__class__.__name__, display_recipient,
                                        self.subject, self.sender)
@@ -1190,7 +1190,7 @@ class ArchivedMessage(AbstractMessage):
 
 class Message(AbstractMessage):
 
-    def topic_name(self) -> Text:
+    def topic_name(self) -> str:
         """
         Please start using this helper to facilitate an
         eventual switch over to a separate topic table.
@@ -1214,7 +1214,7 @@ class Message(AbstractMessage):
         self.save(update_fields=["rendered_content", "rendered_content_version"])
 
     @staticmethod
-    def need_to_render_content(rendered_content: Optional[Text],
+    def need_to_render_content(rendered_content: Optional[str],
                                rendered_content_version: Optional[int],
                                bugdown_version: int) -> bool:
         return (rendered_content is None or
@@ -1245,16 +1245,16 @@ class Message(AbstractMessage):
                                        'desktop app' in sending_client)
 
     @staticmethod
-    def content_has_attachment(content: Text) -> Match:
+    def content_has_attachment(content: str) -> Match:
         return re.search(r'[/\-]user[\-_]uploads[/\.-]', content)
 
     @staticmethod
-    def content_has_image(content: Text) -> bool:
+    def content_has_image(content: str) -> bool:
         return bool(re.search(r'[/\-]user[\-_]uploads[/\.-]\S+\.(bmp|gif|jpg|jpeg|png|webp)',
                               content, re.IGNORECASE))
 
     @staticmethod
-    def content_has_link(content: Text) -> bool:
+    def content_has_link(content: str) -> bool:
         return ('http://' in content or
                 'https://' in content or
                 '/user_uploads' in content or
@@ -1262,7 +1262,7 @@ class Message(AbstractMessage):
                 'bitcoin:' in content)
 
     @staticmethod
-    def is_status_message(content: Text, rendered_content: Text) -> bool:
+    def is_status_message(content: str, rendered_content: str) -> bool:
         """
         Returns True if content and rendered_content are from 'me_message'
         """
@@ -1298,8 +1298,8 @@ post_save.connect(flush_message, sender=Message)
 class Reaction(models.Model):
     user_profile = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
     message = models.ForeignKey(Message, on_delete=CASCADE)  # type: Message
-    emoji_name = models.TextField()  # type: Text
-    emoji_code = models.TextField()  # type: Text
+    emoji_name = models.TextField()  # type: str
+    emoji_code = models.TextField()  # type: str
 
     UNICODE_EMOJI       = u'unicode_emoji'
     REALM_EMOJI         = u'realm_emoji'
@@ -1308,7 +1308,7 @@ class Reaction(models.Model):
                            (REALM_EMOJI, _("Custom emoji")),
                            (ZULIP_EXTRA_EMOJI, _("Zulip extra emoji")))
 
-    reaction_type = models.CharField(default=UNICODE_EMOJI, choices=REACTION_TYPES, max_length=30)  # type: Text
+    reaction_type = models.CharField(default=UNICODE_EMOJI, choices=REACTION_TYPES, max_length=30)  # type: str
 
     class Meta:
         unique_together = ("user_profile", "message", "emoji_name")
@@ -1371,7 +1371,7 @@ class AbstractUserMessage(models.Model):
             mask <<= 1
         return flags
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         display_recipient = get_display_recipient(self.message.recipient)
         return "<%s: %s / %s (%s)>" % (self.__class__.__name__, display_recipient,
                                        self.user_profile.email, self.flags_list())
@@ -1387,11 +1387,11 @@ class UserMessage(AbstractUserMessage):
 
 
 class AbstractAttachment(models.Model):
-    file_name = models.TextField(db_index=True)  # type: Text
+    file_name = models.TextField(db_index=True)  # type: str
     # path_id is a storage location agnostic representation of the path of the file.
     # If the path of a file is http://localhost:9991/user_uploads/a/b/abc/temp_file.py
     # then its path_id will be a/b/abc/temp_file.py.
-    path_id = models.TextField(db_index=True, unique=True)  # type: Text
+    path_id = models.TextField(db_index=True, unique=True)  # type: str
     owner = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
     realm = models.ForeignKey(Realm, blank=True, null=True, on_delete=CASCADE)  # type: Optional[Realm]
     is_realm_public = models.BooleanField(default=False)  # type: bool
@@ -1402,7 +1402,7 @@ class AbstractAttachment(models.Model):
     class Meta:
         abstract = True
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return "<%s: %s>" % (self.__class__.__name__, self.file_name,)
 
 
@@ -1432,7 +1432,7 @@ class Attachment(AbstractAttachment):
             } for m in self.messages.all()]
         }
 
-def validate_attachment_request(user_profile: UserProfile, path_id: Text) -> Optional[bool]:
+def validate_attachment_request(user_profile: UserProfile, path_id: str) -> Optional[bool]:
     try:
         attachment = Attachment.objects.get(path_id=path_id)
         messages = attachment.messages.all()
@@ -1465,7 +1465,7 @@ class Subscription(models.Model):
     in_home_view = models.NullBooleanField(default=True)  # type: Optional[bool]
 
     DEFAULT_STREAM_COLOR = u"#c2c2c2"
-    color = models.CharField(max_length=10, default=DEFAULT_STREAM_COLOR)  # type: Text
+    color = models.CharField(max_length=10, default=DEFAULT_STREAM_COLOR)  # type: str
     pin_to_top = models.BooleanField(default=False)  # type: bool
 
     desktop_notifications = models.BooleanField(default=True)  # type: bool
@@ -1480,7 +1480,7 @@ class Subscription(models.Model):
     class Meta:
         unique_together = ("user_profile", "recipient")
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return "<Subscription: %s -> %s>" % (self.user_profile, self.recipient)
 
 @cache_with_key(user_profile_by_id_cache_key, timeout=3600*24*7)
@@ -1488,25 +1488,25 @@ def get_user_profile_by_id(uid: int) -> UserProfile:
     return UserProfile.objects.select_related().get(id=uid)
 
 @cache_with_key(user_profile_by_email_cache_key, timeout=3600*24*7)
-def get_user_profile_by_email(email: Text) -> UserProfile:
+def get_user_profile_by_email(email: str) -> UserProfile:
     return UserProfile.objects.select_related().get(email__iexact=email.strip())
 
 @cache_with_key(user_profile_by_api_key_cache_key, timeout=3600*24*7)
-def get_user_profile_by_api_key(api_key: Text) -> UserProfile:
+def get_user_profile_by_api_key(api_key: str) -> UserProfile:
     return UserProfile.objects.select_related().get(api_key=api_key)
 
 @cache_with_key(user_profile_cache_key, timeout=3600*24*7)
-def get_user(email: Text, realm: Realm) -> UserProfile:
+def get_user(email: str, realm: Realm) -> UserProfile:
     return UserProfile.objects.select_related().get(email__iexact=email.strip(), realm=realm)
 
-def get_user_including_cross_realm(email: Text, realm: Optional[Realm]=None) -> UserProfile:
+def get_user_including_cross_realm(email: str, realm: Optional[Realm]=None) -> UserProfile:
     if is_cross_realm_bot_email(email):
         return get_system_bot(email)
     assert realm is not None
     return get_user(email, realm)
 
 @cache_with_key(bot_profile_cache_key, timeout=3600*24*7)
-def get_system_bot(email: Text) -> UserProfile:
+def get_system_bot(email: str) -> UserProfile:
     return UserProfile.objects.select_related().get(email__iexact=email.strip())
 
 @cache_with_key(realm_user_dicts_cache_key, timeout=3600*24*7)
@@ -1527,7 +1527,7 @@ def active_user_ids(realm_id: int) -> List[int]:
 def get_bot_dicts_in_realm(realm: Realm) -> List[Dict[str, Any]]:
     return UserProfile.objects.filter(realm=realm, is_bot=True).values(*bot_dict_fields)
 
-def is_cross_realm_bot_email(email: Text) -> bool:
+def is_cross_realm_bot_email(email: str) -> bool:
     return email.lower() in settings.CROSS_REALM_BOT_EMAILS
 
 # The Huddle class represents a group of individuals who have had a
@@ -1539,14 +1539,14 @@ def is_cross_realm_bot_email(email: Text) -> bool:
 class Huddle(models.Model):
     # TODO: We should consider whether using
     # CommaSeparatedIntegerField would be better.
-    huddle_hash = models.CharField(max_length=40, db_index=True, unique=True)  # type: Text
+    huddle_hash = models.CharField(max_length=40, db_index=True, unique=True)  # type: str
 
-def get_huddle_hash(id_list: List[int]) -> Text:
+def get_huddle_hash(id_list: List[int]) -> str:
     id_list = sorted(set(id_list))
     hash_key = ",".join(str(x) for x in id_list)
     return make_safe_digest(hash_key)
 
-def huddle_hash_cache_key(huddle_hash: Text) -> Text:
+def huddle_hash_cache_key(huddle_hash: str) -> str:
     return u"huddle_by_hash:%s" % (huddle_hash,)
 
 def get_huddle(id_list: List[int]) -> Huddle:
@@ -1554,7 +1554,7 @@ def get_huddle(id_list: List[int]) -> Huddle:
     return get_huddle_backend(huddle_hash, id_list)
 
 @cache_with_key(lambda huddle_hash, id_list: huddle_hash_cache_key(huddle_hash), timeout=3600*24*7)
-def get_huddle_backend(huddle_hash: Text, id_list: List[int]) -> Huddle:
+def get_huddle_backend(huddle_hash: str, id_list: List[int]) -> Huddle:
     with transaction.atomic():
         (huddle, created) = Huddle.objects.get_or_create(huddle_hash=huddle_hash)
         if created:
@@ -1578,7 +1578,7 @@ def clear_database() -> None:  # nocoverage # Only used in populate_db
 class UserActivity(models.Model):
     user_profile = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
     client = models.ForeignKey(Client, on_delete=CASCADE)  # type: Client
-    query = models.CharField(max_length=50, db_index=True)  # type: Text
+    query = models.CharField(max_length=50, db_index=True)  # type: str
 
     count = models.IntegerField()  # type: int
     last_visit = models.DateTimeField('last visit')  # type: datetime.datetime
@@ -1738,7 +1738,7 @@ class UserPresence(models.Model):
         return user_statuses
 
     @staticmethod
-    def to_presence_dict(client_name: Text, status: int, dt: datetime.datetime, push_enabled: bool=False,
+    def to_presence_dict(client_name: str, status: int, dt: datetime.datetime, push_enabled: bool=False,
                          has_push_devices: bool=False) -> Dict[str, Any]:
         presence_val = UserPresence.status_to_string(status)
 
@@ -1780,10 +1780,10 @@ class DefaultStream(models.Model):
 
 class DefaultStreamGroup(models.Model):
     MAX_NAME_LENGTH = 60
-    name = models.CharField(max_length=MAX_NAME_LENGTH, db_index=True)  # type: Text
+    name = models.CharField(max_length=MAX_NAME_LENGTH, db_index=True)  # type: str
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
     streams = models.ManyToManyField('Stream')  # type: Manager
-    description = models.CharField(max_length=1024, default=u'')  # type: Text
+    description = models.CharField(max_length=1024, default=u'')  # type: str
 
     class Meta:
         unique_together = ("realm", "name")
@@ -1800,7 +1800,7 @@ def get_default_stream_groups(realm: Realm) -> List[DefaultStreamGroup]:
 class AbstractScheduledJob(models.Model):
     scheduled_timestamp = models.DateTimeField(db_index=True)  # type: datetime.datetime
     # JSON representation of arguments to consumer
-    data = models.TextField()  # type: Text
+    data = models.TextField()  # type: str
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
 
     class Meta:
@@ -1811,7 +1811,7 @@ class ScheduledEmail(AbstractScheduledJob):
     # filter the set of ScheduledEmails.
     user = models.ForeignKey(UserProfile, null=True, on_delete=CASCADE)  # type: Optional[UserProfile]
     # Just the address part of a full "name <address>" email address
-    address = models.EmailField(null=True, db_index=True)  # type: Optional[Text]
+    address = models.EmailField(null=True, db_index=True)  # type: Optional[str]
 
     # Valid types are below
     WELCOME = 1
@@ -1819,15 +1819,15 @@ class ScheduledEmail(AbstractScheduledJob):
     INVITATION_REMINDER = 3
     type = models.PositiveSmallIntegerField()  # type: int
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         return "<ScheduledEmail: %s %s %s>" % (self.type, self.user or self.address,
                                                self.scheduled_timestamp)
 
 class ScheduledMessage(models.Model):
     sender = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
     recipient = models.ForeignKey(Recipient, on_delete=CASCADE)  # type: Recipient
-    subject = models.CharField(max_length=MAX_SUBJECT_LENGTH)  # type: Text
-    content = models.TextField()  # type: Text
+    subject = models.CharField(max_length=MAX_SUBJECT_LENGTH)  # type: str
+    content = models.TextField()  # type: str
     sending_client = models.ForeignKey(Client, on_delete=CASCADE)  # type: Client
     stream = models.ForeignKey(Stream, null=True, on_delete=CASCADE)  # type: Optional[Stream]
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
@@ -1845,7 +1845,7 @@ class ScheduledMessage(models.Model):
     delivery_type = models.PositiveSmallIntegerField(choices=DELIVERY_TYPES,
                                                      default=SEND_LATER)  # type: int
 
-    def __str__(self) -> Text:
+    def __str__(self) -> str:
         display_recipient = get_display_recipient(self.recipient)
         return "<ScheduledMessage: %s %s %s %s>" % (display_recipient,
                                                     self.subject, self.sender,
@@ -1864,12 +1864,12 @@ class RealmAuditLog(models.Model):
     modified_user = models.ForeignKey(UserProfile, null=True, related_name='+', on_delete=CASCADE)  # type: Optional[UserProfile]
     modified_stream = models.ForeignKey(Stream, null=True, on_delete=CASCADE)  # type: Optional[Stream]
     event_last_message_id = models.IntegerField(null=True)  # type: Optional[int]
-    event_type = models.CharField(max_length=40)  # type: Text
+    event_type = models.CharField(max_length=40)  # type: str
     event_time = models.DateTimeField(db_index=True)  # type: datetime.datetime
     # If True, event_time is an overestimate of the true time. Can be used
     # by migrations when introducing a new event_type.
     backfilled = models.BooleanField(default=False)  # type: bool
-    extra_data = models.TextField(null=True)  # type: Optional[Text]
+    extra_data = models.TextField(null=True)  # type: Optional[str]
 
     def __str__(self) -> str:
         if self.modified_user is not None:
@@ -1880,7 +1880,7 @@ class RealmAuditLog(models.Model):
 
 class UserHotspot(models.Model):
     user = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
-    hotspot = models.CharField(max_length=30)  # type: Text
+    hotspot = models.CharField(max_length=30)  # type: str
     timestamp = models.DateTimeField(default=timezone_now)  # type: datetime.datetime
 
     class Meta:
@@ -1890,11 +1890,11 @@ class CustomProfileField(models.Model):
     HINT_MAX_LENGTH = 80
 
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm
-    name = models.CharField(max_length=100)  # type: Text
-    hint = models.CharField(max_length=HINT_MAX_LENGTH, default='', null=True)  # type: Optional[Text]
+    name = models.CharField(max_length=100)  # type: str
+    hint = models.CharField(max_length=HINT_MAX_LENGTH, default='', null=True)  # type: Optional[str]
     # There is no performance overhead of using TextField in PostGreSQL.
     # See https://www.postgresql.org/docs/9.0/static/datatype-character.html
-    field_data = models.TextField(default='', null=True)  # type: Optional[Text]
+    field_data = models.TextField(default='', null=True)  # type: Optional[str]
 
     SHORT_TEXT = 1
     LONG_TEXT = 2
@@ -1924,7 +1924,7 @@ class CustomProfileField(models.Model):
 
     FIELD_VALIDATORS = {item[0]: item[2] for item in FIELD_TYPE_DATA}  # type: Dict[int, Validator]
     FIELD_CONVERTERS = {item[0]: item[3] for item in ALL_FIELD_TYPES}  # type: Dict[int, Callable[[Any], Any]]
-    FIELD_TYPE_CHOICES = [(item[0], item[1]) for item in ALL_FIELD_TYPES]  # type: List[Tuple[int, Text]]
+    FIELD_TYPE_CHOICES = [(item[0], item[1]) for item in ALL_FIELD_TYPES]  # type: List[Tuple[int, str]]
 
     field_type = models.PositiveSmallIntegerField(choices=FIELD_TYPE_CHOICES,
                                                   default=SHORT_TEXT)  # type: int
@@ -1952,7 +1952,7 @@ def custom_profile_fields_for_realm(realm_id: int) -> List[CustomProfileField]:
 class CustomProfileFieldValue(models.Model):
     user_profile = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
     field = models.ForeignKey(CustomProfileField, on_delete=CASCADE)  # type: CustomProfileField
-    value = models.TextField()  # type: Text
+    value = models.TextField()  # type: str
 
     class Meta:
         unique_together = ('user_profile', 'field')
@@ -1981,13 +1981,13 @@ SLACK_INTERFACE = u'SlackOutgoingWebhookService'
 #   embedded bots with the same name will run the same code
 # - base_url and token are currently unused
 class Service(models.Model):
-    name = models.CharField(max_length=UserProfile.MAX_NAME_LENGTH)  # type: Text
+    name = models.CharField(max_length=UserProfile.MAX_NAME_LENGTH)  # type: str
     # Bot user corresponding to the Service.  The bot_type of this user
     # deterines the type of service.  If non-bot services are added later,
     # user_profile can also represent the owner of the Service.
     user_profile = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
-    base_url = models.TextField()  # type: Text
-    token = models.TextField()  # type: Text
+    base_url = models.TextField()  # type: str
+    token = models.TextField()  # type: str
     # Interface / API version of the service.
     interface = models.PositiveSmallIntegerField(default=1)  # type: int
 
@@ -2003,9 +2003,9 @@ class Service(models.Model):
     _interfaces = {
         GENERIC: GENERIC_INTERFACE,
         SLACK: SLACK_INTERFACE,
-    }  # type: Dict[int, Text]
+    }  # type: Dict[int, str]
 
-    def interface_name(self) -> Text:
+    def interface_name(self) -> str:
         # Raises KeyError if invalid
         return self._interfaces[self.interface]
 
@@ -2019,16 +2019,16 @@ def get_service_profile(user_profile_id: str, service_name: str) -> Service:
 
 class BotStorageData(models.Model):
     bot_profile = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
-    key = models.TextField(db_index=True)  # type: Text
-    value = models.TextField()  # type: Text
+    key = models.TextField(db_index=True)  # type: str
+    value = models.TextField()  # type: str
 
     class Meta:
         unique_together = ("bot_profile", "key")
 
 class BotConfigData(models.Model):
     bot_profile = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
-    key = models.TextField(db_index=True)  # type: Text
-    value = models.TextField()  # type: Text
+    key = models.TextField(db_index=True)  # type: str
+    value = models.TextField()  # type: str
 
     class Meta(object):
         unique_together = ("bot_profile", "key")

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -6,7 +6,7 @@ from django.test import override_settings
 from django_auth_ldap.backend import _LDAPUser
 from django.contrib.auth import authenticate
 from django.test.client import RequestFactory
-from typing import Any, Callable, Dict, List, Optional, Text, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from builtins import object
 from oauth2client.crypt import AppIdentityError
 from django.core import signing
@@ -66,7 +66,7 @@ import ujson
 from zerver.lib.test_helpers import MockLDAP, load_subdomain_token
 
 class AuthBackendTest(ZulipTestCase):
-    def get_username(self, email_to_username: Optional[Callable[[Text], Text]]=None) -> Text:
+    def get_username(self, email_to_username: Optional[Callable[[str], str]]=None) -> str:
         username = self.example_email('hamlet')
         if email_to_username is not None:
             username = email_to_username(self.example_email('hamlet'))
@@ -776,7 +776,7 @@ class GoogleOAuthTest(ZulipTestCase):
                            *, subdomain: Optional[str]=None,
                            mobile_flow_otp: Optional[str]=None,
                            is_signup: Optional[str]=None,
-                           next: Text='') -> HttpResponse:
+                           next: str='') -> HttpResponse:
         url = "/accounts/login/google/"
         params = {}
         headers = {}
@@ -898,7 +898,7 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
         return self.client_get(url_path, subdomain=subdomain)
 
     def test_redirect_to_next_url_for_log_into_subdomain(self) -> None:
-        def test_redirect_to_next_url(next: Text='') -> HttpResponse:
+        def test_redirect_to_next_url(next: str='') -> HttpResponse:
             data = {'name': 'Hamlet',
                     'email': self.example_email("hamlet"),
                     'subdomain': 'zulip',
@@ -1595,7 +1595,7 @@ class TestDevAuthBackend(ZulipTestCase):
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
 
     def test_redirect_to_next_url(self) -> None:
-        def do_local_login(formaction: Text) -> HttpResponse:
+        def do_local_login(formaction: str) -> HttpResponse:
             user_email = self.example_email('hamlet')
             data = {'direct_email': user_email}
             return self.client_post(formaction, data)
@@ -1791,7 +1791,7 @@ class TestZulipRemoteUserBackend(ZulipTestCase):
     def test_redirect_to(self) -> None:
         """This test verifies the behavior of the redirect_to logic in
         login_or_register_remote_user."""
-        def test_with_redirect_to_param_set_as_next(next: Text='') -> HttpResponse:
+        def test_with_redirect_to_param_set_as_next(next: str='') -> HttpResponse:
             user_profile = self.example_user('hamlet')
             email = user_profile.email
             with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -51,7 +51,7 @@ import ujson
 
 import urllib
 from zerver.lib.str_utils import NonBinaryStr
-from typing import Any, AnyStr, Dict, List, Optional, Set, Tuple, Text
+from typing import Any, AnyStr, Dict, List, Optional, Set, Tuple
 
 class FencedBlockPreprocessorTest(TestCase):
     def test_simple_quoting(self) -> None:
@@ -166,7 +166,7 @@ class FencedBlockPreprocessorTest(TestCase):
         lines = processor.run(markdown)
         self.assertEqual(lines, expected)
 
-def bugdown_convert(text: Text) -> Text:
+def bugdown_convert(text: str) -> str:
     return bugdown.convert(text, message_realm=get_realm('zulip'))
 
 class BugdownMiscTest(ZulipTestCase):
@@ -179,7 +179,7 @@ class BugdownMiscTest(ZulipTestCase):
     def test_get_full_name_info(self) -> None:
         realm = get_realm('zulip')
 
-        def make_user(email: Text, full_name: Text) -> UserProfile:
+        def make_user(email: str, full_name: str) -> UserProfile:
             return create_user(
                 email=email,
                 password='whatever',
@@ -225,15 +225,15 @@ class BugdownMiscTest(ZulipTestCase):
                 mock_logger.assert_called_with("Cannot find KaTeX for latex rendering!")
 
 class BugdownTest(ZulipTestCase):
-    def assertEqual(self, first: Any, second: Any, msg: Text = "") -> None:
-        if isinstance(first, Text) and isinstance(second, Text):
+    def assertEqual(self, first: Any, second: Any, msg: str = "") -> None:
+        if isinstance(first, str) and isinstance(second, str):
             if first != second:
                 raise AssertionError("Actual and expected outputs do not match; showing diff.\n" +
                                      mdiff.diff_strings(first, second) + msg)
         else:
             super().assertEqual(first, second)
 
-    def load_bugdown_tests(self) -> Tuple[Dict[Text, Any], List[List[Text]]]:
+    def load_bugdown_tests(self) -> Tuple[Dict[str, Any], List[List[str]]]:
         test_fixtures = {}
         data_file = open(os.path.join(os.path.dirname(__file__), 'fixtures/markdown_test_cases.json'), 'r')
         data = ujson.loads('\n'.join(data_file.readlines()))
@@ -278,7 +278,7 @@ class BugdownTest(ZulipTestCase):
             print("Running Bugdown test %s" % (name,))
             self.assertEqual(converted, test['expected_output'])
 
-        def replaced(payload: Text, url: Text, phrase: Text='') -> Text:
+        def replaced(payload: str, url: str, phrase: str='') -> str:
             target = " target=\"_blank\""
             if url[:4] == 'http':
                 href = url
@@ -478,7 +478,7 @@ class BugdownTest(ZulipTestCase):
         self.assertEqual(bugdown.get_tweet_id('https://twitter.com/windyoona/status/410766290349879296/'), '410766290349879296')
 
     def test_inline_interesting_links(self) -> None:
-        def make_link(url: Text) -> Text:
+        def make_link(url: str) -> str:
             return '<a href="%s" target="_blank" title="%s">%s</a>' % (url, url, url)
 
         normal_tweet_html = ('<a href="https://twitter.com/Twitter" target="_blank"'
@@ -498,7 +498,7 @@ class BugdownTest(ZulipTestCase):
 
         emoji_in_tweet_html = """Zulip is <span class="emoji emoji-1f4af" title="hundred points">:hundred_points:</span>% open-source!"""
 
-        def make_inline_twitter_preview(url: Text, tweet_html: Text, image_html: Text='') -> Text:
+        def make_inline_twitter_preview(url: str, tweet_html: str, image_html: str='') -> str:
             ## As of right now, all previews are mocked to be the exact same tweet
             return ('<div class="inline-preview-twitter">'
                     '<div class="twitter-tweet">'
@@ -612,7 +612,7 @@ class BugdownTest(ZulipTestCase):
         self.assertTrue(bugdown.content_has_emoji_syntax(':smile: ::::::'))
 
     def test_realm_emoji(self) -> None:
-        def emoji_img(name: Text, file_name: Text, realm_id: int) -> Text:
+        def emoji_img(name: str, file_name: str, realm_id: int) -> str:
             return '<img alt="%s" class="emoji" src="%s" title="%s">' % (
                 name, get_emoji_url(file_name, realm_id), name[1:-1].replace("_", " "))
 
@@ -796,7 +796,7 @@ class BugdownTest(ZulipTestCase):
         msg = Message(sender=user_profile, sending_client=get_client("test"))
         realm_alert_words = alert_words_in_realm(user_profile.realm)
 
-        def render(msg: Message, content: Text) -> Text:
+        def render(msg: Message, content: str) -> str:
             return render_markdown(msg,
                                    content,
                                    realm_alert_words=realm_alert_words,
@@ -898,7 +898,7 @@ class BugdownTest(ZulipTestCase):
         self.assertEqual(msg.mentions_user_ids, set([user_profile.id]))
 
     def test_possible_mentions(self) -> None:
-        def assert_mentions(content: Text, names: Set[Text]) -> None:
+        def assert_mentions(content: str, names: Set[str]) -> None:
             self.assertEqual(possible_mentions(content), names)
 
         assert_mentions('', set())
@@ -937,7 +937,7 @@ class BugdownTest(ZulipTestCase):
                          '<p>Hey @<strong>Nonexistent User</strong></p>')
         self.assertEqual(msg.mentions_user_ids, set())
 
-    def create_user_group_for_test(self, user_group_name: Text) -> UserGroup:
+    def create_user_group_for_test(self, user_group_name: str) -> UserGroup:
         othello = self.example_user('othello')
         return create_user_group(user_group_name, [othello], get_realm('zulip'))
 
@@ -961,7 +961,7 @@ class BugdownTest(ZulipTestCase):
         self.assertEqual(msg.mentions_user_group_ids, set([user_group.id]))
 
     def test_possible_user_group_mentions(self) -> None:
-        def assert_mentions(content: Text, names: Set[Text]) -> None:
+        def assert_mentions(content: str, names: Set[str]) -> None:
             self.assertEqual(possible_user_group_mentions(content), names)
 
         assert_mentions('', set())

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Union, List, Dict, Text, Any
+from typing import Union, List, Dict, Any
 from mock import patch
 
 from zerver.lib.actions import get_realm, try_add_realm_custom_profile_field, \
@@ -410,7 +410,7 @@ class CustomProfileFieldTest(ZulipTestCase):
         user_profile = self.example_user('iago')
         realm = user_profile.realm
         field = CustomProfileField.objects.get(name="Phone number", realm=realm)
-        data = [{'id': field.id, 'value': u'123456'}]  # type: List[Dict[str, Union[int, Text]]]
+        data = [{'id': field.id, 'value': u'123456'}]  # type: List[Dict[str, Union[int, str]]]
         do_update_user_custom_profile_data(user_profile, data)
 
         self.assertEqual(len(custom_profile_fields_for_realm(realm.id)), self.original_count)

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -5,7 +5,7 @@ import re
 import os
 from collections import defaultdict
 
-from typing import Any, Dict, Iterable, List, Optional, Text, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 from django.test import TestCase, override_settings
 from django.http import HttpResponse, HttpRequest
 from django.test.client import RequestFactory
@@ -236,7 +236,7 @@ class DecoratorTestCase(TestCase):
 
     def test_api_key_only_webhook_view(self) -> None:
         @api_key_only_webhook_view('ClientName')
-        def my_webhook(request: HttpRequest, user_profile: UserProfile) -> Text:
+        def my_webhook(request: HttpRequest, user_profile: UserProfile) -> str:
             return user_profile.email
 
         @api_key_only_webhook_view('ClientName')
@@ -1286,13 +1286,13 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
         self.assert_json_error_contains(self._do_test(user_email), "This organization has been deactivated")
         do_reactivate_realm(user_profile.realm)
 
-    def _do_test(self, user_email: Text) -> HttpResponse:
+    def _do_test(self, user_email: str) -> HttpResponse:
         stream_name = "stream name"
         self.common_subscribe_to_streams(user_email, [stream_name])
         data = {"password": initial_password(user_email), "stream": stream_name}
         return self.client_post(r'/json/subscriptions/exists', data)
 
-    def _login(self, user_email: Text, user_realm: Realm, password: str=None) -> None:
+    def _login(self, user_email: str, user_realm: Realm, password: str=None) -> None:
         if password:
             user_profile = get_user(user_email, user_realm)
             user_profile.set_password(password)
@@ -1439,13 +1439,13 @@ class CacheTestCase(ZulipTestCase):
 
     def test_cachify_is_per_call(self) -> None:
 
-        def test_greetings(greeting: Text) -> Tuple[List[Text], List[Text]]:
+        def test_greetings(greeting: str) -> Tuple[List[str], List[str]]:
 
-            result_log = []  # type: List[Text]
-            work_log = []  # type: List[Text]
+            result_log = []  # type: List[str]
+            work_log = []  # type: List[str]
 
             @cachify
-            def greet(first_name: Text, last_name: Text) -> Text:
+            def greet(first_name: str, last_name: str) -> str:
                 msg = '%s %s %s' % (greeting, first_name, last_name)
                 work_log.append(msg)
                 return msg

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # See https://zulip.readthedocs.io/en/latest/subsystems/events-system.html for
 # high-level documentation on how this system works.
-from typing import Any, Callable, Dict, List, Optional, Set, Text, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 import os
 import shutil
 import sys
@@ -1265,7 +1265,7 @@ class EventsRegisterTest(ZulipTestCase):
         if property_type is bool:
             validator = check_bool
             vals = bool_tests
-        elif property_type is Text:
+        elif property_type is str:
             validator = check_string
         elif property_type is int:
             validator = check_int
@@ -1440,7 +1440,7 @@ class EventsRegisterTest(ZulipTestCase):
         property_type = UserProfile.property_types[setting_name]
         if property_type is bool:
             validator = check_bool
-        elif property_type is Text:
+        elif property_type is str:
             validator = check_string
         else:
             raise AssertionError("Unexpected property type %s" % (property_type,))
@@ -2219,8 +2219,8 @@ class GetUnreadMsgsTest(ZulipTestCase):
         subscription.in_home_view = False
         subscription.save()
 
-    def mute_topic(self, user_profile: UserProfile, stream_name: Text,
-                   topic_name: Text) -> None:
+    def mute_topic(self, user_profile: UserProfile, stream_name: str,
+                   topic_name: str) -> None:
         realm = user_profile.realm
         stream = get_stream(stream_name, realm)
         recipient = get_stream_recipient(stream.id)

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -22,7 +22,6 @@ import mock
 import time
 
 import urllib
-from typing import Text
 
 class MITNameTest(ZulipTestCase):
     def test_valid_hesiod(self) -> None:
@@ -57,7 +56,7 @@ class RateLimitTests(ZulipTestCase):
         settings.RATE_LIMITING = False
         remove_ratelimit_rule(1, 5)
 
-    def send_api_message(self, email: Text, content: Text) -> HttpResponse:
+    def send_api_message(self, email: str, content: str) -> HttpResponse:
         return self.api_post(email, "/api/v1/messages", {"type": "stream",
                                                          "to": "Verona",
                                                          "client": "test suite",

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -8,7 +8,7 @@ from django.http import HttpResponse
 from django.test import override_settings
 from mock import MagicMock, patch
 import urllib
-from typing import Any, Dict, List, Text
+from typing import Any, Dict, List
 
 from zerver.lib.actions import do_create_user
 from zerver.lib.test_classes import ZulipTestCase
@@ -388,7 +388,7 @@ class HomeTest(ZulipTestCase):
         page_params = self._get_page_params(result)
         self.assertEqual(page_params['realm_notifications_stream_id'], get_stream('Denmark', realm).id)
 
-    def create_bot(self, owner: UserProfile, bot_email: Text, bot_name: Text) -> UserProfile:
+    def create_bot(self, owner: UserProfile, bot_email: str, bot_name: str) -> UserProfile:
         user = do_create_user(
             email=bot_email,
             password='123',
@@ -400,7 +400,7 @@ class HomeTest(ZulipTestCase):
         )
         return user
 
-    def create_non_active_user(self, realm: Realm, email: Text, name: Text) -> UserProfile:
+    def create_non_active_user(self, realm: Realm, email: str, name: str) -> UserProfile:
         user = do_create_user(
             email=email,
             password='123',

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Any, Dict, Generator, Mapping, Text, Union
+from typing import Any, Dict, Generator, Mapping, Union
 
 import mock
 
@@ -26,7 +26,7 @@ from zerver.tornado.event_queue import (
 )
 
 class EditMessageSideEffectsTest(ZulipTestCase):
-    def _assert_update_does_not_notify_anybody(self, message_id: int, content: Text) -> None:
+    def _assert_update_does_not_notify_anybody(self, message_id: int, content: str) -> None:
         url = '/json/messages/' + str(message_id)
 
         request = dict(
@@ -57,7 +57,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             content='now we mention @**Cordelia Lear**',
         )
 
-    def _login_and_send_original_stream_message(self, content: Text) -> int:
+    def _login_and_send_original_stream_message(self, content: str) -> int:
         '''
             Note our conventions here:
 
@@ -80,7 +80,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
         return message_id
 
-    def _get_queued_data_for_message_update(self, message_id: int, content: Text,
+    def _get_queued_data_for_message_update(self, message_id: int, content: str,
                                             expect_short_circuit: bool=False) -> Dict[str, Any]:
         '''
         This function updates a message with a post to

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -83,7 +83,7 @@ import DNS
 import mock
 import time
 import ujson
-from typing import Any, Dict, List, Optional, Set, Text
+from typing import Any, Dict, List, Optional, Set
 
 from collections import namedtuple
 
@@ -246,12 +246,12 @@ class TopicHistoryTest(ZulipTestCase):
 
 
 class TestCrossRealmPMs(ZulipTestCase):
-    def make_realm(self, domain: Text) -> Realm:
+    def make_realm(self, domain: str) -> Realm:
         realm = Realm.objects.create(string_id=domain, invite_required=False)
         RealmDomain.objects.create(realm=realm, domain=domain)
         return realm
 
-    def create_user(self, email: Text) -> UserProfile:
+    def create_user(self, email: str) -> UserProfile:
         subdomain = email.split("@")[1]
         self.register(email, 'test', subdomain=subdomain)
         return get_user(email, get_realm(subdomain))
@@ -436,7 +436,7 @@ class PersonalMessagesTest(ZulipTestCase):
         recipient = Recipient.objects.get(type_id=user_profile.id, type=Recipient.PERSONAL)
         self.assertEqual(most_recent_message(user_profile).recipient, recipient)
 
-    def assert_personal(self, sender_email: Text, receiver_email: Text, content: Text="testcontent") -> None:
+    def assert_personal(self, sender_email: str, receiver_email: str, content: str="testcontent") -> None:
         """
         Send a private message from `sender_email` to `receiver_email` and check
         that only those two parties actually received the message.
@@ -489,8 +489,8 @@ class PersonalMessagesTest(ZulipTestCase):
 
 class StreamMessagesTest(ZulipTestCase):
 
-    def assert_stream_message(self, stream_name: Text, topic_name: Text="test topic",
-                              content: Text="test content") -> None:
+    def assert_stream_message(self, stream_name: str, topic_name: str="test topic",
+                              content: str="test content") -> None:
         """
         Check that messages sent to a stream reach all subscribers to that stream.
         """
@@ -657,7 +657,7 @@ class StreamMessagesTest(ZulipTestCase):
         message = most_recent_message(user_profile)
         assert(UserMessage.objects.get(user_profile=user_profile, message=message).flags.mentioned.is_set)
 
-    def _send_stream_message(self, email: Text, stream_name: Text, content: Text) -> Set[int]:
+    def _send_stream_message(self, email: str, stream_name: str, content: str) -> Set[int]:
         with mock.patch('zerver.lib.actions.send_event') as m:
             self.send_stream_message(
                 email,
@@ -1548,8 +1548,8 @@ class ScheduledMessageTest(ZulipTestCase):
         self.assert_json_error(result, 'Missing deliver_at in a request for delayed message delivery')
 
 class EditMessageTest(ZulipTestCase):
-    def check_message(self, msg_id: int, subject: Optional[Text]=None,
-                      content: Optional[Text]=None) -> Message:
+    def check_message(self, msg_id: int, subject: Optional[str]=None,
+                      content: Optional[str]=None) -> Message:
         msg = Message.objects.get(id=msg_id)
         cached = MessageDict.wide_dict(msg)
         MessageDict.finalize_payload(cached, apply_markdown=False, client_gravatar=False)
@@ -1952,7 +1952,7 @@ class EditMessageTest(ZulipTestCase):
             })
             self.assert_json_success(result)
 
-        def do_edit_message_assert_success(id_: int, unique_str: Text, topic_only: bool=False) -> None:
+        def do_edit_message_assert_success(id_: int, unique_str: str, topic_only: bool=False) -> None:
             new_subject = 'subject' + unique_str
             new_content = 'content' + unique_str
             params_dict = {'message_id': id_, 'subject': new_subject}
@@ -1965,7 +1965,7 @@ class EditMessageTest(ZulipTestCase):
             else:
                 self.check_message(id_, subject=new_subject, content=new_content)
 
-        def do_edit_message_assert_error(id_: int, unique_str: Text, error: Text,
+        def do_edit_message_assert_error(id_: int, unique_str: str, error: str,
                                          topic_only: bool=False) -> None:
             message = Message.objects.get(id=id_)
             old_subject = message.topic_name()
@@ -2023,7 +2023,7 @@ class EditMessageTest(ZulipTestCase):
             self.assert_json_success(result)
 
         def do_edit_message_assert_success(id_, unique_str):
-            # type: (int, Text) -> None
+            # type: (int, str) -> None
             new_subject = 'subject' + unique_str
             params_dict = {'message_id': id_, 'subject': new_subject}
             result = self.client_patch("/json/messages/" + str(id_), params_dict)
@@ -2031,7 +2031,7 @@ class EditMessageTest(ZulipTestCase):
             self.check_message(id_, subject=new_subject)
 
         def do_edit_message_assert_error(id_, unique_str, error):
-            # type: (int, Text, Text) -> None
+            # type: (int, str, str) -> None
             message = Message.objects.get(id=id_)
             old_subject = message.topic_name()
             old_content = message.content
@@ -2136,7 +2136,7 @@ class EditMessageTest(ZulipTestCase):
 class MirroredMessageUsersTest(ZulipTestCase):
     def test_invalid_sender(self) -> None:
         user = self.example_user('hamlet')
-        recipients = []  # type: List[Text]
+        recipients = []  # type: List[str]
 
         Request = namedtuple('Request', ['POST'])
         request = Request(POST=dict())  # no sender
@@ -2153,7 +2153,7 @@ class MirroredMessageUsersTest(ZulipTestCase):
         user = self.example_user('hamlet')
         sender = user
 
-        recipients = []  # type: List[Text]
+        recipients = []  # type: List[str]
 
         Request = namedtuple('Request', ['POST', 'client'])
         request = Request(POST = dict(sender=sender.email, type='private'),
@@ -2545,7 +2545,7 @@ class MissedMessageTest(ZulipTestCase):
             )
             self.assertEqual(sorted(user_ids), sorted(presence_idle_user_ids))
 
-        def set_presence(user_id: int, client_name: Text, ago: int) -> None:
+        def set_presence(user_id: int, client_name: str, ago: int) -> None:
             when = timezone_now() - datetime.timedelta(seconds=ago)
             UserPresence.objects.create(
                 user_profile_id=user_id,
@@ -2970,7 +2970,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
             user_messages = get_user_messages(user)
             self.assertEqual(len(user_messages), count)
 
-        def assert_last_um_content(user: UserProfile, content: Text, negate: bool=False) -> None:
+        def assert_last_um_content(user: UserProfile, content: str, negate: bool=False) -> None:
             user_messages = get_user_messages(user)
             if negate:
                 self.assertNotEqual(user_messages[-1].content, content)

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -10,7 +10,7 @@ from django.http import HttpResponse
 from django.test import override_settings
 from email.utils import formataddr
 from mock import patch, MagicMock
-from typing import Any, Dict, List, Text, Optional
+from typing import Any, Dict, List, Optional
 
 from zerver.lib.notifications import fix_emojis, \
     handle_missedmessage_emails, relative_to_full_url
@@ -29,7 +29,7 @@ from zerver.models import (
 from zerver.lib.test_helpers import get_test_image_file
 
 class TestMissedMessages(ZulipTestCase):
-    def normalize_string(self, s: Text) -> Text:
+    def normalize_string(self, s: str) -> str:
         s = s.strip()
         return re.sub(r'\s+', ' ', s)
 

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -8,7 +8,7 @@ import requests
 from builtins import object
 from django.test import override_settings
 from requests import Response
-from typing import Any, Dict, Tuple, Text, Optional
+from typing import Any, Dict, Tuple, Optional
 
 from zerver.lib.outgoing_webhook import do_rest_call, OutgoingWebhookServiceInterface
 from zerver.lib.test_classes import ZulipTestCase
@@ -27,7 +27,7 @@ def timeout_error(http_method: Any, final_url: Any, data: Any, **request_kwargs:
     raise requests.exceptions.Timeout("Time is up!")
 
 class MockServiceHandler(OutgoingWebhookServiceInterface):
-    def process_success(self, response: Response, event: Dict[Text, Any]) -> Tuple[Optional[str], Optional[str]]:
+    def process_success(self, response: Response, event: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
         return "Success!", None
 
 service_handler = MockServiceHandler(None, None, None, None)
@@ -134,7 +134,7 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
         self.assertEqual(last_message.content, "Success! Hidley ho, I'm a webhook responding!")
         self.assertEqual(last_message.sender_id, self.bot_profile.id)
         display_recipient = get_display_recipient(last_message.recipient)
-        # The next two lines error on mypy because the display_recipient is of type Union[Text, List[Dict[str, Any]]].
+        # The next two lines error on mypy because the display_recipient is of type Union[str, List[Dict[str, Any]]].
         # In this case, we know that display_recipient will be of type List[Dict[str, Any]].
         # Otherwise this test will error, which is wanted behavior anyway.
         self.assert_length(display_recipient, 1)  # type: ignore

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -5,7 +5,7 @@ import requests
 import mock
 from mock import call
 import time
-from typing import Any, Dict, List, Optional, Union, SupportsInt, Text
+from typing import Any, Dict, List, Optional, Union, SupportsInt
 
 import base64
 import gcm
@@ -77,7 +77,7 @@ class BouncerTestCase(ZulipTestCase):
             raise AssertionError("Unsupported method for bounce_request")
         return result
 
-    def get_generic_payload(self, method: Text='register') -> Dict[str, Any]:
+    def get_generic_payload(self, method: str='register') -> Dict[str, Any]:
         user_id = 10
         token = "111222"
         token_kind = PushDeviceToken.GCM
@@ -1109,7 +1109,7 @@ class GCMCanonicalTest(GCMTest):
         res['canonical'] = {t1: t2}
         mock_send.return_value = res
 
-        def get_count(hex_token: Text) -> int:
+        def get_count(hex_token: str) -> int:
             token = apn.hex_to_b64(hex_token)
             return PushDeviceToken.objects.filter(
                 token=token, kind=PushDeviceToken.GCM).count()
@@ -1137,7 +1137,7 @@ class GCMCanonicalTest(GCMTest):
         res['canonical'] = {old_token: new_token}
         mock_send.return_value = res
 
-        def get_count(hex_token: Text) -> int:
+        def get_count(hex_token: str) -> int:
             token = apn.hex_to_b64(hex_token)
             return PushDeviceToken.objects.filter(
                 token=token, kind=PushDeviceToken.GCM).count()
@@ -1162,7 +1162,7 @@ class GCMNotRegisteredTest(GCMTest):
         res['errors'] = {'NotRegistered': [token]}
         mock_send.return_value = res
 
-        def get_count(hex_token: Text) -> int:
+        def get_count(hex_token: str) -> int:
             token = apn.hex_to_b64(hex_token)
             return PushDeviceToken.objects.filter(
                 token=token, kind=PushDeviceToken.GCM).count()

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -4,7 +4,7 @@ import ujson
 
 from django.http import HttpResponse
 from mock import patch
-from typing import Any, Dict, List, Text, Union, Mapping
+from typing import Any, Dict, List, Union, Mapping
 
 from zerver.lib.actions import (
     do_change_is_admin,
@@ -21,7 +21,7 @@ from zerver.models import get_realm, Realm, UserProfile, ScheduledEmail, get_str
 
 class RealmTest(ZulipTestCase):
     def assert_user_profile_cache_gets_new_name(self, user_profile: UserProfile,
-                                                new_realm_name: Text) -> None:
+                                                new_realm_name: str) -> None:
         self.assertEqual(user_profile.realm.name, new_realm_name)
 
     def test_do_set_realm_name_caching(self) -> None:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -64,7 +64,7 @@ import re
 import smtplib
 import ujson
 
-from typing import Any, Dict, List, Optional, Set, Text
+from typing import Any, Dict, List, Optional, Set
 
 import urllib
 import os
@@ -126,7 +126,7 @@ class AddNewUserHistoryTest(ZulipTestCase):
         stream_dict = {
             "Denmark": {"description": "A Scandinavian country", "invite_only": False},
             "Verona": {"description": "A city in Italy", "invite_only": False}
-        }  # type: Dict[Text, Dict[Text, Any]]
+        }  # type: Dict[str, Dict[str, Any]]
         realm = get_realm('zulip')
         set_default_streams(realm, stream_dict)
         with patch("zerver.lib.actions.add_new_user_history"):
@@ -351,7 +351,7 @@ class LoginTest(ZulipTestCase):
     def test_register(self) -> None:
         realm = get_realm("zulip")
         stream_dict = {"stream_"+str(i): {"description": "stream_%s_description" % i, "invite_only": False}
-                       for i in range(40)}  # type: Dict[Text, Dict[Text, Any]]
+                       for i in range(40)}  # type: Dict[str, Dict[str, Any]]
         for stream_name in stream_dict.keys():
             self.make_stream(stream_name, realm=realm)
 
@@ -455,7 +455,7 @@ class LoginTest(ZulipTestCase):
         self.assertEqual(response["Location"], "http://zulip.testserver")
 
 class InviteUserBase(ZulipTestCase):
-    def check_sent_emails(self, correct_recipients: List[Text],
+    def check_sent_emails(self, correct_recipients: List[str],
                           custom_from_name: Optional[str]=None) -> None:
         from django.core.mail import outbox
         self.assertEqual(len(outbox), len(correct_recipients))
@@ -469,7 +469,7 @@ class InviteUserBase(ZulipTestCase):
 
         self.assertIn(FromAddress.NOREPLY, outbox[0].from_email)
 
-    def invite(self, users: Text, streams: List[Text], body: str='',
+    def invite(self, users: str, streams: List[str], body: str='',
                invite_as_admin: str="false") -> HttpResponse:
         """
         Invites the specified users to Zulip with the specified streams.
@@ -1096,7 +1096,7 @@ class MultiuseInviteTest(ZulipTestCase):
         self.realm.save()
 
     def generate_multiuse_invite_link(self, streams: List[Stream]=None,
-                                      date_sent: Optional[datetime.datetime]=None) -> Text:
+                                      date_sent: Optional[datetime.datetime]=None) -> str:
         invite = MultiuseInvite(realm=self.realm, referred_by=self.example_user("iago"))
         invite.save()
 
@@ -1111,7 +1111,7 @@ class MultiuseInviteTest(ZulipTestCase):
 
         return confirmation_url(key, self.realm.host, Confirmation.MULTIUSE_INVITE)
 
-    def check_user_able_to_register(self, email: Text, invite_link: Text) -> None:
+    def check_user_able_to_register(self, email: str, invite_link: str) -> None:
         password = "password"
 
         result = self.client_post(invite_link, {'email': email})
@@ -1550,7 +1550,7 @@ class RealmCreationTest(ZulipTestCase):
 
 class UserSignUpTest(ZulipTestCase):
 
-    def _assert_redirected_to(self, result: HttpResponse, url: Text) -> None:
+    def _assert_redirected_to(self, result: HttpResponse, url: str) -> None:
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result['LOCATION'], url)
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Text
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
@@ -947,12 +947,12 @@ class StreamAdminTest(ZulipTestCase):
             status_code=403)
 
 class DefaultStreamTest(ZulipTestCase):
-    def get_default_stream_names(self, realm: Realm) -> Set[Text]:
+    def get_default_stream_names(self, realm: Realm) -> Set[str]:
         streams = get_default_streams_for_realm(realm.id)
         stream_names = [s.name for s in streams]
         return set(stream_names)
 
-    def get_default_stream_descriptions(self, realm: Realm) -> Set[Text]:
+    def get_default_stream_descriptions(self, realm: Realm) -> Set[str]:
         streams = get_default_streams_for_realm(realm.id)
         stream_descriptions = [s.description for s in streams]
         return set(stream_descriptions)
@@ -963,7 +963,7 @@ class DefaultStreamTest(ZulipTestCase):
             "apple": {"description": "A red fruit", "invite_only": False},
             "banana": {"description": "A yellow fruit", "invite_only": False},
             "Carrot Cake": {"description": "A delicious treat", "invite_only": False}
-        }  # type: Dict[Text, Dict[Text, Any]]
+        }  # type: Dict[str, Dict[str, Any]]
         expected_names = list(stream_dict.keys())
         expected_names.append("announce")
         expected_descriptions = [i["description"] for i in stream_dict.values()] + [""]
@@ -981,7 +981,7 @@ class DefaultStreamTest(ZulipTestCase):
             "apple": {"description": "A red fruit", "invite_only": False},
             "banana": {"description": "A yellow fruit", "invite_only": False},
             "Carrot Cake": {"description": "A delicious treat", "invite_only": False}
-        }  # type: Dict[Text, Dict[Text, Any]]
+        }  # type: Dict[str, Dict[str, Any]]
         expected_names = list(stream_dict.keys())
         expected_descriptions = [i["description"] for i in stream_dict.values()]
         set_default_streams(realm, stream_dict)
@@ -1642,7 +1642,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.test_realm = self.user_profile.realm
         self.streams = self.get_streams(self.test_email, self.test_realm)
 
-    def make_random_stream_names(self, existing_stream_names: List[Text]) -> List[Text]:
+    def make_random_stream_names(self, existing_stream_names: List[str]) -> List[str]:
         """
         Helper function to make up random stream names. It takes
         existing_stream_names and randomly appends a digit to the end of each,
@@ -1676,11 +1676,11 @@ class SubscriptionAPITest(ZulipTestCase):
         # also check that this matches the list of your subscriptions
         self.assertEqual(sorted(list_streams), sorted(self.streams))
 
-    def helper_check_subs_before_and_after_add(self, subscriptions: List[Text],
+    def helper_check_subs_before_and_after_add(self, subscriptions: List[str],
                                                other_params: Dict[str, Any],
-                                               subscribed: List[Text],
-                                               already_subscribed: List[Text],
-                                               email: Text, new_subs: List[Text],
+                                               subscribed: List[str],
+                                               already_subscribed: List[str],
+                                               email: str, new_subs: List[str],
                                                realm: Realm,
                                                invite_only: bool=False) -> None:
         """
@@ -1926,8 +1926,8 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assert_json_error(result,
                                "Invalid stream name '%s'" % (invalid_stream_name,))
 
-    def assert_adding_subscriptions_for_principal(self, invitee_email: Text, invitee_realm: Realm,
-                                                  streams: List[Text], invite_only: bool=False) -> None:
+    def assert_adding_subscriptions_for_principal(self, invitee_email: str, invitee_realm: Realm,
+                                                  streams: List[str], invite_only: bool=False) -> None:
         """
         Calling POST /json/users/me/subscriptions on behalf of another principal (for
         whom you have permission to add subscriptions) should successfully add
@@ -2322,9 +2322,9 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assert_json_error(result, "User not authorized to execute queries on behalf of '%s'"
                                % (principal,), status_code=403)
 
-    def helper_check_subs_before_and_after_remove(self, subscriptions: List[Text],
+    def helper_check_subs_before_and_after_remove(self, subscriptions: List[str],
                                                   json_dict: Dict[str, Any],
-                                                  email: Text, new_subs: List[Text],
+                                                  email: str, new_subs: List[str],
                                                   realm: Realm) -> None:
         """
         Check result of removing subscriptions.
@@ -2378,7 +2378,7 @@ class SubscriptionAPITest(ZulipTestCase):
                                     {"subscriptions": ujson.dumps(streams_to_remove)})
         self.assert_json_error(result, "Stream(s) (%s) do not exist" % (random_streams[0],))
 
-    def helper_subscriptions_exists(self, stream: Text, expect_success: bool, subscribed: bool) -> None:
+    def helper_subscriptions_exists(self, stream: str, expect_success: bool, subscribed: bool) -> None:
         """
         Call /json/subscriptions/exists on a stream and expect a certain result.
         """
@@ -2475,7 +2475,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertIn("subscribed", result.json())
         self.assertTrue(result.json()["subscribed"])
 
-    def get_subscription(self, user_profile: UserProfile, stream_name: Text) -> Subscription:
+    def get_subscription(self, user_profile: UserProfile, stream_name: str) -> Subscription:
         stream = get_stream(stream_name, self.test_realm)
         return Subscription.objects.get(
             user_profile=user_profile,
@@ -2727,18 +2727,18 @@ class GetSubscribersTest(ZulipTestCase):
         self.email = self.user_profile.email
         self.login(self.email)
 
-    def assert_user_got_subscription_notification(self, expected_msg: Text) -> None:
+    def assert_user_got_subscription_notification(self, expected_msg: str) -> None:
         # verify that the user was sent a message informing them about the subscription
         msg = self.get_last_message()
         self.assertEqual(msg.recipient.type, msg.recipient.PERSONAL)
         self.assertEqual(msg.sender_id, self.notification_bot().id)
 
-        def non_ws(s: Text) -> Text:
+        def non_ws(s: str) -> str:
             return s.replace('\n', '').replace(' ', '')
 
         self.assertEqual(non_ws(msg.content), non_ws(expected_msg))
 
-    def check_well_formed_result(self, result: Dict[str, Any], stream_name: Text, realm: Realm) -> None:
+    def check_well_formed_result(self, result: Dict[str, Any], stream_name: str, realm: Realm) -> None:
         """
         A successful call to get_subscribers returns the list of subscribers in
         the form:
@@ -2753,12 +2753,12 @@ class GetSubscribersTest(ZulipTestCase):
             stream_name, realm)]
         self.assertEqual(sorted(result["subscribers"]), sorted(true_subscribers))
 
-    def make_subscriber_request(self, stream_id: int, email: Optional[Text]=None) -> HttpResponse:
+    def make_subscriber_request(self, stream_id: int, email: Optional[str]=None) -> HttpResponse:
         if email is None:
             email = self.email
         return self.api_get(email, "/api/v1/streams/%d/members" % (stream_id,))
 
-    def make_successful_subscriber_request(self, stream_name: Text) -> None:
+    def make_successful_subscriber_request(self, stream_name: str) -> None:
         stream_id = get_stream(stream_name, self.user_profile.realm).id
         result = self.make_subscriber_request(stream_id)
         self.assert_json_success(result)
@@ -3043,7 +3043,7 @@ class GetSubscribersTest(ZulipTestCase):
         result_dict = result.json()
         self.assertIn('subscribers', result_dict)
         self.assertIsInstance(result_dict['subscribers'], list)
-        subscribers = []  # type: List[Text]
+        subscribers = []  # type: List[str]
         for subscriber in result_dict['subscribers']:
             self.assertIsInstance(subscriber, str)
             subscribers.append(subscriber)

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -38,24 +38,24 @@ from http.cookies import SimpleCookie
 import urllib.parse
 
 from unittest.mock import patch
-from typing import Any, Callable, Dict, Generator, Optional, Text, List, cast
+from typing import Any, Callable, Dict, Generator, Optional, List, cast
 
 class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
     def setUp(self) -> None:
         super().setUp()
         signals.request_started.disconnect(close_old_connections)
         signals.request_finished.disconnect(close_old_connections)
-        self.session_cookie = None  # type: Optional[Dict[Text, Text]]
+        self.session_cookie = None  # type: Optional[Dict[str, str]]
 
     def tearDown(self) -> None:
         super().tearDown()
-        self.session_cookie = None  # type: Optional[Dict[Text, Text]]
+        self.session_cookie = None  # type: Optional[Dict[str, str]]
 
     @override_settings(DEBUG=False)
     def get_app(self) -> Application:
         return create_tornado_application()
 
-    def client_get(self, path: Text, **kwargs: Any) -> HTTPResponse:
+    def client_get(self, path: str, **kwargs: Any) -> HTTPResponse:
         self.add_session_cookie(kwargs)
         self.set_http_host(kwargs)
         if 'HTTP_HOST' in kwargs:
@@ -63,7 +63,7 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
             del kwargs['HTTP_HOST']
         return self.fetch(path, method='GET', **kwargs)
 
-    def fetch_async(self, method: Text, path: Text, **kwargs: Any) -> None:
+    def fetch_async(self, method: str, path: str, **kwargs: Any) -> None:
         self.add_session_cookie(kwargs)
         self.set_http_host(kwargs)
         if 'HTTP_HOST' in kwargs:
@@ -76,7 +76,7 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
             **kwargs
         )
 
-    def client_get_async(self, path: Text, **kwargs: Any) -> None:
+    def client_get_async(self, path: str, **kwargs: Any) -> None:
         self.set_http_host(kwargs)
         self.fetch_async('GET', path, **kwargs)
 
@@ -88,7 +88,7 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
             "Cookie": "{}={}".format(session_cookie, session_key)
         }
 
-    def get_session_cookie(self) -> Dict[Text, Text]:
+    def get_session_cookie(self) -> Dict[str, str]:
         return {} if self.session_cookie is None else self.session_cookie
 
     def add_session_cookie(self, kwargs: Dict[str, Any]) -> None:
@@ -211,7 +211,7 @@ class TornadoTestCase(WebSocketBaseTestCase):
         raise gen.Return([response_ack, response_message])
 
     @staticmethod
-    def _get_queue_events_data(email: Text) -> Dict[str, Dict[str, str]]:
+    def _get_queue_events_data(email: str) -> Dict[str, Dict[str, str]]:
         user_profile = UserProfile.objects.filter(email=email).first()
         events_query = {
             'queue_id': None,

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -52,7 +52,7 @@ from django.http import HttpRequest
 from django.utils.timezone import now as timezone_now
 from sendfile import _get_sendfile
 
-from typing import Any, Callable, Text
+from typing import Any, Callable
 
 def destroy_uploads() -> None:
     if os.path.exists(settings.LOCAL_UPLOADS_DIR):
@@ -464,7 +464,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
     def test_cross_realm_file_access(self) -> None:
 
-        def create_user(email: Text, realm_id: Text) -> UserProfile:
+        def create_user(email: str, realm_id: str) -> UserProfile:
             self.register(email, 'test', subdomain=realm_id)
             return get_user(email, get_realm(realm_id))
 
@@ -574,8 +574,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
             self.logout()
 
     def test_serve_local(self) -> None:
-        def check_xsend_links(name: Text, name_str_for_test: Text,
-                              content_disposition: Text='') -> None:
+        def check_xsend_links(name: str, name_str_for_test: str,
+                              content_disposition: str='') -> None:
             with self.settings(SENDFILE_BACKEND='sendfile.backends.nginx'):
                 _get_sendfile.clear()  # To clearout cached version of backend from djangosendfile
                 self.login(self.example_email("hamlet"))

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import Any, List, Optional, Text
+from typing import Any, List, Optional
 
 import ujson
 import django
@@ -19,7 +19,7 @@ from zerver.models import UserProfile, UserGroup, get_realm, Realm, \
     UserGroupMembership
 
 class UserGroupTestCase(ZulipTestCase):
-    def create_user_group_for_test(self, group_name: Text,
+    def create_user_group_for_test(self, group_name: str,
                                    realm: Realm=get_realm('zulip')) -> UserGroup:
         members = [self.example_user('othello')]
         return create_user_group(group_name, members, realm)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from typing import (Any, Dict, Iterable, List, Mapping,
-                    Optional, TypeVar, Text, Union)
+                    Optional, TypeVar, Union)
 
 from django.http import HttpResponse
 from django.test import TestCase
@@ -501,7 +501,7 @@ class BulkUsersTest(ZulipTestCase):
 
         hamlet = self.example_user('hamlet')
 
-        def get_hamlet_avatar(client_gravatar: bool) -> Optional[Text]:
+        def get_hamlet_avatar(client_gravatar: bool) -> Optional[str]:
             data = dict(client_gravatar=ujson.dumps(client_gravatar))
             result = self.client_get('/json/users', data)
             self.assert_json_success(result)
@@ -531,12 +531,12 @@ class BulkUsersTest(ZulipTestCase):
 
 class GetProfileTest(ZulipTestCase):
 
-    def common_update_pointer(self, email: Text, pointer: int) -> None:
+    def common_update_pointer(self, email: str, pointer: int) -> None:
         self.login(email)
         result = self.client_post("/json/users/me/pointer", {"pointer": pointer})
         self.assert_json_success(result)
 
-    def common_get_profile(self, user_id: str) -> Dict[Text, Any]:
+    def common_get_profile(self, user_id: str) -> Dict[str, Any]:
         # Assumes all users are example users in realm 'zulip'
         user_profile = self.example_user(user_id)
         self.send_stream_message(user_profile.email, "Verona", "hello")

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1,7 +1,7 @@
 # See https://zulip.readthedocs.io/en/latest/subsystems/events-system.html for
 # high-level documentation on how this system works.
 from typing import cast, AbstractSet, Any, Callable, Dict, List, \
-    Mapping, MutableMapping, Optional, Iterable, Sequence, Set, Text, Union
+    Mapping, MutableMapping, Optional, Iterable, Sequence, Set, Union
 from mypy_extensions import TypedDict
 
 from django.utils.translation import ugettext as _
@@ -59,10 +59,10 @@ HEARTBEAT_MIN_FREQ_SECS = 45
 class ClientDescriptor:
     def __init__(self,
                  user_profile_id: int,
-                 user_profile_email: Text,
+                 user_profile_email: str,
                  realm_id: int, event_queue: 'EventQueue',
                  event_types: Optional[Sequence[str]],
-                 client_type_name: Text,
+                 client_type_name: str,
                  apply_markdown: bool=True,
                  client_gravatar: bool=True,
                  all_public_streams: bool=False,
@@ -76,7 +76,7 @@ class ClientDescriptor:
         self.user_profile_email = user_profile_email
         self.realm_id = realm_id
         self.current_handler_id = None  # type: Optional[int]
-        self.current_client_name = None  # type: Optional[Text]
+        self.current_client_name = None  # type: Optional[str]
         self.event_queue = event_queue
         self.queue_timeout = lifespan_secs
         self.event_types = event_types
@@ -185,7 +185,7 @@ class ClientDescriptor:
         return (self.current_handler_id is None and
                 now - self.last_connection_time >= self.queue_timeout)
 
-    def connect_handler(self, handler_id: int, client_name: Text) -> None:
+    def connect_handler(self, handler_id: int, client_name: str) -> None:
         self.current_handler_id = handler_id
         self.current_client_name = client_name
         set_descriptor_by_handler_id(handler_id, self)
@@ -488,8 +488,8 @@ def fetch_events(query: Mapping[str, Any]) -> Dict[str, Any]:
     last_event_id = query["last_event_id"]  # type: int
     user_profile_id = query["user_profile_id"]  # type: int
     new_queue_data = query.get("new_queue_data")  # type: Optional[MutableMapping[str, Any]]
-    user_profile_email = query["user_profile_email"]  # type: Text
-    client_type_name = query["client_type_name"]  # type: Text
+    user_profile_email = query["user_profile_email"]  # type: str
+    client_type_name = query["client_type_name"]  # type: str
     handler_id = query["handler_id"]  # type: int
 
     try:
@@ -553,7 +553,7 @@ def request_event_queue(user_profile: UserProfile, user_client: Client, apply_ma
                         client_gravatar: bool, queue_lifespan_secs: int,
                         event_types: Optional[Iterable[str]]=None,
                         all_public_streams: bool=False,
-                        narrow: Iterable[Sequence[Text]]=[]) -> Optional[str]:
+                        narrow: Iterable[Sequence[str]]=[]) -> Optional[str]:
     if settings.TORNADO_SERVER:
         req = {'dont_block': 'true',
                'apply_markdown': ujson.dumps(apply_markdown),
@@ -767,7 +767,7 @@ def process_message_event(event_template: Mapping[str, Any], users: Iterable[Map
     sender_id = wide_dict['sender_id']  # type: int
     message_id = wide_dict['id']  # type: int
     message_type = wide_dict['type']  # type: str
-    sending_client = wide_dict['client']  # type: Text
+    sending_client = wide_dict['client']  # type: str
 
     @cachify
     def get_client_payload(apply_markdown: bool, client_gravatar: bool) -> Dict[str, Any]:

--- a/zerver/tornado/socket.py
+++ b/zerver/tornado/socket.py
@@ -1,5 +1,5 @@
 
-from typing import Any, Dict, Mapping, Optional, Text, Union
+from typing import Any, Dict, Mapping, Optional, Union
 
 from django.conf import settings
 from django.utils.timezone import now as timezone_now
@@ -32,7 +32,7 @@ from zerver.tornado.exceptions import BadEventQueueIdError
 
 logger = logging.getLogger('zulip.socket')
 
-def get_user_profile(session_id: Optional[Text]) -> Optional[UserProfile]:
+def get_user_profile(session_id: Optional[str]) -> Optional[UserProfile]:
     if session_id is None:
         return None
 
@@ -66,7 +66,7 @@ def deregister_connection(conn: 'SocketConnection') -> None:
 
 redis_client = get_redis_client()
 
-def req_redis_key(req_id: Text) -> Text:
+def req_redis_key(req_id: str) -> str:
     return 'socket_req_status:%s' % (req_id,)
 
 class CloseErrorInfo:

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -1,6 +1,6 @@
 
 import time
-from typing import Iterable, List, Optional, Sequence, Text, Union
+from typing import Iterable, List, Optional, Sequence, Union
 
 import ujson
 from django.core.handlers.base import BaseHandler
@@ -24,7 +24,7 @@ def notify(request: HttpRequest) -> HttpResponse:
 
 @has_request_variables
 def cleanup_event_queue(request: HttpRequest, user_profile: UserProfile,
-                        queue_id: Text=REQ()) -> HttpResponse:
+                        queue_id: str=REQ()) -> HttpResponse:
     client = get_client_descriptor(str(queue_id))
     if client is None:
         raise BadEventQueueIdError(queue_id)
@@ -39,13 +39,13 @@ def cleanup_event_queue(request: HttpRequest, user_profile: UserProfile,
 def get_events_backend(request: HttpRequest, user_profile: UserProfile, handler: BaseHandler,
                        user_client: Optional[Client]=REQ(converter=get_client, default=None),
                        last_event_id: Optional[int]=REQ(converter=int, default=None),
-                       queue_id: Optional[List[Text]]=REQ(default=None),
+                       queue_id: Optional[List[str]]=REQ(default=None),
                        apply_markdown: bool=REQ(default=False, validator=check_bool),
                        client_gravatar: bool=REQ(default=False, validator=check_bool),
                        all_public_streams: bool=REQ(default=False, validator=check_bool),
-                       event_types: Optional[Text]=REQ(default=None, validator=check_list(check_string)),
+                       event_types: Optional[str]=REQ(default=None, validator=check_list(check_string)),
                        dont_block: bool=REQ(default=False, validator=check_bool),
-                       narrow: Iterable[Sequence[Text]]=REQ(default=[], validator=check_list(None)),
+                       narrow: Iterable[Sequence[str]]=REQ(default=[], validator=check_list(None)),
                        lifespan_secs: int=REQ(default=0, converter=int)
                        ) -> Union[HttpResponse, _RespondAsynchronously]:
     if user_client is None:

--- a/zerver/webhooks/beanstalk/view.py
+++ b/zerver/webhooks/beanstalk/view.py
@@ -2,7 +2,7 @@
 
 import base64
 from functools import wraps
-from typing import Any, Callable, Dict, Optional, Text, TypeVar
+from typing import Any, Callable, Dict, Optional, TypeVar
 
 from django.http import HttpRequest, HttpResponse
 
@@ -41,7 +41,7 @@ def beanstalk_decoder(view_func: ViewFuncT) -> ViewFuncT:
 @has_request_variables
 def api_beanstalk_webhook(request: HttpRequest, user_profile: UserProfile,
                           payload: Dict[str, Any]=REQ(validator=check_dict([])),
-                          branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
+                          branches: Optional[str]=REQ(default=None)) -> HttpResponse:
     # Beanstalk supports both SVN and git repositories
     # We distinguish between the two by checking for a
     # 'uri' key that is only present for git repos

--- a/zerver/webhooks/bitbucket/view.py
+++ b/zerver/webhooks/bitbucket/view.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Text
+from typing import Any, Mapping, Optional
 
 from django.http import HttpRequest, HttpResponse
 
@@ -14,8 +14,8 @@ from zerver.models import UserProfile, get_client
 @authenticated_rest_api_view(webhook_client_name="Bitbucket")
 @has_request_variables
 def api_bitbucket_webhook(request: HttpRequest, user_profile: UserProfile,
-                          payload: Mapping[Text, Any]=REQ(validator=check_dict([])),
-                          branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
+                          payload: Mapping[str, Any]=REQ(validator=check_dict([])),
+                          branches: Optional[str]=REQ(default=None)) -> HttpResponse:
     repository = payload['repository']
 
     commits = [

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any, Dict, Iterable, Optional, Text
+from typing import Any, Dict, Iterable, Optional
 import re
 
 from django.http import HttpRequest, HttpResponse
@@ -20,12 +20,12 @@ class UnknownEventType(Exception):
     pass
 
 
-def get_push_event_body(payload: Dict[str, Any]) -> Text:
+def get_push_event_body(payload: Dict[str, Any]) -> str:
     if payload.get('after') == EMPTY_SHA:
         return get_remove_branch_event_body(payload)
     return get_normal_push_event_body(payload)
 
-def get_normal_push_event_body(payload: Dict[str, Any]) -> Text:
+def get_normal_push_event_body(payload: Dict[str, Any]) -> str:
     compare_url = u'{}/compare/{}...{}'.format(
         get_repository_homepage(payload),
         payload['before'],
@@ -49,20 +49,20 @@ def get_normal_push_event_body(payload: Dict[str, Any]) -> Text:
         commits
     )
 
-def get_remove_branch_event_body(payload: Dict[str, Any]) -> Text:
+def get_remove_branch_event_body(payload: Dict[str, Any]) -> str:
     return get_remove_branch_event_message(
         get_user_name(payload),
         get_branch_name(payload)
     )
 
-def get_tag_push_event_body(payload: Dict[str, Any]) -> Text:
+def get_tag_push_event_body(payload: Dict[str, Any]) -> str:
     return get_push_tag_event_message(
         get_user_name(payload),
         get_tag_name(payload),
         action="pushed" if payload.get('checkout_sha') else "removed"
     )
 
-def get_issue_created_event_body(payload: Dict[str, Any]) -> Text:
+def get_issue_created_event_body(payload: Dict[str, Any]) -> str:
     description = payload['object_attributes'].get('description')
     # Filter out multiline hidden comments
     if description is not None:
@@ -77,7 +77,7 @@ def get_issue_created_event_body(payload: Dict[str, Any]) -> Text:
         get_objects_assignee(payload)
     )
 
-def get_issue_event_body(payload: Dict[str, Any], action: Text) -> Text:
+def get_issue_event_body(payload: Dict[str, Any], action: str) -> str:
     return get_issue_event_message(
         get_issue_user_name(payload),
         action,
@@ -85,12 +85,12 @@ def get_issue_event_body(payload: Dict[str, Any], action: Text) -> Text:
         payload['object_attributes'].get('iid'),
     )
 
-def get_merge_request_updated_event_body(payload: Dict[str, Any]) -> Text:
+def get_merge_request_updated_event_body(payload: Dict[str, Any]) -> str:
     if payload['object_attributes'].get('oldrev'):
         return get_merge_request_event_body(payload, "added commit(s) to")
     return get_merge_request_open_or_updated_body(payload, "updated")
 
-def get_merge_request_event_body(payload: Dict[str, Any], action: Text) -> Text:
+def get_merge_request_event_body(payload: Dict[str, Any], action: str) -> str:
     pull_request = payload['object_attributes']
     return get_pull_request_event_message(
         get_issue_user_name(payload),
@@ -100,7 +100,7 @@ def get_merge_request_event_body(payload: Dict[str, Any], action: Text) -> Text:
         type='MR',
     )
 
-def get_merge_request_open_or_updated_body(payload: Dict[str, Any], action: Text) -> Text:
+def get_merge_request_open_or_updated_body(payload: Dict[str, Any], action: str) -> str:
     pull_request = payload['object_attributes']
     return get_pull_request_event_message(
         get_issue_user_name(payload),
@@ -114,13 +114,13 @@ def get_merge_request_open_or_updated_body(payload: Dict[str, Any], action: Text
         type='MR',
     )
 
-def get_objects_assignee(payload: Dict[str, Any]) -> Optional[Text]:
+def get_objects_assignee(payload: Dict[str, Any]) -> Optional[str]:
     assignee_object = payload.get('assignee')
     if assignee_object:
         return assignee_object.get('name')
     return None
 
-def get_commented_commit_event_body(payload: Dict[str, Any]) -> Text:
+def get_commented_commit_event_body(payload: Dict[str, Any]) -> str:
     comment = payload['object_attributes']
     action = u'[commented]({})'.format(comment['url'])
     return get_commits_comment_action_message(
@@ -131,7 +131,7 @@ def get_commented_commit_event_body(payload: Dict[str, Any]) -> Text:
         comment['note'],
     )
 
-def get_commented_merge_request_event_body(payload: Dict[str, Any]) -> Text:
+def get_commented_merge_request_event_body(payload: Dict[str, Any]) -> str:
     comment = payload['object_attributes']
     action = u'[commented]({}) on'.format(comment['url'])
     url = u'{}/merge_requests/{}'.format(
@@ -147,7 +147,7 @@ def get_commented_merge_request_event_body(payload: Dict[str, Any]) -> Text:
         type='MR'
     )
 
-def get_commented_issue_event_body(payload: Dict[str, Any]) -> Text:
+def get_commented_issue_event_body(payload: Dict[str, Any]) -> str:
     comment = payload['object_attributes']
     action = u'[commented]({}) on'.format(comment['url'])
     url = u'{}/issues/{}'.format(
@@ -163,7 +163,7 @@ def get_commented_issue_event_body(payload: Dict[str, Any]) -> Text:
         type='Issue'
     )
 
-def get_commented_snippet_event_body(payload: Dict[str, Any]) -> Text:
+def get_commented_snippet_event_body(payload: Dict[str, Any]) -> str:
     comment = payload['object_attributes']
     action = u'[commented]({}) on'.format(comment['url'])
     url = u'{}/snippets/{}'.format(
@@ -179,7 +179,7 @@ def get_commented_snippet_event_body(payload: Dict[str, Any]) -> Text:
         type='Snippet'
     )
 
-def get_wiki_page_event_body(payload: Dict[str, Any], action: Text) -> Text:
+def get_wiki_page_event_body(payload: Dict[str, Any], action: str) -> str:
     return u"{} {} [Wiki Page \"{}\"]({}).".format(
         get_issue_user_name(payload),
         action,
@@ -187,7 +187,7 @@ def get_wiki_page_event_body(payload: Dict[str, Any], action: Text) -> Text:
         payload['object_attributes'].get('url'),
     )
 
-def get_build_hook_event_body(payload: Dict[str, Any]) -> Text:
+def get_build_hook_event_body(payload: Dict[str, Any]) -> str:
     build_status = payload.get('build_status')
     if build_status == 'created':
         action = 'was created'
@@ -201,11 +201,11 @@ def get_build_hook_event_body(payload: Dict[str, Any]) -> Text:
         action
     )
 
-def get_test_event_body(payload: Dict[str, Any]) -> Text:
+def get_test_event_body(payload: Dict[str, Any]) -> str:
     return u"Webhook for **{repo}** has been configured successfully! :tada:".format(
         repo=get_repo_name(payload))
 
-def get_pipeline_event_body(payload: Dict[str, Any]) -> Text:
+def get_pipeline_event_body(payload: Dict[str, Any]) -> str:
     pipeline_status = payload['object_attributes'].get('status')
     if pipeline_status == 'pending':
         action = 'was created'
@@ -219,28 +219,28 @@ def get_pipeline_event_body(payload: Dict[str, Any]) -> Text:
         builds_status += u"* {} - {}\n".format(build.get('name'), build.get('status'))
     return u"Pipeline {} with build(s):\n{}.".format(action, builds_status[:-1])
 
-def get_repo_name(payload: Dict[str, Any]) -> Text:
+def get_repo_name(payload: Dict[str, Any]) -> str:
     return payload['project']['name']
 
-def get_user_name(payload: Dict[str, Any]) -> Text:
+def get_user_name(payload: Dict[str, Any]) -> str:
     return payload['user_name']
 
-def get_issue_user_name(payload: Dict[str, Any]) -> Text:
+def get_issue_user_name(payload: Dict[str, Any]) -> str:
     return payload['user']['name']
 
-def get_repository_homepage(payload: Dict[str, Any]) -> Text:
+def get_repository_homepage(payload: Dict[str, Any]) -> str:
     return payload['repository']['homepage']
 
-def get_branch_name(payload: Dict[str, Any]) -> Text:
+def get_branch_name(payload: Dict[str, Any]) -> str:
     return payload['ref'].replace('refs/heads/', '')
 
-def get_tag_name(payload: Dict[str, Any]) -> Text:
+def get_tag_name(payload: Dict[str, Any]) -> str:
     return payload['ref'].replace('refs/tags/', '')
 
-def get_object_iid(payload: Dict[str, Any]) -> Text:
+def get_object_iid(payload: Dict[str, Any]) -> str:
     return payload['object_attributes']['iid']
 
-def get_object_url(payload: Dict[str, Any]) -> Text:
+def get_object_url(payload: Dict[str, Any]) -> str:
     return payload['object_attributes']['url']
 
 EVENT_FUNCTION_MAPPER = {
@@ -272,7 +272,7 @@ EVENT_FUNCTION_MAPPER = {
 @has_request_variables
 def api_gitlab_webhook(request: HttpRequest, user_profile: UserProfile,
                        payload: Dict[str, Any]=REQ(argument_type='body'),
-                       branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
+                       branches: Optional[str]=REQ(default=None)) -> HttpResponse:
     event = get_event(request, payload, branches)
     if event is not None:
         body = get_body_based_on_event(event)(payload)
@@ -283,7 +283,7 @@ def api_gitlab_webhook(request: HttpRequest, user_profile: UserProfile,
 def get_body_based_on_event(event: str) -> Any:
     return EVENT_FUNCTION_MAPPER[event]
 
-def get_subject_based_on_event(event: str, payload: Dict[str, Any]) -> Text:
+def get_subject_based_on_event(event: str, payload: Dict[str, Any]) -> str:
     if event == 'Push Hook':
         return u"{} / {}".format(get_repo_name(payload), get_branch_name(payload))
     elif event == 'Job Hook' or event == 'Build Hook':
@@ -330,7 +330,7 @@ def get_subject_based_on_event(event: str, payload: Dict[str, Any]) -> Text:
         )
     return get_repo_name(payload)
 
-def get_event(request: HttpRequest, payload: Dict[str, Any], branches: Optional[Text]) -> Optional[str]:
+def get_event(request: HttpRequest, payload: Dict[str, Any], branches: Optional[str]) -> Optional[str]:
     # if there is no 'action' attribute, then this is a test payload
     # and we should ignore it
     event = validate_extract_webhook_http_header(request, 'X_GITLAB_EVENT', 'GitLab')

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
-from typing import Any, Dict, Iterable, Optional, Text
+from typing import Any, Dict, Iterable, Optional
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
@@ -15,7 +15,7 @@ from zerver.lib.webhooks.git import SUBJECT_WITH_BRANCH_TEMPLATE, \
     get_pull_request_event_message, get_push_commits_event_message
 from zerver.models import UserProfile
 
-def format_push_event(payload: Dict[str, Any]) -> Text:
+def format_push_event(payload: Dict[str, Any]) -> str:
 
     for commit in payload['commits']:
         commit['sha'] = commit['id']
@@ -31,7 +31,7 @@ def format_push_event(payload: Dict[str, Any]) -> Text:
 
     return get_push_commits_event_message(**data)
 
-def format_new_branch_event(payload: Dict[str, Any]) -> Text:
+def format_new_branch_event(payload: Dict[str, Any]) -> str:
 
     branch_name = payload['ref']
     url = '{}/src/{}'.format(payload['repository']['html_url'], branch_name)
@@ -43,7 +43,7 @@ def format_new_branch_event(payload: Dict[str, Any]) -> Text:
     }
     return get_create_branch_event_message(**data)
 
-def format_pull_request_event(payload: Dict[str, Any]) -> Text:
+def format_pull_request_event(payload: Dict[str, Any]) -> str:
 
     data = {
         'user_name': payload['pull_request']['user']['username'],
@@ -64,7 +64,7 @@ def format_pull_request_event(payload: Dict[str, Any]) -> Text:
 @has_request_variables
 def api_gogs_webhook(request: HttpRequest, user_profile: UserProfile,
                      payload: Dict[str, Any]=REQ(argument_type='body'),
-                     branches: Optional[Text]=REQ(default=None)) -> HttpResponse:
+                     branches: Optional[str]=REQ(default=None)) -> HttpResponse:
 
     repo = payload['repository']['name']
     event = validate_extract_webhook_http_header(request, 'X_GOGS_EVENT', 'Gogs')

--- a/zerver/webhooks/newrelic/view.py
+++ b/zerver/webhooks/newrelic/view.py
@@ -1,5 +1,5 @@
 # Webhooks for external integrations.
-from typing import Any, Callable, Dict, Iterable, Optional, Text, Tuple
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -2,7 +2,7 @@ import itertools
 import os
 import random
 from typing import Any, Callable, Dict, Iterable, List, \
-    Mapping, Optional, Sequence, Set, Text, Tuple
+    Mapping, Optional, Sequence, Set, Tuple
 
 import ujson
 from django.conf import settings
@@ -34,10 +34,10 @@ settings.CACHES['default'] = {
     'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
 }
 
-def create_users(realm: Realm, name_list: Iterable[Tuple[Text, Text]],
+def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]],
                  bot_type: Optional[int]=None,
                  bot_owner: Optional[UserProfile]=None) -> None:
-    user_set = set()  # type: Set[Tuple[Text, Text, Text, bool]]
+    user_set = set()  # type: Set[Tuple[str, str, str, bool]]
     for full_name, email in name_list:
         short_name = email_to_username(email)
         user_set.add((email, full_name, short_name, True))
@@ -229,7 +229,7 @@ class Command(BaseCommand):
                            "invite_only": False, "is_web_public": False},
                 "Rome": {"description": "Yet another Italian city",
                          "invite_only": False, "is_web_public": True}
-            }  # type: Dict[Text, Dict[Text, Any]]
+            }  # type: Dict[str, Dict[str, Any]]
 
             bulk_create_streams(zulip_realm, stream_dict)
             recipient_streams = [Stream.objects.get(name=name, realm=zulip_realm).id
@@ -414,7 +414,7 @@ class Command(BaseCommand):
                                "invite_only": False, "is_web_public": False},
                     "sales": {"description": "For sales discussion",
                               "invite_only": False, "is_web_public": False}
-                }  # type: Dict[Text, Dict[Text, Any]]
+                }  # type: Dict[str, Dict[str, Any]]
 
                 # Calculate the maximum number of digits in any extra stream's
                 # number, since a stream with name "Extra Stream 3" could show
@@ -578,7 +578,7 @@ def send_messages(data: Tuple[int, Sequence[Sequence[int]], Mapping[str, Any],
             # Pick a random subscriber to the stream
             message.sender = random.choice(Subscription.objects.filter(
                 recipient=message.recipient)).user_profile
-            message.subject = stream.name + Text(random.randint(1, 3))
+            message.subject = stream.name + str(random.randint(1, 3))
             saved_data['subject'] = message.subject
 
         # Spoofing time not supported with threading

--- a/zilencer/models.py
+++ b/zilencer/models.py
@@ -1,11 +1,10 @@
 import datetime
-from typing import Text
 
 from django.db import models
 
 from zerver.models import AbstractPushDeviceToken, Realm
 
-def get_remote_server_by_uuid(uuid: Text) -> 'RemoteZulipServer':
+def get_remote_server_by_uuid(uuid: str) -> 'RemoteZulipServer':
     return RemoteZulipServer.objects.get(uuid=uuid)
 
 class RemoteZulipServer(models.Model):
@@ -13,11 +12,11 @@ class RemoteZulipServer(models.Model):
     API_KEY_LENGTH = 64
     HOSTNAME_MAX_LENGTH = 128
 
-    uuid = models.CharField(max_length=UUID_LENGTH, unique=True)  # type: Text
-    api_key = models.CharField(max_length=API_KEY_LENGTH)  # type: Text
+    uuid = models.CharField(max_length=UUID_LENGTH, unique=True)  # type: str
+    api_key = models.CharField(max_length=API_KEY_LENGTH)  # type: str
 
-    hostname = models.CharField(max_length=HOSTNAME_MAX_LENGTH)  # type: Text
-    contact_email = models.EmailField(blank=True, null=False)  # type: Text
+    hostname = models.CharField(max_length=HOSTNAME_MAX_LENGTH)  # type: str
+    contact_email = models.EmailField(blank=True, null=False)  # type: str
     last_updated = models.DateTimeField('last updated', auto_now=True)  # type: datetime.datetime
 
     def __str__(self) -> str:

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -1,5 +1,5 @@
 
-from typing import Any, Dict, Optional, Text, Union, cast
+from typing import Any, Dict, Optional, Union, cast
 
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email, URLValidator
@@ -84,7 +84,7 @@ def register_remote_server(
 def register_remote_push_device(request: HttpRequest, entity: Union[UserProfile, RemoteZulipServer],
                                 user_id: int=REQ(), token: bytes=REQ(),
                                 token_kind: int=REQ(validator=check_int),
-                                ios_app_id: Optional[Text]=None) -> HttpResponse:
+                                ios_app_id: Optional[str]=None) -> HttpResponse:
     validate_bouncer_token_request(entity, token, token_kind)
     server = cast(RemoteZulipServer, entity)
 
@@ -110,7 +110,7 @@ def register_remote_push_device(request: HttpRequest, entity: Union[UserProfile,
 def unregister_remote_push_device(request: HttpRequest, entity: Union[UserProfile, RemoteZulipServer],
                                   token: bytes=REQ(),
                                   token_kind: int=REQ(validator=check_int),
-                                  ios_app_id: Optional[Text]=None) -> HttpResponse:
+                                  ios_app_id: Optional[str]=None) -> HttpResponse:
     validate_bouncer_token_request(entity, token, token_kind)
     server = cast(RemoteZulipServer, entity)
     deleted = RemotePushDeviceToken.objects.filter(token=token,


### PR DESCRIPTION
This PR contains commits which migrate our code base from typing.Text to str. We earlier used to use typing.Text instead of str to maintain python 2 and 3 compatibility but now since we only support python 3. We can get rid of the Text in favour of str.

Related issue: #9203

All the commits in this PR can potentially cause merge conflicts to other PR's.
Detailed list of associated PR's for each file will follow in a comment!