### PR TITLE
Add more space between compose box and selected message.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -164,7 +164,7 @@ exports.maybe_scroll_up_selected_message = function () {
     var cover = selected_row.offset().top + selected_row.height()
         - $("#compose").offset().top;
     if (cover > 0) {
-        message_viewport.user_initiated_animate_scroll(cover + 5);
+        message_viewport.user_initiated_animate_scroll(cover + 20);
     }
 };
 


### PR DESCRIPTION
When we nudge up the feed to prevent the compose box
from obscuring it, we now have 20 pixels of separation
instead of 5.  Before this fix, it was hard for users
to know whether they had any messages being covered.
