### PR TITLE
developer docs: Refer to 'zulipbot add' instead of 'zulipbot label'.

### DIFF
--- a/docs/contributing/accessibility.md
+++ b/docs/contributing/accessibility.md
@@ -60,7 +60,7 @@ Problems with Zulip's accessibility should be reported as
 label.  This label can be added by entering the following text in a separate
 comment on the issue:
 
-    @zulipbot label "area: accessibility"
+    @zulipbot add "area: accessibility"
 
 If you want to help make Zulip more accessible, here is a list of the
 [currently open accessibility issues][accessibility-issues].

--- a/docs/contributing/zulipbot-usage.md
+++ b/docs/contributing/zulipbot-usage.md
@@ -28,11 +28,11 @@ to claim; **@zulipbot** will assign you to the issue and label the issue as
     `@zulipbot abandon` to abandon an issue.
 
 * **Label your issues** — Add appropriate labels to issues that you opened by
-including `@zulipbot label` in an issue comment or the body of your issue
+including `@zulipbot add` in an issue comment or the body of your issue
 followed by the desired labels enclosed within double quotes (`""`).
 
     * For example, to add the **bug** and **help wanted** labels to your
-    issue, comment or include `@zulipbot label "bug" "help wanted"` in the
+    issue, comment or include `@zulipbot add "bug" "help wanted"` in the
     issue body.
 
     * You'll receive an error message if you try to add any labels to your issue


### PR DESCRIPTION
These changes are consistent with naming in zulip/zulipbot. See:
- https://github.com/zulip/zulipbot/commit/e29e7eb
- https://github.com/zulip/zulipbot/wiki/Commands#username-add-label-name

@synicalsyntax 