### PR TITLE
Add postgres docker build for full text search

### DIFF
--- a/Dockerfile-postgresql
+++ b/Dockerfile-postgresql
@@ -1,0 +1,37 @@
+# To build run `docker build -f Dockerfile-postgresql .` from the root of the
+# zulip repo.
+
+# Install build tools and build tsearch_extras for the current postgres
+# version. Currently the postgres images do not support automatic upgrading of
+# the on-disk data in volumes. So the base image can not currently be upgraded
+# without users needing a manual pgdump and restore.
+FROM postgres:9.5
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        postgresql-server-dev-$PG_MAJOR \
+        postgresql-server-dev-all \
+        git \
+        build-essential \
+        fakeroot \
+        devscripts
+RUN git clone https://github.com/zulip/tsearch_extras.git \
+    && cd tsearch_extras \
+    && echo $PG_MAJOR > debian/pgversions \
+    && pg_buildext updatecontrol \
+    && debuild -b -uc -us
+
+# Install tsearch_extras, hunspell, zulip stop words, and run zulip database
+# init.
+FROM postgres:9.5
+ENV TSEARCH_EXTRAS_VERSION=0.4
+ENV TSEARCH_EXTRAS_DEB=postgresql-${PG_MAJOR}-tsearch-extras_${TSEARCH_EXTRAS_VERSION}_amd64.deb
+COPY --from=0 /${TSEARCH_EXTRAS_DEB} /tmp
+COPY puppet/zulip/files/postgresql/zulip_english.stop /usr/share/postgresql/$PG_MAJOR/tsearch_data/zulip_english.stop
+COPY scripts/setup/postgres-create-db /docker-entrypoint-initdb.d/postgres-create-db.sh
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y hunspell-en-us \
+    && DEBIAN_FRONTEND=noninteractive dpkg -i /tmp/${TSEARCH_EXTRAS_DEB} \
+    && rm /tmp/${TSEARCH_EXTRAS_DEB} \
+    && ln -sf /var/cache/postgresql/dicts/en_us.dict "/usr/share/postgresql/$PG_MAJOR/tsearch_data/en_us.dict" \
+    && ln -sf /var/cache/postgresql/dicts/en_us.affix "/usr/share/postgresql/$PG_MAJOR/tsearch_data/en_us.affix" \
+    && rm -rf /var/lib/apt/lists/*

--- a/scripts/setup/postgres-create-db
+++ b/scripts/setup/postgres-create-db
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+set -x
+
+# Make sure the current working directory is readable
+cd /
+
+DATABASE_CREATE="
+CREATE USER zulip;
+ALTER ROLE zulip SET search_path TO zulip,public;
+CREATE DATABASE zulip OWNER=zulip;
+\\connect zulip
+CREATE SCHEMA zulip AUTHORIZATION zulip;
+CREATE EXTENSION tsearch_extras SCHEMA zulip;
+"
+
+if [ -f /.dockerenv ]; then
+    echo "$DATABASE_CREATE" | psql
+else
+    echo "$DATABASE_CREATE" | su postgres -c psql
+fi

--- a/scripts/setup/postgres-init-db
+++ b/scripts/setup/postgres-init-db
@@ -39,16 +39,10 @@ source "$(dirname "$0")/terminate-psql-sessions" postgres zulip zulip_base
 cd /
 
 su "$POSTGRES_USER" -c psql <<EOF
-CREATE USER zulip;
-ALTER ROLE zulip SET search_path TO zulip,public;
 DROP DATABASE IF EXISTS zulip;
-CREATE DATABASE zulip OWNER=zulip;
 EOF
 
-su "$POSTGRES_USER" -c 'psql zulip' <<EOF
-CREATE SCHEMA zulip AUTHORIZATION zulip;
-CREATE EXTENSION tsearch_extras SCHEMA zulip;
-EOF
+"$(dirname "$0")/postgres-create-db"
 )
 
 # Clear memcached to avoid contamination from previous database state


### PR DESCRIPTION
We also include the zulip postgres database init, 

**Testing Plan:** 
1) `docker-compose up` the existing config. 
2) Build the new image
3) Edit docker-compose.yml to use the new image id
3) `docker-compose up` see full text search is still working.