### PR TITLE
 auth: Fix bug with subdomains and social auth causing logouts.

### DIFF
--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -275,8 +275,14 @@ def google_oauth2_csrf(request: HttpRequest, value: str) -> str:
 def reverse_on_root(viewname: str, args: List[str]=None, kwargs: Dict[str, str]=None) -> str:
     return settings.ROOT_DOMAIN_URI + reverse(viewname, args=args, kwargs=kwargs)
 
-def oauth_redirect_to_root(request: HttpRequest, url: str, is_signup: bool=False) -> HttpResponse:
+def oauth_redirect_to_root(request: HttpRequest, url: str,
+                           sso_type: str, is_signup: bool=False) -> HttpResponse:
     main_site_uri = settings.ROOT_DOMAIN_URI + url
+    if settings.SOCIAL_AUTH_SUBDOMAIN is not None and sso_type == 'github':
+        main_site_uri = (settings.EXTERNAL_URI_SCHEME +
+                         settings.SOCIAL_AUTH_SUBDOMAIN +
+                         settings.EXTERNAL_HOST) + url
+
     params = {
         'subdomain': get_subdomain(request),
         'is_signup': '1' if is_signup else '0',
@@ -303,19 +309,20 @@ def start_google_oauth2(request: HttpRequest) -> HttpResponse:
         return redirect_to_config_error("google")
 
     is_signup = bool(request.GET.get('is_signup'))
-    return oauth_redirect_to_root(request, url, is_signup=is_signup)
+    return oauth_redirect_to_root(request, url, 'google', is_signup=is_signup)
 
 def start_social_login(request: HttpRequest, backend: str) -> HttpResponse:
     backend_url = reverse('social:begin', args=[backend])
     if (backend == "github") and not (settings.SOCIAL_AUTH_GITHUB_KEY and
-                                      settings.SOCIAL_AUTH_GITHUB_SECRET):
+                                      settings.SOCIAL_AUTH_GITHUB_SECRET and
+                                      settings.SOCIAL_AUTH_SUBDOMAIN):
         return redirect_to_config_error("github")
 
-    return oauth_redirect_to_root(request, backend_url)
+    return oauth_redirect_to_root(request, backend_url, 'github')
 
 def start_social_signup(request: HttpRequest, backend: str) -> HttpResponse:
     backend_url = reverse('social:begin', args=[backend])
-    return oauth_redirect_to_root(request, backend_url, is_signup=True)
+    return oauth_redirect_to_root(request, backend_url, 'github', is_signup=True)
 
 def send_oauth_request_to_google(request: HttpRequest) -> HttpResponse:
     subdomain = request.GET.get('subdomain', '')

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -161,6 +161,8 @@ AUTHENTICATION_BACKENDS = (
 #SOCIAL_AUTH_GITHUB_TEAM_ID = <your team id>
 #SOCIAL_AUTH_GITHUB_ORG_NAME = <your org name>
 
+# (4) Setting up SOCIAL_AUTH_SUBDOMAIN setting is a requirement for using social login.
+#SOCIAL_AUTH_SUBDOMAIN = 'www.'
 ########
 # SSO via REMOTE_USER.
 #

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -145,6 +145,7 @@ DEFAULT_SETTINGS = {
     'SOCIAL_AUTH_GITHUB_KEY': get_secret('social_auth_github_key', development_only=True),
     'SOCIAL_AUTH_GITHUB_ORG_NAME': None,
     'SOCIAL_AUTH_GITHUB_TEAM_ID': None,
+    'SOCIAL_AUTH_SUBDOMAIN': None,
 
     # Email gateway
     'EMAIL_GATEWAY_PATTERN': '',

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -145,6 +145,7 @@ GOOGLE_OAUTH2_CLIENT_SECRET = "secret"
 
 SOCIAL_AUTH_GITHUB_KEY = "key"
 SOCIAL_AUTH_GITHUB_SECRET = "secret"
+SOCIAL_AUTH_SUBDOMAIN = 'www.'
 
 # By default two factor authentication is disabled in tests.
 # Explicitly set this to True within tests that must have this on.


### PR DESCRIPTION
Basically we add 'www' as a subdomain and start to effectively use
it for the purpose of setting session cookies in case of social
oauth so that it won't interfare with other sessions the people
might have in other subdomains on a zulip server.

Fixes: #9847.

Explanation of why this fixes this issue has been provided by Tim in this message: https://chat.zulip.org/#narrow/stream/57-core-team/subject/important.20bugs/near/608109