### PR TITLE
settings UI: Expand bot card width in narrow windows.

### DIFF
--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -352,3 +352,17 @@
         top: 5%;
     }
 }
+
+@media only screen and (min-width: 700px) and (max-width: 875px) {
+    .bots_list .bot-information-box {
+        width: calc(100% - 10px);
+        max-height: unset;
+    }
+}
+
+@media only screen and (max-width: 625px) {
+    .bots_list .bot-information-box {
+        width: calc(100% - 10px);
+        max-height: unset;
+    }
+}

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -743,7 +743,7 @@ input[type=checkbox].inline-block {
     margin: 10px 0px 5px 0px;
 
     overflow: hidden;
-    max-height: 1em;
+    line-height: 1.3em;
     text-overflow: ellipsis;
     white-space: pre;
 }
@@ -825,6 +825,7 @@ input[type=checkbox].inline-block {
 .bots_list .api_key .api-key-value-and-button {
     font-family: "Inconsolata", Menlo, monospace;
     font-size: 0.85em;
+    display: flex;
 }
 
 .bots_list .bot_info {

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -30,13 +30,13 @@
         {{#if is_active}}
         <div class="api_key">
             <span class="field">{{t "API key" }}</span>
-            <span class="api-key-value-and-button no-select">
+            <div class="api-key-value-and-button no-select">
                 <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
                 <span class="value text-select">{{api_key}}</span>
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
                     <i class="icon-vector-refresh"></i>
                 </button>
-            </span>
+            </div>
             <div class="api_key_error text-error"></div>
         </div>
         <div id="bot_delete_error{{id_suffix}}" class="alert alert-error hide"></div>


### PR DESCRIPTION
Screen width 800px and above:
![screenshot at jun 22 11-49-43](https://user-images.githubusercontent.com/15116870/41794052-f8cd655c-7612-11e8-988a-1b0345ff2807.png)

Screen width between 800px and 700px:
![screenshot at jun 22 11-49-59](https://user-images.githubusercontent.com/15116870/41794053-f9018e04-7612-11e8-832f-9a8a175d5bed.png)

Screen width between 700px and 500px:

![screenshot at jun 22 11-46-37](https://user-images.githubusercontent.com/15116870/41794049-f880a47e-7612-11e8-934f-40406e802fd5.png)

Screen width 500px and under:

![screenshot at jun 22 11-46-50](https://user-images.githubusercontent.com/15116870/41794051-f8a710a0-7612-11e8-909c-bad17741af04.png)

Fixes #9513

Note to reviewers: Issue #9780 still persists, so it's best to rebase the testing branch to a commit before the settings refactoring such as 541ccfeb7f to review the changes.