### PR TITLE
style: Fix the stream and user list buttons on mobile in night mode.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -236,6 +236,17 @@ on a dark background, and don't change the dark labels dark either. */
         color: hsl(0, 0%, 100%);
     }
 
+    #streamlist-toggle,
+    #userlist-toggle {
+        border-color: hsla(199, 33%, 46%, 0.2);
+    }
+
+    #streamlist-toggle-button,
+    #userlist-toggle-button {
+        color: inherit;
+        background-color: inherit;
+    }
+
     li.active-filter,
     li.active-sub-filter {
         background-color: hsla(199, 33%, 46%, 0.2);
@@ -266,6 +277,7 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     #searchbox,
+    #searchbox_legacy,
     .drafts-header,
     .nav > li > a:hover,
     .subscriptions-header,


### PR DESCRIPTION
Currently, these buttons are displayed with a lighter background than other buttons. This PR updates their borders and background colors (along with the border on the search box) so that they match the night theme.

Fixes #10301.

(I made a different PR for this earlier, but I'm opening this PR since I think that I've found a clearer solution, as well as that the reviewer for the earlier PR, synicalsyntax, said on CZO that she won't be able to do reviews for a month or so.)

**Screenshots:**

*Before:*

<img width="317" alt="before" src="https://user-images.githubusercontent.com/17259768/44179868-3ba19900-a0ae-11e8-88c1-cf58f367a61c.png">

*After:*

<img width="317" alt="after" src="https://user-images.githubusercontent.com/17259768/44356154-60599000-a463-11e8-8d1a-4524de7ed837.png">