### PR TITLE
emoji: Don't start typeahead for colon-space.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -983,10 +983,12 @@ user_pill.get_user_ids = function () {
     assert_typeahead_equals(" :", false);
     assert_typeahead_equals(":)", false);
     assert_typeahead_equals(":4", false);
+    assert_typeahead_equals(": la", false);
     assert_typeahead_equals("test :-P", false);
     assert_typeahead_equals("hi emoji :", false);
     assert_typeahead_equals("hi emoj:i", false);
     assert_typeahead_equals("hi emoji :D", false);
+    assert_typeahead_equals("hi emoji : t", false);
     assert_typeahead_equals("hi emoji :t", emoji_list);
     assert_typeahead_equals("hi emoji :ta", emoji_list);
     assert_typeahead_equals("hi emoji :da", emoji_list);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -351,6 +351,10 @@ exports.compose_content_begins_typeahead = function (query) {
         if (/^:-.?$/.test(current_token) || /^:[^a-z+]?$/.test(current_token)) {
             return false;
         }
+        // Don't autocomplete if there is a space following a ':'
+        if (current_token[1] === " ") {
+            return false;
+        }
         this.completing = 'emoji';
         this.token = current_token.substring(1);
         return emoji.emojis;


### PR DESCRIPTION
Fixes #9339.

The PR fixes the case mentioned in the issue as well as the general case when a space is following a colon (e.g.  typehead should start for `:t`, but not for `: t`).