### PR TITLE
Prevent bots from having duplicate full names.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -62,6 +62,7 @@ from zerver.lib.topic_mutes import (
 )
 from zerver.lib.users import (
     bulk_get_users,
+    check_bot_name_available,
     check_full_name,
     get_api_key,
     user_ids_to_users
@@ -2920,6 +2921,22 @@ def check_change_full_name(user_profile: UserProfile, full_name_raw: str,
     new_full_name = check_full_name(full_name_raw)
     do_change_full_name(user_profile, new_full_name, acting_user)
     return new_full_name
+
+def check_change_bot_full_name(user_profile: UserProfile, full_name_raw: str,
+                               acting_user: UserProfile) -> None:
+    new_full_name = check_full_name(full_name_raw)
+
+    if new_full_name == user_profile.full_name:
+        # Our web app will try to patch full_name even if the user didn't
+        # modify the name in the form.  We just silently ignore those
+        # situations.
+        return
+
+    check_bot_name_available(
+        realm_id=user_profile.realm_id,
+        full_name=new_full_name,
+    )
+    do_change_full_name(user_profile, new_full_name, acting_user)
 
 def do_change_bot_owner(user_profile: UserProfile, bot_owner: UserProfile,
                         acting_user: UserProfile) -> None:

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -23,6 +23,16 @@ def check_full_name(full_name_raw: str) -> str:
         raise JsonableError(_("Invalid characters in name!"))
     return full_name
 
+def check_bot_name_available(realm_id: int, full_name: str) -> None:
+    dup_exists = UserProfile.objects.filter(
+        realm_id=realm_id,
+        full_name=full_name.strip(),
+        is_active=True,
+    ).exists()
+
+    if dup_exists:
+        raise JsonableError(_("Name is already in use!"))
+
 def check_short_name(short_name_raw: str) -> str:
     short_name = short_name_raw.strip()
     if len(short_name) == 0:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1769,6 +1769,7 @@ class EventsRegisterTest(ZulipTestCase):
         self.assert_on_error(error)
 
         action = lambda: self.create_bot('test_outgoing_webhook',
+                                         full_name='Outgoing Webhook Bot',
                                          payload_url=ujson.dumps('https://foo.bar.com'),
                                          interface_type=Service.GENERIC,
                                          bot_type=UserProfile.OUTGOING_WEBHOOK_BOT)
@@ -1779,6 +1780,7 @@ class EventsRegisterTest(ZulipTestCase):
         self.assert_on_error(error)
 
         action = lambda: self.create_bot('test_embedded',
+                                         full_name='Embedded Bot',
                                          service_name='helloworld',
                                          config_data=ujson.dumps({'foo': 'bar'}),
                                          bot_type=UserProfile.EMBEDDED_BOT)
@@ -1887,7 +1889,7 @@ class EventsRegisterTest(ZulipTestCase):
         ])
         self.user_profile = self.example_user('aaron')
         owner = self.example_user('hamlet')
-        bot = self.create_bot('test1')
+        bot = self.create_bot('test1', full_name='Test1 Testerson')
         action = lambda: do_change_bot_owner(bot, owner, self.user_profile)
         events = self.do_test(action)
         error = change_bot_owner_checker('events[0]', events[0])
@@ -1914,7 +1916,7 @@ class EventsRegisterTest(ZulipTestCase):
         ])
         previous_owner = self.example_user('aaron')
         self.user_profile = self.example_user('hamlet')
-        bot = self.create_test_bot('test2', previous_owner)
+        bot = self.create_test_bot('test2', previous_owner, full_name='Test2 Testerson')
         action = lambda: do_change_bot_owner(bot, self.user_profile, previous_owner)
         events = self.do_test(action)
         error = change_bot_owner_checker('events[0]', events[0])


### PR DESCRIPTION
Bots are not allowed to use the same name as
other users in the realm (either bot or human).

Fixes #10509
