### PR TITLE
events: Convert custom user field value to json object on update event.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -115,7 +115,7 @@ exports.add_custom_profile_fields_to_settings = function () {
             blueslip.error("Undefined field type.");
         }
 
-        if (value === undefined) {
+        if (value === undefined || value === null) {
             // If user has not set value for field.
             value = "";
         }

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -114,6 +114,7 @@ exports.add_custom_profile_fields_to_settings = function () {
         } else {
             blueslip.error("Undefined field type.");
         }
+
         if (value === undefined) {
             // If user has not set value for field.
             value = "";
@@ -146,7 +147,6 @@ exports.add_custom_profile_fields_to_settings = function () {
                     update_user_custom_profile_fields(fields, channel.patch);
                 }
             }
-
             if (value !== undefined && value.length > 0) {
                 value.forEach(function (user_id) {
                     var user = people.get_person_from_user_id(user_id);

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4871,8 +4871,12 @@ def try_reorder_realm_custom_profile_fields(realm: Realm, order: List[int]) -> N
 
 def notify_user_update_custom_profile_data(user_profile: UserProfile,
                                            field: Dict[str, Union[int, str, List[int], None]]) -> None:
+    if field['type'] == CustomProfileField.USER:
+        field_value = ujson.dumps(field['value'])  # type: Union[int, str, List[int], None]
+    else:
+        field_value = field['value']
     payload = dict(user_id=user_profile.id, custom_profile_field=dict(id=field['id'],
-                                                                      value=field['value']))
+                                                                      value=field_value))
     event = dict(type="realm_user", op="update", person=payload)
     send_event(event, active_user_ids(user_profile.realm.id))
 
@@ -4881,10 +4885,12 @@ def do_update_user_custom_profile_data(user_profile: UserProfile,
     with transaction.atomic():
         update_or_create = CustomProfileFieldValue.objects.update_or_create
         for field in data:
-            update_or_create(user_profile=user_profile,
-                             field_id=field['id'],
-                             defaults={'value': field['value']})
-            notify_user_update_custom_profile_data(user_profile, field)
+            field_value, created = update_or_create(user_profile=user_profile,
+                                                    field_id=field['id'],
+                                                    defaults={'value': field['value']})
+            notify_user_update_custom_profile_data(user_profile, {"id": field['id'],
+                                                                  "value": field['value'],
+                                                                  "type": field_value.field.field_type})
 
 def do_send_create_user_group_event(user_group: UserGroup, members: List[UserProfile]) -> None:
     event = dict(type="user_group",

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1082,6 +1082,16 @@ class EventsRegisterTest(ZulipTestCase):
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
+        # Test we pass correct stringify value in custom-user-field data event
+        field_id = realm.customprofilefield_set.get(realm=realm, name='Mentor').id
+        field = {
+            "id": field_id,
+            "value": [self.example_user("ZOE").id],
+        }
+        events = self.do_test(lambda: do_update_user_custom_profile_data(self.user_profile, [field]))
+        error = schema_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
     def test_presence_events(self) -> None:
         schema_checker = self.check_events_dict([
             ('type', equals('presence')),

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -141,7 +141,9 @@ def remove_user_custom_profile_data(request: HttpRequest, user_profile: UserProf
         except CustomProfileFieldValue.DoesNotExist:
             continue
         field_value.delete()
-        notify_user_update_custom_profile_data(user_profile, {'id': field_id, 'value': None})
+        notify_user_update_custom_profile_data(user_profile, {'id': field_id,
+                                                              'value': None,
+                                                              'type': field.field_type})
 
     return json_success()
 


### PR DESCRIPTION
In user type custom field, field value is list of user ids. We weren't
converting list to json object in update event payload. This throws
error in frontend, cause we store stringify representation of custom
field value. Therefore, after update event is recieved field-value-
type gets updated to array from string which throws json parsing error.

This commit also remove invalid if check of field value in frontend,
which throws an error in value is undefined.

To reproduce the issue:
* Create new user type custom field
* Add value in user type custom field from account settings
* Close modal and again open account settings modal

