### PR TITLE
Zerver: Improve import_realm test coverage

### DIFF
--- a/zerver/tests/fixtures/records.json
+++ b/zerver/tests/fixtures/records.json
@@ -1,0 +1,12 @@
+[
+    {
+        "s3_path":"images/img.jpg",
+        "last_modified":"1526507564.4723451138",
+        "user_profile_id":"2",
+        "size":"6",
+        "path":"records.json",
+        "content_type":"image.jpg",
+        "user_profile_email":"ZOE@zulip.com",
+        "realm_id":"1"
+    }
+]

--- a/zerver/tests/fixtures/records.json
+++ b/zerver/tests/fixtures/records.json
@@ -1,12 +1,3 @@
 [
-    {
-        "s3_path":"images/img.jpg",
-        "last_modified":"1526507564.4723451138",
-        "user_profile_id":"2",
-        "size":"6",
-        "path":"records.json",
-        "content_type":"image.jpg",
-        "user_profile_email":"ZOE@zulip.com",
-        "realm_id":"1"
-    }
+
 ]

--- a/zerver/tests/test_export.py
+++ b/zerver/tests/test_export.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from django.conf import settings
-from django.test import TestCase
 
 import os
 import shutil
@@ -10,13 +9,16 @@ import ujson
 from mock import patch, MagicMock
 from typing import Any, Dict, List, Set, Optional
 
-from zerver.lib.actions import (
-    do_claim_attachments,
-)
 
 from zerver.lib.export import (
     do_export_realm,
     export_usermessages_batch,
+)
+from zerver.lib.import_realm import (
+    import_uploads_s3
+)
+from zerver.lib.test_helpers import (
+    use_s3_backend
 )
 from zerver.lib.upload import (
     claim_attachment,
@@ -37,6 +39,9 @@ from zerver.models import (
     Recipient,
     UserMessage,
 )
+
+from boto.s3.connection import Location, S3Connection
+
 
 def rm_tree(path: str) -> None:
     if os.path.exists(path):
@@ -289,3 +294,11 @@ class ExportTest(ZulipTestCase):
         dummy_user_emails = get_set('zerver_userprofile_mirrordummy', 'email')
         self.assertIn(self.example_email('iago'), dummy_user_emails)
         self.assertNotIn(self.example_email('cordelia'), dummy_user_emails)
+
+    @use_s3_backend
+    def test_import_files_from_s3(self) -> None:
+        conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
+        conn.create_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
+
+        # import_uploads_s3 finds and uses the records.json fixture
+        import_uploads_s3(settings.S3_AUTH_UPLOADS_BUCKET, 'zerver/tests/fixtures/', False)

--- a/zerver/tests/test_export.py
+++ b/zerver/tests/test_export.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Set, Optional
 
 from zerver.lib.export import (
     do_export_realm,
+    export_files_from_s3,
     export_usermessages_batch,
 )
 from zerver.lib.import_realm import (
@@ -36,7 +37,6 @@ from zerver.lib.test_runner import slow
 from zerver.models import (
     Message,
     Realm,
-    Recipient,
     UserMessage,
 )
 
@@ -300,5 +300,15 @@ class ExportTest(ZulipTestCase):
         conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
         conn.create_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
 
-        # import_uploads_s3 finds and uses the records.json fixture
+        # import_uploads_s3 finds and overwrites the records.json fixture
         import_uploads_s3(settings.S3_AUTH_UPLOADS_BUCKET, 'zerver/tests/fixtures/', False)
+
+    @use_s3_backend
+    def test_export_files_from_s3(self) -> None:
+        realm = Realm.objects.get(string_id='zulip')
+        conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
+        conn.create_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
+
+        # export_files_from_s3 finds and overwrites the records.json fixture
+        # currently most of export_files_from_s3 is untested, because there are no bkeys in the bucket_list
+        export_files_from_s3(realm, settings.S3_AUTH_UPLOADS_BUCKET, 'zerver/tests/fixtures/', True)


### PR DESCRIPTION
The previously untested test_import_files_from_s3() function has now been partly tested. A new fixture has been added to complete the unittest.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
