### PR TITLE
settings: Fix focusing of `your-account` prior complete loading.

### DIFF
--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -11,7 +11,7 @@
         <div class="sidebar-list dark-grey small-text">
             <div class="center tab-container"></div>
             <ul class="normal-settings-list">
-                <li tabindex="0" class="active" data-section="your-account">
+                <li tabindex="0" data-section="your-account">
                     <div class="icon icon-vector-user"></div>
                     <div class="text">{{ _('Your account') }}</div>
                 </li>


### PR DESCRIPTION
Fixes: #9686.
![fixed](https://user-images.githubusercontent.com/22238472/41976878-b49a1664-7a3b-11e8-9284-cbbb9ca72be9.gif)
