### PR TITLE
[WIP]thumbnails: Stop thumbnailing urls other than external or user_uploads.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -35,7 +35,7 @@ from zerver.lib.emoji import translate_emoticons, emoticon_regex
 from zerver.lib.mention import possible_mentions, \
     possible_user_group_mentions, extract_user_group
 from zerver.lib.url_encoding import encode_stream
-from zerver.lib.thumbnail import is_thumbor_enabled
+from zerver.lib.thumbnail import is_thumbor_enabled, user_uploads_or_external
 from zerver.lib.timeout import timeout, TimeoutExpired
 from zerver.lib.cache import cache_with_key, NotFoundInCache
 from zerver.lib.url_preview import preview as link_preview
@@ -225,8 +225,7 @@ def add_a(
     if data_id is not None:
         a.set("data-id", data_id)
     img = markdown.util.etree.SubElement(a, "img")
-    user_uploads_or_external = url.startswith('http') or url.lstrip('/').startswith('user_uploads/')
-    if is_thumbor_enabled() and use_thumbnails and user_uploads_or_external:
+    if is_thumbor_enabled() and use_thumbnails and user_uploads_or_external(url):
         # See docs/thumbnailing.md for some high-level documentation.
         #
         # We strip leading '/' from relative URLs here to ensure

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -225,7 +225,8 @@ def add_a(
     if data_id is not None:
         a.set("data-id", data_id)
     img = markdown.util.etree.SubElement(a, "img")
-    if is_thumbor_enabled() and use_thumbnails:
+    user_uploads_or_external = url.startswith('http') or url.lstrip('/').startswith('user_uploads/')
+    if is_thumbor_enabled() and use_thumbnails and user_uploads_or_external:
         # See docs/thumbnailing.md for some high-level documentation.
         #
         # We strip leading '/' from relative URLs here to ensure

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -22,7 +22,7 @@ def user_uploads_or_external(url: str) -> bool:
     return url.startswith('http') or url.lstrip('/').startswith('user_uploads/')
 
 def get_source_type(url: str) -> str:
-    if not (url.startswith('/user_uploads/') or url.startswith('/user_avatars/')):
+    if not url.startswith('/user_uploads/'):
         return THUMBOR_EXTERNAL_TYPE
 
     local_uploads_dir = settings.LOCAL_UPLOADS_DIR
@@ -39,8 +39,7 @@ def generate_thumbnail_url(path: str, size: str='0x0') -> str:
             return get_camo_url(path)
         return path
 
-    # Ignore thumbnailing for static resources.
-    if path.startswith('/static/'):
+    if not user_uploads_or_external(path):
         return path
 
     source_type = get_source_type(path)

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -18,6 +18,9 @@ from zerver.lib.camo import get_camo_url
 def is_thumbor_enabled() -> bool:
     return settings.THUMBOR_URL != ''
 
+def user_uploads_or_external(url: str) -> bool:
+    return url.startswith('http') or url.lstrip('/').startswith('user_uploads/')
+
 def get_source_type(url: str) -> str:
     if not (url.startswith('/user_uploads/') or url.startswith('/user_avatars/')):
         return THUMBOR_EXTERNAL_TYPE

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -376,6 +376,18 @@ class BugdownTest(ZulipTestCase):
             converted = bugdown_convert(msg)
         self.assertIn(thumbnail_img, converted)
 
+        # Any url which is not an external link and doesn't start with
+        # /user_uploads/ is not thumbnailed
+        msg = '[foobar](/static/images/cute/turtle.png)'
+        thumbnail_img = '<div class="message_inline_image"><a href="/static/images/cute/turtle.png" target="_blank" title="foobar"><img src="/static/images/cute/turtle.png"></a></div>'
+        converted = bugdown_convert(msg)
+        self.assertIn(thumbnail_img, converted)
+
+        msg = '[foobar](/user_avatars/2/emoji/images/50.png)'
+        thumbnail_img = '<div class="message_inline_image"><a href="/user_avatars/2/emoji/images/50.png" target="_blank" title="foobar"><img src="/user_avatars/2/emoji/images/50.png"></a></div>'
+        converted = bugdown_convert(msg)
+        self.assertIn(thumbnail_img, converted)
+
     @override_settings(INLINE_IMAGE_PREVIEW=True)
     def test_inline_image_preview(self):
         # type: () -> None

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -72,8 +72,7 @@ class ThumbnailTest(ZulipTestCase):
         # Test full size custom emoji image (for emoji link in messages case).
         result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_emoji_url))
         self.assertEqual(result.status_code, 302, result)
-        expected_part_url = get_file_path_urlpart(custom_emoji_url)
-        self.assertIn(expected_part_url, result.url)
+        self.assertIn(custom_emoji_url, result.url)
 
         # Tests the /api/v1/thumbnail api endpoint with standard API auth
         self.logout()
@@ -215,8 +214,7 @@ class ThumbnailTest(ZulipTestCase):
         # Test full size custom emoji image (for emoji link in messages case).
         result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_emoji_url))
         self.assertEqual(result.status_code, 302, result)
-        expected_part_url = get_file_path_urlpart(custom_emoji_url)
-        self.assertIn(expected_part_url, result.url)
+        self.assertIn(custom_emoji_url, result.url)
 
         # Tests the /api/v1/thumbnail api endpoint with HTTP basic auth.
         self.logout()

--- a/zthumbor/loaders/zloader.py
+++ b/zthumbor/loaders/zloader.py
@@ -35,6 +35,11 @@ def load(context, url, callback):
         return
 
     if source_type == THUMBOR_S3_TYPE:
+        if actual_url.startswith('/user_uploads/'):  # type: ignore # python 2 type differs from python 3 type
+            actual_url = actual_url[len('/user_uploads/'):]
+        else:
+            raise AssertionError("Unexpected s3 file.")
+
         s3_loader.load(context, actual_url, callback)
     elif source_type == THUMBOR_LOCAL_FILE_TYPE:
         if actual_url.startswith('/user_uploads/'):  # type: ignore # python 2 type differs from python 3 type

--- a/zthumbor/loaders/zloader.py
+++ b/zthumbor/loaders/zloader.py
@@ -40,9 +40,6 @@ def load(context, url, callback):
         if actual_url.startswith('/user_uploads/'):  # type: ignore # python 2 type differs from python 3 type
             actual_url = actual_url[len('/user_uploads/'):]
             local_file_path_prefix = 'files/'
-        elif actual_url.startswith('/user_avatars/'):  # type: ignore # python 2 type differs from python 3 type
-            actual_url = actual_url[len('/user_avatars/'):]
-            local_file_path_prefix = 'avatars/'
         else:
             raise AssertionError("Unexpected local file.")
 


### PR DESCRIPTION
We are basically adding a check for url's to be external (belonging
to some 3rd party web site hosting the image) or be one of the
user uploaded files. User uploaded files are served by a separate
endpoint which is /user_uploads/. Any other local url such as
/user_avatars/ or /static/ should never be sent to thumbor for
thumbnailing.
Not sending /user_avatars/ to thumbor for thumbnailing makes sense
because they are already properly thumbnailed and stored properly.
/static/ urls host very few images we use for demo and can be safely
be excluded from thumbnailing.
