### PR TITLE
bug fix: Handle "Subscribe" button in empty views.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -502,7 +502,7 @@ exports.delete_stream = function (stream_id, alert_element, stream_row) {
 };
 
 exports.initialize = function () {
-    $("#zfilt").on("click", ".stream_sub_unsub_button", function (e) {
+    $("#main_div").on("click", ".stream_sub_unsub_button", function (e) {
         e.preventDefault();
         e.stopPropagation();
 


### PR DESCRIPTION
I don't know how long this has been broken, but it seems
some re-design of our message feed moved the Subscribe
button out #zfilt, so we use a different parent selector
now to turn on the click handler.

Hopefully this was a pretty obscure bug.  To reproduce
it go to "Manage Streams" and then select a stream you're
not subscribed to (from "All Streams"), and don't actually
subscribe, but then hit "View stream".

The user experience here is still a bit confusing, but
this is just a quick fix.
