### PR TITLE
webpack: Refactor rows.js and associated files to module format.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,45 @@
+{
+    "env": {
+       "test": {
+           "plugins": [
+             ["transform-es2015-modules-commonjs", {
+                 "strict": false
+             }],
+             "transform-object-rest-spread",
+             ["module-resolver", {
+                 "alias": {
+                   "js": "./static/js"
+                 },
+               "transformFunctions": [
+                   "proxyquire",
+                   "resolvePath"
+               ]
+             }]
+            ]
+       },
+       "testCoverage": {
+           "plugins": [
+             ["transform-es2015-modules-commonjs", {
+                 "strict": false
+             }],
+             "transform-object-rest-spread",
+             ["module-resolver", {
+                 "alias": {
+                   "js": "./static/js"
+                 },
+               "transformFunctions": [
+                   "proxyquire",
+                   "resolvePath"
+               ]
+             }],
+             ["istanbul", {
+                "exclude": [
+                    "**frontend_tests/**",
+                    "**/third/**"
+                ]
+             }]
+            ],
+            "sourceMaps": "inline",
+       }
+     }
+}

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -6,10 +6,26 @@ zrequire('XDate', 'node_modules/xdate/src/xdate');
 zrequire('Filter', 'js/filter');
 zrequire('FetchStatus', 'js/fetch_status');
 zrequire('MessageListData', 'js/message_list_data');
-zrequire('MessageListView', 'js/message_list_view');
-zrequire('message_list');
 
 var noop = function () {};
+var proxyquire =  require('proxyquire').noCallThru();
+// See https://github.com/tleunen/babel-plugin-module-resolver/issues/241
+// for why we need resolvePath
+var resolvePath = global.resolvePath;
+global.MessageListView = proxyquire('js/message_list_view.js', {
+    [resolvePath('js/rows')]: {
+        get_table: function () {
+            return {
+                children: function () {
+                    return {
+                        detach: noop,
+                    };
+                },
+            };
+        },
+    },
+}).default;
+zrequire('message_list');
 
 set_global('page_params', {
     twenty_four_hour_time: false,
@@ -31,18 +47,6 @@ set_global('timerender', {
             return time.toString('HH:mm');
         }
         return time.toString('h:mm TT');
-    },
-});
-
-set_global('rows', {
-    get_table: function () {
-        return {
-            children: function () {
-                return {
-                    detach: noop,
-                };
-            },
-        };
     },
 });
 

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -11,13 +11,11 @@ zrequire('presence');
 var noop =  function () {};
 $.fn.popover = noop; // this will get wrapped by our code
 
-zrequire('popovers');
 
 set_global('current_msg_list', {});
 set_global('page_params', {
     custom_profile_fields: [],
 });
-set_global('rows', {});
 set_global('templates', {});
 
 
@@ -53,6 +51,20 @@ var me = {
     timezone: 'US/Pacific',
 };
 
