### PR TITLE
Revert "webpack: Combine archive-style bundle into archive."

### DIFF
--- a/templates/zerver/archive/index.html
+++ b/templates/zerver/archive/index.html
@@ -15,6 +15,7 @@
     {{ render_bundle('katex', attrs='nonce="%s"' % (csp_nonce)) }}
     {{ render_bundle('portico') }}
     {{ render_bundle('archive') }}
+    {{ render_bundle('archive-styles') }}
 
 {% endblock %}
 

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -14,11 +14,7 @@
         "./static/js/templates.js",
         "./static/js/stream_color.js",
         "./static/js/scroll_bar.js",
-        "./static/templates/compiled.js",
-        "./node_modules/katex/dist/katex.css",
-        "./static/styles/zulip.scss",
-        "./static/styles/media.scss",
-        "./static/styles/archive.scss"
+        "./static/templates/compiled.js"
     ],
     "portico": [
         "./static/js/portico/header.js",
@@ -74,5 +70,11 @@
     ],
     "translations": "./static/js/translations.js",
     "zxcvbn": "./node_modules/zxcvbn/dist/zxcvbn.js",
-    "app": "./static/js/bundles/app.js"
+    "app": "./static/js/bundles/app.js",
+    "archive-styles": [
+        "./node_modules/katex/dist/katex.css",
+        "./static/styles/zulip.scss",
+        "./static/styles/media.scss",
+        "./static/styles/archive.scss"
+    ]
 }


### PR DESCRIPTION
This reverts commit d1d9d638410a86f0542bbd54a705e2c0e27f709f, and fixes
the fonts in webapp being overwritten by bootstarap due to webpack bundling.