### PR TITLE
digest_email: Add endpoint for rendering digest to the web.

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Iterable, List, Set, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Set, Tuple, Union
 
 from collections import defaultdict
 import datetime
@@ -187,7 +187,8 @@ def enough_traffic(unread_pms: str, hot_conversations: str, new_streams: int, ne
         return True
     return False
 
-def handle_digest_email(user_profile_id: int, cutoff: float) -> None:
+def handle_digest_email(user_profile_id: int, cutoff: float,
+                        render_to_web: bool = False) -> Union[None, Dict[str, Any]]:
     user_profile = get_user_profile_by_id(user_profile_id)
 
     # We are disabling digest emails for soft deactivated users for the time.
@@ -250,11 +251,13 @@ def handle_digest_email(user_profile_id: int, cutoff: float) -> None:
         user_profile, cutoff_date)
     context["new_users"] = new_users
 
-    # We don't want to send emails containing almost no information.
-    if enough_traffic(context["unread_pms"], context["hot_conversations"],
-                      new_streams_count, new_users_count):
-        logger.info("Sending digest email for %s" % (user_profile.email,))
-        # Send now, as a ScheduledEmail
-        send_future_email('zerver/emails/digest', user_profile.realm, to_user_id=user_profile.id,
-                          from_name="Zulip Digest", from_address=FromAddress.NOREPLY,
-                          context=context)
+    if not render_to_web:
+        # We don't want to send emails containing almost no information.
+        if enough_traffic(context["unread_pms"], context["hot_conversations"],
+                          new_streams_count, new_users_count):
+            logger.info("Sending digest email for %s" % (user_profile.email,))
+            # Send now, as a ScheduledEmail
+            send_future_email('zerver/emails/digest', user_profile.realm, to_user_id=user_profile.id,
+                              from_name="Zulip Digest", from_address=FromAddress.NOREPLY,
+                              context=context)
+    return context

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -168,3 +168,9 @@ class TestDigestEmailMessages(ZulipTestCase):
         do_create_user('abc@mit.edu', password='abc', realm=user.realm, full_name='abc', short_name='abc')
         gathered_no_of_user, _ = gather_new_users(user, cutoff)
         self.assertEqual(gathered_no_of_user, 0)
+
+class TestDigestContentInBrowser(ZulipTestCase):
+    def test_get_digest_content_in_browser(self) -> None:
+        self.login(self.example_email('hamlet'))
+        result = self.client_get("/digest/")
+        self.assert_in_success_response(["A lot has happened on Zulip while you've been away!"], result)

--- a/zerver/views/digest.py
+++ b/zerver/views/digest.py
@@ -1,0 +1,14 @@
+import time
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.utils.timezone import now as timezone_now
+from zerver.lib.digest import handle_digest_email, DIGEST_CUTOFF
+from zerver.decorator import zulip_login_required
+from datetime import timedelta
+
+@zulip_login_required
+def digest_page(request: HttpRequest) -> HttpResponse:
+    user_profile_id = request.user.id
+    cutoff = time.mktime((timezone_now() - timedelta(days=DIGEST_CUTOFF)).timetuple())
+    context = handle_digest_email(user_profile_id, cutoff, render_to_web=True)
+    return render(request, 'zerver/emails/digest.html', context=context)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -33,6 +33,7 @@ import zerver.views.user_settings
 import zerver.views.muting
 import zerver.views.streams
 import zerver.views.realm
+import zerver.views.digest
 
 from zerver.lib.rest import rest_dispatch
 
@@ -416,6 +417,9 @@ i18n_urls = [
         name='zerver.views.users.avatar'),
     url(r'^avatar/(?P<email_or_id>[\S]+)', zerver.views.users.avatar,
         name='zerver.views.users.avatar'),
+
+    # Displays digest email content in browser.
+    url(r'^digest/$', zerver.views.digest.digest_page),
 
     # Registration views, require a confirmation ID.
     url(r'^accounts/register/social/(\w+)$',


### PR DESCRIPTION
Adds "/digest/" endpoint for rendering content of digest email
to the web.

Fixes #9974