### PR TITLE
bridge docs: Update matrix & IRC after recent changes to matrix.

### DIFF
--- a/templates/zerver/help/include/install-matrix.md
+++ b/templates/zerver/help/include/install-matrix.md
@@ -11,12 +11,12 @@
 1. Activate the virtualenv by running the `source` command printed
    at the end of the `provision` output.
 
-1. To install the Matrix bridge software in your virtualenv, run:
+1.  To install the dependencies of the Matrix bridge software in your virtualenv, run:
 
     ```
     pip install -r zulip/integrations/matrix/requirements.txt
     ```
 
 This will create a new Python virtual environment, with all the
-dependences for this bridge installed.  You'll want to run the bridge
+dependencies for this bridge installed.  You'll want to run the bridge
 service inside this virtualenv.

--- a/templates/zerver/integrations/irc.md
+++ b/templates/zerver/integrations/irc.md
@@ -7,48 +7,81 @@ A bridge for exchanging messages between IRC and Zulip, powered by
 
 {!create-stream.md!}
 
-1. Next, on your Zulip settings page, create a generic bot for Matrix,
-preferably with a formal name like `irc-bot`.
+1.  Next, on your Zulip settings page, create a generic bot for Matrix,
+    preferably with a formal name like `irc-bot`.
 
-1. Subscribe this bot to the Zulip stream where you'd like the bridge
-   traffic to be sent.
+1.  Subscribe this bot to the Zulip stream where you'd like the bridge
+    traffic to be sent.
 
-1.  Edit `zulip/integrations/matrix/matrix_bridge_config.py`, providing
-    the following values for the `zulip` section (the first 3 values
-    come from a `zuliprc` file):
+1.  For the next stage, generate a new sample configuration file by either:
+
+    -   Downloading the information from the bot settings page into a `zuliprc`
+        file, then running:
+
+        ```
+        python matrix_bridge.py --write-sample-config <config_path> --from-zuliprc <zuliprc>`
+        ```
+
+        where `<zuliprc>` is the path to the `zuliprc` file downloaded, and
+        `<config_path>` is the target path to place the new configuration file.
+
+        The new configuration file will automatically contain values from the `zuliprc` file.
+
+    -   Alternatively, first running the following:
+
+        ```
+        python matrix_bridge.py --write-sample-config <config_path>
+        ```
+
+        where `<config_path>` is the target path to place the new configuration file.
+
+        Then accessing the bot settings page and noting the information for your bot
+        (`USERNAME`, `API KEY` and the server name, eg. `https://chat.zulip.org`),
+        and amending the first three lines in the `[zulip]` section to contain the
+        information noted from the bot settings page.
+
+1.  After the previous step, the zulip part of the configuration file should
+    then look something like the following, where the content of the first three
+    lines should match the bot details on the settings page:
 
     ```
-    "zulip": {
-        "email": "matrix-bot@chat.zulip.org",
-        "api_key": "your_key",
-        "site": "https://chat.zulip.org",
-        "stream": "Stream which acts as the bridge",
-        "topic": "Topic of the stream"
-    }
+    [zulip]
+    email = matrix-bot@chat.zulip.org
+    api_key = aPiKeY
+    site = https://chat.zulip.org
+    stream = stream which acts as the bridge
+    topic = topic in the stream
     ```
 
