### PR TITLE
custom field: Update user values when admin modifies field choices.

### DIFF
--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -86,7 +86,6 @@ run_test('populate_profile_fields', () => {
                 name: 'favorite color',
                 hint: 'blue?',
                 type: 'Short Text',
-                choices: [],
                 is_choice_field: false,
             },
             can_modify: true,
@@ -97,10 +96,6 @@ run_test('populate_profile_fields', () => {
                 name: 'meal',
                 hint: 'lunch',
                 type: 'Choice',
-                choices: [
-                    {order: 0, value: 0, text: 'lunch'},
-                    {order: 1, value: 1, text: 'dinner'},
-                ],
                 is_choice_field: true,
             },
             can_modify: true,

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -93,15 +93,9 @@ exports.add_custom_profile_fields_to_settings = function () {
         } else if (is_choice_field) {
             type = "choice";
             var field_choice_dict = JSON.parse(field.field_data);
-            for (var choice in field_choice_dict) {
-                if (choice) {
-                    field_choices[field_choice_dict[choice].order] = {
-                        value: choice,
-                        text: field_choice_dict[choice].text,
-                        selected: choice === value,
-                    };
-                }
-            }
+            field_choices = settings_profile_fields.get_choices_order_wise(field_choice_dict,
+                                                                           value);
+
         } else if (is_date_field) {
             type = "date";
         } else if (field_type === field_types.URL.id) {

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -57,11 +57,11 @@ function delete_profile_field(e) {
 
 function read_field_data_from_form(selector) {
     var field_data = {};
-    var field_order = 1;
+    var field_order = 0;
     selector.each(function () {
-        var text = $(this).find("input")[0].value;
+        var text = $(this).find("input")[0].value.trim();
         if (text) {
-            field_data[field_order - 1] = {text: text, order: field_order.toString()};
+            field_data[text] = {text: text, order: field_order.toString()};
             field_order += 1;
         }
     });

--- a/static/templates/admin_profile_field_list.handlebars
+++ b/static/templates/admin_profile_field_list.handlebars
@@ -41,9 +41,6 @@
                 <div class="profile-field-choices" name="profile_field_choices_edit">
                     <hr />
                     <div class="edit_profile_field_choices_container">
-                        {{#each choices}}
-                        {{partial "profile-field-choice" }}
-                        {{/each}}
                     </div>
                 </div>
             </div>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4854,6 +4854,18 @@ def try_update_realm_custom_profile_field(realm: Realm, field: CustomProfileFiel
     field.name = name
     field.hint = hint
     if field.field_type == CustomProfileField.CHOICE:
+        all_field_values = CustomProfileFieldValue.objects.filter(field=field)
+
+        for field_value in all_field_values:
+            old_choice = field_value.value
+            # If choice text not exists in new choices list,
+            # delete value, as choice no longer exists
+            # in new choices list.
+            if old_choice not in field_data:
+                field_value.delete()
+                notify_user_update_custom_profile_data(field_value.user_profile,
+                                                       {"id": field.id, "value": None})
+
         field.field_data = ujson.dumps(field_data or {})
     field.save()
     notify_realm_custom_profile_fields(realm, 'update')


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes bug mentioned in #10160 
[Issue discussion](https://chat.zulip.org/#narrow/stream/3-backend/subject/custom.20profile.20field)

> This probably should just be moved to a new issue since it's a backendy thing and not directly related, but I'm not sure the right thing happens for users who set e.g. their editor to "Emacs" before that choice value is deleted; I think everyone should be reverted to the "Not selected" value, but I'm not sure that's what happens.




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
