### PR TITLE
typeahead: Count each part of a name as a prefix match.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -731,7 +731,7 @@ run_test('initialize', () => {
 
         fake_this = { completing: 'mention', token: 'ham' };
         actual_value = options.sorter.call(fake_this, [hamletcharacters, hamlet]);
-        expected_value = [hamletcharacters, hamlet];
+        expected_value = [hamlet, hamletcharacters];
         assert.deepEqual(actual_value, expected_value);
 
         fake_this = { completing: 'mention', token: 'ham' };

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -173,10 +173,10 @@ run_test('sort_recipients', () => {
         'b_user_1@zulip.net',
         'b_user_2@zulip.net',
         'b_user_3@zulip.net',
+        'a_bot@zulip.com',
         'b_bot@example.com',
         'a_user@zulip.org',
         'zman@test.net',
-        'a_bot@zulip.com',
     ]);
 
     // Typeahead for private message [query, "", ""]
@@ -233,10 +233,10 @@ run_test('sort_recipients', () => {
         subscriber_email_3,
         subscriber_email_2,
         subscriber_email_1,
+        'a_bot@zulip.com',
         'b_user_1@zulip.net',
         'zman@test.net',
         'a_user@zulip.org',
-        'a_bot@zulip.com',
     ]);
 
     global.recent_senders.process_message_for_senders({
@@ -297,11 +297,11 @@ run_test('sort_recipients', () => {
     assert.deepEqual(get_typeahead_result("b", "Linux", "Linux Topic"), [
         'b_user_3@zulip.net',
         'b_bot@example.com',
+        'a_bot@zulip.com',
         'b_user_1@zulip.net',
         'b_user_2@zulip.net',
         'zman@test.net',
         'a_user@zulip.org',
-        'a_bot@zulip.com',
     ]);
 
     // Test sort_recipients with duplicate people
@@ -314,12 +314,12 @@ run_test('sort_recipients', () => {
     var expected = [
         'b_bot@example.com',
         'b_user_3@zulip.net',
+        'a_bot@zulip.com',
+        'a_bot@zulip.com',
         'b_user_2@zulip.net',
         'b_user_1@zulip.net',
         'a_user@zulip.org',
         'zman@test.net',
-        'a_bot@zulip.com',
-        'a_bot@zulip.com',
     ];
     assert.deepEqual(recipients_email, expected);
 
@@ -581,10 +581,10 @@ run_test('sort_recipientbox_typeahead', () => {
     assert.deepEqual(recipients_email, [
         'b_bot@example.com',
         'b_user_3@zulip.net',
+        'a_bot@zulip.com',
         'b_user_2@zulip.net',
         'b_user_1@zulip.net',
         'a_user@zulip.org',
         'zman@test.net',
-        'a_bot@zulip.com',
     ]);
 });

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -297,8 +297,9 @@ exports.sort_languages = function (matches, query) {
 };
 
 exports.sort_recipients = function (users, query, current_stream, current_subject, groups) {
-    var users_name_results =  util.prefix_sort(
-        query, users, function (x) { return x.full_name; });
+    var users_name_results = util.prefix_sort(
+        query, users, function (x) { return x.full_name; }, true);
+
     var result = exports.sort_for_at_mentioning(
         users_name_results.matches,
         current_stream,

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -227,7 +227,7 @@ exports.is_mobile = function () {
     return new RegExp(regex, "i").test(window.navigator.userAgent);
 };
 
-exports.prefix_sort = function (query, objs, get_item) {
+exports.prefix_sort = function (query, objs, get_item, partial_match) {
     // Based on Bootstrap typeahead's default sorter, but taking into
     // account case sensitivity on "begins with"
     var beginswithCaseSensitive = [];
@@ -242,9 +242,13 @@ exports.prefix_sort = function (query, objs, get_item) {
         } else {
             item = obj;
         }
-        if (item.indexOf(query) === 0) {
+        var index = item.indexOf(query);
+        var index_lower_case = item.toLowerCase().indexOf(query.toLowerCase());
+
+        if (item.indexOf(query) === 0 || partial_match && item[index - 1] === ' ') {
             beginswithCaseSensitive.push(obj);
-        } else if (item.toLowerCase().indexOf(query.toLowerCase()) === 0) {
+
+        } else if (index_lower_case === 0 || partial_match && item[index_lower_case - 1] === ' ') {
             beginswithCaseInsensitive.push(obj);
         } else {
             noMatch.push(obj);


### PR DESCRIPTION
This deals with the second part of the issue #9312 (the first PR is #9414).

Before (the "pro" prefix):
<img width="264" alt="before" src="https://user-images.githubusercontent.com/1227153/40142031-8b34e114-5925-11e8-9daa-a10940071955.png">

After:
<img width="265" alt="after" src="https://user-images.githubusercontent.com/1227153/40142035-8dc8dd7c-5925-11e8-8ffa-ebeb8f9ef001.png">

At the moment, all user matches (first name, last name, email) are treated the same and not prioritized one over the other.