### PR TITLE
settings: Improve buttons and error handling status elements.

### DIFF
--- a/frontend_tests/casper_tests/12-toggle-message-editing.js
+++ b/frontend_tests/casper_tests/12-toggle-message-editing.js
@@ -267,7 +267,7 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.admin-realm-failed-change-status', function () {
+    casper.waitUntilVisible('#org-msg-editing .subsection-failed-status', function () {
         casper.test.assertSelectorHasText('#org-submit-msg-editing',
                                           'Save');
     });

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -146,9 +146,9 @@ function createSaveButtons(subsection) {
     var save_btn_controls = $('.save-btn-controls');
     var stub_save_button = $(`#org-submit-${subsection}`);
     var stub_save_button_text = $('.icon-button-text');
-    stub_save_button_header.prevAll = function () {
-        return $('<stub failed alert status element>');
-    };
+    stub_save_button_header.set_find_results(
+        '.subsection-failed-status p', $('<failed status element>')
+    );
     stub_save_button.closest = function () {
         return stub_save_button_header;
     };

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -572,7 +572,9 @@ function _set_up() {
         e.preventDefault();
         e.stopPropagation();
 
-        var subsection = $(this).closest('.org-subsection-parent');
+        var subsection = $(e.target).closest('.org-subsection-parent');
+        subsection.find('.subsection-failed-status p').hide();
+        subsection.find('.save-button').show();
         var properties_elements = get_subsection_property_elements(subsection);
         var show_change_process_button = false;
         _.each(properties_elements , function (elem) {
@@ -597,7 +599,7 @@ function _set_up() {
     exports.save_organization_settings = function (data, save_button, success_continuation) {
         var subsection_parent = save_button.closest('.org-subsection-parent');
         var save_btn_container = subsection_parent.find('.save-button-controls');
-        var failed_alert_elem = subsection_parent.prevAll('.admin-realm-failed-change-status:first').expectOne();
+        var failed_alert_elem = subsection_parent.find('.subsection-failed-status p');
         exports.change_save_button_state(save_btn_container, "saving");
         channel.patch({
             url: "/json/realm",
@@ -613,7 +615,8 @@ function _set_up() {
             },
             error: function (xhr) {
                 exports.change_save_button_state(save_btn_container, "failed");
-                ui_report.error(i18n.t("Failed"), xhr, failed_alert_elem);
+                save_button.hide();
+                ui_report.error(i18n.t("Save failed"), xhr, failed_alert_elem);
             },
         });
     };

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -459,6 +459,11 @@ input[type=checkbox] + .inline-block {
     display: inline;
 }
 
+.admin-realm-form .subsection-header div.subsection-failed-status p {
+    background-color: white;
+    margin: 0 0 0 10px;
+}
+
 #default_language {
     margin-left: 20px;
 }

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -459,11 +459,6 @@ input[type=checkbox] + .inline-block {
     display: inline;
 }
 
-.admin-realm-form .subsection-header div.subsection-failed-status p {
-    background-color: white;
-    margin: 0 0 0 10px;
-}
-
 #default_language {
     margin-left: 20px;
 }
@@ -1534,6 +1529,18 @@ input[type=text]#settings_search {
     bottom: 0px;
 }
 
+.subsection-failed-status {
+    background: #f2dede;
+    padding: 2px 6px;
+    border-radius: 4px;
+    margin-left: 5px;
+}
+
+.subsection-failed-status p {
+    margin: 0;
+}
+
+
 @media (max-width: 953px) {
     .user-avatar-section,
     .realm-icon-section {
@@ -1548,6 +1555,10 @@ input[type=text]#settings_search {
 
     #settings_content .warning {
         display: none;
+    }
+
+    .subsection-failed-status {
+        margin: 5px 0 0 0;
     }
 }
 

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -1,8 +1,6 @@
 <div id="organization-permissions" data-name="organization-permissions" class="settings-section">
     <form class="form-horizontal admin-realm-form org-permissions-form">
 
-        <div class="alert admin-realm-failed-change-status"></div>
-
         <div id="org-org-join" class="org-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Joining the organization" }}</h3>

--- a/static/templates/settings/organization-profile-admin.handlebars
+++ b/static/templates/settings/organization-profile-admin.handlebars
@@ -1,7 +1,6 @@
 <div id="organization-profile" data-name="organization-profile" class="settings-section">
     <form class="form-horizontal admin-realm-form org-profile-form">
         <div class="alert" id="admin-realm-deactivation-status"></div>
-        <div class="alert admin-realm-failed-change-status"></div>
 
         <div id="org-org-profile" class="org-subsection-parent">
             <div class="subsection-header">

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -2,7 +2,6 @@
     <form class="form-horizontal admin-realm-form org-settings-form">
         <div class="alert" id="admin-realm-notifications-stream-status"></div>
         <div class="alert" id="admin-realm-signup-notifications-stream-status"></div>
-        <div class="alert admin-realm-failed-change-status"></div>
 
         <div id="org-msg-editing" class="org-subsection-parent">
             <div class="subsection-header">

--- a/static/templates/settings/settings-save-discard-widget.handlebars
+++ b/static/templates/settings/settings-save-discard-widget.handlebars
@@ -17,5 +17,6 @@
             </span>
         </div>
     </div>
+    <div class="inline-block subsection-failed-status"><p></p></div>
 </div>
 {{/if}}


### PR DESCRIPTION
This improves the styling of the inline error messages in the settings window. (This PR includes @shubhamdhama's changes in https://github.com/zulip/zulip/pull/9274)

<img width="729" alt="screen shot 2018-06-04 at 2 57 01 pm" src="https://user-images.githubusercontent.com/2905696/40944663-778a84a4-680a-11e8-908e-a0e9bf33e784.png">
