### PR TITLE
stream: Change gather_subscriptions_helper for guest users.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4050,6 +4050,11 @@ def gather_subscriptions_helper(user_profile: UserProfile,
         if stream["invite_only"] and not (sub["active"] or user_profile.is_realm_admin):
             subscribers = None
 
+        # Also don't show subscribers to guest user when guest user isn't subscribed
+        # to a public stream anymore
+        if not sub["active"] and user_profile.is_guest:
+            subscribers = None
+
         stream_dict = {'name': stream["name"],
                        'in_home_view': sub["in_home_view"],
                        'invite_only': stream["invite_only"],

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2213,6 +2213,10 @@ def validate_user_access_to_subscribers_helper(user_profile: Optional[UserProfil
     if user_profile.realm_id != stream_dict["realm_id"]:
         raise ValidationError("Requesting user not in given realm")
 
+    # Guest users can access subscribed public stream's subscribers
+    if user_profile.is_guest and check_user_subscribed():
+        return
+
     if not user_profile.can_access_public_streams() and not stream_dict["invite_only"]:
         raise JsonableError(_("Subscriber data is not available for this stream"))
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -822,7 +822,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     def can_access_public_streams(self) -> bool:
         # This function is intended to be the core function for how
         # guest accounts interact with public streams.
-        return not self.realm.is_zephyr_mirror_realm
+        return not (self.realm.is_zephyr_mirror_realm or self.is_guest)
 
     def major_tos_version(self) -> int:
         if self.tos_version is not None:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3018,6 +3018,47 @@ class GetSubscribersTest(ZulipTestCase):
 
         test_admin_case()
 
+    def test_gather_subscribed_streams_for_guest_user(self) -> None:
+        guest_user = self.example_user("polonius")
+
+        stream_name_sub = "public_stream_1"
+        self.make_stream(stream_name_sub, realm=get_realm("zulip"))
+        self.subscribe(guest_user, stream_name_sub)
+
+        stream_name_unsub = "public_stream_2"
+        self.make_stream(stream_name_unsub, realm=get_realm("zulip"))
+        self.subscribe(guest_user, stream_name_unsub)
+        self.unsubscribe(guest_user, stream_name_unsub)
+
+        stream_name_never_sub = "public_stream_3"
+        self.make_stream(stream_name_never_sub, realm=get_realm("zulip"))
+
+        normal_user = self.example_user("aaron")
+        self.subscribe(normal_user, stream_name_sub)
+        self.subscribe(normal_user, stream_name_unsub)
+        self.subscribe(normal_user, stream_name_unsub)
+
+        subs, unsubs, neversubs = gather_subscriptions_helper(guest_user)
+
+        # Guest users get info about subscribed public stream's subscribers
+        expected_stream_exists = False
+        for sub in subs:
+            if sub["name"] == stream_name_sub:
+                expected_stream_exists = True
+                self.assertEqual(len(sub["subscribers"]), 2)
+        self.assertTrue(expected_stream_exists)
+
+        # Guest users don't get info about unsubscribed public stream's subscribers
+        expected_stream_exists = False
+        for unsub in unsubs:
+            if unsub["name"] == stream_name_unsub:
+                expected_stream_exists = True
+                self.assertNotIn("subscribers", unsub)
+        self.assertTrue(expected_stream_exists)
+
+        # Guest user don't get data about never subscribed public stream's data
+        self.assertEqual(len(neversubs), 0)
+
     def test_previously_subscribed_private_streams(self) -> None:
         admin_user = self.example_user("iago")
         non_admin_user = self.example_user("cordelia")

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3031,17 +3031,17 @@ class GetSubscribersTest(ZulipTestCase):
         self.unsubscribe(admin_user, stream_name)
         self.unsubscribe(non_admin_user, stream_name)
 
-        # Test non admin user shouldn't get previously subscribed private stream's subscribers.
+        # Test admin user shouldn't get previously subscribed private stream's subscribers.
         sub_data = gather_subscriptions_helper(admin_user)
         unsubscribed_streams = sub_data[1]
         self.assertEqual(len(unsubscribed_streams), 1)
         self.assertEqual(len(unsubscribed_streams[0]["subscribers"]), 1)
 
-        # Test admin users can get previously subscribed private stream's subscribers.
+        # Test non admin users can get previously subscribed private stream's subscribers.
         sub_data = gather_subscriptions_helper(non_admin_user)
         unsubscribed_streams = sub_data[1]
         self.assertEqual(len(unsubscribed_streams), 1)
-        self.assertFalse('subscribers' in unsubscribed_streams)
+        self.assertFalse('subscribers' in unsubscribed_streams[0])
 
     def test_gather_subscriptions_mit(self) -> None:
         """


### PR DESCRIPTION
* I don't actually understand where to use `queries_captured()` context manager, i.e. which queries does it counts and do I need to use it here in tests.
* I've added tests in a separate last commit; Except `test_subs: Fix typos in test_previously_s..` commit all can be squashed into one. (All commits passes `test_subs` test individually.)

I've few more doubts which I'll ask in a review comment.

Testing:
* Backend tests
* Manually tested and never subscribed streams never appears in "All streams" tab.
* Image of Unsubscribed Public Stream: 
![unsubscribed public stream](https://user-images.githubusercontent.com/22238472/40872868-95fde518-6673-11e8-8705-67046b8ce964.png)
