### PR TITLE
hotkeys: Use canonical name for reacting with `+` hotkey.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -729,7 +729,10 @@ exports.process_hotkey = function (e, hotkey) {
         reactions.open_reactions_popover();
         return true;
     case 'thumbs_up_emoji': // '+': reacts with thumbs up emoji on selected message
-        reactions.toggle_emoji_reaction(msg.id, "thumbs_up");
+        // Use canonical name.
+        var thumbs_up_emoji_code = '1f44d';
+        var canonical_name = emoji_codes.codepoint_to_name[thumbs_up_emoji_code];
+        reactions.toggle_emoji_reaction(msg.id, canonical_name);
         return true;
     case 'toggle_mute':
         muting_ui.toggle_mute(msg);


### PR DESCRIPTION
This is sort of a temporary fix to bring the state back to how it
was in commit: ef4337edcb4bbdbbd7120c50566f305e376b5c3c. However,
long-term we will need to fix our local echo feature to do merging
of names just like we do on backend.

Testing: Manually tested.