### PR TITLE
Billing followup focused on subscriptions

### DIFF
--- a/stubs/stripe/__init__.pyi
+++ b/stubs/stripe/__init__.pyi
@@ -31,7 +31,6 @@ class Subscription:
     created: int
     status: str
     canceled_at: int
-    cancel_at_period_end: bool
 
     @staticmethod
     def create(customer: str, billing: str, items: List[Dict[str, Any]],

--- a/stubs/stripe/__init__.pyi
+++ b/stubs/stripe/__init__.pyi
@@ -31,6 +31,7 @@ class Subscription:
     created: int
     status: str
     canceled_at: int
+    cancel_at_period_end: bool
 
     @staticmethod
     def create(customer: str, billing: str, items: List[Dict[str, Any]],

--- a/templates/zilencer/billing.html
+++ b/templates/zilencer/billing.html
@@ -30,11 +30,15 @@
                     <div class="tab-pane active" id="overview">
                         <p>Your current plan is <strong>{{ plan_name }}</strong></p>
                         <p>You are paying for <strong>{{ seat_count }} users</strong>.</p>
-                        <p>Your plan will renew on <strong>{{ renewal_date }}</strong> for <strong>${{ renewal_amount }}</strong>.</p>
-                        {% if prorated_charges %}
-                        <p>You have <strong>${{ prorated_charges }}</strong> in prorated charges that will be added to your next bill.</p>
-                        {% elif prorated_credits %}
-                        <p>You have <strong>${{ prorated_credits }}</strong> in prorated credits that will be automatically applied to your next bill.</p>
+                        {% if cancel_at_period_end %}
+                            <p>Your subscription for Zulip Premium is ending on <strong>{{ current_period_end }}</strong>. You would be downgraded to Zulip Free when the subscription ends.</p>
+                        {% else %}
+                            <p>Your plan will renew on <strong>{{ current_period_end }}</strong> for <strong>${{ renewal_amount }}</strong>.</p>
+                            {% if prorated_charges %}
+                            <p>You have <strong>${{ prorated_charges }}</strong> in prorated charges that will be added to your next bill.</p>
+                            {% elif prorated_credits %}
+                            <p>You have <strong>${{ prorated_credits }}</strong> in prorated credits that will be automatically applied to your next bill.</p>
+                            {% endif %}
                         {% endif %}
                     </div>
                     <div class="tab-pane" id="payment-method">

--- a/zilencer/tests/test_stripe.py
+++ b/zilencer/tests/test_stripe.py
@@ -35,12 +35,6 @@ def mock_customer_with_canceled_subscription(*args: Any, **kwargs: Any) -> strip
     customer.subscriptions.data[0].canceled_at = 1532602160
     return customer
 
-def mock_customer_with_cancel_at_period_end_subscription(*args: Any, **kwargs: Any) -> stripe.Customer:
-    customer = mock_customer_with_active_subscription()
-    customer.subscriptions.data[0].canceled_at = 1532602243
-    customer.subscriptions.data[0].cancel_at_period_end = True
-    return customer
-
 def mock_upcoming_invoice(*args: Any, **kwargs: Any) -> stripe.Invoice:
     return stripe.util.convert_to_stripe_object(fixture_data["upcoming_invoice"])
 
@@ -260,6 +254,8 @@ class StripeTest(ZulipTestCase):
         self.assertIsNone(extract_current_subscription(mock_create_customer()))
         subscription = extract_current_subscription(mock_customer_with_active_subscription())
         self.assertEqual(subscription["id"][:4], "sub_")
+        self.assertIsNone(extract_current_subscription(mock_customer_with_canceled_subscription()))
+
         self.assertIsNone(extract_current_subscription(mock_customer_with_canceled_subscription()))
 
     @mock.patch("stripe.Customer.retrieve", side_effect=mock_customer_with_active_subscription)

--- a/zilencer/tests/test_stripe.py
+++ b/zilencer/tests/test_stripe.py
@@ -14,7 +14,8 @@ from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.models import Realm, UserProfile, get_realm, RealmAuditLog
 from zilencer.lib.stripe import StripeError, catch_stripe_errors, \
     do_create_customer_with_payment_source, do_subscribe_customer_to_plan, \
-    get_seat_count, extract_current_subscription, sign_string, unsign_string
+    get_seat_count, extract_current_subscription, sign_string, unsign_string, \
+    BillingError
 from zilencer.models import Customer, Plan
 
 fixture_data_file = open(os.path.join(os.path.dirname(__file__), 'stripe_fixtures.json'), 'r')
@@ -293,7 +294,7 @@ class StripeTest(ZulipTestCase):
 
     @mock.patch("stripe.Customer.retrieve", side_effect=mock_customer_with_active_subscription)
     def test_subscribe_customer_to_second_plan(self, mock_customer_with_active_subscription: mock.Mock) -> None:
-        with self.assertRaisesRegex(AssertionError, "Customer already has an active subscription."):
+        with self.assertRaisesRegex(BillingError, "Your organization has an existing active subscription."):
             do_subscribe_customer_to_plan(stripe.Customer.retrieve(),  # type: ignore # Mocked out function call
                                           self.stripe_plan_id, self.quantity, 0)
 

--- a/zilencer/tests/test_stripe.py
+++ b/zilencer/tests/test_stripe.py
@@ -292,11 +292,9 @@ class StripeTest(ZulipTestCase):
         self.assertEqual(subscription["cancel_at_period_end"], True)
         self.assertIsNotNone(subscription["canceled_at"])
 
-    @mock.patch("stripe.Customer.retrieve", side_effect=mock_customer_with_active_subscription)
-    def test_subscribe_customer_to_second_plan(self, mock_customer_with_active_subscription: mock.Mock) -> None:
+    def test_subscribe_customer_to_second_plan(self) -> None:
         with self.assertRaisesRegex(BillingError, "Your organization has an existing active subscription."):
-            do_subscribe_customer_to_plan(stripe.Customer.retrieve(),  # type: ignore # Mocked out function call
-                                          self.stripe_plan_id, self.quantity, 0)
+            do_subscribe_customer_to_plan(mock_customer_with_active_subscription(), self.stripe_plan_id, self.quantity, 0)
 
     def test_sign_string(self) -> None:
         string = "abc"


### PR DESCRIPTION
There are two ways of canceling a subscription. 

* Cancel immediately
* Cancel automatically when the current billing period ends. 

The first mode of cancellation don't need any changes to billing page as the user would be instantly converted to Zulip Free. In the second mode of cancellation we would need show the user that their subscription will end when the billing period ends. I have modified the billing page to take care of this.
**To test** this open stripe dashboard and cancel the subscription of user. Stripe would ask whether to cancel immediately or later. Choose later and open the billing page.
