### PR TITLE
2FA: Fix check for context_data attr.

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -503,6 +503,10 @@ class LoginTest(ZulipTestCase):
         response = self.client_get("/login/")
         self.assertEqual(response["Location"], "http://zulip.testserver")
 
+    def test_options_request_to_login_page(self) -> None:
+        response = self.client_options('/login/')
+        self.assertEqual(response.status_code, 200)
+
 class InviteUserBase(ZulipTestCase):
     def check_sent_emails(self, correct_recipients: List[str],
                           custom_from_name: Optional[str]=None) -> None:


### PR DESCRIPTION
This PR fixes the if condition in `login_page` view. This view can return both template-based responses and non-template-based responses. If a template-based response is being returned, we need to insert context in `context_data` attribute of the response. This attribute doesn't exist for the other type of template. Previously, this condition assumed that this attribute was missing only in `HttpResponseRedirect`.

@timabbott 