### PR TITLE
Improve "change stream privacy" form

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -518,16 +518,18 @@ exports.initialize = function () {
                                              stream.history_public_to_subscribers),
         };
         var change_privacy_modal = templates.render("subscription_stream_privacy_modal", template_data);
-
+        $("#stream_privacy_modal").remove();
         $("#subscriptions_table").append(change_privacy_modal);
-
-        $("#change-stream-privacy-button").click(function (e) {
-            change_stream_privacy(e);
-        });
+        overlays.open_modal('stream_privacy_modal');
     });
 
-    $("#subscriptions_table").on("click", ".close-privacy-modal", function () {
-        $("#stream_privacy_modal").remove();
+    $("#subscriptions_table").on('click', '#change-stream-privacy-button',
+                                 change_stream_privacy);
+
+    $("#subscriptions_table").on('click', '.close-privacy-modal', function (e) {
+        // This fixes a weird bug in which, subscription_settings hides
+        // unexpectedly by clicking the cancel button.
+        e.stopPropagation();
     });
 
     $("#subscriptions_table").on("click", "#sub_setting_not_in_home_view",

--- a/static/templates/subscription_stream_privacy_modal.handlebars
+++ b/static/templates/subscription_stream_privacy_modal.handlebars
@@ -1,11 +1,11 @@
-<div id="stream_privacy_modal" class="modal modal-bg" tabindex="-1" role="dialog" aria-labelledby="stream_privacy_modal_label" aria-hidden="true">
+<div id="stream_privacy_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="stream_privacy_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close close-privacy-modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <button type="button" class="close close-privacy-modal" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="stream_privacy_modal_label">{{t "Change stream permissions for #" }}{{ stream_name }}<span class="email"></span></h3>
     </div>
     {{ partial "stream_types" }}
     <div class="modal-footer">
-        <button class="btn btn-default close-privacy-modal">{{t "Cancel" }}</button>
+        <button class="btn btn-default close-privacy-modal" data-dismiss="modal">{{t "Cancel" }}</button>
         <button class="btn btn-danger" id="change-stream-privacy-button"
           tabindex="-1" data-stream-id="{{stream_id}}">
             {{t "Save changes"}}

--- a/static/templates/subscription_stream_privacy_modal.handlebars
+++ b/static/templates/subscription_stream_privacy_modal.handlebars
@@ -1,12 +1,12 @@
-<div id="stream_privacy_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="stream_privacy_modal_label" aria-hidden="true">
+<div id="stream_privacy_modal" class="modal modal-bg hide fade new-style" tabindex="-1" role="dialog" aria-labelledby="stream_privacy_modal_label" aria-hidden="true">
     <div class="modal-header">
         <button type="button" class="close close-privacy-modal" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="stream_privacy_modal_label">{{t "Change stream permissions for #" }}{{ stream_name }}<span class="email"></span></h3>
     </div>
     {{ partial "stream_types" }}
     <div class="modal-footer">
-        <button class="btn btn-default close-privacy-modal" data-dismiss="modal">{{t "Cancel" }}</button>
-        <button class="btn btn-danger" id="change-stream-privacy-button"
+        <button class="button rounded close-privacy-modal" data-dismiss="modal">{{t "Cancel" }}</button>
+        <button class="button rounded btn-danger" id="change-stream-privacy-button"
           tabindex="-1" data-stream-id="{{stream_id}}">
             {{t "Save changes"}}
         </button>


### PR DESCRIPTION
![peek 2018-05-31 23-05](https://user-images.githubusercontent.com/22238472/40798137-ef96a7a6-6527-11e8-9f37-4ecf3235dc5f.gif)
- [x] This modal for some reason doesn't have a backdrop. While we're at this, we should audit for others and generally clean things up to make sure all of our modals do this right.
- [x] The positioning feels a bit odd?
- [x] If you hit escape with the modal open, it closes the whole stream settings, leaving the modal open, which is broken. Suggests we're not registering this modal correctly.
- [x] The checkbox in the modal should use our standard settings checkbox styling (though note that it appears correctly in the other rendering of the stream_types.handlebars template, in our settings)