### PR TITLE
stream settings: Fix hide change-sub-type when admin unsubscribe stream.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -60,6 +60,9 @@ exports.hide_sub_settings = function (sub) {
     $settings.find(".regular_subscription_settings").removeClass('in');
     // Clear email address widget
     $settings.find(".email-address").html("");
+    if (!sub.can_change_stream_permissions) {
+        $settings.find(".change-stream-privacy").hide();
+    }
 };
 
 exports.show_sub_settings = function (sub) {


### PR DESCRIPTION
Fixes #10163

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![unsub_stream](https://user-images.githubusercontent.com/25907420/43680519-6791a778-985a-11e8-8fa6-c68974246714.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
