### PR TITLE
WIP: Add limits for how many messages can be fetched with `get_messages` in a single request

### DIFF
--- a/templates/zerver/api/get-messages.md
+++ b/templates/zerver/api/get-messages.md
@@ -14,8 +14,7 @@ this endpoint to fetch the messages matching any search query that is
 supported by Zulip's powerful full-text search backend.
 
 When a narrow is not specified, it can be used to fetch a user's
-entire message history (though we recommend paginating to 1000
-messages at a time).
+message history (We recommend paginating to 1000 messages at a time).
 
 In either case, you specify an `anchor` message (or ask the server to
 calculate the first unread message for you and use that as the
@@ -26,7 +25,9 @@ whether there are more messages matching the query that were not
 returned due to the `num_before` and `num_after` limits.
 
 We recommend using `num_before <= 1000` and `num_after <= 1000` to
-avoid generating very large HTTP responses.
+avoid generating very large HTTP responses. A maximum of 5000 messages
+can be obtained per request; attempting to exceed this will result in an
+error.
 
 ## Usage examples
 

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -778,6 +778,15 @@ class GetOldMessagesTest(ZulipTestCase):
 
         self.get_and_check_messages(dict(narrow=ujson.dumps([dict(operator='pm-with', operand=self.example_email("othello"))])))
 
+    def test_get_messages_limits(self) -> None:
+        """
+        A call to GET /json/messages requesting more than 5000 messages returns an error message.
+        """
+        self.login(self.example_email("hamlet"))
+        result = self.get_messages_response(num_before=3000, num_after=3000)
+        self.assertEqual(result['result'], "error")
+        self.assertEqual(result['msg'], "Total number of messages requested exceeds maximum (5000).")
+
     def test_client_avatar(self) -> None:
         """
         The client_gravatar flag determines whether we send avatar_url.

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -694,6 +694,8 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
                          apply_markdown: bool=REQ(validator=check_bool, default=True)) -> HttpResponse:
     if anchor is None and not use_first_unread_anchor:
         return json_error(_("Missing 'anchor' argument (or set 'use_first_unread_anchor'=True)."))
+    if num_before + num_after >= 5000:
+        return json_error(_("Total number of messages requested exceeds maximum (5000)."))
     include_history = ok_to_include_history(narrow, user_profile)
 
     if include_history:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Addresses #10446. I have encountered issues locally with unrelated tests, and hence am unsure if this PR will itself pass tests, however have created this as a work-in-progress pull request.

Includes a test, and minor documentation edits to inform of the limit.


**Testing Plan:** <!-- How have you tested? -->
I have created a unit-test in order to test the functionality, and attempted to send various requests to check that the functionality is as intended.



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
