### PR TITLE
requirements: Upgrade boto to boto3

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -34,8 +34,12 @@ backports-abc==0.5
 # Needed for Tornado 4 compatibility
 backports.ssl-match-hostname==3.5.0.1
 
-# Needed for S3 file uploads
+# Keep boto since puppet needs boto.utils.get_instance_metadata and this is not implemented in boto3
+# Reference: https://github.com/boto/boto3/issues/313
 boto==2.49.0
+
+# Needed for S3 file uploads
+boto3===1.7.80
 
 certifi==2018.4.16
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,9 +27,9 @@ backcall==0.1.0           # via ipython
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.6.0
-boto3==1.7.11             # via moto
+boto3==1.7.80
 boto==2.49.0
-botocore==1.10.11         # via boto3, moto, s3transfer
+botocore==1.10.80         # via boto3, moto, s3transfer
 cachetools==2.1.0         # via google-auth
 cchardet==2.1.1
 certifi==2018.4.16

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -22,7 +22,9 @@ backcall==0.1.0           # via ipython
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.6.0
+boto3===1.7.80
 boto==2.49.0
+botocore==1.10.80         # via boto3, s3transfer
 cachetools==2.1.0         # via google-auth
 cchardet==2.1.1
 certifi==2018.4.16
@@ -46,6 +48,7 @@ django-two-factor-auth==1.7.0
 django-webpack-loader==0.6.0
 django==1.11.14
 docopt==0.6.2
+docutils==0.14            # via botocore
 gitdb==0.6.4
 google-api-python-client==1.7.4
 google-auth-httplib2==0.0.3  # via google-api-python-client
@@ -62,6 +65,7 @@ ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0
 jedi==0.11.0              # via ipython
 jinja2==2.10
+jmespath==0.9.3           # via boto3, botocore
 libthumbor==1.3.2
 lxml==4.2.3
 markdown-include==0.5.1
@@ -109,6 +113,7 @@ regex==2017.11.9
 requests-oauthlib==0.8.0
 requests[security]==2.18.4  # via matrix-client, premailer, pyoembed, python-gcm, python-twitter, requests-oauthlib, social-auth-core, stripe, twilio
 rsa==3.4.2
+s3transfer==0.1.13        # via boto3
 simplegeneric==0.8.1      # via ipython
 six==1.11.0
 smmap==0.9.0

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1,6 +1,5 @@
 import datetime
-from boto.s3.connection import S3Connection
-from boto.s3.key import Key
+import boto3
 from django.apps import apps
 from django.conf import settings
 from django.db import connection
@@ -1059,39 +1058,45 @@ def export_uploads_and_avatars(realm: Realm, output_dir: Path) -> None:
 
 def _check_key_metadata(
         email_gateway_bot: Optional[UserProfile],
-        key: Key, processing_avatars: bool,
-        realm: Realm, user_ids: Set[int]) -> None:
+        s3_object: boto3.resources.base.ServiceResource,
+        processing_avatars: bool,
+        realm: Realm,
+        user_ids: Set[int]) -> None:
     # This can happen if an email address has moved realms
-    if 'realm_id' in key.metadata and key.metadata['realm_id'] != str(realm.id):
-        if email_gateway_bot is None or key.metadata['user_profile_id'] != str(email_gateway_bot.id):
-            raise AssertionError("Key metadata problem: %s %s / %s" % (key.name, key.metadata, realm.id))
+    if 'realm_id' in s3_object.metadata and s3_object.metadata['realm_id'] != str(realm.id):
+        if email_gateway_bot is None or s3_object.metadata['user_profile_id'] != str(email_gateway_bot.id):
+            raise AssertionError(
+                "Key metadata problem: %s %s / %s"
+                % (s3_object.key, s3_object.metadata, realm.id))
         # Email gateway bot sends messages, potentially including attachments, cross-realm.
-        print("File uploaded by email gateway bot: %s / %s" % (key.name, key.metadata))
+        print("File uploaded by email gateway bot: %s / %s" % (s3_object.key, s3_object.metadata))
     elif processing_avatars:
-        if 'user_profile_id' not in key.metadata:
-            raise AssertionError("Missing user_profile_id in key metadata: %s" % (key.metadata,))
-        if int(key.metadata['user_profile_id']) not in user_ids:
-            raise AssertionError("Wrong user_profile_id in key metadata: %s" % (key.metadata,))
-    elif 'realm_id' not in key.metadata:
-        raise AssertionError("Missing realm_id in key metadata: %s" % (key.metadata,))
+        if 'user_profile_id' not in s3_object.metadata:
+            raise AssertionError("Missing user_profile_id in key metadata: %s" % (s3_object.metadata,))
+        if int(s3_object.metadata['user_profile_id']) not in user_ids:
+            raise AssertionError("Wrong user_profile_id in key metadata: %s" % (s3_object.metadata,))
+    elif 'realm_id' not in s3_object.metadata:
+        raise AssertionError("Missing realm_id in key metadata: %s" % (s3_object.metadata,))
 
 
 def _get_exported_s3_record(
-        bucket_name: str,
-        key: Key,
+        s3_object: boto3.resources.base.ServiceResource,
         processing_avatars: bool,
         processing_emoji: bool) -> Dict[str, Union[str, int]]:
 
