### PR TITLE
mypy: Enable strict optional for check redis management command

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -310,9 +310,6 @@ strict_optional = False
 [mypy-zerver.migrations.0077_add_file_name_field_to_realm_emoji]  #73: error: Argument 2 to "upload_files" of "Uploader" has incompatible type "Optional[bytes]"; expected "bytes"
 strict_optional = False
 
-[mypy-zerver/management/commands/check_redis]  #32: error: Incompatible types in assignment (expression has type "None", variable has type "UserProfile")
-strict_optional = False
-
 [mypy-zilencer.management.commands.calculate_first_visible_message_id]  #33: error: Argument 1 to "maybe_update_first_visible_message_id" has incompatible type "Optional[Realm]"; expected "Realm"
 strict_optional = False
 [mypy-zilencer.management.commands.add_new_realm]  #22: error: List item 0 has incompatible type "Optional[Stream]"; expected "Stream"

--- a/zerver/management/commands/check_redis.py
+++ b/zerver/management/commands/check_redis.py
@@ -26,10 +26,7 @@ class Command(BaseCommand):
     def _check_within_range(self, key: str, count_func: Callable[[], int],
                             trim_func: Optional[Callable[[str, int], None]]=None) -> None:
         user_id = int(key.split(':')[1])
-        try:
-            user = get_user_profile_by_id(user_id)
-        except Exception:
-            user = None
+        user = get_user_profile_by_id(user_id)
         entity = RateLimitedUser(user)
         max_calls = max_api_calls(entity)
 


### PR DESCRIPTION
Removed the error handling on the get_user_profile_by_id function, as it
would have just caused a different error shortly after.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Just refactoring, but I've ensured that existing tests pass locally

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
