### PR TITLE
alert-words:fix overlapping of alert words

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2726,7 +2726,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 .alert-word {
-    background-color: hsla(102, 85%, 57%, 0.5);
+    background-color: hsla(102, 85%, 57%, 1.0);
 }
 
 #organization h1,

--- a/zerver/lib/alert_words.py
+++ b/zerver/lib/alert_words.py
@@ -21,7 +21,7 @@ def add_user_alert_words(user_profile: UserProfile, alert_words: Iterable[str]) 
 
     new_words = [w for w in alert_words if w not in words]
     words.extend(new_words)
-
+    words.sort(key=len, reverse=True)
     set_user_alert_words(user_profile, words)
 
     return words

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -286,8 +286,7 @@ v1_api_and_json_patterns = [
 
     # users/me/alert_words -> zerver.views.alert_words
     url(r'^users/me/alert_words$', rest_dispatch,
-        {'GET': 'zerver.views.alert_words.list_alert_words',
-         'POST': 'zerver.views.alert_words.add_alert_words',
+        {'POST': 'zerver.views.alert_words.add_alert_words',
          'DELETE': 'zerver.views.alert_words.remove_alert_words'}),
 
     # users/me/custom_profile_data -> zerver.views.custom_profile_data


### PR DESCRIPTION
the existing issue was when one or more alert words were substrings of a bigger word,
they overlapped the parent alert word, incase they were created before
the parent word, or the parent word was not highlighted , incase the
parent word was created after the substrings
Reason: 1.The substrings were converted into '<span class='alert-word'>substring
</span>' , thus preventing the regex to find the larger word , or
2.The parent word was highighted, but the substrings were
still being found by regex, and they were overlapping the
parent words' css.
Solution:
1.converted the opacity of class alert-word to 1.0
2.in the backend, whenever alert-words are returned, they
were sorted in descending order and returned
3.the path related to GET Request r'^users/me/alert_words$' was removed,
as it was obsolete.

Fixes:#9157

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This PR solves the issue of overlapping alert words , caused when substrings are present.

**Testing Plan:** <!-- How have you tested? -->
It doesnt change any tests.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
