### PR TITLE
portico: Add page for on-premise plans.

### DIFF
--- a/templates/zerver/plans-on-prem.html
+++ b/templates/zerver/plans-on-prem.html
@@ -1,0 +1,30 @@
+{% extends "zerver/portico.html" %}
+
+{% block title %}
+<title>Zulip On-premise</title>
+{% endblock %}
+
+{% block customhead %}
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{{ render_bundle('landing-page') }}
+{% endblock %}
+
+{% block portico_content %}
+
+{% include 'zerver/landing_nav.html' %}
+
+<div class="portico-landing why-page">
+    <div class="hero">
+        <h1 class="center">{% trans %}Zulip On-premise{% endtrans %}</h1>
+        <p>Plans and pricing for when you make Zulip your home</p>
+    </div>
+    <div class="main">
+        <div class="padded-content">
+            <div class="inner-content">
+                {{ render_markdown_path('zerver/plans-on-prem.md') }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/templates/zerver/plans-on-prem.md
+++ b/templates/zerver/plans-on-prem.md
@@ -1,0 +1,75 @@
+We provide a variety of services to support on-premise deployments.
+
+## Zulip community (free forever)
+
+Zulip takes less than 5 minutes to install with most common configurations.
+Installation instructions are
+[here](https://zulip.readthedocs.io/en/stable/production/install.html).
+
+You do not need a license to use or modify Zulip.
+
+## Installation support (Starts at $1000)
+
+Includes:
+
+* Installing Zulip.
+* Importing data from Slack or HipChat.
+* Help configuring server and organization settings.
+* Setting up unlimited integrations with [products we already support](/integrations).
+  Includes 90 custom integrations as well as the over 1000 products supported by
+  Zapier and IFTTT.
+* Support for any issues that arise in the first 14 days after installation.
+
+**Pricing**:
+
+* Standard: $1000 (requires access to machine)
+* Guided: $2500
+
+For Standard installs, a Zulip engineer will install and configure the software
+on your machine, and provide you with a transcript of what commands were run.
+Guided installs do not require ever giving Zulip access to the machine.
+
+We generally recommend guided installs only when required by corporate policy.
+
+## Technical support (Starts at $4000/year)
+
+Includes everything in **Installation support**, along with
+
+* Year-round technical support, with a best effort response time (typically a day or two)
+* Ability to schedule upgrades for when a Zulip engineer is on-line
+* Informal input into the product roadmap
+
+If you buy installation support and then buy a support contract within 60
+days, we will refund what you paid for installation support.
+
+**Pricing**:
+1-50 users: $4,000/yr.
+Each additional 50 users is an additional $2,000/yr.
+
+For example:
+
+* 100 users: $6,000/yr
+* 200 users: $10,000/yr
+* 500 users: $22,000/yr
+* 1000 users: $42,000/yr
+* 2000 users: $82,000/yr
+* 5000 users: $202,000/yr
+* 10000 users: $402,000/yr
+
+Minimum contract period is 1 year.
+
+## High availability technical support (Starts at $20,000/year)
+
+Custom packages can include
+
+* Setup of a high-availability Zulip installation
+* Detailed technical advice on monitoring, minimal-downtime upgrade processes,
+  maintenance, auditing/compliance tools, backups, etc.
+* SLAs for a response time to priority technical support issues
+* Ability to page a Zulip engineer during service outages
+* Advance notice of security releases (when possible)
+
+**Pricing**: Contact sales@zulipchat.com.
+
+
+*All prices are in USD*

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -52,6 +52,7 @@ IGNORED_PHRASES = [
     r"XML",
     r"Zephyr",
     r"Zulip",
+    r"Zulip On-premise",
     r"Zulip Team",
     r"iPhone",
     r"iOS",

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -105,6 +105,7 @@ class DocPageTest(ZulipTestCase):
         self._test('/for/working-groups-and-communities/', 'standards bodies')
         self._test('/for/mystery-hunt/', 'four SIPB alums')
         self._test('/plans/', 'Community support')
+        self._test('/plans/on-prem', 'Installation support')
         self._test('/devlogin/', 'Normal users', landing_page=False)
         self._test('/devtools/', 'Useful development URLs')
         self._test('/errors/404/', 'Page not found')

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -487,6 +487,8 @@ i18n_urls = [
     url(r'^history/$', TemplateView.as_view(template_name='zerver/history.html')),
     url(r'^apps/(.*)', zerver.views.home.apps_view, name='zerver.views.home.apps_view'),
     url(r'^plans/$', TemplateView.as_view(template_name='zerver/plans.html'), name='plans'),
+    url(r'^plans/on-prem$', TemplateView.as_view(template_name='zerver/plans-on-prem.html'),
+        name='plans-on-prem'),
 
     # Landing page, features pages, signup form, etc.
     url(r'^hello/$', TemplateView.as_view(template_name='zerver/hello.html'), name='landing-page'),


### PR DESCRIPTION
The page doesn't look great; I think we'll need a separate style sheet for our more formal pages like pricing, TOS, Privacy policy, etc. I also put some things in bullets instead of a table because we don't have styling for tables on these pages.

But besides that this is a proposal for the content and url route.