### PR TITLE
eslint: Enable "no-whitespace-before-property".

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -330,7 +330,7 @@
         // Updated regex expressions are currently being tested in casper
         // files and will decide about a potential future enforcement of this rule.
         "no-useless-escape": 0,
-        "no-whitespace-before-property": 0,
+        "no-whitespace-before-property": 2,
         "no-with": 2,
         "one-var": [ "error", "never" ],
         "padded-blocks": 0,

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -754,7 +754,7 @@ exports.by_near_uri = function (message_id) {
 exports.by_conversation_and_time_uri = function (message, is_absolute_url) {
     var absolute_url = "";
     if (is_absolute_url) {
-        absolute_url = window.location .protocol + "//" +
+        absolute_url = window.location.protocol + "//" +
             window.location.host + "/" + window.location.pathname.split('/')[1];
     }
     if (message.type === "stream") {


### PR DESCRIPTION
More info at https://github.com/zulip/zulip/pull/8510#discussion_r190419318
eslint rule: https://eslint.org/docs/rules/no-whitespace-before-property