### PR TITLE
Fix all shellcheck warnings and add shellcheck as a linter

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -44,9 +44,9 @@ fi
 ## Options from environment variables.
 #
 # Specify options for apt.
-APT_OPTIONS="${APT_OPTIONS:-}"
+read -r -a APT_OPTIONS <<< "${APT_OPTIONS:-}"
 # Install additional packages using apt.
-ADDITIONAL_PACKAGES=${ADDITIONAL_PACKAGES:-}
+read -r -a ADDITIONAL_PACKAGES <<< "${ADDITIONAL_PACKAGES:-}"
 # Deployment type is almost always voyager.
 DEPLOYMENT_TYPE="${DEPLOYMENT_TYPE:-voyager}"
 # Comma-separated list of puppet manifests to install.  default is
@@ -70,7 +70,7 @@ fi
 # Do set -x after option parsing is complete
 set -x
 
-ZULIP_PATH="$(readlink -f $(dirname $0)/../..)"
+ZULIP_PATH="$(readlink -f "$(dirname "$0")"/../..)"
 
 # Force a known locale.  Some packages on PyPI fail to install in some locales.
 localedef -i en_US -f UTF-8 en_US.UTF-8
@@ -104,7 +104,7 @@ esac
 # Check for at least ~1.9GB of RAM before starting installation;
 # otherwise users will find out about insufficient RAM via weird
 # errors like a segfault running `pip install`.
-mem_kb=$(cat /proc/meminfo | head -n1 | awk '{print $2}')
+mem_kb=$(head -n1 /proc/meminfo | awk '{print $2}')
 if [ "$mem_kb" -lt 1900000 ]; then
     echo "Insufficient RAM.  Zulip requires at least 2GB of RAM."
     exit 1
@@ -140,11 +140,11 @@ EOF
    exit 1
 fi
 
-apt-get -y dist-upgrade $APT_OPTIONS
+apt-get -y dist-upgrade "${APT_OPTIONS[@]}"
 apt-get install -y \
     puppet git curl wget \
     python python3 python-six python3-six crudini \
-    $ADDITIONAL_PACKAGES
+    "${ADDITIONAL_PACKAGES[@]}"
 
 if [ -n "$USE_CERTBOT" ]; then
     "$ZULIP_PATH"/scripts/setup/setup-certbot \
@@ -253,7 +253,7 @@ if [ "$has_appserver" = 0 ]; then
     if [ -n "$EXTERNAL_HOST" ]; then
         sed -i "s/^EXTERNAL_HOST =.*/EXTERNAL_HOST = '$EXTERNAL_HOST'/" /etc/zulip/settings.py
     fi
-    if [ -n "ZULIP_ADMINISTRATOR" ]; then
+    if [ -n "$ZULIP_ADMINISTRATOR" ]; then
         sed -i "s/^ZULIP_ADMINISTRATOR =.*/ZULIP_ADMINISTRATOR = '$ZULIP_ADMINISTRATOR'/" /etc/zulip/settings.py
     fi
     ln -nsf /etc/zulip/settings.py "$ZULIP_PATH"/zproject/prod_settings.py

--- a/scripts/lib/install-shellcheck
+++ b/scripts/lib/install-shellcheck
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eu
+
+version=0.5.0
+
+if ! out="$(shellcheck --version 2>/dev/null)" || [[ "$out" != *"
+version: $version
+"* ]]; then
+    tmpdir="$(mktemp -d)"
+    trap 'rm -r "$tmpdir"' EXIT
+    cd "$tmpdir"
+    wget -nv "https://storage.googleapis.com/shellcheck/shellcheck-v$version.linux.x86_64.tar.xz"
+    tar -xJf "shellcheck-v$version.linux.x86_64.tar.xz" --no-same-owner --strip-components=1 -C /usr/local/bin "shellcheck-v$version/shellcheck"
+fi

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -260,6 +260,9 @@ def main(options):
         print(WARNING + "`yarn install` failed; retrying..." + ENDC)
         setup_node_modules()
 
+    # Install shellcheck.
+    run(["sudo", "scripts/lib/install-shellcheck"])
+
     # Import tools/setup_venv.py instead of running it so that we get an
     # activated virtualenv for the rest of the provisioning process.
     from tools.setup import setup_venvs

--- a/tools/lint
+++ b/tools/lint
@@ -97,6 +97,7 @@ def run():
     linter_config.external_linter('templates', ['tools/check-templates'], ['handlebars', 'html'])
     linter_config.external_linter('urls', ['tools/check-urls'], ['py'])
     linter_config.external_linter('swagger', ['node', 'tools/check-swagger'], ['yaml'])
+    linter_config.external_linter('shellcheck', ['shellcheck', '-x'], ['sh'])
 
     # Disabled check for imperative mood until it is stabilized
     if not args.no_gitlint:

--- a/tools/linter_lib/exclude.py
+++ b/tools/linter_lib/exclude.py
@@ -8,6 +8,8 @@ EXCLUDED_FILES = [
     "puppet/apt/manifests/release.pp",
     "puppet/apt/manifests/unattended_upgrades.pp",
     "puppet/stdlib/tests/file_line.pp",
+    "puppet/zulip/files/nagios_plugins/zulip_nagios_server/check_website_response.sh",
+    "scripts/lib/third",
     "static/third",
     # Transifex syncs translation.json files without trailing
     # newlines; there's nothing other than trailing newlines we'd be

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -9,17 +9,20 @@
 # contains your provisioned Zulip development environment, the linter
 # will automatically be run through `vagrant ssh`.
 
-changed_files=$(git diff --cached --name-only --diff-filter=ACM)
-if [ -z "$changed_files" ]; then
+changed_files=()
+while read -r -d '' f; do
+    changed_files+=("$f")
+done < <(git diff -z --cached --name-only --diff-filter=ACM)
+if [ ${#changed_files} -eq 0 ]; then
     echo "No changed files to lint."
     exit 0
 fi
 
-if [ -z "$VIRTUAL_ENV" ] && `which vagrant > /dev/null` && [ -e .vagrant ]; then
-    vcmd="/srv/zulip/tools/lint --no-gitlint --force $changed_files || true"
+if [ -z "$VIRTUAL_ENV" ] && command -v vagrant > /dev/null && [ -e .vagrant ]; then
+    vcmd="/srv/zulip/tools/lint --no-gitlint --force $(printf '%q ' "${changed_files[@]}") || true"
     echo "Running lint using vagrant..."
     vagrant ssh -c "$vcmd"
 else
-    ./tools/lint --no-gitlint --force $changed_files || true
+    ./tools/lint --no-gitlint --force "${changed_files[@]}" || true
 fi
 exit 0


### PR DESCRIPTION
[ShellCheck](https://www.shellcheck.net/) is really good at finding shell script quality issues. Maybe a couple of them are more pedantic than we need, but fixing all of them means we won’t have to wade through the pedantic warnings in the future to find real bugs—and I did find real bugs!

I’ve annotated every commit message with the warnings it fixes.