### PR TITLE
compose: Create a "+" button for composing messages on mobile

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1639,3 +1639,13 @@ run_test('nonexistent_stream_reply_error', () => {
     assert.equal($("#compose-reply-error-msg").html(), 'There are no messages to reply to yet.');
     assert(shown < hidden); // test shown before hidden
 });
+
+run_test('narrow_button_titles', () => {
+    util.is_mobile = () => { return false; };
+
+    compose.update_stream_button_for_private();
+    assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("New stream message"));
+
+    compose.update_stream_button_for_stream();
+    assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("New topic"));
+});

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -443,11 +443,23 @@ exports.initialize = function () {
 
 
     $('.compose_stream_button').click(function () {
+        popovers.hide_mobile_message_buttons_popover();
         compose_actions.start('stream', {trigger: 'new topic button'});
     });
     $('.compose_private_button').click(function () {
+        popovers.hide_mobile_message_buttons_popover();
         compose_actions.start('private');
     });
+
+    $('body').on('click', '.compose_mobile_stream_button', function () {
+        popovers.hide_mobile_message_buttons_popover();
+        compose_actions.start('stream', {trigger: 'new topic button'});
+    });
+    $('body').on('click', '.compose_mobile_private_button', function () {
+        popovers.hide_mobile_message_buttons_popover();
+        compose_actions.start('private');
+    });
+
     $('.compose_reply_button').click(function () {
         compose_actions.respond_to_message({trigger: 'reply button'});
     });
@@ -471,6 +483,13 @@ exports.initialize = function () {
         if ($(e.target).is("#emoji_map, img.emoji, .drag")) {
             return;
         }
+
+        // The mobile compose button has its own popover when clicked, so it already.
+        // hides other popovers.
+        if ($(e.target).is(".compose_mobile_button, .compose_mobile_button *")) {
+            return;
+        }
+
         // Don't let clicks in the compose area count as
         // "unfocusing" our compose -- in other words, e.g.
         // clicking "Press enter to send" should not

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -5,6 +5,7 @@ var exports = {};
 var current_actions_popover_elem;
 var current_flatpickr_instance;
 var current_message_info_popover_elem;
+var current_mobile_message_buttons_popover_elem;
 var userlist_placement = "right";
 
 var list_of_popovers = [];
@@ -172,6 +173,37 @@ function show_user_info_popover(element, user, message) {
         current_message_info_popover_elem = elt;
     }
 }
+
+function show_mobile_message_buttons_popover(element) {
+    var last_popover_elem = current_mobile_message_buttons_popover_elem;
+    popovers.hide_all();
+    if (last_popover_elem !== undefined
+        && last_popover_elem.get()[0] === element) {
+        // We want it to be the case that a user can dismiss a popover
+        // by clicking on the same element that caused the popover.
+        return;
+    }
+
+    var $element = $(element);
+    $element.popover({
+        placement: "left",
+        template: templates.render('mobile_message_buttons_popover'),
+        content: templates.render('mobile_message_buttons_popover_content', {
+            is_in_private_narrow: narrow_state.narrowed_to_pms(),
+        }),
+        trigger: "manual",
+    });
+    $element.popover("show");
+
+    current_mobile_message_buttons_popover_elem = $element;
+}
+
+exports.hide_mobile_message_buttons_popover = function () {
+    if (current_mobile_message_buttons_popover_elem) {
+        current_mobile_message_buttons_popover_elem.popover("destroy");
+        current_mobile_message_buttons_popover_elem = undefined;
+    }
+};
 
 exports.hide_user_profile = function () {
     $("#user-profile-modal").modal("hide");
@@ -717,6 +749,12 @@ exports.register_click_handlers = function () {
         exports.hide_user_profile();
     });
 
+    $('body').on('click', '.compose_mobile_button', function (e) {
+        show_mobile_message_buttons_popover(this);
+        e.stopPropagation();
+        e.preventDefault();
+    });
+
     $('#user_presences').on('click', 'span.arrow', function (e) {
         e.stopPropagation();
 
@@ -984,6 +1022,7 @@ exports.hide_all = function () {
     stream_popover.hide_all_messages_popover();
     popovers.hide_user_sidebar_popover();
     popovers.hide_userlist_sidebar();
+    popovers.hide_mobile_message_buttons_popover();
     stream_popover.restore_stream_list_size();
     popovers.hide_user_profile();
 

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -478,7 +478,14 @@ a#undo_markdown_preview {
 }
 
 @media (max-width: 700px) {
-    #compose_buttons .compose_reply_button {
+    #compose_buttons .compose_stream_button,
+    #compose_buttons .compose_private_button {
+        display: none;
+    }
+}
+
+@media (min-width: 700px) {
+    #compose_buttons .compose_mobile_button {
         display: none;
     }
 }

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -477,14 +477,19 @@ a#undo_markdown_preview {
     margin: auto;
 }
 
