### PR TITLE
notification: Add a space in narrow to message content.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -502,7 +502,7 @@ exports.received_messages = function (messages) {
 
 function get_message_header(message) {
     if (message.type === "stream") {
-        return message.stream + ">" + message.subject;
+        return message.stream + " > " + message.subject;
     }
     if (message.display_recipient.length > 2) {
         return "group PM with " + message.display_reply_to;


### PR DESCRIPTION
We have a space for this text in other places but somehow we missed this case. This PR fixes the same.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:

![image](https://user-images.githubusercontent.com/2263909/45637150-5d37db00-bac7-11e8-9f73-28a5d9fbb4cf.png)

<hr>

![image](https://user-images.githubusercontent.com/2263909/45637158-6759d980-bac7-11e8-9252-7c3e3418b59b.png)


After:


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
