### PR TITLE
logging: Show timestamp in UTC in non-django production scripts.

### DIFF
--- a/puppet/zulip/files/postgresql/pg_backup_and_purge
+++ b/puppet/zulip/files/postgresql/pg_backup_and_purge
@@ -8,10 +8,12 @@ import sys
 import logging
 import dateutil.parser
 import pytz
+import time
 from datetime import datetime, timedelta
 if False:
     from typing import Dict, List
 
+logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 

--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -52,6 +52,7 @@ def am_master(cursor):
     cursor.execute("SELECT pg_is_in_recovery()")
     return not cursor.fetchall()[0][0]
 
+logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("process_fts_updates")
 logger.setLevel(logging.DEBUG)

--- a/scripts/lib/upgrade-zulip
+++ b/scripts/lib/upgrade-zulip
@@ -4,6 +4,7 @@ import shutil
 import sys
 import subprocess
 import logging
+import time
 
 TARBALL_ARCHIVE_PATH = "/home/zulip/archives"
 os.environ["PYTHONUNBUFFERED"] = "y"
@@ -12,6 +13,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, \
     su_to_zulip, get_deployment_lock, release_deployment_lock
 
+logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip: %(message)s",
                     level=logging.INFO)
 

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -9,6 +9,7 @@ import subprocess
 import os
 import sys
 import logging
+import time
 
 os.environ["PYTHONUNBUFFERED"] = "y"
 
@@ -20,6 +21,7 @@ os.environ["LANGUAGE"] = "en_US.UTF-8"
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, su_to_zulip
 
+logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip-stage-2: %(message)s",
                     level=logging.INFO)
 

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -9,6 +9,7 @@ import time
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from scripts.lib.zulip_tools import ENDC, OKGREEN, DEPLOYMENTS_DIR
 
+logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s restart-server: %(message)s",
                     level=logging.INFO)
 

--- a/scripts/upgrade-zulip-from-git
+++ b/scripts/upgrade-zulip-from-git
@@ -4,6 +4,7 @@ import configparser
 import sys
 import subprocess
 import logging
+import time
 
 config_file = configparser.RawConfigParser()
 config_file.read("/etc/zulip/zulip.conf")
@@ -24,6 +25,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, make_deploy_path, \
     get_deployment_lock, release_deployment_lock, su_to_zulip
 
+logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip-from-git: %(message)s",
                     level=logging.INFO)
 

--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -465,6 +465,8 @@ def clear_scheduled_emails(user_id: int, email_type: Optional[int]=None) -> None
 
 def log_digest_event(msg: str) -> None:
     import logging
+    import time
+    logging.Formatter.converter = time.gmtime
     logging.basicConfig(filename=settings.DIGEST_LOG_PATH, level=logging.INFO)
     logging.info(msg)
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

No automated tests- couldn't find any relevant files to add tests to.

Tested output of `restart-server, upgrade-from-git, upgrade-zulip, upgrade-zulip-part-2`. The other tools should ideally be working as advertised as well but we couldn't trigger them on nightly (`zerver/management/*`, `puppet/zulip*`). We didn't change this in `tools/*` beause they are meant to be used in the dev env.

**Sample output:**

```
2018-08-11 20:02:57,105 upgrade-zulip-stage-2: Restarting Zulip...
2018-08-11 20:03:01,614 restart-server: Filling memcached caches
2018-08-11 20:03:07.142 INFO [] Successfully populated client cache!  Consumed 1 remote cache queries (0.01 time)
2018-08-11 20:03:07.144 INFO [] Successfully populated huddle cache!  Consumed 1 remote cache queries (0.0 time)
2018-08-11 20:03:07.156 INFO [] Successfully populated stream cache!  Consumed 1 remote cache queries (0.0 time)
2018-08-11 20:03:07.160 INFO [] Successfully populated session cache!  Consumed 1 remote cache queries (0.0 time)
2018-08-11 20:03:07.168 INFO [] Successfully populated user cache!  Consumed 1 remote cache queries (0.0 time)
2018-08-11 20:03:07.172 INFO [] Successfully populated recipient cache!  Consumed 1 remote cache queries (0.0 time)
2018-08-11 20:03:07,514 restart-server: Stopping workers
2018-08-11 20:03:07,914 restart-server: Stopping server core
2018-08-11 20:03:08,287 restart-server: Starting server core
2018-08-11 20:03:12,940 restart-server: Starting workers
2018-08-11 20:03:17,626 restart-server: Done!
2018-08-11 20:03:17,653 upgrade-zulip-stage-2: Upgrade complete!
```

Fixes #9678 .