### PR TITLE
custom profile field: Remove order column in custom-field-choices.

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -27,14 +27,13 @@ function delete_profile_field(e) {
 
 function read_field_data_from_form(selector) {
     var field_data = {};
-    var i = 0;
-    selector.each(function (ind, row) {
-        var value = i;
-        var text = row.children[0].value;
-        var order = row.children[1].value;
-        field_data[value] = {text: text, order: order};
-        i += 1;
+    var field_order = 1;
+    selector.each(function () {
+        var text = $(this).find("input")[0].value;
+        field_data[field_order - 1] = {text: text, order: field_order.toString()};
+        field_order += 1;
     });
+
     return field_data;
 }
 
@@ -115,6 +114,13 @@ function open_edit_form(e) {
     profile_field.form.find('input[name=name]').val(field.name);
     profile_field.form.find('input[name=hint]').val(field.hint);
 
+    if (exports.field_type_id_to_string(field.type) === "Choice") {
+        var choice_list = profile_field.form.find('.edit_profile_field_choices_container')[0];
+        Sortable.create(choice_list, {
+            onUpdate: function () {},
+        });
+    }
+
     profile_field.form.find('.reset').on("click", function () {
         profile_field.form.hide();
         profile_field.row.show();
@@ -138,8 +144,8 @@ function open_edit_form(e) {
                                        data, profile_field_status);
     });
 
-    profile_field.form.find(".profile-field-choices").on("click", "button.add-choice", add_choice_row);
-    profile_field.form.find(".profile-field-choices").on("click", "button.delete-choice", delete_choice_row);
+    profile_field.form.find(".edit_profile_field_choices_container").on("click", "button.add-choice", add_choice_row);
+    profile_field.form.find(".edit_profile_field_choices_container").on("click", "button.delete-choice", delete_choice_row);
 }
 
 exports.reset = function () {
@@ -226,6 +232,11 @@ exports.do_populate_profile_fields = function (profile_fields_data) {
 
 function set_up_choices_field() {
     create_choice_row('#profile_field_choices', false);
+
+    var choice_list = $("#profile_field_choices")[0];
+    Sortable.create(choice_list, {
+        onUpdate: function () {},
+    });
 
     if ($('#profile_field_type').val() !== '3') {
         // If 'Choice' type is already selected, show choice row.

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -103,6 +103,17 @@ function get_profile_field(id) {
     return field;
 }
 
+function set_choice_delete_button(e) {
+    // Choice type field must have at least one choice
+    $(e.target).find(".choice-row .delete-choice").each(function (index) {
+        if (index === 0) {
+            $(this).hide();
+        } else {
+            $(this).show();
+        }
+    });
+}
+
 function open_edit_form(e) {
     var field_id = $(e.currentTarget).attr("data-profile-field-id");
     var profile_field = get_profile_field_info(field_id);
@@ -117,7 +128,7 @@ function open_edit_form(e) {
     if (exports.field_type_id_to_string(field.type) === "Choice") {
         var choice_list = profile_field.form.find('.edit_profile_field_choices_container')[0];
         Sortable.create(choice_list, {
-            onUpdate: function () {},
+            onUpdate: set_choice_delete_button,
         });
     }
 
@@ -235,7 +246,7 @@ function set_up_choices_field() {
 
     var choice_list = $("#profile_field_choices")[0];
     Sortable.create(choice_list, {
-        onUpdate: function () {},
+        onUpdate: set_choice_delete_button,
     });
 
     if ($('#profile_field_type').val() !== '3') {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -702,7 +702,8 @@ input[type=checkbox].inline-block {
     margin: 10px 0px;
 }
 
-.admin_profile_fields_table {
+.admin_profile_fields_table,
+.profile_field_choices_table {
     .movable-profile-field-row {
         cursor: move;
         .fa-ellipsis-v {
@@ -1754,12 +1755,12 @@ thead .actions {
     margin-top: 0;
 }
 
-.profile-field-choices .choice-row button {
-    margin-left: 0 !important;
+.profile-field-choices .choice-row input {
+    width: 190px;
 }
 
-.profile-field-choices .choice-row input {
-    width: 50px;
+.profile-field-choices .choice-row button {
+    margin-left: 0 !important;
 }
 
 .custom_user_field .pill-container {

--- a/static/templates/admin_profile_field_list.handlebars
+++ b/static/templates/admin_profile_field_list.handlebars
@@ -44,9 +44,11 @@
                         <div class='choice-field'>Order</div>
                     </div>
                     <hr />
-                    {{#each choices}}
-                    {{partial "profile-field-choice" }}
-                    {{/each}}
+                    <div class="edit_profile_field_choices_container">
+                        {{#each choices}}
+                        {{partial "profile-field-choice" }}
+                        {{/each}}
+                    </div>
                 </div>
             </div>
             {{/if}}

--- a/static/templates/settings/profile-field-choice.handlebars
+++ b/static/templates/settings/profile-field-choice.handlebars
@@ -1,6 +1,8 @@
-<div class='choice-row'>
+<div class='choice-row movable-profile-field-row'>
+    <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+    <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     <input type='text' data-toggle='tooltip' title='{{t "Text" }}' placeholder='{{t "Text" }}' value="{{ text }}" />
-    <input type='text' data-toggle='tooltip' title='{{t "Order" }}' placeholder='{{t "Order" }}' value="{{ order }}" />
+
     {{#if add_delete_button }}
     <button type='button' class="button rounded small btn-danger delete-choice" title="{{t 'Delete' }}">
         <i class="fa fa-trash-o" aria-hidden="true"></i>

--- a/static/templates/settings/profile-field-choice.handlebars
+++ b/static/templates/settings/profile-field-choice.handlebars
@@ -3,11 +3,10 @@
     <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     <input type='text' data-toggle='tooltip' title='{{t "Text" }}' placeholder='{{t "Text" }}' value="{{ text }}" />
 
-    {{#if add_delete_button }}
-    <button type='button' class="button rounded small btn-danger delete-choice" title="{{t 'Delete' }}">
+    <button type='button' class="button rounded small btn-danger delete-choice" title="{{t 'Delete' }}" {{#unless add_delete_button }} style="display: none;"{{/unless}}>
         <i class="fa fa-trash-o" aria-hidden="true"></i>
     </button>
-    {{/if}}
+
     <button type='button' class="button rounded small sea-green add-choice" title="{{t 'Add' }}">
         <i class="fa fa-plus" aria-hidden="true"></i>
     </button>

--- a/static/templates/settings/profile-field-settings-admin.handlebars
+++ b/static/templates/settings/profile-field-settings-admin.handlebars
@@ -38,7 +38,9 @@
                 </div>
                 <div class="control-group" id="profile_field_choices_row">
                     <label for="profile_field_choices" class="control-label">{{t "Field choices" }}</label>
-                    <div id="profile_field_choices" class="profile-field-choices"></div>
+                    <table class="profile_field_choices_table">
+                        <tbody id="profile_field_choices" class="profile-field-choices"></tbody>
+                    </table>
                 </div>
                 <button type="submit" class="button rounded sea-green">
                     {{t 'Add profile field' }}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is removes order column in choices and add drag & drop type of rows for ordering. 
Fixes #10129 


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![screen shot 2018-08-03 at 1 21 59 am](https://user-images.githubusercontent.com/25907420/43610844-f4d90c26-96c4-11e8-8c23-6f5961e2556d.png)
After:
![screen shot 2018-06-12 at 9 33 11 am](https://user-images.githubusercontent.com/25907420/43610843-f46b17fc-96c4-11e8-9154-0d63783175e2.png)

![cp_10129](https://user-images.githubusercontent.com/25907420/43610723-92a85ee4-96c4-11e8-93af-f7d9c22ef5a6.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
