### PR TITLE
settings: Rename emoji settings.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -111,8 +111,8 @@ function setup_settings_label() {
         left_side_userlist: i18n.t("User list on left sidebar in narrow windows"),
         night_mode: i18n.t("Night mode"),
         twenty_four_hour_time: i18n.t("24-hour time (17:00 instead of 5:00 PM)"),
-        translate_emoji_to_text: i18n.t("Translate emoji to text (Convert 😃 to <code>:smile:</code>)"),
-        translate_emoticons: i18n.t("Translate emoticons (convert <code>:)</code> to 😃 in messages)"),
+        translate_emoji_to_text: i18n.t("View emoji as text (see <code>:smile:</code> when others write 😃)"),
+        translate_emoticons: i18n.t("Convert emoticons before sending (<code>:)</code> becomes 😃)"),
     };
 }
 

--- a/templates/zerver/help/display-emoji-as-text.md
+++ b/templates/zerver/help/display-emoji-as-text.md
@@ -7,4 +7,4 @@ For example, when a heart emoji is displayed as text, it looks like
 
 {settings_tab|display-settings}
 
-2. Under **Emoji settings**, select **Translate emoji to text**.
+2. Under **Emoji settings**, select **View emoji as text**.

--- a/templates/zerver/help/enable-emoticon-translations.md
+++ b/templates/zerver/help/enable-emoticon-translations.md
@@ -18,7 +18,7 @@ automatically by Zulip.
 {settings_tab|display-settings}
 
 2. Select the option labeled
-   **Translate emoticons (convert `:)` to 😃 in messages)**.
+   **Convert emoticons before sending**.
 
 ## Current emoticon conversions
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/890911/44176053-12c4d800-a09d-11e8-9aba-94d9a0d55aed.png)

I think the current names are pretty confusing, but didn't want to generate new strings if we're in a freeze.

Followups if this gets merged:
* The first setting should be moved into `Display Settings`
* The help articles for these should be renamed.
