### PR TITLE
reactions: Only require the parameters that are strictly necessary.

### DIFF
--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -494,6 +494,12 @@ class DefaultEmojiReactionTests(EmojiReactionBase):
         result = self.delete_reaction(reaction_info)
         self.assert_json_success(result)
 
+    def test_delete_insufficient_arguments_reaction(self) -> None:
+        result = self.delete_reaction({})
+        self.assert_json_error(result, 'At least one of the following '
+                               'arguments must be present: emoji_name, '
+                               'emoji_code')
+
     def test_delete_non_existing_emoji_reaction(self) -> None:
         reaction_info = {
             'emoji_name': 'thumbs_up',
@@ -518,6 +524,29 @@ class DefaultEmojiReactionTests(EmojiReactionBase):
         }
         result = self.delete_reaction(reaction_info)
         self.assert_json_success(result)
+
+    def test_delete_reaction_by_name(self) -> None:
+        hamlet = self.example_user('hamlet')
+        message = Message.objects.get(id=1)
+        Reaction.objects.create(user_profile=hamlet,
+                                message=message,
+                                emoji_name='+1',
+                                emoji_code='1f44d',
+                                reaction_type='unicode_emoji',
+                                )
+
+        reaction_info = {
+            'emoji_name': '+1'
+        }
+        result = self.delete_reaction(reaction_info)
+        self.assert_json_success(result)
+        self.assertFalse(
+            Reaction.objects.filter(user_profile=hamlet,
+                                    message=message,
+                                    emoji_name=reaction_info['emoji_name'],
+                                    emoji_code='1f44d',
+                                    reaction_type='unicode_emoji').exists()
+        )
 
     def test_react_historical(self) -> None:
         """

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -442,6 +442,22 @@ class DefaultEmojiReactionTests(EmojiReactionBase):
         result = self.post_reaction(reaction_info)
         self.assert_json_error(result, 'Reaction already exists.')
 
+    def test_add_reaction_by_name(self) -> None:
+        reaction_info = {
+            'emoji_name': '+1'
+        }
+        result = self.post_reaction(reaction_info)
+        self.assert_json_success(result)
+        hamlet = self.example_user('hamlet')
+        message = Message.objects.get(id=1)
+        self.assertTrue(
+            Reaction.objects.filter(user_profile=hamlet,
+                                    message=message,
+                                    emoji_name=reaction_info['emoji_name'],
+                                    emoji_code='1f44d',
+                                    reaction_type='unicode_emoji').exists()
+        )
+
     def test_preserve_non_canonical_name(self) -> None:
         reaction_info = {
             'emoji_name': '+1',

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -1,16 +1,18 @@
-
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
 from zerver.decorator import \
     has_request_variables, REQ, to_non_negative_int
-from zerver.lib.actions import do_add_reaction, do_add_reaction_legacy,\
+from zerver.lib.actions import do_add_reaction, do_add_reaction_legacy, \
     do_remove_reaction, do_remove_reaction_legacy
-from zerver.lib.emoji import check_emoji_request, check_valid_emoji
+from zerver.lib.emoji import check_emoji_request, check_valid_emoji, \
+    emoji_name_to_emoji_code
 from zerver.lib.message import access_message
 from zerver.lib.request import JsonableError
 from zerver.lib.response import json_success
 from zerver.models import Message, Reaction, UserMessage, UserProfile
+
+from typing import Optional
 
 def create_historical_message(user_profile: UserProfile, message: Message) -> None:
     # Users can see and react to messages sent to streams they
@@ -25,9 +27,13 @@ def create_historical_message(user_profile: UserProfile, message: Message) -> No
 @has_request_variables
 def add_reaction(request: HttpRequest, user_profile: UserProfile, message_id: int,
                  emoji_name: str=REQ(),
-                 emoji_code: str=REQ(),
+                 emoji_code: Optional[str]=REQ(default=None),
                  reaction_type: str=REQ(default="unicode_emoji")) -> HttpResponse:
     message, user_message = access_message(user_profile, message_id)
+
+    if emoji_code is None:
+        emoji_code = emoji_name_to_emoji_code(message.sender.realm,
+                                              emoji_name)[0]
 
     if Reaction.objects.filter(user_profile=user_profile,
                                message=message,

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -79,9 +79,19 @@ def add_reaction(request: HttpRequest, user_profile: UserProfile, message_id: in
 
 @has_request_variables
 def remove_reaction(request: HttpRequest, user_profile: UserProfile, message_id: int,
-                    emoji_code: str=REQ(),
+                    emoji_name: Optional[str]=REQ(default=None),
+                    emoji_code: Optional[str]=REQ(default=None),
                     reaction_type: str=REQ(default="unicode_emoji")) -> HttpResponse:
     message, user_message = access_message(user_profile, message_id)
+
+    if emoji_code is None:
+        if emoji_name is not None:
+            # We have got the emoji name, but have to find the code
+            emoji_code = emoji_name_to_emoji_code(message.sender.realm,
+                                                  emoji_name)[0]
+        else:
+            raise JsonableError(_('At least one of the following arguments '
+                                  'must be present: emoji_name, emoji_code'))
 
     if not Reaction.objects.filter(user_profile=user_profile,
                                    message=message,


### PR DESCRIPTION
Followup for [this conversation](https://chat.zulip.org/#narrow/stream/2-general/topic/adding.20emoji.20reactions). The main goal is to make optional some parameters that aren't strictly necessary when adding an emoji reaction.

**Testing Plan:** lint, mypy and backend test run after applying each commit.

