### PR TITLE
widgets: Fix empty message_content of "All messages" widgets.

### DIFF
--- a/static/js/tictactoe_widget.js
+++ b/static/js/tictactoe_widget.js
@@ -120,8 +120,6 @@ var tictactoe_data_holder = function () {
 };
 
 exports.activate = function (opts) {
-    var self = {};
-
     var elem = opts.elem;
     var callback = opts.callback;
 
@@ -141,7 +139,7 @@ exports.activate = function (opts) {
         });
     }
 
-    self.handle_events = function (events) {
+    elem.handle_events = function (events) {
         _.each(events, function (event) {
             tictactoe_data.handle_event(event.sender_id, event.data);
         });
@@ -149,8 +147,6 @@ exports.activate = function (opts) {
     };
 
     render();
-
-    return self;
 };
 
 return exports;

--- a/static/js/voting_widget.js
+++ b/static/js/voting_widget.js
@@ -119,8 +119,6 @@ var poll_data_holder = function () {
 };
 
 exports.activate = function (opts) {
-    var self = {};
-
     var elem = opts.elem;
     var callback = opts.callback;
 
@@ -159,7 +157,7 @@ exports.activate = function (opts) {
         });
     }
 
-    self.handle_events = function (events) {
+    elem.handle_events = function (events) {
         _.each(events, function (event) {
             poll_data.handle_event(event.sender_id, event.data);
         });
@@ -168,8 +166,6 @@ exports.activate = function (opts) {
 
     render();
     render_results();
-
-    return self;
 };
 
 return exports;


### PR DESCRIPTION
Well, there were different cases of the empty content of widgets.
Like, when we first load the page with the home screen ("All messages"),
the widgets appear and they still appear even when narrowed to
stream/topic, but things went wrong when again narrowed to
"All messages".
Another case was when a new widget is created in narrowed stream/topic
but this doesn't appear in "All messages".

But amusingly the fix was this simple, that jQuery isn't doing smart
things when a jQuery object is passed to `.html()` which wasn't
expected at all, so we have to pass the HTML string of `widget_elem`
to `content_holder`.

Fixes: #9827.
![peek 2018-06-26 13-27](https://user-images.githubusercontent.com/22238472/41897337-a9e9a9fc-7944-11e8-90e0-11e91049f7c5.gif)