### PR TITLE
create stream: Fix widget for changing privacy doesn't render initially.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -263,6 +263,10 @@ exports.update_settings_for_subscribed = function (sub) {
 
         button.toggleClass("checked");
         settings_button.text(i18n.t("Unsubscribe"));
+
+        if (sub.can_change_stream_permissions) {
+            $(".change-stream-privacy").show();
+        }
     } else {
         exports.add_sub_to_table(sub);
     }

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -37,9 +37,7 @@
             <div class="subscription-type-text">
                 {{partial "subscription_type"}}
             </div>
-            {{#if can_change_stream_permissions}}
-            <a class="change-stream-privacy">[{{t "Change" }}]</a>
-            {{/if}}
+            <a class="change-stream-privacy" {{#unless can_change_stream_permissions}}style="display: none;"{{/unless}}>[{{t "Change" }}]</a>
         </div>
         <div class="regular_subscription_settings collapse {{#subscribed}}in{{/subscribed}}">
             <div class="subscription-config">


### PR DESCRIPTION
When admin user create new private stream, widget for changing privacy
of stream doesn't render. Because we render subscription-settings
template partially on subscription-add event, so this case wasn't
handled.

Fixes #9469
![changestreamprivacy](https://user-images.githubusercontent.com/25907420/40858638-968cef46-65fc-11e8-9801-ae75d21ffb05.gif)
