### PR TITLE
message: Limit message access for guest users.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -518,6 +518,9 @@ def access_message(user_profile: UserProfile, message_id: int) -> Tuple[Message,
                 raise JsonableError(_("Invalid message(s)"))
 
             # You are subscribed, so let this fall through to the public stream case.
+        elif user_profile.is_guest:
+            # Guest user shouldn't be able to access public stream messages
+            raise JsonableError(_("Invalid message(s)"))
         else:
             # Otherwise, the message was sent to a public stream in
             # your realm, so return the message, user_message pair

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -2521,6 +2521,60 @@ class StarTests(ZulipTestCase):
         self.assertEqual(sent_message.message.content, content)
         self.assertFalse(sent_message.flags.starred)
 
+    def test_change_star_public_stream_security_for_guest_user(self) -> None:
+        # Guest user can't access(star) unsubscribed public stream messages
+        normal_user = self.example_user("hamlet")
+        stream_name = "public_stream"
+        self.make_stream(stream_name)
+        self.subscribe(normal_user, stream_name)
+        self.login(normal_user.email)
+
+        message_id = [
+            self.send_stream_message(normal_user.email, stream_name, "test 1")
+        ]
+
+        guest_user = self.example_user('polonius')
+        self.login(guest_user.email)
+        result = self.change_star(message_id)
+        self.assert_json_error(result, 'Invalid message(s)')
+
+        # Guest user can access messages of subscribed public streams
+        self.subscribe(guest_user, stream_name)
+        self.login(normal_user.email)
+        message_id = [
+            self.send_stream_message(normal_user.email, stream_name, "test 2")
+        ]
+        self.login(guest_user.email)
+        result = self.change_star(message_id)
+        self.assert_json_success(result)
+
+    def test_change_star_private_stream_security_for_guest_user(self) -> None:
+        # Guest user can't access(star) unsubscribed private stream messages
+        normal_user = self.example_user("hamlet")
+        stream_name = "private_stream"
+        self.make_stream(stream_name, invite_only=True)
+        self.subscribe(normal_user, stream_name)
+        self.login(normal_user.email)
+
+        message_id = [
+            self.send_stream_message(normal_user.email, stream_name, "test 1")
+        ]
+
+        guest_user = self.example_user('polonius')
+        self.login(guest_user.email)
+        result = self.change_star(message_id)
+        self.assert_json_error(result, 'Invalid message(s)')
+
+        # Guest user can access messages of subscribed private streams
+        self.subscribe(guest_user, stream_name)
+        self.login(normal_user.email)
+        message_id = [
+            self.send_stream_message(normal_user.email, stream_name, "test 2")
+        ]
+        self.login(guest_user.email)
+        result = self.change_star(message_id)
+        self.assert_json_success(result)
+
 class AttachmentTest(ZulipTestCase):
     def test_basics(self) -> None:
         self.assertFalse(Message.content_has_attachment('whatever'))


### PR DESCRIPTION
While working for this I've done a lot of code read and understanding how access message works so before proceeding further for `access_message` I want to clear the doubt about the UserMessage table: Does every message has column have a row in the UserMessage table? (I think not; all private message and messages with some special flag have a row in the table, if this assumption is correct then what messages don't get into UserMessage table)

Also, what should be the strategy to test `access_message` through UI?

Once above doubts get cleared and if the below changes make sense I'll add tests!
@timabbott FYI