### PR TITLE
Prevent clicks from closing user profile modal.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -700,7 +700,7 @@ exports.initialize = function () {
         }
 
         // Dismiss popovers if the user has clicked outside them
-        if ($('.popover-inner, .emoji-info-popover, .app-main [class^="column-"].expanded').has(e.target).length === 0) {
+        if ($('.popover-inner, #user-profile-modal, .emoji-info-popover, .app-main [class^="column-"].expanded').has(e.target).length === 0) {
             popovers.hide_all();
         }
 


### PR DESCRIPTION
We have a body-level click handler that closes
all modals if you click outside a modal.  This
code is a bit brittle, because we need to first
check that the element we clicked is not in a modal,
and our markup there isn't entirely consistent.

This is a quick fix that just adds `#user-profile-modal`
as one of the selectors to look for.

Fixes #10500

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
