### PR TITLE
Remove dead code in node tests.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -708,17 +708,6 @@ run_test('realm_presence_disabled', () => {
     real_update_huddles();
 });
 
-// Mock the jquery is func
-$('.user-list-filter').is = function (sel) {
-    if (sel === ':focus') {
-        return $('.user-list-filter').is_focused();
-    }
-};
-
-$('.user-list-filter').parent = function () {
-    return $('#user-list .input-append');
-};
-
 run_test('clear_search', () => {
     $('.user-list-filter').val('somevalue');
     activity.user_filter.clear_search();

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -34,10 +34,6 @@ run_test('basics', () => {
             self.class = _.without(tokens, c).join(' ');
         };
 
-        self.click = function () {
-            click_f.call(this);
-        };
-
         self.data = function (name) {
             assert.equal(name, 'tab-id');
             return i;

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -611,7 +611,6 @@ function jquery_elem() {
 
 function make_jquery_helper() {
     const stream_list_filter = jquery_elem();
-    stream_list_filter.is = () => true;
     stream_list_filter.val = () => '';
 
     const stream_filters = jquery_elem();
@@ -623,15 +622,9 @@ function make_jquery_helper() {
 
     function fake_jquery(selector) {
         switch (selector) {
-        case '#stream_filters li.highlighted_stream':
-            return jquery_elem();
         case '.stream-list-filter':
             return stream_list_filter;
-        case '#stream_filters li.narrow-filter':
-            return jquery_elem();
         case 'ul#stream_filters li':
-            return jquery_elem();
-        case '.stream-filters-label':
             return jquery_elem();
         case '#stream_filters':
             return stream_filters;

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -13,10 +13,6 @@ set_global('page_params', {
     is_admin: false,
     realm_users: [],
 });
-// For people.js
-set_global('md5', function (s) {
-    return 'md5-' + s;
-});
 
 zrequire('muting');
 zrequire('stream_data');
@@ -166,15 +162,6 @@ run_test('basic_notifications', () => {
 
     // Notifications API stub
     notifications.set_notification_api({
-        checkPermission: function checkPermission() {
-            if (window.Notification.permission === 'granted') {
-                return 0;
-            }
-            return 2;
-        },
-        requestPermission: function () {
-            return;
-        },
         createNotification: function createNotification(icon, title, content, tag) {
             var notification_object = {icon: icon, body: content, tag: tag};
             // properties for testing.

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -32,25 +32,11 @@ var zero_counts = {
 };
 
 run_test('empty_counts_while_narrowed', () => {
-    narrow_state.active = function () {
-        return true;
-    };
-    current_msg_list.all_messages = function () {
-        return [];
-    };
-
     var counts = unread.get_counts();
     assert.deepEqual(counts, zero_counts);
 });
 
 run_test('empty_counts_while_home', () => {
-    narrow_state.active = function () {
-        return false;
-    };
-    current_msg_list.all_messages = function () {
-        return [];
-    };
-
     var counts = unread.get_counts();
     assert.deepEqual(counts, zero_counts);
 });
@@ -190,10 +176,6 @@ run_test('changing_subjects', () => {
     unread.update_unread_topics(sticky_message, {});
 });
 
-stream_data.get_stream_id = function () {
-    return 999;
-};
-
 run_test('muting', () => {
     stream_data.is_subscribed = function () {
         return true;
@@ -320,9 +302,6 @@ run_test('num_unread_for_topic', () => {
 
 
 run_test('home_messages', () => {
-    narrow_state.active = function () {
-        return false;
-    };
     stream_data.is_subscribed = function () {
         return true;
     };
@@ -344,10 +323,6 @@ run_test('home_messages', () => {
         stream_id: stream_id,
         subject: 'lunch',
         unread: true,
-    };
-
-    home_msg_list.get = function (msg_id) {
-        return (msg_id === '15') ? message : undefined;
     };
 
     var counts = unread.get_counts();
@@ -391,13 +366,6 @@ run_test('phantom_messages', () => {
 });
 
 run_test('private_messages', () => {
-    narrow_state.active = function () {
-        return false;
-    };
-    stream_data.is_subscribed = function () {
-        return true;
-    };
-
     var counts = unread.get_counts();
     assert.equal(counts.private_message_count, 0);
 
@@ -474,13 +442,6 @@ run_test('private_messages', () => {
 
 
 run_test('mentions', () => {
-    narrow_state.active = function () {
-        return false;
-    };
-    stream_data.is_subscribed = function () {
-        return true;
-    };
-
     var counts = unread.get_counts();
     assert.equal(counts.mentioned_message_count, 0);
     assert.deepEqual(unread.get_msg_ids_for_mentions(), []);
@@ -611,8 +572,6 @@ run_test('empty_cases', () => {
 
 run_test('errors', () => {
     unread.declare_bankruptcy();
-
-    global.blueslip.warn = function () {};
 
     // Test unknown message leads to zero count
     var message = {


### PR DESCRIPTION
It's easy to poke around at the node test coverage report to find unneeded mocks/fakes and other cruft.

cc @lonerz who I talked about this with