### PR TITLE
integrations: Hide page content until all data has loaded.

### DIFF
--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -195,6 +195,7 @@ function hide_catalog_show_integration() {
         $(".extra, #integration-main-text, #integration-search").css("display", "none");
 
         show_integration(doc);
+        $(".main").css("visibility", "visible");
     }
 
     $.get({
@@ -249,22 +250,26 @@ function render(next_state) {
     var previous_state = Object.assign({}, state);
     state = next_state;
 
-    if (previous_state.integration !== next_state.integration) {
-        if (next_state.integration !== null) {
-            hide_catalog_show_integration();
-        } else {
+    if (previous_state.integration !== next_state.integration &&
+        next_state.integration !== null) {
+        hide_catalog_show_integration();
+    } else {
+        if (previous_state.integration !== next_state.integration) {
             hide_integration_show_catalog();
         }
+
+        if (previous_state.category !== next_state.category) {
+            update_categories();
+            update_integrations();
+        }
+
+        if (previous_state.query !== next_state.query) {
+            update_integrations();
+        }
+
+        $(".main").css("visibility", "visible");
     }
 
-    if (previous_state.category !== next_state.category) {
-        update_categories();
-        update_integrations();
-    }
-
-    if (previous_state.query !== next_state.query) {
-        update_integrations();
-    }
 }
 
 function dispatch(action, payload) {

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2428,6 +2428,8 @@ nav ul li.active::after {
 
     background-color: #fff;
     box-shadow: 0px 0px 80px hsla(0, 0%, 0%, 0.12);
+
+    visibility: hidden;
 }
 
 .portico-landing.integrations .padded-content {


### PR DESCRIPTION
Set the initial visibility of the page content to hidden via
the stylesheet, and allow any data fetching and rendering to
complete before making content visible.

Adjust the conditional logic within `render` to first check for
the case in which a user goes to a doc link, the case in which
we asynchronously fetch data prior making content visible.

Fixes #9577.