### PR TITLE
Allow users to import settings from other realm during registration

### DIFF
--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -961,3 +961,8 @@ button.login-google-button {
     margin-top: -10px;
     top: 5px;
 }
+
+#source_realm_radio {
+    position: relative;
+    top: 30px;
+}

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -81,6 +81,25 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                     </div>
                 </div>
                 {% endif %}
+                {% if membership_realms %}
+                <div class="input-box">
+                    <label for="source_realm" class="inline-block">{{ _('Do you want to import your user settings from another organization?') }}</label>
+                </div>
+                <div id="source_realm_radio" class="input-group m-10 inline-block">
+                    <div class="input-group radio">
+                        <input class="inline-block" type="radio" name="source_realm"
+                          {% if ("source_realm" in form.data and form.data["source_realm"] == "on") or "source_realm" not in form.data %} checked {% endif %} />
+                        <label for="id_radio_none" class="inline-block">None</label>
+                    </div>
+                    {% for membership_realm in membership_realms %}
+                    <div class="input-group radio">
+                        <input class="inline-block" type="radio" name="source_realm" value="{{ membership_realm.string_id }}"
+                          {% if "source_realm" in form.data and membership_realm.string_id == form.data["source_realm"] %} checked {% endif %} />
+                        <label for="id_radio_{{ membership_realm.string_id }}" class="inline-block">{{ membership_realm.name }}</label>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endif %}
             </section>
 
             {% if default_stream_groups %}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -485,7 +485,8 @@ def do_create_user(email: str, password: Optional[str], realm: Realm, full_name:
                    default_all_public_streams: bool=None,
                    prereg_user: Optional[PreregistrationUser]=None,
                    newsletter_data: Optional[Dict[str, str]]=None,
-                   default_stream_groups: List[DefaultStreamGroup]=[]) -> UserProfile:
+                   default_stream_groups: List[DefaultStreamGroup]=[],
+                   source_profile: Optional[UserProfile]=None) -> UserProfile:
 
     user_profile = create_user(email=email, password=password, realm=realm,
                                full_name=full_name, short_name=short_name,
@@ -494,7 +495,8 @@ def do_create_user(email: str, password: Optional[str], realm: Realm, full_name:
                                tos_version=tos_version, timezone=timezone, avatar_source=avatar_source,
                                default_sending_stream=default_sending_stream,
                                default_events_register_stream=default_events_register_stream,
-                               default_all_public_streams=default_all_public_streams)
+                               default_all_public_streams=default_all_public_streams,
+                               source_profile=source_profile)
 
     event_time = user_profile.date_joined
     RealmAuditLog.objects.create(realm=user_profile.realm, modified_user=user_profile,

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -73,7 +73,8 @@ def create_user(email: str, password: Optional[str], realm: Realm,
                 is_mirror_dummy: bool = False,
                 default_sending_stream: Optional[Stream] = None,
                 default_events_register_stream: Optional[Stream] = None,
-                default_all_public_streams: Optional[bool] = None) -> UserProfile:
+                default_all_public_streams: Optional[bool] = None,
+                source_profile: Optional[UserProfile] = None) -> UserProfile:
     user_profile = create_user_profile(realm, email, password, active, bot_type,
                                        full_name, short_name, bot_owner,
                                        is_mirror_dummy, tos_version, timezone)
