### PR TITLE
lint: Turn off the CSS checker (officially).

### DIFF
--- a/tools/lint
+++ b/tools/lint
@@ -158,7 +158,6 @@ def run():
         lint_functions[name] = run_linter
 
     external_linter('add_class', ['tools/find-add-class'], ['js'])
-    external_linter('css', ['tools/check-css'], ['css'])
     external_linter('eslint', ['node', 'node_modules/.bin/eslint', '--quiet', '--cache'], ['js'])
     external_linter('tslint', ['node', 'node_modules/.bin/tslint', '-c',
                                'static/ts/tslint.json'], ['ts'])
@@ -166,6 +165,9 @@ def run():
     external_linter('templates', ['tools/check-templates'], ['handlebars', 'html'])
     external_linter('urls', ['tools/check-urls'], ['py'])
     external_linter('swagger', ['node', 'tools/check-swagger'], ['yaml'])
+
+    # Note that check-css no longer runs due to the SCSS conversion.
+    # See #8894 for more details.
 
     # Disabled check for imperative mood until it is stabilized
     if not args.no_gitlint:


### PR DESCRIPTION
Our CSS checker globs for .css files.  Since the
SCSS cutover, it has been a no-op, so there's no
sense launching it.  See #8894 for details on
future plans.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
