### PR TITLE
subs: Fix broken streams list header/search container in Safari.

### DIFF
--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -187,7 +187,6 @@
 }
 
 form#add_new_subscription {
-    float: right;
     margin: 0;
 }
 
@@ -487,6 +486,8 @@ form#add_new_subscription {
 .subscriptions-container .left .search-container {
     padding: 6px 8px;
     border-bottom: 1px solid hsl(0, 0%, 86%);
+    display: flex;
+    justify-content: space-between;
 }
 
 .subscriptions-container .right .display-type {

--- a/static/templates/subscription_table_body.handlebars
+++ b/static/templates/subscription_table_body.handlebars
@@ -19,7 +19,6 @@
                         {{/if}}
                         <div class="float-clear"></div>
                     </form>
-                    <div class="clear-float"></div>
                 </div>
                 <div class="streams-list">
                 </div>


### PR DESCRIPTION
Before:
![screenshot at aug 01 19-28-32](https://user-images.githubusercontent.com/15116870/43559326-89e6ff02-95c2-11e8-9b3a-9673191426f8.png)

After:
![screenshot at aug 01 19-28-11](https://user-images.githubusercontent.com/15116870/43559341-91578568-95c2-11e8-92ec-6a46102c081a.png)

Fixes #10064.
