### PR TITLE
Disable appropriate features for guest.

### DIFF
--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -195,3 +195,15 @@ run_test('test tab clicks', () => {
         assert(forms.inactive.visible());
     }());
 });
+
+run_test('can_create_new_bots', () => {
+    page_params.is_admin = true;
+    assert(settings_bots.can_create_new_bots());
+
+    page_params.is_admin = false;
+    page_params.realm_bot_creation_policy = 1;
+    assert(settings_bots.can_create_new_bots());
+
+    page_params.realm_bot_creation_policy = 3;
+    assert(!settings_bots.can_create_new_bots());
+});

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -56,7 +56,7 @@ exports.setup_page = function () {
         realm_name_changes_disabled: page_params.realm_name_changes_disabled,
         realm_email_changes_disabled: page_params.realm_email_changes_disabled,
         realm_add_emoji_by_admins_only: page_params.realm_add_emoji_by_admins_only,
-        can_admin_emojis: page_params.is_admin || !page_params.realm_add_emoji_by_admins_only,
+        can_add_emojis: settings_emoji.can_add_emoji(),
         realm_allow_community_topic_editing: page_params.realm_allow_community_topic_editing,
         realm_message_content_edit_limit_minutes:
             settings_org.get_realm_time_limits_in_minutes('realm_message_content_edit_limit_seconds'),

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -70,6 +70,7 @@ exports.setup_page = function () {
         realm_notifications_stream_id: page_params.realm_notifications_stream_id,
         realm_signup_notifications_stream_id: page_params.realm_signup_notifications_stream_id,
         is_admin: page_params.is_admin,
+        is_guest: page_params.is_guest,
         realm_icon_source: page_params.realm_icon_source,
         realm_icon_url: page_params.realm_icon_url,
         realm_mandatory_topics: page_params.realm_mandatory_topics,

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -136,9 +136,7 @@ exports.setup_page = function () {
         zuliprc: 'zuliprc',
         botserverrc: 'botserverrc',
         timezones: moment.tz.names(),
-        admin_only_bot_creation: page_params.is_admin ||
-            page_params.realm_bot_creation_policy !==
-            settings_bots.bot_creation_policy_values.admins_only.code,
+        can_create_new_bots: settings_bots.can_create_new_bots(),
         settings_label: settings.settings_label,
     });
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -72,8 +72,7 @@ function render_bots() {
         user_owns_an_active_bot = user_owns_an_active_bot || elem.is_active;
     });
 
