### PR TITLE
features: Standardize width of feature blocks with pseudoelements.

### DIFF
--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -245,6 +245,10 @@
             <p>Zulip is open source, so if something important for
             your use case is missing, you can make it happen!</p>
         </div>
+        <!--Hack: These two pseudo elements are here to ensure the flex
+        arrangment uses the proper cell size with 4 elements in 2 rows.-->
+        <div class="feature-block"></div>
+        <div class="feature-block"></div>
     </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
Current status:
![screenshot at jun 11 10-10-14](https://user-images.githubusercontent.com/15116870/41246368-b7a07a1c-6d5f-11e8-9afb-8e775cb3d2ce.png)
![screenshot at jun 11 10-10-24](https://user-images.githubusercontent.com/15116870/41246369-b7d3d844-6d5f-11e8-9494-cf12a49ed466.png)
![screenshot at jun 11 10-10-32](https://user-images.githubusercontent.com/15116870/41246370-b7fd0b60-6d5f-11e8-921e-50c65d3bb2b5.png)

Like the blocks in the previous Apps/API/Integrations section, we add 2 pseudoelements to standardize the width of feature blocks so that the last block shares the same width as all previous blocks.

Note: It's possible to fix this without pseudoelements by setting media selector breakpoints that control the default width of elements according to screen size. But since this hack was already previously used above, I wasn't sure if this was supposed to be the advised way to fix it.

Fixes #9195.
