### PR TITLE
integration docs: Simplify create a bot instructions.

### DIFF
--- a/templates/zerver/help/include/create-a-bot-indented.md
+++ b/templates/zerver/help/include/create-a-bot-indented.md
@@ -1,12 +1,7 @@
-    On your {{ settings_html|safe }},
-    [create a bot](/help/add-a-bot-or-integration) for
+    [Create a bot](/help/add-a-bot-or-integration) for
     {{ integration_display_name }}. Make sure that you select
     **Incoming webhook** as the **Bot type**:
 
     ![](/static/images/help/bot_types.png)
-
-    The API key for an incoming webhook bot cannot be used to read messages out
-    of Zulip. Thus, using an incoming webhook bot lowers the security risk of
-    exposing the bot's API key to a third-party service.
 
     Fill out the rest of the fields, and click **Create bot**.

--- a/templates/zerver/help/include/create-a-bot.md
+++ b/templates/zerver/help/include/create-a-bot.md
@@ -1,12 +1,7 @@
-On your {{ settings_html|safe }},
-[create a bot](/help/add-a-bot-or-integration) for
+[Create a bot](/help/add-a-bot-or-integration) for
 {{ integration_display_name }}. Make sure that you select
 **Incoming webhook** as the **Bot type**:
 
 ![](/static/images/help/bot_types.png)
-
-The API key for an incoming webhook bot cannot be used to read messages out
-of Zulip. Thus, using an incoming webhook bot lowers the security risk of
-exposing the bot's API key to a third-party service.
 
 Fill out the rest of the fields, and click **Create bot**.

--- a/templates/zerver/help/include/create-bot-construct-url-indented.md
+++ b/templates/zerver/help/include/create-bot-construct-url-indented.md
@@ -6,9 +6,9 @@
     {!webhook-url.md!}
 
     Modify the parameters of the URL above, where `api_key` is the API key
-    of your Zulip bot, and `stream` is the stream name you want the
+    of your Zulip bot, and `stream` is the URL-encoded stream name you want the
     notifications sent to. If you do not specify a `stream`, the bot will
     send notifications via PMs to the creator of the bot.
 
     If you'd like this integration to always send to the topic
-    `your_topic`, just add `&topic=your_topic` to the end of the URL.
+    `your topic`, just add `&topic=your%20topic` to the end of the URL.

--- a/templates/zerver/help/include/create-bot-construct-url.md
+++ b/templates/zerver/help/include/create-bot-construct-url.md
@@ -6,9 +6,9 @@ bot using the bot's API key and the desired stream name:
 {!webhook-url.md!}
 
 Modify the parameters of the URL above, where `api_key` is the API key
-of your Zulip bot, and `stream` is the stream name you want the
+of your Zulip bot, and `stream` is the URL-encoded stream name you want the
 notifications sent to. If you do not specify a `stream`, the bot will
 send notifications via PMs to the creator of the bot.
 
 If you'd like this integration to always send to the topic
-`your_topic`, just add `&topic=your_topic` to the end of the URL.
+`your topic`, just add `&topic=your%20topic` to the end of the URL.

--- a/templates/zerver/help/include/create-stream.md
+++ b/templates/zerver/help/include/create-stream.md
@@ -1,5 +1,2 @@
 Create the stream you'd like to use for
-{{ integration_display_name }} notifications, and subscribe all
-interested parties to this stream. We recommend the
-name `{{ recommended_stream_name }}`. You still need to create
-the stream even if you are using this default recommendation.
+{{ integration_display_name }} notifications.

--- a/templates/zerver/help/include/webhook-url.md
+++ b/templates/zerver/help/include/webhook-url.md
@@ -1,1 +1,1 @@
-`{{ api_url }}{{ integration_url }}?api_key=abcdefgh&stream=stream_name`
+`{{ api_url }}{{ integration_url }}?api_key=abcdefgh&stream=stream%20name`

--- a/templates/zerver/help/include/webhook-url.md
+++ b/templates/zerver/help/include/webhook-url.md
@@ -1,1 +1,1 @@
-`{{ api_url }}{{ integration_url }}?api_key=abcdefgh&stream={{ recommended_stream_name }}`
+`{{ api_url }}{{ integration_url }}?api_key=abcdefgh&stream=stream_name`


### PR DESCRIPTION
Contains a number of changes, including one addressing
https://chat.zulip.org/#narrow/stream/101-design/subject/url.20friendly.20stream.20names/near/633654

It's a pretty poor solution, since most people aren't going to know what URL encoding means, but may tide us over until we improve this flow to not need it.

Old 
![image](https://user-images.githubusercontent.com/890911/44378915-5746de00-a4b8-11e8-9547-137c17e3dd4c.png)

New
![image](https://user-images.githubusercontent.com/890911/44378923-5f9f1900-a4b8-11e8-8a1d-95f276e7e2dc.png)
