### PR TITLE
Fix regression with down key.

### DIFF
--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -130,6 +130,16 @@ run_test('basics', () => {
 run_test('prev_next', () => {
     var list = new MessageList({});
 
+    assert.equal(list.prev(), undefined);
+    assert.equal(list.next(), undefined);
+    assert.equal(list.is_at_end(), false);
+
+    // try to confuse things with bogus selected id
+    list.data.set_selected_id(33);
+    assert.equal(list.prev(), undefined);
+    assert.equal(list.next(), undefined);
+    assert.equal(list.is_at_end(), false);
+
     var messages = [{id: 30}, {id: 40}, {id: 50}, {id: 60}];
     list.append(messages, true);
     assert.equal(list.prev(), undefined);
@@ -139,6 +149,7 @@ run_test('prev_next', () => {
     list.data.set_selected_id(45);
     assert.equal(list.prev(), undefined);
     assert.equal(list.next(), undefined);
+    assert.equal(list.is_at_end(), false);
 
     list.data.set_selected_id(30);
     assert.equal(list.prev(), undefined);
@@ -147,10 +158,12 @@ run_test('prev_next', () => {
     list.data.set_selected_id(50);
     assert.equal(list.prev(), 40);
     assert.equal(list.next(), 60);
+    assert.equal(list.is_at_end(), false);
 
     list.data.set_selected_id(60);
     assert.equal(list.prev(), 50);
     assert.equal(list.next(), undefined);
+    assert.equal(list.is_at_end(), true);
 });
 
 run_test('message_range', () => {

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -99,6 +99,10 @@ exports.MessageList.prototype = {
         return this.data.next();
     },
 
+    is_at_end: function () {
+        return this.data.is_at_end();
+    },
+
     nth_most_recent_id: function (n) {
         return this.data.nth_most_recent_id(n);
     },

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -78,6 +78,22 @@ MessageListData.prototype = {
         return this._items[i + 1].id;
     },
 
+    is_at_end: function () {
+        if (this._selected_id === -1) {
+            return false;
+        }
+
+        var n = this._items.length;
+
+        if (n === 0) {
+            return false;
+        }
+
+        var last_msg = this._items[n-1];
+
+        return (last_msg.id === this._selected_id);
+    },
+
     nth_most_recent_id: function (n) {
         var i = this._items.length - n;
         if (i < 0) {

--- a/static/js/navigate.js
+++ b/static/js/navigate.js
@@ -20,23 +20,26 @@ exports.up = function () {
 
 exports.down = function (with_centering) {
     message_viewport.last_movement_direction = 1;
+
+    if (current_msg_list.is_at_end()) {
+        if (with_centering) {
+            // At the last message, scroll to the bottom so we have
+            // lots of nice whitespace for new messages coming in.
+            var current_msg_table = rows.get_table(current_msg_list.table_name);
+            message_viewport.scrollTop(current_msg_table.safeOuterHeight(true) -
+                                       message_viewport.height() * 0.1);
+            unread_ops.mark_current_list_as_read();
+        }
+
+        return;
+    }
+
+    // Normal path starts here.
     var msg_id = current_msg_list.next();
     if (msg_id === undefined) {
         return;
     }
     go_to_row(msg_id);
-
-    if (with_centering) {
-        // At the last message, scroll to the bottom so we have
-        // lots of nice whitespace for new messages coming in.
-        //
-        // FIXME: this doesn't work for End because rows.last_visible()
-        // always returns a message.
-        var current_msg_table = rows.get_table(current_msg_list.table_name);
-        message_viewport.scrollTop(current_msg_table.safeOuterHeight(true) -
-                                   message_viewport.height() * 0.1);
-        unread_ops.mark_current_list_as_read();
-    }
 };
 
 exports.to_home = function () {


### PR DESCRIPTION
The bug that's fixed here repros with any narrow more than a couple pages long.  Go to a long narrow and hit the up key till you're last message falls off the bottom and toggle up/down.