### PR TITLE
notifications: Simplify notification messages for new subscriptions.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2899,8 +2899,7 @@ class GetSubscribersTest(ZulipTestCase):
         self.assert_json_success(ret)
 
         msg = '''
-            Hi there!  We thought you'd like to know that King Hamlet
-            just subscribed you to the following streams:
+            Hi there! King Hamlet just subscribed you to the following streams:
 
             * #**stream_0**
             * #**stream_1**
@@ -2912,8 +2911,6 @@ class GetSubscribersTest(ZulipTestCase):
             * #**stream_7**
             * #**stream_8**
             * #**stream_9**
-
-            You can see historical content on a non-invite-only stream by narrowing to it.
             '''
 
         self.assert_user_got_subscription_notification(msg)
@@ -2936,9 +2933,7 @@ class GetSubscribersTest(ZulipTestCase):
         self.assert_json_success(ret)
 
         msg = '''
-            Hi there!  We thought you'd like to know that King Hamlet
-            just subscribed you to the **invite-only** stream
-            #**stream_invite_only_1**.
+            Hi there! King Hamlet just subscribed you to the stream #**stream_invite_only_1**.
             '''
         self.assert_user_got_subscription_notification(msg)
 


### PR DESCRIPTION
We're adding more stream types, e.g. splitting private streams into
with/without shared history, adding publicly-archived streams, adding
announce-only streams, etc. So maintaining this text is going to get more
complicated over time.

Also, the right place to explain this stuff is in the stream header, or near
the z-in-a-circle.

This commit also adds translation tags to the messages.