### PR TITLE
user_groups: Handle renaming to existing names.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4865,9 +4865,12 @@ def do_send_user_group_update_event(user_group: UserGroup, data: Dict[str, Any])
     send_event(event, active_user_ids(user_group.realm_id))
 
 def do_update_user_group_name(user_group: UserGroup, name: str) -> None:
-    user_group.name = name
-    user_group.save(update_fields=['name'])
-    do_send_user_group_update_event(user_group, dict(name=name))
+    try:
+        user_group.name = name
+        user_group.save(update_fields=['name'])
+        do_send_user_group_update_event(user_group, dict(name=name))
+    except django.db.utils.IntegrityError:
+        raise JsonableError(_("User group '%s' already exists." % (name,)))
 
 def do_update_user_group_description(user_group: UserGroup, description: str) -> None:
     user_group.description = description

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -197,6 +197,20 @@ class UserGroupAPITestCase(ZulipTestCase):
         result = self.client_patch('/json/user_groups/{}'.format(user_group.id), info=params)
         self.assert_json_error(result, "Not allowed for guest users")
 
+    def test_user_group_update_to_already_existing_name(self) -> None:
+        hamlet = self.example_user('hamlet')
+        self.login(hamlet.email)
+        realm = get_realm('zulip')
+        support_user_group = create_user_group('support', [hamlet], realm)
+        marketing_user_group = create_user_group('marketing', [hamlet], realm)
+
+        params = {
+            'name': marketing_user_group.name,
+        }
+        result = self.client_patch('/json/user_groups/{}'.format(support_user_group.id), info=params)
+        self.assert_json_error(
+            result, "User group '{}' already exists.".format(marketing_user_group.name))
+
     def test_user_group_delete(self) -> None:
         hamlet = self.example_user('hamlet')
         self.login(self.example_email("hamlet"))


### PR DESCRIPTION
Renaming a user group to a name shared by other group wasn't a scenario handled by the backend, and the server errored whenever this was attempted.

Now a json_error is returned, letting the user know that a user group with that name already exists.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** lint, mypy and backend w/ coverage tests passed locally.

