### PR TITLE
Adjust the message feed for long messages.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -104,7 +104,11 @@ function clear_box() {
 }
 
 exports.autosize_message_content = function () {
-    $("#compose-textarea").autosize();
+    $("#compose-textarea").autosize({
+        callback: function () {
+            compose_actions.maybe_scroll_up_selected_message();
+        },
+    });
 };
 
 exports.expand_compose_box = function () {


### PR DESCRIPTION
We now have a callback for whenever the compose
box gets autosized by our old vendored version
of the autosize widget.  It calls code to
scroll up the message feed if we are newly
covering it.
