### PR TITLE
help: Replace dead link to function support wiki in KaTex.

### DIFF
--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -171,7 +171,7 @@ You can display mathematical symbols, expressions and equations using Zulip's
 based on [KaTeX](https://github.com/Khan/KaTeX).
 
 !!! tip ""
-    Visit the [KaTeX Wiki](https://github.com/Khan/KaTeX/wiki/Function-Support-in-KaTeX)
+    Visit the [KaTeX Wiki](https://khan.github.io/KaTeX/docs/supported.html)
     to view a complete of compatible commands.
 
 Surround elements in valid TeX syntax with `$$two dollar signs$$` to display it


### PR DESCRIPTION
Fixes #10091.
`https://github.com/Khan/KaTeX/wiki/Function-Support-in-KaTeX` has
been moved from the wiki to the docs at
https://khan.github.io/KaTeX/docs/supported.html in
https://github.com/Khan/KaTeX/pull/1484.