### PR TITLE
stats: Add 1 day actives and total users to number of users chart.

### DIFF
--- a/analytics/lib/counts.py
+++ b/analytics/lib/counts.py
@@ -513,6 +513,9 @@ count_stats_ = [
     # User Activity stats
     # Stats that measure user activity in the UserActivityInterval sense.
 
+    CountStat('1day_actives::day',
+              sql_data_collector(UserCount, check_useractivityinterval_by_user_query, None),
+              CountStat.DAY, interval=timedelta(days=1)-UserActivityInterval.MIN_INTERVAL_LENGTH),
     CountStat('15day_actives::day',
               sql_data_collector(UserCount, check_useractivityinterval_by_user_query, None),
               CountStat.DAY, interval=timedelta(days=15)-UserActivityInterval.MIN_INTERVAL_LENGTH),

--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -80,6 +80,14 @@ class Command(BaseCommand):
                           value=value, **id_args)
                     for end_time, value in zip(end_times, values) if value != 0])
 
+        stat = COUNT_STATS['1day_actives::day']
+        realm_data = {
+            None: self.generate_fixture_data(stat, .08, .02, 3, .3, 6, partial_sum=True),
+        }  # type: Mapping[Optional[str], List[int]]
+        insert_fixture_data(stat, realm_data, RealmCount)
+        FillState.objects.create(property=stat.property, end_time=last_end_time,
+                                 state=FillState.DONE)
+
         stat = COUNT_STATS['realm_active_humans::day']
         realm_data = {
             None: self.generate_fixture_data(stat, .1, .03, 3, .5, 3, partial_sum=True),

--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -85,17 +85,33 @@ class Command(BaseCommand):
             None: self.generate_fixture_data(stat, .08, .02, 3, .3, 6, partial_sum=True),
         }  # type: Mapping[Optional[str], List[int]]
         insert_fixture_data(stat, realm_data, RealmCount)
+        installation_data = {
+            None: self.generate_fixture_data(stat, .8, .2, 4, .3, 6, partial_sum=True),
+        }  # type: Mapping[Optional[str], List[int]]
+        insert_fixture_data(stat, installation_data, InstallationCount)
         FillState.objects.create(property=stat.property, end_time=last_end_time,
                                  state=FillState.DONE)
 
         stat = COUNT_STATS['realm_active_humans::day']
         realm_data = {
             None: self.generate_fixture_data(stat, .1, .03, 3, .5, 3, partial_sum=True),
-        }  # type: Mapping[Optional[str], List[int]]
+        }
         insert_fixture_data(stat, realm_data, RealmCount)
         installation_data = {
             None: self.generate_fixture_data(stat, 1, .3, 4, .5, 3, partial_sum=True),
-        }  # type: Mapping[Optional[str], List[int]]
+        }
+        insert_fixture_data(stat, installation_data, InstallationCount)
+        FillState.objects.create(property=stat.property, end_time=last_end_time,
+                                 state=FillState.DONE)
+
+        stat = COUNT_STATS['active_users_audit:is_bot:day']
+        realm_data = {
+            'false': self.generate_fixture_data(stat, .1, .03, 3.5, .8, 2, partial_sum=True),
+        }
+        insert_fixture_data(stat, realm_data, RealmCount)
+        installation_data = {
+            'false': self.generate_fixture_data(stat, 1, .3, 6, .8, 2, partial_sum=True),
+        }
         insert_fixture_data(stat, installation_data, InstallationCount)
         FillState.objects.create(property=stat.property, end_time=last_end_time,
                                  state=FillState.DONE)

--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -92,6 +92,10 @@ class TestGetChartData(ZulipTestCase):
     def test_number_of_humans(self) -> None:
         stat = COUNT_STATS['realm_active_humans::day']
         self.insert_data(stat, [None], [])
