### PR TITLE
muting: Correct agrammatical error message.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -852,7 +852,7 @@ paths:
                   - $ref: '#/components/schemas/JsonError'
                   - example:
                       {
-                          "msg": "Topic is not there in the muted_topics list",
+                          "msg": "Topic is not muted",
                           "result": "error"
                       }
   /realm/filters:

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -123,8 +123,8 @@ class MutedTopicsTests(ZulipTestCase):
         url = '/api/v1/users/me/subscriptions/muted_topics'
         data = {'stream': 'BOGUS', 'topic': 'Verona3', 'op': 'remove'}
         result = self.api_patch(email, url, data)
-        self.assert_json_error(result, "Topic is not there in the muted_topics list")
+        self.assert_json_error(result, "Topic is not muted")
 
         data = {'stream': 'Verona', 'topic': 'BOGUS', 'op': 'remove'}
         result = self.api_patch(email, url, data)
-        self.assert_json_error(result, "Topic is not there in the muted_topics list")
+        self.assert_json_error(result, "Topic is not muted")

--- a/zerver/views/muting.py
+++ b/zerver/views/muting.py
@@ -25,7 +25,7 @@ def mute_topic(user_profile: UserProfile, stream_name: str,
 
 def unmute_topic(user_profile: UserProfile, stream_name: str,
                  topic_name: str) -> HttpResponse:
-    error = _("Topic is not there in the muted_topics list")
+    error = _("Topic is not muted")
     stream = access_stream_for_unmute_topic(user_profile, stream_name, error)
 
     if not topic_is_muted(user_profile, stream.id, topic_name):


### PR DESCRIPTION
The error message displayed when unmuting a topic that wasn't previously muted wasn't properly formulated.

Followup for #10345.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** `./tools/test-backend zerver.tests.test_muting` passed locally.


