### PR TITLE
style: Fix the stream and user list buttons on mobile in night mode.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -91,6 +91,13 @@ on a dark background, and don't change the dark labels dark either. */
         color: inherit;
     }
 
+    #streamlist-toggle-button,
+    #userlist-toggle-button {
+        background-color: hsl(212, 29%, 12%);
+        border-color: hsla(0, 0%, 0%, 0.6);
+        color: inherit;
+    }
+
     select option {
         background-color: hsl(212, 28%, 18%);
         color: hsl(236, 33%, 90%);
@@ -172,6 +179,10 @@ on a dark background, and don't change the dark labels dark either. */
 
     #searchbox_legacy {
         border-color: hsla(0, 0%, 0%, 0.6);
+
+        .navbar-search {
+            background-color: hsla(0, 0%, 0%, 0.2);
+        }
     }
 
     .overlay,

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -186,7 +186,6 @@
     right: 0px;
     text-align: center;
     vertical-align: middle;
-    border-left: 2px solid hsl(204, 20%, 74%);
 }
 
 #userlist-toggle-button {
@@ -198,6 +197,7 @@
     height: 19px;
     padding-top: 12px;
     padding-bottom: 9px;
+    border-left: 2px solid hsl(204, 20%, 74%);
 }
 
 #group-pm-list {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1689,7 +1689,6 @@ blockquote p {
     left: 0px;
     text-align: center;
     vertical-align: middle;
-    border-right: 2px solid hsl(204, 20%, 74%);
 }
 
 #streamlist-toggle-button {
@@ -1702,6 +1701,7 @@ blockquote p {
     height: 19px;
     padding-top: 12px;
     padding-bottom: 9px;
+    border-right: 2px solid hsl(204, 20%, 74%);
 }
 
 #streamlist-toggle-unreadcount,


### PR DESCRIPTION
Currently, these buttons are displayed with a lighter background than other buttons. This PR updates their borders and background colors (along with the border on the search box) so that they match the night theme.

Fixes #10301.


**Screenshots:**

*Before:*

<img src="https://user-images.githubusercontent.com/17259768/44179868-3ba19900-a0ae-11e8-88c1-cf58f367a61c.png" alt="before" width="300px" />

*After:*

<img src="https://user-images.githubusercontent.com/17259768/44179876-3d6b5c80-a0ae-11e8-89d9-78e711b53352.png" alt="before" width="300px" />
