### PR TITLE
slash commands: Create /mute_topic

### DIFF
--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -60,6 +60,7 @@ function update_setting(command) {
 exports.process = function (message_content) {
 
     var content = message_content.trim();
+    var tokens = content.split(' ');
 
     if (content === '/ping') {
         var start_time = new Date();
@@ -72,6 +73,21 @@ exports.process = function (message_content) {
                 diff = Math.round(diff);
                 var msg = "ping time: " + diff + "ms";
                 exports.tell_user(msg);
+            },
+        });
+        return true;
+    }
+
+    if (tokens[0] === '/mute_topic') {
+
+        exports.send({
+            command: content,
+            on_success: function (data) {
+                if (data.subject && data.stream && data.type) {
+                    muting_ui.toggle_mute(data);
+                } else {
+                    exports.tell_user(data.msg);
+                }
             },
         });
         return true;

--- a/zerver/lib/zcommand.py
+++ b/zerver/lib/zcommand.py
@@ -1,14 +1,38 @@
-from typing import Any, Dict
+from typing import Any, Dict, Tuple, Optional
 from django.utils.translation import ugettext as _
 
-from zerver.models import UserProfile
+from zerver.models import UserProfile, get_realm_stream, \
+    get_stream_recipient, topic_exists, Stream
 from zerver.lib.actions import do_set_user_display_setting
 from zerver.lib.exceptions import JsonableError
+
+import re
+
+MUTE_TOPIC_REGEX = r'^mute_topic[ ]+#\*\*([^*]+)\*\*[ ]+([^*]+)$'
+
+def get_stream_and_topic_from_mute_topic_command(content: str,
+                                                 realm_id: int) -> Tuple[Optional[str],
+                                                                         Optional[str]]:
+    stream, topic = None, None
+    match = re.search(MUTE_TOPIC_REGEX, content)
+    if match:
+        stream, topic = match.group(1), match.group(2)
+        topic = topic.strip()
+    return stream, topic
+
+def get_stream(stream_name: str, realm_id: int) -> Optional[Stream]:
+    try:
+        return get_realm_stream(stream_name=stream_name, realm_id=realm_id)
+    except Stream.DoesNotExist:
+        return None
 
 def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]:
     if not content.startswith('/'):
         raise JsonableError(_('There should be a leading slash in the zcommand.'))
-    command = content[1:]
+    content = content[1:]
+
+    tokens = content.split(' ')
+    command = tokens[0]
 
     if command == 'ping':
         ret = dict()  # type: Dict[str, Any]
@@ -29,6 +53,24 @@ def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]
             do_set_user_display_setting(user_profile, 'night_mode', False)
         else:
             msg = 'You are still in day mode.'
+        ret = dict(msg=msg)
+        return ret
+
+    if command == 'mute_topic':
+        stream_name, topic = get_stream_and_topic_from_mute_topic_command(
+            content, user_profile.realm.id)
+
+        if not stream_name or not topic:
+            return dict(msg="Usage: /mute_topic #<stream_name> <topic_name>")
+
+        stream = get_stream(stream_name, user_profile.realm.id)
+        if stream:
+            if topic_exists(topic, get_stream_recipient(stream.id)):
+                return dict(subject=topic, stream=stream.name, type='stream')
+            msg = "A valid topic is required."
+        else:
+            msg = "A valid stream name is required."
+
         ret = dict(msg=msg)
         return ret
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1309,6 +1309,12 @@ def get_context_for_message(message: Message) -> Sequence[Message]:
         pub_date__gt=message.pub_date - timedelta(minutes=15),
     ).order_by('-id')[:10]
 
