### PR TITLE
emoji: Fix issues with displaying emojis in emoji picker while current emojiset is text.

### DIFF
--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -84,10 +84,18 @@ exports.initialize = function initialize() {
 
     exports.update_emojis(page_params.realm_emoji);
 
+    var emojiset = page_params.emojiset;
+    if (page_params.emojiset === 'text') {
+        // If the current emojiset is `text` then we fallback to `google`
+        // emojiset on the backend(see zerver/views/home.py) for displaying
+        // emojis in emoji picker and composebox typeahead. This logic ensures
+        // that we do prefetching for that case.
+        emojiset = 'google';
+    }
     // Load the sprite image in the background so that the browser
     // can cache it for later use.
     var sprite = new Image();
-    sprite.src = '/static/generated/emoji/sheet_' + page_params.emojiset + '_64.png';
+    sprite.src = '/static/generated/emoji/sheet_' + emojiset + '_64.png';
 };
 
 exports.build_emoji_data = function (realm_emojis) {

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -92,10 +92,12 @@ exports.initialize = function initialize() {
         // that we do prefetching for that case.
         emojiset = 'google';
     }
-    // Load the sprite image in the background so that the browser
-    // can cache it for later use.
+    // Load the sprite image and octopus image in the background so
+    // that the browser can cache it for later use.
     var sprite = new Image();
     sprite.src = '/static/generated/emoji/sheet_' + emojiset + '_64.png';
+    var octopus_image = new Image();
+    octopus_image.src = '/static/generated/emoji/images-' + emojiset + '-64/1f419.png';
 };
 
 exports.build_emoji_data = function (realm_emojis) {

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -804,3 +804,15 @@ class HomeTest(ZulipTestCase):
 
         page_params = self._get_page_params(result)
         self.assertEqual(page_params['default_language'], 'es')
+
+    def test_emojiset(self) -> None:
+        user = self.example_user("hamlet")
+        user.emojiset = 'text'
+        user.save()
+        self.login(user.email)
+        result = self._get_home_page()
+        self.assertEqual(result.status_code, 200)
+
+        html = result.content.decode('utf-8')
+        self.assertIn('google_sprite.css', html)
+        self.assertNotIn('text_sprite.css', html)

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -253,9 +253,15 @@ def home_real(request: HttpRequest) -> HttpResponse:
         page_params['translation_data'] = get_language_translation_data(request_language)
 
     csp_nonce = generate_random_token(48)
+    emojiset = user_profile.emojiset
+    if emojiset == UserProfile.TEXT_EMOJISET:
+        # If current emojiset is `TEXT_EMOJISET` then fallback to GOOGLE_EMOJISET
+        # for displaying emojis in emoji picker and composebox typeahead and also
+        # to avoid 404 for related emojiset files.
+        emojiset = UserProfile.GOOGLE_EMOJISET
     response = render(request, 'zerver/app/index.html',
                       context={'user_profile': user_profile,
-                               'emojiset': user_profile.emojiset,
+                               'emojiset': emojiset,
                                'page_params': JSONEncoderForHTML().encode(page_params),
                                'csp_nonce': csp_nonce,
                                'avatar_url': avatar_url(user_profile),


### PR DESCRIPTION
This PR fixes 404 errors for emojiset related files if the current emojiset is text. If the user has selected `text` as emojiset then we now fall-back to `google` emojiset for displaying emojis in emoji picker and composebox typeahead. It also eventually fixes an unidentified issue which was causing emojis to not appear in emoji picker if the emojiset is to `text`. It also adds code for pre-fetching `:octopus:` emoji so that on slow networks it doesn't appear as if it is not there.

@timabbott FYI. :)