### PR TITLE
auth: Add fakeldap based authentication method in development environment

### DIFF
--- a/zerver/tests/fixtures/ldap_dir.json
+++ b/zerver/tests/fixtures/ldap_dir.json
@@ -1,0 +1,178 @@
+{
+    "a": {
+        "uid=ldap_zoe@zulip.com,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Zoe"
+            ],
+            "userPassword": "ldap_zoe"
+        },
+        "uid=ldap_othello@zulip.com,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Othello, the Moor of Venice"
+            ],
+            "userPassword": "ldap_othello"
+        },
+        "uid=ldap_iago@zulip.com,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Iago"
+            ],
+            "userPassword": "ldap_iago"
+        },
+        "uid=ldap_prospero@zulip.com,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Prospero from The Tempest"
+            ],
+            "userPassword": "ldap_prospero"
+        },
+        "uid=ldap_cordelia@zulip.com,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Cordelia Lear"
+            ],
+            "userPassword": "ldap_cordelia"
+        },
+        "uid=ldap_hamlet@zulip.com,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "King Hamlet"
+            ],
+            "userPassword": "ldap_hamlet"
+        },
+        "uid=ldap_aaron@zulip.com,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "aaron"
+            ],
+            "userPassword": "ldap_aaron"
+        },
+        "uid=ldap_polonius@zulip.com,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Polonius"
+            ],
+            "userPassword": "ldap_polonius"
+        },
+        "uid=ldap_extrauser0@zulip.com,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Extra User 0"
+            ],
+            "userPassword": "ldap_extrauser0"
+        },
+        "uid=ldap_extrauser1@zulip.com,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Extra User 1"
+            ],
+            "userPassword": "ldap_extrauser1"
+        }
+    },
+    "b": {
+        "uid=ldap_zoe,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Zoe"
+            ],
+            "userPassword": "ldap_zoe"
+        },
+        "uid=ldap_othello,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Othello, the Moor of Venice"
+            ],
+            "userPassword": "ldap_othello"
+        },
+        "uid=ldap_iago,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Iago"
+            ],
+            "userPassword": "ldap_iago"
+        },
+        "uid=ldap_prospero,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Prospero from The Tempest"
+            ],
+            "userPassword": "ldap_prospero"
+        },
+        "uid=ldap_cordelia,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Cordelia Lear"
+            ],
+            "userPassword": "ldap_cordelia"
+        },
+        "uid=ldap_hamlet,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "King Hamlet"
+            ],
+            "userPassword": "ldap_hamlet"
+        },
+        "uid=ldap_aaron,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "aaron"
+            ],
+            "userPassword": "ldap_aaron"
+        },
+        "uid=ldap_polonius,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Polonius"
+            ],
+            "userPassword": "ldap_polonius"
+        },
+        "uid=ldap_extrauser0,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Extra User 0"
+            ],
+            "userPassword": "ldap_extrauser0"
+        }
+    },
+    "c": {
+        "uid=ldap_zoe,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Zoe"
+            ],
+            "userPassword": "ldap_zoe_test",
+            "email": "ldap_zoe@zulip.com"
+        },
+        "uid=ldap_othello,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Othello, the Moor of Venice"
+            ],
+            "userPassword": "ldap_othello_test",
+            "email": "ldap_othello@zulip.com"
+        },
+        "uid=ldap_iago,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Iago"
+            ],
+            "userPassword": "ldap_iago_test",
+            "email": "ldap_iago@zulip.com"
+        },
+        "uid=ldap_prospero,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Prospero from The Tempest"
+            ],
+            "userPassword": "ldap_prospero_test",
+            "email": "ldap_prospero@zulip.com"
+        },
+        "uid=ldap_cordelia,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Cordelia Lear"
+            ],
+            "userPassword": "ldap_cordelia_test",
+            "email": "ldap_cordelia@zulip.com"
+        },
+        "uid=ldap_hamlet,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "King Hamlet"
+            ],
+            "userPassword": "ldap_hamlet_test",
+            "email": "ldap_hamlet@zulip.com"
+        },
+        "uid=ldap_aaron,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "aaron"
+            ],
+            "userPassword": "ldap_aaron_test",
+            "email": "ldap_aaron@zulip.com"
+        },
+        "uid=ldap_polonius,ou=users,dc=zulip,dc=com": {
+            "cn": [
+                "Polonius"
+            ],
+            "userPassword": "ldap_polonius_test",
+            "email": "ldap_polonius@zulip.com"
+        }
+    }
+}

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -51,7 +51,7 @@ from zproject.backends import ZulipDummyBackend, EmailAuthBackend, \
     ZulipLDAPUserPopulator, DevAuthBackend, GitHubAuthBackend, ZulipAuthMixin, \
     dev_auth_enabled, password_auth_enabled, github_auth_enabled, \
     require_email_format_usernames, AUTH_BACKEND_NAME_MAP, \
