### PR TITLE
Add stylelint to our packages for dev environment and add some stylistic rules

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,25 @@
+{
+    "rules": {
+        # Stylistic rules for CSS.
+        "declaration-colon-space-after": "always-single-line",
+        "declaration-colon-space-before": "never",
+        "declaration-block-semicolon-newline-after": "always",
+        "declaration-block-semicolon-space-before": "never",
+        "declaration-block-trailing-semicolon": "always",
+
+        "block-closing-brace-newline-after": "always",
+        "block-closing-brace-newline-before": "always",
+        "block-opening-brace-newline-after": "always",
+        "block-opening-brace-space-before": "always",
+
+        "selector-descendant-combinator-no-non-space": true,
+        "selector-list-comma-newline-after": "always",
+        "selector-list-comma-space-before": "never",
+
+        "media-query-list-comma-newline-after": "always",
+        "media-query-list-comma-space-before": "never",
+
+        "comment-whitespace-inside": "always",
+        "indentation": 4,
+    }
+}

--- a/static/styles/hotspots.scss
+++ b/static/styles/hotspots.scss
@@ -60,7 +60,8 @@
 }
 
 @keyframes bounce {
-    0%, 100% {
+    0%,
+    100% {
         -webkit-transform: translateY(0px);
     }
 
@@ -276,5 +277,5 @@
 #hotspot_intro_reply_icon {
     position: relative;
     top: 50%;
-    transform: perspective(1px) translateY(-75%)
+    transform: perspective(1px) translateY(-75%);
 }

--- a/static/styles/input_pill.scss
+++ b/static/styles/input_pill.scss
@@ -113,7 +113,8 @@
 }
 
 @keyframes shake {
-    10%, 90% {
+    10%,
+    90% {
         transform: translate3d(-1px, 0, 0);
     }
 

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -1333,7 +1333,7 @@ nav ul li.active::after {
     z-index: 1;
 }
 
-.carousel.carousel-fade .carousel-inner .item-inner{
+.carousel.carousel-fade .carousel-inner .item-inner {
     position: relative;
 }
 
@@ -1433,7 +1433,7 @@ nav ul li.active::after {
     max-width: 100%;
 }
 
-.tour  .carousel-inner img {
+.tour .carousel-inner img {
     border: 1px solid #f2f3f4;
 }
 
@@ -1451,7 +1451,7 @@ nav ul li.active::after {
 .tour .carousel-inner .mobile-show,
 .tour .carousel-inner img.mobile-show,
 .tour .carousel-inner img.centered-image.mobile-show {
-  display: none;
+    display: none;
 }
 
 .tour .carousel-inner .comparison-slack img {
@@ -1597,13 +1597,13 @@ nav ul li.active::after {
 }
 
 .carousel-indicators li::before {
-	 position: absolute;
-	 top: -10px;
-	 left: 0;
- 	 display: inline-block;
-	 width: 100%;
-	 height: 10px;
-	 content: "";
+    position: absolute;
+    top: -10px;
+    left: 0;
+    display: inline-block;
+    width: 100%;
+    height: 10px;
+    content: "";
 }
 
 .carousel-indicators li::after {
@@ -3171,12 +3171,12 @@ nav ul li.active::after {
     }
 
     .stripe-button-el:active {
-         background: rgb(25, 139, 118);
-         span {
+        background: rgb(25, 139, 118);
+        span {
             background: 0;
             box-shadow: none;
             -webkit-box-shadow: none;
-         }
+        }
     }
 
     #error-message-box {
@@ -3256,7 +3256,8 @@ nav ul li.active::after {
     }
 }
 
-@media (min-width: 1295px), (max-width: 986px) and (min-width: 684px) {
+@media (min-width: 1295px),
+    (max-width: 986px) and (min-width: 684px) {
     /* while there are nine, show only two rows of four. */
     .portico-landing.hello .testimonials .company-box > div:last-of-type {
         display: none;
@@ -3295,10 +3296,10 @@ nav ul li.active::after {
     .tour .carousel-inner img.zulip-topic,
     .tour .carousel-inner img.slack-overwhelming,
     .tour .carousel-inner img.zulip-easy {
-       width: 85%;
-       left: 0;
-       margin-left: auto;
-       margin-right: auto;
+        width: 85%;
+        left: 0;
+        margin-left: auto;
+        margin-right: auto;
     }
 
     .tour .carousel-inner .tour-item-header {
@@ -3306,7 +3307,7 @@ nav ul li.active::after {
     }
 
     .tour .carousel-control.right {
-       right: 20px;
+        right: 20px;
     }
 
     .tour .carousel-control.left {
@@ -3314,17 +3315,17 @@ nav ul li.active::after {
     }
 
     .tour .carousel-inner .zulip-slack-comparison {
-		 width: 650px;
-		 max-width: 100%;
-	}
+        width: 650px;
+        max-width: 100%;
+    }
 
-	.tour .carousel-inner .zulip-slack-comparison .comparison-zulip {
-		 width: 450px;
-	}
+    .tour .carousel-inner .zulip-slack-comparison .comparison-zulip {
+        width: 450px;
+    }
 
-	.tour .carousel-inner .zulip-slack-comparison .comparison-slack {
-		 width: 200px;
-	}
+    .tour .carousel-inner .zulip-slack-comparison .comparison-slack {
+        width: 200px;
+    }
 }
 
 @media (max-width: 1024px) {
@@ -3493,9 +3494,9 @@ nav ul li.active::after {
 
     .tour .carousel-inner img.slack-overwhelming,
     .tour .carousel-inner img.zulip-easy {
-		 width: 80%;
-		 left: 0;
-	}
+        width: 80%;
+        left: 0;
+    }
 }
 
 @media (max-width: 906px) {
@@ -3621,20 +3622,20 @@ nav ul li.active::after {
     }
 
     .portico-landing.hello .apps .left-side .platform-icons .group {
-    		margin: 50px 30px;
-    		display: block;
+        margin: 50px 30px;
+        display: block;
     }
 
     .portico-landing.hello .tour .carousel-inner .item-container {
-       width: 85%;
+        width: 85%;
     }
 
     .tour .carousel-control {
         font-size: 1.2em;
     }
 
-   .tour .carousel-control.right {
-       right: -10px;
+    .tour .carousel-control.right {
+        right: -10px;
     }
 
     .tour .carousel-control.left {
@@ -3642,24 +3643,24 @@ nav ul li.active::after {
     }
 
     .tour .carousel-inner .zulip-slack-comparison {
-		 width: 100%;
-	}
+        width: 100%;
+    }
 
-	.tour .carousel-inner .zulip-slack-comparison .comparison-zulip {
-		 width: 65%;
-	}
+    .tour .carousel-inner .zulip-slack-comparison .comparison-zulip {
+        width: 65%;
+    }
 
-	.tour .carousel-inner .zulip-slack-comparison .comparison-slack {
-		 width: 35%;
-	}
+    .tour .carousel-inner .zulip-slack-comparison .comparison-slack {
+        width: 35%;
+    }
 
-	.tour .carousel-inner .comparison-slack img.slack-unreads {
-	    margin-left: 0;
-	}
+    .tour .carousel-inner .comparison-slack img.slack-unreads {
+        margin-left: 0;
+    }
 
-	.tour .carousel-inner .tour-item-header {
-       font-size: 1.1em;
-   }
+    .tour .carousel-inner .tour-item-header {
+        font-size: 1.1em;
+    }
 }
 
 @media (max-width: 768px) {
@@ -3688,7 +3689,7 @@ nav ul li.active::after {
     }
 
     .portico-landing.hello .open-source .il-block {
-        width: 75%
+        width: 75%;
     }
 
     .portico-landing.integrations .main,
@@ -3720,13 +3721,13 @@ nav ul li.active::after {
     }
 
     .portico-landing.why-page .testimonials .carousel-quotes {
-	     width: 90%;
-	 }
+        width: 90%;
+    }
 
-	 .portico-landing.why-page .testimonials .quote-container {
-	     padding-left: 4%;
-	     font-size: 1em;
-	 }
+    .portico-landing.why-page .testimonials .quote-container {
+        padding-left: 4%;
+        font-size: 1em;
+    }
 
     #integration-instruction-block .integration-lozenge {
         display: none !important;
@@ -4023,8 +4024,8 @@ nav ul li.active::after {
         font-size: 1.1em;
     }
 
-   .tour .carousel-control.right {
-       right: -30px;
+    .tour .carousel-control.right {
+        right: -30px;
     }
 
     .tour .carousel-control.left {
@@ -4120,7 +4121,7 @@ nav ul li.active::after {
         text-align: left;
     }
 
-   .billing-upgrade-page {
+    .billing-upgrade-page {
         .payment-schedule {
             .box {
                 width: 100px;

--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -167,7 +167,8 @@
         margin-left: 7px;
     }
 
-    #searchbox, #searchbox_legacy {
+    #searchbox,
+    #searchbox_legacy {
         margin-left: 42px;
     }
 
@@ -244,7 +245,8 @@
         margin-right: 115px;
     }
 
-    #searchbox, #searchbox_legacy {
+    #searchbox,
+    #searchbox_legacy {
         .input-append .fa-search {
             top: 5px;
         }

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -422,7 +422,8 @@ a.title:hover {
 }
 
 img.screenshot {
-    /* This makes it so screenshots are still shown if they are larger than their span.*/
+    /* This makes it so screenshots are still shown
+    even if they are larger than their span. */
     max-width: 100%;
 }
 
@@ -1890,7 +1891,7 @@ input.new-organization-button {
     }
 
     .line-break-desktop {
-    	display: none;
+        display: none;
     }
 }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1103,10 +1103,10 @@ td.pointer {
 
 .selected_message .messagebox-content {
     box-shadow: inset 0px 0px 0px 2px hsl(215, 47%, 50%),
-                     -1px -1px 0px 0px hsl(215, 47%, 50%),
-                      1px 1px 0px 0px hsl(215, 47%, 50%),
-                     -1px 1px 0px 0px hsl(215, 47%, 50%),
-                      1px -1px 0px 0px hsl(215, 47%, 50%);
+        -1px -1px 0px 0px hsl(215, 47%, 50%),
+        1px 1px 0px 0px hsl(215, 47%, 50%),
+        -1px 1px 0px 0px hsl(215, 47%, 50%),
+        1px -1px 0px 0px hsl(215, 47%, 50%);
 }
 
 .message_sender {
@@ -2005,7 +2005,7 @@ nav a .no-style {
 
     #search_query:focus {
         box-shadow: inset 0px 0px 0px 2px hsl(204, 20%, 74%);
-    }        
+    }
 
     .search_button,
     .search_button[disabled]:hover {

--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -238,7 +238,7 @@ a.button:hover {
         line-height: 100%;
     }
 
-    /* iOS converts adreses in emails to links automatically*/
+    /* iOS converts adreses in emails to links automatically */
     .apple-link a {
         color: inherit !important;
         font-family: inherit !important;

--- a/tools/lint
+++ b/tools/lint
@@ -91,7 +91,7 @@ def run():
             sys.exit(1)
 
     backend_file_types = ['py', 'sh', 'pp', 'json', 'md', 'txt', 'text', 'yaml', 'rst']
-    frontend_file_types = ['js', 'css', 'handlebars', 'html']
+    frontend_file_types = ['js', 'css', 'scss', 'handlebars', 'html']
     file_types = backend_file_types + frontend_file_types
     if args.backend:
         file_types = backend_file_types
@@ -158,6 +158,7 @@ def run():
         lint_functions[name] = run_linter
 
     external_linter('add_class', ['tools/find-add-class'], ['js'])
+    external_linter('css', ['node', 'node_modules/.bin/stylelint'], ['css', 'scss'])
     external_linter('eslint', ['node', 'node_modules/.bin/eslint', '--quiet', '--cache'], ['js'])
     external_linter('tslint', ['node', 'node_modules/.bin/tslint', '-c',
                                'static/ts/tslint.json'], ['ts'])
@@ -165,9 +166,6 @@ def run():
     external_linter('templates', ['tools/check-templates'], ['handlebars', 'html'])
     external_linter('urls', ['tools/check-urls'], ['py'])
     external_linter('swagger', ['node', 'tools/check-swagger'], ['yaml'])
-
-    # Note that check-css no longer runs due to the SCSS conversion.
-    # See #8894 for more details.
 
     # Disabled check for imperative mood until it is stabilized
     if not args.no_gitlint:


### PR DESCRIPTION
 this PR we will proceed with a final goal of having to integrate stylelint into our tooling chain for vetting CSS in development environment so that it is in compliance to some standards of coding style we want to maintain. Among these the main one is the 4 space indentation but there are others as well. 

For the moment this is my plan of action:
- [x] Add stylelint to our package dependencies so its available in dev environment.
- [x] Add stylistic rules to match behaviour with tools/check-css.
- [ ] Add stylistic rules which I feel like we should enforce. (These might have lots of additions to current css parser)
- [ ] Add rules for checking for faulty CSS.
- [ ] Migrate current CSS to match our standards and resolve any issues stylelint rules might have with our current CSS. (We do this by running stylelint manually and fixing violations)

- [x] Enable stylelint to be run as a part of our linters. (Don't merge this commit until all violations our fixed for a given set of rules in .stylelintrc at the time!)