### PR TITLE
webhooks/gitlab: Include title in Issue Hook event messages.

### DIFF
--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -34,6 +34,7 @@ CREATE_BRANCH_MESSAGE_TEMPLATE = "{user_name} created [{branch_name}]({url}) bra
 REMOVE_BRANCH_MESSAGE_TEMPLATE = "{user_name} deleted branch {branch_name}"
 
 PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE = "{user_name} {action} [{type}{id}]({url})"
+PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE_WITH_TITLE = "{user_name} {action} [{type}{id} {title}]({url})"
 PULL_REQUEST_OR_ISSUE_ASSIGNEE_INFO_TEMPLATE = "(assigned to {assignee})"
 PULL_REQUEST_BRANCH_INFO_TEMPLATE = "\nfrom `{target}` to `{base}`"
 
@@ -123,14 +124,21 @@ def get_remove_branch_event_message(user_name: str, branch_name: str) -> str:
 def get_pull_request_event_message(user_name: str, action: str, url: str, number: Optional[int]=None,
                                    target_branch: Optional[str]=None, base_branch: Optional[str]=None,
                                    message: Optional[str]=None, assignee: Optional[str]=None,
-                                   type: Optional[str]='PR') -> str:
-    main_message = PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE.format(
-        user_name=user_name,
-        action=action,
-        type=type,
-        url=url,
-        id=" #{}".format(number) if number is not None else ''
-    )
+                                   type: Optional[str]='PR', title: Optional[str]=None) -> str:
+    kwargs = {
+        'user_name': user_name,
+        'action': action,
+        'type': type,
+        'url': url,
+        'id': ' #{}'.format(number) if number is not None else '',
+        'title': title,
+    }
+
+    if title is not None:
+        main_message = PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE_WITH_TITLE.format(**kwargs)
+    else:
+        main_message = PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE.format(**kwargs)
+
     if assignee:
         main_message += PULL_REQUEST_OR_ISSUE_ASSIGNEE_INFO_TEMPLATE.format(assignee=assignee)
 
@@ -154,7 +162,8 @@ def get_issue_event_message(user_name: str,
                             url: str,
                             number: Optional[int]=None,
                             message: Optional[str]=None,
-                            assignee: Optional[str]=None) -> str:
+                            assignee: Optional[str]=None,
+                            title: Optional[str]=None) -> str:
     return get_pull_request_event_message(
         user_name,
         action,
@@ -162,7 +171,8 @@ def get_issue_event_message(user_name: str,
         number,
         message=message,
         assignee=assignee,
-        type='Issue'
+        type='Issue',
+        title=title,
     )
 
 def get_push_tag_event_message(user_name: str,

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -93,7 +93,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_create_issue_without_assignee_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title"
-        expected_message = u"Tomasz Kolek created [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)\n\n~~~ quote\nIssue description\n~~~"
+        expected_message = u"Tomasz Kolek created [Issue #1 Issue title](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)\n\n~~~ quote\nIssue description\n~~~"
 
         self.send_and_test_stream_message(
             'issue_created_without_assignee',
@@ -104,7 +104,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_create_issue_with_assignee_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title"
-        expected_message = u"Tomasz Kolek created [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)(assigned to Tomasz Kolek)\n\n~~~ quote\nIssue description\n~~~"
+        expected_message = u"Tomasz Kolek created [Issue #1 Issue title](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)(assigned to Tomasz Kolek)\n\n~~~ quote\nIssue description\n~~~"
 
         self.send_and_test_stream_message(
             'issue_created_with_assignee',
@@ -115,7 +115,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_create_issue_with_hidden_comment_in_description(self) -> None:
         expected_subject = u"public-repo / Issue #3 New Issue with hidden comment"
-        expected_message = u"Eeshan Garg created [Issue #3](https://gitlab.com/eeshangarg/public-repo/issues/3)\n\n~~~ quote\nThis description actually has a hidden comment in it!\n~~~"
+        expected_message = u"Eeshan Garg created [Issue #3 New Issue with hidden comment](https://gitlab.com/eeshangarg/public-repo/issues/3)\n\n~~~ quote\nThis description actually has a hidden comment in it!\n~~~"
 
         self.send_and_test_stream_message(
             'issue_created_with_hidden_comment_in_description',
@@ -126,7 +126,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_create_issue_with_null_description(self) -> None:
         expected_subject = u"my-awesome-project / Issue #7 Issue without description"
-        expected_message = u"Eeshan Garg created [Issue #7](https://gitlab.com/eeshangarg/my-awesome-project/issues/7)"
+        expected_message = u"Eeshan Garg created [Issue #7 Issue without description](https://gitlab.com/eeshangarg/my-awesome-project/issues/7)"
         self.send_and_test_stream_message(
             'issue_opened_with_null_description',
             expected_subject,
@@ -136,7 +136,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_update_issue_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
-        expected_message = u"Tomasz Kolek updated [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
+        expected_message = u"Tomasz Kolek updated [Issue #1 Issue title_new](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
 
         self.send_and_test_stream_message(
             'issue_updated',
@@ -147,7 +147,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_close_issue_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
-        expected_message = u"Tomasz Kolek closed [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
+        expected_message = u"Tomasz Kolek closed [Issue #1 Issue title_new](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
 
         self.send_and_test_stream_message(
             'issue_closed',
@@ -158,7 +158,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_reopen_issue_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
-        expected_message = u"Tomasz Kolek reopened [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
+        expected_message = u"Tomasz Kolek reopened [Issue #1 Issue title_new](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
 
         self.send_and_test_stream_message(
             'issue_reopened',

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -71,7 +71,8 @@ def get_issue_created_event_body(payload: Dict[str, Any]) -> str:
         get_object_url(payload),
         payload['object_attributes'].get('iid'),
         description,
-        get_objects_assignee(payload)
+        get_objects_assignee(payload),
+        title=payload['object_attributes'].get('title')
     )
 
 def get_issue_event_body(payload: Dict[str, Any], action: str) -> str:
@@ -80,6 +81,7 @@ def get_issue_event_body(payload: Dict[str, Any], action: str) -> str:
         action,
         get_object_url(payload),
         payload['object_attributes'].get('iid'),
+        title=payload['object_attributes'].get('title')
     )
 
 def get_merge_request_updated_event_body(payload: Dict[str, Any]) -> str:


### PR DESCRIPTION
We already include the issue title in the topic. But if one chooses
to group all gitlab notifications under one topic, the message body
is misleading in the sense that only the Issue ID and the description
are displayed, not the title, which isn't super helpful if the topic
doesn't tell you the title either.

I think we should err on the side of always including the title in
the main message body, which is what this commit does.

Fixes #9913.

@timabbott: FYI :)
