### PR TITLE
Webpack Multiple Bundles / Code Splitting Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jquery": "3.3.1",
     "jquery-validation": "1.17.0",
     "katex": "0.8.3",
-    "mini-css-extract-plugin": "0.4.0",
+    "mini-css-extract-plugin": "0.4.1",
     "moment": "2.22.1",
     "moment-timezone": "0.5.17",
     "node-sass": "4.9.0",

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -1,5 +1,3 @@
-import "js/bundles/commons.js";
-
 // Import Third party libraries
 import "third/bootstrap-notify/js/bootstrap-notify.js";
 import "third/html5-formdata/formdata.js";

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -11,12 +11,10 @@
 </script>
 {% endblock %}
 
-{% block commonjs %}
-{{ render_bundle('app', attrs='nonce="%s"' % (csp_nonce)) }}
-{{ render_bundle('katex', attrs='nonce="%s"' % (csp_nonce)) }}
-{% endblock %}
 
 {% block customhead %}
+{{ render_bundle('app', attrs='nonce="%s"' % (csp_nonce)) }}
+{{ render_bundle('katex', attrs='nonce="%s"' % (csp_nonce)) }}
 <meta name="apple-mobile-web-app-capable" content="yes">
 <link href="/static/images/logo/apple-touch-icon-precomposed.png" rel="apple-touch-icon-precomposed">
 <link id="emoji-spritesheet" href="/static/generated/emoji/{{ emojiset }}_sprite.css" rel="stylesheet" type="text/css">

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -28,6 +28,7 @@
         This allows pages requiring common files via webpack to override
         this block -->
         {% block commonjs %}
+        {{ render_bundle('runtime', attrs='nonce="%s"' % (csp_nonce)) }}
         {{ render_bundle('common', attrs='nonce="%s"' % (csp_nonce)) }}
         {% endblock %}
         {% block customhead %}

--- a/tools/webpack
+++ b/tools/webpack
@@ -61,6 +61,11 @@ def run_test():
                 "publicPath": "http://localhost:3000/webpack-stub/%s-stubentry.js" % (entry,),
                 "path": "/stubfolder/%s-stubfile.js" % (entry,)
             }]
+        entries['runtime'] = [{
+            "name": "runtime.js",
+            "publicPath": "http://localhost:3000/webpack-stub/runtime-stubentry.js",
+            "path": "/stubfolder/runtime-stubfile.js"
+        }]
     stat_data = {
         "status": "done",
         "chunks": entries
@@ -70,7 +75,6 @@ def run_test():
         os.makedirs(directory)
     with open(os.path.join(directory, 'webpack-stats-test.json'), 'w') as outfile:
         json.dump(stat_data, outfile)
-
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--test',

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -5,7 +5,6 @@ import { getExposeLoaders, getImportLoaders } from './webpack-helpers';
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 const assets = require('./webpack.assets.json');
-
 // Adds on css-hot-loader in dev mode
 function getHotCSS(bundle:any[], isProd:boolean) {
     if(isProd) {
@@ -104,6 +103,11 @@ export default (env?: string) : webpack.Configuration => {
         // We prefer it over eval since eval has trouble setting
         // breakpoints in chrome.
         devtool: production ? 'source-map' : 'cheap-module-source-map',
+        optimization: {
+          runtimeChunk: {
+              name: 'runtime'
+          }
+        }
     };
 
     // Add variables within modules
@@ -154,8 +158,8 @@ export default (env?: string) : webpack.Configuration => {
                     }
                     return '[name].[contenthash].css';
                 },
-                chunkFilename: "[chunkhash].css"
-            })
+                chunkFilename: "[name].[chunkhash].css"
+            }),
         ];
     } else {
         // Out JS debugging tools
@@ -170,8 +174,8 @@ export default (env?: string) : webpack.Configuration => {
             new webpack.LoaderOptionsPlugin({debug: true}),
             // Extract CSS from files
             new MiniCssExtractPlugin({
-                filename: "[name].css",
-                chunkFilename: "[chunkhash].css"
+                filename: "[name].[contenthash].css",
+                chunkFilename: "[name].[chunkhash].css"
             }),
         ];
         config.devServer = {

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '25.2'
+PROVISION_VERSION = '25.3'

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,6 +223,17 @@
     "@webassemblyjs/wast-parser" "1.4.3"
     long "^3.2.0"
 
+"@webpack-contrib/schema-utils@^1.0.0-beta.0":
+  version "1.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz#bf9638c9464d177b48209e84209e23bee2eb4f65"
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chalk "^2.3.2"
+    strip-ansi "^4.0.0"
+    text-table "^0.2.0"
+    webpack-log "^1.1.2"
+
 "JSV@>= 4.0.x":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
@@ -6432,10 +6443,11 @@ mimic-response@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
-mini-css-extract-plugin@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.0.tgz#ff3bf08bee96e618e177c16ca6131bfecef707f9"
+mini-css-extract-plugin@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.1.tgz#d2bcf77bb2596b8e4bd9257e43d3f9164c2e86cb"
   dependencies:
+    "@webpack-contrib/schema-utils" "^1.0.0-beta.0"
     loader-utils "^1.1.0"
     webpack-sources "^1.1.0"
 


### PR DESCRIPTION
This commit enables us to run multiple webpack bundles on the
same page efficiently.

This is achieved by telling webpack to write the runtime to a
separate chunk called runtime. In order to achieve this
we use 3 plugins for webpack to be able to include the runtime
in the Django template ( since the runtime is different each
time a different version of the app is built ).

1) html-webpack-plugin
2) inline-manifest-webpack-plugin
3) html-webpack-harddisk-plugin

Each do their job to be able extract it, inline it to a html
template and write it to disk. Subsequently that dynamically
generated webpack_runtime_template is then 'included'
by base.html template in Django.

This enables multiple modules to run on the same
page which would otherwise cause issues like expose-loader
not applying across different bundles, multiple versions
of the runtime on the same page etc.

Potentially this hack could be replaced by using the built-in
webpack code-splitting feature however, we're currently not
able to use it easily due to django-webpack-loader plugin
not supporting this feature for Webpack 4.

See https://github.com/owais/django-webpack-loader/issues/157
and https://github.com/owais/django-webpack-loader/issues/165

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
