### PR TITLE
invitations: Send 'invites_changed' event for invitations events.

### DIFF
--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -26,6 +26,12 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             event.hotspots;
         break;
 
+    case 'invites_changed':
+        if ($('#admin-invites-list').length) {
+            settings_invites.set_up();
+        }
+        break;
+
     case 'muted_topics':
         muting_ui.handle_updates(event.muted_topics);
         break;

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -607,6 +607,8 @@ def apply_event(state: Dict[str, Any],
     elif event['type'] == "update_global_notifications":
         assert event['notification_name'] in UserProfile.notification_setting_types
         state[event['notification_name']] = event['setting']
+    elif event['type'] == "invites_changed":
+        pass
     elif event['type'] == "user_group":
         if event['op'] == 'add':
             state['realm_user_groups'].append(event['group'])

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -454,7 +454,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 72)
+        self.assert_length(queries, 73)
         user_profile = self.nonreg_user('test')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)


### PR DESCRIPTION
**[DON'T MERGE]** 
This is currently simply rebased #7780.
So what it is doing currently:
* Sending an event when a user is invited or his invite is revoked.
* Simply repeats the whole process of setting up the invite page on those events.

@timabbott what are the problems associated with this approach.

* The bug/improvements I can point currently is it doesn't send an event when a user accepts the invitation.
* Both commits needs to be squashed.
* And obviously below change doesn't work as I've removed the `delete` API recently so before adding it I want to make sure if we want to go with this approach or we have changed the plan to do this in some other way?

```diff
+    var invites_list = list_render.get("admin_invites_list");
+
+    if (invites_list) {
+        list_render.delete("admin_invites_list");
+    }
```