### PR TITLE
Warn when promising mobile notifications the server can't deliver

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1075,6 +1075,7 @@ run_test('settings_tab', () => {
         enable_offline_push_notifications: true, enable_online_push_notifications: true,
         enable_digest_emails: true,
         realm_name_in_notifications: true,
+        realm_push_notifications_enabled: true,
     };
     var page_params = $.extend(page_param_checkbox_options, {
         full_name: "Alyssa P. Hacker", password_auth_enabled: true,

--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -66,13 +66,16 @@
 
             {{partial "settings_checkbox"
               "setting_name" "enable_offline_push_notifications"
-              "is_checked" page_params.enable_offline_push_notifications
-              "label" settings_label.enable_offline_push_notifications}}
+              "is_checked" page_params.realm_push_notifications_enabled
+              "is_parent_setting_enabled" page_params.realm_push_notifications_enabled
+              "is_nested" false
+              "label" settings_label.enable_offline_push_notifications
+              "hide_tooltip" false}}
 
             {{partial "settings_checkbox"
               "setting_name" "enable_online_push_notifications"
-              "is_checked" page_params.enable_online_push_notifications
-              "is_parent_setting_enabled" page_params.enable_offline_push_notifications
+              "is_checked" page_params.realm_push_notifications_enabled
+              "is_parent_setting_enabled" page_params.realm_push_notifications_enabled
               "is_nested" true
               "label" settings_label.enable_online_push_notifications}}
         </div>

--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -22,9 +22,11 @@
 
             {{partial "settings_checkbox"
               "setting_name" "enable_stream_push_notifications"
-              "is_checked" page_params.enable_stream_push_notifications
+              "is_parent_setting_enabled" page_params.realm_push_notifications_enabled
+              "is_nested" false
+              "is_checked" page_params.realm_push_notifications_enabled
               "label" settings_label.enable_stream_push_notifications
-              "end_content" '<div class="propagate_stream_notifications_change"></div>'}}
+              "hide_tooltip" false}}
 
             {{partial "settings_checkbox"
               "setting_name" "enable_stream_email_notifications"

--- a/static/templates/settings/settings_checkbox.handlebars
+++ b/static/templates/settings/settings_checkbox.handlebars
@@ -12,4 +12,8 @@
         {{{label}}}
     </label>
     {{{end_content}}}
+    {{#is_false hide_tooltip}}
+    <i class="fa fa-question-circle change_email_tooltip settings-info-icon" {{#if page_params.realm_push_notifications_enabled}}style="display:none"{{/if}}  data-toggle="tooltip"
+      title="{{t 'The server is not configured for push notifications' }}"></i>
+    {{/is_false}}
 </div>


### PR DESCRIPTION
Closes #10331 

![screenshot 2018-09-01 at 12 51 30 am](https://user-images.githubusercontent.com/22795943/44932021-5bf57700-ad81-11e8-89b7-8baf1da3a880.png)
![screenshot 2018-09-01 at 12 51 40 am](https://user-images.githubusercontent.com/22795943/44932022-5bf57700-ad81-11e8-8477-7e99a8972899.png)
![screenshot 2018-09-01 at 12 56 14 am](https://user-images.githubusercontent.com/22795943/44932167-f5bd2400-ad81-11e8-8dd6-1d15d15e3dcb.png)


If the server has not been configured to serve push notifications then the checkbox is disabled and on hovering on the icon, the user is warned about it.