### PR TITLE
Alert Words: Fix overlapping of alert-words.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -545,6 +545,10 @@ on a dark background, and don't change the dark labels dark either. */
         -webkit-filter: invert(100%);
         filter: invert(100%);
     }
+
+    .alert-word {
+        background-color: hsl(110, 44%, 39%);
+    }
 }
 
 @-moz-document url-prefix() {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2779,7 +2779,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 .alert-word {
-    background-color: hsla(102, 85%, 57%, 0.5);
+    background-color: hsl(101, 85.7%, 78%);
 }
 
 #organization h1,

--- a/zerver/lib/alert_words.py
+++ b/zerver/lib/alert_words.py
@@ -22,6 +22,7 @@ def add_user_alert_words(user_profile: UserProfile, alert_words: Iterable[str]) 
     new_words = [w for w in alert_words if w not in words]
     words.extend(new_words)
 
+    words.sort(key=len, reverse=True)
     set_user_alert_words(user_profile, words)
 
     return words

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -38,7 +38,7 @@ class AlertWordTests(ZulipTestCase):
         self.assert_json_success(result)
         user = self.example_user(user_name)
         words = user_alert_words(user)
-        self.assertEqual(words, ['milk', 'cookies'])
+        self.assertCountEqual(words, ['milk', 'cookies'])
 
     def test_default_no_words(self) -> None:
         """
@@ -46,7 +46,7 @@ class AlertWordTests(ZulipTestCase):
         """
         user = self.example_user('cordelia')
         words = user_alert_words(user)
-        self.assertEqual(words, [])
+        self.assertCountEqual(words, [])
 
     def test_add_word(self) -> None:
         """
@@ -58,7 +58,7 @@ class AlertWordTests(ZulipTestCase):
         add_user_alert_words(user, self.interesting_alert_word_list)
 
         words = user_alert_words(user)
-        self.assertEqual(words, self.interesting_alert_word_list)
+        self.assertCountEqual(words, self.interesting_alert_word_list)
 
     def test_remove_word(self) -> None:
         """
@@ -75,8 +75,8 @@ class AlertWordTests(ZulipTestCase):
             remove_user_alert_words(user, alert_word)
             theoretical_remaining_alerts.remove(alert_word)
             actual_remaining_alerts = user_alert_words(user)
-            self.assertEqual(actual_remaining_alerts,
-                             theoretical_remaining_alerts)
+            self.assertCountEqual(actual_remaining_alerts,
+                                  theoretical_remaining_alerts)
 
     def test_realm_words(self) -> None:
         """
@@ -94,9 +94,9 @@ class AlertWordTests(ZulipTestCase):
         realm_words = alert_words_in_realm(user2.realm)
         self.assertEqual(len(realm_words), 2)
         self.assertEqual(list(realm_words.keys()), [user1.id, user2.id])
-        self.assertEqual(realm_words[user1.id],
-                         self.interesting_alert_word_list)
-        self.assertEqual(realm_words[user2.id], ['another'])
+        self.assertCountEqual(realm_words[user1.id],
+                              self.interesting_alert_word_list)
+        self.assertCountEqual(realm_words[user2.id], ['another'])
 
     def test_json_list_default(self) -> None:
         self.login(self.example_email("hamlet"))
@@ -112,25 +112,25 @@ class AlertWordTests(ZulipTestCase):
         self.login(self.example_email('hamlet'))
         result = self.client_get('/json/users/me/alert_words')
         self.assert_json_success(result)
-        self.assertEqual(result.json()['alert_words'], ['one', 'two', 'three'])
+        self.assertCountEqual(result.json()['alert_words'], ['one', 'two', 'three'])
 
     def test_json_list_add(self) -> None:
         self.login(self.example_email("hamlet"))
 
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one ', '\n two', 'three'])})
         self.assert_json_success(result)
-        self.assertEqual(result.json()['alert_words'], ['one', 'two', 'three'])
+        self.assertCountEqual(result.json()['alert_words'], ['one', 'two', 'three'])
 
     def test_json_list_remove(self) -> None:
         self.login(self.example_email("hamlet"))
 
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
         self.assert_json_success(result)
-        self.assertEqual(result.json()['alert_words'], ['one', 'two', 'three'])
+        self.assertCountEqual(result.json()['alert_words'], ['one', 'two', 'three'])
 
         result = self.client_delete('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one'])})
         self.assert_json_success(result)
-        self.assertEqual(result.json()['alert_words'], ['two', 'three'])
+        self.assertCountEqual(result.json()['alert_words'], ['two', 'three'])
 
     def message_does_alert(self, user_profile: UserProfile, message: str) -> bool:
         """Send a bunch of messages as othello, so Hamlet is notified"""
@@ -144,7 +144,7 @@ class AlertWordTests(ZulipTestCase):
 
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
         self.assert_json_success(result)
-        self.assertEqual(result.json()['alert_words'], ['one', 'two', 'three'])
+        self.assertCountEqual(result.json()['alert_words'], ['one', 'two', 'three'])
 
         # Alerts in the middle of messages work.
         self.assertTrue(self.message_does_alert(user_profile_hamlet, "Normal alert one time"))


### PR DESCRIPTION
**Issue Faced:**
    Whenever an alert word was added to the alert-words list, two things happened : 
1. If the new word was a substring of another existing word, this word would be highlighted inside the parent word, causing an odd double highlight effect.
2. If the new word was a super-string of another existing word, only the already existing word would be highlighted.

#9157 

**Solution:**
1. Whenever the user added a new word, the alert-words list was sorted in the backend, on the basis of string length.
2. The opacity of the class `alert-word` was converted to 1.0, and proper color was added to the day and night-mode separately.

**Notes:**

**Why the ordering was done in the backend instead in javascript:**

    The sorting was done in the back, whenever a new word was added to reduce the number of times the sorting process would occur. Incase the sorting was done during rendering, every time the page reloads, the sorting of the words would occur, delaying the rendering of alert words, as well as making the sorting process redundant

****Testing Plan:**** 

**Problem:**

The change in the order of alert-words had caused some tests to fail as the tests employed `assertEqual` method , which compared both the order and the equality of the elements in the list.

**Solution:**

The `assertEqual` methods were changed to `assertCountEqual` method, which checked the number of times an element is present in both the lists, ignoring the **order.**



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

**Alert-Words:** hello, hello world, hello india!, hello world!, worl.


**Before:**

![before](https://user-images.githubusercontent.com/35770004/43579965-74e64388-9671-11e8-924b-1c3c05367af5.png)

![before2](https://user-images.githubusercontent.com/35770004/43579982-7f04f6a2-9671-11e8-917e-d9459dafb770.png)


**After:**


![after1](https://user-images.githubusercontent.com/35770004/43579997-88beb1c4-9671-11e8-8a03-e9cb509feff8.png)


![after2](https://user-images.githubusercontent.com/35770004/43580004-8e16a0d2-9671-11e8-8ebc-c20d0956589a.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

*Mentions:*

@lonerz  : Sir, you had mentioned some errors in my previous commit. I have corrected them in this commit, and the reasons for all code change has been written. Thank you.