-1. Now, create a user on [matrix.org](https://matrix.org/), preferably
-   with a formal name like `zulip-bot`.
-   Matrix has been bridged to several popular
-   [IRC Networks](https://github.com/matrix-org/matrix-appservice-irc/wiki/Bridged-IRC-networks),
-   where the `Room alias format` refers to the `room_id` for the
-   corresponding IRC channel.  For example, the `room_id` would be
-   `#freenode_#zulip-test:matrix.org` for the freenode channel
-   `#zulip-test`.
+1.  Now, create a user on [matrix.org](https://matrix.org/), preferably
+    with a formal name like `zulip-bot`.
 
-1.  Edit `matrix_bridge_config.py` to add the Matrix-side settings:
+1.  Using the username and password of the user created in the previous step,
+    amend the configuration file to add the Matrix-side settings:
 
     ```
-    "matrix": {
-        "host": "https://matrix.org",
-        "username": "username of matrix.org user",
-        "password": "password of matrix.org user",
-        "room_id": "#room:matrix.org"
-    }
+    [matrix]
+    host = https://matrix.org
+    username = matrix_username
+    password = matrix_password
+    room_id = #room:matrix.org
     ```
 
-1. After the steps above have been completed, run `python matrix_bridge.py` to
-start mirroring content.
+    NOTE: The `room_id` specifies where the Matrix end of the bridge connects
+    to, which for IRC generally takes the form of `#<network>_#<channel>:matrix.org` if
+    bridging through the `matrix.org` server. For example, the `room_id` would
+    be `#freenode_#zulip-test:matrix.org` for the freenode channel
+    `#zulip-test`. Matrix has been bridged to several popular
+    [IRC Networks](https://github.com/matrix-org/matrix-appservice-irc/wiki/Bridged-IRC-networks),
+    where the `Room alias format` refers to the `room_id` for the
+    corresponding IRC channel.
+
+1.  After the steps above have been completed, run the following command to
+    start the matrix bridge:
+
+    ```
+    python matrix_bridge.py -c <config_path>
+    ```
 
 If you want to customize the message formatting, you can do so by
 editing the variables `MATRIX_MESSAGE_TEMPLATE` and

--- a/templates/zerver/integrations/matrix.md
+++ b/templates/zerver/integrations/matrix.md
@@ -4,24 +4,52 @@ A bridge for exchanging messages between [matrix.org](https://matrix.org) and Zu
 
 ### Configure the bridge
 
-1. {!create-stream.md!}
+1.  {!create-stream.md!}
 
-1. On your {{ settings_html|safe }}, create a **Generic** bot for
-   {{ integration_display_name }}. Subscribe this bot to the stream
-   created in step 1.
+1.  On your {{ settings_html|safe }}, create a **Generic** bot for
+    {{ integration_display_name }} with a formal name such as `matrix-bot`.
 
-1. Open `zulip/integrations/matrix/matrix_bridge_config.py` with your
-   favorite editor, and change the following lines in the `zulip`
-   section:
+1.  Subscribe this bot to the Zulip stream created in step 1, where the bridge
+    traffic will be sent.
+
+1.  For the next stage, generate a new sample configuration file by either:
+
+    -   Downloading the information from the bot settings page into a `zuliprc`
+        file, then running:
+
+        ```
+        python matrix_bridge.py --write-sample-config <config_path> --from-zuliprc <zuliprc>`
+        ```
+
+        where `<zuliprc>` is the path to the `zuliprc` file downloaded, and
+        `<config_path>` is the target path to place the new configuration file.
+
+        The new configuration file will automatically contain values from the `zuliprc` file.
+
+    -   Alternatively, first running the following:
+
+        ```
+        python matrix_bridge.py --write-sample-config <config_path>
+        ```
+
+        where `<config_path>` is the target path to place the new configuration file.
+
+        Then accessing the bot settings page and noting the information for your bot
+        (`USERNAME`, `API KEY` and the server name, eg. `https://chat.zulip.org`),
+        and amending the first three lines in the `[zulip]` section to contain the
+        information noted from the bot settings page, using your favorite editor.
+
+1.  After the previous step, the zulip part of the configuration file should
+    then look something like the following, where the content of the first three
+    lines should match the bot details on the settings page:
 
     ```
-    "zulip": {
-        "email": "matrix-bot@chat.zulip.org",
-        "api_key": "your_key",
-        "site": "https://chat.zulip.org",
-        "stream": "Stream which acts as the bridge",
-        "topic": "Topic of the stream"
-    }
+    [zulip]
+    email = matrix-bot@chat.zulip.org
+    api_key = aPiKeY
+    site = https://chat.zulip.org
+    stream = stream which acts as the bridge
+    topic = topic in the stream
     ```
 
     **email**, **api_key**, and **site** should come from your
@@ -29,22 +57,29 @@ A bridge for exchanging messages between [matrix.org](https://matrix.org) and Zu
     to the name of the stream created in step 1, and set **topic** to
     a topic of your choice.
 
-1. Create a user on [matrix.org](https://matrix.org/), preferably
-   with a descriptive name such as `zulip-bot`.
+1.  Create a user on [matrix.org](https://matrix.org/), preferably
+    with a descriptive name like `zulip-bot`.
 
-1. Open `matrix_bridge_config.py`, and provide your Matrix credentials
-   in the `matrix` section:
+1.  Using the username and password of the user created in the previous step,
+    amend the configuration file to add the Matrix-side settings, using your
+    favorite editor:
 
     ```
-    "matrix": {
-        "host": "https://matrix.org",
-        "username": "username of matrix.org user",
-        "password": "password of matrix.org user",
-        "room_id": "#room:matrix.org"
-    }
+    [matrix]
+    host = https://matrix.org
+    username = matrix_username
+    password = matrix_password
+    room_id = #room:matrix.org
     ```
 
-1. Run `python matrix_bridge.py` to start mirroring content.
+    NOTE: The `room_id` specifies where the Matrix end of the bridge connects to.
+
+1.  After the steps above have been completed, run the following command to
+    start the matrix bridge:
+
+    ```
+    python matrix_bridge.py -c <config_path>
+    ```
 
 !!! tip ""
 


### PR DESCRIPTION
This updates the matrix integration docs following the changes to the zulip API repo zulip/python-zulip-api#413, whereby the matrix configuration is generated and then edited rather than being in a python module.

NOTES:
* as it stands, the API repo PR should be merged first, at least to include the `--from-zuliprc` option commit (I can amend the docs to not include this, but this seems desirable if we can merge it first);
* this PR doesn't include any changes to how to install the matrix integration, which one part of the API PR installs to `zulip-matrix-bridge` and will improve the user experience in that way, but which felt like a separate step?

I'm not yet familiar with updating documents in the server that need to be rendered, so I've not 'tested' these changes; I wanted to get this up since I'd written it, and am happy to test further first.