### PR TITLE
integrations: Add support for multiple assignees for Gitlab Issues.

### DIFF
--- a/zerver/webhooks/gitlab/fixtures/issue_closed.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_closed.json
@@ -1,58 +1,73 @@
 {
-   "object_kind":"issue",
-   "user":{
-      "name":"Tomasz Kolek",
-      "username":"tomaszkolek0",
-      "avatar_url":"https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80\u0026d=identicon"
-   },
-   "project":{
-      "name":"my-awesome-project",
-      "description":"",
-      "web_url":"https://gitlab.com/tomaszkolek0/my-awesome-project",
-      "avatar_url":null,
-      "git_ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "git_http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git",
-      "namespace":"tomaszkolek0",
-      "visibility_level":0,
-      "path_with_namespace":"tomaszkolek0/my-awesome-project",
-      "default_branch":"master",
-      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project",
-      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git"
-   },
-   "object_attributes":{
-      "id":2788274,
-      "title":"Issue title_new",
-      "assignee_id":670043,
-      "author_id":670043,
-      "project_id":1534233,
-      "created_at":"2016-08-18 17:47:36 UTC",
-      "updated_at":"2016-08-18 18:14:13 UTC",
-      "position":0,
-      "branch_name":null,
-      "description":"Issue description",
-      "milestone_id":null,
-      "state":"closed",
-      "iid":1,
-      "updated_by_id":670043,
-      "weight":3,
-      "confidential":false,
-      "moved_to_id":null,
-      "deleted_at":null,
-      "due_date":"2016-08-01",
-      "url":"https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1",
-      "action":"close"
-   },
-   "repository":{
-      "name":"my-awesome-project",
-      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "description":"",
-      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project"
-   },
-   "assignee":{
-      "name":"Tomasz Kolek",
-      "username":"tomaszkolek0",
-      "avatar_url":"https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80\u0026d=identicon"
-   }
-}
+    "object_kind": "issue",
+    "event_type": "issue",
+    "user": {
+      "name": "Adam Birds",
+      "username": "adambirds",
+      "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+    },
+    "project": {
+      "id": 8427506,
+      "name": "Zulip GitLab Test",
+      "description": "",
+      "web_url": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "git_http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git",
+      "namespace": "adambirds",
+      "visibility_level": 20,
+      "path_with_namespace": "adambirds/zulip-gitlab-test",
+      "default_branch": null,
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git"
+    },
+    "object_attributes": {
+      "author_id": 1102929,
+      "closed_at": "2018-09-17 21:11:31 UTC",
+      "confidential": false,
+      "created_at": "2018-09-17 21:03:26 UTC",
+      "description": "Zulip Test Issue 3",
+      "due_date": null,
+      "id": 14226189,
+      "iid": 3,
+      "last_edited_at": null,
+      "last_edited_by_id": null,
+      "milestone_id": null,
+      "moved_to_id": null,
+      "project_id": 8427506,
+      "relative_position": 1073743323,
+      "state": "closed",
+      "time_estimate": 0,
+      "title": "Zulip Test Issue 3",
+      "updated_at": "2018-09-17 21:11:31 UTC",
+      "updated_by_id": null,
+      "weight": null,
+      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/3",
+      "total_time_spent": 0,
+      "human_total_time_spent": null,
+      "human_time_estimate": null,
+      "assignee_ids": [],
+      "assignee_id": null,
+      "action": "close"
+    },
+    "labels": [],
+    "changes": {
+      "updated_at": {
+        "previous": "2018-09-17 21:11:31 UTC",
+        "current": "2018-09-17 21:11:31 UTC"
+      },
+      "total_time_spent": {
+        "previous": null,
+        "current": 0
+      }
+    },
+    "repository": {
+      "name": "Zulip GitLab Test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "description": "",
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test"
+    }
+  }

