### PR TITLE
install-node: better error handling

### DIFF
--- a/scripts/lib/install-node
+++ b/scripts/lib/install-node
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-set -e
+set -uo pipefail
 
 ZULIP_PATH="$(dirname "$0")/../.."
 ZULIP_SRV="/srv"
-if [ "$TRAVIS" ] ; then
+if [[ -n "${TRAVIS:-}" ]] ; then
     ZULIP_SRV="/home/travis"
 fi
 YARN_BIN="$ZULIP_SRV/zulip-yarn/bin/yarn"
@@ -20,20 +20,23 @@ if node_wrapper_path="$(type -p node)"; then
     current_node_version="$(node --version)"
 fi
 
-if [ "$($YARN_BIN --version 2>/dev/null)" = "$yarn_version" ] && [ "$current_node_version" = "v$node_version" ] && [ -L "$node_wrapper_path" ]; then
+if [[ "$($YARN_BIN --version 2>/dev/null)" == "$yarn_version" \
+          && "$current_node_version" == "v$node_version" \
+          && -L "$node_wrapper_path" ]]; then
     echo "Node version $node_version and yarn version $yarn_version are already installed."
     exit 0
 fi
 
-if [ "$current_node_version" != "v$node_version" ] || ! [ -L "$node_wrapper_path" ]; then
+if [[ "$current_node_version" != "v$node_version" || ! -L "$node_wrapper_path" ]]; then
     export NVM_DIR=/usr/local/nvm
-    if ! [ -e "$NVM_DIR/nvm.sh" ]; then
-        wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+    if  [[ ! -e "$NVM_DIR/nvm.sh" ]]; then
+        wget -O- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
     fi
 
     source "$NVM_DIR/nvm.sh"
     nvm install "$node_version" && nvm alias default "$node_version"
-    export NODE_BIN="$(nvm which default)"
+    export NODE_BIN
+    NODE_BIN=$(nvm which default)
 
     # Fix messed-up uid=500 and group write bits produced by nvm
     n=$(which node)


### PR DESCRIPTION
- don't use set -e, read http://mywiki.wooledge.org/BashFAQ/105#Exercises
- don't mask wget stderr output with -q
- add -o pipefail so wget | bash fails if wget fails

**What's this PR for?**
better error handling in `install-node`

**Testing Plan:**
run the script. The semantics haven't changed.
