### PR TITLE
WIP: Improve floating recipient bar behavior during scrolling using position: sticky

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -238,7 +238,9 @@ body.dark-theme {
         background-color: hsl(212, 28%, 18%);
     }
 
-    .private-message .alert-msg {
+    .private-message .alert-msg,
+    .private-message .messagebox,
+    .private-message .date-row {
         background-color: hsl(208, 17%, 29%);
     }
 
@@ -400,7 +402,7 @@ body.dark-theme {
 
     .message-header-contents,
     .message_header_private_message .message-header-contents {
-        background-color: hsla(0, 0%, 0%, 0.2);
+        background-color: hsl(212, 28%, 14%);
         border-color: transparent;
     }
 

--- a/static/styles/message_edit_history.css
+++ b/static/styles/message_edit_history.css
@@ -15,7 +15,7 @@
     }
 
     .messagebox-content {
-        padding: 0 10px;
+        padding: 0 11px;
     }
 
     .message_edit_history_content {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1043,8 +1043,9 @@ td.pointer {
     white-space: nowrap;
     font-weight: 600;
     line-height: 14px;
-    position: relative;
-    z-index: 0;
+    position: sticky;
+    top: $sidebar_top;
+    z-index: 3;
 }
 
 .message_list {
@@ -2244,6 +2245,7 @@ div.floating_recipient {
 
 #floating_recipient_bar {
     top: $sidebar_top;
+    display: none;
 }
 
 #bottom_whitespace {
@@ -3043,6 +3045,10 @@ select.inline_select_topic_edit {
         white-space: nowrap;
         text-overflow: ellipsis;
         line-height: 15px;
+    }
+
+    .message_header {
+        top: 40px;
     }
 
     #floating_recipient_bar {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1315,7 +1315,7 @@ td.pointer {
     }
 
     .messagebox-content {
-        padding-bottom: 1px;
+        padding-bottom: 2px;
     }
 }
 
@@ -1330,9 +1330,7 @@ td.pointer {
     }
 
     .messagebox-content {
-        box-shadow: inset 0 0 0 2px hsl(215, 47%, 50%),
-            -1px -1px 0 0 hsl(215, 47%, 50%), 1px 1px 0 0 hsl(215, 47%, 50%),
-            -1px 1px 0 0 hsl(215, 47%, 50%), 1px -1px 0 0 hsl(215, 47%, 50%);
+        box-shadow: inset 0 0 0 3px hsl(215, 47%, 50%);
     }
 }
 
@@ -1455,10 +1453,6 @@ div.message_table {
     position: relative;
     border-left: 1px solid hsla(0, 0%, 0%, 0.1);
     border-right: 1px solid hsla(0, 0%, 0%, 0.1);
-
-    &.selected_message {
-        z-index: 2;
-    }
 
     .date_row {
         /* We only want padding for the date rows between recipient blocks */
@@ -1648,7 +1642,8 @@ div.focused_table {
 }
 
 .messagebox-content {
-    padding: 4px 115px 1px 10px;
+    margin: 0 -1px;
+    padding: 4px 116px 1px 11px;
 }
 
 .bookend {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1258,7 +1258,7 @@ td.pointer {
        private messages, mentions, and unread messages */
 
     .message-header-contents {
-        background-color: hsla(192, 19%, 75%, 0.2);
+        background-color: hsl(192, 20%, 95%);
         box-shadow: inset 1px 1px 0 hsl(0, 0%, 88%);
     }
 }
@@ -1270,7 +1270,7 @@ td.pointer {
 
     .messagebox,
     .date_row {
-        background-color: hsla(192, 19%, 75%, 0.2);
+        background-color: hsl(192, 20%, 95%);
         box-shadow: inset 2px 0 0 0 hsl(0, 0%, 27%), -1px 0 0 0 hsl(0, 0%, 27%);
     }
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -434,6 +434,15 @@ p.n-margin {
     .column-middle {
         min-height: 100%;
     }
+
+    .column-middle-inner {
+        /* Override Bootstrap's .tab-content { overflow: auto } so we can use
+           position: sticky inside */
+        overflow: visible;
+        /* Disable margin collapsing */
+        display: flex;
+        flex-direction: column;
+    }
 }
 
 .column-middle,
@@ -777,8 +786,7 @@ li.actual-dropdown-menu i {
 }
 
 .message_area_padder {
-    /* The height of the header and the message_view_header plus a small gap */
-    margin-top: 57px;
+    margin-top: 16px;
     /* This is needed for the floating recipient bar
        in Firefox only, for some reason;
        otherwise it gets a scrollbar */


### PR DESCRIPTION
The current floating recipient header doesn’t update during scrolling; it waits for some delay after scrolling is complete. Users who scroll for too long see an incorrect header until it updates. Of course, doing DOM updates in JavaScript scroll handlers would likely cause a serious performance problem, which probably explains why it was implemented this way.

But now a substitute is available in pure CSS! The idea is to get rid of `floating_recipient_bar` entirely, and instead set `position: sticky` on `message_header`.

I hacked together a prototype of how that would work. It’s marked WIP because of these to-do items:

* If you scroll past a date divider inside a topic, the wrong date is shown.
* The date needs to be added back to the corner when we’re not on the first message of the day. For now, this could just happen on the same timer that currently updates `floating_recipient_bar`. Or maybe we can be more clever and move the dates to their own little `position: sticky` elements.
* ~~`position: sticky` is unsupported in IE before Edge 16 ([caniuse.com](https://caniuse.com/#feat=css-sticky)). Do we care enough about IE that we need to polyfill it?~~ Nobody cares about IE anymore.
* `floating_recipient_bar` should be properly deleted from the code instead of just hidden with `display: none`.

Is this worth pursuing?

Here’s a screencast of the `position: sticky` behavior. Check out the sweet transitions as new headers scroll into place:

![demo](https://user-images.githubusercontent.com/26471/42417947-75e2010e-8263-11e8-9a51-aa2c39d57597.gif)
