### PR TITLE
import: Use default description for imported realms.

### DIFF
--- a/zerver/data_import/gitter.py
+++ b/zerver/data_import/gitter.py
@@ -36,7 +36,7 @@ def gitter_workspace_to_realm(domain_name: str, gitter_data: GitterDataT,
     3. user_map, which is a dictionary to map from gitter user id to zulip user id
     """
     NOW = float(timezone_now().timestamp())
-    zerver_realm = build_zerver_realm(realm_id, realm_subdomain, NOW, 'Gitter')  # type: List[ZerverFieldsT]
+    zerver_realm = build_zerver_realm(realm_id, realm_subdomain, NOW)  # type: List[ZerverFieldsT]
     realm = build_realm(zerver_realm, realm_id, domain_name)
 
     zerver_userprofile, avatars, user_map = build_userprofile(int(NOW), domain_name, gitter_data)

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -16,11 +16,9 @@ from zerver.lib.parallel import run_parallel
 # stubs
 ZerverFieldsT = Dict[str, Any]
 
-def build_zerver_realm(realm_id: int, realm_subdomain: str, time: float,
-                       other_product: str) -> List[ZerverFieldsT]:
+def build_zerver_realm(realm_id: int, realm_subdomain: str, time: float) -> List[ZerverFieldsT]:
     realm = Realm(id=realm_id, date_created=time,
-                  name=realm_subdomain, string_id=realm_subdomain,
-                  description=("Organization imported from %s!" % (other_product)))
+                  name=realm_subdomain, string_id=realm_subdomain)
     auth_methods = [[flag[0], flag[1]] for flag in realm.authentication_methods]
     realm_dict = model_to_dict(realm, exclude='authentication_methods')
     realm_dict['authentication_methods'] = auth_methods

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -57,7 +57,7 @@ def slack_workspace_to_realm(domain_name: str, realm_id: int, user_list: List[Ze
     """
     NOW = float(timezone_now().timestamp())
 
-    zerver_realm = build_zerver_realm(realm_id, realm_subdomain, NOW, 'Slack')  # type: List[ZerverFieldsT]
+    zerver_realm = build_zerver_realm(realm_id, realm_subdomain, NOW)  # type: List[ZerverFieldsT]
     realm = build_realm(zerver_realm, realm_id, domain_name)
 
     zerver_userprofile, avatars, added_users, zerver_customprofilefield, \

--- a/zerver/tests/test_gitter_importer.py
+++ b/zerver/tests/test_gitter_importer.py
@@ -65,9 +65,8 @@ class GitterImporter(ZulipTestCase):
 
         realm = read_file('realm.json')
 
-        # test realm
-        self.assertEqual('Organization imported from Gitter!',
-                         realm['zerver_realm'][0]['description'])
+        # test realm exists
+        self.assertTrue(realm['zerver_realm'][0]['allow_edit_history'])
 
         # test users
         exported_user_ids = get_set(realm['zerver_userprofile'], 'id')

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -100,7 +100,7 @@ class SlackImporter(ZulipTestCase):
         realm_id = 2
         realm_subdomain = "test-realm"
         time = float(timezone_now().timestamp())
-        test_realm = build_zerver_realm(realm_id, realm_subdomain, time, 'Slack')  # type: List[Dict[str, Any]]
+        test_realm = build_zerver_realm(realm_id, realm_subdomain, time)  # type: List[Dict[str, Any]]
         test_zerver_realm_dict = test_realm[0]
 
         self.assertEqual(test_zerver_realm_dict['id'], realm_id)
@@ -350,7 +350,8 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(realm['zerver_userpresence'], [])
         self.assertEqual(realm['zerver_stream'], [])
         self.assertEqual(realm['zerver_userprofile'], [])
-        self.assertEqual(realm['zerver_realm'][0]['description'], 'Organization imported from Slack!')
+        # test realm exists
+        self.assertTrue(realm['zerver_realm'][0]['allow_edit_history'])
 
     def test_get_message_sending_user(self) -> None:
         message_with_file = {'subtype': 'file', 'type': 'message',


### PR DESCRIPTION
The current description adds an extra step in the import process, since the admin has to go change the description to something that can be user facing. 