### PR TITLE
test-api: Fix broken check for get_members.

### DIFF
--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -140,7 +140,14 @@ def get_members(client):
     assert newbie['full_name'] == 'New User'
 
     member_fixture = fixture['members'][0]
-    member_result = result['members'][0]
+
+    # Get Aaron from all the results we got from the API
+    for member in result['members']:
+        if member['email'] == 'AARON@zulip.com':
+            member_result = member
+
+    assert member_result
+
     test_against_fixture(member_result, member_fixture,
                          check_if_exists=member_fixture.keys())
 


### PR DESCRIPTION
The tests for GET /users were looking for a specific user, asuming that
it would always be in the same position. Since the users' sorting isn't
guaranteed in any way, this can lead to errors in the tests.

Now we make sure the user we grab from the list is the one we need by
checking its email address.

This is just a hotfix that addresses the short-term problem: we have
already made some efforts to make sure these tests are more
deterministic, and now we only need to finish the migration of the old
enpoints to the new system as a long-term solution.