### PR TITLE
Git integrations: Include issue/PR title in message body if not in topic.

### DIFF
--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -91,6 +91,12 @@ class Bitbucket2HookTests(WebhookTestCase):
         expected_message = u"kolaszek created [Issue #1](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)(assigned to kolaszek)\n\n~~~ quote\nSuch a bug\n~~~"
         self.send_and_test_stream_message('issue_created', self.EXPECTED_SUBJECT_ISSUE_EVENTS, expected_message)
 
+    def test_bitbucket2_on_issue_created_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic="notifications")
+        expected_subject = u"notifications"
+        expected_message = u"kolaszek created [Issue #1 Bug](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)(assigned to kolaszek)\n\n~~~ quote\nSuch a bug\n~~~"
+        self.send_and_test_stream_message('issue_created', expected_subject, expected_message)
+
     def test_bitbucket2_on_issue_updated_event(self) -> None:
         expected_message = u"kolaszek updated [Issue #1](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)"
         self.send_and_test_stream_message('issue_updated', self.EXPECTED_SUBJECT_ISSUE_EVENTS, expected_message)
@@ -99,12 +105,27 @@ class Bitbucket2HookTests(WebhookTestCase):
         expected_message = u"kolaszek [commented](https://bitbucket.org/kolaszek/repository-name/issues/2#comment-28973596) on [Issue #1](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)"
         self.send_and_test_stream_message('issue_commented', self.EXPECTED_SUBJECT_ISSUE_EVENTS, expected_message)
 
+    def test_bitbucket2_on_issue_commented_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic="notifications")
+        expected_subject = u"notifications"
+        expected_message = u"kolaszek [commented](https://bitbucket.org/kolaszek/repository-name/issues/2#comment-28973596) on [Issue #1 Bug](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)"
+        self.send_and_test_stream_message('issue_commented', expected_subject, expected_message)
+
     def test_bitbucket2_on_pull_request_created_event(self) -> None:
         expected_message = u"kolaszek created [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)(assigned to tkolek)\nfrom `new-branch` to `master`\n\n~~~ quote\ndescription\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:created'
         }
         self.send_and_test_stream_message('pull_request_created_or_updated', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message, **kwargs)
+
+    def test_bitbucket2_on_pull_request_created_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic="notifications")
+        expected_subject = u"notifications"
+        expected_message = u"kolaszek created [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)(assigned to tkolek)\nfrom `new-branch` to `master`\n\n~~~ quote\ndescription\n~~~"
+        kwargs = {
+            "HTTP_X_EVENT_KEY": 'pullrequest:created'
+        }
+        self.send_and_test_stream_message('pull_request_created_or_updated', expected_subject, expected_message, **kwargs)
 
     def test_bitbucket2_on_pull_request_updated_event(self) -> None:
         expected_message = u"kolaszek updated [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)(assigned to tkolek)\nfrom `new-branch` to `master`\n\n~~~ quote\ndescription\n~~~"
@@ -119,6 +140,15 @@ class Bitbucket2HookTests(WebhookTestCase):
             "HTTP_X_EVENT_KEY": 'pullrequest:approved'
         }
         self.send_and_test_stream_message('pull_request_approved_or_unapproved', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message, **kwargs)
+
+    def test_bitbucket2_on_pull_request_approved_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic="notifications")
+        expected_subject = u"notifications"
+        expected_message = u"kolaszek approved [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)"
+        kwargs = {
+            "HTTP_X_EVENT_KEY": 'pullrequest:approved'
+        }
+        self.send_and_test_stream_message('pull_request_approved_or_unapproved', expected_subject, expected_message, **kwargs)
 
     def test_bitbucket2_on_pull_request_unapproved_event(self) -> None:
         expected_message = u"kolaszek unapproved [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)"
@@ -148,12 +178,30 @@ class Bitbucket2HookTests(WebhookTestCase):
         }
         self.send_and_test_stream_message('pull_request_comment_action', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message, **kwargs)
 
+    def test_bitbucket2_on_pull_request_comment_created_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic="notifications")
+        expected_subject = u"notifications"
+        expected_message = u"kolaszek [commented](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/3)\n\n~~~ quote\nComment1\n~~~"
+        kwargs = {
+            "HTTP_X_EVENT_KEY": 'pullrequest:comment_created'
+        }
+        self.send_and_test_stream_message('pull_request_comment_action', expected_subject, expected_message, **kwargs)
+
     def test_bitbucket2_on_pull_request_comment_updated_event(self) -> None:
         expected_message = u"kolaszek updated a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3)\n\n~~~ quote\nComment1\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:comment_updated'
         }
         self.send_and_test_stream_message('pull_request_comment_action', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message, **kwargs)
+
+    def test_bitbucket2_on_pull_request_comment_updated_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic="notifications")
+        expected_subject = u"notifications"
+        expected_message = u"kolaszek updated a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/3)\n\n~~~ quote\nComment1\n~~~"
+        kwargs = {
+            "HTTP_X_EVENT_KEY": 'pullrequest:comment_updated'
+        }
+        self.send_and_test_stream_message('pull_request_comment_action', expected_subject, expected_message, **kwargs)
 
     def test_bitbucket2_on_pull_request_comment_deleted_event(self) -> None:
         expected_message = u"kolaszek deleted a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3)\n\n~~~ quote\nComment1\n~~~"

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -2,6 +2,7 @@
 import re
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional
+from inspect import signature
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
@@ -45,13 +46,10 @@ PULL_REQUEST_SUPPORTED_ACTIONS = [
 @has_request_variables
 def api_bitbucket2_webhook(request: HttpRequest, user_profile: UserProfile,
                            payload: Dict[str, Any]=REQ(argument_type='body'),
-                           branches: Optional[str]=REQ(default=None)) -> HttpResponse:
+                           branches: Optional[str]=REQ(default=None),
+                           user_specified_topic: Optional[str]=REQ("topic", default=None)) -> HttpResponse:
     type = get_type(request, payload)
