### PR TITLE
alert words: Improve API for /users/me/alert_words.

### DIFF
--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -105,13 +105,19 @@ class AlertWordTests(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(result.json()['alert_words'], [])
 
+    def test_json_list_nonempty(self) -> None:
+        hamlet = self.example_user('hamlet')
+        add_user_alert_words(hamlet, ['one', 'two', 'three'])
+
+        self.login(self.example_email('hamlet'))
+        result = self.client_get('/json/users/me/alert_words')
+        self.assert_json_success(result)
+        self.assertEqual(result.json()['alert_words'], ['one', 'two', 'three'])
+
     def test_json_list_add(self) -> None:
         self.login(self.example_email("hamlet"))
 
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one ', '\n two', 'three'])})
-        self.assert_json_success(result)
-
-        result = self.client_get('/json/users/me/alert_words')
         self.assert_json_success(result)
         self.assertEqual(result.json()['alert_words'], ['one', 'two', 'three'])
 
@@ -120,11 +126,9 @@ class AlertWordTests(ZulipTestCase):
 
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
         self.assert_json_success(result)
+        self.assertEqual(result.json()['alert_words'], ['one', 'two', 'three'])
 
         result = self.client_delete('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one'])})
-        self.assert_json_success(result)
-
-        result = self.client_get('/json/users/me/alert_words')
         self.assert_json_success(result)
         self.assertEqual(result.json()['alert_words'], ['two', 'three'])
 
@@ -139,9 +143,6 @@ class AlertWordTests(ZulipTestCase):
         user_profile_hamlet = self.example_user('hamlet')
 
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
-        self.assert_json_success(result)
-
-        result = self.client_get('/json/users/me/alert_words')
         self.assert_json_success(result)
         self.assertEqual(result.json()['alert_words'], ['one', 'two', 'three'])
 

--- a/zerver/views/alert_words.py
+++ b/zerver/views/alert_words.py
@@ -23,11 +23,11 @@ def add_alert_words(request: HttpRequest, user_profile: UserProfile,
                     alert_words: List[str]=REQ(validator=check_list(check_string))
                     ) -> HttpResponse:
     do_add_alert_words(user_profile, clean_alert_words(alert_words))
-    return json_success()
+    return json_success({'alert_words': user_alert_words(user_profile)})
 
 @has_request_variables
 def remove_alert_words(request: HttpRequest, user_profile: UserProfile,
                        alert_words: List[str]=REQ(validator=check_list(check_string))
                        ) -> HttpResponse:
     do_remove_alert_words(user_profile, alert_words)
-    return json_success()
+    return json_success({'alert_words': user_alert_words(user_profile)})

--- a/zerver/views/alert_words.py
+++ b/zerver/views/alert_words.py
@@ -20,14 +20,14 @@ def clean_alert_words(alert_words: List[str]) -> List[str]:
 
 @has_request_variables
 def add_alert_words(request: HttpRequest, user_profile: UserProfile,
-                    alert_words: List[str]=REQ(validator=check_list(check_string), default=[])
+                    alert_words: List[str]=REQ(validator=check_list(check_string))
                     ) -> HttpResponse:
     do_add_alert_words(user_profile, clean_alert_words(alert_words))
     return json_success()
 
 @has_request_variables
 def remove_alert_words(request: HttpRequest, user_profile: UserProfile,
-                       alert_words: List[str]=REQ(validator=check_list(check_string), default=[])
+                       alert_words: List[str]=REQ(validator=check_list(check_string))
                        ) -> HttpResponse:
     do_remove_alert_words(user_profile, alert_words)
     return json_success()


### PR DESCRIPTION
Some improvements in how we manage queries to `/users/me/alert_words`:
- Now POST and DELETE *require* setting a list of alert words, to avoid noop queries.
- Both also now return the updated list of alert words.


**Testing Plan:**
- lint and `test-backend zerver.tests.test_alert_words` passed locally for each commit
- Made sure that the server complained when `alert_words` wasn't provided and
- it returned the updated list when POSTed/DELETEd `/users/me/alert_words`.