### PR TITLE
emoji: Fix some emoji images not loading in missed message emails.

### DIFF
--- a/templates/zerver/help/enable-emoticon-translations.md
+++ b/templates/zerver/help/enable-emoticon-translations.md
@@ -61,7 +61,7 @@ automatically by Zulip.
             <td align="center"><code>&lt;3</code></td>
             <td align="center">
                 <img
-                    src="/static/generated/emoji/images-google-64/2764-fe0f.png"
+                    src="/static/generated/emoji/images-google-64/2764.png"
                     alt="heart"
                     style="width: 30%;">
             </td>

--- a/tools/setup/emoji/build_emoji
+++ b/tools/setup/emoji/build_emoji
@@ -3,6 +3,7 @@
 # See docs/subsystems/emoji.md for a high-level explanation of how this system
 # works.
 import os
+import shutil
 import sys
 import ujson
 
@@ -126,13 +127,31 @@ def generate_sprite_css_files(cache_path: str, emoji_data: List[Dict[str, Any]])
         sprite_css_file.close()
 
 def setup_emoji_farm(cache_path: str, emoji_data: List[Dict[str, Any]]) -> None:
+    def ensure_emoji_image(emoji_dict: Dict[str, Any]) -> None:
+        # We use individual images from emoji farm for rendering emojis
+        # in notification messages. We have a custom emoji formatter in
+        # notifications processing code that converts `span` tags to
+        # `img` and that logic requires us to have non-qualified
+        # `emoji_code` as file name for emoji.
+        emoji_code = get_emoji_code(emoji_dict)
+        img_file_name = emoji_code + '.png'
+        src_file = os.path.join(src_emoji_farm, emoji_dict['image'])
+        dst_file = os.path.join(target_emoji_farm, img_file_name)
+        shutil.copy2(src_file, dst_file)
+
     for emojiset in EMOJISETS:
         # Copy individual emoji images from npm packages.
         src_emoji_farm = os.path.join(
-            NODE_MODULES_PATH, 'emoji-datasource-' + emojiset, 'img', emojiset, '64', '*')
+            NODE_MODULES_PATH, 'emoji-datasource-' + emojiset, 'img', emojiset, '64')
         target_emoji_farm = os.path.join(cache_path, 'images-' + emojiset + '-64')
         run(['mkdir', '-p', target_emoji_farm])
-        run(['cp', '-RPp', src_emoji_farm, target_emoji_farm], shell=True)
+        print("Copying individual image files...")
+        for emoji_dict in emoji_data:
+            if emoji_dict['has_img_' + emojiset]:
+                ensure_emoji_image(emoji_dict)
+                skin_variations = emoji_dict.get('skin_variations', {})
+                for skin_tone in skin_variations:
+                    ensure_emoji_image(skin_variations[skin_tone])
 
         # Copy zulip.png to the emoji farm.
         zulip_image = "{}/static/assets/zulip-emoji/*".format(ZULIP_PATH)

--- a/tools/setup/emoji/build_emoji
+++ b/tools/setup/emoji/build_emoji
@@ -10,8 +10,8 @@ import ujson
 from typing import Any, Dict, List
 
 from emoji_setup_utils import generate_emoji_catalog, generate_codepoint_to_name_map, \
