### PR TITLE
user-docs: Update use of save-changes macro.

### DIFF
--- a/templates/zerver/help/change-a-users-name.md
+++ b/templates/zerver/help/change-a-users-name.md
@@ -14,5 +14,3 @@ the name of the user you want to change.
 3. After clicking on the pencil icon, an input field labeled **Full name** will
 appear to allow you to change the user's name. Enter the user's new name in
 **Full name**.
-
-{!save-changes.md!} account settings.

--- a/templates/zerver/help/configure-email-digest-notifications.md
+++ b/templates/zerver/help/configure-email-digest-notifications.md
@@ -8,5 +8,3 @@ conversations and new users, while you were away.
 
 2. Select the **Send digest emails when I'm away** option under the
 **Other notification settings** section.
-
-{!save-changes.md!} notification settings.

--- a/templates/zerver/help/configure-email-notifications.md
+++ b/templates/zerver/help/configure-email-notifications.md
@@ -7,5 +7,3 @@ for private messages and @-mentions sent while you are offline.
 
 2. Select the **Email notifications** option under the
 **Private messages and @-mentions** section.
-
-{!save-changes.md!} notification settings.

--- a/templates/zerver/help/configure-mobile-notifications.md
+++ b/templates/zerver/help/configure-mobile-notifications.md
@@ -10,5 +10,3 @@ want mobile notifications only when you're offline.
 
     Check the box by **Mobile push notifications always (even when online)** if
 you always want mobile notifications.
-
-{!save-changes.md!} notification settings.


### PR DESCRIPTION
The user documentation utilizes a `save-changes` macro that adds a step to click on a 'Save changes' button after some setting has been changed.

Update articles that describe cases where the application now automatically saves changes instead of presenting a button.