### PR TITLE
compose: Update the `New topic` button to say `New stream message` when in PMs.

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -88,6 +88,8 @@ function expect_stream_subject() {
                 '<p>test message B</p>',
                 '<p>test message D</p>',
             ]);
+
+            casper.test.assertEquals(casper.fetchText('#left_bar_compose_stream_button_big'), 'New topic');
         });
     });
 }
@@ -149,6 +151,8 @@ function expect_all_pm() {
                 '<p>personal D</p>',
                 '<p>personal E</p>',
             ]);
+
+            casper.test.assertEquals(casper.fetchText('#left_bar_compose_stream_button_big'), 'New stream message');
         });
     });
 }

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -10,6 +10,7 @@ zrequire('search_pill');
 
 set_global('blueslip', {});
 set_global('channel', {});
+set_global('compose', {});
 set_global('compose_actions', {});
 set_global('current_msg_list', {});
 set_global('hashchange', {});
@@ -82,6 +83,7 @@ function test_helper() {
     stub('top_left_corner', 'handle_narrow_activated');
     stub('ui_util', 'change_tab_to');
     stub('unread_ops', 'process_visible');
+    stub('compose', 'update_stream_button_for_stream');
 
     stub_trigger(() => { events.push('trigger event'); });
 
@@ -206,6 +208,7 @@ run_test('basics', () => {
         'message_scroll.hide_indicators',
         'unread_ops.process_visible',
         'hashchange.save_narrow',
+        'compose.update_stream_button_for_stream',
         'search.update_button_visibility',
         'compose_actions.on_narrow',
         'top_left_corner.handle_narrow_activated',

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -100,6 +100,16 @@ exports.clear_preview_area = function () {
     $("#markdown_preview").show();
 };
 
+exports.update_stream_button_for_private = function () {
+    $("#left_bar_compose_stream_button_big").html(i18n.t("New stream message"));
+    $("#left_bar_compose_stream_button_big").prop("title", i18n.t("New stream message"));
+};
+
+exports.update_stream_button_for_stream = function () {
+    $("#left_bar_compose_stream_button_big").html(i18n.t("New topic"));
+    $("#left_bar_compose_stream_button_big").prop("title", i18n.t("New topic"));
+};
+
 function update_fade() {
     if (!compose_state.composing()) {
         return;

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -253,6 +253,13 @@ exports.activate = function (raw_operators, opts) {
         });
     }
 
+    if (filter.has_operator("is") && filter.operands("is")[0] === "private"
+        || filter.has_operator("pm-with") || filter.has_operator("group-pm-with")) {
+        compose.update_stream_button_for_private();
+    } else {
+        compose.update_stream_button_for_stream();
+    }
+
     // Put the narrow operators in the search bar.
     $('#search_query').val(Filter.unparse(operators));
     search.update_button_visibility();
@@ -670,6 +677,7 @@ exports.deactivate = function () {
 
     top_left_corner.handle_narrow_deactivated();
     stream_list.handle_narrow_deactivated();
+    compose.update_stream_button_for_stream();
 
     $(document).trigger($.Event('narrow_deactivated.zulip', {msg_list: current_msg_list}));
 


### PR DESCRIPTION
If a user is narrowed by `is:private`, `pm-with`, or `group-pm-with`, this PR changes the `New topic` button to say `New stream message` instead for added clarity.

Fixes #9072.

**Testing Plan:** <!-- How have you tested? -->

This PR adds two new tests to the `narrow` Casper tests and updates the Node tests.

**GIFs or Screenshots:**

*When in a public stream (or "All messages" and other non-private narrows):*

<img width="958" alt="public-screenshot" src="https://user-images.githubusercontent.com/17259768/43877545-5f998b2e-9b4f-11e8-8f65-f26e290f5834.png">

*When in a PM:*

<img width="960" alt="private-screenshot" src="https://user-images.githubusercontent.com/17259768/43877547-617d62f8-9b4f-11e8-853e-ea2d7c53317b.png">
