### PR TITLE
stream settings: Add event to update stream privacy for realm-time-sync.

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -393,6 +393,8 @@ run_test('stream_settings', () => {
         color: 'amber',
         subscribed: true,
         invite_only: true,
+        history_public_to_subscribers: true,
+        is_announcement_only: true,
     };
     stream_data.clear_subscriptions();
     stream_data.add_sub(cinnamon.name, cinnamon);
@@ -412,6 +414,19 @@ run_test('stream_settings', () => {
     assert.equal(sub_rows[1].invite_only, false);
     assert.equal(sub_rows[2].invite_only, false);
 
+    assert.equal(sub_rows[0].history_public_to_subscribers, true);
+    assert.equal(sub_rows[0].is_announcement_only, true);
+
+    var sub = stream_data.get_sub('a');
+    stream_data.update_stream_privacy(sub, {
+        invite_only: false,
+        history_public_to_subscribers: false,
+    });
+    stream_data.update_stream_announcement_only(sub, false);
+    stream_data.update_calculated_fields(sub);
+    assert.equal(sub.invite_only, false);
+    assert.equal(sub.history_public_to_subscribers, false);
+    assert.equal(sub.is_announcement_only, false);
 });
 
 run_test('default_stream_names', () => {

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -109,7 +109,7 @@ run_test('update_property', () => {
     with_overrides(function (override) {
         global.with_stub(function (stub) {
             override('subs.update_stream_description', stub.f);
-            stream_events.update_property(1, 'description', 'we write code');
+            stream_events.update_property(1, 'description', 'we write code', {rendered_description: 'we write code'});
             var args = stub.get_args('sub', 'val');
             assert.equal(args.sub.stream_id, 1);
             assert.equal(args.val, 'we write code');

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -128,6 +128,32 @@ run_test('update_property', () => {
         assert.equal(checkbox.prop('checked'), true);
     });
 
+    // Test stream privacy change event
+    with_overrides(function (override) {
+        global.with_stub(function (stub) {
+            override('subs.update_stream_privacy', stub.f);
+            stream_events.update_property(1, 'invite_only', true, {
+                history_public_to_subscribers: true,
+            });
+            var args = stub.get_args('sub', 'val');
+            assert.equal(args.sub.stream_id, 1);
+            assert.deepEqual(args.val,  {
+                invite_only: true,
+                history_public_to_subscribers: true,
+            });
+        });
+    });
+
+    // Test stream is_announcement_only change event
+    with_overrides(function (override) {
+        global.with_stub(function (stub) {
+            override('subs.update_stream_announcement_only', stub.f);
+            stream_events.update_property(1, 'is_announcement_only', true);
+            var args = stub.get_args('sub', 'val');
+            assert.equal(args.sub.stream_id, 1);
+            assert.equal(args.val, true);
+        });
+    });
 });
 
 run_test('marked_subscribed', () => {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -268,6 +268,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 event.value,
                 {
                     rendered_description: event.rendered_description,
+                    history_public_to_subscribers: event.history_public_to_subscribers,
                 });
             settings_streams.update_default_streams_table();
         } else if (event.op === 'create') {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -266,8 +266,9 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 event.stream_id,
                 event.property,
                 event.value,
-                event.rendered_description
-            );
+                {
+                    rendered_description: event.rendered_description,
+                });
             settings_streams.update_default_streams_table();
         } else if (event.op === 'create') {
             stream_data.create_streams(event.streams);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -264,6 +264,15 @@ exports.get_subscriber_count = function (stream_name) {
     return sub.subscribers.num_items();
 };
 
+exports.update_stream_announcement_only = function (sub, is_announcement_only) {
+    sub.is_announcement_only = is_announcement_only;
+};
+
+exports.update_stream_privacy = function (sub, values) {
+    sub.invite_only = values.invite_only;
+    sub.history_public_to_subscribers = values.history_public_to_subscribers;
+};
+
 exports.update_calculated_fields = function (sub) {
     sub.is_admin = page_params.is_admin;
     // Admin can change any stream's name & description either stream is public or

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -326,12 +326,8 @@ function change_stream_privacy(e) {
         url: "/json/streams/" + stream_id,
         data: data,
         success: function () {
-            subs.update_stream_privacy(sub, {
-                invite_only: invite_only,
-                history_public_to_subscribers: history_public_to_subscribers,
-            });
-            subs.update_stream_announcement_only(sub, is_announcement_only);
             $("#stream_privacy_modal").remove();
+            // The rest will be done by update stream event we will get.
         },
         error: function () {
             $("#change-stream-privacy-button").text(i18n.t("Try again"));

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -326,22 +326,12 @@ function change_stream_privacy(e) {
         url: "/json/streams/" + stream_id,
         data: data,
         success: function () {
-            sub = stream_data.get_sub_by_id(stream_id);
-
-            // save new privacy settings.
-            sub.invite_only = invite_only;
-            sub.is_announcement_only = is_announcement_only;
-            sub.history_public_to_subscribers = history_public_to_subscribers;
-            stream_data.update_calculated_fields(sub);
-
-            stream_ui_updates.update_stream_privacy_type_icon(sub);
-            stream_ui_updates.update_stream_privacy_type_text(sub);
-            stream_list.redraw_stream_privacy(sub);
+            subs.update_stream_privacy(sub, {
+                invite_only: invite_only,
+                history_public_to_subscribers: history_public_to_subscribers,
+            });
+            subs.update_stream_announcement_only(sub, is_announcement_only);
             $("#stream_privacy_modal").remove();
-
-            // For auto update, without rendering whole template
-            stream_data.update_calculated_fields(sub);
-            stream_ui_updates.update_change_stream_privacy_settings(sub);
         },
         error: function () {
             $("#change-stream-privacy-button").text(i18n.t("Try again"));

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -74,6 +74,15 @@ exports.update_property = function (stream_id, property, value, other_values) {
         update_stream_pin(sub, value);
         stream_list.refresh_pinned_or_unpinned_stream(sub);
         break;
+    case 'invite_only':
+        subs.update_stream_privacy(sub, {
+            invite_only: value,
+            history_public_to_subscribers: other_values.history_public_to_subscribers,
+        });
+        break;
+    case 'is_announcement_only':
+        subs.update_stream_announcement_only(sub, value);
+        break;
     default:
         blueslip.warn("Unexpected subscription property type", {property: property,
                                                                 value: value});

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -32,7 +32,7 @@ function update_stream_pin(sub, value) {
     sub.pin_to_top = value;
 }
 
-exports.update_property = function (stream_id, property, value, rendered_description) {
+exports.update_property = function (stream_id, property, value, other_values) {
     var sub = stream_data.get_sub_by_id(stream_id);
     if (sub === undefined) {
         // This isn't a stream we know about, so ignore it.
@@ -65,7 +65,7 @@ exports.update_property = function (stream_id, property, value, rendered_descrip
         subs.update_stream_name(sub, value);
         break;
     case 'description':
-        subs.update_stream_description(sub, value, rendered_description);
+        subs.update_stream_description(sub, value, other_values.rendered_description);
         break;
     case 'email_address':
         sub.email_address = value;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -157,6 +157,24 @@ exports.update_stream_description = function (sub, description, rendered_descrip
     stream_edit.update_stream_description(sub);
 };
 
+exports.update_stream_privacy = function (sub, values) {
+    stream_data.update_stream_privacy(sub, values);
+    stream_data.update_calculated_fields(sub);
+
+    // Update UI elements
+    stream_ui_updates.update_stream_privacy_type_icon(sub);
+    stream_ui_updates.update_stream_privacy_type_text(sub);
+    stream_ui_updates.update_change_stream_privacy_settings(sub);
+    stream_list.redraw_stream_privacy(sub);
+};
+
+exports.update_stream_announcement_only = function (sub, new_value) {
+    stream_data.update_stream_announcement_only(sub, new_value);
+    stream_data.update_calculated_fields(sub);
+
+    stream_ui_updates.update_stream_privacy_type_text(sub);
+};
+
 exports.set_color = function (stream_id, color) {
     var sub = stream_data.get_sub_by_id(stream_id);
     stream_edit.set_stream_property(sub, 'color', color);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -165,6 +165,9 @@ exports.update_stream_privacy = function (sub, values) {
     stream_ui_updates.update_stream_privacy_type_icon(sub);
     stream_ui_updates.update_stream_privacy_type_text(sub);
     stream_ui_updates.update_change_stream_privacy_settings(sub);
+    stream_ui_updates.update_settings_button_for_sub(sub);
+    stream_ui_updates.update_subscribers_count(sub);
+    stream_ui_updates.update_add_subscriptions_elements(sub);
     stream_list.redraw_stream_privacy(sub);
 };
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3441,6 +3441,16 @@ def do_change_stream_invite_only(stream: Stream, invite_only: bool,
     stream.invite_only = invite_only
     stream.history_public_to_subscribers = history_public_to_subscribers
     stream.save(update_fields=['invite_only', 'history_public_to_subscribers'])
+    event = dict(
+        op="update",
+        type="stream",
+        property="invite_only",
+        value=invite_only,
+        history_public_to_subscribers=history_public_to_subscribers,
+        stream_id=stream.id,
+        name=stream.name,
+    )
+    send_event(stream.realm, event, can_access_stream_user_ids(stream))
 
 def do_change_stream_web_public(stream: Stream, is_web_public: bool) -> None:
     stream.is_web_public = is_web_public
@@ -3449,6 +3459,15 @@ def do_change_stream_web_public(stream: Stream, is_web_public: bool) -> None:
 def do_change_stream_announcement_only(stream: Stream, is_announcement_only: bool) -> None:
     stream.is_announcement_only = is_announcement_only
     stream.save(update_fields=['is_announcement_only'])
+    event = dict(
+        op="update",
+        type="stream",
+        property="is_announcement_only",
+        value=is_announcement_only,
+        stream_id=stream.id,
+        name=stream.name,
+    )
+    send_event(stream.realm, event, can_access_stream_user_ids(stream))
 
 def do_rename_stream(stream: Stream,
                      new_name: str,


### PR DESCRIPTION
Add event to update stream settings whenever stream privacy is changed
accordingly.

Fixes #9470

![streamprivacyevent](https://user-images.githubusercontent.com/25907420/40891202-1404d8d2-679f-11e8-9785-12216e4cbbba.gif)
