### PR TITLE
yarn: Remove duplicate clipboard dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "clipboard": "2.0.1",
     "css-hot-loader": "1.3.9",
     "css-loader": "0.28.11",
-    "clipboard": "2.0.0",
     "emoji-datasource-apple": "4.0.4",
     "emoji-datasource-emojione": "4.0.4",
     "emoji-datasource-google": "4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,9 +1974,9 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
-clipboard@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.0.tgz#4661dc972fb72a4c4770b8db78aa9b1caef52b50"
+clipboard@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.1.tgz#a12481e1c13d8a50f5f036b0560fe5d16d74e46a"
   dependencies:
     good-listener "^1.2.2"
     select "^1.1.2"


### PR DESCRIPTION
The clipboard dependency was listed twice in package.json - once with version 2.0.1 and once with version 2.0.0.  The duplicate entry is removed, the higher version is specified, and the lockfile updated.