### PR TITLE
plans: Update faq for non-profit discounts.

### DIFF
--- a/templates/zerver/compare.html
+++ b/templates/zerver/compare.html
@@ -13,7 +13,7 @@
                     <th class="uniform">Zulip</th>
                     <th class="normal uniform">Slack</th>
                     <th class="normal uniform">Mattermost</th>
-                    <th class="normal uniform">Hipchat</th>
+                    <th class="normal uniform">Discord</th>
                 </tr>
             </thead>
             <tbody>
@@ -29,7 +29,7 @@
                     <td class="yes"></td>
                     <td class="yes"></td>
                     <td class="yes"></td>
-                    <td class="yes"></td>
+                    <td class="no"></td>
                 </tr>
                 <tr>
                     <td>Hosting available</td>
@@ -43,14 +43,14 @@
                     <td class="yes"></td>
                     <td class="yes"></td>
                     <td class="yes"></td>
-                    <td class="no"></td>
+                    <td class="yes"></td>
                 </tr>
                 <tr>
                     <td>Markdown formatting</td>
                     <td class="yes"></td>
                     <td class="no"></td>
                     <td class="yes"></td>
-                    <td class="no"></td>
+                    <td class="yes"></td>
                 </tr>
                 <tr>
                     <td>Topic-based threading</td>

--- a/templates/zerver/faq.html
+++ b/templates/zerver/faq.html
@@ -12,12 +12,12 @@
                 </div>
                 <p class="answer">
                     Yes! Zulip Cloud Premium is free for open source
-                    projects and a wide variety of non-commercial
-                    entities. We also often offer steep discounts to
-                    educational institutions, and in other scenarios where
-                    users are not being paid a salary. Just contact
-                    sales@zulipchat.com and we&rsquo;d be happy to discuss your
-                    situation!
+                    projects and affiliated institutions. We also offer
+                    steep discounts to non-profits, educational
+                    institutions, groups of friends, and in scenarios where
+                    most of the users are not paid employees (e.g. company
+                    support forums). Just contact sales@zulipchat.com and
+                    we&rsquo;d be happy to discuss your situation!
                 </p>
                 <p class="answer">
                     You may also be interested in


### PR DESCRIPTION
Also updates the compare section. Possibly "Hosting available" should be something more like "no vendor lock-in, since you can migrate off the SAAS"?

![image](https://user-images.githubusercontent.com/890911/44479039-4602ec00-a5f4-11e8-8fab-2539e97d7eff.png)
