### PR TITLE
api docs: Live reload the OpenAPI spec on update.

### DIFF
--- a/zerver/lib/openapi.py
+++ b/zerver/lib/openapi.py
@@ -9,11 +9,6 @@ OPENAPI_SPEC_PATH = os.path.abspath(os.path.join(
     os.path.dirname(__file__),
     '../openapi/zulip.yaml'))
 
-with open(OPENAPI_SPEC_PATH) as file:
-    yaml_parser = YamoleParser(file)
-
-OPENAPI_SPEC = yaml_parser.data
-
 # A list of exceptions we allow when running validate_against_openapi_schema.
 # The validator will ignore these keys when they appear in the "content"
 # passed.
@@ -25,28 +20,51 @@ EXCLUDE_PROPERTIES = {
     }
 }
 
+class OpenAPISpec():
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.reload()
+
+    def reload(self) -> None:
+        self.last_update = os.path.getmtime(self.path)
+        with open(self.path) as f:
+            yaml_parser = YamoleParser(f)
+        self.data = yaml_parser.data
+
+    def spec(self) -> Dict[str, Any]:
+        """Reload the OpenAPI file if it has been modified after the last time
+        it was read, and then return the parsed data.
+        """
+        last_modified = os.path.getmtime(self.path)
+        # Using != rather than < to cover the corner case of users placing an
+        # earlier version than the current one
+        if self.last_update != last_modified:
+            self.reload()
+        return self.data
 
 class SchemaError(Exception):
     pass
+
+openapi_spec = OpenAPISpec(OPENAPI_SPEC_PATH)
 
 def get_openapi_fixture(endpoint: str, method: str,
                         response: Optional[str]='200') -> Dict[str, Any]:
     """Fetch a fixture from the full spec object.
     """
-    return (OPENAPI_SPEC['paths'][endpoint][method.lower()]['responses']
+    return (openapi_spec.spec()['paths'][endpoint][method.lower()]['responses']
             [response]['content']['application/json']['schema']
             ['example'])
 
 def get_openapi_parameters(endpoint: str,
                            method: str) -> List[Dict[str, Any]]:
-    return (OPENAPI_SPEC['paths'][endpoint][method.lower()]['parameters'])
+    return (openapi_spec.spec()['paths'][endpoint][method.lower()]['parameters'])
 
 def validate_against_openapi_schema(content: Dict[str, Any], endpoint: str,
                                     method: str, response: str) -> None:
     """Compare a "content" dict with the defined schema for a specific method
     in an endpoint.
     """
-    schema = (OPENAPI_SPEC['paths'][endpoint][method.lower()]['responses']
+    schema = (openapi_spec.spec()['paths'][endpoint][method.lower()]['responses']
               [response]['content']['application/json']['schema'])
 
     exclusion_list = (EXCLUDE_PROPERTIES.get(endpoint, {}).get(method, {})

--- a/zerver/lib/openapi.py
+++ b/zerver/lib/openapi.py
@@ -23,7 +23,7 @@ EXCLUDE_PROPERTIES = {
 class OpenAPISpec():
     def __init__(self, path: str) -> None:
         self.path = path
-        self.reload()
+        self.last_update = None  # type: Optional[float]
 
     def reload(self) -> None:
         self.last_update = os.path.getmtime(self.path)

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -6,7 +6,7 @@ import zerver.lib.openapi as openapi
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.openapi import (
     get_openapi_fixture, get_openapi_parameters,
-    validate_against_openapi_schema, to_python_type, SchemaError
+    validate_against_openapi_schema, to_python_type, SchemaError, openapi_spec
 )
 
 TEST_ENDPOINT = '/messages/{message_id}'
@@ -122,3 +122,13 @@ class OpenAPIToolsTest(ZulipTestCase):
 
         for oa_type, py_type in TYPES.items():
             self.assertEqual(to_python_type(oa_type), py_type)
+
+    def test_live_reload(self) -> None:
+        # Force the reload by making the last update date < the file's last
+        # modified date
+        openapi_spec.last_update = 0
+        get_openapi_fixture(TEST_ENDPOINT, TEST_METHOD)
+
+        # Check that the file has been reloaded by verifying that the last
+        # update date isn't zero anymore
+        self.assertNotEqual(openapi_spec.last_update, 0)


### PR DESCRIPTION
Automatically detect if the OpenAPI spec file has been modified since the last time it was loaded into memory, and if it has, automatically reload it to have the latest version.

This feature is designed with development environments in mind. The main benefit is being able to see the changes made to the OpenAPI document without needing to restart the development server, which is tedious and slows the documentation workflow down.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** mypy and lint checks passed locally. Made sure that `zerver.tests.test_openapi.OpenAPIToolsTest` passed and no coverage was lost.
