### PR TITLE
Add /settings command (split out from #9754)

### DIFF
--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -87,6 +87,11 @@ exports.process = function (message_content) {
         return true;
     }
 
+    if (content === '/settings') {
+        window.location.hash = 'settings/your-account';
+        return true;
+    }
+
     // It is incredibly important here to return false
     // if we don't see an actual zcommand, so that compose.js
     // knows this is a normal message.

--- a/zerver/lib/zcommand.py
+++ b/zerver/lib/zcommand.py
@@ -6,7 +6,9 @@ from zerver.lib.actions import do_set_user_display_setting
 from zerver.lib.exceptions import JsonableError
 
 def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]:
-    command = content.replace('/', '')
+    if not content.startswith('/'):
+        raise JsonableError(_('There should be a leading slash in the zcommand.'))
+    command = content[1:]
 
     if command == 'ping':
         ret = dict()  # type: Dict[str, Any]

--- a/zerver/tests/test_zcommand.py
+++ b/zerver/tests/test_zcommand.py
@@ -13,6 +13,10 @@ class ZcommandTest(ZulipTestCase):
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_error(result, "No such command: boil-ocean")
 
+        payload = dict(command="boil-ocean")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_error(result, "There should be a leading slash in the zcommand.")
+
     def test_ping_zcommand(self) -> None:
         self.login(self.example_email("hamlet"))
 


### PR DESCRIPTION
I am splitting out two commands from #9754, which is blocked for the more complicated muting feature.