### PR TITLE
default stream: Fix admin can't remove private unsubscribed default stream.

### DIFF
--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -141,7 +141,7 @@ exports.delete_sub = function (stream_id) {
 exports.get_non_default_stream_names = function () {
     var subs = stream_info.values();
     subs = _.reject(subs, function (sub) {
-        return exports.is_default_stream_id(sub.stream_id);
+        return exports.is_default_stream_id(sub.stream_id) || !sub.subscribed && sub.invite_only;
     });
     var names = _.pluck(subs, 'name');
     return names;

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -102,14 +102,15 @@ def check_stream_name_available(realm: Realm, name: str) -> None:
         pass
 
 def access_stream_by_name(user_profile: UserProfile,
-                          stream_name: str) -> Tuple[Stream, Recipient, Optional[Subscription]]:
+                          stream_name: str,
+                          allow_realm_admin: bool=False) -> Tuple[Stream, Recipient, Optional[Subscription]]:
     error = _("Invalid stream name '%s'" % (stream_name,))
     try:
         stream = get_realm_stream(stream_name, user_profile.realm_id)
     except Stream.DoesNotExist:
         raise JsonableError(error)
 
-    (recipient, sub) = access_stream_common(user_profile, stream, error)
+    (recipient, sub) = access_stream_common(user_profile, stream, error, allow_realm_admin=allow_realm_admin)
     return (stream, recipient, sub)
 
 def access_stream_for_unmute_topic(user_profile: UserProfile, stream_name: str, error: str) -> Stream:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -136,7 +136,7 @@ def remove_default_stream_group(request: HttpRequest, user_profile: UserProfile,
 def remove_default_stream(request: HttpRequest,
                           user_profile: UserProfile,
                           stream_name: str=REQ()) -> HttpResponse:
-    (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name)
+    (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name, allow_realm_admin=True)
     do_remove_default_stream(stream)
     return json_success()
 


### PR DESCRIPTION
Fix admin user can't remove private unsubscribed stream from default
streams.