### PR TITLE
Strict mypy for certain files in zerver/lib

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -256,7 +256,6 @@ ignore_missing_imports = True
 strict_optional = True
 
 # REQ returning None issue
-
 [mypy-zerver.decorator]
 strict_optional = False
 [mypy-zerver.views.zephyr]
@@ -309,7 +308,7 @@ strict_optional = False
 # One change required?
 
 [mypy-zerver.lib.notifications]  # line 122: Using group from regex, which might return None
-strict_optional = False
+strict_optional = True
 [mypy-zerver.lib.avatar]  # str vs Optional[str]
 strict_optional = False
 [mypy-zerver.lib.soft_deactivation]

--- a/mypy.ini
+++ b/mypy.ini
@@ -318,7 +318,7 @@ strict_optional = True
 [mypy-zerver.lib.exceptions]  #21: error: Return type of "__reduce_ex__" incompatible with supertype "object"
 strict_optional = True
 [mypy-zerver.lib.bugdown.api_arguments_table_generator]  #18: error: Item "None" of "Optional[Dict[str, Any]]" has no attribute "items"
-strict_optional = False
+strict_optional = True
 [mypy-zerver.lib.message]  #868: error: Unsupported operand types for - ("Optional[int]" and "int")
 strict_optional = False
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -320,7 +320,7 @@ strict_optional = True
 [mypy-zerver.lib.bugdown.api_arguments_table_generator]  #18: error: Item "None" of "Optional[Dict[str, Any]]" has no attribute "items"
 strict_optional = True
 [mypy-zerver.lib.message]  #868: error: Unsupported operand types for - ("Optional[int]" and "int")
-strict_optional = False
+strict_optional = True
 
 [mypy-zerver.migrations.0077_add_file_name_field_to_realm_emoji]  #73: error: Argument 2 to "upload_files" of "Uploader" has incompatible type "Optional[bytes]"; expected "bytes"
 strict_optional = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -314,7 +314,7 @@ strict_optional = False
 [mypy-zerver.lib.soft_deactivation]
 strict_optional = False
 [mypy-zerver.lib.events]  # signup_notifications_stream is Optional, but accessing id property
-strict_optional = False
+strict_optional = True
 [mypy-zerver.lib.exceptions]  #21: error: Return type of "__reduce_ex__" incompatible with supertype "object"
 strict_optional = False
 [mypy-zerver.lib.bugdown.api_arguments_table_generator]  #18: error: Item "None" of "Optional[Dict[str, Any]]" has no attribute "items"

--- a/mypy.ini
+++ b/mypy.ini
@@ -312,7 +312,7 @@ strict_optional = True
 [mypy-zerver.lib.avatar]  # str vs Optional[str]
 strict_optional = True
 [mypy-zerver.lib.soft_deactivation]
-strict_optional = False
+strict_optional = True
 [mypy-zerver.lib.events]  # signup_notifications_stream is Optional, but accessing id property
 strict_optional = True
 [mypy-zerver.lib.exceptions]  #21: error: Return type of "__reduce_ex__" incompatible with supertype "object"

--- a/mypy.ini
+++ b/mypy.ini
@@ -316,7 +316,7 @@ strict_optional = False
 [mypy-zerver.lib.events]  # signup_notifications_stream is Optional, but accessing id property
 strict_optional = True
 [mypy-zerver.lib.exceptions]  #21: error: Return type of "__reduce_ex__" incompatible with supertype "object"
-strict_optional = False
+strict_optional = True
 [mypy-zerver.lib.bugdown.api_arguments_table_generator]  #18: error: Item "None" of "Optional[Dict[str, Any]]" has no attribute "items"
 strict_optional = False
 [mypy-zerver.lib.message]  #868: error: Unsupported operand types for - ("Optional[int]" and "int")

--- a/mypy.ini
+++ b/mypy.ini
@@ -307,21 +307,6 @@ strict_optional = False
 
 # One change required?
 