-    if type != 'push':
-        subject = get_subject_based_on_type(payload, type)
-        body = get_body_based_on_type(type)(payload)
-        check_send_webhook_message(request, user_profile, subject, body)
-    else:
+    if type == 'push':
         # ignore push events with no changes
         if not payload['push']['changes']:
             return json_success()
@@ -59,10 +57,22 @@ def api_bitbucket2_webhook(request: HttpRequest, user_profile: UserProfile,
         if branch and branches:
             if branches.find(branch) == -1:
                 return json_success()
-        subjects = get_push_subjects(payload)
-        bodies_list = get_push_bodies(payload)
-        for body, subject in zip(bodies_list, subjects):
-            check_send_webhook_message(request, user_profile, subject, body)
+
+    subject = get_subject_based_on_type(payload, type)
+    body_function = get_body_based_on_type(type)
+    if 'include_title' in signature(body_function).parameters:
+        body = body_function(
+            payload,
+            include_title=user_specified_topic is not None
+        )
+    else:
+        body = body_function(payload)
+
+    if type != 'push':
+        check_send_webhook_message(request, user_profile, subject, body)
+    else:
+        for b, s in zip(body, subject):
+            check_send_webhook_message(request, user_profile, s, b)
 
     return json_success()
 
@@ -91,7 +101,7 @@ def get_subject(payload: Dict[str, Any]) -> str:
     assert(payload['repository'] is not None)
     return BITBUCKET_SUBJECT_TEMPLATE.format(repository_name=get_repository_name(payload['repository']))
 
-def get_subject_based_on_type(payload: Dict[str, Any], type: str) -> str:
+def get_subject_based_on_type(payload: Dict[str, Any], type: str) -> Any:
     if type.startswith('pull_request'):
         return SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(
             repo=get_repository_name(payload['repository']),
@@ -106,6 +116,8 @@ def get_subject_based_on_type(payload: Dict[str, Any], type: str) -> str:
             id=payload['issue']['id'],
             title=payload['issue']['title']
         )
+    if type == 'push':
+        return get_push_subjects(payload)
     return get_subject(payload)
 
 def get_type(request: HttpRequest, payload: Dict[str, Any]) -> str:
@@ -140,9 +152,8 @@ def get_type(request: HttpRequest, payload: Dict[str, Any]) -> str:
 
     raise UnexpectedWebhookEventType('BitBucket2', event_key)
 
-def get_body_based_on_type(type: str) -> Callable[[Dict[str, Any]], str]:
+def get_body_based_on_type(type: str) -> Any:
     fn = GET_SINGLE_MESSAGE_BODY_DEPENDING_ON_TYPE_MAPPER.get(type)
-    assert callable(fn)  # type parameter should be pre-checked, so not None
     return fn
 
 def get_push_bodies(payload: Dict[str, Any]) -> List[str]:
@@ -230,11 +241,13 @@ def get_commit_status_changed_body(payload: Dict[str, Any]) -> str:
         status=payload['commit_status']['state']
     )
 
-def get_issue_commented_body(payload: Dict[str, Any]) -> str:
+def get_issue_commented_body(payload: Dict[str, Any],
+                             include_title: Optional[bool]=False) -> str:
     action = '[commented]({}) on'.format(payload['comment']['links']['html']['href'])
-    return get_issue_action_body(payload, action)
+    return get_issue_action_body(payload, action, include_title)
 
-def get_issue_action_body(payload: Dict[str, Any], action: str) -> str:
+def get_issue_action_body(payload: Dict[str, Any], action: str,
+                          include_title: Optional[bool]=False) -> str:
     issue = payload['issue']
     assignee = None
     message = None
@@ -249,19 +262,23 @@ def get_issue_action_body(payload: Dict[str, Any], action: str) -> str:
         issue['links']['html']['href'],
         issue['id'],
         message,
-        assignee
+        assignee,
+        title=issue['title'] if include_title else None
     )
 
-def get_pull_request_action_body(payload: Dict[str, Any], action: str) -> str:
+def get_pull_request_action_body(payload: Dict[str, Any], action: str,
+                                 include_title: Optional[bool]=False) -> str:
     pull_request = payload['pullrequest']
     return get_pull_request_event_message(
         get_user_username(payload),
         action,
         get_pull_request_url(pull_request),
-        pull_request.get('id')
+        pull_request.get('id'),
+        title=pull_request['title'] if include_title else None
     )
 
-def get_pull_request_created_or_updated_body(payload: Dict[str, Any], action: str) -> str:
+def get_pull_request_created_or_updated_body(payload: Dict[str, Any], action: str,
+                                             include_title: Optional[bool]=False) -> str:
     pull_request = payload['pullrequest']
     assignee = None
     if pull_request.get('reviewers'):
@@ -275,25 +292,36 @@ def get_pull_request_created_or_updated_body(payload: Dict[str, Any], action: st
         target_branch=pull_request['source']['branch']['name'],
         base_branch=pull_request['destination']['branch']['name'],
         message=pull_request['description'],
-        assignee=assignee
+        assignee=assignee,
+        title=pull_request['title'] if include_title else None
     )
 
-def get_pull_request_comment_created_action_body(payload: Dict[str, Any]) -> str:
+def get_pull_request_comment_created_action_body(
+        payload: Dict[str, Any],
+        include_title: Optional[bool]=False
+) -> str:
     action = '[commented]({})'.format(payload['comment']['links']['html']['href'])
