### PR TITLE
Add server support for zform-based trivia bot.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
         "$": false,
         "_": false,
         "run_test": false,
+        "schema": false,
         "jQuery": false,
         "Spinner": false,
         "Handlebars": false,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -175,6 +175,7 @@
         "user_events": false,
         "voting_widget": false,
         "tictactoe_widget": false,
+        "zform": false,
         "widgetize": false,
         "submessage": false,
         "Plotly": false,

--- a/frontend_tests/node_tests/schema.js
+++ b/frontend_tests/node_tests/schema.js
@@ -1,0 +1,59 @@
+zrequire('schema');
+
+run_test('basics', () => {
+    assert.equal(schema.check_string('x', 'fred'), undefined);
+    assert.equal(schema.check_string('x', [1,2]), 'x is not a string');
+
+    const fields = {
+        foo: schema.check_string,
+        bar: schema.check_string,
+    };
+
+    const check_rec = (val) => {
+        return schema.check_record('my_rec', val, fields);
+    };
+
+    assert.equal(
+        check_rec({foo: 'apple', bar: 'banana'}),
+        undefined
+    );
+
+    assert.equal(
+        check_rec('bogus'),
+        'my_rec is not a record'
+    );
+
+    assert.equal(
+        check_rec({foo: 'apple'}),
+        'in my_rec bar is missing'
+    );
+
+    assert.equal(
+        check_rec({}),
+        'in my_rec bar is missing, foo is missing'
+    );
+
+    assert.equal(
+        check_rec({foo: 'apple', bar: 42}),
+        'in my_rec bar is not a string'
+    );
+
+    const check_array = (val) => {
+        return schema.check_array('lst', val, schema.check_string);
+    };
+
+    assert.equal(
+        check_array(['foo', 'bar']),
+        undefined
+    );
+
+    assert.equal(
+        check_array('foo'),
+        'lst is not an array'
+    );
+
+    assert.equal(
+        check_array(['foo', 3]),
+        'in lst we found an item where item is not a string'
+    );
+});

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1614,7 +1614,3 @@ run_test('handlebars_bug', () => {
     assert.equal(last_message_text, 'This is message two.');
 
 }());
-// By the end of this test, we should have compiled all our templates.  Ideally,
-// we will also have exercised them to some degree, but that's a little trickier
-// to enforce.
-global.make_sure_all_templates_have_been_compiled();

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -36,8 +36,6 @@ global.with_stub = stub.with_stub;
 
 // Set up helpers to render templates.
 var render = require('./render.js');
-global.make_sure_all_templates_have_been_compiled =
-    render.make_sure_all_templates_have_been_compiled;
 global.find_included_partials = render.find_included_partials;
 global.compile_template = render.compile_template;
 global.render_template = render.render_template;

--- a/frontend_tests/zjsunit/render.js
+++ b/frontend_tests/zjsunit/render.js
@@ -14,19 +14,6 @@ exports.init = function () {
     Handlebars.templates = {};
 };
 
