### PR TITLE
gear menu: Add "Contact support" to gear menu.

### DIFF
--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -120,6 +120,23 @@ exports.initialize = function () {
         }
     });
 
+    $('#contact_support').on('click', function (e) {
+        var menu_item = $(e.target);
+        new ClipboardJS('#contact_support', {
+            text: function () {
+                var data = page_params.zulip_administrator;
+                return data;
+            },
+        });
+        e.stopPropagation();
+        menu_item.html('<i class="fa fa-address-book" aria-hidden="true"></i> Email copied');
+        menu_item.addClass("contact_support-active");
+        setTimeout(function () {
+            menu_item.html('<i class="fa fa-address-book" aria-hidden="true"></i> Contact support');
+            menu_item.removeClass("contact_support-active");
+        }, 2000);
+    });
+
     // The admin and settings pages are generated client-side through
     // templates.
 };

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -3023,3 +3023,8 @@ div.message_content button.tictactoe-square:disabled {
 .flatpickr-months .numInputWrapper span {
     display: none;
 }
+
+.contact_support-active {
+    color: #2d7c6f !important;
+    background-image: linear-gradient(to bottom, #fff, #fff) !important;
+}

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -128,6 +128,11 @@
                                     <i class="fa fa-search" aria-hidden="true"></i> {{ _('Search operators') }}
                                 </a>
                             </li>
+                            <li role="presentation">
+                                <a tabindex="0" role="menuitem" id="contact_support">
+                                    <i class="fa fa-address-book" aria-hidden="true"></i> {{ _('Contact support') }}
+                                </a>
+                            </li>
                             <li class="divider" role="presentation"></li>
                             <li role="presentation">
                                 <a href="{{ apps_page_url }}" target="_blank" role="menuitem">

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -197,6 +197,7 @@ class HomeTest(ZulipTestCase):
             "use_websockets",
             "user_id",
             "warn_no_email",
+            "zulip_administrator",
             "zulip_version",
         ]
 

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -200,6 +200,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
         search_pills_enabled  = settings.SEARCH_PILLS_ENABLED,
 
         # Misc. extra data.
+        zulip_administrator   = settings.ZULIP_ADMINISTRATOR,
         have_initial_messages = user_has_messages,
         initial_servertime    = time.time(),  # Used for calculating relative presence age
         default_language_name = get_language_name(register_ret['default_language']),


### PR DESCRIPTION
Fixes: #10033

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds the option to copy admin details from the gear menu.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![zulip](https://user-images.githubusercontent.com/21174572/44305682-6126ef00-a39b-11e8-9b66-1101c4c8d0f2.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
