### PR TITLE
CSS: Change styling of unread counts.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -86,11 +86,11 @@
 #global_filters li:hover,
 #stream_filters li:hover,
 #stream_filters li.highlighted_stream {
-    background-color: hsl(93, 19%, 88%);
+    background-color: hsl(214, 18%, 92%);
 }
 
 #stream_filters li.active-sub-filter:hover {
-    background-color: hsl(120, 11%, 82%);
+    background-color: hsl(214, 18%, 92%);
 }
 
 ul.filters {
@@ -110,7 +110,7 @@ ul.filters hr {
 li.active-filter,
 li.active-sub-filter {
     font-weight: 600 !important;
-    background: hsl(202, 56%, 91%);
+    background: hsl(211, 100%, 95%);
     position: relative;
 }
 

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -171,14 +171,13 @@ li.active-sub-filter {
 .topic-unread-count,
 .private_message_count {
     float: right;
-    background: hsl(105, 2%, 50%);
     padding: 0 4px;
     height: 16px;
     line-height: 16px;
-    color: hsl(0, 0%, 100%);
     font-size: 12px;
-    font-weight: normal;
+    font-weight: 700;
     letter-spacing: 0.6px;
+    border: 1px solid #bfbfbf;
     border-radius: 4px;
 }
 

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -264,11 +264,11 @@ on a dark background, and don't change the dark labels dark either. */
     #group-pms li:hover,
     #user_presences li:hover,
     #user_presences li.highlighted_user {
-        background-color: hsla(136, 25%, 73%, 0.2);
+        background-color: hsla(208, 25%, 73%, 0.2);
     }
 
     #stream_filters li.active-sub-filter:hover {
-        background-color: hsla(136, 25%, 73%, 0.5);
+        background-color: hsla(208, 25%, 73%, 0.2);
     }
 
     .floating_recipient .recipient_row {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -96,11 +96,6 @@ on a dark background, and don't change the dark labels dark either. */
         color: hsl(236, 33%, 90%);
     }
 
-    .topic-unread-count,
-    .private_message_count {
-        background-color: hsla(105, 2%, 50%, 0.5);
-    }
-
     .pill-container {
         border-style: solid;
         border-width: 1px;

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -10,7 +10,7 @@
 #group-pms li:hover,
 #user_presences li:hover,
 #user_presences li.highlighted_user {
-    background-color: hsl(93, 19%, 88%);
+    background-color: hsl(214, 18%, 92%);
 }
 
 #buddy_list_wrapper,

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -153,18 +153,16 @@
 .group-pms-sidebar-entry .count {
     float: right;
     padding: 0 4px;
-    background: hsl(105, 2%, 50%);
-    border-radius: 0px;
-    color: hsl(0, 0%, 100%);
     font-size: 12px;
     line-height: 14px;
     height: 15px;
-    font-weight: normal;
-    letter-spacing: 0.6px;
     position: relative;
-    top: 3px;
-    border-radius: 4px;
+    top: 1px;
     margin-left: 5px;
+    font-weight: 700;
+    letter-spacing: 0.6px;
+    border: 1px solid #bfbfbf;
+    border-radius: 4px;
 }
 
 .user_sidebar_entry .count {


### PR DESCRIPTION
This commit updates the styling of - 

1) Unread counts on left and right sidebar.
2) Hover and active states on left and right sidebar.
3) Night mode css to accommodate these changes.


**Testing Plan:** <!-- How have you tested? -->
Test regular as well as night mode.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="250" alt="screen shot 2018-09-12 at 6 01 25 pm" src="https://user-images.githubusercontent.com/322991/45425962-72240100-b6b8-11e8-93a8-34b9fdbc19bb.png">

<img width="247" alt="screen shot 2018-09-12 at 6 01 45 pm" src="https://user-images.githubusercontent.com/322991/45425970-76e8b500-b6b8-11e8-8b3a-77832f4cce20.png">



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
