### PR TITLE
stats: Add /stats/installation.

### DIFF
--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -9,7 +9,8 @@ from analytics.lib.counts import COUNT_STATS, \
     CountStat, do_drop_all_analytics_tables
 from analytics.lib.fixtures import generate_time_series_data
 from analytics.lib.time_utils import time_range
-from analytics.models import BaseCount, FillState, RealmCount, UserCount, StreamCount
+from analytics.models import BaseCount, FillState, RealmCount, UserCount, \
+    StreamCount, InstallationCount
 from zerver.lib.timestamp import floor_to_day
 from zerver.models import Realm, UserProfile, Stream, Message, Client, \
     RealmAuditLog, Recipient
@@ -64,6 +65,8 @@ class Command(BaseCommand):
                                 table: Type[BaseCount]) -> None:
             end_times = time_range(last_end_time, last_end_time, stat.frequency,
                                    len(list(fixture_data.values())[0]))
+            if table == InstallationCount:
+                id_args = {}  # type: Dict[str, Any]
             if table == RealmCount:
                 id_args = {'realm': realm}
             if table == UserCount:
@@ -82,6 +85,10 @@ class Command(BaseCommand):
             None: self.generate_fixture_data(stat, .1, .03, 3, .5, 3, partial_sum=True),
         }  # type: Mapping[Optional[str], List[int]]
         insert_fixture_data(stat, realm_data, RealmCount)
+        installation_data = {
+            None: self.generate_fixture_data(stat, 1, .3, 4, .5, 3, partial_sum=True),
+        }  # type: Mapping[Optional[str], List[int]]
+        insert_fixture_data(stat, installation_data, InstallationCount)
         FillState.objects.create(property=stat.property, end_time=last_end_time,
                                  state=FillState.DONE)
 
@@ -92,6 +99,9 @@ class Command(BaseCommand):
         realm_data = {'false': self.generate_fixture_data(stat, 35, 15, 6, .6, 4),
                       'true': self.generate_fixture_data(stat, 15, 15, 3, .4, 2)}
         insert_fixture_data(stat, realm_data, RealmCount)
+        installation_data = {'false': self.generate_fixture_data(stat, 350, 150, 6, .6, 4),
+                             'true': self.generate_fixture_data(stat, 150, 150, 3, .4, 2)}
+        insert_fixture_data(stat, installation_data, InstallationCount)
         FillState.objects.create(property=stat.property, end_time=last_end_time,
                                  state=FillState.DONE)
 
@@ -107,6 +117,12 @@ class Command(BaseCommand):
             'private_message': self.generate_fixture_data(stat, 13, 5, 5, .6, 4),
             'huddle_message': self.generate_fixture_data(stat, 6, 3, 3, .6, 4)}
         insert_fixture_data(stat, realm_data, RealmCount)
+        installation_data = {
+            'public_stream': self.generate_fixture_data(stat, 300, 80, 5, .6, 4),
+            'private_stream': self.generate_fixture_data(stat, 70, 70, 5, .6, 4),
+            'private_message': self.generate_fixture_data(stat, 130, 50, 5, .6, 4),
+            'huddle_message': self.generate_fixture_data(stat, 60, 30, 3, .6, 4)}
+        insert_fixture_data(stat, installation_data, InstallationCount)
         FillState.objects.create(property=stat.property, end_time=last_end_time,
                                  state=FillState.DONE)
 
@@ -136,6 +152,17 @@ class Command(BaseCommand):
             unused.id: self.generate_fixture_data(stat, 0, 0, 0, 0, 0),
             long_webhook.id: self.generate_fixture_data(stat, 5, 5, 2, .6, 3)}
         insert_fixture_data(stat, realm_data, RealmCount)
+        installation_data = {
+            website.id: self.generate_fixture_data(stat, 300, 200, 5, .6, 3),
+            old_desktop.id: self.generate_fixture_data(stat, 50, 30, 8, .6, 3),
+            android.id: self.generate_fixture_data(stat, 50, 50, 2, .6, 3),
+            iOS.id: self.generate_fixture_data(stat, 50, 50, 2, .6, 3),
+            react_native.id: self.generate_fixture_data(stat, 5, 5, 10, .6, 3),
+            API.id: self.generate_fixture_data(stat, 50, 50, 5, .6, 3),
+            zephyr_mirror.id: self.generate_fixture_data(stat, 10, 10, 3, .6, 3),
+            unused.id: self.generate_fixture_data(stat, 0, 0, 0, 0, 0),
+            long_webhook.id: self.generate_fixture_data(stat, 50, 50, 2, .6, 3)}
+        insert_fixture_data(stat, installation_data, InstallationCount)
         FillState.objects.create(property=stat.property, end_time=last_end_time,
                                  state=FillState.DONE)
 

