### PR TITLE
api docs: Migrate endpoints to OpenAPI and minor fixes.

### DIFF
--- a/templates/zerver/api/arguments.json
+++ b/templates/zerver/api/arguments.json
@@ -39,20 +39,6 @@
             "example": "change_all"
         }
     ],
-    "remove-subscriptions.md": [
-        {
-            "argument": "subscriptions",
-            "description": "A list of stream names to unsubscribe from. This argument is called `streams` in our Python API.",
-            "required": true,
-            "example": "['Verona', 'Denmark']"
-        },
-        {
-            "argument": "principals",
-            "description": "A list of email addresses of the users that will be unsubscribed from the streams specified in the `subscriptions` argument. Default is `None`. If not provided, then the requesting user/bot is unsubscribed.",
-            "required": false,
-            "example": "['ZOE@zulip.com']"
-        }
-    ],
     "upload-file.md": [
         {
             "argument": "file",

--- a/templates/zerver/api/arguments.json
+++ b/templates/zerver/api/arguments.json
@@ -39,32 +39,6 @@
             "example": "change_all"
         }
     ],
-    "create-user.md": [
-        {
-            "argument": "email",
-            "description": "The email address of the new user.",
-            "required": true,
-            "example": "newbie@zulip.com"
-        },
-        {
-            "argument": "password",
-            "description": "The password of the new user.",
-            "required": true,
-            "example": "abdec@7982"
-        },
-        {
-            "argument": "full_name",
-            "description": "The full name of the new user.",
-            "required": true,
-            "example": "John Smith"
-        },
-        {
-            "argument": "short_name",
-            "description": "The short name of the new user.",
-            "required": true,
-            "example": "jsmith"
-        }
-    ],
     "remove-subscriptions.md": [
         {
             "argument": "subscriptions",

--- a/templates/zerver/api/arguments.json
+++ b/templates/zerver/api/arguments.json
@@ -38,13 +38,5 @@
             "required": false,
             "example": "change_all"
         }
-    ],
-    "upload-file.md": [
-        {
-            "argument": "file",
-            "description": "File to be uploaded.",
-            "required": true,
-            "example": "See code examples above."
-        }
     ]
 }

--- a/templates/zerver/api/arguments.json
+++ b/templates/zerver/api/arguments.json
@@ -12,31 +12,5 @@
             "required": false,
             "example": "event_types=['message']"
         }
-    ],
-    "update-message.md": [
-        {
-            "argument": "message_id",
-            "description": "The ID of the message that you wish to edit/update.",
-            "required": true,
-            "example": "134"
-        },
-        {
-            "argument": "subject",
-            "description": "The topic of the message. Only required for a stream message. Defaults to `None`. Maximum length of 60 characters.",
-            "required": false,
-            "example": "Castle"
-        },
-        {
-            "argument": "content",
-            "description": "The content of the message. Maximum message size of 10000 bytes.",
-            "required": false,
-            "example": "Hello"
-        },
-        {
-            "argument": "propagate_mode",
-            "description": "In the case of a topic update, `propagate_mode` is a value specifying whether the topic of any other messages in the same conversation would be updated or not. Possible values include: <br/> <br/> * **change_one** (Default): Update the topic only of the message with the given `message_id`. <br/> * **change_all**: Update the topic of all messages with the same previous topic as the message with `message_id`. <br/> * **change_later**: Update the topic of the message with `message_id` *and* update the topic of the messages with the same previous topic after it.",
-            "required": false,
-            "example": "change_all"
-        }
     ]
 }

--- a/templates/zerver/api/create-user.md
+++ b/templates/zerver/api/create-user.md
@@ -31,7 +31,7 @@ curl {{ api_url }}/v1/users \
 
 <div data-language="python" markdown="1">
 
-{generate_code_example(python)|create-user|example(admin_config=True)}
+{generate_code_example(python)|/users:post|example(admin_config=True)}
 
 </div>
 
