### PR TITLE
database: Add database index for private messages.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1472,6 +1472,8 @@ def create_user_messages(message: Message,
             um.flags |= UserMessage.flags.mentioned
         if um.user_profile_id in ids_with_alert_words:
             um.flags |= UserMessage.flags.has_alert_word
+        if message.recipient.type in [Recipient.HUDDLE, Recipient.PERSONAL]:
+            um.flags |= UserMessage.flags.is_private
 
     user_messages = []
     for um in ums_to_create:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3621,6 +3621,9 @@ def do_update_message_flags(user_profile: UserProfile,
                             operation: str,
                             flag: str,
                             messages: List[int]) -> int:
+    valid_flags = [item for item in UserMessage.flags if item not in UserMessage.NON_API_FLAGS]
+    if flag not in valid_flags:
+        raise JsonableError(_("Invalid flag: '%s'" % (flag,)))
     flagattr = getattr(UserMessage.flags, flag)
 
     assert messages is not None

--- a/zerver/migrations/0182_set_initial_value_is_private_flag.py
+++ b/zerver/migrations/0182_set_initial_value_is_private_flag.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import sys
+from django.db import migrations
+
+from django.db import migrations, transaction
+from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import F
+
+def set_initial_value_of_is_private_flag(
+        apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    UserMessage = apps.get_model("zerver", "UserMessage")
+    Message = apps.get_model("zerver", "Message")
+    if not Message.objects.exists():
+        return
+
+    i = 0
+    # Total is only used for the progress bar
+    total = Message.objects.filter(recipient__type__in=[1, 3]).count()
+    processed = 0
+
+    print("\nStart setting initial value for is_private flag...")
+    sys.stdout.flush()
+    while True:
+        range_end = i + 10000
+        # Can't use [Recipient.PERSONAL, Recipient.HUDDLE] in migration files
+        message_ids = list(Message.objects.filter(recipient__type__in=[1, 3],
+                                                  id__gt=i,
+                                                  id__lte=range_end).values_list("id", flat=True).order_by("id"))
+        count = UserMessage.objects.filter(message_id__in=message_ids).update(flags=F('flags').bitor(UserMessage.flags.is_private))
+        if count == 0 and range_end >= Message.objects.last().id:
+            break
+
+        i = range_end
+        processed += len(message_ids)
+        percent = round((processed / total) * 100, 2)
+        print("Processed %s/%s %s%%" % (processed, total, percent))
+        sys.stdout.flush()
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ('zerver', '0181_userprofile_change_emojiset'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_initial_value_of_is_private_flag,
+                             reverse_code=migrations.RunPython.noop),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1519,6 +1519,11 @@ class AbstractUserMessage(models.Model):
     ALL_FLAGS = ['read', 'starred', 'collapsed', 'mentioned', 'wildcard_mentioned',
                  'summarize_in_home', 'summarize_in_stream', 'force_expand', 'force_collapse',
                  'has_alert_word', "historical", "is_private", "active_mobile_push_notification"]
+    # Certain flags are used only for internal accounting within the
+    # Zulip backend, and don't make sense to expose to the API.  A
+    # good example is is_private, which is just a denormalization of
+    # message.recipient_type for database query performance.
+    NON_API_FLAGS = {"is_private"}
     flags = BitField(flags=ALL_FLAGS, default=0)  # type: BitHandler
 
     class Meta:
@@ -1545,7 +1550,7 @@ class AbstractUserMessage(models.Model):
         flags = []
         mask = 1
         for flag in UserMessage.ALL_FLAGS:
-            if val & mask:
+            if (val & mask) and flag not in AbstractUserMessage.NON_API_FLAGS:
                 flags.append(flag)
             mask <<= 1
         return flags

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1523,7 +1523,7 @@ class AbstractUserMessage(models.Model):
     # Zulip backend, and don't make sense to expose to the API.  A
     # good example is is_private, which is just a denormalization of
     # message.recipient_type for database query performance.
-    NON_API_FLAGS = {"is_private"}
+    NON_API_FLAGS = {"is_private", "active_mobile_push_notification"}
     flags = BitField(flags=ALL_FLAGS, default=0)  # type: BitHandler
 
     class Meta:

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -671,6 +671,20 @@ class StreamMessagesTest(ZulipTestCase):
         message = most_recent_message(user_profile)
         assert(UserMessage.objects.get(user_profile=user_profile, message=message).flags.mentioned.is_set)
 
+    def test_is_private_flag(self) -> None:
+        user_profile = self.example_user('iago')
+        self.subscribe(user_profile, "Denmark")
+
+        self.send_stream_message(self.example_email("hamlet"), "Denmark",
+                                 content="test")
+        message = most_recent_message(user_profile)
+        self.assertFalse(UserMessage.objects.get(user_profile=user_profile, message=message).flags.is_private.is_set)
+
+        self.send_personal_message(self.example_email("hamlet"), user_profile.email,
+                                   content="test")
+        message = most_recent_message(user_profile)
+        self.assertTrue(UserMessage.objects.get(user_profile=user_profile, message=message).flags.is_private.is_set)
+
     def _send_stream_message(self, email: str, stream_name: str, content: str) -> Set[int]:
         with mock.patch('zerver.lib.actions.send_event') as m:
             self.send_stream_message(

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -384,6 +384,18 @@ class ExtractedRecipientsTest(TestCase):
 
 class PersonalMessagesTest(ZulipTestCase):
 
+    def test_is_private_flag_not_leaked(self) -> None:
+        """
+        Make sure `is_private` flag is not leaked to the API.
+        """
+        self.login(self.example_email("hamlet"))
+        self.send_personal_message(self.example_email("hamlet"),
+                                   self.example_email("cordelia"),
+                                   "test")
+
+        for msg in self.get_messages():
+            self.assertNotIn('is_private', msg['flags'])
+
     def test_auto_subbed_to_personals(self) -> None:
         """
         Newly created users are auto-subbed to the ability to receive

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -100,12 +100,12 @@ class NarrowBuilderTest(ZulipTestCase):
 
     def test_add_term_using_is_operator_and_private_operand(self) -> None:
         term = dict(operator='is', operand='private')
-        self._do_add_term_test(term, 'WHERE type = :type_1 OR type = :type_2')
+        self._do_add_term_test(term, 'WHERE (flags & :flags_1) != :param_1')
 
     def test_add_term_using_is_operator_private_operand_and_negated(
             self) -> None:  # NEGATED
         term = dict(operator='is', operand='private', negated=True)
-        self._do_add_term_test(term, 'WHERE NOT (type = :type_1 OR type = :type_2)')
+        self._do_add_term_test(term, 'WHERE (flags & :flags_1) = :param_1')
 
     def test_add_term_using_is_operator_and_non_private_operand(self) -> None:
         for operand in ['starred', 'mentioned', 'alerted']:

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -148,12 +148,7 @@ class NarrowBuilder:
 
     def by_is(self, query: Query, operand: str, maybe_negate: ConditionTransform) -> Query:
         if operand == 'private':
-            # The `.select_from` method extends the query with a join.
-            query = query.select_from(join(query.froms[0], table("zerver_recipient"),
-                                           column("recipient_id") ==
-                                           literal_column("zerver_recipient.id")))
-            cond = or_(column("type") == Recipient.PERSONAL,
-                       column("type") == Recipient.HUDDLE)
+            cond = column("flags").op("&")(UserMessage.flags.is_private.mask) != 0
             return query.where(maybe_negate(cond))
         elif operand == 'starred':
             cond = column("flags").op("&")(UserMessage.flags.starred.mask) != 0


### PR DESCRIPTION
Fixes #6896.

For commit 1:
For `set_initial_value_of_is_private_flag`, I tried out two approaches for the migration.

The first was : 
```
    UserMessage = apps.get_model("zerver", "UserMessage")
    all_objects = UserMessage.objects.all()

    for obj in all_objects:
        recipient_type = obj.message.recipient.type
        if recipient_type == 1 or recipient_type == 3:
            obj.flags |= UserMessage.flags.is_private
        else:
            obj.flags &= ~UserMessage.flags.is_private
        obj.save(update_fields=['flags'])
```
And the second one was the currently implemented one.

Although I suspected that the second approach maybe faster, I checked the execution time for both the approaches. The first approach took about ~1.44s for my db and second one about ~0.066s. So I chose to go with the second approach.

For (hah, don't think I can call this testing) testing the migration, I ran
```
for obj in stream_objects:
    if obj.message.recipient.type != 2 or obj.flags.is_private:
        print('fail')
``` 
similarly for `private_objects`.

For commit 2:
Other commits like 8bb812c8a96c9e0427371e7f4688ce85c2623317 also added the sql to the changelog, since there was no changelog file rn, I haven't added it yet.
I've also added the migration to `upgrade-zulip-stage-2` script. From what the script stated, this is used to upgrade to a newer version of Zulip and not any specific version, so I added the migration to it like the other commits.