### PR TITLE
Move create_realm_internal_bots to populate_db

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -384,8 +384,6 @@ def main(options):
         else:
             print("No need to run `manage.py compilemessages`.")
 
-        run(["./manage.py", "create_realm_internal_bots"])  # Creates realm internal bots if required.
-
     run(["scripts/lib/clean-unused-caches"])
 
     version_file = os.path.join(UUID_VAR_PATH, 'provision_version')

--- a/tools/setup/generate-fixtures
+++ b/tools/setup/generate-fixtures
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+export DJANGO_SETTINGS_MODULE=zproject.test_settings
+
 if  [ "$1" != "--force" ]; then
     "$(dirname "$0")/../../scripts/setup/terminate-psql-sessions" zulip zulip_test zulip_test_base zulip_test_template
     psql -h localhost postgres zulip_test << EOF
@@ -21,14 +23,13 @@ CREATE DATABASE zulip_test TEMPLATE zulip_test_base;
 EOF
 sh "$(dirname "$0")/../../scripts/setup/flush-memcached"
 
-./manage.py migrate --noinput --settings=zproject.test_settings
-./manage.py get_migration_status --settings=zproject.test_settings \
-    --output="migration_status_test"
+./manage.py migrate --noinput
+./manage.py get_migration_status --output="migration_status_test"
 
 # This next line can be simplified to "-n0" once we fix our app (and tests) with 0 messages.
-./manage.py populate_db --settings=zproject.test_settings --test-suite -n30 \
-    --threads=1 --huddles=0 --personals=0 --percent-huddles=0 --percent-personals=0
-./manage.py dumpdata  --settings=zproject.test_settings \
+./manage.py populate_db --test-suite -n30 --threads=1 \
+    --huddles=0 --personals=0 --percent-huddles=0 --percent-personals=0
+./manage.py dumpdata \
     zerver.UserProfile zerver.Stream zerver.Recipient \
     zerver.Subscription zerver.Message zerver.Huddle zerver.Realm \
     zerver.UserMessage zerver.Client \

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from zerver.lib.actions import set_default_streams, bulk_add_subscriptions, \
     internal_prep_stream_message, internal_send_private_message, \
     create_stream_if_needed, create_streams_if_needed, do_send_messages, \
-    do_add_reaction_legacy, create_users
+    do_add_reaction_legacy, create_users, missing_any_realm_internal_bots
 from zerver.models import Realm, UserProfile, Message, Reaction, get_system_bot
 
 from typing import Any, Dict, List, Mapping
@@ -26,6 +26,15 @@ def setup_realm_internal_bots(realm: Realm) -> None:
     for bot in bots:
         bot.bot_owner = bot
         bot.save()
+
+def create_if_missing_realm_internal_bots() -> None:
+    """This checks if there is any realm internal bot missing.
+
+    If that is the case, it creates the missing realm internal bots.
+    """
+    if missing_any_realm_internal_bots():
+        for realm in Realm.objects.all():
+            setup_realm_internal_bots(realm)
 
 def send_initial_pms(user: UserProfile) -> None:
     organization_setup_text = ""

--- a/zerver/management/commands/create_realm_internal_bots.py
+++ b/zerver/management/commands/create_realm_internal_bots.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db.models import Count
 
-from zerver.lib.onboarding import setup_realm_internal_bots
+from zerver.lib.onboarding import create_if_missing_realm_internal_bots
 from zerver.models import Realm, UserProfile
 
 class Command(BaseCommand):
@@ -16,19 +16,7 @@ These are normally created when the realm is, so this should be a no-op
 except when upgrading to a version that adds a new realm internal bot.
 """
 
-    @staticmethod
-    def missing_any_bots() -> bool:
-        bot_emails = [bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,)
-                      for bot in settings.REALM_INTERNAL_BOTS]
-        bot_counts = dict(UserProfile.objects.filter(email__in=bot_emails)
-                                             .values_list('email')
-                                             .annotate(Count('id')))
-        realm_count = Realm.objects.count()
-        return any(bot_counts.get(email, 0) < realm_count for email in bot_emails)
-
     def handle(self, *args: Any, **options: Any) -> None:
-        if self.missing_any_bots():
-            for realm in Realm.objects.all():
-                setup_realm_internal_bots(realm)
-                # create_users is idempotent -- it's a no-op when a given email
-                # already has a user in a given realm.
+        create_if_missing_realm_internal_bots()
+        # create_users is idempotent -- it's a no-op when a given email
+        # already has a user in a given realm.

--- a/zerver/tests/test_onboarding.py
+++ b/zerver/tests/test_onboarding.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+from zerver.models import Realm, UserProfile
+from zerver.lib.onboarding import create_if_missing_realm_internal_bots
+from zerver.lib.test_classes import (
+    ZulipTestCase,
+)
+
+class TestRealmInternalBotCreation(ZulipTestCase):
+    def test_create_if_missing_realm_internal_bots(self) -> None:
+        realm_internal_bots_dict = [{'var_name': 'TEST_BOT',
+                                     'email_template': 'test-bot@%s',
+                                     'name': 'Test Bot'}]
+
+        def check_test_bot_exists() -> bool:
+            all_realms_count = Realm.objects.count()
+            all_test_bot_count = UserProfile.objects.filter(
+                email='test-bot@zulip.com'
+            ).count()
+            return all_realms_count == all_test_bot_count
+
+        self.assertFalse(check_test_bot_exists())
+        with self.settings(REALM_INTERNAL_BOTS=realm_internal_bots_dict):
+            create_if_missing_realm_internal_bots()
+        self.assertTrue(check_test_bot_exists())

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2036,7 +2036,7 @@ class SubscriptionAPITest(ZulipTestCase):
             set([user1.id, user2.id, self.test_user.id])
         )
 
-        self.assertEqual(len(add_peer_event['users']), 18)
+        self.assertEqual(len(add_peer_event['users']), 19)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
         self.assertEqual(add_peer_event['event']['user_id'], self.user_profile.id)
@@ -2067,7 +2067,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         # We don't send a peer_add event to othello
         self.assertNotIn(user_profile.id, add_peer_event['users'])
-        self.assertEqual(len(add_peer_event['users']), 18)
+        self.assertEqual(len(add_peer_event['users']), 19)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
         self.assertEqual(add_peer_event['event']['user_id'], user_profile.id)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -17,6 +17,7 @@ from zerver.lib.actions import STREAM_ASSIGNMENT_COLORS, check_add_realm_emoji, 
 from zerver.lib.bulk_create import bulk_create_streams, bulk_create_users
 from zerver.lib.cache import cache_set
 from zerver.lib.generate_test_data import create_test_data
+from zerver.lib.onboarding import create_if_missing_realm_internal_bots
 from zerver.lib.upload import upload_backend
 from zerver.lib.url_preview.preview import CACHE_NAME as PREVIEW_CACHE_NAME
 from zerver.lib.user_groups import create_user_group
@@ -212,6 +213,10 @@ class Command(BaseCommand):
             ]
             create_users(zulip_realm, zulip_outgoing_bots,
                          bot_type=UserProfile.OUTGOING_WEBHOOK_BOT, bot_owner=aaron)
+
+            # Add the realm internl bots to each realm.
+            create_if_missing_realm_internal_bots()
+
             # TODO: Clean up this initial bot creation code
             Service.objects.create(
                 name="test",


### PR DESCRIPTION
In this PR we are trying to speed up provisioning by moving the create_realm_internal_bots to populate db and thus reducing the no-op provisioning time by around 1.8s.

After this no-op on my system is something like this
```
real	0m5.708s
user	0m5.164s
sys	0m0.412s
```