### PR TITLE
backend: Use user IDs as recipients.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1971,7 +1971,8 @@ def check_send_message(sender: UserProfile, client: Client, message_type_name: s
     return do_send_messages([message])[0]
 
 def check_schedule_message(sender: UserProfile, client: Client,
-                           message_type_name: str, message_to: Sequence[str],
+                           message_type_name: str,
+                           message_to: Union[Sequence[str], Sequence[int]],
                            topic_name: Optional[str], message_content: str,
                            delivery_type: str, deliver_at: datetime.datetime,
                            realm: Optional[Realm]=None,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1624,15 +1624,21 @@ def check_send_typing_notification(sender: UserProfile, notification_to: Sequenc
 # check_typing_notification:
 # Returns typing notification ready for sending with do_send_typing_notification on success
 # or the error message (string) on error.
-def check_typing_notification(sender: UserProfile, notification_to: Sequence[str],
+def check_typing_notification(sender: UserProfile,
+                              notification_to: Union[Sequence[str], Sequence[int]],
                               operator: str) -> Dict[str, Any]:
     if len(notification_to) == 0:
         raise JsonableError(_('Missing parameter: \'to\' (recipient)'))
     elif operator not in ('start', 'stop'):
         raise JsonableError(_('Invalid \'op\' value (should be start or stop)'))
+
     try:
-        recipient = recipient_for_emails(notification_to, False,
-                                         sender, sender)
+        if isinstance(notification_to[0], str):
+            emails = cast(Sequence[str], notification_to)
+            recipient = recipient_for_emails(emails, False, sender, sender)
+        elif isinstance(notification_to[0], int):
+            user_ids = cast(Sequence[int], notification_to)
+            recipient = recipient_for_user_ids(user_ids, sender)
     except ValidationError as e:
         assert isinstance(e.messages[0], str)
         raise JsonableError(e.messages[0])

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1950,7 +1950,8 @@ def check_send_private_message(sender: UserProfile, client: Client,
 # check_send_message:
 # Returns the id of the sent message.  Has same argspec as check_message.
 def check_send_message(sender: UserProfile, client: Client, message_type_name: str,
-                       message_to: Sequence[str], topic_name: Optional[str],
+                       message_to: Union[Sequence[int], Sequence[str]],
+                       topic_name: Optional[str],
                        message_content: str, realm: Optional[Realm]=None,
                        forged: bool=False, forged_timestamp: Optional[float]=None,
                        forwarder_user_profile: Optional[UserProfile]=None,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2167,10 +2167,6 @@ def check_message(sender: UserProfile, client: Client, addressee: Addressee,
 
     elif addressee.is_private():
         user_profiles = addressee.user_profiles()
-
-        if user_profiles is None or len(user_profiles) == 0:
-            raise JsonableError(_("Message must have recipients"))
-
         mirror_message = client and client.name in ["zephyr_mirror", "irc_mirror",
                                                     "jabber_mirror", "JabberMirror"]
         not_forged_mirror_message = mirror_message and not forged

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -115,6 +115,9 @@ class Addressee:
 
             return Addressee.for_stream(stream_name, topic_name)
         elif message_type_name == 'private':
+            if not message_to:
+                raise JsonableError(_("Message must have recipients"))
+
             emails = message_to
             return Addressee.for_private(emails, realm)
         else:
@@ -135,6 +138,7 @@ class Addressee:
 
     @staticmethod
     def for_private(emails: Sequence[str], realm: Realm) -> 'Addressee':
+        assert len(emails) > 0
         user_profiles = get_user_profiles(emails, realm)
         return Addressee(
             msg_type='private',
@@ -143,6 +147,7 @@ class Addressee:
 
     @staticmethod
     def for_user_ids(user_ids: Sequence[int], realm: Realm) -> 'Addressee':
+        assert len(user_ids) > 0
         user_profiles = get_user_profiles_by_ids(user_ids, realm)
         return Addressee(
             msg_type='private',

--- a/zerver/lib/bot_lib.py
+++ b/zerver/lib/bot_lib.py
@@ -15,6 +15,8 @@ from zerver.lib.bot_config import get_bot_config, ConfigError
 from zerver.lib.integrations import EMBEDDED_BOTS
 from zerver.lib.topic import get_topic_from_message_info
 
+from django.utils.translation import ugettext as _
+
 import configparser
 
 from mypy_extensions import NoReturn
@@ -60,6 +62,9 @@ class StateHandler:
 class EmbeddedBotQuitException(Exception):
     pass
 
+class EmbeddedBotEmptyRecipientsList(Exception):
+    pass
+
 class EmbeddedBotHandler:
     def __init__(self, user_profile: UserProfile) -> None:
         # Only expose a subset of our UserProfile's functionality
@@ -84,7 +89,9 @@ class EmbeddedBotHandler:
         # usual 'to' field could be either a List[str] or a str.
         recipients = ','.join(message['to']).split(',')
 
-        if len(message['to']) == 1:
+        if len(message['to']) == 0:
+            raise EmbeddedBotEmptyRecipientsList(_('Message must have recipients!'))
+        elif len(message['to']) == 1:
             recipient_user = get_active_user(recipients[0], self.user_profile.realm)
             internal_send_private_message(self.user_profile.realm, self.user_profile,
                                           recipient_user, message['content'])

--- a/zerver/lib/request.pyi
+++ b/zerver/lib/request.pyi
@@ -7,8 +7,7 @@
 # types.
 
 from typing import Any, List, Callable, TypeVar, Optional, Union, Type
-from zerver.lib.types import ViewFuncT, Validator
-
+from zerver.lib.types import ViewFuncT, Validator, ExtractRecipients
 from zerver.lib.exceptions import JsonableError as JsonableError
 
 ResultT = TypeVar('ResultT')
@@ -23,7 +22,7 @@ NotSpecified = _NotSpecified()
 def REQ(whence: Optional[str] = None,
         *,
         type: Type[ResultT] = Type[None],
-        converter: Optional[Callable[[str], ResultT]] = None,
+        converter: Union[Optional[Callable[[str], ResultT]], ExtractRecipients] = None,
         default: Union[_NotSpecified, ResultT, None] = Optional[NotSpecified],
         validator: Optional[Validator] = None,
         str_validator: Optional[Validator] = None,

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Callable, Optional, List, Dict, Union, Tuple, Any
+from typing import TypeVar, Callable, Optional, List, Dict, Union, Tuple, Any, Iterable
 from django.http import HttpResponse
 
 ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
@@ -6,6 +6,12 @@ ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
 # See zerver/lib/validator.py for more details of Validators,
 # including many examples
 Validator = Callable[[str, object], Optional[str]]
+
+# This type is specific for zerver.lib.actions.extract_recipients. After
+# deciding to support IDs for some of our API, extract_recipients'
+# implementation diverged from other converter functions in many ways.
+# See zerver/lib/request.pyi to see how this is used.
+ExtractRecipients = Callable[[Union[str, Iterable[str], Iterable[int]]], Union[List[str], List[int]]]
 ExtendedValidator = Callable[[str, str, object], Optional[str]]
 RealmUserValidator = Callable[[int, List[int], bool], Optional[str]]
 

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -413,6 +413,22 @@ class TestAddressee(ZulipTestCase):
         with assert_invalid_user_id():
             Addressee.for_user_ids(user_ids=[779], realm=get_realm('zulip'))
 
+    def test_addressee_legacy_build_for_user_ids(self) -> None:
+        realm = get_realm('zulip')
+        self.login(self.example_email('hamlet'))
+        user_ids = [self.example_user('cordelia').id,
+                    self.example_user('othello').id]
+
+        result = Addressee.legacy_build(
+            sender=self.example_user('hamlet'), message_type_name='private',
+            message_to=user_ids, topic_name='random_topic',
+            realm=realm
+        )
+        user_profiles = result.user_profiles()
+        result_user_ids = [user_profiles[0].id, user_profiles[1].id]
+
+        self.assertEqual(set(result_user_ids), set(user_ids))
+
 class InternalPrepTest(ZulipTestCase):
 
     def test_returns_for_internal_sends(self) -> None:

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1395,6 +1395,26 @@ class MessagePOSTTest(ZulipTestCase):
                                                      "to": self.example_email("othello")})
         self.assert_json_success(result)
 
+    def test_personal_message_by_id(self) -> None:
+        """
+        Sending a personal message to a valid user ID is successful.
+        """
+        self.login(self.example_email("hamlet"))
+        result = self.client_post(
+            "/json/messages",
+            {
+                "type": "private",
+                "content": "Test message",
+                "client": "test suite",
+                "to": ujson.dumps([self.example_user("othello").id])
+            }
+        )
+        self.assert_json_success(result)
+
+        msg = self.get_last_message()
+        self.assertEqual("Test message", msg.content)
+        self.assertEqual(msg.recipient_id, self.example_user("othello").id)
+
     def test_personal_message_copying_self(self) -> None:
         """
         Sending a personal message to yourself plus another user is successful,
@@ -1714,6 +1734,22 @@ class MessagePOSTTest(ZulipTestCase):
                                                      "to": email},
                                   subdomain="notzephyr")
         self.assert_json_error(result, "Zephyr mirroring is not allowed in this organization")
+
+    @mock.patch("zerver.views.messages.create_mirrored_message_users")
+    def test_send_message_when_client_is_zephyr_mirror_but_recipient_is_user_id(
+            self, create_mirrored_message_users_mock: Any) -> None:
+        create_mirrored_message_users_mock.return_value = (True, True)
+        user = self.mit_user("starnine")
+        user_id = user.id
+        user_email = user.email
+        self.login(user_email, realm=get_realm("zephyr"))
+        result = self.client_post("/json/messages", {"type": "private",
+                                                     "sender": self.mit_email("sipbtest"),
+                                                     "content": "Test message",
+                                                     "client": "zephyr_mirror",
+                                                     "to": ujson.dumps([user_id])},
+                                  subdomain="zephyr")
+        self.assert_json_error(result, "Mirroring not allowed with recipient user IDs")
 
     def test_send_message_irc_mirror(self) -> None:
         self.login(self.example_email('hamlet'))

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -11,7 +11,8 @@ from zerver.lib.actions import (
     do_create_user,
     get_service_bot_events,
 )
-from zerver.lib.bot_lib import StateHandler, EmbeddedBotHandler
+from zerver.lib.bot_lib import StateHandler, EmbeddedBotHandler, \
+    EmbeddedBotEmptyRecipientsList
 from zerver.lib.bot_storage import StateError
 from zerver.lib.bot_config import set_bot_config, ConfigError, load_bot_config_template
 from zerver.lib.test_classes import ZulipTestCase
@@ -398,6 +399,10 @@ class TestServiceBotConfigHandler(ZulipTestCase):
         bot_config = load_bot_config_template('converter')
         self.assertTrue(isinstance(bot_config, dict))
         self.assertEqual(len(bot_config), 0)
+
+    def test_bot_send_pm_with_empty_recipients_list(self) -> None:
+        with self.assertRaisesRegex(EmbeddedBotEmptyRecipientsList, 'Message must have recipients!'):
+            self.bot_handler.send_message(message={'type': 'private', 'to': []})
 
 
 class TestServiceBotEventTriggers(ZulipTestCase):

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -1166,7 +1166,8 @@ def same_realm_jabber_user(user_profile: UserProfile, email: str) -> bool:
     return RealmDomain.objects.filter(realm=user_profile.realm, domain=domain).exists()
 
 def handle_deferred_message(sender: UserProfile, client: Client,
-                            message_type_name: str, message_to: Sequence[str],
+                            message_type_name: str,
+                            message_to: Union[Sequence[str], Sequence[int]],
                             topic_name: Optional[str],
                             message_content: str, delivery_type: str,
                             defer_until: str, tz_guess: str,


### PR DESCRIPTION
@showell, @timabbott: I had to submit another PR because apparently, GitHub doesn't let me re-order history if the branch has already been pushed to a remote once! So I thought, pushing on a new branch might fix that, but that doesn't cut it either. It might reflect the intended ordering of commits once you fetch the PR locally. :/

@showell: The idea is that after the `extract_recipients` commit, I will add another one on top that finally implements the backend support for using IDs in typing notifications. I had to commit the `extract_recipients` work first because it made testing the backend changes a whole lot easier. I'll push the rest of the changes once they are complete. Getting `mypy` to pass took a lot of work!

After that, the idea is that all commits on top of the last one will be geared towards implementing user ID support for sending PMs and what not!

Thanks! :)