### PR TITLE
popovers: Show line breaks in Long type fields in user profile popovers.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -191,6 +191,7 @@ function show_user_profile(element, user) {
 
         profile_field.name = field.name;
         profile_field.is_user_field = false;
+        profile_field.type = field_type;
         if (field_value) {
             if (field_type === field_types.DATE.id) {
                 profile_field.value = moment(field_value).format(localFormat);

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -194,6 +194,11 @@ ul.remind_me_popover .remind_icon {
     font-size: 15px;
 }
 
+.user-profile-key-value-section[data-type="2"] .user-profile-modal-field-value {
+    white-space: pre-line;
+    overflow-wrap: break-word;
+}
+
 #user-profile-modal {
     border-radius: 4px;
 }

--- a/static/templates/user_profile_modal.handlebars
+++ b/static/templates/user_profile_modal.handlebars
@@ -22,7 +22,7 @@
         <div class="user-profile-modal-content">
             {{#each profile_data}}
                 {{#if this.value}}
-                <div class="user-profile-key-value-section">
+                <div data-type="{{this.type}}" class="user-profile-key-value-section">
                     <div class="user-profile-modal-field-name">{{this.name}}:</div>
                     {{#if this.is_user_field}}
                     <div class="pill-container not-editable" data-field-id="{{this.id}}">


### PR DESCRIPTION
Line breaks in long type user profile fields were previously not preserved. This PR fixes that.

![screenshot at aug 07 17-59-49](https://user-images.githubusercontent.com/15116870/43851966-f46ed7e0-9af0-11e8-9804-35aca303c7b1.png)
