### PR TITLE
settings: Fix broken setting items in smaller window.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -728,15 +728,6 @@ exports.initialize = function () {
         e.stopPropagation();
     });
 
-    $("#settings_overlay_container .sidebar").on("click", "li[data-section]", function () {
-
-        var $settings_overlay_container = $("#settings_overlay_container");
-        $settings_overlay_container.find(".right").addClass("show");
-        $settings_overlay_container.find(".settings-header.mobile").addClass("slide-left");
-
-        settings.set_settings_header($(this).attr("data-section"));
-    });
-
     $(".settings-header.mobile .icon-vector-chevron-left").on("click", function () {
         $("#settings_page").find(".right").removeClass("show");
         $(this).parent().removeClass("slide-left");

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -731,9 +731,6 @@ exports.initialize = function () {
     $("#settings_overlay_container .sidebar").on("click", "li[data-section]", function () {
         var $this = $(this);
 
-        $("#settings_overlay_container .sidebar li").removeClass("active no-border");
-        $this.addClass("active").prev().addClass("no-border");
-
         var $settings_overlay_container = $("#settings_overlay_container");
         $settings_overlay_container.find(".right").addClass("show");
         $settings_overlay_container.find(".settings-header.mobile").addClass("slide-left");

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -729,7 +729,6 @@ exports.initialize = function () {
     });
 
     $("#settings_overlay_container .sidebar").on("click", "li[data-section]", function () {
-        var $this = $(this);
 
         var $settings_overlay_container = $("#settings_overlay_container");
         $settings_overlay_container.find(".right").addClass("show");

--- a/static/js/settings_panel_menu.js
+++ b/static/js/settings_panel_menu.js
@@ -90,6 +90,12 @@ exports.make_menu = function (opts) {
             li_elem: $(this),
         });
 
+        var $settings_overlay_container = $("#settings_overlay_container");
+        $settings_overlay_container.find(".right").addClass("show");
+        $settings_overlay_container.find(".settings-header.mobile").addClass("slide-left");
+
+        settings.set_settings_header($(this).attr("data-section"));
+
         e.stopPropagation();
     });
 


### PR DESCRIPTION
Fixes: #9780.

This PR -
a) Removes the duplicate code from `click_handler.js`
b) Unify and refactors code in `settings_panel_menu.js`

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<img src="https://dzwonsemrish7.cloudfront.net/items/1m0C2U3b1n2p0K433x1P/Screen%20Recording%202018-06-20%20at%2006.57%20PM.gif?v=40257d79"/>