### PR TITLE
Implement and document new Botserver setup routine.

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -8,7 +8,7 @@ common.start_and_log_in();
 
 // var form_sel = 'form[action^="/json/settings"]';
 var regex_zuliprc = /^data:application\/octet-stream;charset=utf-8,\[api\]\nemail=.+\nkey=.+\nsite=.+\n$/;
-var regex_flaskbotrc = /^data:application\/octet-stream;charset=utf-8,\[.\]\nemail=.+\nkey=.+\nsite=.+\n$/;
+var regex_flaskbotrc = /^data:application\/octet-stream;charset=utf-8,\[\]\nemail=.+\nkey=.+\nsite=.+\n$/;
 
 casper.then(function () {
     var menu_selector = '#settings-dropdown';

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -52,7 +52,7 @@ run_test('generate_flaskbotrc_content', () => {
         api_key: "nSlA0mUm7G42LP85lMv7syqFTzDE2q34",
     };
     var content = settings_bots.generate_flaskbotrc_content(user.email, user.api_key);
-    var expected = "[vabstest]\nemail=vabstest-bot@zulip.com\n" +
+    var expected = "[]\nemail=vabstest-bot@zulip.com\n" +
                    "key=nSlA0mUm7G42LP85lMv7syqFTzDE2q34\n" +
                    "site=https://chat.example.com\n";
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -110,12 +110,8 @@ exports.generate_zuliprc_content = function (email, api_key) {
            "\n";
 };
 
-function bot_name_from_email(email) {
-    return email.substring(0, email.indexOf("-bot@"));
-}
-
 exports.generate_flaskbotrc_content = function (email, api_key) {
-    return "[" + bot_name_from_email(email) + "]" +
+    return "[]" +
            "\nemail=" + email +
            "\nkey=" + api_key +
            "\nsite=" + page_params.realm_uri +

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -71,7 +71,7 @@
                         <div class="input-group">
                             <label for="create_payload_url">{{t "Endpoint URL" }}</label>
                             <input type="text" name="payload_url" id="create_payload_url"
-                              maxlength=2083 placeholder="https://hostname.example.com/bots/followup" value="" />
+                              maxlength=2083 placeholder="https://hostname.example.com" value="" />
                             <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
                         </div>
                         <div class="input-group">

--- a/templates/zerver/api/deploying-bots.md
+++ b/templates/zerver/api/deploying-bots.md
@@ -62,7 +62,7 @@ pip install zulip_botserver
 
 1. Open the `flaskbotrc`. It should contain one or more sections that look like this:
    ```
-   [foo]
+   []
    email=foo-bot@hostname
    key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
    site=http://hostname

--- a/templates/zerver/api/deploying-bots.md
+++ b/templates/zerver/api/deploying-bots.md
@@ -43,13 +43,12 @@ pip install zulip_botserver
 1. Construct the URL for your bot, which will be of the form:
 
     ```
-    http://<hostname>:<port>/bots/<bot_name>
+    http://<hostname>:<port>
     ```
 
     where the `hostname` is the hostname you'll be running the bot
     server on, and `port` is the port for it (the recommended default
-    is `5002`).  `bot_name` is the name of the Python module for the
-    bot you'd like to run.
+    is `5002`).
 
 1. Register new bot users on the Zulip server's web interface.
 
@@ -59,9 +58,25 @@ pip install zulip_botserver
       the URL from above) and click on *Create bot*.
     * A new bot user should appear in the *Active bots* panel.
 
-1.  Download the `flaskbotrc` from the `your-bots` settings page. It
-    contains the configuration details for all the active outgoing
-    webhook bots. It's structure is very similar to that of zuliprc.
+1. Download the `flaskbotrc` from the `your-bots` settings page.
+
+1. Open the `flaskbotrc`. It should contain one or more sections that look like this:
+   ```
+   [foo]
+   email=foo-bot@hostname
+   key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
+   site=http://hostname
+   ```
+   Each section contains the configuration for an outgoing webhook bot. For each
+   bot, enter the name of the bot you want to run in the square brackets `[]`.
+   For example, if we want `foo-bot@hostname` to run the `helloworld` bot, our
+   new section would look like this:
+   ```
+   [helloworld]
+   email=foo-bot@hostname
+   key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
+   site=http://hostname
+   ```
 
 1.  Run the Zulip Botserver by passing the `flaskbotrc` to it. The
     command format is:

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -25,7 +25,7 @@ class OutgoingWebhookServiceInterface:
     def __init__(self, base_url: str, token: str, user_profile: UserProfile, service_name: str) -> None:
         self.base_url = base_url  # type: str
         self.token = token  # type: str
-        self.user_profile = user_profile  # type: str
+        self.user_profile = user_profile  # type: UserProfile
         self.service_name = service_name  # type: str
 
     # Given an event that triggers an outgoing webhook operation, returns:

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -58,7 +58,9 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
                           'request_kwargs': {}}
         request_data = {"data": event['command'],
                         "message": event['message'],
-                        "token": self.token}
+                        "bot_email": self.user_profile.email,
+                        "token": self.token,
+                        "trigger": event['trigger']}
         return rest_operation, json.dumps(request_data)
 
     def process_success(self, response: Response,

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -8,7 +8,7 @@ from requests.models import Response
 from zerver.lib.outgoing_webhook import GenericOutgoingWebhookService, \
     SlackOutgoingWebhookService
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import Service
+from zerver.models import Service, get_realm, get_user
 
 class TestGenericOutgoingWebhookService(ZulipTestCase):
 
@@ -16,13 +16,15 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
         self.event = {
             u'command': '@**test**',
             u'message': {
-                'content': 'test_content',
-            }
+                'content': '@**test**',
+            },
+            u'trigger': 'mention',
         }
+        self.bot_user = get_user("outgoing-webhook@zulip.com", get_realm("zulip"))
         self.handler = GenericOutgoingWebhookService(service_name='test-service',
                                                      base_url='http://example.domain.com',
                                                      token='abcdef',
-                                                     user_profile=None)
+                                                     user_profile=self.bot_user)
 
     def test_process_event(self) -> None:
         rest_operation, request_data = self.handler.process_event(self.event)


### PR DESCRIPTION
Previously, the Botserver determined which bot to run for an
outgoing webhook by dispatching on a different URL endpoint
for each bot. Now, instead, the Botserver determines which bot
to run by the section header of the bot in the flaskbotrc.
This commit makes the frontend provide the new flaskbotrc
and updates the setup steps for the Botserver in the docs.

This depends on https://github.com/zulip/python-zulip-api/pull/397.
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
