### PR TITLE
messages: Don't require "anchor" when "use_first_unread_anchor" is set.

### DIFF
--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -956,6 +956,13 @@ class MessageDictTest(ZulipTestCase):
         self.assertEqual(msg_dict['reactions'][0]['user']['full_name'],
                          sender.full_name)
 
+    def test_missing_anchor(self) -> None:
+        self.login(self.example_email("hamlet"))
+        result = self.client_get(
+            '/json/messages?use_first_unread_anchor=false&num_before=1&num_after=1')
+
+        self.assert_json_error(
+            result, "Missing 'anchor' argument (or set 'use_first_unread_anchor'=True).")
 
 class SewMessageAndReactionTest(ZulipTestCase):
     def test_sew_messages_and_reaction(self) -> None:

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1697,7 +1697,7 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         self.login(self.example_email("hamlet"))
 
-        required_args = (("anchor", 1), ("num_before", 1), ("num_after", 1))  # type: Tuple[Tuple[str, int], ...]
+        required_args = (("num_before", 1), ("num_after", 1))  # type: Tuple[Tuple[str, int], ...]
 
         for i in range(len(required_args)):
             post_params = dict(required_args[:i] + required_args[i + 1:])

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -688,7 +688,7 @@ def zcommand_backend(request: HttpRequest, user_profile: UserProfile,
 
 @has_request_variables
 def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
-                         anchor: int=REQ(converter=int),
+                         anchor: int=REQ(converter=int, default=None),
                          num_before: int=REQ(converter=to_non_negative_int),
                          num_after: int=REQ(converter=to_non_negative_int),
                          narrow: Optional[List[Dict[str, Any]]]=REQ('narrow', converter=narrow_parameter,
@@ -696,6 +696,8 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
                          use_first_unread_anchor: bool=REQ(validator=check_bool, default=False),
                          client_gravatar: bool=REQ(validator=check_bool, default=False),
                          apply_markdown: bool=REQ(validator=check_bool, default=True)) -> HttpResponse:
+    if anchor is None and not use_first_unread_anchor:
+        return json_error(_("Missing 'anchor' argument (or set 'use_first_unread_anchor'=True)."))
     include_history = ok_to_include_history(narrow, user_profile)
 
     if include_history:


### PR DESCRIPTION
The use_first_unread_anchor parameter allows automatically setting the anchor to the first message that hasn't been read in this narrow. Therefore it isn't necessary to specify an anchor when this parameter is enabled.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** lint, mypy and backend w/ coverage tests passed locally.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
