### PR TITLE
message view: Refactor message CSS to eliminate fixed positioning.

### DIFF
--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -256,39 +256,15 @@
         top: 30px;
     }
 
-    .messagebox-content {
-        padding-right: 15px;
-    }
-
     .message_time {
-        right: auto;
-        left: -3px;
+        margin-left: auto;
     }
 
     .message_controls {
-        width: 56px;
-        right: -10px;
-        top: 0px;
-    }
-
-    .message_hovered .message_controls {
-        z-index: 10;
-    }
-
-    .include-sender .message_controls {
-        background: none !important;
-        padding: none !important;
-        border: none !important;
-        top: -3px;
-    }
-
-    .message_time {
-        left: auto;
-        right: -5px;
-    }
-
-    .message_controls {
-        right: 40px;
+        z-index: 1;
+        position: absolute;
+        top: 24px;
+        right: 0;
     }
 
     .sender_name {
@@ -312,7 +288,7 @@
     }
 
     .message_content {
-        padding-right: 50px;
+        margin-right: 55px;
     }
 }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -587,55 +587,36 @@ td.pointer {
     @include prefixed-transition(all, 3s, ease-in-out);
 }
 
-.include-sender .message_edit_notice {
-    display: inline-block;
-    vertical-align: top;
-    line-height: 14px;
-    margin-left: 0px;
-    position: static;
-    padding: 0px;
-    width: auto;
-}
-
-.sender-status .message_edit_notice {
-    line-height: 18px;
-}
-
 .message_edit_notice {
     font-size: 10px;
+    line-height: 14px;
+    text-transform: uppercase;
     opacity: 0.5;
-    line-height: 0px;
-    text-align: right;
-    width: 45px;
-    position: absolute;
-    left: 0px;
-    top: 16px;
     @include prefixed-user-select(none);
 }
 
