### PR TITLE
 cache: Enable compression in pylibmc for cache stored in memcached.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -108,6 +108,9 @@ pycrypto==2.6.1
 # Needed for memcached usage
 pylibmc==1.5.2
 
+# Needed for compression support in memcached via pylibmc
+django-pylibmc==0.6.1
+
 # Needed for zerver/tests/test_timestamp.py
 python-dateutil==2.6.1
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -51,6 +51,7 @@ django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.4.1.1       # via django-two-factor-auth
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-pipeline==1.6.14
+django-pylibmc==0.6.1
 django-sendfile==0.3.11
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.7.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -38,6 +38,7 @@ django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.4.1.1       # via django-two-factor-auth
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-pipeline==1.6.14
+django-pylibmc==0.6.1
 django-sendfile==0.3.11
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.7.0

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '20.9'
+PROVISION_VERSION = '20.10'

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -610,6 +610,8 @@ RABBITMQ_PASSWORD = get_secret("rabbitmq_password")
 ########################################################################
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+PYLIBMC_MIN_COMPRESS_LEN = 1000000
+PYLIBMC_COMPRESS_LEVEL = 5
 
 CACHES = {
     'default': {

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -613,7 +613,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+        'BACKEND': 'django_pylibmc.memcached.PyLibMCCache',
         'LOCATION': MEMCACHED_LOCATION,
         'TIMEOUT': 3600,
         'OPTIONS': {


### PR DESCRIPTION
This PR helps fix the caching issue which caused the outage being talked about here
https://chat.zulip.org/#narrow/stream/3-backend/topic/outage.20today