### PR TITLE
render_markdown_path: Handle absolute template paths properly.

### DIFF
--- a/templates/zerver/privacy.html
+++ b/templates/zerver/privacy.html
@@ -21,7 +21,7 @@
         <div class="padded-content">
             <div class="inner-content">
                 {% if privacy_policy %}
-                    {{ render_markdown_path(privacy_policy) }}
+                    {{ render_markdown_path(privacy_policy, pure_markdown=True) }}
                 {% else %}
                     {% trans %}
                     This installation of Zulip does not have a configured privacy policy.

--- a/templates/zerver/terms.html
+++ b/templates/zerver/terms.html
@@ -20,7 +20,7 @@
         <div class="padded-content">
             <div class="inner-content">
                 {% if terms_of_service %}
-                    {{ render_markdown_path(terms_of_service) }}
+                    {{ render_markdown_path(terms_of_service, pure_markdown=True) }}
                 {% else %}
                     {% trans %}
                     This installation of Zulip does not have a configured terms of service.


### PR DESCRIPTION
One disadvantage of relying on Jinja2 to load all templates is
that it only searches a finite set of pre-configured template
directories. Unfortunately, that breaks when someone tries to
enable a custom privacy or terms page and has the corresponding
template in a directory outside of Jinja2's recognized directories
(for instance, it won't find `/etc/zulip/terms.md`).

This commit makes it so that render_markdown_path can be more
sensible about pure Markdown files and load templates with
absolute paths directly without relying on Jinja2, if need be.

@timabbott: FYI :)