### PR TITLE
[WIP] archives: Add endpoint to fetch topic history of web public streams.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -214,24 +214,24 @@ def activity_change_requires_seat_update(user: UserProfile) -> bool:
     return user.realm.has_seat_based_plan and not user.is_bot
 
 def generate_topic_history_from_db_rows(rows: List[Tuple[str, int]]) -> List[Dict[str, Any]]:
-    canonical_topic_names = set()  # type: Set[str]
+    canonical_topic_names = {}  # type: Dict[str, Tuple[int, str]]
     history = []
-    # This algorithm relies on the fact that `rows` is reverse-sorted
-    # by `max_message_id`, so that we will correctly use the highest
-    # max_message_id where multiple topics have the same canonical
-    # name.
-    #
-    # Arguably, we should just reimplment this using a dict rather
-    # than a set to remove that assumption for better readability.
+
     for (topic_name, max_message_id) in rows:
         canonical_name = topic_name.lower()
-        if canonical_name in canonical_topic_names:
+
+        if canonical_name not in canonical_topic_names:
+            canonical_topic_names[canonical_name] = (max_message_id, topic_name)
+            history.append(dict(
+                name=topic_name,
+                max_id=max_message_id))
             continue
 
-        canonical_topic_names.add(canonical_name)
-        history.append(dict(
-            name=topic_name,
-            max_id=max_message_id))
+        if max_message_id > canonical_topic_names[canonical_name][0]:
+            canonical_topic_names[canonical_name] = (max_message_id, topic_name)
+            history.append(dict(
+                name=topic_name,
+                max_id=max_message_id))
 
     return history
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -278,6 +278,27 @@ def get_topic_history_for_stream(user_profile: UserProfile,
 
     return generate_topic_history_from_db_rows(rows)
 
+def get_topic_history_for_web_public_stream(recipient: Recipient) -> List[Dict[str, Any]]:
+    cursor = connection.cursor()
+    query = '''
+    SELECT
+        "zerver_message"."subject" as topic,
+        max("zerver_message".id) as max_message_id
+    FROM "zerver_message"
+    WHERE (
+        "zerver_message"."recipient_id" = %s
+    )
+    GROUP BY (
+        "zerver_message"."subject"
+    )
+    ORDER BY max("zerver_message".id) DESC
+    '''
+    cursor.execute(query, [recipient.id])
+    rows = cursor.fetchall()
+    cursor.close()
+
+    return generate_topic_history_from_db_rows(rows)
+
 def send_signup_message(sender: UserProfile, admin_realm_signup_notifications_stream: str,
                         user_profile: UserProfile, internal: bool=False,
                         realm: Optional[Realm]=None) -> None:

--- a/zerver/tests/test_archive.py
+++ b/zerver/tests/test_archive.py
@@ -10,13 +10,13 @@ class GlobalPublicStreamTest(ZulipTestCase):
     def test_non_existant_stream_id(self) -> None:
         # Here we use a relatively big number as stream id assumming such an id
         # won't exist in the test DB.
-        result = self.client_get("/archive/streams/100000000/topic/TopicGlobal")
+        result = self.client_get("/archive/streams/100000000/topics/TopicGlobal")
         self.assert_in_success_response(["This stream does not exist."], result)
 
     def test_non_web_public_stream(self) -> None:
         test_stream = self.make_stream('Test Public Archives')
         result = self.client_get(
-            "/archive/streams/" + str(test_stream.id) + "/topic/notpublicglobalstream"
+            "/archive/streams/" + str(test_stream.id) + "/topics/notpublicglobalstream"
         )
         self.assert_in_success_response(["This stream does not exist."], result)
 
@@ -24,7 +24,7 @@ class GlobalPublicStreamTest(ZulipTestCase):
         test_stream = self.make_stream('Test Public Archives')
         do_change_stream_web_public(test_stream, True)
         result = self.client_get(
-            "/archive/streams/" + str(test_stream.id) + "/topic/nonexistenttopic"
+            "/archive/streams/" + str(test_stream.id) + "/topics/nonexistenttopic"
         )
         self.assert_in_success_response(["This topic does not exist."], result)
 
@@ -40,7 +40,7 @@ class GlobalPublicStreamTest(ZulipTestCase):
                 'TopicGlobal'
             )
             return self.client_get(
-                "/archive/streams/" + str(test_stream.id) + "/topic/TopicGlobal"
+                "/archive/streams/" + str(test_stream.id) + "/topics/TopicGlobal"
             )
 
         result = send_msg_and_get_result('Test Message 1')

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -460,6 +460,9 @@ i18n_urls = [
     url(r'^archive/streams/(?P<stream_id>\d+)/topic/(?P<topic_name>[^/]+)$',
         zerver.views.archive.archive,
         name='zerver.views.archive.archive'),
+    url(r'^archive/streams/(?P<stream_id>\d+)/topics$',
+        zerver.views.archive.get_web_public_topics_backend,
+        name='zerver.views.archive.get_web_public_topics_backend'),
 
     # Login/registration
     url(r'^register/$', zerver.views.registration.accounts_home, name='register'),

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -457,7 +457,7 @@ i18n_urls = [
         zerver.views.registration.create_realm, name='zerver.views.create_realm'),
 
     # Global public streams (Zulip's way of doing archives)
-    url(r'^archive/streams/(?P<stream_id>\d+)/topic/(?P<topic_name>[^/]+)$',
+    url(r'^archive/streams/(?P<stream_id>\d+)/topics/(?P<topic_name>[^/]+)$',
         zerver.views.archive.archive,
         name='zerver.views.archive.archive'),
     url(r'^archive/streams/(?P<stream_id>\d+)/topics$',


### PR DESCRIPTION
In this PR we basically work on adding the topics backend for public archives. It is really gonna be just an endpoint which can return topics history for web public streams without need for authentication!
Currently PR contains 2 commits to get stuff done in this direction.

<2nd commits message>

In this commit we add a new endpoint so as to have a way of fetching
topic history for a given stream id without having to be logged in.
This can only happen if the said stream is web public otherwise we
just return an empty topics list. This endpoint is quite analogous
to get_topics_backend which is used by our main web app.

In this commit we also do a bit of duplication regarding the query
responsible for fetching all the topics from DB. Basically this
query is exactly the same as what we have in the
get_topic_history_for_stream function in actions.py. Basically
duplicating now is the right thing to do because this query is
really gonna change when we add another criteria for filtering
messages which is:
Only topics for messages which were sent during the period the
corresponding stream was web public should be returned.
Now when we will do this, the query will change and thus it won't
really be a code duplication!