-    if (page_params.is_admin || page_params.realm_bot_creation_policy !==
-        exports.bot_creation_policy_values.admins_only.code) {
+    if (settings_bots.can_create_new_bots()) {
         if (!user_owns_an_active_bot) {
             focus_tab.add_a_new_bot_tab();
             return;
@@ -146,6 +145,15 @@ exports.bot_creation_policy_values = {
     },
 };
 
+exports.can_create_new_bots = function () {
+    if (page_params.is_admin) {
+        return true;
+    }
+
+    return page_params.realm_bot_creation_policy !==
+        exports.bot_creation_policy_values.admins_only.code;
+};
+
 exports.update_bot_settings_tip = function () {
     var permission_type = exports.bot_creation_policy_values;
     var current_permission = page_params.realm_bot_creation_policy;
@@ -164,9 +172,7 @@ exports.update_bot_permissions_ui = function () {
     exports.update_bot_settings_tip();
     $('#bot_table_error').hide();
     $("#id_realm_bot_creation_policy").val(page_params.realm_bot_creation_policy);
-    if (page_params.realm_bot_creation_policy ===
-        exports.bot_creation_policy_values.admins_only.code &&
-        !page_params.is_admin) {
+    if (!exports.can_create_new_bots()) {
         $('#create_bot_form').hide();
         $('.add-a-new-bot-tab').hide();
         focus_tab.active_bots_tab();

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -150,6 +150,10 @@ exports.can_create_new_bots = function () {
         return true;
     }
 
+    if (page_params.is_guest) {
+        return false;
+    }
+
     return page_params.realm_bot_creation_policy !==
         exports.bot_creation_policy_values.admins_only.code;
 };

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -6,6 +6,19 @@ var meta = {
     loaded: false,
 };
 
+exports.can_add_emoji = function () {
+    if (page_params.is_guest) {
+        return false;
+    }
+
+    if (page_params.is_admin) {
+        return true;
+    }
+
+    // for normal users, we depend on the setting
+    return !page_params.realm_add_emoji_by_admins_only;
+};
+
 function can_admin_emoji(emoji) {
     if (page_params.is_admin) {
         return true;

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -1,5 +1,6 @@
 <div id="bot-settings" class="settings-section" data-name="your-bots">
     <div class="bot-settings-form">
+        {{#unless page_params.is_guest}}
         <div class="tip">
             {{#tr this}}Looking for our <a href="/integrations" target="_blank">Integrations</a> or <a href="/api" target="_blank">API</a> documentation?{{/tr}}
         </div>
@@ -11,6 +12,7 @@
                 <i class="icon-vector-download-alt sea-green"></i>
             </a>
         </div>
+        {{/unless}}
 
         <ul class="nav nav-tabs nav-justified" id="bots_lists_navbar">
             <li class="active active-bots-tab"><a>{{t "Active bots" }}</a></li>

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -15,7 +15,7 @@
         <ul class="nav nav-tabs nav-justified" id="bots_lists_navbar">
             <li class="active active-bots-tab"><a>{{t "Active bots" }}</a></li>
             <li class="inactive-bots-tab"><a>{{t "Inactive bots" }}</a></li>
-            <li class="add-a-new-bot-tab {{#unless admin_only_bot_creation}}hide{{/unless}}"><a>{{t "Add a new bot" }}</a></li>
+            <li class="add-a-new-bot-tab {{#unless can_create_new_bots}}hide{{/unless}}"><a>{{t "Add a new bot" }}</a></li>
         </ul>
 
         <ol class="bots_list required-text" id="active_bots_list" data-empty="{{t 'You have no active bots.' }}">
@@ -28,7 +28,7 @@
 
         <div id="add-a-new-bot-form">
             <form id="create_bot_form"
-              class="form-horizontal no-padding {{#unless admin_only_bot_creation}}hide{{/unless}}">
+              class="form-horizontal no-padding {{#unless can_create_new_bots}}hide{{/unless}}">
                 <div class="new-bot-form">
                     <div class="input-group">
                         <label for="bot_type">

--- a/static/templates/settings/emoji-settings-admin.handlebars
+++ b/static/templates/settings/emoji-settings-admin.handlebars
@@ -1,8 +1,10 @@
-<div id="emoji-settings" data-name="emoji-settings" class="settings-section {{#if can_admin_emojis}}can-edit{{/if}}">
+<div id="emoji-settings" data-name="emoji-settings" class="settings-section {{#if can_add_emojis}}can-edit{{/if}}">
     <div class="emoji-settings-tip-container">
+        {{#unless is_guest}}
         {{partial "emoji-settings-tip"}}
+        {{/unless}}
     </div>
-    <form class="form-horizontal admin-emoji-form {{#unless can_admin_emojis}}hide{{/unless}}">
+    <form class="form-horizontal admin-emoji-form {{#unless can_add_emojis}}hide{{/unless}}">
         <div class="add-new-emoji-box grey-box">
             <div class="new-emoji-form">
                 <div class="settings-section-title new-emoji-section-title no-padding">{{t "Add a new emoji" }}</div>

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -224,6 +224,7 @@ def fetch_initial_state_data(user_profile: UserProfile,
         state['can_create_streams'] = user_profile.can_create_streams()
         state['cross_realm_bots'] = list(get_cross_realm_dicts())
         state['is_admin'] = user_profile.is_realm_admin
+        state['is_guest'] = user_profile.is_guest
         state['user_id'] = user_profile.id
         state['enter_sends'] = user_profile.enter_sends
         state['email'] = user_profile.email

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -813,7 +813,9 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         diff = (timezone_now() - self.date_joined).days
         if self.is_realm_admin:
             return True
-        elif self.realm.create_stream_by_admins_only:
+        if self.realm.create_stream_by_admins_only:
+            return False
+        if self.is_guest:
             return False
         if diff >= self.realm.waiting_period_threshold:
             return True

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -82,6 +82,7 @@ class HomeTest(ZulipTestCase):
             "hotspots",
             "initial_servertime",
             "is_admin",
+            "is_guest",
             "jitsi_server_url",
             "language_list",
             "language_list_dbl_col",
@@ -600,6 +601,21 @@ class HomeTest(ZulipTestCase):
         result = self._get_home_page()
         html = result.content.decode('utf-8')
         self.assertIn('Invite more users', html)
+
+    def test_show_invites_for_guest_users(self) -> None:
+        user_profile = self.example_user('polonius')
+        email = user_profile.email
+
+        realm = user_profile.realm
+        realm.invite_by_admins_only = False
+        realm.save()
+
+        self.login(email)
+        self.assertFalse(user_profile.is_realm_admin)
+        self.assertFalse(get_realm('zulip').invite_by_admins_only)
+        result = self._get_home_page()
+        html = result.content.decode('utf-8')
+        self.assertNotIn('Invite more users', html)
 
     def test_desktop_home(self) -> None:
         email = self.example_email("hamlet")

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -129,6 +129,14 @@ class RealmEmojiTest(ZulipTestCase):
             result = self.client_post('/json/realm/emoji/my_emoji', info=emoji_data)
         self.assert_json_success(result)
 
+    def test_emoji_upload_by_guest_user(self) -> None:
+        email = self.example_email('polonius')
+        self.login(email)
+        with get_test_image_file('img.png') as fp1:
+            emoji_data = {'f1': fp1}
+            result = self.client_post('/json/realm/emoji/my_emoji', info=emoji_data)
+        self.assert_json_error(result, 'Not allowed for guest users')
+
     def test_delete(self) -> None:
         emoji_author = self.example_user('iago')
         self.login(emoji_author.email)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -820,6 +820,16 @@ earl-test@zulip.com""", ["Denmark"]))
             "You must specify at least one email address.")
         self.check_sent_emails([])
 
+    def test_guest_user_invitation(self) -> None:
+        """
+        Guest user can't invite new users
+        """
+        self.login(self.example_email("polonius"))
+        invitee = "alice-test@zulip.com"
+        self.assert_json_error(self.invite(invitee, ["Denmark"]), "Not allowed for guest users")
+        self.assertEqual(find_key_by_email(invitee), None)
+        self.check_sent_emails([])
+
     def test_invalid_stream(self) -> None:
         """
         Tests inviting to a non-existent stream.

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -28,7 +28,8 @@ from zerver.lib.response import (
 )
 
 from zerver.lib.streams import (
-    access_stream_by_id, access_stream_by_name, filter_stream_authorization
+    access_stream_by_id, access_stream_by_name, filter_stream_authorization,
+    list_to_streams,
 )
 
 from zerver.lib.stream_subscription import (
@@ -2126,6 +2127,17 @@ class SubscriptionAPITest(ZulipTestCase):
         stream = get_stream("Denmark", guest_user.realm)
         self.assertEqual(filter_stream_authorization(guest_user, [stream]),
                          ([], [stream]))
+
+        # Test UserProfile.can_create_streams for guest users.
+        streams_raw = [{
+            'invite_only': False,
+            'history_public_to_subscribers': None,
+            'name': 'new_stream',
+            'is_announcement_only': False
+        }]
+
+        with self.assertRaisesRegex(JsonableError, "User cannot create streams."):
+            list_to_streams(streams_raw, guest_user)
 
         stream = self.make_stream('private_stream', invite_only=True)
         result = self.common_subscribe_to_streams(guest_email, ["private_stream"])

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -245,6 +245,8 @@ def home_real(request: HttpRequest) -> HttpResponse:
     # Some realms only allow admins to invite users
     if user_profile.realm.invite_by_admins_only and not user_profile.is_realm_admin:
         show_invites = False
+    if user_profile.is_guest:
+        show_invites = False
 
     request._log_data['extra'] = "[%s]" % (register_ret["queue_id"],)
 
@@ -264,6 +266,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
                                'pipeline': settings.PIPELINE_ENABLED,
                                'show_invites': show_invites,
                                'is_admin': user_profile.is_realm_admin,
+                               'is_guest': user_profile.is_guest,
                                'show_webathena': user_profile.realm.webathena_enabled,
                                'enable_feedback': settings.ENABLE_FEEDBACK,
                                'embedded': narrow_stream is not None,

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -5,7 +5,9 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 from typing import List, Optional, Set
 
-from zerver.decorator import require_realm_admin, to_non_negative_int
+from zerver.decorator import require_realm_admin, to_non_negative_int, \
+    require_non_guest_human_user
+
 from zerver.lib.actions import do_invite_users, do_revoke_user_invite, do_resend_user_invite_email, \
     get_default_subs, do_get_user_invites, do_create_multiuse_invite_link
 from zerver.lib.request import REQ, has_request_variables, JsonableError
@@ -16,6 +18,7 @@ from zerver.models import PreregistrationUser, Stream, UserProfile
 
 import re
 
+@require_non_guest_human_user
 @has_request_variables
 def invite_users_backend(request: HttpRequest, user_profile: UserProfile,
                          invitee_emails_raw: str=REQ("invitee_emails"),

--- a/zerver/views/realm_emoji.py
+++ b/zerver/views/realm_emoji.py
@@ -8,6 +8,7 @@ from zerver.lib.emoji import check_emoji_admin, check_valid_emoji_name, check_va
 from zerver.lib.request import JsonableError, REQ, has_request_variables
 from zerver.lib.response import json_success, json_error
 from zerver.lib.actions import check_add_realm_emoji, do_remove_realm_emoji
+from zerver.decorator import require_non_guest_human_user
 
 
 def list_emoji(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
@@ -17,6 +18,7 @@ def list_emoji(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     return json_success({'emoji': user_profile.realm.get_emoji()})
 
 
+@require_non_guest_human_user
 @has_request_variables
 def upload_emoji(request: HttpRequest, user_profile: UserProfile,
                  emoji_name: str=REQ()) -> HttpResponse:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR addresses #8385's point:
> For each feature we disable, we'll want to (1) Add the decorator/backend changes and (2) hide the relevant UI for guest users.

Opened as WIP to just check I'm disabling the right features.
**Testing Plan:** <!-- How have you tested? -->
* Backend tests
* Manual checking of the corresponding component

**WIP list of features getting disabled:**
- [x] invite: Make invite other users inaccessible to guest users. Image: [emoji upload](https://user-images.githubusercontent.com/22238472/41161518-c74bd170-6b50-11e8-902f-8d143af5e101.png)
- [x] emoji: Make uploading new realm emoji inaccessible for guest users. Image: [invite](https://user-images.githubusercontent.com/22238472/41161519-c7905d90-6b50-11e8-9f35-09c87ffe8c37.png)
- [x] streams: Hide create stream UI from guest users.
- [x] bots: Hide UI for adding new bots for guest users.

**Questions:**
- [x] `deactivate_bot_backend`? Because guest user can't create any bot.
- [x] Do we want an API key of a guest accessible? I guess "Yes" because API keys can still be used as "Human bots", but I guess there are various other ways a user can access API key so what should be the appropriate behavior here?
- [ ] We haven't thought about the `get_members_backend` function. Having normal access over this endpoint means guest user have access to information from all members of the realm. So here we can either make this to function to return users only subscribers of streams to which the guest user is subscribed or do we have plans to hide bots and users table from guest user.
- [ ] While thinking about the above we should also think about the changes in `get_raw_user_data` function.
- [ ] Any plan for Default streams for guest users.