### PR TITLE
emoji: Change emoticon mapping for `:)`, `(:` and `:(`.

### DIFF
--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -78,7 +78,7 @@ run_test('get_canonical_name', () => {
 run_test('translate_emoticons_to_names', () => {
     // Simple test
     var test_text = 'Testing :)';
-    var expected = 'Testing :smiley:';
+    var expected = 'Testing :slight_smile:';
     var result = emoji.translate_emoticons_to_names(test_text);
     assert.equal(expected, result);
 

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -321,7 +321,7 @@ run_test('marked', () => {
         {input: ':)',
          expected: '<p>:)</p>'},
         {input: ':)',
-         expected: '<p><span class="emoji emoji-1f603" title="smiley">:smiley:</span></p>',
+         expected: '<p><span class="emoji emoji-1f642" title="slight smile">:slight_smile:</span></p>',
          translate_emoticons: true},
         // Test HTML Escape in Custom Zulip Rules
         {input: '@**<h1>The Rogue One</h1>**',

--- a/templates/zerver/help/enable-emoticon-translations.md
+++ b/templates/zerver/help/enable-emoticon-translations.md
@@ -3,14 +3,14 @@
 If you use emoticons like `:)` or `:/`, you can have them translated into
 emoji equivalents like
 <img
-    src="/static/generated/emoji/images/emoji/smile.png"
-    alt="smiley"
+    src="/static/generated/emoji/images-google-64/1f642.png"
+    alt="slight_smile"
     style="width: 3%;"
 />
 or
 <img
-    src="/static/generated/emoji/images/emoji/slightly_frowning_face.png"
-    alt="slightly_frowning_face"
+    src="/static/generated/emoji/images-google-64/1f641.png"
+    alt="slight_frown"
     style="width: 3%;"
 />
 automatically by Zulip.
@@ -34,8 +34,8 @@ automatically by Zulip.
             <td align="center"><code>:)</code></td>
             <td align="center">
                 <img
-                    src="/static/generated/emoji/images/emoji/smiley.png"
-                    alt="smiley"
+                    src="/static/generated/emoji/images-google-64/1f642.png"
+                    alt="slight_smile"
                     style="width: 30%;">
             </td>
         </tr>
@@ -43,8 +43,8 @@ automatically by Zulip.
             <td align="center"><code>(:</code></td>
             <td align="center">
                 <img
-                    src="/static/generated/emoji/images/emoji/smiley.png"
-                    alt="smiley"
+                    src="/static/generated/emoji/images-google-64/1f642.png"
+                    alt="slight_smile"
                     style="width: 30%;">
             </td>
         </tr>
@@ -52,8 +52,8 @@ automatically by Zulip.
             <td align="center"><code>:(</code></td>
             <td align="center">
                 <img
-                    src="/static/generated/emoji/images/emoji/slightly_frowning_face.png"
-                    alt="slightly_frowning_face"
+                    src="/static/generated/emoji/images-google-64/1f641.png"
+                    alt="frown"
                     style="width: 30%;">
             </td>
         </tr>
@@ -61,7 +61,7 @@ automatically by Zulip.
             <td align="center"><code>&lt;3</code></td>
             <td align="center">
                 <img
-                    src="/static/generated/emoji/images/emoji/heart.png"
+                    src="/static/generated/emoji/images-google-64/2764-fe0f.png"
                     alt="heart"
                     style="width: 30%;">
             </td>
@@ -70,7 +70,7 @@ automatically by Zulip.
             <td align="center"><code>:|</code></td>
             <td align="center">
                 <img
-                    src="/static/generated/emoji/images/emoji/expressionless.png"
+                    src="/static/generated/emoji/images-google-64/1f611.png"
                     alt="expressionless"
                     style="width: 30%;">
             </td>
@@ -79,7 +79,7 @@ automatically by Zulip.
             <td align="center"><code>:/</code></td>
             <td align="center">
                 <img
-                    src="/static/generated/emoji/images/emoji/confused.png"
+                    src="/static/generated/emoji/images-google-64/1f615.png"
                     alt="confused"
                     style="width: 30%;">
             </td>

--- a/tools/setup/emoji/emoji_setup_utils.py
+++ b/tools/setup/emoji/emoji_setup_utils.py
@@ -38,9 +38,9 @@ remapped_emojis = {
 # Emoticons and which emoji they should become. Duplicate emoji are allowed.
 # Changes here should be mimicked in `templates/zerver/help/enable-emoticon-translations.md`.
 EMOTICON_CONVERSIONS = {
-    ':)': ':smiley:',
-    '(:': ':smiley:',
-    ':(': ':slight_frown:',
+    ':)': ':slight_smile:',
+    '(:': ':slight_smile:',
+    ':(': ':frown:',
     '<3': ':heart:',
     ':|': ':expressionless:',
     ':/': ':confused:',

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '24.2'
+PROVISION_VERSION = '25.0'

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -360,15 +360,15 @@
     {
       "name": "translate_emoticons_enabled",
       "input": ":)",
-      "expected_output": "<p><span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span></p>",
-      "text_content": "\ud83d\ude03",
+      "expected_output": "<p><span class=\"emoji emoji-1f642\" title=\"slight smile\">:slight_smile:</span></p>",
+      "text_content": "\ud83d\ude42",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons",
-      "input":  ":) foo :( bar <3 with space : ) real emoji :smiley:",
-      "expected_output": "<p><span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span> foo <span class=\"emoji emoji-1f641\" title=\"slight frown\">:slight_frown:</span> bar <span class=\"emoji emoji-2764\" title=\"heart\">:heart:</span> with space : ) real emoji <span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span></p>",
-      "text_content": "\ud83d\ude03 foo \ud83d\ude41 bar \u2764 with space : ) real emoji \ud83d\ude03",
+      "input":  ":) foo :( bar <3 with space : ) real emoji :slight_smile:",
+      "expected_output": "<p><span class=\"emoji emoji-1f642\" title=\"slight smile\">:slight_smile:</span> foo <span class=\"emoji emoji-1f641\" title=\"frown\">:frown:</span> bar <span class=\"emoji emoji-2764\" title=\"heart\">:heart:</span> with space : ) real emoji <span class=\"emoji emoji-1f642\" title=\"slight smile\">:slight_smile:</span></p>",
+      "text_content": "\ud83d\ude42 foo \ud83d\ude41 bar \u2764 with space : ) real emoji \ud83d\ude42",
       "translate_emoticons": true
     },
     {
@@ -381,8 +381,8 @@
     {
       "name": "translate_emoticons_newline",
       "input":  ":) test\n:) test",
-      "expected_output": "<p><span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span> test<br>\n<span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span> test</p>",
-      "text_content": "\ud83d\ude03 test\n\ud83d\ude03 test",
+      "expected_output": "<p><span class=\"emoji emoji-1f642\" title=\"slight smile\">:slight_smile:</span> test<br>\n<span class=\"emoji emoji-1f642\" title=\"slight smile\">:slight_smile:</span> test</p>",
+      "text_content": "\ud83d\ude42 test\n\ud83d\ude42 test",
       "translate_emoticons": true
     },
     {
@@ -395,16 +395,16 @@
     {
       "name": "translate_emoticons_at_sentence_end",
       "input": "Translate this :).",
-      "expected_output": "<p>Translate this <span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span>.</p>",
-      "text_content": "Translate this \ud83d\ude03.",
+      "expected_output": "<p>Translate this <span class=\"emoji emoji-1f642\" title=\"slight smile\">:slight_smile:</span>.</p>",
+      "text_content": "Translate this \ud83d\ude42.",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons_between_symbols",
       "input": "Translate this !:)?",
-      "expected_output": "<p>Translate this !<span class=\"emoji emoji-1f603\" title=\"smiley\">:smiley:</span>?</p>",
+      "expected_output": "<p>Translate this !<span class=\"emoji emoji-1f642\" title=\"slight smile\">:slight_smile:</span>?</p>",
       "marked_expected_output": "<p>Translate this !:)?</p>",
-      "text_content": "Translate this !\ud83d\ude03?",
+      "text_content": "Translate this !\ud83d\ude42?",
       "translate_emoticons": true
     },
     {


### PR DESCRIPTION
See discussion on CZO:
https://chat.zulip.org/#narrow/stream/101-design/subject/emoji.20picker/near/617811

Testing:
1: Re-provision and manually test each emoticon translation.
2: Build docs and check the page `http://127.0.0.1:9991/help/enable-emoticon-translations`.