### PR TITLE
forms: Fix accounts listed in password_reset email to active accounts.

### DIFF
--- a/templates/zerver/emails/password_reset.source.html
+++ b/templates/zerver/emails/password_reset.source.html
@@ -6,20 +6,21 @@
         Someone (possibly you) requested a password reset email for {{ email }}
         on {{ realm_uri }}, but you do not have an
         active account in {{ realm_uri }}.
+        Kindly, contact the organization administrators.
 
-        {% if accounts %}
-            {% if multiple_accounts %}
+        {% if active_accounts %}
+            {% if multiple_active_accounts %}
             However, you do have active accounts in the following
             organizations.
             <ul>
-                {% for account in accounts %}
-                <li>{{ account.realm.uri }}</li>
+                {% for active_account in active_accounts %}
+                <li>{{ active_accounts.realm.uri }}</li>
                 {% endfor %}
             </ul>
             You can try logging in or resetting your password in the organization
             you want.
             {% else %}
-            However, you do have an active account in the {{ accounts[0].realm.uri }}
+            However, you do have an active account in the {{ active_accounts[0].realm.uri }}
             organization; you can try logging in or resetting your password there.
             {% endif %}
         {% endif %}

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -249,10 +249,10 @@ class ZulipPasswordResetForm(PasswordResetForm):
                        context=context)
         else:
             context['no_account_in_realm'] = True
-            accounts = UserProfile.objects.filter(email__iexact=email)
-            if accounts:
-                context['accounts'] = accounts
-                context['multiple_accounts'] = accounts.count() != 1
+            active_accounts = UserProfile.objects.filter(email__iexact=email, is_active=True)
+            if active_accounts:
+                context['active_accounts'] = active_accounts
+                context['multiple_active_accounts'] = active_accounts.count() != 1
             send_email('zerver/emails/password_reset', to_email=email,
                        from_name="Zulip Account Security",
                        from_address=FromAddress.tokenized_no_reply_address(),


### PR DESCRIPTION
Previously we were listing both accounts, active as well as non-active.
Fixes: #10130.
![screenshot from 2018-08-04 18-00-21](https://user-images.githubusercontent.com/22238472/43676495-521e4f12-9810-11e8-8bd3-816fbfbd914e.png)
A better alternative for "Kindly, contact the organization administrators." required.