### PR TITLE
emails: Show HHMM timezone on new login emails.

### DIFF
--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -77,7 +77,8 @@ def email_on_new_login(sender: Any, user: UserProfile, request: Any, **kwargs: A
         if user_tz == '':
             user_tz = timezone_get_current_timezone_name()
         local_time = timezone_now().astimezone(get_timezone(user_tz))
-        context['login_time'] = local_time.strftime('%A, %B %d, %Y at %I:%M%p ') + user_tz
+        utc_offset = local_time.strftime('%z')
+        context['login_time'] = local_time.strftime('%A, %B %d, %Y at %I:%M%p ') + utc_offset
         context['device_ip'] = request.META.get('REMOTE_ADDR') or _("Unknown IP address")
         context['device_os'] = get_device_os(user_agent)
         context['device_browser'] = get_device_browser(user_agent)

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -33,7 +33,8 @@ class SendLoginEmailTest(ZulipTestCase):
             utc = get_timezone('utc')
             user_tz = get_timezone(user.timezone)
             mock_time = datetime.datetime(year=2018, month=1, day=1, tzinfo=utc)
-            reference_time = mock_time.astimezone(user_tz).strftime('%A, %B %d, %Y at %I:%M%p ') + user.timezone
+            utc_offset = mock_time.astimezone(user_tz).strftime('%z')
+            reference_time = mock_time.astimezone(user_tz).strftime('%A, %B %d, %Y at %I:%M%p ') + utc_offset
             with mock.patch('zerver.signals.timezone_now', return_value=mock_time):
                 self.client_post("/accounts/login/", info={"username": user.email, "password": password},
                                  HTTP_USER_AGENT=firefox_windows)


### PR DESCRIPTION
Email notifications for new logins displayed the login timestamp's timezone in the location format (e.g. "Asia/Taipei").
Since that can lead users to understand the login came from that place, the timezone in those emails is now represented in +/-HHMM format.

Fixes #10178.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** backend and lint tests passed locally.

Tried with multiple timezones by changing the `TIME_ZONE` setting in `zproject/settings.py`.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

*CET timezone*
![Email notification CET](https://user-images.githubusercontent.com/7356565/43669975-9759f5f6-9787-11e8-90d9-86eca72ef54d.png)

*EST timezone*
![Email notification EST](https://user-images.githubusercontent.com/7356565/43670013-ed03ffd8-9787-11e8-8c04-37a827da0abb.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
