### PR TITLE
styles: Fix the oversized search bar on mobile.

### DIFF
--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -221,12 +221,16 @@
     #tab_bar,
     #searchbox,
     #searchbox_legacy,
-    #search_query,
     #tab_list li,
     #tab_list,
     .header {
         height: 30px;
         line-height: 30px;
+    }
+
+    #search_query {
+        height: 30px !important;
+        vertical-align: text-bottom;
     }
 
     #streamlist-toggle-button,


### PR DESCRIPTION
On mobile devices, the search bar appears as too tall for the rest of the top header. This PR fixes this by setting `#search_query`'s height and vertical alignment properties.

Fixes #10373.

**GIFs or Screenshots:**

*Before (with input selected so that the size is more evident):*

<img width="320" alt="screen shot 2018-08-20 at 10 34 30 am" src="https://user-images.githubusercontent.com/17259768/44442449-1e296f00-a587-11e8-915b-b9dd04febe64.png">

*After:*

<img width="320" alt="screen shot 2018-08-20 at 10 47 31 am" src="https://user-images.githubusercontent.com/17259768/44442463-2bdef480-a587-11e8-8e0e-2eeb4d698e2e.png">

