### PR TITLE
documentation: Change #electron stream links to #desktop stream link.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ on.
   [bots](https://github.com/zulip/python-zulip-api/issues?q=is%3Aopen+is%3Aissue)
   development, check the respective links for open issues, or post in
   [#mobile](https://chat.zulip.org/#narrow/stream/mobile),
-  [#electron](https://chat.zulip.org/#narrow/stream/electron), or
+  [#desktop](https://chat.zulip.org/#narrow/stream/desktop), or
   [#bots](https://chat.zulip.org/#narrow/stream/bots).
 * For the main server and web repository, start by looking through issues
   with the label
@@ -188,7 +188,7 @@ If you have a feature request or are not yet sure what the underlying bug
 is, the best place to post issues is
 [#issues](https://chat.zulip.org/#narrow/stream/issues) (or
 [#mobile](https://chat.zulip.org/#narrow/stream/mobile) or
-[#electron](https://chat.zulip.org/#narrow/stream/electron)) on the
+[#desktop](https://chat.zulip.org/#narrow/stream/desktop)) on the
 [Zulip community server](https://zulip.readthedocs.io/en/latest/contributing/chat-zulip-org.html).
 This allows us to interactively figure out what is going on, let you know if
 a similar issue has already been opened, and collect any other information

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,20 +58,20 @@ to help.
   [Zulip community server](https://zulip.readthedocs.io/en/latest/contributing/chat-zulip-org.html),
   paying special attention to the community norms. If you'd like, introduce
   yourself in
-  [#new members](https://chat.zulip.org/#narrow/stream/new.20members), using
+  [#new members](https://chat.zulip.org/#narrow/stream/95-new-members), using
   your name as the topic. Bonus: tell us about your first impressions of
   Zulip, and anything that felt confusing/broken as you started using the
   product.
 * Read [What makes a great Zulip contributor](#what-makes-a-great-zulip-contributor).
 * [Install the development environment](https://zulip.readthedocs.io/en/latest/development/overview.html),
   getting help in
-  [#development help](https://chat.zulip.org/#narrow/stream/development.20help)
+  [#development help](https://chat.zulip.org/#narrow/stream/49-development-help)
   if you run into any troubles.
 * Read the
   [Zulip guide to Git](https://zulip.readthedocs.io/en/latest/git/index.html)
   and do the Git tutorial (coming soon) if you are unfamiliar with Git,
   getting help in
-  [#git help](https://chat.zulip.org/#narrow/stream/git.20help) if you run
+  [#git help](https://chat.zulip.org/#narrow/stream/44-git-help) if you run
   into any troubles.
 * Sign the
   [Dropbox Contributor License Agreement](https://opensource.dropbox.com/cla/).
@@ -88,9 +88,9 @@ on.
   or
   [bots](https://github.com/zulip/python-zulip-api/issues?q=is%3Aopen+is%3Aissue)
   development, check the respective links for open issues, or post in
-  [#mobile](https://chat.zulip.org/#narrow/stream/mobile),
-  [#desktop](https://chat.zulip.org/#narrow/stream/desktop), or
-  [#bots](https://chat.zulip.org/#narrow/stream/bots).
+  [#mobile](https://chat.zulip.org/#narrow/stream/48-mobile),
+  [#desktop](https://chat.zulip.org/#narrow/stream/16-desktop), or
+  [#integration](https://chat.zulip.org/#narrow/stream/127-integrations).
 * For the main server and web repository, start by looking through issues
   with the label
   [good first issue](https://github.com/zulip/zulip/issues?q=is%3Aopen+is%3Aissue+label%3A"good+first+issue").
@@ -101,7 +101,7 @@ on.
   click on some of the `area:` labels to see all the issues related to your
   areas of interest.
 * If the lists of issues are overwhelming, post in
-  [#new members](https://chat.zulip.org/#narrow/stream/new.20members) with a
+  [#new members](https://chat.zulip.org/#narrow/stream/95-new-members) with a
   bit about your background and interests, and we'll help you out. The most
   important thing to say is whether you're looking for a backend (Python),
   frontend (JavaScript), mobile (React Native), desktop (Electron),
@@ -111,7 +111,7 @@ on.
 We also welcome suggestions of features that you feel would be valuable or
 changes that you feel would make Zulip a better open source project. If you
 have a new feature you'd like to add, we recommend you start by posting in
-[#new members](https://chat.zulip.org/#narrow/stream/new.20members) with the
+[#new members](https://chat.zulip.org/#narrow/stream/95-new-members) with the
 feature idea and the problem that you're hoping to solve.
 
 Other notes:
@@ -186,9 +186,9 @@ bugs, feel free to just open an issue on the relevant project on GitHub.
 
 If you have a feature request or are not yet sure what the underlying bug
 is, the best place to post issues is
-[#issues](https://chat.zulip.org/#narrow/stream/issues) (or
-[#mobile](https://chat.zulip.org/#narrow/stream/mobile) or
-[#desktop](https://chat.zulip.org/#narrow/stream/desktop)) on the
+[#issues](https://chat.zulip.org/#narrow/stream/9-issues) (or
+[#mobile](https://chat.zulip.org/#narrow/stream/48-mobile) or
+[#desktop](https://chat.zulip.org/#narrow/stream/16-desktop)) on the
 [Zulip community server](https://zulip.readthedocs.io/en/latest/contributing/chat-zulip-org.html).
 This allows us to interactively figure out what is going on, let you know if
 a similar issue has already been opened, and collect any other information

--- a/docs/contributing/chat-zulip-org.md
+++ b/docs/contributing/chat-zulip-org.md
@@ -13,7 +13,7 @@ minutes to a few hours, depending on the time of day.
 ## Community norms
 
 * Send test messages to
-  [#test here](https://chat.zulip.org/#narrow/stream/test.20here) or
+  [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) or
   as a PM to yourself to avoid disturbing others.
 * When asking for help, provide the details needed for others to help
   you.  E.g. include the full traceback in a code block (not a
@@ -37,7 +37,7 @@ minutes to a few hours, depending on the time of day.
   love meeting new people, hearing about what brought them to Zulip,
   and getting their feedback.  If you're not sure where to start,
   introduce yourself and your interests in
-  [#new members](https://chat.zulip.org/#narrow/stream/new.20members),
+  [#new members](https://chat.zulip.org/#narrow/stream/95-new-members),
   using your name as the topic.
 
 ## High traffic community
@@ -67,19 +67,19 @@ secret/embarrassing, etc.
 There are a few streams worth highlighting that are relevant for
 everyone, even non-developers:
 
-* [#announce](https://chat.zulip.org/#narrow/stream/announce) is for
+* [#announce](https://chat.zulip.org/#narrow/stream/1-announce) is for
   announcements and discussions thereof; we try to keep traffic there
   to a minimum.
-* [#feedback](https://chat.zulip.org/#narrow/stream/feedback) is for
+* [#feedback](https://chat.zulip.org/#narrow/stream/137-feedback) is for
   posting feedback on Zulip.
-* [#design](https://chat.zulip.org/#narrow/stream/design) is where we
+* [#design](https://chat.zulip.org/#narrow/stream/101-design) is where we
   discuss UI and feature design and collect feedback on potential design
   changes.  We love feedback, so don't hesitate to speak up!
-* [#user community](https://chat.zulip.org/#narrow/stream/user.20community) is
+* [#user community](https://chat.zulip.org/#narrow/stream/138-user-community) is
   for Zulip users to discuss their experiences using and adopting Zulip.
-* [#production help](https://chat.zulip.org/#narrow/stream/production.20help)
+* [#production help](https://chat.zulip.org/#narrow/stream/31-production-help)
   is for production environment related discussions.
-* [#test here](https://chat.zulip.org/#narrow/stream/test.20here) is
+* [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) is
   for sending test messages without inconveniencing other users :).
   We recommend muting this stream when not using it.
 
@@ -88,25 +88,25 @@ community (e.g. one for each app, etc.); check out the
 [Streams page](https://chat.zulip.org/#streams/all) to see the
 descriptions for all of them.  Relevant to almost everyone are these:
 
-* [#checkins](https://chat.zulip.org/#narrow/stream/checkins) is for
+* [#checkins](https://chat.zulip.org/#narrow/stream/65-checkins) is for
   progress updates on what you're working on and its status; usually
   folks post with their name as the topic.  Everyone is welcome to
   participate!
-* [#development help](https://chat.zulip.org/#narrow/stream/development.20help)
+* [#development help](https://chat.zulip.org/#narrow/stream/49-development-help)
   is for asking for help with any Zulip server/webapp development work
   (use the app streams for help working on one of the apps).
-* [#code review](https://chat.zulip.org/#narrow/stream/code.20review)
+* [#code review](https://chat.zulip.org/#narrow/stream/91-code-review)
   is for getting feedback on your work.  We encourage all developers
   to comment on work posted here, even if you're new to the Zulip
   project; reviewing other PRs is a great way to develop experience,
   and even just manually testing a proposed new feature and posting
   feedback is super helpful.
-* [#documentation](https://chat.zulip.org/#narrow/stream/documentation)
+* [#documentation](https://chat.zulip.org/#narrow/stream/19-documentation)
   is where we discuss improving Zulip's user, sysadmin, and developer
   documentation.
-* [#translation](https://chat.zulip.org/#narrow/stream/translation) is
+* [#translation](https://chat.zulip.org/#narrow/stream/58-translation) is
   for discussing Zulip's translations.
-* [#learning](https://chat.zulip.org/#narrow/stream/learning) is for
+* [#learning](https://chat.zulip.org/#narrow/stream/92-learning) is for
   posting great learning resources one comes across.
 
 ## Chat meetings
@@ -127,13 +127,13 @@ Here are the regular meetings that exist today along with their usual
 times:
 
 * Mobile team on
-[#mobile](https://chat.zulip.org/#narrow/stream/mobile), generally
+[#mobile](https://chat.zulip.org/#narrow/stream/48-mobile), generally
 Wednesdays at 10AM Pacific time.
 
 * Backend/infrastructure team on
-[#backend](https://chat.zulip.org/#narrow/stream/backend), generally
+[#backend](https://chat.zulip.org/#narrow/stream/3-backend), generally
 Fridays at 10AM Pacific time.
 
 * Bots and integrations team on
-[#integrations](https://chat.zulip.org/#narrow/stream/integrations),
+[#integrations](https://chat.zulip.org/#narrow/stream/127-integrations),
 generally Fridays at 9AM Pacific time.

--- a/docs/development/request-remote.md
+++ b/docs/development/request-remote.md
@@ -43,7 +43,7 @@ zulip/zulip, you are ready to request your Zulip developer instance.
 If you haven't already, create an account on https://chat.zulip.org/.
 
 Next, join the [development
-help](https://chat.zulip.org/#narrow/stream/development.20help) stream. Create a
+help](https://chat.zulip.org/#narrow/stream/49-development-help) stream. Create a
 new **stream message** with your GitHub username as the **topic** and request
 your remote dev instance. **Please make sure you have completed steps 1 and 2
 before doing so**. A core developer should reply letting you know they're

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -23,7 +23,7 @@ Contents:
 environment,** check
 [Troubleshooting and Common Errors](#troubleshooting-and-common-errors). If
 that doesn't help, please visit
-[#provision help](https://chat.zulip.org/#narrow/stream/provision.20help)
+[#provision help](https://chat.zulip.org/#narrow/stream/21-provision-help)
 in the [Zulip development community server](../contributing/chat-zulip-org.html) for
 real-time help, send a note to the
 [Zulip-devel Google group](https://groups.google.com/forum/#!forum/zulip-devel)
@@ -341,7 +341,7 @@ without provisioning after the first time).  Other common issues are
 documented in the
 [Troubleshooting and Common Errors](#troubleshooting-and-common-errors)
 section.  If that doesn't help, please visit
-[#provision help](https://chat.zulip.org/#narrow/stream/provision.20help)
+[#provision help](https://chat.zulip.org/#narrow/stream/21-provision-help)
 in the [Zulip development community server](../contributing/chat-zulip-org.html) for
 real-time help.
 
@@ -507,7 +507,7 @@ After provisioning, you'll want to
 [(re)start the Zulip development server](#step-3-start-the-development-environment).
 
 If you run into any trouble, the
-[#provision help](https://chat.zulip.org/#narrow/stream/provision.20help)
+[#provision help](https://chat.zulip.org/#narrow/stream/21-provision-help)
 in the [Zulip development community server](../contributing/chat-zulip-org.html) for
 is a great place to ask for help.
 
@@ -604,7 +604,7 @@ equivalently `vagrant provision` from outside).
 If these solutions aren't working for you or you encounter an issue not
 documented below, there are a few ways to get further help:
 
-* Ask in [#provision help](https://chat.zulip.org/#narrow/stream/provision.20help)
+* Ask in [#provision help](https://chat.zulip.org/#narrow/stream/21-provision-help)
   in the [Zulip development community server](../contributing/chat-zulip-org.html),
 * send a note to the [Zulip-devel Google
   group](https://groups.google.com/forum/#!forum/zulip-devel), or

--- a/docs/overview/gsoc-ideas.md
+++ b/docs/overview/gsoc-ideas.md
@@ -77,7 +77,7 @@ tasks that are great for first-time contributors. Use
 [our first-time Zulip developer guide](../overview/contributing.html#your-first-codebase-contribution)
 to get your Zulip development environment set up and to find your first issue. If you have any
 trouble, please speak up in
-[#GSoC](https://chat.zulip.org/#narrow/stream/GSoC) on
+[#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) on
 [the Zulip development community server](../contributing/chat-zulip-org.html)
 (use your name as the topic).
 
@@ -166,7 +166,7 @@ We have more than a dozen Zulip contributors who are interested in
 mentoring projects.  We usually decide which contributors are
 mentoring which projects based in part on who is a good fit for the
 needs of each student as well as technical expertise.  You can reach
-us via [#GSoC](https://chat.zulip.org/#narrow/stream/GSoC) on
+us via [#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) on
 [the Zulip development community server](../contributing/chat-zulip-org.html),
 (compose a new stream message with your name as the topic).
 

--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -157,7 +157,7 @@ how to debug.
 
 **Community.**
 If the tips above don't help, please visit
-[#production help](https://chat.zulip.org/#narrow/stream/production.20help)
+[#production help](https://chat.zulip.org/#narrow/stream/31-production-help)
 in the [Zulip development community server](../contributing/chat-zulip-org.html) for
 realtime help or email zulip-help@googlegroups.com with the full
 traceback, and we'll try to help you out!  Please provide details like

--- a/docs/translating/translating.md
+++ b/docs/translating/translating.md
@@ -7,7 +7,7 @@ progress. If you speak a language other than English, your help with
 translating Zulip would be greatly appreciated!
 
 If you're interested in contributing translations to Zulip, please
-join [#translation](https://chat.zulip.org/#narrow/stream/translation)
+join [#translation](https://chat.zulip.org/#narrow/stream/58-translation)
 in the [Zulip development community server](../contributing/chat-zulip-org.html), and
 say hello. And please join the
 [Zulip project on Transifex](https://www.transifex.com/zulip/zulip/)
@@ -132,7 +132,7 @@ Some useful tips for your translating journey:
   HTML tags `<...>`).
 
 - When in doubt, ask for context in
-  [#translation](https://chat.zulip.org/#narrow/stream/translation) in
+  [#translation](https://chat.zulip.org/#narrow/stream/58-translation) in
   the [Zulip development community server](../contributing/chat-zulip-org.html).
 
 - If there are multiple possible translations for a term, search for it in


### PR DESCRIPTION
Updating the stream link and name from #electron to #desktop after the change in stream name as discussed [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/Stream.20name) . 

I don't think there are any more mentions of it in this repo. If there is any I missed out please leave a comment I will update the PR.