### PR TITLE
Include all event types in RealmAuditLog

### DIFF
--- a/analytics/lib/counts.py
+++ b/analytics/lib/counts.py
@@ -15,7 +15,7 @@ from analytics.models import Anomaly, BaseCount, \
 from zerver.lib.logging_util import log_to_file
 from zerver.lib.timestamp import ceiling_to_day, \
     ceiling_to_hour, floor_to_hour, verify_UTC
-from zerver.models import Message, Realm, RealmAuditLog, \
+from zerver.models import Message, Realm, \
     Stream, UserActivityInterval, UserProfile, models
 
 ## Logging setup ##

--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
             realm=realm, short_name=full_name, pointer=-1, last_pointer_updater='none',
             api_key='42', date_joined=date_joined)
         RealmAuditLog.objects.create(
-            realm=realm, modified_user=user, event_type='user_created',
+            realm=realm, modified_user=user, event_type=RealmAuditLog.USER_CREATED,
             event_time=user.date_joined)
         return user
 

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -896,7 +896,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
             event_time=self.TIME_ZERO - hours_offset*self.HOUR)
 
     def test_user_deactivated_in_future(self) -> None:
-        self.add_event('user_created', 1)
+        self.add_event(RealmAuditLog.USER_CREATED, 1)
         self.add_event('user_deactivated', 0)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup'], [['false']])
@@ -908,7 +908,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
         self.assertTableState(UserCount, [], [])
 
     def test_user_active_then_deactivated_same_day(self) -> None:
-        self.add_event('user_created', 1)
+        self.add_event(RealmAuditLog.USER_CREATED, 1)
         self.add_event('user_deactivated', .5)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, [], [])
@@ -922,7 +922,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
     # Arguably these next two tests are duplicates of the _in_future tests, but are
     # a guard against future refactorings where they may no longer be duplicates
     def test_user_active_then_deactivated_with_day_gap(self) -> None:
-        self.add_event('user_created', 2)
+        self.add_event(RealmAuditLog.USER_CREATED, 2)
         self.add_event('user_deactivated', 1)
         process_count_stat(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup', 'end_time'],
@@ -935,7 +935,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
         self.assertTableState(UserCount, ['subgroup'], [['false']])
 
     def test_event_types(self) -> None:
-        self.add_event('user_created', 4)
+        self.add_event(RealmAuditLog.USER_CREATED, 4)
         self.add_event('user_deactivated', 3)
         self.add_event('user_activated', 2)
         self.add_event('user_reactivated', 1)
@@ -953,7 +953,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
         user3 = self.create_user(realm=second_realm)
         user4 = self.create_user(realm=second_realm, is_bot=True)
         for user in [user1, user2, user3, user4]:
-            self.add_event('user_created', 1, user=user)
+            self.add_event(RealmAuditLog.USER_CREATED, 1, user=user)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup', 'user'],
                               [['false', user1], ['false', user2], ['false', user3], ['true', user4]])
@@ -971,7 +971,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
     # CountStat.HOUR from CountStat.DAY, this will fail, while many of the
     # tests above will not.
     def test_update_from_two_days_ago(self) -> None:
-        self.add_event('user_created', 2)
+        self.add_event(RealmAuditLog.USER_CREATED, 2)
         process_count_stat(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup', 'end_time'],
                               [['false', self.TIME_ZERO], ['false', self.TIME_ZERO-self.DAY]])
@@ -987,14 +987,14 @@ class TestActiveUsersAudit(AnalyticsTestCase):
         self.assertTableState(UserCount, [], [])
 
     def test_max_audit_entry_is_unrelated(self) -> None:
-        self.add_event('user_created', 1)
+        self.add_event(RealmAuditLog.USER_CREATED, 1)
         self.add_event('unrelated', .5)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup'], [['false']])
 
     # Simultaneous related audit entries should not be allowed, and so not testing for that.
     def test_simultaneous_unrelated_audit_entry(self) -> None:
-        self.add_event('user_created', 1)
+        self.add_event(RealmAuditLog.USER_CREATED, 1)
         self.add_event('unrelated', 1)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup'], [['false']])
@@ -1003,9 +1003,9 @@ class TestActiveUsersAudit(AnalyticsTestCase):
         user1 = self.create_user()
         user2 = self.create_user()
         user3 = self.create_user()
-        self.add_event('user_created', .5, user=user1)
-        self.add_event('user_created', .5, user=user2)
-        self.add_event('user_created', 1, user=user3)
+        self.add_event(RealmAuditLog.USER_CREATED, .5, user=user1)
+        self.add_event(RealmAuditLog.USER_CREATED, .5, user=user2)
+        self.add_event(RealmAuditLog.USER_CREATED, 1, user=user3)
         self.add_event('user_deactivated', .5, user=user3)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['user', 'subgroup'],

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -897,24 +897,24 @@ class TestActiveUsersAudit(AnalyticsTestCase):
 
     def test_user_deactivated_in_future(self) -> None:
         self.add_event(RealmAuditLog.USER_CREATED, 1)
-        self.add_event('user_deactivated', 0)
+        self.add_event(RealmAuditLog.USER_DEACTIVATED, 0)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup'], [['false']])
 
     def test_user_reactivated_in_future(self) -> None:
