### PR TITLE
settings: Fix real-time updation of `full_name` property in page_params.

### DIFF
--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -37,6 +37,7 @@ exports.update_person = function update(person) {
         message_live_update.update_user_full_name(person.user_id, person.full_name);
         pm_list.update_private_messages();
         if (people.is_my_user_id(person.user_id)) {
+            page_params.full_name = person.full_name;
             settings_account.update_full_name(person.full_name);
         }
     }


### PR DESCRIPTION
Due to this if someone updates his/her name from accounts page and close
the modal and then reopen the modal the page still have the old name as
we use `page_params.full_name` in `accounts-settings.handlebars`. This
commit fixes this bug.

Fixes: #10529.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
![peek 2018-09-24 22-26](https://user-images.githubusercontent.com/22238472/45966563-1870ee80-c049-11e8-98a8-e83d51a6f3d5.gif)
@jackrzhang @timabbott FYI.