### PR TITLE
message edit: Fix edit author text overflow on images.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -959,7 +959,7 @@ run_test('message_edit_history', () => {
     });
     var edited_message = $(html).find("div.messagebox-content");
     assert.equal(edited_message.text().trim(),
-                 "1468132659\n                Let's go to lunchdinner!\n                Edited by Alice");
+                 "1468132659\n            Let\'s go to lunchdinner!\n            Edited by Alice");
 });
 
 run_test('message_reaction', () => {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -639,6 +639,10 @@ td.pointer {
     @include prefixed-transition(background-color, 1.5s, ease-in, color 1.5s ease-in);
 }
 
+#message-edit-history .message_time {
+    position: static;
+}
+
 /* The way this overrides the menus with a background-color and a high
    z-index is kinda hacky, and requires some annoying color-matching,
    but it works. */
@@ -1379,11 +1383,7 @@ div.focused_table {
 #message-edit-history .author_details {
     display: block;
     font-size: 12px;
-    vertical-align: middle;
     padding: 1px;
-    position: absolute;
-    right: -80px;
-    line-height: 20px;
     text-align: right;
 }
 
@@ -1459,6 +1459,10 @@ blockquote p {
 
 .messagebox-content {
     padding: 4px 115px 1px 10px;
+}
+
+#message-edit-history .messagebox-content {
+    padding: 0px 10px;
 }
 
 .last_message .messagebox-content {
@@ -1933,6 +1937,7 @@ nav a .no-style {
     color: hsl(0, 0%, 73%);
     text-decoration: line-through;
     background-color: hsl(7, 90%, 92%);
+    word-break: break-all;
 }
 
 #search_arrows {
@@ -2059,6 +2064,14 @@ div.floating_recipient {
     border: none !important;
 }
 
+#message-edit-history .message_inline_image {
+    height: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    margin: 0px;
+}
+
 .message_inline_ref {
     margin-bottom: 5px;
     margin-left: 5px;
@@ -2074,6 +2087,10 @@ div.floating_recipient {
     max-height: 100%;
     float: left;
     margin-right: 10px;
+}
+
+#message-edit-history .message_inline_image img {
+    max-height: 100px;
 }
 
 li .message_inline_image img {

--- a/static/templates/message_edit_history.handlebars
+++ b/static/templates/message_edit_history.handlebars
@@ -4,13 +4,11 @@
     {{#if show_date_row}}
     <div class="date_row"><span>{{ display_date }}</span></div>
     {{/if}}
-    <div class="">
-        <div class="messagebox-border">
-            <div class="messagebox-content">
-                <div class="message_top_line"><span class="message_time">{{ timestamp }}</span></div>
-                <div class="message_edit_content">{{{ body_to_render }}}</div>
-                <div class="message_author"><div class="author_details">{{ posted_or_edited }} {{ edited_by }}</div></div>
-            </div>
+    <div class="messagebox-border">
+        <div class="messagebox-content">
+            <div class="message_top_line"><span class="message_time">{{ timestamp }}</span></div>
+            <div class="message_edit_content">{{{ body_to_render }}}</div>
+            <div class="message_author"><div class="author_details">{{ posted_or_edited }} {{ edited_by }}</div></div>
         </div>
     </div>
     <hr/>


### PR DESCRIPTION
Fixes #9175.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before:
![](https://user-images.githubusercontent.com/18511177/39080403-21a24932-454b-11e8-9652-5808d2ed65ec.png)

After:

![a](https://user-images.githubusercontent.com/15116870/41130761-ff4a0478-6a6c-11e8-9c9e-d4cd7cfdf52f.png)
