### PR TITLE
stream: Deduplicate template code for stream privacy types.

### DIFF
--- a/static/templates/subscription_creation_form.handlebars
+++ b/static/templates/subscription_creation_form.handlebars
@@ -29,32 +29,7 @@
                     {{/tr}}
                 </div>
 
-                <ul class="grey-box">
-                    <li>
-                        <label class="radio">
-                            <input type="radio" name="privacy" value="public" checked />
-                            {{#tr this}}
-                            <b>Public:</b> anyone can join; anyone can view complete message history without joining
-                            {{/tr}}
-                        </label>
-                    </li>
-                    <li>
-                        <label class="radio">
-                            <input type="radio" name="privacy" value="invite-only" />
-                            {{#tr this}}
-                            <b>Private:</b> must be invited by a member; new members can only see messages sent after they join; hidden from non-administrator users
-                            {{/tr}}
-                        </label>
-                    </li>
-                    <li>
-                        <label class="radio">
-                            <input type="radio" name="privacy" value="invite-only-public-history" />
-                            {{#tr this}}
-                            <b>Private with history:</b> must be invited by a member; new members can view complete message history; hidden from non-administrator users
-                            {{/tr}}
-                        </label>
-                    </li>
-                </ul>
+                {{ partial "stream_types" "is_public" true }}
 
                 <div id="announce-new-stream">
                     <label class="checkbox">


### PR DESCRIPTION
Follow-up of #9243.
Manual testing: GIF
![template](https://user-images.githubusercontent.com/22238472/40483909-610f0f06-5f77-11e8-86b1-e58acc2a8059.gif)
