### PR TITLE
import: Process messages batchwise in slack import.

### DIFF
--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -48,6 +48,8 @@ PostProcessData = Any  # TODO: make more specific
 # TODO: tighten this up with a union.
 MessageOutput = Dict[str, Any]
 
+MESSAGE_BATCH_CHUNK_SIZE = 1000
+
 realm_tables = [("zerver_defaultstream", DefaultStream, "defaultstream"),
                 ("zerver_realmemoji", RealmEmoji, "realmemoji"),
                 ("zerver_realmdomain", RealmDomain, "realmdomain"),
@@ -826,7 +828,7 @@ def write_message_export(message_filename: Path, output: MessageOutput) -> None:
 
 def export_partial_message_files(realm: Realm,
                                  response: TableData,
-                                 chunk_size: int=1000,
+                                 chunk_size: int=MESSAGE_BATCH_CHUNK_SIZE,
                                  output_dir: Optional[Path]=None) -> Set[int]:
     if output_dir is None:
         output_dir = tempfile.mkdtemp(prefix="zulip-export")
@@ -895,15 +897,16 @@ def export_partial_message_files(realm: Realm,
             dump_file_id=dump_file_id,
             all_message_ids=all_message_ids,
             output_dir=output_dir,
-            chunk_size=chunk_size,
             user_profile_ids=user_ids_for_us,
+            chunk_size=chunk_size,
         )
 
     return all_message_ids
 
 def write_message_partial_for_query(realm: Realm, message_query: Any, dump_file_id: int,
                                     all_message_ids: Set[int], output_dir: Path,
-                                    chunk_size: int, user_profile_ids: Set[int]) -> int:
+                                    user_profile_ids: Set[int],
+                                    chunk_size: int=MESSAGE_BATCH_CHUNK_SIZE) -> int:
     min_id = -1
 
     while True:
@@ -1334,7 +1337,8 @@ def get_single_user_config() -> Config:
 
     return user_profile_config
 
