### PR TITLE
right-sidebar: Fix keyboard shortcut icon for right night mode coloring.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -72,7 +72,7 @@ function get_new_heights() {
     // RIGHT SIDEBAR
     var buddy_list_wrapper = $('#buddy_list_wrapper').expectOne();
     var group_pms = $('#group-pms').expectOne();
-    var keyboard_popover_shortcut = $('#sidebar-keyboard-shortcuts #keyboard-icon').expectOne();
+    var keyboard_popover_shortcut = $('#keyboard-icon').expectOne();
 
     var usable_height =
         res.right_sidebar_height

--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -51,7 +51,7 @@ exports.initialize = function () {
         $(".compose-content").css({left: sbWidth + "px",
                                    "margin-right": 250 + sbWidth + "px"});
         $("#compose-container").css("max-width", 1400 + sbWidth + "px");
-        $('#sidebar-keyboard-shortcuts #keyboard-icon').css({right: sbWidth + 13 + "px"});
+        $('#keyboard-icon').css({right: sbWidth + 13 + "px"});
 
         $("head").append("<style> @media (max-width: 1025px) { .compose-content, .header-main .column-middle { margin-right: " + (7 + sbWidth) + "px !important; } } " +
                          "@media (max-width: 775px) { .fixed-app .column-middle { margin-left: " + (7 + sbWidth) + "px !important; } } " +

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -219,11 +219,6 @@ function initialize_kitchen_sink_stuff() {
         timerender.set_full_datetime(message, time_elem);
     });
 
-    // compose-content padding = icon bottom to make keyboard popover shortcut
-    // vertically aligned with the compose box
-    $('#sidebar-keyboard-shortcuts #keyboard-icon').css('bottom',
-                                                        parseInt($(".compose-content").css("paddingBottom"), 10));
-
     $('#streams_header h4').tooltip({placement: 'right',
                                      animation: false});
 

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -236,12 +236,13 @@
     margin-right: 10px;
 }
 
-#sidebar-keyboard-shortcuts #keyboard-icon {
+#keyboard-icon {
     position: fixed;
+    bottom: 8px; /* bottom padding of .compose-content */
     cursor: pointer;
     font-size: 20px;
 }
 
-#sidebar-keyboard-shortcuts a {
-    color: hsl(0, 0%, 1.2%); //#333
+#sidebar-keyboard-shortcuts {
+    color: inherit;
 }

--- a/templates/zerver/app/right_sidebar.html
+++ b/templates/zerver/app/right_sidebar.html
@@ -33,10 +33,8 @@
             <ul id="group-pms" class="filters scrolling_list">
             </ul>
         </div>
-        <div id="sidebar-keyboard-shortcuts">
-            <a data-overlay-trigger="keyboard-shortcuts">
-                <i class="fa fa-keyboard-o fa-2x" id="keyboard-icon" data-html="true" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
-            </a>
-        </div>
+        <a id="sidebar-keyboard-shortcuts" data-overlay-trigger="keyboard-shortcuts">
+            <i class="fa fa-keyboard-o fa-2x" id="keyboard-icon" data-html="true" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
+        </a>
     </div>
 </div>


### PR DESCRIPTION
Before:
![screenshot at aug 21 16-43-13](https://user-images.githubusercontent.com/15116870/44434673-53bb6180-a561-11e8-881c-15b3628c2d1a.png)


After:
![screenshot at aug 21 16-42-23](https://user-images.githubusercontent.com/15116870/44434667-44d4af00-a561-11e8-8839-4b166bf3373b.png)
