### PR TITLE
tests: Add test for /poll message.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -97,8 +97,6 @@ not_yet_fully_covered = {
     'zerver/lib/test_fixtures.py',
     'zerver/lib/test_runner.py',
     'zerver/lib/api_test_helpers.py',
-    # Experimental
-    'zerver/lib/widget.py',
     # Data import files
     'zerver/data_import/slack.py',
     'zerver/data_import/gitter.py',

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -10,9 +10,8 @@ from zerver.models import SubMessage
 def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
     valid_widget_types = ['tictactoe', 'poll', 'todo']
     tokens = content.split(' ')
-    if not tokens:
-        return None, None
 
+    # tokens[0] will always exist
     if tokens[0].startswith('/'):
         widget_type = tokens[0][1:]
         if widget_type in valid_widget_types:

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -81,6 +81,38 @@ class WidgetContentTestCase(ZulipTestCase):
         result = self.api_post(sender_email, "/api/v1/messages", payload)
         self.assert_json_error_contains(result, 'Widgets: widget_type is not in widget_content')
 
+    def test_tictactoe(self) -> None:
+        # The tictactoe widget is mostly useful as a code sample,
+        # and it also helps us get test coverage that could apply
+        # to future widgets.
+
+        sender_email = self.example_email('cordelia')
+        stream_name = 'Verona'
+        content = '/tictactoe'
+
+        payload = dict(
+            type="stream",
+            to=stream_name,
+            sender=sender_email,
+            client='test suite',
+            subject='whatever',
+            content=content,
+        )
+        result = self.api_post(sender_email, "/api/v1/messages", payload)
+        self.assert_json_success(result)
+
+        message = self.get_last_message()
+        self.assertEqual(message.content, content)
+
+        expected_submessage_content = dict(
+            widget_type="tictactoe",
+            extra_data=None,
+        )
+
+        submessage = SubMessage.objects.get(message_id=message.id)
+        self.assertEqual(submessage.msg_type, 'widget')
+        self.assertEqual(ujson.loads(submessage.content), expected_submessage_content)
+
     def test_poll_command_extra_data(self) -> None:
         sender_email = self.example_email('cordelia')
         stream_name = 'Verona'


### PR DESCRIPTION
This goes through the /messages endpoint
to get more full-stack testing, and it
focuses on how SubMessage rows get
created.
