### PR TITLE
zcommand: Strip the slash in the server side.

### DIFF
--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -65,7 +65,7 @@ exports.process = function (message_content) {
         var start_time = new Date();
 
         exports.send({
-            command: 'ping',
+            command: content,
             on_success: function () {
                 var end_time = new Date();
                 var diff = end_time - start_time;
@@ -78,12 +78,12 @@ exports.process = function (message_content) {
     }
 
     if (content === '/day') {
-        update_setting('day');
+        update_setting(content);
         return true;
     }
 
     if (content === '/night') {
-        update_setting('night');
+        update_setting(content);
         return true;
     }
 

--- a/zerver/lib/zcommand.py
+++ b/zerver/lib/zcommand.py
@@ -5,7 +5,8 @@ from zerver.models import UserProfile
 from zerver.lib.actions import do_set_user_display_setting
 from zerver.lib.exceptions import JsonableError
 
-def process_zcommands(command: str, user_profile: UserProfile) -> Dict[str, Any]:
+def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]:
+    command = content.replace('/', '')
 
     if command == 'ping':
         ret = dict()  # type: Dict[str, Any]

--- a/zerver/tests/test_zcommand.py
+++ b/zerver/tests/test_zcommand.py
@@ -9,14 +9,14 @@ class ZcommandTest(ZulipTestCase):
     def test_invalid_zcommand(self) -> None:
         self.login(self.example_email("hamlet"))
 
-        payload = dict(command="boil-ocean")
+        payload = dict(command="/boil-ocean")
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_error(result, "No such command: boil-ocean")
 
     def test_ping_zcommand(self) -> None:
         self.login(self.example_email("hamlet"))
 
-        payload = dict(command="ping")
+        payload = dict(command="/ping")
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
 
@@ -26,7 +26,7 @@ class ZcommandTest(ZulipTestCase):
         user.night_mode = False
         user.save()
 
-        payload = dict(command="night")
+        payload = dict(command="/night")
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
         self.assertIn('Changed to night', result.json()['msg'])
@@ -41,7 +41,7 @@ class ZcommandTest(ZulipTestCase):
         user.night_mode = True
         user.save()
 
-        payload = dict(command="day")
+        payload = dict(command="/day")
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
         self.assertIn('Changed to day', result.json()['msg'])


### PR DESCRIPTION
As discussed in https://chat.zulip.org/#narrow/stream/127-integrations, with one change: we continue letting the client strip the extra whitespaces (would seem more cleaner if the server received the command without the whitespaces), but the server now strips the leading slash.

This would make client code cleaner in the slash commands which include parameters (`/subscribe`, `/mute_topic`). 
