### PR TITLE
Use topic_data.js for topic typeaheads.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -17,6 +17,9 @@ set_global('md5', function (s) {
     return 'md5-' + s;
 });
 
+set_global('topic_data', {
+});
+
 var ct = composebox_typeahead;
 var noop = function () {};
 
@@ -92,6 +95,9 @@ var netherland_stream = {
     description: 'The Netherlands, city of dream.',
     stream_id: 3,
 };
+
+stream_data.add_sub('Sweden', sweden_stream);
+stream_data.add_sub('Denmark', denmark_stream);
 
 set_global('$', global.make_zjquery());
 
@@ -174,20 +180,17 @@ user_pill.get_user_ids = function () {
     return [];
 };
 
-run_test('add_topic', () => {
-    ct.add_topic('Denmark', 'civil fears');
-    ct.add_topic('devel', 'fading');
-    ct.add_topic('denmark', 'acceptance');
-    ct.add_topic('denmark', 'Acceptance');
-    ct.add_topic('Denmark', 'With Twisted Metal');
+run_test('topics_seen_for', () => {
+    topic_data.get_recent_names = (stream_id) => {
+        assert.equal(stream_id, denmark_stream.stream_id);
+        return ['With Twisted Metal', 'acceptance', 'civil fears'];
+    };
 
     assert.deepEqual(
         ct.topics_seen_for('Denmark'),
         ['With Twisted Metal', 'acceptance', 'civil fears']
     );
-});
 
-run_test('topics_seen_for', () => {
     // Test when the stream doesn't exist (there are no topics)
     assert.deepEqual(ct.topics_seen_for('non-existing-stream'), []);
 });
@@ -400,14 +403,12 @@ run_test('initialize', () => {
 
     var subject_typeahead_called = false;
     $('#subject').typeahead = function (options) {
-        // options.source()
-        ct.add_topic('Sweden', 'furniture');
-        ct.add_topic('Sweden', 'kronor');
-        ct.add_topic('Sweden', 'ice');
-        ct.add_topic('Sweden', 'more ice');
-        ct.add_topic('Sweden', 'even more ice');
-        ct.add_topic('Sweden', '<&>');
         var topics = ['<&>', 'even more ice', 'furniture', 'ice', 'kronor', 'more ice'];
+        topic_data.get_recent_names = (stream_id) => {
+            assert.equal(stream_id, sweden_stream.stream_id);
+            return topics;
+        };
+
         $('#stream').val('Sweden');
         var actual_value = options.source();
         // Topics should be sorted alphabetically, not by addition order.
@@ -435,7 +436,7 @@ run_test('initialize', () => {
         //
         // Notice that alphabetical sorting isn't managed by this sorter,
         // it is a result of the topics already being sorted after adding
-        // them with ct.add_topic().
+        // them with add_topic().
         options.query = 'furniture';
         actual_value = options.sorter(['furniture']);
         expected_value = ['furniture'];
@@ -909,6 +910,8 @@ run_test('initialize', () => {
     assert(focus_handler_called);
     assert(stream_one_called);
 });
+
+stream_data.clear_subscriptions();
 
 run_test('begins_typeahead', () => {
 

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -89,10 +89,8 @@ const messages = {
 const noop = () => undefined;
 
 set_global('alert_words', {});
-set_global('composebox_typeahead', {});
 
 alert_words.process_message = noop;
-composebox_typeahead.add_topic = noop;
 
 // We can also bring in real code:
 zrequire('recent_senders');

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -4,7 +4,6 @@ zrequire('people');
 zrequire('message_store');
 
 var noop = function () {};
-var with_overrides = global.with_overrides;
 var people = global.people;
 
 set_global('$', global.make_zjquery());
@@ -101,33 +100,18 @@ run_test('add_message_metadata', () => {
         sender_email: 'me@example.com',
         sender_id: me.user_id,
         type: 'stream',
-        display_recipient: [me, cindy],
-        stream: 'Zoolippy',
+        display_recipient: 'Zoolippy',
         topic: 'cool thing',
         subject: 'the_subject',
         id: 2068,
     };
 
-    // test stream properties
-    with_overrides(function (override) {
-        override('compose.empty_topic_placeholder', function () {
-            return 'the_subject';
-        });
-        global.with_stub(function (stub) {
-            set_global('composebox_typeahead', {add_topic: stub.f});
-            message_store.set_message_booleans(message);
-            message_store.add_message_metadata(message);
-            var typeahead_added = stub.get_args('stream', 'subject');
-            assert.deepEqual(typeahead_added.stream, [me, cindy]);
-            assert.equal(message.subject, typeahead_added.subject);
-        });
-
-        assert.deepEqual(message.stream, [me, cindy]);
-        assert.equal(message.reply_to, 'me@example.com');
-        assert.deepEqual(message.flags, undefined);
-        assert.equal(message.alerted, false);
-    });
-
+    message_store.set_message_booleans(message);
+    message_store.add_message_metadata(message);
+    assert.deepEqual(message.stream, message.display_recipient);
+    assert.equal(message.reply_to, 'me@example.com');
+    assert.deepEqual(message.flags, undefined);
+    assert.equal(message.alerted, false);
 });
 
 run_test('errors', () => {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -13,30 +13,13 @@ var composebox_typeahead = (function () {
 
 var exports = {};
 
-var seen_topics = new Dict();
-
-exports.add_topic = function (uc_stream, uc_topic) {
-    // For Denmark/FooBar, we set
-    // seen_topics['denmark']['foobar'] to 'FooBar',
-    // where seen_topics is a Dict of Dicts
-    var stream = uc_stream.toLowerCase();
-    var topic = uc_topic.toLowerCase();
-
-    if (!seen_topics.has(stream)) {
-        seen_topics.set(stream, new Dict());
+exports.topics_seen_for = function (stream_name) {
+    var stream_id = stream_data.get_stream_id(stream_name);
+    if (!stream_id) {
+        return [];
     }
-    var topic_dict = seen_topics.get(stream);
-    if (!topic_dict.has(topic)) {
-        topic_dict.set(topic, uc_topic);
-    }
-};
-
-exports.topics_seen_for = function (stream) {
-    stream = stream.toLowerCase();
-    if (seen_topics.has(stream)) {
-        return seen_topics.get(stream).values().sort();
-    }
-    return [];
+    var topic_names = topic_data.get_recent_names(stream_id);
+    return topic_names;
 };
 
 function query_matches_language(query, lang) {
@@ -619,7 +602,7 @@ exports.initialize = function () {
 
     $("#subject").typeahead({
         source: function () {
-            var stream_name = $("#stream").val();
+            var stream_name = compose_state.stream_name();
             return exports.topics_seen_for(stream_name);
         },
         items: 3,

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -132,7 +132,6 @@ exports.add_message_metadata = function (message) {
     case 'stream':
         message.is_stream = true;
         message.stream = message.display_recipient;
-        composebox_typeahead.add_topic(message.stream, message.subject);
         message.reply_to = message.sender_email;
 
         topic_data.add_message({


### PR DESCRIPTION
This replaces some old code with calls to topic_data.js.

Now our topic typeahead uses the same data as our
sidebar, stream suggestions, and the "n" key, so any
future improvements to that data will benefit all
features the same.

This is an important piece of #9857.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
