### PR TITLE
Avoid shelling out for trivial file operations

### DIFF
--- a/scripts/lib/unpack-zulip
+++ b/scripts/lib/unpack-zulip
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import os
+import shutil
 import sys
 import subprocess
-import datetime
 import tempfile
 import glob
 
@@ -10,7 +10,7 @@ os.environ["PYTHONUNBUFFERED"] = "y"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', ".."))
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, ENDC, make_deploy_path, \
-    get_deployment_version, is_invalid_upgrade
+    get_deployment_version, is_invalid_upgrade, overwrite_symlink
 import version
 
 if len(sys.argv) != 2:
@@ -31,14 +31,14 @@ if is_invalid_upgrade(current_version, new_version):
           "Your current version is very old. Please first upgrade to version "
           "1.4.3 and then upgrade to {}.".format(new_version) +
           ENDC)
-    subprocess.check_call(["rm", "-r", extract_path])
+    shutil.rmtree(extract_path)
     sys.exit(1)
 
-subprocess.check_call(["mv", glob.glob(os.path.join(extract_path, "zulip-server-*"))[0], deploy_path])
-subprocess.check_call(["rmdir", extract_path])
-subprocess.check_call(["ln", "-nsf", "/etc/zulip/settings.py",
-                       os.path.join(deploy_path, "zproject/prod_settings.py")])
-subprocess.check_call(["ln", '-nsf', deploy_path, os.path.join(DEPLOYMENTS_DIR, "next")])
+shutil.move(glob.glob(os.path.join(extract_path, "zulip-server-*"))[0], deploy_path)
+os.rmdir(extract_path)
+overwrite_symlink("/etc/zulip/settings.py",
+                  os.path.join(deploy_path, "zproject/prod_settings.py"))
+overwrite_symlink(deploy_path, os.path.join(DEPLOYMENTS_DIR, "next"))
 
 print(deploy_path)
 sys.exit(0)

--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -24,7 +24,7 @@ os.environ["PYTHONUNBUFFERED"] = "y"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, make_deploy_path, \
-    get_deployment_lock, release_deployment_lock, su_to_zulip, assert_running_as_root
+    get_deployment_lock, overwrite_symlink, release_deployment_lock, su_to_zulip, assert_running_as_root
 
 assert_running_as_root(strip_lib_from_paths=True)
 
@@ -44,9 +44,8 @@ refname = args.refname
 if args.remote_url:
     remote_url = args.remote_url
 
-subprocess.check_call(["mkdir", '-p',
-                       DEPLOYMENTS_DIR,
-                       '/home/zulip/logs'])
+os.makedirs(DEPLOYMENTS_DIR, exist_ok=True)
+os.makedirs('/home/zulip/logs', exist_ok=True)
 
 error_rerun_script = "%s/current/scripts/upgrade-zulip-from-git %s" % (DEPLOYMENTS_DIR, refname)
 get_deployment_lock(error_rerun_script)
@@ -69,10 +68,9 @@ try:
                           preexec_fn=su_to_zulip)
     os.chdir(deploy_path)
 
-    subprocess.check_call(["ln", "-nsf", "/etc/zulip/settings.py",
-                           os.path.join(deploy_path, "zproject/prod_settings.py")])
+    overwrite_symlink("/etc/zulip/settings.py", "zproject/prod_settings.py")
 
-    subprocess.check_call(["ln", '-nsf', deploy_path, os.path.join(DEPLOYMENTS_DIR, "next")])
+    overwrite_symlink(deploy_path, os.path.join(DEPLOYMENTS_DIR, "next"))
 
     subprocess.check_call([os.path.join(deploy_path, "scripts", "lib", "upgrade-zulip-stage-2"),
                            deploy_path, "--from-git"] + deploy_options)

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -61,10 +61,10 @@ if not args.skip_puppet:
     subprocess.check_call(["apt-get", "update"])
     subprocess.check_call(["apt-get", "-y", "upgrade"])
 
-if not os.path.exists((os.path.join(deploy_path, "zproject/prod_settings"))):
+if not os.path.exists((os.path.join(deploy_path, "zproject/prod_settings.py"))):
     # For upgrading from <1.4.0.  See discussion in commit 586b23637.
-    subprocess.check_call(["ln", "-nsf", "/etc/zulip/settings.py",
-                           os.path.join(deploy_path, "zproject/prod_settings.py")])
+    os.symlink("/etc/zulip/settings.py",
+               os.path.join(deploy_path, "zproject/prod_settings.py"))
 
 # Now we should have an environment setup where we can run our tools;
 # first, creating the production venv.

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -174,10 +174,6 @@ def run(args, **kwargs):
     # Output what we're doing in the `set -x` style
     print("+ %s" % (" ".join(map(shlex.quote, args)),))
 
-    if kwargs.get('shell'):
-        # With shell=True we can only pass string to Popen
-        args = " ".join(args)
-
     try:
         subprocess.check_call(args, **kwargs)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
Python’s built-in file operations are generally faster, safer, and more concise than shelling out to `cp`, `ln`, `mkdir`, `mv`, `pwd`, `rm`, and `touch`.

I tested this as far as provisioning a completely fresh dev VM.