### PR TITLE
templates: Replace &nbsp; with normal spaces.

### DIFF
--- a/static/templates/subscription_type.handlebars
+++ b/static/templates/subscription_type.handlebars
@@ -1,5 +1,5 @@
 {{#if invite_only}}
-    {{t 'This is a <span class="fa fa-lock" aria-hidden="true"></span> <b>private stream</b>. Only people who have been invited can access its content, but&nbsp;any&nbsp;member&nbsp;of&nbsp;the&nbsp;stream can&nbsp;invite&nbsp;others.' }}
+    {{t 'This is a <span class="fa fa-lock" aria-hidden="true"></span> <b>private stream</b>. Only people who have been invited can access its content, but any member of the stream can invite others.' }}
     {{#if history_public_to_subscribers}}{{t 'New members can view complete message history.' }}
     {{else}}{{t 'New members can only see messages sent after they join.' }}
     {{/if}}


### PR DESCRIPTION
This line full of non-breaking spaces dates back to before Zulip being open sourced (ca4e6a0ff), so we can assume it was a fix that we don't need anymore.

See [this](https://chat.zulip.org/#narrow/stream/2-general/topic/weird.20space.20escape) for context.