### PR TITLE
subs: Migrate subscriptions modal to use simplebar scrollbars.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -195,6 +195,7 @@
         "panels": false,
         "PerfectScrollbar": false,
         "search_pill": false,
+        "SimpleBar": false,
         "Sortable": false,
         "search_pill_widget": false
     },

--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -106,7 +106,7 @@ casper.then(function () {
         casper.click('input[value="Scotland"] ~ span');
         casper.click('input[value="cordelia@zulip.com"] ~ span');
         casper.click('input[value="othello@zulip.com"] ~ span');
-        casper.click('form#stream_creation_form button.button.sea-green');
+        casper.click('#stream-creation-footer button.button.sea-green');
     });
 });
 
@@ -132,23 +132,23 @@ casper.then(function () {
 casper.then(function () {
     casper.click('#add_new_subscription .create_stream_button');
     casper.fill('form#stream_creation_form', {stream_name: '  '});
-    casper.click('form#stream_creation_form button.button.sea-green');
+    casper.click('#stream-creation-footer button.button.sea-green');
 });
 casper.then(function () {
     casper.waitForSelectorText('#stream_name_error', 'A stream needs to have a name', function () {
         casper.test.assertTextExists('A stream needs to have a name', "Can't create a stream with an empty name");
-        casper.click('form#stream_creation_form button.button.white');
+        casper.click('#stream-creation-footer button.button.white');
         casper.fill('form#add_new_subscription', {stream_name: '  '});
         casper.click('#add_new_subscription .create_stream_button');
         casper.fill('form#stream_creation_form', {stream_name: 'Waseemio'});
-        casper.click('form#stream_creation_form button.button.sea-green');
+        casper.click('#stream-creation-footer button.button.sea-green');
     });
 });
 casper.then(function () {
     casper.waitForSelectorText('#stream_name_error', 'A stream with this name already exists', function () {
         casper.test.assertTextExists('A stream with this name already exists', "Can't create a stream with a duplicate name");
         casper.test.info('Streams should be filtered when typing in the create box');
-        casper.click('form#stream_creation_form button.button.white');
+        casper.click('#stream-creation-footer button.button.white');
     });
 });
 casper.then(function () {

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -1,7 +1,6 @@
 global.stub_out_jquery();
 
 set_global('templates', {});
-set_global('ui', {});
 zrequire('util');
 zrequire('stream_data');
 zrequire('search_util');
@@ -103,12 +102,6 @@ run_test('filter_table', () => {
         sub_table_append.push(rows);
     };
 
-    var ui_called = false;
-    ui.update_scrollbar = function (elem) {
-        ui_called = true;
-        assert.equal(elem, $("#subscription_overlay .streams-list"));
-    };
-
     // Search with single keyword
     subs.filter_table({input: "Po", subscribed_only: false});
     assert($(".stream-row-denmark").hasClass("notdisplayed"));
@@ -117,7 +110,6 @@ run_test('filter_table', () => {
     assert($(".stream-row-cpp").hasClass("notdisplayed"));
 
     // assert these once and call it done
-    assert(ui_called);
     assert(scrolltop_called);
     assert(tooltip_called);
     assert.deepEqual(sub_table_append, [

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -21,6 +21,7 @@ import "node_modules/to-markdown/dist/to-markdown.js";
 import "node_modules/flatpickr/dist/flatpickr.js";
 import "node_modules/flatpickr/dist/plugins/confirmDate/confirmDate.js";
 import "node_modules/perfect-scrollbar/dist/perfect-scrollbar.js";
+import "node_modules/simplebar/dist/simplebar.js";
 import "node_modules/error-stack-parser/dist/error-stack-parser.min.js";
 import "node_modules/sortablejs/Sortable.js";
 import "generated/emoji/emoji_codes.js";

--- a/static/js/bundles/commons.js
+++ b/static/js/bundles/commons.js
@@ -13,6 +13,7 @@ import "third/bootstrap/css/bootstrap.css";
 import "third/bootstrap/css/bootstrap-btn.css";
 import "third/bootstrap/css/bootstrap-responsive.css";
 import "node_modules/perfect-scrollbar/css/perfect-scrollbar.css";
+import "node_modules/simplebar/dist/simplebar.css";
 import "node_modules/font-awesome/css/font-awesome.css";
 import "third/fontawesome-legacy.css";
 import "generated/icons/style.css";

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -249,6 +249,7 @@ function clear_error_display() {
 exports.show_new_stream_modal = function () {
     $("#stream-creation").removeClass("hide");
     $(".right .settings").hide();
+    $("#right-scroll-container").addClass('stream-creation-active');
 
     var all_users = people.get_rest_of_realm();
     // Add current user on top of list
@@ -371,6 +372,11 @@ exports.create_handlers_for_users = function (container) {
 
         update_announce_stream_state();
         e.preventDefault();
+    });
+
+    $('#stream-creation-footer button[type="submit"]').on('click', function (e) {
+        e.preventDefault();
+        $('#stream_creation_form').trigger('submit');
     });
 };
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -49,7 +49,6 @@ exports.rerender_subscribers_list = function (sub) {
             exports.sort_but_pin_current_user_on_top(emails);
             subscribers_list.data(emails);
             subscribers_list.render();
-            ui.update_scrollbar($(".subscriber_list_container"));
         }
         $(".subscriber_list_settings_container").show();
     }
@@ -213,7 +212,7 @@ function show_subscription_settings(sub_row) {
         },
     }).init();
 
-    ui.set_up_scrollbar($(".subscriber_list_container"));
+    ui.set_up_simplebar($(".subscriber_list_container"));
 
     sub_settings.find('input[name="principal"]').typeahead({
         source: people.get_realm_persons, // This is a function.
@@ -255,7 +254,7 @@ exports.show_settings_for = function (node) {
 
     $(".nothing-selected").hide();
 
-    ui.update_scrollbar($("#subscription_overlay .settings"));
+    ui.reset_simplebar($("#subscription_overlay #right-scroll-container"));
 
     sub_settings.addClass("show");
 
@@ -448,7 +447,7 @@ exports.change_stream_name = function (e) {
         error: function (xhr) {
             new_name_box.text(stream_data.maybe_get_stream_name(stream_id));
             ui_report.error(i18n.t("Error"), xhr, $(".stream_change_property_info"));
-            ui.update_scrollbar($("#subscription_overlay .settings"));
+            ui.reset_simplebar($("#subscription_overlay #right-scroll-container"));
         },
     });
 };
@@ -481,7 +480,7 @@ exports.change_stream_description = function (e) {
         error: function (xhr) {
             sub_settings.find('.stream-description-editable').html(sub.rendered_description);
             ui_report.error(i18n.t("Error"), xhr, $(".stream_change_property_info"));
-            ui.update_scrollbar($("#subscription_overlay .settings"));
+            ui.reset_simplebar($("#subscription_overlay #right-scroll-container"));
         },
     });
 };
@@ -611,7 +610,7 @@ exports.initialize = function () {
             }
             stream_subscription_info_elem.addClass('text-success')
                 .removeClass('text-error');
-            ui.update_scrollbar($("#subscription_overlay .settings"));
+            ui.reset_simplebar($("#subscription_overlay #right-scroll-container"));
         }
 
         function removal_failure() {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -9,10 +9,12 @@ exports.show_subs_pane = {
     nothing_selected: function () {
         $(".nothing-selected, #stream_settings_title").show();
         $("#add_new_stream_title, .settings, #stream-creation").hide();
+        $("#right-scroll-container").removeClass('stream-creation-active');
     },
     settings: function () {
         $(".settings, #stream_settings_title").show();
         $("#add_new_stream_title, #stream-creation, .nothing-selected").hide();
+        $("#right-scroll-container").removeClass('stream-creation-active');
     },
 };
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -438,8 +438,6 @@ exports.filter_table = function (query) {
         });
     });
 
-    ui.update_scrollbar($("#subscription_overlay .streams-list"));
-
     var all_stream_ids = [].concat(
         buckets.name,
         buckets.desc,
@@ -616,7 +614,11 @@ exports.change_state = (function () {
                 get_active_data().row.removeClass("active");
                 stream_row.addClass("active");
 
-                scroll_util.scroll_element_into_container(stream_row, stream_row.parent());
+                var simplebar = $("#subscription_overlay #streams-list-container")[0].simplebar;
+                var scrollbar = simplebar.getScrollElement();
+                var position = stream_row.position().top - $(scrollbar.firstChild).position().top;
+
+                scrollbar.scrollTop = position;
 
                 setTimeout(function () {
                     if (hash.arguments[0] === get_active_data().id) {
@@ -641,11 +643,11 @@ exports.launch = function (hash) {
             overlay: $("#subscription_overlay"),
             on_close: exports.close,
         });
+
+        ui.set_up_simplebar($("#subscription_overlay #streams-list-container"));
+        ui.set_up_simplebar($("#subscription_overlay #right-scroll-container"));
+
         exports.change_state(hash);
-
-        ui.set_up_scrollbar($("#subscription_overlay .streams-list"));
-        ui.set_up_scrollbar($("#subscription_overlay .settings"));
-
     });
     if (!get_active_data().id) {
         $('#search_stream_name').focus();

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -24,11 +24,24 @@ exports.set_up_scrollbar = function (element) {
     element[0].perfectScrollbar = perfectScrollbar;
 };
 
+exports.set_up_simplebar = function (element) {
+    var simplebar = new SimpleBar(element[0]);
+    element[0].simplebar = simplebar;
+};
+
 exports.update_scrollbar = function (element) {
     element.scrollTop = 0;
     if (element[0].perfectScrollbar !== undefined) {
         element[0].perfectScrollbar.update();
     }
+};
+
+exports.reset_simplebar = function (element) {
+    if (element[0].simplebar === undefined) {
+        return;
+    }
+    var scrollbar = element[0].simplebar.getScrollElement();
+    scrollbar.scrollTop = 0;
 };
 
 exports.destroy_scrollbar = function (element) {

--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -243,7 +243,6 @@
     background: hsl(0, 0%, 53%);
     color: hsl(0, 0%, 100%);
     border: 1px solid hsl(0, 0%, 46%);
-    z-index: 2;
 }
 
 .new-style .tab-switcher .ind-tab.disabled {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -183,6 +183,7 @@ on a dark background, and don't change the dark labels dark either. */
         box-shadow: 0px 0px 30px hsl(212, 32%, 7%);
     }
 
+    #subscription_overlay #stream-creation-footer,
     .dropdown .dropdown-menu,
     .popover,
     .popover-title,

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -586,6 +586,10 @@ form#add_new_subscription {
     height: calc(95vh - 88px);
 }
 
+#right-scroll-container.stream-creation-active {
+    height: calc(95vh - 148px);
+}
+
 .stream-row {
     padding: 15px 10px 11px 10px;
     border-bottom: 1px solid hsl(0, 0%, 93%);
@@ -732,12 +736,6 @@ form#add_new_subscription {
     -webkit-overflow-scrolling: touch;
 }
 
-#subscription_overlay #stream-creation .modal-footer {
-    position: absolute;
-    bottom: 0;
-    width: calc(100% - 27px);
-}
-
 #stream-creation .stream-creation-body {
     padding: 15px;
 }
@@ -763,7 +761,7 @@ form#add_new_subscription {
 #stream_creation_form #stream_creating_indicator:not(:empty) {
     position: absolute;
     width: 100% !important;
-    height: calc(100% - 105px) !important;
+    height: 100% !important;
     display: flex !important;
     justify-content: center;
     align-items: center;
@@ -1070,6 +1068,10 @@ form#add_new_subscription {
 
     #subscription_overlay #right-scroll-container {
         height: calc(95vh - 44px);
+    }
+
+    #subscription_overlay #right-scroll-container.stream-creation-active {
+        height: calc(95vh - 104px);
     }
 }
 

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -581,12 +581,9 @@ form#add_new_subscription {
     margin-right: 8px;
 }
 
