### PR TITLE
Adds test coverage to previously uncovered function in zerver/apps.py.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -63,7 +63,6 @@ not_yet_fully_covered = {
     'zerver/lib/upload.py',
     # Other lib files that ideally would coverage, but aren't sorted
     'zerver/__init__.py',
-    'zerver/apps.py',
     'zerver/filters.py',
     'zerver/middleware.py',
     'zerver/storage.py',

--- a/zerver/tests/test_apps.py
+++ b/zerver/tests/test_apps.py
@@ -1,0 +1,13 @@
+
+from mock import Mock, patch
+
+from zerver.apps import flush_cache
+from zerver.lib.test_classes import ZulipTestCase
+
+class AppsTest(ZulipTestCase):
+
+    def test_cache_gets_flushed(self) -> None:
+        zerver_config_mock = Mock()
+        with patch('zerver.apps.cache.clear') as mock:
+            flush_cache(zerver_config_mock)
+            mock.assert_called_once()


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR gets test coverage for `zerver/apps.py` to 100%. Associated GitHub issue: https://github.com/zulip/zulip/issues/7089


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
