### PR TITLE
Add detection for ChromeOS User-Agents

### DIFF
--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -53,6 +53,8 @@ def get_device_os(user_agent: str) -> Optional[str]:
         return "iOS"
     elif "like mac os x" in user_agent:
         return "iOS"
+    elif "cros" in user_agent:
+        return "ChromeOS"
     else:
         return None
 

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -153,6 +153,9 @@ class TestBrowserAndOsUserAgentStrings(ZulipTestCase):
              '<WebKit Rev> (KHTML, like Gecko) Chrome/<Chrome Rev> Safari'
              '/<WebKit Rev> Edge/<EdgeHTML Rev>.'
              '<Windows Build>', 'Edge', 'Windows'),
+            ('Mozilla/5.0 (X11; CrOS x86_64 10895.56.0) AppleWebKit/537.36'
+             '(KHTML, like Gecko) Chrome/69.0.3497.95 Safari/537.36',
+             'Chrome', 'ChromeOS'),
             ('', None, None),
         ]
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Noticed that the new login emails said
Device: Chrome on an unknown operating system.

and the OS was definitely not unknown.


**Testing Plan:** <!-- How have you tested? -->
Trusting the CI to run the tests.

