### PR TITLE
hotkey: Use `Ctrl + Alt + S` as a hotkey for showing starred messages.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -70,12 +70,13 @@ run_test('mappings', () => {
         });
     }
 
-    function map_down(which, shiftKey, ctrlKey, metaKey) {
+    function map_down(which, shiftKey, ctrlKey, metaKey, altKey) {
         return hotkey.get_keydown_hotkey({
             which: which,
             shiftKey: shiftKey,
             ctrlKey: ctrlKey,
             metaKey: metaKey,
+            altKey: altKey,
         });
     }
 
@@ -101,6 +102,7 @@ run_test('mappings', () => {
     assert.equal(map_down(219, false, true).name, 'escape'); // ctrl + [
     assert.equal(map_down(75, false, true).name, 'search_with_k'); // ctrl + k
     assert.equal(map_down(83, false, true).name, 'star_message'); // ctrl + s
+    assert.equal(map_down(83, false, true, false, true).name, 'show_starred'); // ctrl + alt + s
 
     // More negative tests.
     assert.equal(map_down(47), undefined);
@@ -124,6 +126,7 @@ run_test('mappings', () => {
     assert.equal(map_down(75, true, true), undefined); // shift + ctrl + k
     assert.equal(map_down(83, true, true), undefined); // shift + ctrl + s
     assert.equal(map_down(219, true, true, false), undefined); // shift + ctrl + [
+    assert.equal(map_down(83, false, false, false, true), undefined); // alt + s
 
     // CMD tests for MacOS
     global.navigator.userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.167 Safari/537.36";

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -57,6 +57,10 @@ var keydown_cmd_or_ctrl_mappings = {
     83: {name: 'star_message', message_view_only: true}, // 's'
 };
 
+var keydown_alt_cmd_or_ctrl_mappings = {
+    83: {name: 'show_starred', message_view_only: true}, // 's'
+};
+
 var keydown_either_mappings = {
     // these can be triggered by key or shift + key
     // Note that codes for letters are still case sensitive!
@@ -112,13 +116,9 @@ var keypress_mappings = {
 };
 
 exports.get_keydown_hotkey = function (e) {
-    if (e.altKey) {
-        return;
-    }
-
     var hotkey;
 
-    if (e.ctrlKey && !e.shiftKey) {
+    if (e.ctrlKey && !e.shiftKey && !e.altKey) {
         hotkey = keydown_ctrl_mappings[e.which];
         if (hotkey) {
             return hotkey;
@@ -126,8 +126,14 @@ exports.get_keydown_hotkey = function (e) {
     }
 
     var isCmdOrCtrl = /Mac/i.test(navigator.userAgent) ? e.metaKey : e.ctrlKey;
-    if (isCmdOrCtrl && !e.shiftKey) {
+    if (isCmdOrCtrl && !e.shiftKey && !e.altKey) {
         hotkey = keydown_cmd_or_ctrl_mappings[e.which];
+        if (hotkey) {
+            return hotkey;
+        }
+        return;
+    } else if (isCmdOrCtrl && !e.shiftKey && e.altKey) {
+        hotkey = keydown_alt_cmd_or_ctrl_mappings[e.which];
         if (hotkey) {
             return hotkey;
         }
@@ -634,6 +640,9 @@ exports.process_hotkey = function (e, hotkey) {
         return true;
     case 'show_shortcuts': // Show keyboard shortcuts page
         info_overlay.maybe_show_keyboard_shortcuts();
+        return true;
+    case 'show_starred':
+        narrow.by('is', 'starred');
         return true;
     case 'stream_cycle_backward':
         narrow.stream_cycle_backward();

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -186,6 +186,10 @@
                     <td class="hotkey">Esc, Ctrl + [</td>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
                 </tr>
+                <tr>
+                    <td class="hotkey">Ctrl + Alt + S</td>
+                    <td class="definition">{% trans %}Narrow to starred messages{% endtrans %}</td>
+                </tr>
             </table>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -76,6 +76,8 @@ below, and add more to your repertoire as needed.
 
 * **Narrow to all private messages**: `P`
 
+* **Narrow to starred messages**: `Ctrl` + `Alt` + `S`
+
 * **Cycle between stream narrows**: `A` (previous) and `D` (next)
 
 * **Narrow to all messages**: `Esc` or `Ctrl` + `[` — Shows all unmuted messages.


### PR DESCRIPTION
This PR adds `Ctrl + Alt + S` as a hotkey for showing starred messages, as well as updating documentation and adding tests. 

Fixes #9684. There’s a lot of disscussion in that issue over what the hotkey should be, but it seems like `Ctrl + Alt + S` is the consensus.

**Testing Plan:** <!-- How have you tested? -->

This PR adds two new tests to [`frontend_tests/node_tests/hotkey.js`](https://github.com/zulip/zulip/compare/master...skunkmb:9684?expand=1#diff-9a21e1e80b69ad136624a71c91147d8f).