### PR TITLE
portico: Fix mis-sized bullets on /for/working-groups.

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2179,6 +2179,9 @@ nav ul li.active::after {
     line-height: 1.6;
     font-size: 1.2em;
     margin-bottom: 5px;
+    p {
+        font-size: 1em;
+    }
 }
 
 .portico-landing.why-page .main li strong {


### PR DESCRIPTION
This fixes the mis-sized text in the bulleted lists on /for/working-groups-and-communities. The error was caused by the text in the `li` tags also being wrapped in `p` tags.

Before:
![image](https://user-images.githubusercontent.com/2905696/44044443-6f4beca4-9eda-11e8-9f80-8deee46d76cf.png)

After:
![image](https://user-images.githubusercontent.com/2905696/44044455-792a0530-9eda-11e8-96a3-35415e85051d.png)