-def export_messages_single_user(user_profile: UserProfile, output_dir: Path, chunk_size: int=1000) -> None:
+def export_messages_single_user(user_profile: UserProfile, output_dir: Path,
+                                chunk_size: int=MESSAGE_BATCH_CHUNK_SIZE) -> None:
     user_message_query = UserMessage.objects.filter(user_profile=user_profile).order_by("id")
     min_id = -1
     dump_file_id = 1

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -503,19 +503,16 @@ def build_subscription(channel_members: List[str], zerver_subscription: List[Zer
 def convert_slack_workspace_messages(slack_data_dir: str, users: List[ZerverFieldsT], realm_id: int,
                                      added_users: AddedUsersT, added_recipient: AddedRecipientsT,
                                      added_channels: AddedChannelsT, realm: ZerverFieldsT,
-                                     zerver_realmemoji: List[ZerverFieldsT],
-                                     domain_name: str) -> Tuple[ZerverFieldsT,
-                                                                List[ZerverFieldsT],
-                                                                List[ZerverFieldsT]]:
+                                     zerver_realmemoji: List[ZerverFieldsT], domain_name: str,
+                                     output_dir: str) -> Tuple[List[ZerverFieldsT],
+                                                               List[ZerverFieldsT],
+                                                               List[ZerverFieldsT]]:
     """
     Returns:
-    1. message.json, Converted messages
+    1. reactions, which is a list of the reactions
     2. uploads, which is a list of uploads to be mapped in uploads records.json
     3. attachment, which is a list of the attachments
     """
-    message_json = {}
-    zerver_message = []  # type: List[ZerverFieldsT]
-    zerver_usermessage = []  # type: List[ZerverFieldsT]
     all_messages = get_all_messages(slack_data_dir, added_channels)
 
     # we sort the messages according to the timestamp to show messages with
@@ -532,13 +529,15 @@ def convert_slack_workspace_messages(slack_data_dir: str, users: List[ZerverFiel
                                                       added_channels,
                                                       domain_name)
 
+    message_json = dict(
+        zerver_message=zerver_message,
+        zerver_usermessage=zerver_usermessage)
+    message_filename = os.path.join(output_dir, "messages-000001.json")
+    logging.info("Writing Messages to %s\n" % (message_filename,))
+    create_converted_data_files(message_json, output_dir, '/messages-000001.json')
+
     logging.info('######### IMPORTING MESSAGES FINISHED #########\n')
-
-    message_json['zerver_message'] = zerver_message
-    message_json['zerver_usermessage'] = zerver_usermessage
-    message_json['zerver_reaction'] = reactions
-
-    return message_json, uploads, attachment
+    return reactions, uploads, attachment
 
 def get_all_messages(slack_data_dir: str, added_channels: AddedChannelsT) -> List[ZerverFieldsT]:
     all_messages = []  # type: List[ZerverFieldsT]
@@ -825,13 +824,12 @@ def do_convert_data(slack_zip_file: str, output_dir: str, token: str, threads: i
                                                  realm_subdomain,
                                                  slack_data_dir, custom_emoji_list)
 
-    message_json, uploads_list, zerver_attachment = convert_slack_workspace_messages(
+    reactions, uploads_list, zerver_attachment = convert_slack_workspace_messages(
         slack_data_dir, user_list, realm_id, added_users, added_recipient, added_channels,
-        realm, realm['zerver_realmemoji'], domain_name)
+        realm, realm['zerver_realmemoji'], domain_name, output_dir)
 
     # Move zerver_reactions to realm.json file
-    realm['zerver_reaction'] = message_json['zerver_reaction']
-    del message_json['zerver_reaction']
+    realm['zerver_reaction'] = reactions
 
     emoji_folder = os.path.join(output_dir, 'emoji')
     os.makedirs(emoji_folder, exist_ok=True)
@@ -849,8 +847,6 @@ def do_convert_data(slack_zip_file: str, output_dir: str, token: str, threads: i
 
     # IO realm.json
     create_converted_data_files(realm, output_dir, '/realm.json')
-    # IO message.json
-    create_converted_data_files(message_json, output_dir, '/messages-000001.json')
     # IO emoji records
     create_converted_data_files(emoji_records, output_dir, '/emoji/records.json')
     # IO avatar records

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -504,9 +504,9 @@ def convert_slack_workspace_messages(slack_data_dir: str, users: List[ZerverFiel
                                      added_users: AddedUsersT, added_recipient: AddedRecipientsT,
                                      added_channels: AddedChannelsT, realm: ZerverFieldsT,
                                      zerver_realmemoji: List[ZerverFieldsT], domain_name: str,
-                                     output_dir: str) -> Tuple[List[ZerverFieldsT],
-                                                               List[ZerverFieldsT],
-                                                               List[ZerverFieldsT]]:
+                                     output_dir: str, chunk_size: int=800) -> Tuple[List[ZerverFieldsT],
+                                                                                    List[ZerverFieldsT],
+                                                                                    List[ZerverFieldsT]]:
     """
     Returns:
     1. reactions, which is a list of the reactions
@@ -521,24 +521,46 @@ def convert_slack_workspace_messages(slack_data_dir: str, users: List[ZerverFiel
 
     logging.info('######### IMPORTING MESSAGES STARTED #########\n')
 
+    total_reactions = []  # type: List[ZerverFieldsT]
+    total_attachments = []  # type: List[ZerverFieldsT]
+    total_uploads = []  # type: List[ZerverFieldsT]
+
     message_id = usermessage_id = reaction_id = attachment_id = 0
     id_list = (message_id, usermessage_id, reaction_id, attachment_id)
 
-    zerver_message, zerver_usermessage, attachment, uploads, \
-        reactions, id_list = channel_message_to_zerver_message(
-            realm_id, users, added_users, added_recipient, all_messages,
-            zerver_realmemoji, realm['zerver_subscription'], added_channels,
-            id_list, domain_name)
+    # The messages are stored in batches
+    low_index = 0
+    upper_index = low_index + chunk_size
+    dump_file_id = 1
 
-    message_json = dict(
-        zerver_message=zerver_message,
-        zerver_usermessage=zerver_usermessage)
-    message_filename = os.path.join(output_dir, "messages-000001.json")
-    logging.info("Writing Messages to %s\n" % (message_filename,))
-    create_converted_data_files(message_json, output_dir, '/messages-000001.json')
+    while True:
+        message_data = all_messages[low_index:upper_index]
+        if len(message_data) == 0:
+            break
+        zerver_message, zerver_usermessage, attachment, uploads, \
+            reactions, id_list = channel_message_to_zerver_message(
+                realm_id, users, added_users, added_recipient, message_data,
+                zerver_realmemoji, realm['zerver_subscription'], added_channels,
+                id_list, domain_name)
+
+        message_json = dict(
+            zerver_message=zerver_message,
+            zerver_usermessage=zerver_usermessage)
+
+        message_file = "/messages-%06d.json" % (dump_file_id,)
+        logging.info("Writing Messages to %s\n" % (output_dir + message_file))
+        create_converted_data_files(message_json, output_dir, message_file)
+
+        total_reactions += reactions
+        total_attachments += attachment
+        total_uploads += uploads
+
+        low_index = upper_index
+        upper_index = chunk_size + low_index
+        dump_file_id += 1
 
     logging.info('######### IMPORTING MESSAGES FINISHED #########\n')
-    return reactions, uploads, attachment
+    return total_reactions, total_uploads, total_attachments
 
 def get_all_messages(slack_data_dir: str, added_channels: AddedChannelsT) -> List[ZerverFieldsT]:
     all_messages = []  # type: List[ZerverFieldsT]

--- a/zerver/lib/slack_data_to_zulip_data.py
+++ b/zerver/lib/slack_data_to_zulip_data.py
@@ -25,6 +25,7 @@ from zerver.lib.parallel import run_parallel
 from zerver.lib.avatar_hash import user_avatar_path_from_ids
 from zerver.lib.actions import STREAM_ASSIGNMENT_COLORS as stream_colors
 from zerver.lib.upload import random_name, sanitize_name
+from zerver.lib.export import MESSAGE_BATCH_CHUNK_SIZE
 from zerver.lib.emoji import NAME_TO_CODEPOINT_PATH
 
 # stubs
@@ -504,9 +505,10 @@ def convert_slack_workspace_messages(slack_data_dir: str, users: List[ZerverFiel
                                      added_users: AddedUsersT, added_recipient: AddedRecipientsT,
                                      added_channels: AddedChannelsT, realm: ZerverFieldsT,
                                      zerver_realmemoji: List[ZerverFieldsT], domain_name: str,
-                                     output_dir: str, chunk_size: int=800) -> Tuple[List[ZerverFieldsT],
-                                                                                    List[ZerverFieldsT],
-                                                                                    List[ZerverFieldsT]]:
+                                     output_dir: str,
+                                     chunk_size: int=MESSAGE_BATCH_CHUNK_SIZE) -> Tuple[List[ZerverFieldsT],
+                                                                                        List[ZerverFieldsT],
+                                                                                        List[ZerverFieldsT]]:
     """
     Returns:
     1. reactions, which is a list of the reactions

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -411,9 +411,10 @@ class SlackImporter(ZulipTestCase):
         zerver_subscription = []  # type: List[Dict[str, Any]]
         added_channels = {'random': ('c5', 1), 'general': ('c6', 2)}  # type: Dict[str, Tuple[str, int]]
         zerver_message, zerver_usermessage, attachment, uploads, \
-            reaction = channel_message_to_zerver_message(1, user_data, added_users, added_recipient,
-                                                         all_messages, zerver_subscription, [],
-                                                         added_channels, 'domain')
+            reaction, id_list = channel_message_to_zerver_message(
+                1, user_data, added_users, added_recipient,
+                all_messages, zerver_subscription, [],
+                added_channels, (0, 0, 0, 0), 'domain')
         # functioning already tested in helper function
         self.assertEqual(zerver_usermessage, [])
         # subtype: channel_join is filtered
@@ -421,6 +422,7 @@ class SlackImporter(ZulipTestCase):
 
         self.assertEqual(uploads, [])
         self.assertEqual(attachment, [])
+        self.assertEqual(id_list, (5, 2, 1, 0))
 
         # Test reactions
         self.assertEqual(reaction[0]['user_profile'], 24)
@@ -460,10 +462,12 @@ class SlackImporter(ZulipTestCase):
         user_list = []  # type: List[Dict[str, Any]]
         reactions = [{"name": "grinning", "users": ["U061A5N1G"], "count": 1}]
         attachments = uploads = []  # type: List[Dict[str, Any]]
+        id_list = (2, 4, 0, 1)
 
         zerver_usermessage = [{'id': 3}, {'id': 5}, {'id': 6}, {'id': 9}]
 
-        mock_message.side_effect = [[zerver_message, zerver_usermessage, attachments, uploads, reactions]]
+        mock_message.side_effect = [[zerver_message, zerver_usermessage, attachments, uploads,
+                                     reactions, id_list]]
         test_reactions, uploads, zerver_attachment = convert_slack_workspace_messages(
             './random_path', user_list, 2, {}, {}, added_channels, realm, [], 'domain', 'var/test-slack-import')
         messages_file = os.path.join('var', 'test-slack-import', 'messages-000001.json')


### PR DESCRIPTION
Write the messages batchwise to prevent memory error.

The same method has been implemented for gitter import (#9569)

TODO: Thread the writing of the message process. I will work on this in a new PR.
