### PR TITLE
node tests: Consolidate some set_global() calls.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -1,30 +1,73 @@
 set_global('$', global.make_zjquery());
+set_global('blueslip', global.make_zblueslip());
 
-set_global('page_params', {
+var filter_key_handlers;
+
+const _page_params = {
     realm_users: [],
     user_id: 999,
-});
+};
 
-set_global('ui', {
-    set_up_scrollbar: function () {},
-});
+const _feature_flags = {};
 
-set_global('feature_flags', {});
-
-set_global('document', {
+const _document = {
     hasFocus: function () {
         return true;
     },
-});
+};
 
-set_global('blueslip', global.make_zblueslip());
-set_global('channel', {});
-set_global('compose_actions', {});
+const _channel = {};
 
-set_global('ui', {
+const _ui = {
     set_up_scrollbar: function () {},
     update_scrollbar: function () {},
-});
+};
+
+const _keydown_util = {
+    handle: (opts) => {
+        filter_key_handlers = opts.handlers;
+    },
+};
+
+const _compose_state = {};
+
+const _scroll_util = {
+    scroll_element_into_container: () => {},
+};
+
+const _popovers = {
+    hide_all: function () {},
+    show_userlist_sidebar: function () {
+        $('.column-right').addClass('expanded');
+    },
+};
+
+const _stream_popover = {
+    show_streamlist_sidebar: function () {
+        $('.column-left').addClass('expanded');
+    },
+};
+
+const _reload = {
+    is_in_progress: () => false,
+};
+
+const _resize = {
+    resize_page_components: () => {},
+};
+
+set_global('channel', _channel);
+set_global('compose_state', _compose_state);
+set_global('document', _document);
+set_global('feature_flags', _feature_flags);
+set_global('keydown_util', _keydown_util);
+set_global('page_params', _page_params);
+set_global('popovers', _popovers);
+set_global('reload', _reload);
+set_global('resize', _resize);
+set_global('scroll_util', _scroll_util);
+set_global('stream_popover', _stream_popover);
+set_global('ui', _ui);
 
 zrequire('compose_fade');
 zrequire('Handlebars', 'handlebars');
@@ -41,40 +84,6 @@ zrequire('buddy_list');
 zrequire('user_search');
 zrequire('list_cursor');
 zrequire('activity');