+        stat = COUNT_STATS['1day_actives::day']
+        self.insert_data(stat, [None], [])
+        stat = COUNT_STATS['active_users_audit:is_bot:day']
+        self.insert_data(stat, ['false'], [])
         result = self.client_get('/json/analytics/chart_data',
                                  {'chart_name': 'number_of_humans'})
         self.assert_json_success(result)
@@ -100,7 +104,7 @@ class TestGetChartData(ZulipTestCase):
             'msg': '',
             'end_times': [datetime_to_timestamp(dt) for dt in self.end_times_day],
             'frequency': CountStat.DAY,
-            'everyone': {'human': self.data(100)},
+            'everyone': {'_1day': self.data(100), '_15day': self.data(100), 'all_time': self.data(100)},
             'display_order': None,
             'result': 'success',
         })
@@ -173,7 +177,7 @@ class TestGetChartData(ZulipTestCase):
                                  {'chart_name': 'number_of_humans'})
         self.assert_json_success(result)
         data = result.json()
-        self.assertEqual(data['everyone'], {'human': [0]})
+        self.assertEqual(data['everyone'], {"_1day": [0], "_15day": [0], "all_time": [0]})
         self.assertFalse('user' in data)
 
         FillState.objects.create(
@@ -213,6 +217,10 @@ class TestGetChartData(ZulipTestCase):
     def test_start_and_end(self) -> None:
         stat = COUNT_STATS['realm_active_humans::day']
         self.insert_data(stat, [None], [])
+        stat = COUNT_STATS['1day_actives::day']
+        self.insert_data(stat, [None], [])
+        stat = COUNT_STATS['active_users_audit:is_bot:day']
+        self.insert_data(stat, ['false'], [])
         end_time_timestamps = [datetime_to_timestamp(dt) for dt in self.end_times_day]
 
         # valid start and end
@@ -223,7 +231,7 @@ class TestGetChartData(ZulipTestCase):
         self.assert_json_success(result)
         data = result.json()
         self.assertEqual(data['end_times'], end_time_timestamps[1:3])
-        self.assertEqual(data['everyone'], {'human': [0, 100]})
+        self.assertEqual(data['everyone'], {'_1day': [0, 100], '_15day': [0, 100], 'all_time': [0, 100]})
 
         # start later then end
         result = self.client_get('/json/analytics/chart_data',
@@ -235,6 +243,10 @@ class TestGetChartData(ZulipTestCase):
     def test_min_length(self) -> None:
         stat = COUNT_STATS['realm_active_humans::day']
         self.insert_data(stat, [None], [])
+        stat = COUNT_STATS['1day_actives::day']
+        self.insert_data(stat, [None], [])
+        stat = COUNT_STATS['active_users_audit:is_bot:day']
+        self.insert_data(stat, ['false'], [])
         # test min_length is too short to change anything
         result = self.client_get('/json/analytics/chart_data',
                                  {'chart_name': 'number_of_humans',
@@ -242,7 +254,7 @@ class TestGetChartData(ZulipTestCase):
         self.assert_json_success(result)
         data = result.json()
         self.assertEqual(data['end_times'], [datetime_to_timestamp(dt) for dt in self.end_times_day])
-        self.assertEqual(data['everyone'], {'human': self.data(100)})
+        self.assertEqual(data['everyone'], {'_1day': self.data(100), '_15day': self.data(100), 'all_time': self.data(100)})
         # test min_length larger than filled data
         result = self.client_get('/json/analytics/chart_data',
                                  {'chart_name': 'number_of_humans',
@@ -251,7 +263,7 @@ class TestGetChartData(ZulipTestCase):
         data = result.json()
         end_times = [ceiling_to_day(self.realm.date_created) + timedelta(days=i) for i in range(-1, 4)]
         self.assertEqual(data['end_times'], [datetime_to_timestamp(dt) for dt in end_times])
-        self.assertEqual(data['everyone'], {'human': [0]+self.data(100)})
+        self.assertEqual(data['everyone'], {'_1day': [0]+self.data(100), '_15day': [0]+self.data(100), 'all_time': [0]+self.data(100)})
 
     def test_non_existent_chart(self) -> None:
         result = self.client_get('/json/analytics/chart_data',

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -94,9 +94,15 @@ def get_chart_data(request: HttpRequest, user_profile: UserProfile, chart_name: 
         aggregate_table = InstallationCount
 
     if chart_name == 'number_of_humans':
-        stats = [COUNT_STATS['realm_active_humans::day']]
+        stats = [
+            COUNT_STATS['1day_actives::day'],
+            COUNT_STATS['realm_active_humans::day'],
+            COUNT_STATS['active_users_audit:is_bot:day']]
         tables = [aggregate_table]
-        subgroup_to_label = {stats[0]: {None: 'human'}}  # type: Dict[CountStat, Dict[Optional[str], str]]
+        subgroup_to_label = {
+            stats[0]: {None: '_1day'},
+            stats[1]: {None: '_15day'},
+            stats[2]: {'false': 'all_time'}}  # type: Dict[CountStat, Dict[Optional[str], str]]
         labels_sort_function = None
         include_empty_subgroups = True
     elif chart_name == 'messages_sent_over_time':

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -152,16 +152,14 @@ def get_chart_data(request: HttpRequest, user_profile: UserProfile, chart_name: 
 
     end_times = time_range(start, end, stat.frequency, min_length)
     data = {'end_times': end_times, 'frequency': stat.frequency}
+
+    aggregation_level = {InstallationCount: 'everyone', RealmCount: 'everyone', UserCount: 'user'}
+    # -1 is a placeholder value, since there is no relevant filtering on InstallationCount
+    id_value = {InstallationCount: -1, RealmCount: realm.id, UserCount: user_profile.id}
     for table in tables:
-        if table == InstallationCount:
-            data['everyone'] = get_time_series_by_subgroup(
-                stat, InstallationCount, -1, end_times, subgroup_to_label, include_empty_subgroups)
-        if table == RealmCount:
-            data['everyone'] = get_time_series_by_subgroup(
-                stat, RealmCount, realm.id, end_times, subgroup_to_label, include_empty_subgroups)
-        if table == UserCount:
-            data['user'] = get_time_series_by_subgroup(
-                stat, UserCount, user_profile.id, end_times, subgroup_to_label, include_empty_subgroups)
+        data[aggregation_level[table]] = get_time_series_by_subgroup(
+            stat, table, id_value[table], end_times, subgroup_to_label, include_empty_subgroups)
+
     if labels_sort_function is not None:
         data['display_order'] = labels_sort_function(data)
     else:

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -94,31 +94,32 @@ def get_chart_data(request: HttpRequest, user_profile: UserProfile, chart_name: 
         aggregate_table = InstallationCount
 
     if chart_name == 'number_of_humans':
-        stat = COUNT_STATS['realm_active_humans::day']
+        stats = [COUNT_STATS['realm_active_humans::day']]
         tables = [aggregate_table]
-        subgroup_to_label = {None: 'human'}  # type: Dict[Optional[str], str]
+        subgroup_to_label = {stats[0]: {None: 'human'}}  # type: Dict[CountStat, Dict[Optional[str], str]]
         labels_sort_function = None
         include_empty_subgroups = True
     elif chart_name == 'messages_sent_over_time':
-        stat = COUNT_STATS['messages_sent:is_bot:hour']
+        stats = [COUNT_STATS['messages_sent:is_bot:hour']]
         tables = [aggregate_table, UserCount]
-        subgroup_to_label = {'false': 'human', 'true': 'bot'}
+        subgroup_to_label = {stats[0]: {'false': 'human', 'true': 'bot'}}
         labels_sort_function = None
         include_empty_subgroups = True
     elif chart_name == 'messages_sent_by_message_type':
-        stat = COUNT_STATS['messages_sent:message_type:day']
+        stats = [COUNT_STATS['messages_sent:message_type:day']]
         tables = [aggregate_table, UserCount]
-        subgroup_to_label = {'public_stream': _('Public streams'),
-                             'private_stream': _('Private streams'),
-                             'private_message': _('Private messages'),
-                             'huddle_message': _('Group private messages')}
+        subgroup_to_label = {stats[0]: {'public_stream': _('Public streams'),
+                                        'private_stream': _('Private streams'),
+                                        'private_message': _('Private messages'),
+                                        'huddle_message': _('Group private messages')}}
         labels_sort_function = lambda data: sort_by_totals(data['everyone'])
         include_empty_subgroups = True
     elif chart_name == 'messages_sent_by_client':
-        stat = COUNT_STATS['messages_sent:client:day']
+        stats = [COUNT_STATS['messages_sent:client:day']]
         tables = [aggregate_table, UserCount]
         # Note that the labels are further re-written by client_label_map
-        subgroup_to_label = {str(id): name for id, name in Client.objects.values_list('id', 'name')}
+        subgroup_to_label = {stats[0]:
+                             {str(id): name for id, name in Client.objects.values_list('id', 'name')}}
         labels_sort_function = sort_client_labels
         include_empty_subgroups = False
     else:
@@ -142,7 +143,8 @@ def get_chart_data(request: HttpRequest, user_profile: UserProfile, chart_name: 
         else:
             start = realm.date_created
     if end is None:
-        end = last_successful_fill(stat.property)
+        end = max(last_successful_fill(stat.property) or
+                  datetime.min.replace(tzinfo=timezone_utc) for stat in stats)
     if end is None or start > end:
         logging.warning("User from realm %s attempted to access /stats, but the computed "
                         "start time: %s (creation of realm or installation) is later than the computed "
@@ -150,15 +152,18 @@ def get_chart_data(request: HttpRequest, user_profile: UserProfile, chart_name: 
                         "analytics cron job running?" % (realm.string_id, start, end))
         raise JsonableError(_("No analytics data available. Please contact your server administrator."))
 
-    end_times = time_range(start, end, stat.frequency, min_length)
-    data = {'end_times': end_times, 'frequency': stat.frequency}
+    assert len(set([stat.frequency for stat in stats])) == 1
+    end_times = time_range(start, end, stats[0].frequency, min_length)
+    data = {'end_times': end_times, 'frequency': stats[0].frequency}  # type: Dict[str, Any]
 
     aggregation_level = {InstallationCount: 'everyone', RealmCount: 'everyone', UserCount: 'user'}
     # -1 is a placeholder value, since there is no relevant filtering on InstallationCount
     id_value = {InstallationCount: -1, RealmCount: realm.id, UserCount: user_profile.id}
     for table in tables:
-        data[aggregation_level[table]] = get_time_series_by_subgroup(
-            stat, table, id_value[table], end_times, subgroup_to_label, include_empty_subgroups)
+        data[aggregation_level[table]] = {}
+        for stat in stats:
+            data[aggregation_level[table]].update(get_time_series_by_subgroup(
+                stat, table, id_value[table], end_times, subgroup_to_label[stat], include_empty_subgroups))
 
     if labels_sort_function is not None:
         data['display_order'] = labels_sort_function(data)

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -630,32 +630,15 @@ function populate_number_of_users(data) {
     var layout = {
         width: 750,
         height: 370,
-        margin: {
-            l: 40, r: 0, b: 100, t: 20,
-        },
+        margin: { l: 40, r: 0, b: 100, t: 20 },
         xaxis: {
             fixedrange: true,
-            rangeselector: {
-                x: 0.808,
-                y: -0.33,
+            rangeselector: { x: 0.808, y: -0.33,
                 buttons: [
-                    {
-                        count: 30,
-                        label: i18n.t('Last 30 days'),
-                        step: 'day',
-                        stepmode: 'backward',
-                    },
-                    {
-                        step: 'all',
-                        label: i18n.t('All time'),
-                    },
-                ],
-            },
-        },
-        yaxis: {
-            fixedrange: true,
-            rangemode: 'tozero',
-        },
+                    { count: 30, label: i18n.t('Last 30 days'), step: 'day', stepmode: 'backward' },
+                    { step: 'all', label: i18n.t('All time') },
+                ]}},
+        yaxis: { fixedrange: true, rangemode: 'tozero' },
         font: font_14pt,
     };
 

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -648,19 +648,49 @@ function populate_number_of_users(data) {
 
     var text = end_dates.map(format_date);
 
-    var trace = {
-        x: end_dates,
-        y: data.everyone.human,
-        type: 'scatter',
-        name: "Active users",
-        hoverinfo: 'none',
-        text: text,
-        visible: true,
-    };
+    function make_traces(values, type) {
+        return {
+            x: end_dates,
+            y: values,
+            type: type,
+            name: i18n.t("Active users"),
+            hoverinfo: 'none',
+            text: text,
+            visible: true,
+        };
+    }
+
+    var _1day_trace = make_traces(data.everyone._1day, 'bar');
+    var _15day_trace = make_traces(data.everyone._15day, 'scatter');
+    var all_time_trace = make_traces(data.everyone.all_time, 'scatter');
 
     $('#id_number_of_users > div').removeClass("spinner");
 
-    Plotly.newPlot('id_number_of_users', [trace], layout, {displayModeBar: false});
+    // Redraw the plot every time for simplicity. If we have perf problems with this in the
+    // future, we can copy the update behavior from populate_messages_sent_over_time
+    function draw_or_update_plot(trace) {
+        $('#1day_actives_button, #15day_actives_button, #all_time_actives_button').removeClass("selected");
+        Plotly.newPlot('id_number_of_users', [trace], layout, {displayModeBar: false});
+    }
+
+    $('#1day_actives_button').click(function () {
+        draw_or_update_plot(_1day_trace);
+        $(this).addClass("selected");
+    });
+
+    $('#15day_actives_button').click(function () {
+        draw_or_update_plot(_15day_trace);
+        $(this).addClass("selected");
+    });
+
+    $('#all_time_actives_button').click(function () {
+        draw_or_update_plot(all_time_trace);
+        $(this).addClass("selected");
+    });
+
+    // Initial drawing of plot
+    draw_or_update_plot(_15day_trace, true);
+    $('#15day_actives_button').addClass("selected");
 
     document.getElementById('id_number_of_users').on('plotly_hover', function (data) {
         $("#users_hover_info").show();

--- a/static/styles/stats.scss
+++ b/static/styles/stats.scss
@@ -104,6 +104,10 @@ hr {
     margin: 3px;
 }
 
+.button-active-users {
+    float: right;
+}
+
 .chart-container .button-container > * {
     display: inline-block;
     vertical-align: top;

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -85,6 +85,13 @@
 
                 <div class="chart-container">
                     <h1>{{ _("Active users") }}</h1>
+                    <div class="button-container">
+                        <div class="buttons button-active-users">
+                            <button class="button" type="button" id="1day_actives_button">{{ _("Daily actives") }}</button>
+                            <button class="button" type="button" id="15day_actives_button">{{ _("15 day actives") }}</button>
+                            <button class="button" type="button" id="all_time_actives_button">{{ _("Total users") }}</button>
+                        </div>
+                    </div>
                     <div id="id_number_of_users">
                         <div class="spinner"></div>
                     </div>


### PR DESCRIPTION
Adds the three buttons in the upper right:
![image](https://user-images.githubusercontent.com/890911/40272982-ddd00fd6-5b6c-11e8-8bac-043a7fe4a115.png)

Caveats:
* When you upgrade to 1.9, the two non-middle buttons will return a string of 0s until the daily cron job runs.
* Still need to write the user docs for this; 1-day actives and the other two treat deactivated users differently, so it's actually possible to have more 1-day actives than total users, e.g. if everyone is active (in the "logged in to zulip" sense) and then a couple of folks get deactivated (in the "banned" sense).