### PR TITLE
guest: Restrict guest users access to user group creation and updation.

### DIFF
--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -26,6 +26,8 @@ set_global('ui_report', {});
 set_global('people', {
     my_current_user_id: noop,
 });
+set_global('page_params', {});
+
 function reset_test_setup(pill_container_stub) {
     function input_pill_stub(opts) {
         assert.equal(opts.container, pill_container_stub);
@@ -39,9 +41,15 @@ function reset_test_setup(pill_container_stub) {
 }
 
 run_test('can_edit', () => {
+    page_params.is_guest = false;
     page_params.is_admin = true;
     assert(settings_user_groups.can_edit(1));
 
+    page_params.is_admin = false;
+    page_params.is_guest = true;
+    assert(!settings_user_groups.can_edit(1));
+
+    page_params.is_guest = false;
     page_params.is_admin = false;
     user_groups.is_member_of = (group_id, user_id) => {
         assert.equal(group_id, 1);

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -39,19 +39,16 @@ function reset_test_setup(pill_container_stub) {
 }
 
 run_test('can_edit', () => {
-    var me = {
-        is_admin: false,
-    };
-    people.get_person_from_user_id = function (id) {
-        assert.equal(id, undefined);
-        return me;
-    };
-    user_groups.is_member_of = function (group_id, user_id) {
+    page_params.is_admin = true;
+    assert(settings_user_groups.can_edit(1));
+
+    page_params.is_admin = false;
+    user_groups.is_member_of = (group_id, user_id) => {
         assert.equal(group_id, 1);
         assert.equal(user_id, undefined);
         return false;
     };
-    settings_user_groups.can_edit(1);
+    assert(!settings_user_groups.can_edit(1));
 });
 
 var user_group_selector = "#user-groups #1";

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -21,10 +21,12 @@ exports.reload = function () {
 };
 
 exports.can_edit = function (group_id) {
-    var me = people.get_person_from_user_id(people.my_current_user_id());
-    return user_groups.is_member_of(group_id, people.my_current_user_id()) || me.is_admin;
-};
+    if (page_params.is_admin) {
+        return true;
+    }
 
+    return user_groups.is_member_of(group_id, people.my_current_user_id());
+};
 exports.populate_user_groups = function () {
 
     var user_groups_section = $('#user-groups').expectOne();

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -25,8 +25,13 @@ exports.can_edit = function (group_id) {
         return true;
     }
 
+    if (page_params.is_guest) {
+        return false;
+    }
+
     return user_groups.is_member_of(group_id, people.my_current_user_id());
 };
+
 exports.populate_user_groups = function () {
 
     var user_groups_section = $('#user-groups').expectOne();

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -496,3 +496,8 @@ body.night-mode #bots_lists_navbar .active a {
     border-color: #ddd;
     border-bottom-color: transparent;
 }
+
+body.night-mode .searching-for-more-topics img {
+    -webkit-filter: invert(100%);
+    filter: invert(100%);
+}

--- a/static/templates/user-groups-admin.handlebars
+++ b/static/templates/user-groups-admin.handlebars
@@ -2,6 +2,7 @@
     {{#unless is_admin}}
     <div class="tip">Only group members and organization administrators can modify a group.</div>
     {{/unless}}
+    {{#unless is_guest}}
     <form class="form-horizontal admin-user-group-form">
         <div class="add-new-user-group-box grey-box">
             <div class="new-user-group-form">
@@ -21,6 +22,7 @@
             </div>
         </div>
     </form>
+    {{/unless}}
 
     <p>{{#tr this}}Add members of your organization to mentionable user groups.{{/tr}}</p>
     <div id="user-groups"></div>

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext as _
 
 from typing import List
 
+from zerver.decorator import require_non_guest_human_user
 from zerver.context_processors import get_realm_from_request
 from zerver.lib.actions import check_add_user_group, do_update_user_group_name, \
     do_update_user_group_description, bulk_add_members_to_user_group, \
@@ -17,6 +18,7 @@ from zerver.lib.user_groups import access_user_group_by_id, get_memberships_of_u
 from zerver.models import UserProfile, UserGroup, UserGroupMembership
 from zerver.views.streams import compose_views, FuncKwargPair
 
+@require_non_guest_human_user
 @has_request_variables
 def add_user_group(request: HttpRequest, user_profile: UserProfile,
                    name: str=REQ(),
@@ -26,6 +28,7 @@ def add_user_group(request: HttpRequest, user_profile: UserProfile,
     check_add_user_group(user_profile.realm, name, user_profiles, description)
     return json_success()
 
+@require_non_guest_human_user
 @has_request_variables
 def edit_user_group(request: HttpRequest, user_profile: UserProfile,
                     user_group_id: int=REQ(validator=check_int),
@@ -47,6 +50,7 @@ def edit_user_group(request: HttpRequest, user_profile: UserProfile,
 
     return json_success(result)
 
+@require_non_guest_human_user
 @has_request_variables
 def delete_user_group(request: HttpRequest, user_profile: UserProfile,
                       user_group_id: int=REQ(validator=check_int)) -> HttpResponse:
@@ -54,6 +58,7 @@ def delete_user_group(request: HttpRequest, user_profile: UserProfile,
     check_delete_user_group(user_group_id, user_profile)
     return json_success()
 
+@require_non_guest_human_user
 @has_request_variables
 def update_user_group_backend(request: HttpRequest, user_profile: UserProfile,
                               user_group_id: int=REQ(validator=check_int),


### PR DESCRIPTION
~[DON'T MERGE]~
This is the continuation of #9714 (Created this as separate because that one was growing in size and eventually updating it would become harder, also we have to think about user group interaction of guest user separately).
* Do we want to show all user group to guest users? I guess no, only those groups in which guest user are involved.
* Can guest user remove itself from a user group, if yes then I've to remove the decorator to manually handle that case.
