### PR TITLE
 settings: Deduplicate notification-settings' dependent checkboxes code.

### DIFF
--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -79,6 +79,13 @@ Handlebars.registerHelper('if_or', function () {
     return options.inverse(this);
 });
 
+Handlebars.registerHelper('is_false', function (variable, options) {
+    if (variable === false) {
+        return options.fn(this);
+    }
+    return options.inverse(this);
+});
+
 Handlebars.registerHelper('t', function (i18n_key) {
     // Marks a string for translation.
     // Example usage:

--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -47,20 +47,12 @@
               "is_checked" page_params.enable_desktop_notifications
               "label" settings_label.enable_desktop_notifications}}
 
-            <div class="input-group disableable {{#unless page_params.enable_desktop_notifications}}control-label-disabled{{/unless}}">
-                <label class="checkbox">
-                    <input type="checkbox" name="pm_content_in_desktop_notifications"
-                      id="pm_content_in_desktop_notifications"
-                      {{#unless page_params.enable_desktop_notifications}}disabled="disabled"{{/unless}}
-                      {{#if page_params.pm_content_in_desktop_notifications}}
-                      checked="checked"
-                      {{/if}} />
-                    <span></span>
-                </label>
-                <label for="pm_content_in_desktop_notifications" id="pm_content_in_desktop_notifications_label" class="inline-block">
-                    {{settings_label.pm_content_in_desktop_notifications}}
-                </label>
-            </div>
+            {{partial "settings_checkbox"
+              "setting_name" "pm_content_in_desktop_notifications"
+              "is_checked" page_params.pm_content_in_desktop_notifications
+              "is_parent_setting_enabled" page_params.enable_desktop_notifications
+              "is_nested" true
+              "label" settings_label.pm_content_in_desktop_notifications}}
 
             {{partial "settings_checkbox"
               "setting_name" "enable_sounds"
@@ -77,19 +69,12 @@
               "is_checked" page_params.enable_offline_push_notifications
               "label" settings_label.enable_offline_push_notifications}}
 
-            <div class="input-group disableable {{#unless page_params.enable_offline_push_notifications}}control-label-disabled{{/unless}}">
-                <label class="checkbox">
-                    <input type="checkbox" name="enable_online_push_notifications" id="enable_online_push_notifications"
-                      {{#unless page_params.enable_offline_push_notifications}}disabled="disabled"{{/unless}}
-                      {{#if page_params.enable_online_push_notifications}}
-                      checked="checked"
-                      {{/if}} />
-                    <span></span>
-                </label>
-                <label for="enable_online_push_notifications" id="enable_online_push_notifications_label" class="inline-block">
-                    {{settings_label.enable_online_push_notifications}}
-                </label>
-            </div>
+            {{partial "settings_checkbox"
+              "setting_name" "enable_online_push_notifications"
+              "is_checked" page_params.enable_online_push_notifications
+              "is_parent_setting_enabled" page_params.enable_offline_push_notifications
+              "is_nested" true
+              "label" settings_label.enable_online_push_notifications}}
         </div>
 
         <div id="other_notifications">

--- a/static/templates/settings/settings_checkbox.handlebars
+++ b/static/templates/settings/settings_checkbox.handlebars
@@ -1,4 +1,4 @@
-<div class="input-group {{#is_false unless}}control-label-disabled{{/is_false}}">
+<div class="input-group {{#if is_nested}}disableable{{/if}} {{#is_false unless}}control-label-disabled{{/is_false}}">
     <label class="checkbox">
         <input type="checkbox" class="inline-block" name="{{setting_name}}"
           id="{{prefix}}{{setting_name}}"

--- a/static/templates/settings/settings_checkbox.handlebars
+++ b/static/templates/settings/settings_checkbox.handlebars
@@ -1,7 +1,8 @@
-<div class="input-group">
+<div class="input-group {{#is_false unless}}control-label-disabled{{/is_false}}">
     <label class="checkbox">
         <input type="checkbox" class="inline-block" name="{{setting_name}}"
           id="{{prefix}}{{setting_name}}"
+          {{#is_false unless}}disabled="disabled"{{/is_false}}
           {{#if is_checked}}
           checked="checked"
           {{/if}} />

--- a/static/templates/settings/settings_checkbox.handlebars
+++ b/static/templates/settings/settings_checkbox.handlebars
@@ -1,8 +1,8 @@
-<div class="input-group {{#if is_nested}}disableable{{/if}} {{#is_false unless}}control-label-disabled{{/is_false}}">
+<div class="input-group {{#if is_nested}}disableable{{/if}} {{#is_false is_parent_setting_enabled}}control-label-disabled{{/is_false}}">
     <label class="checkbox">
         <input type="checkbox" class="inline-block" name="{{setting_name}}"
           id="{{prefix}}{{setting_name}}"
-          {{#is_false unless}}disabled="disabled"{{/is_false}}
+          {{#is_false is_parent_setting_enabled}}disabled="disabled"{{/is_false}}
           {{#if is_checked}}
           checked="checked"
           {{/if}} />


### PR DESCRIPTION
**GIFs or Screenshots:**
There should be **NO** UI change.

**Before**
![image](https://user-images.githubusercontent.com/22238472/44954315-db886080-aebd-11e8-9e41-a730939422f4.png)
**After**
![image](https://user-images.githubusercontent.com/22238472/44954306-bbf13800-aebd-11e8-81e0-5d947333813b.png)

Refernce: #10457
 
While fixing this I found a bug that checkbox for `message_content_in_email_notifications` isn't properly adjusted when `enable_offline_email_notifications` is changed. @pragatiagrawal31 are you interested in taking this as this is similar to #10358.