### PR TITLE
webpack: Reload webpack process on config changes.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -189,7 +189,7 @@ def build_custom_checkers(by_lang):
         {'pattern': '\+.*i18n\.t\(.+\)',
          'description': 'Do not concatenate i18n strings'},
         {'pattern': '[.]includes[(]',
-         'exclude': ['frontend_tests/'],
+         'exclude': ['frontend_tests/', 'tools/'],
          'description': '.includes() is incompatible with Internet Explorer. Use .indexOf() !== -1 instead.'},
         {'pattern': '[.]html[(]',
          'exclude_pattern': '[.]html[(]("|\'|templates|html|message.content|sub.rendered_description|i18n.t|rendered_|$|[)]|error_text|widget_elem|[$]error|[$][(]"<p>"[)])',

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -75,9 +75,9 @@ if not options.force:
         print('If you really know what you are doing, use --force to run anyway.')
         sys.exit(1)
 
+user_id = os.getuid()
+user_name = pwd.getpwuid(user_id).pw_name
 if options.interface is None:
-    user_id = os.getuid()
-    user_name = pwd.getpwuid(user_id).pw_name
     if user_name in ["vagrant", "zulipdev"]:
         # In the Vagrant development environment, we need to listen on
         # all ports, and it's safe to do so, because Vagrant is only
@@ -168,6 +168,8 @@ else:
     webpack_cmd = ['./tools/webpack', '--watch', '--port', str(webpack_port)]
     if options.minify:
         webpack_cmd.append('--minify')
+    if user_name is 'vagrant':
+        webpack_cmd.append('--poll')
     if options.interface is None:
         # If interface is None and we're listening on all ports, we also need
         # to disable the webpack host check so that webpack will serve assets.

--- a/tools/webpack
+++ b/tools/webpack
@@ -32,17 +32,11 @@ def run(quiet):
 def run_watch(host, port, minify, disable_host_check):
     # type: (str, str, bool, bool) -> None
     """watches and rebuilds on changes, serving files from memory via webpack-dev-server"""
-    webpack_dev_args = ['node', 'node_modules/.bin/webpack-dev-server']
+    webpack_dev_args = ['./tools/webpack-dev-server']
     webpack_dev_args += [
-        '--config',
-        'tools/webpack.config.ts',
         '--allowed-hosts', ','.join([host, '.zulipdev.com', '.zulipdev.org']),
         '--host', host,
-        '--port', port,
-        # We add the hot flag using the cli because it takes care
-        # of addition to entry points and adding the plugin
-        # automatically
-        '--hot'
+        '--port', port
     ]
     if minify:
         webpack_dev_args.append('--optimize-minimize')

--- a/tools/webpack
+++ b/tools/webpack
@@ -29,10 +29,10 @@ def run(quiet):
         print('Starting webpack compilation')
     subprocess.check_call(webpack_args)
 
-def run_watch(host, port, minify, disable_host_check):
-    # type: (str, str, bool, bool) -> None
+def run_watch(host, port, minify, disable_host_check, poll):
+    # type: (str, str, bool, bool, bool) -> None
     """watches and rebuilds on changes, serving files from memory via webpack-dev-server"""
-    webpack_dev_args = ['./tools/webpack-dev-server']
+    webpack_dev_args = ['./tools/webpack-dev-server', '--poll=' + str(poll)]
     webpack_dev_args += [
         '--allowed-hosts', ','.join([host, '.zulipdev.com', '.zulipdev.org']),
         '--host', host,
@@ -73,6 +73,9 @@ parser.add_argument('--test',
 parser.add_argument('--quiet',
                     action='store_true', dest='quiet', default=False,
                     help='Minimizes webpack output while running')
+parser.add_argument('--poll',
+                    action='store_true', dest='poll', default=False,
+                    help='Runs ./tools/webpack-dev to use polling.')
 parser.add_argument('--watch',
                     action='store_true', dest='watch', default=False,
                     help='watch for changes to source files (for development)')
@@ -93,6 +96,7 @@ args = parser.parse_args()
 if args.test:
     run_test()
 elif args.watch:
-    run_watch(args.host, args.port, args.minify, args.disable_host_check)
+    run_watch(args.host, args.port, args.minify,
+              args.disable_host_check, args.poll)
 else:
     run(args.quiet)

--- a/tools/webpack
+++ b/tools/webpack
@@ -32,8 +32,8 @@ def run(quiet):
 def run_watch(host, port, minify, disable_host_check):
     # type: (str, str, bool, bool) -> None
     """watches and rebuilds on changes, serving files from memory via webpack-dev-server"""
-    webpack_args = ['node', 'node_modules/.bin/webpack-dev-server']
-    webpack_args += [
+    webpack_dev_args = ['node', 'node_modules/.bin/webpack-dev-server']
+    webpack_dev_args += [
         '--config',
         'tools/webpack.config.ts',
         '--allowed-hosts', ','.join([host, '.zulipdev.com', '.zulipdev.org']),
@@ -45,10 +45,10 @@ def run_watch(host, port, minify, disable_host_check):
         '--hot'
     ]
     if minify:
-        webpack_args.append('--optimize-minimize')
+        webpack_dev_args.append('--optimize-minimize')
     if disable_host_check:
-        webpack_args.append('--disable-host-check')
-    subprocess.Popen(webpack_args)
+        webpack_dev_args.append('--disable-host-check')
+    subprocess.Popen(webpack_dev_args)
 
 def run_test():
     # type: () -> None

--- a/tools/webpack-dev-server
+++ b/tools/webpack-dev-server
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+"use strict";
+
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+
+const additonalWebpackArgs = process.argv.slice(2);
+const webpackArgs = [
+    './node_modules/.bin/webpack-dev-server', '--config',
+    'tools/webpack.config.ts', '--hot',
+    ...additonalWebpackArgs,
+];
+
+const ROOT_DIR = path.join(__dirname, '..');
+const webpackFiles = ['webpack.config.ts', 'webpack.assets.json']
+    .map(file => path.join(__dirname, file));
+
+// creates a new webpack-dev-server process
+// when needed
+function createWebpackDevProcess() {
+    const proc = spawn('node', webpackArgs, {
+        cwd: ROOT_DIR,
+        stdio: 'inherit',
+        detached: true,
+    });
+
+    return proc;
+}
+
+let webpackProcess = createWebpackDevProcess();
+function killWebpackProcess() {
+    // kill the whole process range including
+    // the process webpack-dev-server may have spawned.
+    process.kill(-webpackProcess.pid);
+}
+
+// restarts the webpack dev server if either of two
+// config files are changed
+function restartProcess() {
+    const msg = 'Restarting webpack process, due to changes in webpack config';
+    process.stdout.write(`${msg}...\n`);
+    killWebpackProcess();
+    webpackProcess = createWebpackDevProcess();
+}
+
+
+// watch the files, and restart the process
+// if it changes.
+webpackFiles.forEach(file => {
+    fs.watchFile(file, restartProcess);
+});
+
+// kill the running webpack process before exiting
+process.on('SIGINT', killWebpackProcess);
+process.on('SIGTERM', killWebpackProcess);

--- a/tools/webpack-dev-server
+++ b/tools/webpack-dev-server
@@ -4,8 +4,10 @@
 const path = require('path');
 const fs = require('fs');
 const { spawn } = require('child_process');
+const { promisify } = require('util');
 
-const additonalWebpackArgs = process.argv.slice(2);
+const additonalWebpackArgs = process.argv.slice(3);
+const usePolling = process.argv.includes('--poll=True');
 const webpackArgs = [
     './node_modules/.bin/webpack-dev-server', '--config',
     'tools/webpack.config.ts', '--hot',
@@ -44,12 +46,65 @@ function restartProcess() {
     webpackProcess = createWebpackDevProcess();
 }
 
+const statFile = promisify(fs.stat);
+const mtimes = new Map();
 
-// watch the files, and restart the process
-// if it changes.
+// set initial mtimes
 webpackFiles.forEach(file => {
-    fs.watchFile(file, restartProcess);
+    const stats = fs.statSync(file);
+    mtimes.set(file, stats.mtime);
 });
+
+// get the stats of both config files and
+// if they were changed return true
+async function getConfigStatus() {
+    const statPromises = [];
+    webpackFiles.forEach(file => {
+        statPromises.push(statFile(file));
+    });
+
+    const stats = await Promise.all(statPromises);
+    let configChanged = false;
+    stats.forEach((stat, index) => {
+        const currentFile = webpackFiles[index];
+        const changed = stat.mtime > mtimes.get(currentFile);
+        if (changed) {
+            configChanged = true;
+            mtimes.set(currentFile, stat.mtime);
+        }
+    });
+
+    return configChanged;
+}
+
+async function checkConfig() {
+    const configChanged = await getConfigStatus();
+    if (configChanged) {
+        restartProcess();
+    }
+}
+
+// mimick python's time.sleep
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+if (usePolling) {
+    async function pollForChanges() {
+        while (true) {
+            await checkConfig();
+            await sleep(3000);
+        }
+    }
+
+    pollForChanges();
+} else {
+    // watch the files, and restart the process
+    // if it changes.
+    webpackFiles.forEach(file => {
+        fs.watchFile(file, restartProcess);
+    });
+}
 
 // kill the running webpack process before exiting
 process.on('SIGINT', killWebpackProcess);


### PR DESCRIPTION
Uses a node script and reloads the webpack process when the
webpack config files changes. This uses polling if vagrant is being
used since, watching for file changes doesn't work well with vagrant's nfs
filesystem.

