### PR TITLE
UI improvements on portico pages

### DIFF
--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -434,7 +434,7 @@ html {
 .new-style button {
     display: inline-block;
     vertical-align: top;
-    padding: 15px 22px 13px 22px;
+    padding: 13px 22px 13px 22px;
 
     font-family: "Source Sans Pro";
 

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -339,9 +339,9 @@ html {
 
     width: 280px;
 
-    border: 2px solid hsl(0, 0%, 86%);
+    border: 1px solid hsl(0, 0%, 86%);
     box-shadow: none;
-    border-radius: 0px;
+    border-radius: 4px;
 
     transition: border 0.3s ease;
 }
@@ -352,10 +352,10 @@ html {
 
 .new-style .input-box label {
     position: absolute;
-    top: 0px;
-    left: 0%;
+    top: 0;
+    left: 0;
 
-    margin-top: 5px;
+    margin-top: 1px;
 
     transition: all 0.3s ease;
 }
@@ -381,7 +381,7 @@ html {
 .new-style .input-box input[type=text]:focus,
 .new-style .input-box input[type=email]:focus,
 .new-style .input-box input[type=password]:focus {
-    border: 2px solid hsl(0, 0%, 53%);
+    border: 1px solid hsl(0, 0%, 53%);
 }
 
 .new-style .input-box label,
@@ -446,6 +446,7 @@ html {
     background-color: hsl(213, 23%, 25%);
 
     border: none;
+    border-radius: 4px;
 
     transition: all 0.3s ease;
 }

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -475,8 +475,8 @@ html {
 
 .login-page-container input[type=submit] {
     color: hsl(0, 0%, 66%);
-    border: 2px solid hsl(0, 0%, 86%);
-    border-radius: 0px;
+    border: 1px solid hsl(0, 0%, 86%);
+    border-radius: 4px;
     background: transparent;
 
     transition: color 0.3s ease, border 0.3s ease;


### PR DESCRIPTION
This PR makes the logged-off pages cleaner by adjusting the border-radius, spacing etc.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

First commit (https://github.com/zulip/zulip/pull/10559/commits/abf8877a6451dbe3cf332b817058925801663920) - updates the border-radius to 4px for all the buttons.



![image](https://user-images.githubusercontent.com/2263909/45953023-6e806a80-c026-11e8-8977-9a64dda8165f.png)

![image](https://user-images.githubusercontent.com/2263909/45953036-77713c00-c026-11e8-88a7-e86a5a5e087e.png)

Second commit (https://github.com/zulip/zulip/pull/10559/commits/f36aab7921e3387fbe98ae095ea749192f015dac) - Made the changes as discussed 

http://localhost:9991/login -

![image](https://user-images.githubusercontent.com/2263909/45953750-a7214380-c028-11e8-8ea7-83f1d9d49922.png)

<hr>

http://localhost:9991/register -

![image](https://user-images.githubusercontent.com/2263909/45953770-b607f600-c028-11e8-9e61-f2fc1ce00e4f.png)

Forgot password - 

![image](https://user-images.githubusercontent.com/2263909/45959164-e191dd00-c036-11e8-9091-a9db0902eb46.png)

http://localhost:9991/accounts/find -

![image](https://user-images.githubusercontent.com/2263909/45959210-fcfce800-c036-11e8-85b1-59dbf368568d.png)

http://localhost:9991/new/

![image](https://user-images.githubusercontent.com/2263909/45959234-0f772180-c037-11e8-8f51-dc543c58f517.png)


* Third commit (https://github.com/zulip/zulip/pull/10559/commits/4de2077bd8de56154cbc1756628c2512b866d740) aligns the button properly
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
