### PR TITLE
register: Style avatar that shows when importing settings.

### DIFF
--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -828,6 +828,21 @@ button.login-google-button {
     margin-right: 10px;
 }
 
+#profile_info_section {
+    #profile_avatar {
+        border: 1px solid #f2f2f2;
+        border-radius: 8px;
+        width: 120px;
+        height: 120px;
+        margin: 0 auto 10px;
+    }
+
+    #profile_full_name {
+        font-size: 1.2rem;
+        font-weight: 400;
+    }
+}
+
 /* -- media queries -- */
 
 @media (max-width: 950px) {
@@ -974,4 +989,7 @@ button.login-google-button {
     font-size: 1.2rem;
     height: 45px;
     width: 325px;
+    &:focus {
+        outline: none
+    }
 }

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -18,7 +18,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
 
         <div class="pitch">
             {% trans %}
-            <h1>You're almost there.</h1>
+            <h1>You&rsquo;re almost there.</h1>
             <p>We just need you to do one last thing.</p>
             {% endtrans %}
         </div>
@@ -104,11 +104,11 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
 
                 {% if accounts %}
                 <div class="input-box">
-                    <label for="source_realm" class="inline-block">{{ _('Import settings from an existing Zulip account') }}</label>
+                    <label for="source_realm" class="inline-block">{{ _('Import settings from another Zulip account') }}</label>
                 </div>
                 <div id="source_realm_select_section" class="input-group m-10 inline-block">
                     <select class="select" name="source_realm" id="source_realm_select">
-                        <option value="on" {% if ("source_realm" in form.data and form.data["source_realm"] == "on") or "source_realm" not in form.data %} selected {% endif %}>None</option>
+                        <option value="on" {% if ("source_realm" in form.data and form.data["source_realm"] == "on") or "source_realm" not in form.data %} selected {% endif %}>Don&rsquo;t import settings</option>
                         {% for account in accounts %}
                         <option value="{{ account.string_id }}" data-full-name="{{account.full_name}}" data-avatar="{{account.avatar}}" {% if "source_realm" in form.data and account.string_id == form.data["source_realm"] %} selected {% endif %}>{{ account.realm_name }}</option>
                         {% endfor %}


### PR DESCRIPTION
This styles the avatar and username that show when the registering user is importing their settings from an existing Zulip account.

<img width="481" alt="screen shot 2018-06-25 at 6 32 46 pm" src="https://user-images.githubusercontent.com/2905696/41879172-69fdc920-78a6-11e8-96b6-4983a5c15f7d.png">
