### PR TITLE
Python dependency upgrade

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -79,7 +79,7 @@ httplib2==0.11.3
 premailer==3.2.0
 
 # Needed for JWT-based auth
-PyJWT==1.6.1
+PyJWT==1.6.4
 
 # Needed for including other markdown files for user docs
 markdown-include==0.5.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -120,7 +120,7 @@ pycrypto==2.6.1
 pydispatcher==2.0.5       # via scrapy
 pyflakes==2.0.0
 pygments==2.2.0
-pyjwt==1.6.1
+pyjwt==1.6.4
 pyldap==3.0.0.post1       # via fakeldap
 pylibmc==1.5.2
 pyoembed==0.1.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -85,7 +85,7 @@ pyasn1==0.4.3
 pycparser==2.18           # via cffi
 pycrypto==2.6.1
 pygments==2.2.0
-pyjwt==1.6.1
+pyjwt==1.6.4
 pylibmc==1.5.2
 pyoembed==0.1.2
 pyopenssl==17.3.0         # via ndg-httpsclient

--- a/tools/list-outdated-packages
+++ b/tools/list-outdated-packages
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import subprocess
+import os
+
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.chdir(ZULIP_PATH)
+
+output = subprocess.check_output(['pip', 'list', '--outdated', '--format',
+                                  'columns']).decode('utf-8').splitlines()
+
+packages_info = output[2:]
+
+for package_line in packages_info:
+    package_name = package_line.split()[0]
+    package_current_version = package_line.split()[1]
+    package_latest_version = package_line.split()[2]
+    try:
+        output = subprocess.check_output(['grep', '-r', package_name, 'requirements', '--exclude=*.txt',
+                                          '--include=pip.txt']).decode('utf-8')
+        print(package_name, "|", package_current_version, "|", package_latest_version)
+    except subprocess.CalledProcessError:
+        pass

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '20.2'
+PROVISION_VERSION = '20.3'


### PR DESCRIPTION
# Upgraded

|Package|Old|New|Status|
|---------|----|----|---|
apns2 | 0.3.0 | 0.4.1| :+1: 
disposable-email-domains | 0.0.26 | 0.0.28| :+1: 
ipython | 6.3.1 | 6.4.0| :+1: 
oauthlib | 2.0.7 | 2.1.0| :+1: 
pyasn1 | 0.4.2 | 0.4.3| :+1: 
pyflakes | 1.6.0 | 2.0.0| :+1: 
pytz | 2018.3 | 2018.4| :+1: 
stripe | 1.80.0 | 1.82.1| :+1: 
twilio | 6.13.0 | 6.14.0| :+1: 
setuptools | 39.1.0 | 39.2.0| :+1: 
wheel | 0.30.0 | 0.31.1| :+1: 

# Known issues
|Package|Old|New|Status|
|---------|----|----|---|
CommonMark | 0.5.4 | 0.7.5| Will break
Django | 1.11.11 | 2.0.5| PR open
sh | 1.11 | 1.12.14 | #via gitlint
pika | 0.11.0 | 0.11.2| #8466
pip | 9.0.3 | 10.0.1| #9308
statsd | 3.2.1 | 3.2.2 | # via django-statsd-mozilla
talon | 1.2.11 | 1.4.4| Will break
tornado | 4.5.3 | 5.0.2| Issue open
transifex-client | 0.12.5 | 0.13.3| #8914