-    get_emoji_code, generate_name_to_codepoint_map, get_remapped_emojis_map, \
-    emoji_names_for_picker, EMOJISETS, EMOTICON_CONVERSIONS
+    get_emoji_code, generate_name_to_codepoint_map, emoji_names_for_picker, \
+    EMOJISETS, EMOTICON_CONVERSIONS, REMAPPED_EMOJIS
 from emoji_names import EMOJI_NAME_MAPS
 
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../')
@@ -184,12 +184,8 @@ def setup_old_emoji_farm(cache_path: str,
     unicode_symlink_path = os.path.join(unicode_emoji_cache_path, 'zulip.png')
     os.symlink(image_file_path, unicode_symlink_path)
 
-    # `remapped_emojis` is a mapping which helps in mapping `emoji_map`
-    # codepoints to corresponding images in new emoji farm.
-    remapped_emojis = get_remapped_emojis_map(emoji_data)
-
     for name, codepoint in emoji_map.items():
-        mapped_codepoint = remapped_emojis.get(codepoint, codepoint)
+        mapped_codepoint = REMAPPED_EMOJIS.get(codepoint, codepoint)
         image_file_path = os.path.join(google_emoji_cache_path, '{}.png'.format(mapped_codepoint))
         symlink_path = os.path.join(emoji_cache_path, '{}.png'.format(name))
         os.symlink(image_file_path, symlink_path)

--- a/tools/setup/emoji/emoji_setup_utils.py
+++ b/tools/setup/emoji/emoji_setup_utils.py
@@ -12,17 +12,17 @@ EMOJISETS = ['apple', 'emojione', 'google', 'twitter']
 # farm. `remapped_emojis` is a map that contains a mapping of their name in the old
 # emoji farm to their name in the new emoji farm.
 remapped_emojis = {
-    "0023": "0023-fe0f-20e3",    # Hash
-    "0030": "0030-fe0f-20e3",    # Zero
-    "0031": "0031-fe0f-20e3",    # One
-    "0032": "0032-fe0f-20e3",    # Two
-    "0033": "0033-fe0f-20e3",    # Three
-    "0034": "0034-fe0f-20e3",    # Four
-    "0035": "0035-fe0f-20e3",    # Five
-    "0036": "0036-fe0f-20e3",    # Six
-    "0037": "0037-fe0f-20e3",    # Seven
-    "0038": "0038-fe0f-20e3",    # Eight
-    "0039": "0039-fe0f-20e3",    # Nine
+    "0023": "0023-20e3",         # Hash
+    "0030": "0030-20e3",         # Zero
+    "0031": "0031-20e3",         # One
+    "0032": "0032-20e3",         # Two
+    "0033": "0033-20e3",         # Three
+    "0034": "0034-20e3",         # Four
+    "0035": "0035-20e3",         # Five
+    "0036": "0036-20e3",         # Six
+    "0037": "0037-20e3",         # Seven
+    "0038": "0038-20e3",         # Eight
+    "0039": "0039-20e3",         # Nine
     "1f1e8": "1f1e8-1f1f3",      # cn
     "1f1e9": "1f1e9-1f1ea",      # de
     "1f1ea": "1f1ea-1f1f8",      # es
@@ -114,11 +114,4 @@ def generate_name_to_codepoint_map(emoji_name_maps: Dict[str, Dict[str, Any]]) -
     return name_to_codepoint
 
 def get_remapped_emojis_map(emoji_data: List[Dict[str, Any]]) -> Dict[str, str]:
-    # Extend `remapped_emojis` to include emojis whose filename from version 4
-    # have a emoji presentation selector(FE0F) appended to them.
-    for emoji_dict in emoji_data:
-        if emoji_dict['non_qualified'] is not None:
-            unified_codepoint = emoji_dict['unified'].lower()
-            non_qualified_codepoint = emoji_dict['non_qualified'].lower()
-            remapped_emojis[non_qualified_codepoint] = unified_codepoint
     return remapped_emojis

--- a/tools/setup/emoji/emoji_setup_utils.py
+++ b/tools/setup/emoji/emoji_setup_utils.py
@@ -11,7 +11,7 @@ EMOJISETS = ['apple', 'emojione', 'google', 'twitter']
 # Some image files in the old emoji farm had a different name than in the new emoji
 # farm. `remapped_emojis` is a map that contains a mapping of their name in the old
 # emoji farm to their name in the new emoji farm.
-remapped_emojis = {
+REMAPPED_EMOJIS = {
     "0023": "0023-20e3",         # Hash
     "0030": "0030-20e3",         # Zero
     "0031": "0031-20e3",         # One
@@ -112,6 +112,3 @@ def generate_name_to_codepoint_map(emoji_name_maps: Dict[str, Dict[str, Any]]) -
         for alias in aliases:
             name_to_codepoint[alias] = emoji_code
     return name_to_codepoint
-
-def get_remapped_emojis_map(emoji_data: List[Dict[str, Any]]) -> Dict[str, str]:
-    return remapped_emojis

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.9.0-rc1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '25.6'
+PROVISION_VERSION = '25.7'


### PR DESCRIPTION
`emoji-datasource` package v4.0.4 introduced the concept of qualified
and non-qualified emoji codes. As chat programs don't need to use
emoji representation selector, so we used migrated our infrastructure
to use non-qualified emoji codes. But we missed the fact that the
emoji file names in emoji farm are based on emoji data's 'unified'
field and the value of this field has changed. Consequently the image
file names must also have been changed. We used `emoji_code` while
converting the span tags to img tags while processing notifications.
But since now `emoji_code` refers to non-qualified code while image
file names are based on qualified code, we will now need a mapping
to correctly do the conversion. This commit just fixes this.

@timabbott FYI.