### PR TITLE
stream-settings: Removed restrict posting to org admin from change mo…

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1234,6 +1234,9 @@ run_test('subscription_settings', () => {
     var div = $(html).find(".subscription-type");
     assert(div.text().indexOf('private stream') > 0);
 
+    var is_announcement_only = $(html).find("input[name=is-announcement-only]");
+    assert.equal(is_announcement_only.prop('checked'), false);
+
     var anchor = $(html).find(".change-stream-privacy:first");
     assert.equal(anchor.text(), "[translated: Change]");
 });
@@ -1250,9 +1253,6 @@ run_test('subscription_stream_privacy_modal', () => {
     assert.equal(other_options[0].value, 'public');
     assert.equal(other_options[1].value, 'invite-only-public-history');
     assert.equal(other_options[2].value, 'invite-only');
-
-    var is_announcement_only = $(html).find("input[name=is-announcement-only]");
-    assert.equal(is_announcement_only.prop('checked'), false);
 
     var button = $(html).find("#change-stream-privacy-button");
     assert(button.hasClass("btn-danger"));

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -343,24 +343,38 @@ function redraw_privacy_related_stuff(sub_row, sub) {
 function change_stream_privacy(e) {
     e.stopPropagation();
 
-    var stream_id = $(e.target).data("stream-id");
+    var privacy_setting = $('#stream_privacy_modal input[name=privacy]:checked').val();
+    var stream_id;
+    // function call from admin posting option or general privacy option
+    if (privacy_setting === undefined) {
+        stream_id = get_stream_id(e.target);
+    } else {
+        stream_id = $(e.target).data("stream-id");
+    }
+
     var sub = stream_data.get_sub_by_id(stream_id);
 
-    var privacy_setting = $('#stream_privacy_modal input[name=privacy]:checked').val();
-    var is_announcement_only = $('#stream_privacy_modal input[name=is-announcement-only]').prop('checked');
+    var is_announcement_only = $('#stream_posting_privacy input[name=is-announcement-only]').prop('checked');
 
     var invite_only;
     var history_public_to_subscribers;
 
-    if (privacy_setting === 'invite-only') {
-        invite_only = true;
-        history_public_to_subscribers = false;
-    } else if (privacy_setting === 'invite-only-public-history') {
-        invite_only = true;
-        history_public_to_subscribers = true;
+    if (privacy_setting === undefined) {
+        // use previous values
+        invite_only = sub.invite_only;
+        history_public_to_subscribers = sub.history_public_to_subscribers;
     } else {
-        invite_only = false;
-        history_public_to_subscribers = true;
+        is_announcement_only = sub.is_announcement_only;
+        if (privacy_setting === 'invite-only') {
+            invite_only = true;
+            history_public_to_subscribers = false;
+        } else if (privacy_setting === 'invite-only-public-history') {
+            invite_only = true;
+            history_public_to_subscribers = true;
+        } else {
+            invite_only = false;
+            history_public_to_subscribers = true;
+        }
     }
 
     $(".stream_change_property_info").hide();
@@ -533,6 +547,9 @@ exports.initialize = function () {
     });
 
     $("#subscriptions_table").on('click', '#change-stream-privacy-button',
+                                 change_stream_privacy);
+
+    $("#subscriptions_table").on('click', '#stream_posting_privacy',
                                  change_stream_privacy);
 
     $("#subscriptions_table").on('click', '.close-privacy-modal', function (e) {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2981,3 +2981,8 @@ div.message_content button.tictactoe-square:disabled {
 .flatpickr-months .numInputWrapper span {
     display: none;
 }
+
+.is-announcement-only {
+    padding: 5px;
+    vertical-align: sub;
+}

--- a/static/templates/stream_types.handlebars
+++ b/static/templates/stream_types.handlebars
@@ -17,11 +17,4 @@
             {{t '<b>Private, protected history:</b> must be invited by a member; new members can only see messages sent after they join; hidden from non-administrator users' }}
         </label>
     </li>
-    <li>
-        <label class="checkbox">
-            <input type="checkbox" name="is-announcement-only" value="is-announcement-only" {{#if is_announcement_only}}checked{{/if}}/>
-            <span></span>
-            {{t 'Restrict posting to organization administrators' }}
-        </label>
-    </li>
 </ul>

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -39,6 +39,13 @@
             </div>
             <a class="change-stream-privacy" {{#unless can_change_stream_permissions}}style="display: none;"{{/unless}}>[{{t "Change" }}]</a>
         </div>
+        <div id="stream_posting_privacy" data-stream-id="{{stream_id}}" {{#unless can_change_stream_permissions}}style="display: none;"{{/unless}}>
+            <label>
+                <input type="checkbox" name="is-announcement-only" value="is-announcement-only" {{#if is_announcement_only}}checked{{/if}}/>
+                <span class="is-announcement-only">{{t "Only administrators can post." }}</span>
+            </label>
+        </div>
+        <br>
         <div class="regular_subscription_settings collapse {{#subscribed}}in{{/subscribed}}">
             <div class="subscription-config">
                 <ul class="grey-box">


### PR DESCRIPTION
stream-settings: Removed restrict posting to org admin from change modal.

Moved restrict posting to admin option in streams under "Change" to outside
in the main stream settings.

Fixes: #10524

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![screenshot from 2018-09-24 22-47-08](https://user-images.githubusercontent.com/24277385/46244772-80388800-c401-11e8-82be-9432a67fdb79.png)
