### PR TITLE
hotkey: Add hotkey to narrow to starred messages.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -70,12 +70,13 @@ run_test('mappings', () => {
         });
     }
 
-    function map_down(which, shiftKey, ctrlKey, metaKey) {
+    function map_down(which, shiftKey, ctrlKey, metaKey, altKey) {
         return hotkey.get_keydown_hotkey({
             which: which,
             shiftKey: shiftKey,
             ctrlKey: ctrlKey,
             metaKey: metaKey,
+            altKey: altKey,
         });
     }
 
@@ -135,6 +136,8 @@ run_test('mappings', () => {
     assert.equal(map_down(83, false, true, false), undefined); // ctrl + s
     // Reset userAgent
     global.navigator.userAgent = '';
+
+    assert.equal(map_down(83, false, true, false, true).name, 'narrow_starred'); // ctrl + alt + s
 });
 
 run_test('basic_chars', () => {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -111,12 +111,22 @@ var keypress_mappings = {
     120: {name: 'compose_private_message', message_view_only: true}, // 'x'
 };
 
+var keydown_ctrl_alt_mappings = {
+    83: {name: 'narrow_starred', message_view_only: true}, // 's'
+};
+
 exports.get_keydown_hotkey = function (e) {
+    var hotkey;
+
     if (e.altKey) {
+        if (e.ctrlKey) {
+            hotkey = keydown_ctrl_alt_mappings[e.which];
+            if (hotkey) {
+                return hotkey;
+            }
+        }
         return;
     }
-
-    var hotkey;
 
     if (e.ctrlKey && !e.shiftKey) {
         hotkey = keydown_ctrl_mappings[e.which];
@@ -623,6 +633,10 @@ exports.process_hotkey = function (e, hotkey) {
     case 'narrow_private':
         return do_narrow_action(function (target, opts) {
             narrow.by('is', 'private', opts);
+        });
+    case 'narrow_starred':
+        return do_narrow_action(function (target, opts) {
+            narrow.by('is', 'starred', opts);
         });
     case 'query_streams':
         stream_list.initiate_search();

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -171,6 +171,10 @@
                     <td class="definition">{% trans %}Narrow to all private messages{% endtrans %}</td>
                 </tr>
                 <tr>
+                    <td class="hotkey">Ctrl + Alt + s</td>
+                    <td class="definition">{% trans %}Narrow to starred messages{% endtrans %}</td>
+                </tr>
+                <tr>
                     <td class="hotkey">n</td>
                     <td class="definition">{% trans %}Narrow to next unread topic{% endtrans %}</td>
                 </tr>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -76,6 +76,8 @@ below, and add more to your repertoire as needed.
 
 * **Narrow to all private messages**: `P`
 
+* **Narrow to starred messages**: `Ctrl + Alt + s`
+
 * **Cycle between stream narrows**: `A` (previous) and `D` (next)
 
 * **Narrow to all messages**: `Esc` or `Ctrl` + `[` — Shows all unmuted messages.


### PR DESCRIPTION
Didn't notice that #9967 was open (oops). But, I've been working on making starred (unread) counts on the UI and needed a hotkey to keep bouncing back and forth for starred messages.