### PR TITLE
Fix submessages (part 2)

### DIFF
--- a/frontend_tests/node_tests/submessage.js
+++ b/frontend_tests/node_tests/submessage.js
@@ -2,6 +2,7 @@ zrequire('submessage');
 
 set_global('channel', {});
 set_global('widgetize', {});
+set_global('message_store', {});
 
 run_test('get_message_events', () => {
     var msg = {};
@@ -64,6 +65,7 @@ run_test('handle_event', () => {
     };
 
     const event = {
+        id: 11,
         msg_type: 'widget',
         sender_id: 99,
         message_id: message.id,
@@ -75,6 +77,11 @@ run_test('handle_event', () => {
         args = opts;
     };
 
+    message_store.get = (msg_id) => {
+        assert.equal(msg_id, message.id);
+        return message;
+    };
+
     submessage.handle_event(event);
 
     assert.deepEqual(args, {
@@ -82,4 +89,6 @@ run_test('handle_event', () => {
         message_id: 42,
         data: 'some_data',
     });
+
+    assert.deepEqual(message.submessages[0], event);
 });

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -254,12 +254,17 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         break;
 
     case 'submessage':
-        submessage.handle_event({
+        // The fields in the event don't quite exactly
+        // match the layout of a submessage, since there's
+        // an event id.  We also want to be explicit here.
+        var submsg = {
+            id: event.submessage_id,
             sender_id: event.sender_id,
             msg_type: event.msg_type,
             message_id: event.message_id,
             content: event.content,
-        });
+        };
+        submessage.handle_event(submsg);
         break;
 
     case 'subscription':

--- a/static/js/submessage.js
+++ b/static/js/submessage.js
@@ -81,10 +81,9 @@ exports.do_process_submessages = function (in_opts) {
     });
 };
 
-
-exports.handle_event = function (event) {
+exports.handle_event = function (submsg) {
     // Right now, our only use of submessages is widgets.
-    var msg_type = event.msg_type;
+    var msg_type = submsg.msg_type;
 
     if (msg_type !== 'widget') {
         blueslip.warn('unknown msg_type: ' + msg_type);
@@ -94,15 +93,15 @@ exports.handle_event = function (event) {
     var data;
 
     try {
-        data = JSON.parse(event.content);
+        data = JSON.parse(submsg.content);
     } catch (err) {
-        blueslip.error('server sent us invalid json in handle_event: ' + event.content);
+        blueslip.error('server sent us invalid json in handle_event: ' + submsg.content);
         return;
     }
 
     widgetize.handle_event({
-        sender_id: event.sender_id,
-        message_id: event.message_id,
+        sender_id: submsg.sender_id,
+        message_id: submsg.message_id,
         data: data,
     });
 };

--- a/static/js/submessage.js
+++ b/static/js/submessage.js
@@ -81,7 +81,39 @@ exports.do_process_submessages = function (in_opts) {
     });
 };
 
+exports.update_message = function (submsg) {
+    var message = message_store.get(submsg.message_id);
+
+    if (message === undefined) {
+        // This is generally not a problem--the server
+        // can send us events without us having received
+        // the original message, since the server doesn't
+        // track that.
+        return;
+    }
+
+    var existing = _.find(message.submessages, function (sm) {
+        return sm.id === submsg.id;
+    });
+
+    if (existing !== undefined) {
+        blueslip.warn("Got submessage multiple times: " + submsg.id);
+        return;
+    }
+
+    if (message.submessages === undefined) {
+        message.submessages = [];
+    }
+
+    message.submessages.push(submsg);
+};
+
 exports.handle_event = function (submsg) {
+    // Update message.submessages in case we haven't actually
+    // activated the widget yet, so that when the message does
+    // come in view, the data will be complete.
+    exports.update_message(submsg);
+
     // Right now, our only use of submessages is widgets.
     var msg_type = submsg.msg_type;
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1453,6 +1453,7 @@ def do_add_submessage(sender_id: int,
         type="submessage",
         msg_type=msg_type,
         message_id=message_id,
+        submessage_id=submessage.id,
         sender_id=sender_id,
         content=content,
     )

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -872,6 +872,7 @@ class EventsRegisterTest(ZulipTestCase):
         schema_checker = self.check_events_dict([
             ('type', equals('submessage')),
             ('message_id', check_int),
+            ('submessage_id', check_int),
             ('sender_id', check_int),
             ('msg_type', check_string),
             ('content', check_string),

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -125,8 +125,11 @@ class TestBasics(ZulipTestCase):
             result = self.client_post('/json/submessage', payload)
         self.assert_json_success(result)
 
+        submessage = SubMessage.objects.get(message_id=message_id)
+
         expected_data = dict(
             message_id=message_id,
+            submessage_id=submessage.id,
             content=payload['content'],
             msg_type='whatever',
             sender_id=cordelia.id,


### PR DESCRIPTION
This continues where my earlier PR from today left off.  The best way to test this is to do "/poll" and add a poll item or vote.  Then look at current_msg_list.last().submessages to see that the latest event was added.

I don't actually have an easy repro for the fairly obscure problem this fixes, but I think the data integrity piece can only help here (and the automated tests do help ensure that to some degree).