-.streams-list {
-    position: relative;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
-    height: calc(100% - 45px);
-    width: 100%;
+#right-scroll-container,
+#streams-list-container {
+    height: calc(95vh - 88px);
 }
 
 .stream-row {
@@ -915,13 +912,6 @@ form#add_new_subscription {
     font-weight: 800;
 }
 
-#subscription_overlay .settings {
-    position: relative;
-    height: calc(100% - 45px);
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-}
-
 #subscription_overlay .subscription_settings {
     display: none;
     position: relative;
@@ -1078,10 +1068,8 @@ form#add_new_subscription {
         height: 95%;
     }
 
-    #subscription_overlay .settings {
-        overflow: auto;
-        height: calc(100% - 20px);
-        -webkit-overflow-scrolling: touch;
+    #subscription_overlay #right-scroll-container {
+        height: calc(95vh - 44px);
     }
 }
 

--- a/static/templates/stream_creation_form.handlebars
+++ b/static/templates/stream_creation_form.handlebars
@@ -46,9 +46,5 @@
                 <div class="controls" id="people_to_add"></div>
             </section>
         </div>
-        <div class="modal-footer">
-            <button class="button small white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-            <button class="button small sea-green rounded" type="submit">{{t "Create" }}</button>
-        </div>
     </form>
 </div>

