### PR TITLE
provisioning: Don't rebuild DB if running migrations is sufficient.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -316,12 +316,12 @@ def main(options):
         # of the development environment (it just uses the development
         # environment to build a release tarball).
 
-        # Need to set up Django before using is_template_database_current
+        # Need to set up Django before using template_database_status
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "zproject.settings")
         import django
         django.setup()
 
-        from zerver.lib.test_fixtures import is_template_database_current
+        from zerver.lib.test_fixtures import template_database_status
 
         try:
             from zerver.lib.queue import SimpleQueueClient
@@ -336,20 +336,22 @@ def main(options):
             print("RabbitMQ is already configured.")
 
         migration_status_path = os.path.join(UUID_VAR_PATH, "migration_status_dev")
-        if options.is_force or not is_template_database_current(
-                migration_status=migration_status_path,
-                settings="zproject.settings",
-                database_name="zulip",
-        ):
+        dev_template_db_status = template_database_status(
+            migration_status=migration_status_path,
+            settings="zproject.settings",
+            database_name="zulip",
+        )
+        if options.is_force or dev_template_db_status == 'needs_rebuild':
             run(["tools/setup/postgres-init-dev-db"])
             run(["tools/do-destroy-rebuild-database"])
-        else:
+        elif dev_template_db_status == 'current':
             print("No need to regenerate the dev DB.")
 
-        if options.is_force or not is_template_database_current():
+        test_template_db_status = template_database_status()
+        if options.is_force or test_template_db_status == 'needs_rebuild':
             run(["tools/setup/postgres-init-test-db"])
             run(["tools/do-destroy-rebuild-test-database"])
-        else:
+        elif test_template_db_status == 'current':
             print("No need to regenerate the test DB.")
 
         # Consider updating generated translations data: both `.mo`

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -321,7 +321,7 @@ def main(options):
         import django
         django.setup()
 
-        from zerver.lib.test_fixtures import template_database_status
+        from zerver.lib.test_fixtures import template_database_status, run_db_migrations
 
         try:
             from zerver.lib.queue import SimpleQueueClient
@@ -344,6 +344,8 @@ def main(options):
         if options.is_force or dev_template_db_status == 'needs_rebuild':
             run(["tools/setup/postgres-init-dev-db"])
             run(["tools/do-destroy-rebuild-database"])
+        elif dev_template_db_status == 'run_migrations':
+            run_db_migrations('dev')
         elif dev_template_db_status == 'current':
             print("No need to regenerate the dev DB.")
 
@@ -351,6 +353,8 @@ def main(options):
         if options.is_force or test_template_db_status == 'needs_rebuild':
             run(["tools/setup/postgres-init-test-db"])
             run(["tools/do-destroy-rebuild-test-database"])
+        elif test_template_db_status == 'run_migrations':
+            run_db_migrations('test')
         elif test_template_db_status == 'current':
             print("No need to regenerate the test DB.")
 

--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -19,7 +19,7 @@ TOOLS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if TOOLS_DIR not in sys.path:
     sys.path.insert(0, os.path.dirname(TOOLS_DIR))
 
-from zerver.lib.test_fixtures import is_template_database_current
+from zerver.lib.test_fixtures import template_database_status
 
 def set_up_django(external_host):
     # type: (str) -> None
