### PR TITLE
Add support to `run-mypy` for using the mypy daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ package-lock.json
 /.vagrant
 /var
 
+/.dmypy.json
+
 # Dockerfiles generated for CircleCI
 /tools/circleci/images
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,10 +18,11 @@ local_partial_types = True
 # someone fixes a type error we don't want to add a burden for them.
 #warn_unused_ignores = True
 
-# Options to make the checking *less* strict, which we
-# might ideally eliminate.
-follow_imports = silent
-
+# Error on importing modules that are present but not part of the
+# build.  If the module can't reasonably be made to not error, errors
+# can be suppressed with ignore_errors.
+# (The mypy daemon only supports error and skip for follow_imports)
+follow_imports = error
 
 #
 #

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,9 @@ disallow_any_generics = True
 warn_no_return = True
 no_implicit_optional = True
 
+# The mypy daemon requires using local_partial_types.
+local_partial_types = True
+
 # It's useful to try this occasionally, and keep it clean; but when
 # someone fixes a type error we don't want to add a burden for them.
 #warn_unused_ignores = True

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,6 +9,7 @@
 #
 --no-binary psycopg2
 
+git+https://github.com/python/mypy.git@6a934d32124991a77ea433856cf2d62871ceb632#egg=mypy==0.610+dev.6a934d32124991a77ea433856cf2d62871ceb632
 git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 git+https://github.com/zulip/python-zulip-api.git@0.4.6#egg=zulip==0.4.6_git&subdirectory=zulip
@@ -90,7 +91,6 @@ markdown==2.6.11
 markupsafe==1.0
 mock==2.0.0
 moto==1.3.3
-mypy==0.600
 mypy_extensions==0.3.0
 ndg-httpsclient==0.5.0
 oauth2client==4.1.2
@@ -169,7 +169,7 @@ traitlets==4.3.2          # via ipython
 transifex-client==0.12.5
 twilio==6.13.0
 twisted==18.4.0
-typed-ast==1.1.0          # via mypy
+typed-ast==1.1.0
 typing==3.6.4
 uritemplate==3.0.0
 urllib3==1.22             # via requests, transifex-client

--- a/requirements/mypy.in
+++ b/requirements/mypy.in
@@ -2,7 +2,6 @@
 # /tools/update-locked-requirements to update requirements/dev.txt
 # and requirements/mypy.txt.
 # See requirements/README.md for more detail.
-mypy==0.600
-
+-e git+https://github.com/python/mypy.git@6a934d32124991a77ea433856cf2d62871ceb632#egg=mypy==0.610+dev.6a934d32124991a77ea433856cf2d62871ceb632
 # Include typing explicitly, since it's needed on Python 3.4
 typing==3.6.4

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -7,6 +7,6 @@
 #
 # For details, see requirements/README.md .
 #
-mypy==0.600
-typed-ast==1.1.0          # via mypy
+git+https://github.com/python/mypy.git@6a934d32124991a77ea433856cf2d62871ceb632#egg=mypy==0.610+dev.6a934d32124991a77ea433856cf2d62871ceb632
+typed-ast==1.1.0
 typing==3.6.4

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -27,6 +27,8 @@ parser.add_argument('--quick', action='store_true',
                     help="pass --quick to mypy")
 parser.add_argument('-m', '--modified', action='store_true',
                     help="check only modified files")
