### PR TITLE
Migrate our font awesome icons to use font awesome 4.7 standard prefixes.

### DIFF
--- a/frontend_tests/casper_tests/07-stars.js
+++ b/frontend_tests/casper_tests/07-stars.js
@@ -2,7 +2,7 @@ var common = require('../casper_lib/common.js').common;
 
 function star_count() {
     return casper.evaluate(function () {
-        return $("#zhome .icon-vector-star:not(.empty-star)").length;
+        return $("#zhome .fa-star:not(.empty-star)").length;
     });
 }
 
@@ -40,7 +40,7 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('#zhome .icon-vector-star', function () {
+    casper.waitUntilVisible('#zhome .fa-star', function () {
         casper.test.assertEquals(star_count(), 1,
                                  "Got expected single star count.");
 

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -598,7 +598,7 @@ run_test('initialize', () => {
 
         fake_this = { completing: 'mention', token: 'hamletcharacters' };
         actual_value = options.highlighter.call(fake_this, hamletcharacters);
-        expected_value = '        <i class="typeahead-image icon icon-vector-group"></i>\n<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
+        expected_value = '        <i class="typeahead-image icon fa fa-group" aria-hidden="true"></i>\n<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
         assert.equal(actual_value, expected_value);
 
         // options.matcher()

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -309,7 +309,7 @@ run_test('admin_invites_list', () => {
     var span = $(html).find(".email:first");
     assert.equal(span.text(), "alice@zulip.com");
 
-    var icon = $(html).find(".icon-vector-bolt");
+    var icon = $(html).find(".fa-bolt");
     assert.equal(icon.attr('title'), "translated: Invited as administrator");
 });
 

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1329,7 +1329,7 @@ run_test('topic_edit_form', () => {
     var html = render('topic_edit_form');
 
     var button = $(html).find("button:first");
-    assert.equal(button.find("i").attr("class"), 'icon-vector-ok');
+    assert.equal(button.find("i").attr("class"), 'fa fa-check');
 });
 
 run_test('topic_list_item', () => {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -728,7 +728,7 @@ exports.initialize = function () {
         e.stopPropagation();
     });
 
-    $(".settings-header.mobile .icon-vector-chevron-left").on("click", function () {
+    $(".settings-header.mobile .fa-chevron-left").on("click", function () {
         $("#settings_page").find(".right").removeClass("show");
         $(this).parent().removeClass("slide-left");
     });

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -305,14 +305,14 @@ exports.MessageList.prototype = {
 
     show_edit_topic: function MessageList_show_edit_topic(recipient_row, form) {
         recipient_row.find(".topic_edit_form").empty().append(form);
-        recipient_row.find('.icon-vector-pencil').hide();
+        recipient_row.find('.fa-pencil').hide();
         recipient_row.find(".stream_topic").hide();
         recipient_row.find(".topic_edit").show();
     },
 
     hide_edit_topic: function MessageList_hide_edit_topic(recipient_row) {
         recipient_row.find(".stream_topic").show();
-        recipient_row.find('.icon-vector-pencil').show();
+        recipient_row.find('.fa-pencil').show();
         recipient_row.find(".topic_edit").hide();
     },
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -327,7 +327,7 @@ function redraw_privacy_related_stuff(sub_row, sub) {
     if (sub.invite_only) {
         stream_settings.find(".large-icon")
             .removeClass("hash").addClass("lock")
-            .html("<i class='icon-vector-lock'></i>");
+            .html("<i class='fa fa-lock' aria-hidden='true'></i>");
     } else {
         stream_settings.find(".large-icon")
             .addClass("hash").removeClass("lock")

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -86,9 +86,9 @@ exports.update_starred = function (message) {
     update_message_in_all_views(message.id, function update_row(row) {
         var elt = row.find(".star");
         if (starred) {
-            elt.addClass("icon-vector-star").removeClass("icon-vector-star-empty").removeClass("empty-star");
+            elt.addClass("fa-star").removeClass("fa-star-o").removeClass("empty-star");
         } else {
-            elt.removeClass("icon-vector-star").addClass("icon-vector-star-empty").addClass("empty-star");
+            elt.removeClass("fa-star").addClass("fa-star-o").addClass("empty-star");
         }
         var title_state = starred ? i18n.t("Unstar") : i18n.t("Star");
         elt.attr("title", i18n.t("__starred_status__ this message", {starred_status: title_state}));

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -79,8 +79,9 @@
     width: 100%;
 }
 
-.compose_table .right_part .icon-vector-narrow {
-    font-size: 0.6em;
+.compose_table .right_part .fa-angle-right {
+    font-size: 0.9em;
+    -webkit-text-stroke: 0.05em;
     position: relative;
     margin: 0px 5px;
 }

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -317,7 +317,7 @@ ul.filters li.out_of_home_view li.muted_topic {
     font-size: 15px;
 }
 
-.stream-privacy .icon-vector-lock {
+.stream-privacy .fa-lock {
     display: inline-block;
     width: 9px;
     margin-right: 2px;

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -159,7 +159,7 @@ li.active-sub-filter {
     text-decoration: underline;
 }
 
-#global_filters .global-filter i.icon-vector-home {
+#global_filters .global-filter i.fa-home {
     position: relative;
     top: 1px;
     left: -1px;
@@ -167,7 +167,7 @@ li.active-sub-filter {
     font-size: 16px;
 }
 
-#global_filters .global-filter i.icon-vector-envelope {
+#global_filters .global-filter i.fa-envelope {
     font-size: 13px;
 }
 
@@ -477,6 +477,6 @@ li.show-more-private-messages a {
     display: none;
 }
 
-.show-all-streams .icon-vector-chevron-left {
+.show-all-streams .fa-chevron-left {
     text-decoration: none;
 }

--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -243,7 +243,7 @@
         margin-right: 115px;
     }
 
-    #searchbox .input-append .icon-vector-search {
+    #searchbox .input-append .fa-search {
         top: 5px;
     }
 

--- a/static/styles/reactions.scss
+++ b/static/styles/reactions.scss
@@ -167,7 +167,7 @@
     border-radius: 5px 5px 0px 0px;
 }
 
-.emoji-popover-top .icon-vector-search {
+.emoji-popover-top .fa-search {
     position: absolute;
     color: hsl(0, 0%, 73%);
     top: 15px;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1197,7 +1197,7 @@ input[type=checkbox].inline-block {
     border-bottom: 1px solid hsl(0, 0%, 86%);
 }
 
-.settings-header.mobile .icon-vector-chevron-left {
+.settings-header.mobile .fa-chevron-left {
     float: left;
     position: relative;
     top: 14px;

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -684,7 +684,7 @@ form#add_new_subscription {
     font-size: 1.1em;
 }
 
-.stream-row .icon .icon-vector-lock {
+.stream-row .icon .fa-lock {
     font-size: 1.4em;
 }
 

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -425,7 +425,7 @@ form#add_new_subscription {
 }
 
 .subscriptions-header .fa-chevron-left,
-#settings_overlay_container .settings-header.mobile .icon-vector-chevron-left {
+#settings_overlay_container .settings-header.mobile .fa-chevron-left {
     position: relative;
     transform: translate(-50px, 0px);
     opacity: 0;
@@ -440,7 +440,7 @@ form#add_new_subscription {
 }
 
 .subscriptions-header.slide-left .fa-chevron-left,
-#settings_overlay_container .settings-header.mobile.slide-left .icon-vector-chevron-left {
+#settings_overlay_container .settings-header.mobile.slide-left .fa-chevron-left {
     transform: translate(-0px, 0px);
     opacity: 1;
 }

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1807,7 +1807,7 @@ blockquote p {
     position: relative;
     width: 100%;
 
-    .icon-vector-search {
+    .fa-search {
         padding: 0px;
         font-size: 20px;
         position: absolute;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1754,11 +1754,6 @@ blockquote p {
     text-align: center;
 }
 
-.typeahead-image.icon {
-    /* This aligns the icon vertically. */
-    top: 0px;
-}
-
 .nav .dropdown-menu:after {
     position: absolute;
     width: 0px;

--- a/static/templates/admin_default_streams_list.handlebars
+++ b/static/templates/admin_default_streams_list.handlebars
@@ -1,7 +1,7 @@
 {{#with stream}}
 <tr class="default_stream_row" id="{{name}}">
     <td>
-        {{#if invite_only}}<i class="icon-vector-lock "></i>{{/if}}
+        {{#if invite_only}}<i class="fa fa-lock" aria-hidden="true"></i>{{/if}}
         <span class="default_stream_name">{{name}}</span>
     </td>
     {{#if ../can_modify}}

--- a/static/templates/admin_emoji_list.handlebars
+++ b/static/templates/admin_emoji_list.handlebars
@@ -19,7 +19,7 @@
     </td>
     <td>
         <button class="button rounded small delete btn-danger" {{#unless can_admin_emoji}}disabled="disabled"{{/unless}} data-emoji-name="{{name}}">
-            <i class="icon-vector-trash" aria-hidden="true"></i>
+            <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
     </td>
 </tr>

--- a/static/templates/admin_filter_list.handlebars
+++ b/static/templates/admin_filter_list.handlebars
@@ -9,7 +9,7 @@
     {{#if ../can_modify}}
     <td>
         <button class="button small delete btn-danger" data-filter-id="{{id}}">
-            <i class="icon-vector-trash" aria-hidden="true"></i>
+            <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
     </td>
     {{/if}}

--- a/static/templates/admin_invites_list.handlebars
+++ b/static/templates/admin_invites_list.handlebars
@@ -3,7 +3,7 @@
     <td>
         <span class="email">{{email}}</span>
         {{#if invited_as_admin}}
-        <i title="{{t 'Invited as administrator'}}" class="icon-vector-bolt invited-as-admin"></i>
+        <i title="{{t 'Invited as administrator'}}" class="fa fa-bolt invited-as-admin"></i>
         {{/if}}
     </td>
     <td>

--- a/static/templates/admin_profile_field_list.handlebars
+++ b/static/templates/admin_profile_field_list.handlebars
@@ -2,7 +2,7 @@
 <tr class="profile-field-row" data-profile-field-id="{{id}}">
     <td>
         {{#if ../can_modify}}
-        <i class="fa fa-sort"></i>
+        <i class="fa fa-sort" aria-hidden="true"></i>
         {{/if}}
         <span class="profile_field_name">{{name}}</span>
     </td>
@@ -15,10 +15,10 @@
     {{#if ../can_modify}}
     <td>
         <button class="button rounded small delete btn-danger" title="{{t 'Delete' }}" data-profile-field-id="{{id}}">
-            <i class="icon-vector-trash"></i>
+            <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
         <button class="button rounded small btn-warning open-edit-form" title="{{t 'Edit' }}" data-profile-field-id="{{id}}">
-            <i class="icon-vector-pencil"></i>
+            <i class="fa fa-pencil" aria-hidden="true"></i>
         </button>
     </td>
     {{/if}}

--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -44,7 +44,7 @@
             {{/if}}
         </span>
         <button class="button rounded small btn-warning open-user-form{{#unless is_active}} display-none{{/unless}}" title="{{t 'Edit user' }}" data-user-id="{{user_id}}">
-            <i class="icon-vector-pencil"></i>
+            <i class="fa fa-pencil" aria-hidden="true"></i>
         </button>
     </td>
     {{/if}}

--- a/static/templates/alert_word_settings_item.handlebars
+++ b/static/templates/alert_word_settings_item.handlebars
@@ -25,7 +25,7 @@
         </div>
         <div class="edit-alert-word-buttons">
             <button type="submit" class="button small btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
-                <i class="icon-vector-trash"></i>
+                <i class="fa fa-trash-o" aria-hidden="true"></i>
             </button>
         </div>
     </div>

--- a/static/templates/all_messages_sidebar_actions.handlebars
+++ b/static/templates/all_messages_sidebar_actions.handlebars
@@ -2,7 +2,7 @@
 <ul class="nav nav-list">
     <li>
         <a id="mark_all_messages_as_read">
-            <i class="icon-vector-book"></i>
+            <i class="fa fa-book" aria-hidden="true"></i>
             {{#tr this}}Mark all messages as read{{/tr}}
         </a>
     </li>

--- a/static/templates/bot_avatar_row.handlebars
+++ b/static/templates/bot_avatar_row.handlebars
@@ -6,13 +6,13 @@
             {{#if is_active}}
             <div class="edit-bot-buttons">
                 <button type="submit" class="btn open_edit_bot_form" data-sidebar-form="edit-bot" title="{{t 'Edit bot' }}" data-email="{{email}}">
-                    <i class="icon-vector-pencil blue"></i>
+                    <i class="fa fa-pencil blue" aria-hidden="true"></i>
                 </button>
                 <a type="submit" download="{{zuliprc}}" class="btn download_bot_zuliprc" title="{{t 'Download zuliprc' }}" data-email="{{email}}">
-                    <i class="icon-vector-download-alt sea-green"></i>
+                    <i class="fa fa-download sea-green" aria-hidden="true"></i>
                 </a>
                 <button type="submit" class="btn delete_bot" title="{{t 'Delete bot' }}" data-user-id="{{user_id}}">
-                    <i class="icon-vector-trash danger-red"></i>
+                    <i class="fa fa-trash-o danger-red" aria-hidden="true"></i>
                 </button>
             </div>
             {{/if}}
@@ -34,7 +34,7 @@
                 <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
                 <span class="value text-select">{{api_key}}</span>
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
-                    <i class="icon-vector-refresh"></i>
+                    <i class="fa fa-refresh" aria-hidden="true"></i>
                 </button>
             </span>
             <div class="api_key_error text-error"></div>

--- a/static/templates/draft.handlebars
+++ b/static/templates/draft.handlebars
@@ -33,8 +33,8 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="draft_controls">
-                            <i class="icon-vector-large icon-vector-pencil restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }}"></i>
-                            <i class="icon-vector-large icon-vector-trash delete-draft" data-toggle="tooltip" title="{{t 'Delete draft' }} (Backspace)"></i>
+                            <i class="fa fa-pencil fa-lg restore-draft" aria-hidden="true" data-toggle="tooltip" title="{{t 'Restore draft' }}"></i>
+                            <i class="fa fa-trash-o fa-lg delete-draft" aria-hidden="true" data-toggle="tooltip" title="{{t 'Delete draft' }} (Backspace)"></i>
                         </div>
                     </div>
                     <div class="message_content restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }}">{{{content}}}</div>

--- a/static/templates/emoji_popover_content.handlebars
+++ b/static/templates/emoji_popover_content.handlebars
@@ -1,7 +1,7 @@
 <div class="emoji-popover">
     <div class="emoji-popover-top input-append">
         <input class="emoji-popover-filter" type="text" autofocus placeholder={{t 'Search' }} />
-        <i class="icon-vector-search"></i>
+        <i class="fa fa-search" aria-hidden="true"></i>
     </div>
     <div class="emoji-popover-category-tabs">
         {{#each emoji_categories}}

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -41,7 +41,7 @@
                 <div class="message-edit-timer-control-group">
                     <input type="file" id="message_edit_file_input_{{message_id}}" class="notvisible pull-left" multiple />
                     <a class="message-control-button fa fa-font" aria-hidden="true" title="{{t 'Formatting' }}" data-overlay-trigger="markdown-help" ></a>
-                    <a class="message-control-button icon-vector-paper-clip notdisplayed" id="attach_files_{{message_id}}" href="#" title="{{t "Attach files" }}"></a>
+                    <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files_{{message_id}}" href="#" title="{{t "Attach files" }}"></a>
                 </div>
                 <span><i id="message_edit_tooltip" class="message_edit_tooltip fa fa-question-circle" aria-hidden="true" data-toggle="tooltip"
                     title="{{#tr this}}This organization is configured to restrict editing of message content to __minutes_to_edit__ minutes after it is sent.{{/tr}}"></i>

--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -9,7 +9,7 @@
                 title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;{{/tr}}">
                 {{! invite only lock }}
                 {{#if invite_only}}
-                <i class="icon-vector-lock invite-stream-icon" title="{{t 'This is a private stream' }}"></i>
+                <i class="fa fa-lock invite-stream-icon" aria-hidden="true" title="{{t 'This is a private stream' }}"></i>
                 {{/if}}
                 {{display_recipient}}
             </a>
@@ -33,16 +33,16 @@
             </span><span class="recipient_bar_controls no-select">
                 {{! edit subject pencil icon }}
                 {{#if always_visible_topic_edit}}
-                    <i class="icon-vector-pencil always_visible_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>
+                    <i class="fa fa-pencil always_visible_topic_edit" aria-hidden="true" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>
                 {{else}}
                     {{#if on_hover_topic_edit}}
-                    <i class="icon-vector-pencil on_hover_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>
+                    <i class="fa fa-pencil on_hover_topic_edit" aria-hidden="true" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>
                     {{/if}}
                 {{/if}}
                 {{! exterior links (e.g. to a trac ticket) }}
                 {{#each subject_links}}
                 <a href="{{this}}" target="_blank" class="no-underline">
-                    <i class="icon-vector-external-link-sign"></i>
+                    <i class="fa fa-external-link-square" aria-hidden="true"></i>
                 </a>
                 {{/each}}
 
@@ -50,7 +50,7 @@
                     <span class="topic_edit_form" id="{{id}}"></span>
                 </span>
 
-                <i class="icon-vector-eye-close on_hover_topic_mute" data-stream-id="{{stream_id}}" data-topic-name="{{subject}}" title="{{t 'Mute topic' }} (M)"></i>
+                <i class="fa fa-eye-slash on_hover_topic_mute" aria-hidden="true" data-stream-id="{{stream_id}}" data-topic-name="{{subject}}" title="{{t 'Mute topic' }} (M)"></i>
                 <span class="recipient_row_date {{#if show_date}}{{else}}hide-date{{/if}}">{{{date}}}</span>
             </span>
         </div>

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -13,7 +13,7 @@
                             <i class="fa fa-pencil"></i>
                         </button>
                     </a>
-                    <i class="icon-vector-question-sign change_email_tooltip settings-info-icon" {{#if page_params.is_admin}}style="display:none"{{else}}{{#unless page_params.realm_email_changes_disabled}}style="display:none"{{/unless}}{{/if}}  data-toggle="tooltip"
+                    <i class="fa fa-question-circle change_email_tooltip settings-info-icon" {{#if page_params.is_admin}}style="display:none"{{else}}{{#unless page_params.realm_email_changes_disabled}}style="display:none"{{/unless}}{{/if}}  data-toggle="tooltip"
                       title="{{t 'Changing email addresses has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"></i>
                 </div>
 
@@ -54,7 +54,7 @@
                                 <i class="fa fa-pencil"></i>
                             </button>
                         </a>
-                        <i class="icon-vector-question-sign change_name_tooltip settings-info-icon" data-toggle="tooltip"
+                        <i class="fa fa-question-circle change_name_tooltip settings-info-icon" data-toggle="tooltip"
                           {{#if page_params.is_admin}}style="display:none"{{else}}{{#unless page_params.realm_name_changes_disabled}}style="display:none"{{/unless}}{{/if}}
                           title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
                     </div>

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -9,7 +9,7 @@
         <div>
             <span>{{t 'Download config of all active outgoing webhook bots in Zulip Botserver format.' }}</span>
             <a type="submit" download="{{botserverrc}}" id= "download_botserverrc" class="btn" title="{{t 'Download botserverrc' }}">
-                <i class="icon-vector-download-alt sea-green"></i>
+                <i class="fa fa-download sea-green" aria-hidden="true"></i>
             </a>
         </div>
         {{/unless}}
@@ -35,7 +35,7 @@
                     <div class="input-group">
                         <label for="bot_type">
                             {{t "Bot type" }}
-                            <i class="icon-vector-question-sign settings-info-icon bot_type_tooltip" data-toggle="tooltip"
+                            <i class="fa fa-question-circle settings-info-icon bot_type_tooltip" aria-hidden="true" data-toggle="tooltip"
                               title='{{t "Incoming webhooks can only send messages." }}'></i>
                         </label>
                         <select name="bot_type" id="create_bot_type">

--- a/static/templates/settings/invites-list-admin.handlebars
+++ b/static/templates/settings/invites-list-admin.handlebars
@@ -1,5 +1,5 @@
 <div id="admin-invites-list" class="settings-section" data-name="invites-list-admin">
-    <a class="invite-user-link" href="#invite"><i class="icon-vector-plus-sign"></i>{{t "Invite more users" }}</a>
+    <a class="invite-user-link" href="#invite"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{t "Invite more users" }}</a>
     <input type="text" class="search" placeholder="{{t 'Filter invites' }}" aria-label="{{t 'Filter invites' }}"/>
     <div class="clear-float"></div>
 

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -36,8 +36,8 @@
                 <div class="input-group">
                     <label for="realm_msg_delete_limit_setting" class="dropdown-title">
                         {{t "Allow message deleting" }}
-                        <i class="icon-vector-info-sign settings-info-icon realm_allow_message_deleting_tooltip" data-toggle="tooltip"
-                          title="{{t 'Administrators can always delete any message.' }}"/>
+                        <i class="fa fa-info-circle settings-info-icon realm_allow_message_deleting_tooltip" data-toggle="tooltip"
+                          aria-hidden="true" title="{{t 'Administrators can always delete any message.' }}"/>
                     </label>
                     <select name="realm_msg_delete_limit_setting" id="id_realm_msg_delete_limit_setting">
                         {{#each msg_delete_limit_dropdown_values}}

--- a/static/templates/settings/profile-field-choice.handlebars
+++ b/static/templates/settings/profile-field-choice.handlebars
@@ -3,10 +3,10 @@
     <input type='text' data-toggle='tooltip' title='{{t "Order" }}' placeholder='{{t "Order" }}' value="{{ order }}" />
     {{#if add_delete_button }}
     <button type='button' class="button rounded small btn-danger delete-choice" title="{{t 'Delete' }}">
-        <i class="icon-vector-trash"></i>
+        <i class="fa fa-trash-o" aria-hidden="true"></i>
     </button>
     {{/if}}
     <button type='button' class="button rounded small sea-green add-choice" title="{{t 'Add' }}">
-        <i class="icon-vector-plus"></i>
+        <i class="fa fa-plus" aria-hidden="true"></i>
     </button>
 </div>

--- a/static/templates/sidebar_private_message_list.handlebars
+++ b/static/templates/sidebar_private_message_list.handlebars
@@ -10,7 +10,7 @@
             </div>
         </span>
         <span class="arrow topic-sidebar-arrow">
-            <i class="icon-vector-chevron-down"></i>
+            <i class="fa fa-chevron-down" aria-hidden="true"></i>
         </span>
     </li>
     {{/each}}

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -45,23 +45,23 @@
                         <div class="edit_content"></div>
                         {{else}}
                         <div class="reaction_button">
-                            <i class="icon-vector-smile" title="{{#tr this}}Add emoji reaction{{/tr}} (:)"></i>
+                            <i class="fa fa-smile-o" aria-hidden="true" title="{{#tr this}}Add emoji reaction{{/tr}} (:)"></i>
                         </div>
                         {{/if}}
 
                         {{#unless msg/locally_echoed}}
                         <div class="info actions_hover">
-                            <i class="icon-vector-chevron-down" title="{{#tr this}}Message actions{{/tr}} (i)"></i>
+                            <i class="fa fa-chevron-down" aria-hidden="true" title="{{#tr this}}Message actions{{/tr}} (i)"></i>
                         </div>
                         {{/unless}}
 
                         <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">
-                            <i class="icon-vector-refresh refresh-failed-message" data-toggle="tooltip" title="{{t 'Retry' }}"></i>
-                            <i class="icon-vector-remove-sign remove-failed-message" data-toggle="tooltip" title="{{t 'Cancel' }}"></i>
+                            <i class="fa fa-refresh refresh-failed-message" aria-hidden="true" data-toggle="tooltip" title="{{t 'Retry' }}"></i>
+                            <i class="fa fa-times-circle remove-failed-message" aria-hidden="true" data-toggle="tooltip" title="{{t 'Cancel' }}"></i>
                         </div>
 
                         {{#unless msg/locally_echoed}}
-                        <div class="star {{#if msg/starred}}icon-vector-star{{else}}icon-vector-star-empty{{/if}} {{#if msg/starred}}{{else}}empty-star{{/if}}" title="{{#tr this.msg}}__starred_status__ this message{{/tr}} (*)">
+                        <div class="star fa {{#if msg/starred}}fa-star{{else}}fa-star-o{{/if}} {{#if msg/starred}}{{else}}empty-star{{/if}}" title="{{#tr this.msg}}__starred_status__ this message{{/tr}} (*)">
                         </div>
                         {{/unless}}
 

--- a/static/templates/stream_privacy.handlebars
+++ b/static/templates/stream_privacy.handlebars
@@ -1,6 +1,6 @@
 {{! This controls whether the swatchnext to streams in the left sidebar has a lock icon. }}
 {{#if invite_only}}
-<i class="icon-vector-lock"></i>
+<i class="fa fa-lock" aria-hidden="true"></i>
 {{ else }}
 <span class="hashtag"></span>
 {{/if}}

--- a/static/templates/stream_sidebar_actions.handlebars
+++ b/static/templates/stream_sidebar_actions.handlebars
@@ -2,19 +2,19 @@
 <ul class="nav nav-list streams_popover" data-stream-id="{{ stream.stream_id }}" data-name="{{ stream.name }}">
     <li>
         <a class="open_stream_settings">
-            <i class="icon-vector-cog"></i>
+            <i class="fa fa-cog" aria-hidden="true"></i>
             {{t "Stream settings" }}
         </a>
     </li>
     <li>
         <a class="narrow_to_stream">
-            <i class="icon-vector-bullhorn"></i>
+            <i class="fa fa-bullhorn" aria-hidden="true"></i>
             {{#tr this}}Narrow to stream <b>__stream.name__</b>{{/tr}}
         </a>
     </li>
     <li>
         <a class="pin_to_top">
-            <i class="icon-vector-pushpin stream-pin-icon"></i>
+            <i class="fa fa-thumb-tack stream-pin-icon" aria-hidden="true"></i>
             {{#if stream.pin_to_top}}
                 {{#tr this}}Unpin stream <b>__stream.name__</b> from top{{/tr}}
             {{else}}
@@ -24,30 +24,30 @@
     </li>
     <li>
         <a class="compose_to_stream">
-            <i class="icon-vector-edit"></i>
+            <i class="fa fa-edit" aria-hidden="true"></i>
             {{#tr this}}Compose a message to stream <b>__stream.name__</b>{{/tr}}
         </a>
     </li>
     <li>
         <a class="mark_stream_as_read">
-            <i class="icon-vector-book"></i>
+            <i class="fa fa-book" aria-hidden="true"></i>
             {{#tr this}}Mark all messages in <b>__stream.name__</b> as read{{/tr}}
         </a>
     </li>
     <li>
         <a class="toggle_home">
             {{#if stream.in_home_view}}
-                <i class="icon-vector-eye-close"></i>
+                <i class="fa fa-eye-slash" aria-hidden="true"></i>
                 {{#tr this}}Mute the stream <b>__stream.name__</b>{{/tr}}
             {{else}}
-                <i class="icon-vector-eye-open"></i>
+                <i class="fa fa-eye" aria-hidden="true"></i>
                 {{#tr this}}Unmute the stream <b>__stream.name__</b>{{/tr}}
             {{/if}}
         </a>
     </li>
     <li>
         <a class="popover_sub_unsub_button" data-name="{{stream.name}}">
-            <i class='icon-vector-envelope'></i>
+            <i class='fa fa-envelope' aria-hidden="true"></i>
             {{t "Unsubscribe" }}
         </a>
     </li>

--- a/static/templates/stream_sidebar_row.handlebars
+++ b/static/templates/stream_sidebar_row.handlebars
@@ -13,6 +13,6 @@
 
         <div class="count"><div class="value"></div></div>
     </div>
-    <span class="arrow stream-sidebar-arrow"><i class="icon-vector-chevron-down"></i></span>
+    <span class="arrow stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
 
 </li>

--- a/static/templates/subscription_count.handlebars
+++ b/static/templates/subscription_count.handlebars
@@ -1,6 +1,6 @@
-<i class="fa fa-user-o"></i>
+<i class="fa fa-user-o" aria-hidden="true"></i>
 {{#if can_access_subscribers}}
 <span class="subscriber-count-text">{{subscriber_count}}</span>
 {{else}}
-<i class="subscriber-count-lock icon-vector-lock"></i>
+<i class="subscriber-count-lock fa fa-lock" aria-hidden="true"></i>
 {{/if}}

--- a/static/templates/subscription_setting_icon.handlebars
+++ b/static/templates/subscription_setting_icon.handlebars
@@ -1,7 +1,7 @@
 <div class="icon" style="background-color: {{color}}">
     <div class="flex">
         {{#if invite_only}}
-        <i class="icon-vector-lock"></i>
+        <i class="fa fa-lock" aria-hidden="true"></i>
         {{else}}
         <span class="hashtag">#</span>
         {{/if}}

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -5,7 +5,7 @@
         <div class="stream-header">
             {{#if invite_only}}
             <div class="large-icon lock" style="color: {{color}}">
-                <i class="icon-vector-lock"></i>
+                <i class="fa fa-lock" aria-hidden="true"></i>
             </div>
             {{else}}
             <div class="large-icon hash" style="color: {{color}}"></div>
@@ -19,7 +19,7 @@
             </div>
             <div class="button-group">
                 {{#if is_admin}}
-                <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Delete stream'}}">{{t 'Delete' }} <i class="icon-vector-trash" aria-hidden="true"></i></button>
+                <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Delete stream'}}">{{t 'Delete' }} <i class="fa fa-trash-o" aria-hidden="true"></i></button>
                 {{/if}}
                 <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" title="{{t 'Toggle subscription'}} (S)" {{#unless should_display_subscription_button}}style="display: none"{{/unless}}>
                     {{#if subscribed }}{{#tr oneself }}Unsubscribe{{/tr}}{{else}}{{#tr oneself }}Subscribe{{/tr}}{{/if}}</button>
@@ -85,7 +85,7 @@
                 </ul>
             </div>
             <div class="stream-email-box" {{#unless email_address}}style="display: none;"{{/unless}}>
-                <div class="sub_settings_title">{{t "Email address" }} <i class="icon-vector-question-sign stream-email-hint"></i></div>
+                <div class="sub_settings_title">{{t "Email address" }} <i class="fa fa-question-circle stream-email-hint" aria-hidden="true"></i></div>
                 <div class="stream-email">
                     <span class="email-address">{{email_address}}</span>
                 </div>

--- a/static/templates/subscription_type.handlebars
+++ b/static/templates/subscription_type.handlebars
@@ -1,10 +1,10 @@
 {{#if invite_only}}
-    {{t 'This is a <span class="icon-vector-lock"></span> <b>private stream</b>. Only people who have been invited can access its content, but&nbsp;any&nbsp;member&nbsp;of&nbsp;the&nbsp;stream can&nbsp;invite&nbsp;others.' }}
+    {{t 'This is a <span class="fa fa-lock" aria-hidden="true"></span> <b>private stream</b>. Only people who have been invited can access its content, but&nbsp;any&nbsp;member&nbsp;of&nbsp;the&nbsp;stream can&nbsp;invite&nbsp;others.' }}
     {{#if history_public_to_subscribers}}{{t 'New members can view complete message history.' }}
     {{else}}{{t 'New members can only see messages sent after they join.' }}
     {{/if}}
 {{else}}
-    {{t 'This is a <span class="icon-vector-globe"></span> <b>public stream</b>. Anybody in your organization can join.' }}
+    {{t 'This is a <span class="fa fa-globe" aria-hidden="true"></span> <b>public stream</b>. Anybody in your organization can join.' }}
 {{/if}}
 {{#if is_announcement_only}}
 {{t 'Only organization administrators can post.'}}

--- a/static/templates/tab_bar.handlebars
+++ b/static/templates/tab_bar.handlebars
@@ -2,18 +2,18 @@
     {{#each tabs}}
     <li class="{{active}} {{cls}} {{#if home}}home-link{{/if}}" {{#if data}}data-name="{{data}}"{{/if}}>
         {{#if icon}}
-        <i class="icon-vector-narrow icon-vector-small"></i>
+        <i class="fa fa-angle-right" aria-hidden="true"></i>
         {{/if}}
         {{! Most tabs are links, but some are not since we don't have a narrow for them (e.g. Search) }}
         {{#if hash}}
             {{#if home}}
-            <a href="{{hash}}" title="{{t 'All messages' }} (Esc)"><i class="icon-vector-home"></i></a>
+            <a href="{{hash}}" title="{{t 'All messages' }} (Esc)"><i class="fa fa-home" aria-hidden="true"></i></a>
             {{else}}
             <a href="{{hash}}">{{title}}</a>
             {{/if}}
         {{else}}
             {{#if home}}
-            <i class="icon-vector-home"></i>
+            <i class="fa fa-home" aria-hidden="true"></i>
             {{/if}}
             {{#unless home}}
             {{title}}

--- a/static/templates/topic_edit_form.handlebars
+++ b/static/templates/topic_edit_form.handlebars
@@ -3,8 +3,8 @@
 <form id="topic_edit_form" class="form-horizontal">
     <input type="text" value="" class="inline_topic_edit header-v" id="inline_topic_edit"
       autocomplete="off" />
-    <button type="button" class="topic_edit_save primary"><i class="icon-vector-ok"></i></button>
-    <button type="button" class="topic_edit_cancel primary"><i class="icon-vector-remove"></i></button>
+    <button type="button" class="topic_edit_save primary"><i class="fa fa-check" aria-hidden="true"></i></button>
+    <button type="button" class="topic_edit_cancel primary"><i class="fa fa-remove" aria-hidden="true"></i></button>
     <div class="topic_edit_spinner"></div>
     <div class="alert alert-error edit_error hide"></div>
 </form>

--- a/static/templates/typeahead_list_item.handlebars
+++ b/static/templates/typeahead_list_item.handlebars
@@ -14,7 +14,7 @@
         {{/if}}
     {{else}}
         {{#if is_user_group}}
-        <i class="typeahead-image icon icon-vector-group"></i>
+        <i class="typeahead-image icon fa fa-group" aria-hidden="true"></i>
         {{/if}}
     {{/if}}
 {{/if}}

--- a/static/templates/uploaded_files_list.handlebars
+++ b/static/templates/uploaded_files_list.handlebars
@@ -23,12 +23,12 @@
             <button type="submit"
               class="button small no-style remove-attachment"
               title="{{t 'Delete file' }}" data-attachment="{{id}}">
-                <i class="fa fa-trash" aria-hidden="true"></i>
+                <i class="fa fa-trash-o" aria-hidden="true"></i>
             </button>
         </span>
         <span class="edit-attachment-buttons">
             <a type="submit" href="/user_uploads/{{path_id}}" class="btn no-style" title="{{t 'Download file' }}" id="download_attachment" download>
-                <i class="icon-vector-download-alt sea-green"></i>
+                <i class="fa fa-download sea-green" aria-hidden="true"></i>
             </a>
         </span>
     </td>

--- a/static/templates/user_group_info_popover_content.handlebars
+++ b/static/templates/user_group_info_popover_content.handlebars
@@ -23,7 +23,7 @@
 <ul class="nav nav-list">
     <li>
         <a href="#organization/user-groups-admin">
-            <i class="icon-vector-cog"></i>
+            <i class="fa fa-cog" aria-hidden="true"></i>
             {{t 'Manage user groups' }}
         </a>
     </li>

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -52,7 +52,7 @@
     {{#if is_me}}
     <li>
         <a href="/#settings/your-account">
-            <i class="icon-vector-edit" aria-hidden="true"></i> {{#tr this}}Edit your profile{{/tr}}
+            <i class="fa fa-edit" aria-hidden="true"></i> {{#tr this}}Edit your profile{{/tr}}
         </a>
     </li>
     {{/if}}
@@ -67,13 +67,13 @@
     {{#unless is_me}}
     <li>
         <a href="{{ pm_with_uri }}" class="narrow_to_private_messages">
-            <i class="icon-vector-lock"></i> {{#tr this}}View private messages{{/tr}}
+            <i class="fa fa-lock" aria-hidden="true"></i> {{#tr this}}View private messages{{/tr}}
         </a>
     </li>
     {{/unless}}
     <li>
         <a href="{{ sent_by_uri }}" class="narrow_to_messages_sent">
-            <i class="icon-vector-bullhorn"></i> {{#tr this}}View messages sent{{/tr}}
+            <i class="fa fa-bullhorn" aria-hidden="true"></i> {{#tr this}}View messages sent{{/tr}}
         </a>
     </li>
 </ul>

--- a/static/templates/user_presence_row.handlebars
+++ b/static/templates/user_presence_row.handlebars
@@ -10,5 +10,5 @@
         </a>
         <span class="count"><span class="value">{{#if num_unread}}{{num_unread}}{{/if}}</span></span>
     </div>
-    <span class="arrow"><i class="icon-vector-chevron-down"></i></span>
+    <span class="arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
 </li>

--- a/static/templates/user_profile_modal.handlebars
+++ b/static/templates/user_profile_modal.handlebars
@@ -10,7 +10,7 @@
                 {{full_name}}
                 {{#if is_me}}
                 <a href="/#settings/your-account">
-                    <i class="icon-vector-edit user-profile-modal-edit-button" aria-hidden="true"></i>
+                    <i class="fa fa-edit user-profile-modal-edit-button" aria-hidden="true"></i>
                 </a>
                 {{/if}}
             </div>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -61,10 +61,10 @@
                             <div class="message_header_colorblock message_header_stream left_part"></div>
                             <div class="right_part">
                                 <span id="compose-lock-icon">
-                                    <i class="icon-vector-lock" title="{{ _('This is a private stream') }}"></i>
+                                    <i class="fa fa-lock" title="{{ _('This is a private stream') }}" aria-hidden="true"></i>
                                 </span>
                                 <input type="text" class="recipient_box" name="stream" id="stream" maxlength="30" value="" placeholder="{{ _('Stream') }}" autocomplete="off" tabindex="0" aria-label="{{ _('Stream') }}" />
-                                <i class="icon-vector-narrow icon-vector-small"></i>
+                                <i class="fa fa-angle-right" aria-hidden="true"></i>
                                 <input type="text" class="recipient_box" name="subject" id="subject" maxlength="60" value="" placeholder="{{ _('Topic') }}" autocomplete="off" tabindex="0" aria-label="{{ _('Topic') }}" />
                             </div>
                         </div>
@@ -90,12 +90,12 @@
                                 <div class="drag"></div>
                                 <div id="below-compose-content">
                                     <input type="file" id="file_input" class="notvisible pull-left" multiple />
-                                    <a class="message-control-button icon-vector-smile" id="emoji_map" href="#" title="{{ _('Add emoji') }}"></a>
-                                    <a class="message-control-button icon-vector-font" title="{{ _('Formatting') }}" data-overlay-trigger="markdown-help"></a>
-                                    <a class="message-control-button icon-vector-paper-clip notdisplayed" id="attach_files" href="#" title="{{ _('Attach files') }}"></a> {% if jitsi_server_url %}
-                                    <a class="message-control-button fa fa-video-camera" id="video_link" href="#" title="{{ _('Add video call') }}"></a> {% endif %}
-                                    <a id="undo_markdown_preview" class="message-control-button icon-vector-edit" style="display:none;" title="{{ _('Write') }}"></a>
-                                    <a id="markdown_preview" class="message-control-button icon-vector-eye-open" title="{{ _('Preview') }}"></a>
+                                    <a class="message-control-button fa fa-smile-o" aria-hidden="true" id="emoji_map" href="#" title="{{ _('Add emoji') }}"></a>
+                                    <a class="message-control-button fa fa-font" aria-hidden="true" title="{{ _('Formatting') }}" data-overlay-trigger="markdown-help"></a>
+                                    <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files" href="#" title="{{ _('Attach files') }}"></a> {% if jitsi_server_url %}
+                                    <a class="message-control-button fa fa-video-camera" aria-hidden="true" id="video_link" href="#" title="{{ _('Add video call') }}"></a> {% endif %}
+                                    <a id="undo_markdown_preview" class="message-control-button fa fa-edit" aria-hidden="true" style="display:none;" title="{{ _('Write') }}"></a>
+                                    <a id="markdown_preview" class="message-control-button fa fa-eye" aria-hidden="true" title="{{ _('Preview') }}"></a>
                                     <a class="drafts-link" href="#drafts" title="{{ _('Drafts') }} (d)">{{ _('Drafts') }}</a>
                                     <span id="sending-indicator"></span>
                                     <div id="send_controls" class="new-style">

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -119,7 +119,7 @@
                         <div id="alert-bar" class="alert-bar">
                             <div id="alert-bar-contents" class="alert-bar-contents">
                                 <div id="custom-alert-bar-content"></div>
-                                <i class="icon-vector-remove close-alert-icon"></i>
+                                <i class="fa fa-remove close-alert-icon" aria-hidden="true"></i>
                             </div>
                         </div>
                     </div>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -5,19 +5,19 @@
             <li data-name="home" class="global-filter active-filter home-link" title="{{ _('All messages') }} (Esc)">
                 <a href="#">
                     <span class="filter-icon">
-                        <i class="icon-vector-home"></i>
+                        <i class="fa fa-home" aria-hidden="true"></i>
                     </span>
                     <span class="hover-underline">{{ _('All messages') }}</span>
                     <span class="count">
                         <span class="value"></span>
                     </span>
                 </a>
-                <span class="arrow stream-sidebar-arrow"><i class="icon-vector-chevron-down"></i></span>
+                <span class="arrow stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
             </li>
             <li data-name="private" class="global-filter" title="{{ _('Private messages') }} (P)">
                 <a href="#narrow/is/private">
                     <span class="filter-icon">
-                        <i class="icon-vector-envelope"></i>
+                        <i class="fa fa-envelope" aria-hidden="true"></i>
                     </span>
                     <span class="hover-underline">{{ _('Private messages') }}</span>
                     <span class="count">
@@ -28,7 +28,7 @@
             <li data-name="starred" class="global-filter">
                 <a href="#narrow/is/starred">
                     <span class="filter-icon">
-                        <i class="icon-vector-star"></i>
+                        <i class="fa fa-star" aria-hidden="true"></i>
                     </span>
                     <span class="hover-underline">{{ _('Starred messages') }}</span>
                 </a>
@@ -36,7 +36,7 @@
             <li data-name="mentioned" class="global-filter">
                 <a href="#narrow/is/mentioned">
                     <span class="filter-icon">
-                        <i class="fa fa-at"></i>
+                        <i class="fa fa-at" aria-hidden="true"></i>
                     </span>
                     <span class="hover-underline">{{ _('Mentions') }}</span>
                     <span class="count">
@@ -47,17 +47,17 @@
         </ul>
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Subscribed streams') }}">{{ _('STREAMS') }}</h4>
-                <i id="streams_inline_cog" class='icon-vector-cog' data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
-                <i id="streams_filter_icon" class='icon-vector-search' data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
+                <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
+                <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
             </div>
             <div id="topics_header">
-                <a href="" class="show-all-streams"> <i class="icon-vector-chevron-left"></i>{{ _('All streams') }}</a>
+                <a href="" class="show-all-streams"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{ _('All streams') }}</a>
             </div>
             <div id="stream-filters-container" class="scrolling_list">
                 <div class="input-append notdisplayed">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">
-                        <i class="icon-vector-remove"></i>
+                        <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
                 </div>
                 <ul id="stream_filters" class="filters"></ul>

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -40,7 +40,7 @@
         <div class="column-middle" id="navbar-middle">
             <div class="column-middle-inner">
                 <div id="streamlist-toggle" {%if embedded %} style="visibility: hidden"{% endif %}>
-                    <a href="#" id="streamlist-toggle-button" role="button"><i class="icon-vector-reorder"></i>
+                    <a href="#" id="streamlist-toggle-button" role="button"><i class="fa fa-reorder" aria-hidden="true"></i>
                         <span id="streamlist-toggle-unreadcount">0</span>
                     </a>
                 </div>
@@ -52,8 +52,8 @@
                             <input class="search-query input-block-level" id="search_query" type="text" placeholder="{{ _('Search') }}"
                               autocomplete="off" aria-label="{{ _('Search') }}" title="{{ _('Search') }} (/)"/>
                             {# Start the button off disabled since there is no active search #}
-                            <button class="btn search_button" type="button" id="search_exit" disabled="disabled" aria-label="{{ _('Exit search') }}"><i class="icon-vector-remove"></i></button>
-                            <a class="search_icon" href="#search-operators" data-overlay-trigger="search-operators" title="{{ _('Search help') }}"><i class="icon-vector-search"></i></a>
+                            <button class="btn search_button" type="button" id="search_exit" disabled="disabled" aria-label="{{ _('Exit search') }}"><i class="fa fa-remove" aria-hidden="true"></i></button>
+                            <a class="search_icon" href="#search-operators" data-overlay-trigger="search-operators" title="{{ _('Search help') }}"><i class="fa fa-search" aria-hidden="true"></i></a>
                         </div>
                     </form>
                 </div>{# /searchbox #}
@@ -61,7 +61,7 @@
         </div>
         <div class="column-right">
             <div id="userlist-toggle">
-                <a href="#" id="userlist-toggle-button" role="button"><i class="icon-vector-group"></i>
+                <a href="#" id="userlist-toggle-button" role="button"><i class="fa fa-group" aria-hidden="true"></i>
                     <span id="userlist-toggle-unreadcount">0</span>
                 </a>
             </div>
@@ -69,7 +69,7 @@
                 <ul class="nav" role="navigation">
                     <li class="dropdown actual-dropdown-menu" id="gear-menu">
                         <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle" data-target="nada" data-toggle="dropdown" title="{{ _('Menu') }} (g)">
-                            <i class="icon-vector-cog"></i><i class="icon-vector-caret-down settings-dropdown-caret"></i>
+                            <i class="fa fa-cog" aria-hidden="true"></i><i class="fa fa-caret-down settings-dropdown-caret" aria-hidden="true"></i>
                         </a>
                         <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">
                             {#
@@ -80,60 +80,60 @@
                             <li class="invisible" style="display:none;" role="presentation"><a href="#home" data-toggle="tab"></a></li>
                             <li role="presentation">
                                 <a href="#streams" role="menuitem">
-                                    <i class="icon-vector-exchange"></i> {{ _('Manage streams') }}
+                                    <i class="fa fa-exchange" aria-hidden="true"></i> {{ _('Manage streams') }}
                                 </a>
                             </li>
                             <li role="presentation">
                                 <a href="#settings" role="menuitem">
-                                    <i class="icon-vector-wrench"></i> {{ _('Settings') }}
+                                    <i class="fa fa-wrench" aria-hidden="true"></i> {{ _('Settings') }}
                                 </a>
                             </li>
                             <li class="admin-menu-item" role="presentation">
                                 <a href="#organization" role="menuitem">
-                                    <i class="icon-vector-bolt"></i>
+                                    <i class="fa fa-bolt" aria-hidden="true"></i>
                                     <span>{{ _('Manage organization') }}</span>
                                 </a>
                             </li>
                             <li class="divider"></li>
                             <li role="presentation">
                                 <a href="/help" target="_blank" role="menuitem">
-                                    <i class="icon-vector-question-sign"></i> {{ _('User documentation') }}
+                                    <i class="fa fa-question-circle" aria-hidden="true"></i> {{ _('User documentation') }}
                                 </a>
                             </li>
                             <li role="presentation">
                                 <a tabindex="0" role="menuitem" data-overlay-trigger="keyboard-shortcuts">
-                                    <i class="icon-vector-keyboard"></i> {{ _('Keyboard shortcuts') }} <span class="hotkey-hint">(?)</span>
+                                    <i class="fa fa-keyboard-o" aria-hidden="true"></i> {{ _('Keyboard shortcuts') }} <span class="hotkey-hint">(?)</span>
                                 </a>
                             </li>
                             <li role="presentation">
                                 <a tabindex="0" role="menuitem" data-overlay-trigger="markdown-help">
-                                    <i class="icon-vector-pencil"></i> {{ _('Message formatting') }}
+                                    <i class="fa fa-pencil" aria-hidden="true"></i> {{ _('Message formatting') }}
                                 </a>
                             </li>
                             <li role="presentation">
                                 <a tabindex="0" role="menuitem" data-overlay-trigger="search-operators">
-                                    <i class="icon-vector-search"></i> {{ _('Search operators') }}
+                                    <i class="fa fa-search" aria-hidden="true"></i> {{ _('Search operators') }}
                                 </a>
                             </li>
                             <li class="divider" role="presentation"></li>
                             <li role="presentation">
                                 <a href="{{ apps_page_url }}" target="_blank" role="menuitem">
-                                    <i class="icon-vector-desktop"></i> {{ _('Desktop & mobile apps') }}
+                                    <i class="fa fa-desktop" aria-hidden="true"></i> {{ _('Desktop & mobile apps') }}
                                 </a>
                             </li>
                             <li role="presentation">
                                 <a href="/integrations" target="_blank" role="menuitem">
-                                    <i class="icon-vector-github"></i> {{ _('Integrations') }}
+                                    <i class="fa fa-github" aria-hidden="true"></i> {{ _('Integrations') }}
                                 </a>
                             </li>
                             <li role="presentation">
                                 <a href="/api" target="_blank" role="menuitem">
-                                    <i class="icon-vector-sitemap"></i> {{ _('API documentation') }}
+                                    <i class="fa fa-sitemap" aria-hidden="true"></i> {{ _('API documentation') }}
                                 </a>
                             </li>
                             <li role="presentation">
                                 <a href="/stats" target="_blank" role="menuitem">
-                                    <i class="icon-vector-bar-chart"></i>
+                                    <i class="fa fa-bar-chart" aria-hidden="true"></i>
                                     <span>{{ _('Statistics') }}</span>
                                 </a>
                             </li>
@@ -141,14 +141,14 @@
                             {% if enable_feedback %}
                             <li role="presentation">
                                 <a href="#feedback" class="feedback" role="menuitem">
-                                    <i class="icon-vector-comment"></i> {{ _('Feedback') }}
+                                    <i class="fa fa-comment" aria-hidden="true"></i> {{ _('Feedback') }}
                                 </a>
                             </li>
                             {% endif %}
                             {% if show_invites %}
                             <li role="presentation">
                                 <a href="#invite" role="menuitem">
-                                    <i class="icon-vector-plus-sign"></i> {{ _('Invite users') }}
+                                    <i class="fa fa-plus-circle" aria-hidden="true"></i> {{ _('Invite users') }}
                                 </a>
                             </li>
                             <li class="divider" role="presentation"></li>
@@ -156,19 +156,19 @@
                             {% if show_webathena %}
                             <li title="{% trans %}Grant Zulip the Kerberos tickets needed to run your Zephyr mirror via Webathena{% endtrans %}" id="webathena_login_menu" role="presentation">
                                 <a href="#webathena" class="webathena_login" role="menuitem">
-                                    <i class="icon-vector-bolt"></i>{{ _('Link with Webathena') }}
+                                    <i class="fa fa-bolt" aria-hidden="true"></i>{{ _('Link with Webathena') }}
                                 </a>
                             </li>
                             {% endif %}
                             <li role="presentation">
                                 <a href="#logout" class="logout_button" role="menuitem">
-                                    <i class="icon-vector-off"></i> {{ _('Log out') }}
+                                    <i class="fa fa-power-off" aria-hidden="true"></i> {{ _('Log out') }}
                                 </a>
                             </li>
                             {% if show_debug %}
                             <li role="presentation">
                                 <a href="#debug" data-toggle="tab" role="menuitem">
-                                    <i class="icon-vector-barcode"></i> {{ _('Debug') }}
+                                    <i class="fa fa-barcode" aria-hidden="true"></i> {{ _('Debug') }}
                                 </a>
                             </li>
                             {% endif %}

--- a/templates/zerver/app/right_sidebar.html
+++ b/templates/zerver/app/right_sidebar.html
@@ -3,24 +3,24 @@
         {% if enable_feedback %}
         <div id="feedback_section" class="new-style">
             <button type="button" class="button small rounded" id="feedback_button">
-                <i class="icon-vector-comment"></i>&nbsp;&nbsp;{{ _('Send feedback') }}
+                <i class="fa fa-comment" aria-hidden="true"></i>&nbsp;&nbsp;{{ _('Send feedback') }}
             </button>
         </div>
         {% endif %}
         <div id="user-list">
             <div id="userlist-header">
                 <h4 class='sidebar-title' id='userlist-title' data-toggle="tooltip" title="{{ _('Filter users') }}">{{ _('USERS') }}</h4>
-                <i id="user_filter_icon" class='fa fa-search' aria-label="{{ _('Filter users') }}" data-toggle="tooltip" title="{{ _('Filter users') }} (w)"></i>
+                <i id="user_filter_icon" class='fa fa-search' aria-hidden="true" aria-label="{{ _('Filter users') }}" data-toggle="tooltip" title="{{ _('Filter users') }} (w)"></i>
             </div>
             <div class="input-append notdisplayed">
                 <input class="user-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search people') }}" />
                 <button type="button" class="btn clear_search_button" id="clear_search_people_button">
-                    <i class="icon-vector-remove"></i>
+                    <i class="fa fa-remove" aria-hidden="true"></i>
                 </button>
             </div>
             <ul id="user_presences" class="filters scrolling_list"></ul>
             {% if show_invites %}
-            <a id="invite-user-link" href="#invite"><i class="icon-vector-plus-sign"></i>{{ _('Invite more users') }}</a>
+            <a id="invite-user-link" href="#invite"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Invite more users') }}</a>
             {% endif %}
         </div>
         <div id="group-pm-list">
@@ -31,7 +31,7 @@
             </ul>
         </div>
         <div id="sidebar-keyboard-shortcuts">
-            <i id="keyboard-icon" class="fa fa-keyboard-o fa-2x" data-html="true" data-overlay-trigger="keyboard-shortcuts" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
+            <i id="keyboard-icon" class="fa fa-keyboard-o fa-2x" aria-hidden="true" data-html="true" data-overlay-trigger="keyboard-shortcuts" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
         </div>
     </div>
 </div>

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -1,6 +1,6 @@
 <div id="settings_page" class="new-style overlay-content modal-bg">
     <div class="settings-header mobile">
-        <div class="icon-vector-chevron-left"></div>
+        <i class="fa fa-chevron-left" aria-hidden="true"></i>
         <h1>{{ _('Settings') }}<span class="section"></span></h1>
         <div class="exit">
             <span class="exit-sign">&times;</span>
@@ -12,91 +12,91 @@
             <div class="center tab-container"></div>
             <ul class="normal-settings-list">
                 <li tabindex="0" data-section="your-account">
-                    <div class="icon icon-vector-user"></div>
+                    <i class="icon fa fa-user" aria-hidden="true"></i>
                     <div class="text">{{ _('Your account') }}</div>
                 </li>
                 <li tabindex="0" data-section="display-settings">
-                    <div class="icon icon-vector-time"></div>
+                    <i class="icon fa fa-clock-o" aria-hidden="true"></i>
                     <div class="text">{{ _('Display settings') }}</div>
                 </li>
                 <li tabindex="0" data-section="notifications">
-                    <div class="icon icon-vector-warning-sign"></div>
+                    <i class="icon fa fa-exclamation-triangle" aria-hidden="true"></i>
                     <div class="text">{{ _('Notifications') }}</div>
                 </li>
                 <li tabindex="0" data-section="your-bots">
-                    <div class="icon icon-vector-github"></div>
+                    <i class="icon fa fa-github" aria-hidden="true"></i>
                     <div class="text">{{ _('Your bots') }}</div>
                 </li>
                 <li tabindex="0" data-section="alert-words">
-                    <div class="icon icon-vector-book"></div>
+                    <i class="icon fa fa-book" aria-hidden="true"></i>
                     <div class="text">{{ _('Alert words') }}</div>
                 </li>
                 <li tabindex="0" data-section="uploaded-files">
-                    <div class="icon icon-vector-paper-clip"></div>
+                    <i class="icon fa fa-paperclip" aria-hidden="true"></i>
                     <div class="text">{{ _('Uploaded files') }}</div>
                 </li>
                 <li tabindex="0" data-section="muted-topics">
-                    <div class="icon icon-vector-eye-close"></div>
+                    <i class="icon fa fa-eye-slash" aria-hidden="true"></i>
                     <div class="text">{{ _('Muted topics') }}</div>
                 </li>
             </ul>
 
             <ul class="org-settings-list">
                 <li tabindex="0" data-section="organization-profile">
-                    <i class="icon icon-vector-lock"></i>
+                    <i class="icon fa fa-lock" aria-hidden="true"></i>
                     <div class="text">{{ _('Organization profile') }}</div>
                 </li>
                 <li tabindex="0" data-section="organization-settings">
-                    <i class="icon icon-vector-beaker"></i>
+                    <i class="icon fa fa-flask" aria-hidden="true"></i>
                     <div class="text">{{ _('Organization settings') }}</div>
                 </li>
                 <li tabindex="0" data-section="organization-permissions">
-                    <i class="icon icon-vector-lock"></i>
+                    <i class="icon fa fa-lock" aria-hidden="true"></i>
                     <div class="text">{{ _('Organization permissions') }}</div>
                 </li>
                 <li tabindex="0" data-section="emoji-settings">
-                    <i class="icon icon-vector-smile"></i>
+                    <i class="icon fa fa-smile-o" aria-hidden="true"></i>
                     <div class="text">{{ _('Custom emoji') }}</div>
                 </li>
                 <li tabindex="0" data-section="user-groups-admin">
-                    <i class="icon icon-vector-group"></i>
+                    <i class="icon fa fa-group" aria-hidden="true"></i>
                     <div class="text">{{ _('User groups') }}</div>
                 </li>
                 <li tabindex="0" data-section="auth-methods">
-                    <i class="icon icon-vector-lock"></i>
+                    <i class="icon fa fa-lock" aria-hidden="true"></i>
                     <div class="text">{{ _('Authentication methods') }}</div>
                 </li>
                 <li tabindex="0" data-section="user-list-admin">
-                    <i class="icon icon-vector-user"></i>
+                    <i class="icon fa fa-user" aria-hidden="true"></i>
                     <div class="text">{{ _('Users') }}</div>
                 </li>
                 {% if is_admin %}
                 <li tabindex="0" data-section="deactivated-users-admin">
-                    <i class="icon icon-vector-trash"></i>
+                    <i class="icon fa fa-trash-o" aria-hidden="true"></i>
                     <div class="text">{{ _('Deactivated users') }}</div>
                 </li>
                 {% endif %}
                 <li tabindex="0" data-section="bot-list-admin">
-                    <i class="icon icon-vector-github"></i>
+                    <i class="icon fa fa-github" aria-hidden="true"></i>
                     <div class="text">{{ _('Bots') }}</div>
                 </li>
                 <li tabindex="0" data-section="default-streams-list">
-                    <i class="icon icon-vector-exchange"></i>
+                    <i class="icon fa fa-exchange" aria-hidden="true"></i>
                     <div class="text">{{ _('Default streams') }}</div>
                 </li>
                 <li tabindex="0" data-section="filter-settings">
-                    <i class="icon icon-vector-font"></i>
+                    <i class="icon fa fa-font" aria-hidden="true"></i>
                     <div class="text">{{ _('Filter settings') }}</div>
                 </li>
                 {% if custom_profile_fields_enabled %}
                 <li tabindex="0" data-section="profile-field-settings">
-                    <i class="icon icon-vector-user"></i>
+                    <i class="icon fa fa-user" aria-hidden="true"></i>
                     <div class="text">{{ _('Custom profile fields') }}</div>
                 </li>
                 {% endif %}
                 {% if is_admin %}
                 <li tabindex="0" data-section="invites-list-admin">
-                    <i class="icon icon-vector-user"></i>
+                    <i class="icon fa fa-user" aria-hidden="true"></i>
                     <div class="text">{{ _('Invitations') }}</div>
                 </li>
                 {% endif %}

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -144,8 +144,8 @@
                         </div>
                     </div>
 
-                    <a class="carousel-control left visibility-control hide" href="#tour-carousel" data-slide="prev"><i class="fa fa-chevron-left"></i></a>
-                    <a class="carousel-control right visibility-control" href="#tour-carousel" data-slide="next"><i class="fa fa-chevron-right"></i></a>
+                    <a class="carousel-control left visibility-control hide" href="#tour-carousel" data-slide="prev"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
+                    <a class="carousel-control right visibility-control" href="#tour-carousel" data-slide="next"><i class="fa fa-chevron-right" aria-hidden="true"></i></a>
                     <ol class="carousel-indicators">
                         <li data-target="#tour-carousel" data-slide-to="0" class="active"></li>
                         <li data-target="#tour-carousel" data-slide-to="1"></li>
@@ -179,28 +179,28 @@
                 <div class="group">
                     <h2>Web</h2>
                     <a href="{{ apps_page_url }}">
-                        <i class="icon-vector-desktop platform-icon"></i>
+                        <i class="fa fa-desktop platform-icon" aria-hidden="true"></i>
                     </a>
                 </div>
                 <div class="group">
                     <h2>Desktop</h2>
                     <a href="{{ apps_page_url }}mac">
-                        <i class="icon-vector-apple platform-icon"></i>
+                        <i class="fa fa-apple platform-icon" aria-hidden="true"></i>
                     </a>
                     <a href="{{ apps_page_url }}windows">
-                        <i class="icon-vector-windows platform-icon"></i>
+                        <i class="fa fa-windows platform-icon" aria-hidden="true"></i>
                     </a>
                     <a href="{{ apps_page_url }}linux">
-                        <i class="icon-vector-linux platform-icon"></i>
+                        <i class="fa fa-linux platform-icon" aria-hidden="true"></i>
                     </a>
                 </div>
                 <div class="group">
                     <h2>Mobile</h2>
                     <a href="{{ apps_page_url }}ios">
-                        <i class="icon-vector-mobile-phone platform-icon"></i>
+                        <i class="fa fa-mobile-phone platform-icon" aria-hidden="true"></i>
                     </a>
                     <a href="{{ apps_page_url }}android">
-                        <i class="icon-vector-android platform-icon"></i>
+                        <i class="fa fa-android platform-icon" aria-hidden="true"></i>
                     </a>
                 </div>
             </div>
@@ -475,10 +475,10 @@
                 </div>
 
                 <div class="left visibility-control hide">
-                    <a class="fa fa-chevron-left" href="#quote-carousel" data-slide="prev"></a>
+                    <a class="fa fa-chevron-left" aria-hidden="true" href="#quote-carousel" data-slide="prev"></a>
                 </div>
                 <div class="right visibility-control">
-                    <a class="fa fa-chevron-right" href="#quote-carousel" data-slide="next"></a>
+                    <a class="fa fa-chevron-right" aria-hidden="true" href="#quote-carousel" data-slide="next"></a>
                 </div>
             </div>
 


### PR DESCRIPTION
In this PR we migrate most of our codebase to start using the font awesome 4.7 standard icon prefixes so that we can finally drop support for older font awesome versions. We decided to stick with font awesome version 4.7 despite FA-5.0 being released and again fiddling with the icon prefixes because the icons in font-awesome 5.0 have quite a number of instances where the icon which we want to use has been changed or came under paid scheme.

In this PR we migrate to use the prefixes standard of `fa fa-<icon-name>`