### PR TITLE
settings: Adjust checkbox for message content in email properly.

### DIFF
--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -90,6 +90,7 @@ exports.set_up = function () {
     $("#enable_offline_push_notifications").change(function () {
         settings_ui.disable_sub_setting_onchange(this.checked, "enable_online_push_notifications", true);
     });
+
 };
 
 exports.update_page = function () {

--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -107,20 +107,10 @@
               "is_checked" page_params.enable_login_emails
               "label" settings_label.enable_login_emails}}
 
-            <div class="input-group {{#unless page_params.enable_offline_email_notifications}}control-label-disabled{{/unless}}">
-                <label class="checkbox">
-                    <input type="checkbox" name="message_content_in_email_notifications"
-                      id="message_content_in_email_notifications"
-                      {{#unless page_params.enable_offline_email_notifications}}disabled="disabled"{{/unless}}
-                      {{#if page_params.message_content_in_email_notifications}}
-                      checked="checked"
-                      {{/if}} />
-                    <span></span>
-                </label>
-                <label for="message_content_in_email_notifications" id="message_content_in_email_notifications_label" class="inline-block">
-                    {{settings_label.message_content_in_email_notifications}}
-                </label>
-            </div>
+            {{partial "settings_checkbox"
+              "setting_name" "message_content_in_email_notifications"
+              "is_checked" page_params.message_content_in_email_notifications
+              "label" settings_label.message_content_in_email_notifications}}
 
             {{partial "settings_checkbox"
               "setting_name" "realm_name_in_notifications"


### PR DESCRIPTION
It fixes the bug that checkbox for
message_content_in_email_notifications isn't properly adjusted when
enable_offline_email_notifications is changed.

**GIFs or Screenshots:** 
![pragato](https://user-images.githubusercontent.com/40331304/44959590-a9531f00-af0e-11e8-8b71-c93e80f90061.gif)