--- a/zerver/webhooks/gitlab/fixtures/issue_created_with_hidden_comment_in_description.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_created_with_hidden_comment_in_description.json
@@ -1,67 +1,109 @@
 {
     "object_kind": "issue",
+    "event_type": "issue",
     "user": {
-        "name": "Eeshan Garg",
-        "username": "eeshangarg",
-        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+      "name": "Adam Birds",
+      "username": "adambirds",
+      "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
     },
     "project": {
-        "id": 3319013,
-        "name": "public-repo",
-        "description": null,
-        "web_url": "https://gitlab.com/eeshangarg/public-repo",
-        "avatar_url": null,
-        "git_ssh_url": "git@gitlab.com:eeshangarg/public-repo.git",
-        "git_http_url": "https://gitlab.com/eeshangarg/public-repo.git",
-        "namespace": "eeshangarg",
-        "visibility_level": 0,
-        "path_with_namespace": "eeshangarg/public-repo",
-        "default_branch": "changes",
-        "ci_config_path": null,
-        "homepage": "https://gitlab.com/eeshangarg/public-repo",
-        "url": "git@gitlab.com:eeshangarg/public-repo.git",
-        "ssh_url": "git@gitlab.com:eeshangarg/public-repo.git",
-        "http_url": "https://gitlab.com/eeshangarg/public-repo.git"
+      "id": 8427506,
+      "name": "Zulip GitLab Test",
+      "description": "",
+      "web_url": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "git_http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git",
+      "namespace": "adambirds",
+      "visibility_level": 20,
+      "path_with_namespace": "adambirds/zulip-gitlab-test",
+      "default_branch": null,
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git"
     },
     "object_attributes": {
-        "author_id": 1129123,
-        "closed_at": null,
-        "confidential": false,
-        "created_at": "2018-01-24 00:47:44 UTC",
-        "description": "This description actually has a hidden comment in it!\n\n<!-- This is\na multiline\ncomment -->\n\n<!-- one line comment -->\n\n<!--\nanother\nmultiline\ncomment\n-->",
-        "due_date": null,
-        "id": 8816601,
-        "iid": 3,
-        "last_edited_at": null,
-        "last_edited_by_id": null,
-        "milestone_id": null,
-        "moved_to_id": null,
-        "project_id": 3319013,
-        "relative_position": 1073743323,
-        "state": "opened",
-        "time_estimate": 0,
-        "title": "New Issue with hidden comment",
-        "updated_at": "2018-01-24 00:47:44 UTC",
-        "updated_by_id": null,
-        "url": "https://gitlab.com/eeshangarg/public-repo/issues/3",
-        "total_time_spent": 0,
-        "human_total_time_spent": null,
-        "human_time_estimate": null,
-        "assignee_ids": [],
-        "assignee_id": null,
-        "action": "open"
+      "author_id": 1102929,
+      "closed_at": null,
+      "confidential": false,
+      "created_at": "2018-09-17 21:03:26 UTC",
+      "description": "This description actually has a hidden comment in it!\n\n<!-- This is\na multiline\ncomment -->\n\n<!-- one line comment -->\n\n<!--\nanother\nmultiline\ncomment\n-->",
+      "due_date": null,
+      "id": 14226189,
+      "iid": 3,
+      "last_edited_at": null,
+      "last_edited_by_id": null,
+      "milestone_id": null,
+      "moved_to_id": null,
+      "project_id": 8427506,
+      "relative_position": 1073743323,
+      "state": "opened",
+      "time_estimate": 0,
+      "title": "Zulip Test Issue 3",
+      "updated_at": "2018-09-17 21:03:26 UTC",
+      "updated_by_id": null,
+      "weight": null,
+      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/3",
+      "total_time_spent": 0,
+      "human_total_time_spent": null,
+      "human_time_estimate": null,
+      "assignee_ids": [],
+      "assignee_id": null,
+      "action": "open"
     },
     "labels": [],
     "changes": {
-        "total_time_spent": {
-            "previous": null,
-            "current": 0
-        }
+      "author_id": {
+        "previous": null,
+        "current": 1102929
+      },
+      "created_at": {
+        "previous": null,
+        "current": "2018-09-17 21:03:26 UTC"
+      },
+      "description": {
+        "previous": null,
+        "current": "Zulip Test Issue 3"
+      },
+      "id": {
+        "previous": null,
+        "current": 14226189
+      },
+      "iid": {
+        "previous": null,
+        "current": 3
+      },
+      "project_id": {
+        "previous": null,
+        "current": 8427506
+      },
+      "relative_position": {
+        "previous": null,
+        "current": 1073743323
+      },
+      "state": {
+        "previous": null,
+        "current": "opened"
+      },
+      "title": {
+        "previous": null,
+        "current": "Zulip Test Issue 3"
+      },
+      "updated_at": {
+        "previous": null,
+        "current": "2018-09-17 21:03:26 UTC"
+      },
+      "total_time_spent": {
+        "previous": null,
+        "current": 0
+      }
     },
     "repository": {
-        "name": "public-repo",
-        "url": "git@gitlab.com:eeshangarg/public-repo.git",
-        "description": null,
-        "homepage": "https://gitlab.com/eeshangarg/public-repo"
+      "name": "Zulip GitLab Test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "description": "",
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test"
     }
-}
+  }

