### PR TITLE
Add deploy hook support for certbot scripts

### DIFF
--- a/scripts/lib/certbot-maybe-renew
+++ b/scripts/lib/certbot-maybe-renew
@@ -15,6 +15,8 @@ if ! zulip_conf_get_boolean certbot auto_renew; then
     exit 0
 fi
 
+deploy_hook="${ZULIP_CERTBOT_DEPLOY_HOOK:-service nginx reload}"
+
 /usr/local/sbin/certbot-auto renew --quiet \
   --webroot --webroot-path=/var/lib/zulip/certbot-webroot/ \
-  --deploy-hook 'service nginx reload'
+  --deploy-hook "$deploy_hook"

--- a/scripts/setup/setup-certbot
+++ b/scripts/setup/setup-certbot
@@ -15,7 +15,7 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 method=webroot
-args="$(getopt -o '' --long help,hostname:,email:,method:,no-zulip-conf -n "$0" -- "$@")"
+args="$(getopt -o '' --long help,hostname:,email:,method:,deploy-hook:,no-zulip-conf,agree-tos -n "$0" -- "$@")"
 eval "set -- $args"
 while true; do
     case "$1" in
@@ -32,6 +32,15 @@ while true; do
         --method)
             method="$2"
             shift
+            shift
+            ;;
+        --deploy-hook)
+            deploy_hook=(--deploy-hook "$2")
+            shift
+            shift
+            ;;
+        --agree-tos)
+            agree_tos=--agree-tos
             shift
             ;;
         --no-zulip-conf)
@@ -84,7 +93,11 @@ chmod a+x "$CERTBOT_PATH"
 # to agree to the Let's Encrypt Subscriber Agreement (aka ToS).
 # Passing --force-interactive suppresses a warning, but also brings up
 # an annoying prompt we stifle with --no-eff-email.
-"$CERTBOT_PATH" certonly "${method_args[@]}" -d "$DOMAIN" -m "$EMAIL" --force-interactive --no-eff-email
+"$CERTBOT_PATH" certonly "${method_args[@]}" \
+                -d "$DOMAIN" -m "$EMAIL" \
+                $agree_tos --force-renewal \
+                "${deploy_hook[@]}" \
+                --force-interactive --no-eff-email
 
 symlink_with_backup() {
     if [ -e "$2" ]; then
@@ -96,9 +109,13 @@ symlink_with_backup() {
     ln -nsf "$1" "$2"
 }
 
-CERT_DIR=/etc/letsencrypt/live/"$DOMAIN"
-symlink_with_backup "$CERT_DIR"/privkey.pem /etc/ssl/private/zulip.key
-symlink_with_backup "$CERT_DIR"/fullchain.pem /etc/ssl/certs/zulip.combined-chain.crt
+if [ -z "$deploy_hook" ]; then
+    # If no deploy hook was specified, assume we're deploying to the default
+    # location Zulip wants.
+    CERT_DIR=/etc/letsencrypt/live/"$DOMAIN"
+    symlink_with_backup "$CERT_DIR"/privkey.pem /etc/ssl/private/zulip.key
+    symlink_with_backup "$CERT_DIR"/fullchain.pem /etc/ssl/certs/zulip.combined-chain.crt
+fi
 
 case "$method" in
     webroot)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This adds hooks into certbot's registration and renewal. The primary goal is to address https://github.com/zulip/docker-zulip/issues/120 which has some unique requirements regarding where certs are stored. Given the custom deploy hook I'm proposing (https://github.com/zulip/docker-zulip/pull/139) for docker-zulip, along with this support for parameterizing such hooks, it's possible to have a fully automated LetsEncrypt setup for Zulip within Docker.

**Testing Plan:** <!-- How have you tested? -->

With this, I have set up my production server using docker-zulip + LetsEncrypt. :smiley:

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![zulip-certbot](https://user-images.githubusercontent.com/1057635/43051145-bdb8c384-8dc9-11e8-8938-5fd8bc82d8e8.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
