### PR TITLE
portico: Make Why Zulip more prominent in the nav bar.

### DIFF
--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -14,6 +14,9 @@
             <li data-on-page="hello">
                 <a href="/hello/">Home</a>
             </li>
+            <li data-on-page="why-zulip">
+                <a href="/why-zulip/">Why Zulip</a>
+            </li>
             <li data-on-page="features">
                 <a href="/features/">Features</a>
             </li>
@@ -25,9 +28,6 @@
             </li>
             <li data-on-page="integrations">
                 <a href="/integrations/">Integrations</a>
-            </li>
-            <li data-on-page="why-zulip">
-                <a href="/why-zulip/">Why Zulip</a>
             </li>
             {% if user_is_authenticated %}
                 {% include 'zerver/portico-header-dropdown.html' %}


### PR DESCRIPTION
New:
![image](https://user-images.githubusercontent.com/890911/46247440-56ab3c80-c3c0-11e8-91fd-a6996069cb00.png)

Old:
![image](https://user-images.githubusercontent.com/890911/46247453-7fcbcd00-c3c0-11e8-9b48-8a454cbccf87.png)
