### PR TITLE
settings: Remove reminder-bot from REALM_INTERNAL_BOTS.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2170,7 +2170,7 @@ class SubscriptionAPITest(ZulipTestCase):
         )
 
         self.assertNotIn(self.example_user('polonius').id, add_peer_event['users'])
-        self.assertEqual(len(add_peer_event['users']), 18)
+        self.assertEqual(len(add_peer_event['users']), 17)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
         self.assertEqual(add_peer_event['event']['user_id'], self.user_profile.id)
@@ -2202,7 +2202,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # We don't send a peer_add event to othello
         self.assertNotIn(user_profile.id, add_peer_event['users'])
         self.assertNotIn(self.example_user('polonius').id, add_peer_event['users'])
-        self.assertEqual(len(add_peer_event['users']), 18)
+        self.assertEqual(len(add_peer_event['users']), 17)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
         self.assertEqual(add_peer_event['event']['user_id'], user_profile.id)

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -775,9 +775,8 @@ INTERNAL_BOTS = [{'var_name': 'NOTIFICATION_BOT',
                   'email_template': 'welcome-bot@%s',
                   'name': 'Welcome Bot'}]
 
-REALM_INTERNAL_BOTS = [{'var_name': 'REMINDER_BOT',
-                        'email_template': 'reminder-bot@%s',
-                        'name': 'Reminder Bot'}]
+# Bots that are created for each realm like the reminder-bot goes here.
+REALM_INTERNAL_BOTS = []
 
 if PRODUCTION:
     INTERNAL_BOTS += [


### PR DESCRIPTION

So removing reminder-bot from REALM_INTERNAL_BOTS has pretty much no effect on the realms that are already created. They would continue to have reminder-bot. On the other hand, new realms created would no longer have reminder-bot. To remove the reminder-bot in existing realms we would need to run a query manually to deactivate them.


Something like this
```
users = UserProfile.objects.filter(email="reminder-bot@zulip.com")
for user in users:
    do_deactivate_user(user)
```

![screenshot from 2018-09-24 16-07-23](https://user-images.githubusercontent.com/7190633/45948071-3d973a00-c014-11e8-96f9-6aaf94f80e0d.png)


Deactivating reminder bot would get rid of it from stream settings and typeahead. But it would still be visible in /#organization/bot-list-admin.
