### PR TITLE
pill: Fix broken width of input-pill.

### DIFF
--- a/static/styles/input_pill.scss
+++ b/static/styles/input_pill.scss
@@ -87,7 +87,7 @@
 .pm_recipient .pill-container {
     padding: 0px 2px;
     border: none;
-
+    flex-grow: 1;
     align-content: center;
 }
 


### PR DESCRIPTION
This PR fixes a UI bug which was caused by removing the width of pill-container.




**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before -

<img src="http://chat.zulip.org/user_uploads/2/78/iAeD60WbMH-wilnoslmBWbhH/pasted_image.png"/>

<hr>

After - 

<img src="http://chat.zulip.org/user_uploads/2/83/hdt5KpSYt-qcg1ZbvMoF4hVi/pasted_image.png"/>

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Changes are not visible in the day mode because of the white background.
