### PR TITLE
search: Always encode match_subject as HTML.

### DIFF
--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -1472,7 +1472,7 @@ def messages_in_narrow_backend(request: HttpRequest, user_profile: UserProfile,
         else:
             search_fields[message_id] = dict(
                 match_content=rendered_content,
-                match_subject=subject
+                match_subject=escape_html(subject),
             )
 
     return json_success({"messages": search_fields})


### PR DESCRIPTION
The `match_subject` field is supposed to contain HTML; that's how
the highlighting is done.  But the `subject` field is plain text --
it must be encoded if we want corresponding HTML.

Of the three places the `match_subject` field is populated -- two
here in messages_in_narrow_backend, one in get_messages_backend --
two of them already do this correctly, via get_search_fields.
Fix the remaining one, where in a `/messages/matches_narrow` query
we populate `matches_subject` even if the query didn't involve a
full-text search.

This doesn't affect the webapp, which ignores `match_subject` unless
it knows it did a full-text search; nor the mobile app, which
doesn't use `/messages/matches_narrow` at all.
