### PR TITLE
export: Support export of Reactions and Custom emojis.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -141,7 +141,8 @@ def re_map_foreign_keys(data: TableData,
                         related_table: TableName,
                         verbose: bool=False,
                         id_field: bool=False,
-                        recipient_field: bool=False) -> None:
+                        recipient_field: bool=False,
+                        reaction_field: bool=False) -> None:
     """
     This is a wrapper function for all the realm data tables
     and only avatar and attachment records need to be passed through the internal function
@@ -149,7 +150,7 @@ def re_map_foreign_keys(data: TableData,
     and List[Record] corresponding to the avatar and attachment records)
     """
     re_map_foreign_keys_internal(data[table], table, field_name, related_table, verbose, id_field,
-                                 recipient_field)
+                                 recipient_field, reaction_field)
 
 def re_map_foreign_keys_internal(data_table: List[Record],
                                  table: TableName,
@@ -157,7 +158,8 @@ def re_map_foreign_keys_internal(data_table: List[Record],
                                  related_table: TableName,
                                  verbose: bool=False,
                                  id_field: bool=False,
-                                 recipient_field: bool=False) -> None:
+                                 recipient_field: bool=False,
+                                 reaction_field: bool=False) -> None:
     '''
     We occasionally need to assign new ids to rows during the
     import/export process, to accommodate things like existing rows
@@ -177,6 +179,11 @@ def re_map_foreign_keys_internal(data_table: List[Record],
             else:
                 continue
         old_id = item[field_name]
+        if reaction_field:
+            if item['reaction_type'] == Reaction.REALM_EMOJI:
+                old_id = int(old_id)
+            else:
+                continue
         if old_id in lookup_table:
             new_id = lookup_table[old_id]
             if verbose:
@@ -190,7 +197,10 @@ def re_map_foreign_keys_internal(data_table: List[Record],
             item[field_name + "_id"] = new_id
             del item[field_name]
         else:
-            item[field_name] = new_id
+            if reaction_field:
+                item[field_name] = str(new_id)
+            else:
+                item[field_name] = new_id
 
 def fix_bitfield_keys(data: TableData, table: TableName, field_name: Field) -> None:
     for item in data[table]:
@@ -539,18 +549,12 @@ def do_import_realm(import_dir: Path, subdomain: str) -> Realm:
     # Import zerver_message and zerver_usermessage
     import_message_data(import_dir)
 
-    # As the export of Reactions is not supported, Zulip exported
-    # data would not contain this field.
-    # However this is supported in slack importer script
-    if 'zerver_reaction' in data:
-        re_map_foreign_keys(data, 'zerver_reaction', 'message', related_table="message")
-        re_map_foreign_keys(data, 'zerver_reaction', 'user_profile', related_table="user_profile")
-        for reaction in data['zerver_reaction']:
-            if reaction['reaction_type'] == Reaction.REALM_EMOJI:
-                re_map_foreign_keys(data, 'zerver_reaction', 'emoji_code',
-                                    related_table="realmemoji", id_field=True)
-        update_model_ids(Reaction, data, 'zerver_reaction', 'reaction')
-        bulk_import_model(data, Reaction, 'zerver_reaction')
+    re_map_foreign_keys(data, 'zerver_reaction', 'message', related_table="message")
+    re_map_foreign_keys(data, 'zerver_reaction', 'user_profile', related_table="user_profile")
+    re_map_foreign_keys(data, 'zerver_reaction', 'emoji_code', related_table="realmemoji", id_field=True,
+                        reaction_field=True)
+    update_model_ids(Reaction, data, 'zerver_reaction', 'reaction')
+    bulk_import_model(data, Reaction, 'zerver_reaction')
 
     # Do attachments AFTER message data is loaded.
     # TODO: de-dup how we read these json files.

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -446,13 +446,6 @@ def do_import_realm(import_dir: Path, subdomain: str) -> Realm:
     realm.notifications_stream_id = notifications_stream_id
     realm.save()
 
-    re_map_foreign_keys(data, 'zerver_defaultstream', 'stream', related_table="stream")
-    re_map_foreign_keys(data, 'zerver_realmemoji', 'author', related_table="user_profile")
-    for (table, model, related_table) in realm_tables:
-        re_map_foreign_keys(data, table, 'realm', related_table="realm")
-        update_model_ids(model, data, table, related_table)
-        bulk_import_model(data, model, table)
-
     # Remap the user IDs for notification_bot and friends to their
     # appropriate IDs on this server
     for item in data['zerver_userprofile_crossrealm']:
@@ -489,6 +482,13 @@ def do_import_realm(import_dir: Path, subdomain: str) -> Realm:
     for user_profile in user_profiles:
         user_profile.set_unusable_password()
     UserProfile.objects.bulk_create(user_profiles)
+
+    re_map_foreign_keys(data, 'zerver_defaultstream', 'stream', related_table="stream")
+    re_map_foreign_keys(data, 'zerver_realmemoji', 'author', related_table="user_profile")
+    for (table, model, related_table) in realm_tables:
+        re_map_foreign_keys(data, table, 'realm', related_table="realm")
+        update_model_ids(model, data, table, related_table)
+        bulk_import_model(data, model, table)
 
     if 'zerver_huddle' in data:
         bulk_import_model(data, Huddle, 'zerver_huddle')

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -829,6 +829,10 @@ def do_convert_data(slack_zip_file: str, output_dir: str, token: str, threads: i
         slack_data_dir, user_list, realm_id, added_users, added_recipient, added_channels,
         realm, realm['zerver_realmemoji'], domain_name)
 
+    # Move zerver_reactions to realm.json file
+    realm['zerver_reaction'] = message_json['zerver_reaction']
+    del message_json['zerver_reaction']
+
     emoji_folder = os.path.join(output_dir, 'emoji')
     os.makedirs(emoji_folder, exist_ok=True)
     emoji_records = process_emojis(realm['zerver_realmemoji'], emoji_folder, emoji_url_map, threads)


### PR DESCRIPTION
Gist of the PR:
**Commit 1:**
Moved 'zerver_reaction' field from the messages file to `realm.json` file.

**commit 2:**
Reactions are obtained from the messages exported.

**commit 3:**
In `zerver_reaction`, `the emoji_code` should be updated with the RealmEmoji allocated id when the `reaction_type` is `realm_emoji`. Hence we add an extra field `reaction_field` in function `re_map_foreign_keys`, to process the above mentioned condition.

**commit 4:**
RealmEmoji should be imported after UserProfile,
as the new user_profile ids are not allocated
if we import it before.

**commit 5**:
Export of RealmEmoji should also include the image file of those emojis.
Here, we export emojis both for local and S3 backend in a method with is similar to attachments and avatars.
Added tests for the same

Next I'll work upon: adding further tests for both `import_realm` and `export` modules and also finish up #9439 

