### PR TITLE
outgoing webhooks: Change default URL in all tests.

### DIFF
--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -1194,7 +1194,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             'full_name': 'Outgoing Webhook test bot',
             'short_name': 'outgoingservicebot',
             'bot_type': UserProfile.OUTGOING_WEBHOOK_BOT,
-            'payload_url': ujson.dumps('http://127.0.0.1:5002/bots/followup'),
+            'payload_url': ujson.dumps('http://127.0.0.1:5002'),
             'interface_type': -1,
         }
         result = self.client_post("/json/bots", bot_info)
@@ -1210,7 +1210,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             'full_name': 'Outgoing Webhook test bot',
             'short_name': 'outgoingservicebot',
             'bot_type': UserProfile.OUTGOING_WEBHOOK_BOT,
-            'payload_url': ujson.dumps('http://127.0.0.1:5002/bots/followup'),
+            'payload_url': ujson.dumps('http://127.0.0.1:5002'),
         }
         bot_info.update(extras)
         result = self.client_post("/json/bots", bot_info)
@@ -1224,11 +1224,11 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         self.assertEqual(len(services), 1)
         self.assertEqual(service.name, "outgoingservicebot")
-        self.assertEqual(service.base_url, "http://127.0.0.1:5002/bots/followup")
+        self.assertEqual(service.base_url, "http://127.0.0.1:5002")
         self.assertEqual(service.user_profile, bot)
 
         # invalid URL test case.
-        bot_info['payload_url'] = ujson.dumps('http://127.0.0.:5002/bots/followup')
+        bot_info['payload_url'] = ujson.dumps('http://127.0.0.:5002')
         result = self.client_post("/json/bots", bot_info)
         self.assert_json_error(result, "payload_url is not a URL")
 
@@ -1253,7 +1253,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             'full_name': 'Outgoing Webhook test bot',
             'short_name': 'outgoingservicebot',
             'bot_type': UserProfile.OUTGOING_WEBHOOK_BOT,
-            'payload_url': ujson.dumps('http://127.0.0.1:5002/bots/followup'),
+            'payload_url': ujson.dumps('http://127.0.0.1:5002'),
             'interface_type': -1,
         }
         result = self.client_post("/json/bots", bot_info)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -221,7 +221,7 @@ class Command(BaseCommand):
             Service.objects.create(
                 name="test",
                 user_profile=get_user("outgoing-webhook@zulip.com", zulip_realm),
-                base_url="http://127.0.0.1:5002/bots/followup",
+                base_url="http://127.0.0.1:5002",
                 token="abcd1234",
                 interface=1)
 


### PR DESCRIPTION
This reflects the changes to the default URL publicly
displayed to the user. It also changes the default
URL of the default test server outgoing webhook, which
prevented the test server flaskbotrc from working out
of the box.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