-[mypy-zerver.lib.notifications]  # line 122: Using group from regex, which might return None
-strict_optional = True
-[mypy-zerver.lib.avatar]  # str vs Optional[str]
-strict_optional = True
-[mypy-zerver.lib.soft_deactivation]
-strict_optional = True
-[mypy-zerver.lib.events]  # signup_notifications_stream is Optional, but accessing id property
-strict_optional = True
-[mypy-zerver.lib.exceptions]  #21: error: Return type of "__reduce_ex__" incompatible with supertype "object"
-strict_optional = True
-[mypy-zerver.lib.bugdown.api_arguments_table_generator]  #18: error: Item "None" of "Optional[Dict[str, Any]]" has no attribute "items"
-strict_optional = True
-[mypy-zerver.lib.message]  #868: error: Unsupported operand types for - ("Optional[int]" and "int")
-strict_optional = True
-
 [mypy-zerver.migrations.0077_add_file_name_field_to_realm_emoji]  #73: error: Argument 2 to "upload_files" of "Uploader" has incompatible type "Optional[bytes]"; expected "bytes"
 strict_optional = False
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -310,7 +310,7 @@ strict_optional = False
 [mypy-zerver.lib.notifications]  # line 122: Using group from regex, which might return None
 strict_optional = True
 [mypy-zerver.lib.avatar]  # str vs Optional[str]
-strict_optional = False
+strict_optional = True
 [mypy-zerver.lib.soft_deactivation]
 strict_optional = False
 [mypy-zerver.lib.events]  # signup_notifications_stream is Optional, but accessing id property

--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -10,7 +10,7 @@ from zerver.lib.upload import upload_backend, MEDIUM_AVATAR_SIZE
 from zerver.models import UserProfile
 import urllib
 
