### PR TITLE
help: Update duplicate article links.

### DIFF
--- a/templates/zerver/help/include/sidebar.md
+++ b/templates/zerver/help/include/sidebar.md
@@ -50,7 +50,7 @@
 * [View the Markdown source of a message](/help/view-the-markdown-source-of-a-message)
 * [View the exact time a message was sent](/help/view-the-exact-time-a-message-was-sent)
 * [View an image at full size](/help/view-an-image-at-full-size)
-* [See all images in a narrow](/help/view-an-image-at-full-size)
+* [See all images in a narrow](/help/see-all-images-in-a-narrow)
 * [Collapse a message](/help/collapse-a-message)
 * [Star a message](/help/star-a-message)
 * [Emoji reactions](/help/add-an-emoji-reaction-to-a-message)

--- a/templates/zerver/help/see-all-images-in-a-narrow.md
+++ b/templates/zerver/help/see-all-images-in-a-narrow.md
@@ -1,0 +1,14 @@
+# See all images in a narrow
+
+When someone sends an image in a message, Zulip generates a small preview if
+the image is a common image type, like PNG, JPEG, or GIF.
+
+To **view the image at full size**, click on the preview. From there, you
+can **pan and zoom**, **download** the image, and **navigate to other
+images** in the narrow. You can close the full screen view by clicking
+anywhere outside the image.
+
+!!! tip ""
+    Use `v` to **open** the full screen view. From there you
+    can use the arrow keys to navigate to other images in the narrow.
+    Use `v` or `Esc` to **close**.


### PR DESCRIPTION
We have same link for following two articles -

* [View an image at full size](/help/view-an-image-at-full-size)
* [See all images in a narrow](/help/view-an-image-at-full-size)

This PR adds the same content and update the links since we want to keep both the links in left sidebar.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<img src="https://chat.zulip.org/user_uploads/2/62/zIqVl6ZwYJUvoKlLEClVlgAF/bb.gif"/>
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
