### PR TITLE
Refine how we nudge message feed when expanding the compose box.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -164,7 +164,7 @@ exports.maybe_scroll_up_selected_message = function () {
     var cover = selected_row.offset().top + selected_row.height()
         - $("#compose").offset().top;
     if (cover > 0) {
-        message_viewport.user_initiated_animate_scroll(cover + 20);
+        message_viewport.scroll_message_feed(cover + 20);
     }
 };
 

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -164,7 +164,7 @@ exports.maybe_scroll_up_selected_message = function () {
     var cover = selected_row.offset().top + selected_row.height()
         - $("#compose").offset().top;
     if (cover > 0) {
-        message_viewport.scroll_message_feed(cover + 20);
+        message_viewport.scroll_message_feed(cover + 40);
     }
 };
 

--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -267,15 +267,12 @@ exports.system_initiated_animate_scroll = function (scroll_amount) {
     });
 };
 
-exports.user_initiated_animate_scroll = function (scroll_amount) {
+exports.scroll_message_feed = function (scroll_amount) {
     pointer.suppress_scroll_pointer_update = true; // Gets set to false in the scroll handler.
-    in_stoppable_autoscroll = false; // defensive
 
     var viewport_offset = exports.scrollTop();
 
-    exports.message_pane.animate({
-        scrollTop: viewport_offset + scroll_amount,
-    });
+    exports.message_pane.scrollTop(viewport_offset + scroll_amount);
 };
 
 exports.recenter_view = function (message, opts) {


### PR DESCRIPTION
I think both of these commits help, and they're not mutually exclusive.

I think getting rid of the animation is most helpful ("Scroll feed immediately...").

If you're on a laptop that constrains the height of your browser, the auto-nudge eventually runs up against the fact that #bottom_whitespace maxes out to 40%, and that feels a bit funny to me.  Changing that would be a bit tricky.  You could allow #bottom_whitespace to be relative to actual available area (subtract out the compose box height).  Or you could just put a cap on the height of the compose box.  I think I prefer the latter, since while we certainly don't want to restrict folks from going above 3 or 4 lines, we **do** want to discourage really long messages.  The user could still scroll within the compose box if they wanted to ramble, but it wouldn't obscure the feed.