### PR TITLE
settings: Remove PRIVATE_STREAM_HISTORY_FOR_SUBSCRIBERS.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1603,10 +1603,8 @@ def get_default_value_for_history_public_to_subscribers(
 ) -> bool:
     if invite_only:
         if history_public_to_subscribers is None:
-            # TODO: Once we have a UI for this feature, we'll remove
-            # settings.PRIVATE_STREAM_HISTORY_FOR_SUBSCRIBERS and set
-            # this to be False here
-            history_public_to_subscribers = settings.PRIVATE_STREAM_HISTORY_FOR_SUBSCRIBERS
+            # A private stream's history is non-public by default
+            history_public_to_subscribers = False
     else:
         # If we later decide to support public streams without
         # history, we can remove this code path.

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -185,30 +185,6 @@ class TestCreateStreams(ZulipTestCase):
             if stream.name == 'publictrywithouthistory':
                 self.assertTrue(stream.history_public_to_subscribers)
 
-    @override_settings(PRIVATE_STREAM_HISTORY_FOR_SUBSCRIBERS=True)
-    def test_history_public_to_subscribers_on_stream_creation_with_setting(self) -> None:
-        realm = get_realm('zulip')
-
-        stream, created = create_stream_if_needed(realm, "private_stream", invite_only=True)
-        self.assertTrue(created)
-        self.assertTrue(stream.invite_only)
-        self.assertTrue(stream.history_public_to_subscribers)
-
-        stream, created = create_stream_if_needed(realm, "history_stream",
-                                                  invite_only=True,
-                                                  history_public_to_subscribers=False)
-        self.assertTrue(created)
-        self.assertTrue(stream.invite_only)
-        self.assertFalse(stream.history_public_to_subscribers)
-
-        # You can't make a public stream limited in this way
-        stream, created = create_stream_if_needed(realm, "public_history_stream",
-                                                  invite_only=False,
-                                                  history_public_to_subscribers=False)
-        self.assertTrue(created)
-        self.assertFalse(stream.invite_only)
-        self.assertTrue(stream.history_public_to_subscribers)
-
     def test_history_public_to_subscribers_zephyr_realm(self) -> None:
         realm = get_realm('zephyr')
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -321,12 +321,6 @@ DEFAULT_SETTINGS.update({
     'MAX_ICON_FILE_SIZE': 5,
     'MAX_EMOJI_FILE_SIZE': 5,
 
-    # TODO: This server setting is a hack to help with folks who are
-    # finding our private stream security model painful.  Future work
-    # will migrate this to be a property of Stream or maybe Realm and
-    # this setting will be deprecated.
-    'PRIVATE_STREAM_HISTORY_FOR_SUBSCRIBERS': False,
-
     # Limits to help prevent spam, in particular by sending invitations.
     #
     # A non-admin user who's joined an open realm this recently can't invite at all.


### PR DESCRIPTION
@timabbott: FYI, I am not sure what else we need to do here. I think the way things are right now makes sense to me! Any thoughts? :)