### PR TITLE
 i18n: Tag followup_day1 email templates for translation.

### DIFF
--- a/templates/zerver/emails/confirm_new_email.source.html
+++ b/templates/zerver/emails/confirm_new_email.source.html
@@ -26,6 +26,6 @@
 
 <p>
     {{ _("Cheers,") }}<br />
-    {{ _("Team Zulip") }}
+    {{ _("The Zulip Team") }}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/confirm_new_email.txt
+++ b/templates/zerver/emails/confirm_new_email.txt
@@ -13,4 +13,4 @@ If you did not request this change, please contact us immediately at
 {% endtrans %}
 
 {{ _("Cheers,") }}
-{{ _("Team Zulip") }}
+{{ _("The Zulip Team") }}

--- a/templates/zerver/emails/confirm_registration.source.html
+++ b/templates/zerver/emails/confirm_registration.source.html
@@ -24,6 +24,6 @@
 </p>
 <p>
     {{ _("Cheers,") }}<br />
-    {{ _("Team Zulip") }}
+    {{ _("The Zulip Team") }}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/confirm_registration.txt
+++ b/templates/zerver/emails/confirm_registration.txt
@@ -8,4 +8,4 @@
 {% trans %}Feel free to give us a shout at <{{ support_email }}> if you have any questions.{% endtrans %}
 
 {{ _("Cheers,") }}
-{{ _("Team Zulip") }}
+{{ _("The Zulip Team") }}

--- a/templates/zerver/emails/followup_day1.source.html
+++ b/templates/zerver/emails/followup_day1.source.html
@@ -5,42 +5,61 @@
 {% endblock %}
 
 {% block content %}
-<p>Hi there,</p>
+<p>{{ _('Hi there,') }}</p>
 
-<p>Welcome to Zulip! A few tips to get you started:</p>
+<p>{{ _('Welcome to Zulip! A few tips to get you started:') }}</p>
 <p>
-    &bull; Zulip works best when it's always open, so we suggest downloading
+    &bull;
+    {% trans %}
+    Zulip works best when it's always open, so we suggest downloading
     our <a href="https://zulipchat.com/apps">desktop and mobile apps</a>.
+    {% endtrans %}
     <br/><br/>
-    You'll need an Organization URL when first starting the app. That's
-    <br/><b>{{ realm_uri }}</b>
+    {% trans %}
+    You'll need an Organization URL when first starting the app, which is:
+    {% endtrans %}
+    <br/>
+    <b>{{ realm_uri }}</b>
 </p>
 <p>
-    &bull; Become a Zulip pro with a few
+    &bull;
+    {% trans %}
+    Become a Zulip pro with a few
     <a href="{{ keyboard_shortcuts_link }}">keyboard shortcuts</a>:
+    {% endtrans %}
     <br/>
-    <b>n</b>: Next unread thread<br/>
-    <b>r</b>: Reply to message under the blue box<br/>
-    <b>c</b>: Start a new topic
+    <b>n</b>: {{ _('Next unread thread') }}<br/>
+    <b>r</b>: {{ _('Reply to message under the blue box') }}<br/>
+    <b>c</b>: {{ _('Start a new topic') }}
 </p>
 <p>
-    &bull; Give our <a href="{{ getting_started_link }}">guide for new
+    &bull;
+    {% trans %}
+    Give our <a href="{{ getting_started_link }}">guide for new
     {{ user_role_group }}</a> a spin.
+    {% endtrans %}
 </p>
 <p>
     <br/>
+    {% trans %}
     Zulip combines the real-time ease of chat with the threaded organization
     of email. Zulip is about productivity&mdash;making communication fun and
     easy, while avoiding the distracting and disorganized conversations of
     chatrooms. We hope you love using Zulip as much as we do.
+    {% endtrans %}
 </p>
 
-<p>Cheers,<br/>Team Zulip</p>
+<p>
+    {{ _("Cheers,") }}<br />
+    {{ _("Team Zulip") }}
+</p>
 
 <p>
