### PR TITLE
subs: Fix regression in Filter streams input focus during modal opening.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -452,6 +452,7 @@ exports.setup_page = function (callback) {
     // Also, we'll always go back to the "Subscribed" tab.
     function initialize_components() {
         exports.toggler = components.toggle({
+            child_wants_focus: true,
             values: [
                 { label: i18n.t("Subscribed"), key: "subscribed" },
                 { label: i18n.t("All streams"), key: "all-streams" },


### PR DESCRIPTION
This behavior was originally implemented in commit 6993f89, but due to not
specifying a toggle option, the Subscribed/All streams switcher tab was
focused after the input was focused, leading to the input's loss of focus.

Fixes #9981.