### PR TITLE
edit bot: Fix UI element shows incorrect interface for outgoing webhook.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1573,8 +1573,8 @@ run_test('handlebars_bug', () => {
                   interface: "1"},
     };
     var html = render('edit-outgoing-webhook-service', args);
-    assert.equal($(html).find('#edit_service_base_url').attr('value'), args.service.base_url);
-    assert.equal($(html).find('#edit_service_interface').attr('value'), args.service.interface);
+    assert.equal($(html).find('#edit_service_base_url').val(), args.service.base_url);
+    assert.equal($(html).find('#edit_service_interface').val(), args.service.interface);
 }());
 
 (function edit_embedded_bot_service() {

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -373,6 +373,7 @@ exports.set_up = function () {
         if (bot.bot_type.toString() === OUTGOING_WEBHOOK_BOT_TYPE) {
             $("#service_data").append(templates.render("edit-outgoing-webhook-service",
                                                        {service: service}));
+            $("#edit_service_interface").val(service.interface);
         }
         if (bot.bot_type.toString() === EMBEDDED_BOT_TYPE) {
             $("#service_data").append(templates.render("edit-embedded-bot-service",

--- a/static/templates/settings/edit-outgoing-webhook-service.handlebars
+++ b/static/templates/settings/edit-outgoing-webhook-service.handlebars
@@ -5,7 +5,7 @@
 </div>
 <div class="">
     <label for="edit_service_interface">{{t "Interface" }}</label>
-    <select id="edit_service_interface" name="service_interface" value="{{service.interface}}">
+    <select id="edit_service_interface" name="service_interface">
         <option value="1">{{t "Generic" }}</option>
         <option value="2">{{t "Slack's outgoing webhooks" }}</option>
     </select>


### PR DESCRIPTION
Fixes #9419

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![editoutgoingwebhookbot](https://user-images.githubusercontent.com/25907420/40237433-0d01870c-5ace-11e8-90e6-518db4ea23b9.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
