### PR TITLE
Fix scrolling issues in left sidebar/stream settings (from #10010)

### DIFF
--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -69,7 +69,7 @@ run_test('scroll_element_into_container', () => {
     }());
 
     const elem1 = {
-        height: () => 25,
+        innerHeight: () => 25,
         position: () => {
             return {
                 top: 0,
@@ -80,7 +80,7 @@ run_test('scroll_element_into_container', () => {
     assert.equal(container.scrollTop(), 3);
 
     const elem2 = {
-        height: () => 15,
+        innerHeight: () => 15,
         position: () => {
             return {
                 top: 250,

--- a/static/js/scroll_util.js
+++ b/static/js/scroll_util.js
@@ -35,7 +35,7 @@ exports.scroll_element_into_container = function (elem, container) {
     // the element visible.
 
     var elem_top = elem.position().top;
-    var elem_bottom = elem_top + elem.height();
+    var elem_bottom = elem_top + elem.innerHeight();
 
     var opts = {
         elem_top: elem_top,

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -181,11 +181,11 @@ function zoom_in(options) {
 function zoom_out(options) {
     popovers.hide_all();
     topic_list.zoom_out();
+    exports.show_all_streams();
 
     if (options.stream_li) {
         exports.scroll_stream_into_view(options.stream_li);
     }
-    exports.show_all_streams();
 }
 
 exports.show_all_streams = function () {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -573,29 +573,11 @@ exports.change_state = (function () {
             // if the first argument is a valid number.
             } else if (/\d+/.test(hash.arguments[0])) {
                 var stream_row = row_for_stream_id(hash.arguments[0]);
-                var streams_list = $(".streams-list")[0];
 
                 get_active_data().row.removeClass("active");
                 stream_row.addClass("active");
 
-                if ($(".stream-row:not(.notdisplayed):first")[0] === stream_row[0]) {
-                    streams_list.scrollTop = 0;
-                }
-
-                if ($(".stream-row:not(.notdisplayed):last")[0] === stream_row[0]) {
-                    streams_list.scrollTop = streams_list.scrollHeight - $(".streams-list").height();
-                }
-
-                if (stream_row.position().top < 70) {
-                    streams_list.scrollTop -= streams_list.clientHeight / 2;
-                }
-
-                var dist_from_top = stream_row.position().top;
-                var total_dist = dist_from_top + stream_row[0].clientHeight;
-                var dist_from_bottom = streams_list.clientHeight - total_dist;
-                if (dist_from_bottom < -4) {
-                    streams_list.scrollTop += streams_list.clientHeight / 2;
-                }
+                scroll_util.scroll_element_into_container(stream_row, stream_row.parent());
 
                 setTimeout(function () {
                     if (hash.arguments[0] === get_active_data().id) {

--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -277,20 +277,6 @@
     pointer-events: all;
 }
 
-.overlay .overlay-content {
-    -webkit-transform: scale(0.5);
-    transform: scale(0.5);
-
-    z-index: 102;
-
-    transition: transform 0.3s ease;
-}
-
-.overlay.show .overlay-content {
-    -webkit-transform: scale(1);
-    transform: scale(1);
-}
-
 .input-append {
     font-size: 90%;
     letter-spacing: -.3em;

--- a/static/styles/drafts.scss
+++ b/static/styles/drafts.scss
@@ -131,22 +131,8 @@
     opacity: 1;
 }
 
-@media (max-width: 1130px) {
-    .drafts-container {
-        max-width: 60%;
-    }
-}
-
 @media (max-width: 500px) {
     .draft-row .draft-info-box .draft_controls {
         right: 0px;
-    }
-}
-
-@media (max-width: 700px) {
-    #draft_overlay .drafts-container {
-        height: 95%;
-        max-width: none;
-        width: 90%;
     }
 }

--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -1,10 +1,7 @@
-.informational-overlays .overlay-content {
+.informational-overlays .modal-bg {
     /* because zoom breaks at 525px perhaps due to rounding errors, so add a
        trivial amount of width so it doesn't break. */
-    width: 550px;
-    margin: 0 auto;
-    position: relative;
-    top: calc((30vh - 50px) / 2);
+    max-width: 550px;
     border-radius: 4px;
     overflow: hidden;
 
@@ -87,10 +84,6 @@
 }
 
 @media only screen and (max-width: 768px) {
-    .informational-overlays .overlay-content {
-        width: calc(100% - 20px);
-    }
-
     .informational-overlays .tab-switcher.large .ind-tab {
         width: 100%;
     }

--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -179,6 +179,11 @@
     .navbar-search {
         margin-right: 81px;
     }
+
+    .overlay .modal-bg {
+        height: 95%;
+        width: 90%;
+    }
 }
 
 @media (max-width: 767px) {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1,6 +1,12 @@
-#settings {
-    margin-top: 55px;
-    margin-left: 15px;
+#settings_page .modal-bg {
+    position: relative;
+    height: 95%;
+    border-radius: 4px;
+    padding: 0px;
+    width: 85%;
+    overflow: hidden;
+    max-width: 1200px;
+    max-height: 1000px;
 }
 
 label {
@@ -1147,7 +1153,7 @@ input[type=checkbox].inline-block {
 }
 
 /* -- new settings overlay -- */
-#settings_page {
+#settings_page .modal-page {
     height: 95vh;
     width: 97vw;
     max-width: 1024px;
@@ -1182,10 +1188,6 @@ input[type=checkbox].inline-block {
 }
 
 #settings_page .content-wrapper {
-    position: absolute;
-    left: 251px;
-    /* the width of the settings sidbar this is right of is 250px + 1px border. */
-    width: calc(100% - 250px - 1px);
     height: 100%;
     overflow: hidden;
 }
@@ -1342,9 +1344,6 @@ input[type=checkbox].inline-block {
 }
 
 #settings_page .sidebar .header {
-    height: auto;
-    position: relative;
-    width: calc(100% - 20px);
     padding: 10px;
     text-align: center;
     text-transform: uppercase;

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -192,8 +192,6 @@ form#add_new_subscription {
 }
 
 .create_stream_button {
-    margin: 0px 0px 0px 5px;
-
     border: none;
     outline: none;
     background-color: transparent;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2443,7 +2443,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 #invite-user .overlay-content {
     position: relative;
-    width: 500px;
+    max-width: 500px;
     border-radius: 4px;
 }
 

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -138,14 +138,16 @@
         </div><!--/right sidebar-->
     </div><!--/row-->
     <div class="informational-overlays overlay new-style" data-overlay="informationalOverlays" aria-hidden="true">
-        <div class="overlay-content modal-bg">
-            <div class="overlay-tabs">
-                <button class="button no-style exit">&times;</button>
-            </div>
-            <div class="overlay-body">
-                {% include "zerver/app/keyboard_shortcuts.html" %}
-                {% include "zerver/app/search_operators.html" %}
-                {% include "zerver/app/markdown_help.html" %}
+        <div class="flex overlay-content">
+            <div class="modal-bg">
+                <div class="overlay-tabs">
+                    <button class="button no-style exit">&times;</button>
+                </div>
+                <div class="overlay-body">
+                    {% include "zerver/app/keyboard_shortcuts.html" %}
+                    {% include "zerver/app/search_operators.html" %}
+                    {% include "zerver/app/markdown_help.html" %}
+                </div>
             </div>
         </div>
     </div>

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -1,124 +1,126 @@
-<div id="settings_page" class="new-style overlay-content modal-bg">
-    <div class="settings-header mobile">
-        <i class="fa fa-chevron-left" aria-hidden="true"></i>
-        <h1>{{ _('Settings') }}<span class="section"></span></h1>
-        <div class="exit">
-            <span class="exit-sign">&times;</span>
-        </div>
-        <div class="clear-float"></div>
-    </div>
-    <div class="sidebar left">
-        <div class="sidebar-list dark-grey small-text">
-            <div class="center tab-container"></div>
-            <ul class="normal-settings-list">
-                <li tabindex="0" data-section="your-account">
-                    <i class="icon fa fa-user" aria-hidden="true"></i>
-                    <div class="text">{{ _('Your account') }}</div>
-                </li>
-                <li tabindex="0" data-section="display-settings">
-                    <i class="icon fa fa-clock-o" aria-hidden="true"></i>
-                    <div class="text">{{ _('Display settings') }}</div>
-                </li>
-                <li tabindex="0" data-section="notifications">
-                    <i class="icon fa fa-exclamation-triangle" aria-hidden="true"></i>
-                    <div class="text">{{ _('Notifications') }}</div>
-                </li>
-                <li tabindex="0" data-section="your-bots">
-                    <i class="icon fa fa-github" aria-hidden="true"></i>
-                    <div class="text">{{ _('Your bots') }}</div>
-                </li>
-                <li tabindex="0" data-section="alert-words">
-                    <i class="icon fa fa-book" aria-hidden="true"></i>
-                    <div class="text">{{ _('Alert words') }}</div>
-                </li>
-                <li tabindex="0" data-section="uploaded-files">
-                    <i class="icon fa fa-paperclip" aria-hidden="true"></i>
-                    <div class="text">{{ _('Uploaded files') }}</div>
-                </li>
-                <li tabindex="0" data-section="muted-topics">
-                    <i class="icon fa fa-eye-slash" aria-hidden="true"></i>
-                    <div class="text">{{ _('Muted topics') }}</div>
-                </li>
-            </ul>
-
-            <ul class="org-settings-list">
-                <li tabindex="0" data-section="organization-profile">
-                    <i class="icon fa fa-lock" aria-hidden="true"></i>
-                    <div class="text">{{ _('Organization profile') }}</div>
-                </li>
-                <li tabindex="0" data-section="organization-settings">
-                    <i class="icon fa fa-flask" aria-hidden="true"></i>
-                    <div class="text">{{ _('Organization settings') }}</div>
-                </li>
-                <li tabindex="0" data-section="organization-permissions">
-                    <i class="icon fa fa-lock" aria-hidden="true"></i>
-                    <div class="text">{{ _('Organization permissions') }}</div>
-                </li>
-                <li tabindex="0" data-section="emoji-settings">
-                    <i class="icon fa fa-smile-o" aria-hidden="true"></i>
-                    <div class="text">{{ _('Custom emoji') }}</div>
-                </li>
-                <li tabindex="0" data-section="user-groups-admin">
-                    <i class="icon fa fa-group" aria-hidden="true"></i>
-                    <div class="text">{{ _('User groups') }}</div>
-                </li>
-                <li tabindex="0" data-section="auth-methods">
-                    <i class="icon fa fa-lock" aria-hidden="true"></i>
-                    <div class="text">{{ _('Authentication methods') }}</div>
-                </li>
-                <li tabindex="0" data-section="user-list-admin">
-                    <i class="icon fa fa-user" aria-hidden="true"></i>
-                    <div class="text">{{ _('Users') }}</div>
-                </li>
-                {% if is_admin %}
-                <li tabindex="0" data-section="deactivated-users-admin">
-                    <i class="icon fa fa-trash-o" aria-hidden="true"></i>
-                    <div class="text">{{ _('Deactivated users') }}</div>
-                </li>
-                {% endif %}
-                <li tabindex="0" data-section="bot-list-admin">
-                    <i class="icon fa fa-github" aria-hidden="true"></i>
-                    <div class="text">{{ _('Bots') }}</div>
-                </li>
-                <li tabindex="0" data-section="default-streams-list">
-                    <i class="icon fa fa-exchange" aria-hidden="true"></i>
-                    <div class="text">{{ _('Default streams') }}</div>
-                </li>
-                <li tabindex="0" data-section="filter-settings">
-                    <i class="icon fa fa-font" aria-hidden="true"></i>
-                    <div class="text">{{ _('Filter settings') }}</div>
-                </li>
-                {% if custom_profile_fields_enabled %}
-                <li tabindex="0" data-section="profile-field-settings">
-                    <i class="icon fa fa-user" aria-hidden="true"></i>
-                    <div class="text">{{ _('Custom profile fields') }}</div>
-                </li>
-                {% endif %}
-                {% if is_admin %}
-                <li tabindex="0" data-section="invites-list-admin">
-                    <i class="icon fa fa-user" aria-hidden="true"></i>
-                    <div class="text">{{ _('Invitations') }}</div>
-                </li>
-                {% endif %}
-            </ul>
-        </div>
-    </div>
-    <div class="content-wrapper right">
-        <div class="settings-header">
+<div id="settings_page" class="new-style overlay-content flex">
+    <div class="modal-bg">
+        <div class="settings-header mobile">
+            <i class="fa fa-chevron-left" aria-hidden="true"></i>
             <h1>{{ _('Settings') }}<span class="section"></span></h1>
             <div class="exit">
                 <span class="exit-sign">&times;</span>
             </div>
+            <div class="clear-float"></div>
         </div>
-        <div id="settings_content">
-            <div class="organization-box organization">
+        <div class="sidebar left">
+            <div class="sidebar-list dark-grey small-text">
+                <div class="center tab-container"></div>
+                <ul class="normal-settings-list">
+                    <li tabindex="0" data-section="your-account">
+                        <i class="icon fa fa-user" aria-hidden="true"></i>
+                        <div class="text">{{ _('Your account') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="display-settings">
+                        <i class="icon fa fa-clock-o" aria-hidden="true"></i>
+                        <div class="text">{{ _('Display settings') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="notifications">
+                        <i class="icon fa fa-exclamation-triangle" aria-hidden="true"></i>
+                        <div class="text">{{ _('Notifications') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="your-bots">
+                        <i class="icon fa fa-github" aria-hidden="true"></i>
+                        <div class="text">{{ _('Your bots') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="alert-words">
+                        <i class="icon fa fa-book" aria-hidden="true"></i>
+                        <div class="text">{{ _('Alert words') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="uploaded-files">
+                        <i class="icon fa fa-paperclip" aria-hidden="true"></i>
+                        <div class="text">{{ _('Uploaded files') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="muted-topics">
+                        <i class="icon fa fa-eye-slash" aria-hidden="true"></i>
+                        <div class="text">{{ _('Muted topics') }}</div>
+                    </li>
+                </ul>
 
-            </div>
-            <div class="settings-box">
-
+                <ul class="org-settings-list">
+                    <li tabindex="0" data-section="organization-profile">
+                        <i class="icon fa fa-lock" aria-hidden="true"></i>
+                        <div class="text">{{ _('Organization profile') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="organization-settings">
+                        <i class="icon fa fa-flask" aria-hidden="true"></i>
+                        <div class="text">{{ _('Organization settings') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="organization-permissions">
+                        <i class="icon fa fa-lock" aria-hidden="true"></i>
+                        <div class="text">{{ _('Organization permissions') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="emoji-settings">
+                        <i class="icon fa fa-smile-o" aria-hidden="true"></i>
+                        <div class="text">{{ _('Custom emoji') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="user-groups-admin">
+                        <i class="icon fa fa-group" aria-hidden="true"></i>
+                        <div class="text">{{ _('User groups') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="auth-methods">
+                        <i class="icon fa fa-lock" aria-hidden="true"></i>
+                        <div class="text">{{ _('Authentication methods') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="user-list-admin">
+                        <i class="icon fa fa-user" aria-hidden="true"></i>
+                        <div class="text">{{ _('Users') }}</div>
+                    </li>
+                    {% if is_admin %}
+                    <li tabindex="0" data-section="deactivated-users-admin">
+                        <i class="icon fa fa-trash-o" aria-hidden="true"></i>
+                        <div class="text">{{ _('Deactivated users') }}</div>
+                    </li>
+                    {% endif %}
+                    <li tabindex="0" data-section="bot-list-admin">
+                        <i class="icon fa fa-github" aria-hidden="true"></i>
+                        <div class="text">{{ _('Bots') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="default-streams-list">
+                        <i class="icon fa fa-exchange" aria-hidden="true"></i>
+                        <div class="text">{{ _('Default streams') }}</div>
+                    </li>
+                    <li tabindex="0" data-section="filter-settings">
+                        <i class="icon fa fa-font" aria-hidden="true"></i>
+                        <div class="text">{{ _('Filter settings') }}</div>
+                    </li>
+                    {% if custom_profile_fields_enabled %}
+                    <li tabindex="0" data-section="profile-field-settings">
+                        <i class="icon fa fa-user" aria-hidden="true"></i>
+                        <div class="text">{{ _('Custom profile fields') }}</div>
+                    </li>
+                    {% endif %}
+                    {% if is_admin %}
+                    <li tabindex="0" data-section="invites-list-admin">
+                        <i class="icon fa fa-user" aria-hidden="true"></i>
+                        <div class="text">{{ _('Invitations') }}</div>
+                    </li>
+                    {% endif %}
+                </ul>
             </div>
         </div>
+        <div class="content-wrapper right">
+            <div class="settings-header">
+                <h1>{{ _('Settings') }}<span class="section"></span></h1>
+                <div class="exit">
+                    <span class="exit-sign">&times;</span>
+                </div>
+            </div>
+            <div id="settings_content">
+                <div class="organization-box organization">
 
-        {% include "zerver/app/settings_sidebar.html" %}
+                </div>
+                <div class="settings-box">
+
+                </div>
+            </div>
+
+            {% include "zerver/app/settings_sidebar.html" %}
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Part of PR #10010 

Currently on zoom out from stream topics, scrollbar didn't scroll back
to opened stream. Because call to scroll-to-stream func isn't called
after all streams view is displayed. So wrong stream element is
passed to func.

Fix this by calling scroll-to-stream func after all-stream-list view
is displayed.

Before:
![stream_scroll_2 1](https://user-images.githubusercontent.com/25907420/43306893-500976e2-919a-11e8-9fa6-b0b52740de93.gif)



After:
![stream_scroll](https://user-images.githubusercontent.com/25907420/43306868-40014086-919a-11e8-995f-8efe8ec20a65.gif)