+def topic_exists(topic_name: str, recipient: Recipient) -> bool:
+    topic_exists = Message.objects.filter(
+        subject__iexact=topic_name,
+        recipient=recipient).exists()
+    return topic_exists
+
 post_save.connect(flush_message, sender=Message)
 
 class SubMessage(models.Model):

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -65,7 +65,7 @@ from zerver.models import (
     Message, Realm, Recipient, Stream, UserMessage, UserProfile, Attachment,
     RealmAuditLog, RealmDomain, get_realm, UserPresence, Subscription,
     get_stream, get_stream_recipient, get_system_bot, get_user, Reaction,
-    flush_per_request_caches, ScheduledMessage
+    flush_per_request_caches, ScheduledMessage, topic_exists, get_realm_stream
 )
 
 
@@ -638,6 +638,16 @@ class StreamMessagesTest(ZulipTestCase):
 
         stream = get_stream('Denmark', user_profile.realm)
         self.assertEqual(dct['stream_id'], stream.id)
+
+    def test_topic_exists(self) -> None:
+        user_profile = self.example_user('iago')
+        self.subscribe(user_profile, "Denmark")
+        self.send_stream_message(self.example_email("hamlet"), "Denmark",
+                                 content="whatever", topic_name="my topic")
+        stream = get_realm_stream("Denmark", user_profile.realm.id)
+        recipient = get_stream_recipient(stream.id)
+        self.assertTrue(topic_exists('My Topic', recipient))
+        self.assertFalse(topic_exists('This topic does not exist!', recipient))
 
     def test_stream_message_unicode(self) -> None:
         user_profile = self.example_user('iago')

--- a/zerver/tests/test_zcommand.py
+++ b/zerver/tests/test_zcommand.py
@@ -3,6 +3,9 @@
 from zerver.lib.test_classes import (
     ZulipTestCase,
 )
+from zerver.lib.actions import (
+    create_stream_if_needed, get_realm,
+)
 
 class ZcommandTest(ZulipTestCase):
 
@@ -53,3 +56,59 @@ class ZcommandTest(ZulipTestCase):
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
         self.assertIn('still in day mode', result.json()['msg'])
+
+    def test_mute_topic_zcommand(self) -> None:
+        self.login(self.example_email("hamlet"))
+        realm = get_realm("zulip")
+
+        # Test invalid usage of mute_topic command
+        payload = dict(command="/mute_topic invalid")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn('Usage: /mute_topic #<stream_name> <topic_name>', result.json()['msg'])
+
+        # Test invalid stream and topic
+        payload = dict(command="/mute_topic #**test stream with spaces** topic")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn('A valid stream name is required.', result.json()['msg'])
+
+        # Test invalid topic
+        payload = dict(command="/mute_topic #**Denmark** invalid_topic")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn('A valid topic is required.', result.json()['msg'])
+
+        create_stream_if_needed(realm, "test stream with spaces")
+
+        # Test stream with spaces in the name
+        payload = dict(command="/mute_topic #**test stream with spaces** invalid_topic")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn('A valid topic is required.', result.json()['msg'])
+
+        self.send_stream_message(self.example_email('hamlet'), "test stream with spaces",
+                                 content="test", topic_name="my topic")
+
+        # Test muting of a topic
+        payload = dict(command="/mute_topic  #**Verona** Verona1")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn("Verona1", result.json()['subject'])
+        self.assertIn("Verona", result.json()['stream'])
+        self.assertIn("stream", result.json()['type'])
+
+        payload = dict(command="/mute_topic #**test stream with spaces** My topic")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn("My topic", result.json()['subject'])
+        self.assertIn("test stream with spaces", result.json()['stream'])
+        self.assertIn("stream", result.json()['type'])
+
+        # Test muting an already muted topic
+        payload = dict(command="/mute_topic #**Verona**  Verona1")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn("Verona1", result.json()['subject'])
+        self.assertIn("Verona", result.json()['stream'])
+        self.assertIn("stream", result.json()['type'])


### PR DESCRIPTION
Two slash commands:

* /mute_topic: For this command, the usage is `/mute_topic <topic> #<stream_name>` and `/mute_topic #<stream_name> <topic>`. Both would work. The muting occurs using `muting_ui` in the frontend, where as the server side code checks if the stream and topic to be muted exists.
Added tests for the server side code as well.
* /settings