### PR TITLE
[WIP] auth: Force remove session cookies set on root domain for clients.

### DIFF
--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -168,6 +168,10 @@ AUTHENTICATION_BACKENDS = (
 # subdomain; if you're using this setting, the "Callback URL" should be e.g.:
 #   https://auth.zulip.example.com/complete/github/
 #
+# If you end up using a sub domain other then the default recommendation, you
+# must add the subdomain to the 'ROOT_SUBDOMAIN_ALIASES' list present in the
+# zproject/settings.py
+#
 #SOCIAL_AUTH_SUBDOMAIN = 'auth'
 
 ########

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -355,7 +355,8 @@ DEFAULT_SETTINGS.update({
     'EMAIL_DELIVERER_DISABLED': False,
 
     # What domains to treat like the root domain
-    'ROOT_SUBDOMAIN_ALIASES': ["www"],
+    # "auth" is by default a reserved subdomain for the use by python-social-auth.
+    'ROOT_SUBDOMAIN_ALIASES': ["www", "auth"],
     # Whether the root domain is a landing page or can host a realm.
     'ROOT_DOMAIN_LANDING_PAGE': False,
 


### PR DESCRIPTION
This will break the login loops for people who tried login using
github (social auth) and got stuck in endless login loops.
The issue of login loops has been reported to happen on Microsoft Edge
only.
For other browsers like Firefox or Chrome, people seemed to aparantly
get logged out of their sessions on realms (which are hosted on same
Zulip server) when they logged into another realm on same server
using github (social auth). Trying to login back into the realms from
which user got logged out worked fine.

This behaviour difference seems to orginate from the way browsers
arrange the list of cookies to be sent to the server in the headers.
Django seems to maintain the cookies in its Request Objects using
dictionaries with cookie name being used as a key. Therefore if
multiple cookies with same name were sent from browser Django would
retian only one of them and which cookie would be retained would
probably depend on the order they are parsed from the request
headers.

Chrome and Firefox seem to arrange cookies sent in request headers
according to expiry (ascending order). This behaviour makes
logging back in possible because now the expiry of the session
cookie for the subdomain would be greater than that of the cookie
setup by python-social-auth (which was set when user logged into
another realm before causing log outs in the first place).

Microsoft Edge doesn't seem follow the same pattern of arranging
cookies into the request headers. Instead it seems like it always
puts in the cookie setup on root domain at the end. This results
people getting stuck in login loops because no matter what one
may do, once the cookie on root domain is created it will endup
masking other session cookies.

Fixes: #9940.