### PR TITLE
message: Fix opening of compose box on mobile webapp.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -65,15 +65,30 @@ exports.initialize = function () {
         var MS_DELAY = 750;
         var meta = {
             touchdown: false,
+            current_target: undefined,
         };
 
         $("#main_div").on("touchstart", ".messagebox", function () {
             meta.touchdown = true;
             meta.invalid = false;
-
+            var id = rows.id($(this).closest(".message_row"));
+            meta.current_target = id;
+            if (!id) {
+                return;
+            }
+            current_msg_list.select_id(id);
             setTimeout(function () {
+                // The algorithm to trigger long tap is that first, we check
+                // whether the message is still touched after MS_DELAY ms and
+                // the user isn't scrolling the messages(see other touch event
+                // handlers to see how these meta variables are handled).
+                // Later we check whether after MS_DELAY the user is still
+                // long touching the same message as it can be possible that
+                // user touched another message within MS_DELAY period.
                 if (meta.touchdown === true && !meta.invalid) {
-                    $(this).trigger("longtap");
+                    if (id === meta.current_target) {
+                        $(this).trigger("longtap");
+                    }
                 }
             }.bind(this), MS_DELAY);
         });


### PR DESCRIPTION
~This first commit includes a minor refactor and then in the second commit,~ the change is explained in a comment as it will be helpful for the future maintainer to understand the logic here.
I think we need some volunteers to very that whether this fixes the opening of composing box issue. It works great for me.
@HarshitOnGitHub FYI since you reported the [issue here](https://chat.zulip.org/#narrow/stream/3-backend/subject/webapp.20on.20mobile/near/596212). 
[edit] I've deleted the first commit because that commit doesn't make sense anymore after fixing the Casper tests.
