### PR TITLE
api docs: Explain clearly how to create new streams.

### DIFF
--- a/templates/zerver/api/create-stream.md
+++ b/templates/zerver/api/create-stream.md
@@ -1,0 +1,5 @@
+# Create a stream
+
+The way how streams are created through Zulip's REST API is by adding a user
+(like yourself) to a non-existing streams. To read more on how to do that, see
+how to [add subscriptions](/api/add-subscriptions).

--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -8,6 +8,7 @@
 #### Streams
 
 * [Get all streams](/api/get-all-streams)
+* [Create a stream](/api/create-stream)
 * [Get stream ID](/api/get-stream-id)
 * [Get subscribed streams](/api/get-subscribed-streams)
 * [Add subscriptions](/api/add-subscriptions)


### PR DESCRIPTION
Apparently our docs aren't too clear on how to create a stream ([example](https://chat.zulip.org/#narrow/stream/127-integrations/topic/Create.20stream.20via.20API)), so this should ease things a bit and make the path more visible.

**Testing Plan:** checked that the docs show properly.