--- a/zerver/webhooks/gitlab/fixtures/issue_created_with_ten_assignees.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_created_with_ten_assignees.json
@@ -1,0 +1,219 @@
+{
+    "object_kind": "issue",
+    "event_type": "issue",
+    "user": {
+      "name": "Adam Birds",
+      "username": "adambirds",
+      "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+    },
+    "project": {
+      "id": 8427506,
+      "name": "Zulip GitLab Test",
+      "description": "",
+      "web_url": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "git_http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git",
+      "namespace": "adambirds",
+      "visibility_level": 20,
+      "path_with_namespace": "adambirds/zulip-gitlab-test",
+      "default_branch": null,
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git"
+    },
+    "object_attributes": {
+      "author_id": 1102929,
+      "closed_at": null,
+      "confidential": false,
+      "created_at": "2018-09-17 21:01:30 UTC",
+      "description": "Zulip Test Issue 2",
+      "due_date": null,
+      "id": 14226169,
+      "iid": 2,
+      "last_edited_at": null,
+      "last_edited_by_id": null,
+      "milestone_id": null,
+      "moved_to_id": null,
+      "project_id": 8427506,
+      "relative_position": 1073742823,
+      "state": "opened",
+      "time_estimate": 0,
+      "title": "Zulip Test Issue 2",
+      "updated_at": "2018-09-17 21:01:30 UTC",
+      "updated_by_id": null,
+      "weight": null,
+      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/2",
+      "total_time_spent": 0,
+      "human_total_time_spent": null,
+      "human_time_estimate": null,
+      "assignee_ids": [
+        1102929,
+        1129123
+      ],
+      "assignee_id": 1102929,
+      "action": "open"
+    },
+    "labels": [],
+    "changes": {
+      "author_id": {
+        "previous": null,
+        "current": 1102929
+      },
+      "created_at": {
+        "previous": null,
+        "current": "2018-09-17 21:01:30 UTC"
+      },
+      "description": {
+        "previous": null,
+        "current": "Zulip Test Issue 2"
+      },
+      "id": {
+        "previous": null,
+        "current": 14226169
+      },
+      "iid": {
+        "previous": null,
+        "current": 2
+      },
+      "project_id": {
+        "previous": null,
+        "current": 8427506
+      },
+      "relative_position": {
+        "previous": null,
+        "current": 1073742823
+      },
+      "state": {
+        "previous": null,
+        "current": "opened"
+      },
+      "title": {
+        "previous": null,
+        "current": "Zulip Test Issue 2"
+      },
+      "updated_at": {
+        "previous": null,
+        "current": "2018-09-17 21:01:30 UTC"
+      },
+      "assignees": {
+        "previous": [],
+        "current": [
+          {
+            "name": "Adam Birds",
+            "username": "adambirds",
+            "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+          },
+          {
+            "name": "Eeshan Garg",
+            "username": "eeshangarg",
+            "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+          },
+          {
+            "name": "Tim Abbott",
+            "username": "timabbott",
+            "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+          },
+          {
+            "name": "Adam Birds",
+            "username": "adambirds",
+            "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+          },
+          {
+            "name": "Eeshan Garg",
+            "username": "eeshangarg",
+            "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+          },
+          {
+            "name": "Tim Abbott",
+            "username": "timabbott",
+            "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+          },
+          {
+            "name": "Adam Birds",
+            "username": "adambirds",
+            "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+          },
+          {
+            "name": "Eeshan Garg",
+            "username": "eeshangarg",
+            "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+          },
+          {
+            "name": "Tim Abbott",
+            "username": "timabbott",
+            "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+          },
+          {
+            "name": "Tim Abbott",
+            "username": "timabbott",
+            "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+          }
+        ]
+      },
+      "total_time_spent": {
+        "previous": null,
+        "current": 0
+      }
+    },
+    "repository": {
+      "name": "Zulip GitLab Test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "description": "",
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test"
+    },
+    "assignees": [
+      {
+        "name": "Adam Birds",
+        "username": "adambirds",
+        "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+      },
+      {
+        "name": "Eeshan Garg",
+        "username": "eeshangarg",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+      },
+      {
+        "name": "Tim Abbott",
+        "username": "timabbott",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+      },
+      {
+        "name": "Adam Birds",
+        "username": "adambirds",
+        "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+      },
+      {
+        "name": "Eeshan Garg",
+        "username": "eeshangarg",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+      },
+      {
+        "name": "Tim Abbott",
+        "username": "timabbott",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+      },
+      {
+        "name": "Adam Birds",
+        "username": "adambirds",
+        "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+      },
+      {
+        "name": "Eeshan Garg",
+        "username": "eeshangarg",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+      },
+      {
+        "name": "Tim Abbott",
+        "username": "timabbott",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+      },
+      {
+        "name": "Tim Abbott",
+        "username": "timabbott",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+      }
+    ]
+  }

--- a/zerver/webhooks/gitlab/fixtures/issue_created_with_three_assignees.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_created_with_three_assignees.json
@@ -28,29 +28,30 @@
       "author_id": 1102929,
       "closed_at": null,
       "confidential": false,
-      "created_at": "2018-09-17 21:00:09 UTC",
-      "description": "Zulip Test Issue",
+      "created_at": "2018-09-17 21:01:30 UTC",
+      "description": "Zulip Test Issue 2",
       "due_date": null,
-      "id": 14226153,
-      "iid": 1,
+      "id": 14226169,
+      "iid": 2,
       "last_edited_at": null,
       "last_edited_by_id": null,
       "milestone_id": null,
       "moved_to_id": null,
       "project_id": 8427506,
-      "relative_position": 1073742323,
+      "relative_position": 1073742823,
       "state": "opened",
       "time_estimate": 0,
-      "title": "Zulip Test Issue",
-      "updated_at": "2018-09-17 21:00:09 UTC",
+      "title": "Zulip Test Issue 2",
+      "updated_at": "2018-09-17 21:01:30 UTC",
       "updated_by_id": null,
       "weight": null,
-      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/1",
+      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/2",
       "total_time_spent": 0,
       "human_total_time_spent": null,
       "human_time_estimate": null,
       "assignee_ids": [
-        1102929
+        1102929,
+        1129123
       ],
       "assignee_id": 1102929,
       "action": "open"
@@ -63,19 +64,19 @@
       },
       "created_at": {
         "previous": null,
-        "current": "2018-09-17 21:00:09 UTC"
+        "current": "2018-09-17 21:01:30 UTC"
       },
       "description": {
         "previous": null,
-        "current": "Zulip Test Issue"
+        "current": "Zulip Test Issue 2"
       },
       "id": {
         "previous": null,
-        "current": 14226153
+        "current": 14226169
       },
       "iid": {
         "previous": null,
-        "current": 1
+        "current": 2
       },
       "project_id": {
         "previous": null,
@@ -83,7 +84,7 @@
       },
       "relative_position": {
         "previous": null,
-        "current": 1073742323
+        "current": 1073742823
       },
       "state": {
         "previous": null,
@@ -91,11 +92,11 @@
       },
       "title": {
         "previous": null,
-        "current": "Zulip Test Issue"
+        "current": "Zulip Test Issue 2"
       },
       "updated_at": {
         "previous": null,
-        "current": "2018-09-17 21:00:09 UTC"
+        "current": "2018-09-17 21:01:30 UTC"
       },
       "assignees": {
         "previous": [],
@@ -104,6 +105,16 @@
             "name": "Adam Birds",
             "username": "adambirds",
             "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+          },
+          {
+            "name": "Eeshan Garg",
+            "username": "eeshangarg",
+            "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+          },
+          {
+            "name": "Tim Abbott",
+            "username": "timabbott",
+            "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
           }
         ]
       },
@@ -123,6 +134,16 @@
         "name": "Adam Birds",
         "username": "adambirds",
         "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+      },
+      {
+        "name": "Eeshan Garg",
+        "username": "eeshangarg",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
+      },
+      {
+        "name": "Tim Abbott",
+        "username": "timabbott",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
       }
     ]
   }

--- a/zerver/webhooks/gitlab/fixtures/issue_created_with_two_assignees.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_created_with_two_assignees.json
@@ -28,29 +28,30 @@
       "author_id": 1102929,
       "closed_at": null,
       "confidential": false,
-      "created_at": "2018-09-17 21:00:09 UTC",
-      "description": "Zulip Test Issue",
+      "created_at": "2018-09-17 21:01:30 UTC",
+      "description": "Zulip Test Issue 2",
       "due_date": null,
-      "id": 14226153,
-      "iid": 1,
+      "id": 14226169,
+      "iid": 2,
       "last_edited_at": null,
       "last_edited_by_id": null,
       "milestone_id": null,
       "moved_to_id": null,
       "project_id": 8427506,
-      "relative_position": 1073742323,
+      "relative_position": 1073742823,
       "state": "opened",
       "time_estimate": 0,
-      "title": "Zulip Test Issue",
-      "updated_at": "2018-09-17 21:00:09 UTC",
+      "title": "Zulip Test Issue 2",
+      "updated_at": "2018-09-17 21:01:30 UTC",
       "updated_by_id": null,
       "weight": null,
-      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/1",
+      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/2",
       "total_time_spent": 0,
       "human_total_time_spent": null,
       "human_time_estimate": null,
       "assignee_ids": [
-        1102929
+        1102929,
+        1129123
       ],
       "assignee_id": 1102929,
       "action": "open"
@@ -63,19 +64,19 @@
       },
       "created_at": {
         "previous": null,
-        "current": "2018-09-17 21:00:09 UTC"
+        "current": "2018-09-17 21:01:30 UTC"
       },
       "description": {
         "previous": null,
-        "current": "Zulip Test Issue"
+        "current": "Zulip Test Issue 2"
       },
       "id": {
         "previous": null,
-        "current": 14226153
+        "current": 14226169
       },
       "iid": {
         "previous": null,
-        "current": 1
+        "current": 2
       },
       "project_id": {
         "previous": null,
@@ -83,7 +84,7 @@
       },
       "relative_position": {
         "previous": null,
-        "current": 1073742323
+        "current": 1073742823
       },
       "state": {
         "previous": null,
@@ -91,11 +92,11 @@
       },
       "title": {
         "previous": null,
-        "current": "Zulip Test Issue"
+        "current": "Zulip Test Issue 2"
       },
       "updated_at": {
         "previous": null,
-        "current": "2018-09-17 21:00:09 UTC"
+        "current": "2018-09-17 21:01:30 UTC"
       },
       "assignees": {
         "previous": [],
@@ -104,6 +105,11 @@
             "name": "Adam Birds",
             "username": "adambirds",
             "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+          },
+          {
+            "name": "Eeshan Garg",
+            "username": "eeshangarg",
+            "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
           }
         ]
       },
@@ -123,6 +129,11 @@
         "name": "Adam Birds",
         "username": "adambirds",
         "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+      },
+      {
+        "name": "Eeshan Garg",
+        "username": "eeshangarg",
+        "avatar_url": "https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80&d=identicon"
       }
     ]
   }

--- a/zerver/webhooks/gitlab/fixtures/issue_created_without_assignee.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_created_without_assignee.json
@@ -1,53 +1,109 @@
 {
-   "object_kind":"issue",
-   "user":{
-      "name":"Tomasz Kolek",
-      "username":"tomaszkolek0",
-      "avatar_url":"https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80\u0026d=identicon"
-   },
-   "project":{
-      "name":"my-awesome-project",
-      "description":"",
-      "web_url":"https://gitlab.com/tomaszkolek0/my-awesome-project",
-      "avatar_url":null,
-      "git_ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "git_http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git",
-      "namespace":"tomaszkolek0",
-      "visibility_level":0,
-      "path_with_namespace":"tomaszkolek0/my-awesome-project",
-      "default_branch":"master",
-      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project",
-      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git"
-   },
-   "object_attributes":{
-      "id":2788274,
-      "title":"Issue title",
-      "assignee_id":670043,
-      "author_id":670043,
-      "project_id":1534233,
-      "created_at":"2016-08-18 17:47:36 UTC",
-      "updated_at":"2016-08-18 17:47:36 UTC",
-      "position":0,
-      "branch_name":null,
-      "description":"Issue description",
-      "milestone_id":null,
-      "state":"opened",
-      "iid":1,
-      "updated_by_id":null,
-      "weight":3,
-      "confidential":false,
-      "moved_to_id":null,
-      "deleted_at":null,
-      "due_date":"2016-08-01",
-      "url":"https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1",
-      "action":"open"
-   },
-   "repository":{
-      "name":"my-awesome-project",
-      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "description":"",
-      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project"
-   }
-}
+    "object_kind": "issue",
+    "event_type": "issue",
+    "user": {
+      "name": "Adam Birds",
+      "username": "adambirds",
+      "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+    },
+    "project": {
+      "id": 8427506,
+      "name": "Zulip GitLab Test",
+      "description": "",
+      "web_url": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "git_http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git",
+      "namespace": "adambirds",
+      "visibility_level": 20,
+      "path_with_namespace": "adambirds/zulip-gitlab-test",
+      "default_branch": null,
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git"
+    },
+    "object_attributes": {
+      "author_id": 1102929,
+      "closed_at": null,
+      "confidential": false,
+      "created_at": "2018-09-17 21:03:26 UTC",
+      "description": "Zulip Test Issue 3",
+      "due_date": null,
+      "id": 14226189,
+      "iid": 3,
+      "last_edited_at": null,
+      "last_edited_by_id": null,
+      "milestone_id": null,
+      "moved_to_id": null,
+      "project_id": 8427506,
+      "relative_position": 1073743323,
+      "state": "opened",
+      "time_estimate": 0,
+      "title": "Zulip Test Issue 3",
+      "updated_at": "2018-09-17 21:03:26 UTC",
+      "updated_by_id": null,
+      "weight": null,
+      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/3",
+      "total_time_spent": 0,
+      "human_total_time_spent": null,
+      "human_time_estimate": null,
+      "assignee_ids": [],
+      "assignee_id": null,
+      "action": "open"
+    },
+    "labels": [],
+    "changes": {
+      "author_id": {
+        "previous": null,
+        "current": 1102929
+      },
+      "created_at": {
+        "previous": null,
+        "current": "2018-09-17 21:03:26 UTC"
+      },
+      "description": {
+        "previous": null,
+        "current": "Zulip Test Issue 3"
+      },
+      "id": {
+        "previous": null,
+        "current": 14226189
+      },
+      "iid": {
+        "previous": null,
+        "current": 3
+      },
+      "project_id": {
+        "previous": null,
+        "current": 8427506
+      },
+      "relative_position": {
+        "previous": null,
+        "current": 1073743323
+      },
+      "state": {
+        "previous": null,
+        "current": "opened"
+      },
+      "title": {
+        "previous": null,
+        "current": "Zulip Test Issue 3"
+      },
+      "updated_at": {
+        "previous": null,
+        "current": "2018-09-17 21:03:26 UTC"
+      },
+      "total_time_spent": {
+        "previous": null,
+        "current": 0
+      }
+    },
+    "repository": {
+      "name": "Zulip GitLab Test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "description": "",
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test"
+    }
+  }

--- a/zerver/webhooks/gitlab/fixtures/issue_opened_with_null_description.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_opened_with_null_description.json
@@ -1,71 +1,109 @@
 {
-    "object_kind":"issue",
-    "user":{
-        "name":"Eeshan Garg",
-        "username":"eeshangarg",
-        "avatar_url":"https://secure.gravatar.com/avatar/cd181af88d928dab53c55600c9f7551d?s=80\u0026d=identicon"
+    "object_kind": "issue",
+    "event_type": "issue",
+    "user": {
+      "name": "Adam Birds",
+      "username": "adambirds",
+      "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
     },
-    "project":{
-        "id":3319043,
-        "name":"my-awesome-project",
-        "description":"",
-        "web_url":"https://gitlab.com/eeshangarg/my-awesome-project",
-        "avatar_url":null,
-        "git_ssh_url":"git@gitlab.com:eeshangarg/my-awesome-project.git",
-        "git_http_url":"https://gitlab.com/eeshangarg/my-awesome-project.git",
-        "namespace":"eeshangarg",
-        "visibility_level":20,
-        "path_with_namespace":"eeshangarg/my-awesome-project",
-        "default_branch":"feature",
-        "ci_config_path":null,
-        "homepage":"https://gitlab.com/eeshangarg/my-awesome-project",
-        "url":"git@gitlab.com:eeshangarg/my-awesome-project.git",
-        "ssh_url":"git@gitlab.com:eeshangarg/my-awesome-project.git",
-        "http_url":"https://gitlab.com/eeshangarg/my-awesome-project.git"
+    "project": {
+      "id": 8427506,
+      "name": "Zulip GitLab Test",
+      "description": "",
+      "web_url": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "git_http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git",
+      "namespace": "adambirds",
+      "visibility_level": 20,
+      "path_with_namespace": "adambirds/zulip-gitlab-test",
+      "default_branch": null,
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git"
     },
-    "object_attributes":{
-        "author_id":1129123,
-        "closed_at":null,
-        "confidential":false,
-        "created_at":"2018-03-23 17:35:53 UTC",
-        "description":null,
-        "due_date":null,
-        "id":9892394,
-        "iid":7,
-        "last_edited_at":null,
-        "last_edited_by_id":null,
-        "milestone_id":null,
-        "moved_to_id":null,
-        "project_id":3319043,
-        "relative_position":1073745323,
-        "state":"opened",
-        "time_estimate":0,
-        "title":"Issue without description",
-        "updated_at":"2018-03-23 17:35:53 UTC",
-        "updated_by_id":null,
-        "url":"https://gitlab.com/eeshangarg/my-awesome-project/issues/7",
-        "total_time_spent":0,
-        "human_total_time_spent":null,
-        "human_time_estimate":null,
-        "assignee_ids":[
-
-        ],
-        "assignee_id":null,
-        "action":"open"
+    "object_attributes": {
+      "author_id": 1102929,
+      "closed_at": null,
+      "confidential": false,
+      "created_at": "2018-09-17 21:03:26 UTC",
+      "description":null,
+      "due_date": null,
+      "id": 14226189,
+      "iid": 3,
+      "last_edited_at": null,
+      "last_edited_by_id": null,
+      "milestone_id": null,
+      "moved_to_id": null,
+      "project_id": 8427506,
+      "relative_position": 1073743323,
+      "state": "opened",
+      "time_estimate": 0,
+      "title": "Zulip Test Issue 3",
+      "updated_at": "2018-09-17 21:03:26 UTC",
+      "updated_by_id": null,
+      "weight": null,
+      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/3",
+      "total_time_spent": 0,
+      "human_total_time_spent": null,
+      "human_time_estimate": null,
+      "assignee_ids": [],
+      "assignee_id": null,
+      "action": "open"
     },
-    "labels":[
-
-    ],
-    "changes":{
-        "total_time_spent":{
-            "previous":null,
-            "current":0
-        }
+    "labels": [],
+    "changes": {
+      "author_id": {
+        "previous": null,
+        "current": 1102929
+      },
+      "created_at": {
+        "previous": null,
+        "current": "2018-09-17 21:03:26 UTC"
+      },
+      "description": {
+        "previous": null,
+        "current": "Zulip Test Issue 3"
+      },
+      "id": {
+        "previous": null,
+        "current": 14226189
+      },
+      "iid": {
+        "previous": null,
+        "current": 3
+      },
+      "project_id": {
+        "previous": null,
+        "current": 8427506
+      },
+      "relative_position": {
+        "previous": null,
+        "current": 1073743323
+      },
+      "state": {
+        "previous": null,
+        "current": "opened"
+      },
+      "title": {
+        "previous": null,
+        "current": "Zulip Test Issue 3"
+      },
+      "updated_at": {
+        "previous": null,
+        "current": "2018-09-17 21:03:26 UTC"
+      },
+      "total_time_spent": {
+        "previous": null,
+        "current": 0
+      }
     },
-    "repository":{
-        "name":"my-awesome-project",
-        "url":"git@gitlab.com:eeshangarg/my-awesome-project.git",
-        "description":"",
-        "homepage":"https://gitlab.com/eeshangarg/my-awesome-project"
+    "repository": {
+      "name": "Zulip GitLab Test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "description": "",
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test"
     }
-}
+  }

--- a/zerver/webhooks/gitlab/fixtures/issue_reopened.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_reopened.json
@@ -1,58 +1,81 @@
 {
-   "object_kind":"issue",
-   "user":{
-      "name":"Tomasz Kolek",
-      "username":"tomaszkolek0",
-      "avatar_url":"https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80\u0026d=identicon"
-   },
-   "project":{
-      "name":"my-awesome-project",
-      "description":"",
-      "web_url":"https://gitlab.com/tomaszkolek0/my-awesome-project",
-      "avatar_url":null,
-      "git_ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "git_http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git",
-      "namespace":"tomaszkolek0",
-      "visibility_level":0,
-      "path_with_namespace":"tomaszkolek0/my-awesome-project",
-      "default_branch":"master",
-      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project",
-      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git"
-   },
-   "object_attributes":{
-      "id":2788274,
-      "title":"Issue title_new",
-      "assignee_id":670043,
-      "author_id":670043,
-      "project_id":1534233,
-      "created_at":"2016-08-18 17:47:36 UTC",
-      "updated_at":"2016-08-18 18:15:07 UTC",
-      "position":0,
-      "branch_name":null,
-      "description":"Issue description",
-      "milestone_id":null,
-      "state":"reopened",
-      "iid":1,
-      "updated_by_id":670043,
-      "weight":3,
-      "confidential":false,
-      "moved_to_id":null,
-      "deleted_at":null,
-      "due_date":"2016-08-01",
-      "url":"https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1",
-      "action":"reopen"
-   },
-   "repository":{
-      "name":"my-awesome-project",
-      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "description":"",
-      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project"
-   },
-   "assignee":{
-      "name":"Tomasz Kolek",
-      "username":"tomaszkolek0",
-      "avatar_url":"https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80\u0026d=identicon"
-   }
-}
+    "object_kind": "issue",
+    "event_type": "issue",
+    "user": {
+      "name": "Adam Birds",
+      "username": "adambirds",
+      "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+    },
+    "project": {
+      "id": 8427506,
+      "name": "Zulip GitLab Test",
+      "description": "",
+      "web_url": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "git_http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git",
+      "namespace": "adambirds",
+      "visibility_level": 20,
+      "path_with_namespace": "adambirds/zulip-gitlab-test",
+      "default_branch": null,
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git"
+    },
+    "object_attributes": {
+      "author_id": 1102929,
+      "closed_at": null,
+      "confidential": false,
+      "created_at": "2018-09-17 21:03:26 UTC",
+      "description": "Zulip Test Issue 3",
+      "due_date": null,
+      "id": 14226189,
+      "iid": 3,
+      "last_edited_at": null,
+      "last_edited_by_id": null,
+      "milestone_id": null,
+      "moved_to_id": null,
+      "project_id": 8427506,
+      "relative_position": 1073743323,
+      "state": "opened",
+      "time_estimate": 0,
+      "title": "Zulip Test Issue 3",
+      "updated_at": "2018-09-17 21:11:36 UTC",
+      "updated_by_id": null,
+      "weight": null,
+      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/3",
+      "total_time_spent": 0,
+      "human_total_time_spent": null,
+      "human_time_estimate": null,
+      "assignee_ids": [],
+      "assignee_id": null,
+      "action": "reopen"
+    },
+    "labels": [],
+    "changes": {
+      "closed_at": {
+        "previous": "2018-09-17 21:11:31 UTC",
+        "current": null
+      },
+      "state": {
+        "previous": "closed",
+        "current": "opened"
+      },
+      "updated_at": {
+        "previous": "2018-09-17 21:11:31 UTC",
+        "current": "2018-09-17 21:11:36 UTC"
+      },
+      "total_time_spent": {
+        "previous": null,
+        "current": 0
+      }
+    },
+    "repository": {
+      "name": "Zulip GitLab Test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "description": "",
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test"
+    }
+  }

--- a/zerver/webhooks/gitlab/fixtures/issue_updated.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_updated.json
@@ -1,58 +1,85 @@
 {
-   "object_kind":"issue",
-   "user":{
-      "name":"Tomasz Kolek",
-      "username":"tomaszkolek0",
-      "avatar_url":"https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80\u0026d=identicon"
-   },
-   "project":{
-      "name":"my-awesome-project",
-      "description":"",
-      "web_url":"https://gitlab.com/tomaszkolek0/my-awesome-project",
-      "avatar_url":null,
-      "git_ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "git_http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git",
-      "namespace":"tomaszkolek0",
-      "visibility_level":0,
-      "path_with_namespace":"tomaszkolek0/my-awesome-project",
-      "default_branch":"master",
-      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project",
-      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git"
-   },
-   "object_attributes":{
-      "id":2788274,
-      "title":"Issue title_new",
-      "assignee_id":670043,
-      "author_id":670043,
-      "project_id":1534233,
-      "created_at":"2016-08-18 17:47:36 UTC",
-      "updated_at":"2016-08-18 17:56:30 UTC",
-      "position":0,
-      "branch_name":null,
-      "description":"Issue description",
-      "milestone_id":null,
-      "state":"opened",
-      "iid":1,
-      "updated_by_id":670043,
-      "weight":3,
-      "confidential":false,
-      "moved_to_id":null,
-      "deleted_at":null,
-      "due_date":"2016-08-01",
-      "url":"https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1",
-      "action":"update"
-   },
-   "repository":{
-      "name":"my-awesome-project",
-      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
-      "description":"",
-      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project"
-   },
-   "assignee":{
-      "name":"Tomasz Kolek",
-      "username":"tomaszkolek0",
-      "avatar_url":"https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80\u0026d=identicon"
-   }
-}
+    "object_kind": "issue",
+    "event_type": "issue",
+    "user": {
+      "name": "Adam Birds",
+      "username": "adambirds",
+      "avatar_url": "https://secure.gravatar.com/avatar/1e00d93acdfdddc06304143a1dfcd0b4?s=80&d=identicon"
+    },
+    "project": {
+      "id": 8427506,
+      "name": "Zulip GitLab Test",
+      "description": "",
+      "web_url": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "git_http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git",
+      "namespace": "adambirds",
+      "visibility_level": 20,
+      "path_with_namespace": "adambirds/zulip-gitlab-test",
+      "default_branch": null,
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "ssh_url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "http_url": "https://gitlab.com/adambirds/zulip-gitlab-test.git"
+    },
+    "object_attributes": {
+      "author_id": 1102929,
+      "closed_at": null,
+      "confidential": false,
+      "created_at": "2018-09-17 21:03:26 UTC",
+      "description": "Zulip Test Issue 3 - Updated",
+      "due_date": null,
+      "id": 14226189,
+      "iid": 3,
+      "last_edited_at": "2018-09-17 21:13:41 UTC",
+      "last_edited_by_id": 1102929,
+      "milestone_id": null,
+      "moved_to_id": null,
+      "project_id": 8427506,
+      "relative_position": 1073743323,
+      "state": "opened",
+      "time_estimate": 0,
+      "title": "Zulip Test Issue 3",
+      "updated_at": "2018-09-17 21:13:41 UTC",
+      "updated_by_id": 1102929,
+      "weight": null,
+      "url": "https://gitlab.com/adambirds/zulip-gitlab-test/issues/3",
+      "total_time_spent": 0,
+      "human_total_time_spent": null,
+      "human_time_estimate": null,
+      "assignee_ids": [],
+      "assignee_id": null,
+      "action": "update"
+    },
+    "labels": [],
+    "changes": {
+      "description": {
+        "previous": "Zulip Test Issue 3",
+        "current": "Zulip Test Issue 3 - Updated"
+      },
+      "last_edited_at": {
+        "previous": null,
+        "current": "2018-09-17 21:13:41 UTC"
+      },
+      "last_edited_by_id": {
+        "previous": null,
+        "current": 1102929
+      },
+      "updated_at": {
+        "previous": "2018-09-17 21:11:36 UTC",
+        "current": "2018-09-17 21:13:41 UTC"
+      },
+      "updated_by_id": {
+        "previous": null,
+        "current": 1102929
+      }
+    },
+    "repository": {
+      "name": "Zulip GitLab Test",
+      "url": "git@gitlab.com:adambirds/zulip-gitlab-test.git",
+      "description": "",
+      "homepage": "https://gitlab.com/adambirds/zulip-gitlab-test"
+    }
+  }

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -92,8 +92,8 @@ class GitlabHookTests(WebhookTestCase):
         )
 
     def test_create_issue_without_assignee_event_message(self) -> None:
-        expected_subject = u"my-awesome-project / Issue #1 Issue title"
-        expected_message = u"Tomasz Kolek created [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)\n\n~~~ quote\nIssue description\n~~~"
+        expected_subject = u"Zulip GitLab Test / Issue #3 Zulip Test Issue 3"
+        expected_message = u"Adam Birds created [Issue #3](https://gitlab.com/adambirds/zulip-gitlab-test/issues/3)\n\n~~~ quote\nZulip Test Issue 3\n~~~"
 
         self.send_and_test_stream_message(
             'issue_created_without_assignee',
@@ -105,7 +105,7 @@ class GitlabHookTests(WebhookTestCase):
     def test_create_issue_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic='notifications')
         expected_subject = u"notifications"
-        expected_message = u"Tomasz Kolek created [Issue #1 Issue title](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)\n\n~~~ quote\nIssue description\n~~~"
+        expected_message = u"Adam Birds created [Issue #3 Zulip Test Issue 3](https://gitlab.com/adambirds/zulip-gitlab-test/issues/3)\n\n~~~ quote\nZulip Test Issue 3\n~~~"
 
         self.send_and_test_stream_message(
             'issue_created_without_assignee',
@@ -115,8 +115,8 @@ class GitlabHookTests(WebhookTestCase):
         )
 
     def test_create_issue_with_assignee_event_message(self) -> None:
-        expected_subject = u"my-awesome-project / Issue #1 Issue title"
-        expected_message = u"Tomasz Kolek created [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)(assigned to Tomasz Kolek)\n\n~~~ quote\nIssue description\n~~~"
+        expected_subject = u"Zulip GitLab Test / Issue #1 Zulip Test Issue"
+        expected_message = u"Adam Birds created [Issue #1](https://gitlab.com/adambirds/zulip-gitlab-test/issues/1)(assigned to adambirds)\n\n~~~ quote\nZulip Test Issue\n~~~"
 
         self.send_and_test_stream_message(
             'issue_created_with_assignee',
@@ -125,9 +125,42 @@ class GitlabHookTests(WebhookTestCase):
             HTTP_X_GITLAB_EVENT="Issue Hook"
         )
 
+    def test_create_issue_with_two_assignees_event_message(self) -> None:
+        expected_subject = u"Zulip GitLab Test / Issue #2 Zulip Test Issue 2"
+        expected_message = u"Adam Birds created [Issue #2](https://gitlab.com/adambirds/zulip-gitlab-test/issues/2)(assigned to adambirds and eeshangarg)\n\n~~~ quote\nZulip Test Issue 2\n~~~"
+
+        self.send_and_test_stream_message(
+            'issue_created_with_two_assignees',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Issue Hook"
+        )
+
+    def test_create_issue_with_three_assignees_event_message(self) -> None:
+        expected_subject = u"Zulip GitLab Test / Issue #2 Zulip Test Issue 2"
+        expected_message = u"Adam Birds created [Issue #2](https://gitlab.com/adambirds/zulip-gitlab-test/issues/2)(assigned to adambirds, eeshangarg and timabbott)\n\n~~~ quote\nZulip Test Issue 2\n~~~"
+
+        self.send_and_test_stream_message(
+            'issue_created_with_three_assignees',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Issue Hook"
+        )
+
+    def test_create_issue_with_ten_assignees_event_message(self) -> None:
+        expected_subject = u"Zulip GitLab Test / Issue #2 Zulip Test Issue 2"
+        expected_message = u"Adam Birds created [Issue #2](https://gitlab.com/adambirds/zulip-gitlab-test/issues/2)(assigned to adambirds, eeshangarg, timabbott and 7 others)\n\n~~~ quote\nZulip Test Issue 2\n~~~"
+
+        self.send_and_test_stream_message(
+            'issue_created_with_ten_assignees',
+            expected_subject,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Issue Hook"
+        )
+
     def test_create_issue_with_hidden_comment_in_description(self) -> None:
-        expected_subject = u"public-repo / Issue #3 New Issue with hidden comment"
-        expected_message = u"Eeshan Garg created [Issue #3](https://gitlab.com/eeshangarg/public-repo/issues/3)\n\n~~~ quote\nThis description actually has a hidden comment in it!\n~~~"
+        expected_subject = u"Zulip GitLab Test / Issue #3 Zulip Test Issue 3"
+        expected_message = u"Adam Birds created [Issue #3](https://gitlab.com/adambirds/zulip-gitlab-test/issues/3)\n\n~~~ quote\nThis description actually has a hidden comment in it!\n~~~"
 
         self.send_and_test_stream_message(
             'issue_created_with_hidden_comment_in_description',
@@ -137,8 +170,8 @@ class GitlabHookTests(WebhookTestCase):
         )
 
     def test_create_issue_with_null_description(self) -> None:
-        expected_subject = u"my-awesome-project / Issue #7 Issue without description"
-        expected_message = u"Eeshan Garg created [Issue #7](https://gitlab.com/eeshangarg/my-awesome-project/issues/7)"
+        expected_subject = u"Zulip GitLab Test / Issue #3 Zulip Test Issue 3"
+        expected_message = u"Adam Birds created [Issue #3](https://gitlab.com/adambirds/zulip-gitlab-test/issues/3)"
         self.send_and_test_stream_message(
             'issue_opened_with_null_description',
             expected_subject,
@@ -147,8 +180,8 @@ class GitlabHookTests(WebhookTestCase):
         )
 
     def test_update_issue_event_message(self) -> None:
-        expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
-        expected_message = u"Tomasz Kolek updated [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
+        expected_subject = u"Zulip GitLab Test / Issue #3 Zulip Test Issue 3"
+        expected_message = u"Adam Birds updated [Issue #3](https://gitlab.com/adambirds/zulip-gitlab-test/issues/3)"
 
         self.send_and_test_stream_message(
             'issue_updated',
@@ -160,7 +193,7 @@ class GitlabHookTests(WebhookTestCase):
     def test_update_issue_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic='notifications')
         expected_subject = u"notifications"
-        expected_message = u"Tomasz Kolek updated [Issue #1 Issue title_new](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
+        expected_message = u"Adam Birds updated [Issue #3 Zulip Test Issue 3](https://gitlab.com/adambirds/zulip-gitlab-test/issues/3)"
 
         self.send_and_test_stream_message(
             'issue_updated',
@@ -170,8 +203,8 @@ class GitlabHookTests(WebhookTestCase):
         )
 
     def test_close_issue_event_message(self) -> None:
-        expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
-        expected_message = u"Tomasz Kolek closed [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
+        expected_subject = u"Zulip GitLab Test / Issue #3 Zulip Test Issue 3"
+        expected_message = u"Adam Birds closed [Issue #3](https://gitlab.com/adambirds/zulip-gitlab-test/issues/3)"
 
         self.send_and_test_stream_message(
             'issue_closed',
@@ -181,8 +214,8 @@ class GitlabHookTests(WebhookTestCase):
         )
 
     def test_reopen_issue_event_message(self) -> None:
-        expected_subject = u"my-awesome-project / Issue #1 Issue title_new"
-        expected_message = u"Tomasz Kolek reopened [Issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)"
+        expected_subject = u"Zulip GitLab Test / Issue #3 Zulip Test Issue 3"
+        expected_message = u"Adam Birds reopened [Issue #3](https://gitlab.com/adambirds/zulip-gitlab-test/issues/3)"
 
         self.send_and_test_stream_message(
             'issue_reopened',
@@ -296,7 +329,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_merge_request_created_with_assignee_event_message(self) -> None:
         expected_subject = u"my-awesome-project / MR #3 New Merge Request"
-        expected_message = u"Tomasz Kolek created [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3)(assigned to Tomasz Kolek)\nfrom `tomek` to `master`\n\n~~~ quote\ndescription of merge request\n~~~"
+        expected_message = u"Tomasz Kolek created [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3)(assigned to tomaszkolek0)\nfrom `tomek` to `master`\n\n~~~ quote\ndescription of merge request\n~~~"
         self.send_and_test_stream_message(
             'merge_request_created_with_assignee',
             expected_subject,
@@ -351,7 +384,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_merge_request_updated_event_message(self) -> None:
         expected_subject = u"my-awesome-project / MR #3 New Merge Request"
-        expected_message = u"Tomasz Kolek updated [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3)(assigned to Tomasz Kolek)\nfrom `tomek` to `master`\n\n~~~ quote\nupdated desc\n~~~"
+        expected_message = u"Tomasz Kolek updated [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3)(assigned to tomaszkolek0)\nfrom `tomek` to `master`\n\n~~~ quote\nupdated desc\n~~~"
         self.send_and_test_stream_message(
             'merge_request_updated',
             expected_subject,


### PR DESCRIPTION
**Whats this for?**
Fixes issues with assignees not appearing for GitLab Issues, due to them switching the payload to support multiple assignees.

**Testing Plan:**
Ran ./tools/test-all
Tested with curl.
Tested GitLab and GitHub integrations due to changing `zerver/lib/webhooks/git.py`

@eeshangarg as we discussed.