### PR TITLE
Better Font Readability

### DIFF
--- a/static/styles/alerts.scss
+++ b/static/styles/alerts.scss
@@ -23,8 +23,6 @@
     width: 900px;
     margin-left: calc(50% - 450px);
     z-index: 220;
-
-    -webkit-font-smoothing: antialiased;
 }
 
 .alert-box .alert.show {

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -163,8 +163,6 @@ table.compose_table {
     width: 100%;
     max-width: 1400px;
     margin: auto;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
 }
 
 .compose-content {

--- a/static/styles/drafts.scss
+++ b/static/styles/drafts.scss
@@ -1,6 +1,3 @@
-.drafts {
-    -webkit-font-smoothing: antialiased;
-}
 
 .drafts-container {
     position: relative;
@@ -58,7 +55,6 @@
     font-size: 1.5em;
     color: hsl(0, 0%, 66%);
     pointer-events: none;
-    -webkit-font-smoothing: antialiased;
 }
 
 .drafts-list .removed-drafts {
@@ -67,7 +63,6 @@
     font-size: 1em;
     color: hsl(0, 0%, 66%);
     pointer-events: none;
-    -webkit-font-smoothing: antialiased;
 }
 
 .draft-row {

--- a/static/styles/hotspots.scss
+++ b/static/styles/hotspots.scss
@@ -74,8 +74,6 @@
 .hotspot.overlay {
     z-index: 104;
     background-color: hsla(191, 7%, 20%, 0.15);
-
-    -webkit-font-smoothing: antialiased;
 }
 
 .hotspot.overlay .hotspot-popover {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -1,7 +1,4 @@
 #left-sidebar {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-
     font-size: 0.89rem;
 }
 

--- a/static/styles/lightbox.scss
+++ b/static/styles/lightbox.scss
@@ -1,8 +1,5 @@
 #lightbox_overlay {
     background-color: hsl(227, 40%, 16%);
-
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
 }
 
 #lightbox_overlay .image-preview {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -1,7 +1,6 @@
 body.night-mode {
     background-color: hsl(212, 28%, 18%);
     color: hsl(236, 33%, 90%);
-    -webkit-font-smoothing: antialiased;
 
     .app-main,
     .header-main,

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -1,5 +1,4 @@
 .right-sidebar {
-    -webkit-font-smoothing: antialiased;
     font-size: 0.89rem;
 }
 

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1158,10 +1158,6 @@ input[type=checkbox].inline-block {
     margin: 2.5vh auto;
     overflow: hidden;
     border-radius: 4px;
-
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-
     transition: transform 0.2s ease;
 }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -16,6 +16,9 @@ html {
 
 body {
     font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-smoothing: antialiased;
 }
 
 /* Common background color */
@@ -175,8 +178,6 @@ p.n-margin {
 }
 
 #panels {
-    -webkit-font-smoothing: antialiased;
-
     font-size: 1rem;
 }
 
@@ -2412,11 +2413,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
     margin-bottom: 0px;
 }
 
-#invite-user {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-}
-
 #invite-user .modal-header {
     padding: 7px 15px;
     border-color: hsl(0, 0%, 86%);
@@ -2779,10 +2775,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
     height: 80px;
     padding: 5px;
     z-index: 1;
-
-    -moz-osx-font-smoothing: grayscale;
-    font-smoothing: antialiased;
-    -webkit-font-smoothing: antialiased;
     text-shadow: rgba(0, 0, 0, .01) 0 0 1px;
 }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -452,7 +452,7 @@ pre {
     direction: ltr;
     /* code block text is a bit smaller than normal text */
     font-size: 0.8em;
-    line-height: 1.4;
+    line-height: 1.6;
     white-space: pre;
     overflow-x: auto;
     word-wrap: normal;
@@ -460,10 +460,7 @@ pre {
     margin-top: 5px;
     margin-bottom: 5px;
     /* Bootstrap's default here is 9.5 on all sides */
-    padding-top: 5px;
-    padding-bottom: 3px;
-    padding-left: 7px;
-    padding-right: 7px;
+    padding: 1em 0.5em;
 }
 
 /* Ensure the horizontal scrollbar is visible on Mac */
@@ -1316,8 +1313,8 @@ div.focused_table {
 }
 
 .message_content {
-    line-height: 17px;
-    min-height: 17px;
+    line-height: 19px;
+    min-height: 19px;
     font-size: 14px;
     margin-left: 46px;
     display: block;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is for improving the legibility of fonts on the zulip web app. It includes two commits, one that improves line-heights and the second that includes antialiasing properties of fonts.

Previous concerns about performance and adoptability shouldn't hold as this property is being widely used both within our app and across the web, including by high-profile projects.

**New Style**

<img width="786" alt="screen shot 2018-08-22 at 5 37 42 pm" src="https://user-images.githubusercontent.com/322991/44462561-97ca6700-a632-11e8-85f2-9c9c847fb6ae.png">

**Old Style**
<img width="786" alt="screen shot 2018-08-22 at 5 38 20 pm" src="https://user-images.githubusercontent.com/322991/44462566-9b5dee00-a632-11e8-9c0e-6147ee1359f2.png">