### PR TITLE
Enable pycodestyle W605 (invalid escape sequence)

### DIFF
--- a/scripts/lib/process-mobile-i18n
+++ b/scripts/lib/process-mobile-i18n
@@ -11,7 +11,7 @@ def get_json_filename(locale: str) -> str:
 def get_locales() -> List[str]:
     tracked_files = check_output(['git', 'ls-files', 'static/locale'])
     tracked_files = tracked_files.decode().split()
-    regex = re.compile('static/locale/(\w+)/LC_MESSAGES/django.po')
+    regex = re.compile(r'static/locale/(\w+)/LC_MESSAGES/django.po')
     locales = ['en']
     for tracked_file in tracked_files:
         matched = regex.search(tracked_file)

--- a/tools/check-urls
+++ b/tools/check-urls
@@ -12,8 +12,8 @@ def check_urls():
                  'analytics/urls.py',
                  'zilencer/urls.py']
 
-    pattern_1 = "\s+\[?url\(.+,\s*'.+'\s*,\s*.*\)"
-    pattern_2 = '\s+\[?url\(.+,\s*".+"\s*,\s*.*\)'
+    pattern_1 = r"\s+\[?url\(.+,\s*'.+'\s*,\s*.*\)"
+    pattern_2 = r'\s+\[?url\(.+,\s*".+"\s*,\s*.*\)'
 
     for url_file in url_files:
         with open(url_file) as f:

--- a/tools/documentation_crawler/documentation_crawler/spiders/check_documentation.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/check_documentation.py
@@ -19,5 +19,5 @@ def get_start_url() -> List[str]:
 class DocumentationSpider(BaseDocumentationSpider):
     name = "documentation_crawler"
     deny_domains = ['localhost:9991']
-    deny = ['\_sources\/.*\.txt']
+    deny = [r'\_sources\/.*\.txt']
     start_urls = get_start_url()

--- a/tools/get-handlebar-vars
+++ b/tools/get-handlebar-vars
@@ -16,14 +16,14 @@ def debug(obj):
 def parse_file(fn):
     # type: (str) -> Dict[str, Any]
     text = open(fn).read()
-    tags = re.findall('{+\s*(.*?)\s*}+', text)
+    tags = re.findall(r'{+\s*(.*?)\s*}+', text)
     root = {}  # type: Dict[str, Any]
     context = root
     stack = []  # type: List[Dict[str, Any]]
 
     def set_var(var, val):
         # type: (str, Any) -> None
-        num_levels_up = len(re.findall('\.\.', var))
+        num_levels_up = len(re.findall(r'\.\.', var))
         if num_levels_up:
             var = var.split('/')[-1]
             stack[-1 * num_levels_up][var] = val

--- a/tools/js-dep-visualizer.py
+++ b/tools/js-dep-visualizer.py
@@ -44,11 +44,11 @@ def get_js_edges():
         modules.append(dict(
             name=name,
             path=path,
-            regex=re.compile('[^_]{}\.\w+\('.format(name))
+            regex=re.compile(r'[^_]{}\.\w+\('.format(name))
         ))
 
-    comment_regex = re.compile('\s+//')
-    call_regex = re.compile('[^_](\w+\.\w+)\(')
+    comment_regex = re.compile(r'\s+//')
+    call_regex = re.compile(r'[^_](\w+\.\w+)\(')
 
     methods = defaultdict(list)  # type: DefaultDict[Edge, List[Method]]
     edges = set()

--- a/tools/lib/find_add_class.py
+++ b/tools/lib/find_add_class.py
@@ -81,7 +81,7 @@ def find(fns):
         for i, line in enumerate(lines):
             if 'addClass' in line:
                 html_classes = []  # type: List[str]
-                m = re.search('addClass\([\'"](.*?)[\'"]', line)
+                m = re.search(r'''addClass\(['"](.*?)['"]''', line)
                 if m:
                     html_classes = [m.group(1)]
                 if not html_classes:

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -97,10 +97,10 @@ def custom_check_file(fn, identifier, rules, color, skip_rules=None, max_length=
         if (max_length is not None and line_length > max_length and
             '# type' not in line and 'test' not in fn and 'example' not in fn and
             # Don't throw errors for markdown format URLs
-            not re.search("^\[[ A-Za-z0-9_:,&()-]*\]: http.*", line) and
+            not re.search(r"^\[[ A-Za-z0-9_:,&()-]*\]: http.*", line) and
             # Don't throw errors for URLs in code comments
-            not re.search("[#].*http.*", line) and
-            not re.search("`\{\{ api_url \}\}[^`]+`", line) and
+            not re.search(r"[#].*http.*", line) and
+            not re.search(r"`\{\{ api_url \}\}[^`]+`", line) and
                 "# ignorelongline" not in line and 'migrations' not in fn):
             print("Line too long (%s) at %s line %s: %s" % (len(line), fn, i+1, line_newline_stripped))
             failed = True
@@ -138,7 +138,7 @@ def build_custom_checkers(by_lang):
     # 'exclude_line': 'set([(<path>, <line>), ...])' - excludes all lines matching <line> in the file <path> from linting.
     # 'include_only': 'set([<path>, ...])' - includes only those files where <path> is a substring of the filepath.
     trailing_whitespace_rule = {
-        'pattern': '\s+$',
+        'pattern': r'\s+$',
         'strip': '\n',
         'description': 'Fix trailing whitespace'
     }
@@ -160,11 +160,11 @@ def build_custom_checkers(by_lang):
          'good_lines': ['foo(1, 2, 3)', 'foo = bar  # some inline comment'],
          'bad_lines': ['foo(1,  2, 3)', 'foo(1,    2, 3)']},
     ]  # type: RuleList
