### PR TITLE
Establish a consistent naming for the Zulip Flask Botserver vocabulary.

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -8,7 +8,7 @@ common.start_and_log_in();
 
 // var form_sel = 'form[action^="/json/settings"]';
 var regex_zuliprc = /^data:application\/octet-stream;charset=utf-8,\[api\]\nemail=.+\nkey=.+\nsite=.+\n$/;
-var regex_flaskbotrc = /^data:application\/octet-stream;charset=utf-8,\[\]\nemail=.+\nkey=.+\nsite=.+\n$/;
+var regex_botserverrc = /^data:application\/octet-stream;charset=utf-8,\[\]\nemail=.+\nkey=.+\nsite=.+\n$/;
 
 casper.then(function () {
     var menu_selector = '#settings-dropdown';
@@ -142,14 +142,14 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('#download_flaskbotrc', function () {
-        casper.click("#download_flaskbotrc");
+    casper.waitUntilVisible('#download_botserverrc', function () {
+        casper.click("#download_botserverrc");
 
-        casper.waitUntilVisible('#download_flaskbotrc[href^="data:application"]', function () {
+        casper.waitUntilVisible('#download_botserverrc[href^="data:application"]', function () {
             casper.test.assertMatch(
-                decodeURIComponent(casper.getElementsAttribute('#download_flaskbotrc', 'href')),
-                regex_flaskbotrc,
-                'Looks like a flaskbotrc file');
+                decodeURIComponent(casper.getElementsAttribute('#download_botserverrc', 'href')),
+                regex_botserverrc,
+                'Looks like a botserverrc file');
         });
     });
 });

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -46,12 +46,12 @@ run_test('generate_zuliprc_content', () => {
     assert.equal(content, expected);
 });
 
-run_test('generate_flaskbotrc_content', () => {
+run_test('generate_botserverrc_content', () => {
     var user = {
         email: "vabstest-bot@zulip.com",
         api_key: "nSlA0mUm7G42LP85lMv7syqFTzDE2q34",
     };
-    var content = settings_bots.generate_flaskbotrc_content(user.email, user.api_key);
+    var content = settings_bots.generate_botserverrc_content(user.email, user.api_key);
     var expected = "[]\nemail=vabstest-bot@zulip.com\n" +
                    "key=nSlA0mUm7G42LP85lMv7syqFTzDE2q34\n" +
                    "site=https://chat.example.com\n";

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -139,7 +139,7 @@ function _setup_page() {
         full_name: people.my_full_name(),
         page_params: page_params,
         zuliprc: 'zuliprc',
-        flaskbotrc: 'flaskbotrc',
+        botserverrc: 'botserverrc',
         timezones: moment.tz.names(),
         admin_only_bot_creation: page_params.is_admin ||
             page_params.realm_bot_creation_policy !==

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -110,7 +110,7 @@ exports.generate_zuliprc_content = function (email, api_key) {
            "\n";
 };
 
-exports.generate_flaskbotrc_content = function (email, api_key) {
+exports.generate_botserverrc_content = function (email, api_key) {
     return "[]" +
            "\nemail=" + email +
            "\nkey=" + api_key +
@@ -177,12 +177,12 @@ exports.set_up = function () {
     $('#config_inputbox').children().hide();
     $("[name*='"+selected_embedded_bot+"']").show();
 
-    $('#download_flaskbotrc').click(function () {
+    $('#download_botserverrc').click(function () {
         var OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
         var content = "";
         _.each(bot_data.get_all_bots_for_current_user(), function (bot) {
             if (bot.is_active && bot.bot_type === OUTGOING_WEBHOOK_BOT_TYPE_INT) {
-                content += exports.generate_flaskbotrc_content(bot.email, bot.api_key);
+                content += exports.generate_botserverrc_content(bot.email, bot.api_key);
             }
         });
         $(this).attr("href", "data:application/octet-stream;charset=utf-8," + encodeURIComponent(content));

--- a/static/locale/bg/translations.json
+++ b/static/locale/bg/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "Изтегли файл",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "Чернови",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/cs/translations.json
+++ b/static/locale/cs/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "Stáhnout .zuliprc",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "Stáhnout nastavení všech činných robotů měnících činnost internetových stránek (odchozí zpětné volání HTTP) ve formátu robotického serveru Zulipu.",
   "Download file": "Stáhnout soubor",
-  "Download flaskbotrc": "Stáhnout flaskbotrc",
+  "Download botserverrc": "Stáhnout botserverrc",
   "Download zuliprc": "Stáhnout zuliprc",
   "Drafts": "Návrhy",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "Návrhy starší než <strong>__draft_lifetime__</strong> dnů jsou automaticky odstraněny",

--- a/static/locale/de/translations.json
+++ b/static/locale/de/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": ".zuliprc herunterladen",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "Konfigurationsdatei für alle aktiven Outgoing Webhook Bots herunterladen.",
   "Download file": "Datei herunterladen",
-  "Download flaskbotrc": "'flaskbotrc' herunterladen",
+  "Download botserverrc": "'botserverrc' herunterladen",
   "Download zuliprc": "zuliprc herunterladen",
   "Drafts": "Entwürfe",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "Nachrichten, die älter als <strong>__draft_lifetime__</strong> Tage sind, werden automatisch gelöscht.",

--- a/static/locale/es/translations.json
+++ b/static/locale/es/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "Descargar .zuliprc",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "Descargar la configuración de todos los bots con webhooks de salida activos en formato Zulip Botserver.",
   "Download file": "Descargar archivo",
-  "Download flaskbotrc": "Descargar flaskbotrc",
+  "Download botserverrc": "Descargar botserverrc",
   "Download zuliprc": "Descargar zuliprc",
   "Drafts": "Borradores",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "Los borradores de hace más de <strong>__draft_lifetime__</strong> días serán eliminados automáticamente",

--- a/static/locale/fr/translations.json
+++ b/static/locale/fr/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "Télécharger .zuliprc",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "Télécharger la configuration de tous les webhooks sortant actifs dans le format Botserver de Zulip.",
   "Download file": "Télécharger le fichier",
-  "Download flaskbotrc": "Télécharger flaskbotrc",
+  "Download botserverrc": "Télécharger botserverrc",
   "Download zuliprc": "Télécharger zuliprc",
   "Drafts": "Brouillons",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/hi/translations.json
+++ b/static/locale/hi/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "डाउनलोड फाइल",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/hu/translations.json
+++ b/static/locale/hu/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": ".zuliprc letöltése",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "Piszkozatok",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/id_ID/translations.json
+++ b/static/locale/id_ID/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "Unduh .zuliprc",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "Unggah semua pengaturan untuk robot outgoing webhook dalam format Zulip Botserver.",
   "Download file": "Unggah file",
-  "Download flaskbotrc": "Unduh flaskbotrc",
+  "Download botserverrc": "Unduh botserverrc",
   "Download zuliprc": "Unggah zuliprc",
   "Drafts": "Konsep",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/it/translations.json
+++ b/static/locale/it/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/ja/translations.json
+++ b/static/locale/ja/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": ".zuliprcをダウンロード",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "Zulip Botserver形式の有効な外部向けwebhookボット全ての設定をダウンロードします。",
   "Download file": "ファイルをダウンロード",
-  "Download flaskbotrc": "flaskbotrcをダウンロード",
+  "Download botserverrc": "botserverrcをダウンロード",
   "Download zuliprc": "",
   "Drafts": "下書き",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/ko/translations.json
+++ b/static/locale/ko/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": ".zuliprc 다운로드",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "Zulip Botserver 형식에서 모든 활성화되어 외부로 나가는 webhook 봇의 구성을 다운로드하십시오.",
   "Download file": "파일 다운로드",
-  "Download flaskbotrc": "flaskbotrc 다운로드",
+  "Download botserverrc": "botserverrc 다운로드",
   "Download zuliprc": "zuliprc 다운로드",
   "Drafts": "임시 보관함",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/ml/translations.json
+++ b/static/locale/ml/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/nl/translations.json
+++ b/static/locale/nl/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "Downloaden .zuliprc",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "Concepten",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/pl/translations.json
+++ b/static/locale/pl/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "Pobierz .zuliprc",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "Kopie robocze",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/pt/translations.json
+++ b/static/locale/pt/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "Rascunhos",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/ru/translations.json
+++ b/static/locale/ru/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "Скачать .zuliprc",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "Загрузить конфигурацию всех исходящих вебхук ботов в формате Zulip Botserver",
   "Download file": "Скачать файл",
-  "Download flaskbotrc": "Скачать flaskbotrc",
+  "Download botserverrc": "Скачать botserverrc",
   "Download zuliprc": "Скачать zuliprc",
   "Drafts": "Черновики",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "Черновики старше <strong>__draft_lifetime__</strong> дней автоматически удаляются",

--- a/static/locale/sr/translations.json
+++ b/static/locale/sr/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/ta/translations.json
+++ b/static/locale/ta/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "வரைவுகள்",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/tr/translations.json
+++ b/static/locale/tr/translations.json
@@ -154,7 +154,7 @@
   "Download .zuliprc": ".zuliprc indir",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "Tüm faal dış yönlü webhook botlarının ayarlarını Zulip Botserver formatında indir.",
   "Download file": "Dosya indir",
-  "Download flaskbotrc": "flaskbotrc indir",
+  "Download botserverrc": "botserverrc indir",
   "Download zuliprc": "zuliprc indir",
   "Drafts": "Taslak",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "<strong>__draft_lifetime__</strong> günden daha eski taslaklar otomatik olarak silinecektir",

--- a/static/locale/zh_Hans/translations.json
+++ b/static/locale/zh_Hans/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "下载 .zuliprc",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "以Zulip Botserver格式下载所有活动的外发webhook机器人的配置。",
   "Download file": "下载文件",
-  "Download flaskbotrc": "下载 flaskbotrc",
+  "Download botserverrc": "下载 botserverrc",
   "Download zuliprc": "下载 zuliprc",
   "Drafts": "草稿",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/locale/zh_Hant/translations.json
+++ b/static/locale/zh_Hant/translations.json
@@ -153,7 +153,7 @@
   "Download .zuliprc": "",
   "Download config of all active outgoing webhook bots in Zulip Botserver format.": "",
   "Download file": "",
-  "Download flaskbotrc": "",
+  "Download botserverrc": "",
   "Download zuliprc": "",
   "Drafts": "草稿",
   "Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed": "",

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -7,7 +7,7 @@
 
         <div>
             <span>{{t 'Download config of all active outgoing webhook bots in Zulip Botserver format.' }}</span>
-            <a type="submit" download="{{flaskbotrc}}" id= "download_flaskbotrc" class="btn" title="{{t 'Download flaskbotrc' }}">
+            <a type="submit" download="{{botserverrc}}" id= "download_botserverrc" class="btn" title="{{t 'Download botserverrc' }}">
                 <i class="icon-vector-download-alt sea-green"></i>
             </a>
         </div>

--- a/templates/zerver/api/deploying-bots.md
+++ b/templates/zerver/api/deploying-bots.md
@@ -61,20 +61,20 @@ pip install zulip_botserver
 1. Download the `zuliprc` file for your bot from the *Active Bots*
    panel, using the download button.
 
-1. Run the bot server, where `helloworld` is the name of the bot you
+1. Run the Botserver, where `helloworld` is the name of the bot you
    want to run:
    `zulip-bot-server --config-file <path_to_zuliprc> --bot-name=helloworld`
 
     You can specify the port number and various other options; run
     `zulip-bot-server --help` to see how to do this.
 
-1.  Congrats, everything is set up! Test your botserver like you would
+1.  Congrats, everything is set up! Test your Botserver like you would
     test a normal bot.
 
-### Running multiple bots using the Zulip botserver
+### Running multiple bots using the Zulip Botserver
 
-The Zulip botserver also supports running multiple bots from a single
-botserver process.  You can do this with the following procedure.
+The Zulip Botserver also supports running multiple bots from a single
+Botserver process.  You can do this with the following procedure.
 
 1. Download the `botserverrc` from the `your-bots` settings page, using
    the "Download config of all active outgoing webhook bots in Zulip
@@ -134,7 +134,7 @@ running it manually.
             command=zulip-bot-server --config-file=<path/to/your/botserverrc>
             --hostname <address> --port <port>
             startsecs=3
-            stdout_logfile=/var/log/zulip-botserver.log ; all output of your botserver will be logged here
+            stdout_logfile=/var/log/zulip-botserver.log ; all output of your Botserver will be logged here
             redirect_stderr=true
 
     * Edit the `<>` sections according to your preferences.
@@ -156,6 +156,6 @@ running it manually.
    The output should include a line similar to this:
    > zulip-bot-server                 RUNNING   pid 28154, uptime 0:00:27
 
-   The standard output of the bot server will be logged to the path in
+   The standard output of the Botserver will be logged to the path in
    your *supervisord* configuration.
 

--- a/templates/zerver/api/deploying-bots.md
+++ b/templates/zerver/api/deploying-bots.md
@@ -76,11 +76,11 @@ pip install zulip_botserver
 The Zulip botserver also supports running multiple bots from a single
 botserver process.  You can do this with the following procedure.
 
-1. Download the `flaskbotrc` from the `your-bots` settings page, using
+1. Download the `botserverrc` from the `your-bots` settings page, using
    the "Download config of all active outgoing webhook bots in Zulip
    Botserver format." option at the top.
 
-1. Open the `flaskbotrc`. It should contain one or more sections that look like this:
+1. Open the `botserverrc`. It should contain one or more sections that look like this:
 ```
 []
 email=foo-bot@hostname
@@ -99,11 +99,11 @@ key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
 site=http://hostname
 ```
 
-3.  Run the Zulip Botserver by passing the `flaskbotrc` to it. The
+3.  Run the Zulip Botserver by passing the `botserverrc` to it. The
     command format is:
 
     ```
-    zulip-bot-server  --config-file <path_to_flaskbotrc>
+    zulip-bot-server  --config-file <path_to_botserverrc>
     ```
 
     If omitted, `hostname` defaults to `127.0.0.1` and `port` to `5002`.
@@ -131,7 +131,7 @@ running it manually.
       * Copy the following section into your existing supervisord config file.
 
             [program:zulip-bot-server]
-            command=zulip-bot-server --config-file=<path/to/your/flaskbotrc>
+            command=zulip-bot-server --config-file=<path/to/your/botserverrc>
             --hostname <address> --port <port>
             startsecs=3
             stdout_logfile=/var/log/zulip-botserver.log ; all output of your botserver will be logged here

--- a/templates/zerver/api/outgoing-webhooks.md
+++ b/templates/zerver/api/outgoing-webhooks.md
@@ -5,7 +5,7 @@ which are notified when certain types of messages are sent in
 Zulip. When one of those events is triggered, we'll send a HTTP POST
 payload to the webhook's configured URL.  Webhooks can be used to
 power a wide range of Zulip integrations.  For example, the
-[Zulip botserver][zulip-botserver] is built on top of this API.
+[Zulip Botserver][zulip-botserver] is built on top of this API.
 
 Zulip supports outgoing webhooks both in a clean native Zulip format,
 as well as a format that's compatible with

--- a/templates/zerver/help/add-a-bot-or-integration.md
+++ b/templates/zerver/help/add-a-bot-or-integration.md
@@ -51,7 +51,7 @@ You can create three types of bots:
   to this Endpoint URL.
   Choose this type if you want to:
     * make Zulip post messages to a URL.
-    * deploy Zulip's [botserver](/api/deploying-bots).
+    * deploy Zulip's [Botserver](/api/deploying-bots).
       *This is the default way of deploying bots used in production.*
 
 ## Add an integration

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -595,6 +595,8 @@ def build_custom_checkers(by_lang):
          'description': "!!! warning is invalid; it's spelled '!!! warn'"},
         {'pattern': 'Terms of service',
          'description': "The S in Terms of Service is capitalized"},
+        {'pattern': '[^-_]botserver(?!rc)|bot server',
+         'description': "Use Botserver instead of botserver or Botserver."},
     ]) + comma_whitespace_rule
     html_rules = whitespace_rules + prose_style_rules + [
         {'pattern': 'placeholder="[^{#](?:(?!\.com).)+$',


### PR DESCRIPTION
* flaskbotrc -> botserverrc
* botserver, bot server -> Botserver

I wasn't completely sure if we update translation files manually, so I put translation updates in a separate commit.