### PR TITLE
features-portico: Minor design changes in features section.

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -655,9 +655,23 @@ nav ul li.active::after {
     flex: 1 0 100%;
 }
 
-.portico-landing.features-app section > .feature-block {
+.portico-landing.features-app .keyboard-shortcuts .feature-block {
     margin: 10px 20px;
     flex: 1 1 320px;
+}
+.portico-landing.features-app .feature-details .feature-block {
+    margin: 10px auto 20px 10px;
+    flex: 0 1 320px;
+    padding: 25px;
+}
+
+.portico-landing.features-app .feature-details .feature-block:hover {
+    -webkit-box-shadow: 10px 20px 80px rgba(0, 0, 0, 0.15);
+    -moz-box-shadow: 10px 20px 80px rgba(0, 0, 0, 0.15);
+    box-shadow: 10px 20px 80px rgba(0, 0, 0, 0.15);
+    border-radius: 10px;
+    -webkit-transform: scale(1.01);
+    transform: scale(1.01);
 }
 
 .portico-landing.features-app .feature-block h3 {

--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -102,7 +102,7 @@
         <img class="image" src="/static/images/landing-page/love-keyboard-shortcuts.svg" />
     </section>
 
-    <section>
+    <section class="feature-details">
         <h2>Apps, Integrations, and API</h2>
 
         <div class="feature-block">
@@ -131,13 +131,9 @@
             <p>Prefer Zulip in its own window and rich, OS-level
             notifications? Enjoy Zulip on your desktop.</p>
         </div>
-        <!--Hack: These two pseudo elements are here to ensure the flex
-        arrangment uses the proper cell size with 4 elements in 2 rows.-->
-        <div class="feature-block"></div>
-        <div class="feature-block"></div>
     </section>
 
-    <section>
+    <section class="feature-details">
         <h2>And everything else you need...</h2>
 
         <div class="feature-block">
@@ -252,10 +248,6 @@
             <p>Zulip is open source, so if something important for
             your use case is missing, you can make it happen!</p>
         </div>
-        <!--Hack: These two pseudo elements are here to ensure the flex
-        arrangment uses the proper cell size with 4 elements in 2 rows.-->
-        <div class="feature-block"></div>
-        <div class="feature-block"></div>
     </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR adds a transform animation to the feature-block in order to highlight the content properly. Also, removed the hacky flex arrangement by setting the flex-grow to 0.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![local_file](https://user-images.githubusercontent.com/2263909/44707043-10ad4100-aac1-11e8-8a81-960edb55e2b9.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
