### PR TITLE
hotkeys: Use `D` to open the last draft.

### DIFF
--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -151,6 +151,7 @@ populated and where the focus is placed.
     - use R to reply to the author of a PM stream
     - use c to compose a stream message
     - use x to compose a new PM
+    - use D to restore the last draft
 
 - Buttons
     - Narrow to a stream and click on "New topic"

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -248,6 +248,8 @@ run_test('basic_chars', () => {
     overlays.is_active = return_false;
     assert_mapping('d', 'drafts.launch');
 
+    assert_mapping('D', 'drafts.restore_last_draft');
+
     // Next, test keys that only work on a selected message.
     var message_view_only_keys = '@+>RjJkKsSuvi:GM';
 

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -235,9 +235,6 @@ run_test('basic_chars', () => {
     assert_mapping('w', 'activity.initiate_search');
     assert_mapping('q', 'stream_list.initiate_search');
 
-    assert_mapping('A', 'narrow.stream_cycle_backward');
-    assert_mapping('D', 'narrow.stream_cycle_forward');
-
     assert_mapping('c', 'compose_actions.start');
     assert_mapping('x', 'compose_actions.start');
     assert_mapping('P', 'narrow.by');

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -119,7 +119,7 @@ exports.delete_draft_after_send = function () {
     $("#compose-textarea").removeData("draft-id");
 };
 
-exports.restore_draft = function (draft_id) {
+exports.restore_draft = function (draft_id, close_overlay) {
     var draft = draft_model.getDraft(draft_id);
     if (!draft) {
         return;
@@ -151,7 +151,9 @@ exports.restore_draft = function (draft_id) {
         }
     }
 
-    overlays.close_overlay("drafts");
+    if (close_overlay || close_overlay === undefined) {
+        overlays.close_overlay("drafts");
+    }
     compose_fade.clear_compose();
     compose.clear_preview_area();
 
@@ -434,6 +436,17 @@ exports.launch = function () {
             var focus_element = last_draft_element[0].children[0];
             focus_element.focus();
             $(".drafts-list")[0].scrollTop = $('.drafts-list')[0].scrollHeight - $('.drafts-list').height();
+        }
+    });
+};
+
+exports.restore_last_draft = function () {
+    exports.setup_page(function () {
+        var draft_list = drafts.draft_model.get();
+        var draft_id_list = Object.getOwnPropertyNames(draft_list);
+        if (draft_id_list.length > 0) {
+            var last_draft = draft_id_list[draft_id_list.length-1];
+            exports.restore_draft(last_draft, false);
         }
     });
 };

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -84,6 +84,7 @@ var keypress_mappings = {
     64: {name: 'compose_reply_with_mention', message_view_only: true}, // '@'
     65: {name: 'A_deprecated', message_view_only: true}, // 'A'
     67: {name: 'C_deprecated', message_view_only: true}, // 'C'
+    68: {name: 'open_last_draft', message_view_only: true}, // 'D'
     71: {name: 'G_end', message_view_only: true}, // 'G'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
     75: {name: 'vim_page_up', message_view_only: true}, // 'K'
@@ -651,6 +652,9 @@ exports.process_hotkey = function (e, hotkey) {
         return true;
     case 'open_drafts':
         drafts.launch();
+        return true;
+    case 'open_last_draft':
+        drafts.restore_last_draft();
         return true;
     case 'reply_message': // 'r': respond to message
         // Note that you can "enter" to respond to messages as well,

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -82,9 +82,8 @@ var keypress_mappings = {
     62: {name: 'compose_quote_reply', message_view_only: true}, // '>'
     63: {name: 'show_shortcuts', message_view_only: false}, // '?'
     64: {name: 'compose_reply_with_mention', message_view_only: true}, // '@'
-    65: {name: 'stream_cycle_backward', message_view_only: true}, // 'A'
+    65: {name: 'A_deprecated', message_view_only: true}, // 'A'
     67: {name: 'C_deprecated', message_view_only: true}, // 'C'
-    68: {name: 'stream_cycle_forward', message_view_only: true}, // 'D'
     71: {name: 'G_end', message_view_only: true}, // 'G'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
     75: {name: 'vim_page_up', message_view_only: true}, // 'K'
@@ -657,6 +656,9 @@ exports.process_hotkey = function (e, hotkey) {
         // Note that you can "enter" to respond to messages as well,
         // but that is handled in process_enter_key().
         compose_actions.respond_to_message({trigger: 'hotkey'});
+        return true;
+    case 'A_deprecated':
+        ui.maybe_show_deprecation_notice('A');
         return true;
     case 'C_deprecated':
         ui.maybe_show_deprecation_notice('C');

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -126,7 +126,9 @@ exports.show_failed_message_success = function (message_id) {
 var shown_deprecation_notices = [];
 exports.maybe_show_deprecation_notice = function (key) {
     var message;
-    if (key === 'C') {
+    if (key === 'A') {
+        message = i18n.t('We\'ve removed the "A" hotkey.');
+    } else if (key === 'C') {
         message = i18n.t('We\'ve replaced the "C" hotkey with "x" to make this common shortcut easier to trigger.');
     } else if (key === '*') {
         message = i18n.t('We\'ve replaced the "*" hotkey with "Ctrl + s" to make this common shortcut easier to trigger.');

--- a/static/styles/drafts.scss
+++ b/static/styles/drafts.scss
@@ -61,13 +61,20 @@
     -webkit-font-smoothing: antialiased;
 }
 
-.drafts-list .removed-drafts {
+.drafts-list .removed-drafts,
+.drafts-list .last-draft-hotkey {
     display: block;
     text-align: center;
     font-size: 1em;
     color: hsl(0, 0%, 66%);
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
+}
+
+.drafts-list .last-draft-hotkey {
+    position: absolute;
+    bottom: 10px;
+    width: 100%;
 }
 
 .draft-row {

--- a/static/templates/draft_table_body.handlebars
+++ b/static/templates/draft_table_body.handlebars
@@ -18,6 +18,10 @@
                 {{#each drafts}}
                 {{partial "draft"}}
                 {{/each}}
+
+                <div class="last-draft-hotkey">
+                    {{#tr this}} Type <strong>shift + d</strong> from the main message feed to restore the last draft {{/tr}}
+                </div>
             </div>
         </div>
     </div>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -179,10 +179,6 @@
                     <td class="definition">{% trans %}Narrow to next unread private message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">A, D</td>
-                    <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
-                </tr>
-                <tr>
                     <td class="hotkey">Esc, Ctrl + [</td>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
                 </tr>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -249,6 +249,10 @@
                     <td class="hotkey">Backspace</td>
                     <td class="definition">{% trans %}Delete selected draft{% endtrans %}</td>
                 </tr>
+                <tr>
+                    <td class="hotkey">D</td>
+                    <td class="definition">{% trans %}Edit last draft{% endtrans %}</td>
+                </tr>
             </table>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -76,8 +76,6 @@ below, and add more to your repertoire as needed.
 
 * **Narrow to all private messages**: `P`
 
-* **Cycle between stream narrows**: `A` (previous) and `D` (next)
-
 * **Narrow to all messages**: `Esc` or `Ctrl` + `[` — Shows all unmuted messages.
 
 ## Composing messages

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -135,6 +135,8 @@ title="thumbs up"/>**: `+`
 
 * **Toggle drafts view**: `d`
 
+* **Edit last draft**: `D`
+
 ### Within the drafts view
 
 * **Edit selected draft**: `Enter`


### PR DESCRIPTION
This PR fixes #9612.

It updates the `D` hotkey to edit the last draft, removes hotkey `A`, adds a deprecation notice for `A`, and adds a message to the bottom of the drafts view about the `D` hotkey.

**Testing Plan:** <!-- How have you tested? -->

Tests have been updated to remove tests for `A` and fix texts for `D`.

**Screenshot:**

Drafts list with new message at the bottom:

<img width="890" alt="screen shot 2018-06-03 at 10 10 49 am" src="https://user-images.githubusercontent.com/17259768/40889143-6ce4e9e4-6716-11e8-8cce-2eb3f7d6cc4e.png">
