### PR TITLE
[proof of concept] Add basic zgram class for experimentation.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -165,6 +165,7 @@
         "markdown": false,
         "local_message": false,
         "echo": false,
+        "zgram": false,
         "localstorage": false,
         "localStorage": false,
         "current_msg_list": true,

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -56,6 +56,7 @@ global.document.location.protocol = 'https:';
 global.document.location.host = 'foo.com';
 
 zrequire('zcommand');
+zrequire('zgram');
 zrequire('compose_ui');
 zrequire('util');
 zrequire('common');

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -249,6 +249,7 @@ run_test('predicate_basics', () => {
 
     predicate = get_predicate([['topic', 'Bar']]);
     assert(!predicate({type: 'private'}));
+    assert(predicate({type: 'zgram'}));
 
     predicate = get_predicate([['is', 'private']]);
     assert(predicate({type: 'private'}));
@@ -278,6 +279,7 @@ run_test('predicate_basics', () => {
     predicate = get_predicate([['in', 'home']]);
     assert(!predicate({stream_id: unknown_stream_id, stream: 'unknown'}));
     assert(predicate({type: 'private'}));
+    assert(predicate({type: 'zgram'}));
     global.page_params.narrow_stream = 'kiosk';
     assert(predicate({stream: 'kiosk'}));
 
@@ -866,6 +868,17 @@ run_test('update_email', () => {
     assert.deepEqual(filter.operands('stream'), ['steve@foo.com']);
 });
 
+run_test('zgram while loading', () => {
+    var terms = [
+        {operator: 'pm-with', operand: 'steve@foo.com'},
+    ];
+    var filter = new Filter(terms);
+    var predicate = filter.predicate();
+    filter.local_load = true;
+    assert.equal(predicate({type: 'zgram'}), false);
+    filter.local_load = false;
+    assert.equal(predicate({type: 'zgram'}), true);
+});
 
 run_test('error_cases', () => {
     // This test just gives us 100% line coverage on defensive code that

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -398,6 +398,10 @@ run_test('subject_links', () => {
     assert.equal(message.subject_links.length, 0);
 });
 
+run_test('convert_text', () => {
+    assert.equal(markdown.convert_text('**foo**'), '<p><strong>foo</strong></p>');
+});
+
 run_test('message_flags', () => {
     var input = "/me is testing this";
     var message = {subject: "No links here", raw_content: input};

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -17,6 +17,7 @@ set_global('sent_messages', {
     report_server_ack: noop,
 });
 set_global('blueslip', global.make_zblueslip());
+set_global('zgram', {});
 
 zrequire('people');
 zrequire('transmit');
@@ -249,6 +250,36 @@ run_test('reply_message_private', () => {
         type: 'private',
         to: '["fred@example.com"]',
         content: 'hello',
+    });
+});
+
+run_test('zgram', () => {
+    page_params.user_id = 99;
+
+    const message = {
+        sender_id: 55,
+        type: 'zgram',
+    };
+
+    var send_opts;
+
+    zgram.send = (opts) => {
+        send_opts = opts;
+    };
+
+    transmit.reply_message({
+        message: message,
+        content: 'hello',
+    });
+
+    assert.deepEqual(send_opts, {
+        data: {
+            queue_id: send_opts.data.queue_id,
+            local_id: send_opts.data.local_id,
+            sender_id: page_params.user_id,
+            target_user_id: message.sender_id,
+            content: 'hello',
+        },
     });
 });
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -310,6 +310,12 @@ exports.finish = function () {
         return;
     }
 
+    if (zgram.process(message_content)) {
+        exports.do_post_send_tasks();
+        clear_compose_box();
+        return;
+    }
+
     if (!compose.validate()) {
         return false;
     }

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -297,6 +297,18 @@ exports.respond_to_message = function (opts) {
         return;
     }
 
+    var pm_recipient;
+
+    if (message.type === 'zgram') {
+
+        pm_recipient = people.get_person_from_user_id(message.sender_id).email;
+        var start_options = {
+            private_message_recipient: pm_recipient,
+        };
+        exports.start('private', start_options);
+        return;
+    }
+
     unread_ops.notify_server_message_read(message);
 
     var stream = '';
@@ -306,7 +318,7 @@ exports.respond_to_message = function (opts) {
         subject = message.subject;
     }
 
-    var pm_recipient = message.reply_to;
+    pm_recipient = message.reply_to;
     if (message.type === "private") {
         if (opts.reply_type === "personal") {
             // reply_to for private messages is everyone involved, so for

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -6,6 +6,10 @@ var focused_recipient;
 var normal_display = false;
 
 exports.should_fade_message =  function (message) {
+    if (message.type === 'zgram') {
+        return false;
+    }
+
     return !util.same_recipient(focused_recipient, message);
 };
 

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -479,7 +479,20 @@ Filter.prototype = {
         // We could turn it into something more like a compiler:
         // build JavaScript code in a string and then eval() it.
 
+        var self = this;
+
         return function (message) {
+            if (message.type === 'zgram') {
+                if (self.local_load) {
+                    // local_load is kind of a hack--we set it only
+                    // while loading up a narrow from locally cached
+                    // messages, which is a good time to exclude zgrams
+                    return false;
+                }
+
+                return true;
+            }
+
             return _.all(operators, function (term) {
                 var ok = message_matches_search_term(message, term.operator, term.operand);
                 if (term.negated) {

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -93,6 +93,10 @@ exports.apply_markdown = function (message) {
     message.is_me_message = exports.is_status_message(message.raw_content, message.content);
 };
 
+exports.convert_text = function (content) {
+    return marked(content).trim();
+};
+
 exports.add_subject_links = function (message) {
     if (message.type !== 'stream') {
         message.subject_links = [];

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -439,6 +439,11 @@ MessageListView.prototype = {
                 row: row,
                 message_id: id,
             });
+
+            zgram.process_row({
+                row: row,
+                message_id: id,
+            });
         });
     },
 

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -95,6 +95,7 @@ function set_topic_edit_properties(group, message) {
 function populate_group_from_message_container(group, message_container) {
     group.is_stream = message_container.msg.is_stream;
     group.is_private = message_container.msg.is_private;
+    group.is_zgram = message_container.msg.zgram;
 
     if (group.is_stream) {
         group.background_color = stream_data.get_color(message_container.msg.stream);
@@ -447,7 +448,7 @@ MessageListView.prototype = {
         var msg_to_render = _.extend(message_container, {
             table_name: this.table_name,
         });
-        return templates.render('single_message', msg_to_render);
+        return templates.render('message_row', msg_to_render);
     },
 
     render: function MessageListView__render(messages, where, messages_are_new) {

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -128,6 +128,8 @@ exports.add_message_metadata = function (message) {
         message.sender_email = sender.email;
     }
 
+    message.zgram = message.type === 'zgram';
+
     switch (message.type) {
     case 'stream':
         message.is_stream = true;

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -283,7 +283,10 @@ function load_local_messages(msg_data) {
     // one message the user will expect to see in the new narrow.
 
     var in_msgs = message_list.all.all_messages();
+
+    msg_data.filter.local_load = true;
     msg_data.add_messages(in_msgs);
+    msg_data.filter.local_load = false;
 
     return !msg_data.empty();
 }

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -549,6 +549,13 @@ exports.notify_local_mixes = function (messages) {
     */
 
     _.each(messages, function (message) {
+        if (message.simulated) {
+            // TODO: This is just a hack from an early proof-of-concept
+            //       of zgrams that used the local-message code to simulate
+            ///      messages.
+            return;
+        }
+
         if (!people.is_my_user_id(message.sender_id)) {
             blueslip.warn('We did not expect messages sent by others to get here');
             return;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -435,6 +435,10 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         }
         settings_user_groups.reload();
         break;
+
+    case 'zgram':
+        zgram.handle_event(event);
+        break;
     }
 };
 

--- a/static/js/transmit.js
+++ b/static/js/transmit.js
@@ -129,6 +129,16 @@ exports.reply_message = function (opts) {
         return;
     }
 
+    if (message.type === 'zgram') {
+        reply.target_user_id = message.sender_id;
+        reply.content = content;
+
+        zgram.send({
+            data: reply,
+        });
+        return;
+    }
+
     blueslip.error('unknown message type: ' + message.type);
 };
 

--- a/static/js/zform.js
+++ b/static/js/zform.js
@@ -62,6 +62,7 @@ exports.activate = function (opts) {
         // JS code to use later.
         _.each(data.choices, function (choice, idx) {
             choice.idx = idx;
+            choice.long_name_html = markdown.convert_text(choice.long_name);
         });
 
         var html = templates.render('zform-choices', data);

--- a/static/js/zgram.js
+++ b/static/js/zgram.js
@@ -29,6 +29,16 @@ exports.send = function (opts) {
     });
 };
 
+exports.handle_event = function (event) {
+    var message = event.data;
+
+    message.id = local_message.get_next_id();
+    message.timestamp = local_message.now();
+    message.simulated = true;
+    message.type = 'zgram';
+    local_message.insert_message(message);
+};
+
 exports.simulate_simple_message = function () {
     var message = {
         type: 'zgram',

--- a/static/js/zgram.js
+++ b/static/js/zgram.js
@@ -1,0 +1,47 @@
+var zgram = (function () {
+
+var exports = {};
+
+exports._fake_send = function (message) {
+    /*
+        In early versions we are only building out the
+        client side of zgrams, but they will eventually
+        have a server-side component.  For now we
+        simulate the "round trip" by immediately calling
+        local_message.insert_message().
+    */
+    message.id = local_message.get_next_id();
+    message.timestamp = local_message.now();
+    message.simulated = true;
+    message.sender_id = exports._fake_sender_id();
+    message.type = 'zgram';
+    local_message.insert_message(message);
+};
+
+exports.simulate_simple_message = function () {
+    var message = {
+        type: 'zgram',
+        display_recipient: people.my_full_name(),
+        content: 'this is a simulated zgram (proof of concept)',
+    };
+
+    exports._fake_send(message);
+};
+
+exports._fake_sender_id = function () {
+    var person = people.get_by_email('zoe@zulip.com');
+
+    if (!person) {
+        blueslip.error('The demo only works in a realm with zoe.');
+        return;
+    }
+
+    return person.user_id;
+};
+
+return exports;
+
+}());
+if (typeof module !== 'undefined') {
+    module.exports = zgram;
+}

--- a/static/js/zgram.js
+++ b/static/js/zgram.js
@@ -18,6 +18,17 @@ exports._fake_send = function (message) {
     local_message.insert_message(message);
 };
 
+exports.send = function (opts) {
+    var data = opts.data;
+
+    channel.post({
+        url: '/json/zgram',
+        data: {
+            data: JSON.stringify(data),
+        },
+    });
+};
+
 exports.simulate_simple_message = function () {
     var message = {
         type: 'zgram',

--- a/static/js/zgram.js
+++ b/static/js/zgram.js
@@ -39,6 +39,58 @@ exports.handle_event = function (event) {
     local_message.insert_message(message);
 };
 
+exports.process = function (content) {
+    // TEMPORARY CODE:
+    //
+    // We probably will eventually just have API clients
+    // send zgrams, with no UI hooks.  But this is convenient
+    // code for prototyping purposes.
+
+    var prefix = '/yesno ';
+    if (content.startsWith(prefix)) {
+        var pill_user_ids = compose_pm_pill.get_user_ids();
+
+        if (pill_user_ids.length !== 1) {
+            blueslip.warn('/yesno requires a single PM user target');
+            return false;
+        }
+
+        var question = content.slice(prefix.length);
+
+        var extra_data = {
+            type: 'choices',
+            heading: question,
+            choices: [
+                {
+                    short_name: 'Y',
+                    long_name: 'yes',
+                    reply: 'yes',
+                },
+                {
+                    short_name: 'N',
+                    long_name: 'no',
+                    reply: 'no',
+                },
+            ],
+        };
+
+        var target_user_id = pill_user_ids[0];
+
+        var data = {
+            content: content,
+            target_user_id: target_user_id,
+            extra_data: extra_data,
+            widget_type: 'zform',
+        };
+        exports.send({
+            data: data,
+        });
+        return true;
+    }
+
+    return false;
+};
+
 exports.simulate_simple_message = function () {
     var message = {
         type: 'zgram',

--- a/static/js/zgram.js
+++ b/static/js/zgram.js
@@ -60,6 +60,54 @@ exports._fake_sender_id = function () {
     return person.user_id;
 };
 
+exports.process_row = function (in_opts) {
+    var row = in_opts.row;
+
+    var message_id = in_opts.message_id;
+    var message = message_store.get(message_id);
+
+    if (!message) {
+        return;
+    }
+
+    if (message.type !== 'zgram') {
+        return;
+    }
+
+    var content_holder = row.find('.message_content');
+
+    var widget_elem;
+    if (message.widget) {
+        // Use local to work around linter.  We can trust this
+        // value because it comes from a template.
+        widget_elem = message.widget_elem;
+        content_holder.html(widget_elem);
+        return;
+    }
+
+    var widget_type = message.widget_type;
+    var extra_data = message.extra_data;
+
+    if (widget_type !== 'zform') {
+        // Right now zform is our only widget that works with
+        // zgrams.  More complicated widgets like tictactoe and
+        // surveys need "real" Zulip messages under the current
+        // architecture.
+        return;
+    }
+
+    widget_elem = $('<div>');
+    content_holder.html(widget_elem);
+
+    zform.activate({
+        elem: widget_elem,
+        message: message,
+        extra_data: extra_data,
+    });
+
+    message.widget_elem = widget_elem;
+};
+
 return exports;
 
 }());

--- a/static/styles/widgets.scss
+++ b/static/styles/widgets.scss
@@ -70,3 +70,16 @@ button.poll-comment, button.poll-question {
 button.poll-comment:hover, button.poll-question:hover {
     border-color: #999999;
 }
+
+// This file isn't necessarily the best place for this style,
+// but while it's experimental I don't want to muck with existing
+// code too much.
+
+.zgram_row {
+    background: khaki;
+}
+
+.zgram_header {
+    color: white;
+    background: navy;
+}

--- a/static/templates/message_group.handlebars
+++ b/static/templates/message_group.handlebars
@@ -15,7 +15,7 @@
             {{partial "recipient_row" "use_match_properties" ../use_match_properties}}
             {{#each message_containers}}
                 {{#with this}}
-                {{partial "single_message" "use_match_properties" ../../use_match_properties "table_name" ../../table_name}}
+                {{partial "message_row" "use_match_properties" ../../use_match_properties "table_name" ../../table_name}}
                 {{/with}}
             {{/each}}
         </div>

--- a/static/templates/message_row.handlebars
+++ b/static/templates/message_row.handlebars
@@ -1,0 +1,5 @@
+{{#if msg/zgram}}
+{{partial "zgram"}}
+{{else}}
+{{partial "single_message"}}
+{{/if}}

--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -56,6 +56,10 @@
         </div>
     </div>
 </div>
+{{else if is_zgram}}
+<div class="zgram_header">
+    {{t 'Quick question:' }}
+</div>
 {{else}}
 <div class="message_header message_header_private_message dark_background">
     <div class="message-header-wrapper">

--- a/static/templates/widgets/zform-choices.handlebars
+++ b/static/templates/widgets/zform-choices.handlebars
@@ -5,7 +5,7 @@
         <li>
             <button data-idx="{{ this.idx }}">{{ this.short_name }}</button>
             &nbsp;
-            {{ this.long_name }}
+            {{{ this.long_name_html }}}
         </li>
         {{/each}}
     </ul>

--- a/static/templates/zgram.handlebars
+++ b/static/templates/zgram.handlebars
@@ -1,0 +1,19 @@
+<div zid="{{msg/id}}" id="{{table_name}}{{msg/id}}" class="zgram_row message_row selectable_row">
+    <div class="messagebox" style="box-shadow: inset 2px 0px 0px 0px, -1px 0px 0px 0px;">
+        <div class="messagebox-border">
+            <div class="messagebox-content">
+                <div class="message_top_line">
+                    <span class="message_sender sender_info_hover no-select">
+                        <div class="u-{{msg/sender_id}} inline_profile_picture">
+                            <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
+                        </div>
+                        <span class="sender_name auto-select">{{msg/sender_full_name}}</span>
+                    </span>
+                </div>
+                <div class="message_content">
+                    {{{msg/content}}}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -670,6 +670,7 @@ def build_custom_checkers(by_lang):
              'static/templates/draft.handlebars',
              'static/templates/subscription.handlebars',
              'static/templates/single_message.handlebars',
+             'static/templates/zgram.handlebars',
 
              # Old-style email templates need to use inline style
              # attributes; it should be possible to clean these up

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1125,6 +1125,15 @@ def do_schedule_messages(messages: Sequence[Mapping[str, Any]]) -> List[int]:
     return [scheduled_message.id for scheduled_message in scheduled_messages]
 
 
+def do_send_zgram(sender_id: int, data: Dict[str, Any]) -> None:
+    data['sender_id'] = sender_id
+    target_user_id = data['target_user_id']
+    event = dict(
+        type='zgram',
+        data=data
+    )
+    send_event(event, [target_user_id])
+
 def do_send_messages(messages_maybe_none: Sequence[Optional[MutableMapping[str, Any]]],
                      email_gateway: Optional[bool]=False) -> List[int]:
     # Filter out messages which didn't pass internal_prep_message properly

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -999,6 +999,18 @@ class SewMessageAndReactionTest(ZulipTestCase):
 
 class MessagePOSTTest(ZulipTestCase):
 
+    def test_zgram(self) -> None:
+        self.login(self.example_email("hamlet"))
+
+        data = dict(
+            content='hello',
+            target_user_id=self.example_user("cordelia").id
+        )
+
+        payload = dict(data=ujson.dumps(data))
+        result = self.client_post("/json/zgram", payload)
+        self.assert_json_success(result)
+
     def test_message_to_self(self) -> None:
         """
         Sending a message to a stream to which you are subscribed is

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -19,6 +19,7 @@ from zerver.lib.actions import recipient_for_emails, do_update_message_flags, \
     create_mirror_user_if_needed, check_send_message, do_update_message, \
     extract_recipients, truncate_body, render_incoming_message, do_delete_message, \
     do_mark_all_as_read, do_mark_stream_messages_as_read, \
+    do_send_zgram, \
     get_user_info_for_message_updates, check_schedule_message
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.message import (
@@ -680,6 +681,16 @@ def find_first_unread_anchor(sa_conn: Any,
         anchor = LARGER_THAN_MAX_MESSAGE_ID
 
     return anchor
+
+@has_request_variables
+def zgram_backend(request: HttpRequest, user_profile: UserProfile,
+                  data: str=REQ('data')) -> HttpResponse:
+    # TODO: make this not so opaque, add validation, etc.
+    zgram_data = ujson.loads(data)
+    do_send_zgram(sender_id=user_profile.id, data=zgram_data)
+
+    ret = dict()  # type: Dict[str, Any]
+    return json_success(ret)
 
 @has_request_variables
 def zcommand_backend(request: HttpRequest, user_profile: UserProfile,

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -971,6 +971,7 @@ JS_SPECS = {
             'js/markdown.js',
             'js/local_message.js',
             'js/echo.js',
+            'js/zgram.js',
             'js/socket.js',
             'js/sent_messages.js',
             'js/compose_state.js',

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -164,6 +164,8 @@ v1_api_and_json_patterns = [
 
     url(r'^zcommand$', rest_dispatch,
         {'POST': 'zerver.views.messages.zcommand_backend'}),
+    url(r'^zgram$', rest_dispatch,
+        {'POST': 'zerver.views.messages.zgram_backend'}),
 
     # messages -> zerver.views.messages
     # GET returns messages, possibly filtered, POST sends a message


### PR DESCRIPTION
This is code that @lonerz, @rheaparekh, and others may wish to build off for experiments with ephemeral messages, bot widgets, etc.

It basically creates a lightweight message called a "zgram" that mostly works like regular messages, but which can be rendered in any narrow, doesn't have the ability to be edited, etc.