### PR TITLE
Python dependency upgrade

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -102,7 +102,7 @@ pika==0.11.0
 psycopg2==2.7.5 --no-binary psycopg2
 
 pyasn1==0.4.4
-pyasn1-modules==0.2.1
+pyasn1-modules==0.2.2
 pycrypto==2.6.1
 
 # Needed for memcached usage

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -46,7 +46,7 @@ chardet==3.0.4
 
 # Pinned version because older versions don't compile on newer Linux.
 # Not actually a direct dependency.
-cryptography==2.2.2
+cryptography==2.3
 
 # Needed for integrations
 defusedxml==0.5.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -3,7 +3,7 @@
 # and requirements/prod.txt.
 # See requirements/README.md for more detail.
 # Django itself
-Django==1.11.13
+Django==1.11.14
 
 # needed for mypy TypedDict
 mypy_extensions==0.3.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -35,7 +35,7 @@ backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 
 # Needed for S3 file uploads
-boto==2.48.0
+boto==2.49.0
 
 certifi==2018.4.16
 

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -182,7 +182,7 @@ py3dns==3.1.0
 social-auth-app-django==2.1.0
 
 # Needed for messages' rendered content parsing in push notifications.
-lxml==4.2.1
+lxml==4.2.3
 
 # Needed for 2-factor authentication
 django-two-factor-auth==1.7.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -186,7 +186,7 @@ lxml==4.2.3
 
 # Needed for 2-factor authentication
 django-two-factor-auth==1.7.0
-twilio==6.14.0
+twilio==6.15.2
 
 # Needed for processing payments (in zilencer)
 stripe==1.82.1

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -153,7 +153,7 @@ django-webpack-loader==0.6.0
 # Needed for iOS push notifications
 apns2==0.4.1
 
-python-twitter==3.4.1
+python-twitter==3.4.2
 
 # To parse po files
 polib==1.1.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -99,7 +99,7 @@ ndg-httpsclient==0.5.1
 pika==0.11.0
 
 # Needed to access our database
-psycopg2==2.7.4 --no-binary psycopg2
+psycopg2==2.7.5 --no-binary psycopg2
 
 pyasn1==0.4.3
 pyasn1-modules==0.2.1

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -101,7 +101,7 @@ pika==0.11.0
 # Needed to access our database
 psycopg2==2.7.5 --no-binary psycopg2
 
-pyasn1==0.4.3
+pyasn1==0.4.4
 pyasn1-modules==0.2.1
 pycrypto==2.6.1
 

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -92,7 +92,7 @@ oauthlib==2.1.0
 
 # Enhanced HTTPS support for httplib and urllib2 using PyOpenSSL
 # Needed by requests to send https request to some sites.
-ndg-httpsclient==0.5.0
+ndg-httpsclient==0.5.1
 
 # Needed to access rabbitmq
 # See #8466 for why we're not using the latest version.

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -23,7 +23,7 @@ ipython==6.5.0
 Pillow==5.1.0
 
 # Needed for building complex DB queries
-SQLAlchemy==1.2.7
+SQLAlchemy==1.2.10
 
 # Needed for password hashing
 argon2-cffi==18.1.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -195,7 +195,7 @@ stripe==1.82.1
 django-sendfile==0.3.11
 
 # For checking whether email of the user is from a disposable email provider.
-disposable-email-domains==0.0.28
+disposable-email-domains==0.0.30
 
 # Needed for parsing YAML with JSON references from the REST API spec files
 yamole==2.1.5

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -115,7 +115,7 @@ django-pylibmc==0.6.1
 python-dateutil==2.6.1
 
 # Needed for timezone work
-pytz==2018.4
+pytz==2018.5
 
 # Needed for redis
 redis==2.10.6

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -68,7 +68,7 @@ python-gcm==0.4
 gitdb==0.6.4
 
 # Needed for Google Apps mobile auth
-google-api-python-client==1.6.7
+google-api-python-client==1.7.4
 
 # Needed for the email mirror
 html2text==2018.1.9

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -17,7 +17,7 @@ MarkupSafe==1.0
 Pygments==2.2.0
 
 # Needed for manage.py