--- a/static/templates/subscription_table_body.handlebars
+++ b/static/templates/subscription_table_body.handlebars
@@ -21,7 +21,9 @@
                     </form>
                     <div class="clear-float"></div>
                 </div>
-                <div class="streams-list">
+                <div id="streams-list-container">
+                    <div class="streams-list">
+                    </div>
                 </div>
             </div>
             <div class="right">
@@ -35,10 +37,12 @@
                     <span>{{t 'First time? Read our <a href="/help/create-a-stream" target="_blank">guidelines</a> for creating and naming streams.' }}</span>
                     {{/if}}
                 </div>
-                <div class="settings">
-                    {{!-- edit stream here --}}
+                <div id="right-scroll-container">
+                    <div class="settings">
+                        {{!-- edit stream here --}}
+                    </div>
+                    {{ partial "stream_creation_form" }}
                 </div>
-                {{ partial "stream_creation_form" }}
             </div>
         </div>
     </div>

--- a/static/templates/subscription_table_body.handlebars
+++ b/static/templates/subscription_table_body.handlebars
@@ -43,6 +43,10 @@
                     </div>
                     {{ partial "stream_creation_form" }}
                 </div>
+                <div id="stream-creation-footer" class="modal-footer">
+                    <button class="button small white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+                    <button class="button small sea-green rounded" type="submit">{{t "Create" }}</button>
+                </div>
             </div>
         </div>
     </div>

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -43,6 +43,8 @@
         "./static/third/fontawesome-legacy.css",
         "./static/generated/icons/style.css",
         "./node_modules/source-sans-pro/source-sans-pro.css",
+        "./node_modules/simplebar/dist/simplebar.css",
+        "./node_modules/simplebar/dist/simplebar.js",
         "./static/styles/pygments.scss"
     ],
     "help": [

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -124,7 +124,7 @@ export default (env?: string) : webpack.Configuration => {
         { path: "../node_modules/clipboard/dist/clipboard.js", name: "ClipboardJS" },
         { path: "../node_modules/xdate/src/xdate.js", name: "XDate" },
         { path: "../node_modules/perfect-scrollbar/dist/perfect-scrollbar.js", name: "PerfectScrollbar" },
-        { path: "../node_modules/simplebar/dist/simplebar.js"},
+        { path: "../node_modules/simplebar/dist/simplebar.js", name: "SimpleBar"},
         { path: "../static/third/marked/lib/marked.js" },
         { path: "../static/generated/emoji/emoji_codes.js" },
         { path: "../static/generated/pygments_data.js" },

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '25.4'
+PROVISION_VERSION = '25.5'


### PR DESCRIPTION
This PR is a part of solving #10055 and migrates scrollbars only in the subscriptions modal to use simplebar instead of perfect-scrollbar.

Various areas of the modal DOM needed to be refactored to support simplebar.