### PR TITLE
Fix styling of devtools page.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -2148,6 +2148,19 @@ input.new-organization-button {
 #devtools-page {
     max-width: 800px;
     margin: 0 auto;
+    padding-top: 100px;
+
+    p {
+        font-size: 1.2em;
+        margin: 0 0 20px;
+        line-height: 1.4;
+    }
+
+    ul li {
+        font-size: 1.2em;
+        line-height: 1.6;
+        margin-bottom: 5px;
+    }
 }
 
 .portico-page.error {

--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -59,7 +59,7 @@
             </select>
         </form>
         <div id="devtools-wrapper">
-            <a id="devtools-link" href="/devtools">Zulip developer tools</a>
+            <a href="/devtools">Zulip developer tools</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
* The devtools-page content was hidden in the top navbar, added top padding to fix the same. Also, added a bit of styling to the page.

* Second commit removes the unused id from the dev-login page.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before: 

![image](https://user-images.githubusercontent.com/2263909/44949232-39c82b80-ae4b-11e8-87dd-3af5bbddf4b0.png)

![image](https://user-images.githubusercontent.com/2263909/44949251-83b11180-ae4b-11e8-88ee-797751b4f67b.png)



<hr>


After: 

![image](https://user-images.githubusercontent.com/2263909/44949243-6aa86080-ae4b-11e8-9499-aa65f4fc3184.png)


![image](https://user-images.githubusercontent.com/2263909/44949246-73009b80-ae4b-11e8-815c-6deafaeaa1f0.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

