### PR TITLE
Reword push notifications alert text.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -440,11 +440,8 @@ def get_alert_from_message(message: Message) -> str:
         return "New private message from %s" % (sender_str,)
     elif message.is_stream_message() and message.trigger == 'mentioned':
         return "New mention from %s" % (sender_str,)
-    elif (message.is_stream_message() and
-            (message.trigger == 'stream_push_notify' and message.stream_name)):
+    else:  # message.is_stream_message() and message.trigger == 'stream_push_notify'
         return "New stream message from %s in %s" % (sender_str, message.stream_name,)
-    else:
-        return "New Zulip mentions and private messages from %s" % (sender_str,)
 
 def get_mobile_push_content(rendered_content: str) -> str:
     def get_text(elem: LH.HtmlElement) -> str:

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -731,42 +731,7 @@ class TestAPNs(PushNotificationTest):
         self.assertEqual(
             apn.modernize_apns_payload(payload),
             payload)
-
-class TestGetAlertFromMessage(PushNotificationTest):
-    def test_get_alert_from_private_group_message(self) -> None:
-        message = self.get_message(Recipient.HUDDLE)
-        message.trigger = 'private_message'
-        alert = apn.get_alert_from_message(message)
-        self.assertEqual(alert, "New private group message from King Hamlet")
-
-    def test_get_alert_from_private_message(self) -> None:
-        message = self.get_message(Recipient.PERSONAL)
-        message.trigger = 'private_message'
-        alert = apn.get_alert_from_message(message)
-        self.assertEqual(alert, "New private message from King Hamlet")
-
-    def test_get_alert_from_mention(self) -> None:
-        message = self.get_message(Recipient.STREAM)
-        message.trigger = 'mentioned'
-        alert = apn.get_alert_from_message(message)
-        self.assertEqual(alert, "New mention from King Hamlet")
-
-    def test_get_alert_from_stream_message(self) -> None:
-        message = self.get_message(Recipient.STREAM)
-        message.trigger = 'stream_push_notify'
-        message.stream_name = 'Denmark'
-        alert = apn.get_alert_from_message(message)
-        self.assertEqual(alert, "New stream message from King Hamlet in Denmark")
-
-    def test_get_alert_from_other_message(self) -> None:
-        message = self.get_message(0)
-        message.trigger = 'stream_push_notify'
-        alert = apn.get_alert_from_message(message)
-        alert = apn.get_alert_from_message(self.get_message(0))
-        self.assertEqual(alert,
-                         "New Zulip mentions and private messages from King "
-                         "Hamlet")
-
+            
 class TestGetAPNsPayload(PushNotificationTest):
     def test_get_apns_payload(self) -> None:
         user_profile = self.example_user("othello")

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -731,9 +731,40 @@ class TestAPNs(PushNotificationTest):
         self.assertEqual(
             apn.modernize_apns_payload(payload),
             payload)
-            
+
 class TestGetAPNsPayload(PushNotificationTest):
-    def test_get_apns_payload(self) -> None:
+    def test_get_apns_payload_personal_message(self) -> None:
+        user_profile = self.example_user("othello")
+        message_id = self.send_personal_message(
+            self.example_email('hamlet'),
+            self.example_email('othello'),
+            'Content of personal message',
+        )
+        message = Message.objects.get(id=message_id)
+        message.trigger = 'private_message'
+        payload = apn.get_apns_payload(user_profile, message)
+        expected = {
+            'alert': {
+                'title': 'King Hamlet says:',
+                'subtitle': '',
+                'body': message.content,
+            },
+            'badge': 0,
+            'custom': {
+                'zulip': {
+                    'message_ids': [message.id],
+                    'recipient_type': 'private',
+                    'sender_email': 'hamlet@zulip.com',
+                    'sender_id': 4,
+                    'server': settings.EXTERNAL_HOST,
+                    'realm_id': message.sender.realm.id,
+                    'realm_uri': message.sender.realm.uri,
+                }
+            }
+        }
+        self.assertDictEqual(payload, expected)
+
+    def test_get_apns_payload_huddle_message(self) -> None:
         user_profile = self.example_user("othello")
         message_id = self.send_huddle_message(
             self.sender.email,
@@ -743,7 +774,8 @@ class TestGetAPNsPayload(PushNotificationTest):
         payload = apn.get_apns_payload(user_profile, message)
         expected = {
             'alert': {
-                'title': "New private group message from King Hamlet",
+                'title': 'Cordelia Lear, King Hamlet, Othello, the Moor of Venice',
+                'subtitle': 'King Hamlet says:',
                 'body': message.content,
             },
             'badge': 0,
@@ -765,7 +797,38 @@ class TestGetAPNsPayload(PushNotificationTest):
         }
         self.assertDictEqual(payload, expected)
 
-    def test_get_apns_payload_stream(self):
+    def test_get_apns_payload_stream_message(self):
+        # type: () -> None
+        user_profile = self.example_user("hamlet")
+        stream = Stream.objects.filter(name='Verona').get()
+        message = self.get_message(Recipient.STREAM, stream.id)
+        message.trigger = 'push_stream_notify'
+        message.stream_name = 'Verona'
+        payload = apn.get_apns_payload(user_profile, message)
+        expected = {
+            'alert': {
+                'title': '#Verona > Test Message',
+                'subtitle': 'King Hamlet says:',
+                'body': message.content,
+            },
+            'badge': 0,
+            'custom': {
+                'zulip': {
+                    'message_ids': [message.id],
+                    'recipient_type': 'stream',
+                    'sender_email': 'hamlet@zulip.com',
+                    'sender_id': 4,
+                    "stream": apn.get_display_recipient(message.recipient),
+                    "topic": message.subject,
+                    'server': settings.EXTERNAL_HOST,
+                    'realm_id': message.sender.realm.id,
+                    'realm_uri': message.sender.realm.uri,
+                }
+            }
+        }
+        self.assertDictEqual(payload, expected)
+
+    def test_get_apns_payload_stream_mention(self):
         # type: () -> None
         user_profile = self.example_user("othello")
         stream = Stream.objects.filter(name='Verona').get()
@@ -775,7 +838,8 @@ class TestGetAPNsPayload(PushNotificationTest):
         payload = apn.get_apns_payload(user_profile, message)
         expected = {
             'alert': {
-                'title': "New mention from King Hamlet",
+                'title': '#Verona > Test Message',
+                'subtitle': 'King Hamlet mentioned you:',
                 'body': message.content,
             },
             'badge': 0,
@@ -806,7 +870,8 @@ class TestGetAPNsPayload(PushNotificationTest):
         payload = apn.get_apns_payload(user_profile, message)
         expected = {
             'alert': {
-                'title': "New private group message from King Hamlet",
+                'title': 'Cordelia Lear, King Hamlet, Othello, the Moor of Venice',
+                'subtitle': "King Hamlet says:",
                 'body': "***REDACTED***",
             },
             'badge': 0,


### PR DESCRIPTION
This addresses https://github.com/zulip/zulip/issues/9949 and https://github.com/zulip/zulip-mobile/issues/1316.

- Omit the adjective 'new', which is implied.
- Omit the proper noun 'Zulip', which is already shown in the header
of a notification.
- Prefer 'PM' over 'private message'. This abbreviation
is becoming more conventional.
- Prefix stream names with '#'.
- Use the verb 'post' in order to describe the action of a user
sending a message to a topic in a stream.