### PR TITLE
search: fix negated suggestions not working in some cases

### DIFF
--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -575,12 +575,30 @@ run_test('sent_by_me_suggestions', () => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
+    query = '-sender';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "-sender",
+        "-sender:bob@zulip.com",
+        "-sender:",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
     query = 'from';
     suggestions = search.get_suggestions(query);
     expected = [
         "from",
         "from:bob@zulip.com",
         "from:",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = '-from';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "-from",
+        "-from:bob@zulip.com",
+        "-from:",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -603,6 +621,14 @@ run_test('sent_by_me_suggestions', () => {
     expected = [
         "sent",
         "sender:bob@zulip.com",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = '-sent';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "-sent",
+        "-sender:bob@zulip.com",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -904,6 +930,7 @@ run_test('operator_suggestions', () => {
     suggestions = search.get_suggestions(query);
     expected = [
         '-s',
+        '-sender:bob@zulip.com',
         '-stream:',
         '-sender:',
     ];
@@ -913,6 +940,7 @@ run_test('operator_suggestions', () => {
     suggestions = search.get_suggestions(query);
     expected = [
         'stream:Denmark is:alerted -f',
+        'stream:Denmark is:alerted -from:bob@zulip.com',
         'stream:Denmark is:alerted -from:',
         'stream:Denmark is:alerted',
         'stream:Denmark',

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -109,8 +109,8 @@ run_test('private_suggestions', () => {
     expected = [
         "is:private al",
         "is:private is:alerted",
-        "is:private pm-with:alice@zulip.com",
         "is:private sender:alice@zulip.com",
+        "is:private pm-with:alice@zulip.com",
         "is:private group-pm-with:alice@zulip.com",
         "is:private",
     ];
@@ -212,8 +212,8 @@ run_test('private_suggestions', () => {
     expected = [
         "is:starred has:link is:private al",
         "is:starred has:link is:private is:alerted",
-        "is:starred has:link is:private pm-with:alice@zulip.com",
         "is:starred has:link is:private sender:alice@zulip.com",
+        "is:starred has:link is:private pm-with:alice@zulip.com",
         "is:starred has:link is:private group-pm-with:alice@zulip.com",
         "is:starred has:link is:private",
         "is:starred has:link",
@@ -870,10 +870,10 @@ run_test('people_suggestions', () => {
 
     var expected = [
         "te",
-        "pm-with:bob@zulip.com", // bob térry
-        "pm-with:ted@zulip.com",
         "sender:bob@zulip.com",
         "sender:ted@zulip.com",
+        "pm-with:bob@zulip.com", // bob térry
+        "pm-with:ted@zulip.com",
         "group-pm-with:bob@zulip.com",
         "group-pm-with:ted@zulip.com",
     ];
@@ -891,8 +891,8 @@ run_test('people_suggestions', () => {
 
     expected = [
         "Ted",
-        "pm-with:ted@zulip.com",
         "sender:ted@zulip.com",
+        "pm-with:ted@zulip.com",
         "group-pm-with:ted@zulip.com",
     ];
 

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -467,7 +467,7 @@ run_test('empty_query_suggestions', () => {
     assert.equal(describe('has:attachment'), 'Messages with one or more attachment');
 });
 
-run_test('has_operator_suggestions', () => {
+run_test('has_suggestions', () => {
     // Checks that category wise suggestions are displayed instead of a single
     // default suggestion when suggesting `has` operator.
     var query = 'h';
@@ -507,6 +507,48 @@ run_test('has_operator_suggestions', () => {
     assert.equal(describe('-has:link'), 'Exclude messages with one or more link');
     assert.equal(describe('-has:image'), 'Exclude messages with one or more image');
     assert.equal(describe('-has:attachment'), 'Exclude messages with one or more attachment');
+
+    // operand suggestions follow.
+
+    query = 'has:';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'has:link',
+        'has:image',
+        'has:attachment',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'has:im';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'has:image',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = '-has:im';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        '-has:image',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'att';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'att',
+        'has:attachment',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'stream:Denmark is:alerted has:lin';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'stream:Denmark is:alerted has:link',
+        'stream:Denmark is:alerted',
+        'stream:Denmark',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
 });
 
 run_test('sent_by_me_suggestions', () => {
@@ -822,48 +864,6 @@ run_test('people_suggestions', () => {
 
     assert.deepEqual(suggestions.strings, expected);
 
-});
-
-run_test('contains_suggestions', () => {
-    var query = 'has:';
-    var suggestions = search.get_suggestions(query);
-    var expected = [
-        'has:link',
-        'has:image',
-        'has:attachment',
-    ];
-    assert.deepEqual(suggestions.strings, expected);
-
-    query = 'has:im';
-    suggestions = search.get_suggestions(query);
-    expected = [
-        'has:image',
-    ];
-    assert.deepEqual(suggestions.strings, expected);
-
-    query = '-has:im';
-    suggestions = search.get_suggestions(query);
-    expected = [
-        '-has:image',
-    ];
-    assert.deepEqual(suggestions.strings, expected);
-
-    query = 'att';
-    suggestions = search.get_suggestions(query);
-    expected = [
-        'att',
-        'has:attachment',
-    ];
-    assert.deepEqual(suggestions.strings, expected);
-
-    query = 'stream:Denmark is:alerted has:lin';
-    suggestions = search.get_suggestions(query);
-    expected = [
-        'stream:Denmark is:alerted has:link',
-        'stream:Denmark is:alerted',
-        'stream:Denmark',
-    ];
-    assert.deepEqual(suggestions.strings, expected);
 });
 
 run_test('operator_suggestions', () => {

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -485,7 +485,6 @@ run_test('has_operator_suggestions', () => {
         'has:image',
         'has:attachment',
     ];
-
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
@@ -495,6 +494,19 @@ run_test('has_operator_suggestions', () => {
     assert.equal(describe('has:link'), 'Messages with one or more link');
     assert.equal(describe('has:image'), 'Messages with one or more image');
     assert.equal(describe('has:attachment'), 'Messages with one or more attachment');
+
+    query = '-h';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "-h",
+        '-has:link',
+        '-has:image',
+        '-has:attachment',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+    assert.equal(describe('-has:link'), 'Exclude messages with one or more link');
+    assert.equal(describe('-has:image'), 'Exclude messages with one or more image');
+    assert.equal(describe('-has:attachment'), 'Exclude messages with one or more attachment');
 });
 
 run_test('sent_by_me_suggestions', () => {

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -788,6 +788,14 @@ run_test('stream_completion', () => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
+    query = '-stream:of';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        "-stream:of",
+        "-stream:office",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
     query = 'hel';
     suggestions = search.get_suggestions(query);
     expected = [

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -517,24 +517,6 @@ function get_sent_by_me_suggestions(last, operators) {
     return [];
 }
 
-function get_containing_suggestions(last) {
-    if (!(last.operator === 'search' || last.operator === 'has')) {
-        return [];
-    }
-
-    var choices = ['link', 'image', 'attachment'];
-    choices = _.filter(choices, function (choice) {
-        return phrase_match(choice, last.operand);
-    });
-
-    return _.map(choices, function (choice) {
-        var op = [{operator: 'has', operand: choice, negated: last.negated}];
-        var search_string = Filter.unparse(op);
-        var description = Filter.describe(op);
-        return {description: description, search_string: search_string};
-    });
-}
-
 function get_operator_suggestions(last) {
     if (!(last.operator === 'search')) {
         return [];
@@ -638,9 +620,6 @@ exports.get_suggestions = function (query) {
     attach_suggestions(result, base, suggestions);
 
     suggestions = get_has_filter_suggestions(last, base_operators);
-    attach_suggestions(result, base, suggestions);
-
-    suggestions = get_containing_suggestions(last);
     attach_suggestions(result, base, suggestions);
 
     suggestions = get_operator_subset_suggestions(operators);

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -488,9 +488,17 @@ function get_has_filter_suggestions(last, operators) {
 
 function get_sent_by_me_suggestions(last, operators) {
     var last_string = Filter.unparse([last]).toLowerCase();
-    var sender_query = 'sender:' + people.my_current_email();
-    var from_query = 'from:' + people.my_current_email();
-    var description = 'sent by me';
+    var negated = last.negated || (last.operator === 'search' && last.operand[0] === '-');
+    var negated_symbol = negated ? '-' : '';
+    var verb = negated ? 'exclude ' : '';
+
+    var sender_query = negated_symbol + 'sender:' + people.my_current_email();
+    var from_query = negated_symbol + 'from:' + people.my_current_email();
+    var sender_me_query = negated_symbol + 'sender:me';
+    var from_me_query = negated_symbol + 'from:me';
+    var sent_string = negated_symbol + 'sent';
+    var description = verb + 'sent by me';
+
     var invalid = [
         {operator: 'sender'},
         {operator: 'from'},
@@ -501,14 +509,14 @@ function get_sent_by_me_suggestions(last, operators) {
     }
 
     if (last.operator === '' || sender_query.indexOf(last_string) === 0 ||
-        'sender:me'.indexOf(last_string) === 0 || last_string === 'sent') {
+        sender_me_query.indexOf(last_string) === 0 || last_string === sent_string) {
         return [
             {
                 search_string: sender_query,
                 description: description,
             },
         ];
-    } else if (from_query.indexOf(last_string) === 0 || 'sender:me'.indexOf(last_string) === 0) {
+    } else if (from_query.indexOf(last_string) === 0 || from_me_query.indexOf(last_string) === 0) {
         return [
             {
                 search_string: from_query,

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -98,10 +98,12 @@ function get_stream_suggestions(last, operators) {
     var objs = _.map(streams, function (stream) {
         var prefix = 'stream';
         var highlighted_stream = typeahead_helper.highlight_with_escaping(query, stream);
-        var description = prefix + ' ' + highlighted_stream;
+        var verb = last.negated ? 'exclude ' : '';
+        var description = verb + prefix + ' ' + highlighted_stream;
         var term = {
             operator: 'stream',
             operand: stream,
+            negated: last.negated,
         };
         var search_string = Filter.unparse([term]);
         return {description: description, search_string: search_string};

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -608,10 +608,10 @@ exports.get_suggestions = function (query) {
 
     var persons = people.get_all_persons();
 
-    suggestions = get_person_suggestions(persons, last, base_operators, 'pm-with');
+    suggestions = get_person_suggestions(persons, last, base_operators, 'sender');
     attach_suggestions(result, base, suggestions);
 
-    suggestions = get_person_suggestions(persons, last, base_operators, 'sender');
+    suggestions = get_person_suggestions(persons, last, base_operators, 'pm-with');
     attach_suggestions(result, base, suggestions);
 
     suggestions = get_person_suggestions(persons, last, base_operators, 'from');


### PR DESCRIPTION
fixes #9461.
fixes #9313.

negated special filter operator suggestions
![selection_127](https://user-images.githubusercontent.com/13910561/40293281-da46bd4c-5ced-11e8-91fe-697cdc7689ba.png)

negated special filter operand suggestions
![selection_128](https://user-images.githubusercontent.com/13910561/40293307-f5ef2174-5ced-11e8-8251-1ebfe73899dd.png)

negated stream suggestions:
![selection_129](https://user-images.githubusercontent.com/13910561/40293319-052b48fc-5cee-11e8-9eec-3705e1e59d7f.png)

negated sent_by_me suggestions:
![selection_130](https://user-images.githubusercontent.com/13910561/40293340-25e3ee50-5cee-11e8-8319-3ac52e16a1f9.png)

previously sent by me suggestion was not occurring in the below query:
![selection_131](https://user-images.githubusercontent.com/13910561/40293384-4c74bbc6-5cee-11e8-93d4-9c542dd6490c.png)





