### PR TITLE
Fix tracebacks related to direct use of msg_list._items.

### DIFF
--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -50,7 +50,7 @@ exports.save_pre_narrow_offset_for_reload = function () {
             blueslip.debug("narrow.activate missing selected row", {
                 selected_id: current_msg_list.selected_id(),
                 selected_idx: current_msg_list.selected_idx(),
-                selected_idx_exact: current_msg_list._items.indexOf(
+                selected_idx_exact: current_msg_list.all_messages().indexOf(
                     current_msg_list.get(current_msg_list.selected_id())),
                 render_start: current_msg_list.view._render_win_start,
                 render_end: current_msg_list.view._render_win_end,

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -183,17 +183,18 @@ function initialize_kitchen_sink_stuff() {
         if (event.then_scroll) {
             if (row.length === 0) {
                 var row_from_dom = current_msg_list.get_row(event.id);
+                var messages = event.msg_list.all_messages();
                 blueslip.debug("message_selected missing selected row", {
                     previously_selected: event.previously_selected,
                     selected_id: event.id,
                     selected_idx: event.msg_list.selected_idx(),
-                    selected_idx_exact: event.msg_list._items.indexOf(event.msg_list.get(event.id)),
+                    selected_idx_exact: messages.indexOf(event.msg_list.get(event.id)),
                     render_start: event.msg_list.view._render_win_start,
                     render_end: event.msg_list.view._render_win_end,
-                    selected_id_from_idx: event.msg_list._items[event.msg_list.selected_idx()].id,
+                    selected_id_from_idx: messages[event.msg_list.selected_idx()].id,
                     msg_list_sorted: _.isEqual(
-                        _.pluck(event.msg_list._items, 'id'),
-                        _.chain(current_msg_list._items).pluck('id').clone().value().sort()
+                        _.pluck(messages, 'id'),
+                        _.chain(current_msg_list.all_messages()).pluck('id').clone().value().sort()
                     ),
                     found_in_dom: row_from_dom.length,
                 });


### PR DESCRIPTION
We had debug code that was reaching into msg_list._items when
it could use msg_list.all_messages() instead.

When we split out MessageListData, using _items started
breaking this code.