-    return get_pull_request_comment_action_body(payload, action)
+    return get_pull_request_comment_action_body(payload, action, include_title)
 
-def get_pull_request_deleted_or_updated_comment_action_body(payload: Dict[str, Any], action: str) -> str:
+def get_pull_request_deleted_or_updated_comment_action_body(
+        payload: Dict[str, Any], action: str,
+        include_title: Optional[bool]=False
+) -> str:
     action = "{} a [comment]({})".format(action, payload['comment']['links']['html']['href'])
-    return get_pull_request_comment_action_body(payload, action)
+    return get_pull_request_comment_action_body(payload, action, include_title)
 
-def get_pull_request_comment_action_body(payload: Dict[str, Any], action: str) -> str:
+def get_pull_request_comment_action_body(
+        payload: Dict[str, Any], action: str,
+        include_title: Optional[bool]=False
+) -> str:
     action += ' on'
     return get_pull_request_event_message(
         get_user_username(payload),
         action,
         payload['pullrequest']['links']['html']['href'],
         payload['pullrequest']['id'],
-        message=payload['comment']['content']['raw']
+        message=payload['comment']['content']['raw'],
+        title=payload['pullrequest']['title'] if include_title else None
     )
 
 def get_push_tag_body(payload: Dict[str, Any], change: Dict[str, Any]) -> str:
@@ -385,5 +413,6 @@ GET_SINGLE_MESSAGE_BODY_DEPENDING_ON_TYPE_MAPPER = {
                                             action='updated'),
     'pull_request_comment_deleted': partial(get_pull_request_deleted_or_updated_comment_action_body,
                                             action='deleted'),
+    'push': get_push_bodies,
     'repo:updated': get_repo_updated_body,
 }

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -117,9 +117,21 @@ class GithubWebhookTest(WebhookTestCase):
         expected_message = u"baxterthehacker [commented](https://github.com/baxterthehacker/public-repo/issues/2#issuecomment-99262140) on [Issue #2](https://github.com/baxterthehacker/public-repo/issues/2)\n\n~~~ quote\nYou are totally right! I'll get this fixed right away.\n~~~"
         self.send_and_test_stream_message('issue_comment', self.EXPECTED_SUBJECT_ISSUE_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='issue_comment')
 
+    def test_issue_comment_msg_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"baxterthehacker [commented](https://github.com/baxterthehacker/public-repo/issues/2#issuecomment-99262140) on [Issue #2 Spelling error in the README file](https://github.com/baxterthehacker/public-repo/issues/2)\n\n~~~ quote\nYou are totally right! I'll get this fixed right away.\n~~~"
+        self.send_and_test_stream_message('issue_comment', expected_subject, expected_message, HTTP_X_GITHUB_EVENT='issue_comment')
+
     def test_issue_msg(self) -> None:
         expected_message = u"baxterthehacker opened [Issue #2](https://github.com/baxterthehacker/public-repo/issues/2)\n\n~~~ quote\nIt looks like you accidently spelled 'commit' with two 't's.\n~~~"
         self.send_and_test_stream_message('issue', self.EXPECTED_SUBJECT_ISSUE_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='issues')
+
+    def test_issue_msg_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"baxterthehacker opened [Issue #2 Spelling error in the README file](https://github.com/baxterthehacker/public-repo/issues/2)\n\n~~~ quote\nIt looks like you accidently spelled 'commit' with two 't's.\n~~~"
+        self.send_and_test_stream_message('issue', expected_subject, expected_message, HTTP_X_GITHUB_EVENT='issues')
 
     def test_membership_msg(self) -> None:
         expected_message = u"baxterthehacker added [kdaigle](https://github.com/kdaigle) to Contractors team"
@@ -130,19 +142,31 @@ class GithubWebhookTest(WebhookTestCase):
         self.send_and_test_stream_message('member', self.EXPECTED_SUBJECT_REPO_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='member')
 
     def test_pull_request_opened_msg(self) -> None:
-        expected_message = u"baxterthehacker opened [PR](https://github.com/baxterthehacker/public-repo/pull/1)\nfrom `changes` to `master`\n\n~~~ quote\nThis is a pretty simple change that we need to pull into master.\n~~~"
+        expected_message = u"baxterthehacker opened [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)\nfrom `changes` to `master`\n\n~~~ quote\nThis is a pretty simple change that we need to pull into master.\n~~~"
         self.send_and_test_stream_message('opened_pull_request', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='pull_request')
 
+    def test_pull_request_opened_msg_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"baxterthehacker opened [PR #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1)\nfrom `changes` to `master`\n\n~~~ quote\nThis is a pretty simple change that we need to pull into master.\n~~~"
+        self.send_and_test_stream_message('opened_pull_request', expected_subject, expected_message, HTTP_X_GITHUB_EVENT='pull_request')
+
     def test_pull_request_synchronized_msg(self) -> None:
-        expected_message = u"baxterthehacker updated [PR](https://github.com/baxterthehacker/public-repo/pull/1)\nfrom `changes` to `master`"
+        expected_message = u"baxterthehacker updated [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)\nfrom `changes` to `master`"
         self.send_and_test_stream_message('synchronized_pull_request', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='pull_request')
 
     def test_pull_request_closed_msg(self) -> None:
-        expected_message = u"baxterthehacker closed without merge [PR](https://github.com/baxterthehacker/public-repo/pull/1)"
+        expected_message = u"baxterthehacker closed without merge [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)"
         self.send_and_test_stream_message('closed_pull_request', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='pull_request')
 
