### PR TITLE
streams: Add create and edit ui for is_announcement_only.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1259,6 +1259,9 @@ run_test('handlebars_bug', () => {
     assert.equal(other_options[1].value, 'invite-only');
     assert.equal(other_options[2].value, 'invite-only-public-history');
 
+    var is_announcement_only = $(html).find("input[name=is-announcement-only]");
+    assert.equal(is_announcement_only.prop('checked'), false);
+
     var button = $(html).find("#change-stream-privacy-button");
     assert(button.hasClass("btn-danger"));
     assert.equal(button.text().trim(), "translated: Change privacy");

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1251,6 +1251,7 @@ run_test('handlebars_bug', () => {
     var args = {
         stream_id: 999,
         is_private: true,
+        is_admin: true,
     };
     var html = render('subscription_stream_privacy_modal', args);
 

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1265,7 +1265,7 @@ run_test('handlebars_bug', () => {
 
     var button = $(html).find("#change-stream-privacy-button");
     assert(button.hasClass("btn-danger"));
-    assert.equal(button.text().trim(), "translated: Change privacy");
+    assert.equal(button.text().trim(), "translated: Save changes");
 }());
 
 

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -98,7 +98,7 @@ var stream_name_error = (function () {
 }());
 
 function ajaxSubscribeForCreation(stream_name, description, principals, invite_only,
-                                  announce, history_public_to_subscribers) {
+                                  is_announcement_only, announce, history_public_to_subscribers) {
     // Subscribe yourself and possible other people to a new stream.
     return channel.post({
         url: "/json/users/me/subscriptions",
@@ -106,6 +106,7 @@ function ajaxSubscribeForCreation(stream_name, description, principals, invite_o
                                                description: description}]),
                principals: JSON.stringify(principals),
                invite_only: JSON.stringify(invite_only),
+               is_announcement_only: JSON.stringify(is_announcement_only),
                announce: JSON.stringify(announce),
                history_public_to_subscribers: JSON.stringify(history_public_to_subscribers),
         },
@@ -171,6 +172,7 @@ function create_stream() {
     var stream_name = $.trim($("#create_stream_name").val());
     var description = $.trim($("#create_stream_description").val());
     var privacy_setting = $('#stream_creation_form input[name=privacy]:checked').val();
+    var is_announcement_only = $('#stream_creation_form input[name=is-announcement-only]').prop('checked');
     var principals = get_principals();
 
     var invite_only;
@@ -199,6 +201,7 @@ function create_stream() {
         description,
         principals,
         invite_only,
+        is_announcement_only,
         announce,
         history_public_to_subscribers
     );

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -509,6 +509,7 @@ exports.initialize = function () {
         var stream_id = get_stream_id(e.target);
         var stream = stream_data.get_sub_by_id(stream_id);
         var template_data = {
+            is_admin: page_params.is_admin,
             stream_id: stream_id,
             stream_name: stream.name,
             is_announcement_only: stream.is_announcement_only,

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -344,6 +344,7 @@ function change_stream_privacy(e) {
     var sub = stream_data.get_sub_by_id(stream_id);
 
     var privacy_setting = $('#stream_privacy_modal input[name=privacy]:checked').val();
+    var is_announcement_only = $('#stream_privacy_modal input[name=is-announcement-only]').prop('checked');
 
     var invite_only;
     var history_public_to_subscribers;
@@ -364,6 +365,7 @@ function change_stream_privacy(e) {
         stream_name: sub.name,
         // toggle the privacy setting
         is_private: JSON.stringify(invite_only),
+        is_announcement_only: JSON.stringify(is_announcement_only),
         history_public_to_subscribers: JSON.stringify(history_public_to_subscribers),
     };
 
@@ -376,6 +378,7 @@ function change_stream_privacy(e) {
 
             // save new privacy settings.
             sub.invite_only = invite_only;
+            sub.is_announcement_only = is_announcement_only;
             sub.history_public_to_subscribers = history_public_to_subscribers;
 
             redraw_privacy_related_stuff(sub_row, sub);
@@ -508,6 +511,7 @@ exports.initialize = function () {
         var template_data = {
             stream_id: stream_id,
             stream_name: stream.name,
+            is_announcement_only: stream.is_announcement_only,
             is_public: !stream.invite_only,
             is_private: stream.invite_only && !stream.history_public_to_subscribers,
             is_private_with_public_history: (stream.invite_only &&

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -484,6 +484,7 @@ exports.setup_page = function (callback) {
         $('#subscriptions_table').empty();
 
         var template_data = {
+            is_admin: page_params.is_admin,
             can_create_streams: page_params.can_create_streams,
             subscriptions: sub_rows,
             hide_all_streams: !should_list_all_streams(),

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -589,6 +589,10 @@ form#add_new_subscription {
     margin: 5px;
 }
 
+.stream-creation-body #make-invite-only .grey-box .checkbox {
+    margin: 5px;
+}
+
 #announce-new-stream {
     margin-top: 10px;
 }
@@ -962,7 +966,10 @@ form#add_new_subscription {
     padding: 5px 0px;
 }
 
-#stream_privacy_modal ul.grey-box li input[type=checkbox],
+#stream_privacy_modal ul.grey-box li input[type=checkbox] {
+    margin-top: 4px;
+}
+
 #subscription_overlay ul.grey-box li input[type=checkbox] {
     margin-top: 0px;
 }

--- a/static/templates/stream_types.handlebars
+++ b/static/templates/stream_types.handlebars
@@ -23,6 +23,7 @@
             {{/tr}}
         </label>
     </li>
+    {{#if is_admin}}
     <li>
         <label class="checkbox">
             <input type="checkbox" name="is-announcement-only" value="is-announcement-only" {{#if is_announcement_only}}checked{{/if}}/>
@@ -31,4 +32,5 @@
             {{t "Only organization admins can post." }}
         </label>
     </li>
+    {{/if}}
 </ul>

--- a/static/templates/stream_types.handlebars
+++ b/static/templates/stream_types.handlebars
@@ -23,4 +23,12 @@
             {{/tr}}
         </label>
     </li>
+    <li>
+        <label class="checkbox">
+            <input type="checkbox" name="is-announcement-only" value="is-announcement-only" {{#if is_announcement_only}}checked{{/if}}/>
+            <span></span>
+            <b>{{t "Make stream announcement only:"}}</b>
+            {{t "Only organization admins can post." }}
+        </label>
+    </li>
 </ul>

--- a/static/templates/subscription_stream_privacy_modal.handlebars
+++ b/static/templates/subscription_stream_privacy_modal.handlebars
@@ -8,7 +8,7 @@
         <button class="btn btn-default close-privacy-modal">{{t "Cancel" }}</button>
         <button class="btn btn-danger" id="change-stream-privacy-button"
           tabindex="-1" data-stream-id="{{stream_id}}">
-            {{t "Change privacy"}}
+            {{t "Save changes"}}
         </button>
     </div>
 </div>

--- a/static/templates/subscription_type.handlebars
+++ b/static/templates/subscription_type.handlebars
@@ -6,3 +6,6 @@
 {{else}}
     {{t 'This is a <span class="icon-vector-globe"></span> <b>public stream</b>. Anybody in your organization can join.' }}
 {{/if}}
+{{#if is_announcement_only}}
+{{t 'This stream is announcement only. Only organization admins can post.'}}
+{{/if}}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1621,6 +1621,7 @@ def create_stream_if_needed(realm: Realm,
                             stream_name: str,
                             *,
                             invite_only: bool=False,
+                            is_announcement_only: Optional[bool]=False,
                             history_public_to_subscribers: Optional[bool]=None,
                             stream_description: str="") -> Tuple[Stream, bool]:
 
@@ -1634,6 +1635,7 @@ def create_stream_if_needed(realm: Realm,
             name=stream_name,
             description=stream_description,
             invite_only=invite_only,
+            is_announcement_only=is_announcement_only,
             history_public_to_subscribers=history_public_to_subscribers,
             is_in_zephyr_realm=realm.is_zephyr_mirror_realm
         )
@@ -1667,6 +1669,7 @@ def create_streams_if_needed(realm: Realm,
             realm,
             stream_dict["name"],
             invite_only=stream_dict.get("invite_only", False),
+            is_announcement_only=stream_dict.get("is_announcement_only", False),
             history_public_to_subscribers=stream_dict.get("history_public_to_subscribers"),
             stream_description=stream_dict.get("description", "")
         )

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -115,7 +115,8 @@ class TestCreateStreams(ZulipTestCase):
             realm,
             [{"name": stream_name,
               "description": stream_description,
-              "invite_only": True}
+              "invite_only": True,
+              "is_announcement_only": True}
              for (stream_name, stream_description) in zip(stream_names, stream_descriptions)])
 
         self.assertEqual(len(new_streams), 3)
@@ -127,6 +128,7 @@ class TestCreateStreams(ZulipTestCase):
         self.assertEqual(actual_stream_descriptions, set(stream_descriptions))
         for stream in new_streams:
             self.assertTrue(stream.invite_only)
+            self.assertTrue(stream.is_announcement_only)
 
         new_streams, existing_streams = create_streams_if_needed(
             realm,

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -294,6 +294,7 @@ def add_subscriptions_backend(
         streams_raw: Iterable[Mapping[str, str]]=REQ(
             "subscriptions", validator=check_list(check_dict([('name', check_string)]))),
         invite_only: bool=REQ(validator=check_bool, default=False),
+        is_announcement_only: bool=REQ(validator=check_bool, default=False),
         history_public_to_subscribers: Optional[bool]=REQ(validator=check_bool, default=None),
         announce: bool=REQ(validator=check_bool, default=False),
         principals: List[str]=REQ(validator=check_list(check_string), default=[]),
@@ -307,6 +308,7 @@ def add_subscriptions_backend(
         # Strip the stream name here.
         stream_dict_copy['name'] = stream_dict_copy['name'].strip()
         stream_dict_copy["invite_only"] = invite_only
+        stream_dict_copy["is_announcement_only"] = is_announcement_only
         stream_dict_copy["history_public_to_subscribers"] = history_public_to_subscribers
         stream_dicts.append(stream_dict_copy)
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -308,7 +308,10 @@ def add_subscriptions_backend(
         # Strip the stream name here.
         stream_dict_copy['name'] = stream_dict_copy['name'].strip()
         stream_dict_copy["invite_only"] = invite_only
-        stream_dict_copy["is_announcement_only"] = is_announcement_only
+        if user_profile.is_realm_admin:
+            stream_dict_copy["is_announcement_only"] = is_announcement_only
+        else:
+            stream_dict_copy["is_announcement_only"] = False
         stream_dict_copy["history_public_to_subscribers"] = history_public_to_subscribers
         stream_dicts.append(stream_dict_copy)
 


### PR DESCRIPTION
![selection_153](https://user-images.githubusercontent.com/13910561/40744682-ff3d2b04-6472-11e8-9e10-87811454e19e.png)
![selection_152](https://user-images.githubusercontent.com/13910561/40744683-001f9c50-6473-11e8-98ae-ccc282bb80dc.png)

- Default value for is_announcement_only while creating a stream is true
- FYI: taken care of: value of is_annoucement_only populated when opening the privacy modal.
- The second last commit lets only admins set the property while creating a stream. The checkbox disappears for non-admin users. While non-admin users can set other privacy properties, letting a non-admin user create a stream where only admins can post. (If this is not desired, you can skip the commit)
- The last commit just changes, the save button text. I was not sure of this change, that's why the seperate commit. Feel free to skip it. (or change it to something else)