### PR TITLE
Add page for entering into an organization subdomain

### DIFF
--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -1031,6 +1031,12 @@ button.login-google-button {
         font-size: 0.9em;
     }
 
+    #create-organization-section {
+        text-align: center;
+        margin-top: 20px;
+        font-weight: 500;
+        margin-left: -28px;
+        font-size: 0.9em;
     }
 
     .find-account-link {

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -127,6 +127,11 @@ html {
     font-weight: 400;
 }
 
+.app-main.goto-account-page-container {
+    width: 500px;
+    font-weight: 400;
+}
+
 .app-main.confirm-continue-page-container {
     width: 400px;
     font-weight: 400;
@@ -933,6 +938,7 @@ button.login-google-button {
     .app-main.register-page-container,
     .app-main.login-page-container,
     .app-main.find-account-page-container,
+    .app-main.goto-account-page-container,
     .app-main.forgot-password-container {
         display: inline-block;
         padding: 20px;
@@ -993,4 +999,37 @@ button.login-google-button {
     font-size: 1.2rem;
     height: 45px;
     width: 325px;
+}
+
+.goto-account-page {
+    #realm_redirect_subdomain {
+        text-align: right;
+        position: relative;
+        padding-right: 10px;
+    }
+
+    #realm_redirect_external_host {
+        font-size: 20px;
+        top: 13px;
+        left: 5px;
+        position: relative;
+    }
+
+    #realm_redirect_description {
+        top: 15px;
+        position: relative;
+    }
+
+    #enter-realm-button {
+        margin-top: 14px;
+    }
+
+    #find-account-section {
+        margin-top: 20px;
+        text-align: center;
+    }
+
+    .find-account-link {
+        color: hsl(165, 100.0%, 14.7%);
+    }
 }

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -1027,6 +1027,10 @@ button.login-google-button {
     #find-account-section {
         margin-top: 20px;
         text-align: center;
+        font-weight: 500;
+        font-size: 0.9em;
+    }
+
     }
 
     .find-account-link {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -2178,33 +2178,3 @@ input.new-organization-button {
     margin-top: 20px;
     padding-right: 10px;
 }
-
-#realm_redirect_subdomain {
-    text-align: right;
-    position: relative;
-    padding-right: 10px;
-}
-
-#realm_redirect_external_host {
-    font-size: 20px;
-    top: 13px;
-    left: 5px;
-    position: relative;
-}
-
-#realm_redirect_description {
-    top: 15px;
-    position: relative;
-}
-
-.realm-redirect-form #find-account-link {
-    color: hsl(165, 100.0%, 14.7%);
-}
-
-.realm-redirect-form #find-account-section {
-    margin-top: 20px;
-}
-
-.realm-redirect-form #enter-realm-button {
-    margin-top: 10px;
-}

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -94,7 +94,7 @@
                                         </button>
                                     </a>
                                     {% else %}
-                                    <a href="/new">
+                                    <a href="/upgrade">
                                         <button class="green" type="button">
                                             Buy Standard
                                         </button>

--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -11,7 +11,7 @@
         <div class="app-main goto-account-page-container white-box">
             <div class="realm-redirect-form">
                 <form class="form-inline" name="realm_redirect_form"
-                  action="/accounts/go/?{{ request.GET.urlencode() }}" method="post">
+                  action="/accounts/go/{% if request.GET %}?{{ request.GET.urlencode() }}{% endif %}" method="post">
                     {{ csrf_input }}
                     <div class="input-box moving-label horizontal">
                         <div class="inline-block relative">

--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -15,7 +15,7 @@
                     {{ csrf_input }}
                     <div class="input-box moving-label horizontal">
                         <div class="inline-block relative">
-                            <p id="realm_redirect_description">{{ _("Enter your organization URL:") }}</p>
+                            <p id="realm_redirect_description">{{ _("Enter your organization's Zulip URL:") }}</p>
                             <input
                               type="text" value="{% if form.subdomain.value() %}{{ form.subdomain.value() }}{% endif %}"
                               placeholder="{{ _('your-organization-url') }}" autofocus id="realm_redirect_subdomain" name="subdomain"
@@ -31,8 +31,8 @@
                         </div>
                         <button id="enter-realm-button" type="submit">{{ _('Next') }}</button>
                         <p id="find-account-section">
-                            {{ _("Can't remember your organization URL?") }}
-                            <a target="_blank" class="find-account-link" href="/accounts/find/">{{ _("Find your account.") }}</a>
+                            {{ _("Don't know your organization URL?") }}
+                            <a target="_blank" class="find-account-link" href="/accounts/find/">{{ _("Find your organization") }}</a>
                         </p>
                     </div>
                 </form>

--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -2,13 +2,13 @@
 
 {% block portico_content %}
 
-<div class="app find-account-page flex full-page">
+<div class="app goto-account-page flex full-page">
     <div class="inline-block new-style">
         <div class="lead">
             <h1 class="get-started">{{ _("Log in to your organization") }}</h1>
         </div>
 
-        <div class="app-main find-account-page-container white-box">
+        <div class="app-main goto-account-page-container white-box">
             <div class="realm-redirect-form">
                 <form class="form-inline" name="realm_redirect_form"
                   action="/accounts/go/?{{ request.GET.urlencode() }}" method="post">
@@ -32,7 +32,7 @@
                         <button id="enter-realm-button" type="submit">{{ _('Next') }}</button>
                         <p id="find-account-section">
                             {{ _("Can't remember your organization URL?") }}
-                            <a target="_blank" id="find-account-link" href="/accounts/find/">{{ _("Find your account.") }}</a>
+                            <a target="_blank" class="find-account-link" href="/accounts/find/">{{ _("Find your account.") }}</a>
                         </p>
                     </div>
                 </form>

--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -38,6 +38,11 @@
                 </form>
             </div>
         </div>
+
+        <div id="create-organization-section">
+            {{ _("Need to get your group started on Zulip?") }} <a target="_blank" class="find-account-link" href="/new/">{{ _("Create a new organization") }}</a>
+        </div>
     </div>
+
 </div>
 {% endblock %}

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3166,7 +3166,7 @@ class NameRestrictionsTest(ZulipTestCase):
 class RealmRedirectTest(ZulipTestCase):
     def test_realm_redirect_without_next_param(self) -> None:
         result = self.client_get("/accounts/go/")
-        self.assert_in_success_response(["Enter your organization URL"], result)
+        self.assert_in_success_response(["Enter your organization's Zulip URL"], result)
 
         result = self.client_post("/accounts/go/", {"subdomain": "zephyr"})
         self.assertEqual(result.status_code, 302)
@@ -3177,7 +3177,7 @@ class RealmRedirectTest(ZulipTestCase):
 
     def test_realm_redirect_with_next_param(self) -> None:
         result = self.client_get("/accounts/go/?next=billing")
-        self.assert_in_success_response(['Enter your organization URL', 'action="/accounts/go/?next=billing"'], result)
+        self.assert_in_success_response(["Enter your organization's Zulip URL", 'action="/accounts/go/?next=billing"'], result)
 
         result = self.client_post("/accounts/go/?next=billing", {"subdomain": "lear"})
         self.assertEqual(result.status_code, 302)


### PR DESCRIPTION
To test set `ROOT_DOMAIN_LANDING_PAGE = True` in dev_settings.py and open http://zulipdev.com:9991/plans and click on Buy Premium. After entering zulip and logging in you would be redirected to /upgrade page. (or /billing page if you have already enabled billing for zulip realm) 