### PR TITLE
css: Fix code block formatting issues in our Markdown docs.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1682,6 +1682,14 @@ input.new-organization-button {
     margin: 5px 25px 5px;
 }
 
+.markdown .content code {
+    display: inline-block;
+}
+
+.markdown .content ol li p:not(:first-child) {
+    display: block;
+}
+
 .markdown ol p {
     margin: 0 0 2px;
 }

--- a/templates/zerver/api/deploying-bots.md
+++ b/templates/zerver/api/deploying-bots.md
@@ -33,6 +33,7 @@ in production.
 ### Installing the Zulip Botserver
 
 Install the `zulip_botserver` PyPI package using `pip`:
+
 ```
 pip install zulip_botserver
 ```
@@ -63,7 +64,8 @@ pip install zulip_botserver
 
 1. Run the Botserver, where `helloworld` is the name of the bot you
    want to run:
-   `zulip-bot-server --config-file <path_to_zuliprc> --bot-name=helloworld`
+
+    `zulip-bot-server --config-file <path_to_zuliprc> --bot-name=helloworld`
 
     You can specify the port number and various other options; run
     `zulip-bot-server --help` to see how to do this.
@@ -81,32 +83,34 @@ Botserver process.  You can do this with the following procedure.
    Botserver format." option at the top.
 
 1. Open the `botserverrc`. It should contain one or more sections that look like this:
-```
-[]
-email=foo-bot@hostname
-key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
-site=http://hostname
-```
-   Each section contains the configuration for an outgoing webhook bot. For each
-   bot, enter the name of the bot you want to run in the square brackets `[]`.
-   For example, if we want `foo-bot@hostname` to run the `helloworld` bot, our
-   new section would look like this:
 
-```
-[helloworld]
-email=foo-bot@hostname
-key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
-site=http://hostname
-```
+    ```
+    []
+    email=foo-bot@hostname
+    key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
+    site=http://hostname
+    ```
 
-3.  Run the Zulip Botserver by passing the `botserverrc` to it. The
+    Each section contains the configuration for an outgoing webhook bot. For each
+    bot, enter the name of the bot you want to run in the square brackets `[]`.
+    For example, if we want `foo-bot@hostname` to run the `helloworld` bot, our
+    new section would look like this:
+
+    ```
+    [helloworld]
+    email=foo-bot@hostname
+    key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
+    site=http://hostname
+    ```
+
+1.  Run the Zulip Botserver by passing the `botserverrc` to it. The
     command format is:
 
-    ```
-    zulip-bot-server  --config-file <path_to_botserverrc>
-    ```
+     ```
+     zulip-bot-server  --config-file <path_to_botserverrc>
+     ```
 
-    If omitted, `hostname` defaults to `127.0.0.1` and `port` to `5002`.
+     If omitted, `hostname` defaults to `127.0.0.1` and `port` to `5002`.
 
 ### Running Zulip Botserver with supervisord
 
@@ -119,9 +123,10 @@ Running the Zulip Botserver with *supervisord* works almost like
 running it manually.
 
 1.  Install *supervisord* via your package manager; e.g. on Debian/Ubuntu:
-    ```
-    sudo apt-get install supervisor
-    ```
+
+     ```
+     sudo apt-get install supervisor
+     ```
 
 1.  Configure *supervisord*.  *supervisord* stores its configuration in
     `/etc/supervisor/conf.d`.
@@ -142,20 +147,23 @@ running it manually.
 [supervisord-config-file]: https://raw.githubusercontent.com/zulip/python-zulip-api/master/zulip_botserver/zulip-botserver-supervisord.conf
 
 1. Update *supervisord* to read the configuration file:
-   ```
-   supervisorctl reread
-   supervisorctl update
-   ```
-   (or you can use `/etc/init.d/supervisord restart`, but this is less
-   disruptive if you're using *supervisord* for other services as well).
+
+    ```
+    supervisorctl reread
+    supervisorctl update
+    ```
+
+    (or you can use `/etc/init.d/supervisord restart`, but this is less
+    disruptive if you're using *supervisord* for other services as well).
 
 1. Test if your setup is successful:
-   ```
-   supervisorctl status
-   ```
-   The output should include a line similar to this:
-   > zulip-bot-server                 RUNNING   pid 28154, uptime 0:00:27
 
-   The standard output of the Botserver will be logged to the path in
-   your *supervisord* configuration.
+    ```
+    supervisorctl status
+    ```
 
+    The output should include a line similar to this:
+    > zulip-bot-server                 RUNNING   pid 28154, uptime 0:00:27
+
+    The standard output of the Botserver will be logged to the path in
+    your *supervisord* configuration.


### PR DESCRIPTION
@timabbott: I tracked down the bug (and fixed it but only partially so) but I ran into a few other concerns:

* Rendering code blocks as `inline-blocks` increases their line-height (try opening `deploying-bots.md` before and after this change to see the difference). But I can't decrease the line height because that affects all code blocks, including multiline code blocks whose line height should ideally be larger than their inline/non-multiline counterparts.

* You will notice that the code blocks do not take the full width of the paragraph they belong to and are only as wide as the content inside. I tried very hard to fix this but I couldn't, simply because all code blocks get affected by a `width: 100%` setting. So, `<p>Here is one <code>element</code></p>` and `<p><code>multiline code block that occupies the same paragraph with no content outside the code tags</code></p>` are both affected equally. The former example's `<code>` block shouldn't have `width: 100%`. But it is really hard to use CSS to distinguish between inline code blocks vs. multiline code blocks.

* I notice that our "fenced code" extension renders code blocks as `<div class=codehilite><pre></pre></div>` blocks but it doesn't work for when the code block is inside a numbered list. At some point we should probably rewrite the extension to also carve out code blocks inside numbered lists and render them in a similar fashion.

* As for the `p:not(:first-child)` change, please see [this commit](https://github.com/zulip/zulip/commit/da4ac38e372388dac7fdd600748c4d2fbac26d36#diff-596f742ad1a85ee9cfdfd8c35ea88057) and its commit message as to why this "workaround" is necessary across our Markdown docs.

These are just some things I came across while tackling this. I am by no means a CSS expert (I'm not even moderately competent at CSS), so I think at some point we might want to have someone more experienced make a follow-up to this PR! Thanks! 