### PR TITLE
test flake: Prevent flaky test with less common id.

### DIFF
--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -733,8 +733,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         email = 'hambot-bot@zulip.testserver'
         profile = get_user('hambot-bot@zulip.testserver', get_realm('zulip'))
 
+        bad_bot_owner_id = 999999
         bot_info = {
-            'bot_owner_id': 100,
+            'bot_owner_id': bad_bot_owner_id,
         }
         result = self.client_patch("/json/bots/{}".format(self.get_bot_user(email).id), bot_info)
         self.assert_json_error(result, "Failed to change owner, no such user")


### PR DESCRIPTION
This fixes a test flake introduced here:

    317a2fff2a878ed65d47f901664e53e0a99842a3

We need a higher bogus bot owner id to prevent
flakes where our userid sequence gets to 100.  (Tests
aren't completely deterministic in what data you
use, since sequences don't get rolled back when
you roll back transactions.)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