+    def test_pull_request_closed_msg_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"baxterthehacker closed without merge [PR #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1)"
+        self.send_and_test_stream_message('closed_pull_request', expected_subject, expected_message, HTTP_X_GITHUB_EVENT='pull_request')
+
     def test_pull_request_merged_msg(self) -> None:
-        expected_message = u"baxterthehacker merged [PR](https://github.com/baxterthehacker/public-repo/pull/1)"
+        expected_message = u"baxterthehacker merged [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)"
         self.send_and_test_stream_message('merged_pull_request', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='pull_request')
 
     def test_public_msg(self) -> None:
@@ -181,26 +205,45 @@ class GithubWebhookTest(WebhookTestCase):
         expected_message = u"baxterthehacker submitted [PR Review](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884)"
         self.send_and_test_stream_message('pull_request_review', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='pull_request_review')
 
+    def test_pull_request_review_msg_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"baxterthehacker submitted [PR Review for #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884)"
+        self.send_and_test_stream_message('pull_request_review', expected_subject, expected_message, HTTP_X_GITHUB_EVENT='pull_request_review')
+
     def test_pull_request_review_comment_msg(self) -> None:
         expected_message = u"baxterthehacker created [PR Review Comment](https://github.com/baxterthehacker/public-repo/pull/1#discussion_r29724692)\n\n~~~ quote\nMaybe you should use more emojji on this line.\n~~~"
         self.send_and_test_stream_message('pull_request_review_comment', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='pull_request_review_comment')
+
+    def test_pull_request_review_comment_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"baxterthehacker created [PR Review Comment on #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1#discussion_r29724692)\n\n~~~ quote\nMaybe you should use more emojji on this line.\n~~~"
+        self.send_and_test_stream_message('pull_request_review_comment', expected_subject, expected_message, HTTP_X_GITHUB_EVENT='pull_request_review_comment')
 
     def test_push_tag_msg(self) -> None:
         expected_message = u"baxterthehacker pushed tag abc"
         self.send_and_test_stream_message('push_tag', self.EXPECTED_SUBJECT_REPO_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='push')
 
     def test_pull_request_edited_msg(self) -> None:
-        expected_message = u"baxterthehacker edited [PR](https://github.com/baxterthehacker/public-repo/pull/1)\nfrom `changes` to `master`"
+        expected_message = u"baxterthehacker edited [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)\nfrom `changes` to `master`"
         self.send_and_test_stream_message('edited_pull_request', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message,
                                           HTTP_X_GITHUB_EVENT='pull_request')
 
     def test_pull_request_assigned_msg(self) -> None:
-        expected_message = u"baxterthehacker assigned [PR](https://github.com/baxterthehacker/public-repo/pull/1) to baxterthehacker"
+        expected_message = u"baxterthehacker assigned [PR #1](https://github.com/baxterthehacker/public-repo/pull/1) to baxterthehacker"
         self.send_and_test_stream_message('assigned_pull_request', self.EXPECTED_SUBJECT_PR_EVENTS, expected_message,
                                           HTTP_X_GITHUB_EVENT='pull_request')
 
+    def test_pull_request_assigned_msg_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"baxterthehacker assigned [PR #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1) to baxterthehacker"
+        self.send_and_test_stream_message('assigned_pull_request', expected_subject, expected_message,
+                                          HTTP_X_GITHUB_EVENT='pull_request')
+
     def test_pull_request_unassigned_msg(self) -> None:
-        expected_message = u"eeshangarg unassigned [PR](https://github.com/zulip-test-org/helloworld/pull/1)"
+        expected_message = u"eeshangarg unassigned [PR #1](https://github.com/zulip-test-org/helloworld/pull/1)"
         self.send_and_test_stream_message(
             'unassigned_pull_request',
             'helloworld / PR #1 Mention that Zulip rocks!',
@@ -219,6 +262,15 @@ class GithubWebhookTest(WebhookTestCase):
         expected_message = u"**eeshangarg** requested [showell](https://github.com/showell), and [timabbott](https://github.com/timabbott) for a review on [PR #1](https://github.com/eeshangarg/Scheduler/pull/1)."
         self.send_and_test_stream_message('pull_request_review_requested_multiple_reviewers',
                                           'Scheduler / PR #1 This is just a test commit',
+                                          expected_message,
+                                          HTTP_X_GITHUB_EVENT='pull_request')
+
+    def test_pull_request_review_requested_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"**eeshangarg** requested [showell](https://github.com/showell) for a review on [PR #1 This is just a test commit](https://github.com/eeshangarg/Scheduler/pull/1)."
+        self.send_and_test_stream_message('pull_request_review_requested',
+                                          expected_subject,
                                           expected_message,
                                           HTTP_X_GITHUB_EVENT='pull_request')
 

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -2,6 +2,7 @@ import logging
 import re
 from functools import partial
 from typing import Any, Callable, Dict, Optional
+from inspect import signature
 
 from django.http import HttpRequest, HttpResponse
 
@@ -20,7 +21,8 @@ from zerver.models import UserProfile
 class UnknownEventType(Exception):
     pass
 
-def get_opened_or_update_pull_request_body(payload: Dict[str, Any]) -> str:
+def get_opened_or_update_pull_request_body(payload: Dict[str, Any],
+                                           include_title: Optional[bool]=False) -> str:
     pull_request = payload['pull_request']
     action = payload['action']
     if action == 'synchronize':
@@ -36,10 +38,13 @@ def get_opened_or_update_pull_request_body(payload: Dict[str, Any]) -> str:
         target_branch=pull_request['head']['ref'],
         base_branch=pull_request['base']['ref'],
         message=pull_request['body'],
-        assignee=assignee
+        assignee=assignee,
+        number=pull_request['number'],
+        title=pull_request['title'] if include_title else None
     )
 