-        self.add_event('user_deactivated', 1)
+        self.add_event(RealmAuditLog.USER_DEACTIVATED, 1)
         self.add_event('user_reactivated', 0)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, [], [])
 
     def test_user_active_then_deactivated_same_day(self) -> None:
         self.add_event(RealmAuditLog.USER_CREATED, 1)
-        self.add_event('user_deactivated', .5)
+        self.add_event(RealmAuditLog.USER_DEACTIVATED, .5)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, [], [])
 
     def test_user_unactive_then_activated_same_day(self) -> None:
-        self.add_event('user_deactivated', 1)
+        self.add_event(RealmAuditLog.USER_DEACTIVATED, 1)
         self.add_event('user_reactivated', .5)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup'], [['false']])
@@ -923,20 +923,20 @@ class TestActiveUsersAudit(AnalyticsTestCase):
     # a guard against future refactorings where they may no longer be duplicates
     def test_user_active_then_deactivated_with_day_gap(self) -> None:
         self.add_event(RealmAuditLog.USER_CREATED, 2)
-        self.add_event('user_deactivated', 1)
+        self.add_event(RealmAuditLog.USER_DEACTIVATED, 1)
         process_count_stat(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup', 'end_time'],
                               [['false', self.TIME_ZERO - self.DAY]])
 
     def test_user_deactivated_then_reactivated_with_day_gap(self) -> None:
-        self.add_event('user_deactivated', 2)
+        self.add_event(RealmAuditLog.USER_DEACTIVATED, 2)
         self.add_event('user_reactivated', 1)
         process_count_stat(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup'], [['false']])
 
     def test_event_types(self) -> None:
         self.add_event(RealmAuditLog.USER_CREATED, 4)
-        self.add_event('user_deactivated', 3)
+        self.add_event(RealmAuditLog.USER_DEACTIVATED, 3)
         self.add_event(RealmAuditLog.USER_ACTIVATED, 2)
         self.add_event('user_reactivated', 1)
         for i in range(4):
@@ -1006,7 +1006,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
         self.add_event(RealmAuditLog.USER_CREATED, .5, user=user1)
         self.add_event(RealmAuditLog.USER_CREATED, .5, user=user2)
         self.add_event(RealmAuditLog.USER_CREATED, 1, user=user3)
-        self.add_event('user_deactivated', .5, user=user3)
+        self.add_event(RealmAuditLog.USER_DEACTIVATED, .5, user=user3)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['user', 'subgroup'],
                               [[user1, 'false'], [user2, 'false']])

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -903,7 +903,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
 
     def test_user_reactivated_in_future(self) -> None:
         self.add_event(RealmAuditLog.USER_DEACTIVATED, 1)
-        self.add_event('user_reactivated', 0)
+        self.add_event(RealmAuditLog.USER_REACTIVATED, 0)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, [], [])
 
@@ -915,7 +915,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
 
     def test_user_unactive_then_activated_same_day(self) -> None:
         self.add_event(RealmAuditLog.USER_DEACTIVATED, 1)
-        self.add_event('user_reactivated', .5)
+        self.add_event(RealmAuditLog.USER_REACTIVATED, .5)
         do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup'], [['false']])
 
@@ -930,7 +930,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
 
     def test_user_deactivated_then_reactivated_with_day_gap(self) -> None:
         self.add_event(RealmAuditLog.USER_DEACTIVATED, 2)
-        self.add_event('user_reactivated', 1)
+        self.add_event(RealmAuditLog.USER_REACTIVATED, 1)
         process_count_stat(self.stat, self.TIME_ZERO)
         self.assertTableState(UserCount, ['subgroup'], [['false']])
 
@@ -938,7 +938,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
         self.add_event(RealmAuditLog.USER_CREATED, 4)
         self.add_event(RealmAuditLog.USER_DEACTIVATED, 3)
         self.add_event(RealmAuditLog.USER_ACTIVATED, 2)
