### PR TITLE
hotkey: Narrow to current compose box context.

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -3,9 +3,19 @@ zrequire('hashchange');
 zrequire('narrow_state');
 zrequire('people');
 zrequire('stream_data');
+zrequire('util');
 zrequire('Filter', 'js/filter');
 
 zrequire('narrow');
+
+set_global('topic_data', {
+});
+
+set_global('window', {
+    location : {
+        hash : 'foobar',
+    },
+});
 
 function set_filter(operators) {
     operators = _.map(operators, function (op) {
@@ -151,4 +161,153 @@ run_test('show_empty_narrow_message', () => {
     narrow.show_empty_narrow_message();
     assert.equal(hide_id,'.empty_feed_notice');
     assert.equal(show_id, '#empty_search_narrow_message');
+});
+
+run_test('test_by_stream_topic_name', () => {
+    var stream_ids = {
+        Veronica : 10,
+        Rome : 21,
+        zulip : 31,
+    };
+    var all_topics = {
+        10 : ['Veronica1', 'Veronica2'],
+        21 : [],
+        31 : ['issue1'],
+    };
+    stream_data.get_stream_id = function (stream) {
+        return stream_ids[stream];
+    };
+    topic_data.get_recent_names = function (stream_id) {
+        return all_topics[stream_id];
+    };
+
+
+
+    function get_operators(stream, topic) {
+        var operators;
+        narrow.activate = function (raw_operators) {
+            operators = raw_operators;
+            return;
+        };
+        narrow.by_stream_topic_name(stream, topic);
+        return operators;
+    }
+
+    // Both stream and Topic are existing
+    assert.deepEqual(get_operators('Veronica', 'Veronica1'), [
+        {operator: 'stream', operand: 'Veronica'},
+        {operator: 'topic', operand: 'Veronica1'},
+    ]);
+
+    // Only stream
+    assert.deepEqual(get_operators('Veronica', ''), [
+        {operator: 'stream', operand: 'Veronica'},
+    ]);
+
+    // Stream with incorrect topic
+    assert.deepEqual(get_operators('Veronica', 'Ver'), [
+        {operator: 'stream', operand: 'Veronica'},
+    ]);
+
+    // Stream with no topics in it
+    assert.deepEqual(get_operators('Rome', 'rome1'), [
+        {operator: 'stream', operand: 'Rome'},
+    ]);
+
+    // A topic with no stream
+    assert.deepEqual(get_operators('', 'Veronica2'), undefined);
+});
+
+run_test('test_by_recipient_name', () => {
+
+    function get_narrow_call(recipient) {
+        var called = '';
+        narrow.by = function (type) {
+            called = type;
+        };
+        narrow.by_recipient_name(recipient);
+        return called;
+    }
+
+    var valid_emails = ['aaron@zulip.com', 'iago@github.com'];
+    people.is_valid_email_for_compose = function (email) {
+        return valid_emails.includes(email);
+    };
+
+    people.email_list_to_user_ids_string = function () {};
+
+    // Invalid recipient
+    assert.equal(get_narrow_call('foo@zulip.com'), 'is');
+    assert.equal(get_narrow_call(''), 'is');
+    assert.equal(get_narrow_call('foo@zulip.com, aaron@zulip.com'), 'is');
+
+    // Valid recipient with different types of input
+    assert.equal(get_narrow_call('aaron@zulip.com'), 'pm-with');
+    assert.equal(get_narrow_call('aaron@zulip.com, iago@github.com'), 'pm-with');
+    assert.equal(get_narrow_call('aaron@zulip.com,iago@github.com, '), 'pm-with');
+
+});
+
+run_test('test_to_compose_target', () => {
+    set_global('compose_state', {
+    });
+
+    set_global('compose_actions', {
+        start : function () {},
+    });
+
+    function get_narrow_call() {
+        var narrow_by;
+        narrow.by_stream_topic_name = function () {
+            narrow_by = 'by_stream_topic_name';
+        };
+        narrow.by_recipient_name = function () {
+            narrow_by = 'by_recipient_name';
+        };
+        narrow.to_compose_target();
+        return narrow_by;
+    }
+
+    // Test if get_message_type is neither 'stream' nor 'private'
+    compose_state.get_message_type =  function () {
+        return '';
+    };
+    assert.equal(narrow.to_compose_target(), false);
+
+    // Test sending message to stream
+    compose_state.get_message_type =  function () {
+        return 'stream';
+    };
+
+    // Test if stream is empty
+    compose_state.stream_name = function () {
+        return '';
+    };
+    assert.equal(narrow.to_compose_target(), false);
+
+    // Test if stream is non empty with different topics.
+
+    _.each(['alpha', 'gamma'], function (stream_name) {
+        _.each(['', 'alpha-beta'], function (subject) {
+            compose_state.stream_name = function () {
+                return stream_name;
+            };
+            compose_state.subject = function () {
+                return subject;
+            };
+            assert.equal(get_narrow_call(), 'by_stream_topic_name');
+        });
+    });
+
+    // Test sending private message
+    compose_state.get_message_type =  function () {
+        return 'private';
+    };
+    _.each(['', 'alpha@beta.com, ', 'alpha@beta.com, gamma@beta.com'], function (recipient) {
+        compose_state.recipient = function () {
+            return recipient;
+        };
+        assert.equal(get_narrow_call(),'by_recipient_name');
+    });
+
 });

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -400,6 +400,15 @@ exports.quote_and_reply = function (opts) {
     });
 };
 
+exports.on_compose_narrow = function () {
+    if (compose_state.composing()) {
+        compose_fade.update_message_list();
+        return;
+    }
+
+    exports.cancel();
+};
+
 exports.on_narrow = function (opts) {
     // We use force_close when jumping between PM narrows with the "p" key,
     // so that we don't have an open compose box that makes it difficult

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -50,6 +50,7 @@ var keydown_unshift_mappings = {
 var keydown_cmd_or_ctrl_mappings = {
     75: {name: 'search_with_k', message_view_only: false}, // 'K'
     219: {name: 'escape', message_view_only: false}, // '['
+    220: {name: 'narrow_compose', message_view_only: false}, // '\'
 };
 
 var keydown_either_mappings = {
@@ -493,6 +494,11 @@ exports.process_hotkey = function (e, hotkey) {
             return true;
         }
         return false;
+    }
+
+    if (event_name === "narrow_compose" && compose_state.composing()) {
+        narrow.to_compose_target();
+        return true;
     }
 
     if ((event_name === 'up_arrow' || event_name === 'down_arrow') && overlays.streams_open()) {

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -256,7 +256,13 @@ exports.activate = function (raw_operators, opts) {
     $('#search_query').val(Filter.unparse(operators));
     search.update_button_visibility();
 
-    compose_actions.on_narrow(opts);
+    // If the trigger was due to compose_hotkey we
+    // keep the compose box in its previous state,
+    if (opts.trigger === "compose_hotkey") {
+        compose_actions.on_compose_narrow(opts);
+    } else {
+        compose_actions.on_narrow(opts);
+    }
 
     var current_filter = narrow_state.get_current_filter();
 
@@ -384,6 +390,67 @@ exports.update_selection = function (opts) {
         message_list.narrowed.view.set_message_offset(select_offset);
     }
     unread_ops.process_visible();
+};
+
+exports.to_compose_target = function () {
+    if (compose_state.get_message_type() === 'stream' && compose_state.stream_name() !== '') {
+        var stream = compose_state.stream_name();
+        var topic = compose_state.subject();
+        exports.by_stream_topic_name(stream, topic);
+        return true;
+    }
+    if (compose_state.get_message_type() === 'private') {
+        exports.by_recipient_name(compose_state.recipient());
+        return true;
+    }
+    return false;
+};
+
+exports.by_stream_topic_name = function (stream, topic) {
+    var stream_id = stream_data.get_stream_id(stream);
+
+    // If stream is incorrect, we dont do anything.
+    if (stream_id === undefined) {
+        return;
+    }
+
+    var topics = topic_data.get_recent_names(stream_id);
+
+    var opts = {
+        select_first_unread: true,
+        trigger: 'compose_hotkey',
+    };
+    // Narrow to stream only, if topic fails the check below.
+    var raw_operators = [
+        {operator: 'stream', operand: stream},
+    ];
+
+    // If topic is not null and exists in the stream,
+    // We narrow to topic, else stream.
+    if (topic !== '' && _.indexOf(topics, topic) >= 0) {
+        raw_operators.push({operator: 'topic', operand: topic});
+    }
+
+    exports.activate(raw_operators, opts);
+};
+
+exports.by_recipient_name = function (recipient) {
+    var private_recipients = util.extract_pm_recipients(recipient);
+    var invalid_recipients = _.reject(private_recipients, people.is_valid_email_for_compose);
+
+    var opts = {
+        select_first_unread: true,
+        trigger: 'compose_hotkey',
+    };
+
+    // If recipient contains invalid recipients or recipient is empty,
+    // narrow to all PMs.
+    if (invalid_recipients.length !== 0 || recipient === '') {
+        exports.by('is', 'private', opts);
+        return;
+    }
+    // For the well formed recipient, we narrow to that PM.
+    exports.by('pm-with', util.normalize_recipients(recipient), opts);
 };
 
 exports.stream_topic = function () {

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -186,6 +186,10 @@
                     <td class="hotkey">Esc, Ctrl + [</td>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
                 </tr>
+                <tr>
+                    <td class="hotkey">Ctrl + \</td>
+                    <td class="definition">{% trans %}Narrow to current compose box context{% endtrans %}</td>
+                </tr>
             </table>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -80,6 +80,8 @@ below, and add more to your repertoire as needed.
 
 * **Narrow to all messages**: `Esc` or `Ctrl` + `[` — Shows all unmuted messages.
 
+* **Narrow to current compose box context**: `Ctrl` + `\` — Narrows to the current stream/topic/PM in the compose box.
+
 ## Composing messages
 
 * **Reply to message**: `r` or `Enter` — Reply to the selected


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #6546.
Supersedes/revives: #7804 

Adds key <kbd>ctrl</kbd> + <kbd>\\</kbd>.

@showell had given an LGTM on the original PR. The rebase was a little tricky due to the branch being outdated but the main code is untouched.

**Testing Plan:** <!-- How have you tested? -->

Adds node tests. Manually tested.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
