### PR TITLE
settings: Add a minimum width to "person picker" custom fields.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1426,6 +1426,10 @@ body:not(.night-mode) #account-settings .custom_user_field .datepicker {
     opacity: 1;
 }
 
+#settings_page .custom_user_field .person_picker {
+    min-width: 206px;
+}
+
 #settings_page #change_password_modal .change_password_info,
 #settings_page #change_email_modal .change_email_info,
 #settings_page #change_full_name_modal .change_full_name_info {

--- a/static/templates/settings/custom-user-profile-field.handlebars
+++ b/static/templates/settings/custom-user-profile-field.handlebars
@@ -10,7 +10,7 @@
         {{/each}}
     </select>
     {{else if is_user_field }}
-    <div class="pill-container">
+    <div class="pill-container person_picker">
         <div class="input" contenteditable="true"></div>
     </div>
     {{else if is_date_field }}


### PR DESCRIPTION
Currently, empty "person picker" fields appear with a much smaller width than all other custom fields. This PR increases the `min-width` of the field that it matches the widths of other text boxes.

Fix #10414.

**Screenshots:**

*Before (with normal custom text field for comparison):*

<p align="center">
<img width="238" alt="screen shot 2018-08-24 at 4 18 22 pm" src="https://user-images.githubusercontent.com/17259768/44612548-2fa88c00-a7be-11e8-95f6-6abf76159ae0.png">
</p>

*After (GIF):*

![working](https://user-images.githubusercontent.com/17259768/44612491-d2acd600-a7bd-11e8-85e3-d01fe8eabac9.gif)