+    {% trans %}
     PS: Follow us on <a href="https://twitter.com/zulip">Twitter</a>,
     star us on <a href="https://github.com/zulip/zulip">GitHub</a>, or
     chat with us live on the
     <a href="https://chat.zulip.org">Zulip community server</a>!
+    {% endtrans %}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/followup_day1.source.html
+++ b/templates/zerver/emails/followup_day1.source.html
@@ -24,13 +24,8 @@
     <b>c</b>: Start a new topic
 </p>
 <p>
-    &bull; Give our
-    {% if is_realm_admin %}
-    <a href="{{ organization_setup_advice_link }}">guide for new admins</a>
-    {% else %}
-    <a href="{{ getting_started_with_zulip_link }}">guide for new users</a>
-    a spin.
-    {% endif %}
+    &bull; Give our <a href="{{ getting_started_link }}">guide for new
+    {{ user_role_group }}</a> a spin.
 </p>
 <p>
     <br/>

--- a/templates/zerver/emails/followup_day1.source.html
+++ b/templates/zerver/emails/followup_day1.source.html
@@ -51,7 +51,7 @@
 
 <p>
     {{ _("Cheers,") }}<br />
-    {{ _("Team Zulip") }}
+    {{ _("The Zulip Team") }}
 </p>
 
 <p>

--- a/templates/zerver/emails/followup_day1.subject
+++ b/templates/zerver/emails/followup_day1.subject
@@ -1,1 +1,1 @@
-Welcome to Zulip
+{{ _('Welcome to Zulip') }}

--- a/templates/zerver/emails/followup_day1.txt
+++ b/templates/zerver/emails/followup_day1.txt
@@ -13,12 +13,8 @@ You'll need an Organization URL when installing the apps. That's
   r: Reply to message under the blue box
   c: Start a new topic
 
-* Check out our guide for new users:
-{% if is_realm_admin %}
-{{ organization_setup_advice_link }}.
-{% else %}
-{{ getting_started_with_zulip_link }}.
-{% endif %}
+* Give our guide for new {{ user_role_group }} ({{ getting_started_link }})
+  a spin.
 
 * Zulip combines the real-time ease of chat with the threaded organization
   of email. Zulip is about productivity---making communication fun and

--- a/templates/zerver/emails/followup_day1.txt
+++ b/templates/zerver/emails/followup_day1.txt
@@ -1,29 +1,39 @@
-Hi there,
+{{ _('Hi there,') }}
 
-Welcome to Zulip! A few tips to get you started:
+{{ _('Welcome to Zulip! A few tips to get you started:') }}
 
+{% trans %}
 * Zulip works best when it's always open, so we suggest pinning a browser
