### PR TITLE
portico: Align terms of service checkbox.

### DIFF
--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -223,7 +223,7 @@ html {
 
 .register-account .terms-of-service .input-group {
     width: 330px;
-    margin-bottom: 0 auto 10px;
+    margin: 0 auto 10px;
 }
 
 .register-account .terms-of-service .text-error {


### PR DESCRIPTION
This fixes an invalid css property from 30815b4, which addressed #9328.


Before:

![image](https://user-images.githubusercontent.com/12771126/42358047-98253b12-808f-11e8-8a89-828f7411d2be.png)

After:

![image](https://user-images.githubusercontent.com/12771126/42358176-2a33fb74-8090-11e8-8cc5-9f38357674e5.png)

