### PR TITLE
Attempt to optimize Zulip import performance with lazy loading

### DIFF
--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -8,7 +8,6 @@ from zerver.lib.redis_utils import get_redis_client
 
 from zerver.models import UserProfile
 
-import redis
 import time
 import logging
 
@@ -177,6 +176,7 @@ def is_ratelimited(entity: RateLimitedObject) -> Tuple[bool, float]:
 
 def incr_ratelimit(entity: RateLimitedObject) -> None:
     """Increases the rate-limit for the specified entity"""
+    import redis
     list_key, set_key, _ = entity.get_keys()
     now = time.time()
 

--- a/zerver/lib/redis_utils.py
+++ b/zerver/lib/redis_utils.py
@@ -1,8 +1,10 @@
 
 from django.conf import settings
 
-import redis
+if False:
+    import redis
 
-def get_redis_client() -> redis.StrictRedis:
+def get_redis_client() -> 'redis.StrictRedis':
+    import redis
     return redis.StrictRedis(host=settings.REDIS_HOST, port=settings.REDIS_PORT,
                              password=settings.REDIS_PASSWORD, db=0)

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -659,7 +659,7 @@ class TestAPNs(PushNotificationTest):
         import zerver.lib.push_notifications
         zerver.lib.push_notifications._apns_client_initialized = False
         with self.settings(APNS_CERT_FILE='/foo.pem'), \
-                mock.patch('zerver.lib.push_notifications.APNsClient') as mock_client:
+                mock.patch('apns2.client.APNsClient') as mock_client:
             client = get_apns_client()
             self.assertEqual(mock_client.return_value, client)
 


### PR DESCRIPTION
This is work on #9953.  @andersk can you try doing your flame graph on top of this branch?  I'm curious what replaces the python-twitter and apns imports.  

(You can use `tools/fetch-rebase-pull-request <PRID>` to check this out)