+    # Caution: e_tag attribute does not contain md5 when files are uploaded via multipart.
+    # Reference: https://stackoverflow.com/questions/6591047/etag-definition-changed-in-amazon-s3/19304527#19304527
+    # Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
     record = dict(
-        s3_path=key.name,
-        bucket=bucket_name,
-        size=key.size,
-        last_modified=key.last_modified,
-        content_type=key.content_type,
-        md5=key.md5)
-    record.update(key.metadata)
+        s3_path=s3_object.key,
+        bucket=s3_object.bucket_name,
+        size=s3_object.content_length,
+        last_modified=s3_object.last_modified,
+        content_type=s3_object.content_type,
+        md5=s3_object.e_tag)
+    record.update(s3_object.metadata)
     if processing_emoji:
-        record['file_name'] = os.path.basename(key.name)
+        record['file_name'] = os.path.basename(s3_object.key)
     # A few early avatars don't have 'realm_id' on the object; fix their metadata
     user_profile = get_user_profile_by_id(record['user_profile_id'])
     if 'realm_id' not in record:
@@ -1101,31 +1106,35 @@ def _get_exported_s3_record(
     record['user_profile_id'] = int(record['user_profile_id'])
     record['realm_id'] = int(record['realm_id'])
     if processing_avatars or processing_emoji:
-        record['path'] = key.name
+        record['path'] = s3_object.key
     else:
-        fields = key.name.split('/')
+        fields = s3_object.key.split('/')
         if len(fields) != 3:
-            raise AssertionError("Suspicious key with invalid format %s" % (key.name))
+            raise AssertionError("Suspicious key with invalid format %s" % (s3_object.key,))
         record['path'] = os.path.join(fields[1], fields[2])
     return record
 
 
-def _save_s3_object_to_file(key: Key, output_dir: str, path: str) -> None:
+def _save_s3_object_to_file(
+        s3_object: boto3.resources.base.ServiceResource,
+        output_dir: str,
+        path: str) -> None:
     filename = os.path.join(output_dir, path)
     dirname = os.path.dirname(filename)
     if not os.path.exists(dirname):
         os.makedirs(dirname)
-    key.get_contents_to_filename(filename)
+    s3_object.download_file(filename)
 
 
 def export_files_from_s3(realm: Realm, bucket_name: str, output_dir: Path,
                          processing_avatars: bool=False,
                          processing_emoji: bool=False) -> None:
-    conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
-    bucket = conn.get_bucket(bucket_name, validate=True)
+    session = boto3.Session(settings.S3_KEY, settings.S3_SECRET_KEY)
+    s3 = session.resource('s3')
+    bucket = s3.Bucket(bucket_name)
     records = []
 
-    logging.info("Downloading uploaded files from %s" % (bucket_name))
+    logging.info("Downloading uploaded files from %s" % (bucket_name,))
 
     avatar_hash_values = set()
     user_ids = set()
@@ -1135,24 +1144,25 @@ def export_files_from_s3(realm: Realm, bucket_name: str, output_dir: Path,
             avatar_hash_values.add(avatar_path)
             avatar_hash_values.add(avatar_path + ".original")
             user_ids.add(user_profile.id)
-    if processing_emoji:
-        bucket_list = bucket.list(prefix="%s/emoji/images/" % (realm.id,))
-    else:
-        bucket_list = bucket.list(prefix="%s/" % (realm.id,))
 
     if settings.EMAIL_GATEWAY_BOT is not None:
         email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT)  # type: Optional[UserProfile]
     else:
         email_gateway_bot = None
 
+    if processing_emoji:
+        object_prefix = "%s/emoji/images/" % (realm.id,)
+    else:
+        object_prefix = "%s/" % (realm.id,)
+
     count = 0
-    for bkey in bucket_list:
-        if processing_avatars and bkey.name not in avatar_hash_values:
+    for s3_object_summary in bucket.objects.filter(Prefix=object_prefix):
+        s3_object = s3_object_summary.Object()
+        if processing_avatars and s3_object.key not in avatar_hash_values:
             continue
-        key = bucket.get_key(bkey.name)
-        _check_key_metadata(email_gateway_bot, key, processing_avatars, realm, user_ids)
-        record = _get_exported_s3_record(bucket_name, key, processing_avatars, processing_emoji)
-        _save_s3_object_to_file(key, output_dir, str(record['path']))
+        _check_key_metadata(email_gateway_bot, s3_object, processing_avatars, realm, user_ids)
+        record = _get_exported_s3_record(s3_object, processing_avatars, processing_emoji)
+        _save_s3_object_to_file(s3_object, output_dir, str(record['path']))
         records.append(record)
         count += 1
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -63,6 +63,7 @@ import unittest
 import urllib
 from zerver.lib.str_utils import NonBinaryStr
 from moto import mock_s3
+import boto3
 
 import fakeldap
 import ldap
@@ -465,6 +466,14 @@ def use_s3_backend(method: FuncT) -> FuncT:
         finally:
             zerver.lib.upload.upload_backend = LocalUploadBackend()
     return new_method
+
+
+def create_s3_bucket(*bucket_names: Tuple[str]) -> boto3.resources.base.ServiceResource:
+    session = boto3.Session(settings.S3_KEY, settings.S3_SECRET_KEY)
+    s3 = session.resource('s3')
+    buckets = [s3.create_bucket(Bucket=name) for name in bucket_names]
+    return buckets
+
 
 def use_db_models(method: Callable[..., None]) -> Callable[..., None]:
     def method_patched_with_mock(self: 'MigrationsTestCase', apps: StateApps) -> None:

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -62,7 +62,7 @@ import ujson
 import unittest
 import urllib
 from zerver.lib.str_utils import NonBinaryStr
-from moto import mock_s3_deprecated
+from moto import mock_s3
 
 import fakeldap
 import ldap
@@ -456,7 +456,7 @@ def load_subdomain_token(response: HttpResponse) -> Dict[str, Any]:
 FuncT = TypeVar('FuncT', bound=Callable[..., None])
 
 def use_s3_backend(method: FuncT) -> FuncT:
-    @mock_s3_deprecated
+    @mock_s3
     @override_settings(LOCAL_UPLOADS_DIR=None)
     def new_method(*args: Any, **kwargs: Any) -> Any:
         zerver.lib.upload.upload_backend = S3UploadBackend()

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -11,7 +11,6 @@ from PIL import Image
 from mock import patch, MagicMock
 from typing import Any, Dict, List, Set, Optional, Tuple, Callable, \
     FrozenSet
-import boto3
 import botocore.exceptions
 
 from zerver.lib.export import (
@@ -40,6 +39,7 @@ from zerver.lib.test_classes import (
 )
 from zerver.lib.test_helpers import (
     use_s3_backend,
+    create_s3_bucket
 )
 
 from zerver.lib.topic_mutes import (
@@ -337,10 +337,9 @@ class ImportExportTest(ZulipTestCase):
 
     @use_s3_backend
     def test_export_files_from_s3(self) -> None:
-        session = boto3.Session(settings.S3_KEY, settings.S3_SECRET_KEY)
-        s3 = session.resource('s3')
-        s3.create_bucket(Bucket=settings.S3_AUTH_UPLOADS_BUCKET)
-        s3.create_bucket(Bucket=settings.S3_AVATAR_BUCKET)
+        create_s3_bucket(
+            settings.S3_AUTH_UPLOADS_BUCKET,
+            settings.S3_AVATAR_BUCKET)
 
         realm = Realm.objects.get(string_id='zulip')
         attachment_path_id, emoji_path, original_avatar_path_id, test_image = self._setup_export_files()
@@ -768,10 +767,9 @@ class ImportExportTest(ZulipTestCase):
 
     @use_s3_backend
     def test_import_files_from_s3(self) -> None:
-        session = boto3.Session(settings.S3_KEY, settings.S3_SECRET_KEY)
-        s3 = session.resource('s3')
-        uploads_bucket = s3.create_bucket(Bucket=settings.S3_AUTH_UPLOADS_BUCKET)
-        avatar_bucket = s3.create_bucket(Bucket=settings.S3_AVATAR_BUCKET)
+        uploads_bucket, avatar_bucket = create_s3_bucket(
+            settings.S3_AUTH_UPLOADS_BUCKET,
+            settings.S3_AVATAR_BUCKET)
 
         realm = Realm.objects.get(string_id='zulip')
         self._setup_export_files()

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -793,16 +793,7 @@ class ImportExportTest(ZulipTestCase):
             emoji_file_name=realm_emoji.file_name,
         )
         emoji_key = avatar_bucket.Object(emoji_path)
-        # Work around since python unittest does not have assertNotRaises
-        try:
-            emoji_key.load()
-        except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == '404':
-                self.fail(
-                    'Test raises ClientError exception due to non-exist s3 object %s' % (emoji_key.key,))
-            else:
-                raise
-
+        self.assertIsNotNone(emoji_key.get()['Body'].read())
         self.assertEqual(emoji_key.key, emoji_path)
 
         # Test avatars

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from zerver.lib.test_classes import ZulipTestCase, UploadSerializeMixin
 from zerver.lib.test_helpers import (
     use_s3_backend,
+    create_s3_bucket,
     override_settings,
     get_test_image_file
 )
@@ -11,7 +12,6 @@ from zerver.lib.upload import upload_backend, upload_emoji_image
 from zerver.lib.users import get_api_key
 
 from io import StringIO
-import boto3
 import ujson
 import urllib
 import base64
@@ -26,11 +26,9 @@ class ThumbnailTest(ZulipTestCase):
                 url_in_result = '/%s/%s' % (size, url_in_result)
             hex_uri = base64.urlsafe_b64encode(uri.encode()).decode('utf-8')
             return url_in_result % (hex_uri)
-
-        session = boto3.Session(settings.S3_KEY, settings.S3_SECRET_KEY)
-        s3 = session.resource('s3')
-        s3.create_bucket(Bucket=settings.S3_AUTH_UPLOADS_BUCKET)
-        s3.create_bucket(Bucket=settings.S3_AVATAR_BUCKET)
+        create_s3_bucket(
+            settings.S3_AUTH_UPLOADS_BUCKET,
+            settings.S3_AVATAR_BUCKET)
 
         self.login(self.example_email("hamlet"))
         fp = StringIO("zulip!")

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -11,7 +11,7 @@ from zerver.lib.upload import upload_backend, upload_emoji_image
 from zerver.lib.users import get_api_key
 
 from io import StringIO
-from boto.s3.connection import S3Connection
+import boto3
 import ujson
 import urllib
 import base64
@@ -27,9 +27,10 @@ class ThumbnailTest(ZulipTestCase):
             hex_uri = base64.urlsafe_b64encode(uri.encode()).decode('utf-8')
             return url_in_result % (hex_uri)
 
-        conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
-        conn.create_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
-        conn.create_bucket(settings.S3_AVATAR_BUCKET)
+        session = boto3.Session(settings.S3_KEY, settings.S3_SECRET_KEY)
+        s3 = session.resource('s3')
+        s3.create_bucket(Bucket=settings.S3_AUTH_UPLOADS_BUCKET)
+        s3.create_bucket(Bucket=settings.S3_AVATAR_BUCKET)
 
         self.login(self.example_email("hamlet"))
         fp = StringIO("zulip!")

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -50,6 +50,7 @@ import shutil
 import re
 import datetime
 import requests
+import botocore.exceptions
 import base64
 from datetime import timedelta
 from django.http import HttpRequest
@@ -1281,8 +1282,13 @@ class S3Test(ZulipTestCase):
 
     @use_s3_backend
     def test_message_image_delete_when_file_doesnt_exist(self) -> None:
-        bucket, = create_s3_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
+        create_s3_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
         self.assertEqual(False, delete_message_image('non-existant-file'))
+
+    @use_s3_backend
+    def test_message_image_delete_when_bucket_doesnt_exist(self) -> None:
+        with self.assertRaises(botocore.exceptions.ClientError):
+            delete_message_image('non-existant-file')
 
     @use_s3_backend
     def test_file_upload_authed(self) -> None:
@@ -1398,8 +1404,12 @@ class S3Test(ZulipTestCase):
 
     @use_s3_backend
     def test_get_realm_for_filename_when_key_doesnt_exist(self) -> None:
-        bucket, = create_s3_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
+        create_s3_bucket(settings.S3_AUTH_UPLOADS_BUCKET)
         self.assertEqual(None, get_realm_for_filename('non-existent-file-path'))
+
+    def test_get_realm_for_filename_when_bucket_doesnt_exist(self) -> None:
+        with self.assertRaises(botocore.exceptions.ClientError):
+            get_realm_for_filename('non-existent-file-path')
 
     @use_s3_backend
     def test_upload_realm_icon_image(self) -> None:


### PR DESCRIPTION
requirements: Upgrade boto to boto3.

Mainly three files are changed:
1) zerver/lib/export.py;
2) zerver/lib/import_realm.py;
3) zerver/lib/upload.py.

The current code converage for these files are 90%, 92% and 99%
while cases related to s3 are mostly covered (99% above)

This fix comes along with some refactors. 

boto2 is still kept due to the dependency in puppet script.

Fix: #3490.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
