### PR TITLE
general UI: Normalize Keyboard shortcuts icon tooltip.

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -240,8 +240,6 @@ function initialize_kitchen_sink_stuff() {
 
     $('.copy_message[data-toggle="tooltip"]').tooltip();
 
-    $('#keyboard-icon').tooltip();
-
     $("body").on("mouseover", ".message_edit_content", function () {
         $(this).closest(".message_row").find(".copy_message").show();
     });

--- a/templates/zerver/app/right_sidebar.html
+++ b/templates/zerver/app/right_sidebar.html
@@ -31,7 +31,7 @@
             </ul>
         </div>
         <div id="sidebar-keyboard-shortcuts">
-            <i id="keyboard-icon" class="fa fa-keyboard-o fa-2x" data-html="true" data-overlay-trigger="keyboard-shortcuts" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
+            <i id="keyboard-icon" class="fa fa-keyboard-o fa-2x" title="{{ _('Keyboard shortcuts') }} (?)"></i>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Changes the Keyboard shortcuts icon tooltip to resemble the Drafts/Reply button tooltips.

Before:
![screenshot at may 29 14-49-23](https://user-images.githubusercontent.com/15116870/40687451-849163da-634f-11e8-8c34-0dc41fd16e81.png)

After:
![screenshot at may 29 14-35-29](https://user-images.githubusercontent.com/15116870/40687179-a624b110-634e-11e8-9977-2b2f585a1454.png)

Fixes #9446.