### PR TITLE
emoji: Disable support for letting users switch emojisets.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -111,6 +111,7 @@ function setup_settings_label() {
         left_side_userlist: i18n.t("User list on left sidebar in narrow windows"),
         night_mode: i18n.t("Night mode"),
         twenty_four_hour_time: i18n.t("24-hour time (17:00 instead of 5:00 PM)"),
+        translate_emoji_to_text: i18n.t("Translate emoji to text (Convert 😃 to <code>:smile:</code>)"),
         translate_emoticons: i18n.t("Translate emoticons (convert <code>:)</code> to 😃 in messages)"),
     };
 }

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -33,7 +33,9 @@ exports.set_up = function () {
     $("#display-settings-status").hide();
 
     $("#user_timezone").val(page_params.timezone);
-    $(".emojiset_choice[value=" + page_params.emojiset + "]").prop("checked", true);
+
+    // $(".emojiset_choice[value=" + page_params.emojiset + "]").prop("checked", true);
+    $("#translate_emoji_to_text").prop('checked', page_params.emojiset === "text");
 
     $("#default_language_modal [data-dismiss]").click(function () {
         overlays.close_modal('default_language_modal');
@@ -107,7 +109,12 @@ exports.set_up = function () {
         change_display_setting(data, '#time-settings-status');
     });
 
-    $(".emojiset_choice").click(function () {
+    /* Due to copyright issues with Apple emojiset and iamcal removing support
+       for emojione emojiset, we have disabled support for changing emojiset.
+       All the users have been migrated to default google emojiset. We have
+       added an additional checkbox for users to still allow them to change to
+       plain text option.
+     $(".emojiset_choice").click(function () {
         var emojiset = $(this).val();
         var data = {};
         data.emojiset = JSON.stringify(emojiset);
@@ -120,9 +127,21 @@ exports.set_up = function () {
             success: function () {
             },
             error: function (xhr) {
-                ui_report.error(settings_ui.strings.failure, xhr, $('#emoji-settings-status').expectOne());
+                ui_report.error(settings_ui.strings.failure, xhr,
+                                $('#emoji-settings-status').expectOne());
             },
         });
+    }); */
+
+    $("#translate_emoji_to_text").change(function () {
+        var data = {};
+        var is_checked = $("#translate_emoji_to_text").is(":checked");
+        if (is_checked) {
+            data.emojiset = JSON.stringify("text");
+        } else {
+            data.emojiset = JSON.stringify("google");
+        }
+        change_display_setting(data, '#emoji-settings-status');
     });
 
     $("#translate_emoticons").change(function () {
@@ -169,6 +188,7 @@ exports.update_page = function () {
     $("#twenty_four_hour_time").prop('checked', page_params.twenty_four_hour_time);
     $("#left_side_userlist").prop('checked', page_params.left_side_userlist);
     $("#default_language_name").text(page_params.default_language_name);
+    $("#translate_emoji_to_text").prop('checked', page_params.emojiset === "text");
     $("#translate_emoticons").prop('checked', page_params.translate_emoticons);
     $("#night_mode").prop('checked', page_params.night_mode);
     // TODO: Set emojiset selector here.

--- a/static/templates/settings/display-settings.handlebars
+++ b/static/templates/settings/display-settings.handlebars
@@ -72,9 +72,10 @@
         </div>
 
         <div id="user-emoji-settings">
-            <h3 class="inline-block light">Emoji style</h3>
+            <h3 class="inline-block light">Emoji settings</h3>
             <div class="alert-notification" id="emoji-settings-status"></div>
 
+            {{#if false}}
             <div class="input-group">
                 <div class="emojiset_choices grey-box">
                     {{#each page_params.emojiset_choices }}
@@ -95,6 +96,12 @@
                     {{/each}}
                 </div>
             </div>
+            {{/if}}
+
+            {{partial "settings_checkbox"
+              "setting_name" "translate_emoji_to_text"
+              "is_checked" false
+              "label" settings_label.translate_emoji_to_text}}
 
             {{partial "settings_checkbox"
               "setting_name" "translate_emoticons"

--- a/zerver/migrations/0181_userprofile_change_emojiset.py
+++ b/zerver/migrations/0181_userprofile_change_emojiset.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from django.db import migrations, models
+from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+def change_emojiset_choice(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    UserProfile = apps.get_model('zerver', 'UserProfile')
+    UserProfile.objects.exclude(emojiset__in=['google', 'text']).update(emojiset='google')
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0180_usermessage_add_active_mobile_push_notification'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            change_emojiset_choice,
+            reverse_code=migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='userprofile',
+            name='emojiset',
+            field=models.CharField(choices=[('google', 'Google'), ('text', 'Plain text')], default='google', max_length=20),
+        ),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -771,15 +771,9 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     timezone = models.CharField(max_length=40, default=u'')  # type: str
 
     # Emojisets
-    APPLE_EMOJISET      = u'apple'
-    EMOJIONE_EMOJISET   = u'emojione'
     GOOGLE_EMOJISET     = u'google'
-    TWITTER_EMOJISET    = u'twitter'
     TEXT_EMOJISET       = u'text'
     EMOJISET_CHOICES    = ((GOOGLE_EMOJISET, "Google"),
-                           (APPLE_EMOJISET, "Apple"),
-                           (TWITTER_EMOJISET, "Twitter"),
-                           (EMOJIONE_EMOJISET, "EmojiOne"),
                            (TEXT_EMOJISET, "Plain text"))
     emojiset = models.CharField(default=GOOGLE_EMOJISET, choices=EMOJISET_CHOICES, max_length=20)  # type: str
 


### PR DESCRIPTION
Given the effort went in support this feature and how well it worked I am really sad to see this feature going. :disappointed: 

Testing I performed:
1: Destroyed and re-built the database and set the emojisets for three users to emojisets other than `google` and `text`.
2: Ran the migration and verified that it works as expected for each user.
3: Verified that for users using `text` emojiset, the check box for translating emojis to text gets checked automatically.
4: Verified that switching between `google` and `text` emojiset is working as expected.

Screenshots:
Before disabling the feature:
![image](https://user-images.githubusercontent.com/16687990/43281584-b27af166-9131-11e8-9608-df08fa1ce234.png)

After disabling the feature:
![image](https://user-images.githubusercontent.com/16687990/43281618-d718d902-9131-11e8-8a17-41ea0f1c46ff.png)

@timabbott FYI.