### PR TITLE
message view: Add loading indicator to bankruptcy modal.

### DIFF
--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -108,6 +108,8 @@ exports.initialize = function () {
         pointer.fast_forward_pointer();
         $("#yes-bankrupt").hide();
         $("#no-bankrupt").hide();
+        $('#bankruptcy-loader').css('margin', '0 auto');
+        loading.make_indicator($('#bankruptcy-loader'), {text: i18n.t('Marking all messages as read.')});
         $(this).after($("<div>").addClass("alert alert-info settings_committed")
             .text(i18n.t("Bringing you to your latest messages…")));
     });

--- a/templates/zerver/app/bankruptcy.html
+++ b/templates/zerver/app/bankruptcy.html
@@ -9,6 +9,7 @@
     <div id="bankruptcy-unread-count"></div>
 
     <div class="modal-footer">
+        <div id="bankruptcy-loader"></div>
         <button id="yes-bankrupt" class="bankruptcy_button button small rounded sea-green">{{ _('Yes, please!') }}</button>
         <button id="no-bankrupt" class="bankruptcy_button button small rounded"
           data-dismiss="modal">{{ _("No, I'll catch up.") }}</button>


### PR DESCRIPTION
Fixes: #9629

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**GIF:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![ezgif-2-263c127b2d](https://user-images.githubusercontent.com/21174572/41063738-1e213bf8-69f7-11e8-94b4-579ee9774180.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
