### PR TITLE
Add delivery_email field to page_params.

### DIFF
--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -9,7 +9,7 @@
                     <a id="change_email" {{#if page_params.is_admin}}href="#change_email"{{else}}{{#unless page_params.realm_email_changes_disabled}}href="#change_email"{{/unless}}{{/if}}>
                         <button type="button" class="button small rounded inline-block" id='email_value'
                           {{#unless page_params.is_admin}}{{#if page_params.realm_email_changes_disabled}}disabled="disabled"{{/if}}{{/unless}}>
-                            {{page_params.email}}
+                            {{page_params.delivery_email}}
                             <i class="fa fa-pencil"></i>
                         </button>
                     </a>

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -228,6 +228,7 @@ def fetch_initial_state_data(user_profile: UserProfile,
         state['user_id'] = user_profile.id
         state['enter_sends'] = user_profile.enter_sends
         state['email'] = user_profile.email
+        state['delivery_email'] = user_profile.delivery_email
         state['full_name'] = user_profile.full_name
 
     if want('realm_bot'):

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -57,6 +57,7 @@ class HomeTest(ZulipTestCase):
             "debug_mode",
             "default_language",
             "default_language_name",
+            "delivery_email",
             "dense_mode",
             "development_environment",
             "email",


### PR DESCRIPTION
This allows the frontend to use the `delivery_email`
field for display use.