+var message = {
+    id: 999,
+    sender_id: alice.user_id,
+};
+
+var proxyquire =  require('proxyquire').noCallThru();
+// See https://github.com/tleunen/babel-plugin-module-resolver/issues/241
+// for why we need resolvePath
+var resolvePath = global.resolvePath;
+global.popovers = proxyquire('js/popovers.js', {
+    [resolvePath('js/rows')]: {
+        id: () => message.id,
+    },
+}).default;
 function initialize_people() {
     people.init();
     people.add_in_realm(me);
@@ -96,11 +108,6 @@ run_test('sender_hover', () => {
         stopPropagation: noop,
     };
 
-    var message = {
-        id: 999,
-        sender_id: alice.user_id,
-    };
-
     var target = $.create('click target');
 
     target.offset = () => {
@@ -109,7 +116,6 @@ run_test('sender_hover', () => {
         };
     };
 
-    rows.id = () => message.id;
 
     current_msg_list.get = (msg_id) => {
         assert.equal(msg_id, message.id);

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -1,6 +1,7 @@
+/* eslint-disable no-unused-vars */
+
 var path = require('path');
 var fs = require('fs');
-
 global.assert = require('assert');
 require('node_modules/string.prototype.codepointat/codepointat.js');
 
@@ -18,6 +19,7 @@ global.window = _.extend({}, windowObj, {
 });
 
 global.Dict = require('js/dict');
+global.resolvePath = x => x;
 
 // Create a helper function to avoid sneaky delays in tests.
 function immediate(f) {

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -25,6 +25,10 @@ exports.zrequire = function (name, fn) {
     }
     delete require.cache[require.resolve(fn)];
     var obj = require(fn);
+    // This is for compatibility with with ESM style modules
+    if (obj.default) {
+        obj = obj.default;
+    }
     requires.push(fn);
     set_global(name, obj);
     return obj;

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -354,7 +354,6 @@ exports.make_new_elem = function (selector, opts) {
     }
 
     self[0] = 'you-must-set-the-child-yourself';
-
     self.selector = selector;
 
     return self;

--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
   "dependencies": {
     "@types/node": "8.0.34",
     "@types/webpack": "4.4.0",
+    "babel-plugin-istanbul": "4.1.6",
+    "babel-plugin-module-resolver": "3.1.1",
+    "babel-plugin-transform-es2015-modules-commonjs": "6.6.0",
+    "babel-plugin-transform-object-rest-spread": "6.26.0",
+    "babel-register": "6.26.0",
     "blueimp-md5": "2.10.0",
     "clipboard": "2.0.1",
+    "cross-env": "5.2.0",
     "css-hot-loader": "1.3.9",
     "css-loader": "0.28.11",
     "emoji-datasource-apple": "4.0.4",
@@ -32,12 +38,14 @@
     "node-sass": "4.9.0",
     "perfect-scrollbar": "1.3.0",
     "plotly.js": "1.37.1",
+    "proxyquire": "2.0.1",
     "sass-loader": "7.0.1",
     "script-loader": "0.7.2",
     "simplebar": "^2.6.1",
     "sortablejs": "^1.7.0",
     "sorttable": "1.0.2",
     "source-map-loader": "0.2.3",
+    "source-map-support": "0.5.6",
     "source-sans-pro": "2.20.2",
     "string.prototype.codepointat": "0.2.1",
     "string.prototype.endswith": "0.2.0",
@@ -82,5 +90,12 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/zulip/zulip.git"
+  },
+  "nyc": {
+    "sourceMap": false,
+    "instrument": false,
+    "require": [
+      "babel-register"
+    ]
   }
 }

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var click_handlers = (function () {
 
 // We don't actually export anything yet; this is just for consistency.
@@ -738,7 +740,5 @@ return exports;
 
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = click_handlers;
-}
+export default click_handlers;
 window.click_handlers = click_handlers;

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var compose_fade = (function () {
 
 var exports = {};
@@ -258,7 +260,5 @@ return exports;
 
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = compose_fade;
-}
+export default compose_fade;
 window.compose_fade = compose_fade;

--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var condense = (function () {
 
 var exports = {};
@@ -213,7 +215,5 @@ exports.initialize = function () {
 return exports;
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = condense;
-}
+export default condense;
 window.condense = condense;

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var copy_and_paste = (function () {
 
 var exports = {};
@@ -235,7 +237,5 @@ exports.initialize = function () {
 return exports;
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = copy_and_paste;
-}
+export default copy_and_paste;
 window.copy_and_paste = copy_and_paste;

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var echo = (function () {
 
 var exports = {};
@@ -271,7 +273,6 @@ exports.initialize = function () {
 return exports;
 
 }());
-if (typeof module !== 'undefined') {
-    module.exports = echo;
-}
+
+export default echo;
 window.echo = echo;

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var emoji_picker = (function () {
 
 var exports = {};
@@ -718,7 +720,5 @@ return exports;
 
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = emoji_picker;
-}
+export default emoji_picker;
 window.emoji_picker = emoji_picker;

--- a/static/js/floating_recipient_bar.js
+++ b/static/js/floating_recipient_bar.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var floating_recipient_bar = (function () {
 
 var exports = {};
@@ -108,7 +110,5 @@ exports.update = function () {
 return exports;
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = floating_recipient_bar;
-}
+export default floating_recipient_bar;
 window.floating_recipient_bar = floating_recipient_bar;

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -31,7 +31,6 @@ exports.create = function (opts) {
         blueslip.error('Pill needs get_text_from_item');
         return;
     }
-
     // a stateful object of this `pill_container` instance.
     // all unique instance information is stored in here.
     var store = {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var message_edit = (function () {
 var exports = {};
 var currently_editing_messages = {};
@@ -594,7 +596,5 @@ $(document).on('narrow_deactivated.zulip', function () {
 return exports;
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = message_edit;
-}
+export default message_edit;
 window.message_edit = message_edit;

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1,3 +1,4 @@
+import rows from 'js/rows';
 function MessageListView(list, table_name, collapse_messages) {
     this.list = list;
     this.collapse_messages = collapse_messages;
@@ -1059,7 +1060,5 @@ MessageListView.prototype = {
 
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = MessageListView;
-}
+export default MessageListView;
 window.MessageListView = MessageListView;

--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var message_viewport = (function () {
 var exports = {};
 
@@ -410,7 +412,5 @@ exports.initialize = function () {
 return exports;
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = message_viewport;
-}
+export default message_viewport;
 window.message_viewport = message_viewport;

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -362,7 +362,6 @@ exports.is_for_stream_id = function (stream_id) {
 return exports;
 
 }());
-if (typeof module !== 'undefined') {
-    module.exports = narrow_state;
-}
+
+export default narrow_state;
 window.narrow_state = narrow_state;

--- a/static/js/navigate.js
+++ b/static/js/navigate.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var navigate = (function () {
 
 var exports = {};
@@ -143,7 +145,5 @@ exports.maybe_scroll_to_selected = function () {
 return exports;
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = navigate;
-}
+export default navigate;
 window.navigate = navigate;

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 var popovers = (function () {
 
 var exports = {};
@@ -1000,7 +1002,5 @@ exports.compute_placement = function (elt, popover_height, popover_width,
 return exports;
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = popovers;
-}
+export default popovers;
 window.popovers = popovers;

--- a/static/js/rows.js
+++ b/static/js/rows.js
@@ -111,7 +111,4 @@ return exports;
 
 }());
 
-if (typeof module !== 'undefined') {
-    module.exports = rows;
-}
-window.rows = rows;
+export default rows;

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -1,3 +1,5 @@
+import rows from 'js/rows';
+
 (function () {
 
 // This is where most of our initialization takes place.

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -122,22 +122,35 @@ individual_files = options.args
 # reports.  Running under nyc is slower and creates funny
 # tracebacks, so you generally want to get coverage reports only
 # after making sure tests will pass.
-node_tests_cmd = ['node', '--stack-trace-limit=100', INDEX_JS]
-node_tests_cmd += individual_files
+cross_env = os.path.join(ROOT_DIR, 'node_modules/.bin/cross-env')
+
 if options.coverage:
     coverage_dir = os.path.join(ROOT_DIR, 'var/node-coverage')
     coverage_lcov_file = os.path.join(coverage_dir, 'lcov.info')
 
     nyc = os.path.join(ROOT_DIR, 'node_modules/.bin/nyc')
-    command = [nyc, '--report-dir', coverage_dir]
+    command = [cross_env, 'NODE_ENV=testCoverage', nyc, '--report-dir', coverage_dir]
     command += ['--temp-directory', coverage_dir, '-r=text-summary']
-    command += node_tests_cmd
-    command += ['&&', 'nyc', 'report', '-r=lcov', '-r=json']
+    command += [
+        'node',
+        '--stack-trace-limit=100',
+        INDEX_JS
+    ]
+    command += individual_files
+    command += ['&&', nyc, 'report', '-r=lcov', '-r=json']
     command += ['>', coverage_lcov_file]
 else:
     # Normal testing, no coverage analysis.
     # Run the index.js test runner, which runs all the other tests.
-    command = node_tests_cmd
+    command = [
+        cross_env, 'NODE_ENV=test',
+        cross_env, 'BABEL_DISABLE_CACHE=1',
+        'node',
+        '-r', 'babel-register',
+        '--stack-trace-limit=100',
+        INDEX_JS
+    ]
+    command += individual_files
 
 print('Starting node tests...')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,6 +848,25 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-istanbul@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+    find-up "^2.1.0"
+    istanbul-lib-instrument "^1.10.1"
+    test-exclude "^4.2.1"
+
+babel-plugin-module-resolver@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.1.1.tgz#881cf67e3d4b8400d5eaaefc1be44d2dc1fe404f"
+  dependencies:
+    find-babel-config "^1.1.0"
+    glob "^7.1.2"
+    pkg-up "^2.0.0"
+    reselect "^3.0.1"
+    resolve "^1.4.0"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -884,7 +903,7 @@ babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
 
-babel-plugin-syntax-object-rest-spread@^6.8.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -1019,6 +1038,15 @@ babel-plugin-transform-es2015-modules-amd@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
+babel-plugin-transform-es2015-modules-commonjs@6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.6.0.tgz#0079ca0e69a587dbfa5ddf9b4a9f887ff00b7bee"
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.5.2"
+    babel-runtime "^5.0.0"
+    babel-template "^6.6.0"
+    babel-types "^6.6.0"
+
 babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
@@ -1125,7 +1153,7 @@ babel-plugin-transform-flow-strip-types@^6.8.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-object-rest-spread@^6.22.0:
+babel-plugin-transform-object-rest-spread@6.26.0, babel-plugin-transform-object-rest-spread@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
   dependencies:
@@ -1138,7 +1166,7 @@ babel-plugin-transform-regenerator@^6.24.1:
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-strict-mode@^6.24.1:
+babel-plugin-transform-strict-mode@^6.24.1, babel-plugin-transform-strict-mode@^6.5.2:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
   dependencies:
@@ -1201,7 +1229,7 @@ babel-preset-stage-3@^6.24.1:
     babel-plugin-transform-exponentiation-operator "^6.24.1"
     babel-plugin-transform-object-rest-spread "^6.22.0"
 
-babel-register@^6.26.0, babel-register@^6.9.0:
+babel-register@6.26.0, babel-register@^6.26.0, babel-register@^6.9.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
   dependencies:
@@ -1213,6 +1241,12 @@ babel-register@^6.26.0, babel-register@^6.9.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
+babel-runtime@^5.0.0:
+  version "5.8.38"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
+  dependencies:
+    core-js "^1.0.0"
+
 babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
@@ -1220,7 +1254,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.6.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -1244,7 +1278,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0, babel-types@^6.6.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -1600,6 +1634,10 @@ bubleify@^1.0.0, bubleify@^1.1.0:
 buffer-equal@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.1.tgz#91bc74b11ea405bc916bc6aa908faafa5b4aac4b"
+
+buffer-from@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
 
 buffer-indexof@^1.0.0:
   version "1.1.1"
@@ -2329,6 +2367,10 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+
 core-js@^2.0.0, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
@@ -2375,6 +2417,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
 
 cross-spawn@^3.0.0:
   version "3.0.1"
@@ -3652,6 +3701,13 @@ filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -3689,6 +3745,13 @@ finalhandler@1.1.1:
     parseurl "~1.3.2"
     statuses "~1.4.0"
     unpipe "~1.0.0"
+
+find-babel-config@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
 
 find-cache-dir@^0.1.1:
   version "0.1.1"
@@ -5339,7 +5402,7 @@ is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
-is-object@^1.0.1:
+is-object@^1.0.1, is-object@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
 
@@ -5455,7 +5518,7 @@ is-whitespace-character@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
 
-is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -5507,7 +5570,7 @@ istanbul-lib-hook@^1.1.0:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.10.0:
+istanbul-lib-instrument@^1.10.0, istanbul-lib-instrument@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
   dependencies:
@@ -6335,7 +6398,7 @@ meow@^5.0.0:
     trim-newlines "^2.0.0"
     yargs-parser "^10.0.0"
 
-merge-descriptors@1.0.1:
+merge-descriptors@1.0.1, merge-descriptors@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
@@ -6524,6 +6587,10 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+module-not-found-error@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
 
 moment-timezone@0.5.17:
   version "0.5.17"
@@ -7486,6 +7553,12 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  dependencies:
+    find-up "^2.1.0"
+
 planar-dual@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/planar-dual/-/planar-dual-1.0.2.tgz#b6a4235523b1b0cb79e5f926f8ea335dd982d563"
@@ -8023,6 +8096,14 @@ proxy-addr@~2.0.3:
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.6.0"
+
+proxyquire@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.0.1.tgz#958d732be13d21d374cc2256645a5ff97c76a669"
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.0"
+    resolve "~1.5.0"
 
 prr@~1.0.1:
   version "1.0.1"
@@ -8681,6 +8762,10 @@ requires-port@1.0.x, requires-port@1.x.x, requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resize-observer-polyfill@^1.4.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
@@ -8731,6 +8816,12 @@ resolve@^0.6.1:
 resolve@^1.0.0, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.3.2, resolve@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
+
+resolve@^1.4.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
 
@@ -9318,6 +9409,13 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-support@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-support@^0.4.0, source-map-support@^0.4.15:
   version "0.4.18"
@@ -10022,7 +10120,7 @@ temp@^0.8.1:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
-test-exclude@^4.2.0:
+test-exclude@^4.2.0, test-exclude@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
   dependencies:


### PR DESCRIPTION
This commit refactors rows.js to use the ESM module format. In
addition all files that import or depend on rows.js have also been
converted to ESM.

In order for tests to work with this change this commit adds
babel-register and its associated plugins to transpile test code
on the fly from ESM to commonjs and will allow future use of babel
within the codebase to be tested in node.

It also adds proxyquire in order to be able to correctly mock
dependencies within nodejs.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
