### PR TITLE
outgoing webhooks: Fix sample timestamp, service_id and token for slack outgoing webhooks

### DIFF
--- a/templates/zerver/api/outgoing-webhooks.md
+++ b/templates/zerver/api/outgoing-webhooks.md
@@ -174,17 +174,17 @@ webhook expects:
 The above data is posted as list of tuples (not JSON), here's an example:
 
 ```
-[('token', 'abcdef'),
+[('token', 'v9fpCdldZIej2bco3uoUvGp06PowKFOf'),
  ('team_id', 'zulip'),
  ('team_domain', 'zulip.com'),
  ('channel_id', '123'),
  ('channel_name', 'integrations'),
- ('timestamp', 123456),
+ ('timestamp', 1532078950),
  ('user_id', 21),
  ('user_name', 'Sample User'),
  ('text', '@**test**'),
  ('trigger_word', 'mention'),
- ('service_id', None)]
+ ('service_id', 27)]
 ```
 
 * For successful request, if data is returned, it returns that data,


### PR DESCRIPTION
Added the correct timestamp, service_id and token formats. The 'service_id' should be the ID of the bot user([ref](https://api.slack.com/methods/team.integrationLogs)). The token should be a sample token generated from 'random_api_key()'.

Follow up from #9628.

Current sample data for Zulip:
```
team_domain: zulip.com
service_id: 3
channel_name: Verona
team_id: zulip
user_name: Iago
text: @**slack2** hi
token: v9fpCdldZIej2bco3uoUvGp06PowKFOf
channel_id: 5
trigger_word: mention
user_id: 5
timestamp: 1532081986
```

Current sample data for slack:
```
team_domain: plan8team
service_id: 402196424437
channel_name: general
team_id: T5YFFM2QY
user_name: rheaparekh12
text: hey
token: waobNjxtW1acnIL23x0C8K6X
channel_id: C5Z73A7RA
trigger_word: hey
user_id: U8W3QFGQ5
timestamp: 1532079092.000148
```

Things to Note:
1. Slack's token is 24 chars long, whereas `random_api_key()` generates 32 chars long token.
2. In Slack, for the outgoing webhooks, we set a trigger word, for example `"hey"`. So whenever `hey` is mentioned a particular stream, the outgoing webhooks is triggered. Whereas we are using the `trigger_word` to be `mention`(see [here](https://github.com/zulip/zulip/blob/master/zerver/lib/outgoing_webhook.py#L98)) literally. Is this fine?