### PR TITLE
settings: Fix an error for non-admins on the custom profile fields page.

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -317,11 +317,14 @@ function set_up_choices_field() {
     create_choice_row('#profile_field_choices');
     update_choice_delete_btn($("#profile_field_choices"), false);
 
-    var choice_list = $("#profile_field_choices")[0];
+    if (page_params.is_admin) {
+        var choice_list = $("#profile_field_choices")[0];
+        Sortable.create(choice_list, {
+            onUpdate: function () {},
+        });
+    }
+
     var field_type = $('#profile_field_type').val();
-    Sortable.create(choice_list, {
-        onUpdate: function () {},
-    });
 
     if (parseInt(field_type, 10) !== field_types.CHOICE.id) {
         // If 'Choice' type is already selected, show choice row.


### PR DESCRIPTION
When non-admin users visit the custom profile fields settings page, the `Sortable` error 

    Uncaught Sortable: `el` must be HTMLElement, and not [object Undefined]

is thrown, with `undefined: undefined | No stacktrace available` being shown by Blueslip. Additionally, the settings pane is blank. This PR fixes this by only using `Sortable` if the user is an admin.

Fixes #10403.

**Before Error:**

<img width="1343" alt="before" src="https://user-images.githubusercontent.com/17259768/44565853-464bd600-a71f-11e8-9f30-3fe6fbe7593f.png">

**Fixed Page:**

<img width="1344" alt="after" src="https://user-images.githubusercontent.com/17259768/44565859-51066b00-a71f-11e8-99d1-cf405b7167ed.png">
