### PR TITLE
custom fields: Fix buggy behaviour of trash icon in choice type of field.

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -81,7 +81,7 @@ function add_choice_row(e) {
 }
 
 function delete_choice_row(e) {
-    var row = $(e.target).parent();
+    var row = $(e.currentTarget).parent();
     row.remove();
 }
 


### PR DESCRIPTION
Followup of #9355 

In admin UI for creating new choice type of custom field, the behavior
of trash icon for removing choice field is buggy.
When admin clicks on trash icon it disappears, but the row does not
and admin end up being unable to create the field.

Fix this by selecting proper element to find and delete choice row.

![choicetrashicon](https://user-images.githubusercontent.com/25907420/40887759-eda9e5da-676a-11e8-9582-a87da9f20e20.gif)
