### PR TITLE
custom profile fields: Fix click handler executed multiple times.

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -62,16 +62,23 @@ function create_profile_field(e) {
 
     var selector = $('.admin-profile-field-form div.choice-row');
     var field_data = {};
+
     if ($('#profile_field_type').val() === '3') {
         // Only read choice data if we are creating a choice field.
         field_data = read_field_data_from_form(selector);
     }
-    $('#profile_field_data').val(JSON.stringify(field_data));
+
     var opts = {
         success_continuation: clear_form_data,
     };
+    var form_data = {
+        name: $("#profile_field_name").val(),
+        field_type: $("#profile_field_type").val(),
+        hint: $("#profile_field_hint").val(),
+        field_data: JSON.stringify(field_data),
+    };
 
-    settings_ui.do_settings_change(channel.post, "/json/realm/profile_fields", $(this).serialize(),
+    settings_ui.do_settings_change(channel.post, "/json/realm/profile_fields", form_data,
                                    $('#admin-profile-field-status').expectOne(), opts);
 }
 
@@ -253,7 +260,7 @@ exports.set_up = function () {
     meta.loaded = true;
 
     $('#admin_profile_fields_table').on('click', '.delete', delete_profile_field);
-    $(".organization").on("submit", "form.admin-profile-field-form", create_profile_field);
+    $("#profile-field-settings").on("click", "#add-custom-profile-field-btn", create_profile_field);
     $("#admin_profile_fields_table").on("click", ".open-edit-form", open_edit_form);
     set_up_choices_field();
 };

--- a/static/templates/settings/profile-field-settings-admin.handlebars
+++ b/static/templates/settings/profile-field-settings-admin.handlebars
@@ -15,7 +15,6 @@
     </div>
     {{#if is_admin}}
     <form class="form-horizontal admin-profile-field-form">
-        <input id="profile_field_data" type="hidden" name="field_data" />
         <div class="add-new-profile-field-box grey-box">
             <div class="new-profile-field-form wrapper">
                 <div class="settings-section-title new-profile-field-section-title">{{t "Add a new profile field" }}</div>
@@ -40,7 +39,7 @@
                     <label for="profile_field_choices" class="control-label">{{t "Field choices" }}</label>
                     <div id="profile_field_choices" class="profile-field-choices"></div>
                 </div>
-                <button type="submit" class="button rounded sea-green">
+                <button type="submit" class="button rounded sea-green" id="add-custom-profile-field-btn">
                     {{t 'Add profile field' }}
                 </button>
             </div>


### PR DESCRIPTION
We setup click handler on create-custom-field-btn each time settings
overlay opens, which executes handler multiple times results in
more than one HTTP request to server for custom field creation.

To fix this, first removed previously initialized handler on button
before setting new handler.

Fixes #10126

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![cp_10126](https://user-images.githubusercontent.com/25907420/43603145-bcf53b50-96af-11e8-942c-f07567bef044.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
