### PR TITLE
pills: Add `flex-wrap: wrap` to pill container for all pills.

### DIFF
--- a/static/styles/input_pill.scss
+++ b/static/styles/input_pill.scss
@@ -1,5 +1,6 @@
 .pill-container {
     display: inline-flex;
+    flex-wrap: wrap;
 
     padding: 2px;
     border: 1px solid hsla(0, 0%, 0%, 0.15);
@@ -87,9 +88,7 @@
     padding: 0px 2px;
     border: none;
 
-    display: flex;
     align-content: center;
-    flex-wrap: wrap;
 }
 
 .pm_recipient .pill-container .input {


### PR DESCRIPTION
Fixes #10059.
In 66df4e3,
`display: inline-flex` was added to `.pill-container` but
`flex-wrap: wrap` was missing which forced overflow pills to be on
one line and made the pill text overflow vertically. This was not
observed in composebox pills as `.pm_recipient .pill-container`
already had a `flex-wrap: wrap` rule which has been removed in this
commit to avoid duplication.

Before:
![selection_193](https://user-images.githubusercontent.com/13910561/43232241-95b1dd46-908d-11e8-9195-35e1c5fee9e7.png)

After:
![selection_194](https://user-images.githubusercontent.com/13910561/43232253-9c599030-908d-11e8-9191-c6e3cccdae6c.png)

