### PR TITLE
webpack: migrate archive bundle to webpack

### DIFF
--- a/templates/zerver/archive/index.html
+++ b/templates/zerver/archive/index.html
@@ -15,7 +15,6 @@
     {{ render_bundle('katex', attrs='nonce="%s"' % (csp_nonce)) }}
     {{ render_bundle('portico') }}
     {{ render_bundle('archive') }}
-    {{ render_bundle('archive-styles') }}
 
 {% endblock %}
 

--- a/templates/zerver/archive/index.html
+++ b/templates/zerver/archive/index.html
@@ -11,10 +11,10 @@
         }
     </style>
 
-    {{ minified_js('archive', csp_nonce)|safe }}
     {{ render_bundle('translations', attrs='nonce="%s"' % (csp_nonce)) }}
     {{ render_bundle('katex', attrs='nonce="%s"' % (csp_nonce)) }}
     {{ render_bundle('portico') }}
+    {{ render_bundle('archive') }}
     {{ render_bundle('archive-styles') }}
 
 {% endblock %}

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -3,6 +3,19 @@
         "./node_modules/sorttable/sorttable.js",
         "./static/styles/activity.scss"
     ],
+    "archive": [
+        "./node_modules/xdate/src/xdate.js",
+        "./node_modules/perfect-scrollbar/dist/perfect-scrollbar.js",
+        "./node_modules/handlebars/dist/handlebars.runtime.js",
+        "./static/js/archive.js",
+        "./static/js/colorspace.js",
+        "./static/js/floating_recipient_bar.js",
+        "./static/js/timerender.js",
+        "./static/js/templates.js",
+        "./static/js/stream_color.js",
+        "./static/js/scroll_bar.js",
+        "./static/templates/compiled.js"
+    ],
     "portico": [
         "./static/js/portico/header.js",
         "./static/styles/portico-styles.scss"

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -14,7 +14,11 @@
         "./static/js/templates.js",
         "./static/js/stream_color.js",
         "./static/js/scroll_bar.js",
-        "./static/templates/compiled.js"
+        "./static/templates/compiled.js",
+        "./node_modules/katex/dist/katex.css",
+        "./static/styles/zulip.scss",
+        "./static/styles/media.scss",
+        "./static/styles/archive.scss"
     ],
     "portico": [
         "./static/js/portico/header.js",
@@ -70,11 +74,5 @@
     ],
     "translations": "./static/js/translations.js",
     "zxcvbn": "./node_modules/zxcvbn/dist/zxcvbn.js",
-    "app": "./static/js/bundles/app.js",
-    "archive-styles": [
-        "./node_modules/katex/dist/katex.css",
-        "./static/styles/zulip.scss",
-        "./static/styles/media.scss",
-        "./static/styles/archive.scss"
-    ]
+    "app": "./static/js/bundles/app.js"
 }

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -927,23 +927,6 @@ JS_SPECS = {
         ],
         'output_filename': 'min/zxcvbn.js'
     },
-    # This is used for displaying archives.
-    'archive': {
-        'source_filenames': [
-            'js/archive.js',
-            'js/colorspace.js',
-            'js/floating_recipient_bar.js',
-            'js/timerender.js',
-            'node_modules/handlebars/dist/handlebars.runtime.js',
-            'js/templates.js',
-            'js/stream_color.js',
-            'js/scroll_bar.js',
-            'node_modules/xdate/src/xdate.js',
-            'node_modules/perfect-scrollbar/dist/perfect-scrollbar.js',
-            'templates/compiled.js',
-        ],
-        'output_filename': 'min/archive.js'
-    },
 }
 
 if DEVELOPMENT:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR migrates the final archive bundle to webpack.

@timabbott after this migration, there is no need for the `minifed_js` code so should we remove the whole code path? And if there is no `minified_js` being used currently, there is no needs for the files in `zproject/settings.py` at `JS_SPECS` so do we need to remove them as well?

**Testing Plan:** <!-- How have you tested? -->
Tested by visiting the archive page: localhost:9991/archive/streams/1/topics/denmark3