### PR TITLE
org settings: Show pointer on hovering labels of checkboxes.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -329,6 +329,10 @@ td .button {
     margin: 10px 0px;
 }
 
+.input-group label.checkbox + label {
+    cursor: pointer;
+}
+
 .no-margin {
     margin: 0px;
 }


### PR DESCRIPTION
Fixes: #9447.
GIF:
![peek 2018-05-22 17-43](https://user-images.githubusercontent.com/22238472/40361676-c2610dc2-5de7-11e8-86be-abb6baaea585.gif)
