### PR TITLE
tests: Add check for duplicate items in check_events_dict.

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -580,6 +580,9 @@ class EventsRegisterTest(ZulipTestCase):
 
     def check_events_dict(self, required_keys: List[Tuple[str, Validator]]) -> Validator:
         required_keys.append(('id', check_int))
+        # Raise AssertionError if `required_keys` contains duplicate items.
+        keys = [key[0] for key in required_keys]
+        self.assertEqual(len(keys), len(set(keys)), 'Duplicate items found in required_keys.')
         return check_dict_only(required_keys)
 
     def test_mentioned_send_message_events(self) -> None:


### PR DESCRIPTION
This check raises AssertionError if list containing duplicate items
is passed through `check_events_dict` function.