### PR TITLE
Add puppet-lint into our linting tool chain.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -129,6 +129,7 @@ UBUNTU_COMMON_APT_DEPENDENCIES = [
     "wget",
     "ca-certificates",      # Explicit dependency in case e.g. wget is already installed
     "puppet",               # Used by lint
+    "puppet-lint",
     "gettext",              # Used by makemessages i18n
     "curl",                 # Used for fetching PhantomJS as wget occasionally fails on redirects
     "netcat",               # Used for flushing memcached

--- a/tools/lint
+++ b/tools/lint
@@ -42,7 +42,7 @@ def run():
     sys.path.insert(0, root_dir)
 
     from tools.linter_lib.custom_check import build_custom_checkers
-    from tools.linter_lib.exclude import EXCLUDED_FILES
+    from tools.linter_lib.exclude import EXCLUDED_FILES, PUPPET_CHECK_RULES_TO_EXCLUDE
     from tools.linter_lib.pyflakes import check_pyflakes
     from tools.linter_lib.pep8 import check_pep8
 
@@ -92,6 +92,8 @@ def run():
     linter_config.external_linter('tslint', ['node', 'node_modules/.bin/tslint', '-c',
                                              'static/ts/tslint.json'], ['ts'])
     linter_config.external_linter('puppet', ['puppet', 'parser', 'validate'], ['pp'])
+    linter_config.external_linter('puppet-lint',
+                                  ['puppet-lint'] + PUPPET_CHECK_RULES_TO_EXCLUDE, ['pp'])
     linter_config.external_linter('templates', ['tools/check-templates'], ['handlebars', 'html'])
     linter_config.external_linter('urls', ['tools/check-urls'], ['py'])
     linter_config.external_linter('swagger', ['node', 'tools/check-swagger'], ['yaml'])

--- a/tools/linter_lib/exclude.py
+++ b/tools/linter_lib/exclude.py
@@ -3,9 +3,19 @@ EXCLUDED_FILES = [
     # Third-party code that doesn't match our style
     "puppet/apt/.forge-release",
     "puppet/apt/README.md",
+    "puppet/apt/manifests/unattended_upgrades.pp",
+    "puppet/apt/manifests/params.pp",
+    "puppet/stdlib/tests/file_line.pp",
     "static/third",
     # Transifex syncs translation.json files without trailing
     # newlines; there's nothing other than trailing newlines we'd be
     # checking for in these anyway.
     "static/locale",
+]
+
+PUPPET_CHECK_RULES_TO_EXCLUDE = [
+    "--no-arrow_alignment-check",
+    "--no-double_quoted_strings-check",
+    "--no-2sp_soft_tabs-check",
+    "--no-documentation-check",
 ]

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.8.1+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '25.6'
+PROVISION_VERSION = '25.7'


### PR DESCRIPTION
In this PR we add puppet-lint to our linting tool chain. It has a series of commits which first add the puppet-lint module to the environment by adding installing it during provisioning. We do this carefully so that the no-op optimisations of the provisioning process we did don't lose their touch. We then fix some lint errors by either adding exceptions for it on a per line basis, excluding the rule from the checks entirely or fixing the error. Finally we hook up puppet-lint to run as part of tools/lint.

Fixes: #9185 