### PR TITLE
search-pills: Fix visual bugs due to CSS refactoring of input pills.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1865,12 +1865,14 @@ nav a .no-style {
         width: calc(100% - 66px);
         float: none;
         overflow: hidden;
-        height: 40px;
+        height: 100%;
     }
 
     .input-append {
+        height: 100%;
         align-items: center;
         display: flex;
+        flex-wrap: nowrap;
         position: relative;
         width: calc(100% - 28px);
     }
@@ -1943,12 +1945,8 @@ nav a .no-style {
 
     @media (min-width: 500px) {
         .pill {
-            padding: 2px 18px 2px 3px !important;
+            padding: 2px 0px 2px 0px !important;
             font-size: 14px;
-
-            .exit {
-                top: 2px !important; /* pill's top padding + border */
-            }
         }
     }
     @media (max-width: 500px) {


### PR DESCRIPTION
Changed search pill padding, `.navbar-search` flex-wrap to match with
the CSS refactoring in 66df4e3.
The `height: 100%` changes to `.navbar-search` and `.input-append`
make up for the issue in which the pills overflowed in the mobile
view due to `.navbar-search` height being declared 40px explicitly
while the actual height in mobile view was shorter.

For mobile view:

Before:

![selection_195](https://user-images.githubusercontent.com/13910561/43295651-ec1501be-9163-11e8-8044-656d41e93b03.png)

After:

![selection_196](https://user-images.githubusercontent.com/13910561/43295656-f3684a7a-9163-11e8-993c-14da8e903b8c.png)


