### PR TITLE
poll widget: Handle unknown keys.

### DIFF
--- a/static/js/voting_widget.js
+++ b/static/js/voting_widget.js
@@ -90,8 +90,14 @@ var poll_data_holder = function () {
             inbound: function (sender_id, data) {
                 var key = data.key;
                 var vote = data.vote;
+                var comment = key_to_comment[key];
 
-                var votes = key_to_comment[key].votes;
+                if (comment === undefined) {
+                    blueslip.error('unknown key for poll: ' + key);
+                    return;
+                }
+
+                var votes = comment.votes;
 
                 if (vote === 1) {
                     votes[sender_id] = 1;


### PR DESCRIPTION
This directly prevents a traceback when submessage events
arrive in the wrong order.  This was probably a symptom
of not updating message.submessages for not-yet-widgeted
messages, which was fixed in an earlier commit, but we
want defensive code in case of races or other glitches, and
it's not the end of the world is somebody sees partial
survey results due to some corner case.
