### PR TITLE
slash commands: Add /subscribe command (via zcommand).

### DIFF
--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -60,6 +60,7 @@ function update_setting(command) {
 exports.process = function (message_content) {
 
     var content = message_content.trim();
+    var tokens = content.split(' ');
 
     if (content === '/ping') {
         var start_time = new Date();
@@ -89,6 +90,25 @@ exports.process = function (message_content) {
 
     if (content === '/settings') {
         window.location.hash = 'settings/your-account';
+        return true;
+    }
+
+    if (tokens[0] === '/subscribe') {
+
+        exports.send({
+            command: content,
+            on_success: function (data) {
+                if (data.stream && data.user_id) {
+                    if (!stream_data.is_user_subscribed(data.stream, data.user_id)) {
+                        stream_data.add_subscriber(data.stream, data.user_id);
+                        data.msg = "Subcribed user to '" + data.stream + "'!";
+                    } else {
+                        data.msg = "User is already subscribed!";
+                    }
+                }
+                exports.tell_user(data.msg);
+            },
+        });
         return true;
     }
 

--- a/zerver/lib/zcommand.py
+++ b/zerver/lib/zcommand.py
@@ -1,14 +1,40 @@
-from typing import Any, Dict
+from typing import Any, Dict, Tuple, Optional
 from django.utils.translation import ugettext as _
 
-from zerver.models import UserProfile
+from zerver.models import UserProfile, get_realm_stream, Stream
 from zerver.lib.actions import do_set_user_display_setting
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.bugdown import MentionData
+
+import re
+
+SUBSCRIBE_REGEX = r'^subscribe[ ]+#\*\*([^*]+)\*\*[ ]+(@\*\*[^*]+\*\*)$'
+
+def get_user_and_stream_subscribe_command(content: str,
+                                          realm_id: int) -> Tuple[Optional[Stream],
+                                                                  Optional[int]]:
+    stream, user_id = None, None
+    match = re.search(SUBSCRIBE_REGEX, content)
+    if match:
+        stream_name, user_mention = match.group(1), match.group(2)
+
+        try:
+            stream = get_realm_stream(stream_name=stream_name, realm_id=realm_id)
+        except Stream.DoesNotExist:
+            pass
+
+        mentioned_user_id = MentionData(realm_id, user_mention).get_user_ids()
+        if len(mentioned_user_id) == 1:
+            [user_id] = mentioned_user_id
+    return stream, user_id
 
 def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]:
     if not content.startswith('/'):
         raise JsonableError(_('There should be a leading slash in the zcommand.'))
-    command = content[1:]
+    content = content[1:]
+
+    tokens = content.split(' ')
+    command = tokens[0]
 
     if command == 'ping':
         ret = dict()  # type: Dict[str, Any]
@@ -29,6 +55,22 @@ def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]
             do_set_user_display_setting(user_profile, 'night_mode', False)
         else:
             msg = 'You are still in day mode.'
+        ret = dict(msg=msg)
+        return ret
+
+    if command == 'subscribe':
+        stream, user_id = get_user_and_stream_subscribe_command(
+            content, user_profile.realm.id)
+
+        if stream and user_id:
+            return dict(stream=stream.name, user_id=user_id)
+
+        if not stream and not user_id:
+            msg = "Usage: /subscribe #<stream_name> @<user>"
+        elif not stream:
+            msg = 'A valid stream name is required.'
+        else:
+            msg = 'A valid user is required.'
         ret = dict(msg=msg)
         return ret
 

--- a/zerver/tests/test_zcommand.py
+++ b/zerver/tests/test_zcommand.py
@@ -3,6 +3,9 @@
 from zerver.lib.test_classes import (
     ZulipTestCase,
 )
+from zerver.lib.actions import (
+    create_stream_if_needed, get_realm,
+)
 
 class ZcommandTest(ZulipTestCase):
 
@@ -53,3 +56,36 @@ class ZcommandTest(ZulipTestCase):
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
         self.assertIn('still in day mode', result.json()['msg'])
+
+    def test_subscribe_zcommand(self) -> None:
+        self.login(self.example_email("hamlet"))
+        realm = get_realm('zulip')
+
+        payload = dict(command="/subscribe invalide")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn('Usage: /subscribe #<stream_name> @<user>', result.json()['msg'])
+
+        payload = dict(command="/subscribe #**test stream** @**invalid user**")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn('Usage: /subscribe #<stream_name> @<user>', result.json()['msg'])
+
+        payload = dict(command="/subscribe #**test stream** @**Cordelia Lear**")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn('A valid stream name is required.', result.json()['msg'])
+
+        create_stream_if_needed(realm, "test stream")
+        user = self.example_user('cordelia')
+
+        payload = dict(command="/subscribe #**test stream** @**invalid user**")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn('A valid user is required.', result.json()['msg'])
+
+        payload = dict(command="/subscribe #**test stream** @**Cordelia Lear**")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        self.assertIn("test stream", result.json()['stream'])
+        self.assertEqual(user.id, result.json()['user_id'])


### PR DESCRIPTION
The user is subscribe using `add_subscriber` in `stream_data.js`, whereas the server side code checks if the linked stream and mentioned user to be subscribed exists.
Added tests for the server side code as well.

This is very raw right now, the messages to be displayed to the user can be changed. 

Also one thing that looks ugly here is: When you write the command `/subscribe #<stream_name> @user"` and the user is _not subscribed_ to the narrowed down stream, we get the mention popup `user is not subscribed to this stream. They will not be notified unless you subscribe them.`

Separated this from #9754 for a easy review.