### PR TITLE
Include token in outgoing webhook zuliprc.

### DIFF
--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -5,6 +5,11 @@ set_global("page_params", {
         {name:"giphy", config: {key: "12345678"}},
         {name:"foobot", config: {bar: "baz", qux: "quux"}},
     ],
+    realm_bots: [{api_key: 'QadL788EkiottHmukyhHgePUFHREiu8b',
+                  email: 'error-bot@zulip.org',
+                  full_name: 'Error bot',
+                  user_id: 1},
+    ],
 });
 
 set_global("avatar", {});
@@ -16,14 +21,13 @@ set_global('document', 'document-stub');
 zrequire('bot_data');
 zrequire('settings_bots');
 zrequire('Handlebars', 'handlebars');
+zrequire('people');
 zrequire('templates');
 
+bot_data.initialize();
+
 run_test('generate_zuliprc_uri', () => {
-    var bot = {
-        email: "error-bot@zulip.org",
-        api_key: "QadL788EkiottHmukyhHgePUFHREiu8b",
-    };
-    var uri = settings_bots.generate_zuliprc_uri(bot.email, bot.api_key);
+    var uri = settings_bots.generate_zuliprc_uri(1);
     var expected = "data:application/octet-stream;charset=utf-8," + encodeURIComponent(
         "[api]\nemail=error-bot@zulip.org\n" +
         "key=QadL788EkiottHmukyhHgePUFHREiu8b\n" +

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -207,10 +207,9 @@ exports.set_up = function () {
     });
 
     $("#download_zuliprc").on("click", function () {
-        $(this).attr("href", settings_bots.generate_zuliprc_uri(
-            people.my_current_email(),
-            $("#api_key_value").text()
-        ));
+        var data = settings_bots.generate_zuliprc_content(people.my_current_email(),
+                                                          $("#api_key_value").text());
+        $(this).attr("href", settings_bots.encode_zuliprc_as_uri(data));
     });
 
     function clear_password_change() {

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -95,9 +95,9 @@ function render_bots() {
     }
 }
 
-exports.generate_zuliprc_uri = function (email, api_key) {
-    var data = exports.generate_zuliprc_content(email, api_key);
-
+exports.generate_zuliprc_uri = function (bot_id) {
+    var bot = bot_data.get(bot_id);
+    var data = exports.generate_zuliprc_content(bot.email, bot.api_key);
     return "data:application/octet-stream;charset=utf-8," + encodeURIComponent(data);
 };
 
@@ -444,13 +444,9 @@ exports.set_up = function () {
     });
 
     $("#active_bots_list").on("click", "a.download_bot_zuliprc", function () {
-        var bot_info = $(this).closest(".bot-information-box");
-        var email = bot_info.find(".email .value").text();
-        var api_key = bot_info.find(".api_key .api-key-value-and-button .value").text();
-
-        $(this).attr("href", exports.generate_zuliprc_uri(
-            $.trim(email), $.trim(api_key)
-        ));
+        var bot_info = $(this).closest(".bot-information-box").find(".bot_info");
+        var bot_id = bot_info.attr("data-user-id");
+        $(this).attr("href", exports.generate_zuliprc_uri(bot_id));
     });
 
     $("#bots_lists_navbar .add-a-new-bot-tab").click(function (e) {

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -97,7 +97,14 @@ function render_bots() {
 
 exports.generate_zuliprc_uri = function (bot_id) {
     var bot = bot_data.get(bot_id);
-    var data = exports.generate_zuliprc_content(bot.email, bot.api_key);
+    var data;
+    var token;
+    // For outgoing webhooks, include the token in the zuliprc.
+    // It's needed for authenticating to the Botserver.
+    if (bot.bot_type === 3) {
+        token = bot_data.get_services(bot_id)[0].token;
+    }
+    data = exports.generate_zuliprc_content(bot.email, bot.api_key, token);
     return exports.encode_zuliprc_as_uri(data);
 };
 
@@ -105,11 +112,12 @@ exports.encode_zuliprc_as_uri = function (zuliprc) {
     return "data:application/octet-stream;charset=utf-8," + encodeURIComponent(zuliprc);
 };
 
-exports.generate_zuliprc_content = function (email, api_key) {
+exports.generate_zuliprc_content = function (email, api_key, token) {
     return "[api]" +
            "\nemail=" + email +
            "\nkey=" + api_key +
            "\nsite=" + page_params.realm_uri +
+           (token === undefined ? "" : ("\ntoken=" + token)) +
            // Some tools would not work in files without a trailing new line.
            "\n";
 };

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -98,7 +98,11 @@ function render_bots() {
 exports.generate_zuliprc_uri = function (bot_id) {
     var bot = bot_data.get(bot_id);
     var data = exports.generate_zuliprc_content(bot.email, bot.api_key);
-    return "data:application/octet-stream;charset=utf-8," + encodeURIComponent(data);
+    return exports.encode_zuliprc_as_uri(data);
+};
+
+exports.encode_zuliprc_as_uri = function (zuliprc) {
+    return "data:application/octet-stream;charset=utf-8," + encodeURIComponent(zuliprc);
 };
 
 exports.generate_zuliprc_content = function (email, api_key) {

--- a/templates/zerver/api/deploying-bots.md
+++ b/templates/zerver/api/deploying-bots.md
@@ -65,10 +65,10 @@ pip install zulip_botserver
 1. Run the Botserver, where `helloworld` is the name of the bot you
    want to run:
 
-    `zulip-bot-server --config-file <path_to_zuliprc> --bot-name=helloworld`
+    `zulip-botserver --config-file <path_to_zuliprc> --bot-name=helloworld`
 
     You can specify the port number and various other options; run
-    `zulip-bot-server --help` to see how to do this.
+    `zulip-botserver --help` to see how to do this.
 
 1.  Congrats, everything is set up! Test your Botserver like you would
     test a normal bot.
@@ -119,7 +119,7 @@ Botserver process.  You can do this with the following procedure.
     command format is:
 
      ```
-     zulip-bot-server  --config-file <path_to_botserverrc>
+     zulip-botserver  --config-file <path_to_botserverrc>
      ```
 
      If omitted, `hostname` defaults to `127.0.0.1` and `port` to `5002`.
@@ -147,8 +147,8 @@ running it manually.
         and store it in `/etc/supervisor/conf.d/zulip-botserver.conf`.
       * Copy the following section into your existing supervisord config file.
 
-            [program:zulip-bot-server]
-            command=zulip-bot-server --config-file=<path/to/your/botserverrc>
+            [program:zulip-botserver]
+            command=zulip-botserver --config-file=<path/to/your/botserverrc>
             --hostname <address> --port <port>
             startsecs=3
             stdout_logfile=/var/log/zulip-botserver.log ; all output of your Botserver will be logged here
@@ -175,7 +175,7 @@ running it manually.
     ```
 
     The output should include a line similar to this:
-    > zulip-bot-server                 RUNNING   pid 28154, uptime 0:00:27
+    > zulip-botserver                 RUNNING   pid 28154, uptime 0:00:27
 
     The standard output of the Botserver will be logged to the path in
     your *supervisord* configuration.

--- a/templates/zerver/api/deploying-bots.md
+++ b/templates/zerver/api/deploying-bots.md
@@ -83,12 +83,24 @@ Botserver process.  You can do this with the following procedure.
    Botserver format." option at the top.
 
 1. Open the `botserverrc`. It should contain one or more sections that look like this:
-
     ```
     []
     email=foo-bot@hostname
     key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
     site=http://hostname
+    token=aQVQmSd6j6IHphJ9m1jhgHdbnhl5ZcsY
+    ```
+    Each section contains the configuration for an outgoing webhook bot. For each
+    bot, enter the name of the bot you want to run in the square brackets `[]`.
+    For example, if we want `foo-bot@hostname` to run the `helloworld` bot, our
+    new section would look like this:
+
+    ```
+    [helloworld]
+    email=foo-bot@hostname
+    key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
+    site=http://hostname
+    token=aQVQmSd6j6IHphJ9m1jhgHdbnhl5ZcsY
     ```
 
     Each section contains the configuration for an outgoing webhook bot. For each


### PR DESCRIPTION
We need this for the Botserver to work with a zuliprc.

Casper is failing for the `bots: Add token to outgoing webhook zuliprc` commit (things worked in manual tests, tho):
![image](https://user-images.githubusercontent.com/7950151/40839100-5051ecc6-65a1-11e8-8d83-17a82da9a145.png)

I tried to debug the error in casper, but didn't come very far. Is it possible that somewhere in the test database, a bot isn't fully initialized and is missing it's bot_type value?