### PR TITLE
Upgrade django-auth-ldap to 1.6.0.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -52,7 +52,7 @@ cryptography==2.3
 defusedxml==0.5.0
 
 # Needed for LDAP support
-django-auth-ldap==1.5.0
+django-auth-ldap==1.6.0
 
 # Django extension providing bitfield support
 -e git+https://github.com/zulip/django-bitfield@0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38#egg=django-bitfield==1.9.3+dev.0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -46,7 +46,7 @@ cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
 disposable-email-domains==0.0.30
-django-auth-ldap==1.5.0
+django-auth-ldap==1.6.0
 django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.4.1.1       # via django-two-factor-auth
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -135,7 +135,7 @@ pysocks==1.6.7            # via twilio
 python-dateutil==2.6.1
 python-digitalocean==1.13.2
 python-gcm==0.4
-python-ldap==3.0.0        # via django-auth-ldap, pyldap
+python-ldap==3.1.0        # via django-auth-ldap, pyldap
 python-twitter==3.4.2
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.5

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -34,7 +34,7 @@ cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
 disposable-email-domains==0.0.30
-django-auth-ldap==1.5.0
+django-auth-ldap==1.6.0
 django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.4.1.1       # via django-two-factor-auth
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -97,7 +97,7 @@ pyopenssl==17.3.0         # via ndg-httpsclient, requests
 pysocks==1.6.7            # via twilio
 python-dateutil==2.6.1
 python-gcm==0.4
-python-ldap==3.0.0        # via django-auth-ldap
+python-ldap==3.1.0        # via django-auth-ldap
 python-twitter==3.4.2
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.5

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '25.4'
+PROVISION_VERSION = '25.5'

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -292,6 +292,7 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
             return None
 
         return ZulipLDAPAuthBackendBase.authenticate(self,
+                                                     request=None,
                                                      username=username,
                                                      password=password)
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -138,7 +138,7 @@ DEFAULT_SETTINGS = {
     'AUTH_LDAP_SERVER_URI': "",
     'LDAP_EMAIL_ATTR': None,
     # Disable django-auth-ldap caching, to prevent problems with OU changes.
-    'AUTH_LDAP_GROUP_CACHE_TIMEOUT': 0,
+    'AUTH_LDAP_CACHE_TIMEOUT': 0,
 
     # Social auth; we support providing values for some of these
     # settings in zulip-secrets.conf instead of settings.py in development.


### PR DESCRIPTION
The autenticate function now follows the signature of Django 2.0 https://github.com/django-auth-ldap/django-auth-ldap/commit/27a8052b26f1d3a43cdbcdfc8e7dc0322580adae

Also `AUTH_LDAP_CACHE_GROUPS` is depricated in favor of `AUTH_LDAP_CACHE_TIMEOUT`.

1.7.0 is unreleased version so I have upgraded only to 1.6.0

