### PR TITLE
left-sidebar: Add max-height to private message container. [WIP]

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -345,6 +345,8 @@ ul.expanded_private_messages {
     margin-left: 0px;
     padding-bottom: 2px;
     margin-top: 3px;
+    max-height: 200px;
+    overflow: scroll;
 }
 
 li.show-more-topics,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Add max-height to PM section so that it doesn't cover the screen when a user has too many conversations. Fixes #5384. 




**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<img src="https://dzwonsemrish7.cloudfront.net/items/2f3F2b1G200i1l2o0x2A/Screen%20Recording%202018-07-20%20at%2008.18%20PM.gif?v=36310bdc"/>

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
