### PR TITLE
typeahead: Replace `no-break space (U+00A0)` in query with `space (U+…

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -539,6 +539,13 @@ run_test('initialize', () => {
         expected_value = [];
         assert.deepEqual(actual_value, expected_value);
 
+        // Adds a `no break-space` at the end. This should fail
+        // if there wasn't any logic replacing `no break-space`
+        // with normal space.
+        options.query = 'cordelia' + String.fromCharCode(160);
+        assert.equal(options.matcher(cordelia), true);
+        assert.equal(options.matcher(othello), false);
+
         var event = {
             target: '#doesnotmatter',
         };

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -28,8 +28,13 @@ function query_matches_language(query, lang) {
 }
 
 function query_matches_string(query, source_str, split_char) {
+    // When `abc ` with a space at the end is typed in say the
+    // composebox, the space at the end was a
+    // `no break-space (U+00A0)`  instead of `space (U+0020)`
+    // which lead to no matches in those cases.
+    query = query.replace(/\u00A0/g, String.fromCharCode(32));
     // If query doesn't contain a separator, we just want an exact
-    // match where query is a substring of one of the target characers.
+    // match where query is a substring of one of the target characters.
     if (query.indexOf(split_char) > 0) {
         // If there's a whitespace character in the query, then we
         // require a perfect prefix match (e.g. for 'ab cd ef',

--- a/static/js/user_pill.js
+++ b/static/js/user_pill.js
@@ -120,6 +120,7 @@ exports.set_up_typeahead_on_pills = function (input, pills, update_func) {
         },
         matcher: function (item) {
             var query = this.query.toLowerCase();
+            query = query.replace(/\u00A0/g, String.fromCharCode(32));
             return item.email.toLowerCase().indexOf(query) !== -1
                     || item.full_name.toLowerCase().indexOf(query) !== -1;
         },


### PR DESCRIPTION
…0020)`.

Fixes #10039.
Typing "tim " did not did not produce any match when suggesting person
in composebox typeahead or user group typeahead as the space at the
end of the "tim " string passed by the browser was a
`no break-space (U+00A0)`  instead of `space (U+0020)`.
Although there are unicode characters other than `no break-space` which
represent spaces, only U+00A0 is replaced as it was the only space
character encountered when testing this issue manually.

One of the follow up issue after this would be to use `composebox_typeahead.query_matches_person` in user group settings typeahead after extracting `query_matches_*` functions to somewhere appropriate (I'm not sure about what location is appropriate atm, would put some more thought into it.).