@@ -64,7 +64,7 @@ zulip(config).then((client) => {
 
 ## Arguments
 
-{generate_api_arguments_table|arguments.json|create-user.md}
+{generate_api_arguments_table|zulip.yaml|/users:post}
 
 ## Response
 
@@ -72,9 +72,9 @@ zulip(config).then((client) => {
 
 A typical successful JSON response may look like:
 
-{generate_code_example|successful-response-empty|fixture}
+{generate_code_example|/users:post|fixture(200)}
 
 A typical JSON response for when another user with the same
 email address already exists in the realm:
 
-{generate_code_example|email_already_used_error|fixture}
+{generate_code_example|/users:post|fixture(400)}

--- a/templates/zerver/api/fixtures.json
+++ b/templates/zerver/api/fixtures.json
@@ -5,10 +5,6 @@
         "queue_id": "1518820930:1",
         "result": "error"
     },
-    "email_already_used_error": {
-        "msg": "Email 'newbie@zulip.com' already in use",
-        "result": "error"
-    },
     "get-profile": {
         "client_id": "74c768b081076fdb3c4326256c17467e",
         "email": "iago@zulip.com",

--- a/templates/zerver/api/fixtures.json
+++ b/templates/zerver/api/fixtures.json
@@ -111,20 +111,6 @@
         "result": "error",
         "var_name": "content"
     },
-    "nonexistent-stream-error": {
-        "code": "STREAM_DOES_NOT_EXIST",
-        "msg": "Stream 'nonexistent_stream' does not exist",
-        "result": "error",
-        "stream": "nonexistent_stream"
-    },
-    "remove-subscriptions": {
-        "msg": "",
-        "not_subscribed": [],
-        "removed": [
-            "new stream"
-        ],
-        "result": "success"
-    },
     "successful-response-empty": {
         "msg": "",
         "result": "success"

--- a/templates/zerver/api/fixtures.json
+++ b/templates/zerver/api/fixtures.json
@@ -120,11 +120,6 @@
         "msg": "You don't have permission to edit this message",
         "result": "error"
     },
-    "upload-file": {
-        "msg": "",
-        "result": "success",
-        "uri": "/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/zulip.txt"
-    },
     "user-not-authorized-error": {
         "code": "BAD_REQUEST",
         "msg": "User not authorized for this query",

--- a/templates/zerver/api/remove-subscriptions.md
+++ b/templates/zerver/api/remove-subscriptions.md
@@ -36,7 +36,7 @@ administrative privileges.
 
 <div data-language="python" markdown="1">
 
-{generate_code_example(python)|remove-subscriptions|example}
+{generate_code_example(python)|/users/me/subscriptions:delete|example}
 
 </div>
 
@@ -73,7 +73,7 @@ zulip(config).then((client) => {
 
 ## Arguments
 
-{generate_api_arguments_table|arguments.json|remove-subscriptions.md}
+{generate_api_arguments_table|zulip.yaml|/users/me/subscriptions:delete}
 
 #### Return values
 
@@ -87,8 +87,8 @@ zulip(config).then((client) => {
 
 A typical successful JSON response may look like:
 
-{generate_code_example|remove-subscriptions|fixture}
+{generate_code_example|/users/me/subscriptions:delete|fixture(200)}
 
 A typical failed JSON response for when the target stream does not exist:
 
-{generate_code_example|nonexistent-stream-error|fixture}
+{generate_code_example|/users/me/subscriptions:delete|fixture(400)}

--- a/templates/zerver/api/upload-file.md
+++ b/templates/zerver/api/upload-file.md
@@ -2,7 +2,7 @@
 
 Upload a single file and get the corresponding URI.
 
-`POST {{ api_url}}/v1/user_uploads`
+`POST {{ api_url }}/v1/user_uploads`
 
 ## Usage examples
 <div class="code-section" markdown="1">
@@ -13,7 +13,7 @@ Upload a single file and get the corresponding URI.
 
 <div data-language="python" markdown="1">
 
-{generate_code_example(python)|upload-file|example}
+{generate_code_example(python)|/user_uploads:post|example}
 
 </div>
 
@@ -23,7 +23,8 @@ Upload a single file and get the corresponding URI.
 
 ## Arguments
 
-{generate_api_arguments_table|arguments.json|upload-file.md}
+The file to upload must be provided, and it should be placed in the request's
+body as `multipart` media type.
 
 ## Maximum file size
 
@@ -44,4 +45,4 @@ to 25MB.
 
 A typical successful JSON response may look like:
 
-{generate_code_example|upload-file|fixture}
+{generate_code_example|/user_uploads:post|fixture(200)}

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -113,14 +113,12 @@ def create_user(client):
     result = client.create_user(request)
     # {code_example|end}
 
-    fixture = FIXTURES['successful-response-empty']
-    test_against_fixture(result, fixture)
+    validate_against_openapi_schema(result, '/users', 'post', '200')
 
     # Test "Email already used error"
     result = client.create_user(request)
 
-    fixture = FIXTURES['email_already_used_error']
-    test_against_fixture(result, fixture)
+    validate_against_openapi_schema(result, '/users', 'post', '400')
 
 def get_members(client):
     # type: (Client) -> None
@@ -474,7 +472,7 @@ TEST_FUNCTIONS = {
     '/get_stream_id:get': get_stream_id,
     'get-subscribed-streams': list_subscriptions,
     '/streams:get': get_streams,
-    'create-user': create_user,
+    '/users:post': create_user,
     'get-profile': get_profile,
     'add-subscriptions': add_subscriptions,
     'remove-subscriptions': remove_subscriptions,

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -433,9 +433,7 @@ def upload_file(client):
     )
     # {code_example|end}
 
-    fixture = FIXTURES['upload-file']
-    test_against_fixture(result, fixture, check_if_equal=['msg', 'result'],
-                         check_if_exists=['uri'])
+    validate_against_openapi_schema(result, '/user_uploads', 'post', '200')
 
 def get_stream_topics(client, stream_id):
     # type: (Client, int) -> None
@@ -480,7 +478,7 @@ TEST_FUNCTIONS = {
     '/users:get': get_members,
     '/register:post': register_queue,
     '/events:delete': deregister_queue,
-    'upload-file': upload_file,
+    '/user_uploads:post': upload_file,
     '/users/me/{stream_id}/topics:get': get_stream_topics
 }
 

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -235,8 +235,8 @@ def remove_subscriptions(client):
     )
     # {code_example|end}
 
-    fixture = FIXTURES['remove-subscriptions']
-    test_against_fixture(result, fixture)
+    validate_against_openapi_schema(result, '/users/me/subscriptions',
+                                    'delete', '200')
 
     # test it was actually removed
     result = client.list_subscriptions()
@@ -252,7 +252,8 @@ def remove_subscriptions(client):
     )
     # {code_example|end}
 
-    test_against_fixture(result, fixture)
+    validate_against_openapi_schema(result, '/users/me/subscriptions',
+                                    'delete', '200')
 
 def render_message(client):
     # type: (Client) -> None
@@ -475,7 +476,7 @@ TEST_FUNCTIONS = {
     '/users:post': create_user,
     'get-profile': get_profile,
     'add-subscriptions': add_subscriptions,
-    'remove-subscriptions': remove_subscriptions,
+    '/users/me/subscriptions:delete': remove_subscriptions,
     '/users:get': get_members,
     '/register:post': register_queue,
     '/events:delete': deregister_queue,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -626,6 +626,8 @@ paths:
           in our Python API."
         schema:
           type: array
+          items:
+            type: object
         example: [{"name": "Verona"}]
         required: true
       - name: invite_only
@@ -652,6 +654,8 @@ paths:
           If not provided, then the requesting user/bot is subscribed.
         schema:
           type: array
+          items:
+            type: string
           default: []
         example: ['ZOE@zulip.com']
       - name: authorization_errors_fatal

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -273,20 +273,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/CodedError'
-                - properties:
-                    stream:
-                      type: string
-                      description: The name of the stream that could not be
-                        found.
-                - example:
-                    {
-                        "code": "STREAM_DOES_NOT_EXIST",
-                        "msg": "Stream 'nonexistent_stream' does not exist",
-                        "result": "error",
-                        "stream": "nonexistent_stream"
-                    }
+                $ref: '#/components/schemas/NonExistingStreamError'
         '400_non_existing_user':
           description: Bad request.
           content:
@@ -802,20 +789,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/CodedError'
-                - properties:
-                    stream:
-                      type: string
-                      description: The name of the stream that could not be
-                        found.
-                - example:
-                    {
-                        "code": "STREAM_DOES_NOT_EXIST",
-                        "msg": "Stream 'nonexistent_stream' does not exist",
-                        "result": "error",
-                        "stream": "nonexistent_stream"
-                    }
+                $ref: '#/components/schemas/NonExistingStreamError'
   /register:
     post:
       description: This powerful endpoint can be used to register a Zulip
@@ -1107,6 +1081,21 @@ components:
               "queue_id": "1518820930:1",
               "result": "error"
           }
+    NonExistingStreamError:
+      allOf:
+        - $ref: '#/components/schemas/CodedError'
+        - properties:
+            stream:
+              type: string
+              description: The name of the stream that could not be
+                found.
+        - example:
+            {
+                "code": "STREAM_DOES_NOT_EXIST",
+                "msg": "Stream 'nonexistent_stream' does not exist",
+                "result": "error",
+                "stream": "nonexistent_stream"
+            }
     AddSubscriptionsResponse:
       allOf:
       - $ref: '#/components/schemas/JsonSuccess'

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18,7 +18,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: 'https://your.zulip.server/api/v1'
+- url: 'https://your.zulip.server/api/v1'
 
 #######################
 # Endpoint definitions
@@ -61,7 +61,7 @@ paths:
       - basicAuth: []
       responses:
         '200':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -134,7 +134,7 @@ paths:
                         "result": "success"
                     }
         '400':
-          description: Bad request
+          description: Bad request.
           content:
             application/json:
               schema:
@@ -147,7 +147,7 @@ paths:
         description: The ID of a queue that you registered via
           `POST /api/v1/register`(see [Register a queue](/api/register-queue).
         schema:
-           type: string
+          type: string
         example: 1375801870:2942
         required: true
       security:
@@ -173,14 +173,14 @@ paths:
         in: query
         description: The name of the stream to retrieve the ID for.
         schema:
-           type: string
+          type: string
         example: Denmark
         required: true
       security:
       - basicAuth: []
       responses:
         '200':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -197,7 +197,7 @@ paths:
                         "stream_id": 15
                     }
         '400':
-          description: Bad request
+          description: Bad request.
           content:
             application/json:
               schema:
@@ -220,8 +220,8 @@ paths:
         schema:
           type: string
           enum:
-            - private
-            - stream
+          - private
+          - stream
         example: private
         required: true
       - name: to
@@ -252,7 +252,7 @@ paths:
       - basicAuth: []
       responses:
         '200':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -313,19 +313,17 @@ paths:
         required: true
       - name: subject
         in: query
-        description: |
-          The topic of the message. Only required for stream messages.
-          Maximum length of 60 characters.
+        description: The topic of the message. Only required for stream
+          messages. Maximum length of 60 characters.
         schema:
           type: string
           default:
         example: Castle
       - name: propagate_mode
         in: query
-        description: |
-          Which message(s) should be edited: just the one indicated in
-          `message_id`, messages in the same topic that had been sent after
-          this one, or all of them.
+        description: "Which message(s) should be edited: just the one
+          indicated in `message_id`, messages in the same topic that had been
+          sent after this one, or all of them."
         schema:
           type: string
           enum:
@@ -336,8 +334,8 @@ paths:
         example: change_all
       - name: content
         in: query
-        description: |
-          The content of the message. Maximum message size of 10000 bytes.
+        description: The content of the message. Maximum message size of 10000
+          bytes.
         schema:
           type: string
         example: Hello
@@ -345,7 +343,7 @@ paths:
       - basicAuth: []
       responses:
         '200':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -375,18 +373,18 @@ paths:
     post:
       description: Render a message to HTML.
       parameters:
-        - name: content
-          in: query
-          description: The content of the message.
-          schema:
-             type: string
-          example: '**foo**'
-          required: true
+      - name: content
+        in: query
+        description: The content of the message.
+        schema:
+          type: string
+        example: '**foo**'
+        required: true
       security:
       - basicAuth: []
       responses:
         '200':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -442,14 +440,14 @@ paths:
         description: The `client_gravatar` field is set to `true` if clients
           can compute their own gravatars.
         schema:
-           type: boolean
-           default : false
+          type: boolean
+          default: false
         example: true
       security:
       - basicAuth: []
       responses:
         '200':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -505,28 +503,28 @@ paths:
         in: query
         description: The email address of the new user.
         schema:
-           type: string
+          type: string
         example: newbie@zulip.com
         required: true
       - name: password
         in: query
         description: The password of the new user.
         schema:
-           type: string
+          type: string
         example: abdec@7982
         required: true
       - name: full_name
         in: query
         description: The full name of the new user.
         schema:
-           type: string
+          type: string
         example: John Smith
         required: true
       - name: short_name
         in: query
         description: The short name of the new user.
         schema:
-           type: string
+          type: string
         example: jsmith
         required: true
       security:
@@ -565,7 +563,7 @@ paths:
       - basicAuth: []
       responses:
         '200':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -622,19 +620,17 @@ paths:
       parameters:
       - name: subscriptions
         in: query
-        description: |
-          A list of dictionaries, where each dictionary contains key/value
-          pairs specifying a particular stream to subscribe to.
+        description: "A list of dictionaries, where each dictionary contains
+          key/value pairs specifying a particular stream to subscribe to.
           **Note**: This argument is called `streams` and not `subscriptions`
-          in our Python API.
+          in our Python API."
         schema:
-          type: string
+          type: array
         example: [{"name": "Verona"}]
         required: true
       - name: invite_only
         in: query
-        description: |
-          A boolean specifying whether the streams specified in
+        description: A boolean specifying whether the streams specified in
           `subscriptions` are invite-only or not.
         schema:
           type: boolean
@@ -642,9 +638,8 @@ paths:
         example: true
       - name: announce
         in: query
-        description: |
-          If `announce` is `True` and one of the streams specified in
-          `subscriptions` has to be created (i.e. doesn't exist to begin
+        description: If `announce` is `True` and one of the streams specified
+          in `subscriptions` has to be created (i.e. doesn't exist to begin
           with), an announcement will be made notifying that a new stream was
           created.
         schema:
@@ -652,23 +647,21 @@ paths:
         example: true
       - name: principals
         in: query
-        description: |
-          A list of email addresses of the users that will be subscribed to
-          the streams specified in the `subscriptions` argument. If not
-          provided, then the requesting user/bot is subscribed.
+        description: A list of email addresses of the users that will be
+          subscribed to the streams specified in the `subscriptions` argument.
+          If not provided, then the requesting user/bot is subscribed.
         schema:
-          type: string
+          type: array
           default: []
         example: ['ZOE@zulip.com']
       - name: authorization_errors_fatal
         in: query
-        description: |
-          A boolean specifying whether authorization errors (such as when the
-          requesting user is not authorized to access a private stream) should
-          be considered fatal or not. When `True`, an authorization error is
-          reported as such. When set to `False`, the returned JSON payload
-          indicates that there was an authorization error, but the response is
-          still considered a successful one.
+        description: A boolean specifying whether authorization errors (such
+          as when the requesting user is not authorized to access a private
+          stream) should be considered fatal or not. When `True`, an
+          authorization error is reported as such. When set to `False`, the
+          returned JSON payload indicates that there was an authorization
+          error, but the response is still considered a successful one.
         schema:
           type: boolean
           default: true
@@ -677,7 +670,7 @@ paths:
       - basicAuth: []
       responses:
         '200_without_principals':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -695,7 +688,7 @@ paths:
                         }
                     }
         '200_already_subscribed':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -713,7 +706,7 @@ paths:
                         "subscribed": {}
                     }
         '400_unauthorized_errors_fatal_true':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -725,7 +718,7 @@ paths:
                         "result": "error"
                     }
         '400_unauthorized_errors_fatal_false':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -832,16 +825,16 @@ paths:
           rendered in HTML format (by default, the API returns the raw text
           that the user entered)
         schema:
-           type: boolean
-           default : false
+          type: boolean
+          default: false
         example: true
       - name: client_gravatar
         in: query
         description: The `client_gravatar` field is set to `true` if clients
           can compute their own gravatars.
         schema:
-           type: boolean
-           default : false
+          type: boolean
+          default: false
         example: true
       - name: event_types
         in: query
@@ -857,23 +850,23 @@ paths:
           your client code. For most applications, one is only interested in
           messages, so one specifies: `event_types=['message']`"
         schema:
-           type: string
+          type: string
         example: event_types=['message']
       - name: all_public_streams
         in: query
         description: Set to `True` if you would like to receive events that
           occur within all public streams.
         schema:
-           type: boolean
-           default: false
+          type: boolean
+          default: false
         example: true
       - name: include_subscribers
         in: query
         description: Set to `True` if you would like to receive events that
           include the subscribers for each stream.
         schema:
-           type: boolean
-           default : false
+          type: boolean
+          default: false
         example: true
       - name: fetch_event_types
         in: query
@@ -882,7 +875,7 @@ paths:
           `fetch_event_types` is not provided, `event_types` is used and if
           `event_types` is not provided, this argument defaults to `None`.
         schema:
-           type: string
+          type: string
         example: event_types=['message']
       - name: narrow
         in: query
@@ -892,14 +885,14 @@ paths:
           `narrow=['stream', 'Denmark']`. Another example is
           `narrow=['is', 'private']` for private messages.
         schema:
-           type: string
-           default : narrow=[]
+          type: string
+          default: narrow=[]
         example: narrow=['stream', 'Denmark']
       security:
       - basicAuth: []
       responses:
         '200':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -942,36 +935,36 @@ paths:
         in: query
         description: Include all public streams.
         schema:
-           type: boolean
-           default : true
+          type: boolean
+          default: true
         example: false
       - name: include_subscribed
         in: query
         description: Include all streams that the user is subscribed to.
         schema:
-           type: boolean
-           default : true
+          type: boolean
+          default: true
         example: false
       - name: include_all_active
         in: query
         description: Include all active streams. The user must have
           administrative privileges to use this parameter.
         schema:
-           type: boolean
-           default : false
+          type: boolean
+          default: false
         example: true
       - name: include_default
         in: query
         description: Include all default streams for the user's realm.
         schema:
-           type: boolean
-           default : false
+          type: boolean
+          default: false
         example: true
       security:
       - basicAuth: []
       responses:
         '200':
-          description: Success
+          description: Success.
           content:
             application/json:
               schema:
@@ -1050,10 +1043,9 @@ components:
     BasicAuth:
       type: http
       scheme: basic
-      description: |
-        Basic authentication, with the user's email as the username, and the
-        API key as the password. The API key can be fetched using the
-        `/fetch_api_key` or `/dev_fetch_api_key` endpoints.
+      description: Basic authentication, with the user's email as the
+        username, and the API key as the password. The API key can be fetched
+        using the `/fetch_api_key` or `/dev_fetch_api_key` endpoints.
 
   schemas:
     JsonResponse:
@@ -1117,30 +1109,27 @@ components:
       - properties:
           subscribed:
             type: object
-            description: |
-              A dictionary where the key is the email address of the user/bot
-              and the value is a list of the names of the streams that were
-              subscribed to as a result of the query.
+            description: A dictionary where the key is the email address of
+              the user/bot and the value is a list of the names of the streams
+              that were subscribed to as a result of the query.
           already_subscribed:
             type: object
-            description: |
-              A dictionary where the key is the email address of the user/bot
-              and the value is a list of the names of the streams that the
-              user/bot is already subscribed to.
+            description: A dictionary where the key is the email address of
+              the user/bot and the value is a list of the names of the streams
+              that the user/bot is already subscribed to.
           unauthorized:
             type: array
             items:
               type: string
-            description: |
-              A list of names of streams that the requesting user/bot was not
-              authorized to subscribe to.
+            description: A list of names of streams that the requesting
+              user/bot was not authorized to subscribe to.
 
   ###################
   # Shared responses
   ###################
   responses:
     SimpleSuccess:
-      description: Success
+      description: Success.
       content:
         application/json:
           schema:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -710,6 +710,84 @@ paths:
                             "private_stream"
                         ]
                     }
