### PR TITLE
Less dense mode

### DIFF
--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -345,3 +345,14 @@
     background-color: hsl(0, 0%, 100%);
     border: 1px solid hsl(0, 0%, 86%);
 }
+
+.less_dense_mode {
+    .popover-content {
+        font-size: 16px;
+
+        li {
+            padding-top: 2px;
+            padding-bottom: 2px;
+        }
+    }
+}

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -487,3 +487,32 @@ a#undo_markdown_preview {
         display: none;
     }
 }
+
+.less_dense_mode {
+    .compose-content {
+        padding: 12px 10px;
+    }
+
+    #compose_buttons .button.small {
+        font-size: 1.1em;
+        padding: 5px 10px;
+    }
+
+    .compose_table {
+        font-size: 16px;
+    }
+
+    #stream-message,
+    #private-message {
+        padding: 5px 0;
+    }
+
+    textarea.new_message_textarea,
+    compose_table .recipient_box {
+        margin: 10px 0;
+    }
+
+    #send_controls {
+        font-size: 0.9em;
+    }
+}

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -93,8 +93,10 @@
     background-color: hsl(93, 19%, 88%);
 }
 
-#stream_filters li.active-sub-filter:hover {
+#stream_filters .topic-list li:hover,
+#global_filters li.expanded_private_message:hover {
     background-color: hsl(120, 11%, 82%);
+    cursor: pointer;
 }
 
 ul.filters {
@@ -163,11 +165,10 @@ li.active-sub-filter {
     text-decoration: underline;
 }
 
-#global_filters .global-filter i.fa-home {
+#global_filters .global-filter i.icon-vector-home {
     position: relative;
     top: 1px;
     left: -1px;
-
     font-size: 16px;
 }
 
@@ -221,8 +222,17 @@ li.active-sub-filter {
     line-height: 1.1;
 }
 
-.left-sidebar li a.topic-name:hover {
-    text-decoration: underline;
+.topic-unread-count,
+.private_message_count {
+    line-height: 1em;
+    padding: 1px 4px 1px 4px;
+    background: hsl(107, 5%, 66%);
+    color: hsl(0, 0%, 100%);
+    border-radius: 1px;
+    font-size: 12px;
+    font-weight: normal;
+    letter-spacing: 0.6px;
+    border-radius: 4px;
 }
 
 ul.filters i {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -67,6 +67,10 @@
     margin-left: 0px;
 }
 
+.less_dense_mode #stream_filters li ul.topic-list li {
+    padding: 3px 0px 3px 29px;
+}
+
 #stream_filters li ul.topic-list li {
     padding: 2px 0px 2px 29px;
 }
@@ -479,4 +483,44 @@ li.show-more-private-messages a {
 
 .show-all-streams .fa-chevron-left {
     text-decoration: none;
+}
+
+.less_dense_mode {
+    #left-sidebar {
+        font-size: 1rem;
+    }
+
+    #streams_inline_cog,
+    #streams_filter_icon {
+        font-size: 15px;
+    }
+
+    #stream_filters li {
+        padding: 3px 10px;
+    }
+
+    #global_filters .global-filter {
+        padding: 3px 10px;
+    }
+
+    ul.expanded_private_messages {
+        font-size: 1em;
+    }
+
+    #streams_header {
+        margin-bottom: 5px;
+    }
+
+    #global_filters .count,
+    #stream_filters .count,
+    .topic-unread-count,
+    .private_message_count {
+        height: 18px;
+        line-height: 18px;
+        font-size: 14px;
+    }
+
+    #stream_filters li ul.topic-list li.show-more-topics {
+        padding-top: 0;
+    }
 }

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -231,3 +231,28 @@
     cursor: pointer;
     font-size: 20px;
 }
+
+.less_dense_mode {
+    .right-sidebar {
+        font-size: 1rem;
+    }
+
+    #user_filter_icon {
+        font-size: 15px;
+    }
+
+    #user_presences li,
+    #group-pms li {
+        padding: 3px 15px 3px 0;
+    }
+
+    .user-status-indicator,
+    .group-pm-status-indicator {
+        top: 9px;
+    }
+
+    #group-pm-list {
+        margin-top: 10px;
+    }
+
+}

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2978,3 +2978,62 @@ div.message_content button.tictactoe-square:disabled {
 .flatpickr-months .numInputWrapper span {
     display: none;
 }
+
+.less_dense_mode {
+    .message_header,
+    .message_header_private_message,
+    .message_header_private_message .message_label_clickable {
+        font-size: 16px;
+        line-height: 22px;
+    }
+
+    .stream_label {
+        height: 22px;
+        line-height: 22px;
+    }
+
+    .message_time,
+    .recipient_row_date {
+        font-size: 14px;
+    }
+
+    .recipient_row_date {
+        top: 5px;
+    }
+
+    .sender_name {
+        font-size: 16px;
+        line-height: 22px;
+    }
+
+    .message_content {
+        font-size: 16px;
+        line-height: 22px;
+    }
+
+    .sub-unsub-message,
+    .date_row {
+        margin-bottom: 20px;
+        span {
+            font-size: 1em;
+        }
+    }
+
+    .message_list .recipient_row {
+        margin-bottom: 20px;
+    }
+
+    .messagebox {
+        p,
+        blockquote {
+            margin: 6px 0 20px;
+        }
+        p:last-of-type {
+            margin-bottom: 10px;
+        }
+    }
+
+    .message_controls {
+        right: -40px;
+    }
+}

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -3036,4 +3036,30 @@ div.message_content button.tictactoe-square:disabled {
     .message_controls {
         right: -40px;
     }
+
+    .user-status-indicator.popover_user_presence {
+        top: 0;
+    }
+
+    .popover_info {
+        .user_active {
+            padding-top: 10px;
+        }
+        .user_popover_email {
+            padding-bottom: 10px;
+        }
+    }
+
+    .nav .dropdown-menu {
+        font-size: 16px;
+        li {
+            padding: 2px 0;
+            i {
+                margin-right: 5px;
+            }
+        }
+        li.divider {
+            padding: 0;
+        }
+    }
 }


### PR DESCRIPTION
This adds less dense mode, which can be enabled by deselecting "Dense mode" in Display settings. Less dense mode has larger fonts and bigger spacing, and affects the left and right sidebars, the center messages column, and the compose box.

Less dense mode:
![image](https://user-images.githubusercontent.com/2905696/41563522-a31f25c0-7304-11e8-9c52-d80ae45a792d.png)

Dense (normal) mode:
![image](https://user-images.githubusercontent.com/2905696/41563844-c2d22434-7305-11e8-8537-31e0b470cb6c.png)


Less dense mode currently has no effect on other parts of the app like dropdown menus and the settings windows.

This also includes a commit changing the hover state for items in the topic and private message lists
from an underline to a background highlight, which eliminates the dead spots (areas where there was no visible hover state even though the list item actually was being hovered over). It also makes the hover state of unselected items consistent with that of selected items, which were already using a background highlight.

**Before** (cursor is hovering over dropbox)
![image](https://user-images.githubusercontent.com/2905696/41563650-17b6976a-7305-11e8-8614-ba9b76e4d717.png)

**After** (cursor is hovering over Verona1)
![image](https://user-images.githubusercontent.com/2905696/41563697-3e54eb38-7305-11e8-9106-1746fdaad2a0.png)