### PR TITLE
hotkeys: Replace Esc with "a" for "All Messages".

### DIFF
--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -376,11 +376,12 @@ exports.expected_messages = function (table, headings, bodies) {
 
 exports.un_narrow = function () {
     casper.test.info('Un-narrowing');
-    if (casper.visible('.message_comp')) {
-        // close the compose box
-        common.keypress(27); // Esc
-    }
+
+    // Press the escape key to close any open modals.
     common.keypress(27); // Esc
+
+    // Then hit a to go to All Messages
+    casper.page.sendEvent('keypress', 'a');
 };
 
 return exports;

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -170,7 +170,7 @@ run_test('basic_chars', () => {
 
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
-    assert_unmapped('abefhlmotyz');
+    assert_unmapped('befhlmotyz');
     assert_unmapped('BEFHILNOQTUWXYZ');
 
     // We have to skip some checks due to the way the code is
@@ -289,6 +289,7 @@ run_test('basic_chars', () => {
     assert_mapping('i', 'popovers.open_message_menu');
     assert_mapping(':', 'reactions.open_reactions_popover', true);
     assert_mapping('>', 'compose_actions.quote_and_reply');
+    assert_mapping('a', 'narrow.deactivate');
 
     overlays.is_active = return_true;
     overlays.lightbox_open = return_true;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -95,6 +95,7 @@ var keypress_mappings = {
     82: {name: 'respond_to_author', message_view_only: true}, // 'R'
     83: {name: 'narrow_by_topic', message_view_only: true}, //'S'
     86: {name: 'view_selected_stream', message_view_only: false}, //'V'
+    97: {name: 'all_messages', message_view_only: true}, // 'a'
     99: {name: 'compose', message_view_only: true}, // 'c'
     100: {name: 'open_drafts', message_view_only: true}, // 'd'
     103: {name: 'gear_menu', message_view_only: true}, // 'g'
@@ -284,7 +285,7 @@ exports.process_escape_key = function (e) {
         return true;
     }
 
-    narrow.deactivate();
+    ui.maybe_show_deprecation_notice('Esc');
     return true;
 };
 
@@ -633,6 +634,9 @@ exports.process_hotkey = function (e, hotkey) {
         return true;
     case 'compose_private_message':
         compose_actions.start('private', {trigger: "compose_hotkey"});
+        return true;
+    case 'all_messages':
+        narrow.deactivate();
         return true;
     case 'narrow_private':
         return do_narrow_action(function (target, opts) {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -133,6 +133,10 @@ exports.get_hotkey_deprecation_notice = function (originalHotkey, replacementHot
 
 var shown_deprecation_notices = [];
 exports.maybe_show_deprecation_notice = function (key) {
+    if (page_params.test_suite) {
+        return;
+    }
+
     var message;
     var isCmdOrCtrl = /Mac/i.test(navigator.userAgent) ? "Cmd" : "Ctrl";
     if (key === 'C') {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -141,6 +141,8 @@ exports.maybe_show_deprecation_notice = function (key) {
     var isCmdOrCtrl = /Mac/i.test(navigator.userAgent) ? "Cmd" : "Ctrl";
     if (key === 'C') {
         message = exports.get_hotkey_deprecation_notice('C', 'x');
+    } else if (key === 'Esc') {
+        message = i18n.t('We\'ve replaced the "Esc" hotkey with "a" to got to "All messages".');
     } else if (key === '*') {
         message = exports.get_hotkey_deprecation_notice("*", isCmdOrCtrl + " + s");
     } else {

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -183,7 +183,7 @@
                     <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Esc, Ctrl + [</td>
+                    <td class="hotkey">a</td>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
                 </tr>
                 <tr>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -78,7 +78,7 @@ below, and add more to your repertoire as needed.
 
 * **Cycle between stream narrows**: `A` (previous) and `D` (next)
 
-* **Narrow to all messages**: `Esc` or `Ctrl` + `[` — Shows all unmuted messages.
+* **Narrow to all messages**: `a` — Shows all unmuted messages.
 
 * **Narrow to current compose box recipient**: `Ctrl` + `.`
 


### PR DESCRIPTION
This avoids a common pitfall where you hit the Esc key once to do something like close a modal or exit search, and then hit it again cause the app is sluggish, and then you get surprisingly dumped into the interleaved view, which is very jarring.