### PR TITLE
help: Fix broken anchor link scrolling in documentation pages.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -178,8 +178,8 @@ function scrollToHash(container) {
     $('.help .sidebar h1, .help .sidebar h2, .help .sidebar h3').removeAttr('id');
 
     // Scroll to anchor link when clicked
-    $('.markdown .content h1, .markdown .content h2, .markdown .content h3').on('click', function () {
-        window.location.href = window.location.href.replace(/#.*/, '') + '#' + $(this).attr("id");
+    $(document).on('click', '.markdown .content h1, .markdown .content h2, .markdown .content h3', function () {
+        location.hash = $(this).attr("id");
     });
 
     $(".hamburger").click(function () {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1569,6 +1569,15 @@ input.new-organization-button {
     font-weight: 700;
 }
 
+.markdown h1,
+.markdown h2,
+.markdown h3 {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
 .markdown h1:hover,
 .markdown h2:hover,
 .markdown h3:hover {


### PR DESCRIPTION
Whenever a link is clicked, the page link changes, and the content
of the `.markdown .content` node updates, preventing the old
listener to catch any future anchor link clicks. 

We attach the listener to the document instead and only activate
it when the target element is a proper anchor link heading.

Fixes #9767.

(Second commit just prevents anchor link text from being selected on double click, commit can be dropped if behavior is desired)