### PR TITLE
uploads: Create a placeholder when uploading.

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -43,8 +43,12 @@ function make_textbox(s) {
         widget.focused = false;
     };
 
-    widget.val = function () {
-        return widget.s;
+    widget.val = function (new_val) {
+        if (new_val) {
+            widget.s = new_val;
+        } else {
+            return widget.s;
+        }
     };
 
     widget.trigger = function () {
@@ -107,3 +111,12 @@ run_test('smart_insert', () => {
     // like emojis and file links.
 });
 
+run_test('replace_syntax', () => {
+    $('#compose-textarea').val('abcabc');
+
+    compose_ui.replace_syntax('a', 'A');
+    assert.equal($('#compose-textarea').val(), 'Abcabc');
+
+    compose_ui.replace_syntax(/b/g, 'B');
+    assert.equal($('#compose-textarea').val(), 'ABcaBc');
+});

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -38,9 +38,18 @@ run_test('upload_started', () => {
     $("#compose-send-status").append = function (html) {
         assert.equal(html, test_html);
     };
+    $('#compose-textarea').caret = function () {
+        return 0;
+    };
+    document.execCommand = function (command, show_default, value) {
+        assert.equal(value, "[Uploading some-file…]() ");
+    };
 
     upload_opts.drop();
-    upload_opts.uploadStarted(0, {lastModified: 1549958107000}, 1);
+    upload_opts.uploadStarted(0, {
+        lastModified: 1549958107000,
+        name: 'some-file',
+    }, 1);
 
     assert.equal($("#compose-send-button").attr("disabled"), '');
     assert($("#compose-send-status").hasClass("alert-info"));
@@ -103,7 +112,8 @@ run_test('upload_finish', () => {
     function test(i, response, textbox_val) {
         var compose_ui_autosize_textarea_checked = false;
         var compose_actions_start_checked = false;
-        var syntax_to_insert;
+        var syntax_to_replace;
+        var syntax_to_replace_with;
         var file_input_clear = false;
 
         function setup() {
@@ -111,8 +121,9 @@ run_test('upload_finish', () => {
             compose_ui.autosize_textarea = function () {
                 compose_ui_autosize_textarea_checked = true;
             };
-            compose_ui.insert_syntax_and_focus = function (syntax) {
-                syntax_to_insert = syntax;
+            compose_ui.replace_syntax = function (old_syntax, new_syntax) {
+                syntax_to_replace = old_syntax;
+                syntax_to_replace_with = new_syntax;
             };
             compose_state.set_message_type();
             global.compose_actions = {
@@ -142,7 +153,8 @@ run_test('upload_finish', () => {
 
         function assert_side_effects() {
             if (response.uri) {
-                assert.equal(syntax_to_insert, textbox_val);
+                assert.equal(syntax_to_replace, '[Uploading some-file…]()');
+                assert.equal(syntax_to_replace_with, textbox_val);
                 assert(compose_actions_start_checked);
                 assert(compose_ui_autosize_textarea_checked);
                 assert.equal($("#compose-send-button").prop('disabled'), false);
@@ -161,7 +173,10 @@ run_test('upload_finish', () => {
         };
 
         setup();
-        upload_opts.uploadFinished(i, {lastModified: 1549958107000}, response);
+        upload_opts.uploadFinished(i, {
+            lastModified: 1549958107000,
+            name: 'some-file',
+        }, response);
         upload_opts.progressUpdated(1, {lastModified: 1549958107000}, 100);
         assert_side_effects();
     }

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -49,6 +49,19 @@ exports.insert_syntax_and_focus = function (syntax, textarea) {
     exports.smart_insert(textarea, syntax);
 };
 
+exports.replace_syntax = function (old_syntax, new_syntax, textarea) {
+    // Replaces `old_syntax` with `new_syntax` text in the compose box. Due to
+    // the way that JavaScript handles string replacements, if `old_syntax` is
+    // a string it will only replace the first instance. If `old_syntax` is
+    // a RegExp with a global flag, it will replace all instances.
+
+    if (textarea === undefined) {
+        textarea = $('#compose-textarea');
+    }
+
+    textarea.val(textarea.val().replace(old_syntax, new_syntax));
+};
+
 return exports;
 
 }());

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -73,6 +73,7 @@ exports.options = function (config) {
         send_status.append('<div class="progress active">' +
                            '<div class="bar" id="' + upload_bar + '-' + file.lastModified + '" style="width: 0"></div>' +
                            '</div>');
+        compose_ui.insert_syntax_and_focus("[Uploading " + file.name + "…]()", textarea);
     };
 
     var progressUpdated = function (i, file, progress) {
@@ -132,11 +133,11 @@ exports.options = function (config) {
         if (i === -1) {
             // This is a paste, so there's no filename. Show the image directly
             var pasted_image_uri = "[pasted image](" + uri + ")";
-            compose_ui.insert_syntax_and_focus(pasted_image_uri, textarea);
+            compose_ui.replace_syntax("[Uploading " + file.name + "…]()", pasted_image_uri, textarea);
         } else {
             // This is a dropped file, so make the filename a link to the image
             var filename_uri = "[" + filename + "](" + uri + ")";
-            compose_ui.insert_syntax_and_focus(filename_uri, textarea);
+            compose_ui.replace_syntax("[Uploading " + file.name + "…]()", filename_uri, textarea);
         }
         compose_ui.autosize_textarea();
 


### PR DESCRIPTION
This PR adds a placeholder when uploading files, so that images are properly placed even if a user keeps typing while they are uploading. The placeholder `[uploading file]()` is used. This is based
on GitHub's handling of image uploading.

Fixes #10305.

**Testing Plan:** <!-- How have you tested? -->

This PR adds tests to the `upload` Node tests and update existing tests to account for the new behavior.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

This GIF shows the placeholder inserted, and how the image is placed at its initial location, even after `qwerty` is typed during the upload:

![fileupload](https://user-images.githubusercontent.com/17259768/44129097-85da9868-9ffb-11e8-89d1-71d839b3e619.gif)