### PR TITLE
lightbox: Display thumbnail while full-size image loads.

### DIFF
--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -28,6 +28,7 @@ set_global('$', function () {
             show: () => {},
         }),
         hide: () => {},
+        on: () => {},
         show: () => {},
         text: () => '',
     };

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -42,9 +42,17 @@ function display_image(payload, options) {
         photo.speed(2.3);
     } else {
         var img = new Image();
-        img.src = payload.source;
+        img.src = payload.preview;
 
         $("#lightbox_overlay .image-preview").html(img).show();
+
+        if (payload.preview !== payload.source) {
+            var fullsize_img = new Image();
+            fullsize_img.src = payload.source;
+            $(fullsize_img).on("load", function () {
+                $("#lightbox_overlay .image-preview img").attr("src", $(this).attr("src"));
+            });
+        }
     }
 
     $(".image-description .title").text(payload.title || "N/A");


### PR DESCRIPTION
We improve UX by making the loading process of images in lightbox
transparent to users. What users see is a thumbnail which a few
milliseconds later is replaces by a bigger and more clear picture.

Fixes: #10119 