### PR TITLE
lightbox: Make `v` close the lightbox during Pan & Zoom.

### DIFF
--- a/static/js/lightbox_canvas.js
+++ b/static/js/lightbox_canvas.js
@@ -158,6 +158,8 @@ var LightboxCanvas = (function () {
                 } else if (e.key === "z" || e.key === '-') {
                     funcs.setZoom(meta, '-');
                     funcs.displayImage(canvas, context, meta);
+                } else if (e.key === 'v') {
+                    overlays.close_overlay('lightbox');
                 }
                 e.preventDefault();
                 e.stopPropagation();


### PR DESCRIPTION
When Pan & Zoom (canvas) is enabled in lightbox, the `v` hotkey does not work due to `LightboxCanvas` overriding the `keydown` event. This PR adds `v` as an option in the listener.

Fixes #9777.