### PR TITLE
search: Add #searchbox_legacy selector to #searchbox rules in media.s…

### DIFF
--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -167,7 +167,7 @@
         margin-left: 7px;
     }
 
-    #searchbox {
+    #searchbox, #searchbox_legacy {
         margin-left: 42px;
     }
 
@@ -219,6 +219,7 @@
     .navbar-search,
     #tab_bar,
     #searchbox,
+    #searchbox_legacy,
     #search_query,
     #tab_list li,
     #tab_list,
@@ -243,13 +244,15 @@
         margin-right: 115px;
     }
 
-    #searchbox .input-append .fa-search {
-        top: 5px;
-    }
+    #searchbox, #searchbox_legacy {
+        .input-append .fa-search {
+            top: 5px;
+        }
 
-    #searchbox .search_button,
-    #searchbox .search_button[disabled]:hover {
-        top: 2px;
+        .search_button,
+        .search_button[disabled]:hover {
+            top: 2px;
+        }
     }
 
     #tab_bar_underpadding {


### PR DESCRIPTION
…css.

This is a fixup for e1291cf8392d403bbdc14601e6229811eeac06bf.
While copying the the rules of `#searchbox` to `#searchbox_legacy`
in the search pills feature, the existing `#searchbox` rules were
missed in the conversion.
`#searchbox_legacy` has been added beside `#searchbox` in `media.scss`
instead of replacing that as both of them need those rules for the
mobile view.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