-ipython==6.4.0
+ipython==6.5.0
 
 # Needed for Image Processing
 Pillow==5.1.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -176,7 +176,7 @@ pyoembed==0.1.2
 -e "git+https://github.com/zulip/python-zulip-api.git@0.5.2#egg=zulip_bots==0.5.2+git&subdirectory=zulip_bots"
 
 # Used for Hesiod lookups, etc.
-py3dns==3.1.0
+py3dns==3.2.0
 
 # Install Python Social Auth
 social-auth-app-django==2.1.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -11,7 +11,7 @@ moto==1.3.3
 Twisted==18.4.0
 
 # Needed for documentation links test
-Scrapy==1.5.0
+Scrapy==1.5.1
 
 # Needed to compute test coverage
 coverage==4.5.1

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -20,7 +20,7 @@ coverage==4.5.1
 fakeldap==0.6.1
 
 # For testing mock http requests
-httpretty==0.9.4
+httpretty==0.9.5
 
 # For sorting imports
 isort==4.3.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,7 +72,7 @@ h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 html2text==2018.1.9
 httplib2==0.11.3
-httpretty==0.9.4
+httpretty==0.9.5
 hyper==0.7.0              # via apns2
 hyperframe==3.2.0         # via h2, hyper
 hyperlink==17.3.1         # via twisted

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -118,7 +118,7 @@ ptyprocess==0.5.2         # via pexpect
 py3dns==3.2.0
 pyaml==17.10.0            # via moto
 pyasn1-modules==0.2.1
-pyasn1==0.4.3
+pyasn1==0.4.4
 pycodestyle==2.4.0
 pycparser==2.18           # via cffi
 pycrypto==2.6.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,7 +39,7 @@ commonmark==0.5.4
 constantly==15.1.0        # via twisted
 cookies==2.2.1            # via moto, responses
 coverage==4.5.1
-cryptography==2.2.2
+cryptography==2.3
 cssselect==1.0.1          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -150,7 +150,7 @@ requests[security]==2.18.4  # via aws-xray-sdk, docker, moto, premailer, pyoembe
 responses==0.9.0          # via moto
 rsa==3.4.2
 s3transfer==0.1.11        # via boto3
-scrapy==1.5.0
+scrapy==1.5.1
 service-identity==17.0.0  # via scrapy
 sh==1.11                  # via gitlint
 simplegeneric==0.8.1      # via ipython

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -165,7 +165,7 @@ sourcemap==0.2.1
 sphinx-rtd-theme==0.4.1
 sphinx==1.7.6
 sphinxcontrib-websupport==1.0.1  # via sphinx
-sqlalchemy==1.2.7
+sqlalchemy==1.2.10
 statsd==3.2.1             # via django-statsd-mozilla
 stripe==1.82.1
 tblib==1.3.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,7 +44,7 @@ cssselect==1.0.1          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
-disposable-email-domains==0.0.28
+disposable-email-domains==0.0.30
 django-auth-ldap==1.5.0
 django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.4.1.1       # via django-two-factor-auth

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -115,7 +115,7 @@ premailer==3.2.0
 prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.5
 ptyprocess==0.5.2         # via pexpect
-py3dns==3.1.0
+py3dns==3.2.0
 pyaml==17.10.0            # via moto
 pyasn1-modules==0.2.1
 pyasn1==0.4.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -117,7 +117,7 @@ psycopg2==2.7.5
 ptyprocess==0.5.2         # via pexpect
 py3dns==3.2.0
 pyaml==17.10.0            # via moto
-pyasn1-modules==0.2.1
+pyasn1-modules==0.2.2
 pyasn1==0.4.4
 pycodestyle==2.4.0
 pycparser==2.18           # via cffi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -163,7 +163,7 @@ social-auth-core==1.5.0   # via social-auth-app-django
 sockjs-tornado==1.0.3
 sourcemap==0.2.1
 sphinx-rtd-theme==0.3.1
-sphinx==1.7.4
+sphinx==1.7.6
 sphinxcontrib-websupport==1.0.1  # via sphinx
 sqlalchemy==1.2.7
 statsd==3.2.1             # via django-statsd-mozilla

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -138,7 +138,7 @@ python-gcm==0.4
 python-ldap==3.0.0        # via django-auth-ldap, pyldap
 python-twitter==3.4.2
 python3-openid==3.1.0     # via social-auth-core
