### PR TITLE
user groups: Sanitize pill_container selector to avoid escaped strings.

### DIFF
--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -128,7 +128,7 @@ run_test('populate_user_groups', () => {
 
     var all_pills = {};
 
-    var pill_container_stub = $('.pill-container[data-group-pills="Mobile"]');
+    var pill_container_stub = $('.pill-container[data-group-pills="1"]');
     pills.appendValidatedData = function (item) {
         var id = item.user_id;
         assert.equal(all_pills[id], undefined);
@@ -357,7 +357,7 @@ run_test('with_external_user', () => {
         }
     };
 
-    var pill_container_stub = $('.pill-container[data-group-pills="Mobile"]');
+    var pill_container_stub = $('.pill-container[data-group-pills="1"]');
     var pill_stub = $.create('fake-pill');
     var pill_container_find_called = 0;
     pill_container_stub.find = function (elem) {

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -353,12 +353,12 @@ run_test('handlebars_bug', () => {
     html += '</div>';
 
     var group_id = $(html).find('.user-group:first').prop('id');
-    var group_name_pills = $(html).find('.user-group:first .pill-container').attr('data-group-pills');
+    var group_pills_id = $(html).find('.user-group:first .pill-container').attr('data-group-pills');
     var group_name_display = $(html).find('.user-group:first .name').text().trim().replace(/\s+/g, ' ');
     var group_description = $(html).find('.user-group:first .description').text().trim().replace(/\s+/g, ' ');
 
     assert.equal(group_id, '9');
-    assert.equal(group_name_pills, 'uranohoshi');
+    assert.equal(group_pills_id, '9');
     assert.equal(group_name_display, 'uranohoshi');
     assert.equal(group_description, 'Students at Uranohoshi Academy');
 }());
@@ -1022,12 +1022,12 @@ run_test('handlebars_bug', () => {
     html += '</div>';
 
     var group_id = $(html).find('.user-group:first').prop('id');
-    var group_name_pills = $(html).find('.user-group:first .pill-container').attr('data-group-pills');
+    var group_pills_id = $(html).find('.user-group:first .pill-container').attr('data-group-pills');
     var group_name_display = $(html).find('.user-group:first .name').text().trim().replace(/\s+/g, ' ');
     var group_description = $(html).find('.user-group:first .description').text().trim().replace(/\s+/g, ' ');
 
     assert.equal(group_id, '9');
-    assert.equal(group_name_pills, 'uranohoshi');
+    assert.equal(group_pills_id, '9');
     assert.equal(group_name_display, 'uranohoshi');
     assert.equal(group_description, 'Students at Uranohoshi Academy');
 }());

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -37,7 +37,7 @@ exports.populate_user_groups = function () {
                 description: data.description,
             },
         }));
-        var pill_container = $('.pill-container[data-group-pills="' + data.name + '"]');
+        var pill_container = $('.pill-container[data-group-pills="' + data.id + '"]');
         var pills = user_pill.create_pills(pill_container);
 
         function get_pill_user_ids() {

--- a/static/templates/admin_user_group_list.handlebars
+++ b/static/templates/admin_user_group_list.handlebars
@@ -17,7 +17,7 @@
     </h4>
     <p>
         {{t 'Subscribers' }}
-        <div class="pill-container" data-group-pills="{{name}}">
+        <div class="pill-container" data-group-pills="{{id}}">
             <div class="input" contenteditable="true" data-placeholder="{{t 'Add member...' }}"></div>
         </div>
         <div class="save-instructions">

--- a/static/templates/non_editable_user_group.handlebars
+++ b/static/templates/non_editable_user_group.handlebars
@@ -7,7 +7,7 @@
     </h4>
     <p>
         {{t 'Subscribers' }}
-        <div class="pill-container notmem" data-group-pills="{{name}}"></div>
+        <div class="pill-container notmem" data-group-pills="{{id}}"></div>
     </p>
 </div>
 {{/with}}


### PR DESCRIPTION
Fixes #9325.

![screenshot at may 18 13-09-02](https://user-images.githubusercontent.com/15116870/40255642-b87b2f02-5a9c-11e8-8e7e-ea1e4620cdc1.png)

User groups with common string escape characters can now be safely created without throwing any jQuery selector errors.