### PR TITLE
settings: Improve error message when deactivating the last user.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -440,8 +440,18 @@ exports.set_up = function () {
                     window.location.href = "/login";
                 },
                 error: function (xhr) {
+                    var error_last_admin = i18n.t("Error: Cannot deactivate the only organization administrator.");
+                    var error_last_user = i18n.t("Error: Cannot deactivate the only user. You can deactivate the whole organization though in your <a target=\"_blank\" href=\"/#organization/organization-profile\">Organization profile settings</a>.");
+                    var rendered_error_msg;
+                    if (xhr.responseJSON.code === "CANNOT_DEACTIVATE_LAST_USER") {
+                        if (xhr.responseJSON.is_last_admin) {
+                            rendered_error_msg = error_last_admin;
+                        } else {
+                            rendered_error_msg = error_last_user;
+                        }
+                    }
                     $("#deactivate_self_modal").modal("hide");
-                    ui_report.error(i18n.t("Error deactivating account"), xhr, $('#account-settings-status').expectOne());
+                    $("#account-settings-status").addClass("alert-error").html(rendered_error_msg).show();
                 },
             });
         }, 5000);

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -93,6 +93,8 @@ IGNORED_PHRASES = [
     r"was too large; the maximum file size is 25MiB.",
     r"selected message",
     r"a-z",
+    r"organization administrator",
+    r"user",
 
     # SPECIAL CASES
     # Enter is usually capitalized

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -31,6 +31,7 @@ class ErrorCode(AbstractEnum):
     BAD_IMAGE = ()
     REALM_UPLOAD_QUOTA = ()
     BAD_NARROW = ()
+    CANNOT_DEACTIVATE_LAST_USER = ()
     MISSING_HTTP_EVENT_HEADER = ()
     STREAM_DOES_NOT_EXIST = ()
     UNAUTHORIZED_PRINCIPAL = ()
@@ -136,6 +137,18 @@ class StreamDoesNotExistError(JsonableError):
     @staticmethod
     def msg_format() -> str:
         return _("Stream '{stream}' does not exist")
+
+class CannotDeactivateLastUserError(JsonableError):
+    code = ErrorCode.CANNOT_DEACTIVATE_LAST_USER
+    data_fields = ['is_last_admin', 'entity']
+
+    def __init__(self, is_last_admin: bool) -> None:
+        self.is_last_admin = is_last_admin
+        self.entity = _("organization administrator") if is_last_admin else _("user")
+
+    @staticmethod
+    def msg_format() -> str:
+        return _("Cannot deactivate the only {entity}.")
 
 class RateLimited(PermissionDenied):
     def __init__(self, msg: str="") -> None:


### PR DESCRIPTION
This PR was originally started by Rishi Gupta (see #10383). This PR is a follow-up to #10383.

@timabbott, @rishig: Okay, so I ran into a few interesting problems. I had to spend quite a bit of time on this. It could be that I am simply not well-versed enough in JavaScript to work on this problem, but I have a feeling there is a discussion to be had here.

Here are a few problems with this PR:
* I can add links within an `alert` box, but only if I set it in the frontend. I can't just make the custom exception return an HTML error message, which seems like a poor design choice anyway.
* After, I add the link, it gets rendered, but clicking on it doesn't do anything. The URL changes, but you aren't redirected to the **Organization profile** settings tab. However, when you open the link in a new tab, it works.
* Also, and this isn't a huge deal, the link is blue, despite the class of the link being `alert-link`, which should color the link to a shade of the enclosing red alert label, according to [this page](http://www.tutorialspark.com/twitterBootstrap/TwitterBootstrap_Alerts_Links.php).

Another concern I have is that the error message that the custom exception should return changes based on whether the last user is an admin or not. There are distinct reasons for not being able to deactivate an admin and a regular last user. We could simply pass in a different message for each case, but I'm not sure if that's the best way though.

Looking forward to your feedback! Thanks! :)