-def avatar_url(user_profile: UserProfile, medium: bool=False, client_gravatar: bool=False) -> str:
+def avatar_url(user_profile: UserProfile, medium: bool=False, client_gravatar: bool=False) -> Optional[str]:
 
     return get_avatar_field(
         user_id=user_profile.id,
@@ -112,6 +112,11 @@ def _get_unversioned_avatar_url(user_profile_id: int,
     return _get_unversioned_gravatar_url(email, medium)
 
 def absolute_avatar_url(user_profile: UserProfile) -> str:
-    """Absolute URLs are used to simplify logic for applications that
-    won't be served by browsers, such as rendering GCM notifications."""
-    return urllib.parse.urljoin(user_profile.realm.uri, avatar_url(user_profile))
+    """
+    Absolute URLs are used to simplify logic for applications that
+    won't be served by browsers, such as rendering GCM notifications.
+    """
+    avatar = avatar_url(user_profile)
+    # avatar_url can return None if client_gravatar=True, however here we use the default value of False
+    assert avatar is not None
+    return urllib.parse.urljoin(user_profile.realm.uri, avatar)

--- a/zerver/lib/bugdown/api_arguments_table_generator.py
+++ b/zerver/lib/bugdown/api_arguments_table_generator.py
@@ -11,7 +11,9 @@ REGEXP = re.compile(r'\{generate_api_arguments_table\|\s*(.+?)\s*\|\s*(.+?)\s*\}
 
 
 class MarkdownArgumentsTableGenerator(Extension):
-    def __init__(self, configs: Optional[Dict[str, Any]]={}) -> None:
+    def __init__(self, configs: Optional[Dict[str, Any]]=None) -> None:
+        if configs is None:
+            configs = {}
         self.config = {
             'base_path': ['.', 'Default location from which to evaluate relative paths for the JSON files.'],
         }

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -180,8 +180,8 @@ def fetch_initial_state_data(user_profile: UserProfile,
         else:
             state['realm_notifications_stream_id'] = -1
 
-        if realm.get_signup_notifications_stream():
-            signup_notifications_stream = realm.get_signup_notifications_stream()
+        signup_notifications_stream = realm.get_signup_notifications_stream()
+        if signup_notifications_stream:
             state['realm_signup_notifications_stream_id'] = signup_notifications_stream.id
         else:
             state['realm_signup_notifications_stream_id'] = -1

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type
+from mypy_extensions import NoReturn
 
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _
@@ -20,7 +21,7 @@ class AbstractEnum(Enum):
     def value(self) -> None:
         raise AssertionError("Not implemented")
 
-    def __reduce_ex__(self, proto: int) -> None:
+    def __reduce_ex__(self, proto: int) -> NoReturn:
         raise AssertionError("Not implemented")
 
 class ErrorCode(AbstractEnum):

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -875,6 +875,8 @@ def maybe_update_first_visible_message_id(realm: Realm, lookback_hours: int) -> 
 
 def update_first_visible_message_id(realm: Realm) -> None:
     try:
+        # We have verified that the limit is not none before calling this function.
+        assert realm.message_visibility_limit is not None
         first_visible_message_id = Message.objects.filter(sender__realm=realm).values('id').\
             order_by('-id')[realm.message_visibility_limit - 1]["id"]
     except IndexError:

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -25,6 +25,7 @@ from zerver.models import (
 
 from datetime import timedelta, datetime
 from email.utils import formataddr
+from lxml.cssselect import CSSSelector
 import lxml.html
 import re
 import subprocess
@@ -115,10 +116,14 @@ def relative_to_full_url(base_url: str, content: str) -> str:
     return content
 
 def fix_emojis(content: str, base_url: str, emojiset: str) -> str:
-    def make_emoji_img_elem(emoji_span_elem: Any) -> Dict[str, Any]:
+    def make_emoji_img_elem(emoji_span_elem: CSSSelector) -> Dict[str, Any]:
         # Convert the emoji spans to img tags.
         classes = emoji_span_elem.get('class')
         match = re.search('emoji-(?P<emoji_code>\S+)', classes)
+        # re.search is capable of returning None,
+        # but since the parent function should only be called with a valid css element
+        # we assert that it does not.
+        assert match is not None
         emoji_code = match.group('emoji_code')
         emoji_name = emoji_span_elem.get('title')
         alt_code = emoji_span_elem.text

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -119,6 +119,8 @@ def add_missing_messages(user_profile: UserProfile) -> None:
     for sub in all_stream_subs:
         stream_subscription_logs = all_stream_subscription_logs[sub['recipient__type_id']]
         if (stream_subscription_logs[-1].event_type == 'subscription_deactivated' and
+                stream_subscription_logs[-1].event_last_message_id is not None and
+                user_profile.last_active_message_id is not None and
                 stream_subscription_logs[-1].event_last_message_id <= user_profile.last_active_message_id):
             # We are going to short circuit this iteration as its no use
             # iterating since user unsubscribed before soft-deactivation

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -728,12 +728,12 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
         with self.settings(ENABLE_GRAVATAR=True):
             response = self.client_get("/avatar/cordelia@zulip.com?foo=bar")
             redirect_url = response['Location']
-            self.assertEqual(redirect_url, avatar_url(cordelia) + '&foo=bar')
+            self.assertEqual(redirect_url, str(avatar_url(cordelia)) + '&foo=bar')
 
         with self.settings(ENABLE_GRAVATAR=False):
             response = self.client_get("/avatar/cordelia@zulip.com?foo=bar")
             redirect_url = response['Location']
-            self.assertTrue(redirect_url.endswith(avatar_url(cordelia) + '&foo=bar'))
+            self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia)) + '&foo=bar'))
 
     def test_get_user_avatar(self) -> None:
         self.login(self.example_email("hamlet"))
@@ -743,11 +743,11 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
         cordelia.save()
         response = self.client_get("/avatar/cordelia@zulip.com?foo=bar")
         redirect_url = response['Location']
-        self.assertTrue(redirect_url.endswith(avatar_url(cordelia) + '&foo=bar'))
+        self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia)) + '&foo=bar'))
 
         response = self.client_get("/avatar/%s?foo=bar" % (cordelia.id))
         redirect_url = response['Location']
-        self.assertTrue(redirect_url.endswith(avatar_url(cordelia) + '&foo=bar'))
+        self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia)) + '&foo=bar'))
 
         response = self.client_get("/avatar/")
         self.assertEqual(response.status_code, 404)
@@ -760,11 +760,11 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
         cordelia.save()
         response = self.client_get("/avatar/cordelia@zulip.com/medium?foo=bar")
         redirect_url = response['Location']
-        self.assertTrue(redirect_url.endswith(avatar_url(cordelia, True) + '&foo=bar'))
+        self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia, True)) + '&foo=bar'))
 
         response = self.client_get("/avatar/%s/medium?foo=bar" % (cordelia.id,))
         redirect_url = response['Location']
-        self.assertTrue(redirect_url.endswith(avatar_url(cordelia, True) + '&foo=bar'))
+        self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia, True)) + '&foo=bar'))
 
     def test_non_valid_user_avatar(self) -> None:
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Enabling `strict_optional` for certain files in `zerver/lib`

**Testing Plan:** <!-- How have you tested? -->
My changes are involve small refactors, changing type signatures, and adding asserts. I have modified existing tests where necessary to adapt to new type-signatures but otherwise I have just ensured that the tests (and mypy) are passing. 


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
No UI changes.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
