### PR TITLE
Tab opens empty typeahead

### DIFF
--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -77,7 +77,8 @@ run_test('initizalize', () => {
         assert.equal(opts.fixed, true);
         assert.equal(opts.items, 12);
         assert.equal(opts.naturalSearch, true);
-        assert.equal(opts.helpOnEmptyStrings, true);
+        assert.equal(opts.tabOpensEmptyTypeahead, true);
+        assert.equal(opts.helpOnEmptyStrings, false);
         assert.equal(opts.matcher(), true);
 
         {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -70,6 +70,7 @@ exports.initialize = function () {
     // just represents the key of the hash, so it's redundant.)
     var search_object = {};
 
+    // tabOpensEmptyTypeahead overrides helpOnEmptyStrings.
     search_query_box.typeahead({
         source: function (query) {
             var suggestions;
@@ -86,7 +87,8 @@ exports.initialize = function () {
         },
         fixed: true,
         items: 12,
-        helpOnEmptyStrings: true,
+        tabOpensEmptyTypeahead: page_params.search_pills_enabled,
+        helpOnEmptyStrings: !page_params.search_pills_enabled,
         naturalSearch: true,
         highlighter: function (item) {
             var obj = search_object[item];

--- a/static/third/bootstrap/js/bootstrap.js
+++ b/static/third/bootstrap/js/bootstrap.js
@@ -1900,10 +1900,10 @@
 
   , lookup: function (event) {
       var items
+      var from_tab = (event === 'from_tab')
 
       this.query = this.$element.is("[contenteditable]") ? this.$element.text() :  this.$element.val();
-
-      if (!this.options.helpOnEmptyStrings) {
+      if (!this.options.helpOnEmptyStrings && !(from_tab && this.options.tabOpensEmptyTypeahead)) {
         if (!this.query || this.query.length < this.options.minLength) {
           return this.shown ? this.hide() : this
         }
@@ -2070,7 +2070,7 @@
 
         case 9: // tab
           if (!this.shown) {
-            this.lookup()
+            this.lookup('from_tab')
             return
           }
           this.select(e)
@@ -2143,6 +2143,7 @@
   , stopAdvance: false
   , dropup: false
   , advanceKeyCodes: []
+  , tabOpensEmptyTypeahead: false
   }
 
   $.fn.typeahead.Constructor = Typeahead

--- a/static/third/bootstrap/js/bootstrap.js
+++ b/static/third/bootstrap/js/bootstrap.js
@@ -2026,7 +2026,7 @@
     }
 
   , move: function (e) {
-      if (!this.shown) return
+      if (!this.shown && e.keyCode != 9) return
 
       switch(e.keyCode) {
         case 9: // tab
@@ -2069,6 +2069,13 @@
           break
 
         case 9: // tab
+          if (!this.shown) {
+            this.lookup()
+            return
+          }
+          this.select(e)
+          break
+        
         case 13: // enter
           if (!this.shown) return
           this.select(e)


### PR DESCRIPTION
Commit 1:

typeahead: Tab opens typeahead if not open with a non-empty input. 
Fixes part of #10026.
NOTE: The Tab key will select option from typeahead if the typeahead
is already open i.e the same behaviour as Enter.
NOTE: This behaviour applies irrespective of search pills are enabled
or not.

Commit 2:

search: Open typeahead on empty string only if lookup triggered by Tab.  …
Fixes part of #10026.
Adds additional option to typeahead:
`tabOpensEmptyTypeahead`(default: false):
tabOpensEmptyTypeahead overrides helpOnEmptyStrings.
This commit sets helpOnEmptyStrings to false and
tabOpensEmptyTypeahead to true. Now typeahead will
open on an empty string only if Tab has been pressed.

![peek 2018-08-08 23-43](https://user-images.githubusercontent.com/13910561/43857360-b8ecac9c-9b68-11e8-903a-558d1b532235.gif)
