### PR TITLE
message-view: Handle trailing slashes in narrowing URLs.

### DIFF
--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -81,6 +81,18 @@ set_global('blueslip', {
     ]);
 }());
 
+(function test_operators_trailing_slash() {
+    var hash;
+    var narrow;
+
+    hash = '#narrow/stream/devel/topic/algol/';
+    narrow = hashchange.parse_narrow(hash.split('/'));
+    assert.deepEqual(narrow, [
+        {operator: 'stream', operand: 'devel', negated: false},
+        {operator: 'topic', operand: 'algol', negated: false},
+    ]);
+}());
+
 (function test_people_slugs() {
     var operators;
     var hash;

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -77,6 +77,11 @@ exports.parse_narrow = function (hash) {
         // but the user might write one.
         try {
             var operator = hash_util.decodeHashComponent(hash[i]);
+            // Do not parse further if empty operator encountered.
+            if (operator === '') {
+                break;
+            }
+
             var operand  = hash_util.decode_operand(operator, hash[i+1] || '');
             var negated = false;
             if (operator[0] === '-') {


### PR DESCRIPTION
Fixes #9305.
Empty operators are not allowed while parsing narrowing URLs.
`parse_narrow` stops parsing further if it encounters an empty string
operator.

Another approach would have been to fix the trailing slash before passing it to `parse_narrow`, but that would require trusting the developer to take care of the trailing slashes anywhere this function is used.