### PR TITLE
message-model: Add `zulipterminal` to sent_by_human clients.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1260,7 +1260,7 @@ class Message(AbstractMessage):
 
         return (sending_client in ('zulipandroid', 'zulipios', 'zulipdesktop',
                                    'zulipmobile', 'zulipelectron', 'snipe',
-                                   'website', 'ios', 'android')) or (
+                                   'website', 'ios', 'android', 'zulipterminal')) or (
                                        'desktop app' in sending_client)
 
     @staticmethod


### PR DESCRIPTION
@timabbott this make server respond to messages send via zt with 'read' flag as discussed.