### PR TITLE
Integrations: Improvements to dropdown menu behaviour on docs home page.

### DIFF
--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -319,6 +319,22 @@ function dispatch(action, payload) {
     }
 }
 
+function toggle_categories_dropdown() {
+    var $dropdown_list = $('.integration-categories-dropdown .dropdown-list');
+    $dropdown_list.toggle();
+
+    if ($dropdown_list.css('display') === 'none' &&
+        state.category === INITIAL_STATE.category) {
+        $('.integration-categories-dropdown i')
+            .removeClass('fa-angle-down')
+            .addClass('fa-angle-right');
+    } else {
+        $('.integration-categories-dropdown i')
+            .removeClass('fa-angle-right')
+            .addClass('fa-angle-down');
+    }
+}
+
 function integration_events() {
     $('#integration-search input[type="text"]').keypress(function (e) {
         var integrations = $('.integration-lozenges').children().toArray();
@@ -335,19 +351,7 @@ function integration_events() {
     });
 
     $('.integration-categories-dropdown .dropdown-toggle').click(function () {
-        var $dropdown_list = $('.integration-categories-dropdown .dropdown-list');
-        $dropdown_list.toggle();
-
-        if ($dropdown_list.css('display') === 'none' &&
-            state.category === INITIAL_STATE.category) {
-            $('.integration-categories-dropdown i')
-                .removeClass('fa-angle-down')
-                .addClass('fa-angle-right');
-        } else {
-            $('.integration-categories-dropdown i')
-                .removeClass('fa-angle-right')
-                .addClass('fa-angle-down');
-        }
+        toggle_categories_dropdown();
     });
 
     $('.integration-instruction-block').on('click', 'a .integration-category', function (e) {
@@ -359,6 +363,7 @@ function integration_events() {
     $('.integrations a .integration-category').on('click', function (e) {
         var category = $(e.target).data('category');
         dispatch('CHANGE_CATEGORY', { category: category });
+        toggle_categories_dropdown();
         return false;
     });
 

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -321,18 +321,19 @@ function dispatch(action, payload) {
 
 function toggle_categories_dropdown() {
     var $dropdown_list = $('.integration-categories-dropdown .dropdown-list');
-    $dropdown_list.toggle();
 
     if ($dropdown_list.css('display') === 'none' &&
         state.category === INITIAL_STATE.category) {
         $('.integration-categories-dropdown i')
-            .removeClass('fa-angle-down')
-            .addClass('fa-angle-right');
-    } else {
-        $('.integration-categories-dropdown i')
             .removeClass('fa-angle-right')
             .addClass('fa-angle-down');
+    } else {
+        $('.integration-categories-dropdown i')
+            .removeClass('fa-angle-down')
+            .addClass('fa-angle-right');
     }
+
+    $dropdown_list.slideToggle(250);
 }
 
 function integration_events() {

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -81,14 +81,10 @@ function update_categories() {
     $('[data-category="' + state.category + '"]').addClass('selected');
 
     var $dropdown_label = $('.integration-categories-dropdown .dropdown-category-label');
-    var $dropdown_icon = $('.integration-categories-dropdown i');
     if (state.category === INITIAL_STATE.category) {
         $dropdown_label.text(i18n.t('Filter by category'));
     } else {
         $dropdown_label.text(CATEGORIES[state.category]);
-        $dropdown_icon
-            .removeClass('fa-angle-right')
-            .addClass('fa-angle-down');
     }
 
     $('.integration-lozenges').animate(
@@ -321,18 +317,6 @@ function dispatch(action, payload) {
 
 function toggle_categories_dropdown() {
     var $dropdown_list = $('.integration-categories-dropdown .dropdown-list');
-
-    if ($dropdown_list.css('display') === 'none' &&
-        state.category === INITIAL_STATE.category) {
-        $('.integration-categories-dropdown i')
-            .removeClass('fa-angle-right')
-            .addClass('fa-angle-down');
-    } else {
-        $('.integration-categories-dropdown i')
-            .removeClass('fa-angle-down')
-            .addClass('fa-angle-right');
-    }
-
     $dropdown_list.slideToggle(250);
 }
 

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -335,7 +335,7 @@ function integration_events() {
         }
     });
 
-    $('.integration-categories-dropdown h3, i').click(function () {
+    $('.integration-categories-dropdown .dropdown-toggle').click(function () {
         toggle_categories_dropdown();
     });
 

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -350,7 +350,7 @@ function integration_events() {
         }
     });
 
-    $('.integration-categories-dropdown .dropdown-toggle').click(function () {
+    $('.integration-categories-dropdown h3, i').click(function () {
         toggle_categories_dropdown();
     });
 

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -3510,13 +3510,14 @@ nav ul li.active::after {
     .portico-landing.integrations .integration-categories-dropdown h3,
     .portico-landing.integrations .integration-categories-dropdown h4 {
         font-weight: 400;
-        margin: 0 25px;
+        margin: 0;
         padding: 12px 20px;
         border-bottom: 1px solid hsl(208, 46%, 93%);
     }
 
     .portico-landing.integrations .integration-categories-dropdown .dropdown-toggle {
         position: relative;
+        padding: 0 25px;
     }
 
     .portico-landing.integrations .integration-categories-dropdown i {
@@ -3528,6 +3529,7 @@ nav ul li.active::after {
 
     .portico-landing.integrations .integration-categories-dropdown .dropdown-list {
         display: none;
+        padding: 0 25px;
     }
 
     .portico-landing.integrations .integration-categories-dropdown h3 {

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2583,7 +2583,7 @@ nav ul li.active::after {
 
 .portico-landing.integrations .integration-categories-dropdown {
     cursor: pointer;
-    margin: 30px 0;
+    margin: 30px auto;
     display: none;
 }
 
@@ -3505,6 +3505,7 @@ nav ul li.active::after {
 
     .portico-landing.integrations .integration-categories-dropdown {
         display: block;
+        width: 670px;
     }
 
     .portico-landing.integrations .integration-categories-dropdown h3,
@@ -3662,6 +3663,16 @@ nav ul li.active::after {
 	.tour .carousel-inner .tour-item-header {
        font-size: 1.1em;
    }
+
+   .portico-landing.integrations .integration-categories-dropdown {
+       width: 666px;
+   }
+}
+
+@media (max-width: 786px) {
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 509px;
+    }
 }
 
 @media (max-width: 768px) {
@@ -3797,6 +3808,10 @@ nav ul li.active::after {
 
     .portico-landing.features-app section {
         padding: 0px 20px;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 666px;
     }
 
     .billing-upgrade-page {
@@ -4044,11 +4059,21 @@ nav ul li.active::after {
     .tour .carousel-inner button.call-to-action {
         margin: 40px auto;
     }
+
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 509px;
+    }
 }
 
 @media (max-width: 640px) {
     .portico-landing.hello .integrations .integration-icons .group {
         margin: 10px 16px 0 16px;
+    }
+}
+
+@media (max-width: 578px) {
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 351px;
     }
 }
 
@@ -4247,6 +4272,10 @@ nav ul li.active::after {
     .portico-landing.features-app section.keyboard-shortcuts::after {
         left: 0;
     }
+
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 323px;
+    }
 }
 
 @media (max-width: 357px) {
@@ -4270,6 +4299,10 @@ nav ul li.active::after {
 
     .portico-landing.integrations .integration-lozenge .integration-category {
         font-size: .77em;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 299px;
     }
 }
 

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2582,7 +2582,6 @@ nav ul li.active::after {
 }
 
 .portico-landing.integrations .integration-categories-dropdown {
-    cursor: pointer;
     margin: 30px auto;
     display: none;
 }
@@ -3517,20 +3516,26 @@ nav ul li.active::after {
     }
 
     .portico-landing.integrations .integration-categories-dropdown .dropdown-toggle {
+        cursor: pointer;
         position: relative;
-        padding: 0 25px;
+        padding: 0;
+        margin-left: 25px;
+        margin-right: 25px;
     }
 
     .portico-landing.integrations .integration-categories-dropdown i {
         position: absolute;
         top: 10px;
-        right: 36px;
+        right: 11px;
         font-size: 24px;
     }
 
     .portico-landing.integrations .integration-categories-dropdown .dropdown-list {
         display: none;
-        padding: 0 25px;
+        cursor: pointer;
+        padding: 0;
+        margin-left: 25px;
+        margin-right: 25px;
     }
 
     .portico-landing.integrations .integration-categories-dropdown h3 {

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -3512,21 +3512,22 @@ nav ul li.active::after {
         font-weight: 400;
         margin: 0;
         padding: 12px 20px;
-        border-bottom: 1px solid hsl(208, 46%, 93%);
     }
 
     .portico-landing.integrations .integration-categories-dropdown .dropdown-toggle {
         cursor: pointer;
+        display: flex;
         position: relative;
         padding: 0;
+        align-items: center;
+        justify-content: space-between;
         margin-left: 25px;
         margin-right: 25px;
+        border: 1px solid hsl(208, 46%, 93%);
     }
 
     .portico-landing.integrations .integration-categories-dropdown i {
-        position: absolute;
-        top: 10px;
-        right: 11px;
+        margin-right: 10px;
         font-size: 24px;
     }
 
@@ -3539,9 +3540,6 @@ nav ul li.active::after {
     }
 
     .portico-landing.integrations .integration-categories-dropdown h3 {
-        border-top: 1px solid hsl(208, 46%, 93%);
-        border-left: 1px solid hsl(208, 46%, 93%);
-        border-right: 1px solid hsl(208, 46%, 93%);
         font-size: 1em;
         text-align: left;
     }
@@ -3549,6 +3547,7 @@ nav ul li.active::after {
     .portico-landing.integrations .integration-categories-dropdown h4 {
         border-left: 1px solid #E4EDF5;
         border-right: 1px solid #E4EDF5;
+        border-bottom: 1px solid hsl(208, 46%, 93%);
         transition: all 0.3s ease;
         font-size: .9em;
     }

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -46,7 +46,7 @@
                 <div class="integration-categories-dropdown">
                     <div class="dropdown-toggle">
                         <h3 class="dropdown-category-label">{% trans %}Filter by category{% endtrans %}</h3>
-                        <i class="fa fa-angle-right" aria-hidden="true"></i>
+                        <i class="fa fa-angle-down" aria-hidden="true"></i>
                     </div>
                     <div class="dropdown-list">
                         <a href="/integrations">


### PR DESCRIPTION
In this PR we have commits which migrate integrations docs page to use font awesome 4.7 prefixes and fixes buggy behaviour around the categories drop down and its alignment relative to the integration lozenges.

Below I attach a number of pics relating to the alignment improvements I did. I am gonna attach pics for the page in different resolution as it would look after merging this PR rather than doing an old vs new on the images. I am not attaching screens at some resolutions (of course each screenshot represents a change in resolution level in the sense what we define using media queries) because things around the drop down don't change at those levels.

![image](https://user-images.githubusercontent.com/17237412/42049821-d0096384-7b24-11e8-80e9-793573f4464b.png)

![image](https://user-images.githubusercontent.com/17237412/42049840-e3205aa4-7b24-11e8-893e-0804b0ef2f8c.png)


![image](https://user-images.githubusercontent.com/17237412/42049884-04e35538-7b25-11e8-8870-ad0f78a0010e.png)


![image](https://user-images.githubusercontent.com/17237412/42049960-3ef20832-7b25-11e8-9a8c-89131396a385.png)

![image](https://user-images.githubusercontent.com/17237412/42049983-512c61fa-7b25-11e8-9807-256f0dfb5ed6.png)

![image](https://user-images.githubusercontent.com/17237412/42050010-6205b8b4-7b25-11e8-83d0-e2e521d7d933.png)


![image](https://user-images.githubusercontent.com/17237412/42050043-7693dbda-7b25-11e8-86e0-1340c785645a.png)