-@media (max-width: 700px) {
+.compose_mobile_stream_button i,
+.compose_mobile_private_button i {
+    margin-right: 4px;
+}
+
+@media (max-width: 550px) {
     #compose_buttons .compose_stream_button,
     #compose_buttons .compose_private_button {
         display: none;
     }
 }
 
-@media (min-width: 700px) {
+@media (min-width: 551px) {
     #compose_buttons .compose_mobile_button {
         display: none;
     }

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -52,6 +52,16 @@
     width: calc(100% - 13px);
 }
 
+.mobile-message-buttons-popover {
+    position: absolute;
+    top: auto !important;
+    right: 8px;
+    bottom: 48px;
+    left: auto !important;
+    width: 175px;
+    height: 65px;
+}
+
 .streams_popover .sp-palette-container {
     border-right: none;
 }

--- a/static/templates/mobile_message_buttons_popover.handlebars
+++ b/static/templates/mobile_message_buttons_popover.handlebars
@@ -1,0 +1,7 @@
+<div class="popover mobile-message-buttons-popover">
+    <div class="popover-inner">
+        <div class="popover-content">
+            <div></div>
+        </div>
+    </div>
+</div>

--- a/static/templates/mobile_message_buttons_popover_content.handlebars
+++ b/static/templates/mobile_message_buttons_popover_content.handlebars
@@ -1,0 +1,22 @@
+<ul class="nav nav-list">
+    <li>
+        <a class="compose_mobile_stream_button">
+            <i class="fa fa-bullhorn" aria-hidden="true"></i>
+            {{#if is_in_private_narrow }}
+            {{t "New stream message" }}
+            {{else}}
+            {{t "New topic" }}
+            {{/if}}
+        </a>
+    </li>
+    <li>
+        <a class="compose_mobile_private_button">
+            <i class="fa fa-envelope" aria-hidden="true"></i>
+            {{#if is_in_private_narrow }}
+            {{t "New conversation" }}
+            {{else}}
+            {{t "New private message" }}
+            {{/if}}
+        </a>
+    </li>
+</ul>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -15,6 +15,13 @@
                     <span class="alert-draft pull-left">{{ _('Saved as draft') }}</span>
                 </span>
                 <span class="new_message_button">
+                    <button type="button" class="button small rounded compose_mobile_button"
+                      id="left_bar_compose_mobile_button_big"
+                      title="{{ _('New message') }} (c)">
+                        <i class="fa fa-plus" aria-hidden="true"></i>
+                    </button>
+                </span>
+                <span class="new_message_button">
                     <button type="button" class="button small rounded compose_stream_button"
                       id="left_bar_compose_stream_button_big"
                       title="{{ _('New topic') }} (c)">

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -18,7 +18,7 @@
                     <button type="button" class="button small rounded compose_mobile_button"
                       id="left_bar_compose_mobile_button_big"
                       title="{{ _('New message') }} (c)">
-                        <i class="fa fa-plus" aria-hidden="true"></i>
+                        +
                     </button>
                 </span>
                 <span class="new_message_button">


### PR DESCRIPTION
In order to prevent the compose buttons from overflowing when on mobile, this PR **replaces the buttons with a `+` icon when on mobile**, per [@rishig's suggestion](https://github.com/zulip/zulip/pull/10270#issuecomment-412196284).

When the `+` button is clicked, a `popover` is opened. Similarly to the current desktop buttons, the link titles within the popover change depending on the current narrow: if in a stream narrow, it says `New topic` to open a new stream message, but if in a private message, it says `New stream message` specifically.

This PR contains 6 commits in order to simplify the review process. (Before merging, I think that the last 4 should probably be squashed so that each commit can stand alone.)

**Testing plan:**

This PR adds new tests and updates old tests to account for the new functionality.

**Screenshots:**

*Public stream on Desktop:*
<img width="1241" alt="public-desktop-2" src="https://user-images.githubusercontent.com/17259768/44059744-3863f538-9f07-11e8-8301-8133d1084fe9.png">

*Private chat on Desktop:*
<img width="1240" alt="private-desktop-2" src="https://user-images.githubusercontent.com/17259768/44059743-3847257a-9f07-11e8-9af7-b402c1e07256.png">

*Public stream on Mobile:*
<img width="218" alt="public-mobile-2" src="https://user-images.githubusercontent.com/17259768/44059745-3883c958-9f07-11e8-8ca9-8dd090647159.png">

*Private stream on Mobile:*
<img width="218" alt="private-mobile-2" src="https://user-images.githubusercontent.com/17259768/44059746-389d590e-9f07-11e8-9c11-fd660077ee1a.png">