@@ -87,6 +88,10 @@ def create_user(email: str, password: Optional[str], realm: Realm,
         user_profile.default_all_public_streams = default_all_public_streams
 
     user_profile.save()
+
+    if source_profile is not None:
+        user_profile = copy_user_settings(source_profile, user_profile)
+
     recipient = Recipient.objects.create(type_id=user_profile.id,
                                          type=Recipient.PERSONAL)
     Subscription.objects.create(user_profile=user_profile, recipient=recipient)

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -14,6 +14,19 @@ def random_api_key() -> str:
     altchars = ''.join([choices[ord(os.urandom(1)) % 62] for _ in range(2)]).encode("utf-8")
     return base64.b64encode(os.urandom(24), altchars=altchars).decode("utf-8")
 
+def copy_user_settings(source_profile: UserProfile,
+                       target_profile: UserProfile) -> UserProfile:
+    for settings_name in UserProfile.property_types:
+        value = getattr(source_profile, settings_name)
+        setattr(target_profile, settings_name, value)
+
+    for settings_name in UserProfile.notification_setting_types:
+        value = getattr(source_profile, settings_name)
+        setattr(target_profile, settings_name, value)
+
+    target_profile.save()
+    return target_profile
+
 # create_user_profile is based on Django's User.objects.create_user,
 # except that we don't save to the database so it can used in
 # bulk_creates

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -299,7 +299,8 @@ class ZulipTestCase(TestCase):
             realm_subdomain: Optional[str]="zuliptest",
             from_confirmation: Optional[str]='', full_name: Optional[str]=None,
             timezone: Optional[str]='', realm_in_root_domain: Optional[str]=None,
-            default_stream_groups: Optional[List[str]]=[], **kwargs: Any) -> HttpResponse:
+            default_stream_groups: Optional[List[str]]=[],
+            source_realm: Optional[str]='', **kwargs: Any) -> HttpResponse:
         """
         Stage two of the two-step registration process.
 
@@ -320,6 +321,7 @@ class ZulipTestCase(TestCase):
             'terms': True,
             'from_confirmation': from_confirmation,
             'default_stream_group': default_stream_groups,
+            'source_realm': source_realm,
         }
         if realm_in_root_domain is not None:
             payload['realm_in_root_domain'] = realm_in_root_domain

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -15,7 +15,7 @@ from zerver.context_processors import get_realm_from_request
 from zerver.models import UserProfile, Realm, Stream, MultiuseInvite, \
     name_changes_disabled, email_to_username, email_allowed_for_realm, \
     get_realm, get_user, get_default_stream_groups, DisposableEmailError, \
-    DomainNotAllowedForRealmError
+    DomainNotAllowedForRealmError, get_membership_realms, get_source_profile
 from zerver.lib.send_email import send_email, FromAddress
 from zerver.lib.events import do_events_register
 from zerver.lib.actions import do_change_password, do_change_full_name, do_change_is_admin, \
@@ -198,6 +198,11 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
         if 'timezone' in request.POST and request.POST['timezone'] in get_all_timezones():
             timezone = request.POST['timezone']
 
+        if 'source_realm' in request.POST and request.POST["source_realm"] != "on":
+            source_profile = get_source_profile(email, request.POST["source_realm"])
+        else:
+            source_profile = None
+
         if not realm_creation:
             try:
                 existing_user_profile = get_user(email, realm)  # type: Optional[UserProfile]
@@ -249,7 +254,8 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
                                           tos_version=settings.TOS_VERSION,
                                           timezone=timezone,
                                           newsletter_data={"IP": request.META['REMOTE_ADDR']},
-                                          default_stream_groups=default_stream_groups)
+                                          default_stream_groups=default_stream_groups,
+                                          source_profile=source_profile)
 
         if realm_creation:
             bulk_add_subscriptions([realm.signup_notifications_stream], [user_profile])
@@ -290,6 +296,7 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
                  'password_auth_enabled': password_auth_enabled(realm),
                  'root_domain_available': is_root_domain_available(),
                  'default_stream_groups': get_default_stream_groups(realm),
+                 'membership_realms': get_membership_realms(email),
                  'MAX_REALM_NAME_LENGTH': str(Realm.MAX_REALM_NAME_LENGTH),
                  'MAX_NAME_LENGTH': str(UserProfile.MAX_NAME_LENGTH),
                  'MAX_PASSWORD_LENGTH': str(form.MAX_PASSWORD_LENGTH),


### PR DESCRIPTION
Not completed. I have to add checkbox asking whether they want to import settings before showing the organizations list. As well as to add the tests.

@timabbott Is this going in the direction you imagined? 

![import-settings](https://user-images.githubusercontent.com/7190633/40196960-a84bbe3e-5a2f-11e8-925e-c6d53032d3ca.gif)
