### PR TITLE
sidebar: Add missing title attribute for small screen size

### DIFF
--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -39,7 +39,7 @@
         </div>
         <div class="column-middle" id="navbar-middle">
             <div class="column-middle-inner">
-                <div id="streamlist-toggle" {%if embedded %} style="visibility: hidden"{% endif %}>
+                <div id="streamlist-toggle" title="{{ _('Stream list') }} (q)" {%if embedded %} style="visibility: hidden"{% endif %}>
                     <a href="#" id="streamlist-toggle-button" role="button"><i class="fa fa-reorder" aria-hidden="true"></i>
                         <span id="streamlist-toggle-unreadcount">0</span>
                     </a>

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -60,7 +60,7 @@
             </div>
         </div>
         <div class="column-right">
-            <div id="userlist-toggle">
+            <div id="userlist-toggle" title="{{ _('User list') }} (w)">
                 <a href="#" id="userlist-toggle-button" role="button"><i class="fa fa-group" aria-hidden="true"></i>
                     <span id="userlist-toggle-unreadcount">0</span>
                 </a>


### PR DESCRIPTION
Fixes #9785.

![screenshot from 2018-07-22 17-46-55](https://user-images.githubusercontent.com/13910561/43045519-97f42be4-8dd7-11e8-96c7-3a484fceff1a.png)

![screenshot from 2018-07-22 17-47-10](https://user-images.githubusercontent.com/13910561/43045520-9820340a-8dd7-11e8-94ec-5c6c5b6bb9da.png)

Note: The position of the tooltip depends on the mouse pointer position which is not visible in the screenshot.

pinging @rishig for a review on the title's names.