### PR TITLE
emails: fix preheader coming up inside email.

### DIFF
--- a/templates/zerver/emails/email_base_default.source.html
+++ b/templates/zerver/emails/email_base_default.source.html
@@ -14,7 +14,9 @@
                         <a href="#" class="illustration">
                             {% block illustration %}{% endblock %}
                         </a>
-                        {% block preheader %}{% endblock %}
+                        <span class="preheader">
+                            {% block preheader %}{% endblock %}
+                        </span>
                         <table class="main">
                             <tr>
                                 <td class="wrapper">


### PR DESCRIPTION
This makes the preheader invisible inside the email.
before:
![](https://chat.zulip.org/user_uploads/2/3e/Jeb6pg7T6MaXIxTSMU4oZyKK/pasted_image.png)
after:
![zulip 25-07-2018 18-39-16](https://user-images.githubusercontent.com/21174572/43203300-78f1d870-903b-11e8-99df-0b56cab7cfb0.png)
