### PR TITLE
linter: Fix issue with check-templates output.

### DIFF
--- a/tools/lib/pretty_print.py
+++ b/tools/lib/pretty_print.py
@@ -194,7 +194,7 @@ def validate_indent_html(fn):
         temp_file.write(phtml)
         temp_file.close()
         print('Invalid Indentation detected in file: '
-              '%s\nDiff for the file against expected indented file:' % (fn))
+              '%s\nDiff for the file against expected indented file:' % (fn), flush=True)
         subprocess.call(['diff', fn, '/var/tmp/pretty_html.txt'], stderr=subprocess.STDOUT)
         return 0
     return 1


### PR DESCRIPTION
We fix the issue of check-templates spitting out diff between
expected and found indentation of a file before mentioning the
error message and the file name. Basically stuff was being in the
wrong order despite the fact that in code stuff was happening in the
correct order ie, first print the error message along with the filename
and then the actual diff between expected and found file indentation.

Fixes: #9533.

Outputs Before:
```
(zulip-py3-venv)vagrant@vagrant-base-trusty-amd64:/srv/zulip$ tools/lint
templates | 26,29c26,29
templates | <               {{partial "settings_checkbox"
templates | <                 "setting_name" "night_mode"
templates | <                 "is_checked" page_params.night_mode
templates | <                 "label" settings_label.night_mode}}
templates | ---
templates | >             {{partial "settings_checkbox"
templates | >               "setting_name" "night_mode"
templates | >               "is_checked" page_params.night_mode
templates | >               "label" settings_label.night_mode}}
templates | Invalid Indentation detected in file: static/templates/settings/display-settings.handlebars
templates | Diff for the file against expected indented file:
```

Outputs now: 
```
(zulip-py3-venv)vagrant@vagrant-base-trusty-amd64:/srv/zulip$ tools/lint
templates | Invalid Indentation detected in file: static/templates/settings/display-settings.handlebars
templates | Diff for the file against expected indented file:
templates | 26,29c26,29
templates | <               {{partial "settings_checkbox"
templates | <                 "setting_name" "night_mode"
templates | <                 "is_checked" page_params.night_mode
templates | <                 "label" settings_label.night_mode}}
templates | ---
templates | >             {{partial "settings_checkbox"
templates | >               "setting_name" "night_mode"
templates | >               "is_checked" page_params.night_mode
templates | >               "label" settings_label.night_mode}}
```