### PR TITLE
refactor: Extract data code from sub.js (for stream settings)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -102,6 +102,7 @@
         "Filter": false,
         "flatpickr": false,
         "pointer": false,
+        "search_util": false,
         "util": false,
         "rtl": false,
         "MessageListData": false,

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -733,3 +733,10 @@ run_test('invite_streams', () => {
     expected_list.push('Inviter');
     assert.deepEqual(stream_data.invite_streams(), expected_list);
 });
+
+run_test('edge_cases', () => {
+    var bad_stream_ids = [555555, 99999];
+
+    // just make sure we don't explode
+    stream_data.sort_for_stream_settings(bad_stream_ids);
+});

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -85,13 +85,7 @@ run_test('filter_table', () => {
     var sub_table = $('#subscriptions_table .streams-list');
     var sub_table_append = [];
     sub_table.append = function (rows) {
-        if (typeof rows === "string") {
-            sub_table_append.push(rows);
-        } else {
-            _.each(rows, function (row) {
-                sub_table_append.push(row);
-            });
-        }
+        sub_table_append.push(rows);
     };
 
     var ui_called = false;

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -1,7 +1,7 @@
 global.stub_out_jquery();
 
 set_global('ui', {});
-set_global('stream_data', {});
+zrequire('stream_data');
 global.patch_builtin('window', {
     location: {
         hash: "#streams/1/announce",
@@ -55,6 +55,10 @@ run_test('filter_table', () => {
         description: 'programming lang',
     };
 
+    _.each(sub_row_data, function (sub) {
+        stream_data.add_sub(sub.name, sub);
+    });
+
     var sub_stubs = [];
     _.each(sub_row_data, function (data) {
         var sub_row = ".stream-row-" + data.elem;
@@ -74,10 +78,6 @@ run_test('filter_table', () => {
             placement: 'left',
             animation: false,
         });
-    };
-
-    stream_data.get_sub_by_id = function (id) {
-        return sub_row_data[id];
     };
 
     $.stub_selector("#subscriptions_table .stream-row", sub_stubs);

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -1,6 +1,8 @@
 global.stub_out_jquery();
 
+set_global('templates', {});
 set_global('ui', {});
+zrequire('util');
 zrequire('stream_data');
 zrequire('search_util');
 
@@ -13,6 +15,8 @@ global.patch_builtin('window', {
 zrequire('subs');
 
 set_global('$', global.make_zjquery());
+
+stream_data.update_calculated_fields = () => {};
 
 run_test('filter_table', () => {
     var stream_list = $(".streams-list");
@@ -61,8 +65,17 @@ run_test('filter_table', () => {
         stream_data.add_sub(sub.name, sub);
     });
 
+    var populated_subs;
+
+    templates.render = (fn, data) => {
+        assert.equal(fn, 'subscriptions');
+        populated_subs = data.subscriptions;
+    }
+
+    subs.populate_stream_settings_left_panel();
+
     var sub_stubs = [];
-    _.each(sub_row_data, function (data) {
+    _.each(populated_subs, function (data) {
         var sub_row = ".stream-row-" + data.elem;
         sub_stubs.push(sub_row);
 

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -2,6 +2,8 @@ global.stub_out_jquery();
 
 set_global('ui', {});
 zrequire('stream_data');
+zrequire('search_util');
+
 global.patch_builtin('window', {
     location: {
         hash: "#streams/1/announce",

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -33,6 +33,7 @@ import "js/feature_flags.js";
 import "js/loading.js";
 import 'js/schema.js';
 import "js/util.js";
+import "js/search_util.js";
 import "js/keydown_util.js";
 import "js/lightbox_canvas.js";
 import "js/rtl.js";

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -411,7 +411,7 @@ exports.compose_content_begins_typeahead = function (query) {
 
         this.completing = 'stream';
         this.token = current_token;
-        return stream_data.get_streams_for_settings_page();
+        return stream_data.get_unsorted_subs();
     }
     return false;
 };

--- a/static/js/search_util.js
+++ b/static/js/search_util.js
@@ -1,0 +1,37 @@
+var search_util = (function () {
+
+var exports = {};
+
+exports.get_search_terms = function (input) {
+    var search_terms = input.toLowerCase().split(",").map(function (s) {
+        return s.trim();
+    });
+    return search_terms;
+};
+
+exports.vanilla_match = function (opts) {
+    /*
+        This is a pretty vanilla search criteria
+        where we see if any of our search terms
+        is in our value. When in doubt we should use
+        this for all Zulip filters, but we may
+        have more complicated use cases in some
+        places.
+
+        This is case insensitive.
+    */
+    var val = opts.val.toLowerCase();
+    return _.any(opts.search_terms, function (term) {
+        if (val.indexOf(term) !== -1) {
+            return true;
+        }
+    });
+};
+
+return exports;
+
+}());
+if (typeof module !== 'undefined') {
+    module.exports = search_util;
+}
+window.search_util = search_util;

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -151,6 +151,20 @@ exports.get_unsorted_subs = function () {
     return stream_info.values();
 };
 
+exports.get_updated_unsorted_subs = function () {
+    // This function is expensive in terms of calculating
+    // some values (particularly stream counts) but avoids
+    // prematurely sorting subs.
+    var all_subs = stream_info.values();
+
+    // Add in admin options and stream counts.
+    _.each(all_subs, function (sub) {
+        exports.update_calculated_fields(sub);
+    });
+
+    return all_subs;
+};
+
 exports.subscribed_subs = function () {
     return _.where(stream_info.values(), {subscribed: true});
 };
@@ -478,6 +492,11 @@ exports.receives_audible_notifications = function (stream_name) {
 };
 
 exports.get_streams_for_settings_page = function () {
+    // TODO: This function is only used for copy-from-stream, so
+    //       the current name is slightly misleading now, plus
+    //       it's not entirely clear we need unsubscribed streams
+    //       for that.  Also we may be revisiting that UI.
+
     // Build up our list of subscribed streams from the data we already have.
     var subscribed_rows = exports.subscribed_subs();
     var unsubscribed_rows = exports.unsubscribed_subs();

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -494,6 +494,27 @@ exports.get_streams_for_settings_page = function () {
     return all_subs;
 };
 
+exports.sort_for_stream_settings = function (stream_ids) {
+    // TODO: We may want to simply use util.strcmp here,
+    //       which uses Intl.Collator() when possible.
+
+    function name(stream_id) {
+        var sub = stream_data.get_sub_by_id(stream_id);
+        if (!sub) {
+            return '';
+        }
+        return sub.name.toLocaleLowerCase();
+    }
+
+    function by_stream_name(id_a, id_b) {
+        var stream_a_name = name(id_a);
+        var stream_b_name = name(id_b);
+        return String.prototype.localeCompare.call(stream_a_name, stream_b_name);
+    }
+
+    stream_ids.sort(by_stream_name);
+};
+
 exports.get_streams_for_admin = function () {
     // Sort and combine all our streams.
     function by_name(a,b) {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -147,6 +147,10 @@ exports.get_non_default_stream_names = function () {
     return names;
 };
 
+exports.get_unsorted_subs = function () {
+    return stream_info.values();
+};
+
 exports.subscribed_subs = function () {
     return _.where(stream_info.values(), {subscribed: true});
 };

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -318,19 +318,14 @@ function remove_temporarily_miscategorized_streams() {
 exports.remove_miscategorized_streams = remove_temporarily_miscategorized_streams;
 
 function stream_matches_query(query, sub, attr) {
-    var search_terms = query.input.toLowerCase().split(",").map(function (s) {
-        return s.trim();
+    var search_terms = search_util.get_search_terms(query.input);
+    var val = sub[attr];
+
+    var flag = search_util.vanilla_match({
+        val: val,
+        search_terms: search_terms,
     });
 
-    var flag = true;
-    flag = flag && (function () {
-        var sub_attr = sub[attr].toLowerCase();
-        return _.any(search_terms, function (o) {
-            if (sub_attr.indexOf(o) !== -1) {
-                return true;
-            }
-        });
-    }());
     flag = flag && (sub.subscribed || !query.subscribed_only ||
                     sub.data_temp_view === "true");
     return flag;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -318,17 +318,26 @@ function remove_temporarily_miscategorized_streams() {
 exports.remove_miscategorized_streams = remove_temporarily_miscategorized_streams;
 
 function stream_matches_query(query, sub, attr) {
+
+    if (query.subscribed_only) {
+        // reject non-subscribed streams
+        if (!sub.subscribed) {
+            // data_temp_view is a hack to prevent us
+            // from removing list items immediately after
+            // unsubscribing them
+            if (sub.data_temp_view !== 'true') {
+                return false;
+            }
+        }
+    }
+
     var search_terms = search_util.get_search_terms(query.input);
     var val = sub[attr];
 
-    var flag = search_util.vanilla_match({
+    return search_util.vanilla_match({
         val: val,
         search_terms: search_terms,
     });
-
-    flag = flag && (sub.subscribed || !query.subscribed_only ||
-                    sub.data_temp_view === "true");
-    return flag;
 }
 
 exports.populate_stream_settings_left_panel = function () {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -357,7 +357,7 @@ exports.filter_table = function (query) {
 
     var stream_name_match_stream_ids = [];
     var stream_description_match_stream_ids = [];
-    var others = [];
+    var other_stream_ids = [];
     var stream_id_to_stream_name = {};
     var widgets = {};
     var streams_list_scrolltop = $(".streams-list").scrollTop();
@@ -374,22 +374,17 @@ exports.filter_table = function (query) {
 
         if (stream_matches_query(query, sub, 'name')) {
             $(row).removeClass("notdisplayed");
-
-            stream_id_to_stream_name[sub.stream_id] = sub.name;
             stream_name_match_stream_ids.push(sub.stream_id);
-
-            widgets[sub.stream_id] = $(row).detach();
         } else if (stream_matches_query(query, sub, 'description')) {
             $(row).removeClass("notdisplayed");
-
-            stream_id_to_stream_name[sub.stream_id] = sub.name;
             stream_description_match_stream_ids.push(sub.stream_id);
-
-            widgets[sub.stream_id] = $(row).detach();
         } else {
             $(row).addClass("notdisplayed");
-            others.push($(row).detach());
+            other_stream_ids.push(sub.stream_id);
         }
+
+        stream_id_to_stream_name[sub.stream_id] = sub.name;
+        widgets[sub.stream_id] = $(row).detach();
 
         $(row).find('.sub-info-box [class$="-bar"] [class$="-count"]').tooltip({
             placement: 'left', animation: false,
@@ -401,15 +396,15 @@ exports.filter_table = function (query) {
     stream_name_match_stream_ids.sort(sort_by_stream_name);
     stream_description_match_stream_ids.sort(sort_by_stream_name);
 
-    _.each(stream_name_match_stream_ids, function (stream_id) {
+    var all_stream_ids = [].concat(
+        stream_name_match_stream_ids,
+        stream_description_match_stream_ids,
+        other_stream_ids
+    );
+
+    _.each(all_stream_ids, function (stream_id) {
         $('#subscriptions_table .streams-list').append(widgets[stream_id]);
     });
-
-    _.each(stream_description_match_stream_ids, function (stream_id) {
-        $('#subscriptions_table .streams-list').append(widgets[stream_id]);
-    });
-
-    $('#subscriptions_table .streams-list').append(others);
 
     if ($(".stream-row.active").hasClass("notdisplayed")) {
         $(".right .settings").hide();

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -358,15 +358,8 @@ exports.filter_table = function (query) {
     var stream_name_match_stream_ids = [];
     var stream_description_match_stream_ids = [];
     var other_stream_ids = [];
-    var stream_id_to_stream_name = {};
     var widgets = {};
     var streams_list_scrolltop = $(".streams-list").scrollTop();
-
-    function sort_by_stream_name(a, b) {
-        var stream_a_name = stream_id_to_stream_name[a].toLocaleLowerCase();
-        var stream_b_name = stream_id_to_stream_name[b].toLocaleLowerCase();
-        return String.prototype.localeCompare.call(stream_a_name, stream_b_name);
-    }
 
     _.each($("#subscriptions_table .stream-row"), function (row) {
         var sub = stream_data.get_sub_by_id($(row).attr("data-stream-id"));
@@ -383,7 +376,6 @@ exports.filter_table = function (query) {
             other_stream_ids.push(sub.stream_id);
         }
 
-        stream_id_to_stream_name[sub.stream_id] = sub.name;
         widgets[sub.stream_id] = $(row).detach();
 
         $(row).find('.sub-info-box [class$="-bar"] [class$="-count"]').tooltip({
@@ -393,8 +385,8 @@ exports.filter_table = function (query) {
 
     ui.update_scrollbar($("#subscription_overlay .streams-list"));
 
-    stream_name_match_stream_ids.sort(sort_by_stream_name);
-    stream_description_match_stream_ids.sort(sort_by_stream_name);
+    stream_data.sort_for_stream_settings(stream_name_match_stream_ids);
+    stream_data.sort_for_stream_settings(stream_description_match_stream_ids);
 
     var all_stream_ids = [].concat(
         stream_name_match_stream_ids,

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -382,7 +382,7 @@ function get_stream_id_buckets(stream_ids, query) {
 }
 
 exports.populate_stream_settings_left_panel = function () {
-    var sub_rows = stream_data.get_streams_for_settings_page();
+    var sub_rows = stream_data.get_updated_unsorted_subs();
     var template_data = {
         subscriptions: sub_rows,
     };

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -60,6 +60,7 @@ enforce_fully_covered = {
     'static/js/scroll_util.js',
     'static/js/search.js',
     'static/js/search_suggestion.js',
+    'static/js/search_util.js',
     # Removed because we're migrating code from uncovered other settings pages to here.
     # 'static/js/settings_ui.js',
     'static/js/settings_muting.js',


### PR DESCRIPTION
There are a few goals here:

* Remove some noise from subs.js for possible big changes that are upcoming.
* Move data-oriented code to modules where we can enforce 100% coverage.
* Make progress toward having stream-related code use similar sorting functions.
* Extract search_util code for more consistency in our search filters.

Hopefully we can merge this fairly soon, before some more complicated search settings endeavors.