-
-var filter_key_handlers;
-set_global('keydown_util', {
-    handle: (opts) => {
-        filter_key_handlers = opts.handlers;
-    },
-});
-
-set_global('compose_state', {});
-
-set_global('scroll_util', {
-    scroll_element_into_container: () => {},
-});
-
-set_global('popovers', {
-    hide_all: function () {},
-    show_userlist_sidebar: function () {
-        $('.column-right').addClass('expanded');
-    },
-});
-
-set_global('stream_popover', {
-    show_streamlist_sidebar: function () {
-        $('.column-left').addClass('expanded');
-    },
-});
-
-
-set_global('reload', {
-    is_in_progress: () => false,
-});
-set_global('resize', {
-    resize_page_components: () => {},
-});
 
 const me = {
     email: 'me@zulip.com',

--- a/frontend_tests/node_tests/alert_words.js
+++ b/frontend_tests/node_tests/alert_words.js
@@ -1,10 +1,8 @@
-set_global('page_params', {
+var _page_params = {
     alert_words: ['alertone', 'alerttwo', 'alertthree', 'al*rt.*s', '.+', 'emoji'],
-});
+};
 
-set_global('feature_flags', {
-    alert_words: true,
-});
+set_global('page_params', _page_params);
 
 zrequire('people');
 zrequire('alert_words');

--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -1,17 +1,19 @@
-zrequire('people');
-zrequire('bot_data');
-
-set_global('settings_bots', {
+var _settings_bots = {
     render_bots: () => {},
-});
+};
 
-const page_params = {
+const _page_params = {
     realm_bots: [{email: 'bot0@zulip.com', user_id: 42, full_name: 'Bot 0'},
                  {email: 'outgoingwebhook@zulip.com', user_id: 314, full_name: "Outgoing webhook",
                   services: [{base_url: "http://foo.com", interface: 1}]}],
     is_admin: false,
 };
-set_global('page_params', page_params);
+
+set_global('page_params', _page_params);
+set_global('settings_bots', _settings_bots);
+
+zrequire('people');
+zrequire('bot_data');
 
 global.people.add({
     email: 'owner@zulip.com',

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -1,3 +1,6 @@
+const _page_params = {};
+
+set_global('page_params', _page_params);
 zrequire('people');
 zrequire('presence');
 zrequire('util');
@@ -8,7 +11,6 @@ zrequire('buddy_data');
 // here.
 
 
-set_global('page_params', {});
 
 run_test('make_people', () => {
     _.each(_.range(1000, 2000), (i) => {

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -1,8 +1,9 @@
+set_global('blueslip', global.make_zblueslip());
+set_global('$', {});
+
+set_global('reload', {});
 zrequire('channel');
 
-set_global('$', {});
-set_global('reload', {});
-set_global('blueslip', global.make_zblueslip());
 
 const default_stub_xhr = 'default-stub-xhr';
 

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -1,6 +1,6 @@
-zrequire('common');
-
 set_global('$', global.make_zjquery());
+
+zrequire('common');
 
 run_test('basics', () => {
     common.autofocus('#home');

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -1,13 +1,16 @@
+set_global('$', global.make_zjquery());
+
+const _people = {
+    small_avatar_url_for_person: function () {
+        return 'http://example.com/example.png';
+    },
+};
+
+set_global('people', _people);
 zrequire('compose_pm_pill');
 zrequire('input_pill');
 zrequire('user_pill');
 
-set_global('$', global.make_zjquery());
-set_global('people', {
-    small_avatar_url_for_person: function () {
-        return 'http://example.com/example.png';
-    },
-});
 var pills = {
     pill: {},
 };
@@ -117,9 +120,7 @@ run_test('pills', () => {
         return pills;
     }
 
-    set_global('input_pill', {
-        create: input_pill_stub,
-    });
+    input_pill.create = input_pill_stub;
 
     compose_pm_pill.initialize();
     assert(compose_pm_pill.widget);

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -1,46 +1,76 @@
 set_global('$', global.make_zjquery());
 set_global('i18n', global.stub_i18n);
-
-zrequire('stream_data');
-zrequire('settings_account');
-zrequire('settings_org');
-zrequire('settings_ui');
-zrequire('settings_ui');
+set_global('blueslip', global.make_zblueslip());
 
 const noop = () => {};
 
-set_global('blueslip', global.make_zblueslip());
+var form_data;
 
-set_global('loading', {
+const _jQuery = {
+    each: function (lst, f) {
+        _.each(lst, function (v, k) {
+            f(k, v);
+        });
+    },
+};
+
+const _FormData = function () {
+    return form_data;
+};
+
+const _loading = {
     make_indicator: noop,
     destroy_indicator: noop,
-});
+};
 
-set_global('page_params', {
+const _page_params = {
     is_admin: false,
     realm_domains: [
         { domain: 'example.com', allow_subdomains: true },
         { domain: 'example.org', allow_subdomains: false },
     ],
-});
+};
 
-set_global('realm_icon', {
-});
+const _realm_icon = {};
+const _channel = {};
 
-set_global('channel', {
-});
-
-set_global('templates', {
+const _templates = {
     render: function (name, data) {
         if (name === 'admin-realm-domains-list') {
             assert(data.realm_domain.domain);
             return 'stub-domains-list';
         }
     },
-});
+};
 
-set_global('overlays', {
-});
+const _overlays = {};
+
+const _ui_report = {
+    success: function (msg, elem) {
+        elem.val(msg);
+    },
+
+    error: function (msg, xhr, elem) {
+        elem.val(msg);
+    },
+};
+
+set_global('channel', _channel);
+set_global('csrf_token', 'token-stub');
+set_global('FormData', _FormData);
+set_global('jQuery', _jQuery);
+set_global('loading', _loading);
+set_global('overlays', _overlays);
+set_global('page_params', _page_params);
+set_global('realm_icon', _realm_icon);
+set_global('templates', _templates);
+set_global('ui_report', _ui_report);
+
+zrequire('stream_data');
+zrequire('settings_account');
+zrequire('settings_org');
+zrequire('settings_ui');
+zrequire('settings_ui');
 
 run_test('unloaded', () => {
     // This test mostly gets us line coverage, and makes
@@ -49,16 +79,6 @@ run_test('unloaded', () => {
     settings_org.reset();
     settings_org.populate_realm_domains();
     settings_org.populate_auth_methods();
-});
-
-set_global('ui_report', {
-    success: function (msg, elem) {
-        elem.val(msg);
-    },
-
-    error: function (msg, xhr, elem) {
-        elem.val(msg);
-    },
 });
 
 function simulate_auth_methods() {
@@ -276,24 +296,11 @@ function test_change_save_button_state() {
 }
 
 function test_upload_realm_icon(upload_realm_icon) {
-    var form_data = {
+    form_data = {
         append: function (field, val) {
             form_data[field] = val;
         },
     };
-
-    set_global('csrf_token', 'token-stub');
-    set_global('jQuery', {
-        each: function (lst, f) {
-            _.each(lst, function (v, k) {
-                f(k, v);
-            });
-        },
-    });
-
-    set_global('FormData', function () {
-        return form_data;
-    });
 
     var file_input = [
         {files: ['image1.png', 'image2.png']},


### PR DESCRIPTION
Hopefully these cleanups will make it a little easier
to migrate our tests to take advantage of a true
module loading system.