-.include-sender .message_edit_notice:before {
-    content: "(";
+.status-message .message_edit_notice {
+    min-width: 55px;
+    line-height: 16px;
+    word-break: break-word;
 }
 
-.include-sender .message_edit_notice:after {
-    content: ")";
-}
-
-.include-sender .message_time {
-    top: -4px;
+.prev_is_same_sender .message_edit_notice {
+    width: 50px;
+    text-align: center;
+    position: absolute;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin-top: 3px;
+    margin-left: -6px;
+    line-height: 17px;
 }
 
 .message_time {
-    display: block;
+    min-width: 45px;
     font-size: 12px;
-    opacity: 0.4;
-    vertical-align: middle;
-    padding: 1px;
-    font-weight: 400;
-    position: absolute;
-    right: -105px;
-    line-height: 20px;
-    text-align: right;
+    opacity: .4;
     @include prefixed-transition(background-color, 1.5s, ease-in, color 1.5s ease-in);
 }
 
@@ -647,15 +628,16 @@ td.pointer {
    z-index is kinda hacky, and requires some annoying color-matching,
    but it works. */
 .alert-msg {
-    position: absolute;
-    right: -110px;
-    font-size: 14px;
+    font-size: 12px;
     color: hsl(170, 47%, 54%);
     background-color: hsl(0, 0%, 100%);
+    outline: hsl(170, 47%, 54%);
+    border-radius: 2px;
+    padding: 0 2px;
     z-index: 999;
-    padding-left: 20px;
-    padding-right: 40px;
     font-weight: 400;
+    position: absolute;
+    right: 10px;
     display: none;
 }
 
@@ -663,20 +645,10 @@ td.pointer {
     background-color: hsl(192, 19%, 95%);
 }
 
-.include-sender .alert-msg {
-    top: -3px;
-}
-
-.status-time {
-    top: 8px !important;
-}
-
 .message_controls {
-    display: inline-block;
-    position: absolute;
-    top: 2px;
-    right: -56px;
-    z-index: 1;
+    min-width: 55px;
+    margin-left: auto;
+    margin-right: 8px;
 }
 
 .message_controls > div {
@@ -693,10 +665,6 @@ td.pointer {
 
 .message_controls > div {
     padding: 0px 1px;
-}
-
-.include-sender .message_controls {
-    top: -3px;
 }
 
 .message_data {
@@ -1044,10 +1012,6 @@ td.pointer {
     background-color: hsl(8, 94%, 94%);
 }
 
-.messagebox .message_top_line {
-    position: relative;
-}
-
 .recipient_row .message_row:first-child .unread_marker {
     top: 0px;
 }
@@ -1100,45 +1064,39 @@ td.pointer {
                       1px -1px 0px 0px hsl(215, 47%, 50%);
 }
 
-.message_sender {
-    height: 0px;
-    vertical-align: top;
-    position: relative;
-}
-
-.sender_name {
-    display: inline-block;
+.sender_name,
+.sender_name-in-status {
+    height: 14px;
+    margin-right: 3px;
+    line-height: 14px;
     font-weight: 700;
-    vertical-align: top;
-    line-height: 12px;
-    font-size: 14px;
-    margin-left: -3px;
 }
 
 .sender-status {
-    display: inline-block;
-    margin: 8px 0px 8px -3px;
-    /* this normalizes the margin of the emoji reactions with normal messages. */
-    padding-bottom: 5px;
-    vertical-align: middle;
-    line-height: 18px;
-    font-size: 14px;
-    position: relative;
-    max-width: calc(100% - 50px);
+    display: flex;
+    align-items: baseline;
+    flex-flow: wrap;
 }
 
-.message_controls.sender-status-controls {
-    top: 10px;
-}
-
-.sender_name-in-status {
-    margin-right: 3px;
-    font-weight: 700;
+.status-message {
+    word-break: break-all;
+    line-height: 14px;
 }
 
 .sender_name_hovered .sender_name,
 .sender_name_hovered .sender_name-in-status {
     color: hsl(200, 100%, 40%);
+}
+
+.message_sender {
+    display: flex;
+    height: 0;
+}
+
+.has_status .message_sender {
+    height: auto;
+    align-items: center;
+    max-width: calc(100% - 55px);
 }
 
 .message_sender i.zulip-icon.bot,
@@ -1150,10 +1108,11 @@ td.pointer {
 
 .message_sender i.zulip-icon.bot {
     font-size: 12px;
+    line-height: 14px;
 }
 
 .popover_info i.zulip-icon.bot {
-    margin-top: 3px;
+    line-height: 20px;
 }
 
 .actions_hover:hover {
@@ -1243,8 +1202,9 @@ a.dark_background:hover,
 }
 
 .message_top_line {
+    display: flex;
+    height: 0;
     pointer-events: none;
-    position: relative;
 }
 
 .message_top_line * {
@@ -1252,7 +1212,13 @@ a.dark_background:hover,
 }
 
 .include-sender .message_top_line {
-    margin-top: 6px;
+    margin-top: 5px;
+    height: auto;
+}
+
+.has_status .message_top_line {
+    margin-top: 3px;
+    margin-bottom: 5px;
 }
 
 .small {
@@ -1301,15 +1267,12 @@ div.focused_table {
     display: block;
 }
 
-.include-sender .message_content:not(:empty) {
-    margin-top: -16px;
-}
-
 .message_content {
     line-height: 17px;
     min-height: 17px;
     font-size: 14px;
     margin-left: 46px;
+    margin-right: 115px;
     display: block;
     position: relative;
 }
@@ -1348,6 +1311,10 @@ div.focused_table {
 #inline_topic_edit,
 #message_edit_topic {
     margin-bottom: 5px;
+}
+
+#message_edit_topic {
+    max-width: calc(100% - 75px);
 }
 
 #inline_topic_edit.header-v {
@@ -1458,7 +1425,7 @@ blockquote p {
 }
 
 .messagebox-content {
-    padding: 4px 115px 1px 10px;
+    padding: 4px 10px 1px 10px;
 }
 
 #message-edit-history .messagebox-content {
@@ -1502,13 +1469,13 @@ blockquote p {
 }
 
 .inline_profile_picture {
-    display: inline-block;
+    min-width: 35px;
     width: 35px;
     height: 35px;
     margin-right: 11px;
-    vertical-align: top;
     border-radius: 4px;
     overflow: hidden;
+    display: inline-block;
 }
 
 .home-error-bar {
@@ -1656,7 +1623,6 @@ blockquote p {
     white-space: nowrap;
     margin-left: 15px;
     margin-top: 7px;
-    display: inline-block;
     float: right;
 }
 
@@ -2491,10 +2457,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
 .date_row span:after {
     left: 0.5em;
     margin-right: -50%;
-}
-
-.include-sender .message_edit {
-    margin-top: -14px;
 }
 
 .message_edit {

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -1,45 +1,46 @@
 <div zid="{{msg/id}}" id="{{table_name}}{{msg/id}}"
-  class="message_row{{^msg/is_stream}} private-message{{/msg/is_stream}}{{#include_sender}} include-sender{{/include_sender}}{{#contains_mention}} mention{{/contains_mention}}{{#include_footer}} last_message{{/include_footer}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row">
+  class="message_row{{^msg/is_stream}} private-message{{/msg/is_stream}}{{#include_sender}} include-sender{{/include_sender}}{{#if status_message}} has_status{{/if}}{{#contains_mention}} mention{{/contains_mention}}{{#include_footer}} last_message{{/include_footer}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
     <div class="messagebox{{^include_sender}} prev_is_same_sender{{/include_sender}}{{^msg/is_stream}} private-message{{/msg/is_stream}} {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
       style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">
         <div class="messagebox-border">
             <div class="messagebox-content">
                 <div class="message_top_line">
-                    <span class="message_sender{{^status_message}} sender_info_hover{{/status_message}} no-select">
+                    <div class="message_sender{{^status_message}} sender_info_hover{{/status_message}} no-select">
                         {{#include_sender}}
                             {{! See ../js/notifications.js for another user of avatar_url. }}
                             <div class="u-{{msg/sender_id}} inline_profile_picture{{#status_message}} sender_info_hover{{/status_message}}">
                                 <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
                             </div>
                             {{#if status_message}}
-                                <span class="sender-status">
-                                    <span class="sender_name-in-status auto-select sender_info_hover">{{msg/sender_full_name}}</span>
+                            <div class="sender-status">
+                                <span class="sender_name-in-status auto-select sender_info_hover">
+                                    {{msg/sender_full_name}}
                                     {{#if sender_is_bot}}
                                     <i class="zulip-icon bot" aria-hidden="true"></i>
                                     {{/if}}
-                                    <span class="status-message">
-                                        {{{ status_message }}}
-                                    </span>
+                                </span>
+                                <span class="status-message">
+                                    {{{ status_message }}}
                                     {{#if_and last_edit_timestr include_sender}}
-                                    <div class="message_edit_notice" title="{{#tr this}}Edited (__last_edit_timestr__){{/tr}}">{{t "EDITED" }}</div>
+                                    <span class="message_edit_notice" title="{{#tr this}}Edited (__last_edit_timestr__){{/tr}}">({{t "Edited" }})</span>
                                     {{/if_and}}
                                 </span>
+                            </div>
                             {{else}}
-                                <span class="sender_name auto-select">{{msg/sender_full_name}}</span>
+                            <span class="sender_name auto-select">{{msg/sender_full_name}}
                                 {{#if sender_is_bot}}
                                 <i class="zulip-icon bot" aria-hidden="true"></i>
                                 {{/if}}
+                            </span>
                             {{/if}}
+                            {{#if_and last_edit_timestr include_sender}}
+                                {{#unless status_message}}
+                                <span class="message_edit_notice" title="{{#tr this}}Edited (__last_edit_timestr__){{/tr}}">({{t "Edited" }})</span>
+                                {{/unless}}
+                            {{/if_and}}
                         {{/include_sender}}
-                    </span>
-                    <span class="alert-msg pull-right"></span>
-                    <span class="message_time{{#if msg.locally_echoed}} notvisible{{/if}}{{#if status_message}} status-time{{/if}}">{{timestr}}</span>
-                    {{#if_and last_edit_timestr include_sender}}
-                        {{#unless status_message}}
-                        <div class="message_edit_notice" title="{{#tr this}}Edited (__last_edit_timestr__){{/tr}}">{{t "EDITED" }}</div>
-                        {{/unless}}
-                    {{/if_and}}
+                    </div>
                     <div class="message_controls{{#status_message}} sender-status-controls{{/status_message}} no-select">
                         {{#if msg/sent_by_me}}
                         <div class="edit_content"></div>
@@ -64,15 +65,16 @@
                         <div class="star {{#if msg/starred}}icon-vector-star{{else}}icon-vector-star-empty{{/if}} {{#if msg/starred}}{{else}}empty-star{{/if}}" title="{{#tr this.msg}}__starred_status__ this message{{/tr}} (*)">
                         </div>
                         {{/unless}}
-
                     </div>
+                    <span class="message_time{{#if msg.locally_echoed}} notvisible{{/if}}{{#if status_message}} status-time{{/if}}">{{timestr}}</span>
+                    <span class="alert-msg pull-right"></span>
                 </div>
-                <div class="message_content">{{#unless status_message}}{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}{{/unless}}</div>
                 {{#if last_edit_timestr}}
                     {{#unless include_sender}}
-                    <div class="message_edit_notice" title="{{#tr this}}Edited (__last_edit_timestr__){{/tr}}">{{t "EDITED" }}</div>
+                    <span class="message_edit_notice" title="{{#tr this}}Edited (__last_edit_timestr__){{/tr}}">({{t "Edited" }})</span>
                     {{/unless}}
                 {{/if}}
+                <div class="message_content">{{#unless status_message}}{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}{{/unless}}</div>
                 <div class="message_edit">
                     <div class="message_edit_form"></div>
                 </div>


### PR DESCRIPTION
A lot of the current styling for the message box heavily relies on fixed widths and positioning, resulting in undesired element mispositioning or overflows in narrow screens. By switching to a flexbox layout, the message view is more flexible on differing screen widths. (Note: There are various other elements that still have fixed positions, but I'm hoping to get feedback on these changes first before moving on to fixing others)

![screenshot at jun 14 16-32-26](https://user-images.githubusercontent.com/15116870/41443236-8bd3e476-6ff0-11e8-9160-9886728d53a2.png)
![screenshot at jun 14 16-44-21](https://user-images.githubusercontent.com/15116870/41443502-37362058-6ff2-11e8-89b5-d2dfb15f7c42.png)

Note: in mobile view, message controls were moved to be under the message timestamp because they often overlapped the message content in their original position; if this is a desired bug, I can revert my changes.