--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -11,8 +11,11 @@ i18n_urlpatterns = [
         name='analytics.views.get_realm_activity'),
     url(r'^user_activity/(?P<email>[\S]+)/$', analytics.views.get_user_activity,
         name='analytics.views.get_user_activity'),
+
     url(r'^stats/realm/(?P<realm_str>[\S]+)/$', analytics.views.stats_for_realm,
         name='analytics.views.stats_for_realm'),
+    url(r'^stats/installation$', analytics.views.stats_for_installation,
+        name='analytics.views.stats_for_installation'),
 
     # User-visible stats page
     url(r'^stats$', analytics.views.stats,
@@ -33,6 +36,8 @@ v1_api_and_json_patterns = [
         {'GET': 'analytics.views.get_chart_data'}),
     url(r'^analytics/chart_data/realm/(?P<realm_str>[\S]+)$', rest_dispatch,
         {'GET': 'analytics.views.get_chart_data_for_realm'}),
+    url(r'^analytics/chart_data/installation$', rest_dispatch,
+        {'GET': 'analytics.views.get_chart_data_for_installation'}),
 ]
 
 i18n_urlpatterns += [

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -44,7 +44,7 @@ def render_stats(request: HttpRequest, data_url_suffix: str, target_name: str) -
     )
     return render(request,
                   'analytics/stats.html',
-                  context=dict(target_realm_name=target_name,
+                  context=dict(target_name=target_name,
                                page_params=JSONEncoderForHTML().encode(page_params)))
 
 @zulip_login_required

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -96,7 +96,7 @@ def get_chart_data(request: HttpRequest, user_profile: UserProfile, chart_name: 
                              'private_stream': _('Private streams'),
                              'private_message': _('Private messages'),
                              'huddle_message': _('Group private messages')}
-        labels_sort_function = lambda data: sort_by_totals(data['realm'])
+        labels_sort_function = lambda data: sort_by_totals(data['everyone'])
         include_empty_subgroups = True
     elif chart_name == 'messages_sent_by_client':
         stat = COUNT_STATS['messages_sent:client:day']
@@ -135,7 +135,7 @@ def get_chart_data(request: HttpRequest, user_profile: UserProfile, chart_name: 
     data = {'end_times': end_times, 'frequency': stat.frequency}
     for table in tables:
         if table == RealmCount:
-            data['realm'] = get_time_series_by_subgroup(
+            data['everyone'] = get_time_series_by_subgroup(
                 stat, RealmCount, realm.id, end_times, subgroup_to_label, include_empty_subgroups)
         if table == UserCount:
             data['user'] = get_time_series_by_subgroup(
@@ -158,7 +158,7 @@ def sort_by_totals(value_arrays: Dict[str, List[int]]) -> List[str]:
 # tries to rank the clients so that taking the first N elements of the
 # sorted list has a reasonable chance of doing so.
 def sort_client_labels(data: Dict[str, Dict[str, List[int]]]) -> List[str]:
-    realm_order = sort_by_totals(data['realm'])
+    realm_order = sort_by_totals(data['everyone'])
     user_order = sort_by_totals(data['user'])
     label_sort_values = {}  # type: Dict[str, float]
     for i, label in enumerate(realm_order):

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -37,22 +37,20 @@ from zerver.lib.timestamp import ceiling_to_day, \
 from zerver.models import Client, get_realm, Realm, \
     UserActivity, UserActivityInterval, UserProfile
 
-def render_stats(request: HttpRequest, realm: Realm) -> HttpRequest:
+def render_stats(request: HttpRequest, data_url_suffix: str, target_name: str) -> HttpRequest:
     page_params = dict(
-        is_staff        = request.user.is_staff,
-        stats_realm     = realm.string_id,
-        debug_mode      = False,
+        data_url_suffix=data_url_suffix,
+        debug_mode=False,
     )
-
     return render(request,
                   'analytics/stats.html',
-                  context=dict(target_realm_name=realm.name,
+                  context=dict(target_realm_name=target_name,
                                page_params=JSONEncoderForHTML().encode(page_params)))
 
 @zulip_login_required
 def stats(request: HttpRequest) -> HttpResponse:
     realm = request.user.realm
-    return render_stats(request, realm)
+    return render_stats(request, '', realm.name or realm.string_id)
 
 @require_server_admin
 @has_request_variables
@@ -61,7 +59,7 @@ def stats_for_realm(request: HttpRequest, realm_str: str) -> HttpResponse:
     if realm is None:
         return HttpResponseNotFound("Realm %s does not exist" % (realm_str,))
 
-    return render_stats(request, realm)
+    return render_stats(request, '/realm/%s' % (realm_str,), realm.name or realm.string_id)
 
 @require_server_admin_api
 @has_request_variables

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -83,29 +83,6 @@ $(function () {
     });
 });
 
-
-function get_chart_data(data, callback) {
-    var url;
-    if (page_params.is_staff) {
-        url = '/json/analytics/chart_data/realm/' + page_params.stats_realm;
-    } else {
-        url = '/json/analytics/chart_data';
-    }
-
-    $.get({
-        url: url,
-        data: data,
-        idempotent: true,
-        success: function (data) {
-            callback(data);
-            update_last_full_update(data.end_times);
-        },
-        error: function (xhr) {
-            $('#id_stats_errors').show().text(JSON.parse(xhr.responseText).msg);
-        },
-    });
-}
-
 function populate_messages_sent_over_time(data) {
     if (data.end_times.length === 0) {
         // TODO: do something nicer here
@@ -327,11 +304,6 @@ function populate_messages_sent_over_time(data) {
     }
 }
 
-get_chart_data(
-    {chart_name: 'messages_sent_over_time', min_length: '10'},
-    populate_messages_sent_over_time
-);
-
 function round_to_percentages(values, total) {
     return values.map(function (x) {
         if (x === total) {
@@ -545,11 +517,6 @@ function populate_messages_sent_by_client(data) {
     });
 }
 
-get_chart_data(
-    {chart_name: 'messages_sent_by_client', min_length: '10'},
-    populate_messages_sent_by_client
-);
-
 function populate_messages_sent_by_message_type(data) {
     var layout = {
         margin: { l: 90, r: 0, b: 0, t: 0 },
@@ -656,11 +623,6 @@ function populate_messages_sent_by_message_type(data) {
     });
 }
 
-get_chart_data(
-    {chart_name: 'messages_sent_by_message_type', min_length: '10'},
-    populate_messages_sent_by_message_type
-);
-
 function populate_number_of_users(data) {
     var layout = {
         width: 750,
@@ -721,6 +683,44 @@ function populate_number_of_users(data) {
         $("#users_hover_humans_value").text(data.points[0].y);
     });
 }
+
+
+function get_chart_data(data, callback) {
+    var url;
+    if (page_params.is_staff) {
+        url = '/json/analytics/chart_data/realm/' + page_params.stats_realm;
+    } else {
+        url = '/json/analytics/chart_data';
+    }
+
+    $.get({
+        url: url,
+        data: data,
+        idempotent: true,
+        success: function (data) {
+            callback(data);
+            update_last_full_update(data.end_times);
+        },
+        error: function (xhr) {
+            $('#id_stats_errors').show().text(JSON.parse(xhr.responseText).msg);
+        },
+    });
+}
+
+get_chart_data(
+    {chart_name: 'messages_sent_over_time', min_length: '10'},
+    populate_messages_sent_over_time
+);
+
+get_chart_data(
+    {chart_name: 'messages_sent_by_client', min_length: '10'},
+    populate_messages_sent_by_client
+);
+
+get_chart_data(
+    {chart_name: 'messages_sent_by_message_type', min_length: '10'},
+    populate_messages_sent_by_message_type
+);
 
 get_chart_data(
     {chart_name: 'number_of_humans', min_length: '10'},

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -188,7 +188,7 @@ function populate_messages_sent_over_time(data) {
         var current = {human: 0, bot: 0, me: 0};
         var i_init = 0;
         if (is_boundary(start_dates[0])) {
-            current = {human: data.realm.human[0], bot: data.realm.bot[0], me: data.user.human[0]};
+            current = {human: data.everyone.human[0], bot: data.everyone.bot[0], me: data.user.human[0]};
             i_init = 1;
         }
         for (var i = i_init; i < start_dates.length; i += 1) {
@@ -199,8 +199,8 @@ function populate_messages_sent_over_time(data) {
                 values.me.push(current.me);
                 current = {human: 0, bot: 0, me: 0};
             }
-            current.human += data.realm.human[i];
-            current.bot += data.realm.bot[i];
+            current.human += data.everyone.human[i];
+            current.bot += data.everyone.bot[i];
             current.me += data.user.human[i];
         }
         values.human.push(current.human);
@@ -216,7 +216,7 @@ function populate_messages_sent_over_time(data) {
     var date_formatter = function (date) {
         return format_date(date, true);
     };
-    var values = {me: data.user.human, human: data.realm.human, bot: data.realm.bot};
+    var values = {me: data.user.human, human: data.everyone.human, bot: data.everyone.bot};
 
     var info = aggregate_data('day');
     date_formatter = function (date) {
@@ -235,7 +235,7 @@ function populate_messages_sent_over_time(data) {
     var dates = data.end_times.map(function (timestamp) {
         return new Date(timestamp*1000);
     });
-    values = {human: partial_sums(data.realm.human), bot: partial_sums(data.realm.bot),
+    values = {human: partial_sums(data.everyone.human), bot: partial_sums(data.everyone.bot),
               me: partial_sums(data.user.human)};
     date_formatter = function (date) {
         return format_date(date, true);
@@ -382,12 +382,12 @@ function populate_messages_sent_by_client(data) {
     };
 
     // sort labels so that values are descending in the default view
-    var realm_month = compute_summary_chart_data(data.realm, 30, data.display_order.slice(0, 12));
+    var everyone_month = compute_summary_chart_data(data.everyone, 30, data.display_order.slice(0, 12));
     var label_values = [];
-    for (var i=0; i<realm_month.values.length; i+=1) {
+    for (var i=0; i<everyone_month.values.length; i+=1) {
         label_values.push({
-            label: realm_month.labels[i],
-            value: realm_month.labels[i] === "Other" ? -1 : realm_month.values[i],
+            label: everyone_month.labels[i],
+            value: everyone_month.labels[i] === "Other" ? -1 : everyone_month.values[i],
         });
     }
     label_values.sort(function (a, b) { return b.value - a.value; });
@@ -431,11 +431,11 @@ function populate_messages_sent_by_client(data) {
     }
 
     var plot_data = {
-        realm: {
-            cumulative: make_plot_data(data.realm, data.end_times.length),
-            year: make_plot_data(data.realm, 365),
-            month: make_plot_data(data.realm, 30),
-            week: make_plot_data(data.realm, 7),
+        everyone: {
+            cumulative: make_plot_data(data.everyone, data.end_times.length),
+            year: make_plot_data(data.everyone, 365),
+            month: make_plot_data(data.everyone, 30),
+            week: make_plot_data(data.everyone, 7),
         },
         user: {
             cumulative: make_plot_data(data.user, data.end_times.length),
@@ -445,7 +445,7 @@ function populate_messages_sent_by_client(data) {
         },
     };
 
-    var user_button = 'realm';
+    var user_button = 'everyone';
     var time_button;
     if (data.end_times.length >= 30) {
         time_button = 'month';
@@ -553,11 +553,11 @@ function populate_messages_sent_by_message_type(data) {
     }
 
     var plot_data = {
-        realm: {
-            cumulative: make_plot_data(data.realm, data.end_times.length),
-            year: make_plot_data(data.realm, 365),
-            month: make_plot_data(data.realm, 30),
-            week: make_plot_data(data.realm, 7),
+        everyone: {
+            cumulative: make_plot_data(data.everyone, data.end_times.length),
+            year: make_plot_data(data.everyone, 365),
+            month: make_plot_data(data.everyone, 30),
+            week: make_plot_data(data.everyone, 7),
         },
         user: {
             cumulative: make_plot_data(data.user, data.end_times.length),
@@ -567,7 +567,7 @@ function populate_messages_sent_by_message_type(data) {
         },
     };
 
-    var user_button = 'realm';
+    var user_button = 'everyone';
     var time_button;
     if (data.end_times.length >= 30) {
         time_button = 'month';
@@ -664,7 +664,7 @@ function populate_number_of_users(data) {
 
     var trace = {
         x: end_dates,
-        y: data.realm.human,
+        y: data.everyone.human,
         type: 'scatter',
         name: "Active users",
         hoverinfo: 'none',

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -686,15 +686,8 @@ function populate_number_of_users(data) {
 
 
 function get_chart_data(data, callback) {
-    var url;
-    if (page_params.is_staff) {
-        url = '/json/analytics/chart_data/realm/' + page_params.stats_realm;
-    } else {
-        url = '/json/analytics/chart_data';
-    }
-
     $.get({
-        url: url,
+        url: '/json/analytics/chart_data' + page_params.data_url_suffix,
         data: data,
         idempotent: true,
         success: function (data) {

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -19,7 +19,7 @@
     <div class="page-content">
         <div id="id_stats_errors" class="alert alert-error"></div>
         <div class="center-charts">
-            <h1 class="analytics-page-header">{% trans %}Zulip analytics for {{ target_realm_name }}{% endtrans %}</h1>
+            <h1 class="analytics-page-header">{% trans %}Zulip analytics for {{ target_name }}{% endtrans %}</h1>
 
             <div class="left">
                 <div class="chart-container">


### PR DESCRIPTION
The views code is kind of hacky, and the /stats/installation page still has shells of the other 3 graphs. But it will at least give us the info we're looking for, in terms of number of users over time. 

Removing the assumption that all stats are realm-based will be a bit of work; the assumption is baked into the entire pipeline. If we have a concrete set of metrics we want to track though I could at some point go and do it.

As a small note, I used the `A or B` notation in a few places, where it didn't seem too important to have a test for the `A is None` case (e.g. `realm.name or realm.string_id` for displaying which realm it is). Let me know if it would have been better to separate it out.

[The circleCI error seems unrelated, unless I'm misunderstanding the error]