### PR TITLE
settings UI: Improve manual styling of user profile pill containers.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1745,3 +1745,18 @@ thead .actions {
 .profile-field-choices .choice-row input {
     width: 50px;
 }
+
+.custom_user_field .pill-container {
+    padding: 2px 6px;
+    height: 24px;
+}
+
+.custom_user_field .pill-container:focus-within {
+    border-color: rgba(82, 168, 236, 0.8);
+    outline: 0;
+    outline: thin dotted \9;
+
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+    -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+}

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1745,18 +1745,3 @@ thead .actions {
 .profile-field-choices .choice-row input {
     width: 50px;
 }
-
-#settings_page .pill-container {
-    background: #fff;
-    border: 1px solid #cccccc;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-    transition: border linear 0.2s, box-shadow linear 0.2s;
-    min-width: 206px;
-    padding: 2px 6px;
-}
-
-#settings_page .pill-container:active,
-#settings_page .pill-container:focus {
-    border-color: rgba(82, 168, 236, 0.8);
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
-}

--- a/static/templates/settings/custom-user-profile-field.handlebars
+++ b/static/templates/settings/custom-user-profile-field.handlebars
@@ -10,7 +10,7 @@
         {{/each}}
     </select>
     {{else if is_user_field }}
-    <div class="pill-container">
+    <div class="pill-container uneditable-input">
         <div class="input" contenteditable="true"></div>
     </div>
     {{else if is_date_field }}


### PR DESCRIPTION
Previously, commit e5d2e95 attempted to change the styling of the user profile pill containers to match the inputs above it. However, it used an incorrect selector (`#settings_page`), resulting in **all** other pill containers on settings pages being changed to match it as well (example: User groups pill containers in Organization settings). Additionally, its selector's specified `background` attribute resulted in problems in dark mode, such as:

![screenshot at jul 10 10-29-43](https://user-images.githubusercontent.com/15116870/42528288-ddcd37e8-842f-11e8-8f90-52c16784a94e.png)

To correctly style the user profile pill containers to match the other input's styling, we apply the `uneditable-input` class native to Bootstrap so that we don't need to create an entirely new selector to style it. Note that the `.custom_user_field .pill-container` selector was added so that it could match the padding of inputs. Also, the `.custom_user_field .pill-container:focus-within` selector was added with attributes straight from Bootstrap's `input:focus` selectors so that `.custom_user_field .pill-container` would have a blue outline while users were typing in the input pill, just like the other inputs.

Results:
![screenshot at jul 10 10-50-54](https://user-images.githubusercontent.com/15116870/42528487-74751a08-8430-11e8-878f-0e115c6a71a0.png)
![screenshot at jul 10 10-52-51](https://user-images.githubusercontent.com/15116870/42528488-749d23fe-8430-11e8-81bf-2ec8d27bb279.png)
![screenshot at jul 10 10-53-04](https://user-images.githubusercontent.com/15116870/42528489-74d11614-8430-11e8-83c7-d12ddc1e5df4.png)