-exports.make_sure_all_templates_have_been_compiled = function () {
-    var files = exports.template_finder.get_all();
-
-    _.each(files, function (file) {
-        if (file.name.indexOf('widget') >= 0) {
-            return;
-        }
-        if (!Handlebars.templates[file.name]) {
-            throw "The file " + file.url + " has no test coverage.";
-        }
-    });
-};
-
 exports.render_template = function (name, args) {
     exports.compile_template(name);
     return global.templates.render(name, args);

--- a/static/js/schema.js
+++ b/static/js/schema.js
@@ -1,0 +1,65 @@
+var schema = (function () {
+
+var exports = {};
+
+/*
+
+These runtime schema validators are defensive and
+should always succeed, so we don't necessarily want
+to translate these.  These are very similar to server
+side validators in zerver/lib/validator.py.
+
+*/
+
+exports.check_string = function (var_name, val) {
+    if (!_.isString(val)) {
+        return var_name + ' is not a string';
+    }
+};
+
+exports.check_record = function (var_name, val, fields) {
+    if (!_.isObject(val)) {
+        return var_name + ' is not a record';
+    }
+
+    var field_results = _.map(fields, function (f, field_name) {
+        if (val[field_name] === undefined) {
+            return field_name + ' is missing';
+        }
+        return f(field_name, val[field_name]);
+    });
+
+    var msg = _.filter(field_results).sort().join(', ');
+
+    if (msg) {
+        return 'in ' + var_name + ' ' + msg;
+    }
+};
+
+exports.check_array = function (var_name, val, checker) {
+    if (!_.isArray(val)) {
+        return var_name + ' is not an array';
+    }
+
+    var msg;
+
+    _.find(val, function (item) {
+        var res = checker('item', item);
+
+        if (res) {
+            msg = res;
+            return msg;
+        }
+    });
+
+    if (msg) {
+        return 'in ' + var_name + ' we found an item where ' + msg;
+    }
+};
+
+return exports;
+
+}());
+if (typeof module !== 'undefined') {
+    module.exports = schema;
+}

--- a/static/js/submessage.js
+++ b/static/js/submessage.js
@@ -30,6 +30,16 @@ exports.get_message_events = function (message) {
 };
 
 exports.process_submessages = function (in_opts) {
+    // This happens in our rendering path, so we try to limit any
+    // damage that may be triggered by one rogue message.
+    try {
+        return exports.do_process_submessages(in_opts);
+    } catch (err) {
+        blueslip.error('in process_submessages: ' + err.message);
+    }
+};
+
+exports.do_process_submessages = function (in_opts) {
     var message_id = in_opts.message_id;
     var message = message_store.get(message_id);
 

--- a/static/js/widgetize.js
+++ b/static/js/widgetize.js
@@ -6,6 +6,7 @@ var widgets = {};
 
 widgets.poll = voting_widget;
 widgets.tictactoe = tictactoe_widget;
+widgets.zform = zform;
 
 exports.activate = function (in_opts) {
     var widget_type = in_opts.widget_type;

--- a/static/js/zform.js
+++ b/static/js/zform.js
@@ -1,0 +1,115 @@
+var zform = (function () {
+
+var exports = {};
+
+exports.validate_extra_data = function (data) {
+    function check(data) {
+        function check_choice_data(data) {
+            function check_choice_item(field_name, val) {
+                return schema.check_record(field_name, val, {
+                    short_name: schema.check_string,
+                    long_name: schema.check_string,
+                    reply: schema.check_string,
+                });
+            }
+
+            function check_choices(field_name, val) {
+                return schema.check_array(
+                    field_name,
+                    val,
+                    check_choice_item
+                );
+            }
+
+            return schema.check_record('zform data', data, {
+                heading: schema.check_string,
+                choices: check_choices,
+            });
+        }
+
+        if (data.type === 'choices') {
+            return check_choice_data(data);
+        }
+
+        return 'unknown zform type: ' + data.type;
+    }
+
+
+    var msg = check(data);
+
+    if (msg) {
+        blueslip.warn(msg);
+        return false;
+    }
+
+    return true;
+};
+
+exports.activate = function (opts) {
+    var self = {};
+
+    var outer_elem = opts.elem;
+    var data = opts.extra_data;
+
+    if (!exports.validate_extra_data(data)) {
+        // callee will log reason we fail
+        return;
+    }
+
+    function make_choices(data) {
+        // Assign idx values to each of our choices so that
+        // our template can create data-idx values for our
+        // JS code to use later.
+        _.each(data.choices, function (choice, idx) {
+            choice.idx = idx;
+        });
+
+        var html = templates.render('zform-choices', data);
+        var elem = $(html);
+
+        elem.find('button').on('click', function (e) {
+            e.stopPropagation();
+
+            // Grab our index from the markup.
+            var idx = $(e.target).attr('data-idx');
+
+            // Use the index from the markup to dereference our
+            // data structure.
+            var reply_content = data.choices[idx].reply;
+
+            transmit.reply_message({
+                message: opts.message,
+                content: reply_content,
+            });
+        });
+
+        return elem;
+    }
+
+    function render() {
+        var rendered_widget;
+
+        if (data.type === 'choices') {
+            rendered_widget = make_choices(data);
+            outer_elem.html(rendered_widget);
+        }
+    }
+
+    self.handle_events = function (events) {
+        if (events) {
+            blueslip.info('unexpected');
+        }
+        render();
+    };
+
+    render();
+
+    return self;
+};
+
+return exports;
+
+}());
+if (typeof module !== 'undefined') {
+    module.exports = zform;
+}

--- a/static/styles/widgets.scss
+++ b/static/styles/widgets.scss
@@ -1,0 +1,17 @@
+.widget-choices ul {
+    padding: 3px;
+}
+
+.widget-choices li {
+    padding: 2px;
+    list-style: none;
+}
+
+.widget-choices button {
+    font-weight: 700;
+    color: blue;
+}
+
+.widget-choices-heading {
+    font-weight: 600;
+}

--- a/static/templates/widgets/zform-choices.handlebars
+++ b/static/templates/widgets/zform-choices.handlebars
@@ -1,0 +1,12 @@
+<div class="widget-choices">
+    <div class="widget-choices-heading">{{ heading }}</div>
+    <ul>
+        {{#each choices}}
+        <li>
+            <button data-idx="{{ this.idx }}">{{ this.short_name }}</button>
+            &nbsp;
+            {{ this.long_name }}
+        </li>
+        {{/each}}
+    </ul>
+</div>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -54,6 +54,7 @@ enforce_fully_covered = {
     'static/js/reactions.js',
     'static/js/recent_senders.js',
     'static/js/rtl.js',
+    'static/js/schema.js',
     'static/js/scroll_util.js',
     'static/js/search_suggestion.js',
     # Removed because we're migrating code from uncovered other settings pages to here.

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -141,7 +141,7 @@ except OSError:
     print('Bad command: %s' % (command,))
     raise
 except subprocess.CalledProcessError as e:
-    print('Tests failed, please fix!')
+    print('\n** Tests failed, PLEASE FIX! **\n')
     sys.exit(1)
 
 def check_line_coverage(fn, line_coverage, line_mapping, log=True):

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -79,7 +79,8 @@
         "./static/styles/media.scss",
         "./static/styles/typing_notifications.scss",
         "./static/styles/hotspots.scss",
-        "./static/styles/night_mode.scss"
+        "./static/styles/night_mode.scss",
+        "./static/styles/widgets.scss"
     ],
     "archive-styles": [
         "./node_modules/katex/dist/katex.css",

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -237,3 +237,48 @@ def validate_choice_field(var_name: str, field_data: str, value: object) -> None
     if value not in field_data_dict:
         msg = _("'{value}' is not a valid choice for '{field_name}'.")
         return msg.format(value=value, field_name=var_name)
+
+def check_widget_content(widget_content: object) -> Optional[str]:
+    if not isinstance(widget_content, dict):
+        return 'widget_content is not a dict'
+
+    if 'widget_type' not in widget_content:
+        return 'widget_type is not in widget_content'
+
+    if 'extra_data' not in widget_content:
+        return 'extra_data is not in widget_content'
+
+    widget_type = widget_content['widget_type']
+    extra_data = widget_content['extra_data']
+
+    if not isinstance(extra_data, dict):
+        return 'extra_data is not a dict'
+
+    if widget_type == 'zform':
+
+        if 'type' not in extra_data:
+            return 'zform is missing type field'
+
+        if extra_data['type'] == 'choices':
+            check_choices = check_list(
+                check_dict([
+                    ('short_name', check_string),
+                    ('long_name', check_string),
+                    ('reply', check_string),
+                ]),
+            )
+
+            checker = check_dict([
+                ('heading', check_string),
+                ('choices', check_choices),
+            ])
+
+            msg = checker('extra_data', extra_data)
+            if msg:
+                return msg
+
+            return None
+
+        return 'unknown zform type: ' + extra_data['type']
+
+    return 'unknown widget type: ' + widget_type

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -46,6 +46,13 @@ def do_widget_post_save_actions(message: MutableMapping[str, Any]) -> None:
     if content in ['/poll', '/tictactoe']:
         widget_type = content[1:]
 
+    widget_content = message.get('widget_content')
+    if widget_content is not None:
+        # Note that we validate this data in check_message,
+        # so we can trust it here.
+        widget_type = widget_content['widget_type']
+        extra_data = widget_content['extra_data']
+
     if widget_type:
         content = dict(
             widget_type=widget_type,

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -1,0 +1,56 @@
+from typing import Dict, Any
+
+from zerver.lib.test_classes import ZulipTestCase
+
+from zerver.lib.validator import check_widget_content
+
+class WidgetContentTestCase(ZulipTestCase):
+    def test_validation(self) -> None:
+        def assert_error(obj: object, msg: str) -> None:
+            self.assertEqual(check_widget_content(obj), msg)
+
+        assert_error(5,
+                     'widget_content is not a dict')
+
+        assert_error({},
+                     'widget_type is not in widget_content')
+
+        assert_error(dict(widget_type='whatever'),
+                     'extra_data is not in widget_content')
+
+        assert_error(dict(widget_type='zform', extra_data=4),
+                     'extra_data is not a dict')
+
+        assert_error(dict(widget_type='bogus', extra_data={}),
+                     'unknown widget type: bogus')
+
+        extra_data = dict()  # type: Dict[str, Any]
+        obj = dict(widget_type='zform', extra_data=extra_data)
+
+        assert_error(obj, 'zform is missing type field')
+
+        extra_data['type'] = 'bogus'
+        assert_error(obj, 'unknown zform type: bogus')
+
+        extra_data['type'] = 'choices'
+        assert_error(obj, 'heading key is missing from extra_data')
+
+        extra_data['heading'] = 'whatever'
+        assert_error(obj, 'choices key is missing from extra_data')
+
+        extra_data['choices'] = 99
+        assert_error(obj, 'extra_data["choices"] is not a list')
+
+        extra_data['choices'] = [99]
+        assert_error(obj, 'extra_data["choices"][0] is not a dict')
+
+        extra_data['choices'] = [
+            dict(long_name='foo', reply='bar'),
+        ]
+        assert_error(obj, 'short_name key is missing from extra_data["choices"][0]')
+
+        extra_data['choices'] = [
+            dict(short_name='a', long_name='foo', reply='bar'),
+        ]
+
+        self.assertEqual(check_widget_content(obj), None)

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -1153,6 +1153,7 @@ def send_message_backend(request: HttpRequest, user_profile: UserProfile,
                          topic_name: Optional[str]=REQ('subject',
                                                        converter=lambda x: x.strip(), default=None),
                          message_content: str=REQ('content'),
+                         widget_content: Optional[str]=REQ(default=None),
                          realm_str: Optional[str]=REQ('realm_str', default=None),
                          local_id: Optional[str]=REQ(default=None),
                          queue_id: Optional[str]=REQ(default=None),
@@ -1217,7 +1218,8 @@ def send_message_backend(request: HttpRequest, user_profile: UserProfile,
                              topic_name, message_content, forged=forged,
                              forged_timestamp = request.POST.get('time'),
                              forwarder_user_profile=user_profile, realm=realm,
-                             local_id=local_id, sender_queue_id=queue_id)
+                             local_id=local_id, sender_queue_id=queue_id,
+                             widget_content=widget_content)
     return json_success({"id": ret})
 
 def fill_edit_history_entries(message_history: List[Dict[str, Any]], message: Message) -> None:

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -958,6 +958,7 @@ JS_SPECS = {
             'js/filter.js',
             'js/voting_widget.js',
             'js/tictactoe_widget.js',
+            'js/zform.js',
             'js/widgetize.js',
             'js/submessage.js',
             'js/fetch_status.js',

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -923,6 +923,7 @@ JS_SPECS = {
             'templates/compiled.js',
             'js/feature_flags.js',
             'js/loading.js',
+            'js/schema.js',
             'js/util.js',
             'js/keydown_util.js',
             'js/lightbox_canvas.js',


### PR DESCRIPTION
These commits provide server-side support for building generic forms in the client specifying only **data** to the server.  The first example of this will be a triva bot.

The first four commits here are pretty foundational and straightforward, and I hope to get them to master soon.  The last couple are probably better targets for czo test deployment.

The trivia bot commit is not ready to merge, but it's worth mentioning here for further discussion:

https://github.com/zulip/python-zulip-api/pull/328