### PR TITLE
subs: Limit editing subscribers for waiting period users.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -901,13 +901,14 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         return {row['id']: row['email'] for row in rows}
 
     def can_create_streams(self) -> bool:
-        diff = (timezone_now() - self.date_joined).days
         if self.is_realm_admin:
             return True
         if self.realm.create_stream_by_admins_only:
             return False
         if self.is_guest:
             return False
+
+        diff = (timezone_now() - self.date_joined).days
         if diff >= self.realm.waiting_period_threshold:
             return True
         return False

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -913,6 +913,17 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
             return True
         return False
 
+    def can_subscribe_other_users(self) -> bool:
+        if self.is_realm_admin:
+            return True
+        if self.is_guest:
+            return False
+
+        diff = (timezone_now() - self.date_joined).days
+        if diff >= self.realm.waiting_period_threshold:
+            return True
+        return False
+
     def can_access_public_streams(self) -> bool:
         return not (self.is_guest or self.realm.is_zephyr_mirror_realm)
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext as _
 from django.conf import settings
 from django.db import transaction
 from django.http import HttpRequest, HttpResponse
+from django.utils.timezone import now as timezone_now
 
 from zerver.lib.exceptions import JsonableError, ErrorCode
 from zerver.lib.request import REQ, has_request_variables
@@ -309,6 +310,8 @@ def add_subscriptions_backend(
     if len(principals) > 0:
         if user_profile.realm.is_zephyr_mirror_realm and not all(stream.invite_only for stream in streams):
             return json_error(_("You can only invite other Zephyr mirroring users to private streams."))
+        if not user_profile.can_subscribe_other_users():
+            return json_error(_("Your account is too new to modify other users' subscriptions."))
         subscribers = set(principal_to_user_profile(user_profile, principal) for principal in principals)
     else:
         subscribers = set([user_profile])


### PR DESCRIPTION
Commit 1:
This is a preparatory refactor for adding
UserProfile.can_subscribe_other_users.
Although there existed a test for limiting users from creating
streams at `test_subs.test_user_settings_for_adding_streams`,
it did not test the logic inside can_add_streams, tests have
been added to solve that issue.

Commit 2:
Does not let you subscribe other users if you are a guest or a
waiting period user.

