### PR TITLE
settings_org: Disable topic editing checkbox when message editing is off

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -70,7 +70,6 @@ zrequire('stream_data');
 zrequire('settings_account');
 zrequire('settings_org');
 zrequire('settings_ui');
-zrequire('settings_ui');
 
 run_test('unloaded', () => {
     // This test mostly gets us line coverage, and makes
@@ -697,6 +696,10 @@ run_test('set_up', () => {
     const parent_elem = $.create('waiting-period-parent-stub');
     $('#id_realm_waiting_period_threshold').set_parent(parent_elem);
     $("#allowed_domains_label").set_parent($.create('<stub-allowed-domain-label-parent>'));
+
+    const allow_topic_edit_label_parent = $.create('allow-topic-edit-label-parent');
+    $('#id_realm_allow_community_topic_editing_label').set_parent(allow_topic_edit_label_parent);
+
     // TEST set_up() here, but this mostly just allows us to
     // get access to the click handlers.
     settings_org.set_up();

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -249,6 +249,8 @@ function set_msg_edit_limit_dropdown() {
     } else {
         $("#id_realm_message_content_edit_limit_minutes").parent().hide();
     }
+    settings_ui.disable_sub_setting_onchange(value !== "never",
+                                             "id_realm_allow_community_topic_editing", true);
 }
 
 function set_msg_delete_limit_dropdown() {


### PR DESCRIPTION
Fixes: #10327

**GIFs or Screenshots:** 
![image](https://user-images.githubusercontent.com/40331304/44298642-481f2f00-a304-11e8-9607-628e241dbd1c.png)



