### PR TITLE
Fix typo: premise -> premises

### DIFF
--- a/templates/zerver/for/companies.md
+++ b/templates/zerver/for/companies.md
@@ -20,10 +20,10 @@ If you haven't read [why Zulip](/why-zulip), read that first. We've also
 collected a list of features we think will be of particular interest for
 companies using Zulip.
 
-### On-premise and in the cloud
+### On-premises and in the cloud
 
 High quality export and import tools make it easy to start with Zulip in the
-cloud, knowing that you can move to a on-premise deployment (or back) if
+cloud, knowing that you can move to a on-premises deployment (or back) if
 your budget or security needs change.
 
 ### No vendor lock-in

--- a/templates/zerver/help/configure-authentication-methods.md
+++ b/templates/zerver/help/configure-authentication-methods.md
@@ -3,8 +3,8 @@
 {!admin-only.md!}
 
 You can configure your organization settings to allow users to authenticate
-themselves using passwords, Google/GitHub OAuth, LDAP (currently on premise
-only), and/or various other SSO methods (also currently on premise only).
+themselves using passwords, Google/GitHub OAuth, LDAP (currently on premises
+only), and/or various other SSO methods (also currently on premises only).
 
 !!! tip ""
     If you are unsure about what these mean, don't worry! Zulip

--- a/templates/zerver/help/gdpr-compliance.md
+++ b/templates/zerver/help/gdpr-compliance.md
@@ -50,8 +50,8 @@ Kandra Labs also acts as a data processor to deliver the
 [Mobile Push Notification Service][mobile-push], which uses the same
 hosting infrastructure and terms of service as Zulip Cloud.
 
-The [on-premise section](#gdpr-compliance-on-premise) of this page
-discusses how the Zulip on-premise software works in relation to GDPR
+The [on-premises section](#gdpr-compliance-on-premises) of this page
+discusses how the Zulip on-premises software works in relation to GDPR
 compliance.
 
 [mobile-push](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html)
@@ -118,14 +118,14 @@ GDPR:
 Contact [support@zulipchat.com](mailto:support@zulipchat.com) for
 any assistance related to this topic.
 
-## GDPR compliance on-premise
+## GDPR compliance on-premises
 
-Compliance is often simpler when running software on-premise, since
+Compliance is often simpler when running software on-premises, since
 you can have complete control over how your organization uses the data
 you collect.
 
 In addition to the features described above that are available in
-Zulip Cloud (which are also available on-premise), the following tools
+Zulip Cloud (which are also available on-premises), the following tools
 may be useful:
 
 * The Zulip server comes with a command-line tool, `manage.py

--- a/templates/zerver/team.html
+++ b/templates/zerver/team.html
@@ -99,7 +99,7 @@
                 </div>
                 <h3>Kandra Labs</h3>
                 <p>
-                    Kandra Labs provides commercial Zulip hosting and on-premise support
+                    Kandra Labs provides commercial Zulip hosting and on-premises support
                     at <a href="https://zulipchat.com/plans">https://zulipchat.com</a>,
                     and employs the core developers of the project. It was
                     started in June 2016 to help sustain the growth of the Zulip


### PR DESCRIPTION
"premise" isn't the word used in the context of location,
it is always "premises". A commonly made mistake,
this pull-request fixes the typo.

Ref: https://brians.wsu.edu/2016/05/30/premise-premises/