### PR TITLE
message-box: Show zoom-in cursor on hovering over images.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2223,6 +2223,10 @@ div.floating_recipient {
     margin-right: 10px;
 }
 
+.message_inline_image img {
+    cursor: zoom-in;
+}
+
 .rtl .twitter-image img,
 .rtl .message_inline_image img,
 .rtl .message_inline_ref img {


### PR DESCRIPTION
This PR adds a zoom-in cursor to all the images in the message-box container. This makes the UX of clicking on images better and intuitive.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:

<img src="https://cl.ly/8d789d898f69/download/Screen%20Recording%202018-09-13%20at%2004.13%20PM.gif"/>

<hr>


After: 

<img src="https://cl.ly/12c18b66beb9/download/Screen%20Recording%202018-09-13%20at%2004.12%20PM.gif"/>


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
