### PR TITLE
Styling for the logged-in top navbar.

### DIFF
--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -46,7 +46,7 @@
     }
 
     #top_navbar.rightside-userlist .navbar-search {
-        margin-right: 100px;
+        margin-right: 85px;
     }
 
     #top_navbar.rightside-userlist #navbar-buttons {
@@ -172,10 +172,6 @@
         margin-left: 42px;
     }
 
-    #top_navbar.rightside-userlist .navbar-search {
-        margin-right: 127px;
-    }
-
     .navbar-search {
         margin-right: 81px;
     }
@@ -239,10 +235,6 @@
     #navbar-buttons ul.nav .dropdown-toggle,
     #navbar-buttons ul.nav li.active .dropdown-toggle {
         top: -5px;
-    }
-
-    #top_navbar.rightside-userlist .navbar-search {
-        margin-right: 115px;
     }
 
     #searchbox,

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1563,103 +1563,139 @@ blockquote p {
     float: left;
     letter-spacing: normal;
     height: 40px;
-}
-
-#tab_list {
-    list-style: none;
-    margin: 0px 0px 0px 0px;
-    height: 40px;
-    line-height: 40px;
-    font-size: 16px;
-    border: none;
-    white-space: nowrap;
-}
-
-#tab_list li {
-    white-space: nowrap;
-    list-style-type: none;
-    display: inline-block;
-    position: relative;
-    font-weight: 300;
-    background-color: hsl(0, 0%, 97%);
-    margin: 0px;
-    padding: 0px;
-    text-overflow: ellipsis;
-    height: 40px;
-    padding: 0 5px;
-}
-
-#tab_list li.inactive {
-    background-color: hsl(0, 0%, 88%);
-    border-width: 0px;
-    margin-right: -4px;
-    font-size: 14px;
-}
-
-#tab_list li.private_message a {
-    color: hsl(0, 0%, 100%);
-}
-
-#tab_list li.inactive::before {
-    left: 100%;
-    top: 50%;
-    content: " ";
-    height: 0px;
-    width: 0px;
-    position: absolute;
-    pointer-events: none;
-    z-index: 1;
-    -moz-transform: scale(.9999);
-}
-
-#tab_list a {
-    text-decoration: none;
-    color: inherit;
-    border-color: inherit;
     width: 100%;
-    display: inline-block;
-    padding: 0px 5px;
-    max-width: 150px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
 
-#tab_list li.active {
-    background-color: hsl(0, 0%, 88%);
-    max-width: 150px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
+    #tab_list {
+        list-style: none;
+        margin: 0;
+        height: 40px;
+        line-height: 40px;
+        font-size: 16px;
+        border: none;
+        white-space: nowrap;
+        width: 100%;
 
-#tab_list li.active.root {
-    padding: 0px 10px;
-}
+        li {
+            white-space: nowrap;
+            list-style-type: none;
+            display: inline-block;
+            vertical-align: top;
+            position: relative;
+            font-weight: 600;
+            font-size: 16px;
+            line-height: 16px;
+            background-color: hsl(0, 0%, 97%);
+            margin: 0 -4px 0 0;
+            text-overflow: ellipsis;
+            padding: 12px 5px;
+            background: 0 !important; // Hack to override bg color that's set inline via js
+            @media (max-width: 500px) {
+                padding: 8px 5px;
+            }
+            .hash {
+                font-size: 1.2rem;
+            }
+            .hash,
+            i {
+                margin-right: 3px;
+            }
+        }
 
-#tab_list li.private_message {
-    border-top-color: hsla(0, 0%, 0%, 0.0);
-    border-right-color: hsla(0, 0%, 0%, 0.0);
-    border-bottom-color: hsla(0, 0%, 0%, 0.0);
-    background-color: hsl(0, 0%, 27%);
-    border-left-color: hsl(0, 0%, 27%);
-    color: hsl(0, 0%, 100%);
-    border-width: 0px;
-}
+        li.private_message a {
+            color: hsl(0, 0%, 100%);
+        }
 
