### PR TITLE
actions: Changed do_change_is_admin Exception to AssertionError.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2947,7 +2947,7 @@ def do_change_is_admin(user_profile: UserProfile, value: bool,
         user_profile.is_api_super_user = value
         user_profile.save(update_fields=["is_api_super_user"])
     else:
-        raise Exception("Unknown permission")
+        raise AssertionError("Invalid admin permission")
 
     if permission == 'administer':
         event = dict(type="realm_user", op="update",

--- a/zerver/management/commands/knight.py
+++ b/zerver/management/commands/knight.py
@@ -28,6 +28,7 @@ ONLY perform this on customer request from an authorized person.
                             dest='permission',
                             action="store",
                             default='administer',
+                            choices=['administer', 'api_super_user', ],
                             help='Permission to grant/remove.')
         parser.add_argument('email', metavar='<email>', type=str,
                             help="email of user to knight")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -56,6 +56,25 @@ def find_dict(lst: Iterable[Dict[K, V]], k: K, v: V) -> Dict[K, V]:
     raise AssertionError('Cannot find element in list where key %s == %s' % (k, v))
 
 class PermissionTest(ZulipTestCase):
+
+    def test_do_change_is_admin(self) -> None:
+        """
+        Ensures change_is_admin raises an AssertionError when invalid permissions
+        are provided to it.
+        """
+
+        # this should work fine
+        user_profile = self.example_user('hamlet')
+        do_change_is_admin(user_profile, True)
+
+        # this should work a-ok as well
+        do_change_is_admin(user_profile, True, permission='administer')
+
+        # this should "fail" with an assertion, if it doesn't, then we have a
+        # problem.
+        with self.assertRaises(AssertionError):
+            do_change_is_admin(user_profile, True, permission='totally-not-valid-perm')
+
     def test_get_admin_users(self) -> None:
         user_profile = self.example_user('hamlet')
         do_change_is_admin(user_profile, False)


### PR DESCRIPTION

https://paper.dropbox.com/doc/Zulip-sprints-backend-test-projects-3HjAzwNDXqAno1R9Zzjs9
`do_change_is_admin`: Verify that the views code that calls this validates the input, and then change to an AssertionError (no need to actually test).  

**Testing Plan:** 

I ran the management command with the 2 allowed and 1 disallowed permission to ensure it refuses bad data. I wrote the test, then checked to ensure that it was properly trapping the raised assertion by changing the 3rd test to a valid permission (which caused the test to fail, because the assertion was not raised). 
