### PR TITLE
bugdown: Extract common function from `__init__.py`.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -56,6 +56,9 @@ import zerver.lib.mention as mention
 from zerver.lib.tex import render_tex
 from zerver.lib.exceptions import BugdownRenderingException
 from zerver.lib.bugdown import arguments
+from zerver.lib.bugdown.links import (
+    url_filename, sanitize_url, rewrite_local_links_to_relative,
+)
 
 FullNameInfo = TypedDict('FullNameInfo', {
     'id': int,
@@ -82,18 +85,6 @@ STREAM_LINK_REGEX = r"""
                     """
 
 bugdown_logger = logging.getLogger()
-
-def rewrite_local_links_to_relative(link: str) -> str:
-    """ If the link points to a local destination we can just switch to that
-    instead of opening a new tab. """
-
-    if arguments.db_data:
-        realm_uri_prefix = arguments.db_data['realm_uri'] + "/"
-        if link.startswith(realm_uri_prefix):
-            # +1 to skip the `/` before the hash link.
-            return link[len(realm_uri_prefix):]
-
-    return link
 
 def url_embed_preview_enabled_for_realm(message: Optional[Message]) -> bool:
     if message is not None:
@@ -1082,14 +1073,6 @@ class Tex(markdown.inlinepatterns.Pattern):
             span.text = '$$' + match.group('body') + '$$'
             return span
 
-upload_title_re = re.compile("^(https?://[^/]*)?(/user_uploads/\\d+)(/[^/]*)?/[^/]*/(?P<filename>[^/]*)$")
-def url_filename(url: str) -> str:
-    """Extract the filename if a URL is an uploaded file, or return the original URL"""
-    match = upload_title_re.match(url)
-    if match:
-        return match.group('filename')
-    else:
-        return url
 
 def fixup_link(link: markdown.util.etree.Element, target_blank: bool=True) -> None:
     """Set certain attributes we want on every link."""
@@ -1097,60 +1080,6 @@ def fixup_link(link: markdown.util.etree.Element, target_blank: bool=True) -> No
         link.set('target', '_blank')
     link.set('title', url_filename(link.get('href')))
 
-
-def sanitize_url(url: str) -> Optional[str]:
-    """
-    Sanitize a url against xss attacks.
-    See the docstring on markdown.inlinepatterns.LinkPattern.sanitize_url.
-    """
-    try:
-        parts = urllib.parse.urlparse(url.replace(' ', '%20'))
-        scheme, netloc, path, params, query, fragment = parts
-    except ValueError:
-        # Bad url - so bad it couldn't be parsed.
-        return ''
-
-    # If there is no scheme or netloc and there is a '@' in the path,
-    # treat it as a mailto: and set the appropriate scheme
-    if scheme == '' and netloc == '' and '@' in path:
-        scheme = 'mailto'
-    elif scheme == '' and netloc == '' and len(path) > 0 and path[0] == '/':
-        # Allow domain-relative links
-        return urllib.parse.urlunparse(('', '', path, params, query, fragment))
-    elif (scheme, netloc, path, params, query) == ('', '', '', '', '') and len(fragment) > 0:
-        # Allow fragment links
-        return urllib.parse.urlunparse(('', '', '', '', '', fragment))
-
-    # Zulip modification: If scheme is not specified, assume http://
-    # We re-enter sanitize_url because netloc etc. need to be re-parsed.
-    if not scheme:
-        return sanitize_url('http://' + url)
-
-    locless_schemes = ['mailto', 'news', 'file', 'bitcoin']
-    if netloc == '' and scheme not in locless_schemes:
-        # This fails regardless of anything else.
-        # Return immediately to save additional processing
-        return None
-
-    # Upstream code will accept a URL like javascript://foo because it
-    # appears to have a netloc.  Additionally there are plenty of other
-    # schemes that do weird things like launch external programs.  To be
-    # on the safe side, we whitelist the scheme.
-    if scheme not in ('http', 'https', 'ftp', 'mailto', 'file', 'bitcoin'):
-        return None
-
-    # Upstream code scans path, parameters, and query for colon characters
-    # because
-    #
-    #    some aliases [for javascript:] will appear to urllib.parse to have
-    #    no scheme. On top of that relative links (i.e.: "foo/bar.html")
-    #    have no scheme.
-    #
-    # We already converted an empty scheme to http:// above, so we skip
-    # the colon check, which would also forbid a lot of legitimate URLs.
-
-    # Url passes all tests. Return url as-is.
-    return urllib.parse.urlunparse((scheme, netloc, path, params, query, fragment))
 
 def url_to_a(url: str, text: Optional[str]=None) -> Union[Element, str]:
     a = markdown.util.etree.Element('a')

--- a/zerver/lib/bugdown/links.py
+++ b/zerver/lib/bugdown/links.py
@@ -1,0 +1,81 @@
+import re
+import urllib
+
+from typing import Optional
+from xml.etree.cElementTree import Element, SubElement
+from zerver.lib.bugdown import arguments
+
+def rewrite_local_links_to_relative(link: str) -> str:
+    """ If the link points to a local destination we can just switch to that
+    instead of opening a new tab. """
+
+    if arguments.db_data:
+        realm_uri_prefix = arguments.db_data['realm_uri'] + "/"
+        if link.startswith(realm_uri_prefix):
+            # +1 to skip the `/` before the hash link.
+            return link[len(realm_uri_prefix):]
+
+    return link
+
+upload_title_re = re.compile("^(https?://[^/]*)?(/user_uploads/\\d+)(/[^/]*)?/[^/]*/(?P<filename>[^/]*)$")
+def url_filename(url: str) -> str:
+    """Extract the filename if a URL is an uploaded file, or return the original URL"""
+    match = upload_title_re.match(url)
+    if match:
+        return match.group('filename')
+    else:
+        return url
+
+def sanitize_url(url: str) -> Optional[str]:
+    """
+    Sanitize a url against xss attacks.
+    See the docstring on markdown.inlinepatterns.LinkPattern.sanitize_url.
+    """
+    try:
+        parts = urllib.parse.urlparse(url.replace(' ', '%20'))
+        scheme, netloc, path, params, query, fragment = parts
+    except ValueError:
+        # Bad url - so bad it couldn't be parsed.
+        return ''
+
+    # If there is no scheme or netloc and there is a '@' in the path,
+    # treat it as a mailto: and set the appropriate scheme
+    if scheme == '' and netloc == '' and '@' in path:
+        scheme = 'mailto'
+    elif scheme == '' and netloc == '' and len(path) > 0 and path[0] == '/':
+        # Allow domain-relative links
+        return urllib.parse.urlunparse(('', '', path, params, query, fragment))
+    elif (scheme, netloc, path, params, query) == ('', '', '', '', '') and len(fragment) > 0:
+        # Allow fragment links
+        return urllib.parse.urlunparse(('', '', '', '', '', fragment))
+
+    # Zulip modification: If scheme is not specified, assume http://
+    # We re-enter sanitize_url because netloc etc. need to be re-parsed.
+    if not scheme:
+        return sanitize_url('http://' + url)
+
+    locless_schemes = ['mailto', 'news', 'file', 'bitcoin']
+    if netloc == '' and scheme not in locless_schemes:
+        # This fails regardless of anything else.
+        # Return immediately to save additional processing
+        return None
+
+    # Upstream code will accept a URL like javascript://foo because it
+    # appears to have a netloc.  Additionally there are plenty of other
+    # schemes that do weird things like launch external programs.  To be
+    # on the safe side, we whitelist the scheme.
+    if scheme not in ('http', 'https', 'ftp', 'mailto', 'file', 'bitcoin'):
+        return None
+
+    # Upstream code scans path, parameters, and query for colon characters
+    # because
+    #
+    #    some aliases [for javascript:] will appear to urllib.parse to have
+    #    no scheme. On top of that relative links (i.e.: "foo/bar.html")
+    #    have no scheme.
+    #
+    # We already converted an empty scheme to http:// above, so we skip
+    # the colon check, which would also forbid a lot of legitimate URLs.
+
+    # Url passes all tests. Return url as-is.
+    return urllib.parse.urlunparse((scheme, netloc, path, params, query, fragment))

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -8,7 +8,7 @@ from zerver.lib.avatar import (
     get_avatar_field,
 )
 from zerver.lib.avatar_hash import user_avatar_path
-from zerver.lib.bugdown import url_filename
+from zerver.lib.bugdown.links import url_filename
 from zerver.lib.realm_icon import realm_icon_url
 from zerver.lib.test_classes import ZulipTestCase, UploadSerializeMixin
 from zerver.lib.test_helpers import (


### PR DESCRIPTION
* This is a WIP pr, meant for modularizing our bugdown code which is mostly residing in `__init__.py`, as it is growing and becoming complex, so eventually, it would become difficult to maintain.
* Since this is such a large and complex module, I'm doing changes as small as possible so that it won't break things. Before extracting `InlineInterestingLinkProcessor` I'm extracting some common and generic functions. 
* I want feedback about a better name for `actions.py`(it is inspired by `zerver.lib.actions.py` but I'm not sure this name fits here or not).
* Also, feedback about whether I'm going in the right direction is welcomed.

(The best part of doing this is I'm getting to read each line to see if any line which isn't covered tests we don't miss imports.)