### PR TITLE
messages: Allow "no topic" topics editable indefinitely.

### DIFF
--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -2116,6 +2116,12 @@ class EditMessageTest(ZulipTestCase):
         self.login(self.example_email("cordelia"))
         do_edit_message_assert_error(id_, 'F', "The time limit for editing this message has passed")
 
+        # anyone should be able to edit "no topic" indefinitely
+        message.subject = "(no topic)"
+        message.save()
+        self.login(self.example_email("cordelia"))
+        do_edit_message_assert_success(id_, 'D')
+
     def test_propagate_topic_forward(self) -> None:
         self.login(self.example_email("hamlet"))
         id1 = self.send_stream_message(self.example_email("hamlet"), "Scotland",


### PR DESCRIPTION
Fixes: #9484.
Just to make sure, message who don't have any topic have `subject` as `(no topic)`?