### PR TITLE
import: Import from gitter.

### DIFF
--- a/templates/zerver/help/import-data-from-gitter.md
+++ b/templates/zerver/help/import-data-from-gitter.md
@@ -1,0 +1,58 @@
+# Import data from Gitter (beta)
+
+Zulip supports importing data from Gitter, including users, channels,
+messages, attachments, and avatars.
+
+!!! warn ""
+    These instructions require shell access to the Zulip server. If you'd like
+    to import a Gitter organization into the hosted zulipchat.com service,
+    contact support@zulipchat.com.
+
+First, you need to do some things in Gitter to setup the export:
+
+1. [Export your Gitter data](https://github.com/minrk/archive-gitter). You will
+   receive json files of the public rooms that you are a part of.
+   Select the file, `gitter_data.json`, of the room which you want to import to the
+   Zulip server.
+
+    !!! warn ""
+        **Note:** You need the gitter API token to export data. You can get the
+        this token by following the instructions mentioned in the
+        [gitter documentation](https://developer.gitter.im/docs/).
+
+### Import into a new Zulip server
+
+Log in to a shell on your Zulip server as the `zulip` user. Run the
+following commands.
+
+```
+./manage.py convert_gitter_data gitter_data.json --output converted_gitter_data
+./manage.py import --destroy-rebuild-database '' converted_gitter_data
+```
+
+!!! warn ""
+    **Warning:** This will destroy all existing data in your Zulip server
+
+### Import into an existing Zulip server
+
+If you already have some organizations hosted on your Zulip server,
+and want to add import your Gitter data as a new Zulip organization,
+you can use the following procedure.
+
+Log in to your Zulip server as the `zulip` user. Run the following
+commands, replacing `<subdomain>` with the subdomain of the URL
+you'd like for your imported Zulip organization.
+
+```
+./manage.py convert_gitter_data gitter_data.json --output converted_gitter_data
+./manage.py import --destroy-rebuild-database <subdomain> converted_gitter_data
+```
+
+{!import-login.md!}
+
+## Caveats
+
+- [Gitter data export](https://github.com/minrk/archive-gitter) doesn't support
+  the export of the private gitter rooms.
+
+- Gitter markdown and issue mentions hasn't been mapped yet.

--- a/templates/zerver/help/include/sidebar.md
+++ b/templates/zerver/help/include/sidebar.md
@@ -113,6 +113,7 @@
 * [Update your organization's settings](/help/change-your-organization-settings)
 * [Link to your Zulip from the web](/help/join-zulip-chat-badge)
 * [Import data from Slack](/help/import-data-from-slack)
+* [Import data from Gitter](/help/import-data-from-gitter)
 * [Import or export a Zulip organization](/help/import-or-export-a-zulip-organization)
 * [Restrict new users by email domain](/help/restrict-user-email-addresses-to-certain-domains)
 * [Allow joining without an invitation](/help/allow-anyone-to-join-without-an-invitation)

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -72,6 +72,7 @@ not_yet_fully_covered = {
     'zerver/lib/export.py',
     'zerver/lib/feedback.py',
     'zerver/lib/fix_unreads.py',
+    'zerver/lib/gitter_import.py',
     'zerver/lib/html_diff.py',
     'zerver/lib/import_realm.py',
     'zerver/lib/logging_util.py',

--- a/zerver/lib/gitter_import.py
+++ b/zerver/lib/gitter_import.py
@@ -1,0 +1,369 @@
+import os
+import dateutil.parser
+import random
+import requests
+import json
+import logging
+import shutil
+import subprocess
+
+from django.conf import settings
+from django.forms.models import model_to_dict
+from django.utils.timezone import now as timezone_now
+from typing import Any, Dict, List, Tuple
+
+from zerver.models import Realm, UserProfile
+from zerver.lib.actions import STREAM_ASSIGNMENT_COLORS as stream_colors
+from zerver.lib.avatar_hash import user_avatar_path_from_ids
+from zerver.lib.parallel import run_parallel
+
+# stubs
+GitterDataT = List[Dict[str, Any]]
+ZerverFieldsT = Dict[str, Any]
+
+realm_id = 0
+
+def gitter_workspace_to_realm(domain_name: str, gitter_data: GitterDataT,
+                              realm_subdomain: str) -> Tuple[ZerverFieldsT,
+                                                             List[ZerverFieldsT],
+                                                             Dict[str, int]]:
+    """
+    Returns:
+    1. realm, Converted Realm data
+    2. avatars, which is list to map avatars to zulip avatar records.json
+    3. user_map, which is a dictionary to map from gitter user id to zulip user id
+    """
+    NOW = float(timezone_now().timestamp())
+    zerver_realm = build_zerver_realm(realm_subdomain, NOW)
+
+    realm = dict(zerver_client=[{"name": "populate_db", "id": 1},
+                                {"name": "website", "id": 2},
+                                {"name": "API", "id": 3}],
+                 zerver_customprofilefield=[],
+                 zerver_customprofilefieldvalue=[],
+                 zerver_userpresence=[],  # shows last logged in data, which is not available in gitter
+                 zerver_userprofile_mirrordummy=[],
+                 zerver_realmdomain=[{"realm": realm_id,
+                                      "allow_subdomains": False,
+                                      "domain": domain_name,
+                                      "id": realm_id}],
+                 zerver_useractivity=[],
+                 zerver_realm=zerver_realm,
+                 zerver_huddle=[],
+                 zerver_userprofile_crossrealm=[],
+                 zerver_useractivityinterval=[],
+                 zerver_reaction=[],
+                 zerver_realmemoji=[],
+                 zerver_realmfilter=[])
+
+    zerver_userprofile, avatars, user_map = build_userprofile(int(NOW), domain_name, gitter_data)
+    zerver_stream, zerver_defaultstream = build_stream(int(NOW))
+    zerver_recipient, zerver_subscription = build_recipient_and_subscription(
+        zerver_userprofile, zerver_stream)
+
+    realm['zerver_userprofile'] = zerver_userprofile
+    realm['zerver_stream'] = zerver_stream
+    realm['zerver_defaultstream'] = zerver_defaultstream
+    realm['zerver_recipient'] = zerver_recipient
+    realm['zerver_subscription'] = zerver_subscription
+
+    return realm, avatars, user_map
+
+def build_zerver_realm(realm_subdomain: str, time: float) -> List[ZerverFieldsT]:
+    realm = Realm(id=realm_id, date_created=time,
+                  name=realm_subdomain, string_id=realm_subdomain,
+                  description="Organization imported from Gitter!")
+    auth_methods = [[flag[0], flag[1]] for flag in realm.authentication_methods]
+    realm_dict = model_to_dict(realm, exclude='authentication_methods')
+    realm_dict['authentication_methods'] = auth_methods
+    return[realm_dict]
+
+def build_userprofile(timestamp: Any, domain_name: str,
+                      gitter_data: GitterDataT) -> Tuple[List[ZerverFieldsT],
+                                                         List[ZerverFieldsT],
+                                                         Dict[str, int]]:
+    """
+    Returns:
+    1. zerver_userprofile, which is a list of user profile
+    2. avatar_list, which is list to map avatars to zulip avatard records.json
+    3. added_users, which is a dictionary to map from gitter user id to zulip id
+    """
+    logging.info('######### IMPORTING USERS STARTED #########\n')
+    zerver_userprofile = []
+    avatar_list = []  # type: List[ZerverFieldsT]
+    user_map = {}  # type: Dict[str, int]
+    user_id = 0
+
+    for data in gitter_data:
+        if data['fromUser']['id'] not in user_map:
+            user_data = data['fromUser']
+            user_map[user_data['id']] = user_id
+
+            email = get_user_email(user_data, domain_name)
+            build_avatar(user_id, realm_id, email, user_data, timestamp, avatar_list)
+
+            # Build userprofile object
+            userprofile = UserProfile(
+                full_name=user_data['displayName'],
+                short_name=user_data['username'],
+                id=user_id,
+                email=email,
+                avatar_source='U',
+                pointer=-1,
+                date_joined=timestamp,
+                last_login=timestamp)
+            userprofile_dict = model_to_dict(userprofile)
+            # Set realm id separately as the corresponding realm is not yet a Realm model
+            # instance
+            userprofile_dict['realm'] = realm_id
+            zerver_userprofile.append(userprofile_dict)
+            user_id += 1
+    logging.info('######### IMPORTING USERS FINISHED #########\n')
+    return zerver_userprofile, avatar_list, user_map
+
+def get_user_email(user_data: ZerverFieldsT, domain_name: str) -> str:
+    # TODO Get user email from github
+    email = ("%s@users.noreply.github.com" % user_data['username'])
+    return email
+
+def build_avatar(user_id: int, realm_id: int, email: str, user_data: ZerverFieldsT,
+                 timestamp: Any, avatar_list: List[ZerverFieldsT]) -> None:
+    avatar_url = user_data['avatarUrl']
+    avatar = dict(
+        path=avatar_url,  # Save the avatar url here, which is downloaded later
+        realm_id=realm_id,
+        content_type=None,
+        user_profile_id=user_id,
+        last_modified=timestamp,
+        user_profile_email=email,
+        s3_path="",
+        size="")
+    avatar_list.append(avatar)
+
+def build_stream(timestamp: Any) -> Tuple[List[ZerverFieldsT],
+                                          List[ZerverFieldsT]]:
+    logging.info('######### IMPORTING STREAM STARTED #########\n')
+    # We have only one stream for gitter export
+    stream = dict(
+        realm=realm_id,
+        name="from gitter",
+        deactivated=False,
+        description="Imported from gitter",
+        invite_only=False,
+        date_created=timestamp,
+        id=0)
+
+    defaultstream = dict(
+        stream=0,
+        realm=realm_id,
+        id=0)
+    logging.info('######### IMPORTING STREAMS FINISHED #########\n')
+    return [stream], [defaultstream]
+
+def build_recipient_and_subscription(
+    zerver_userprofile: List[ZerverFieldsT],
+    zerver_stream: List[ZerverFieldsT]) -> Tuple[List[ZerverFieldsT],
+                                                 List[ZerverFieldsT]]:
+    """
+    Returns:
+    1. zerver_recipient, which is a list of mapped recipient
+    2. zerver_subscription, which is a list of mapped subscription
+    """
+    zerver_recipient = []
+    zerver_subscription = []
+    recipient_id = subscription_id = 0
+
+    # For stream
+
+    # We have only one recipient, because we have only one stream
+    # Hence 'recipient_id'=0 corresponds to 'stream_id'=0
+    recipient = build_recipient(0, recipient_id, 2)
+    zerver_recipient.append(recipient)
+
+    for user in zerver_userprofile:
+        subscription = build_subscription(recipient_id, user['id'], subscription_id)
+        zerver_subscription.append(subscription)
+        subscription_id += 1
+    recipient_id += 1
+
+    # For users
+    for user in zerver_userprofile:
+        recipient = build_recipient(user['id'], recipient_id, 1)
+        subscription = build_subscription(recipient_id, user['id'], subscription_id)
+        zerver_recipient.append(recipient)
+        zerver_subscription.append(subscription)
+        recipient_id += 1
+        subscription_id += 1
+
+    return zerver_recipient, zerver_subscription
+
+def build_recipient(type_id: int, recipient_id: int, type: int) -> ZerverFieldsT:
+    recipient = dict(
+        type_id=type_id,  # stream id
+        id=recipient_id,
+        type=type)
+    return recipient
+
+def build_subscription(recipient_id: int, user_id: int,
+                       subscription_id: int) -> ZerverFieldsT:
+    subscription = dict(
+        recipient=recipient_id,
+        notifications=False,
+        color=random.choice(stream_colors),
+        desktop_notifications=True,
+        pin_to_top=False,
+        in_home_view=True,
+        active=True,
+        user_profile=user_id,
+        id=subscription_id)
+    return subscription
+
+def convert_gitter_workspace_messages(message_data: GitterDataT,
+                                      zerver_subscription: List[ZerverFieldsT],
+                                      user_map: Dict[str, int]) -> ZerverFieldsT:
+    """
+    Returns:
+    1. message.json, Converted messages
+    """
+    logging.info('######### IMPORTING MESSAGES STARTED #########\n')
+    message_json = {}
+    zerver_message = []
+    zerver_usermessage = []
+    message_id = usermessage_id = 0
+
+    recipient_id = 0  # Corresponding to stream "gitter"
+
+    for message in message_data:
+        message_time = dateutil.parser.parse(message['sent']).timestamp()
+        rendered_content = None
+
+        zulip_message = dict(
+            sending_client=1,
+            rendered_content_version=1,  # This is Zulip-specific
+            has_image=False,
+            subject='imported from gitter',
+            pub_date=float(message_time),
+            id=message_id,
+            has_attachment=False,
+            edit_history=None,
+            sender=user_map[message['fromUser']['id']],
+            content=message['text'],
+            rendered_content=rendered_content,
+            recipient=recipient_id,
+            last_edit_time=None,
+            has_link=False)
+        zerver_message.append(zulip_message)
+
+        for subscription in zerver_subscription:
+            if subscription['recipient'] == recipient_id:
+                flags_mask = 1  # For read
+                usermessage = dict(
+                    user_profile=subscription['user_profile'],
+                    id=usermessage_id,
+                    flags_mask=flags_mask,
+                    message=message_id)
+                usermessage_id += 1
+                zerver_usermessage.append(usermessage)
+        message_id += 1
+
+    message_json['zerver_message'] = zerver_message
+    message_json['zerver_usermessage'] = zerver_usermessage
+
+    logging.info('######### IMPORTING MESSAGES FINISHED #########\n')
+    return message_json
+
+def do_convert_data(gitter_data_file: str, output_dir: str, threads: int=6) -> None:
+    #  Subdomain is set by the user while running the import commands
+    realm_subdomain = ""
+    domain_name = settings.EXTERNAL_HOST
+
+    os.makedirs(output_dir, exist_ok=True)
+    # output directory should be empty initially
+    if os.listdir(output_dir):
+        raise Exception("Output directory should be empty!")
+
+    # Read data from the gitter file
+    gitter_data = json.load(open(gitter_data_file))
+
+    realm, avatar_list, user_map = gitter_workspace_to_realm(
+        domain_name, gitter_data, realm_subdomain)
+    message_json = convert_gitter_workspace_messages(gitter_data,
+                                                     realm['zerver_subscription'],
+                                                     user_map)
+
+    avatar_folder = os.path.join(output_dir, 'avatars')
+    avatar_realm_folder = os.path.join(avatar_folder, str(realm_id))
+    os.makedirs(avatar_realm_folder, exist_ok=True)
+    avatar_records = process_avatars(avatar_list, avatar_folder, threads)
+
+    attachment = {"zerver_attachment": []}  # type: Dict[str, List[Any]]
+
+    # IO realm.json
+    create_converted_data_files(realm, output_dir, '/realm.json')
+    # IO message.json
+    create_converted_data_files(message_json, output_dir, '/messages-000001.json')
+    # IO emoji records
+    create_converted_data_files([], output_dir, '/emoji/records.json')
+    # IO avatar records
+    create_converted_data_files(avatar_records, output_dir, '/avatars/records.json')
+    # IO uploads records
+    create_converted_data_files([], output_dir, '/uploads/records.json')
+    # IO attachments records
+    create_converted_data_files(attachment, output_dir, '/attachment.json')
+
+    subprocess.check_call(["tar", "-czf", output_dir + '.tar.gz', output_dir, '-P'])
+
+    logging.info('######### DATA CONVERSION FINISHED #########\n')
+    logging.info("Zulip data dump created at %s" % (output_dir))
+
+def process_avatars(avatar_list: List[ZerverFieldsT], avatar_dir: str,
+                    threads: int) -> List[ZerverFieldsT]:
+    """
+    This function gets the gitter avatar of the user and saves it in the
+    user's avatar directory with both the extensions '.png' and '.original'
+    """
+    def get_avatar(avatar_upload_list: List[str]) -> int:
+        gitter_avatar_url = avatar_upload_list[0]
+        image_path = avatar_upload_list[1]
+        original_image_path = avatar_upload_list[2]
+        response = requests.get(gitter_avatar_url, stream=True)
+        with open(image_path, 'wb') as image_file:
+            shutil.copyfileobj(response.raw, image_file)
+        shutil.copy(image_path, original_image_path)
+        return 0
+
+    logging.info('######### GETTING AVATARS #########\n')
+    logging.info('DOWNLOADING AVATARS .......\n')
+    avatar_original_list = []
+    avatar_upload_list = []
+    for avatar in avatar_list:
+        avatar_hash = user_avatar_path_from_ids(avatar['user_profile_id'], realm_id)
+        gitter_avatar_url = avatar['path']
+        avatar_original = dict(avatar)
+
+        image_path = ('%s/%s.png' % (avatar_dir, avatar_hash))
+        original_image_path = ('%s/%s.original' % (avatar_dir, avatar_hash))
+
+        avatar_upload_list.append([gitter_avatar_url, image_path, original_image_path])
+        # We don't add the size field here in avatar's records.json,
+        # since the metadata is not needed on the import end, and we
+        # don't have it until we've downloaded the files anyway.
+        avatar['path'] = image_path
+        avatar['s3_path'] = image_path
+
+        avatar_original['path'] = original_image_path
+        avatar_original['s3_path'] = original_image_path
+        avatar_original_list.append(avatar_original)
+
+    # Run downloads parallely
+    output = []
+    for (status, job) in run_parallel(get_avatar, avatar_upload_list, threads=threads):
+        output.append(job)
+
+    logging.info('######### GETTING AVATARS FINISHED #########\n')
+    return avatar_list + avatar_original_list
+
+def create_converted_data_files(data: Any, output_dir: str, file_path: str) -> None:
+    output_file = output_dir + file_path
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    json.dump(data, open(output_file, 'w'), indent=4)

--- a/zerver/management/commands/convert_gitter_data.py
+++ b/zerver/management/commands/convert_gitter_data.py
@@ -1,0 +1,50 @@
+
+import argparse
+import os
+import subprocess
+import tempfile
+import shutil
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser, CommandError
+
+from zerver.lib.gitter_import import do_convert_data
+
+class Command(BaseCommand):
+    help = """Convert the Gitter data into Zulip data format."""
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument('gitter_data', nargs='+',
+                            metavar='<gitter data>',
+                            help="Gitter data in json format")
+
+        parser.add_argument('--output', dest='output_dir',
+                            action="store", default=None,
+                            help='Directory to write exported data to.')
+
+        parser.add_argument('--threads',
+                            dest='threads',
+                            action="store",
+                            default=6,
+                            help='Threads to download avatars and attachments faster')
+
+        parser.formatter_class = argparse.RawTextHelpFormatter
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        output_dir = options["output_dir"]
+        if output_dir is None:
+            output_dir = tempfile.mkdtemp(prefix="/tmp/converted-gitter-data-")
+        else:
+            output_dir = os.path.realpath(output_dir)
+
+        num_threads = int(options['threads'])
+        if num_threads < 1:
+            raise CommandError('You must have at least one thread.')
+
+        for path in options['gitter_data']:
+            if not os.path.exists(path):
+                print("Gitter data file not found: '%s'" % (path,))
+                exit(1)
+            # TODO add json check
+            print("Converting Data ...")
+            do_convert_data(path, output_dir, num_threads)

--- a/zerver/tests/fixtures/gitter_data.json
+++ b/zerver/tests/fixtures/gitter_data.json
@@ -1,0 +1,44 @@
+[
+{
+    "fromUser": {
+        "avatarUrl": "https://avatars-02.gitter.im/gh/uv/4/username",
+        "displayName": "User Full Name",
+        "gv": "4",
+        "id": "54d7876c15522ed4b3dbbefb",
+        "url": "/user1",
+        "username": "username1",
+        "v": 17
+    },
+    "html": "test message",
+    "id": "57509d0ef44fde236e52f395",
+    "issues": [],
+    "meta": [],
+    "readBy": 8,
+    "sent": "2016-06-02T20:54:38.747Z",
+    "text": "test message",
+    "unread": false,
+    "urls": [],
+    "v": 1
+},
+{
+    "fromUser": {
+        "avatarUrl": "https://avatars-02.gitter.im/gh/uv/4/username",
+        "displayName": "User Full Name 2",
+        "gv": "3",
+        "id": "54d7876c15522ed4b3dbtest",
+        "url": "/user2",
+        "username": "username2",
+        "v": 17
+    },
+    "html": "test message 2",
+    "id": "57509d0ef44fde236e52f395",
+    "issues": [],
+    "meta": [],
+    "readBy": 8,
+    "sent": "2016-07-02T19:54:38.747Z",
+    "text": "test message 2",
+    "unread": false,
+    "urls": [],
+    "v": 1
+}
+]

--- a/zerver/tests/test_gitter_importer.py
+++ b/zerver/tests/test_gitter_importer.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+from django.utils.timezone import now as timezone_now
+
+from zerver.lib.import_realm import (
+    do_import_realm,
+)
+from zerver.lib.test_classes import (
+    ZulipTestCase,
+)
+from zerver.tests.test_import_export import (
+    rm_tree,
+)
+from zerver.lib.test_helpers import (
+    get_test_image_file,
+)
+from zerver.models import (
+    Realm,
+    get_realm,
+)
+from zerver.lib.gitter_import import (
+    do_convert_data,
+)
+
+import ujson
+import json
+import logging
+import shutil
+import os
+import mock
+from typing import Any, AnyStr, Dict, List, Optional, Set, Tuple
+
+class GitterImporter(ZulipTestCase):
+    logger = logging.getLogger()
+    # set logger to a higher level to suppress 'logger.INFO' outputs
+    logger.setLevel(logging.WARNING)
+
+    def _make_output_dir(self) -> str:
+        output_dir = 'var/test-gitter-import'
+        rm_tree(output_dir)
+        os.makedirs(output_dir, exist_ok=True)
+        return output_dir
+
+    @mock.patch('zerver.lib.gitter_import.process_avatars', return_value=[])
+    def test_gitter_import_to_existing_database(self, mock_process_avatars: mock.Mock) -> None:
+        output_dir = self._make_output_dir()
+        gitter_file = os.path.join(os.path.dirname(__file__), 'fixtures/gitter_data.json')
+        do_convert_data(gitter_file, output_dir)
+
+        def read_file(output_file: str) -> Any:
+            full_path = os.path.join(output_dir, output_file)
+            with open(full_path) as f:
+                return ujson.load(f)
+
+        def get_set(data: List[Dict[str, Any]], field: str) -> Set[str]:
+            values = set(r[field] for r in data)
+            return values
+
+        self.assertEqual(os.path.exists(os.path.join(output_dir, 'avatars')), True)
+        self.assertEqual(os.path.exists(os.path.join(output_dir, 'emoji')), True)
+        self.assertEqual(os.path.exists(os.path.join(output_dir, 'attachment.json')), True)
+
+        realm = read_file('realm.json')
+
+        # test realm
+        self.assertEqual('Organization imported from Gitter!',
+                         realm['zerver_realm'][0]['description'])
+
+        # test users
+        exported_user_ids = get_set(realm['zerver_userprofile'], 'id')
+        exported_user_full_name = get_set(realm['zerver_userprofile'], 'full_name')
+        self.assertIn('User Full Name', exported_user_full_name)
+        exported_user_email = get_set(realm['zerver_userprofile'], 'email')
+        self.assertIn('username2@users.noreply.github.com', exported_user_email)
+
+        # test stream
+        self.assertEqual(len(realm['zerver_stream']), 1)
+        self.assertEqual(realm['zerver_stream'][0]['name'], 'from gitter')
+        self.assertEqual(realm['zerver_stream'][0]['deactivated'], False)
+        self.assertEqual(realm['zerver_stream'][0]['realm'], realm['zerver_realm'][0]['id'])
+
+        self.assertEqual(realm['zerver_defaultstream'][0]['stream'], realm['zerver_stream'][0]['id'])
+
+        # test recipient
+        exported_recipient_id = get_set(realm['zerver_recipient'], 'id')
+        exported_recipient_type = get_set(realm['zerver_recipient'], 'type')
+        self.assertEqual(set([1, 2]), exported_recipient_type)
+
+        # test subscription
+        exported_subscription_userprofile = get_set(realm['zerver_subscription'], 'user_profile')
+        self.assertEqual(set([0, 1]), exported_subscription_userprofile)
+        exported_subscription_recipient = get_set(realm['zerver_subscription'], 'recipient')
+        self.assertEqual(len(exported_subscription_recipient), 3)
+        self.assertIn(realm['zerver_subscription'][1]['recipient'], exported_recipient_id)
+
+        messages = read_file('messages-000001.json')
+
+        # test messages
+        exported_messages_id = get_set(messages['zerver_message'], 'id')
+        self.assertIn(messages['zerver_message'][0]['sender'], exported_user_ids)
+        self.assertIn(messages['zerver_message'][1]['recipient'], exported_recipient_id)
+        self.assertIn(messages['zerver_message'][0]['content'], 'test message')
+
+        # test usermessages
+        exported_usermessage_userprofile = get_set(messages['zerver_usermessage'], 'user_profile')
+        self.assertEqual(exported_user_ids, exported_usermessage_userprofile)
+        exported_usermessage_message = get_set(messages['zerver_usermessage'], 'message')
+        self.assertEqual(exported_usermessage_message, exported_messages_id)


### PR DESCRIPTION
This successfully imports gitter data to Zulip. 

Things done:
Mapping users, stream, recipients, subscriptions, messages, avatars, added Management command `convert_gitter_data`, added basic tests, basic documentation, support user mentions.

Things to do:
Improve documentation, See how markdown conversion can be improved after feedback.


**To Test:** 

1. Get the sample dataset in a file `gitter.json`.
2. Use `./manage.py convert_gitter_data gitter.json --output gitter_data` to get the converted file.
3. Use `./manage.py import 'test-gitter-import' gitter_data` to import. This will create a realm with the name `test-gitter-import`.