### PR TITLE
 hotkeys: Add "Ctrl+Shift+s" and change "S" to "T" hotkey.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -101,6 +101,7 @@ run_test('mappings', () => {
     assert.equal(map_down(219, false, true).name, 'escape'); // ctrl + [
     assert.equal(map_down(75, false, true).name, 'search_with_k'); // ctrl + k
     assert.equal(map_down(83, false, true).name, 'star_message'); // ctrl + s
+    assert.equal(map_down(83, true, true, false).name, 'narrow_starred'); // ctrl + shift + s
 
     // More negative tests.
     assert.equal(map_down(47), undefined);
@@ -130,6 +131,7 @@ run_test('mappings', () => {
     assert.equal(map_down(75, false, true, false), undefined); // ctrl + k
     assert.equal(map_down(83, false, false, true).name, 'star_message'); // cmd + s
     assert.equal(map_down(83, false, true, false), undefined); // ctrl + s
+    assert.equal(map_down(83, true, false, true).name, 'narrow_starred'); // cmd + shift + s
     // Reset userAgent
     global.navigator.userAgent = '';
 });
@@ -165,7 +167,7 @@ run_test('basic_chars', () => {
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
     assert_unmapped('abefhlmotyz');
-    assert_unmapped('BEFHILNOQTUWXYZ');
+    assert_unmapped('BEFHILNOQUWXYZ');
 
     // We have to skip some checks due to the way the code is
     // currently organized for mapped keys.
@@ -221,7 +223,7 @@ run_test('basic_chars', () => {
     page_params.can_create_streams = true;
     overlays.streams_open = return_true;
     overlays.is_active = return_true;
-    assert_mapping('S', 'subs.keyboard_sub');
+    assert_mapping('T', 'subs.keyboard_sub');
     assert_mapping('V', 'subs.view_stream');
     assert_mapping('n', 'subs.new_stream_clicked');
     page_params.can_create_streams = false;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -56,6 +56,10 @@ var keydown_cmd_or_ctrl_mappings = {
     83: {name: 'star_message', message_view_only: true}, // 's'
 };
 
+var keydown_cmd_or_ctrl_and_shift_mappings = {
+    83: {name: 'narrow_starred', message_view_only: false}, // 's'
+};
+
 var keydown_either_mappings = {
     // these can be triggered by key or shift + key
     // Note that codes for letters are still case sensitive!
@@ -92,6 +96,7 @@ var keypress_mappings = {
     80: {name: 'narrow_private', message_view_only: true}, // 'P'
     82: {name: 'respond_to_author', message_view_only: true}, // 'R'
     83: {name: 'narrow_by_subject', message_view_only: true}, //'S'
+    84: {name: 'toggle_subscription', message_view_only: true}, //'T'
     86: {name: 'view_selected_stream', message_view_only: false}, //'V'
     99: {name: 'compose', message_view_only: true}, // 'c'
     100: {name: 'open_drafts', message_view_only: true}, // 'd'
@@ -126,7 +131,11 @@ exports.get_keydown_hotkey = function (e) {
 
     var isCmdOrCtrl = /Mac/i.test(navigator.userAgent) ? e.metaKey : e.ctrlKey;
     if (isCmdOrCtrl) {
-        hotkey = keydown_cmd_or_ctrl_mappings[e.which];
+        if (e.shiftKey) {
+            hotkey = keydown_cmd_or_ctrl_and_shift_mappings[e.which];
+        } else {
+            hotkey = keydown_cmd_or_ctrl_mappings[e.which];
+        }
         if (hotkey) {
             return hotkey;
         }
@@ -461,6 +470,10 @@ exports.process_hotkey = function (e, hotkey) {
             return false;
         }
         if (event_name === 'narrow_by_subject' && overlays.streams_open()) {
+            ui.maybe_show_deprecation_notice('S');
+            return true;
+        }
+        if (event_name === 'toggle_subscription' && overlays.streams_open()) {
             subs.keyboard_sub();
             return true;
         }
@@ -664,6 +677,8 @@ exports.process_hotkey = function (e, hotkey) {
     case 'star_deprecated':
         ui.maybe_show_deprecation_notice('*');
         return true;
+    case 'narrow_starred':
+        return narrow.by('is', 'starred');
     }
 
     if (current_msg_list.empty()) {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -130,6 +130,8 @@ exports.maybe_show_deprecation_notice = function (key) {
         message = i18n.t('We\'ve replaced the "C" hotkey with "x" to make this common shortcut easier to trigger.');
     } else if (key === '*') {
         message = i18n.t('We\'ve replaced the "*" hotkey with "Ctrl + s" to make this common shortcut easier to trigger.');
+    } else if (key === 'S') {
+        message = i18n.t('We\'ve replaced the "S" hotkey with "T" to make this common shortcut easier to trigger.');
     } else {
         blueslip.error("Unexpected deprecation notice for hotkey:", key);
         return;

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -171,6 +171,10 @@
                     <td class="definition">{% trans %}Narrow to all private messages{% endtrans %}</td>
                 </tr>
                 <tr>
+                    <td class="hotkey">Ctrl + Shift + s</td>
+                    <td class="definition">{% trans %}Narrow to all starred messages{% endtrans %}</td>
+                </tr>
+                <tr>
                     <td class="hotkey">n</td>
                     <td class="definition">{% trans %}Narrow to next unread topic{% endtrans %}</td>
                 </tr>
@@ -299,7 +303,7 @@
                     <td class="definition">{% trans %}View stream messages{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">S</td>
+                    <td class="hotkey">T</td>
                     <td class="definition">{% trans %}Subscribe to/unsubscribe from selected stream{% endtrans %}</td>
                 </tr>
                 <tr>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -76,6 +76,8 @@ below, and add more to your repertoire as needed.
 
 * **Narrow to all private messages**: `P`
 
+* **Narrow to all starred messages**: `Ctrl + Shift + s`
+
 * **Cycle between stream narrows**: `A` (previous) and `D` (next)
 
 * **Narrow to all messages**: `Esc` or `Ctrl` + `[` — Shows all unmuted messages.
@@ -174,4 +176,4 @@ Keyboard navigation (e.g. arrow keys) works as expected.
 
 * **View stream messages**: `V`
 
-* **Toggle subscription**: `S`
+* **Toggle subscription**: `T`


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
~~This PR is divided into 3 commits.~~
~~1. Resolves #9614.~~
~~2. For the issue #9613 (replace * hotkey with Ctrl + s), there is a comment in hotkey.js which refer to * hotkey, it has been replaced with Ctrl + s.~~ (Commit Merged)
~~3. Close deprecation notice on Enter keypress.~~ (Commit Merged)

Fixes: #9684 and #9614.