@@ -63,7 +63,8 @@ def test_server_running(force: bool=False, external_host: str='testserver',
 
     if use_db:
         generate_fixtures_command = ['tools/setup/generate-fixtures']
-        if not is_template_database_current():
+        test_template_db_status = template_database_status()
+        if test_template_db_status == 'needs_rebuild':
             generate_fixtures_command.append('--force')
         subprocess.check_call(generate_fixtures_command)
 

--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -19,7 +19,7 @@ TOOLS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if TOOLS_DIR not in sys.path:
     sys.path.insert(0, os.path.dirname(TOOLS_DIR))
 
-from zerver.lib.test_fixtures import template_database_status
+from zerver.lib.test_fixtures import run_generate_fixtures_if_required
 
 def set_up_django(external_host):
     # type: (str) -> None
@@ -62,11 +62,7 @@ def test_server_running(force: bool=False, external_host: str='testserver',
     set_up_django(external_host)
 
     if use_db:
-        generate_fixtures_command = ['tools/setup/generate-fixtures']
-        test_template_db_status = template_database_status()
-        if test_template_db_status == 'needs_rebuild':
-            generate_fixtures_command.append('--force')
-        subprocess.check_call(generate_fixtures_command)
+        run_generate_fixtures_if_required()
 
     # Run this not through the shell, so that we have the actual PID.
     run_dev_server_command = ['tools/run-dev.py', '--test']

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -171,7 +171,7 @@ if __name__ == "__main__":
     os.environ["http_proxy"] = ""
     os.environ["https_proxy"] = ""
 
-    from zerver.lib.test_fixtures import template_database_status
+    from zerver.lib.test_fixtures import run_generate_fixtures_if_required
 
     from tools.lib.test_script import (
         get_provisioning_status,
@@ -344,11 +344,7 @@ if __name__ == "__main__":
     # files, since part of setup is importing the models for all applications in INSTALLED_APPS.
     django.setup()
 
-    test_template_db_status = template_database_status()
-    if options.generate_fixtures or test_template_db_status == 'needs_rebuild':
-        generate_fixtures_command = [os.path.join(TOOLS_DIR, 'setup', 'generate-fixtures')]
-        generate_fixtures_command.append('--force')
-        subprocess.call(generate_fixtures_command)
+    run_generate_fixtures_if_required(options.generate_fixtures)
 
     subprocess.check_call(['tools/webpack', '--test'])
 

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -171,7 +171,7 @@ if __name__ == "__main__":
     os.environ["http_proxy"] = ""
     os.environ["https_proxy"] = ""
 
-    from zerver.lib.test_fixtures import is_template_database_current
+    from zerver.lib.test_fixtures import template_database_status
 
     from tools.lib.test_script import (
         get_provisioning_status,
@@ -344,7 +344,8 @@ if __name__ == "__main__":
     # files, since part of setup is importing the models for all applications in INSTALLED_APPS.
     django.setup()
 
-    if options.generate_fixtures or not is_template_database_current():
+    test_template_db_status = template_database_status()
+    if options.generate_fixtures or test_template_db_status == 'needs_rebuild':
         generate_fixtures_command = [os.path.join(TOOLS_DIR, 'setup', 'generate-fixtures')]
         generate_fixtures_command.append('--force')
         subprocess.call(generate_fixtures_command)

--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -17,16 +17,31 @@ from django.core.management import call_command
 from django.utils.module_loading import module_has_submodule
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
-from scripts.lib.zulip_tools import get_dev_uuid_var_path
+from scripts.lib.zulip_tools import get_dev_uuid_var_path, run
 
 UUID_VAR_DIR = get_dev_uuid_var_path()
 FILENAME_SPLITTER = re.compile('[\W\-_]')
+
+def run_db_migrations(platform: str) -> None:
+    if platform == 'dev':
+        migration_status_file = 'migration_status_dev'
+        settings = 'zproject.settings'
+    elif platform == 'test':
+        migration_status_file = 'migration_status_test'
+        settings = 'zproject.test_settings'
+
+    run(['env', ('DJANGO_SETTINGS_MODULE=%s' % settings), './manage.py',
+         'migrate', '--no-input'])
+    run(['env', ('DJANGO_SETTINGS_MODULE=%s' % settings), './manage.py',
+         'get_migration_status', '--output=%s' % (migration_status_file)])
 
 def run_generate_fixtures_if_required(use_force: bool=False) -> None:
     generate_fixtures_command = ['tools/setup/generate-fixtures']
     test_template_db_status = template_database_status()
     if use_force or test_template_db_status == 'needs_rebuild':
         generate_fixtures_command.append('--force')
+    elif test_template_db_status == 'run_migrations':
+        run_db_migrations('test')
     subprocess.check_call(generate_fixtures_command)
 
 def database_exists(database_name: str, **options: Any) -> bool:
@@ -68,13 +83,31 @@ def get_migration_status(**options: Any) -> str:
     output = out.read()
     return re.sub('\x1b\[(1|0)m', '', output)
 
-def are_migrations_the_same(migration_file: str, **options: Any) -> bool:
+def extract_migrations_as_list(migration_status: str) -> List[str]:
+    MIGRATIONS_RE = re.compile('\[[X| ]\] (\d+_.+)\n')
+    return MIGRATIONS_RE.findall(migration_status)
+
+def what_to_do_with_migrations(migration_file: str, **options: Any) -> str:
     if not os.path.exists(migration_file):
-        return False
+        return 'scrap'
 
     with open(migration_file) as f:
-        migration_content = f.read()
-    return migration_content == get_migration_status(**options)
+        previous_migration_status = f.read()
+    current_migration_status = get_migration_status(**options)
+    all_curr_migrations = extract_migrations_as_list(current_migration_status)
+    all_prev_migrations = extract_migrations_as_list(previous_migration_status)
+
+    if len(all_curr_migrations) < len(all_prev_migrations):
+        return 'scrap'
+
+    for migration in all_prev_migrations:
+        if migration not in all_curr_migrations:
+            return 'scrap'
+
+    if len(all_curr_migrations) == len(all_prev_migrations):
+        return 'migrations_are_latest'
+
+    return 'migrate'
 
 def _get_hash_file_path(source_file_path: str, status_dir: str) -> str:
     basename = os.path.basename(source_file_path)
@@ -152,8 +185,16 @@ def template_database_status(
         settings_hash_status = all([check_setting_hash(setting_name, status_dir)
                                     for setting_name in check_settings])
         hash_status = files_hash_status and settings_hash_status
+        if not hash_status:
+            return 'needs_rebuild'
 
-        if are_migrations_the_same(migration_status, settings=settings) and hash_status:
-            return 'current'
+        migration_op = what_to_do_with_migrations(migration_status, settings=settings)
+        if migration_op == 'scrap':
+            return 'needs_rebuild'
+
+        if migration_op == 'migrate':
+            return 'run_migrations'
+
+        return 'current'
 
     return 'needs_rebuild'

--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import hashlib
+import subprocess
 import sys
 from typing import Any, List, Optional
 from importlib import import_module
@@ -20,6 +21,13 @@ from scripts.lib.zulip_tools import get_dev_uuid_var_path
 
 UUID_VAR_DIR = get_dev_uuid_var_path()
 FILENAME_SPLITTER = re.compile('[\W\-_]')
+
+def run_generate_fixtures_if_required(use_force: bool=False) -> None:
+    generate_fixtures_command = ['tools/setup/generate-fixtures']
+    test_template_db_status = template_database_status()
+    if use_force or test_template_db_status == 'needs_rebuild':
+        generate_fixtures_command.append('--force')
+    subprocess.check_call(generate_fixtures_command)
 
 def database_exists(database_name: str, **options: Any) -> bool:
     db = options.get('database', DEFAULT_DB_ALIAS)

--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -107,14 +107,15 @@ def check_setting_hash(setting_name: str, status_dir: str) -> bool:
 
     return _check_hash(source_hash_file, target_content)
 
-def is_template_database_current(
+def template_database_status(
         database_name: str='zulip_test_template',
         migration_status: Optional[str]=None,
         settings: str='zproject.test_settings',
         status_dir: Optional[str]=None,
         check_files: Optional[List[str]]=None,
-        check_settings: Optional[List[str]]=None) -> bool:
-    # Using str type for check_files because re.split doesn't accept unicode
+        check_settings: Optional[List[str]]=None) -> str:
+    # This function returns a status string specifying the type of
+    # state the template db is in and thus the kind of action required.
     if check_files is None:
         check_files = [
             'zilencer/management/commands/populate_db.py',
@@ -144,6 +145,7 @@ def is_template_database_current(
                                     for setting_name in check_settings])
         hash_status = files_hash_status and settings_hash_status
 
-        return are_migrations_the_same(migration_status, settings=settings) and hash_status
+        if are_migrations_the_same(migration_status, settings=settings) and hash_status:
+            return 'current'
 
-    return False
+    return 'needs_rebuild'


### PR DESCRIPTION
So to do this one we basically rather than just saying in Boolean terms if db was current or not, we make levels 3, 2, 1 which are returned by  `is_template_database_current` and on that basis we decide what has to be done.

Fixes: #9512.
