### PR TITLE
portico: Redesign download button on apps page.

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2062,10 +2062,6 @@ nav ul li.active::after {
 
     font-size: 1em;
     font-weight: 600;
-
-    border: 2px solid #fff;
-    color: #fff;
-    background-color: transparent;
 }
 
 .portico-landing.apps .other-apps {

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -24,7 +24,7 @@
                         <p class="description"></p>
                         <p class="download-instructions">For download instructions, go to the <a class="silver bold" href="/help/desktop-app-install-guide" target="_blank">desktop app install guide</a>.</p>
                         <a class="link no-action" href="">
-                            <button type="button" name="button">Download Zulip for <span class="platform"></span></button>
+                            <button type="button" name="button" class="green">Download Zulip for <span class="platform"></span></button>
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
This PR updates the styling of download button so that it matches with the other buttons on portico pages.

Partially fixes #10104.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:

![image](https://user-images.githubusercontent.com/2263909/43482255-ce780adc-9525-11e8-8399-a7cdd7a236d5.png)

<hr>

After:

<img src="https://dzwonsemrish7.cloudfront.net/items/2b2d1b440m201w0A383p/Screen%20Recording%202018-07-30%20at%2004.35%20PM.gif?v=d46e02b9"/>

![image](https://user-images.githubusercontent.com/2263909/43482227-c0cbcedc-9525-11e8-97cb-a98e880cfbb3.png)

