### PR TITLE
 list_render: Make list creation logic as an export in list_render module.

### DIFF
--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -1,17 +1,5 @@
-// TODO: make an initialize function for list_render.
-const initialize = (function () {
-    var initalize_function;
-
-    set_global('$', (f) => {
-        initalize_function = f;
-    });
-
-    // We can move this module scope when we have
-    // an explicit initialize function.
-    zrequire('list_render');
-
-    return initalize_function;
-}());
+set_global('$', () => {});
+zrequire('list_render');
 
 // We need these stubs to get by instanceof checks.
 // The list_render library allows you to insert objects
@@ -22,27 +10,12 @@ set_global('Element', function () {
     return { };
 });
 
-// This function will be the anonymous click handler
-// for clicking on any element that matches the
-// CSS selector of "[data-sort]".
-var handle_sort_click;
-
 // We only need very simple jQuery wrappers for when the
 // "real" code wraps html or sets up click handlers.
 // We'll simulate most other objects ourselves.
 set_global('$', (arg) => {
     if (arg.to_jquery) {
         return arg.to_jquery();
-    }
-
-    if (arg === 'body') {
-        return {
-            on: (event_name, selector, f) => {
-                assert.equal(event_name, 'click');
-                assert.equal(selector, '[data-sort]');
-                handle_sort_click = f;
-            },
-        };
     }
 
     return {
@@ -266,7 +239,6 @@ run_test('sorting', () => {
     }
 
     list_render.create(container, list, opts);
-    initialize();
 
     var button_opts;
     var button;
@@ -281,7 +253,7 @@ run_test('sorting', () => {
 
     button = sort_button(button_opts);
 
-    handle_sort_click.call(button);
+    list_render.handle_sort.call(button);
 
     assert(cleared);
     assert(button.siblings_deactivated);
@@ -302,7 +274,7 @@ run_test('sorting', () => {
     cleared = false;
     button.siblings_deactivated = false;
 
-    handle_sort_click.call(button);
+    list_render.handle_sort.call(button);
 
     assert(cleared);
     assert(button.siblings_deactivated);

--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -1,4 +1,3 @@
-set_global('$', () => {});
 zrequire('list_render');
 
 // We need these stubs to get by instanceof checks.

--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -142,7 +142,7 @@ run_test('list_render', () => {
         modifier: (item) => div(item),
     };
 
-    const widget = list_render(container, list, opts);
+    const widget = list_render.create(container, list, opts);
 
     widget.render();
 
@@ -265,7 +265,7 @@ run_test('sorting', () => {
         return _.map(people, opts.modifier).join('');
     }
 
-    list_render(container, list, opts);
+    list_render.create(container, list, opts);
     initialize();
 
     var button_opts;

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -53,6 +53,7 @@ function render_attachments_ui() {
                 ui.update_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));
             },
         },
+        parent_container: $('#attachments-settings').expectOne(),
     }).init();
 
     list.add_sort_function("mentioned-in", function (a, b) {

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -39,7 +39,7 @@ function render_attachments_ui() {
     var uploaded_files_table = $("#uploaded_files_table").expectOne();
     var $search_input = $("#upload_file_search");
 
-    var list = list_render(uploaded_files_table, attachments, {
+    var list = list_render.create(uploaded_files_table, attachments, {
         name: "uploaded-files-list",
         modifier: function (attachment) {
             return templates.render("uploaded_files_list", { attachment: attachment });

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -329,35 +329,26 @@ var list_render = (function () {
         return DEFAULTS.instances[name] || false;
     };
 
-    return exports;
-}());
+    exports.handle_sort = function () {
+        /*
+        one would specify sort parameters like this:
+            - name => sort alphabetic.
+            - age  => sort numeric.
 
-if (typeof module !== 'undefined') {
-    module.exports = list_render;
-}
+        you MUST specify the `data-list-render` in the `.progressive-table-wrapper`
 
-$(function () {
-    /*
-    one would specify sort parameters like this:
-        - name => sort alphabetic.
-        - age  => sort numeric.
-
-    you MUST specify the `data-list-render` in the `.progressive-table-wrapper`
-    otherwise it will not know what `list_render` instance to look up.
-
-    <table>
-        <tr>
-            <td data-sort="alphabetic" data-sort-prop="name">
-            <td data-sort="numeric" data-sort-prop="age">
-        </tr>
-    </table>
-    <div class="progressive-table-wrapper" data-list-render="some-list">
         <table>
-            <tbody></tbody>
+            <tr>
+                <td data-sort="alphabetic" data-sort-prop="name">
+                <td data-sort="numeric" data-sort-prop="age">
+            </tr>
         </table>
-    </div>
-    */
-    $("body").on("click", "[data-sort]", function () {
+        <div class="progressive-table-wrapper" data-list-render="some-list">
+            <table>
+                <tbody></tbody>
+            </table>
+        </div>
+        */
         var $this = $(this);
         var sort_type = $this.data("sort");
         var prop_name = $this.data("sort-prop");
@@ -388,5 +379,15 @@ $(function () {
 
         $this.siblings(".active").removeClass("active");
         $this.addClass("active");
-    });
+    };
+
+    return exports;
+}());
+
+$(function () {
+    $("body").on("click", "[data-sort]", list_render.handle_sort);
 });
+
+if (typeof module !== 'undefined') {
+    module.exports = list_render;
+}

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -329,18 +329,6 @@ var list_render = (function () {
         return DEFAULTS.instances[name] || false;
     };
 
-    // this can delete list render issues and free up memory if needed.
-    exports.delete = function (name) {
-        if (DEFAULTS.instances[name]) {
-            delete DEFAULTS.instances[name];
-            return true;
-        }
-
-        blueslip.error("The progressive list render instance with the name '" +
-                      name + "' does not exist.");
-        return false;
-    };
-
     return exports;
 }());
 

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -1,6 +1,9 @@
 /* eslint indent: "off" */
 
 var list_render = (function () {
+
+    var exports = {};
+
     var DEFAULTS = {
         INITIAL_RENDER_COUNT: 80,
         LOAD_COUNT: 20,
@@ -11,7 +14,7 @@ var list_render = (function () {
     // container: jQuery object to append to.
     // list: The list of items to progressively append.
     // opts: An object of random preferences.
-    var func = function ($container, list, opts) {
+    exports.create = function ($container, list, opts) {
         // this memoizes the results and will return a previously invoked
         // instance's prototype.
         if (opts.name && DEFAULTS.instances[opts.name]) {
@@ -322,12 +325,12 @@ var list_render = (function () {
         return prototype;
     };
 
-    func.get = function (name) {
+    exports.get = function (name) {
         return DEFAULTS.instances[name] || false;
     };
 
     // this can delete list render issues and free up memory if needed.
-    func.delete = function (name) {
+    exports.delete = function (name) {
         if (DEFAULTS.instances[name]) {
             delete DEFAULTS.instances[name];
             return true;
@@ -338,7 +341,7 @@ var list_render = (function () {
         return false;
     };
 
-    return func;
+    return exports;
 }());
 
 if (typeof module !== 'undefined') {

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -322,6 +322,11 @@ var list_render = (function () {
             DEFAULTS.instances[opts.name] = prototype;
         }
 
+        // Attach click handler to column heads for sorting rows accordingly
+        if (opts.parent_container) {
+            opts.parent_container.on("click", "[data-sort]", exports.handle_sort);
+        }
+
         return prototype;
     };
 
@@ -383,10 +388,6 @@ var list_render = (function () {
 
     return exports;
 }());
-
-$(function () {
-    $("body").on("click", "[data-sort]", list_render.handle_sort);
-});
 
 if (typeof module !== 'undefined') {
     module.exports = list_render;

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -28,7 +28,7 @@ function populate_invites(invites_data) {
         admin_invites_list.set_container(invites_table);
         admin_invites_list.render();
     } else {
-        list_render(invites_table, invites_data.invites, {
+        list_render.create(invites_table, invites_data.invites, {
             name: "admin_invites_list",
             modifier: function (item) {
                 item.invited = timerender.absolute_time(item.invited * 1000);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -348,7 +348,7 @@ exports.populate_notifications_stream_dropdown = function (stream_list) {
     var dropdown_list_body = $("#id_realm_notifications_stream .dropdown-list-body").expectOne();
     var search_input = $("#id_realm_notifications_stream .dropdown-search > input[type=text]");
 
-    list_render(dropdown_list_body, stream_list, {
+    list_render.create(dropdown_list_body, stream_list, {
         name: "admin-realm-notifications-stream-dropdown-list",
         modifier: function (item) {
             return templates.render("admin-realm-dropdown-stream-list", { stream: item });
@@ -379,7 +379,7 @@ exports.populate_signup_notifications_stream_dropdown = function (stream_list) {
     var dropdown_list_body = $("#id_realm_signup_notifications_stream .dropdown-list-body").expectOne();
     var search_input = $("#id_realm_signup_notifications_stream .dropdown-search > input[type=text]");
 
-    list_render(dropdown_list_body, stream_list, {
+    list_render.create(dropdown_list_body, stream_list, {
         name: "admin-realm-signup-notifications-stream-dropdown-list",
         modifier: function (item) {
             return templates.render("admin-realm-dropdown-stream-list", { stream: item });

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -17,7 +17,7 @@ exports.build_default_stream_table = function (streams_data) {
 
     var table = $("#admin_default_streams_table").expectOne();
 
-    list_render(table, streams_data, {
+    list_render.create(table, streams_data, {
         name: "default_streams_list",
         modifier: function (item) {
             var row = $(templates.render("admin_default_streams_list", { stream: item, can_modify: page_params.is_admin }));

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -112,7 +112,7 @@ function populate_users(realm_people_data) {
     };
 
     var $bots_table = $("#admin_bots_table");
-    list_render($bots_table, bots, {
+    list_render.create($bots_table, bots, {
         name: "admin_bot_list",
         modifier: function (item) {
             return templates.render("admin_user_list", { user: item, can_modify: page_params.is_admin });
@@ -130,7 +130,7 @@ function populate_users(realm_people_data) {
     }).init();
 
     var $users_table = $("#admin_users_table");
-    list_render($users_table, active_users, {
+    list_render.create($users_table, active_users, {
         name: "users_table_list",
         modifier: function (item) {
             var activity_rendered;
@@ -170,7 +170,7 @@ function populate_users(realm_people_data) {
     }).init();
 
     var $deactivated_users_table = $("#admin_deactivated_users_table");
-    list_render($deactivated_users_table, deactivated_users, {
+    list_render.create($deactivated_users_table, deactivated_users, {
         name: "deactivated_users_table_list",
         modifier: function (item) {
             return templates.render("admin_user_list", { user: item, can_modify: page_params.is_admin });

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -193,7 +193,7 @@ function show_subscription_settings(sub_row) {
     var emails = get_email_of_subscribers(sub.subscribers);
     exports.sort_but_pin_current_user_on_top(emails);
 
-    list_render(list, emails, {
+    list_render.create(list, emails, {
         name: "stream_subscribers/" + stream_id,
         modifier: function (item) {
             return format_member_list_elem(item);


### PR DESCRIPTION
@showell FYI, Is this the right implementation of what you suggested in https://github.com/zulip/zulip/pull/9773?

Also, along with this should we fix the indentation of the module and enable the eslint here?