### PR TITLE
status: Allow selecting status message text.

### DIFF
--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -6,7 +6,7 @@
         <div class="messagebox-border">
             <div class="messagebox-content">
                 <div class="message_top_line">
-                    <span class="message_sender{{^status_message}} sender_info_hover{{/status_message}} no-select">
+                    <span class="message_sender{{^status_message}} sender_info_hover{{/status_message}}">
                         {{#include_sender}}
                             {{! See ../js/notifications.js for another user of avatar_url. }}
                             <div class="u-{{msg/sender_id}} inline_profile_picture{{#status_message}} sender_info_hover{{/status_message}}">


### PR DESCRIPTION
This PR removes the no-select class from the status message container which was unnecessarily added. This change allows users to select the text of the status message.

