### PR TITLE
widgets: Prevent traceback for submessage event.

### DIFF
--- a/static/js/widgetize.js
+++ b/static/js/widgetize.js
@@ -67,9 +67,9 @@ exports.activate = function (in_opts) {
 exports.handle_event = function (widget_event) {
     var message = message_store.get(widget_event.message_id);
 
-    if (!message) {
+    if (!message || !message.widget) {
         // It is common for submessage events to arrive on
-        // messages that we don't yet have in storage. We
+        // messages that we don't yet have in view. We
         // just ignore them completely here.
         return;
     }


### PR DESCRIPTION
We can have this scenario:

    - somebody else creates a widget-ready message
    - message arrives in storage
    - (message is not yet in view, so no message.widget)
    - new submessage event arrives

We want to just ignore submessage events in that case.

(There's a more complete fix coming for this scenario, where
we at least update message.submessages for the eventuality
that we do render the message later.)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
