### PR TITLE
search pills: Backspace should remove a search pill with typeahead open.

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -117,6 +117,7 @@ exports.initialize = function () {
             return items;
         },
         stopAdvance: page_params.search_pills_enabled,
+        advanceKeyCodes: [8],
     });
 
     searchbox_form.on('compositionend', function () {

--- a/static/third/bootstrap/js/bootstrap.js
+++ b/static/third/bootstrap/js/bootstrap.js
@@ -2046,7 +2046,8 @@
           break
       }
 
-      if (this.options.stopAdvance || (e.keyCode != 9 && e.keyCode != 13)) {
+      if ((this.options.stopAdvance || (e.keyCode != 9 && e.keyCode != 13)) 
+          && $.inArray(e.keyCode, this.options.advanceKeyCodes)) {
           e.stopPropagation()
       }
     }
@@ -2082,7 +2083,8 @@
           this.lookup()
       }
 
-      if (this.options.stopAdvance || (e.keyCode != 9 && e.keyCode != 13)) {
+      if ((this.options.stopAdvance || (e.keyCode != 9 && e.keyCode != 13))
+          && $.inArray(e.keyCode, this.options.advanceKeyCodes)) {
           e.stopPropagation()
       }
 
@@ -2133,6 +2135,7 @@
   , minLength: 1
   , stopAdvance: false
   , dropup: false
+  , advanceKeyCodes: []
   }
 
   $.fn.typeahead.Constructor = Typeahead


### PR DESCRIPTION
Partially fixes #10026.
Typeaheads stopped propogation of keydown and keyup events for any
key except tab and enter. If stopAdvance was true even tab and enter
were not allowed.
advanceKeyCodes option was added to typeahead which allowed to specify
key codes for which propogation of keydown and keyup events should not
stop. advanceKeyCodes does not respect the stopAdvance option.
As the backspace key code is added to advanceKeyCodes in search.js,
the backspace key deletes pill on pressing backspace if input is empty
or only consists of spaces.

I'm not sure why the all the key codes except tab and enter aren't allowed.
Another approach would have been to allow backspace for all typeaheads without adding the `advanceKeyCodes` option, but I figured it would safer to allow it only for the search typeahead.

![peek 2018-07-28 11-13](https://user-images.githubusercontent.com/13910561/43353487-de3b69bc-9257-11e8-816b-a7d20aa4ba4d.gif)
