### PR TITLE
Billing & upgrade styling updates

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -3105,7 +3105,7 @@ nav ul li.active::after {
             }
         }
         .box {
-            width: 100px;
+            width: 120px;
             height: 70px;
             background: #efefef;
             transition: all .2s ease;

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -3164,7 +3164,8 @@ nav ul li.active::after {
         box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.3);
     }
 
-    .stripe-button-el:active {
+    .stripe-button-el:active,
+    .stripe-button-el:not(:disabled):active {
         background: rgb(25, 139, 118);
         span {
             background: 0;

--- a/templates/zilencer/billing.html
+++ b/templates/zilencer/billing.html
@@ -19,6 +19,12 @@
         <div class="page-content">
             <div class="main">
 
+                {% if error_message %}
+                <div class="alert alert-danger" id="error-message-box">
+                    {{ error_message }}
+                </div>
+                {% endif %}
+
                 <h1>{{ _("Billing") }}</h1>
                 {% if admin_access %}
                 <ul class="nav nav-tabs" id="billing-tabs">

--- a/templates/zilencer/upgrade.html
+++ b/templates/zilencer/upgrade.html
@@ -33,7 +33,7 @@
                         <label>
                             <input type="radio" name="plan" value="{{ nickname_annual }}" checked />
                             <div class="box">
-                                <div class="schedule-time">{{ _("Pay annually") }}</div>
+                                <div class="schedule-time annually">{{ _("Pay annually") }}</div>
                                 <div class="schedule-amount">
                                     $6.67/user/month
                                     <div class="schedule-amount-2">


### PR DESCRIPTION
This makes a few small style fixes to the billing & upgrade pages:
- Upgrade: properly center the text in the monthly/annually buttons
- Upgrade: fix the active state of the Add Card button (it was previously turning blue when clicked because it was pulling in the default Stripe styling)
- Upgrade/billing: add styled space for error messages

<img width="881" alt="screen shot 2018-08-06 at 9 56 27 am" src="https://user-images.githubusercontent.com/2905696/43730357-ed9227d4-995f-11e8-8067-8a15f8f3fd21.png">
