### PR TITLE
Migration: Move from the use of typing.Text to use str

### DIFF
--- a/docs/tutorials/writing-views.md
+++ b/docs/tutorials/writing-views.md
@@ -275,7 +275,7 @@ and in [zerver/lib/actions.py](https://github.com/zulip/zulip/blob/master/zerver
 
 ```py
 def do_set_realm_name(realm, name):
-    # type: (Realm, Text) -> None
+    # type: (Realm, str) -> None
     realm.name = name
     realm.save(update_fields=['name'])
     event = dict(

--- a/scripts/lib/clean-emoji-cache
+++ b/scripts/lib/clean-emoji-cache
@@ -4,7 +4,7 @@ import os
 import sys
 
 if False:
-    from typing import Set, Text
+    from typing import Set
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(ZULIP_PATH)
@@ -18,7 +18,7 @@ if ENV == "travis":
     EMOJI_CACHE_PATH = os.path.join(os.environ["HOME"], "zulip-emoji-cache")
 
 def get_caches_in_use(threshold_days):
-    # type: (int) -> Set[Text]
+    # type: (int) -> Set[str]
     setups_to_check = set([ZULIP_PATH, ])
     caches_in_use = set()
 

--- a/scripts/lib/clean-npm-cache
+++ b/scripts/lib/clean-npm-cache
@@ -5,7 +5,7 @@ import subprocess
 import sys
 
 if False:
-    from typing import Set, Text
+    from typing import Set
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(ZULIP_PATH)
@@ -26,7 +26,7 @@ if ENV == "travis":
         sys.exit(0)
 
 def get_caches_in_use(threshold_days):
-    # type: (int) -> Set[Text]
+    # type: (int) -> Set[str]
     setups_to_check = set([ZULIP_PATH, ])
     caches_in_use = set()
 

--- a/scripts/purge-old-deployments
+++ b/scripts/purge-old-deployments
@@ -5,7 +5,7 @@ import subprocess
 import sys
 
 if False:
-    from typing import Set, Text
+    from typing import Set
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(ZULIP_PATH)
@@ -36,7 +36,7 @@ def parse_args():
     return args
 
 def get_deployments_to_be_purged(recent_deployments):
-    # type: (Set[Text]) -> Set[Text]
+    # type: (Set[str]) -> Set[str]
     all_deployments = set([os.path.join(DEPLOYMENTS_DIR, deployment)
                            for deployment in os.listdir(DEPLOYMENTS_DIR)])
     deployments_to_purge = set()

--- a/templates/zerver/api/webhook-walkthrough.md
+++ b/templates/zerver/api/webhook-walkthrough.md
@@ -58,7 +58,7 @@ python file, `zerver/webhooks/mywebhook/view.py`.
 The Hello World integration is in `zerver/webhooks/helloworld/view.py`:
 
 ```
-from typing import Any, Dict, Iterable, Optional, Text
+from typing import Any, Dict, Iterable, Optional
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
@@ -240,7 +240,7 @@ class HelloWorldHookTests(WebhookTestCase):
         self.send_and_test_stream_message('hello', expected_subject, expected_message,
                                           content_type="application/x-www-form-urlencoded")
 
-    def get_body(self, fixture_name: Text) -> Text:
+    def get_body(self, fixture_name: str) -> str:
         return self.webhook_fixture_data("helloworld", fixture_name, file_type="json")
 
 ```
@@ -503,7 +503,7 @@ class QuerytestHookTests(WebhookTestCase):
         self.send_and_test_stream_message('test_one', expected_subject, expected_message,
                                           content_type="application/x-www-form-urlencoded")
 
-    def get_body(self, fixture_name: Text) -> Text:
+    def get_body(self, fixture_name: str) -> str:
         return self.webhook_fixture_data("querytest", fixture_name, file_type="json")
 ```
 

--- a/tools/check-css
+++ b/tools/check-css
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from lib.css_parser import parse, CssParserException
-from typing import Iterable, Text
+from typing import Iterable
 import sys
 import glob
 import subprocess

--- a/tools/check-issue-labels
+++ b/tools/check-issue-labels
@@ -7,7 +7,7 @@ import sys
 import os
 
 import ConfigParser
-from typing import Any, Dict, MutableMapping, Optional, Text
+from typing import Any, Dict, MutableMapping, Optional
 
 # Scans zulip repositary for issues that don't have any `area` labels.
 # GitHub API token is required as GitHub limits unauthenticated
@@ -62,7 +62,7 @@ def check_issue_labels():
                   "your api token. If you want to continue without using a token use --force.")
             sys.exit(1)
 
