### PR TITLE
portico: Restyle blockquotes on Why Zulip.

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2193,27 +2193,20 @@ nav ul li.active::after {
 }
 
 .portico-landing.why-page .main blockquote {
-    border: none;
-    position: relative;
-}
-
-.portico-landing.why-page .main blockquote p {
-    font-weight: 400;
-    color: #525e7a;
+    background: white;
+    border-color: #65a195;
+    padding: 20px 30px;
     margin-top: 20px;
-    padding-left: 20px;
-}
-
-.portico-landing.why-page .main blockquote:before {
-    color: #ccc;
-    content: '\201c';
-    font-size: 10em;
-    position: absolute;
-    top: 40px;
-    left: -10px;
-    font-weight: 600;
-    color: rgba(221,234,244,0.7);
-    z-index: -10;
+    font-size: 1.05em;
+    p {
+        line-height: 1.5;
+        margin: 0;
+        font-weight: 400;
+        color: #414e68;
+    }
+    p:last-child {
+        margin-top: 10px;
+    }
 }
 
 .portico-landing.why-page .main img {

--- a/templates/zerver/why-zulip.md
+++ b/templates/zerver/why-zulip.md
@@ -116,7 +116,7 @@ ceiling on how useful Slack can be to an organization.
 > our distributed team of engineers and PMs across 7+ time zones. We tried
 > Slack, Mattermost, and other team chat products that claim to support
 > threading, and nothing handles synchronous and asynchronous communication
-> so intuitively.&rdquo;
+> so intuitively.
 >
 > &mdash;Jacinda Shelly, CTO, Doctor On Demand
 
@@ -153,7 +153,7 @@ transform how your organization communicates:
 > Zulip’s topic-based threading helps us manage discussions with clarity,
 > ensuring the right people can pay attention to the right messages. This
 > makes our large-group discussion far more manageable than what we’ve
-> experienced with Skype and Slack.&rdquo;
+> experienced with Skype and Slack.
 >
 > &mdash;Grahame Grieve, founder, FHIR health care standards body
 


### PR DESCRIPTION
This restyles the blockquotes on the Why Zulip page.
<img width="780" alt="screen shot 2018-06-06 at 1 57 56 pm" src="https://user-images.githubusercontent.com/2905696/41064935-e3ceedf2-6991-11e8-8fe8-e9a51ab5ea71.png">
