### PR TITLE
messages: Allow fetching unedited messages' history.

### DIFF
--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1859,6 +1859,22 @@ class EditMessageTest(ZulipTestCase):
                           '</span> <span class="highlight_text_deleted"> Link: http://www.zulip.org .'
                           '</span> </a></p>'))
 
+    def test_edit_history_unedited(self) -> None:
+        self.login(self.example_email('hamlet'))
+
+        msg_id = self.send_stream_message(
+            self.example_email('hamlet'),
+            'Scotland',
+            topic_name='editing',
+            content='This message has not been edited.')
+
+        result = self.client_get('/json/messages/{}/history'.format(msg_id))
+
+        self.assert_json_success(result)
+
+        message_history = result.json()['message_history']
+        self.assert_length(message_history, 1)
+
     def test_user_info_for_updates(self) -> None:
         hamlet = self.example_user('hamlet')
         cordelia = self.example_user('cordelia')

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -1240,7 +1240,12 @@ def fill_edit_history_entries(message_history: List[Dict[str, Any]], message: Me
     prev_content = message.content
     prev_rendered_content = message.rendered_content
     prev_topic = message.subject
-    assert(datetime_to_timestamp(message.last_edit_time) == message_history[0]['timestamp'])
+
+    # Make sure that the latest entry in the history corresponds to the
+    # message's last edit time
+    if len(message_history) > 0:
+        assert(datetime_to_timestamp(message.last_edit_time) ==
+               message_history[0]['timestamp'])
 
     for entry in message_history:
         entry['topic'] = prev_topic
@@ -1277,7 +1282,10 @@ def get_message_edit_history(request: HttpRequest, user_profile: UserProfile,
     message, ignored_user_message = access_message(user_profile, message_id)
 
     # Extract the message edit history from the message
-    message_edit_history = ujson.loads(message.edit_history)
+    if message.edit_history is not None:
+        message_edit_history = ujson.loads(message.edit_history)
+    else:
+        message_edit_history = []
 
     # Fill in all the extra data that will make it usable
     fill_edit_history_entries(message_edit_history, message)


### PR DESCRIPTION
When GETting an unedited message's edit history, the server wasn't able to reply properly and produced a 500 error (because the message's edit history was empty, something that `ujson` can't parse),

Now when that happens, we return a message history that only contains the original message.

The reason why I took this approach can be found [here](https://chat.zulip.org/#narrow/stream/3-backend/topic/empty.20message.20history).

**Testing Plan:** lint and backend tests passed locally.

## Steps to reproduce

To reproduce the issue, make a GET request to `/api/v1/messages/<message_id>/history`, being `message_id` the ID of a message that hasn't been edited before.