-        self.add_event('user_reactivated', 1)
+        self.add_event(RealmAuditLog.USER_REACTIVATED, 1)
         for i in range(4):
             do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO - i*self.DAY)
         self.assertTableState(UserCount, ['subgroup', 'end_time'],

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -937,7 +937,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
     def test_event_types(self) -> None:
         self.add_event(RealmAuditLog.USER_CREATED, 4)
         self.add_event('user_deactivated', 3)
-        self.add_event('user_activated', 2)
+        self.add_event(RealmAuditLog.USER_ACTIVATED, 2)
         self.add_event('user_reactivated', 1)
         for i in range(4):
             do_fill_count_stat_at_hour(self.stat, self.TIME_ZERO - i*self.DAY)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -708,7 +708,7 @@ def do_deactivate_user(user_profile: UserProfile,
     event_time = timezone_now()
     RealmAuditLog.objects.create(realm=user_profile.realm, modified_user=user_profile,
                                  acting_user=acting_user,
-                                 event_type='user_deactivated', event_time=event_time,
+                                 event_type=RealmAuditLog.USER_DEACTIVATED, event_time=event_time,
                                  requires_billing_update=activity_change_requires_seat_update(user_profile))
     do_increment_logging_stat(user_profile.realm, COUNT_STATS['active_users_log:is_bot:day'],
                               user_profile.is_bot, event_time, increment=-1)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2823,7 +2823,7 @@ def do_change_bot_owner(user_profile: UserProfile, bot_owner: UserProfile,
     user_profile.save()  # Can't use update_fields because of how the foreign key works.
     event_time = timezone_now()
     RealmAuditLog.objects.create(realm=user_profile.realm, acting_user=acting_user,
-                                 modified_user=user_profile, event_type='bot_owner_changed',
+                                 modified_user=user_profile, event_type=RealmAuditLog.BOT_OWNER_CHANGED,
                                  event_time=event_time)
 
     update_users = bot_owner_user_ids(user_profile)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -691,7 +691,7 @@ def do_reactivate_realm(realm: Realm) -> None:
 
     event_time = timezone_now()
     RealmAuditLog.objects.create(
-        realm=realm, event_type='realm_reactivated', event_time=event_time)
+        realm=realm, event_type=RealmAuditLog.REALM_REACTIVATED, event_time=event_time)
 
 def do_deactivate_user(user_profile: UserProfile,
                        acting_user: Optional[UserProfile]=None,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -511,7 +511,7 @@ def do_create_user(email: str, password: Optional[str], realm: Realm, full_name:
 
     event_time = user_profile.date_joined
     RealmAuditLog.objects.create(realm=user_profile.realm, modified_user=user_profile,
-                                 event_type='user_created', event_time=event_time,
+                                 event_type=RealmAuditLog.USER_CREATED, event_time=event_time,
                                  requires_billing_update=activity_change_requires_seat_update(user_profile))
     do_increment_logging_stat(user_profile.realm, COUNT_STATS['active_users_log:is_bot:day'],
                               user_profile.is_bot, event_time)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2785,7 +2785,7 @@ def do_change_password(user_profile: UserProfile, password: str, commit: bool=Tr
         user_profile.save(update_fields=["password"])
     event_time = timezone_now()
     RealmAuditLog.objects.create(realm=user_profile.realm, acting_user=user_profile,
-                                 modified_user=user_profile, event_type='user_change_password',
+                                 modified_user=user_profile, event_type=RealmAuditLog.USER_CHANGE_PASSWORD,
                                  event_time=event_time)
 
 def do_change_full_name(user_profile: UserProfile, full_name: str,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -788,7 +788,7 @@ def do_change_user_email(user_profile: UserProfile, new_email: str) -> None:
                active_user_ids(user_profile.realm_id))
     event_time = timezone_now()
     RealmAuditLog.objects.create(realm=user_profile.realm, acting_user=user_profile,
-                                 modified_user=user_profile, event_type='user_email_changed',
+                                 modified_user=user_profile, event_type=RealmAuditLog.USER_EMAIL_CHANGED,
                                  event_time=event_time)
 
 def do_start_email_change_process(user_profile: UserProfile, new_email: str) -> None:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2686,7 +2686,7 @@ def bulk_remove_subscriptions(users: Iterable[UserProfile],
                                                    modified_user=sub.user_profile,
                                                    modified_stream=stream,
                                                    event_last_message_id=event_last_message_id,
-                                                   event_type='subscription_deactivated',
+                                                   event_type=RealmAuditLog.SUBSCRIPTION_DEACTIVATED,
                                                    event_time=event_time))
     # Now since we have all log objects generated we can do a bulk insert
     RealmAuditLog.objects.bulk_create(all_subscription_logs)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2872,7 +2872,7 @@ def do_regenerate_api_key(user_profile: UserProfile, acting_user: UserProfile) -
     user_profile.save(update_fields=["api_key"])
     event_time = timezone_now()
     RealmAuditLog.objects.create(realm=user_profile.realm, acting_user=acting_user,
-                                 modified_user=user_profile, event_type='user_api_key_changed',
+                                 modified_user=user_profile, event_type=RealmAuditLog.USER_API_KEY_CHANGED,
                                  event_time=event_time)
 
     if user_profile.is_bot:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -536,7 +536,7 @@ def do_activate_user(user_profile: UserProfile) -> None:
 
     event_time = user_profile.date_joined
     RealmAuditLog.objects.create(realm=user_profile.realm, modified_user=user_profile,
-                                 event_type='user_activated', event_time=event_time,
+                                 event_type=RealmAuditLog.USER_ACTIVATED, event_time=event_time,
                                  requires_billing_update=activity_change_requires_seat_update(user_profile))
     do_increment_logging_stat(user_profile.realm, COUNT_STATS['active_users_log:is_bot:day'],
                               user_profile.is_bot, event_time)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2795,7 +2795,7 @@ def do_change_full_name(user_profile: UserProfile, full_name: str,
     user_profile.save(update_fields=["full_name"])
     event_time = timezone_now()
     RealmAuditLog.objects.create(realm=user_profile.realm, acting_user=acting_user,
-                                 modified_user=user_profile, event_type='user_full_name_changed',
+                                 modified_user=user_profile, event_type=RealmAuditLog.USER_FULL_NAME_CHANGED,
                                  event_time=event_time, extra_data=old_name)
     payload = dict(email=user_profile.email,
                    user_id=user_profile.id,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2889,7 +2889,7 @@ def do_change_avatar_fields(user_profile: UserProfile, avatar_source: str) -> No
     user_profile.save(update_fields=["avatar_source", "avatar_version"])
     event_time = timezone_now()
     RealmAuditLog.objects.create(realm=user_profile.realm, modified_user=user_profile,
-                                 event_type='user_change_avatar_source',
+                                 event_type=RealmAuditLog.USER_CHANGE_AVATAR_SOURCE,
                                  extra_data={'avatar_source': avatar_source},
                                  event_time=event_time)
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2515,7 +2515,7 @@ def bulk_add_subscriptions(streams: Iterable[Stream],
                                                    modified_user=sub.user_profile,
                                                    modified_stream=stream,
                                                    event_last_message_id=event_last_message_id,
-                                                   event_type='subscription_created',
+                                                   event_type=RealmAuditLog.SUBSCRIPTION_CREATED,
                                                    event_time=event_time))
     for (sub, stream) in subs_to_activate:
         all_subscription_logs.append(RealmAuditLog(realm=sub.user_profile.realm,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -551,7 +551,7 @@ def do_reactivate_user(user_profile: UserProfile, acting_user: Optional[UserProf
 
     event_time = timezone_now()
     RealmAuditLog.objects.create(realm=user_profile.realm, modified_user=user_profile,
-                                 event_type='user_reactivated', event_time=event_time,
+                                 event_type=RealmAuditLog.USER_REACTIVATED, event_time=event_time,
                                  acting_user=acting_user,
                                  requires_billing_update=activity_change_requires_seat_update(user_profile))
     do_increment_logging_stat(user_profile.realm, COUNT_STATS['active_users_log:is_bot:day'],

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -672,7 +672,7 @@ def do_deactivate_realm(realm: Realm) -> None:
 
     event_time = timezone_now()
     RealmAuditLog.objects.create(
-        realm=realm, event_type='realm_deactivated', event_time=event_time)
+        realm=realm, event_type=RealmAuditLog.REALM_DEACTIVATED, event_time=event_time)
 
     ScheduledEmail.objects.filter(realm=realm).delete()
     for user in active_humans_in_realm(realm):

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2863,7 +2863,8 @@ def do_change_tos_version(user_profile: UserProfile, tos_version: str) -> None:
     user_profile.save(update_fields=["tos_version"])
     event_time = timezone_now()
     RealmAuditLog.objects.create(realm=user_profile.realm, acting_user=user_profile,
-                                 modified_user=user_profile, event_type='user_tos_version_changed',
+                                 modified_user=user_profile,
+                                 event_type=RealmAuditLog.USER_TOS_VERSION_CHANGED,
                                  event_time=event_time)
 
 def do_regenerate_api_key(user_profile: UserProfile, acting_user: UserProfile) -> None:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2523,7 +2523,7 @@ def bulk_add_subscriptions(streams: Iterable[Stream],
                                                    modified_user=sub.user_profile,
                                                    modified_stream=stream,
                                                    event_last_message_id=event_last_message_id,
-                                                   event_type='subscription_activated',
+                                                   event_type=RealmAuditLog.SUBSCRIPTION_ACTIVATED,
                                                    event_time=event_time))
     # Now since we have all log objects generated we can do a bulk insert
     RealmAuditLog.objects.bulk_create(all_subscription_logs)

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -32,7 +32,7 @@ def bulk_create_users(realm: Realm,
 
     RealmAuditLog.objects.bulk_create(
         [RealmAuditLog(realm=realm, modified_user=profile_,
-                       event_type='user_created', event_time=profile_.date_joined)
+                       event_type=RealmAuditLog.USER_CREATED, event_time=profile_.date_joined)
          for profile_ in profiles_to_create])
 
     profiles_by_email = {}  # type: Dict[str, UserProfile]

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -31,7 +31,7 @@ def filter_by_subscription_history(user_profile: UserProfile,
         for log_entry in stream_subscription_logs:
             if len(stream_messages) == 0:
                 continue
-            if log_entry.event_type == 'subscription_deactivated':
+            if log_entry.event_type == RealmAuditLog.SUBSCRIPTION_DEACTIVATED:
                 for stream_message in stream_messages:
                     if stream_message['id'] <= log_entry.event_last_message_id:
                         store_user_message_to_insert(stream_message)
@@ -105,7 +105,7 @@ def add_missing_messages(user_profile: UserProfile) -> None:
     # For Stream messages we need to check messages against data from
     # RealmAuditLog for visibility to user. So we fetch the subscription logs.
     stream_ids = [sub['recipient__type_id'] for sub in all_stream_subs]
-    events = [RealmAuditLog.SUBSCRIPTION_CREATED, 'subscription_deactivated', 'subscription_activated']
+    events = [RealmAuditLog.SUBSCRIPTION_CREATED, RealmAuditLog.SUBSCRIPTION_DEACTIVATED, 'subscription_activated']
     subscription_logs = list(RealmAuditLog.objects.select_related(
         'modified_stream').filter(
         modified_user=user_profile,
@@ -119,7 +119,7 @@ def add_missing_messages(user_profile: UserProfile) -> None:
     recipient_ids = []
     for sub in all_stream_subs:
         stream_subscription_logs = all_stream_subscription_logs[sub['recipient__type_id']]
-        if stream_subscription_logs[-1].event_type == 'subscription_deactivated':
+        if stream_subscription_logs[-1].event_type == RealmAuditLog.SUBSCRIPTION_DEACTIVATED:
             assert stream_subscription_logs[-1].event_last_message_id is not None
             if stream_subscription_logs[-1].event_last_message_id <= user_profile.last_active_message_id:
                 # We are going to short circuit this iteration as its no use

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -38,7 +38,7 @@ def filter_by_subscription_history(user_profile: UserProfile,
                     else:
                         break
             elif log_entry.event_type in ('subscription_activated',
-                                          'subscription_created'):
+                                          RealmAuditLog.SUBSCRIPTION_CREATED):
                 initial_msg_count = len(stream_messages)
                 for i, stream_message in enumerate(stream_messages):
                     if stream_message['id'] > log_entry.event_last_message_id:
@@ -57,7 +57,7 @@ def filter_by_subscription_history(user_profile: UserProfile,
             # UserMessage rows for any of the remaining messages.
             if stream_subscription_logs[-1].event_type in (
                     'subscription_activated',
-                    'subscription_created'):
+                    RealmAuditLog.SUBSCRIPTION_CREATED):
                 for stream_message in stream_messages:
                     store_user_message_to_insert(stream_message)
     return user_messages_to_insert
@@ -105,7 +105,7 @@ def add_missing_messages(user_profile: UserProfile) -> None:
     # For Stream messages we need to check messages against data from
     # RealmAuditLog for visibility to user. So we fetch the subscription logs.
     stream_ids = [sub['recipient__type_id'] for sub in all_stream_subs]
-    events = ['subscription_created', 'subscription_deactivated', 'subscription_activated']
+    events = [RealmAuditLog.SUBSCRIPTION_CREATED, 'subscription_deactivated', 'subscription_activated']
     subscription_logs = list(RealmAuditLog.objects.select_related(
         'modified_stream').filter(
         modified_user=user_profile,

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -37,7 +37,7 @@ def filter_by_subscription_history(user_profile: UserProfile,
                         store_user_message_to_insert(stream_message)
                     else:
                         break
-            elif log_entry.event_type in ('subscription_activated',
+            elif log_entry.event_type in (RealmAuditLog.SUBSCRIPTION_ACTIVATED,
                                           RealmAuditLog.SUBSCRIPTION_CREATED):
                 initial_msg_count = len(stream_messages)
                 for i, stream_message in enumerate(stream_messages):
@@ -56,7 +56,7 @@ def filter_by_subscription_history(user_profile: UserProfile,
             # event was a subscription_deactivated then we don't want to create
             # UserMessage rows for any of the remaining messages.
             if stream_subscription_logs[-1].event_type in (
-                    'subscription_activated',
+                    RealmAuditLog.SUBSCRIPTION_ACTIVATED,
                     RealmAuditLog.SUBSCRIPTION_CREATED):
                 for stream_message in stream_messages:
                     store_user_message_to_insert(stream_message)
@@ -105,7 +105,8 @@ def add_missing_messages(user_profile: UserProfile) -> None:
     # For Stream messages we need to check messages against data from
     # RealmAuditLog for visibility to user. So we fetch the subscription logs.
     stream_ids = [sub['recipient__type_id'] for sub in all_stream_subs]
-    events = [RealmAuditLog.SUBSCRIPTION_CREATED, RealmAuditLog.SUBSCRIPTION_DEACTIVATED, 'subscription_activated']
+    events = [RealmAuditLog.SUBSCRIPTION_CREATED, RealmAuditLog.SUBSCRIPTION_DEACTIVATED,
+              RealmAuditLog.SUBSCRIPTION_ACTIVATED]
     subscription_logs = list(RealmAuditLog.objects.select_related(
         'modified_stream').filter(
         modified_user=user_profile,

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -197,7 +197,7 @@ def maybe_catch_up_soft_deactivated_user(user_profile: UserProfile) -> Union[Use
         RealmAuditLog.objects.create(
             realm=user_profile.realm,
             modified_user=user_profile,
-            event_type='user_soft_activated',
+            event_type=RealmAuditLog.USER_SOFT_ACTIVATED,
             event_time=timezone_now()
         )
         logger.info('Soft Reactivated user %s (%s)' %

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -181,7 +181,7 @@ def do_soft_deactivate_users(users: List[UserProfile]) -> List[UserProfile]:
             log = RealmAuditLog(
                 realm=user.realm,
                 modified_user=user,
-                event_type='user_soft_deactivated',
+                event_type=RealmAuditLog.USER_SOFT_DEACTIVATED,
                 event_time=event_time
             )
             realm_logs.append(log)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1970,6 +1970,7 @@ class RealmAuditLog(models.Model):
     USER_CHANGE_AVATAR_SOURCE = 'user_change_avatar_source'
     USER_FULL_NAME_CHANGED = 'user_full_name_changed'
     USER_EMAIL_CHANGED = 'user_email_changed'
+    USER_TOS_VERSION_CHANGED = 'user_tos_version_changed'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1974,6 +1974,7 @@ class RealmAuditLog(models.Model):
     USER_API_KEY_CHANGED = 'user_api_key_changed'
 
     REALM_DEACTIVATED = 'realm_deactivated'
+    REALM_REACTIVATED = 'realm_reactivated'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1976,6 +1976,8 @@ class RealmAuditLog(models.Model):
     REALM_DEACTIVATED = 'realm_deactivated'
     REALM_REACTIVATED = 'realm_reactivated'
 
+    BOT_OWNER_CHANGED = 'bot_owner_changed'
+
     event_type = models.CharField(max_length=40)  # type: str
 
     def __str__(self) -> str:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1971,6 +1971,7 @@ class RealmAuditLog(models.Model):
     USER_FULL_NAME_CHANGED = 'user_full_name_changed'
     USER_EMAIL_CHANGED = 'user_email_changed'
     USER_TOS_VERSION_CHANGED = 'user_tos_version_changed'
+    USER_API_KEY_CHANGED = 'user_api_key_changed'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1967,6 +1967,7 @@ class RealmAuditLog(models.Model):
     USER_DEACTIVATED = 'user_deactivated'
     USER_REACTIVATED = 'user_reactivated'
     USER_CHANGE_PASSWORD = 'user_change_password'
+    USER_CHANGE_AVATAR_SOURCE = 'user_change_avatar_source'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1978,6 +1978,7 @@ class RealmAuditLog(models.Model):
 
     BOT_OWNER_CHANGED = 'bot_owner_changed'
     SUBSCRIPTION_CREATED = 'subscription_created'
+    SUBSCRIPTION_DEACTIVATED = 'subscription_deactivated'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1966,6 +1966,7 @@ class RealmAuditLog(models.Model):
     USER_ACTIVATED = 'user_activated'
     USER_DEACTIVATED = 'user_deactivated'
     USER_REACTIVATED = 'user_reactivated'
+    USER_CHANGE_PASSWORD = 'user_change_password'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1966,6 +1966,7 @@ class RealmAuditLog(models.Model):
     USER_DEACTIVATED = 'user_deactivated'
     USER_REACTIVATED = 'user_reactivated'
     USER_SOFT_ACTIVATED = 'user_soft_activated'
+    USER_SOFT_DEACTIVATED = 'user_soft_deactivated'
     USER_CHANGE_PASSWORD = 'user_change_password'
     USER_CHANGE_AVATAR_SOURCE = 'user_change_avatar_source'
     USER_FULL_NAME_CHANGED = 'user_full_name_changed'

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1977,6 +1977,7 @@ class RealmAuditLog(models.Model):
     REALM_REACTIVATED = 'realm_reactivated'
 
     BOT_OWNER_CHANGED = 'bot_owner_changed'
+    SUBSCRIPTION_CREATED = 'subscription_created'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1963,6 +1963,7 @@ class RealmAuditLog(models.Model):
     PLAN_UPDATE_QUANTITY = 'plan_update_quantity'
 
     USER_CREATED = 'user_created'
+    USER_ACTIVATED = 'user_activated'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1964,6 +1964,7 @@ class RealmAuditLog(models.Model):
 
     USER_CREATED = 'user_created'
     USER_ACTIVATED = 'user_activated'
+    USER_DEACTIVATED = 'user_deactivated'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1965,6 +1965,7 @@ class RealmAuditLog(models.Model):
     USER_ACTIVATED = 'user_activated'
     USER_DEACTIVATED = 'user_deactivated'
     USER_REACTIVATED = 'user_reactivated'
+    USER_SOFT_ACTIVATED = 'user_soft_activated'
     USER_CHANGE_PASSWORD = 'user_change_password'
     USER_CHANGE_AVATAR_SOURCE = 'user_change_avatar_source'
     USER_FULL_NAME_CHANGED = 'user_full_name_changed'

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1969,6 +1969,7 @@ class RealmAuditLog(models.Model):
     USER_CHANGE_PASSWORD = 'user_change_password'
     USER_CHANGE_AVATAR_SOURCE = 'user_change_avatar_source'
     USER_FULL_NAME_CHANGED = 'user_full_name_changed'
+    USER_EMAIL_CHANGED = 'user_email_changed'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1961,6 +1961,9 @@ class RealmAuditLog(models.Model):
     CARD_ADDED = 'card_added'
     PLAN_START = 'plan_start'
     PLAN_UPDATE_QUANTITY = 'plan_update_quantity'
+
+    USER_CREATED = 'user_created'
+
     event_type = models.CharField(max_length=40)  # type: str
 
     def __str__(self) -> str:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1973,6 +1973,8 @@ class RealmAuditLog(models.Model):
     USER_TOS_VERSION_CHANGED = 'user_tos_version_changed'
     USER_API_KEY_CHANGED = 'user_api_key_changed'
 
+    REALM_DEACTIVATED = 'realm_deactivated'
+
     event_type = models.CharField(max_length=40)  # type: str
 
     def __str__(self) -> str:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1965,6 +1965,7 @@ class RealmAuditLog(models.Model):
     USER_CREATED = 'user_created'
     USER_ACTIVATED = 'user_activated'
     USER_DEACTIVATED = 'user_deactivated'
+    USER_REACTIVATED = 'user_reactivated'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1968,6 +1968,7 @@ class RealmAuditLog(models.Model):
     USER_REACTIVATED = 'user_reactivated'
     USER_CHANGE_PASSWORD = 'user_change_password'
     USER_CHANGE_AVATAR_SOURCE = 'user_change_avatar_source'
+    USER_FULL_NAME_CHANGED = 'user_full_name_changed'
 
     event_type = models.CharField(max_length=40)  # type: str
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1956,7 +1956,6 @@ class RealmAuditLog(models.Model):
     requires_billing_update = models.BooleanField(default=False)  # type: bool
     extra_data = models.TextField(null=True)  # type: Optional[str]
 
-    # Partial list of event_types.
     STRIPE_START = 'stripe_start'
     CARD_ADDED = 'card_added'
     PLAN_START = 'plan_start'
@@ -1978,6 +1977,7 @@ class RealmAuditLog(models.Model):
 
     BOT_OWNER_CHANGED = 'bot_owner_changed'
     SUBSCRIPTION_CREATED = 'subscription_created'
+    SUBSCRIPTION_ACTIVATED = 'subscription_activated'
     SUBSCRIPTION_DEACTIVATED = 'subscription_deactivated'
 
     event_type = models.CharField(max_length=40)  # type: str

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -69,7 +69,7 @@ class TestRealmAuditLog(ZulipTestCase):
         req = dict(full_name=ujson.dumps(new_name))
         result = self.client_patch('/json/users/{}'.format(self.example_user("hamlet").id), req)
         self.assertTrue(result.status_code == 200)
-        query = RealmAuditLog.objects.filter(event_type='user_full_name_changed',
+        query = RealmAuditLog.objects.filter(event_type=RealmAuditLog.USER_FULL_NAME_CHANGED,
                                              event_time__gte=start)
         self.assertEqual(query.count(), 1)
 

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -29,7 +29,7 @@ class TestRealmAuditLog(ZulipTestCase):
             event_time__gte=now, event_time__lte=now+timedelta(minutes=60))
             .order_by('event_time').values_list('event_type', flat=True))
         self.assertEqual(event_types, [RealmAuditLog.USER_CREATED, RealmAuditLog.USER_DEACTIVATED, RealmAuditLog.USER_ACTIVATED,
-                                       RealmAuditLog.USER_DEACTIVATED, 'user_reactivated'])
+                                       RealmAuditLog.USER_DEACTIVATED, RealmAuditLog.USER_REACTIVATED])
 
     def test_change_password(self) -> None:
         now = timezone_now()

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -88,7 +88,7 @@ class TestRealmAuditLog(ZulipTestCase):
         bot = self.notification_bot()
         bot_owner = self.example_user('hamlet')
         do_change_bot_owner(bot, bot_owner, admin)
-        self.assertEqual(RealmAuditLog.objects.filter(event_type='bot_owner_changed',
+        self.assertEqual(RealmAuditLog.objects.filter(event_type=RealmAuditLog.BOT_OWNER_CHANGED,
                                                       event_time__gte=now).count(), 1)
         self.assertEqual(bot_owner, bot.bot_owner)
 

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -96,7 +96,7 @@ class TestRealmAuditLog(ZulipTestCase):
         now = timezone_now()
         user = self.example_user('hamlet')
         do_regenerate_api_key(user, user)
-        self.assertEqual(RealmAuditLog.objects.filter(event_type='user_api_key_changed',
+        self.assertEqual(RealmAuditLog.objects.filter(event_type=RealmAuditLog.USER_API_KEY_CHANGED,
                                                       event_time__gte=now).count(), 1)
         self.assertTrue(user.api_key)
 

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -58,7 +58,7 @@ class TestRealmAuditLog(ZulipTestCase):
         user = self.example_user('hamlet')
         avatar_source = u'G'
         do_change_avatar_fields(user, avatar_source)
-        self.assertEqual(RealmAuditLog.objects.filter(event_type='user_change_avatar_source',
+        self.assertEqual(RealmAuditLog.objects.filter(event_type=RealmAuditLog.USER_CHANGE_AVATAR_SOURCE,
                                                       event_time__gte=now).count(), 1)
         self.assertEqual(avatar_source, user.avatar_source)
 

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -113,7 +113,7 @@ class TestRealmAuditLog(ZulipTestCase):
         self.assertEqual(subscription_creation_logs[0].modified_user, user[0])
 
         bulk_remove_subscriptions(user, stream)
-        subscription_deactivation_logs = RealmAuditLog.objects.filter(event_type='subscription_deactivated',
+        subscription_deactivation_logs = RealmAuditLog.objects.filter(event_type=RealmAuditLog.SUBSCRIPTION_DEACTIVATED,
                                                                       event_time__gte=now)
         self.assertEqual(subscription_deactivation_logs.count(), 1)
         self.assertEqual(subscription_deactivation_logs[0].modified_stream.id, stream[0].id)

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -28,7 +28,7 @@ class TestRealmAuditLog(ZulipTestCase):
             realm=realm, acting_user=None, modified_user=user, modified_stream=None,
             event_time__gte=now, event_time__lte=now+timedelta(minutes=60))
             .order_by('event_time').values_list('event_type', flat=True))
-        self.assertEqual(event_types, [RealmAuditLog.USER_CREATED, 'user_deactivated', 'user_activated',
+        self.assertEqual(event_types, [RealmAuditLog.USER_CREATED, 'user_deactivated', RealmAuditLog.USER_ACTIVATED,
                                        'user_deactivated', 'user_reactivated'])
 
     def test_change_password(self) -> None:

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -78,7 +78,7 @@ class TestRealmAuditLog(ZulipTestCase):
         user = self.example_user("hamlet")
         tos_version = 'android'
         do_change_tos_version(user, tos_version)
-        self.assertEqual(RealmAuditLog.objects.filter(event_type='user_tos_version_changed',
+        self.assertEqual(RealmAuditLog.objects.filter(event_type=RealmAuditLog.USER_TOS_VERSION_CHANGED,
                                                       event_time__gte=now).count(), 1)
         self.assertEqual(tos_version, user.tos_version)
 

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -106,7 +106,7 @@ class TestRealmAuditLog(ZulipTestCase):
         stream = [self.make_stream('test_stream')]
 
         bulk_add_subscriptions(stream, user)
-        subscription_creation_logs = RealmAuditLog.objects.filter(event_type='subscription_created',
+        subscription_creation_logs = RealmAuditLog.objects.filter(event_type=RealmAuditLog.SUBSCRIPTION_CREATED,
                                                                   event_time__gte=now)
         self.assertEqual(subscription_creation_logs.count(), 1)
         self.assertEqual(subscription_creation_logs[0].modified_stream.id, stream[0].id)

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -28,8 +28,8 @@ class TestRealmAuditLog(ZulipTestCase):
             realm=realm, acting_user=None, modified_user=user, modified_stream=None,
             event_time__gte=now, event_time__lte=now+timedelta(minutes=60))
             .order_by('event_time').values_list('event_type', flat=True))
-        self.assertEqual(event_types, [RealmAuditLog.USER_CREATED, 'user_deactivated', RealmAuditLog.USER_ACTIVATED,
-                                       'user_deactivated', 'user_reactivated'])
+        self.assertEqual(event_types, [RealmAuditLog.USER_CREATED, RealmAuditLog.USER_DEACTIVATED, RealmAuditLog.USER_ACTIVATED,
+                                       RealmAuditLog.USER_DEACTIVATED, 'user_reactivated'])
 
     def test_change_password(self) -> None:
         now = timezone_now()

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -45,12 +45,12 @@ class TestRealmAuditLog(ZulipTestCase):
         user = self.example_user('hamlet')
         email = 'test@example.com'
         do_change_user_email(user, email)
-        self.assertEqual(RealmAuditLog.objects.filter(event_type='user_email_changed',
+        self.assertEqual(RealmAuditLog.objects.filter(event_type=RealmAuditLog.USER_EMAIL_CHANGED,
                                                       event_time__gte=now).count(), 1)
         self.assertEqual(email, user.email)
 
         # Test the RealmAuditLog stringification
-        audit_entry = RealmAuditLog.objects.get(event_type='user_email_changed', event_time__gte=now)
+        audit_entry = RealmAuditLog.objects.get(event_type=RealmAuditLog.USER_EMAIL_CHANGED, event_time__gte=now)
         self.assertTrue(str(audit_entry).startswith("<RealmAuditLog: <UserProfile: test@example.com <Realm: zulip 1>> user_email_changed "))
 
     def test_change_avatar_source(self) -> None:

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -28,7 +28,7 @@ class TestRealmAuditLog(ZulipTestCase):
             realm=realm, acting_user=None, modified_user=user, modified_stream=None,
             event_time__gte=now, event_time__lte=now+timedelta(minutes=60))
             .order_by('event_time').values_list('event_type', flat=True))
-        self.assertEqual(event_types, ['user_created', 'user_deactivated', 'user_activated',
+        self.assertEqual(event_types, [RealmAuditLog.USER_CREATED, 'user_deactivated', 'user_activated',
                                        'user_deactivated', 'user_reactivated'])
 
     def test_change_password(self) -> None:

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -36,7 +36,7 @@ class TestRealmAuditLog(ZulipTestCase):
         user = self.example_user('hamlet')
         password = 'test1'
         do_change_password(user, password)
-        self.assertEqual(RealmAuditLog.objects.filter(event_type='user_change_password',
+        self.assertEqual(RealmAuditLog.objects.filter(event_type=RealmAuditLog.USER_CHANGE_PASSWORD,
                                                       event_time__gte=now).count(), 1)
         self.assertIsNone(validate_password(password, user))
 

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -2913,7 +2913,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         self.assert_length(queries, 7)
         self.assertFalse(long_term_idle_user.long_term_idle)
         self.assertEqual(last_realm_audit_log_entry(
-            'user_soft_activated').modified_user, long_term_idle_user)
+            RealmAuditLog.USER_SOFT_ACTIVATED).modified_user, long_term_idle_user)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assertEqual(len(idle_user_msg_list), idle_user_msg_count + 1)
         self.assertEqual(idle_user_msg_list[-1].content, message)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -295,7 +295,7 @@ class Command(BaseCommand):
                                     modified_user=profile,
                                     modified_stream_id=recipient.type_id,
                                     event_last_message_id=0,
-                                    event_type='subscription_created',
+                                    event_type=RealmAuditLog.SUBSCRIPTION_CREATED,
                                     event_time=event_time)
                 all_subscription_logs.append(log)
 
@@ -493,7 +493,7 @@ class Command(BaseCommand):
                                             modified_user=profile,
                                             modified_stream=stream,
                                             event_last_message_id=0,
-                                            event_type='subscription_created',
+                                            event_type=RealmAuditLog.SUBSCRIPTION_CREATED,
                                             event_time=event_time)
                         all_subscription_logs.append(log)
                 Subscription.objects.bulk_create(subscriptions_to_add)


### PR DESCRIPTION
Skipping the present->past tense changes due to migration issues for now.

The PR has a lot of commits but should be pretty easy/fast to review.