### PR TITLE
org settings: Enforce unsigned integers on input elements.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -548,35 +548,6 @@ function test_sync_realm_settings() {
     }
 }
 
-function test_parse_time_limit() {
-    const elem = $('#id_realm_message_content_edit_limit_minutes');
-    const test_function = (value, expected_value = value) => {
-        elem.val(value);
-        global.page_params.realm_message_content_edit_limit_seconds =
-            settings_org.parse_time_limit(elem);
-        assert.equal(expected_value,
-                     settings_org.get_realm_time_limits_in_minutes(
-                         'realm_message_content_edit_limit_seconds'));
-    };
-
-    test_function('0.01', '0');
-    test_function('0.1');
-    test_function('0.122', '0.1');
-    test_function('0.155', '0.2');
-    test_function('0.150', '0.1');
-    test_function('0.5');
-    test_function('1');
-    test_function('1.1');
-    test_function('10.5');
-    test_function('50.3');
-    test_function('100');
-    test_function('100.1');
-    test_function('127.79', '127.8');
-    test_function('201.1');
-    test_function('501.15', '501.1');
-    test_function('501.34', '501.3');
-}
-
 function test_discard_changes_button(discard_changes) {
     const ev = {
         preventDefault: noop,
@@ -687,6 +658,7 @@ run_test('set_up', () => {
     $("#id_realm_message_content_delete_limit_minutes").set_parent($.create('<stub delete limti parent>'));
     $("#id_realm_msg_edit_limit_setting").change = noop;
     $('#id_realm_msg_delete_limit_setting').change = noop;
+    $('.admin-realm-time-limit-input').keypress = noop;
     const parent_elem = $.create('waiting-period-parent-stub');
     $('#id_realm_waiting_period_threshold').set_parent(parent_elem);
     $("#allowed_domains_label").set_parent($.create('<stub-allowed-domain-label-parent>'));
@@ -706,7 +678,6 @@ run_test('set_up', () => {
     test_extract_property_name();
     test_change_save_button_state();
     test_sync_realm_settings();
-    test_parse_time_limit();
     test_discard_changes_button(discard_changes);
 
     settings_org.render_notifications_stream_ui = stub_render_notifications_stream_ui;

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -59,9 +59,9 @@ exports.setup_page = function () {
         can_add_emojis: settings_emoji.can_add_emoji(),
         realm_allow_community_topic_editing: page_params.realm_allow_community_topic_editing,
         realm_message_content_edit_limit_minutes:
-            settings_org.get_realm_time_limits_in_minutes('realm_message_content_edit_limit_seconds'),
+            Math.ceil(page_params.realm_message_content_edit_limit_seconds / 60),
         realm_message_content_delete_limit_minutes:
-            settings_org.get_realm_time_limits_in_minutes('realm_message_content_delete_limit_seconds'),
+            Math.ceil(page_params.realm_message_content_delete_limit_seconds / 60),
         realm_message_retention_days: page_params.realm_message_retention_days,
         realm_allow_edit_history: page_params.realm_allow_edit_history,
         language_list: page_params.language_list,

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -89,23 +89,15 @@ function get_subsection_property_types(subsection) {
     return;
 }
 
-exports.get_realm_time_limits_in_minutes = function (property) {
-    var val = (page_params[property] / 60).toFixed(1);
-    if (parseFloat(val, 10) === parseInt(val, 10)) {
-        val = parseInt(val, 10);
-    }
-    return val.toString();
-};
-
 function get_property_value(property_name) {
     var value;
 
     if (property_name === 'realm_message_content_edit_limit_minutes') {
-        return exports.get_realm_time_limits_in_minutes('realm_message_content_edit_limit_seconds');
+        return Math.ceil(page_params.realm_message_content_edit_limit_seconds / 60).toString();
     }
 
     if (property_name === 'realm_message_content_delete_limit_minutes') {
-        return exports.get_realm_time_limits_in_minutes('realm_message_content_delete_limit_seconds');
+        return Math.ceil(page_params.realm_message_content_delete_limit_seconds / 60).toString();
     }
 
     if (property_name === 'realm_create_stream_permission') {
@@ -635,11 +627,6 @@ exports.set_up = function () {
         });
     };
 
-    function parse_time_limit(elem) {
-        return Math.floor(parseFloat(elem.val(), 10).toFixed(1) * 60);
-    }
-    exports.parse_time_limit = parse_time_limit;
-
     function get_complete_data_for_subsection(subsection) {
         var opts = {};
         if (subsection === 'msg_editing') {
@@ -648,9 +635,8 @@ exports.set_up = function () {
             if (edit_limit_setting_value === 'never') {
                 opts.data.allow_message_editing = false;
             } else if (edit_limit_setting_value === 'custom_limit') {
-                opts.data.message_content_edit_limit_seconds = parse_time_limit($('#id_realm_message_content_edit_limit_minutes'));
-                // Disable editing if the parsed time limit is 0 seconds
-                opts.data.allow_message_editing = !!opts.data.message_content_edit_limit_seconds;
+                opts.data.allow_message_editing = true;
+                opts.data.message_content_edit_limit_seconds = parseInt($("#id_realm_message_content_edit_limit_minutes").val(), 10) * 60;
             } else {
                 opts.data.allow_message_editing = true;
                 opts.data.message_content_edit_limit_seconds =
@@ -660,9 +646,8 @@ exports.set_up = function () {
             if (delete_limit_setting_value === 'never') {
                 opts.data.allow_message_deleting = false;
             } else if (delete_limit_setting_value === 'custom_limit') {
-                opts.data.message_content_delete_limit_seconds = parse_time_limit($('#id_realm_message_content_delete_limit_minutes'));
-                // Disable deleting if the parsed time limit is 0 seconds
-                opts.data.allow_message_deleting = !!opts.data.message_content_delete_limit_seconds;
+                opts.data.allow_message_deleting = true;
+                opts.data.message_content_delete_limit_seconds = parseInt($("#id_realm_message_content_delete_limit_minutes").val(), 10) * 60;
             } else {
                 opts.data.allow_message_deleting = true;
                 opts.data.message_content_delete_limit_seconds =
@@ -816,6 +801,11 @@ exports.set_up = function () {
         e.stopPropagation();
     });
 
+    $('.admin-realm-time-limit-input').keypress(function (e) {
+        if (e.which !== 8 && e.which !== 0 && (e.which < 48 || e.which > 57)) {
+            e.preventDefault();
+        }
+    });
 
     $('#admin_auth_methods_table').change(function () {
         var new_auth_methods = {};


### PR DESCRIPTION
There is no simple HTML way to achieve this so used the jQuery hack.
It also:
Reverts "org settings: Handle floating point durations better for
time limits."

This reverts commit ccd5581bcd88921b1be9934727cdc5109c03ca68.
Testing: Manual testing.

[EDIT]: Ahh.. forget to mention the jquery logic is taken from a public jsfiddle https://jsfiddle.net/lesson8/HkEuf/1/