### PR TITLE
custom profile field: UI Style followup. 

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -177,7 +177,7 @@ exports.hide_user_profile = function () {
     $("#user-profile-modal").modal("hide");
 };
 
-function show_user_profile(element, user) {
+exports.show_user_profile = function (element, user) {
     popovers.hide_all();
 
     var profile_data = [];
@@ -253,7 +253,7 @@ function show_user_profile(element, user) {
             });
         }
     });
-}
+};
 
 function get_user_info_popover_items() {
     if (!current_message_info_popover_elem) {
@@ -707,7 +707,7 @@ exports.register_click_handlers = function () {
     $('body').on('click', '.info_popover_actions .view_user_profile', function (e) {
         var user_id = $(e.target).parents('ul').attr('data-user-id');
         var user = people.get_person_from_user_id(user_id);
-        show_user_profile(e.target, user);
+        exports.show_user_profile(e.target, user);
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -191,6 +191,7 @@ function show_user_profile(element, user) {
 
         profile_field.name = field.name;
         profile_field.is_user_field = false;
+        profile_field.is_link = field_type === field_types.URL.id;
         if (field_value) {
             if (field_type === field_types.DATE.id) {
                 profile_field.value = moment(field_value).format(localFormat);

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -447,6 +447,14 @@ exports.set_up = function () {
         }, 5000);
     });
 
+    $("#show_my_user_profile_modal").on('click', function (e) {
+        overlays.close_overlay("settings");
+        var user = people.get_person_from_user_id(people.my_current_user_id());
+        setTimeout(function () {
+            popovers.show_user_profile(e.target, user);
+        }, 100);
+    });
+
 
     function upload_avatar(file_input) {
         var form_data = new FormData();

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -20,8 +20,6 @@ exports.field_type_id_to_string = function (type_id) {
                 field_type_str = "Date";
             } else if (field_type.name === "Person picker") {
                 field_type_str = "Person";
-            } else if (field_type.name === "List of options") {
-                field_type_str = "List";
             } else {
                 field_type_str = field_type.name;
             }

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -179,7 +179,7 @@ ul.remind_me_popover .remind_icon {
 }
 
 .user-profile-key-value-section {
-    margin: 8px 0;
+    margin-top: 8px;
 }
 
 .user-profile-modal-content {
@@ -200,9 +200,13 @@ ul.remind_me_popover .remind_icon {
 
 #user-profile-modal-body {
     padding-bottom: 10px;
-    padding-top: 10px;
+    padding-top: 4px;
     margin-bottom: 10px;
     margin-top: 10px;
+}
+
+#user-profile-modal #user-profile-modal-body .exit-sign {
+    font-size: 1.5rem;
 }
 
 .user-profile-modal-edit-button {

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -127,6 +127,9 @@
             <h3 class="inline-block" id="custom-field-header" {{#unless page_params.custom_profile_fields}}style="display: none"{{/unless}}>{{t "Profile" }}</h3>
             <div class="alert-notification" id="custom-field-status"></div>
             <form class="form-horizontal custom-profile-fields-form grid"></form>
+            <button class="button rounded sea-green w-200 block" id="show_my_user_profile_modal">
+                {{t 'View my profile' }}
+            </button>
 
         </div>
 

--- a/static/templates/user_profile_modal.handlebars
+++ b/static/templates/user_profile_modal.handlebars
@@ -28,6 +28,8 @@
                     <div class="pill-container not-editable" data-field-id="{{this.id}}">
                         <div class="input" contenteditable="false" style="display: none;"></div>
                     </div>
+                    {{else if this.is_link}}
+                    <a href={{this.value}} target="_blank" class="user-profile-modal-field-value">{{this.value}}</a>
                     {{else}}
                     <div class="user-profile-modal-field-value">{{this.value}}</div>
                     {{/if}}

--- a/static/templates/user_profile_modal.handlebars
+++ b/static/templates/user_profile_modal.handlebars
@@ -2,7 +2,7 @@
   role="dialog" aria-labelledby="user_profile_modal_label" aria-hidden="true">
     <div class="modal-body" id="user-profile-modal-body">
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}">
-            <span aria-hidden="true">&times;</span>
+            <span aria-hidden="true" class="exit-sign">&times;</span>
         </button>
         <div class="user-profile-modal-avatar" style="background-image: url('{{user_avatar}}');" ></div>
         <div class="user-profile-modal-name-email-section">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Issue #10303 

**User Settings**

- [ ] For "Date" type, it should start at the current day if the field is empty. (To repro: pick a random day from the date picker. Then delete it. Then open the date picker again)

- [X] Could be followup, but there should be a way to view your profile from this page.
![screen shot 2018-08-25 at 7 35 59 pm](https://user-images.githubusercontent.com/25907420/44619044-3c9cac80-a89e-11e8-940c-20cdbbda70ec.png)

**Admin Settings**

- [X] I think let's just go with something; "List of options" would be consistent with other products, and let's start with using that in both places.
![screen shot 2018-08-25 at 7 34 47 pm](https://user-images.githubusercontent.com/25907420/44619046-3d354300-a89e-11e8-85b5-4e23c498cc69.png)


**Viewing profile**

- [X] Some visual styling things that could be followup: I think the x could be better, and also I think the whole popover could have slightly looser spacing.

![screen shot 2018-08-25 at 7 35 19 pm](https://user-images.githubusercontent.com/25907420/44619037-2989dc80-a89e-11e8-88fd-33b47f62be19.png)


- [ ] We show the perfect scrollbar too soon; we should wait to show it until the mouse is closer to the right edge.



