### PR TITLE
hotkey: Update deprecation notice for '*' hotkey.

### DIFF
--- a/frontend_tests/node_tests/ui.js
+++ b/frontend_tests/node_tests/ui.js
@@ -1,8 +1,21 @@
 var ui = zrequire('ui');
 set_global('i18n', global.stub_i18n);
 
+set_global('navigator', {
+    userAgent: '',
+});
+
 run_test('get_hotkey_deprecation_notice', () => {
     var expected = 'translated: We\'ve replaced the "*" hotkey with "Ctrl + s" to make this common shortcut easier to trigger.';
     var actual = ui.get_hotkey_deprecation_notice('*', 'Ctrl + s');
     assert.equal(expected, actual);
+});
+
+run_test('get_hotkey_deprecation_notice_mac', () => {
+    global.navigator.userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.167 Safari/537.36";
+    var expected = 'translated: We\'ve replaced the "*" hotkey with "Cmd + s" to make this common shortcut easier to trigger.';
+    var actual = ui.get_hotkey_deprecation_notice('*', 'Cmd + s');
+    assert.equal(expected, actual);
+    // Reset userAgent
+    global.navigator.userAgent = '';
 });

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -134,10 +134,11 @@ exports.get_hotkey_deprecation_notice = function (originalHotkey, replacementHot
 var shown_deprecation_notices = [];
 exports.maybe_show_deprecation_notice = function (key) {
     var message;
+    var isCmdOrCtrl = /Mac/i.test(navigator.userAgent) ? "Cmd" : "Ctrl";
     if (key === 'C') {
         message = exports.get_hotkey_deprecation_notice('C', 'x');
     } else if (key === '*') {
-        message = exports.get_hotkey_deprecation_notice('*', 'Ctrl + s');
+        message = exports.get_hotkey_deprecation_notice("*", isCmdOrCtrl + " + s");
     } else {
         blueslip.error("Unexpected deprecation notice for hotkey:", key);
         return;


### PR DESCRIPTION
This PR updates the shortcut of the deprecation notice for '*' hotkey. On macOS, it should be 'Cmd + s' instead of 'Ctrl'.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

macOS -

![image](https://user-images.githubusercontent.com/2263909/45805499-75cd0e80-bcdc-11e8-8b55-0e9ebbbea388.png)

<hr>

Windows:

![image](https://user-images.githubusercontent.com/2263909/45805576-a7de7080-bcdc-11e8-9a30-868a4a50d5e0.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
