### PR TITLE
editorconfig: Enforce a 110 chars max line length.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ insert_final_newline = true
 [*.{sh,py,pyi,js,json,yml,xml,css,md,markdown,handlebars,html}]
 indent_style = space
 indent_size = 4
+max_line_length = 110
 
 [*.{svg,rb,pp,pl}]
 indent_style = space


### PR DESCRIPTION
Make supported IDEs and text editors keep a maximum line length of 110 characters for most code files.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** verified that it works fine in vim with the [EditorConfig plugin for vim](https://github.com/editorconfig/editorconfig-vim).

