### PR TITLE
user docs: Add docs for self-signed certs and proxy-ing from desktop.

### DIFF
--- a/templates/zerver/help/connect-through-a-proxy.md
+++ b/templates/zerver/help/connect-through-a-proxy.md
@@ -1,0 +1,71 @@
+# Connect through a proxy
+
+Some corporate and university networks may require you to connect to Zulip
+via a proxy.
+
+## Web
+
+Zulip uses your browser's default proxy settings. To set a custom proxy just
+for Zulip, check your browser's instructions for setting a custom proxy for
+a single website.
+
+## Desktop
+
+1. Click on the **gear** (<i class="icon-vector-cog"></i>) icon in the lower left corner.
+
+2. Select the **Network** tab.
+
+### System proxy settings
+
+3. Click **Use system proxy settings**.
+
+4. Restart the Zulip desktop app.
+
+### Custom proxy settings
+
+3. Click **Manual proxy configuration**.
+
+4. Either enter a URL for **PAC script**, or fill out **Proxy rules** and
+  **Proxy bypass rules**.
+
+5. Click **Save changes**.
+
+In most corporate environments, your network administrator will provide a
+URL for the **PAC script**.
+
+The second most common configuration is that your network administrator has
+set up a proxy server for accessing the public internet, but URLs on the
+local network must be accessed directly. In that case set **Proxy rules** to
+the URL of the proxy server (it may look something like
+`http://proxy.example.edu:port`), and **Proxy bypass rules** to cover local URLs
+(it may look something like `*.example.edu,10.0.0.0/8`).
+
+If either of those apply, you can skip the rest of this guide. If not, we
+document the syntax for **Proxy rules** and **Proxy bypass rules** below.
+
+#### Proxy rules
+
+A semicolon-separated list of `protocolRule`s.
+
+```
+protocolRule -> [<protocol>"="]<URLList>
+protocol -> "http" | "https" | "ftp" | "socks"
+URLList -> comma-separated list of URLs, ["direct://"]
+```
+
+Some examples:
+
+* `http=http://foo:80;ftp=http://bar:1080` - Use proxy `http://foo:80`
+  for `http://` URLs, and proxy `http://bar:1080` for `ftp://` URLs.
+* `http://foo:80` - Use proxy `http://foo:80` for all URLs.
+* `http://foo:80,socks5://bar,direct://` - Use proxy `http://foo:80` for
+  all URLs, failing over to `socks5://bar` if `http://foo:80` is
+  unavailable, and after that using no proxy.
+* `http=http://foo;socks5://bar` -  Use proxy `http://foo` for `http://` URLs,
+  and use `socks5://bar` for all other URLs.
+
+#### Proxy bypass rules
+
+A comma-separated list of URIs. The URIs can be hostnames, IP address
+literals, or IP ranges in CIDR notation. Hostnames can use the `*`
+wildcard. Use `<local>` to match any of `127.0.0.1`, `::1`, or `localhost`.

--- a/templates/zerver/help/custom-certificates.md
+++ b/templates/zerver/help/custom-certificates.md
@@ -1,0 +1,34 @@
+# Add a custom certificate
+
+By default, Zulip generates a signed certificate during the server install
+process. In some cases, a server administrator may choose not to use that
+feature, in which case your Zulip server may be using a self-signed
+certificate. This is most common for Zulip servers not connected to the
+public internet.
+
+## Web
+
+Most browsers will show a warning if you try to connect to a Zulip server
+with a self-signed certificate.
+
+If you are absolutely, 100% sure that the Zulip server you are connecting to
+is supposed to have a self-signed certificate, click through the warnings
+and follow the instructions on-screen.
+
+If you are less than 100% sure, contact your server administrator. Accepting
+a malicious self-signed certificate would give a stranger full access to
+your Zulip, including your username and password.
+
+## Desktop
+
+For safety reasons, we require you to manually enter the certificate details
+before you can connect to your Zulip server. You'll need to get a
+certificate file (should end in `.crt` or `.pem`) from your server
+administrator.
+
+1. Click on the **gear** (<i class="icon-vector-cog"></i>) icon in the lower left corner.
+
+2. Select the **Organizations** tab.
+
+3. Under **Add Custom Certificates**, enter your organization URL and add
+   the custom certificate file (should end in `.crt` or `.pem`).

--- a/templates/zerver/help/include/sidebar.md
+++ b/templates/zerver/help/include/sidebar.md
@@ -96,6 +96,7 @@
 * [Display the buddy list on narrow screens](/help/move-the-users-list-to-the-left-sidebar)
 * [View organization statistics](/help/analytics)
 * [Connect through a proxy](/help/connect-through-a-proxy)
+* [Add a custom certificate](/help/custom-certificates)
 
 ## Apps
 * [Desktop installation guides](/help/desktop-app-install-guide)

--- a/templates/zerver/help/include/sidebar.md
+++ b/templates/zerver/help/include/sidebar.md
@@ -95,6 +95,7 @@
 * [Display emoji as text](/help/display-emoji-as-text)
 * [Display the buddy list on narrow screens](/help/move-the-users-list-to-the-left-sidebar)
 * [View organization statistics](/help/analytics)
+* [Connect through a proxy](/help/connect-through-a-proxy)
 
 ## Apps
 * [Desktop installation guides](/help/desktop-app-install-guide)


### PR DESCRIPTION
This is a quick rewrite of #9841. I didn't have access to the zulip desktop app at the time, so some things like field names are just placeholders (please correct them in comments!)

@abhigyank and @akashnimare, could you give this a skim and check for factual errors? Either with regards to how the desktop app settings work, or how our proxy and self-signed cert system works, or how proxies and self-signed certs work in general.

One thing I notice already is that the example proxy bypass rule has a semicolon, but it isn't clear that the format for the proxy bypass rule allows semicolons. 
(Also the numbering in the green circles is off.)

Thanks @abhigyank for writing the original draft! 