### PR TITLE
api docs: Fix the live reload system.

### DIFF
--- a/zerver/lib/openapi.py
+++ b/zerver/lib/openapi.py
@@ -38,7 +38,7 @@ class OpenAPISpec():
         last_modified = os.path.getmtime(self.path)
         # Using != rather than < to cover the corner case of users placing an
         # earlier version than the current one
-        if self.last_update != last_modified:
+        if self.last_update != last_modified or self.data is None:
             self.reload()
         return self.data
 


### PR DESCRIPTION
After adding the commit for loading the OpenAPI file only whe necessary, we didn't take into account the fact that self.data isn't initialized on the first run of spec().

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** lint and mypy checks passed locally. Made sure that you can reach a docs page right after starting the server.

