### PR TITLE
node tests: Change timezone for node tests

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -98,7 +98,7 @@ if not options.force:
         sys.exit(1)
 
 os.environ['NODE_PATH'] = 'static'
-os.environ['TZ'] = 'UTC'
+os.environ['TZ'] = 'UTC +5:30'
 
 INDEX_JS = 'frontend_tests/zjsunit/index.js'
 


### PR DESCRIPTION
The timezone environment variable was set to UTC initially. It was
changed to something other than UTC so that any local vs UTC
conversion issues will manifest in the tests.

Fixes: #5105

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Issue #5105 

**Testing Plan:** <!-- How have you tested? -->
Node tests are running fine
