### PR TITLE
night-mode: Fix incorrectly-colored user profile in mobile view.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -185,8 +185,9 @@ body.night-mode .informational-overlays .overlay-content {
 
 body.night-mode .dropdown .dropdown-menu,
 body.night-mode .popover,
-body.night-mode .popover-title {
-    background: hsl(212, 32%, 14%);
+body.night-mode .popover-title,
+body.night-mode .popover-content {
+    background-color: hsl(212, 32%, 14%);
 }
 
 body.night-mode .dropdown-menu a {


### PR DESCRIPTION
Before:

![screenshot at jun 11 21-59-53](https://user-images.githubusercontent.com/15116870/41301681-7b71bcc2-6e1d-11e8-8d3b-f2310daf27d0.png)

After:

![screenshot at jun 11 21-59-11](https://user-images.githubusercontent.com/15116870/41301695-8812e8a2-6e1d-11e8-8efc-a859a36b791c.png)
