### PR TITLE
puppet: Add cron package dependency

### DIFF
--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -23,6 +23,8 @@ class zulip::base {
     'moreutils',
     # Required for using HTTPS in apt repositories.
     'apt-transport-https',
+    # Needed for the cron jobs installed by puppet
+    'cron',
   ]
   package { $base_packages: ensure => 'installed' }
 


### PR DESCRIPTION
The Zulip puppet installs various cron jobs and will fail if cron is not
installed. This was found when installing Zulip in a minimal docker
image.

**Testing Plan:**
`docker-compose build` in galexrt/docker-zulip