### PR TITLE
search: Handle pm-with/sender failures better. 

### DIFF
--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -237,11 +237,8 @@ run_test('pm_string', () => {
     set_filter([['pm-with', '']]);
     assert.equal(narrow_state.pm_string(), undefined);
 
-    blueslip.set_test_data('warn', 'Unknown emails: bogus@foo.com');
     set_filter([['pm-with', 'bogus@foo.com']]);
     assert.equal(narrow_state.pm_string(), undefined);
-    assert.equal(blueslip.get_test_logs('warn').length, 1);
-    blueslip.clear_test_data();
 
     var alice = {
         email: 'alice@foo.com',

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -579,8 +579,7 @@ run_test('slugs', () => {
     assert.equal(email, 'debbie71@example.com');
 
     // Test undefined slug
-    people.emails_strings_to_user_ids_string = function () { return; };
-    assert.equal(people.emails_to_slug(), undefined);
+    assert.equal(people.emails_to_slug('does@not.exist'), undefined);
 });
 
 initialize();

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -44,12 +44,8 @@ global.people.add_in_realm(me);
 global.people.initialize_current_user(me.user_id);
 
 run_test('get_conversation_li', () => {
-    var test_conversation = 'foo@example.com,bar@example.com';
-    blueslip.set_test_data('warn', 'Unknown conversation: ' + test_conversation);
-    blueslip.set_test_data('warn', 'Unknown emails: ' + test_conversation); // people.js
+    var test_conversation = 'foo@example.com,bar@example.com'; // people.js
     pm_list.get_conversation_li(test_conversation);
-    assert.equal(blueslip.get_test_logs('warn').length, 2);
-    blueslip.clear_test_data();
 });
 
 run_test('close', () => {

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -167,7 +167,7 @@ exports.pm_string = function () {
         return;
     }
 
-    var user_ids_string = people.emails_strings_to_user_ids_string(emails_string);
+    var user_ids_string = people.reply_to_to_user_ids_string(emails_string);
 
     return user_ids_string;
 };

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -462,7 +462,7 @@ exports.pm_with_operand_ids = function (operand) {
 };
 
 exports.emails_to_slug = function (emails_string) {
-    var slug = exports.emails_strings_to_user_ids_string(emails_string);
+    var slug = exports.reply_to_to_user_ids_string(emails_string);
 
     if (!slug) {
         return;

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -34,9 +34,8 @@ function set_count(count) {
 
 exports.get_conversation_li = function (conversation) {
     // conversation is something like "foo@example.com,bar@example.com"
-    var user_ids_string = people.emails_strings_to_user_ids_string(conversation);
+    var user_ids_string = people.reply_to_to_user_ids_string(conversation);
     if (!user_ids_string) {
-        blueslip.warn('Unknown conversation: ' + conversation);
         return;
     }
     return exports.get_li_for_user_ids_string(user_ids_string);

--- a/static/js/typing_events.js
+++ b/static/js/typing_events.js
@@ -27,9 +27,8 @@ function get_users_typing_for_narrow() {
         // Get list of users typing in this conversation
         var narrow_emails_string = first_term.operand;
         // TODO: Create people.emails_strings_to_user_ids.
-        var narrow_user_ids_string = people.emails_strings_to_user_ids_string(narrow_emails_string);
+        var narrow_user_ids_string = people.reply_to_to_user_ids_string(narrow_emails_string);
         if (!narrow_user_ids_string) {
-            blueslip.warn('Bad narrow for typing indicators: ' + narrow_emails_string);
             return [];
         }
         var narrow_user_ids = narrow_user_ids_string.split(',').map(function (user_id_string) {


### PR DESCRIPTION
Fixes #3380. Rebasing on the previous PR for this issue was not viable due to the change in validation logic and overwrites due to that.

For the last commit:
The blueslip warning mentioned in #3380 were from paths ending at people.email_list_to_user_ids_string. Some additional blueslip warnings
were raised after using that function.
Although we can put a validation check somewhere in the call stack of
people.email_list_to_user_ids_string, this function itself is used to
validate the operand by the higher order functions,so it wouldn't make
sense to put a  validation check before that. Instead, removing the
blueslip warning altogether was chosen.
people.email_list_to_user_ids_string was replaced by
people.reply_to_to_user_ids_string which is a blueslip-free version
of the same. Other blueslip warnings were removed.

Last commit was made what **I thought** was the best solution. Let me know if any changes need to be made to the last commit :smiley: (since it does not seem like the traditional way to deal with warnings)