### PR TITLE
Fix low-hanging HTML validation problems.

### DIFF
--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -2,7 +2,7 @@
 
 <p id="utctime" style="text-align: center;"></p>
 <p id="localtime" style="text-align: center;"></p>
-<script type="text/javascript">
+<script>
     var now = moment('{{ now }}');
     $('#utctime')[0].innerHTML = moment.utc(now).format('YYYY-MM-DD HH:mm') + 'Z';
     $('#localtime')[0].innerHTML = '(' + now.format('YYYY-MM-DD HH:mm ZZ') + ')';

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -1,7 +1,7 @@
 {% extends "zerver/base.html" %}
 
 {% block page_params %}
-<script type="text/javascript">
+<script>
     var page_params = {{ page_params|safe }};
 </script>
 {% endblock %}

--- a/templates/confirmation/confirm_preregistrationuser.html
+++ b/templates/confirmation/confirm_preregistrationuser.html
@@ -15,7 +15,7 @@ post to another view which executes in our code to produce the desired form.
     <input type="hidden" value="{% if full_name %}{{ full_name }}{% endif %}" name="full_name"/>
 </form>
 
-<script type="text/javascript">
+<script>
     $(function () {
         $("#register").submit();
     });

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -4,7 +4,7 @@
 {# This is where we pitch the app and solicit signups. #}
 
 {% block portico_content %}
-<script type="text/javascript">
+<script>
 $(function () {
     common.autofocus('#email');
 });
@@ -102,7 +102,7 @@ $(function () {
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 if (window.location.hash.substring(0, 1) === "#") {
     document.email_form.action += window.location.hash;
 }

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -67,7 +67,7 @@ $(function () {
                                     {% endif %}
                                 </div>
 
-                                <button class="full-width" type="submit" name="">{{ _('Sign up') }}</button>
+                                <button class="full-width" type="submit">{{ _('Sign up') }}</button>
                             </form>
 
                             {% if any_oauth_backend_enabled %}

--- a/templates/zerver/accounts_send_confirm.html
+++ b/templates/zerver/accounts_send_confirm.html
@@ -29,7 +29,7 @@
 
 {% block customhead %}
 {{ super() }}
-<script type="text/javascript">
+<script>
 $(function() {
     $("#resend_email_link").click(function () {
         $('#resend_confirm').submit();

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -73,14 +73,14 @@
                             <div class="right_part">
                                 <div class="pm_recipient">
                                     <div class="pill-container" data-before="{{ _('You and') }}">
-                                        <div class="input" contenteditable="true" id="private_message_recipient" name="recipient" data-no-recipients-text="{{ _('Add one or more users') }}" data-some-recipients-text="{{ _('Add another user...') }}"></div>
+                                        <div class="input" contenteditable="true" id="private_message_recipient" data-no-recipients-text="{{ _('Add one or more users') }}" data-some-recipients-text="{{ _('Add another user...') }}"></div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                         <div>
-                            <div class="messagebox" colspan="2">
-                                <textarea class="new_message_textarea" name="content" id='compose-textarea' value="" placeholder="{{ _('Compose your message here') }}" tabindex="0" maxlength="10000" aria-label="{{ _('Compose your message here...') }}"></textarea>
+                            <div class="messagebox">
+                                <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{ _('Compose your message here') }}" tabindex="0" maxlength="10000" aria-label="{{ _('Compose your message here...') }}"></textarea>
                                 <div class="scrolling_list" id="preview_message_area" style="display:none;">
                                     <div id="markdown_preview_spinner"></div>
                                     <div id="preview_content"></div>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -4,7 +4,7 @@
 
 {% block page_params %}
 {# Insert parameters, which have been encoded with JSONEncoderForHTML. #}
-<script type="text/javascript" nonce="{{ csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
     {% autoescape off %}
     var page_params = {{ page_params }};
     {% endautoescape %}
@@ -20,7 +20,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <link href="/static/images/logo/apple-touch-icon-precomposed.png" rel="apple-touch-icon-precomposed">
 <link id="emoji-spritesheet" href="/static/generated/emoji/{{ emojiset }}_sprite.css" rel="stylesheet" type="text/css">
-<style type="text/css">
+<style>
     #css-loading {
     background: white;
     position: fixed;

--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -60,7 +60,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>:heart: (and <a href="http://www.emoji-cheat-sheet.com/" target="_blank">many others</a>, from the <a href="https://code.google.com/p/noto/" license="/static/generated/emoji/images/emoji/NOTICE" target="_blank">Noto Project</a>)</td>
+                        <td>:heart: (and <a href="http://www.emoji-cheat-sheet.com/" target="_blank">many others</a>, from the <a href="https://code.google.com/p/noto/" target="_blank">Noto Project</a>)</td>
                         <td><img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/heart.png" title=":heart:" /></td>
                     </tr>
                     <tr>

--- a/templates/zerver/archive/index.html
+++ b/templates/zerver/archive/index.html
@@ -2,7 +2,7 @@
 
 {% block customhead %}
     <link id="emoji-spritesheet" href="/static/generated/emoji/google_sprite.css" rel="stylesheet" type="text/css">
-    <style type="text/css">
+    <style>
         .portico-header {
         padding-bottom: 0px;
         padding-top: 10px;

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -20,7 +20,7 @@
 
         {% block page_params %}
         {# blueslip needs page_params.debug_mode.  Set it to false by default. #}
-        <script type="text/javascript">
+        <script>
         var page_params = {debug_mode: false};
         </script>
         {% endblock %}

--- a/templates/zerver/create_realm.html
+++ b/templates/zerver/create_realm.html
@@ -4,7 +4,7 @@
 {# This is where we pitch the app and solicit signups. #}
 
 {% block portico_content %}
-<script type="text/javascript">
+<script>
 $(function () {
     common.autofocus('#email');
 });

--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -64,7 +64,7 @@
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 if (window.location.hash.substring(0, 1) === "#") {
     /* We append the location.hash to the formaction so that URL can be
     preserved after user is logged in. See this:

--- a/templates/zerver/email_log.html
+++ b/templates/zerver/email_log.html
@@ -59,7 +59,7 @@
             <button data-dismiss="modal">Close</button>
         </div>
     </div>
-    <script type="text/javascript">
+    <script>
     $('#toggle').change(function() {
         if($('.email-text').css('display') == 'none') {
             $(".email-text").each(function() {

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -11,7 +11,7 @@
 
 
     {% if password_auth_enabled %}
-    <script type="text/javascript">
+    <script>
         {% if email %}
         common.autofocus('#id_password');
         {% else %}
@@ -168,7 +168,7 @@
             </div>
         </div>
     </div>
-    <script type="text/javascript">
+    <script>
     if (window.location.hash.substring(0, 1) === "#") {
         /* We append the location.hash to the formaction so that URL can be
         preserved after user is logged in. See this:

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -209,7 +209,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 if ($("#id_team_name").length === 1) {
     common.autofocus('#id_team_name');
 } else if (($('#id_email').length === 1) && (!$('#id_email').attr('disabled'))) {

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -39,7 +39,7 @@
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     common.autofocus('#id_email');
 </script>
 

--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -65,7 +65,7 @@
                 </div>
             </form>
 
-            <script type="text/javascript">
+            <script>
                 common.autofocus('#id_new_password1');
             </script>
             {% else %}

--- a/zerver/templatetags/minified_js.py
+++ b/zerver/templatetags/minified_js.py
@@ -24,7 +24,6 @@ class MinifiedJSNode(Node):
         else:
             scripts = [settings.JS_SPECS[self.sourcefile]['output_filename']]
         script_urls = [staticfiles_storage.url(script) for script in scripts]
-        script_tags = [('<script type="text/javascript" nonce="%s"'
-                       ' src="%s" charset="utf-8"></script>') % (self.csp_nonce, url)
+        script_tags = ['<script nonce="%s" src="%s"></script>' % (self.csp_nonce, url)
                        for url in script_urls]
         return '\n'.join(script_tags)


### PR DESCRIPTION
This fixes a bunch of small issues found by HTML validation with the validator.nu code. Most of them looked invisible but a handful had really been rendering wrong (e.g. “located in zulip_bots/bots//” in /api/running-bots).

You run a local copy of validator.nu with `npm -g install validator-nu; java -jar ~/.local/lib/node_modules/vnu-jar/build/dist/vnu.jar`. Perhaps we can eventually run it on a bunch of pages as part of linting?