-    ZulipLDAPConfigurationError
+    ZulipLDAPConfigurationError, generate_dev_ldap_dir
 
 from zerver.views.auth import (maybe_send_to_registration,
                                login_or_register_remote_user,
@@ -2093,6 +2093,18 @@ class TestLDAP(ZulipTestCase):
         realm = user_profile.realm
         realm.string_id = 'zulip'
         realm.save()
+
+    def test_generate_dev_ldap_dir(self) -> None:
+        fixtures = ujson.loads(self.fixture_data("ldap_dir.json"))
+
+        ldap_dir = generate_dev_ldap_dir('A', 2)
+        self.assertEqual(ldap_dir, fixtures['a'])
+
+        ldap_dir = generate_dev_ldap_dir('b', 1)
+        self.assertEqual(ldap_dir, fixtures['b'])
+
+        ldap_dir = generate_dev_ldap_dir('c', 0)
+        self.assertEqual(ldap_dir, fixtures['c'])
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_success(self) -> None:

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -89,6 +89,32 @@ SENDFILE_BACKEND = 'sendfile.backends.development'
 # Set this True to send all hotspots in development
 ALWAYS_SEND_ALL_HOTSPOTS = False  # type: bool
 
+# Set to None to disable FakeLDAP server.
+# Three modes are allowed.
+#   (A) If users' email addresses are in LDAP and used as username.
+#   (B) If LDAP only has usernames but email addresses are of the form
+#       username@example.com
+#   (C) If LDAP username are completely unrelated to email addresses,
+# Refer `prod_settings_template.py` for description of the modes.
+FAKE_LDAP_MODE = None  # type: Optional[str]
+
+# By default 8 users are populated in the LDAP directory.
+FAKE_LDAP_EXTRA_USER = 0
+
+if FAKE_LDAP_MODE:
+    LDAP_APPEND_DOMAIN = None
+    AUTH_LDAP_USER_DN_TEMPLATE = 'uid=%(user)s,ou=users,dc=zulip,dc=com'
+
+    if FAKE_LDAP_MODE == 'a':
+        import ldap
+        from django_auth_ldap.config import LDAPSearch
+        AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=users,dc=zulip,dc=com",
+                                           ldap.SCOPE_SUBTREE, "(email=%(user)s)")
+    elif FAKE_LDAP_MODE == 'b':
+        LDAP_APPEND_DOMAIN = 'zulip.com'
+    elif FAKE_LDAP_MODE == 'c':
+        LDAP_EMAIL_ATTR = 'email'  # type: Optional[str]
+
 THUMBOR_URL = 'http://127.0.0.1:9995'
 
 SEARCH_PILLS_ENABLED = os.getenv('SEARCH_PILLS_ENABLED', False)

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -140,6 +140,8 @@ DEFAULT_SETTINGS = {
     'LDAP_EMAIL_ATTR': None,
     # Disable django-auth-ldap caching, to prevent problems with OU changes.
     'AUTH_LDAP_CACHE_TIMEOUT': 0,
+    'FAKE_LDAP_MODE': None,
+    'FAKE_LDAP_EXTRA_USER': 0,
 
     # Social auth; we support providing values for some of these
     # settings in zulip-secrets.conf instead of settings.py in development.


### PR DESCRIPTION
Fixes #9934.
Uses MockLDAP class of fakeldap to fake a ldap server as also done
in tests of `test_auth_backends.py`.
Adds the following settings:
- FAKE_LDAP_AUTH_ENABLED = Toggle Faking LDAP server. If this option
is set to true and the user is not in the development environment,
fake ldap server will not be activated.
- FAKE_LDAP_MODE: Lets user choose out of three preset configurations.
The default mode if someone erases the entry in settings is 'a'.
- FAKE_LDAP_EXTRA_USERS: No. of extra users in LDAP directory except
the default 8.

Note: ZulipLDAPAuthBackend has not been added to
AUTHENTICATION_BACKENDS in this commit, user has to add that to enable
fake ldap in development environment.
(Note: Not doing the above change assuming that there are some users using an actual LDAP server in the dev environment (?). For them we set FAKE_LDAP_ENABLED to false, so they'll not start using fake LDAP all of a sudden. But the users without an LDAP server now have LDAP in AUTHENTICATION_BACKENDS and fake LDAP disabled which will cause them errors.)