### PR TITLE
import: Create subscription_created events in RealmAuditLog.

### DIFF
--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -18,7 +18,8 @@ from zerver.models import UserProfile, Realm, Client, Huddle, Stream, \
     UserMessage, Subscription, Message, RealmEmoji, RealmFilter, Reaction, \
     RealmDomain, Recipient, DefaultStream, get_user_profile_by_id, \
     UserPresence, UserActivity, UserActivityInterval, CustomProfileField, \
-    CustomProfileFieldValue, get_display_recipient, Attachment, get_system_bot
+    CustomProfileFieldValue, get_display_recipient, Attachment, get_system_bot, \
+    RealmAuditLog
 from zerver.lib.parallel import run_parallel
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, \
     Iterable, Union
@@ -167,7 +168,6 @@ NON_EXPORTED_TABLES = {
     'zerver_botstoragedata',
     'zerver_botconfigdata',
     'zerver_mutedtopic',
-    'zerver_realmauditlog',
     'zerver_pushdevicetoken',
     'zerver_service',
     'zerver_usergroup',
@@ -201,6 +201,7 @@ DATE_FIELDS = {
     'zerver_useractivityinterval': ['start', 'end'],
     'zerver_userpresence': ['timestamp'],
     'zerver_userprofile': ['date_joined', 'last_login', 'last_reminder'],
+    'zerver_realmauditlog': ['event_time'],
 }  # type: Dict[TableName, List[Field]]
 
 def sanity_check_output(data: TableData) -> None:
@@ -576,6 +577,13 @@ def get_realm_config() -> Config:
         model=UserActivityInterval,
         normal_parent=user_profile_config,
         parent_key='user_profile__in',
+    )
+
+    Config(
+        table='zerver_realmauditlog',
+        model=RealmAuditLog,
+        normal_parent=user_profile_config,
+        parent_key='modified_user__in',
     )
 
     # Some of these tables are intermediate "tables" that we

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -9,7 +9,8 @@ from boto.s3.connection import S3Connection
 from boto.s3.key import Key
 from django.conf import settings
 from django.db import connection
-from django.utils.timezone import utc as timezone_utc
+from django.db.models import Max
+from django.utils.timezone import utc as timezone_utc, now as timezone_now
 from typing import Any, Dict, List, Optional, Set, Tuple, \
     Iterable
 
@@ -94,6 +95,37 @@ def fix_upload_links(data: TableData, message_table: TableName) -> None:
                     message['content'] = message['content'].replace(key, value)
                     if message['rendered_content']:
                         message['rendered_content'] = message['rendered_content'].replace(key, value)
