### PR TITLE
register: Update UI of realm_creation_fail page.

### DIFF
--- a/templates/zerver/realm_creation_failed.html
+++ b/templates/zerver/realm_creation_failed.html
@@ -19,7 +19,7 @@
             <div class="inner-content">
                 <p>{{ _('This server does not allow members of the public to create new organizations.') }}</p>
                 <p>{% trans %}Zulip is open source, so you can install your own Zulip server by following the instructions on
-                    <a href="https://www.zulip.org/">www.zulip.org</a>{% endtrans %}</p>
+                    <a href="https://zulip.readthedocs.io/en/stable/production/install.html">www.zulip.org</a>{% endtrans %}</p>
             </div>
         </div>
     </div>

--- a/templates/zerver/realm_creation_failed.html
+++ b/templates/zerver/realm_creation_failed.html
@@ -1,11 +1,28 @@
 {% extends "zerver/portico.html" %}
 
+{% block customhead %}
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{{ render_bundle('landing-page') }}
+
+{% endblock %}
+
 {% block portico_content %}
 
-<br/>
-<p class="lead">{{ message }}</p>
+{% include 'zerver/landing_nav.html' %}
 
-<p>{{ _('This server does not allow members of the public to create new organizations.') }}</p>
-<p>{% trans %}Zulip is open source, so you can install your own Zulip server by following the instructions on <a href="https://www.zulip.org/">www.zulip.org</a>{% endtrans %}</p>
+<div class="portico-landing why-page">
+    <div class="hero small-hero">
+        <h1 class="center">{{ message }}</h1>
+    </div>
+    <div class="main">
+        <div class="padded-content">
+            <div class="inner-content">
+                <p>{{ _('This server does not allow members of the public to create new organizations.') }}</p>
+                <p>{% trans %}Zulip is open source, so you can install your own Zulip server by following the instructions on
+                    <a href="https://www.zulip.org/">www.zulip.org</a>{% endtrans %}</p>
+            </div>
+        </div>
+    </div>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
Updated the `realm_creation_fail` page so that the styling matches with other pages like `terms`, `why-zulip` etc.

Before - 

<img src="https://chat.zulip.org/user_uploads/2/e9/ERUASfQOc8lomWtZXu-IISvp/pasted_image.png"/>

<hr>

After -

![image](https://user-images.githubusercontent.com/2263909/43371824-2e2c4b48-93b7-11e8-89b2-f7ac0f62c5c3.png)
