### PR TITLE
general UI: Preserve whitespace in message topic names.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -930,7 +930,7 @@ run_test('message_group', () => {
     var last_message_html = $(html).next('.recipient_row').find('div.messagebox:last .message_content').html().trim();
     assert.equal(last_message_html, 'This is message <span class="highlight">two</span>.');
 
-    var highlighted_subject_word = $(html).find('a.narrows_by_topic .highlight').text();
+    var highlighted_subject_word = $(html).find('.highlight').text();
     assert.equal(highlighted_subject_word, 'two');
 });
 

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -210,6 +210,7 @@ li.active-sub-filter {
 .topic-name {
     /* TODO: We should figure out how to remove this without changing the spacing */
     line-height: 1.1;
+    white-space: pre;
 }
 
 .left-sidebar li a.topic-name:hover {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -804,6 +804,10 @@ td.pointer {
     line-height: 17px;
 }
 
+.stream_topic .message_label_clickable {
+    white-space: pre;
+}
+
 .recipient_row_date {
     position: absolute;
     right: 0;

--- a/static/templates/archive_recipient_row.handlebars
+++ b/static/templates/archive_recipient_row.handlebars
@@ -13,8 +13,8 @@
                 {{! topic link }}
                 <a class="message_label_clickable narrows_by_topic"
                   href="{{topic_url}}"
-                  title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;, topic &quot;__topic__&quot;{{/tr}}">
-                    {{topic}}
+                  title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;, topic &quot;__subject__&quot;{{/tr}}">
+                    {{~ subject ~}}
                 </a>
             </span>
             <span class="recipient_row_date">{{{date}}}</span>

--- a/static/templates/draft.handlebars
+++ b/static/templates/draft.handlebars
@@ -9,9 +9,9 @@
                 </div>
 
                 <span class="stream_topic">
-                    <div class="message_label_clickable narrows_by_topic">
-                        {{topic}}
-                    </div>
+                    <span class="message_label_clickable narrows_by_subject">
+                        {{~ topic ~}}
+                    </span>
                 </span>
                 <div class="recipient_row_date" title="{{t 'Last modified'}}">{{ time_stamp }}</div>
             </div>

--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -22,12 +22,12 @@
                 {{! topic link }}
                 <a class="message_label_clickable narrows_by_topic"
                     href="{{topic_url}}"
-                    title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;, topic &quot;__topic__&quot;{{/tr}}">
-                    {{#if use_match_properties}}
-                    {{{match_topic}}}
-                    {{else}}
-                    {{topic}}
-                    {{/if}}
+                    title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;, topic &quot;__subject__&quot;{{/tr}}">
+                    {{~#if use_match_properties~}}
+                    {{~ match_subject ~}}
+                    {{~ else ~}}
+                    {{~ subject ~}}
+                    {{~/if~}}
                 </a>
                 <!-- The missing whitespace on the next line is a hack; ideally, would be user-select: none. -->
             </span><span class="recipient_bar_controls no-select">

--- a/static/templates/topic_list_item.handlebars
+++ b/static/templates/topic_list_item.handlebars
@@ -1,7 +1,7 @@
 <li class='{{#if is_zero}}zero-subject-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
     <span class='topic-box'>
         <a href='{{url}}' class="topic-name" title="{{topic_name}}">
-            {{topic_name}}
+            {{~ topic_name ~}}
         </a>
         <div class="topic-unread-count {{#if is_zero}}zero_count{{/if}}">
             <div class="value">{{unread}}</div>


### PR DESCRIPTION
In order to preserve whitespace in message topic names, we change its `whitespace: nowrap` property to `white-space: pre` and modify Handlebars templates to eliminate extraneous whitespace using the `~` character.

![screenshot at jul 30 18-02-03](https://user-images.githubusercontent.com/15116870/43432368-5c1a442c-9427-11e8-95a0-e49a4be95f3f.png)
