### PR TITLE
tools: Only files starting with same migration number conflict.

### DIFF
--- a/tools/renumber-migrations
+++ b/tools/renumber-migrations
@@ -62,10 +62,11 @@ if __name__ == '__main__':
         file_index = [file[0:4] for file in files_list]
 
         for file in file_index:
-            counter = file_index.count(file[0:4])
+            migration_number = file[0:4]
+            counter = file_index.count(migration_number)
             if counter > 1 and file[0:4] not in stack:
-                conflicts += [file_name for file_name in files_list if file[0:4] in file_name]
-                stack.append(file[0:4])
+                conflicts += [file_name for file_name in files_list if file_name.startswith(migration_number)]
+                stack.append(migration_number)
 
         if len(conflicts) > 0:
             resolve_conflicts(conflicts, files_list)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing Plan:** <!-- How have you tested? -->

```sh
$ touch zerver/migrations/0170_foo.py

# Before the change
$ ./tools/renumber-migrations 
Conflicting migrations:
1. 0170_foo.py
2. 0089_auto_20170710_1353.py
3. 0170_submessage.py

# After the change
$ ./tools/renumber-migrations 
Conflicting migrations:
1. 0170_foo.py
2. 0170_submessage.py
Enter the order in which these migrations should be arranged: 
```