-pytz==2018.4
+pytz==2018.5
 pyyaml==3.12              # via pyaml, yamole
 qrcode==4.0.4             # via django-two-factor-auth
 queuelib==1.4.2           # via scrapy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -162,7 +162,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.5.0   # via social-auth-app-django
 sockjs-tornado==1.0.3
 sourcemap==0.2.1
-sphinx-rtd-theme==0.3.1
+sphinx-rtd-theme==0.4.1
 sphinx==1.7.6
 sphinxcontrib-websupport==1.0.1  # via sphinx
 sqlalchemy==1.2.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -89,7 +89,7 @@ jmespath==0.9.3           # via boto3, botocore
 jsondiff==1.1.1           # via moto
 jsonpickle==0.9.5         # via aws-xray-sdk, python-digitalocean
 libthumbor==1.3.2
-lxml==4.2.1
+lxml==4.2.3
 markdown-include==0.5.1
 markdown==2.6.11
 markupsafe==1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -136,7 +136,7 @@ python-dateutil==2.6.1
 python-digitalocean==1.13.2
 python-gcm==0.4
 python-ldap==3.0.0        # via django-auth-ldap, pyldap
-python-twitter==3.4.1
+python-twitter==3.4.2
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.4
 pyyaml==3.12              # via pyaml, yamole

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -113,7 +113,7 @@ pip-tools==2.0.2
 polib==1.1.0
 premailer==3.2.0
 prompt-toolkit==1.0.15    # via ipython
-psycopg2==2.7.4
+psycopg2==2.7.5
 ptyprocess==0.5.2         # via pexpect
 py3dns==3.1.0
 pyaml==17.10.0            # via moto

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,6 +30,7 @@ beautifulsoup4==4.6.0
 boto3==1.7.11             # via moto
 boto==2.49.0
 botocore==1.10.11         # via boto3, moto, s3transfer
+cachetools==2.1.0         # via google-auth
 cchardet==2.1.1
 certifi==2018.4.16
 cffi==1.11.5
@@ -64,7 +65,9 @@ fakeldap==0.6.1
 first==2.0.1              # via pip-tools
 gitdb==0.6.4
 gitlint==0.10.0
-google-api-python-client==1.6.7
+google-api-python-client==1.7.4
+google-auth-httplib2==0.0.3  # via google-api-python-client
+google-auth==1.5.0        # via google-api-python-client, google-auth-httplib2
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 html2text==2018.1.9

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#
 git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 git+https://github.com/zulip/python-zulip-api.git@0.5.2#egg=zulip==0.5.2_git&subdirectory=zulip
 git+https://github.com/zulip/python-zulip-api.git@0.5.2#egg=zulip_bots==0.5.2+git&subdirectory=zulip_bots
-alabaster==0.7.10
+alabaster==0.7.11
 apns2==0.4.1
 argon2-cffi==18.1.0
 arrow==0.10.0             # via gitlint

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -81,7 +81,7 @@ ijson==2.3
 imagesize==1.0.0
 incremental==17.5.0       # via twisted
 ipython-genutils==0.2.0   # via traitlets
-ipython==6.4.0
+ipython==6.5.0
 isort==4.3.4
 jedi==0.11.0              # via ipython
 jinja2==2.10

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.6.0
 boto3==1.7.11             # via moto
-boto==2.48.0
+boto==2.49.0
 botocore==1.10.11         # via boto3, moto, s3transfer
 cchardet==2.1.1
 certifi==2018.4.16

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -97,7 +97,7 @@ mock==2.0.0
 moto==1.3.3
 mypy==0.620
 mypy_extensions==0.3.0
-ndg-httpsclient==0.5.0
+ndg-httpsclient==0.5.1
 oauth2client==4.1.2
 oauthlib==2.1.0
 packaging==16.8           # via sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,7 +55,7 @@ django-sendfile==0.3.11
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.7.0
 django-webpack-loader==0.6.0
-django==1.11.13
+django==1.11.14
 docker-pycreds==0.2.1     # via docker
 docker==2.6.1             # via moto
 docopt==0.6.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -172,7 +172,7 @@ tblib==1.3.2
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 transifex-client==0.12.5
-twilio==6.14.0
+twilio==6.15.2
 twisted==18.4.0
 typed-ast==1.1.0          # via mypy
 typing==3.6.4

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -9,7 +9,7 @@
 
 # Needed to build RTD docs
 sphinx==1.7.6
