### PR TITLE
api docs: Improve how arguments are handled.

### DIFF
--- a/zerver/lib/bugdown/api_arguments_table_generator.py
+++ b/zerver/lib/bugdown/api_arguments_table_generator.py
@@ -126,7 +126,9 @@ class APIArgumentsTablePreprocessor(Preprocessor):
             # be added for this.
             table.append(tr.format(
                 argument=argument.get('argument') or argument.get('name'),
-                example=argument['example'],
+                # Show this as JSON to avoid changing the quoting style, which
+                # may cause problems with JSON encoding.
+                example=ujson.dumps(argument['example']),
                 required='Yes' if argument.get('required') else 'No',
                 description=md_engine.convert(description),
             ))

--- a/zerver/lib/bugdown/api_arguments_table_generator.py
+++ b/zerver/lib/bugdown/api_arguments_table_generator.py
@@ -48,18 +48,32 @@ class APIArgumentsTablePreprocessor(Preprocessor):
 
                     if not os.path.isabs(filename):
                         parent_dir = self.base_path
-                        filename = os.path.normpath(os.path.join(parent_dir, filename))
+                        filename = os.path.normpath(os.path.join(parent_dir,
+                                                                 filename))
 
                     if is_openapi_format:
                         endpoint, method = doc_name.rsplit(':', 1)
-                        arguments = get_openapi_parameters(endpoint, method)
+                        arguments = []  # type: List[Dict[str, Any]]
+
+                        try:
+                            arguments = get_openapi_parameters(endpoint,
+                                                               method)
+                        except KeyError as e:
+                            # Don't raise an exception if the "parameters"
+                            # field is missing; we assume that's because the
+                            # endpoint doesn't accept any parameters
+                            if e.args != ('parameters',):
+                                raise e
                     else:
                         with open(filename, 'r') as fp:
                             json_obj = ujson.load(fp)
                             arguments = json_obj[doc_name]
 
-                    text = self.render_table(arguments)
-
+                    if arguments:
+                        text = self.render_table(arguments)
+                    else:
+                        text = ['This endpoint does not consume any '
+                                'arguments.']
                     # The line that contains the directive to include the macro
                     # may be preceded or followed by text or tags, in that case
                     # we need to make sure that any preceding or following text

--- a/zerver/lib/bugdown/api_arguments_table_generator.py
+++ b/zerver/lib/bugdown/api_arguments_table_generator.py
@@ -50,23 +50,15 @@ class APIArgumentsTablePreprocessor(Preprocessor):
                         parent_dir = self.base_path
                         filename = os.path.normpath(os.path.join(parent_dir, filename))
 
-                    try:
-                        if is_openapi_format:
-                            endpoint, method = doc_name.rsplit(':', 1)
-                            arguments = get_openapi_parameters(endpoint, method)
-                        else:
-                            with open(filename, 'r') as fp:
-                                json_obj = ujson.load(fp)
-                                arguments = json_obj[doc_name]
+                    if is_openapi_format:
+                        endpoint, method = doc_name.rsplit(':', 1)
+                        arguments = get_openapi_parameters(endpoint, method)
+                    else:
+                        with open(filename, 'r') as fp:
+                            json_obj = ujson.load(fp)
+                            arguments = json_obj[doc_name]
 
-                        text = self.render_table(arguments)
-                    except Exception as e:
-                        print('Warning: could not find file {}. Ignoring '
-                              'statement. Error: {}'.format(filename, e))
-                        # If the file cannot be opened, just substitute an empty line
-                        # in place of the macro include line
-                        lines[loc] = REGEXP.sub('', line)
-                        break
+                    text = self.render_table(arguments)
 
                     # The line that contains the directive to include the macro
                     # may be preceded or followed by text or tags, in that case


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** lint and mypy checks passed locally. Also, in order to make sure that the changes worked properly, I removed the following from `zerver/openapi/zulip.yaml`:

~~~diff
diff --git a/zerver/openapi/zulip.yaml b/zerver/openapi/zulip.yaml
index 2aa379797..dadb6ef5e 100644
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -98,14 +98,6 @@ paths:
   /users/me/{stream_id}/topics:
     get:
       description: Get all the topics in a specific stream.
-      parameters:
-      - name: stream_id
-        in: path
-        description: The unique ID of the stream.
-        schema:
-          type: integer
-        example: 42
-        required: true
       security:
       - basicAuth: []
       responses:
~~~

This way, I could compare between these two:

- http://localhost:9991/api/add-subscriptions (which has arguments)
- http://localhost:9991/api/get-stream-topics (which now should have no arguments and thus display the message, only for testing purposes).

**GIFs or Screenshots:**

![Endpoint with no args](https://user-images.githubusercontent.com/7356565/42633441-23dbed18-85fe-11e8-8623-0bea90aaaf5c.png)
