### PR TITLE
stream-settings: Remove unnecessary delete text from button.

### DIFF
--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -19,7 +19,7 @@
             </div>
             <div class="button-group">
                 {{#if is_admin}}
-                <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Delete stream'}}">{{t 'Delete' }} <i class="fa fa-trash-o" aria-hidden="true"></i></button>
+                <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Delete stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
                 {{/if}}
                 <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" title="{{t 'Toggle subscription'}} (S)" {{#unless should_display_subscription_button}}style="display: none"{{/unless}}>
                     {{#if subscribed }}{{#tr oneself }}Unsubscribe{{/tr}}{{else}}{{#tr oneself }}Subscribe{{/tr}}{{/if}}</button>


### PR DESCRIPTION
We are already showing the Delete icon so it's unnecessary to have the "Delete" text. This PR removes the same.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:

![image](https://user-images.githubusercontent.com/2263909/45616279-93a43480-ba8c-11e8-9c21-f448979f3bf5.png)


<hr>

After:

![image](https://user-images.githubusercontent.com/2263909/45616292-9ef76000-ba8c-11e8-810d-f1c72d4e2f87.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
