### PR TITLE
portico: Fix scrollbar appears for `not long` domain name.

### DIFF
--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -149,7 +149,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                     </label>
                     {% endif %}
 
-                    <div class="inline-block" id="subdomain_section" {% if root_domain_available and
+                    <div id="subdomain_section" {% if root_domain_available and
                       not form.realm_subdomain.errors and not form.realm_subdomain.value() %}style="display: none;"{% endif %}>
                         <div class="or"><span>{{ _('OR') }}</span></div>
                         <div class="inline-block relative">


### PR DESCRIPTION
Fixes #9516.
Scrollbar appeared in the subdomain input box while registering an
org. This is a hacky solution to the problem and doesn't work for
long domain names. A proper fix for the same should be provided in
the future.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->




![selection_137](https://user-images.githubusercontent.com/13910561/40448441-2962d9d6-5ef3-11e8-838d-21d24105317d.png)

