### PR TITLE
search: Show category-wise suggestions for has operator.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -665,6 +665,20 @@ run_test('describe', () => {
     string = 'stream devel, exclude messages with one or more image';
     assert.equal(Filter.describe(narrow), string);
 
+    narrow = [
+        {operator: 'has', operand: 'abc', negated: true},
+        {operator: 'stream', operand: 'devel'},
+    ];
+    string = 'invalid abc operand for has operator, stream devel';
+    assert.equal(Filter.describe(narrow), string);
+
+    narrow = [
+        {operator: 'has', operand: 'image', negated: true},
+        {operator: 'stream', operand: 'devel'},
+    ];
+    string = 'exclude messages with one or more image, stream devel';
+    assert.equal(Filter.describe(narrow), string);
+
     narrow = [];
     string = 'all messages';
     assert.equal(Filter.describe(narrow), string);

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -446,6 +446,9 @@ run_test('empty_query_suggestions', () => {
         "sender:bob@zulip.com",
         "stream:devel",
         "stream:office",
+        'has:link',
+        'has:image',
+        'has:attachment',
     ];
 
     assert.deepEqual(suggestions.strings, expected);
@@ -459,6 +462,39 @@ run_test('empty_query_suggestions', () => {
     assert.equal(describe('is:alerted'), 'Alerted messages');
     assert.equal(describe('is:unread'), 'Unread messages');
     assert.equal(describe('sender:bob@zulip.com'), 'Sent by me');
+    assert.equal(describe('has:link'), 'Messages with one or more link');
+    assert.equal(describe('has:image'), 'Messages with one or more image');
+    assert.equal(describe('has:attachment'), 'Messages with one or more attachment');
+});
+
+run_test('has_operator_suggestions', () => {
+    // Checks that category wise suggestions are displayed instead of a single
+    // default suggestion when suggesting `has` operator.
+    var query = 'h';
+    global.stream_data.subscribed_streams = function () {
+        return ['devel', 'office'];
+    };
+    global.narrow_state.stream = function () {
+        return;
+    };
+
+    var suggestions = search.get_suggestions(query);
+    var expected = [
+        "h",
+        'has:link',
+        'has:image',
+        'has:attachment',
+    ];
+
+    assert.deepEqual(suggestions.strings, expected);
+
+    function describe(q) {
+        return suggestions.lookup_table[q].description;
+    }
+
+    assert.equal(describe('has:link'), 'Messages with one or more link');
+    assert.equal(describe('has:image'), 'Messages with one or more image');
+    assert.equal(describe('has:attachment'), 'Messages with one or more attachment');
 });
 
 run_test('sent_by_me_suggestions', () => {

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -780,7 +780,6 @@ run_test('contains_suggestions', () => {
     var query = 'has:';
     var suggestions = search.get_suggestions(query);
     var expected = [
-        'has:',
         'has:link',
         'has:image',
         'has:attachment',
@@ -790,7 +789,6 @@ run_test('contains_suggestions', () => {
     query = 'has:im';
     suggestions = search.get_suggestions(query);
     expected = [
-        'has:im',
         'has:image',
     ];
     assert.deepEqual(suggestions.strings, expected);
@@ -798,7 +796,6 @@ run_test('contains_suggestions', () => {
     query = '-has:im';
     suggestions = search.get_suggestions(query);
     expected = [
-        '-has:im',
         '-has:image',
     ];
     assert.deepEqual(suggestions.strings, expected);
@@ -814,7 +811,6 @@ run_test('contains_suggestions', () => {
     query = 'stream:Denmark is:alerted has:lin';
     suggestions = search.get_suggestions(query);
     expected = [
-        'stream:Denmark is:alerted has:lin',
         'stream:Denmark is:alerted has:link',
         'stream:Denmark is:alerted',
         'stream:Denmark',

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -553,6 +553,7 @@ Filter.operator_to_prefix = function (operator, negated) {
     case 'near':
         return verb + 'messages around';
 
+    // Note: We hack around using this in "describe" below.
     case 'has':
         return verb + 'messages with one or more';
 
@@ -622,6 +623,14 @@ function describe_unescaped(operators) {
                 return verb + 'unread messages';
             }
             return operand + ' messages';
+        }
+        if (canonicalized_operator ==='has') {
+            // search_suggestion.get_suggestions takes care that this message will
+            // only be shown if the `has` operator is not at the last.
+            var valid_has_operands = ['image', 'images', 'link', 'links', 'attachment', 'attachments'];
+            if (valid_has_operands.indexOf(operand) === -1) {
+                return 'invalid ' + operand + ' operand for has operator';
+            }
         }
         var prefix_for_operator = Filter.operator_to_prefix(canonicalized_operator,
                                                             elem.negated);

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -538,7 +538,10 @@ exports.get_suggestions = function (query) {
     }
 
     // Display the default first
-    if (last.operator !== '') {
+    // `has` operator works only on predefined categories. Default suggestion
+    // is not displayed in that case. e.g. `messages with one or more abc` as
+    // a suggestion for `has:abc`does not make sense.
+    if (last.operator !== '' && last.operator !== 'has') {
         suggestion = get_default_suggestion(operators);
         result = [suggestion];
     }


### PR DESCRIPTION
**Commit 1**:
Default suggestion e.g `messages with one or more abc` as a suggestion for `has:abc` is not shown in a new suggestion. But if the has operator is already present before any other operator, the default message text will be used. e.g `has:abc sender:abc@zulipchat.com` will have all the suggestions with the prefix `messages with one or more abc, sent by abc@zulipchat.com`.

![selection_122](https://user-images.githubusercontent.com/13910561/40228887-2dbb2a52-5ab0-11e8-81de-0cbc5e12f64b.png)

![selection_121](https://user-images.githubusercontent.com/13910561/40228894-2fd5cf90-5ab0-11e8-8e5c-4c0cccbdbb17.png)

**Commit 2:**
`has` operator uses predefined categories. This commit displays an invalid operand message if the operand does not fall in to any of these categories and the `has` operator is not at the last.
e.g. `has:abc sender:abc@zulipchat.com` will have `invalid abc operand for has operator, sent by abc@zulipchat.com` as a prefix for all its suggestions.
![selection_123](https://user-images.githubusercontent.com/13910561/40228987-7d355fda-5ab0-11e8-97b5-502d9b5ab1ef.png)

**Commit 3:**
Another issue was getting the default suggestion `messages with one or more` when getting the suggestions for chosing the operator as shown below:
![screenshot from 2018-05-18 11-40-48](https://user-images.githubusercontent.com/13910561/40229106-ee4a8934-5ab0-11e8-9761-d76d3fee8f2f.png)

This commit takes care of that issue.
Results:
![screenshot from 2018-05-18 12-21-27](https://user-images.githubusercontent.com/13910561/40229274-67f0f778-5ab1-11e8-8e9f-e658a52a67b9.png)

Note: categories exist for the `is` operator, removal of default suggestion needs to be done.