### PR TITLE
Styling for listing stream names

### DIFF
--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -231,3 +231,41 @@
     cursor: pointer;
     font-size: 20px;
 }
+
+#invite-stream-checkboxes {
+    .stream-name {
+        padding: 2px 0;
+    }
+
+    .stream-privacy {
+        font-size: 15px;
+        width: 9px;
+        margin-right: 2px;
+        margin-left: 1px;
+        position: relative;
+        top: 1px;
+        color: hsl(0, 0%, 38%);
+    }
+
+    span.stream-hashtag {
+        top: -2px;
+        margin: 0 2px 0 0;
+        padding: 0;
+        height: auto;
+        width: auto;
+        font-weight: 800;
+        line-height: auto;
+        text-align: left;
+        border: none;
+        color: hsl(0, 0%, 38%);
+        cursor: auto;
+
+        &::after {
+            content: "#";
+            font-size: 1.3rem;
+            font-weight: 800;
+            line-height: 0;
+        }
+    }
+
+}

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2206,6 +2206,44 @@ li .message_inline_image img {
     cursor: pointer;
 }
 
+#stream-checkboxes {
+    .stream-name {
+        padding: 2px 0;
+    }
+
+    .stream-privacy {
+        font-size: 15px;
+        width: 9px;
+        margin-right: 2px;
+        margin-left: 1px;
+        position: relative;
+        top: 1px;
+        color: hsl(0, 0%, 38%);
+    }
+
+    span.stream-hashtag {
+        top: -2px;
+        margin: 0 2px 0 0;
+        padding: 0;
+        height: auto;
+        width: auto;
+        font-weight: 800;
+        line-height: auto;
+        text-align: left;
+        border: none;
+        color: hsl(0, 0%, 38%);
+        cursor: auto;
+
+        &::after {
+            content: "#";
+            font-size: 1.3rem;
+            font-weight: 800;
+            line-height: 0;
+        }
+    }
+}
+
+
 .sub_button_row {
     text-align: center;
 }

--- a/static/templates/invite_subscription.handlebars
+++ b/static/templates/invite_subscription.handlebars
@@ -6,11 +6,12 @@
 <div id="invite-stream-checkboxes" class="new-style">
     {{#each streams}}
 
-    <label class="checkbox display-block">
+    <label class="checkbox display-block stream-name">
         <input type="checkbox" name="stream" value="{{name}}"
           {{#if default_stream}}checked="checked"{{/if}} />
         <span></span>
-        {{#if invite_only}}<i class="fa fa-lock" aria-hidden="true"></i>{{/if}}
+        {{#if invite_only}}<i class="fa fa-lock stream-privacy" aria-hidden="true"></i>{{/if}}
+        {{#unless invite_only}}<span class="stream-hashtag"></span>{{/unless}}
         {{name}}
     </label>
     {{/each}}

--- a/static/templates/new_stream_users.handlebars
+++ b/static/templates/new_stream_users.handlebars
@@ -12,6 +12,8 @@
     <label class="checkbox add-user-label" data-stream-id="{{this.stream_id}}" data-stream-name="{{this.name}}">
         <input type="checkbox" name="stream" value="{{this.name}}" />
         <span></span>
+        {{#if invite_only}}<i class="fa fa-lock stream-privacy" aria-hidden="true"></i>{{/if}}
+        {{#unless invite_only}}<span class="stream-hashtag"></span>{{/unless}}
         {{this.name}} ( <i class="fa fa-user" aria-hidden="true"></i> {{this.subscriber_count}})
     </label>
     {{/each}}


### PR DESCRIPTION
This styles the list of stream names that appears on the invite users modal, and when copying users to invite from an existing stream when creating a new stream.

<img width="354" alt="screen shot 2018-07-06 at 1 39 05 pm" src="https://user-images.githubusercontent.com/2905696/42393055-0b205c80-8123-11e8-8abc-b74edcf6c740.png">
<img width="211" alt="screen shot 2018-07-06 at 1 44 23 pm" src="https://user-images.githubusercontent.com/2905696/42393057-0b912154-8123-11e8-854e-388680a963ee.png">

One thing to note: the way the "new style" checkboxes are coded precludes implementing this cleanly. Those checkboxes are created by applying styles to any `span` element within a `label` element. Since we need to use the span element to style items in a list of radio buttons or checkboxes, we have to add a bunch of styles essentially "un-styling" the default in-label `span` element.

The ideal way to implement a reusable, formatted stream name component would be to start by refactoring the new style checkboxes to use a `span` element with a class so that further `span` elements can be used inside those `label` elements, but that's a project for another time.