### PR TITLE
left-sidebar: Fix opening of compose box on narrowing using hotkeys.

### DIFF
--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -5,8 +5,8 @@ zrequire('components');
 
 var noop = function () {};
 
-var LEFT_KEY = { which: 37, preventDefault: noop };
-var RIGHT_KEY = { which: 39, preventDefault: noop };
+var LEFT_KEY = { which: 37, preventDefault: noop, stopPropagation:noop };
+var RIGHT_KEY = { which: 39, preventDefault: noop, stopPropagation:noop };
 
 run_test('basics', () => {
     var keydown_f;

--- a/static/js/keydown_util.js
+++ b/static/js/keydown_util.js
@@ -32,6 +32,7 @@ exports.handle = function (opts) {
 
         if (handled) {
             e.preventDefault();
+            e.stopPropagation();
         }
     });
 };


### PR DESCRIPTION
Explaining the problem a bit: When we narrow to a stream/private message
using `q+Enter`/`w+Enter` compose box opens which isn't desirable here.
The bug here was the propagation of event after getting handled in
`keydown_util.handle` to `hotkeys.process_enter_key`.

![working](https://user-images.githubusercontent.com/22238472/41188509-08476a14-6bdc-11e8-81a6-09af6338be8d.gif)
