### PR TITLE
test-api: Pass non-admin client to the test helpers.

### DIFF
--- a/tools/test-api
+++ b/tools/test-api
@@ -22,6 +22,7 @@ from zerver.lib.api_test_helpers import test_the_api, test_invalid_api_key, \
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'zproject.test_settings'
 django.setup()
+from zerver.lib.actions import do_create_user
 from zerver.models import get_user, get_realm
 
 usage = """test-js-with-casper [options]"""
@@ -39,6 +40,9 @@ if not options.force:
         sys.exit(1)
 
 with test_server_running(force=options.force, external_host='zulipdev.com:9981'):
+    print("Running API tests...")
+
+    # Prepare the admin client
     email = 'iago@zulip.com'  # Iago is an admin
     realm = get_realm("zulip")
     api_key = get_user(email, realm).api_key
@@ -47,25 +51,21 @@ with test_server_running(force=options.force, external_host='zulipdev.com:9981')
     client = Client(
         email=email,
         api_key=api_key,
-        site=site)
+        site=site
+    )
 
-    print("Running API tests...")
-    test_the_api(client)
-
-    email = 'newbie@zulip.com'  # newbie is not an admin
-    realm = get_realm("zulip")
-    api_key = get_user(email, realm).api_key
-    site = 'http://zulip.zulipdev.com:9981'
+    # Prepare the admin client
+    email = 'guest@zulip.com'  # guest is not an admin
+    guest_user = do_create_user('guest@zulip.com', 'secret',
+                                get_realm('zulip'), 'Mr. Guest', 'guest')
+    api_key = guest_user.api_key
     nonadmin_client = Client(
         email=email,
         api_key=api_key,
         site=site
     )
 
-    # Run tests that require non-admin client
-    test_update_message_edit_permission_error(client, nonadmin_client)
-    test_user_not_authorized_error(nonadmin_client)
-    test_authorization_errors_fatal(client, nonadmin_client)
+    test_the_api(client, nonadmin_client)
 
     # Test error payloads
     client = Client(

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -553,8 +553,8 @@ def assertIn(key, result):
     else:
         assert key in result
 
-def test_messages(client):
-    # type: (Client) -> None
+def test_messages(client, nonadmin_client):
+    # type: (Client, Client) -> None
 
     render_message(client)
     message_id = stream_message(client)
@@ -563,6 +563,8 @@ def test_messages(client):
 
     test_nonexistent_stream_error(client)
     test_private_message_invalid_recipient(client)
+    test_update_message_edit_permission_error(client, nonadmin_client)
+
 
 def test_users(client):
     # type: (Client) -> None
@@ -572,8 +574,8 @@ def test_users(client):
     get_profile(client)
     upload_file(client)
 
-def test_streams(client):
-    # type: (Client) -> None
+def test_streams(client, nonadmin_client):
+    # type: (Client, Client) -> None
 
     add_subscriptions(client)
     test_add_subscriptions_already_subscribed(client)
@@ -582,6 +584,10 @@ def test_streams(client):
     get_streams(client)
     get_subscribers(client)
     remove_subscriptions(client)
+
+    test_user_not_authorized_error(nonadmin_client)
+    test_authorization_errors_fatal(client, nonadmin_client)
+
 
 def test_queues(client):
     # type: (Client) -> None
@@ -598,12 +604,12 @@ def test_errors(client):
     test_missing_request_argument(client)
     test_invalid_stream_error(client)
 
-def test_the_api(client):
-    # type: (Client) -> None
+def test_the_api(client, nonadmin_client):
+    # type: (Client, Client) -> None
 
     get_user_agent(client)
     test_users(client)
-    test_streams(client)
-    test_messages(client)
+    test_streams(client, nonadmin_client)
+    test_messages(client, nonadmin_client)
     test_queues(client)
     test_errors(client)


### PR DESCRIPTION
Refactors how we create and use the clients in the API tests, in order to make them easier to read.

**Testing Plan:** API tests, lint, and mypy checks passed.



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
