### PR TITLE
emails: Include the timezone's name on login notifications.

### DIFF
--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -79,7 +79,11 @@ def email_on_new_login(sender: Any, user: UserProfile, request: Any, **kwargs: A
         if user_tz == '':
             user_tz = timezone_get_current_timezone_name()
         local_time = timezone_now().astimezone(get_timezone(user_tz))
-        context['login_time'] = local_time.strftime('%A, %B %d, %Y at %I:%M%p %Z')
+        if user.twenty_four_hour_time:
+            hhmm_string = local_time.strftime('%H:%M')
+        else:
+            hhmm_string = local_time.strftime('%I:%M%p')
+        context['login_time'] = local_time.strftime('%A, %B %d, %Y at {} %Z'.format(hhmm_string))
         context['device_ip'] = request.META.get('REMOTE_ADDR') or _("Unknown IP address")
         context['device_os'] = get_device_os(user_agent)
         context['device_browser'] = get_device_browser(user_agent)

--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -79,8 +79,7 @@ def email_on_new_login(sender: Any, user: UserProfile, request: Any, **kwargs: A
         if user_tz == '':
             user_tz = timezone_get_current_timezone_name()
         local_time = timezone_now().astimezone(get_timezone(user_tz))
-        utc_offset = local_time.strftime('%z')
-        context['login_time'] = local_time.strftime('%A, %B %d, %Y at %I:%M%p ') + utc_offset
+        context['login_time'] = local_time.strftime('%A, %B %d, %Y at %I:%M%p %Z')
         context['device_ip'] = request.META.get('REMOTE_ADDR') or _("Unknown IP address")
         context['device_os'] = get_device_os(user_agent)
         context['device_browser'] = get_device_browser(user_agent)

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -35,8 +35,8 @@ class SendLoginEmailTest(ZulipTestCase):
             password = initial_password(user.email)
             firefox_windows = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"
             user_tz = get_timezone(user.timezone)
-            utc_offset = mock_time.astimezone(user_tz).strftime('%z')
-            reference_time = mock_time.astimezone(user_tz).strftime('%A, %B %d, %Y at %I:%M%p ') + utc_offset
+            mock_time = datetime.datetime(year=2018, month=1, day=1, tzinfo=utc)
+            reference_time = mock_time.astimezone(user_tz).strftime('%A, %B %d, %Y at %I:%M%p %Z')
             with mock.patch('zerver.signals.timezone_now', return_value=mock_time):
                 self.client_post("/accounts/login/", info={"username": user.email, "password": password},
                                  HTTP_USER_AGENT=firefox_windows)


### PR DESCRIPTION
Followup for cf813b44b, where we started showing the timezone's offset rather than one of its locations.

After these changes, we also display the timezone's abbreviation to give the user a clearer idea of which region in the globe the login is from.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** backend tests passed locally and made sure that the login emails showed up as expected in `/emails`.


**GIFs or Screenshots:**
![UTC timezone email](https://user-images.githubusercontent.com/7356565/43674643-bdcb8ac4-97d7-11e8-936f-22f1433ee5ed.png)

![CET](https://user-images.githubusercontent.com/7356565/43674652-e226fd22-97d7-11e8-85f1-1ded4f0fa336.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
