### PR TITLE
tests: Make retention tests less time-sensitive.

### DIFF
--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -21,6 +21,7 @@ class TestRetentionLib(ZulipTestCase):
         super().setUp()
         self.zulip_realm = self._set_realm_message_retention_value('zulip', 30)
         self.mit_realm = self._set_realm_message_retention_value('zephyr', 100)
+        Message.objects.all().update(pub_date=timezone_now())
 
     @staticmethod
     def _set_realm_message_retention_value(realm_str: str, retention_period: int) -> Realm:


### PR DESCRIPTION
We now update all test messages to have a pub_date
of "now" in the setUp() function in TestRetentionLib.

We've seen tests flake on query counts before this
patch.  It's not certain that the test flaked due
to time-related glitches, but it seems the most
plausible explanation.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
