### PR TITLE
portico: Align ToS checkbox with full name input box.

### DIFF
--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -222,7 +222,8 @@ html {
 }
 
 .register-account .terms-of-service .input-group {
-    margin: 0px 30px 10px 32px;
+    width: 330px;
+    margin-bottom: 0 auto 10px;
 }
 
 .register-account .terms-of-service .text-error {


### PR DESCRIPTION
Fixes #9328.
Makes the width on checkbox input-group same as full name input box
width and centers it horizontally.

![selection_133](https://user-images.githubusercontent.com/13910561/40302696-9c5e9b06-5d0d-11e8-9a13-9bf76e2f8759.png)
