### PR TITLE
analytics: Add "last 2 months" and "last 6 months" button.

### DIFF
--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -635,9 +635,10 @@ function populate_number_of_users(data) {
             fixedrange: true,
             rangeslider: { bordercolor: '#D8D8D8', borderwidth: 1 },
             rangeselector: {
-                x: 0.78, y: -0.72,
+                x: 0.64, y: -0.79,
                 buttons: [
-                    { count: 30, label: i18n.t('Last 30 days'), step: 'day', stepmode: 'backward' },
+                    { count: 2, label: i18n.t('Last 2 months'), step: 'month', stepmode: 'backward' },
+                    { count: 6, label: i18n.t('Last 6 months'), step: 'month', stepmode: 'backward' },
                     { step: 'all', label: i18n.t('All time') },
                 ]}},
         yaxis: { fixedrange: true, rangemode: 'tozero' },


### PR DESCRIPTION
"last 30 months" button has been removed and some layout changes has been done to accomodate rangeslider with extra introduced buttons.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is in continuation for the PR #9618 for the issue #9557.

Screenshot:
![screenshot from 2018-06-01 23-11-21](https://user-images.githubusercontent.com/21174572/40855128-3c3f8a5e-65f1-11e8-990d-0689625d53b3.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
