### PR TITLE
emoji: Fix a bug where emoticon translation is not done after a newline.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1560,7 +1560,7 @@ class Bugdown(markdown.Extension):
             'tex',
             Tex(r'\B(?<!\$)\$\$(?P<body>[^\n_$](\\\$|[^$\n])*)\$\$(?!\$)\B'),
             '>backtick')
-        md.inlinePatterns.add('emoji', Emoji(EMOJI_REGEX), '_end')
+        md.inlinePatterns.add('emoji', Emoji(EMOJI_REGEX), '<nl')
         md.inlinePatterns.add('translate_emoticons', EmoticonTranslation(emoticon_regex), '>emoji')
         md.inlinePatterns.add('unicodeemoji', UnicodeEmoji(unicode_emoji_regex), '_end')
         md.inlinePatterns.add('link', AtomicLinkPattern(markdown.inlinepatterns.LINK_RE, md), '>avatar')

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -385,6 +385,13 @@
       "translate_emoticons": true
     },
     {
+      "name": "translate_emoticons_newline",
+      "input":  ":) test\n:) test",
+      "expected_output": "<p><span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span> test<br>\n<span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span> test</p>",
+      "text_content": "\ud83d\ude03 test\n\ud83d\ude03 test",
+      "translate_emoticons": true
+    },
+    {
       "name": "translate_emoticons_in_code",
       "input":  "`:)`",
       "expected_output": "<p><code>:)</code></p>",


### PR DESCRIPTION
Currently, there is a bug where an emoticon after a newline would not be translated. Fix #9763.

**Testing Plan:**

A new test fixture is added in order to ensure that this newline bug does not occur.
