### PR TITLE
portico: Use `1 commit` instead of `1 commits` on the Team page.

### DIFF
--- a/templates/zerver/team.html
+++ b/templates/zerver/team.html
@@ -167,7 +167,7 @@
                             </div>
                             <div class='info'>
                                 <b>@<%= name %></b><br />
-                                <%= commits %> commits
+                                <%= commits %> <%= commits === 1 ? 'commit' : 'commits' %>
                             </div>
                         </a>
                     </div>


### PR DESCRIPTION
Currently, `1 commits` is shown for users with one commit to a project on the Team page. This PR makes it so that `1 commit` is displayed instead of the incorrect `1 commits`.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

*Before (`1 commits`):*

<img width="716" alt="screen shot 2018-07-25 at 6 18 14 pm" src="https://user-images.githubusercontent.com/17259768/43236018-c0051618-9037-11e8-88a6-9a202232cc12.png">

*After (fixed `1 commit`):*

<img width="726" alt="screen shot 2018-07-25 at 6 21 14 pm" src="https://user-images.githubusercontent.com/17259768/43236022-c842c816-9037-11e8-955f-e59b8f0170a9.png">
