### PR TITLE
 bots: Do not show `not_subscribed` warning for bots on private streams.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -938,6 +938,49 @@ run_test('trigger_submit_compose_form', () => {
     assert(compose_finish_checked);
 });
 
+run_test('needs_subscribe_warning', () => {
+    people.get_active_user_for_email = function () {
+        return;
+    };
+
+    assert.equal(compose.needs_subscribe_warning(), false);
+
+    compose_state.stream_name('random');
+    assert.equal(compose.needs_subscribe_warning(), false);
+
+    var sub = {
+        stream_id: 111,
+        name: 'random',
+        subscribed: true,
+    };
+    stream_data.add_sub('random', sub);
+    assert.equal(compose.needs_subscribe_warning(), false);
+
+    people.get_active_user_for_email = function () {
+        return {
+            user_id: 99,
+            is_bot: true,
+        };
+    };
+    assert.equal(compose.needs_subscribe_warning(), false);
+
+    people.get_active_user_for_email = function () {
+        return {
+            user_id: 99,
+            is_bot: false,
+        };
+    };
+    stream_data.is_user_subscribed = function () {
+        return true;
+    };
+    assert.equal(compose.needs_subscribe_warning(), false);
+
+    stream_data.is_user_subscribed = function () {
+        return false;
+    };
+    assert.equal(compose.needs_subscribe_warning(), true);
+});
+
 run_test('on_events', () => {
     (function test_usermention_completed_zulip_triggered() {
         var handler = $(document).get_on_handler('usermention_completed.zulip');

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -711,7 +711,7 @@ exports.needs_subscribe_warning = function (email) {
     //  * the stream in the compose box is valid
     //  * the user is not already subscribed to the stream
     //  * the user has no back-door way to see stream messages
-    //    (i.e. bots on public streams)
+    //    (i.e. bots on public/private streams)
     //
     //  You can think of this as roughly answering "is there an
     //  actionable way to subscribe the user and do they actually
@@ -733,8 +733,8 @@ exports.needs_subscribe_warning = function (email) {
         return false;
     }
 
-    if (user.is_bot && !sub.invite_only) {
-        // Bots may receive messages on public streams even if they are
+    if (user.is_bot) {
+        // Bots may receive messages on public/private streams even if they are
         // not subscribed.
         return false;
     }


### PR DESCRIPTION
Fixes #9373.
I noticed that test for `needs_subscribe_warning` was msising, so added a test in the second commit. I divided this into two commits as the test was added for the whole `needs_subscribe_warning` and not just the `is_bot` change (let me know if this needs to be changed).