### PR TITLE
message-view: show error icons without hover

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1170,6 +1170,10 @@ td.pointer {
     color: hsl(200, 100%, 40%);
 }
 
+.m-l-10 {
+    margin-left: 10px;
+}
+
 .message_failed,
 .message_local {
     display: inline-block;
@@ -1178,7 +1182,9 @@ td.pointer {
 }
 
 .message_failed {
+    left: 20px;
     font-weight: bold;
+    opacity: 1 !important;
     color: hsl(0, 100%, 50%);
     position: relative;
 }

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -56,8 +56,8 @@
                         {{/unless}}
 
                         <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">
-                            <i class="fa fa-refresh refresh-failed-message" aria-hidden="true" data-toggle="tooltip" title="{{t 'Retry' }}"></i>
-                            <i class="fa fa-times-circle remove-failed-message" aria-hidden="true" data-toggle="tooltip" title="{{t 'Cancel' }}"></i>
+                            <i class="fa fa-refresh refresh-failed-message m-l-10" aria-hidden="true" data-toggle="tooltip" title="{{t 'Retry' }}"></i>
+                            <i class="fa fa-times-circle remove-failed-message m-l-10" aria-hidden="true" data-toggle="tooltip" title="{{t 'Cancel' }}"></i>
                         </div>
 
                         {{#unless msg/locally_echoed}}


### PR DESCRIPTION
Instead of displaying failed message error on mouse hover the error should be shown normally without hover.
Added opacity: 1 !important  in message_failed class.
Fixes: #10537

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![screenshot from 2018-09-24 14-36-45](https://user-images.githubusercontent.com/24277385/45944375-9d3b1880-c007-11e8-8897-3d0e7f658943.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
This is my first PR, @rishig please review.