### PR TITLE
ui: Simplify hotkey deprecation notices.

### DIFF
--- a/frontend_tests/node_tests/ui.js
+++ b/frontend_tests/node_tests/ui.js
@@ -1,0 +1,8 @@
+var ui = zrequire('ui');
+set_global('i18n', global.stub_i18n);
+
+run_test('get_hotkey_deprecation_notice', () => {
+    var expected = 'translated: We\'ve replaced the "*" hotkey with "Ctrl + s" to make this common shortcut easier to trigger.';
+    var actual = ui.get_hotkey_deprecation_notice('*', 'Ctrl + s');
+    assert.equal(expected, actual);
+});

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -123,13 +123,21 @@ exports.show_failed_message_success = function (message_id) {
     });
 };
 
+exports.get_hotkey_deprecation_notice = function (originalHotkey, replacementHotkey) {
+    return i18n.t(
+        'We\'ve replaced the "__originalHotkey__" hotkey with "__replacementHotkey__" '
+            + 'to make this common shortcut easier to trigger.',
+        { originalHotkey: originalHotkey, replacementHotkey: replacementHotkey }
+    );
+};
+
 var shown_deprecation_notices = [];
 exports.maybe_show_deprecation_notice = function (key) {
     var message;
     if (key === 'C') {
-        message = i18n.t('We\'ve replaced the "C" hotkey with "x" to make this common shortcut easier to trigger.');
+        message = exports.get_hotkey_deprecation_notice('C', 'x');
     } else if (key === '*') {
-        message = i18n.t('We\'ve replaced the "*" hotkey with "Ctrl + s" to make this common shortcut easier to trigger.');
+        message = exports.get_hotkey_deprecation_notice('*', 'Ctrl + s');
     } else {
         blueslip.error("Unexpected deprecation notice for hotkey:", key);
         return;


### PR DESCRIPTION
The hotkey deprecation notices use essentially the same message, with the respective hotkeys swapped in. To reduce code duplication when creating hotkey deprecation notices, this PR creates a separate function for the messages.

**Testing Plan:** <!-- How have you tested? -->

Since there wasn't a `ui` testing file, this PR creates one including test for the new function.