### PR TITLE
message edit: Add support for markdown in message edit UI.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -347,7 +347,7 @@ run_test('markdown_rtl', () => {
     assert.equal(textarea.hasClass('rtl'), false);
 
     textarea.val('```quote foo');
-    compose.handle_keydown(event);
+    compose.handle_keydown(event, $("#compose-textarea"));
 
     assert.equal(textarea.hasClass('rtl'), true);
 });
@@ -365,7 +365,7 @@ run_test('markdown_ltr', () => {
 
     assert.equal(textarea.hasClass('rtl'), true);
     textarea.val('```quote foo');
-    compose.handle_keydown(event);
+    compose.handle_keydown(event, textarea);
 
     assert.equal(textarea.hasClass('rtl'), false);
 });
@@ -414,7 +414,7 @@ run_test('markdown_shortcuts', () => {
         event.which = 73;
         event.metaKey = isCmd;
         event.ctrlKey = isCtrl;
-        compose.handle_keydown(event);
+        compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal("i", $('#compose-textarea').val());
     }
 
@@ -433,13 +433,13 @@ run_test('markdown_shortcuts', () => {
         event.keyCode = 66;
         event.ctrlKey = isCtrl;
         event.metaKey = isCmd;
-        compose.handle_keydown(event);
+        compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal("Any **text**.", $('#compose-textarea').val());
         // Test if no text is selected.
         range_start = 0;
         // Change cursor to first position.
         range_length = 0;
-        compose.handle_keydown(event);
+        compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal("****Any **text**.", $('#compose-textarea').val());
 
         // Test italic:
@@ -450,13 +450,13 @@ run_test('markdown_shortcuts', () => {
         range_length = selected_word.length;
         event.keyCode = 73;
         event.shiftKey = false;
-        compose.handle_keydown(event);
+        compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal("Any *text*.", $('#compose-textarea').val());
         // Test if no text is selected.
         range_length = 0;
         // Change cursor to first position.
         range_start = 0;
-        compose.handle_keydown(event);
+        compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal("**Any *text*.", $('#compose-textarea').val());
 
         // Test link insertion:
@@ -468,11 +468,11 @@ run_test('markdown_shortcuts', () => {
         event.keyCode = 76;
         event.which = undefined;
         event.shiftKey = true;
-        compose.handle_keydown(event);
+        compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal("Any [text](url).", $('#compose-textarea').val());
         // Test if exec command is not enabled in browser.
         queryCommandEnabled = false;
-        compose.handle_keydown(event);
+        compose.handle_keydown(event, $("#compose-textarea"));
     }
 
     // This function cross tests the cmd/ctrl + markdown shortcuts in
@@ -490,17 +490,17 @@ run_test('markdown_shortcuts', () => {
         event.ctrlKey = isCtrl;
 
         event.keyCode = 66;
-        compose.handle_keydown(event);
+        compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal(input_text, $('#compose-textarea').val());
 
         event.keyCode = 73;
         event.shiftKey = false;
-        compose.handle_keydown(event);
+        compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal(input_text, $('#compose-textarea').val());
 
         event.keyCode = 76;
         event.shiftKey = true;
-        compose.handle_keydown(event);
+        compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal(input_text, $('#compose-textarea').val());
     }
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -565,7 +565,7 @@ exports.validate = function () {
 };
 
 exports.handle_keydown = function (event) {
-    var textarea = $("#compose-textarea");
+    var textarea = $("#compose-textarea").expectOne();
 
     // Set the rtl class if the text has an rtl direction, remove it otherwise
     rtl.set_rtl_class_for_textarea(textarea);
@@ -580,33 +580,30 @@ exports.handle_keydown = function (event) {
 
     if ((isBold || isItalic || isLink) && isCmdOrCtrl) {
         var range = textarea.range();
-
-        function add_markdown(markdown) {
-            var textarea = $("#compose-textarea");
-            var range = textarea.range();
-            if (!document.execCommand('insertText', false, markdown)) {
-                textarea.range(range.start, range.end).range(markdown);
+        function wrap_text_with_markdown(prefix, suffix) {
+            if (!document.execCommand('insertText', false, prefix + range.text + suffix)) {
+                textarea.range(range.start, range.end).range(prefix + range.text + suffix);
             }
             event.preventDefault();
         }
 
         if (isBold) {
             // ctrl + b: Convert selected text to bold text
-            add_markdown("**" + range.text + "**");
+            wrap_text_with_markdown("**", "**");
             if (!range.length) {
                 textarea.caret(textarea.caret() - 2);
             }
         }
         if (isItalic) {
             // ctrl + i: Convert selected text to italic text
-            add_markdown("*" + range.text + "*");
+            wrap_text_with_markdown("*", "*");
             if (!range.length) {
                 textarea.caret(textarea.caret() - 1);
             }
         }
         if (isLink) {
             // ctrl + l: Insert a link to selected text
-            add_markdown("[" + range.text + "](url)");
+            wrap_text_with_markdown("[", "](url)");
             var position = textarea.caret();
             var txt = document.getElementById("compose-textarea");
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -564,9 +564,7 @@ exports.validate = function () {
     return validate_stream_message();
 };
 
-exports.handle_keydown = function (event) {
-    var textarea = $("#compose-textarea").expectOne();
-
+exports.handle_keydown = function (event, textarea) {
     // Set the rtl class if the text has an rtl direction, remove it otherwise
     rtl.set_rtl_class_for_textarea(textarea);
 
@@ -605,7 +603,7 @@ exports.handle_keydown = function (event) {
             // ctrl + l: Insert a link to selected text
             wrap_text_with_markdown("[", "](url)");
             var position = textarea.caret();
-            var txt = document.getElementById("compose-textarea");
+            var txt = document.getElementById(textarea[0].id);
 
             // Include selected text in between [] parantheses and insert '(url)'
             // where "url" should be automatically selected.
@@ -675,7 +673,10 @@ exports.needs_subscribe_warning = function (email) {
 exports.initialize = function () {
     $('#stream,#subject,#private_message_recipient').on('keyup', update_fade);
     $('#stream,#subject,#private_message_recipient').on('change', update_fade);
-    $('#compose-textarea').on('keydown', exports.handle_keydown);
+    $('#compose-textarea').on('keydown', function (event) {
+        var textarea = $("#compose-textarea").expectOne();
+        exports.handle_keydown(event, textarea);
+    });
 
     $("#compose form").on("submit", function (e) {
         e.preventDefault();

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -289,6 +289,9 @@ function edit_message(row, raw_content) {
             currently_editing_messages[rows.id(row)].listeners = listeners;
         }
         composebox_typeahead.initialize_compose_typeahead(edit_id);
+        $(edit_id).on('keydown', function (event) {
+            compose.handle_keydown(event, $(this).expectOne());
+        });
     }
 
     // Add tooltip


### PR DESCRIPTION
Fixes #9917

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![rtl](https://user-images.githubusercontent.com/25907420/42927382-fa7af082-8b51-11e8-9fe8-065a7b21bd95.gif)