-def get_assigned_or_unassigned_pull_request_body(payload: Dict[str, Any]) -> str:
+def get_assigned_or_unassigned_pull_request_body(payload: Dict[str, Any],
+                                                 include_title: Optional[bool]=False) -> str:
     pull_request = payload['pull_request']
     assignee = pull_request.get('assignee')
     if assignee is not None:
@@ -49,18 +54,23 @@ def get_assigned_or_unassigned_pull_request_body(payload: Dict[str, Any]) -> str
         get_sender_name(payload),
         payload['action'],
         pull_request['html_url'],
+        number=pull_request['number'],
+        title=pull_request['title'] if include_title else None
     )
     if assignee is not None:
         return "{} to {}".format(base_message, assignee)
     return base_message
 
-def get_closed_pull_request_body(payload: Dict[str, Any]) -> str:
+def get_closed_pull_request_body(payload: Dict[str, Any],
+                                 include_title: Optional[bool]=False) -> str:
     pull_request = payload['pull_request']
     action = 'merged' if pull_request['merged'] else 'closed without merge'
     return get_pull_request_event_message(
         get_sender_name(payload),
         action,
         pull_request['html_url'],
+        number=pull_request['number'],
+        title=pull_request['title'] if include_title else None
     )
 
 def get_membership_body(payload: Dict[str, Any]) -> str:
@@ -88,7 +98,8 @@ def get_member_body(payload: Dict[str, Any]) -> str:
         payload['repository']['html_url']
     )
 
-def get_issue_body(payload: Dict[str, Any]) -> str:
+def get_issue_body(payload: Dict[str, Any],
+                   include_title: Optional[bool]=False) -> str:
     action = payload['action']
     issue = payload['issue']
     assignee = issue['assignee']
@@ -98,10 +109,12 @@ def get_issue_body(payload: Dict[str, Any]) -> str:
         issue['html_url'],
         issue['number'],
         issue['body'],
-        assignee=assignee['login'] if assignee else None
+        assignee=assignee['login'] if assignee else None,
+        title=issue['title'] if include_title else None
     )
 
-def get_issue_comment_body(payload: Dict[str, Any]) -> str:
+def get_issue_comment_body(payload: Dict[str, Any],
+                           include_title: Optional[bool]=False) -> str:
     action = payload['action']
     comment = payload['comment']
     issue = payload['issue']
@@ -118,6 +131,7 @@ def get_issue_comment_body(payload: Dict[str, Any]) -> str:
         issue['html_url'],
         issue['number'],
         comment['body'],
+        title=issue['title'] if include_title else None
     )
 
 def get_fork_body(payload: Dict[str, Any]) -> str:
@@ -257,34 +271,52 @@ def get_status_body(payload: Dict[str, Any]) -> str:
         status
     )
 
-def get_pull_request_review_body(payload: Dict[str, Any]) -> str:
+def get_pull_request_review_body(payload: Dict[str, Any],
+                                 include_title: Optional[bool]=False) -> str:
+    title = "for #{} {}".format(
+        payload['pull_request']['number'],
+        payload['pull_request']['title']
+    )
     return get_pull_request_event_message(
         get_sender_name(payload),
         'submitted',
         payload['review']['html_url'],
-        type='PR Review'
+        type='PR Review',
+        title=title if include_title else None
     )
 
-def get_pull_request_review_comment_body(payload: Dict[str, Any]) -> str:
+def get_pull_request_review_comment_body(payload: Dict[str, Any],
+                                         include_title: Optional[bool]=False) -> str:
     action = payload['action']
     message = None
     if action == 'created':
         message = payload['comment']['body']
+
+    title = "on #{} {}".format(
+        payload['pull_request']['number'],
+        payload['pull_request']['title']
+    )
 
     return get_pull_request_event_message(
         get_sender_name(payload),
         action,
         payload['comment']['html_url'],
         message=message,
-        type='PR Review Comment'
+        type='PR Review Comment',
+        title=title if include_title else None
     )
 
-def get_pull_request_review_requested_body(payload: Dict[str, Any]) -> str:
+def get_pull_request_review_requested_body(payload: Dict[str, Any],
+                                           include_title: Optional[bool]=False) -> str:
     requested_reviewers = payload['pull_request']['requested_reviewers']
     sender = get_sender_name(payload)
     pr_number = payload['pull_request']['number']
     pr_url = payload['pull_request']['html_url']
     message = "**{sender}** requested {reviewers} for a review on [PR #{pr_number}]({pr_url})."
+    message_with_title = ("**{sender}** requested {reviewers} for a review on "
+                          "[PR #{pr_number} {title}]({pr_url}).")
+    body = message_with_title if include_title else message
+
     reviewers = ""
     if len(requested_reviewers) == 1:
         reviewers = "[{login}]({html_url})".format(**requested_reviewers[0])
@@ -293,11 +325,12 @@ def get_pull_request_review_requested_body(payload: Dict[str, Any]) -> str:
             reviewers += "[{login}]({html_url}), ".format(**reviewer)
         reviewers += "and [{login}]({html_url})".format(**requested_reviewers[-1])
 
