### PR TITLE
[WIP] Migrate code base to use font awesome 5 syntax standards.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "",
   "main": "",
   "dependencies": {
+    "@fortawesome/fontawesome-free-webfonts": "1.0.9",
     "@types/node": "8.0.34",
     "@types/webpack": "4.4.0",
     "blueimp-md5": "2.10.0",

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -718,7 +718,7 @@ exports.initialize = function () {
         settings.set_settings_header($(this).attr("data-section"));
     });
 
-    $(".settings-header.mobile .icon-vector-chevron-left").on("click", function () {
+    $(".settings-header.mobile .fa-chevron-left").on("click", function () {
         $("#settings_page").find(".right").removeClass("show");
         $(this).parent().removeClass("slide-left");
     });

--- a/static/styles/portico-styles.scss
+++ b/static/styles/portico-styles.scss
@@ -3,6 +3,10 @@
 @import "portico";
 @import "portico-signin";
 @import "pygments";
+@import "../node_modules/@fortawesome/fontawesome-free-webfonts/css/fontawesome.css";
+@import "../node_modules/@fortawesome/fontawesome-free-webfonts/css/fa-solid.css";
+@import "../node_modules/@fortawesome/fontawesome-free-webfonts/css/fa-regular.css";
+@import "../node_modules/@fortawesome/fontawesome-free-webfonts/css/fa-brands.css";
 @import "../node_modules/font-awesome/css/font-awesome.css";
 @import "../third/fontawesome-legacy.css";
 @import "../generated/icons/style.css";

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1169,7 +1169,7 @@ input[type=checkbox].inline-block {
     border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
-.settings-header.mobile .icon-vector-chevron-left {
+.settings-header.mobile .fa-chevron-left {
     float: left;
     position: relative;
     top: 14px;
@@ -1470,7 +1470,7 @@ input[type=text]#settings_search {
 #settings_page .sidebar li .text,
 #settings_page .sidebar li .icon {
     display: inline-block;
-    vertical-align: top;
+    vertical-align: 25%;
 }
 
 #settings_page .sidebar li .text {
@@ -1482,8 +1482,7 @@ input[type=text]#settings_search {
     width: 18px;
     height: 18px;
     margin: 10px 10px;
-
-    font-size: 1.4em;
+    font-size: 1.22em;
     color: hsl(0, 0%, 53%);
 
     background-size: cover;

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -425,7 +425,7 @@ form#add_new_subscription {
 }
 
 .subscriptions-header .fa-chevron-left,
-#settings_overlay_container .settings-header.mobile .icon-vector-chevron-left {
+#settings_overlay_container .settings-header.mobile .fa-chevron-left {
     position: relative;
     transform: translate(-50px, 0px);
     opacity: 0;
@@ -440,7 +440,7 @@ form#add_new_subscription {
 }
 
 .subscriptions-header.slide-left .fa-chevron-left,
-#settings_overlay_container .settings-header.mobile.slide-left .icon-vector-chevron-left {
+#settings_overlay_container .settings-header.mobile.slide-left .fa-chevron-left {
     transform: translate(-0px, 0px);
     opacity: 1;
 }

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -1,6 +1,6 @@
 <div id="settings_page" class="new-style overlay-content modal-bg">
     <div class="settings-header mobile">
-        <div class="icon-vector-chevron-left"></div>
+        <i class="fas fa-chevron-left"></i>
         <h1>{{ _('Settings') }}<span class="section"></span></h1>
         <div class="exit">
             <span class="exit-sign">&times;</span>
@@ -12,89 +12,89 @@
             <div class="center tab-container"></div>
             <ul class="settings-list">
                 <li tabindex="0" class="active" data-section="your-account">
-                    <div class="icon icon-vector-user"></div>
+                    <div class="icon fas fa-user"></div>
                     <div class="text">{{ _('Your account') }}</div>
                 </li>
                 <li tabindex="0" data-section="display-settings">
-                    <div class="icon icon-vector-time"></div>
+                    <div class="icon far fa-clock"></div>
                     <div class="text">{{ _('Display settings') }}</div>
                 </li>
                 <li tabindex="0" data-section="notifications">
-                    <div class="icon icon-vector-warning-sign"></div>
+                    <div class="icon fas fa-exclamation-triangle"></div>
                     <div class="text">{{ _('Notifications') }}</div>
                 </li>
                 <li tabindex="0" data-section="your-bots">
-                    <div class="icon icon-vector-github"></div>
+                    <div class="icon fab fa-github"></div>
                     <div class="text">{{ _('Your bots') }}</div>
                 </li>
                 <li tabindex="0" data-section="alert-words">
-                    <div class="icon icon-vector-book"></div>
+                    <div class="icon fas fa-book"></div>
                     <div class="text">{{ _('Alert words') }}</div>
                 </li>
                 <li tabindex="0" data-section="uploaded-files">
-                    <div class="icon icon-vector-paper-clip"></div>
+                    <div class="icon fas fa-paperclip"></div>
                     <div class="text">{{ _('Uploaded files') }}</div>
                 </li>
                 <li tabindex="0" data-section="muted-topics">
-                    <div class="icon icon-vector-eye-close"></div>
+                    <div class="icon far fa-eye-slash"></div>
                     <div class="text">{{ _('Muted topics') }}</div>
                 </li>
 
                 <li class="admin" tabindex="0" data-section="organization-profile">
-                    <i class="icon icon-vector-lock"></i>
+                    <i class="icon fas fa-lock"></i>
                     <div class="text">{{ _('Organization profile') }}</div>
                 </li>
                 <li class="admin" tabindex="0" data-section="organization-settings">
-                    <i class="icon icon-vector-beaker"></i>
+                    <i class="icon fas fa-flask"></i>
                     <div class="text">{{ _('Organization settings') }}</div>
                 </li>
                 <li class="admin" tabindex="0" data-section="organization-permissions">
-                    <i class="icon icon-vector-lock"></i>
+                    <i class="icon fas fa-lock"></i>
                     <div class="text">{{ _('Organization permissions') }}</div>
                 </li>
                 <li class="admin" tabindex="0" data-section="emoji-settings">
-                    <i class="icon icon-vector-smile"></i>
+                    <i class="icon far fa-smile"></i>
                     <div class="text">{{ _('Custom emoji') }}</div>
                 </li>
                 <li class="admin" tabindex="0" data-section="user-groups-admin">
-                    <i class="icon icon-vector-group"></i>
+                    <i class="icon fas fa-users"></i>
                     <div class="text">{{ _('User groups') }}</div>
                 </li>
                 <li class="admin" tabindex="0" data-section="auth-methods">
-                    <i class="icon icon-vector-lock"></i>
+                    <i class="icon fas fa-lock"></i>
                     <div class="text">{{ _('Authentication methods') }}</div>
                 </li>
                 <li class="admin" tabindex="0" data-section="user-list-admin">
-                    <i class="icon icon-vector-user"></i>
+                    <i class="icon fas fa-user"></i>
                     <div class="text">{{ _('Users') }}</div>
                 </li>
                 {% if is_admin %}
                 <li class="admin" tabindex="0" data-section="deactivated-users-admin">
-                    <i class="icon icon-vector-trash"></i>
+                    <i class="icon far fa-trash-alt"></i>
                     <div class="text">{{ _('Deactivated users') }}</div>
                 </li>
                 {% endif %}
                 <li class="admin" tabindex="0" data-section="bot-list-admin">
-                    <i class="icon icon-vector-github"></i>
+                    <i class="icon fab fa-github"></i>
                     <div class="text">{{ _('Bots') }}</div>
                 </li>
                 <li class="admin" tabindex="0" data-section="default-streams-list">
-                    <i class="icon icon-vector-exchange"></i>
+                    <i class="icon fas fa-exchange-alt"></i>
                     <div class="text">{{ _('Default streams') }}</div>
                 </li>
                 <li class="admin" tabindex="0" data-section="filter-settings">
-                    <i class="icon icon-vector-font"></i>
+                    <i class="icon fas fa-font"></i>
                     <div class="text">{{ _('Filter settings') }}</div>
                 </li>
                 {% if development_environment %}
                 <li class="admin" tabindex="0" data-section="profile-field-settings">
-                    <i class="icon icon-vector-user"></i>
+                    <i class="icon fas fa-user"></i>
                     <div class="text">{{ _('Custom profile fields') }}</div>
                 </li>
                 {% endif %}
                 {% if is_admin %}
                 <li class="admin" tabindex="0" data-section="invites-list-admin">
-                    <i class="icon icon-vector-user"></i>
+                    <i class="icon fas fa-user"></i>
                     <div class="text">{{ _('Invitations') }}</div>
                 </li>
                 {% endif %}
@@ -104,7 +104,7 @@
         <div class="sidebar-bottom-anchor dark-grey small-text">
             <ul>
                 <li class="border-top">
-                    <div class="icon icon-vector-off"></div>
+                    <i class="icon fas fa-power-off"></i>
                     <a href="#logout" class="no-style logout_button"><div class="text">{{ _('Log out') }}</div></a>
                 </li>
             </ul>

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -53,6 +53,10 @@
     "app-styles": [
         "./static/third/bootstrap-notify/css/bootstrap-notify.css",
         "./static/third/spectrum/spectrum.css",
+        "./node_modules/@fortawesome/fontawesome-free-webfonts/css/fontawesome.css",
+        "./node_modules/@fortawesome/fontawesome-free-webfonts/css/fa-solid.css",
+        "./node_modules/@fortawesome/fontawesome-free-webfonts/css/fa-regular.css",
+        "./node_modules/@fortawesome/fontawesome-free-webfonts/css/fa-brands.css",
         "./node_modules/font-awesome/css/font-awesome.css",
         "./static/third/fontawesome-legacy.css",
         "./static/generated/icons/style.css",

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '20.0'
+PROVISION_VERSION = '20.1'

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,10 @@
     orbit-camera-controller "^4.0.0"
     turntable-camera-controller "^3.0.0"
 
+"@fortawesome/fontawesome-free-webfonts@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free-webfonts/-/fontawesome-free-webfonts-1.0.9.tgz#72f2c10453422aba0d338fa6a9cb761b50ba24d5"
+
 "@mapbox/geojson-area@0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz#18d7814aa36bf23fbbcc379f8e26a22927debf10"


### PR DESCRIPTION
In this PR we first add font awesome 5 support so that we can use the new icons introduced, while still maintaining support for older v4.7 and the legacy version before 3.0. The need to this multi versions support is that our code base has extensive use of older icons. When we say older icons we essentially mean to say that icons represented by older syntax standard. We have 'icon-vetor' prefixes and 'fa' prefixes already in the code base. Migration from the older legacy version to v3.0+ was long due and with the release of v5.0 with different prefixes we have now the opportunity to directly migrate to font awesome 5 syntax standards.