### PR TITLE
help: Highlight article heading in left-sidebar.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -27,6 +27,8 @@ function highlight_current_article() {
     }
 
     var article = $('.help .sidebar a[href="' + path[0] + '"]');
+    // Highlight current article link and the heading of the same
+    article.closest('ul').css('display', 'block');
     article.addClass('highlighted');
 }
 


### PR DESCRIPTION
This fixes a bug where we don't toggle the article heading
if you open it direclty.

Fixes: #9700.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before - 

![image](https://user-images.githubusercontent.com/2263909/41067051-c69f0dfa-6a01-11e8-80e6-ee9096c2fd84.png)

![be](https://user-images.githubusercontent.com/2263909/41067706-303d2754-6a04-11e8-837b-96935c326b52.gif)

<hr>

After - 

![image](https://user-images.githubusercontent.com/2263909/41067063-d2c5c236-6a01-11e8-84f4-9cfe1a560a3d.png)

![after](https://user-images.githubusercontent.com/2263909/41067509-84b8ab88-6a03-11e8-9686-fb7e14b29da3.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
