### PR TITLE
streams: Handle guest user ids for stream settings changes' events.

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -331,6 +331,9 @@ def realm_user_dicts_cache_key(realm_id: int) -> str:
 def active_user_ids_cache_key(realm_id: int) -> str:
     return "active_user_ids:%s" % (realm_id,)
 
+def active_non_guest_user_ids_cache_key(realm_id: int) -> str:
+    return "active_non_guest_user_ids:%s" % (realm_id,)
+
 bot_dict_fields = ['id', 'full_name', 'short_name', 'bot_type', 'email',
                    'is_active', 'default_sending_stream__name',
                    'realm_id',
@@ -388,6 +391,10 @@ def flush_user_profile(sender: Any, **kwargs: Any) -> None:
 
     if changed(['is_active']):
         cache_delete(active_user_ids_cache_key(user_profile.realm_id))
+        cache_delete(active_non_guest_user_ids_cache_key(user_profile.realm_id))
+
+    if changed(['is_guest']):
+        cache_delete(active_non_guest_user_ids_cache_key(user_profile.realm_id))
 
     if changed(['email', 'full_name', 'short_name', 'id', 'is_mirror_dummy']):
         delete_display_recipient_cache(user_profile)
@@ -420,6 +427,7 @@ def flush_realm(sender: Any, **kwargs: Any) -> None:
         cache_delete(active_user_ids_cache_key(realm.id))
         cache_delete(bot_dicts_in_realm_cache_key(realm))
         cache_delete(realm_alert_words_cache_key(realm))
+        cache_delete(active_non_guest_user_ids_cache_key(realm.id))
 
 def realm_alert_words_cache_key(realm: 'Realm') -> str:
     return "realm_alert_words:%s" % (realm.string_id,)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -16,7 +16,7 @@ from django.core.validators import URLValidator, MinLengthValidator, \
     RegexValidator
 from django.dispatch import receiver
 from zerver.lib.cache import cache_with_key, flush_user_profile, flush_realm, \
-    user_profile_by_api_key_cache_key, \
+    user_profile_by_api_key_cache_key, active_non_guest_user_ids_cache_key, \
     user_profile_by_id_cache_key, user_profile_by_email_cache_key, \
     user_profile_cache_key, generic_bulk_cached_fetch, cache_set, flush_stream, \
     display_recipient_cache_key, cache_delete, active_user_ids_cache_key, \
@@ -1558,6 +1558,15 @@ def active_user_ids(realm_id: int) -> List[int]:
     query = UserProfile.objects.filter(
         realm_id=realm_id,
         is_active=True
+    ).values_list('id', flat=True)
+    return list(query)
+
+@cache_with_key(active_non_guest_user_ids_cache_key, timeout=3600*24*7)
+def active_non_guest_user_ids(realm_id: int) -> List[int]:
+    query = UserProfile.objects.filter(
+        realm_id=realm_id,
+        is_active=True,
+        is_guest=False,
     ).values_list('id', flat=True)
     return list(query)
 


### PR DESCRIPTION
@timabbott Can you review the approach to address these points
> * peer_add events in bulk_add_subscriptions and peer_remove events in bulk_remove_subscriptions should exclude "guest users" from the "everyone for public streams" logic; instead, it should be everyone but non-subscribed guest users. In short, get_peer_user_ids_for_stream_change should replace active_user_ids with active_non_guest_user_ids and then add back in any subscribed user IDs.
> * Through Stream.is_public, can_access_stream_user_ids should use active_non_guest_user_ids for public streams.
> * Through Stream.is_public, send_stream_creation_event should use active_non_guest_user_ids for public streams.

I'll update Backend tests tomorrow.