### PR TITLE
portico: Slightly shrink the Core Team profiles' width.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -931,7 +931,7 @@ a.bottom-signup-button {
 
 .team .core-team .profile {
     flex: 1;
-    min-width: 130px;
+    min-width: 120px;
     text-align: center;
     align-content: center;
     margin-bottom: 20px;
@@ -939,8 +939,8 @@ a.bottom-signup-button {
 }
 
 .team .core-team .profile .profile-picture {
-    width: 130px;
-    height: 130px;
+    width: 120px;
+    height: 120px;
     border-radius: 50%;
     pointer-events: none;
     box-shadow: 1px 2px 2px hsla(217, 47%, 17%, 0.03), 2px 2px 12px hsla(217, 47%, 17%, 0.09);


### PR DESCRIPTION
This PR shrinks the Core Team profiles' widths, which enables all five core team profiles to be aligned on the same line, instead of having four on the first line and one profile on its own line. Having 5 in a row seems more visually appealing than having one on a separate row.

**GIFs or Screenshots:** 

*Before:*

<img width="1680" alt="Before (4 and 1)" src="https://user-images.githubusercontent.com/17259768/43041253-591ba74e-8d0f-11e8-871e-754ea170ed61.png">

*After:*

<img width="1680" alt="After (5)" src="https://user-images.githubusercontent.com/17259768/43041445-b6fb4ec2-8d15-11e8-8e19-4f8bd4bcff8e.png">
