### PR TITLE
compose: Shorten new message buttons' text on mobile

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1640,3 +1640,31 @@ run_test('nonexistent_stream_reply_error', () => {
     assert.equal($("#compose-reply-error-msg").html(), 'There are no messages to reply to yet.');
     assert(shown < hidden); // test shown before hidden
 });
+
+run_test('narrow_button_titles', () => {
+    util.is_mobile = () => { return false; };
+
+    compose.update_buttons_for_private();
+
+    assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("New stream message"));
+    assert.equal($("#left_bar_compose_private_button_big").text(), i18n.t("New private message"));
+
+    compose.update_buttons_for_stream();
+
+    assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("New topic"));
+    assert.equal($("#left_bar_compose_private_button_big").text(), i18n.t("New private message"));
+});
+
+run_test('narrow_button_titles_mobile', () => {
+    util.is_mobile = () => { return true; };
+
+    compose.update_buttons_for_private();
+
+    assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("Stream message"));
+    assert.equal($("#left_bar_compose_private_button_big").text(), i18n.t("New PM"));
+
+    compose.update_buttons_for_stream();
+
+    assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("New topic"));
+    assert.equal($("#left_bar_compose_private_button_big").text(), i18n.t("New PM"));
+});

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -83,7 +83,7 @@ function test_helper() {
     stub('top_left_corner', 'handle_narrow_activated');
     stub('ui_util', 'change_tab_to');
     stub('unread_ops', 'process_visible');
-    stub('compose', 'update_stream_button_for_stream');
+    stub('compose', 'update_buttons_for_stream');
 
     stub_trigger(() => { events.push('trigger event'); });
 
@@ -208,7 +208,7 @@ run_test('basics', () => {
         'message_scroll.hide_indicators',
         'unread_ops.process_visible',
         'hashchange.save_narrow',
-        'compose.update_stream_button_for_stream',
+        'compose.update_buttons_for_stream',
         'search.update_button_visibility',
         'compose_actions.on_narrow',
         'top_left_corner.handle_narrow_activated',

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -111,13 +111,23 @@ function update_stream_button(title) {
 }
 
 exports.update_buttons_for_private = function () {
-    update_stream_button(i18n.t("New stream message"));
-    update_private_button(i18n.t("New private message"));
+    if (util.is_mobile()) {
+        update_stream_button(i18n.t("Stream message"));
+        update_private_button(i18n.t("New PM"));
+    } else {
+        update_stream_button(i18n.t("New stream message"));
+        update_private_button(i18n.t("New private message"));
+    }
 };
 
 exports.update_buttons_for_stream = function () {
-    update_stream_button(i18n.t("New topic"));
-    update_private_button(i18n.t("New private message"));
+    if (util.is_mobile()) {
+        update_stream_button(i18n.t("New topic"));
+        update_private_button(i18n.t("New PM"));
+    } else {
+        update_stream_button(i18n.t("New topic"));
+        update_private_button(i18n.t("New private message"));
+    }
 };
 
 function update_fade() {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -100,14 +100,17 @@ exports.clear_preview_area = function () {
     $("#markdown_preview").show();
 };
 
+function update_stream_button(title) {
+    $("#left_bar_compose_stream_button_big").text(title);
+    $("#left_bar_compose_stream_button_big").prop("title", title);
+}
+
 exports.update_stream_button_for_private = function () {
-    $("#left_bar_compose_stream_button_big").html(i18n.t("New stream message"));
-    $("#left_bar_compose_stream_button_big").prop("title", i18n.t("New stream message"));
+    update_stream_button(i18n.t("New stream message"));
 };
 
 exports.update_stream_button_for_stream = function () {
-    $("#left_bar_compose_stream_button_big").html(i18n.t("New topic"));
-    $("#left_bar_compose_stream_button_big").prop("title", i18n.t("New topic"));
+    update_stream_button(i18n.t("New topic"));
 };
 
 function update_fade() {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -100,17 +100,24 @@ exports.clear_preview_area = function () {
     $("#markdown_preview").show();
 };
 
+function update_private_button(title) {
+    $("#left_bar_compose_private_button_big").text(title);
+    $("#left_bar_compose_private_button_big").prop("title", title);
+}
+
 function update_stream_button(title) {
     $("#left_bar_compose_stream_button_big").text(title);
     $("#left_bar_compose_stream_button_big").prop("title", title);
 }
 
-exports.update_stream_button_for_private = function () {
+exports.update_buttons_for_private = function () {
     update_stream_button(i18n.t("New stream message"));
+    update_private_button(i18n.t("New private message"));
 };
 
-exports.update_stream_button_for_stream = function () {
+exports.update_buttons_for_stream = function () {
     update_stream_button(i18n.t("New topic"));
+    update_private_button(i18n.t("New private message"));
 };
 
 function update_fade() {

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -255,9 +255,9 @@ exports.activate = function (raw_operators, opts) {
 
     if (filter.has_operator("is") && filter.operands("is")[0] === "private"
         || filter.has_operator("pm-with") || filter.has_operator("group-pm-with")) {
-        compose.update_stream_button_for_private();
+        compose.update_buttons_for_private();
     } else {
-        compose.update_stream_button_for_stream();
+        compose.update_buttons_for_stream();
     }
 
     // Put the narrow operators in the search bar.
@@ -677,7 +677,7 @@ exports.deactivate = function () {
 
     top_left_corner.handle_narrow_deactivated();
     stream_list.handle_narrow_deactivated();
-    compose.update_stream_button_for_stream();
+    compose.update_buttons_for_stream();
 
     $(document).trigger($.Event('narrow_deactivated.zulip', {msg_list: current_msg_list}));
 

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -37,6 +37,7 @@ IGNORED_PHRASES = [
     r"OTP",
     r"Pivotal",
     r"Play Store",
+    r"PM",
     r'REMOTE_USER',
     r'Slack',
     r"SSO",


### PR DESCRIPTION
This PR shortens the `New private message` and `New stream message` buttons' text when on mobile. With these changes, the buttons will fit (not wrap) on any mobile devices that have a width of around `285px` or greater.

The titles used are as follows:

<table >
    <tbody>
        <tr>
            <td></td>
            <td> <b>Private</b> Message button, <b>Private</b> narrow </td>
            <td> <b>Stream</b> Message button, <b>Private</b> narrow </td>
            <td> <b>Private</b> Message button, <b>Public</b> narrow </td>
            <td> <b>Stream</b> Message button, <b>Public</b> narrow </td>
        </tr>
        <tr>
            <td> <b>On Desktop</b> </td>
            <td> <code>New private message</code> </td>
            <td> <code>New stream message</code> </td>
            <td> <code>New private message</code> </td>
            <td> <code>New topic</code> </td>
        </tr>
        <tr>
            <td> <b>On Mobile</b> </td>
            <td> <code>New PM</code> </td>
            <td> <code>Stream message</code> </td>
            <td> <code>New PM</code> </td>
            <td> <code>New topic</code> </td>
        </tr>
    </tbody>
</table>

**Testing Plan:** <!-- How have you tested? -->

This PR updates the current Node tests to account for the new function name `update_buttons_for_stream` as well as creates two new tests for both `update_buttons_for_private` and `update_buttons_for_stream` on desktop and on mobile.

**Screenshots:**

*Private narrow buttons on desktop:*

<img width="1046" alt="private-desktop" src="https://user-images.githubusercontent.com/17259768/43977807-11883ede-9c9a-11e8-8dd5-77e134fb824a.png">

*Shortened private narrow buttons on mobile:*

<img width="319" alt="private-mobile" src="https://user-images.githubusercontent.com/17259768/43977813-143a8c9a-9c9a-11e8-855a-98ce3a86283a.png">

*Public narrow buttons on desktop:*

<img width="1046" alt="public-desktop" src="https://user-images.githubusercontent.com/17259768/43977819-18073e36-9c9a-11e8-8f7d-60f02ea0cb35.png">

*Shortened public narrow buttons on mobile:*

<img width="318" alt="public-mobile" src="https://user-images.githubusercontent.com/17259768/43977828-1c3364da-9c9a-11e8-9f79-29fe91645c42.png">