-tab or downloading our desktop and mobile apps (https://zulipchat.com/apps).
+  tab or downloading our desktop and mobile apps (https://zulipchat.com/apps).
+{% endtrans %}
 
-You'll need an Organization URL when installing the apps. That's
+{% trans %}
+You'll need an Organization URL when installing the apps, which is:
+{% endtrans %}
 {{ realm_uri }}
 
-* Become a Zulip pro with a few keyboard shortcuts:
-  n: Next unread thread
-  r: Reply to message under the blue box
-  c: Start a new topic
+* {{ _('Become a Zulip pro with a few keyboard shortcuts:') }}
+  n: {{ _('Next unread thread') }}
+  r: {{ _('Reply to message under the blue box') }}
+  c: {{ _('Start a new topic') }}
 
+{% trans %}
 * Give our guide for new {{ user_role_group }} ({{ getting_started_link }})
   a spin.
+{% endtrans %}
 
+{% trans %}
 * Zulip combines the real-time ease of chat with the threaded organization
   of email. Zulip is about productivity---making communication fun and
   easy, while avoiding the distracting and disorganized conversations of
   chatrooms. We hope you love using Zulip as much as we do.
+{% endtrans %}
 
-Cheers,
-Team Zulip
+{{ _("Cheers,") }}
+{{ _("Team Zulip") }}
 
+{% trans %}
 PS: Check us out on Twitter (@zulip), star us on GitHub
 (https://github.com/zulip/zulip), or chat with us live on the
 Zulip community server (https://chat.zulip.org)!
+{% endtrans %}

--- a/templates/zerver/emails/followup_day1.txt
+++ b/templates/zerver/emails/followup_day1.txt
@@ -30,7 +30,7 @@ You'll need an Organization URL when installing the apps, which is:
 {% endtrans %}
 
 {{ _("Cheers,") }}
-{{ _("Team Zulip") }}
+{{ _("The Zulip Team") }}
 
 {% trans %}
 PS: Check us out on Twitter (@zulip), star us on GitHub

--- a/templates/zerver/emails/invitation.source.html
+++ b/templates/zerver/emails/invitation.source.html
@@ -23,6 +23,6 @@
 </p>
 <p>
     {{ _("Cheers,") }}<br />
-    {{ _("Zulip Team") }}
+    {{ _("The Zulip Team") }}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/invitation.txt
+++ b/templates/zerver/emails/invitation.txt
@@ -8,4 +8,4 @@
 {% trans %}Feel free to give us a shout at <{{ support_email }}> if you have any questions.{% endtrans %}
 
 {{ _("Cheers,") }}
-{{ _("Zulip Team") }}
+{{ _("The Zulip Team") }}

--- a/templates/zerver/emails/invitation_reminder.source.html
+++ b/templates/zerver/emails/invitation_reminder.source.html
@@ -19,6 +19,6 @@
 </p>
 <p>
     {{ _("Cheers,") }}<br />
-    {{ _("Zulip Team") }}
+    {{ _("The Zulip Team") }}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/invitation_reminder.txt
+++ b/templates/zerver/emails/invitation_reminder.txt
@@ -8,4 +8,4 @@
 {% trans %}We're here for you at <{{ support_email }}> if you have any questions.{% endtrans %}
 
 {{ _("Cheers,") }}
-{{ _("Zulip Team") }}
+{{ _("The Zulip Team") }}

--- a/templates/zerver/emails/notify_change_in_email.source.html
+++ b/templates/zerver/emails/notify_change_in_email.source.html
@@ -11,6 +11,6 @@
 </p>
 <p>
     {{ _("Best,") }}<br />
-    {{ _("Team Zulip") }}
+    {{ _("The Zulip Team") }}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/notify_change_in_email.txt
+++ b/templates/zerver/emails/notify_change_in_email.txt
@@ -7,4 +7,4 @@ please contact us immediately at <{{ support_email }}>.
 {% endtrans %}
 
 {{ _("Best,") }}
-{{ _("Team Zulip") }}
+{{ _("The Zulip Team") }}

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -511,12 +511,13 @@ def enqueue_welcome_emails(user: UserProfile) -> None:
     context = common_context(user)
     context.update({
         'unsubscribe_link': unsubscribe_link,
-        'organization_setup_advice_link':
-        user.realm.uri + '/help/getting-your-organization-started-with-zulip',
-        'getting_started_with_zulip_link':
-        user.realm.uri + '/help/getting-started-with-zulip',
+        'user_role_group': 'admins' if user.is_realm_admin else 'users',
+        'getting_started_link':
+            user.realm.uri +
+            ('/help/getting-your-organization-started-with-zulip'
+             if user.is_realm_admin else
+             '/help/getting-started-with-zulip'),
         'keyboard_shortcuts_link': user.realm.uri + '/help/keyboard-shortcuts',
-        'is_realm_admin': user.is_realm_admin,
     })
     send_future_email(
         "zerver/emails/followup_day1", user.realm, to_user_id=user.id, from_name=from_name,


### PR DESCRIPTION
Tagging for translation the text in the `followup_day1` email templates.

**Testing Plan:** All lint and template checks passed.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