-sphinx-rtd-theme==0.3.1
+sphinx-rtd-theme==0.4.1
 
 # Needed to build markdown docs
 recommonmark==0.4.0

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -15,7 +15,7 @@ sphinx-rtd-theme==0.3.1
 recommonmark==0.4.0
 
 # Dependencies of Sphinx
-alabaster==0.7.10
+alabaster==0.7.11
 babel==2.5.3
 # Upgrading to the latest version of CommonMark breaks the
 # compatibility with recommonmark.  See

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -8,7 +8,7 @@
 # See requirements/README.md for more detail.
 
 # Needed to build RTD docs
-sphinx==1.7.4
+sphinx==1.7.6
 sphinx-rtd-theme==0.3.1
 
 # Needed to build markdown docs

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -25,7 +25,7 @@ recommonmark==0.4.0
 requests==2.18.4          # via sphinx
 six==1.11.0               # via packaging, sphinx
 snowballstemmer==1.2.1
-sphinx-rtd-theme==0.3.1
+sphinx-rtd-theme==0.4.1
 sphinx==1.7.6
 sphinxcontrib-websupport==1.0.1  # via sphinx
 typing==3.6.4

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -26,7 +26,7 @@ requests==2.18.4          # via sphinx
 six==1.11.0               # via packaging, sphinx
 snowballstemmer==1.2.1
 sphinx-rtd-theme==0.3.1
-sphinx==1.7.4
+sphinx==1.7.6
 sphinxcontrib-websupport==1.0.1  # via sphinx
 typing==3.6.4
 urllib3==1.22             # via requests

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,7 +7,7 @@
 #
 # For details, see requirements/README.md .
 #
-alabaster==0.7.10
+alabaster==0.7.11
 babel==2.5.3
 certifi==2017.11.5        # via requests
 chardet==3.0.4            # via requests

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
 pip==18.0
 setuptools==40.0.0
-wheel==0.30.0
+wheel==0.30.1

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
 pip==18.0
 setuptools==40.0.0
-wheel==0.30.1
+wheel==0.31.1

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
-pip==9.0.3
+pip==18.0
 setuptools==39.2.0
 wheel==0.30.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
 pip==18.0
-setuptools==39.2.0
+setuptools==40.0.0
 wheel==0.30.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -23,6 +23,7 @@ backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.6.0
 boto==2.49.0
+cachetools==2.1.0         # via google-auth
 cchardet==2.1.1
 certifi==2018.4.16
 cffi==1.11.5
@@ -46,7 +47,9 @@ django-webpack-loader==0.6.0
 django==1.11.14
 docopt==0.6.2
 gitdb==0.6.4
-google-api-python-client==1.6.7
+google-api-python-client==1.7.4
+google-auth-httplib2==0.0.3  # via google-api-python-client
+google-auth==1.5.0        # via google-api-python-client, google-auth-httplib2
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 html2text==2018.1.9

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -86,7 +86,7 @@ psycopg2==2.7.5
 ptyprocess==0.5.2         # via pexpect
 py3dns==3.2.0
 pyasn1-modules==0.2.1
-pyasn1==0.4.3
+pyasn1==0.4.4
 pycparser==2.18           # via cffi
 pycrypto==2.6.1
 pygments==2.2.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -84,7 +84,7 @@ premailer==3.2.0
 prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.5
 ptyprocess==0.5.2         # via pexpect
-py3dns==3.1.0
+py3dns==3.2.0
 pyasn1-modules==0.2.1
 pyasn1==0.4.3
 pycparser==2.18           # via cffi

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -69,7 +69,7 @@ markdown==2.6.11
 markupsafe==1.0
 mock==2.0.0
 mypy_extensions==0.3.0
-ndg-httpsclient==0.5.0
+ndg-httpsclient==0.5.1
 oauth2client==4.1.2
 oauthlib==2.1.0
 parso==0.1.0              # via jedi

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -59,7 +59,7 @@ hyperframe==3.2.0         # via h2, hyper
 idna==2.6                 # via cryptography, requests
 ijson==2.3
 ipython-genutils==0.2.0   # via traitlets
