### PR TITLE
Add confirm dialog for deleting user groups.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,7 @@
         "compose_ui": false,
         "composebox_typeahead": false,
         "condense": false,
+        "confirm_dialog": false,
         "copy_and_paste": false,
         "csrf_token": false,
         "current_msg_list": true,

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -4,6 +4,7 @@ zrequire('settings_user_groups');
 
 set_global('$', global.make_zjquery());
 set_global('i18n', global.stub_i18n);
+set_global('confirm_dialog', {});
 
 var noop = function () {};
 
@@ -585,6 +586,10 @@ run_test('on_events', () => {
             fake_this.text(i18n.t('fake-text'));
             opts.error();
             assert.equal(fake_this.text(), 'translated: Failed!');
+        };
+
+        confirm_dialog.launch = (conf) => {
+            conf.on_click();
         };
 
         handler.call(fake_this);

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -164,6 +164,7 @@ import "js/upload_widget.js";
 import "js/avatar.js";
 import "js/realm_icon.js";
 import 'js/reminder.js';
+import 'js/confirm_dialog.js';
 import "js/settings_account.js";
 import "js/settings_display.js";
 import "js/settings_notifications.js";

--- a/static/js/confirm_dialog.js
+++ b/static/js/confirm_dialog.js
@@ -1,0 +1,86 @@
+var confirm_dialog = (function () {
+
+var exports = {};
+
+/*
+    Look for confirm_dialog in settings_user_groups
+    to see an example of how to use this widget.  It's
+    pretty simple to use!
+
+    Some things to note:
+
+        1) We create DOM on the fly, and we remove
+           the DOM once it's closed.
+
+        2) We attach the DOM for the modal to conf.parent,
+           and this temporary DOM location will influence
+           how styles work.
+
+        3) The cancel button is driven by bootstrap.js.
+
+        4) For settings, we have a click handler in settings.js
+           that will close the dialog via overlays.close_active_modal.
+
+        5) We assume that since this is a modal, you will
+           only ever have one confirm dialog active at any
+           time.
+
+*/
+
+exports.launch = function (conf) {
+    var html = templates.render("confirm_dialog");
+    var confirm_dialog = $(html);
+
+    var conf_fields = [
+        // The next three fields should be safe HTML. If callers
+        // interpolate user data into strings, they should use
+        // templates.
+        'html_heading',
+        'html_body',
+        'html_yes_button',
+        'on_click',
+        'parent',
+    ];
+
+    _.each(conf_fields, function (f) {
+        if (!conf[f]) {
+            blueslip.error('programmer omitted ' + f);
+        }
+    });
+
+    conf.parent.append(confirm_dialog);
+
+    // Close any existing modals--on settings screens you can
+    // have multiple buttons that need confirmation.
+    if (overlays.is_modal_open()) {
+        overlays.close_modal('confirm_dialog_modal');
+    }
+
+    confirm_dialog.find('.confirm_dialog_heading').html(conf.html_heading);
+    confirm_dialog.find('.confirm_dialog_body').html(conf.html_body);
+
+    var yes_button = confirm_dialog.find('.confirm_dialog_yes_button');
+
+    yes_button.html(conf.html_yes_button);
+
+    // Set up handlers.
+    yes_button.on('click', function () {
+        overlays.close_modal('confirm_dialog_modal');
+        conf.on_click();
+    });
+
+    confirm_dialog.on('hide', function () {
+        confirm_dialog.remove();
+    });
+
+    // Open the modal
+    overlays.open_modal('confirm_dialog_modal');
+};
+
+return exports;
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = confirm_dialog;
+}
+window.confirm_dialog = confirm_dialog;

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -316,7 +316,20 @@ exports.set_up = function () {
             });
         }
 
-        delete_user_group();
+        // This is mostly important for styling concerns.
+        var modal_parent = $('#settings_content');
+
+        var html_body = templates.render('confirm_delete_user', {
+            group_name: user_group.name,
+        });
+
+        confirm_dialog.launch({
+            parent: modal_parent,
+            html_heading: i18n.t('Delete user group'),
+            html_body: html_body,
+            html_yes_button: i18n.t('Delete'),
+            on_click: delete_user_group,
+        });
     });
 
     $('#user-groups').on('keypress', '.user-group h4 > span', function (e) {

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -299,19 +299,24 @@ exports.set_up = function () {
         }
         var user_group = user_groups.get_user_group_from_id(group_id);
         var btn = $(this);
-        channel.del({
-            url: "/json/user_groups/" + group_id,
-            data: {
-                id: group_id,
-            },
-            success: function () {
-                user_groups.remove(user_group);
-                settings_user_groups.reload();
-            },
-            error: function () {
-                btn.text(i18n.t("Failed!"));
-            },
-        });
+
+        function delete_user_group() {
+            channel.del({
+                url: "/json/user_groups/" + group_id,
+                data: {
+                    id: group_id,
+                },
+                success: function () {
+                    user_groups.remove(user_group);
+                    settings_user_groups.reload();
+                },
+                error: function () {
+                    btn.text(i18n.t("Failed!"));
+                },
+            });
+        }
+
+        delete_user_group();
     });
 
     $('#user-groups').on('keypress', '.user-group h4 > span', function (e) {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1445,6 +1445,7 @@ body:not(.night-mode) #account-settings .custom_user_field .datepicker {
     margin: 10px;
 }
 
+#confirm_dialog_modal,
 #deactivation_user_modal.fade.in {
     top: calc(50% - 120px);
 }

--- a/static/templates/confirm_delete_user.handlebars
+++ b/static/templates/confirm_delete_user.handlebars
@@ -1,0 +1,5 @@
+<p>
+    {{#tr this}}
+    Are you sure you want to delete <b>__group_name__</b>?
+    {{/tr}}
+</p>

--- a/static/templates/confirm_dialog.handlebars
+++ b/static/templates/confirm_dialog.handlebars
@@ -1,0 +1,12 @@
+<div class="modal modal-bg hide fade" id="confirm_dialog_modal" tabindex="-1" role="dialog" aria-labelledby="confirm_dialog_modal" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <h3 class="confirm_dialog_heading"></h3>
+    </div>
+    <div class="modal-body confirm_dialog_body">
+    </div>
+    <div class="modal-footer">
+        <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+        <button class="button rounded btn-danger confirm_dialog_yes_button"></button>
+    </div>
+</div>

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -194,6 +194,7 @@ def build_custom_checkers(by_lang):
         {'pattern': '[.]html[(]',
          'exclude_pattern': '[.]html[(]("|\'|templates|html|message.content|sub.rendered_description|i18n.t|rendered_|$|[)]|error_text|widget_elem|[$]error|[$][(]"<p>"[)])',
          'exclude': ['static/js/portico', 'static/js/lightbox.js', 'static/js/ui_report.js',
+                     'static/js/confirm_dialog.js',
                      'frontend_tests/'],
          'description': 'Setting HTML content with jQuery .html() can lead to XSS security bugs.  Consider .text() or using rendered_foo as a variable name if content comes from handlebars and thus is already sanitized.'},
         {'pattern': '["\']json/',


### PR DESCRIPTION
This adds a confirmation dialog for deleting user groups.  It builds this on top of a generic confirm_dialog mechanism.

To test: Add a couple groups, which is pretty fast in the Org screens.  Try deleting user groups.  There are multiple ways to cancel/close the dialog, including clicking outside of it, and you should try all those ways.  It's also good to check clicking on on Delete when another confirmation modal is already open (the prior one will close).
