### PR TITLE
emoji: Add support for animated GIF images.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -189,7 +189,7 @@ ignore_missing_imports = True
 [mypy-pika,pika.*]
 ignore_missing_imports = True
 
-[mypy-PIL]
+[mypy-PIL,PIL.*]
 ignore_missing_imports = True
 
 [mypy-pipeline.storage]


### PR DESCRIPTION
This commit adds 'resize_gif()' function which extracts each frame,
resize it and coalesces them again to form the resized GIF while
preserving the duration of the GIF. I read some stackoverflow
answers all of which were referring to BiggleZX's script
(https://gist.github.com/BigglesZX/4016539) for working with animated
GIF. I modified the script to fit to our usecase and did some manual
testing but the function was failing for some specific GIFs and was not
preserving the duration of animation. So I went ahead and read about
GIF format itself as well as PIL's `GifImagePlugin` code and came up
with this simple function which gets the worked done in a much cleaner
way. It tested this function on a number of GIF images from giphy.com
and it resized all of them correctly.

Fixes: #9945.