-ipython==6.4.0
+ipython==6.5.0
 jedi==0.11.0              # via ipython
 jinja2==2.10
 libthumbor==1.3.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -63,7 +63,7 @@ ipython==6.5.0
 jedi==0.11.0              # via ipython
 jinja2==2.10
 libthumbor==1.3.2
-lxml==4.2.1
+lxml==4.2.3
 markdown-include==0.5.1
 markdown==2.6.11
 markupsafe==1.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -100,7 +100,7 @@ python-gcm==0.4
 python-ldap==3.0.0        # via django-auth-ldap
 python-twitter==3.4.2
 python3-openid==3.1.0     # via social-auth-core
-pytz==2018.4
+pytz==2018.5
 pyyaml==3.12              # via yamole
 qrcode==4.0.4             # via django-two-factor-auth
 redis==2.10.6

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -120,7 +120,7 @@ statsd==3.2.1             # via django-statsd-mozilla
 stripe==1.82.1
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
-twilio==6.14.0
+twilio==6.15.2
 typing==3.6.4
 uritemplate==3.0.0
 urllib3==1.22             # via requests

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -32,7 +32,7 @@ cssselect==1.0.1          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
-disposable-email-domains==0.0.28
+disposable-email-domains==0.0.30
 django-auth-ldap==1.5.0
 django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.4.1.1       # via django-two-factor-auth

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -85,7 +85,7 @@ prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.5
 ptyprocess==0.5.2         # via pexpect
 py3dns==3.2.0
-pyasn1-modules==0.2.1
+pyasn1-modules==0.2.2
 pyasn1==0.4.4
 pycparser==2.18           # via cffi
 pycrypto==2.6.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -98,7 +98,7 @@ pysocks==1.6.7            # via twilio
 python-dateutil==2.6.1
 python-gcm==0.4
 python-ldap==3.0.0        # via django-auth-ldap
-python-twitter==3.4.1
+python-twitter==3.4.2
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.4
 pyyaml==3.12              # via yamole

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -43,7 +43,7 @@ django-sendfile==0.3.11
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.7.0
 django-webpack-loader==0.6.0
-django==1.11.13
+django==1.11.14
 docopt==0.6.2
 gitdb==0.6.4
 google-api-python-client==1.6.7

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -115,7 +115,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.5.0   # via social-auth-app-django
 sockjs-tornado==1.0.3
 sourcemap==0.2.1
-sqlalchemy==1.2.7
+sqlalchemy==1.2.10
 statsd==3.2.1             # via django-statsd-mozilla
 stripe==1.82.1
 tornado==4.5.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -82,7 +82,7 @@ pillow==5.1.0
 polib==1.1.0
 premailer==3.2.0
 prompt-toolkit==1.0.15    # via ipython
-psycopg2==2.7.4
+psycopg2==2.7.5
 ptyprocess==0.5.2         # via pexpect
 py3dns==3.1.0
 pyasn1-modules==0.2.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -27,7 +27,7 @@ cchardet==2.1.1
 certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
-cryptography==2.2.2
+cryptography==2.3
 cssselect==1.0.1          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -22,7 +22,7 @@ backcall==0.1.0           # via ipython
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.6.0
-boto==2.48.0
+boto==2.49.0
 cchardet==2.1.1
 certifi==2018.4.16
 cffi==1.11.5

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '25.3'
+PROVISION_VERSION = '25.4'


### PR DESCRIPTION
I left out the following packages because of major changes and doesn't seem to include any security fixes.

* django-auth-ldap | 1.5.0 | 1.7.0 -> http://django-auth-ldap.readthedocs.io/en/latest/changes.html
* Pillow | 5.1.0 | 5.2.0 -> https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
* python-dateutil | 2.6.1 | 2.7.3 -> https://github.com/dateutil/dateutil/releases
* stripe | 1.82.1 | 2.3.0 -> https://github.com/stripe/stripe-python/releases
* tornado | 4.5.3 | 5.1 -> #8913 http://www.tornadoweb.org/en/stable/releases/v5.0.0.html 
* Twisted | 18.4.0 | 18.7.0 -> https://github.com/twisted/twisted/blob/twisted-18.7.0/NEWS.rst
