### PR TITLE
search: Fix "Enter to search" while using an input method.

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -2,8 +2,13 @@ var search = (function () {
 
 var exports = {};
 
+var is_using_input_method = false;
+
 function narrow_or_search_for_term(search_string) {
     var search_query_box = $("#search_query");
+    if (is_using_input_method) {
+        return search_query_box.val();
+    }
     ui_util.change_tab_to('#home');
     var operators = Filter.parse(search_string);
     narrow.activate(operators, {trigger: 'search'});
@@ -69,6 +74,15 @@ exports.initialize = function () {
         },
     });
 
+    $('#searchbox_form').on('compositionend', function () {
+        // Set `is_using_input_method` to true if enter is pressed to exit
+        // the input tool popover and get the text in the search bar. Then
+        // we suppress searching triggered by this enter key by checking
+        // `is_using_input_method` before searching.
+        // More details in the commit message that added this line.
+        is_using_input_method = true;
+    });
+
     $("#searchbox_form").keydown(function (e) {
         exports.update_button_visibility();
         var code = e.which;
@@ -81,6 +95,10 @@ exports.initialize = function () {
             return false;
         }
     }).keyup(function (e) {
+        if (is_using_input_method) {
+            is_using_input_method = false;
+            return;
+        }
         var code = e.which;
         var search_query_box = $("#search_query");
         if (code === 13 && search_query_box.is(":focus")) {


### PR DESCRIPTION
(This is one of the nastiest bugs I've faced(maybe because I've to read complete searching mechanism code which I think is the thing I can keep with me :) and come up with this hack-y solution, not sure whether this is the best solution possible but I tried to explain it as much as possible) 
NOTE:   To test this locally I've used Google Chrome input tool.
        This change will not affect users who don't use input tools.

Here is the algorithm used to deal with this case and other important
points:

* Here I've used `compositionend` event which is triggered
as soon as an input tool completes a word or user press "enter"
to get the suggested text. (There was a situation where it is
triggered even when input tool wasn't closed, that is when we
press space, but it also triggers another `compositionstart`
event simultaneously so our logic can't be affected by this.)

* We are using a variable `is_using_input_method` which sets to
`true` when `compositionend` event is triggered.

* Basically our searching is initiated by `keyup` event which
is triggered by the same keypress which triggers `compositionend`
event to get the text, so our main goal is to suppress the searching
triggered by this key pressing.

* Observation shows that `compositionend` is triggered before the
`keyup` and calling of callback `narrow_or_search_for_term`
used by typeahead.
    i.e. chronological order of triggering of this event is
`compositionend` > calling of `narrow_or_search_for_term` > `keyup`.

* So the main logic is to set `is_using_input_method` to `false`
by default and if used the input tool then when we press enter
to get the suggested text we set it to `true` which indicate
further events triggered after it to skip the searching and
finally, in `keyup` we set it to default `false` so when pressed
enter again we have it set to false and we have a successful
search.

Fixes: #9396.
