### PR TITLE
portico: Adjust registeration form size based on subdomain name length.

### DIFF
--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -223,7 +223,7 @@ html {
 
 .register-account .terms-of-service .input-group {
     width: 330px;
-    margin-bottom: 0 auto 10px;
+    margin: 0 auto 10px;
 }
 
 .register-account .terms-of-service .text-error {
@@ -401,11 +401,10 @@ html {
     font-size: 0.7em;
     font-weight: 600;
     text-align: left;
-    height: 0;
 
     position: relative;
     top: -4px;
-    left: 1px;
+    margin-left: 1px;
 }
 
 .new-style .input-box label.text-error {
@@ -689,16 +688,15 @@ button.login-google-button {
 
 #registration .input-box label {
     position: absolute;
-    margin: 0;
+    margin: 0 0 2px 0;
     top: 0;
-    left: 2px;
 }
 
 #registration .input-box label.static {
-    width: 100%;
+    width: 330px;
+    margin: 0 auto;
     text-align: left;
     position: static !important;
-    margin-left: 2px;
 }
 
 #registration [for="realm_in_root_domain"] {
@@ -716,6 +714,7 @@ button.login-google-button {
 }
 
 #registration #id_team_subdomain.subdomain {
+    display: inline-block;
     text-align: right;
     position: relative;
     padding-right: 10px;
@@ -725,20 +724,14 @@ button.login-google-button {
 
 #registration #id_team_subdomain.subdomain + .realm_subdomain_label {
     margin-top: 12px;
-    margin-left: 180px;
     display: inline-block;
+    position: relative;
 
     font-weight: normal;
-    font-size: inherit;
 }
 
 #registration #id_team_subdomain.subdomain {
     margin-top: 0px;
-}
-
-#registration #subdomain_section .inline-block {
-    width: 100%;
-    overflow-x: auto;
 }
 
 #registration #subdomain_section .or {
@@ -751,6 +744,17 @@ button.login-google-button {
 
 .static.org-url + #subdomain_section .or {
     display: none;
+}
+
+#org-url-input-box {
+    width: unset !important;
+}
+
+#subdomain-container {
+    max-width: calc(100vw - 60px);    
+    width: 100%;
+    white-space: nowrap;
+    overflow-x: auto;
 }
 
 #registration .input-box.full-width {

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -47,7 +47,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                     </div>
                 </div>
 
-                <div class="input-box">
+                <div id="org-url-input-box" class="input-box">
                     <label class="static org-url">
                         {{ _('Organization URL') }}
                     </label>
@@ -63,7 +63,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                     <div id="subdomain_section" {% if root_domain_available and
                       not form.realm_subdomain.errors and not form.realm_subdomain.value() %}style="display: none;"{% endif %}>
                         <div class="or"><span>{{ _('OR') }}</span></div>
-                        <div class="inline-block relative">
+                        <div id="subdomain-container" class="relative">
                             <input id="id_team_subdomain"
                               class="{% if root_domain_landing_page %}required{% endif %} subdomain" type="text"
                               placeholder="acme"


### PR DESCRIPTION
For desktop screens, scrollbar won't appear for long domain names.
While for mobile screens, scrollbar may appear for long domain names.
Note: 330px is the width of an input box.

Desktop:
![selection_145](https://user-images.githubusercontent.com/13910561/40501640-129498bc-5fa6-11e8-99fd-046954195cd0.png)

Mobile:
![peek 2018-05-24 22-58](https://user-images.githubusercontent.com/13910561/40501648-1d4326de-5fa6-11e8-9597-4ed462f45a67.gif)

(I generally tend to take screenshots larger than the area effected by PR changes in order to give an overall feel of the changes, let me know if you prefer clear-cut screenshot of the changes)

The ____ input suggested [here](https://chat.zulip.org/#narrow/stream/101-design/topic/org.20register.20long.20domain) can be pursued in a follow up issue
