### PR TITLE
help: Rename back button text.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -177,7 +177,7 @@ body {
 }
 
 .help .sidebar.slide h2::before {
-    display: inline-block;
+    display: block;
     font: normal normal normal 14px/1 FontAwesome;
     font-size: inherit;
     text-rendering: auto;
@@ -186,6 +186,7 @@ body {
 
     content: "\f107";
     margin-right: 5px;
+    float: right;
 
     opacity: 0.5;
 }

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -160,10 +160,16 @@ body {
     font-size: 1.25em;
     line-height: 1.5;
     margin-bottom: 0px;
+    border-bottom: 1px solid #fff;
 }
 
 .help .sidebar h1:not(:first-of-type) {
     margin-top: 20px;
+}
+
+.help .sidebar h1:first-of-type,
+.help .sidebar h1.home-link {
+    border-bottom: none;
 }
 
 .help .sidebar h2 {

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -6,7 +6,7 @@
 <div class="app help terms-page inline-block">
     <div class="{{ sidebar_class }}">
         <div class="content">
-            <h1><a href="{{ doc_root }}" class="no-underline">Index</a></h1>
+            <h1><a href="{{ doc_root }}" class="no-underline">Home</a></h1>
             {{ render_markdown_path(sidebar_index, api_uri_context) }}
             <h1 class="home-link"><a href="/" class="no-underline">Back to Zulip</a></h1>
         </div>

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -8,7 +8,7 @@
         <div class="content">
             <h1><a href="{{ doc_root }}" class="no-underline">Index</a></h1>
             {{ render_markdown_path(sidebar_index, api_uri_context) }}
-            <h1 class="home-link"><a href="/" class="no-underline">Back to Home</a></h1>
+            <h1 class="home-link"><a href="/" class="no-underline">Back to Zulip</a></h1>
         </div>
     </div>
 


### PR DESCRIPTION
Renamed back button text to Zulip instead of Home.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:

![image](https://user-images.githubusercontent.com/2263909/45409186-23f90880-b68c-11e8-836d-e5b720d5ea09.png)

<hr>

After:

![right_sidebar](https://user-images.githubusercontent.com/2263909/45408761-f1024500-b68a-11e8-89e9-f0a05f7dbe10.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
