### PR TITLE
night-mode: Remove background from edit topic form.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2547,7 +2547,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
     display: inline-block;
     margin: 0 0 0 0;
     height: 22px;
-    background: hsl(0, 0%, 88%);
     padding-left: 20px;
     padding-right: 3px;
     line-height: 22px;


### PR DESCRIPTION
That background is not needed since it already we're already adding the bg color to `message_header`.

Before -

![image](https://user-images.githubusercontent.com/2263909/41638724-7af74fc6-7478-11e8-9b2a-b09786afb584.png)



After -

![image](https://user-images.githubusercontent.com/2263909/41638634-087f9c46-7478-11e8-8fc5-30fbd7cf6a99.png)
