### PR TITLE
api docs: Migrate the docs for some endpoints to OpenAPI.

### DIFF
--- a/templates/zerver/api/arguments.json
+++ b/templates/zerver/api/arguments.json
@@ -1,12 +1,4 @@
 {
-    "get-stream-id.md": [
-        {
-            "argument": "stream",
-            "description": "The name of the stream to retrieve the ID for.",
-            "required": true,
-            "example": "Denmark"
-        }
-    ],
     "render-message.md": [
         {
             "argument": "content",

--- a/templates/zerver/api/arguments.json
+++ b/templates/zerver/api/arguments.json
@@ -1,12 +1,4 @@
 {
-    "get-all-users.md": [
-        {
-            "argument": "client_gravatar",
-            "description": "The `client_gravatar` field is set to `True` if clients can compute their own gravatars. Default is `False`.",
-            "required": false,
-            "example": "`True` or `False`"
-        }
-    ],
     "register-queue.md": [
         {
             "argument": "apply_markdown",

--- a/templates/zerver/api/arguments.json
+++ b/templates/zerver/api/arguments.json
@@ -1,30 +1,4 @@
 {
-    "get-all-streams.md": [
-        {
-            "argument": "include_public",
-            "description": "Include all public streams. Default is `True`.",
-            "required": false,
-            "example": "`True` or `False`"
-        },
-        {
-            "argument": "include_subscribed",
-            "description": "Include all streams that the user is subscribed to. Default is `True`.",
-            "required": false,
-            "example": "`True` or `False`"
-        },
-        {
-            "argument": "include_all_active",
-            "description": "Include all active streams. The user must have administrative privileges to use this parameter. Default is `False`.",
-            "required": false,
-            "example": "`True` or `False`"
-        },
-        {
-            "argument": "include_default",
-            "description": "Include all default streams for the user's realm. Default is `False`.",
-            "required": false,
-            "example": "`True` or `False`"
-        }
-    ],
     "get-stream-id.md": [
         {
             "argument": "stream",

--- a/templates/zerver/api/arguments.json
+++ b/templates/zerver/api/arguments.json
@@ -1,12 +1,4 @@
 {
-    "render-message.md": [
-        {
-            "argument": "content",
-            "description": "The content of the message.",
-            "required": true,
-            "example": "**foo**"
-        }
-    ],
     "get-all-users.md": [
         {
             "argument": "client_gravatar",

--- a/templates/zerver/api/fixtures.json
+++ b/templates/zerver/api/fixtures.json
@@ -115,11 +115,6 @@
         "short_name": "iago",
         "user_id": 5
     },
-    "get-stream-id": {
-        "msg": "",
-        "result": "success",
-        "stream_id": 15
-    },
     "get-subscribed-streams": {
         "msg": "",
         "result": "success",
@@ -205,11 +200,6 @@
     },
     "invalid-api-key": {
         "msg": "Invalid API key",
-        "result": "error"
-    },
-    "invalid-stream-error": {
-        "code": "BAD_REQUEST",
-        "msg": "Invalid stream name 'nonexistent'",
         "result": "error"
     },
     "missing-request-argument-error": {

--- a/templates/zerver/api/fixtures.json
+++ b/templates/zerver/api/fixtures.json
@@ -241,11 +241,6 @@
         ],
         "result": "success"
     },
-    "render-message": {
-        "msg": "",
-        "rendered": "<p><strong>foo</strong></p>",
-        "result": "success"
-    },
     "successful-response-empty": {
         "msg": "",
         "result": "success"

--- a/templates/zerver/api/fixtures.json
+++ b/templates/zerver/api/fixtures.json
@@ -9,42 +9,6 @@
         "msg": "Email 'newbie@zulip.com' already in use",
         "result": "error"
     },
-    "get-all-users": {
-        "members": [
-            {
-                "avatar_url": "https://secure.gravatar.com/avatar/818c212b9f8830dfef491b3f7da99a14?d=identicon&version=1",
-                "bot_type": null,
-                "email": "AARON@zulip.com",
-                "full_name": "aaron",
-                "is_active": true,
-                "is_admin": false,
-                "is_bot": false,
-                "user_id": 1
-            },
-            {
-                "avatar_url": "https://secure.gravatar.com/avatar/77c3871a68c8d70356156029fd0a4999?d=identicon&version=1",
-                "bot_type": null,
-                "email": "cordelia@zulip.com",
-                "full_name": "Cordelia Lear",
-                "is_active": true,
-                "is_admin": false,
-                "is_bot": false,
-                "user_id": 3
-            },
-            {
-                "avatar_url": "https://secure.gravatar.com/avatar/0cbf08f3a355995fa2ec542246e35123?d=identicon&version=1",
-                "bot_type": null,
-                "email": "newbie@zulip.com",
-                "full_name": "New User",
-                "is_active": true,
-                "is_admin": false,
-                "is_bot": false,
-                "user_id": 24
-            }
-        ],
-        "msg": "",
-        "result": "success"
-    },
     "get-events-from-queue": {
         "events": [
             {

--- a/templates/zerver/api/fixtures.json
+++ b/templates/zerver/api/fixtures.json
@@ -9,48 +9,6 @@
         "msg": "Email 'newbie@zulip.com' already in use",
         "result": "error"
     },
-    "get-all-streams": {
-        "msg": "",
-        "result": "success",
-        "streams": [
-            {
-                "description": "A Scandinavian country",
-                "invite_only": false,
-                "name": "Denmark",
-                "stream_id": 1
-            },
-            {
-                "description": "Yet another Italian city",
-                "invite_only": false,
-                "name": "Rome",
-                "stream_id": 2
-            },
-            {
-                "description": "Located in the United Kingdom",
-                "invite_only": false,
-                "name": "Scotland",
-                "stream_id": 3
-            },
-            {
-                "description": "A northeastern Italian city",
-                "invite_only": false,
-                "name": "Venice",
-                "stream_id": 4
-            },
-            {
-                "description": "A city in Italy",
-                "invite_only": false,
-                "name": "Verona",
-                "stream_id": 5
-            },
-            {
-                "description": "New stream for testing",
-                "invite_only": false,
-                "name": "new stream",
-                "stream_id": 6
-            }
-        ]
-    },
     "get-all-users": {
         "members": [
             {

--- a/templates/zerver/api/get-all-streams.md
+++ b/templates/zerver/api/get-all-streams.md
@@ -31,7 +31,7 @@ curl {{ api_url }}/v1/streams?include_public=false \
 
 <div data-language="python" markdown="1">
 
-{generate_code_example(python)|get-all-streams|example}
+{generate_code_example(python)|/streams:get|example}
 
 </div>
 
@@ -61,7 +61,7 @@ zulip(config).then((client) => {
 
 **Note**: The following arguments are all URL query parameters.
 
-{generate_api_arguments_table|arguments.json|get-all-streams.md}
+{generate_api_arguments_table|zulip.yaml|/streams:get}
 
 ## Response
 
@@ -77,10 +77,10 @@ zulip(config).then((client) => {
 
 A typical successful JSON response may look like:
 
-{generate_code_example|get-all-streams|fixture}
+{generate_code_example|/streams:get|fixture(200)}
 
 An example JSON response for when the user is not authorized to use the
 `include_all_active` parameter (i.e. because they are not an organization
 administrator):
 
-{generate_code_example|user-not-authorized-error|fixture}
+{generate_code_example|/streams:get|fixture(400)}

--- a/templates/zerver/api/get-all-users.md
+++ b/templates/zerver/api/get-all-users.md
@@ -30,7 +30,7 @@ curl {{ api_url }}/v1/users?client_gravatar=true \
 
 <div data-language="python" markdown="1">
 
-{generate_code_example(python)|get-all-users|example}
+{generate_code_example(python)|/users:get|example}
 
 </div>
 
@@ -62,7 +62,7 @@ zulip(config).then((client) => {
 
 **Note**: The following arguments are all URL query parameters.
 
-{generate_api_arguments_table|arguments.json|get-all-users.md}
+{generate_api_arguments_table|zulip.yaml|/users:get}
 
 ## Response
 
@@ -88,4 +88,4 @@ zulip(config).then((client) => {
 
 A typical successful JSON response may look like:
 
-{generate_code_example|get-all-users|fixture}
+{generate_code_example|/users:get|fixture(200)}

--- a/templates/zerver/api/get-stream-id.md
+++ b/templates/zerver/api/get-stream-id.md
@@ -24,7 +24,7 @@ curl {{ api_url }}/v1/get_stream_id?stream=Denmark \
 
 <div data-language="python" markdown="1">
 
-{generate_code_example(python)|get-stream-id|example}
+{generate_code_example(python)|/get_stream_id:get|example}
 
 </div>
 
@@ -53,7 +53,7 @@ zulip(config).then((client) => {
 
 **Note**: The following arguments are all URL query parameters.
 
-{generate_api_arguments_table|arguments.json|get-stream-id.md}
+{generate_api_arguments_table|zulip.yaml|/get_stream_id:get}
 
 ## Response
 
@@ -65,8 +65,8 @@ zulip(config).then((client) => {
 
 A typical successful JSON response may look like:
 
-{generate_code_example|get-stream-id|fixture}
+{generate_code_example|/get_stream_id:get|fixture(200)}
 
 An example JSON response for when the supplied stream does not exist:
 
-{generate_code_example|invalid-stream-error|fixture}
+{generate_code_example|/get_stream_id:get|fixture(400)}

--- a/templates/zerver/api/render-message.md
+++ b/templates/zerver/api/render-message.md
@@ -25,7 +25,7 @@ curl {{ api_url }}/v1/messages/render \
 
 <div data-language="python" markdown="1">
 
-{generate_code_example(python)|render-message|example}
+{generate_code_example(python)|/messages/render:post|example}
 
 </div>
 
@@ -56,7 +56,7 @@ zulip(config).then((client) => {
 
 ## Arguments
 
-{generate_api_arguments_table|arguments.json|render-message.md}
+{generate_api_arguments_table|zulip.yaml|/messages/render:post}
 
 ## Response
 
@@ -68,4 +68,4 @@ zulip(config).then((client) => {
 
 A typical successful JSON response may look like:
 
-{generate_code_example|render-message|fixture}
+{generate_code_example|/messages/render:post|fixture(200)}

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -188,9 +188,7 @@ def get_stream_id(client):
     result = client.get_stream_id(stream_name)
     # {code_example|end}
 
-    fixture = FIXTURES['get-stream-id']
-    test_against_fixture(result, fixture, check_if_equal=['msg', 'result'],
-                         check_if_exists=['stream_id'])
+    validate_against_openapi_schema(result, '/get_stream_id', 'get', '200')
 
 def get_streams(client):
     # type: (Client) -> None
@@ -491,14 +489,13 @@ def test_invalid_stream_error(client):
     # type: (Client) -> None
     result = client.get_stream_id('nonexistent')
 
-    fixture = FIXTURES['invalid-stream-error']
-    test_against_fixture(result, fixture)
+    validate_against_openapi_schema(result, '/get_stream_id', 'get', '400')
 
 TEST_FUNCTIONS = {
     'render-message': render_message,
     '/messages:post': send_message,
     '/messages/{message_id}:patch': update_message,
-    'get-stream-id': get_stream_id,
+    '/get_stream_id:get': get_stream_id,
     'get-subscribed-streams': list_subscriptions,
     '/streams:get': get_streams,
     'create-user': create_user,

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -200,10 +200,7 @@ def get_streams(client):
     result = client.get_streams()
     # {code_example|end}
 
-    fixture = FIXTURES['get-all-streams']
-    test_against_fixture(result, fixture, check_if_equal=['msg', 'result'],
-                         check_if_exists=['streams'])
-    assert len(result['streams']) == len(fixture['streams'])
+    validate_against_openapi_schema(result, '/streams', 'get', '200')
     streams = [s for s in result['streams'] if s['name'] == 'new stream']
     assert streams[0]['description'] == 'New stream for testing'
 
@@ -213,8 +210,7 @@ def get_streams(client):
     result = client.get_streams(include_public=False)
     # {code_example|end}
 
-    test_against_fixture(result, fixture, check_if_equal=['msg', 'result'],
-                         check_if_exists=['streams'])
+    validate_against_openapi_schema(result, '/streams', 'get', '200')
     assert len(result['streams']) == 4
 
 def test_user_not_authorized_error(nonadmin_client):
@@ -504,7 +500,7 @@ TEST_FUNCTIONS = {
     '/messages/{message_id}:patch': update_message,
     'get-stream-id': get_stream_id,
     'get-subscribed-streams': list_subscriptions,
-    'get-all-streams': get_streams,
+    '/streams:get': get_streams,
     'create-user': create_user,
     'get-profile': get_profile,
     'add-subscriptions': add_subscriptions,

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -140,10 +140,7 @@ def get_members(client):
 
     # {code_example|start}
     # You may pass the `client_gravatar` query parameter as follows:
-    result = client.call_endpoint(
-        url='users?client_gravatar=true',
-        method='GET',
-    )
+    result = client.get_members({'client_gravatar': True})
     # {code_example|end}
 
     validate_against_openapi_schema(result, '/users', 'get', '200')

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -130,26 +130,13 @@ def get_members(client):
     result = client.get_members()
     # {code_example|end}
 
-    fixture = FIXTURES['get-all-users']
-    test_against_fixture(result, fixture, check_if_equal=['msg', 'result'],
-                         check_if_exists=['members'])
+    validate_against_openapi_schema(result, '/users', 'get', '200')
+
     members = [m for m in result['members'] if m['email'] == 'newbie@zulip.com']
     assert len(members) == 1
     newbie = members[0]
     assert not newbie['is_admin']
     assert newbie['full_name'] == 'New User'
-
-    member_fixture = fixture['members'][0]
-
-    # Get Aaron from all the results we got from the API
-    for member in result['members']:
-        if member['email'] == 'AARON@zulip.com':
-            member_result = member
-
-    assert member_result
-
-    test_against_fixture(member_result, member_fixture,
-                         check_if_exists=member_fixture.keys())
 
     # {code_example|start}
     # You may pass the `client_gravatar` query parameter as follows:
@@ -159,8 +146,7 @@ def get_members(client):
     )
     # {code_example|end}
 
-    test_against_fixture(result, fixture, check_if_equal=['msg', 'result'],
-                         check_if_exists=['members'])
+    validate_against_openapi_schema(result, '/users', 'get', '200')
     assert result['members'][0]['avatar_url'] is None
 
 def get_profile(client):
@@ -501,7 +487,7 @@ TEST_FUNCTIONS = {
     'get-profile': get_profile,
     'add-subscriptions': add_subscriptions,
     'remove-subscriptions': remove_subscriptions,
-    'get-all-users': get_members,
+    '/users:get': get_members,
     'register-queue': register_queue,
     'delete-queue': deregister_queue,
     'upload-file': upload_file,

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -284,8 +284,7 @@ def render_message(client):
     result = client.render_message(request)
     # {code_example|end}
 
-    fixture = FIXTURES['render-message']
-    test_against_fixture(result, fixture)
+    validate_against_openapi_schema(result, '/messages/render', 'post', '200')
 
 def send_message(client):
     # type: (Client) -> int
@@ -492,7 +491,7 @@ def test_invalid_stream_error(client):
     validate_against_openapi_schema(result, '/get_stream_id', 'get', '400')
 
 TEST_FUNCTIONS = {
-    'render-message': render_message,
+    '/messages/render:post': render_message,
     '/messages:post': send_message,
     '/messages/{message_id}:patch': update_message,
     '/get_stream_id:get': get_stream_id,

--- a/zerver/lib/bugdown/api_arguments_table_generator.py
+++ b/zerver/lib/bugdown/api_arguments_table_generator.py
@@ -115,11 +115,17 @@ class APIArgumentsTablePreprocessor(Preprocessor):
         md_engine = markdown.Markdown(extensions=[])
 
         for argument in arguments:
+            description = argument['description']
+
             oneof = ['`' + item + '`'
                      for item in argument.get('schema', {}).get('enum', [])]
-            description = argument['description']
             if oneof:
                 description += '\nMust be one of: {}.'.format(', '.join(oneof))
+
+            default = argument.get('schema', {}).get('default')
+            if default is not None:
+                description += '\nDefaults to `{}`.'.format(ujson.dumps(default))
+
             # TODO: Swagger allows indicating where the argument goes
             # (path, querystring, form data...). A column in the table should
             # be added for this.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -230,6 +230,37 @@ paths:
                         "msg": "You don't have permission to edit this message",
                         "result": "error"
                     }
+  /messages/render:
+    post:
+      description: Render a message to HTML.
+      parameters:
+        - name: content
+          in: query
+          description: The content of the message.
+          schema:
+             type: string
+          example: '**foo**'
+          required: true
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JsonSuccess'
+                - properties:
+                    rendered:
+                      type: string
+                      description: The rendered HTML.
+                - example:
+                    {
+                        "msg": "",
+                        "rendered": "<p><strong>foo</strong></p>",
+                        "result": "success"
+                    }
   /users/me/{stream_id}/topics:
     get:
       description: Get all the topics in a specific stream.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -24,6 +24,50 @@ servers:
 # Endpoint definitions
 #######################
 paths:
+  /get_stream_id:
+    get:
+      description: Get the unique ID of a given stream.
+      parameters:
+      - name: stream
+        in: query
+        description: The name of the stream to retrieve the ID for.
+        schema:
+           type: string
+        example: Denmark
+        required: true
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JsonSuccess'
+                - properties:
+                    stream_id:
+                      type: integer
+                      description: The ID of the given stream.
+                - example:
+                    {
+                        "msg": "",
+                        "result": "success",
+                        "stream_id": 15
+                    }
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/CodedError'
+                - example:
+                    {
+                        "code": "BAD_REQUEST",
+                        "msg": "Invalid stream name 'nonexistent'",
+                        "result": "error"
+                    }
   /messages:
     post:
       description: Send a message.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -377,7 +377,113 @@ paths:
                             "private_stream"
                         ]
                     }
-
+  /streams:
+    get:
+      description: Get all streams that the user has access to.
+      parameters:
+      - name: include_public
+        in: query
+        description: Include all public streams.
+        schema:
+           type: boolean
+           default : true
+        example: false
+      - name: include_subscribed
+        in: query
+        description: Include all streams that the user is subscribed to.
+        schema:
+           type: boolean
+           default : true
+        example: false
+      - name: include_all_active
+        in: query
+        description: Include all active streams. The user must have
+          administrative privileges to use this parameter.
+        schema:
+           type: boolean
+           default : false
+        example: true
+      - name: include_default
+        in: query
+        description: Include all default streams for the user's realm.
+        schema:
+           type: boolean
+           default : false
+        example: true
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JsonSuccess'
+                - properties:
+                    streams:
+                      type: array
+                      items:
+                        type: object
+                      description: A list of `stream` objects, which contain a
+                        `description`, a `name`, their `stream_id` and whether
+                        they are `invite_only` or not.
+                - example:
+                    {
+                        "msg": "",
+                        "result": "success",
+                        "streams": [
+                            {
+                                "description": "A Scandinavian country",
+                                "invite_only": false,
+                                "name": "Denmark",
+                                "stream_id": 1
+                            },
+                            {
+                                "description": "Yet another Italian city",
+                                "invite_only": false,
+                                "name": "Rome",
+                                "stream_id": 2
+                            },
+                            {
+                                "description": "Located in the United Kingdom",
+                                "invite_only": false,
+                                "name": "Scotland",
+                                "stream_id": 3
+                            },
+                            {
+                                "description": "A northeastern Italian city",
+                                "invite_only": false,
+                                "name": "Venice",
+                                "stream_id": 4
+                            },
+                            {
+                                "description": "A city in Italy",
+                                "invite_only": false,
+                                "name": "Verona",
+                                "stream_id": 5
+                            },
+                            {
+                                "description": "New stream for testing",
+                                "invite_only": false,
+                                "name": "new stream",
+                                "stream_id": 6
+                            }
+                        ]
+                    }
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/CodedError'
+                - example:
+                    {
+                        "code": "BAD_REQUEST",
+                        "msg": "User not authorized for this query",
+                        "result": "error"
+                    }
 
 components:
   #######################

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -261,6 +261,71 @@ paths:
                         "rendered": "<p><strong>foo</strong></p>",
                         "result": "success"
                     }
+  /users:
+    get:
+      description: Retrieve all users in a realm.
+      parameters:
+      - name: client_gravatar
+        in: query
+        description: The `client_gravatar` field is set to `true` if clients
+          can compute their own gravatars.
+        schema:
+           type: boolean
+           default : false
+        example: true
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JsonSuccess'
+                - properties:
+                    members:
+                      type: array
+                      description: A list of `member` objects, each containing
+                        details of a user in the realm (like their email, name,
+                        avatar, user type...).
+                - example:
+                    {
+                        "members": [
+                            {
+                                "avatar_url": "https://secure.gravatar.com/avatar/818c212b9f8830dfef491b3f7da99a14?d=identicon&version=1",
+                                "bot_type": null,
+                                "email": "AARON@zulip.com",
+                                "full_name": "aaron",
+                                "is_active": true,
+                                "is_admin": false,
+                                "is_bot": false,
+                                "user_id": 1
+                            },
+                            {
+                                "avatar_url": "https://secure.gravatar.com/avatar/77c3871a68c8d70356156029fd0a4999?d=identicon&version=1",
+                                "bot_type": null,
+                                "email": "cordelia@zulip.com",
+                                "full_name": "Cordelia Lear",
+                                "is_active": true,
+                                "is_admin": false,
+                                "is_bot": false,
+                                "user_id": 3
+                            },
+                            {
+                                "avatar_url": "https://secure.gravatar.com/avatar/0cbf08f3a355995fa2ec542246e35123?d=identicon&version=1",
+                                "bot_type": null,
+                                "email": "newbie@zulip.com",
+                                "full_name": "New User",
+                                "is_active": true,
+                                "is_admin": false,
+                                "is_bot": false,
+                                "user_id": 24
+                            }
+                        ],
+                        "msg": "",
+                        "result": "success"
+                    }
   /users/me/{stream_id}/topics:
     get:
       description: Get all the topics in a specific stream.


### PR DESCRIPTION
Migrate the following endpoints to OpenAPI format:

- `GET /streams`
- `GET /get_stream_id`
- `POST /messages/render`
- `GET /users`

Plus a small improvement in the API docs system, that allows grabbing the default values from the OpenAPI spec file.

**Testing Plan:** API tests passed locally and made sure the docs display properly side-by-side. Also, lint and mypy checks passed locally for the code commit.

