### PR TITLE
Update teamcity webhook to include branch name

### DIFF
--- a/zerver/webhooks/teamcity/fixtures/success_branch.json
+++ b/zerver/webhooks/teamcity/fixtures/success_branch.json
@@ -1,0 +1,52 @@
+{
+	"build": {
+		"buildStatus": "Tests passed: 27",
+		"buildResult": "success",
+		"buildResultPrevious": "success",
+		"buildResultDelta": "unchanged",
+		"notifyType": "buildFinished",
+		"buildFullName": "Project :: Compile",
+		"buildName": "Compile",
+		"buildId": "19952",
+		"buildTypeId": "Project_Compile",
+		"buildInternalTypeId": "bt1",
+		"buildExternalTypeId": "Project_Compile",
+		"buildStatusUrl": "http://teamcity/viewLog.html?buildTypeId=Project_Compile&buildId=19952",
+		"buildStatusHtml": "<span class=\"tcWebHooksMessage\"><a href=\"http://teamcity/project.html?projectId=Project\">Project</a> :: <a href=\"http://teamcity/viewType.html?buildTypeId=Project_Compile\">Compile</a> # <a href=\"http://teamcity/viewLog.html?buildTypeId=Project_Compile&buildId=19952\"><strong>5535 - CL 123456</strong></a> has <strong>finished</strong> with a status of <a href=\"http://teamcity/viewLog.html?buildTypeId=Project_Compile&buildId=19952\"> <strong>success</strong></a> and was triggered by <strong>Perforce</strong></span>",
+		"rootUrl": "http://teamcity",
+		"projectName": "Project",
+		"projectId": "Project",
+		"projectInternalId": "project1",
+		"projectExternalId": "Project",
+		"branchName": "MyBranch",
+	    "branchDisplayName": "MyBranch",
+		"buildNumber": "5535 - CL 123456",
+		"agentName": "agent123",
+		"agentOs": "Windows 10, version 10.0",
+		"agentHostname": "agent123.company.com",
+		"triggeredBy": "Perforce",
+		"message": "Build Project :: Compile has finished. This is build number 5535 - CL 123456, has a status of \"success\" and was triggered by Perforce",
+		"text": "Project :: Compile has finished. Status: success",
+		"buildStateDescription": "finished",
+		"buildRunners": [
+			"Command Line",
+			"Command Line",
+			"Command Line",
+			"Command Line",
+			"Command Line",
+			"Command Line"
+		],
+		"extraParameters": [],
+		"teamcityProperties": [{
+				"name": "DotNetFramework2.0.50727_x64_Path",
+				"value": "C:\\Windows\\Microsoft.NET\\Framework64\\v2.0.50727"
+			}, {
+				"name": "DotNetFramework2.0.50727_x86_Path",
+				"value": "C:\\Windows\\Microsoft.NET\\Framework\\v2.0.50727"
+			}, {
+				"name": "DotNetFramework2.0_x64",
+				"value": "2.0.50727"
+			}
+		]
+	}
+}

--- a/zerver/webhooks/teamcity/tests.py
+++ b/zerver/webhooks/teamcity/tests.py
@@ -14,6 +14,11 @@ class TeamcityHookTests(WebhookTestCase):
         expected_message = u"Project :: Compile build 5535 - CL 123456 was successful! :thumbs_up:\nDetails: [changes](http://teamcity/viewLog.html?buildTypeId=Project_Compile&buildId=19952&tab=buildChangesDiv), [build log](http://teamcity/viewLog.html?buildTypeId=Project_Compile&buildId=19952)"
         self.send_and_test_stream_message('success', self.SUBJECT, expected_message)
 
+    def test_teamcity_success_branch(self) -> None:
+        expected_message = u"Project :: Compile build 5535 - CL 123456 was successful! :thumbs_up:\nDetails: [changes](http://teamcity/viewLog.html?buildTypeId=Project_Compile&buildId=19952&tab=buildChangesDiv), [build log](http://teamcity/viewLog.html?buildTypeId=Project_Compile&buildId=19952)"
+        expected_subject = u"Project :: Compile (MyBranch)"
+        self.send_and_test_stream_message('success_branch', expected_subject, expected_message)
+
     def test_teamcity_broken(self) -> None:
         expected_message = u"Project :: Compile build 5535 - CL 123456 is broken with status Exit code 1 (new)! :thumbs_down:\nDetails: [changes](http://teamcity/viewLog.html?buildTypeId=Project_Compile&buildId=19952&tab=buildChangesDiv), [build log](http://teamcity/viewLog.html?buildTypeId=Project_Compile&buildId=19952)"
         self.send_and_test_stream_message('broken', self.SUBJECT, expected_message)

--- a/zerver/webhooks/teamcity/view.py
+++ b/zerver/webhooks/teamcity/view.py
@@ -69,7 +69,11 @@ def api_teamcity_webhook(request: HttpRequest, user_profile: UserProfile,
         u'Details: [changes](%s), [build log](%s)')
 
     body = template % (build_name, build_number, status, changes_url, build_url)
-    topic = build_name
+
+    if 'branchDisplayName' in message:
+        topic = build_name + ' (' + message['branchDisplayName'] + ')'
+    else:
+        topic = build_name
 
     # Check if this is a personal build, and if so try to private message the user who triggered it.
     if get_teamcity_property_value(message['teamcityProperties'], 'env.BUILD_IS_PERSONAL') == 'true':


### PR DESCRIPTION
When using git backend with teamcity, the branch being built or failed is a very important piece of data for us.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Ran a few builds with and without branches names on our server

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