+    delete:
+      description: Unsubscribe yourself or other users from one or more
+        streams.
+      parameters:
+      - name: subscriptions
+        in: query
+        description: A list of stream names to unsubscribe from. This argument
+          is called `streams` in our Python API.
+        schema:
+          type: array
+          items:
+            type: string
+        example: ['Verona', 'Denmark']
+        required: true
+      - name: principals
+        in: query
+        description: A list of email addresses of the users that will be
+          unsubscribed from the streams specified in the `subscriptions`
+          argument. If not provided, then the requesting user/bot is
+          unsubscribed.
+        schema:
+          type: array
+          items:
+            type: string
+          default:
+        example: ['ZOE@zulip.com']
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JsonSuccess'
+                - properties:
+                    not_subscribed:
+                      type: array
+                      items:
+                        type: string
+                      description: A list of the names of streams that the
+                        user is already unsubscribed from, and hence doesn't
+                        need to be unsubscribed.
+                    removed:
+                      type: array
+                      items:
+                        type: string
+                      description: A list of the names of streams which were
+                        unsubscribed from as a result of the query.
+                - example:
+                    {
+                        "msg": "",
+                        "not_subscribed": [],
+                        "removed": [
+                            "new stream"
+                        ],
+                        "result": "success"
+                    }
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/CodedError'
+                - properties:
+                    stream:
+                      type: string
+                      description: The name of the stream that could not be
+                        found.
+                - example:
+                    {
+                        "code": "STREAM_DOES_NOT_EXIST",
+                        "msg": "Stream 'nonexistent_stream' does not exist",
+                        "result": "error",
+                        "stream": "nonexistent_stream"
+                    }
   /register:
     post:
       description: This powerful endpoint can be used to register a Zulip

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -402,6 +402,37 @@ paths:
                         "rendered": "<p><strong>foo</strong></p>",
                         "result": "success"
                     }
