### PR TITLE
settings: Clean up styling of the Mentor field.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1721,3 +1721,18 @@ thead .actions {
 .profile-field-choices .choice-row input {
     width: 50px;
 }
+
+#settings_page .pill-container {
+    background: #fff;
+    border: 1px solid #cccccc;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    transition: border linear 0.2s, box-shadow linear 0.2s;
+    min-width: 206px;
+    padding: 2px 6px;
+}
+
+#settings_page .pill-container:active,
+#settings_page .pill-container:focus {
+    border-color: rgba(82, 168, 236, 0.8);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+}


### PR DESCRIPTION
This restyles the Mentor custom profile field in Settings > Your account to better match the rest of the profile fields.
<img width="257" alt="screen shot 2018-06-19 at 2 23 39 pm" src="https://user-images.githubusercontent.com/2905696/41625077-690a9572-73cc-11e8-89d5-ba1d635df4fb.png">
