### PR TITLE
settings: Improve error message when deactivating the last user.

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2811,6 +2811,14 @@ class DeactivateUserTest(ZulipTestCase):
         self.assert_json_success(result)
         do_change_is_admin(user, True)
 
+    def test_do_not_deactivate_final_user(self) -> None:
+        realm = get_realm('zulip')
+        UserProfile.objects.filter(realm=realm, is_realm_admin=False).update(is_active=False)
+        email = self.example_email("iago")
+        self.login(email)
+        result = self.client_delete('/json/users/me')
+        self.assert_json_error_contains(result, "Cannot deactivate the only user. You")
+
 class TestLoginPage(ZulipTestCase):
     def test_login_page_wrong_subdomain_error(self) -> None:
         result = self.client_get("/login/?subdomain=1")

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -46,8 +46,11 @@ def deactivate_user_backend(request: HttpRequest, user_profile: UserProfile,
     return _deactivate_user_profile_backend(request, user_profile, target)
 
 def deactivate_user_own_backend(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
-
     if user_profile.is_realm_admin and check_last_admin(user_profile):
+        if UserProfile.objects.filter(realm=user_profile.realm, is_active=True).count() == 1:
+            return json_error(_(
+                'Cannot deactivate the only user. '
+                'You can deactivate the whole organization though in Organization -> Organization profile.'))
         return json_error(_('Cannot deactivate the only organization administrator'))
     do_deactivate_user(user_profile, acting_user=user_profile)
     return json_success()


### PR DESCRIPTION
Did the simplest possible thing. If it's easy to add html links to the error message, could be improved significantly. 

Old:
![image](https://user-images.githubusercontent.com/890911/44383985-6dac6400-a4cf-11e8-8e21-a13b0dfc6471.png)

New:
![image](https://user-images.githubusercontent.com/890911/44384006-874dab80-a4cf-11e8-9f33-358bdfe2fe60.png)
