### PR TITLE
Modify APNS payload for playing the default sound on notification on iOS

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -527,6 +527,7 @@ def get_apns_payload(message: Message) -> Dict[str, Any]:
             'title': get_alert_from_message(message),
             'body': content,
         },
+        'sound': 'default',
         'badge': 0,  # TODO: set badge count in a better way
         'custom': {'zulip': zulip_data},
     }

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -780,6 +780,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'body': message.content,
             },
             'badge': 0,
+            'sound': 'default',
             'custom': {
                 'zulip': {
                     'message_ids': [message.id],
@@ -811,6 +812,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'body': message.content,
             },
             'badge': 0,
+            'sound': 'default',
             'custom': {
                 'zulip': {
                     'message_ids': [message.id],
@@ -841,6 +843,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'body': "***REDACTED***",
             },
             'badge': 0,
+            'sound': 'default',
             'custom': {
                 'zulip': {
                     'message_ids': [message.id],


### PR DESCRIPTION
Haven't tested this but it should fix the notification sound not playing on iOS. This issue (https://github.com/zulip/zulip-mobile/issues/2651) 

According to the docs for payload APNS (https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1) 

> Include this key when you want the system to play a sound. The value of this key is the name of a sound file in your app’s main bundle or in the Library/Sounds folder of your app’s data container. If the sound file cannot be found, or if you specify defaultfor the value, the system plays the default alert sound.

It's not clear by these docs what happens if we don't include the sound key in the dictionary (the case which is followed now , but reading the stackoverflow answer here https://stackoverflow.com/questions/26973415/ios-8-1-push-notification-no-sound suggests the OP got it working after adding this key 