### PR TITLE
avatar-ui: Change UI for delete/edit.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1785,3 +1785,37 @@ thead .actions {
     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
 }
+
+// User profile icon
+.avatar_container {
+    position: relative;
+    width: 100%;
+}
+
+.avatar_overlay {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 100%;
+    width: 100%;
+    opacity: 0;
+    transition: .1s ease;
+    background-color: black;
+}
+
+.avatar_container:hover .avatar_overlay {
+    opacity: 0.3;
+}
+.remove_avatar_icon:hover {
+    color: red;
+}
+.remove_avatar_icon {
+    cursor: pointer;
+    color: white;
+    font-size: 25px;
+    position: absolute;
+    top: 2%;
+    right: 2%;
+}

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -138,8 +138,13 @@
             <h3>{{t "User avatar" }}</h3>
 
             <div class="inline-block">
-                <div id="user-settings-avatar">
+                <div id="user-settings-avatar" class="avatar_container">
                     <img id="user-avatar-block" src="{{ page_params.avatar_url_medium }}" />
+                    <div class="avatar_overlay" id="user_avatar_upload_button" title="{{t "Upload new avatar" }}">
+                        <div id="user_avatar_delete_button" class="remove_avatar_icon" title="{{t "Delete avatar" }}">
+                            <i class="fa fa-times"></i>
+                        </div>
+                    </div>
                     <div id="user-avatar-source">
                         <a href="https://en.gravatar.com/" target="_blank" class="white-color">{{t "Avatar from Gravatar" }}</a>
                     </div>
@@ -148,13 +153,7 @@
                 <div id="upload_avatar_spinner"></div>
             </div>
             <div class="avatar-controls">
-                <button class="button rounded sea-green w-200 block" id="user_avatar_upload_button">
-                    {{t 'Upload new avatar' }}
-                </button>
                 <div id="user_avatar_file_input_error" class="text-error"></div>
-                <button class="button rounded btn-danger w-200 m-t-20 block" id="user_avatar_delete_button">
-                    {{t 'Delete avatar' }}
-                </button>
             </div>
         </div>
         <div class="clear-float"></div>


### PR DESCRIPTION
Instead of having giant box for upload/delete
following changes are implemented.
(1) an X in the upper-left corner to remove the avatar.
(2) UI for uploading a new avatar potentially triggered by clicking on the avatar.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
 Fixes: #10255
![screenshot from 2018-09-29 15-47-36](https://user-images.githubusercontent.com/24277385/46244639-64cc7d80-c3ff-11e8-8c5c-bbff6b82172e.png)
![screenshot from 2018-09-29 15-48-20](https://user-images.githubusercontent.com/24277385/46244640-64cc7d80-c3ff-11e8-878a-f405c1811fe3.png)