-    next_page_url = 'https://api.github.com/repos/zulip/zulip/issues'  # type: Optional[Text]
+    next_page_url = 'https://api.github.com/repos/zulip/zulip/issues'  # type: Optional[str]
     unlabeled_issue_urls = []
     while next_page_url:
         try:

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -515,6 +515,21 @@ def build_custom_checkers(by_lang):
          'bad_lines': ['desc = models.TextField()  # type: Optional[Text]',
                        'stream = models.ForeignKey(Stream, on_delete=CASCADE)  # type: Optional[Stream]'],
          },
+        {'pattern': '[\s([]Text([^\s\w]|$)',
+         'exclude': set([
+             # We are likely to want to keep these dirs Python 2+3 compatible,
+             # since the plan includes extracting them to a separate project eventually.
+             'tools/check-frontend-i18n',
+             'tools/lib',
+             'tools/linter_lib',
+             # We don't want to migrate every migration already using typing.Text
+             # to use str.
+             'zerver/migrations/',
+             # thumbor is (currently) python2 only
+             'zthumbor/',
+         ]),
+         'description': "Now that we're a Python 3 only codebase, we don't need to use typing.Text. Please use str instead.",
+         },
     ]) + whitespace_rules + comma_whitespace_rule
     bash_rules = cast(RuleList, [
         {'pattern': '#!.*sh [-xe]',

--- a/tools/setup/generate_zulip_bots_static_files
+++ b/tools/setup/generate_zulip_bots_static_files
@@ -9,7 +9,7 @@ ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 if ZULIP_PATH not in sys.path:
     sys.path.append(ZULIP_PATH)
 
-from typing import List, Text
+from typing import List
 from zproject import settings
 from zulip_bots.lib import get_bots_directory_path
 
@@ -29,7 +29,7 @@ if os.path.isdir(bots_dir):
 os.makedirs(bots_dir, exist_ok=True)
 
 def copyfiles(paths):
-    # type: (List[Text]) -> None
+    # type: (List[str]) -> None
     for src_path in paths:
         bot_name = os.path.basename(os.path.dirname(src_path))
 

--- a/tools/test-queue-worker-reload
+++ b/tools/test-queue-worker-reload
@@ -12,7 +12,7 @@ import re
 from lib import sanity_check
 sanity_check.check_venv(__file__)
 
-from typing import IO, Text
+from typing import IO
 
 # TODO: Convert this to use scripts/lib/queue_workers.py
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tools/update-authors-json
+++ b/tools/update-authors-json
@@ -8,7 +8,7 @@ JSON data for the /team page contributors section.
 from lib import sanity_check
 sanity_check.check_venv(__file__)
 
-from typing import Any, Dict, List, Optional, Union, Text, cast
+from typing import Any, Dict, List, Optional, Union, cast
 from mypy_extensions import TypedDict
 
 import os

--- a/zerver/lib/request.pyi
+++ b/zerver/lib/request.pyi
@@ -6,7 +6,7 @@
 # scan the parameter list for REQ objects and patch the parameters as the true
 # types.
 
-from typing import Any, Callable, Text, TypeVar, Optional, Union, Type
+from typing import Any, Callable, TypeVar, Optional, Union, Type
 from zerver.lib.types import ViewFuncT, Validator
 
 from zerver.lib.exceptions import JsonableError as JsonableError


### PR DESCRIPTION
This is the last PR in a series of PR's which migrated our code base from the use of typing.Text to str.
This contains some final migration commits and also a commit which adds linting rules against the use of Text further in the code base and promote use of str.

Fixes: #9203 