### PR TITLE
Custom fields cleanup

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -705,6 +705,17 @@ input[type=checkbox].inline-block {
 .admin_profile_fields_table,
 .admin_filters_table {
     margin-top: 20px;
+    .movable-profile-field-row {
+        cursor: move;
+        i {
+            color: hsl(0, 0, 75%);
+            position: relative;
+            top: 1px;
+            + i {
+                margin-right: 5px;
+            }
+        }
+    }
 }
 
 #admin-filter-pattern-status,

--- a/static/templates/admin_profile_field_list.handlebars
+++ b/static/templates/admin_profile_field_list.handlebars
@@ -1,8 +1,9 @@
 {{#with profile_field}}
-<tr class="profile-field-row" data-profile-field-id="{{id}}">
+<tr class="profile-field-row movable-profile-field-row" data-profile-field-id="{{id}}">
     <td>
         {{#if ../can_modify}}
-        <i class="fa fa-sort"></i>
+        <i class="fa fa-ellipsis-v"></i>
+        <i class="fa fa-ellipsis-v"></i>
         {{/if}}
         <span class="profile_field_name">{{name}}</span>
     </td>


### PR DESCRIPTION
Cleanup of custom fields as described in https://github.com/zulip/zulip/issues/9875

Hide the up/down arrows from the year field in the datepicker:
![image](https://user-images.githubusercontent.com/2905696/42509949-7bb93908-841b-11e8-8e9d-6292ab695770.png)


Change styling for draggable rows to the standard "drag" element:
![image](https://user-images.githubusercontent.com/2905696/42509975-8815ef20-841b-11e8-9ff4-67ed8cb9243f.png)


Clean up the "x" for deleting the value of the date field:
![image](https://user-images.githubusercontent.com/2905696/42509954-7fee491e-841b-11e8-9061-a22687132857.png)
