### PR TITLE
help: Minor improvements and fixes in left sidebar.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -169,8 +169,9 @@ function scrollToHash(container) {
     });
 
     // Show Guides user docs in sidebar by default
-    $('.help .sidebar h2#guides + ul').css('display', 'block');
-
+    if (window.location.pathname === '/help/') {
+        $('.help .sidebar h2#guides + ul').show();
+    }
     // Remove ID attributes from sidebar links so they don't conflict with index page anchor links
     $('.help .sidebar h1, .help .sidebar h2, .help .sidebar h3').removeAttr('id');
 

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -135,6 +135,9 @@ function scrollToHash(container) {
         var $next = $(e.target).next();
 
         if ($next.is("ul")) {
+            // Close other article's headings first
+            $('.sidebar ul').not($next).hide();
+            // Toggle the heading
             $next.slideToggle("fast", "swing", function () {
                 markdownPS.update();
             });

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -236,6 +236,12 @@ body {
     padding-left: 40px;
 }
 
+.help .sidebar a:active,
+.help .sidebar a:hover,
+.help .sidebar a:focus,
+.help .sidebar a:visited {
+    outline: none;
+}
 .app.help .hamburger {
     display: none;
 }


### PR DESCRIPTION
This PR adds two minor improvements + one bug fix in the left sidebar.

a) First commit adds an ability to close other opened headings while user clicks on some article heading.

<img src="https://dzwonsemrish7.cloudfront.net/items/0Q3f191B2w2V0U1T0O2b/Screen%20Recording%202018-06-07%20at%2004.48%20AM.gif"/>
<hr>

b) The second commit removes the default heading on non-index help pages. So if you're on https://chat.zulip.org/help/create-a-stream page we don't need to open the default "Guides" heading.

Before - 

![image](https://user-images.githubusercontent.com/2263909/41114769-fc590fee-6aa2-11e8-83c2-e97fabfb9cd8.png)

After -

![image](https://user-images.githubusercontent.com/2263909/41114793-1464074c-6aa3-11e8-8866-24d426d0a24b.png)

<hr>

c) The third commit removes the ugly dotted outline from the article links which Mozilla adds. 

Before -

<img src="https://user-images.githubusercontent.com/2263909/41116017-cd27dfc6-6aa6-11e8-8873-2cb891f41630.png" height="600"/>

After - 

<img src="https://user-images.githubusercontent.com/2263909/41116129-1127bb2e-6aa7-11e8-9557-35a955dc33f5.png" height="600"/>

