### PR TITLE
Style upgrade & billing pages

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -3088,6 +3088,95 @@ nav ul li.active::after {
 
     .support-link {
         margin: 10px 20px;
+        a,
+        a:hover,
+        a:visited {
+            color: hsl(170, 47%, 33%);
+            font-weight: 500;
+        }
+    }
+
+    .payment-schedule {
+        label {
+            display: inline-block;
+        }
+        input[type="radio"] {
+            display: none;
+            &:checked {
+                + .box {
+                    background: #69b190;
+                    color: white;
+                    border-color: #438667;
+                }
+            }
+        }
+        .box {
+            width: 100px;
+            height: 70px;
+            background: #efefef;
+            transition: all .2s ease;
+            display: inline-block;
+            text-align: center;
+            cursor: pointer;
+            position: relative;
+            border: 1px solid #e7e7e7;
+            border-radius: 8px;
+            margin: 0 10px 5px 0;
+            padding: 30px 20px;
+            vertical-align: top;
+            &:hover {
+                background: #e7e7e7;
+                border-color: #cbcbcb;
+            }
+            .schedule-time {
+                font-weight: bold;
+                font-size: 1.2em;
+                margin-top: 10px;
+            }
+            .schedule-amount {
+                margin-top: 5px;
+                font-size: 1.1em;
+                height: 50px;
+            }
+            .schedule-amount-2 {
+                font-size: 0.9em;
+            }
+        }
+    }
+
+    .stripe-button-el {
+        padding: 11px 25px 11px 25px;
+        font-weight: 400;
+        color: white;
+        background: #61b1b8;
+        background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
+        box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.2);
+        border: 0;
+        width: 150px;
+        height: 40px;
+        margin: 5px 0 0 0;
+        span {
+            background: 0;
+            box-shadow: none;
+            -webkit-box-shadow: none;
+            font-family: 'Source Sans Pro', Helvetica, Arial;
+            font-size: 1.4em;
+            line-height: 20px;
+        }
+    }
+
+    .stripe-button-el:hover {
+        background: rgb(37, 177, 151);
+        box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.3);
+    }
+
+    .stripe-button-el:active {
+         background: rgb(25, 139, 118);
+         span {
+            background: 0;
+            box-shadow: none;
+            -webkit-box-shadow: none;
+         }
     }
 }
 
@@ -4024,6 +4113,15 @@ nav ul li.active::after {
         opacity: 0.8;
         font-size: 90%;
         text-align: left;
+    }
+
+   .billing-upgrade-page {
+        .payment-schedule {
+            .box {
+                width: 100px;
+                height: 80px;
+            }
+        }
     }
 }
 

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -3036,6 +3036,61 @@ nav ul li.active::after {
     background-color: #3ca08d;
 }
 
