### PR TITLE
search: Respect spaces in person name in new suggestions only.

### DIFF
--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -993,6 +993,28 @@ run_test('people_suggestions', () => {
 
     assert.deepEqual(suggestions.strings, expected);
 
+    query = 'sender:ted sm';
+    expected = [
+        'sender:ted+sm',
+        'sender:ted@zulip.com',
+    ];
+    suggestions = search.get_suggestions(query);
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'sender:ted@zulip.com new';
+    expected = [
+        'sender:ted@zulip.com new',
+        'sender:ted@zulip.com',
+    ];
+    suggestions = search.get_suggestions(query);
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = 'sender:ted@tulip.com new';
+    expected = [
+        'sender:ted@tulip.com+new',
+    ];
+    suggestions = search.get_suggestions(query);
+    assert.deepEqual(suggestions.strings, expected);
 });
 
 run_test('operator_suggestions', () => {


### PR DESCRIPTION
Fixes #6515.
New suggestions for `sender:King ha` will respect spaces and the new
suggestion will be `Sent by King Hamlet <email>` instead of `Sent by King,
search for ha`. But if first term of sender operand is a valid user email,
tokens will be seperated by spaces. e.g `sender:hamlet@zulip.com abc`
will show `Sent by King Hamlet <email>, search for abc`.

![selection_149](https://user-images.githubusercontent.com/13910561/40552992-f5a1d2d8-605e-11e8-865f-a366fc823604.png)

![selection_148](https://user-images.githubusercontent.com/13910561/40552994-f5d83fc6-605e-11e8-91f0-63c600260e10.png)


The original issue mentioned
> considering things with spaces in them if and only if the thing after the : is an exact prefix of someone's name.

I think that will not be necessary in this case as we are using only emails for filtering. If it's not an exact prefix, e.g `sender:Kin ha`, the prefix check would enable to make the suggestion `Sent by Kin, search for ha`. But since `Kin` is not a valid email, it's of no use and any query following it would result in empty search. The result without the prefix check would be `Sent by Kin Ha`. Thus, I think it's better to skip this check and (presumably) save some time. (Let me know if this needs to be changed) 