### PR TITLE
populate_db: Include populating analytics database.

### DIFF
--- a/docs/subsystems/analytics.md
+++ b/docs/subsystems/analytics.md
@@ -161,8 +161,10 @@ statistics, etc.). There is currently a reference implementation of a
 ### Setup and Testing
 
 The main testing approach for the /stats page UI is manual testing.  For UI
-testing, you want a comprehensive initial data set.  You can create
-one by using the `./manage.py populate_analytics_db` command from the
+testing, you want a comprehensive initial data set, which is automatically
+created while populating the database by `./manage.py populate_db`
+but you can create that explicity by yourself using the
+`./manage.py populate_analytics_db` command from the
 main `zulip` directory inside your development environment.
 
 Then, in the development server web UI, (logout if needed) and then

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Iterable, List, \
 
 import ujson
 from django.conf import settings
+from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandParser
 from django.db.models import F, Max
 from django.utils.timezone import now as timezone_now
@@ -526,6 +527,11 @@ class Command(BaseCommand):
                         pointer=user['pointer'])
 
             create_user_groups()
+
+            if not options["test_suite"]:
+                # We populate the analytics database here for
+                # development purpose only
+                call_command('populate_analytics_db')
             self.stdout.write("Successfully populated test database.\n")
 
 recipient_hash = {}  # type: Dict[int, Recipient]


### PR DESCRIPTION
This is a rudimentary PR(Created to ask doubts here).
Still I've to include `management.call_command` in populate_db.py. So test may fail.