### PR TITLE
tests: Add coverage to compose.js.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1394,9 +1394,11 @@ run_test('on_events', () => {
         page_params.jitsi_server_url = 'https://meet.jit.si';
 
         var syntax_to_insert;
+        var called = false;
 
         compose_ui.insert_syntax_and_focus = function (syntax) {
             syntax_to_insert = syntax;
+            called = true;
         };
 
         var handler = $("#compose").get_on_handler("click", "#video_link");
@@ -1407,6 +1409,20 @@ run_test('on_events', () => {
         // video link ids consist of 15 random digits
         var video_link_regex = /\[Click to join video call\]\(https:\/\/meet.jit.si\/\d{15}\)/;
         assert(video_link_regex.test(syntax_to_insert));
+
+        page_params.realm_video_chat_provider = 'Google Hangouts';
+        page_params.realm_google_hangouts_domain = 'zulip';
+
+        handler(event);
+
+        video_link_regex = /\[Click to join video call\]\(https:\/\/hangouts.google.com\/hangouts\/\_\/zulip\/\d{15}\)/;
+        assert(video_link_regex.test(syntax_to_insert));
+
+        page_params.jitsi_server_url = null;
+        called = false;
+
+        handler(event);
+        assert(!called);
     }());
 
     (function test_markdown_preview_compose_clicked() {

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1613,3 +1613,20 @@ run_test('create_message_object', () => {
     assert.equal(message.content, 'burrito');
 
 });
+
+run_test('nonexistent_stream_reply_error', () => {
+    set_global('$', global.make_zjquery());
+
+    var shown;
+    var hidden;
+    $("#nonexistent_stream_reply_error").show = () => {
+        shown = _.uniqueId();
+    };
+    $("#nonexistent_stream_reply_error").hide = () => {
+        hidden = _.uniqueId();
+    };
+
+    compose.nonexistent_stream_reply_error();
+    assert.equal($("#compose-reply-error-msg").html(), 'There are no messages to reply to yet.');
+    assert(shown < hidden); // test shown before hidden
+});

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -213,7 +213,9 @@ run_test('validate', () => {
     initialize_pm_pill();
     add_content_to_compose_box();
 
+    // test validating private messages
     compose_state.set_message_type('private');
+
     compose_state.recipient('');
     assert(!compose.validate());
     assert.equal($('#compose-error-msg').html(), i18n.t('Please specify at least one valid recipient'));
@@ -234,6 +236,10 @@ run_test('validate', () => {
     people.add_in_realm(bob);
     compose_state.recipient('bob@example.com');
     assert(compose.validate());
+
+    page_params.realm_is_zephyr_mirror_realm = true;
+    assert(compose.validate());
+    page_params.realm_is_zephyr_mirror_realm = false;
 
     compose_state.set_message_type('stream');
     compose_state.stream_name('');


### PR DESCRIPTION
This is a pretty minor PR with basic tests added.

I've been looking into the function `validate_private_message()` and I'm pretty sure there's no way to cover the if statements at the end but still looking over it.