-#tab_list .root {
-    border-color: hsl(0, 0%, 88%);
-    background-color: hsl(0, 0%, 88%);
-    margin: 0px;
-}
+        a {
+            text-decoration: none;
+            color: inherit;
+            border-color: inherit;
+            width: 100%;
+            display: inline-block;
+            padding: 0px 5px;
+            max-width: 150px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
 
-#tab_list li.root a {
-    color: hsl(0, 0%, 52%);
-    padding-right: 2px;
-}
+        li.active {
+            background-color: hsl(0, 0%, 88%);
+            max-width: 150px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
 
-#tab_list .root a:hover {
-    color: hsl(0, 0%, 0%);
+        li.private_message {
+            border-top-color: hsla(0, 0%, 0%, 0.0);
+            border-right-color: hsla(0, 0%, 0%, 0.0);
+            border-bottom-color: hsla(0, 0%, 0%, 0.0);
+            background-color: hsl(0, 0%, 27%);
+            border-left-color: hsl(0, 0%, 27%);
+            color: hsl(0, 0%, 100%);
+            border-width: 0px;
+        }
+
+        li.number_of_users,
+        li.stream_description {
+            background: none;
+            font-size: 14px;
+            color: hsl(0, 0%, 40%);
+            font-weight: 400;
+            line-height: 20px;
+            margin-left: 10px;
+        }
+
+        li.number_of_users {
+            &::before {
+                content: "";
+                position: absolute;
+                left: -5px;
+                top: 25%;
+                width: 1px;
+                height: 50%;
+                background: hsl(0, 0%, 88%);
+                @media (max-width: 500px) {
+                    top: 10%;
+                }
+            }
+            &::after {
+                content: "";
+                position: absolute;
+                right: -5px;
+                top: 25%;
+                width: 1px;
+                height: 50%;
+                background: hsl(0, 0%, 88%);
+                @media (max-width: 500px) {
+                    top: 10%;
+                }
+            }
+        }
+
+        li.stream_description {
+            max-width: calc(100% - 170px);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            @media (max-width: 500px) {
+                display: none;
+            }
+        }
+
+        .root {
+            border-color: hsl(0, 0%, 88%);
+            background-color: hsl(0, 0%, 88%);
+            margin: 0px;
+            a {
+                color: hsl(0, 0%, 52%);
+                padding-right: 2px;
+                &:hover {
+                    color: hsl(0, 0%, 0%);
+                }
+            }
+        }
+    }
 }
 
 #tab_bar_underpadding {
@@ -1858,7 +1894,6 @@ nav a .no-style {
     display: flex;
     width: 100%;
     height: 40px;
-    border-left: 1px solid hsl(0, 0%, 88%);
     border-right: 1px solid hsl(0, 0%, 88%);
 
     .navbar-search {
@@ -1923,6 +1958,7 @@ nav a .no-style {
         text-decoration: none;
         padding: 0 10px;
         font-size: 20px;
+        border-left: 1px solid hsl(0, 0%, 88%);
         z-index: 5;
         float: left;
 
@@ -1965,14 +2001,29 @@ nav a .no-style {
     width: 100%;
     height: 40px;
     border-left: 1px solid hsl(0, 0%, 88%);
-    border-right: 1px solid hsl(0, 0%, 88%);
 
     .navbar-search {
+        position: absolute;
+        right: 0;
         margin-top: 0px;
-        width: auto;
-        float: none;
+        width: 40px;
         overflow: hidden;
-        height: 40px;
+        border-right: 1px solid hsl(0, 0%, 87.8%);
+        .search_button {
+            display: none;
+        }
+    }
+
+    .navbar-search.expanded {
+        width: 100%;
+        position: absolute;
+        border-left: 1px solid hsl(0, 0%, 87.8%);
+        .search_button {
+            display: inline;
+        }
+        @media (max-width: 1025px) {
+            width: calc(100% - 85px);
+        }
     }
 
     .input-append {

--- a/static/templates/tab_bar.handlebars
+++ b/static/templates/tab_bar.handlebars
@@ -9,16 +9,18 @@
             {{#if home}}
             <a href="{{hash}}" title="{{t 'All messages' }} (Esc)"><i class="fa fa-home" aria-hidden="true"></i></a>
             {{else}}
-            <a href="{{hash}}">{{title}}</a>
+            <a href="{{hash}}"><span class="hash">#</span> <i class="fa fa-lock"></i> {{title}}</a>
             {{/if}}
         {{else}}
             {{#if home}}
             <i class="fa fa-home" aria-hidden="true"></i>
             {{/if}}
             {{#unless home}}
-            {{title}}
+            <span class="hash">#</span> <i class="fa fa-lock"></i> {{title}}
             {{/unless}}
         {{/if}}
     </li>
     {{/each}}
+    <li class="number_of_users"><i class="fa fa-user-o"></i> 50</li>
+    <li class="stream_description">This is the stream description.</li>
 </ul>


### PR DESCRIPTION
This updates the logged-in top navbar to display the stream/message name, number of users, and description. It also replaces the search bar with a search icon that expands into a full-width search bar. 

This commit contains only the CSS for these changes; they are not yet functional. It also refactors both the app navbar and legacy searchbox CSS to use SCSS nesting.

New navbar:
<img width="922" alt="screen shot 2018-07-29 at 3 02 48 pm" src="https://user-images.githubusercontent.com/2905696/43369796-eefc001e-9341-11e8-87ef-a61ea257a693.png">

Long stream descriptions are truncated (and hidden entirely at smaller sizes):
<img width="693" alt="screen shot 2018-07-29 at 2 55 22 pm" src="https://user-images.githubusercontent.com/2905696/43369798-f8c84922-9341-11e8-9465-c8e0fb6155b5.png">

The searchbox expands when the icon is clicked (it doesn't actually right now; add the `expanded` class to the `navbar-search` div to see this):
<img width="657" alt="screen shot 2018-07-29 at 3 03 13 pm" src="https://user-images.githubusercontent.com/2905696/43369805-173a97c0-9342-11e8-9d97-da9d2b67b1f9.png">

This still needs a few changes in the handlebars template:
- Replace the dummy text for stream description/number of people in a stream with the real values, and hide those for home and private messages
- Just show stream when in a topic (i.e. don't show stream > topic)

I also think this would look better if we removed the stream background color; that's being added inline somewhere and I couldn't figure out how to get rid of it.