+
+def create_subscription_events(data: TableData, table: TableName) -> None:
+    """
+    When the export data doesn't contain the table `zerver_realmauditlog`,
+    this functions creates RealmAuditLog objects for `subscription_created`
+    type event for all the existing subscriptions.
+
+    This would be common for all the export tools which do not include the
+    table `zerver_realmauditlog`.
+    """
+    all_subscription_logs = []
+
+    # from bulk_add_subscriptions in lib/actions
+    event_last_message_id = Message.objects.aggregate(Max('id'))['id__max']
+    if event_last_message_id is None:
+        event_last_message_id = -1
+    event_time = timezone_now()
+
+    for item in data[table]:
+        recipient = Recipient.objects.get(id=item['recipient_id'])
+        if recipient.type == Recipient.STREAM:
+            stream = Stream.objects.get(id=recipient.type_id)
+            user = UserProfile.objects.get(id=item['user_profile_id'])
+
+            all_subscription_logs.append(RealmAuditLog(realm=user.realm,
+                                                       modified_user=user,
+                                                       modified_stream=stream,
+                                                       event_last_message_id=event_last_message_id,
+                                                       event_time=event_time,
+                                                       event_type='subscription_created'))
+    RealmAuditLog.objects.bulk_create(all_subscription_logs)
 
 def current_table_ids(data: TableData, table: TableName) -> List[int]:
     """
@@ -512,6 +544,21 @@ def do_import_realm(import_dir: Path, subdomain: str) -> Realm:
     update_model_ids(Subscription, data, 'zerver_subscription', 'subscription')
     bulk_import_model(data, Subscription, 'zerver_subscription')
 
+    if 'zerver_realmauditlog' in data:
+        fix_datetime_fields(data, 'zerver_realmauditlog')
+        re_map_foreign_keys(data, 'zerver_realmauditlog', 'realm', related_table="realm")
+        re_map_foreign_keys(data, 'zerver_realmauditlog', 'modified_user',
+                            related_table='user_profile')
+        re_map_foreign_keys(data, 'zerver_realmauditlog', 'acting_user',
+                            related_table='user_profile')
+        re_map_foreign_keys(data, 'zerver_realmauditlog', 'modified_stream',
+                            related_table="stream")
+        update_model_ids(RealmAuditLog, data, 'zerver_realmauditlog',
+                         related_table="realmauditlog")
+        bulk_import_model(data, RealmAuditLog, 'zerver_realmauditlog')
+    else:
+        create_subscription_events(data, 'zerver_subscription')
+
     fix_datetime_fields(data, 'zerver_userpresence')
     re_map_foreign_keys(data, 'zerver_userpresence', 'user_profile', related_table="user_profile")
     re_map_foreign_keys(data, 'zerver_userpresence', 'client', related_table='client')
@@ -542,18 +589,6 @@ def do_import_realm(import_dir: Path, subdomain: str) -> Realm:
     update_model_ids(CustomProfileFieldValue, data, 'zerver_customprofilefieldvalue',
                      related_table="customprofilefieldvalue")
     bulk_import_model(data, CustomProfileFieldValue, 'zerver_customprofilefieldvalue')
-
-    fix_datetime_fields(data, 'zerver_realmauditlog')
-    re_map_foreign_keys(data, 'zerver_realmauditlog', 'realm', related_table="realm")
-    re_map_foreign_keys(data, 'zerver_realmauditlog', 'modified_user',
-                        related_table='user_profile')
-    re_map_foreign_keys(data, 'zerver_realmauditlog', 'acting_user',
-                        related_table='user_profile')
-    re_map_foreign_keys(data, 'zerver_realmauditlog', 'modified_stream',
-                        related_table="stream")
-    update_model_ids(RealmAuditLog, data, 'zerver_realmauditlog',
-                     related_table="realmauditlog")
-    bulk_import_model(data, RealmAuditLog, 'zerver_realmauditlog')
 
     # Import uploaded files and avatars
     import_uploads(os.path.join(import_dir, "avatars"), processing_avatars=True)

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -54,6 +54,7 @@ from zerver.models import (
     UserMessage,
     CustomProfileField,
     CustomProfileFieldValue,
+    RealmAuditLog,
     get_active_streams,
     get_stream_recipient,
     get_personal_recipient,
@@ -534,6 +535,15 @@ class ImportExportTest(ZulipTestCase):
             {custom_profile_field.name for custom_profile_field in realm_custom_profile_field}
             for realm_custom_profile_field in custom_profile_field]
         self.assertEqual(custom_profile_field_name[0], custom_profile_field_name[1])
+
+        # test realmauditlog
+        realmauditlogs = [
+            RealmAuditLog.objects.filter(realm=realm)
+            for realm in realms]
+        realmauditlog_event_type = [
+            {log.event_type for log in realmauditlog}
+            for realmauditlog in realmauditlogs]
+        self.assertEqual(realmauditlog_event_type[0], realmauditlog_event_type[1])
 
         # test messages
         stream_message = [


### PR DESCRIPTION
The export and import of `RealmAuditLog` is added here. 

For export tools like Slack and Gitter, I have used the logic that if `zerver_realmauditlog` present in the exported data, it would be imported. If not, `create_subscription_events` function in `import_realm` would create the `subscription_created` events for the RealmAuditLog. The reason I have put this function in the `import_realm` files and not in the export tool scripts (like Slack), because it will be common for all the export tools.

