### PR TITLE
Remove "/stats" command for now.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -88,8 +88,7 @@ from zerver.lib.alert_words import alert_words_in_realm
 from zerver.lib.avatar import avatar_url, avatar_url_from_dict
 from zerver.lib.stream_recipient import StreamRecipientMap
 from zerver.lib.validator import check_widget_content
-from zerver.lib.widget import do_widget_post_save_actions, \
-    do_widget_pre_save_actions
+from zerver.lib.widget import do_widget_post_save_actions
 
 from django.db import transaction, IntegrityError, connection
 from django.db.models import F, Q, Max, Sum
@@ -1209,9 +1208,6 @@ def do_send_messages(messages_maybe_none: Sequence[Optional[MutableMapping[str, 
         message['local_id'] = message.get('local_id', None)
         message['sender_queue_id'] = message.get('sender_queue_id', None)
         message['realm'] = message.get('realm', message['message'].sender.realm)
-
-        # Some widgets need to overwrite content/etc. before message is saved.
-        do_widget_pre_save_actions(message)
 
         mention_data = bugdown.MentionData(
             realm_id=message['realm'].id,

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -7,16 +7,6 @@ import json
 from zerver.models import SubMessage
 
 
-def do_widget_pre_save_actions(message: MutableMapping[str, Any]) -> None:
-    if not settings.ALLOW_SUB_MESSAGES:
-        return
-
-    content = message['message'].content
-
-    if content == '/stats':
-        message['message'].content = 'We are running **1 server**.'
-        return
-
 def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
     valid_widget_types = ['tictactoe', 'poll', 'todo']
     tokens = content.split(' ')


### PR DESCRIPTION
The "/stats" command doesn't actually do anything
interesting yet, and it also writes to the message
feed instead of replying directly to the user.

The history of this command was that it was
written during a PyCon sprint.  It was mainly intended
as an example for subsequent slash commands.  The
ones we built after "/stats" have sort of outgrown
"/stats" and don't follow the original structure
for "/stats".  (The "/day", "/ping", and "/settings"
commands were built shortly after.)j

We probably want to ressurect "/stats" fairly soon,
after figuring out some useful stats and refining
the UI.

As you can see from this commit, resurrecting the
code here shouldn't be too difficult, but it
may actually be pretty rare that we just translate
slash commands into fleshed out messages.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
