### PR TITLE
outgoing webhooks: Warn user that PMs are not supported in Slack-format webhook.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -83,7 +83,9 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
                           'request_kwargs': {}}
 
         if event['message']['type'] == 'private':
-            raise NotImplementedError("Private messaging service not supported.")
+            failure_message = "Private messaging service not supported."
+            fail_with_message(event, failure_message)
+            return None, None
 
         request_data = [("token", self.token),
                         ("team_id", event['message']['sender_realm_str']),

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -54,7 +54,7 @@ mock_service = Service()
 class TestSlackOutgoingWebhookService(ZulipTestCase):
 
     def setUp(self) -> None:
-        self.event = {
+        self.stream_message_event = {
             u'command': '@**test**',
             u'user_profile_id': 12,
             u'service_name': 'test-service',
@@ -76,8 +76,8 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
                                                    user_profile=None,
                                                    service_name='test-service')
 
-    def test_process_event(self) -> None:
-        rest_operation, request_data = self.handler.process_event(self.event)
+    def test_process_event_stream_message(self, mock_get_service_profile: mock.Mock) -> None:
+        rest_operation, request_data = self.handler.process_event(self.stream_message_event)
 
         self.assertEqual(rest_operation['base_url'], 'http://example.domain.com')
         self.assertEqual(rest_operation['method'], 'POST')
@@ -96,9 +96,9 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
     def test_process_success(self) -> None:
         response = mock.Mock(spec=Response)
         response.text = json.dumps({"response_not_required": True})
-        success_response, _ = self.handler.process_success(response, self.event)
+        success_response, _ = self.handler.process_success(response, self.stream_message_event)
         self.assertEqual(success_response, None)
 
         response.text = json.dumps({"text": 'test_content'})
-        success_response, _ = self.handler.process_success(response, self.event)
+        success_response, _ = self.handler.process_success(response, self.stream_message_event)
         self.assertEqual(success_response, 'test_content')

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -479,7 +479,8 @@ class OutgoingWebhookWorker(QueueProcessingWorker):
             dup_event['service_name'] = str(service.name)
             service_handler = get_outgoing_webhook_service_handler(service)
             rest_operation, request_data = service_handler.process_event(dup_event)
-            do_rest_call(rest_operation, request_data, dup_event, service_handler)
+            if rest_operation:
+                do_rest_call(rest_operation, request_data, dup_event, service_handler)
 
 @assign_queue('embedded_bots')
 class EmbeddedBotWorker(QueueProcessingWorker):


### PR DESCRIPTION
Private messages are not supported in Slack-format webhook. Instead of raising a `NotImplementedError`, we warn the user that PM service is not supported by sending a message to the user.
Added tests for the same.

Fixes #9239

Screenshot:
![screen shot 2018-06-24 at 12 27 58 pm](https://user-images.githubusercontent.com/25330892/41816711-8ae8181e-77a9-11e8-921e-de33ef8938d9.png)
