### PR TITLE
Add sharpen filter for thumbnails and increase default pixel size

### DIFF
--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -49,7 +49,7 @@ def generate_thumbnail_url(path: str, size: str='0x0') -> str:
         width=width,
         height=height,
         smart=True,
-        filters=['no_upscale()'],
+        filters=['no_upscale()', 'sharpen(2.2,0.8,false)'],
         image_url=image_url
     )
 

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -21,7 +21,7 @@ class ThumbnailTest(ZulipTestCase):
     @use_s3_backend
     def test_s3_source_type(self) -> None:
         def get_file_path_urlpart(uri: str, size: str='') -> str:
-            url_in_result = 'smart/filters:no_upscale()/%s/source_type/s3'
+            url_in_result = 'smart/filters:no_upscale():sharpen(2.2,0.8,false)/%s/source_type/s3'
             if size:
                 url_in_result = '/%s/%s' % (size, url_in_result)
             hex_uri = base64.urlsafe_b64encode(uri.encode()).decode('utf-8')
@@ -99,13 +99,13 @@ class ThumbnailTest(ZulipTestCase):
             encoded_url = base64.urlsafe_b64encode(image_url.encode()).decode('utf-8')
             result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_url))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
+            expected_part_url = '/smart/filters:no_upscale():sharpen(2.2,0.8,false)/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
             # Test thumbnail size.
             result = self.client_get("/thumbnail?url=%s&size=thumbnail" % (quoted_url))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/0x300/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
+            expected_part_url = '/0x300/smart/filters:no_upscale():sharpen(2.2,0.8,false)/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
             # Test api endpoint with standard API authentication.
@@ -114,7 +114,7 @@ class ThumbnailTest(ZulipTestCase):
             result = self.api_get(user_profile.email,
                                   "/thumbnail?url=%s&size=thumbnail" % (quoted_url,))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/0x300/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
+            expected_part_url = '/0x300/smart/filters:no_upscale():sharpen(2.2,0.8,false)/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
             # Test api endpoint with legacy API authentication.
@@ -122,7 +122,7 @@ class ThumbnailTest(ZulipTestCase):
             result = self.client_get("/thumbnail?url=%s&size=thumbnail&api_key=%s" % (
                 quoted_url, get_api_key(user_profile)))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/0x300/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
+            expected_part_url = '/0x300/smart/filters:no_upscale():sharpen(2.2,0.8,false)/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
             # Test a second logged-in user; they should also be able to access it
@@ -130,7 +130,7 @@ class ThumbnailTest(ZulipTestCase):
             result = self.client_get("/thumbnail?url=%s&size=thumbnail&api_key=%s" % (
                 quoted_url, get_api_key(user_profile)))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/0x300/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
+            expected_part_url = '/0x300/smart/filters:no_upscale():sharpen(2.2,0.8,false)/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
             # Test with another user trying to access image using thumbor.
@@ -138,7 +138,7 @@ class ThumbnailTest(ZulipTestCase):
             self.login(self.example_email("iago"))
             result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_url))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
+            expected_part_url = '/smart/filters:no_upscale():sharpen(2.2,0.8,false)/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
         image_url = 'https://images.foobar.com/12345'
@@ -149,7 +149,7 @@ class ThumbnailTest(ZulipTestCase):
 
     def test_local_file_type(self) -> None:
         def get_file_path_urlpart(uri: str, size: str='') -> str:
-            url_in_result = 'smart/filters:no_upscale()/%s/source_type/local_file'
+            url_in_result = 'smart/filters:no_upscale():sharpen(2.2,0.8,false)/%s/source_type/local_file'
             if size:
                 url_in_result = '/%s/%s' % (size, url_in_result)
             hex_uri = base64.urlsafe_b64encode(uri.encode()).decode('utf-8')
@@ -309,12 +309,12 @@ class ThumbnailTest(ZulipTestCase):
         self.assertEqual(result.status_code, 302, result)
         base = 'http://test-thumborhost.com/'
         self.assertEqual(base, result.url[:len(base)])
-        expected_part_url = '/smart/filters:no_upscale()/' + hex_uri + '/source_type/local_file'
+        expected_part_url = '/smart/filters:no_upscale():sharpen(2.2,0.8,false)/' + hex_uri + '/source_type/local_file'
         self.assertIn(expected_part_url, result.url)
 
     def test_with_different_sizes(self) -> None:
         def get_file_path_urlpart(uri: str, size: str='') -> str:
