### PR TITLE
help: Fix scrolling issues on /help pages.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -1,5 +1,5 @@
 /* eslint indent: "off" */
-import PerfectScrollbar from 'perfect-scrollbar';
+import SimpleBar from 'simplebar';
 
 function registerCodeSection($codeSection) {
     const $li = $codeSection.find("ul.nav li");
@@ -78,10 +78,12 @@ function render_code_sections() {
 
 function scrollToHash(container) {
     var hash = window.location.hash;
+    var simplebar = new SimpleBar(container).getScrollElement();
     if (hash !== '') {
-        container.scrollTop = $(hash).position().top - $('.markdown .content').position().top;
+        var position = $(hash).position().top - $(container).position().top;
+        simplebar.scrollTop = position;
     } else {
-        container.scrollTop = 0;
+        simplebar.scrollTop = 0;
     }
 }
 
@@ -91,12 +93,7 @@ function scrollToHash(container) {
         name: null,
     };
 
-    var markdownPS = new PerfectScrollbar($(".markdown")[0], {
-        suppressScrollX: true,
-        useKeyboard: false,
-        wheelSpeed: 0.68,
-        scrollingThreshold: 50,
-    });
+    var markdownSB = new SimpleBar($(".markdown")[0]);
 
     var fetch_page = function (path, callback) {
         $.get(path, function (res) {
@@ -111,7 +108,7 @@ function scrollToHash(container) {
         if (html_map[path]) {
             $(".markdown .content").html(html_map[path]);
             render_code_sections();
-            markdownPS.update();
+            markdownSB.recalculate();
             scrollToHash(container);
         } else {
             loading.name = path;
@@ -119,18 +116,13 @@ function scrollToHash(container) {
                 html_map[path] = res;
                 $(".markdown .content").html(html_map[path]);
                 loading.name = null;
-                markdownPS.update();
+                markdownSB.recalculate();
                 scrollToHash(container);
             });
         }
     };
 
-    new PerfectScrollbar($(".sidebar")[0], {
-        suppressScrollX: true,
-        useKeyboard: false,
-        wheelSpeed: 0.68,
-        scrollingThreshold: 50,
-    });
+    new SimpleBar($(".sidebar")[0]);
 
     $(".sidebar.slide h2").click(function (e) {
         var $next = $(e.target).next();
@@ -140,7 +132,7 @@ function scrollToHash(container) {
             $('.sidebar ul').not($next).hide();
             // Toggle the heading
             $next.slideToggle("fast", "swing", function () {
-                markdownPS.update();
+                markdownSB.recalculate();
             });
         }
     });
@@ -199,7 +191,7 @@ function scrollToHash(container) {
     scrollToHash(container);
 
     window.onresize = function () {
-        markdownPS.update();
+        markdownSB.recalculate();
     };
 
     window.addEventListener("popstate", function () {

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -207,4 +207,5 @@ function scrollToHash(container) {
         update_page(html_map, path, container);
     });
 
+    $('body').addClass('noscroll');
 }());

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -187,6 +187,7 @@ html {
     background-color: #fff;
     position: fixed;
     width: 100%;
+    top: 0;
 }
 
 .header .top-links a,

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -185,6 +185,8 @@ html {
 
 .header {
     background-color: #fff;
+    position: fixed;
+    width: 100%;
 }
 
 .header .top-links a,

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -2,6 +2,11 @@ body {
     background-color: #fafafa;
 }
 
+.noscroll {
+    overflow: hidden;
+    position: fixed;
+}
+
 .container-fluid {
     padding: 0px;
     min-height: 100%;
@@ -117,6 +122,7 @@ body {
     position: fixed;
     width: 100vw;
     height: calc(100vh - 59px);
+    margin-top: 59px;
     left: 0px;
 
     box-shadow: 0px -20px 50px rgba(0, 0, 0, 0.04);
@@ -1930,6 +1936,7 @@ input.new-organization-button {
     .app.help {
         position: absolute;
         height: calc(100vh - 40px);
+        margin-top: 39px;
     }
 
     .app.help .sidebar {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1940,11 +1940,13 @@ input.new-organization-button {
     }
 
     .app.help .sidebar {
+        pointer-events: none;
         width: calc(100% - 40px);
         height: calc(100vh - 40px - 10px - 9px);
     }
 
     .app.help .sidebar.show {
+        pointer-events: initial;
         transform: translateX(calc(100% - 50px));
     }
 

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -118,12 +118,13 @@ body {
     display: block;
 }
 
-.app.help {
-    position: fixed;
-    width: 100vw;
-    height: calc(100vh - 59px);
+.help .app-main {
+    padding: 0;
     margin-top: 59px;
-    left: 0px;
+}
+
+.app.help {
+    display: inline-flex;
 
     box-shadow: 0px -20px 50px rgba(0, 0, 0, 0.04);
     overflow: auto;
@@ -133,12 +134,9 @@ body {
 
 .help .sidebar {
     width: 300px;
-
-    position: fixed;
     z-index: 1;
     /* 100vh - navbar - paddingTop - paddingBottom - bottomNav */
-    height: calc(100vh - 59px - 10px - 10px);
-    padding: 10px 20px 10px 20px;
+    height: calc(100vh - 59px);
 
     border-right: 1px solid hsl(219, 10%, 97%);
     overflow: auto;
@@ -147,6 +145,10 @@ body {
     color: hsl(0, 0%, 100%);
 
     -webkit-overflow-scrolling: touch;
+}
+
+.help .sidebar .content {
+    padding: 10px 20px;
 }
 
 .help .sidebar h1,
@@ -1509,19 +1511,14 @@ input.new-organization-button {
 
 /* -- markdown styling -- */
 .markdown {
-    position: absolute;
-    right: 0px;
-    /* 100vw - sidebar width - paddingTop - paddingBottom */
-    width: calc(100vw - 340px - 30px);
-    padding: 0px 30px 0px 30px;
-
-    height: calc(100vh - 59px);
     font-weight: 400;
     font-size: 1rem;
     line-height: 1.5;
 
     background-color: #fff;
 
+    width: calc(100vw - 300px);
+    height: calc(100vh - 59px);
     overflow: auto;
 
     -webkit-font-smoothing: antialiased;
@@ -1529,11 +1526,6 @@ input.new-organization-button {
 
 .markdown .content {
     padding: 30px;
-    max-width: 768px;
-    margin-left: 0px;
-
-    min-height: calc(100% - 60px);
-
     background: #fff;
 }
 
@@ -1784,16 +1776,14 @@ input.new-organization-button {
     margin-bottom: 25px !important;
 }
 
-@media (max-width: 1000px) {
+@media (max-width: 800px) {
     .app.help .markdown {
-        width: calc(100vw - 50px);
-        height: calc(100vh - 59px);
-        left: 50px;
-        padding: 0px;
+        width: 100vw;
     }
 
     .app.help .markdown .content {
         max-width: none;
+        margin-left: 50px;
     }
 
     .app.help .hamburger {
@@ -1804,45 +1794,50 @@ input.new-organization-button {
         fill: hsl(0, 0%, 100%);
         z-index: 2;
 
-
         transition: all 0.3s ease;
         cursor: pointer;
     }
 
     .app.help .sidebar {
+        position: fixed;
+        top: 59px;
         right: calc(100vw - 50px);
-        padding-right: 80px;
+
+        width: 100%;
+        min-width: unset;
+        height: calc(100vh - 59px);
+
+        pointer-events: none;
+        overflow: hidden;
         transform: translateX(0);
         transition: all 0.3s ease;
-        overflow: hidden;
-        height: 100vh;
     }
 
     .app.help .sidebar.show {
-        padding-right: 20px;
-        transform: translateX(280px);
+        pointer-events: initial;
+        transform: translateX(calc(100% - 50px));
+        overflow: auto;
     }
 
     .app.help .sidebar.show + .hamburger {
-        transform: translateX(280px);
+        transform: translateX(calc(100vw - 50px));
     }
 
     .app.help .sidebar.show ~ .markdown {
         -webkit-filter: brightness(0.7);
     }
 
-    .app.help .sidebar:not(.show) .ps__rail-y {
-        display: none; /* Hide y-scrollbar on collapsed sidebar view */
-    }
-}
-
-@media (max-width: 950px) {
-    .footer-main {
-        text-align: center;
+    .app-main,
+    .header-main {
+        min-width: auto;
     }
 
-    .footer-navigation {
-        margin-left: 0px;
+    .app-main {
+        padding: 0;
+    }
+
+    .help .sidebar:not(.show) a.highlighted {
+        background-color: transparent;
     }
 }
 
@@ -1916,13 +1911,31 @@ input.new-organization-button {
 }
 
 @media (max-width: 500px) {
+    .help .app-main {
+        margin-top: 39px;
+    }
+
+    .app.help .sidebar {
+        top: 39px;
+        height: calc(100vh - 39px);
+    }
+
+    .app.help .hamburger {
+        top: 50px;
+    }
+
     .error_page .lead {
         font-size: 1.5em;
         margin-bottom: 10px;
     }
 
+    .markdown {
+        height: calc(100vh - 39px);
+        width: 100%;
+    }
+
     .markdown .content {
-        padding: 30px 10px 80px 10px;
+        padding: 10px;
     }
 
     .brand.logo .light {
@@ -1933,63 +1946,17 @@ input.new-organization-button {
         display: block;
     }
 
-    .app.help {
-        position: absolute;
-        height: calc(100vh - 40px);
-        margin-top: 39px;
-    }
-
-    .app.help .sidebar {
-        pointer-events: none;
-        width: calc(100% - 40px);
-        height: calc(100vh - 40px - 10px - 9px);
-    }
-
-    .app.help .sidebar.show {
-        pointer-events: initial;
-        transform: translateX(calc(100% - 50px));
-    }
-
-    .app.help .sidebar.show + .hamburger {
-        transform: translateX(calc(100vw - 50px));
-    }
-
-    .app.help .hamburger {
-        top: 50px;
-    }
-
-    .app.help .markdown {
-        height: 100%;
-    }
-
-    .app.help .footer-main {
-        padding: 0;
-    }
-
-    .app-main,
-    .header-main,
-    .footer-main {
-        min-width: auto;
-    }
-
-    .app-main {
-        padding: 0px;
-    }
-
     .header {
         padding: 4px 0px 6px 0px;
     }
 
     .header-main {
         max-width: 100vw;
+        padding: 0 10px;
     }
 
     .markdown ol {
         margin-left: 0px;
-    }
-
-    .footer-navigation {
-        font-size: 12px;
     }
 
     .markdown a {

--- a/templates/zerver/api/main.html
+++ b/templates/zerver/api/main.html
@@ -5,9 +5,11 @@
 {% block portico_content %}
 <div class="app help api-docs terms-page inline-block">
     <div class="sidebar">
-        <h1 class="no-arrow"><a href="/api/" class="no-underline">Home</a></h1>
-        {{ render_markdown_path("zerver/api/sidebar.md", api_uri_context) }}
-        <h1 class="home-link"><a href="/" class="no-underline">Back to Home</a></h1>
+        <div class="content">
+            <h1 class="no-arrow"><a href="/api/" class="no-underline">Home</a></h1>
+            {{ render_markdown_path("zerver/api/sidebar.md", api_uri_context) }}
+            <h1 class="home-link"><a href="/" class="no-underline">Back to Home</a></h1>
+        </div>
     </div>
 
     <svg height="32px" class="hamburger" style="enable-background:new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="32px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/templates/zerver/help/main.html
+++ b/templates/zerver/help/main.html
@@ -5,9 +5,11 @@
 {% block portico_content %}
 <div class="app help terms-page inline-block">
     <div class="sidebar slide">
-        <h1><a href="/help/" class="no-underline">Index</a></h1>
-        {{ render_markdown_path("zerver/help/include/sidebar.md", api_uri_context) }}
-        <h1 class="home-link"><a href="/" class="no-underline">Back to Home</a></h1>
+        <div class="content">
+            <h1><a href="/help/" class="no-underline">Index</a></h1>
+            {{ render_markdown_path("zerver/help/include/sidebar.md", api_uri_context) }}
+            <h1 class="home-link"><a href="/" class="no-underline">Back to Home</a></h1>
+        </div>
     </div>
 
     <svg height="32px" class="hamburger" style="enable-background:new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="32px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
## First two commits

Fixes issues such as broken scrolling when the cursor is focused on the navbar or a collapsed sidebar in mobile view.

Before: 
[![https://gyazo.com/4289b586334a3399e6f875a4cd0d6c38](https://i.gyazo.com/4289b586334a3399e6f875a4cd0d6c38.gif)](https://gyazo.com/4289b586334a3399e6f875a4cd0d6c38)

After:
[![https://gyazo.com/551e2dc33d3533d6d42b83e14328dd8d](https://i.gyazo.com/551e2dc33d3533d6d42b83e14328dd8d.gif)](https://gyazo.com/551e2dc33d3533d6d42b83e14328dd8d)

## Other commits

Given the various scrolling problems reported in #8887 and #9748, @akashnimare and I worked together to search for replacements for perfect-scrollbar. [simplebar](https://github.com/Grsmto/simpleba) was discovered to be a suitable alternative; however, the scrollbars were mispositioned because the scrollbar content's parent div elements had padding that wasn't accounted for by the package (see Grsmto/simplebar#90 for why upstream decided against fixing the bug). Therefore, I refactored the CSS to have the parent elements not use any padding, which allowed the scrollbars to be positioned correctly and allow us to successfully migrate to simplebar.