### PR TITLE
popovers: Enable keyboard navigation on user profile menu.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -174,6 +174,7 @@ run_test('basic_chars', () => {
 
     set_global('popovers', {
         actions_popped: return_false,
+        message_info_popped: return_false,
     });
     set_global('emoji_picker', {
         reactions_popped: return_false,

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -7,7 +7,8 @@ function do_narrow_action(action) {
     return true;
 }
 
-var actions_dropdown_hotkeys = [
+// For message actions and user profile menu.
+var menu_dropdown_hotkeys = [
     'down_arrow',
     'up_arrow',
     'vim_up',
@@ -519,7 +520,7 @@ exports.process_hotkey = function (e, hotkey) {
         }
     }
 
-    if (actions_dropdown_hotkeys.indexOf(event_name) !== -1 && popovers.actions_popped()) {
+    if (menu_dropdown_hotkeys.indexOf(event_name) !== -1 && popovers.actions_popped()) {
         popovers.actions_menu_handle_keyboard(event_name);
         return true;
     }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -520,9 +520,16 @@ exports.process_hotkey = function (e, hotkey) {
         }
     }
 
-    if (menu_dropdown_hotkeys.indexOf(event_name) !== -1 && popovers.actions_popped()) {
-        popovers.actions_menu_handle_keyboard(event_name);
-        return true;
+    if (menu_dropdown_hotkeys.indexOf(event_name) !== -1) {
+        if (popovers.actions_popped()) {
+            popovers.actions_menu_handle_keyboard(event_name);
+            return true;
+        }
+
+        if (popovers.message_info_popped()) {
+            popovers.user_info_popover_handle_keyboard(event_name);
+            return true;
+        }
     }
 
     // The next two sections date back to 00445c84 and are Mac/Chrome-specific,

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -537,6 +537,13 @@ exports.hide_user_sidebar_popover = function () {
     }
 };
 
+function focus_user_info_popover_item() {
+    // For now I recommend only calling this when the user opens the menu with a hotkey.
+    // Our popup menus act kind of funny when you mix keyboard and mouse.
+    var items = get_user_info_popover_items();
+    focus_first_popover_item(items);
+}
+
 exports.show_sender_info = function () {
     var $message = $(".selected_message");
     var $sender = $message.find(".sender_info_hover");
@@ -551,6 +558,9 @@ exports.show_sender_info = function () {
     var message = current_msg_list.get(rows.id($message));
     var user = people.get_person_from_user_id(message.sender_id);
     show_user_info_popover($sender[0], user, message);
+    if (current_message_info_popover_elem) {
+        focus_user_info_popover_item();
+    }
 };
 
 exports.register_click_handlers = function () {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -400,15 +400,39 @@ function get_action_menu_menu_items() {
     return $('li:not(.divider):visible a', popover_data.$tip);
 }
 
-function focus_first_action_popover_item() {
-    // For now I recommend only calling this when the user opens the menu with a hotkey.
-    // Our popup menus act kind of funny when you mix keyboard and mouse.
-    var items = get_action_menu_menu_items();
+function focus_first_popover_item(items) {
     if (!items) {
         return;
     }
 
     items.eq(0).expectOne().focus();
+}
+
+function popover_items_handle_keyboard(key, items) {
+    if (!items) {
+        return;
+    }
+
+    var index = items.index(items.filter(':focus'));
+
+    if (key === "enter" && index >= 0 && index < items.length) {
+        return items[index].click();
+    }
+    if (index === -1) {
+        index = 0;
+    } else if ((key === 'down_arrow' || key === 'vim_down') && index < items.length - 1) {
+        index += 1;
+    } else if ((key === 'up_arrow' || key === 'vim_up') && index > 0) {
+        index -= 1;
+    }
+    items.eq(index).focus();
+}
+
+function focus_first_action_popover_item() {
+    // For now I recommend only calling this when the user opens the menu with a hotkey.
+    // Our popup menus act kind of funny when you mix keyboard and mouse.
+    var items = get_action_menu_menu_items();
+    focus_first_popover_item(items);
 }
 
 exports.open_message_menu = function (message) {
@@ -429,23 +453,7 @@ exports.open_message_menu = function (message) {
 
 exports.actions_menu_handle_keyboard = function (key) {
     var items = get_action_menu_menu_items();
-    if (!items) {
-        return;
-    }
-
-    var index = items.index(items.filter(':focus'));
-
-    if (key === "enter" && index >= 0 && index < items.length) {
-        return items[index].click();
-    }
-    if (index === -1) {
-        index = 0;
-    } else if ((key === 'down_arrow' || key === 'vim_down') && index < items.length - 1) {
-        index += 1;
-    } else if ((key === 'up_arrow' || key === 'vim_up') && index > 0) {
-        index -= 1;
-    }
-    items.eq(index).focus();
+    popover_items_handle_keyboard(key, items);
 };
 
 exports.actions_popped = function () {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -487,12 +487,12 @@ exports.hide_actions_popover = function () {
     }
 };
 
-function message_info_popped() {
+exports.message_info_popped = function () {
     return current_message_info_popover_elem !== undefined;
-}
+};
 
 exports.hide_message_info_popover = function () {
-    if (message_info_popped()) {
+    if (exports.message_info_popped()) {
         current_message_info_popover_elem.popover("destroy");
         current_message_info_popover_elem = undefined;
     }
@@ -543,6 +543,11 @@ function focus_user_info_popover_item() {
     var items = get_user_info_popover_items();
     focus_first_popover_item(items);
 }
+
+exports.user_info_popover_handle_keyboard = function (key) {
+    var items = get_user_info_popover_items();
+    popover_items_handle_keyboard(key, items);
+};
 
 exports.show_sender_info = function () {
     var $message = $(".selected_message");
@@ -915,7 +920,7 @@ exports.any_active = function () {
     // Expanded sidebars on mobile view count as popovers as well.
     return popovers.actions_popped() || user_sidebar_popped() ||
         stream_popover.stream_popped() || stream_popover.topic_popped() ||
-        message_info_popped() || emoji_picker.reactions_popped() ||
+        exports.message_info_popped() || emoji_picker.reactions_popped() ||
         $("[class^='column-'].expanded").length;
 };
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -210,6 +210,21 @@ function show_user_profile(element, user) {
     $("#user-profile-modal").modal("show");
 }
 
+function get_user_info_popover_items() {
+    if (!current_message_info_popover_elem) {
+        blueslip.error('Trying to get menu items when action popover is closed.');
+        return;
+    }
+
+    var popover_data = current_message_info_popover_elem.data('popover');
+    if (!popover_data) {
+        blueslip.error('Cannot find popover data for actions menu.');
+        return;
+    }
+
+    return $('li:not(.divider):visible a', popover_data.$tip);
+}
+
 function fetch_group_members(member_ids) {
     return member_ids
         .map(function (m) {

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -58,7 +58,7 @@
     {{/if}}
     {{#unless is_me}}
     <li>
-        <a class="mention_user">
+        <a href="#" class="mention_user">
             <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
         </a>
     </li>


### PR DESCRIPTION
Fixes #9318.

![peek 2018-06-12 16-09](https://user-images.githubusercontent.com/13910561/41285840-22c6cb24-6e5b-11e8-82a4-908d4cc546d0.gif)

From the original issue:
> poke around other menus while you're at it to see if similar bugs exist

Keyboard navigation worked in the other menus which were being open by keyboard.
```
g | Toggle the gear menu
i | Open message menu
: | Open reactions menu
? | Show keyboard shortcuts
```
