### PR TITLE
drafts: Don't save drafts with 2 or less characters.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -71,6 +71,12 @@ var draft_2 = {
     type: "private",
     content: "Test Private Message",
 };
+var short_msg = {
+    stream: "stream",
+    subject: "topic",
+    type: "stream",
+    content: "a",
+};
 
 run_test('draft_model', () => {
     var draft_model = drafts.draft_model;
@@ -151,6 +157,9 @@ run_test('snapshot_message', () => {
 
     stub_draft(draft_2);
     assert.deepEqual(drafts.snapshot_message(), draft_2);
+
+    stub_draft(short_msg);
+    assert.deepEqual(drafts.snapshot_message(), undefined);
 
     stub_draft({});
     assert.equal(drafts.snapshot_message(), undefined);

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -64,9 +64,9 @@ var draft_model = (function () {
 exports.draft_model = draft_model;
 
 exports.snapshot_message = function () {
-    if (!compose_state.composing() || compose_state.message_content() === "") {
+    if (!compose_state.composing() || compose_state.message_content().length <= 2) {
         // If you aren't in the middle of composing the body of a
-        // message, don't try to snapshot.
+        // message or the message is shorter than 2 characters long, don't try to snapshot.
         return;
     }
 


### PR DESCRIPTION
Fixes #10357.