### PR TITLE
custom fields: Fix exception in rendering custom profile field template.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -35,6 +35,7 @@ set_global('settings_emoji', {
 set_global('settings_account', {
     update_email_change_display: noop,
     update_name_change_display: noop,
+    add_custom_profile_fields_to_settings: noop,
 });
 set_global('settings_display', {
     update_page: noop,

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -175,6 +175,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
     case 'custom_profile_fields':
         page_params.custom_profile_fields = event.fields;
         settings_profile_fields.populate_profile_fields(page_params.custom_profile_fields);
+        settings_account.add_custom_profile_fields_to_settings();
         break;
 
     case 'realm_domains':

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -64,6 +64,11 @@ function update_user_custom_profile_fields(fields, method) {
 }
 
 exports.add_custom_profile_fields_to_settings = function () {
+    if (!overlays.settings_open()) {
+        return;
+    }
+
+    $("#account-settings .custom-profile-fields-form").html("");
     var all_custom_fields = page_params.custom_profile_fields;
 
     all_custom_fields.forEach(function (field) {

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -167,9 +167,6 @@ exports.reset = function () {
 };
 
 exports.populate_profile_fields = function (profile_fields_data) {
-    $("#account-settings .custom-profile-fields-form").html("");
-    settings_account.add_custom_profile_fields_to_settings();
-
     if (!meta.loaded) {
         return;
     }


### PR DESCRIPTION
Function `settings_account.add_custom_profile_fields_to_settings` called
twice, which results in two templates objects. Function also doesn't
include check whether settings overlay is open or not, which throws
"undefined" error.

Fixes #9668

