### PR TITLE
Fix unread counts bug reported by Rishi.

### DIFF
--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -19,7 +19,7 @@ exports.suspect_offline = false;
 
 function get_events_success(events) {
     var messages = [];
-    var messages_to_update = [];
+    var update_message_events = [];
     var new_pointer;
 
     var clean_event = function clean_event(event) {
@@ -69,7 +69,7 @@ function get_events_success(events) {
             break;
 
         case 'update_message':
-            messages_to_update.push(event);
+            update_message_events.push(event);
             break;
 
         default:
@@ -116,9 +116,9 @@ function get_events_success(events) {
         home_msg_list.select_id(home_msg_list.first().id, {then_scroll: false});
     }
 
-    if (messages_to_update.length !== 0) {
+    if (update_message_events.length !== 0) {
         try {
-            message_events.update_messages(messages_to_update);
+            message_events.update_messages(update_message_events);
         } catch (ex3) {
             blueslip.error('Failed to update messages\n' +
                            blueslip.exception_msg(ex3),

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -20,6 +20,7 @@ exports.suspect_offline = false;
 function get_events_success(events) {
     var messages = [];
     var update_message_events = [];
+    var post_message_events = [];
     var new_pointer;
 
     var clean_event = function clean_event(event) {
@@ -70,6 +71,12 @@ function get_events_success(events) {
 
         case 'update_message':
             update_message_events.push(event);
+            break;
+
+        case 'delete_message':
+        case 'submessage':
+        case 'update_message_flags':
+            post_message_events.push(event);
             break;
 
         default:
@@ -126,6 +133,13 @@ function get_events_success(events) {
                            ex3.stack);
         }
     }
+
+    // We do things like updating message flags and deleting messages last,
+    // to avoid ordering issues that are caused by batch handling of
+    // messages above.
+    _.each(post_message_events, function (event) {
+        server_events_dispatch.dispatch_normal_event(event);
+    });
 }
 
 function get_events(options) {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -14,9 +14,31 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         attachments_ui.update_attachments(event);
         break;
 
+    case 'custom_profile_fields':
+        page_params.custom_profile_fields = event.fields;
+        settings_profile_fields.populate_profile_fields(page_params.custom_profile_fields);
+        settings_account.add_custom_profile_fields_to_settings();
+        break;
+
     case 'default_streams':
         stream_data.set_realm_default_streams(event.default_streams);
         settings_streams.update_default_streams_table();
+        break;
+
+    case 'delete_message':
+        var msg_id = event.message_id;
+        // message is passed to unread.get_unread_messages,
+        // which returns all the unread messages out of a given list.
+        // So double marking something as read would not occur
+        unread_ops.process_read_messages_event([msg_id]);
+        if (event.message_type === 'stream') {
+            topic_data.remove_message({
+                stream_id: event.stream_id,
+                topic_name: event.topic,
+            });
+            stream_list.update_streams_sidebar();
+        }
+        ui.remove_message(msg_id);
         break;
 
     case 'hotspots':
@@ -176,12 +198,6 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         page_params.realm_filters = event.realm_filters;
         markdown.set_realm_filters(page_params.realm_filters);
         settings_filters.populate_filters(page_params.realm_filters);
-        break;
-
-    case 'custom_profile_fields':
-        page_params.custom_profile_fields = event.fields;
-        settings_profile_fields.populate_profile_fields(page_params.custom_profile_fields);
-        settings_account.add_custom_profile_fields_to_settings();
         break;
 
     case 'realm_domains':
@@ -420,22 +436,6 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             unread_ops.process_read_messages_event(event.messages);
             break;
         }
-        break;
-
-    case 'delete_message':
-        var msg_id = event.message_id;
-        // message is passed to unread.get_unread_messages,
-        // which returns all the unread messages out of a given list.
-        // So double marking something as read would not occur
-        unread_ops.process_read_messages_event([msg_id]);
-        if (event.message_type === 'stream') {
-            topic_data.remove_message({
-                stream_id: event.stream_id,
-                topic_name: event.topic,
-            });
-            stream_list.update_streams_sidebar();
-        }
-        ui.remove_message(msg_id);
         break;
 
     case 'user_group':


### PR DESCRIPTION
Rishi has long been reporting glitches in the unread counts when you have multiple tabs open, and we finally found the bug, in part due to a careful repro on his part.

The root cause of the bug here was really in the events system, not the unread code. The last commit here fixes the problem @rishig reported, and it extends to potential bugs related to deleting messages and/or widgetizing messages.  That commit has a lot of detail in the commit message for how to reproduce the problem.