-            url_in_result = 'smart/filters:no_upscale()/%s/source_type/local_file'
+            url_in_result = 'smart/filters:no_upscale():sharpen(2.2,0.8,false)/%s/source_type/local_file'
             if size:
                 url_in_result = '/%s/%s' % (size, url_in_result)
             hex_uri = base64.urlsafe_b64encode(uri.encode()).decode('utf-8')

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -54,7 +54,7 @@ class ThumbnailTest(ZulipTestCase):
         # Test thumbnail size.
         result = self.client_get("/thumbnail?url=%s&size=thumbnail" % (quoted_uri))
         self.assertEqual(result.status_code, 302, result)
-        expected_part_url = get_file_path_urlpart(uri, '0x100')
+        expected_part_url = get_file_path_urlpart(uri, '0x300')
         self.assertIn(expected_part_url, result.url)
 
         # Test custom emoji urls in Zulip messages.
@@ -105,7 +105,7 @@ class ThumbnailTest(ZulipTestCase):
             # Test thumbnail size.
             result = self.client_get("/thumbnail?url=%s&size=thumbnail" % (quoted_url))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/0x100/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
+            expected_part_url = '/0x300/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
             # Test api endpoint with standard API authentication.
@@ -114,7 +114,7 @@ class ThumbnailTest(ZulipTestCase):
             result = self.api_get(user_profile.email,
                                   "/thumbnail?url=%s&size=thumbnail" % (quoted_url,))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/0x100/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
+            expected_part_url = '/0x300/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
             # Test api endpoint with legacy API authentication.
@@ -122,7 +122,7 @@ class ThumbnailTest(ZulipTestCase):
             result = self.client_get("/thumbnail?url=%s&size=thumbnail&api_key=%s" % (
                 quoted_url, get_api_key(user_profile)))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/0x100/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
+            expected_part_url = '/0x300/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
             # Test a second logged-in user; they should also be able to access it
@@ -130,7 +130,7 @@ class ThumbnailTest(ZulipTestCase):
             result = self.client_get("/thumbnail?url=%s&size=thumbnail&api_key=%s" % (
                 quoted_url, get_api_key(user_profile)))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/0x100/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
+            expected_part_url = '/0x300/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
             # Test with another user trying to access image using thumbor.
@@ -179,7 +179,7 @@ class ThumbnailTest(ZulipTestCase):
         # Test thumbnail size.
         result = self.client_get("/thumbnail?url=%s&size=thumbnail" % (quoted_uri))
         self.assertEqual(result.status_code, 302, result)
-        expected_part_url = get_file_path_urlpart(uri, '0x100')
+        expected_part_url = get_file_path_urlpart(uri, '0x300')
         self.assertIn(expected_part_url, result.url)
 
         # Test with a unicode filename.
@@ -333,12 +333,12 @@ class ThumbnailTest(ZulipTestCase):
         self.assertEqual(base, uri[:len(base)])
 
         # Test with size supplied as a query parameter.
-        # size=thumbnail should return a 0x100 sized image.
+        # size=thumbnail should return a 0x300 sized image.
         # size=full should return the original resolution image.
         quoted_uri = urllib.parse.quote(uri[1:], safe='')
         result = self.client_get("/thumbnail?url=%s&size=thumbnail" % (quoted_uri))
         self.assertEqual(result.status_code, 302, result)
-        expected_part_url = get_file_path_urlpart(uri, '0x100')
+        expected_part_url = get_file_path_urlpart(uri, '0x300')
         self.assertIn(expected_part_url, result.url)
 
         result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_uri))

--- a/zerver/views/thumbnail.py
+++ b/zerver/views/thumbnail.py
@@ -28,7 +28,7 @@ def backend_serve_thumbnail(request: HttpRequest, user_profile: UserProfile,
 
     size = None
     if size_requested == 'thumbnail':
-        size = '0x100'
+        size = '0x300'
     elif size_requested == 'full':
         size = '0x0'
 


### PR DESCRIPTION
In this PR we address the issue of making thumbnails look better on high resolution devices.

Fixes: #10218 #10219 