### PR TITLE
requirements: Upgrade python-zulip-api/zulip to 7dfecf557.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -173,7 +173,7 @@ pyoembed==0.1.2
 # release tarballs (which is a bug).  So we need to pin it makes sense
 # to pin a version from Git rather than a release.
 -e "git+https://github.com/zulip/python-zulip-api.git@0.5.2#egg=zulip==0.5.2_git&subdirectory=zulip"
--e "git+https://github.com/zulip/python-zulip-api.git@0.5.2#egg=zulip_bots==0.5.2+git&subdirectory=zulip_bots"
+-e "git+https://github.com/zulip/python-zulip-api.git@7dfecf557743dc0bed6a20cdd50f5e825beac4ce#egg=zulip_bots==0.5.2+git&subdirectory=zulip_bots"
 
 # Used for Hesiod lookups, etc.
 py3dns==3.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,7 @@ git+https://github.com/zulip/django-bitfield@0d2b15cdb5af5ddec88d41cac19c0f2ce1b
 git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 git+https://github.com/zulip/python-zulip-api.git@0.5.2#egg=zulip==0.5.2_git&subdirectory=zulip
-git+https://github.com/zulip/python-zulip-api.git@0.5.2#egg=zulip_bots==0.5.2+git&subdirectory=zulip_bots
+git+https://github.com/zulip/python-zulip-api.git@7dfecf557743dc0bed6a20cdd50f5e825beac4ce#egg=zulip_bots==0.5.2+git&subdirectory=zulip_bots
 alabaster==0.7.11
 apns2==0.4.1
 argon2-cffi==18.1.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -13,7 +13,7 @@ git+https://github.com/zulip/django-bitfield@0d2b15cdb5af5ddec88d41cac19c0f2ce1b
 git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 git+https://github.com/zulip/python-zulip-api.git@0.5.2#egg=zulip==0.5.2_git&subdirectory=zulip
-git+https://github.com/zulip/python-zulip-api.git@0.5.2#egg=zulip_bots==0.5.2+git&subdirectory=zulip_bots
+git+https://github.com/zulip/python-zulip-api.git@7dfecf557743dc0bed6a20cdd50f5e825beac4ce#egg=zulip_bots==0.5.2+git&subdirectory=zulip_bots
 apns2==0.4.1
 argon2-cffi==18.1.0
 asn1crypto==0.23.0        # via cryptography


### PR DESCRIPTION
Upgrade the Python bindings to include the new methods we added recently for interacting with the API.