### PR TITLE
user docs: Fix some wording in desktop notifications doc.

### DIFF
--- a/templates/zerver/help/configure-desktop-notifications.md
+++ b/templates/zerver/help/configure-desktop-notifications.md
@@ -1,7 +1,7 @@
 # Configure desktop notifications
 
-You can receive desktop notifications for messages sent while Zulip is
-offscreen.
+You can receive desktop notifications in the corner of your main monitor for
+messages sent while Zulip is offscreen.
 
 ## Stream messages
 
@@ -37,7 +37,7 @@ to allow Zulip to send you desktop notifications.
 
 ### Zulip Desktop app on Mac OS
 
-1. From your desktop, open **System Notifications** and select **Notifications**.
+1. From your desktop, open **System Preferences** and select **Notifications**.
 
 2. Select **Zulip** from the list of apps.
 
@@ -80,3 +80,4 @@ to allow Zulip to send you desktop notifications.
 
 5. Paste the Zulip URL for your organization into the site field, and click
     **Add**.
+

--- a/templates/zerver/help/include/stream-actions.md
+++ b/templates/zerver/help/include/stream-actions.md
@@ -1,3 +1,2 @@
-1. On the left sidebar in the **Streams** section, hover over a stream to reveal
-a down chevron (<i class="icon-vector-chevron-down"></i>) icon to the right of
-the stream name.
+1. On the left sidebar, hover over a stream name to reveal
+a down chevron (<i class="icon-vector-chevron-down"></i>) to the right.

--- a/templates/zerver/help/mute-a-stream.md
+++ b/templates/zerver/help/mute-a-stream.md
@@ -1,24 +1,28 @@
 # Mute a stream
 
-If you would like to stop receiving notifications from a certain stream, you can
-choose to mute it. You can also [mute individual topics](/help/mute-a-topic).
+Muted streams do not show up in **All messages** unless you are @-mentioned.
+Muted streams do not generate alert word notifications. Muted
+streams appear grayed out in the left sidebar. Unread
+counts of muted streams still appear next to the stream name in the left
+sidebar.
+
+## Mute a stream
 
 {!stream-actions.md!}
 
-2. Click on the {!down-chevron.md!} Select the **Mute the stream (stream name)**
-option from the actions dropdown.
+2. Click on the {!down-chevron.md!}.
 
-3. Upon selecting the **Mute the stream (stream name)** option, the selected
-stream will be grayed out in the left sidebar, confirming the success of your
-muting.
+3. Select **Mute the stream (stream name)**.
+
 
 ## Unmute a stream
 
 {!stream-actions.md!}
 
-2. Click on the {!down-chevron.md!} Select the **Unmute the stream (stream name)**
-option from the actions dropdown.
+2. Click on the {!down-chevron.md!}.
 
-3. Upon selecting the **Unmute the stream (stream name)** option, the selected
-stream will stop being grayed out in the left sidebar, confirming the success
-of your unmuting.
+3. Select the **Unmute the stream (stream name)**.
+
+## Related Articles
+
+[Mute individual topics](/help/mute-a-topic)


### PR DESCRIPTION
Addresses @akashnimare 's comment in the troubleshooting docs, and adds a little bit of explanation of what desktop notifications are. 
