### PR TITLE
import: Fix rendered_content in imported messages.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -420,6 +420,7 @@ def build_custom_checkers(by_lang):
         {'pattern': '[^r]Message.objects.get',
          'exclude': set(["zerver/tests",
                          "zerver/lib/onboarding.py",
+                         "zerver/lib/import_realm.py",
                          "zilencer/management/commands/add_mock_conversation.py",
                          "zerver/worker/queue_processors.py"]),
          'description': 'Please use access_message() to fetch Message objects',

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -18,6 +18,8 @@ from zerver.lib.bulk_create import bulk_create_users
 from zerver.lib.create_user import random_api_key
 from zerver.lib.export import DATE_FIELDS, realm_tables, \
     Record, TableData, TableName, Field, Path
+from zerver.lib.message import save_message_rendered_content
+from zerver.lib.bugdown import version as bugdown_version
 from zerver.lib.upload import random_name, sanitize_name, \
     S3UploadBackend, LocalUploadBackend
 from zerver.lib.create_user import random_api_key
@@ -196,6 +198,21 @@ def fix_customprofilefield(data: TableData) -> None:
                 related_table='user_profile',
                 old_id_list=old_user_id_list)
             item['value'] = ujson.dumps(new_id_list)
+
+def fix_message_rendered_content(data: TableData, field: TableName) -> None:
+    """
+    This function sets the rendered_content of all the messages
+    after the messages have been imported.
+    """
+    for message in data[field]:
+        message_object = Message.objects.get(id=message['id'])
+        try:
+            rendered_content = save_message_rendered_content(message_object, message['content'])
+        except Exception:
+            logging.warning("Error in markdown rendering for message ID %s; continuing" % (message['id']))
+
+        if rendered_content is None:
+            logging.warning("Error in markdown rendering for message ID %s; continuing" % (message['id']))
 
 def current_table_ids(data: TableData, table: TableName) -> List[int]:
     """
@@ -861,6 +878,7 @@ def import_message_data(import_dir: Path) -> None:
 
         re_map_foreign_keys(data, 'zerver_message', 'id', related_table='message', id_field=True)
         bulk_import_model(data, Message)
+        fix_message_rendered_content(data, 'zerver_message')
 
         # Due to the structure of these message chunks, we're
         # guaranteed to have already imported all the Message objects

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -151,6 +151,13 @@ def stringify_message_dict(message_dict: Dict[str, Any]) -> bytes:
 def message_to_dict_json(message: Message) -> bytes:
     return MessageDict.to_dict_uncached(message)
 
+def save_message_rendered_content(message: Message, content: str) -> str:
+    rendered_content = render_markdown(message, content, realm=message.get_realm())
+    message.rendered_content = rendered_content
+    message.rendered_content_version = bugdown.version
+    message.save_rendered_content()
+    return rendered_content
+
 class MessageDict:
     @staticmethod
     def wide_dict(message: Message) -> Dict[str, Any]:
@@ -347,10 +354,7 @@ class MessageDict:
             assert message is not None  # Hint for mypy.
             # It's unfortunate that we need to have side effects on the message
             # in some cases.
-            rendered_content = render_markdown(message, content, realm=message.get_realm())
-            message.rendered_content = rendered_content
-            message.rendered_content_version = bugdown.version
-            message.save_rendered_content()
+            rendered_content = save_message_rendered_content(message, content)
 
         if rendered_content is not None:
             obj['rendered_content'] = rendered_content


### PR DESCRIPTION
After the messages have been imported, set the rendered_content of the messages instead of
leaving its value to be `None`.

Fixes #9168

