### PR TITLE
search: Do not show default suggestion for `is` operator.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -627,7 +627,7 @@ run_test('describe', () => {
     narrow = [
         {operator: 'is', operand: 'something_we_do_not_support'},
     ];
-    string = 'something_we_do_not_support messages';
+    string = 'invalid something_we_do_not_support operand for is operator';
     assert.equal(Filter.describe(narrow), string);
 
     // this should be unreachable, but just in case

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -551,6 +551,101 @@ run_test('has_suggestions', () => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
+run_test('check_is_suggestions', () => {
+    var query = 'i';
+    global.stream_data.subscribed_streams = function () {
+        return ['devel', 'office'];
+    };
+    global.narrow_state.stream = function () {
+        return;
+    };
+
+    var suggestions = search.get_suggestions(query);
+    var expected = [
+        'i',
+        'is:private',
+        'is:starred',
+        'is:mentioned',
+        'is:alerted',
+        'is:unread',
+        'has:image',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    function describe(q) {
+        return suggestions.lookup_table[q].description;
+    }
+
+    assert.equal(describe('is:private'), 'Private messages');
+    assert.equal(describe('is:starred'), 'Starred messages');
+    assert.equal(describe('is:mentioned'), '@-mentions');
+    assert.equal(describe('is:alerted'), 'Alerted messages');
+    assert.equal(describe('is:unread'), 'Unread messages');
+
+    query = '-i';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        '-i',
+        '-is:private',
+        '-is:starred',
+        '-is:mentioned',
+        '-is:alerted',
+        '-is:unread',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    assert.equal(describe('-is:private'), 'Exclude private messages');
+    assert.equal(describe('-is:starred'), 'Exclude starred messages');
+    assert.equal(describe('-is:mentioned'), 'Exclude @-mentions');
+    assert.equal(describe('-is:alerted'), 'Exclude alerted messages');
+    assert.equal(describe('-is:unread'), 'Exclude unread messages');
+
+    // operand suggestions follow.
+
+    query = 'is:';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'is:private',
+        'is:starred',
+        'is:mentioned',
+        'is:alerted',
+        'is:unread',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'is:st';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'is:starred',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = '-is:st';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        '-is:starred',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'st';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'st',
+        'is:starred',
+        'stream:',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'stream:Denmark has:link is:sta';
+    suggestions = search.get_suggestions(query);
+    expected = [
+        'stream:Denmark has:link is:starred',
+        'stream:Denmark has:link',
+        'stream:Denmark',
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+});
+
 run_test('sent_by_me_suggestions', () => {
     global.stream_data.subscribed_streams = function () {
         return [];

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -622,7 +622,7 @@ function describe_unescaped(operators) {
             } else if (operand === 'unread') {
                 return verb + 'unread messages';
             }
-            return operand + ' messages';
+            return 'invalid ' + operand + ' operand for is operator';
         }
         if (canonicalized_operator ==='has') {
             // search_suggestion.get_suggestions takes care that this message will

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -581,10 +581,10 @@ exports.get_suggestions = function (query) {
     }
 
     // Display the default first
-    // `has` operator works only on predefined categories. Default suggestion
+    // `has` and `is` operators work only on predefined categories. Default suggestion
     // is not displayed in that case. e.g. `messages with one or more abc` as
     // a suggestion for `has:abc`does not make sense.
-    if (last.operator !== '' && last.operator !== 'has') {
+    if (last.operator !== '' && last.operator !== 'has' && last.operator !== 'is') {
         suggestion = get_default_suggestion(operators);
         result = [suggestion];
     }


### PR DESCRIPTION
Fixes #9492.

Commit 1:
Default suggestion e.g `abc messages` as a suggestion for `is:abc`
is not shown in a new suggestion. But if the is operator is already
present before any other operator, the default message text will be
used. e.g `is:abc sender:abc@zulipchat.com` will have all the suggestions
with the prefix `abc messages, sent by abc@zulipchat.com`.
![selection_135](https://user-images.githubusercontent.com/13910561/40363741-0dd4ac5e-5dee-11e8-9fa6-8a70093f920e.png)


Commit 2:
`is` operator uses predefined categories. This commit
displays an invalid operand message if the operand does not fall into
any of these categories and the `is` operator is not at the last.
e.g. `is:abc sender:abc@zulipchat.com` will have `invalid abc operand
for has operator, sent by abc@zulipchat.com` as a prefix for all its
suggestions.
![selection_136](https://user-images.githubusercontent.com/13910561/40363742-0dd958a8-5dee-11e8-9be8-dbdcd4e2a229.png)

