### PR TITLE
typeahead: Count an email address as a prefix match.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -731,7 +731,7 @@ run_test('initialize', () => {
 
         fake_this = { completing: 'mention', token: 'ham' };
         actual_value = options.sorter.call(fake_this, [hamletcharacters, hamlet]);
-        expected_value = [hamletcharacters, hamlet];
+        expected_value = [hamlet, hamletcharacters];
         assert.deepEqual(actual_value, expected_value);
 
         fake_this = { completing: 'mention', token: 'ham' };
@@ -746,7 +746,7 @@ run_test('initialize', () => {
 
         fake_this = { completing: 'mention', token: 'ham' };
         actual_value = options.sorter.call(fake_this, [hamletcharacters, hammer]);
-        expected_value = [hamletcharacters, hammer];
+        expected_value = [hammer, hamletcharacters];
         assert.deepEqual(actual_value, expected_value);
 
         fake_this = { completing: 'stream', token: 'de' };

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -299,8 +299,12 @@ exports.sort_languages = function (matches, query) {
 exports.sort_recipients = function (users, query, current_stream, current_subject, groups) {
     var users_name_results =  util.prefix_sort(
         query, users, function (x) { return x.full_name; });
+
+    var email_results = util.prefix_sort(
+        query, users_name_results.rest, function (x) { return x.email; });
+
     var result = exports.sort_for_at_mentioning(
-        users_name_results.matches,
+        users_name_results.matches.concat(email_results.matches),
         current_stream,
         current_subject
     );
@@ -311,13 +315,6 @@ exports.sort_recipients = function (users, query, current_stream, current_subjec
         result = result.concat(groups_results.matches);
     }
 
-    var email_results = util.prefix_sort(query, users_name_results.rest,
-                                         function (x) { return x.email; });
-    result = result.concat(exports.sort_for_at_mentioning(
-        email_results.matches,
-        current_stream,
-        current_subject
-    ));
     var rest_sorted = exports.sort_for_at_mentioning(
         email_results.rest,
         current_stream,


### PR DESCRIPTION
This deals with the first part of the issue #9312 (counting an email address as a prefix match).

Before (the "pro" prefix):
<img width="265" alt="before" src="https://user-images.githubusercontent.com/1227153/40085072-502e5a1e-5867-11e8-942b-60870b183c9d.png">

After:
<img width="264" alt="after" src="https://user-images.githubusercontent.com/1227153/40134031-490ae56a-590f-11e8-9ed4-c0dd088baa56.png">

The second step would be to improve the matching of a last name (in the example above, it will put Hamlet Prospero after Prospero Lear).