### PR TITLE
compose: Fix extra space below compose error text.

### DIFF
--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -44,7 +44,7 @@
         <div class="message_comp compose-content">
             <div class="alert" id="compose-send-status">
                 <span class="compose-send-status-close">&times;</span>
-                <p id="compose-error-msg"></p>
+                <span id="compose-error-msg"></span>
             </div>
             <div id="compose_invite_users" class="alert home-error-bar"></div>
             <div id="compose-all-everyone" class="alert home-error-bar"></div>


### PR DESCRIPTION
Fixes #9433.
Extra bottom margin was observed when using `compose_error` which
was caused by paragraphs in bootstrap having a bottom margin of 10px.
The paragraph tag has been replaced by a span tag.
![selection_116](https://user-images.githubusercontent.com/13910561/40145777-cf4d5a38-5980-11e8-987d-dfb7bc4efab0.png)

Result:
![selection_115](https://user-images.githubusercontent.com/13910561/40145804-e93ca822-5980-11e8-9e0d-2e6fc912d781.png)
