### PR TITLE
outgoing-webhooks.md: Document example endpoint responses.

### DIFF
--- a/templates/zerver/api/outgoing-webhooks.md
+++ b/templates/zerver/api/outgoing-webhooks.md
@@ -109,15 +109,38 @@ is helpful to distinguish deliberate non-responses from bugs.)
 
 ### Example incoming payload
 
+This is an example of the JSON payload that the Zulip server will `POST`
+to your server:
+
 {generate_code_example|zulip-outgoing-webhook-payload|fixture}
+
+### Example response payloads
+
+Here's an example of the JSON your server should respond with if
+you would not like to send a response message:
+
+```
+{
+    "response_not_required": true
+}
+```
+
+Here's an example of the JSON your server should respond with if
+you would like to send a response message:
+
+```
+{
+    "content": "Hey, we just received something from Zulip!"
+}
+```
 
 ## Slack-format webhook format
 
-This interface translates the Zulip's outgoing webhook's request into
-Slack's outgoing webhook request.  Hence the outgoing webhook bot
-would be able to post data to URLs which support Slack's outgoing
-webhooks.  Here's how we fill in the fields that a Slack format
-webhook expects:
+This interface translates Zulip's outgoing webhook's request into
+the format that Slack expects.  Hence the outgoing webhook bot
+would be able to post data to URLs which support Slack-style
+webhook payloads.  Here's how we fill in the fields that a
+Slack-format webhook expects:
 
 <table class="table">
     <thead>

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -758,7 +758,7 @@ def build_custom_checkers(by_lang):
          'strip': '\n',
          'exclude': set(['zerver/webhooks/']),
          'description': 'Fix tab-based whitespace'},
-        {'pattern': r':["\[\{]',
+        {'pattern': r'":["\[\{]',
          'exclude': set(['zerver/webhooks/', 'zerver/tests/fixtures/']),
          'description': 'Require space after : in JSON'},
     ]  # type: RuleList


### PR DESCRIPTION
This is a follow-up to Tim's feedback on #9628.

@timabbott: FYI :) Are there any other example responses we should display here that I am not aware of perhaps? 