### PR TITLE
billing: Reflect plan_type on /plans.

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -183,6 +183,13 @@ button.green {
     border: 1px solid hsl(169, 45%, 43%);
 }
 
+button.black-disabled {
+    cursor: default;
+    color: #333;
+    background-color: transparent;
+    border: 1px solid #888;
+}
+
 button.button.grey-transparent {
     display: block;
     margin: 0 auto;

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -38,6 +38,7 @@
                             </div>
                             <div class="bottom">
                                 <div class="text-content">
+                                    {% if realm_plan_type == 0 %}
                                     <div class="pricing-details">
                                         Free
                                     </div>
@@ -46,6 +47,12 @@
                                             Sign up now
                                         </button>
                                     </a>
+                                    {% elif realm_plan_type == 2 %}
+                                    <div class="pricing-details"></div>
+                                    <button class="black-disabled" type="button">
+                                        Current plan
+                                    </button>
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>
@@ -76,11 +83,23 @@
                                             $8/month billed monthly
                                         </div>
                                     </div>
-                                    <a href="/new/">
+                                    {% if realm_plan_type in [3, 4] %}
+                                    <button class="black-disabled" type="button">
+                                        Current plan
+                                    </button>
+                                    {% elif realm_plan_type == 2 %}
+                                    <a href="/upgrade">
                                         <button class="green" type="button">
-                                            Try it free
+                                            Buy Premium
                                         </button>
                                     </a>
+                                    {% else %}
+                                    <a href="/new">
+                                        <button class="green" type="button">
+                                            Buy Premium
+                                        </button>
+                                    </a>
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -56,6 +56,7 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         realm_icon = None
         realm_description = None
         realm_invite_required = False
+        realm_plan_type = 0
     else:
         realm_uri = realm.uri
         realm_name = realm.name
@@ -63,6 +64,7 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         realm_description_raw = realm.description or "The coolest place in the universe."
         realm_description = convert(realm_description_raw, message_realm=realm)
         realm_invite_required = realm.invite_required
+        realm_plan_type = realm.plan_type
 
     register_link_disabled = settings.REGISTER_LINK_DISABLED
     login_link_disabled = settings.LOGIN_LINK_DISABLED
@@ -114,6 +116,7 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         'realm_name': realm_name,
         'realm_icon': realm_icon,
         'realm_description': realm_description,
+        'realm_plan_type': realm_plan_type,
         'root_domain_uri': settings.ROOT_DOMAIN_URI,
         'apps_page_url': apps_page_url,
         'open_realm_creation': settings.OPEN_REALM_CREATION,

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -294,6 +294,8 @@ def apps_view(request: HttpRequest, _: str) -> HttpResponse:
 def plans_view(request: HttpRequest) -> HttpResponse:
     realm = get_realm_from_request(request)
     if realm is not None:
+        if realm.plan_type == Realm.SELF_HOSTED:
+            return HttpResponseRedirect(reverse('zerver.views.home.home'))
         if not request.user.is_authenticated():
             return redirect_to_login(next="plans")
     return render(request, "zerver/plans.html")

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -8,7 +8,9 @@ from django.utils import translation
 from django.utils.cache import patch_cache_control
 from itertools import zip_longest
 
-from zerver.decorator import zulip_login_required, process_client
+from zerver.context_processors import get_realm_from_request
+from zerver.decorator import zulip_login_required, process_client, \
+    redirect_to_login
 from zerver.forms import ToSForm
 from zerver.lib.realm_icon import realm_icon_url
 from zerver.models import Message, UserProfile, Stream, Subscription, Huddle, \
@@ -288,3 +290,10 @@ def apps_view(request: HttpRequest, _: str) -> HttpResponse:
     if settings.ZILENCER_ENABLED:
         return render(request, 'zerver/apps.html')
     return HttpResponseRedirect('https://zulipchat.com/apps/', status=301)
+
+def plans_view(request: HttpRequest) -> HttpResponse:
+    realm = get_realm_from_request(request)
+    if realm is not None:
+        if not request.user.is_authenticated():
+            return redirect_to_login(next="plans")
+    return render(request, "zerver/plans.html")

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -484,7 +484,7 @@ i18n_urls = [
     url(r'^team/$', zerver.views.users.team_view),
     url(r'^history/$', TemplateView.as_view(template_name='zerver/history.html')),
     url(r'^apps/(.*)', zerver.views.home.apps_view, name='zerver.views.home.apps_view'),
-    url(r'^plans/$', TemplateView.as_view(template_name='zerver/plans.html'), name='plans'),
+    url(r'^plans/$', zerver.views.home.plans_view, name='plans'),
 
     # Landing page, features pages, signup form, etc.
     url(r'^hello/$', TemplateView.as_view(template_name='zerver/hello.html'), name='landing-page'),


### PR DESCRIPTION
The one thing remaining here is that "Buy Premium" on the root domain should do something better (Vishnu has some work on it, but it's not in this PR).

Would be great to get a careful review of the (few lines of) changes to `home.py` and the CSS.

![image](https://user-images.githubusercontent.com/890911/44692913-01bf8380-aa1a-11e8-816b-6da238db7c65.png)

![image](https://user-images.githubusercontent.com/890911/44692933-1c91f800-aa1a-11e8-8b92-e6612c43e98c.png)

