### PR TITLE
 digest: Make newly registered users data inaccessible to guest users.

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -146,7 +146,7 @@ def gather_hot_conversations(user_profile: UserProfile, stream_messages: QuerySe
 def gather_new_users(user_profile: UserProfile, threshold: datetime.datetime) -> Tuple[int, List[str]]:
     # Gather information on users in the realm who have recently
     # joined.
-    if user_profile.realm.is_zephyr_mirror_realm:
+    if not user_profile.can_access_all_realm_members():
         new_users = []  # type: List[UserProfile]
     else:
         new_users = list(UserProfile.objects.filter(

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -825,7 +825,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         return not self.realm.is_zephyr_mirror_realm
 
     def can_access_all_realm_members(self) -> bool:
-        return not self.realm.is_zephyr_mirror_realm
+        return not (self.realm.is_zephyr_mirror_realm or self.is_guest)
 
     def major_tos_version(self) -> int:
         if self.tos_version is not None:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -824,6 +824,9 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         # guest accounts interact with public streams.
         return not self.realm.is_zephyr_mirror_realm
 
+    def can_access_all_realm_members(self) -> bool:
+        return not self.realm.is_zephyr_mirror_realm
+
     def major_tos_version(self) -> int:
         if self.tos_version is not None:
             return int(self.tos_version.split('.')[0])


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Again, both commits can be squashed into one(if needed).
**Testing Plan:** <!-- How have you tested? -->
Backend tests only.


