### PR TITLE
Fix clicking keyboard shortcuts icon on bottom right closes compose box.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -705,7 +705,7 @@ exports.initialize = function () {
         }
 
         if (compose_state.composing()) {
-            if ($(e.target).is("a")) {
+            if ($(e.target).closest("a").length > 0) {
                 // Refocus compose message text box if link is clicked
                 $("#compose-textarea").focus();
             } else if (!$(e.target).closest(".overlay").length &&

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -231,3 +231,7 @@
     cursor: pointer;
     font-size: 20px;
 }
+
+#sidebar-keyboard-shortcuts a {
+    color: hsl(0, 0%, 1.2%); //#333
+}

--- a/templates/zerver/app/right_sidebar.html
+++ b/templates/zerver/app/right_sidebar.html
@@ -31,7 +31,9 @@
             </ul>
         </div>
         <div id="sidebar-keyboard-shortcuts">
-            <i id="keyboard-icon" class="fa fa-keyboard-o fa-2x" aria-hidden="true" data-html="true" data-overlay-trigger="keyboard-shortcuts" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
+            <a data-overlay-trigger="keyboard-shortcuts">
+                <i class="fa fa-keyboard-o fa-2x" id="keyboard-icon" data-html="true" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
+            </a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes #9803.

commit 1:
When the icon or the text of a menu item in settings dropdown was
clicked, already open compose box was closed. Clicking on the empty
area of that menu item i.e the area where the icon or text was not
present did not close compose box. This commits check whether the
target itself is an anchor tag or of any of its parent contains the
anchor tag.

commit 2:
The compose box closes on any click in the document outside the compose
box except for an element with an anchor tag or in its parents.
This commit adds an anchor tag as parent of the keyboard shortcuts
icon.

Result:
![peek 2018-06-22 23-07](https://user-images.githubusercontent.com/13910561/41791715-37214074-7674-11e8-9a61-205e0d5f9d8d.gif)


