### PR TITLE
help: Fix styling of emoticons on help pages.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1620,6 +1620,19 @@ input.new-organization-button {
     box-shadow: none;
 }
 
+.markdown img.emoji-small {
+    width: 20px;
+    box-shadow: none;
+    border: none;
+    vertical-align: sub;
+}
+
+.markdown img.emoji-big {
+    width: 25px;
+    box-shadow: none;
+    border: none;
+}
+
 .integration-instructions .tip,
 .markdown .warn,
 .markdown .tip,

--- a/templates/zerver/help/enable-emoticon-translations.md
+++ b/templates/zerver/help/enable-emoticon-translations.md
@@ -5,13 +5,13 @@ emoji equivalents like
 <img
     src="/static/generated/emoji/images-google-64/1f642.png"
     alt="slight_smile"
-    style="width: 3%;"
+    class="emoji-small"
 />
 or
 <img
     src="/static/generated/emoji/images-google-64/1f641.png"
     alt="slight_frown"
-    style="width: 3%;"
+    class="emoji-small"
 />
 automatically by Zulip.
 

--- a/zerver/lib/bugdown/help_emoticon_translations_table.py
+++ b/zerver/lib/bugdown/help_emoticon_translations_table.py
@@ -29,7 +29,7 @@ ROW_HTML = """
         <img
             src="/static/generated/emoji/images-google-64/{codepoint}.png"
             alt="{name}"
-            style="width: 30%;">
+            class="emoji-big">
     </td>
 </tr>
 """


### PR DESCRIPTION
Before -

![image](https://user-images.githubusercontent.com/2263909/44237150-148db900-a1cd-11e8-9f58-d865d2c32a4d.png)

<hr>


After -

![image](https://user-images.githubusercontent.com/2263909/44237134-06d83380-a1cd-11e8-8913-ab24d88902e7.png)
