### PR TITLE
streams-settings: Fix toggle icon not updating.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -328,7 +328,7 @@ exports.create_handlers_for_users = function (container) {
 
     container.on('click', '#copy-from-stream-expand-collapse', function (e) {
         $('#stream-checkboxes').toggle();
-        $("#copy-from-stream-expand-collapse .toggle").toggleClass('icon-vector-caret-right icon-vector-caret-down');
+        $("#copy-from-stream-expand-collapse .toggle").toggleClass('fa-caret-right fa-caret-down');
         e.preventDefault();
         update_announce_stream_state();
     });


### PR DESCRIPTION
This PR fixes a regression which was introduced in https://github.com/zulip/zulip/commit/a02937e3b4c589292ba83cbfed6f820f966bfd13 while we were removing icon-vector and replacing the same with font-awesome. We forgot to update the toggle icons from the JS file.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before: -


![igg](https://user-images.githubusercontent.com/2263909/41864842-e33b9066-78c8-11e8-9fbc-fc77cecf932a.gif)


<hr>

After:

![screen recording 2018-06-25 at 10 35 pm](https://user-images.githubusercontent.com/2263909/41864721-85e73f46-78c8-11e8-8c4e-a660f6596826.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
