### PR TITLE
tests: Tests query count when creating stream with subscriptions API.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2767,6 +2767,52 @@ class SubscriptionAPITest(ZulipTestCase):
         with self.assertRaises(ValidationError):
             validate_user_access_to_subscribers_helper(user_profile, stream_dict, lambda: True)
 
+    def test_subscriptions_query_count(self) -> None:
+        """
+        Test database query count when creating stream with api/v1/users/me/subscriptions.
+        """
+        user1 = self.example_user("cordelia")
+        user2 = self.example_user("iago")
+        new_streams = [
+            'query_count_stream_1',
+            'query_count_stream_2',
+            'query_count_stream_3'
+        ]
+
+        # Test creating a public stream when realm does not have a notification stream.
+        with queries_captured() as queries:
+            self.common_subscribe_to_streams(
+                self.test_email,
+                [new_streams[0]],
+                dict(principals=ujson.dumps([user1.email, user2.email])),
+            )
+        self.assert_length(queries, 43)
+
+        # Test creating private stream.
+        with queries_captured() as queries:
+            self.common_subscribe_to_streams(
+                self.test_email,
+                [new_streams[1]],
+                dict(principals=ujson.dumps([user1.email, user2.email])),
+                invite_only=True,
+            )
+        self.assert_length(queries, 38)
+
+        # Test creating a public stream with announce when realm has a notification stream.
+        notifications_stream = get_stream(self.streams[0], self.test_realm)
+        self.test_realm.notifications_stream_id = notifications_stream.id
+        self.test_realm.save()
+        with queries_captured() as queries:
+            self.common_subscribe_to_streams(
+                self.test_email,
+                [new_streams[2]],
+                dict(
+                    announce='true',
+                    principals=ujson.dumps([user1.email, user2.email])
+                )
+            )
+        self.assert_length(queries, 52)
+
 class GetPublicStreamsTest(ZulipTestCase):
 
     def test_public_streams_api(self) -> None:


### PR DESCRIPTION

These test cases are used to test the cost of stream creation.
Three scenarios of stream creation are covered:
1) create a public stream;
2) create a private stream;
3) create a public stream with announce=true when there is a notification stream.

Fix: #[4804](https://github.com/zulip/zulip/issues/4804).

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
