### PR TITLE
Realm filters: Allow `#`(hash) based URLs in filter patterns.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -548,7 +548,7 @@ def filter_pattern_validator(value: str) -> None:
         raise ValidationError(error_msg)
 
 def filter_format_validator(value: str) -> None:
-    regex = re.compile(r'^[\.\/:a-zA-Z0-9_?=-]+%\(([a-zA-Z0-9_-]+)\)s[a-zA-Z0-9_-]*$')
+    regex = re.compile(r'^[\.\/:a-zA-Z0-9#_?=-]+%\(([a-zA-Z0-9_-]+)\)s[a-zA-Z0-9_-]*$')
 
     if not regex.match(value):
         raise ValidationError('URL format string must be in the following format: '

--- a/zerver/tests/test_realm_filters.py
+++ b/zerver/tests/test_realm_filters.py
@@ -44,7 +44,7 @@ class RealmFilterTest(ZulipTestCase):
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_error(result, 'URL format string must be in the following format: `https://example.com/%(\\w+)s`')
 
-        data['url_format_string'] = 'https://realm.com/my_realm_filter/%(id)s'
+        data['url_format_string'] = 'https://realm.com/my_realm_filter/#hashtag/%(id)s'
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_success(result)
 


### PR DESCRIPTION
Fixes #9817.
Use case: When people try to add a filter to a site that uses
a hash based router, which makes the URL like:
`http://some-site.domain.com/#/c/$(id)s`.