### PR TITLE
Remove `code` from JsonableError.__init__.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -58,7 +58,6 @@ not_yet_fully_covered = {
     'zerver/lib/bugdown/__init__.py',
     'zerver/lib/cache.py',
     'zerver/lib/cache_helpers.py',
-    'zerver/lib/exceptions.py',
     'zerver/lib/i18n.py',
     'zerver/lib/notifications.py',
     'zerver/lib/send_email.py',

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -43,7 +43,7 @@ class ErrorCode(AbstractEnum):
 class JsonableError(Exception):
     '''A standardized error format we can turn into a nice JSON HTTP response.
 
-    This class can be invoked in several ways.
+    This class can be invoked in a couple ways.
 
      * Easiest, but completely machine-unreadable:
 
@@ -53,16 +53,6 @@ class JsonableError(Exception):
        so translation is required.  Because the text will vary depending
        on the user's language, it's not possible for code to distinguish
        this error from others in a non-buggy way.
-
-     * Partially machine-readable, with an error code:
-
-         raise JsonableError(_("No such widget: {}").format(widget_name),
-                             ErrorCode.NO_SUCH_WIDGET)
-
-       Now the error's `code` attribute can be used, both in server
-       and client code, to identify this type of error.  The data
-       (here, the widget name) is still embedded inside a translated
-       string, and can't be accessed by code.
 
      * Fully machine-readable, with an error code and structured data:
 
@@ -79,13 +69,13 @@ class JsonableError(Exception):
 
          raise NoSuchWidgetError(widget_name)
 
-       Now both server and client code see a `widget_name` attribute.
+       Now both server and client code see a `widget_name` attribute
+       and an error code.
 
     Subclasses may also override `http_status_code`.
     '''
 
-    # Override this in subclasses, or just pass a `code` argument
-    # to the JsonableError constructor.
+    # Override this in subclasses, as needed.
     code = ErrorCode.BAD_REQUEST  # type: ErrorCode
 
     # Override this in subclasses if providing structured data.
@@ -95,10 +85,7 @@ class JsonableError(Exception):
     # like 403 or 404.
     http_status_code = 400  # type: int
 
-    def __init__(self, msg: str, code: Optional[ErrorCode]=None) -> None:
-        if code is not None:
-            self.code = code
-
+    def __init__(self, msg: str) -> None:
         # `_msg` is an implementation detail of `JsonableError` itself.
         self._msg = msg  # type: str
 


### PR DESCRIPTION
Since this class was built, folks have always chosen
to subclass JsonableError for situations where
the default of ErrorCode.BAD_REQUEST is insufficient.

So now we simplify the use cases, which also gets
us 100% coverage on this core module.
