### PR TITLE
team: Complete some of the "TODOs" in `team.js`.

### DIFF
--- a/docs/subsystems/dependencies.md
+++ b/docs/subsystems/dependencies.md
@@ -287,7 +287,9 @@ the current version of Zulip in the /about page.  These data are
 fetched using the GitHub API with `tools/update-authors-json`.  In
 development, it just returns some basic test data to avoid adding load
 to GitHub's APIs unnecessarily; it's primarily run as part of building
-a release tarball.
+a release tarball. `tools/update-authors-json` often must be run with GitHub
+authentication to prevent rate-limiting, through the environment variables
+`GITHUB_USERNAME` and `GITHUB_PASSWORD`.
 
 ## Modifying provisioning
 

--- a/static/js/portico/team.js
+++ b/static/js/portico/team.js
@@ -21,7 +21,6 @@ function contrib_total_commits(contrib) {
 
 // TODO (for v2 of /team contributors):
 //   - Make tab header responsive.
-//   - Display full name instead of github username.
 export default function render_tabs() {
     var template = _.template($('#contributors-template').html());
 
@@ -36,6 +35,7 @@ export default function render_tabs() {
     var total_tab_html = _.chain(contributors_list)
         .map(function (c) {
             return {
+                username: c.username,
                 name: c.name,
                 avatar: c.avatar,
                 commits: contrib_total_commits(c),
@@ -62,6 +62,7 @@ export default function render_tabs() {
                     .reverse()
                     .map(function (c) {
                         return template({
+                            username: c.username,
                             name: c.name,
                             avatar: c.avatar,
                             commits: c[repo],

--- a/templates/zerver/team.html
+++ b/templates/zerver/team.html
@@ -163,12 +163,12 @@
                 <!-- Compiled using underscore -->
                 <script type="text/template" id="contributors-template">
                     <div class="person">
-                        <a href="https://github.com/<%= name %>" target="_blank" class="no-underline">
+                        <a href="https://github.com/<%= username %>" target="_blank" class="no-underline">
                             <div class="avatar">
                                 <img class="avatar_img" src="<%= avatar %>" alt="{{ _('Avatar') }}" />
                             </div>
                             <div class='info'>
-                                <b>@<%= name %></b><br />
+                                <b><%= name %></b><br />
                                 <%= commits %> <%= commits === 1 ? 'commit' : 'commits' %>
                             </div>
                         </a>

--- a/tools/update-authors-json
+++ b/tools/update-authors-json
@@ -49,8 +49,19 @@ ContributorsJSON = TypedDict('ContributorsJSON', {
 
 
 def fetch_contributors(repo_link: str) -> Optional[List[Dict[str, Dict[str, Any]]]]:
-    r = requests.get(repo_link, verify=os.environ.get('CUSTOM_CA_CERTIFICATES'))  # type: requests.Response
+    r = requests.get(repo_link, verify=os.environ.get('CUSTOM_CA_CERTIFICATES'),
+                     auth=(os.environ.get('GITHUB_USERNAME'), os.environ.get('GITHUB_PASSWORD')))  # type: requests.Response
     return r.json() if r.status_code == 200 else None
+
+def fetch_name(username: str) -> str:
+    user_url = 'https://api.github.com/users/' + username
+    default_name = '@' + username
+    r = requests.get(user_url, verify=os.environ.get('CUSTOM_CA_CERTIFICATES'),
+                     auth=(os.environ.get('GITHUB_USERNAME'), os.environ.get('GITHUB_PASSWORD')))  # type: requests.Response
+
+    # `name` might be set to `None` instead of just being empty, so a default
+    # `get` parameter won't handle names. (They'll show as `null`.)
+    return (r.json().get('name') if r.json() else None) or default_name
 
 def write_to_disk(json_data: ContributorsJSON, out_file: str) -> None:
     with open(out_file, 'w') as f:
@@ -86,6 +97,10 @@ def run_production() -> None:
     data = dict(date=str(date.today()), contrib=[])  # type: ContributorsJSON
     contribs_list = {}  # type: Dict[str, Dict[str, Union[str, int]]]
 
+    # Store the names for each username to decrease the number of requests,
+    # instead of re-fetching for different repositories.
+    names_list = {}  # type: Dict[str, str]
+
     for _ in range(args.max_retries):
         repos_done = []
         for name, link in repositories.items():
@@ -108,8 +123,14 @@ def run_production() -> None:
                     total = contrib.get('total')
                     assert total is not None  # TODO: To improve/clarify
 
+                    full_name = names_list.get(username)
+                    if not full_name:
+                        full_name = fetch_name(username)
+                        names_list[username] = full_name
+
                     contrib_data = {
                         'avatar': avatar,
+                        'name': full_name,
                         name: total,
                     }
                     if username in contribs_list:
@@ -141,8 +162,8 @@ def run_production() -> None:
         if not args.not_required:
             sys.exit(1)
 
-    for contributor_name, contributor_data in contribs_list.items():
-        contributor_data['name'] = contributor_name
+    for contributor_username, contributor_data in contribs_list.items():
+        contributor_data['username'] = contributor_username
         data['contrib'].append(contributor_data)
 
     write_to_disk(data, settings.CONTRIBUTORS_DATA)


### PR DESCRIPTION
This PR completes some of the "TODOs" in `team.js`:

 1. It **freezes contribution data** for legacy repositories (`zulip-ios-legacy` and `zulip-android`) and includes them in the total tab.

 2. It **lazy-loads** all contributions tabs except for the total tab.

 3. It **displays users' full names** instead of their GitHub usernames, when possible. If a full name is not possible, it uses `@their-username`.

This PR is split into three commits, one for each of the tasks above. (There is also a fourth todo, "Make tab header responsive," but I'm not sure what that would mean specifically, so I didn't include it.)

For these changes work properly, `update-authors-json` must be used. (Also note, I'm not sure how author updating is normally done, but for me I had to authenticate in order for it to work properly due to the added requests from fetching full names.)

**GIF of new teams list with lazy-loading and full names (delay added to loading for emphasis):**

![new team list](https://user-images.githubusercontent.com/17259768/44638647-dd599d80-a96c-11e8-934c-9b1c77f85448.gif)