-    markdown_whitespace_rules = list([rule for rule in whitespace_rules if rule['pattern'] != '\s+$']) + [
+    markdown_whitespace_rules = list([rule for rule in whitespace_rules if rule['pattern'] != r'\s+$']) + [
         # Two spaces trailing a line with other content is okay--it's a markdown line break.
         # This rule finds one space trailing a non-space, three or more trailing spaces, and
         # spaces on an empty line.
-        {'pattern': '((?<!\s)\s$)|(\s\s\s+$)|(^\s+$)',
+        {'pattern': r'((?<!\s)\s$)|(\s\s\s+$)|(^\s+$)',
          'strip': '\n',
          'description': 'Fix trailing whitespace'},
         {'pattern': '^#+[A-Za-z0-9]',
@@ -174,19 +174,19 @@ def build_custom_checkers(by_lang):
          'bad_lines': ['###some heading', '#another heading']},
     ]  # type: RuleList
     js_rules = cast(RuleList, [
-        {'pattern': '[^_]function\(',
+        {'pattern': r'[^_]function\(',
          'description': 'The keyword "function" should be followed by a space'},
-        {'pattern': '.*blueslip.warning\(.*',
+        {'pattern': r'.*blueslip.warning\(.*',
          'description': 'The module blueslip has no function warning, try using blueslip.warn'},
         {'pattern': '[)]{$',
          'description': 'Missing space between ) and {'},
-        {'pattern': 'i18n\.t\([^)]+[^,\{\)]$',
+        {'pattern': r'i18n\.t\([^)]+[^,\{\)]$',
          'description': 'i18n string should not be a multiline string'},
-        {'pattern': 'i18n\.t\([\'\"].+?[\'\"]\s*\+',
+        {'pattern': r'''i18n\.t\(['"].+?['"]\s*\+''',
          'description': 'Do not concatenate arguments within i18n.t()'},
-        {'pattern': 'i18n\.t\(.+\).*\+',
+        {'pattern': r'i18n\.t\(.+\).*\+',
          'description': 'Do not concatenate i18n strings'},
-        {'pattern': '\+.*i18n\.t\(.+\)',
+        {'pattern': r'\+.*i18n\.t\(.+\)',
          'description': 'Do not concatenate i18n strings'},
         {'pattern': '[.]includes[(]',
          'exclude': ['frontend_tests/'],
@@ -211,7 +211,7 @@ def build_custom_checkers(by_lang):
          'description': 'Write JS else statements on same line as }'},
         {'pattern': '^else if',
          'description': 'Write JS else statements on same line as }'},
-        {'pattern': 'const\s',
+        {'pattern': r'const\s',
          'exclude': set(['frontend_tests/zjsunit',
                          'frontend_tests/node_tests',
                          'static/js/portico',
@@ -225,22 +225,22 @@ def build_custom_checkers(by_lang):
                          'static/js/debug.js',
                          'tools/generate-custom-icon-webfont']),
          'description': 'console.log and similar should not be used in webapp'},
-        {'pattern': '[.]text\(["\'][a-zA-Z]',
+        {'pattern': r'''[.]text\(["'][a-zA-Z]''',
          'description': 'Strings passed to $().text should be wrapped in i18n.t() for internationalization'},
-        {'pattern': 'compose_error\(["\']',
+        {'pattern': r'''compose_error\(["']''',
          'description': 'Argument to compose_error should be a literal string enclosed '
                         'by i18n.t()'},
-        {'pattern': 'ui.report_success\(',
+        {'pattern': r'ui.report_success\(',
          'description': 'Deprecated function, use ui_report.success.'},
-        {'pattern': 'report.success\(["\']',
+        {'pattern': r'''report.success\(["']''',
          'description': 'Argument to report_success should be a literal string enclosed '
                         'by i18n.t()'},
-        {'pattern': 'ui.report_error\(',
+        {'pattern': r'ui.report_error\(',
          'description': 'Deprecated function, use ui_report.error.'},
-        {'pattern': 'report.error\(["\']',
+        {'pattern': r'''report.error\(["']''',
          'description': 'Argument to report_error should be a literal string enclosed '
                         'by i18n.t()'},
-        {'pattern': '\$\(document\)\.ready\(',
+        {'pattern': r'\$\(document\)\.ready\(',
          'description': "`Use $(f) rather than `$(document).ready(f)`",
          'good_lines': ['$(function () {foo();}'],
          'bad_lines': ['$(document).ready(function () {foo();}']},
@@ -281,11 +281,11 @@ def build_custom_checkers(by_lang):
          'exclude': set(['zerver/tests', 'zerver/lib/create_user.py']),
          'good_lines': ['user_profile.save(update_fields=["pointer"])'],
          'bad_lines': ['user_profile.save()']},
-        {'pattern': '^[^"]*"[^"]*"%\(',
+        {'pattern': r'^[^"]*"[^"]*"%\(',
          'description': 'Missing space around "%"',
          'good_lines': ['"%s" % ("foo")', '"%s" % (foo)'],
          'bad_lines': ['"%s"%("foo")', '"%s"%(foo)']},
-        {'pattern': "^[^']*'[^']*'%\(",
+        {'pattern': r"^[^']*'[^']*'%\(",
          'description': 'Missing space around "%"',
          'good_lines': ["'%s' % ('foo')", "'%s' % (foo)"],
          'bad_lines': ["'%s'%('foo')", "'%s'%(foo)"]},
@@ -298,15 +298,15 @@ def build_custom_checkers(by_lang):
          'description': 'Missing whitespace after "="',
          'good_lines': ['a = b', '5 == 6'],
          'bad_lines': ['a =b', 'asdf =42']},
-        {'pattern': '":\w[^"]*$',
+        {'pattern': r'":\w[^"]*$',
          'description': 'Missing whitespace after ":"',
          'good_lines': ['"foo": bar', '"some:string:with:colons"'],
          'bad_lines': ['"foo":bar', '"foo":1']},
-        {'pattern': "':\w[^']*$",
+        {'pattern': r"':\w[^']*$",
          'description': 'Missing whitespace after ":"',
          'good_lines': ["'foo': bar", "'some:string:with:colons'"],
          'bad_lines': ["'foo':bar", "'foo':1"]},
-        {'pattern': "^\s+#\w",
+        {'pattern': r"^\s+#\w",
          'strip': '\n',
          'exclude': set(['tools/droplets/create.py']),
          'description': 'Missing whitespace after "#"',
@@ -354,14 +354,14 @@ def build_custom_checkers(by_lang):
         # This next check could have false positives, but it seems pretty
         # rare; if we find any, they can be added to the exclude list for
         # this rule.
-        {'pattern': ' % [a-zA-Z0-9_."\']*\)?$',
+        {'pattern': r''' % [a-zA-Z0-9_."']*\)?$''',
          'exclude_line': set([
              ('tools/tests/test_template_parser.py', '{% foo'),
          ]),
          'description': 'Used % comprehension without a tuple',
          'good_lines': ['"foo %s bar" % ("baz",)'],
          'bad_lines': ['"foo %s bar" % "baz"']},
-        {'pattern': '.*%s.* % \([a-zA-Z0-9_."\']*\)$',
+        {'pattern': r'''.*%s.* % \([a-zA-Z0-9_."']*\)$''',
          'description': 'Used % comprehension without a tuple',
          'good_lines': ['"foo %s bar" % ("baz",)"'],
          'bad_lines': ['"foo %s bar" % ("baz")']},
@@ -385,16 +385,16 @@ def build_custom_checkers(by_lang):
          'description': 'We prefer user_id over userid.',
          'good_lines': ['id = alice.user_id'],
          'bad_lines': ['id = alice.userid']},
-        {'pattern': 'json_success\({}\)',
+        {'pattern': r'json_success\({}\)',
          'description': 'Use json_success() to return nothing',
          'good_lines': ['return json_success()'],
          'bad_lines': ['return json_success({})']},
-        {'pattern': '\Wjson_error\(_\(?\w+\)',
+        {'pattern': r'\Wjson_error\(_\(?\w+\)',
          'exclude': set(['zerver/tests']),
          'description': 'Argument to json_error should be a literal string enclosed by _()',
          'good_lines': ['return json_error(_("string"))'],
          'bad_lines': ['return json_error(_variable)', 'return json_error(_(variable))']},
-        {'pattern': '\Wjson_error\([\'"].+[),]$',
+        {'pattern': r'''\Wjson_error\(['"].+[),]$''',
          'exclude': set(['zerver/tests']),
          'exclude_line': set([
              # We don't want this string tagged for translation.
@@ -402,15 +402,15 @@ def build_custom_checkers(by_lang):
          ]),
          'description': 'Argument to json_error should a literal string enclosed by _()'},
         # To avoid JsonableError(_variable) and JsonableError(_(variable))
-        {'pattern': '\WJsonableError\(_\(?\w.+\)',
+        {'pattern': r'\WJsonableError\(_\(?\w.+\)',
          'exclude': set(['zerver/tests']),
          'description': 'Argument to JsonableError should be a literal string enclosed by _()'},
-        {'pattern': '\WJsonableError\(["\'].+\)',
+        {'pattern': r'''\WJsonableError\(["'].+\)''',
          'exclude': set(['zerver/tests']),
          'description': 'Argument to JsonableError should be a literal string enclosed by _()'},
-        {'pattern': '([a-zA-Z0-9_]+)=REQ\([\'"]\\1[\'"]',
+        {'pattern': r'''([a-zA-Z0-9_]+)=REQ\(['"]\1['"]''',
          'description': 'REQ\'s first argument already defaults to parameter name'},
-        {'pattern': 'self\.client\.(get|post|patch|put|delete)',
+        {'pattern': r'self\.client\.(get|post|patch|put|delete)',
          'description': \
          '''Do not call self.client directly for put/patch/post/get.
     See WRAPPER_COMMENT in test_helpers.py for details.
@@ -461,7 +461,7 @@ def build_custom_checkers(by_lang):
          'description': "Don't use datetime in backend code.\n"
          "See https://zulip.readthedocs.io/en/latest/contributing/code-style.html#naive-datetime-objects",
          },
-        {'pattern': 'render_to_response\(',
+        {'pattern': r'render_to_response\(',
          'description': "Use render() instead of render_to_response().",
          },
         {'pattern': 'from os.path',
@@ -470,16 +470,16 @@ def build_custom_checkers(by_lang):
         {'pattern': 'import os.path',
          'description': "Use import os instead of import os.path",
          },
-        {'pattern': '(logging|logger)\.warn\W',
+        {'pattern': r'(logging|logger)\.warn\W',
          'description': "Logger.warn is a deprecated alias for Logger.warning; Use 'warning' instead of 'warn'.",
          'good_lines': ["logging.warning('I am a warning.')", "logger.warning('warning')"],
          'bad_lines': ["logging.warn('I am a warning.')", "logger.warn('warning')"]},
-        {'pattern': '\.pk',
+        {'pattern': r'\.pk',
          'exclude_pattern': '[.]_meta[.]pk',
          'description': "Use `id` instead of `pk`.",
          'good_lines': ['if my_django_model.id == 42', 'self.user_profile._meta.pk'],
          'bad_lines': ['if my_django_model.pk == 42']},
-        {'pattern': '^[ ]*# type: \(',
+        {'pattern': r'^[ ]*# type: \(',
          'exclude': set([
              # These directories, especially scripts/ and puppet/,
              # have tools that need to run before a Zulip environment
@@ -498,7 +498,7 @@ def build_custom_checkers(by_lang):
          ]),
          'description': 'Comment-style function type annotation. Use Python3 style annotations instead.',
          },
-        {'pattern': ' = models[.].*null=True.*\)  # type: (?!Optional)',
+        {'pattern': r' = models[.].*null=True.*\)  # type: (?!Optional)',
          'include_only': {"zerver/models.py"},
          'description': 'Model variable with null=true not annotated as Optional.',
          'good_lines': ['desc = models.TextField(null=True)  # type: Optional[Text]',
@@ -508,7 +508,7 @@ def build_custom_checkers(by_lang):
          'bad_lines': ['desc = models.CharField(null=True)  # type: Text',
                        'stream = models.ForeignKey(Stream, null=True, on_delete=CASCADE)  # type: Stream'],
          },
-        {'pattern': ' = models[.](?!NullBoolean).*\)  # type: Optional',  # Optional tag, except NullBoolean(Field)
+        {'pattern': r' = models[.](?!NullBoolean).*\)  # type: Optional',  # Optional tag, except NullBoolean(Field)
          'exclude_pattern': 'null=True',
          'include_only': {"zerver/models.py"},
          'description': 'Model variable annotated with Optional but variable does not have null=true.',
@@ -519,7 +519,7 @@ def build_custom_checkers(by_lang):
          'bad_lines': ['desc = models.TextField()  # type: Optional[Text]',
                        'stream = models.ForeignKey(Stream, on_delete=CASCADE)  # type: Optional[Stream]'],
          },
-        {'pattern': '[\s([]Text([^\s\w]|$)',
+        {'pattern': r'[\s([]Text([^\s\w]|$)',
          'exclude': set([
              # We are likely to want to keep these dirs Python 2+3 compatible,
              # since the plan includes extracting them to a separate project eventually.
@@ -548,11 +548,11 @@ def build_custom_checkers(by_lang):
          ]), },
     ]) + whitespace_rules[0:1]
     css_rules = cast(RuleList, [
-        {'pattern': 'calc\([^+]+\+[^+]+\)',
+        {'pattern': r'calc\([^+]+\+[^+]+\)',
          'description': "Avoid using calc with '+' operator. See #8403 : in CSS.",
          'good_lines': ["width: calc(20% - -14px);"],
          'bad_lines': ["width: calc(20% + 14px);"]},
-        {'pattern': '^[^:]*:\S[^:]*;$',
+        {'pattern': r'^[^:]*:\S[^:]*;$',
          'description': "Missing whitespace after : in CSS",
          'good_lines': ["background-color: white;", "text-size: 16px;"],
          'bad_lines': ["background-color:white;", "text-size:16px;"]},
@@ -570,7 +570,7 @@ def build_custom_checkers(by_lang):
          'strip': '\n',
          'good_lines': ["    color: white;", "color: white;"],
          'bad_lines': ["  color: white;"]},
-        {'pattern': '{\w',
+        {'pattern': r'{\w',
          'description': "Missing whitespace after '{' in CSS (should be newline).",
          'good_lines': ["{\n"],
          'bad_lines': ["{color: LightGoldenRodYellow;"]},
@@ -588,9 +588,9 @@ def build_custom_checkers(by_lang):
          'bad_lines': ["border-width: thick;", "border: thick solid black;"]},
     ]) + whitespace_rules + comma_whitespace_rule
     prose_style_rules = cast(RuleList, [
-        {'pattern': '[^\/\#\-\"]([jJ]avascript)',  # exclude usage in hrefs/divs
+        {'pattern': r'[^\/\#\-"]([jJ]avascript)',  # exclude usage in hrefs/divs
          'description': "javascript should be spelled JavaScript"},
-        {'pattern': '[^\/\-\.\"\'\_\=\>]([gG]ithub)[^\.\-\_\"\<]',  # exclude usage in hrefs/divs
+        {'pattern': r'''[^\/\-\."'\_\=\>]([gG]ithub)[^\.\-\_"\<]''',  # exclude usage in hrefs/divs
          'description': "github should be spelled GitHub"},
         {'pattern': '[oO]rganisation',  # exclude usage in hrefs/divs
          'description': "Organization is spelled with a z",
@@ -603,7 +603,7 @@ def build_custom_checkers(by_lang):
          'description': "Use Botserver instead of botserver or bot server."},
     ]) + comma_whitespace_rule
     html_rules = whitespace_rules + prose_style_rules + [
-        {'pattern': 'placeholder="[^{#](?:(?!\.com).)+$',
+        {'pattern': r'placeholder="[^{#](?:(?!\.com).)+$',
          'description': "`placeholder` value should be translatable.",
          'exclude_line': [('templates/zerver/register.html', 'placeholder="acme"'),
                           ('templates/zerver/register.html', 'placeholder="Acme or Aκμή"')],
@@ -630,21 +630,21 @@ def build_custom_checkers(by_lang):
          'description': "`title` value should be translatable.",
          'good_lines': ['<link rel="author" title="{{ _(\'About these documents\') }}" />'],
          'bad_lines': ["<p title='foo'></p>"]},
-        {'pattern': 'title="[^{\:]',
+        {'pattern': r'title="[^{\:]',
          'exclude_line': set([
              ('templates/zerver/app/markdown_help.html',
               '<td><img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/heart.png" title=":heart:" /></td>')
          ]),
          'exclude': set(["templates/zerver/emails"]),
          'description': "`title` value should be translatable."},
-        {'pattern': '\Walt=["\'][^{"\']',
+        {'pattern': r'''\Walt=["'][^{"']''',
          'description': "alt argument should be enclosed by _() or it should be an empty string.",
          'exclude': set(['static/templates/settings/display-settings.handlebars',
                          'templates/zerver/app/keyboard_shortcuts.html',
                          'templates/zerver/app/markdown_help.html']),
          'good_lines': ['<img src="{{source_url}}" alt="{{ _(name) }}" />', '<img alg="" />'],
          'bad_lines': ['<img alt="Foo Image" />']},
-        {'pattern': '\Walt=["\']{{ ?["\']',
+        {'pattern': r'''\Walt=["']{{ ?["']''',
          'description': "alt argument should be enclosed by _().",
          'good_lines': ['<img src="{{source_url}}" alt="{{ _(name) }}" />'],
          'bad_lines': ['<img alt="{{ " />']},
@@ -721,11 +721,11 @@ def build_custom_checkers(by_lang):
          'description': "Do not use inline <script> tags here; put JavaScript in static/js instead."},
         {'pattern': '{{ t ("|\')',
          'description': 'There should be no spaces before the "t" in a translation tag.'},
-        {'pattern': "{{t '.*' }}[\.\?!]",
+        {'pattern': r"{{t '.*' }}[\.\?!]",
          'description': "Period should be part of the translatable string."},
-        {'pattern': '{{t ".*" }}[\.\?!]',
+        {'pattern': r'{{t ".*" }}[\.\?!]',
          'description': "Period should be part of the translatable string."},
-        {'pattern': "{{/tr}}[\.\?!]",
+        {'pattern': r"{{/tr}}[\.\?!]",
          'description': "Period should be part of the translatable string."},
         {'pattern': '{{t ("|\') ',
          'description': 'Translatable strings should not have leading spaces.'},
@@ -735,9 +735,9 @@ def build_custom_checkers(by_lang):
          'description': 'Translatable strings should not have trailing spaces.'},
     ]
     jinja2_rules = html_rules + [
-        {'pattern': "{% endtrans %}[\.\?!]",
+        {'pattern': r"{% endtrans %}[\.\?!]",
          'description': "Period should be part of the translatable string."},
-        {'pattern': "{{ _(.+) }}[\.\?!]",
+        {'pattern': r"{{ _(.+) }}[\.\?!]",
          'description': "Period should be part of the translatable string."},
     ]
     json_rules = [
@@ -753,19 +753,19 @@ def build_custom_checkers(by_lang):
          'strip': '\n',
          'exclude': set(['zerver/webhooks/']),
          'description': 'Fix tab-based whitespace'},
-        {'pattern': ':[\"\[\{]',
+        {'pattern': r':["\[\{]',
          'exclude': set(['zerver/webhooks/', 'zerver/tests/fixtures/']),
          'description': 'Require space after : in JSON'},
     ]  # type: RuleList
     markdown_rules = markdown_whitespace_rules + prose_style_rules + [
-        {'pattern': '\[(?P<url>[^\]]+)\]\((?P=url)\)',
+        {'pattern': r'\[(?P<url>[^\]]+)\]\((?P=url)\)',
          'description': 'Linkified markdown URLs should use cleaner <http://example.com> syntax.'},
         {'pattern': 'https://zulip.readthedocs.io/en/latest/[a-zA-Z0-9]',
          'exclude': ['docs/overview/contributing.md', 'docs/overview/readme.md', 'docs/README.md'],
          'include_only': set(['docs/']),
          'description': "Use relative links (../foo/bar.html) to other documents in docs/",
          },
-        {'pattern': '\][(][^#h]',
+        {'pattern': r'\][(][^#h]',
          'include_only': set(['README.md', 'CONTRIBUTING.md']),
          'description': "Use absolute links from docs served by GitHub",
          },

--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -41,7 +41,7 @@ def check_pep8(files):
         'E226',
 
         # New rules in pycodestyle 2.4.0 that we haven't decided whether to comply with yet
-        'E252', 'W605', 'W504',
+        'E252', 'W504',
 
         # "multiple spaces after ':'"
         # This is the `{}` analogue of E221, and these are similarly being used

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3944,7 +3944,7 @@ def encode_email_address_helper(name: str, email_token: str) -> str:
     # everything that isn't alphanumeric plus _ as the percent-prefixed integer
     # ordinal of that character, padded with zeroes to the maximum number of
     # bytes of a UTF-8 encoded Unicode character.
-    encoded_name = re.sub("\W", lambda x: "%" + str(ord(x.group(0))).zfill(4), name)
+    encoded_name = re.sub(r"\W", lambda x: "%" + str(ord(x.group(0))).zfill(4), name)
     encoded_token = "%s+%s" % (encoded_name, email_token)
     return settings.EMAIL_GATEWAY_PATTERN % (encoded_token,)
 
@@ -3975,7 +3975,7 @@ def decode_email_address(email: str) -> Optional[Tuple[str, str]]:
         encoded_stream_name, token = msg_string.split('.')
     else:
         encoded_stream_name, token = msg_string.split('+')
-    stream_name = re.sub("%\d{4}", lambda x: chr(int(x.group(0)[1:])), encoded_stream_name)
+    stream_name = re.sub(r"%\d{4}", lambda x: chr(int(x.group(0)[1:])), encoded_stream_name)
     return stream_name, token
 
 SubHelperT = Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1322,7 +1322,7 @@ def prepare_realm_pattern(source: str) -> str:
     """ Augment a realm filter so it only matches after start-of-string,
     whitespace, or opening delimiters, won't match if there are word
     characters directly after, and saves what was matched as "name". """
-    return r"""(?<![^\s'"\(,:<])(?P<name>""" + source + ')(?!\w)'
+    return r"""(?<![^\s'"\(,:<])(?P<name>""" + source + r')(?!\w)'
 
 # Given a regular expression pattern, linkifies groups that match it
 # using the provided format string to construct the URL.

--- a/zerver/lib/emoji.py
+++ b/zerver/lib/emoji.py
@@ -114,7 +114,7 @@ def check_emoji_admin(user_profile: UserProfile, emoji_name: Optional[str]=None)
         raise JsonableError(_("Must be an organization administrator or emoji author"))
 
 def check_valid_emoji_name(emoji_name: str) -> None:
-    if re.match('^[0-9a-z.\-_]+(?<![.\-_])$', emoji_name):
+    if re.match(r'^[0-9a-z.\-_]+(?<![.\-_])$', emoji_name):
         return
     raise JsonableError(_("Invalid characters in emoji name"))
 

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -120,7 +120,7 @@ def fix_emojis(content: str, base_url: str, emojiset: str) -> str:
     def make_emoji_img_elem(emoji_span_elem: CSSSelector) -> Dict[str, Any]:
         # Convert the emoji spans to img tags.
         classes = emoji_span_elem.get('class')
-        match = re.search('emoji-(?P<emoji_code>\S+)', classes)
+        match = re.search(r'emoji-(?P<emoji_code>\S+)', classes)
         # re.search is capable of returning None,
         # but since the parent function should only be called with a valid css element
         # we assert that it does not.

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -444,7 +444,7 @@ def get_mobile_push_content(rendered_content: str) -> str:
         # Convert default emojis to their unicode equivalent.
         classes = elem.get("class", "")
         if "emoji" in classes:
-            match = re.search("emoji-(?P<emoji_code>\S+)", classes)
+            match = re.search(r"emoji-(?P<emoji_code>\S+)", classes)
             if match:
                 emoji_code = match.group('emoji_code')
                 char_repr = ""

--- a/zerver/lib/subdomains.py
+++ b/zerver/lib/subdomains.py
@@ -23,7 +23,7 @@ def get_subdomain(request: HttpRequest) -> str:
 
     host = request.get_host().lower()
 
-    m = re.search('\.%s(:\d+)?$' % (settings.EXTERNAL_HOST,),
+    m = re.search(r'\.%s(:\d+)?$' % (settings.EXTERNAL_HOST,),
                   host)
     if m:
         subdomain = host[:m.start()]
@@ -32,7 +32,7 @@ def get_subdomain(request: HttpRequest) -> str:
         return subdomain
 
     for subdomain, realm_host in settings.REALM_HOSTS.items():
-        if re.search('^%s(:\d+)?$' % (realm_host,),
+        if re.search(r'^%s(:\d+)?$' % (realm_host,),
                      host):
             return subdomain
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -353,7 +353,7 @@ class ZulipTestCase(TestCase):
         from django.core.mail import outbox
         if url_pattern is None:
             # This is a bit of a crude heuristic, but good enough for most tests.
-            url_pattern = settings.EXTERNAL_HOST + "(\S+)>"
+            url_pattern = settings.EXTERNAL_HOST + r"(\S+)>"
         for message in reversed(outbox):
             if email_address in message.to:
                 return re.search(url_pattern, message.body).groups()[0]

--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -20,7 +20,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 from scripts.lib.zulip_tools import get_dev_uuid_var_path, run
 
 UUID_VAR_DIR = get_dev_uuid_var_path()
-FILENAME_SPLITTER = re.compile('[\W\-_]')
+FILENAME_SPLITTER = re.compile(r'[\W\-_]')
 
 def run_db_migrations(platform: str) -> None:
     if platform == 'dev':
@@ -85,10 +85,10 @@ def get_migration_status(**options: Any) -> str:
     connections.close_all()
     out.seek(0)
     output = out.read()
-    return re.sub('\x1b\[(1|0)m', '', output)
+    return re.sub(r'\x1b\[(1|0)m', '', output)
 
 def extract_migrations_as_list(migration_status: str) -> List[str]:
-    MIGRATIONS_RE = re.compile('\[[X| ]\] (\d+_.+)\n')
+    MIGRATIONS_RE = re.compile(r'\[[X| ]\] (\d+_.+)\n')
     return MIGRATIONS_RE.findall(migration_status)
 
 def what_to_do_with_migrations(migration_file: str, **options: Any) -> str:

--- a/zerver/lib/tex.py
+++ b/zerver/lib/tex.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from typing import Optional
 
 def render_tex(tex: str, is_inline: bool=True) -> Optional[str]:
-    """Render a TeX string into HTML using KaTeX
+    r"""Render a TeX string into HTML using KaTeX
 
     Returns the HTML string, or None if there was some error in the TeX syntax
 

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -53,10 +53,10 @@ DEFAULT_EMOJI_SIZE = 64
 class RealmUploadQuotaError(JsonableError):
     code = ErrorCode.REALM_UPLOAD_QUOTA
 
-attachment_url_re = re.compile('[/\-]user[\-_]uploads[/\.-].*?(?=[ )]|\Z)')
+attachment_url_re = re.compile(r'[/\-]user[\-_]uploads[/\.-].*?(?=[ )]|\Z)')
 
 def attachment_url_to_path_id(attachment_url: str) -> str:
-    path_id_raw = re.sub('[/\-]user[\-_]uploads[/\.-]', '', attachment_url)
+    path_id_raw = re.sub(r'[/\-]user[\-_]uploads[/\.-]', '', attachment_url)
     # Remove any extra '.' after file extension. These are probably added by the user
     return re.sub('[.]+$', '', path_id_raw, re.M)
 
@@ -72,8 +72,8 @@ def sanitize_name(value: NonBinaryStr) -> str:
     * preserving the case of the value.
     """
     value = unicodedata.normalize('NFKC', value)
-    value = re.sub('[^\w\s._-]', '', value, flags=re.U).strip()
-    return mark_safe(re.sub('[-\s]+', '-', value, flags=re.U))
+    value = re.sub(r'[^\w\s._-]', '', value, flags=re.U).strip()
+    return mark_safe(re.sub(r'[-\s]+', '-', value, flags=re.U))
 
 def random_name(bytes: int=60) -> str:
     return base64.urlsafe_b64encode(os.urandom(bytes)).decode('utf-8')

--- a/zerver/management/commands/compilemessages.py
+++ b/zerver/management/commands/compilemessages.py
@@ -67,7 +67,7 @@ class Command(compilemessages.Command):
         return "{}/{}/translations.json".format(locale_path, locale)
 
     def get_name_from_po_file(self, po_filename: str, locale: str) -> str:
-        lang_name_re = re.compile('"Language-Team: (.*?) \(')
+        lang_name_re = re.compile(r'"Language-Team: (.*?) \(')
         with open(po_filename, 'r') as reader:
             result = lang_name_re.search(reader.read())
             if result:
@@ -82,7 +82,7 @@ class Command(compilemessages.Command):
     def get_locales(self) -> List[str]:
         tracked_files = check_output(['git', 'ls-files', 'static/locale'])
         tracked_files = tracked_files.decode().split()
-        regex = re.compile('static/locale/(\w+)/LC_MESSAGES/django.po')
+        regex = re.compile(r'static/locale/(\w+)/LC_MESSAGES/django.po')
         locales = ['en']
         for tracked_file in tracked_files:
             matched = regex.search(tracked_file)

--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -48,19 +48,19 @@ strip_whitespace_right = re.compile("(%s-?\\s*(trans|pluralize).*?-%s)\\s+" % (
 strip_whitespace_left = re.compile("\\s+(%s-\\s*(endtrans|pluralize).*?-?%s)" % (
                                    BLOCK_TAG_START, BLOCK_TAG_END), re.U)
 
-regexes = ['{{#tr .*?}}([\s\S]*?){{/tr}}',  # '.' doesn't match '\n' by default
-           '{{\s*t "(.*?)"\W*}}',
-           "{{\s*t '(.*?)'\W*}}",
-           "i18n\.t\('([^\']*?)'\)",
-           "i18n\.t\('(.*?)',\s*.*?[^,]\)",
-           'i18n\.t\("([^\"]*?)"\)',
-           'i18n\.t\("(.*?)",\s*.*?[^,]\)',
+regexes = [r'{{#tr .*?}}([\s\S]*?){{/tr}}',  # '.' doesn't match '\n' by default
+           r'{{\s*t "(.*?)"\W*}}',
+           r"{{\s*t '(.*?)'\W*}}",
+           r"i18n\.t\('([^']*?)'\)",
+           r"i18n\.t\('(.*?)',\s*.*?[^,]\)",
+           r'i18n\.t\("([^"]*?)"\)',
+           r'i18n\.t\("(.*?)",\s*.*?[^,]\)',
            ]
 tags = [('err_', "error"),
         ]
 
 frontend_compiled_regexes = [re.compile(regex) for regex in regexes]
-multiline_js_comment = re.compile("/\*.*?\*/", re.DOTALL)
+multiline_js_comment = re.compile(r"/\*.*?\*/", re.DOTALL)
 singleline_js_comment = re.compile("//.*?\n")
 
 def strip_whitespaces(src: str) -> str:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -513,7 +513,7 @@ def filter_format_validator(value: str) -> None:
 
     if not regex.match(value):
         raise ValidationError('URL format string must be in the following format: '
-                              '`https://example.com/%(\w+)s`')
+                              r'`https://example.com/%(\w+)s`')
 
 class RealmFilter(models.Model):
     realm = models.ForeignKey(Realm, on_delete=CASCADE)  # type: Realm

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -318,7 +318,7 @@ class HomeTest(ZulipTestCase):
     def _get_page_params(self, result: HttpResponse) -> Dict[str, Any]:
         html = result.content.decode('utf-8')
         lines = html.split('\n')
-        page_params_line = [l for l in lines if re.match('^\s*var page_params', l)][0]
+        page_params_line = [l for l in lines if re.match(r'^\s*var page_params', l)][0]
         page_params_json = page_params_line.split(' = ')[1].rstrip(';')
         page_params = ujson.loads(page_params_json)
         return page_params

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -214,7 +214,7 @@ class TestGenerateRealmCreationLink(ZulipTestCase):
         self.assertIsNone(get_realm('test'))
         result = self.client_post(generated_link, {'email': email})
         self.assertEqual(result.status_code, 302)
-        self.assertTrue(re.search('/accounts/do_confirm/\w+$', result["Location"]))
+        self.assertTrue(re.search(r'/accounts/do_confirm/\w+$', result["Location"]))
 
         # Bypass sending mail for confirmation, go straight to creation form
         result = self.client_get(result["Location"])

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -38,7 +38,7 @@ class SlowQueryTest(ZulipTestCase):
         self.assertIn("logs", str(last_message.recipient))
         self.assertEqual(last_message.topic_name(), "testserver: slow queries")
         self.assertRegexpMatches(last_message.content,
-                                 "123\.456\.789\.012 SOCKET  200 10\.\ds .*")
+                                 r"123\.456\.789\.012 SOCKET  200 10\.\ds .*")
 
     @override_settings(ERROR_BOT=None)
     @patch('logging.info')

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -55,7 +55,7 @@ def get_sqlalchemy_query_params(query: str) -> Dict[str, str]:
     return comp.params
 
 def fix_ws(s: str) -> str:
-    return re.sub('\s+', ' ', str(s)).strip()
+    return re.sub(r'\s+', ' ', str(s)).strip()
 
 def get_recipient_id_for_stream_name(realm: Realm, stream_name: str) -> str:
     stream = get_stream(stream_name, realm)
@@ -2020,7 +2020,7 @@ class GetOldMessagesTest(ZulipTestCase):
             queries = [q for q in all_queries if '/* get_messages */' in q['sql']]
             sql = queries[0]['sql']
 
-            m = re.findall('AND message_id >= (\d+)', str(sql))
+            m = re.findall(r'AND message_id >= (\d+)', str(sql))
             self.assertEqual(m, [str(first_visible_message_id)])
 
     def test_use_first_unread_anchor_with_muted_topics(self) -> None:

--- a/zerver/tests/test_notifications.py
+++ b/zerver/tests/test_notifications.py
@@ -491,7 +491,7 @@ class TestMissedMessages(ZulipTestCase):
         for test_name in test_fixtures:
             test_data = test_fixtures[test_name]["expected_output"]
             output_data = relative_to_full_url("http://example.com", test_data)
-            if re.search("(?<=\=['\"])/(?=[^<]+>)", output_data) is not None:
+            if re.search(r"""(?<=\=['"])/(?=[^<]+>)""", output_data) is not None:
                 raise AssertionError("Relative URL present in email: " + output_data +
                                      "\nFailed test case's name is: " + test_name +
                                      "\nIt is present in markdown_test_cases.json")

--- a/zerver/tests/test_realm_filters.py
+++ b/zerver/tests/test_realm_filters.py
@@ -30,16 +30,16 @@ class RealmFilterTest(ZulipTestCase):
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_error(result, 'Invalid filter pattern, you must use the following format OPTIONAL_PREFIX(?P<id>.+)')
 
-        data['pattern'] = 'ZUL-(?P<id>\d++)'
+        data['pattern'] = r'ZUL-(?P<id>\d++)'
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_error(result, 'Invalid filter pattern, you must use the following format OPTIONAL_PREFIX(?P<id>.+)')
 
-        data['pattern'] = 'ZUL-(?P<id>\d+)'
+        data['pattern'] = r'ZUL-(?P<id>\d+)'
         data['url_format_string'] = '$fgfg'
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_error(result, 'Enter a valid URL.')
 
-        data['pattern'] = 'ZUL-(?P<id>\d+)'
+        data['pattern'] = r'ZUL-(?P<id>\d+)'
         data['url_format_string'] = 'https://realm.com/my_realm_filter/'
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_error(result, 'URL format string must be in the following format: `https://example.com/%(\\w+)s`')
@@ -48,7 +48,7 @@ class RealmFilterTest(ZulipTestCase):
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_success(result)
 
-        data['pattern'] = 'ZUL2-(?P<id>\d+)'
+        data['pattern'] = r'ZUL2-(?P<id>\d+)'
         data['url_format_string'] = 'https://realm.com/my_realm_filter/?value=%(id)s'
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_success(result)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -187,7 +187,7 @@ class PasswordResetTest(ZulipTestCase):
 
         # Visit the password reset link.
         password_reset_url = self.get_confirmation_url_from_outbox(
-            email, url_pattern=settings.EXTERNAL_HOST + "(\S+)")
+            email, url_pattern=settings.EXTERNAL_HOST + r"(\S+)")
         result = self.client_get(password_reset_url)
         self.assertEqual(result.status_code, 200)
 
@@ -2268,7 +2268,7 @@ class UserSignUpTest(ZulipTestCase):
         from django.core.mail import outbox
         for message in reversed(outbox):
             if email in message.to:
-                confirmation_link_pattern = re.compile(settings.EXTERNAL_HOST + "(\S+)>")
+                confirmation_link_pattern = re.compile(settings.EXTERNAL_HOST + r"(\S+)>")
                 confirmation_url = confirmation_link_pattern.search(
                     message.body).groups()[0]
                 break
@@ -2645,7 +2645,7 @@ class UserSignUpTest(ZulipTestCase):
         from django.core.mail import outbox
         for message in reversed(outbox):
             if email in message.to:
-                confirmation_link_pattern = re.compile(settings.EXTERNAL_HOST + "(\S+)>")
+                confirmation_link_pattern = re.compile(settings.EXTERNAL_HOST + r"(\S+)>")
                 confirmation_url = confirmation_link_pattern.search(
                     message.body).groups()[0]
                 break
@@ -2705,7 +2705,7 @@ class UserSignUpTest(ZulipTestCase):
         from django.core.mail import outbox
         for message in reversed(outbox):
             if email in message.to:
-                confirmation_link_pattern = re.compile(settings.EXTERNAL_HOST + "(\S+)>")
+                confirmation_link_pattern = re.compile(settings.EXTERNAL_HOST + r"(\S+)>")
                 confirmation_url = confirmation_link_pattern.search(
                     message.body).groups()[0]
                 break

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -114,11 +114,11 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(get_admin(user_data[3]), False)
 
     def test_get_timezone(self) -> None:
-        user_chicago_timezone = {"tz": r"America\/Chicago"}
+        user_chicago_timezone = {"tz": "America/Chicago"}
         user_timezone_none = {"tz": None}
         user_no_timezone = {}  # type: Dict[str, Any]
 
-        self.assertEqual(get_user_timezone(user_chicago_timezone), r"America\/Chicago")
+        self.assertEqual(get_user_timezone(user_chicago_timezone), "America/Chicago")
         self.assertEqual(get_user_timezone(user_timezone_none), "America/New_York")
         self.assertEqual(get_user_timezone(user_no_timezone), "America/New_York")
 
@@ -145,7 +145,7 @@ class SlackImporter(ZulipTestCase):
                       'name': 'Jane',
                       "real_name": "Jane Doe",
                       "deleted": False,
-                      "profile": {"image_32": r"https:\/\/secure.gravatar.com\/avatar\/random.png",
+                      "profile": {"image_32": "https://secure.gravatar.com/avatar/random.png",
                                   "fields": custom_profile_field_user2,
                                   "email": "jane@foo.com", "avatar_hash": "hash"}},
                      {"id": "U09TYF5Sk",
@@ -154,7 +154,7 @@ class SlackImporter(ZulipTestCase):
                       "real_name": "Bot",
                       "is_bot": True,
                       "deleted": False,
-                      "profile": {"image_32": r"https:\/\/secure.gravatar.com\/avatar\/random1.png",
+                      "profile": {"image_32": "https://secure.gravatar.com/avatar/random1.png",
                                   "skype": "test_skype_name",
                                   "email": "bot1@zulipchat.com", "avatar_hash": "hash"}}]
 

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -114,11 +114,11 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(get_admin(user_data[3]), False)
 
     def test_get_timezone(self) -> None:
-        user_chicago_timezone = {"tz": "America\/Chicago"}
+        user_chicago_timezone = {"tz": r"America\/Chicago"}
         user_timezone_none = {"tz": None}
         user_no_timezone = {}  # type: Dict[str, Any]
 
-        self.assertEqual(get_user_timezone(user_chicago_timezone), "America\/Chicago")
+        self.assertEqual(get_user_timezone(user_chicago_timezone), r"America\/Chicago")
         self.assertEqual(get_user_timezone(user_timezone_none), "America/New_York")
         self.assertEqual(get_user_timezone(user_no_timezone), "America/New_York")
 
@@ -145,7 +145,7 @@ class SlackImporter(ZulipTestCase):
                       'name': 'Jane',
                       "real_name": "Jane Doe",
                       "deleted": False,
-                      "profile": {"image_32": "https:\/\/secure.gravatar.com\/avatar\/random.png",
+                      "profile": {"image_32": r"https:\/\/secure.gravatar.com\/avatar\/random.png",
                                   "fields": custom_profile_field_user2,
                                   "email": "jane@foo.com", "avatar_hash": "hash"}},
                      {"id": "U09TYF5Sk",
@@ -154,7 +154,7 @@ class SlackImporter(ZulipTestCase):
                       "real_name": "Bot",
                       "is_bot": True,
                       "deleted": False,
-                      "profile": {"image_32": "https:\/\/secure.gravatar.com\/avatar\/random1.png",
+                      "profile": {"image_32": r"https:\/\/secure.gravatar.com\/avatar\/random1.png",
                                   "skype": "test_skype_name",
                                   "email": "bot1@zulipchat.com", "avatar_hash": "hash"}}]
 

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -124,7 +124,7 @@ class TemplateTestCase(ZulipTestCase):
 
         # Since static/generated/bots/ is searched by Jinja2 for templates,
         # it mistakes logo files under that directory for templates.
-        bot_logos_regexp = re.compile('\w+\/logo\.(svg|png)$')
+        bot_logos_regexp = re.compile(r'\w+\/logo\.(svg|png)$')
 
         skip = covered + defer + logged_out + logged_in + unusual + ['tests/test_markdown.html',
                                                                      'zerver/terms.html',

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1483,7 +1483,7 @@ class SanitizeNameTests(TestCase):
         self.assertEqual(sanitize_name(u'*testingfile?*.txt'), u'testingfile.txt')
         self.assertEqual(sanitize_name(u'snowman☃.txt'), u'snowman.txt')
         self.assertEqual(sanitize_name(u'테스트.txt'), u'테스트.txt')
-        self.assertEqual(sanitize_name(u'~/."\`\?*"u0`000ssh/test.t**{}ar.gz'), u'.u0000sshtest.tar.gz')
+        self.assertEqual(sanitize_name(u'~/."\\`\\?*"u0`000ssh/test.t**{}ar.gz'), u'.u0000sshtest.tar.gz')
 
 
 class UploadSpaceTests(UploadSerializeMixin, ZulipTestCase):

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -384,7 +384,7 @@ class NarrowBuilder:
         # search here so we can ignore punctuation and do
         # stemming, but there isn't a standard phrase search
         # mechanism in Postgres
-        for term in re.findall('"[^"]+"|\S+', operand):
+        for term in re.findall(r'"[^"]+"|\S+', operand):
             if term[0] == '"' and term[-1] == '"':
                 term = term[1:-1]
                 term = '%' + connection.ops.prep_for_like_query(term) + '%'

--- a/zerver/webhooks/appfollow/view.py
+++ b/zerver/webhooks/appfollow/view.py
@@ -16,7 +16,7 @@ from zerver.models import UserProfile
 def api_appfollow_webhook(request: HttpRequest, user_profile: UserProfile,
                           payload: Dict[str, Any]=REQ(argument_type="body")) -> HttpResponse:
     message = payload["text"]
-    app_name_search = re.search('\A(.+)', message)
+    app_name_search = re.search(r'\A(.+)', message)
     assert app_name_search is not None
     app_name = app_name_search.group(0)
     topic = app_name

--- a/zerver/webhooks/github_legacy/view.py
+++ b/zerver/webhooks/github_legacy/view.py
@@ -267,7 +267,7 @@ def api_github_landing(request: HttpRequest, user_profile: UserProfile, event: s
     if event == 'push':
         # If we are given a whitelist of branches, then we silently ignore
         # any push notification on a branch that is not in our whitelist.
-        if branches and short_ref not in re.split('[\s,;|]+', branches):
+        if branches and short_ref not in re.split(r'[\s,;|]+', branches):
             return json_success()
 
     # Map payload to the handler with the right version

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -75,7 +75,7 @@ def convert_jira_markup(content: str, realm: Realm) -> str:
     # Zulip user mention. We don't know the email, just the JIRA username,
     # so we naively guess at their Zulip account using this
     if realm:
-        mention_re = re.compile(u'\[~(.*?)\]')
+        mention_re = re.compile(u'\\[~(.*?)\\]')
         for username in mention_re.findall(content):
             # Try to look up username
             user_profile = guess_zulip_user_from_jira(username, realm)
@@ -103,7 +103,7 @@ def get_issue_string(payload: Dict[str, Any], issue_id: Optional[str]=None) -> s
     if issue_id is None:
         issue_id = get_issue_id(payload)
 
-    base_url = re.match("(.*)\/rest\/api/.*", get_in(payload, ['issue', 'self']))
+    base_url = re.match(r"(.*)\/rest\/api/.*", get_in(payload, ['issue', 'self']))
     if base_url and len(base_url.groups()):
         return u"[{}]({}/browse/{})".format(issue_id, base_url.group(1), issue_id)
     else:

--- a/zilencer/management/commands/add_mock_conversation.py
+++ b/zilencer/management/commands/add_mock_conversation.py
@@ -55,7 +55,7 @@ From image editing program:
              "You can have:\n* bulleted lists\n  * with sub-bullets too\n"
              "* **bold**, *italic*, and ~~strikethrough~~ text\n"
              "* LaTeX for mathematical formulas, both inline -- $$O(n^2)$$ -- and displayed:\n"
-             "```math\n\\int_a^b f(t)\, dt=F(b)-F(a)\n```"},
+             "```math\n\\int_a^b f(t)\\, dt=F(b)-F(a)\n```"},
             {'sender': fisher,
              'content': "My favorite is the syntax highlighting for code blocks\n"
              "```python\ndef fib(n: int) -> int:\n    # returns the n-th Fibonacci number\n"


### PR DESCRIPTION
The only changes visible at the AST level, checked using https://github.com/asottile/astpretty, are

```
zerver/lib/test_fixtures.py:
'\x1b\\[(1|0)m' ↦ '\\x1b\\[(1|0)m'
'\\[[X| ]\\] (\\d+_.+)\n' ↦ '\\[[X| ]\\] (\\d+_.+)\\n'
```

which is fine because `re` treats `'\\x1b'` and `'\\n'` the same way as `'\x1b'` and `'\n'`.