### PR TITLE
Allow users to import settings from another organisation follwup

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -187,11 +187,13 @@ def get_test_image_file(filename: str) -> IO[Any]:
     test_avatar_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../tests/images'))
     return open(os.path.join(test_avatar_dir, filename), 'rb')
 
-def avatar_disk_path(user_profile: UserProfile, medium: bool=False) -> str:
+def avatar_disk_path(user_profile: UserProfile, medium: bool=False, original: bool=False) -> str:
     avatar_url_path = avatar_url(user_profile, medium)
     avatar_disk_path = os.path.join(settings.LOCAL_UPLOADS_DIR, "avatars",
                                     avatar_url_path.split("/")[-2],
                                     avatar_url_path.split("/")[-1].split("?")[0])
+    if original:
+        avatar_disk_path.replace(".png", ".original")
     return avatar_disk_path
 
 def make_client(name: str) -> Client:

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -441,12 +441,7 @@ class LocalUploadBackend(ZulipUploadBackend):
         logging.warning("%s does not exist. Its entry in the database will be removed." % (file_name,))
         return False
 
-    def upload_avatar_image(self, user_file: File,
-                            acting_user_profile: UserProfile,
-                            target_user_profile: UserProfile) -> None:
-        file_path = user_avatar_path(target_user_profile)
-
-        image_data = user_file.read()
+    def write_avatar_images(self, file_path: str, image_data: bytes) -> None:
         write_local_file('avatars', file_path + '.original', image_data)
 
         resized_data = resize_avatar(image_data)
@@ -454,6 +449,14 @@ class LocalUploadBackend(ZulipUploadBackend):
 
         resized_medium = resize_avatar(image_data, MEDIUM_AVATAR_SIZE)
         write_local_file('avatars', file_path + '-medium.png', resized_medium)
+
+    def upload_avatar_image(self, user_file: File,
+                            acting_user_profile: UserProfile,
+                            target_user_profile: UserProfile) -> None:
+        file_path = user_avatar_path(target_user_profile)
+
+        image_data = user_file.read()
+        self.write_avatar_images(file_path, image_data)
 
     def get_avatar_url(self, hash_key: str, medium: bool=False) -> str:
         # ?x=x allows templates to append additional parameters with &s

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -274,14 +274,10 @@ class S3UploadBackend(ZulipUploadBackend):
         logging.warning("%s does not exist. Its entry in the database will be removed." % (file_name,))
         return False
 
-    def upload_avatar_image(self, user_file: File,
-                            acting_user_profile: UserProfile,
-                            target_user_profile: UserProfile) -> None:
-        content_type = guess_type(user_file.name)[0]
+    def write_avatar_images(self, s3_file_name: str, target_user_profile: UserProfile,
+                            image_data: bytes, content_type: Optional[str]) -> None:
         bucket_name = settings.S3_AVATAR_BUCKET
-        s3_file_name = user_avatar_path(target_user_profile)
 
-        image_data = user_file.read()
         upload_image_to_s3(
             bucket_name,
             s3_file_name + ".original",
@@ -310,6 +306,16 @@ class S3UploadBackend(ZulipUploadBackend):
         )
         # See avatar_url in avatar.py for URL.  (That code also handles the case
         # that users use gravatar.)
+
+    def upload_avatar_image(self, user_file: File,
+                            acting_user_profile: UserProfile,
+                            target_user_profile: UserProfile) -> None:
+        content_type = guess_type(user_file.name)[0]
+        s3_file_name = user_avatar_path(target_user_profile)
+
+        image_data = user_file.read()
+        self.write_avatar_images(s3_file_name, target_user_profile,
+                                 image_data, content_type)
 
     def get_avatar_url(self, hash_key: str, medium: bool=False) -> str:
         bucket = settings.S3_AVATAR_BUCKET


### PR DESCRIPTION
- [X] Move organization section to top.

- [x] Use select instead of radio in import settings.

- [x] Keep settings export select after email.

- [x]  Copy user full_name when importing settings.

- [ ] When a realm is selected replace full_name input with Profile Pic and full name

#9519