+  /user_uploads:
+    post:
+      description: Upload a single file and get the corresponding URI.
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                filename:
+                  type: string
+                  format: binary
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JsonSuccess'
+                - properties:
+                    uri:
+                      type: string
+                      description: The URI of the uploaded file.
+                - example:
+                    {
+                        "msg": "",
+                        "result": "success",
+                        "uri": "/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/zulip.txt"
+                    }
   /users:
     get:
       description: Retrieve all users in a realm.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -467,6 +467,58 @@ paths:
                         "msg": "",
                         "result": "success"
                     }
+    post:
+      description: Create a new user in a realm.
+      parameters:
+      - name: email
+        in: query
+        description: The email address of the new user.
+        schema:
+           type: string
+        example: newbie@zulip.com
+        required: true
+      - name: password
+        in: query
+        description: The password of the new user.
+        schema:
+           type: string
+        example: abdec@7982
+        required: true
+      - name: full_name
+        in: query
+        description: The full name of the new user.
+        schema:
+           type: string
+        example: John Smith
+        required: true
+      - name: short_name
+        in: query
+        description: The short name of the new user.
+        schema:
+           type: string
+        example: jsmith
+        required: true
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonSuccess'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JsonError'
+                - example:
+                    {
+                        "msg": "Email 'newbie@zulip.com' already in use",
+                        "result": "error"
+                    }
   /users/me/{stream_id}/topics:
     get:
       description: Get all the topics in a specific stream.


### PR DESCRIPTION
Migration to OpenAPI of the documentation for the following endpoints:

- `POST /users`
- `DELETE /users/me/subscriptions`
- `POST /user_uploads`

Plus a few fixes, mostly dedicated to improve the OpenAPI YAML file.

**Testing Plan:** API tests passed locally and compared the migrated docs side-by-side.