+parser.add_argument('-d', '--daemon', action='store_true',
+                    help="Start and run the mypy fine-grained incremental daemon")
 parser.add_argument('--scripts-only', action='store_true',
                     help="only check extensionless python scripts")
 parser.add_argument('-a', '--all', action='store_true',
@@ -44,13 +46,15 @@ if not args.force:
         print('If you really know what you are doing, use --force to run anyway.')
         sys.exit(1)
 
+command_name = "mypy" if not args.daemon else "dmypy"
+
 # Use zulip-py3-venv's mypy if it's available.
 VENV_DIR = "/srv/zulip-py3-venv"
-MYPY_VENV_PATH = os.path.join(VENV_DIR, "bin", "mypy")
+MYPY_VENV_PATH = os.path.join(VENV_DIR, "bin", command_name)
 if os.path.exists(MYPY_VENV_PATH):
     mypy_command = MYPY_VENV_PATH
 else:
-    mypy_command = "mypy"
+    mypy_command = command_name
 
 if args.version:
     print("mypy command:", mypy_command)
@@ -79,7 +83,11 @@ if args.linecoverage_report:
 if args.quick:
     extra_args.append("--quick")
 
-rc = subprocess.call([mypy_command] + extra_args + python_files + pyi_files)
+mypy_args = extra_args + python_files + pyi_files
+if args.daemon:
+    rc = subprocess.call([mypy_command, 'run', '--'] + mypy_args)
+else:
+    rc = subprocess.call([mypy_command] + mypy_args)
 
 if args.linecoverage_report:
     # Move the coverage report to where codecov will look for it.

--- a/zerver/lib/debug.py
+++ b/zerver/lib/debug.py
@@ -68,7 +68,7 @@ def tracemalloc_listen_sock(sock: socket.socket) -> None:
         sock.recv(1)
         tracemalloc_dump()
 
-listener_pid = None  # Optional[int]
+listener_pid = None  # type: Optional[int]
 
 def tracemalloc_listen() -> None:
     global listener_pid

--- a/zerver/lib/sqlalchemy_utils.py
+++ b/zerver/lib/sqlalchemy_utils.py
@@ -1,3 +1,5 @@
+from typing import Optional, Any
+
 from django.db import connection
 from zerver.lib.db import TimeTrackingConnection
 
@@ -21,7 +23,7 @@ class NonClosingPool(sqlalchemy.pool.NullPool):
                               logging_name=self._orig_logging_name,
                               _dispatch=self.dispatch)
 
-sqlalchemy_engine = None
+sqlalchemy_engine = None  # type: Optional[Any]
 def get_sqlalchemy_connection() -> sqlalchemy.engine.base.Connection:
     global sqlalchemy_engine
     if sqlalchemy_engine is None:

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -54,8 +54,8 @@ def display_list(values: List[str], display_limit: int) -> str:
 
     return display_string
 
-md_extensions = None
-md_macro_extension = None
+md_extensions = None  # type: Optional[List[Any]]
+md_macro_extension = None  # type: Optional[Any]
 # Prevent the automatic substitution of macros in these docs. If
 # they contain a macro, it is always used literally for documenting
 # the macro system.

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -11,7 +11,8 @@ from django.utils.log import AdminEmailHandler
 from functools import wraps
 from mock import MagicMock, patch
 from mypy_extensions import NoReturn
-from typing import Any, Callable, Dict, Mapping, Optional, Iterator
+from typing import Any, Callable, Dict, Mapping, Optional, Iterator, Optional, Tuple, Type
+from types import TracebackType
 
 from zerver.lib.request import JsonableError
 from zerver.lib.types import ViewFuncT
@@ -22,7 +23,7 @@ from zerver.views.compatibility import check_compatibility
 from zerver.worker.queue_processors import QueueProcessingWorker
 
 captured_request = None  # type: Optional[HttpRequest]
-captured_exc_info = None
+captured_exc_info = None  # type: Tuple[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]]
 def capture_and_throw(domain: Optional[str]=None) -> Callable[[ViewFuncT], ViewFuncT]:
     def wrapper(view_func: ViewFuncT) -> ViewFuncT:
         @wraps(view_func)

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -23,7 +23,7 @@ import os
 import logging
 import ujson
 
-js_source_map = None
+js_source_map = None  # type: Optional[SourceMap]
 
 # Read the source map information for decoding JavaScript backtraces.
 def get_js_source_map() -> Optional[SourceMap]:


### PR DESCRIPTION
mypy 0.600 introduced support for `dmypy`, a way of using mypy that can substantially speed up typechecking. 

The daemon can be invoked with `tools/run-mypy -d`. It will be automatically started if not running and will automatically restart on version or configuration changes.

This adds support for using taking advantage of that mode. A few preliminaries were necessary:
 * Daemon mode requres using `local_partial_types = True`, so set that flag and fix the problems it causes
 * Daemon mode only supports `follow_imports` values of `error` and `skip`. This is annoying, but switching to `error` shouldn't cause much trouble, since `run-mypy` ought to find all of the sources.
 * The control interface for dmypy that shipped with 0.600 was kind of lacking, and faced with Zulip needing a bunch of glue logic to use dmypy, I went and implemented a mode of launching that daemon that I ought to have built for the 0.600 launch in the first place. Additionally, some of my testing against the Zulip code revealed dmypy crash bugs, which needed to be fixed. As a result, we need to upgrade mypy to a current development version.

I've done some manual testing, though nothing exhaustive.

This doesn't take advantage of mypy caching to speed up cold starts, since currently the cache would need to come from a local non-daemon run, and there has not been much validation on using the daemon on caches generated by runs that produced errors.