### PR TITLE
emoji: Add support for changing emojisets and infra for "old google" and twitter emojisets.

### DIFF
--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -56,8 +56,8 @@ run_test('initialize', () => {
     emoji.initialize();
     assert(image_stub);
     assert.equal(calls, 2);
-    assert.deepEqual(urls, ['/static/generated/emoji/sheet-google-64.png',
-                            '/static/generated/emoji/images-google-64/1f419.png']);
+    assert.deepEqual(urls, ['/static/generated/emoji/sheet-google-blob-64.png',
+                            '/static/generated/emoji/images-google-blob-64/1f419.png']);
 });
 
 run_test('get_canonical_name', () => {

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -91,7 +91,7 @@ exports.initialize = function initialize() {
         // for displaying emojis in emoji picker and composebox
         // typeahead. This logic ensures that we do sprite sheet
         // prefetching for that case.
-        emojiset = 'google';
+        emojiset = 'google-blob';
     }
     // Load the sprite image and octopus image in the background, so
     // that the browser will cache it for later use.

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -158,18 +158,21 @@ exports.report_emojiset_change = function () {
         }
     }
 
+    var emojiset = page_params.emojiset;
+
     if (page_params.emojiset === 'text') {
-        emoji_success();
-        return;
+        // For `text` emojiset we fallback to `google-blob` emojiset
+        // for displaying emojis in emoji picker and typeahead.
+        emojiset = 'google-blob';
     }
 
     var sprite = new Image();
     sprite.onload = function () {
-        var sprite_css_href = "/static/generated/emoji/" + page_params.emojiset + "-sprite.css";
+        var sprite_css_href = "/static/generated/emoji/" + emojiset + "-sprite.css";
         $("#emoji-spritesheet").attr('href', sprite_css_href);
         emoji_success();
     };
-    sprite.src = "/static/generated/emoji/sheet-" + page_params.emojiset + "-64.png";
+    sprite.src = "/static/generated/emoji/sheet-" + emojiset + "-64.png";
 };
 
 exports.update_page = function () {

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -872,5 +872,5 @@ class HomeTest(ZulipTestCase):
         self.assertEqual(result.status_code, 200)
 
         html = result.content.decode('utf-8')
-        self.assertIn('google-sprite.css', html)
+        self.assertIn('google-blob-sprite.css', html)
         self.assertNotIn('text-sprite.css', html)

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -272,7 +272,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
         # GOOGLE_EMOJISET for picking which spritesheet's CSS to
         # include (and thus how to display emojis in the emoji picker
         # and composebox typeahead).
-        emojiset = UserProfile.GOOGLE_EMOJISET
+        emojiset = UserProfile.GOOGLE_BLOB_EMOJISET
     response = render(request, 'zerver/app/index.html',
                       context={'user_profile': user_profile,
                                'emojiset': emojiset,


### PR DESCRIPTION
Due to a large number of people not liking the Google's new emojiset, we are re-adding support for switching emojisets after doing infrastructure changes for supporting Google's old blobs as well as twitter emojiset.

Fixes: #10158.

@timabbott FYI.