+// Billing & Upgrade
+.billing-upgrade-page {
+    font-family: Source Sans Pro, Helvetica, Arial, sans-serif;
+    background: #fafafa;
+    height: 100vh;
+
+    .hero {
+        background: #69b190;
+        color: #69b190;
+        position: absolute;
+        top: 0;
+        width: 100%;
+    }
+
+    .small-hero {
+        padding: 120px 50px 0;
+    }
+
+    .main {
+        width: 800px;
+        max-width: 90%;
+        margin: 0 auto;
+    }
+
+    h1 {
+        margin: 30px 0;
+        font-weight: bold;
+    }
+
+    .nav {
+        margin-bottom: 0;
+    }
+
+    .nav-tabs {
+        border-bottom: 0;
+        font-size: 1.2em;
+        a {
+            font-weight: bold;
+        }
+    }
+
+    .tab-content {
+        border: 1px solid #ddd;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        padding: 20px;
+        background: #fefefe;
+        font-size: 1.1em;
+    }
+
+    .support-link {
+        margin: 10px 20px;
+    }
+}
+
 @keyframes box-shadow-pulse {
     0% {
         box-shadow: 0px 0px 0px rgba(106, 201, 185, 0);
@@ -3646,6 +3701,13 @@ nav ul li.active::after {
 
     .portico-landing.features-app section {
         padding: 0px 20px;
+    }
+
+    .billing-upgrade-page {
+        .nav-tabs,
+        .tab-content {
+            font-size: 1em;
+        }
     }
 
 }

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1786,6 +1786,7 @@ input.new-organization-button {
     margin-bottom: 25px !important;
 }
 
+
 @media (max-width: 1000px) {
     .app.help .markdown {
         width: calc(100vw - 50px);

--- a/templates/zerver/billing_nav.html
+++ b/templates/zerver/billing_nav.html
@@ -1,0 +1,13 @@
+<nav class="portico-header">
+    <div class="content">
+        <a class="brand logo" href="{{ root_domain_uri }}">
+            <svg class="brand-logo" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 40" version="1.1">
+                <g transform="translate(-297.14285,-466.64792)">
+                    <circle cx="317.14285" cy="486.64792" r="19.030317" style="fill:#fff;stroke-width:1.93936479;stroke:transparent"></circle>
+                    <path d="m309.24286 477.14791 14.2 0 1.6 3.9-11.2 11.9 9.6 0 1.6 3.2-14.2 0-1.6-3.9 11.2-11.9-9.6 0z" style="fill:#52c2af;stroke:#52c2af"></path>
+                </g>
+            </svg>
+            <span>Zulip</span>
+        </a>
+    </div>
+</nav>

--- a/templates/zilencer/billing.html
+++ b/templates/zilencer/billing.html
@@ -1,4 +1,4 @@
-{% extends "zerver/base.html" %}
+{% extends "zerver/portico.html" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -6,29 +6,55 @@
 {% endblock %}
 
 {% block content %}
+
 <div class="app portico-page">
+
+    {% include 'zerver/billing_nav.html' %}
 
     {{ render_bundle('translations') }}
 
-    <div class="page-content">
-        <h1>{{ _("Billing") }}</h1>
-        Plan<br/>
-        {{ plan_name }}<br/>
-        <br/>
-        You are paying for {{ seat_count }} users.<br/>
-        Your plan will renew on {{ renewal_date }} for ${{ renewal_amount }}.<br/>
-        {% if prorated_charges %}
-        You have ${{ prorated_charges }} in prorated charges that will be
-        added to your next bill.
-        {% elif prorated_credits %}
-        You have ${{ prorated_credits }} in prorated credits that will be
-        automatically applied to your next bill.
-        {% endif %}
-        <br/>
-        <br/>
-        Payment method: {{ payment_method }}.<br/>
-        <br/>
-        Contact support@zulipchat.com for billing history or to make changes to your subscription.
+    <div class="portico-landing billing-upgrade-page">
+        <div class="hero small-hero"></div>
+
+        <div class="page-content">
+            <div class="main">
+
+                <h1>{{ _("Billing") }}</h1>
+
+                <ul class="nav nav-tabs" id="billing-tabs">
+                    <li class="active"><a href="#overview">Overview</a></li>
+                    <li><a href="#payment-method">Payment Method</a></li>
+                </ul>
+
+                <div class="tab-content">
+                    <div class="tab-pane active" id="overview">
+                        <p>Your current plan is <strong>{{ plan_name }}</strong></p>
+                        <p>You are paying for <strong>{{ seat_count }} users</strong>.</p>
+                        <p>Your plan will renew on <strong>{{ renewal_date }}</strong> for <strong>${{ renewal_amount }}</strong>.</p>
+                        {% if prorated_charges %}
+                        <p>You have <strong>${{ prorated_charges }}</strong> in prorated charges that will be added to your next bill.</p>
+                        {% elif prorated_credits %}
+                        <p>You have <strong>${{ prorated_credits }}</strong> in prorated credits that will be automatically applied to your next bill.</p>
+                        {% endif %}
+                    </div>
+                    <div class="tab-pane" id="payment-method">
+                        <p>Your current payment method is <strong>{{ payment_method }}</strong>.</p>
+                    </div>
+                </div>
+
+                <div class="support-link">
+                    <p>Contact <a href="mailto:support@zulipchat.com">support@zulipchat.com</a> for billing history or to make changes to your subscription.</p>
+                </div>
+
+                <script>
+                $('#billing-tabs a').click(function (e) {
+                    e.preventDefault();
+                    $(this).tab('show');
+                })
+                </script>
+
+            </div>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/templates/zilencer/upgrade.html
+++ b/templates/zilencer/upgrade.html
@@ -1,50 +1,67 @@
-{% extends "zerver/base.html" %}
+{% extends "zerver/portico.html" %}
 
 {% block customhead %}
-{% stylesheet 'portico' %}
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{{ render_bundle('landing-page') }}
 {% endblock %}
 
 {% block content %}
 <div class="app portico-page">
 
+    {% include 'zerver/billing_nav.html' %}
+
     {{ render_bundle('translations') }}
 
-    <div class="page-content">
-        <h1>{% trans %}Upgrade to {{ plan }}{% endtrans %}</h1>
-        <form method="post">
-            {{ csrf_input }}
-            <input type="hidden" name="seat_count" value="{{ seat_count }}">
-            <div class="payment-schedule">
-                <h3>{{ _("Payment schedule") }}</h3>
-                <input type="radio" name="plan" value="{{ nickname_annual }}" checked />
-                {{ _("Pay annually") }} | $80/user/year <br/>
-                <input type="radio" name="plan" value="{{ nickname_monthly }}" />
-                {{ _("Pay monthly") }} | $8/user/month <br/>
+    <div class="portico-landing billing-upgrade-page">
+        <div class="hero small-hero"></div>
+
+        <div class="page-content">
+            <div class="main">
+                <h1>{% trans %}Upgrade to {{ plan }}{% endtrans %}</h1>
+                <form method="post">
+                    {{ csrf_input }}
+                    <input type="hidden" name="seat_count" value="{{ seat_count }}">
+                    <div class="payment-schedule">
+                        <h3>{{ _("Payment schedule") }}</h3>
+                        <label>
+                            <input type="radio" name="plan" value="{{ nickname_annual }}" checked />
+                            <div class="box">
+                                <div class="schedule-time">{{ _("Pay annually") }}</div>
+                                <div class="schedule-amount">
+                                    $6.67/user/month
+                                    <div class="schedule-amount-2">
+                                        ($80/user/year)
+                                    </div>
+                                </div>
+                            </div>
+                        </label>
+                        <label>
+                            <input type="radio" name="plan" value="{{ nickname_monthly }}" />
+                            <div class="box">
+                                <div class="schedule-time">{{ _("Pay monthly") }}</div>
+                                <div class="schedule-amount">$8/user/month</div>
+                            </div>
+                        </label>
+                    </div>
+                    <p>You&rsquo;ll initially be charged <b><span id="charged_amount">XXX</span></b> for <b>{{ seat_count }}</b> users. You&rsquo;ll receive prorated charges and credits as users are added, deactivated, or become inactive.</p>
+                    <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+                    data-key="{{ publishable_key }}"
+                    data-image="/static/images/logo/zulip-icon-128x128.png"
+                    data-name="Zulip"
+                    data-description="Zulip Cloud Premium"
+                    data-locale="auto"
+                    data-zip-code="true"
+                    data-billing-address="true"
+                    data-panel-label="Make payment"
+                    data-email="{{ email }}"
+                    data-label="{{ _('Add card') }}"
+                    data-allow-remember-me="false"
+                    >
+                    </script>
+                </form>
+                <p>We can also bill by invoice for annual contracts over $2,000. Contact <a href="mailto:support@zulipchat.com">support@zulipchat.com</a> to pay by invoice or for any other billing questions.</p>
             </div>
-            <p>
-                You'll initially be charged <b><span id="charged_amount">XXX</span></b>
-                for <b>{{ seat_count }}</b> users. You'll receive prorated charges
-                and credits as users are added, deactivated, or become inactive.
-            </p>
-            <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-                data-key="{{ publishable_key }}"
-                data-image="/static/images/logo/zulip-icon-128x128.png"
-                data-name="Zulip"
-                data-description="Zulip Cloud Premium"
-                data-locale="auto"
-                data-zip-code="true"
-                data-billing-address="true"
-                data-panel-label="Make payment"
-                data-email="{{ email }}"
-                data-label="{{ _('Add card') }}"
-                data-allow-remember-me="false">
-            </script>
-        </form>
-        <p>
-            We can also bill by invoice for annual contracts over
-            $2000. Contact support@zulipchat.com to pay by invoice or for
-            any other billing questions.
-        </p>
+        </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This styles the billing and upgrade pages @rishig created in https://github.com/zulip/zulip/pull/9818. (It also includes his work there.)

Each page has a simple, reusable nav component (billing_nav.html). (It has no nav options right now, but can easily incorporate them if we want to add some later.)

/billing contains a quick snippet of inline Javascript (to control the tabs). Wasn't sure if best practice was to pull this out or not, so I just went with the simplest solution and left it inline for now.

<img width="1384" alt="screen shot 2018-07-03 at 10 42 43 am" src="https://user-images.githubusercontent.com/2905696/42227891-97ef4c36-7eb0-11e8-96ec-5a0bc42a9c61.png">

<img width="1398" alt="screen shot 2018-07-02 at 11 21 09 am" src="https://user-images.githubusercontent.com/2905696/42227888-958106a6-7eb0-11e8-8874-c9569ff2fb91.png">
