### PR TITLE
bot settings: Fix bugs w/errors and reactivation.

### DIFF
--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -1,10 +1,9 @@
 zrequire('people');
 zrequire('bot_data');
 
-set_global('$', () => {
-    return {trigger: () => {}};
+set_global('settings_bots', {
+    render_bots: () => {},
 });
-set_global('document', null);
 
 const page_params = {
     realm_bots: [{email: 'bot0@zulip.com', user_id: 42, full_name: 'Bot 0'},

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -16,7 +16,6 @@ set_global("avatar", {});
 
 set_global('$', global.make_zjquery());
 set_global('i18n', global.stub_i18n);
-set_global('document', 'document-stub');
 
 zrequire('bot_data');
 zrequire('settings_bots');

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -12,7 +12,7 @@ var bot_data = (function () {
                            'config_data', 'service_name', 'token'];
 
     var send_change_event = _.debounce(function () {
-        $(document).trigger('zulip.bot_data_changed');
+        settings_bots.render_bots();
     }, 50);
 
     var set_can_admin = function bot_data__set_can_admin(bot) {

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -2,6 +2,11 @@ var settings_bots = (function () {
 
 var exports = {};
 
+exports.hide_errors = function () {
+    $('#bot_table_error').hide();
+    $('.bot_error').hide();
+};
+
 var focus_tab = {
     add_a_new_bot_tab: function () {
         $("#bots_lists_navbar .active").removeClass("active");
@@ -9,7 +14,7 @@ var focus_tab = {
         $("#add-a-new-bot-form").show();
         $("#active_bots_list").hide();
         $("#inactive_bots_list").hide();
-        $('#bot_table_error').hide();
+        exports.hide_errors();
     },
     active_bots_tab: function () {
         $("#bots_lists_navbar .active").removeClass("active");
@@ -17,7 +22,7 @@ var focus_tab = {
         $("#add-a-new-bot-form").hide();
         $("#active_bots_list").show();
         $("#inactive_bots_list").hide();
-        $('#bot_table_error').hide();
+        exports.hide_errors();
     },
     inactive_bots_tab: function () {
         $("#bots_lists_navbar .active").removeClass("active");
@@ -25,12 +30,23 @@ var focus_tab = {
         $("#add-a-new-bot-form").hide();
         $("#active_bots_list").hide();
         $("#inactive_bots_list").show();
-        $('#bot_table_error').hide();
+        exports.hide_errors();
     },
 };
 
+exports.get_bot_info_div = function (bot_id) {
+    var sel = '.bot_info[data-user-id="' + bot_id + '"]';
+    return $(sel).expectOne();
+};
+
+exports.bot_error = function (bot_id, xhr) {
+    var bot_info = exports.get_bot_info_div(bot_id);
+    var bot_error_div = bot_info.find('.bot_error');
+    bot_error_div.text(JSON.parse(xhr.responseText).msg);
+    bot_error_div.show();
+};
+
 function add_bot_row(info) {
-    info.id_suffix = _.uniqueId('_bot_');
     var row = $(templates.render('bot_avatar_row', info));
     if (info.is_active) {
         $('#active_bots_list').append(row);
@@ -174,7 +190,7 @@ exports.update_bot_settings_tip = function () {
 
 exports.update_bot_permissions_ui = function () {
     exports.update_bot_settings_tip();
-    $('#bot_table_error').hide();
+    exports.hide_errors();
     $("#id_realm_bot_creation_policy").val(page_params.realm_bot_creation_policy);
     if (!exports.can_create_new_bots()) {
         $('#create_bot_form').hide();
@@ -227,7 +243,7 @@ exports.set_up = function () {
     $('#create_bot_form').validate({
         errorClass: 'text-error',
         success: function () {
-            $('#bot_table_error').hide();
+            exports.hide_errors();
         },
         submitHandler: function () {
             var bot_type = $('#create_bot_type :selected').val();
@@ -267,7 +283,7 @@ exports.set_up = function () {
                 processData: false,
                 contentType: false,
                 success: function () {
-                    $('#bot_table_error').hide();
+                    exports.hide_errors();
                     $('#create_bot_name').val('');
                     $('#create_bot_short_name').val('');
                     $('#create_payload_url').val('');
@@ -332,7 +348,7 @@ exports.set_up = function () {
                 row.hide('slow', function () { row.remove(); });
             },
             error: function (xhr) {
-                $('#bot_delete_error').text(JSON.parse(xhr.responseText).msg).show();
+                exports.bot_error(bot_id, xhr);
             },
         });
     });
@@ -343,7 +359,7 @@ exports.set_up = function () {
         channel.post({
             url: '/json/users/' + encodeURIComponent(user_id) + "/reactivate",
             error: function (xhr) {
-                $('#bot_delete_error').text(JSON.parse(xhr.responseText).msg).show();
+                exports.bot_error(user_id, xhr);
             },
         });
     });

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -51,7 +51,7 @@ exports.type_id_to_string = function (type_id) {
     return i18n.t(name);
 };
 
-function render_bots() {
+exports.render_bots = function () {
     $('#active_bots_list').empty();
     $('#inactive_bots_list').empty();
 
@@ -92,7 +92,7 @@ function render_bots() {
         $("#active_bots_list").hide();
         $("#inactive_bots_list").show();
     }
-}
+};
 
 exports.generate_zuliprc_uri = function (bot_id) {
     var bot = bot_data.get(bot_id);
@@ -208,9 +208,7 @@ exports.set_up = function () {
         $(this).attr("href", "data:application/octet-stream;charset=utf-8," + encodeURIComponent(content));
     });
 
-    // TODO: render bots xxxx
-    render_bots();
-    $(document).on('zulip.bot_data_changed', render_bots);
+    exports.render_bots();
 
     $.validator.addMethod("bot_local_part",
                           function (value, element) {

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -41,7 +41,7 @@
         </div>
         <div id="bot_delete_error{{id_suffix}}" class="alert alert-error hide"></div>
         {{else}}
-        <button class="button round btn-warning reactivate_bot" title="{{t 'Reactivate bot' }}" data-email="{{email}}">{{t "Reactivate bot" }}</button>
+        <button class="button round btn-warning reactivate_bot" title="{{t 'Reactivate bot' }}" data-user-id="{{user_id}}">{{t "Reactivate bot" }}</button>
         {{/if}}
     </div>
 </li>

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -39,9 +39,9 @@
             </span>
             <div class="api_key_error text-error"></div>
         </div>
-        <div id="bot_delete_error{{id_suffix}}" class="alert alert-error hide"></div>
         {{else}}
         <button class="button round btn-warning reactivate_bot" title="{{t 'Reactivate bot' }}" data-user-id="{{user_id}}">{{t "Reactivate bot" }}</button>
         {{/if}}
+        <div class="bot_error alert alert-error hide"></div>
     </div>
 </li>


### PR DESCRIPTION
Testing reactivation is easy--just delete the bot, go the Inactive tab, and reactivate.

For testing error handling you can simulate errors by putting `return json_error('foo')` at the top of `deactivate_bot_backend` or `reactivate_user_backend`.  Then use the trash can icon to delete or the "Reactivate" button to reactivate.

We may just want to use a single error area for all bot errors; this fix just tries to make the code work as originally intended.