### PR TITLE
left sidebar: Re-narrow after initial streams list rebuild after reload.

### DIFF
--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -28,7 +28,9 @@ set_global('narrow_state', {});
 set_global('pm_list', {});
 set_global('resize', {});
 set_global('server_events', {});
-set_global('stream_list', {});
+set_global('stream_list', {
+    maybe_scroll_narrow_into_view: () => {},
+});
 
 muting.is_topic_muted = function () { return false; };
 resize.resize_bottom_whitespace = noop;

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -51,6 +51,7 @@ function process_result(data, opts) {
     activity.process_loaded_messages(messages);
     stream_list.update_streams_sidebar();
     pm_list.update_private_messages();
+    stream_list.maybe_scroll_narrow_into_view();
 
     if (opts.cont !== undefined) {
         opts.cont(data);

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -2,6 +2,8 @@ var stream_list = (function () {
 
 var exports = {};
 
+var has_scrolled = false;
+
 exports.update_count_in_dom = function (unread_count_elem, count) {
     var count_span = unread_count_elem.find('.count');
     var value_span = count_span.find('.value');
@@ -523,6 +525,13 @@ exports.initialize = function () {
         exports.toggle_filter_displayed(e);
     });
 
+    // check for user scrolls on streams list for first time
+    $('#stream-filters-container').on('scroll', function () {
+        has_scrolled = true;
+        // remove listener once user has scrolled
+        $(this).off('scroll');
+    });
+
     exports.stream_cursor = list_cursor({
         list: {
             container: $('#stream-filters-container'),
@@ -629,6 +638,36 @@ exports.scroll_stream_into_view = function (stream_li) {
     }
 
     scroll_util.scroll_element_into_container(stream_li, container);
+};
+
+exports.maybe_scroll_narrow_into_view = function () {
+    // we don't want to interfere with user scrolling once the page loads
+    if (has_scrolled) {
+        return;
+    }
+
+    var stream_li = stream_list.get_current_stream_li();
+    if (stream_li) {
+        stream_list.scroll_stream_into_view(stream_li);
+    }
+};
+
+exports.get_current_stream_li = function () {
+    var stream_id = topic_list.active_stream_id();
+
+    if (!stream_id) {
+        // stream_id is undefined in non-stream narrows
+        return;
+    }
+
+    var stream_li = stream_list.get_stream_li(stream_id);
+
+    if (!stream_li) {
+        blueslip.warn('No active stream_li found for defined id');
+        return;
+    }
+
+    return stream_li;
 };
 
 return exports;


### PR DESCRIPTION
[![https://gyazo.com/23e85037b880f37a39a5c6e07a065bf7](https://i.gyazo.com/23e85037b880f37a39a5c6e07a065bf7.gif)](https://gyazo.com/23e85037b880f37a39a5c6e07a065bf7)

We use `handle_narrow_activated` instead of `update_sidebar_for_narrow` because the latter doesn't call `scroll_stream_into_view`, resulting in wrong scroll position of the left sidebar after the streams list get rebuilt after reload. `handle_narrow_activated` also calls `update_sidebar_for_narrow`, so there should be no issues in switching to this function.

Fixes #9043.