-    return message.format(
+    return body.format(
         sender=sender,
         reviewers=reviewers,
         pr_number=pr_number,
         pr_url=pr_url,
+        title=payload['pull_request']['title'] if include_title else None
     )
 
 def get_ping_body(payload: Dict[str, Any]) -> str:
@@ -393,11 +426,19 @@ EVENT_FUNCTION_MAPPER = {
 def api_github_webhook(
         request: HttpRequest, user_profile: UserProfile,
         payload: Dict[str, Any]=REQ(argument_type='body'),
-        branches: str=REQ(default=None)) -> HttpResponse:
+        branches: str=REQ(default=None),
+        user_specified_topic: Optional[str]=REQ("topic", default=None)) -> HttpResponse:
     event = get_event(request, payload, branches)
     if event is not None:
         subject = get_subject_based_on_type(payload, event)
-        body = get_body_function_based_on_type(event)(payload)
+        body_function = get_body_function_based_on_type(event)
+        if 'include_title' in signature(body_function).parameters:
+            body = body_function(
+                payload,
+                include_title=user_specified_topic is not None
+            )
+        else:
+            body = body_function(payload)
         check_send_webhook_message(request, user_profile, subject, body)
     return json_success()
 

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -93,6 +93,18 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_create_issue_without_assignee_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title"
+        expected_message = u"Tomasz Kolek created [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)\n\n~~~ quote\nIssue description\n~~~"
+
+        self.send_and_test_stream_message(
+            'issue_created_without_assignee',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Issue Hook"
+        )
+
+    def test_create_issue_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
         expected_message = u"Tomasz Kolek created [Issue #1 Issue title](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)\n\n~~~ quote\nIssue description\n~~~"
 
         self.send_and_test_stream_message(
@@ -104,7 +116,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_create_issue_with_assignee_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title"
-        expected_message = u"Tomasz Kolek created [Issue #1 Issue title](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)(assigned to Tomasz Kolek)\n\n~~~ quote\nIssue description\n~~~"
+        expected_message = u"Tomasz Kolek created [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)(assigned to Tomasz Kolek)\n\n~~~ quote\nIssue description\n~~~"
 
         self.send_and_test_stream_message(
             'issue_created_with_assignee',
@@ -115,7 +127,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_create_issue_with_hidden_comment_in_description(self) -> None:
         expected_subject = u"public-repo / Issue #3 New Issue with hidden comment"
-        expected_message = u"Eeshan Garg created [Issue #3 New Issue with hidden comment](https://gitlab.com/eeshangarg/public-repo/issues/3)\n\n~~~ quote\nThis description actually has a hidden comment in it!\n~~~"
+        expected_message = u"Eeshan Garg created [Issue #3](https://gitlab.com/eeshangarg/public-repo/issues/3)\n\n~~~ quote\nThis description actually has a hidden comment in it!\n~~~"
 
         self.send_and_test_stream_message(
             'issue_created_with_hidden_comment_in_description',
@@ -126,7 +138,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_create_issue_with_null_description(self) -> None:
         expected_subject = u"my-awesome-project / Issue #7 Issue without description"
-        expected_message = u"Eeshan Garg created [Issue #7 Issue without description](https://gitlab.com/eeshangarg/my-awesome-project/issues/7)"
+        expected_message = u"Eeshan Garg created [Issue #7](https://gitlab.com/eeshangarg/my-awesome-project/issues/7)"
         self.send_and_test_stream_message(
             'issue_opened_with_null_description',
             expected_subject,
@@ -136,6 +148,18 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_update_issue_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
+        expected_message = u"Tomasz Kolek updated [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
+
+        self.send_and_test_stream_message(
+            'issue_updated',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Issue Hook"
+        )
+
+    def test_update_issue_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
         expected_message = u"Tomasz Kolek updated [Issue #1 Issue title_new](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
 
         self.send_and_test_stream_message(
@@ -147,7 +171,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_close_issue_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
-        expected_message = u"Tomasz Kolek closed [Issue #1 Issue title_new](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
+        expected_message = u"Tomasz Kolek closed [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
 
         self.send_and_test_stream_message(
             'issue_closed',
@@ -158,7 +182,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_reopen_issue_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
-        expected_message = u"Tomasz Kolek reopened [Issue #1 Issue title_new](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
+        expected_message = u"Tomasz Kolek reopened [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
 
         self.send_and_test_stream_message(
             'issue_reopened',
@@ -189,9 +213,33 @@ class GitlabHookTests(WebhookTestCase):
             HTTP_X_GITLAB_EVENT="Note Hook"
         )
 
+    def test_note_merge_request_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"Tomasz Kolek [commented](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/1#note_14171860) on [MR #1 Tomek](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/1)\n\n~~~ quote\nNice merge request!\n~~~"
+
+        self.send_and_test_stream_message(
+            'merge_request_note',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Note Hook"
+        )
+
     def test_note_issue_event_message(self) -> None:
         expected_subject = u"my-awesome-project / Issue #2 abc"
         expected_message = u"Tomasz Kolek [commented](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/2#note_14172057) on [Issue #2](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/2)\n\n~~~ quote\nNice issue\n~~~"
+
+        self.send_and_test_stream_message(
+            'issue_note',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Note Hook"
+        )
+
+    def test_note_issue_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"Tomasz Kolek [commented](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/2#note_14172057) on [Issue #2 abc](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/2)\n\n~~~ quote\nNice issue\n~~~"
 
         self.send_and_test_stream_message(
             'issue_note',
@@ -211,9 +259,33 @@ class GitlabHookTests(WebhookTestCase):
             HTTP_X_GITLAB_EVENT="Note Hook"
         )
 
+    def test_note_snippet_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"Tomasz Kolek [commented](https://gitlab.com/tomaszkolek0/my-awesome-project/snippets/2#note_14172058) on [Snippet #2 test](https://gitlab.com/tomaszkolek0/my-awesome-project/snippets/2)\n\n~~~ quote\nNice snippet\n~~~"
+
+        self.send_and_test_stream_message(
+            'snippet_note',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Note Hook"
+        )
+
     def test_merge_request_created_without_assignee_event_message(self) -> None:
         expected_subject = u"my-awesome-project / MR #2 NEW MR"
         expected_message = u"Tomasz Kolek created [MR #2](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/2)\nfrom `tomek` to `master`\n\n~~~ quote\ndescription of merge request\n~~~"
+
+        self.send_and_test_stream_message(
+            'merge_request_created_without_assignee',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Merge Request Hook"
+        )
+
+    def test_merge_request_created_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"Tomasz Kolek created [MR #2 NEW MR](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/2)\nfrom `tomek` to `master`\n\n~~~ quote\ndescription of merge request\n~~~"
 
         self.send_and_test_stream_message(
             'merge_request_created_without_assignee',
@@ -235,6 +307,18 @@ class GitlabHookTests(WebhookTestCase):
     def test_merge_request_closed_event_message(self) -> None:
         expected_subject = u"my-awesome-project / MR #2 NEW MR"
         expected_message = u"Tomasz Kolek closed [MR #2](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/2)"
+
+        self.send_and_test_stream_message(
+            'merge_request_closed',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Merge Request Hook"
+        )
+
+    def test_merge_request_closed_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"Tomasz Kolek closed [MR #2 NEW MR](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/2)"
 
         self.send_and_test_stream_message(
             'merge_request_closed',

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -1,5 +1,6 @@
 from functools import partial
 from typing import Any, Dict, Iterable, Optional
+from inspect import signature
 import re
 
 from django.http import HttpRequest, HttpResponse
@@ -59,12 +60,14 @@ def get_tag_push_event_body(payload: Dict[str, Any]) -> str:
         action="pushed" if payload.get('checkout_sha') else "removed"
     )
 
-def get_issue_created_event_body(payload: Dict[str, Any]) -> str:
+def get_issue_created_event_body(payload: Dict[str, Any],
+                                 include_title: Optional[bool]=False) -> str:
     description = payload['object_attributes'].get('description')
     # Filter out multiline hidden comments
     if description is not None:
         description = re.sub('<!--.*?-->', '', description, 0, re.DOTALL)
         description = description.rstrip()
+
     return get_issue_event_message(
         get_issue_user_name(payload),
         'created',
@@ -72,24 +75,34 @@ def get_issue_created_event_body(payload: Dict[str, Any]) -> str:
         payload['object_attributes'].get('iid'),
         description,
         get_objects_assignee(payload),
-        title=payload['object_attributes'].get('title')
+        title=payload['object_attributes'].get('title') if include_title else None
     )
 
-def get_issue_event_body(payload: Dict[str, Any], action: str) -> str:
+def get_issue_event_body(payload: Dict[str, Any], action: str,
+                         include_title: Optional[bool]=False) -> str:
     return get_issue_event_message(
         get_issue_user_name(payload),
         action,
         get_object_url(payload),
         payload['object_attributes'].get('iid'),
-        title=payload['object_attributes'].get('title')
+        title=payload['object_attributes'].get('title') if include_title else None
     )
 
-def get_merge_request_updated_event_body(payload: Dict[str, Any]) -> str:
+def get_merge_request_updated_event_body(payload: Dict[str, Any],
+                                         include_title: Optional[bool]=False) -> str:
     if payload['object_attributes'].get('oldrev'):
-        return get_merge_request_event_body(payload, "added commit(s) to")
-    return get_merge_request_open_or_updated_body(payload, "updated")
+        return get_merge_request_event_body(
+            payload, "added commit(s) to",
+            include_title=include_title
+        )
 
-def get_merge_request_event_body(payload: Dict[str, Any], action: str) -> str:
+    return get_merge_request_open_or_updated_body(
+        payload, "updated",
+        include_title=include_title
+    )
+
+def get_merge_request_event_body(payload: Dict[str, Any], action: str,
+                                 include_title: Optional[bool]=False) -> str:
     pull_request = payload['object_attributes']
     return get_pull_request_event_message(
         get_issue_user_name(payload),
@@ -97,9 +110,11 @@ def get_merge_request_event_body(payload: Dict[str, Any], action: str) -> str:
         pull_request.get('url'),
         pull_request.get('iid'),
         type='MR',
+        title=payload['object_attributes'].get('title') if include_title else None
     )
 
-def get_merge_request_open_or_updated_body(payload: Dict[str, Any], action: str) -> str:
+def get_merge_request_open_or_updated_body(payload: Dict[str, Any], action: str,
+                                           include_title: Optional[bool]=False) -> str:
     pull_request = payload['object_attributes']
     return get_pull_request_event_message(
         get_issue_user_name(payload),
@@ -111,6 +126,7 @@ def get_merge_request_open_or_updated_body(payload: Dict[str, Any], action: str)
         pull_request.get('description'),
         get_objects_assignee(payload),
         type='MR',
+        title=payload['object_attributes'].get('title') if include_title else None
     )
 
 def get_objects_assignee(payload: Dict[str, Any]) -> Optional[str]:
@@ -130,52 +146,61 @@ def get_commented_commit_event_body(payload: Dict[str, Any]) -> str:
         comment['note'],
     )
 
-def get_commented_merge_request_event_body(payload: Dict[str, Any]) -> str:
+def get_commented_merge_request_event_body(payload: Dict[str, Any],
+                                           include_title: Optional[bool]=False) -> str:
     comment = payload['object_attributes']
     action = u'[commented]({}) on'.format(comment['url'])
     url = u'{}/merge_requests/{}'.format(
         payload['project'].get('web_url'),
         payload['merge_request'].get('iid')
     )
+
     return get_pull_request_event_message(
         get_issue_user_name(payload),
         action,
         url,
         payload['merge_request'].get('iid'),
         message=comment['note'],
-        type='MR'
+        type='MR',
+        title=payload.get('merge_request').get('title') if include_title else None
     )
 
-def get_commented_issue_event_body(payload: Dict[str, Any]) -> str:
+def get_commented_issue_event_body(payload: Dict[str, Any],
+                                   include_title: Optional[bool]=False) -> str:
     comment = payload['object_attributes']
     action = u'[commented]({}) on'.format(comment['url'])
     url = u'{}/issues/{}'.format(
         payload['project'].get('web_url'),
         payload['issue'].get('iid')
     )
+
     return get_pull_request_event_message(
         get_issue_user_name(payload),
         action,
         url,
         payload['issue'].get('iid'),
         message=comment['note'],
-        type='Issue'
+        type='Issue',
+        title=payload.get('issue').get('title') if include_title else None
     )
 
-def get_commented_snippet_event_body(payload: Dict[str, Any]) -> str:
+def get_commented_snippet_event_body(payload: Dict[str, Any],
+                                     include_title: Optional[bool]=False) -> str:
     comment = payload['object_attributes']
     action = u'[commented]({}) on'.format(comment['url'])
     url = u'{}/snippets/{}'.format(
         payload['project'].get('web_url'),
         payload['snippet'].get('id')
     )
+
     return get_pull_request_event_message(
         get_issue_user_name(payload),
         action,
         url,
         payload['snippet'].get('id'),
         message=comment['note'],
-        type='Snippet'
+        type='Snippet',
+        title=payload.get('snippet').get('title') if include_title else None
     )
 
 def get_wiki_page_event_body(payload: Dict[str, Any], action: str) -> str:
@@ -271,10 +296,19 @@ EVENT_FUNCTION_MAPPER = {
 @has_request_variables
 def api_gitlab_webhook(request: HttpRequest, user_profile: UserProfile,
                        payload: Dict[str, Any]=REQ(argument_type='body'),
-                       branches: Optional[str]=REQ(default=None)) -> HttpResponse:
+                       branches: Optional[str]=REQ(default=None),
+                       user_specified_topic: Optional[str]=REQ("topic", default=None)) -> HttpResponse:
     event = get_event(request, payload, branches)
     if event is not None:
-        body = get_body_based_on_event(event)(payload)
+        event_body_function = get_body_based_on_event(event)
+        if 'include_title' in signature(event_body_function).parameters:
+            body = event_body_function(
+                payload,
+                include_title=user_specified_topic is not None
+            )
+        else:
+            body = event_body_function(payload)
+
         topic = get_subject_based_on_event(event, payload)
         check_send_webhook_message(request, user_profile, topic, body)
     return json_success()

--- a/zerver/webhooks/gogs/tests.py
+++ b/zerver/webhooks/gogs/tests.py
@@ -69,6 +69,13 @@ class GogsHookTests(WebhookTestCase):
 from `feature` to `master`"""
         self.send_and_test_stream_message('pull_request_opened', expected_subject, expected_message, HTTP_X_GOGS_EVENT='pull_request')
 
+    def test_pull_request_opened_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic='notifications')
+        expected_subject = u"notifications"
+        expected_message = u"""john opened [PR #1 Title Text for Pull Request](http://localhost:3000/john/try-git/pulls/1)
+from `feature` to `master`"""
+        self.send_and_test_stream_message('pull_request_opened', expected_subject, expected_message, HTTP_X_GOGS_EVENT='pull_request')
+
     def test_pull_request_closed(self) -> None:
         expected_subject = u"try-git / PR #1 Title Text for Pull Request"
         expected_message = u"""john closed [PR #1](http://localhost:3000/john/try-git/pulls/1)

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -43,7 +43,8 @@ def format_new_branch_event(payload: Dict[str, Any]) -> str:
     }
     return get_create_branch_event_message(**data)
 
-def format_pull_request_event(payload: Dict[str, Any]) -> str:
+def format_pull_request_event(payload: Dict[str, Any],
+                              include_title: Optional[bool]=False) -> str:
 
     data = {
         'user_name': payload['pull_request']['user']['username'],
@@ -52,6 +53,7 @@ def format_pull_request_event(payload: Dict[str, Any]) -> str:
         'number': payload['pull_request']['number'],
         'target_branch': payload['pull_request']['head_branch'],
         'base_branch': payload['pull_request']['base_branch'],
+        'title': payload['pull_request']['title'] if include_title else None
     }
 
     if payload['pull_request']['merged']:
@@ -64,7 +66,8 @@ def format_pull_request_event(payload: Dict[str, Any]) -> str:
 @has_request_variables
 def api_gogs_webhook(request: HttpRequest, user_profile: UserProfile,
                      payload: Dict[str, Any]=REQ(argument_type='body'),
-                     branches: Optional[str]=REQ(default=None)) -> HttpResponse:
+                     branches: Optional[str]=REQ(default=None),
+                     user_specified_topic: Optional[str]=REQ("topic", default=None)) -> HttpResponse:
 
     repo = payload['repository']['name']
     event = validate_extract_webhook_http_header(request, 'X_GOGS_EVENT', 'Gogs')
@@ -84,7 +87,10 @@ def api_gogs_webhook(request: HttpRequest, user_profile: UserProfile,
             branch=payload['ref']
         )
     elif event == 'pull_request':
-        body = format_pull_request_event(payload)
+        body = format_pull_request_event(
+            payload,
+            include_title=user_specified_topic is not None
+        )
         topic = SUBJECT_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(
             repo=repo,
             type='PR',


### PR DESCRIPTION
This is a follow-up in response to Tim's comments on #9951.

In instances where all messages from a Gitlab integration are
grouped under one user-specified topic (specified in the URL), we
should include the title of the issue/MR in the message body, since
the availability of a user-specified topic precludes us from
including it in the topic itself (which was the default behavior).

@timabbott: FYI :) Hope to tackle GitHub next! 