### PR TITLE
/help/gdpr-compliance: Fix weird code block formatting.

### DIFF
--- a/templates/zerver/help/gdpr-compliance.md
+++ b/templates/zerver/help/gdpr-compliance.md
@@ -128,8 +128,8 @@ In addition to the features described above that are available in
 Zulip Cloud (which are also available on-premise), the following tools
 may be useful:
 
-* The Zulip server comes with a command-line tool, `manage.py
-  export_single_user`, which is a variant of the main Zulip export
+* The Zulip server comes with a command-line tool,
+  `manage.py export_single_user`, which is a variant of the main Zulip export
   tools that exports a single Zulip user's account details,
   preferences, stream subscriptions, and message history in a
   structured JSON format.


### PR DESCRIPTION
Apparently, you can't break up `a code block like this` over
multiple lines.

The only way to fix this permanently is to make sure our
"fenced code" Markdown extension applies to multiline code blocks
inside numbered lists. Once we have that done, this should be a
non-issue! Also, I am currently working on that!

@timabbott: FYI 