### PR TITLE
org settings: Add column for "role" under active-users

### DIFF
--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -9,6 +9,15 @@
     <td>
         <span class="email">{{email}}</span>
     </td>
+    <td>
+        <span class="user_role">
+            {{#if is_admin}}
+            {{t "Administrator" }}
+            {{else}}
+            {{t "Member" }}
+            {{/if}}
+        </span>
+    </td>
     {{#if is_bot}}
     <td>
         <span class="owner">{{bot_owner}}</span>

--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -2,9 +2,6 @@
 <tr class="user_row{{#unless is_active}} deactivated_user{{/unless}}" data-user-id="{{user_id}}" data-email="{{email}}">
     <td>
         <span class="user_name">{{full_name}}</span>
-        <span id="admin_icon" class="{{#unless is_admin}}hide{{/unless}}">
-            &nbsp;<i class="fa fa-bolt" title="{{t 'Organization administrator' }}" aria-label="{{t 'Organization administrator' }}"></i>
-        </span>
     </td>
     <td>
         <span class="email">{{email}}</span>

--- a/static/templates/settings/user-list-admin.handlebars
+++ b/static/templates/settings/user-list-admin.handlebars
@@ -6,6 +6,7 @@
         <thead>
             <th class="wrapped-cell">{{t "Name" }}</th>
             <th>{{t "Email" }}</th>
+            <th class="user_role">{{t "Role" }}</th>
             <th class="last_active">{{t "Last active" }}</th>
             {{#if is_admin}}
             <th class="actions">{{t "Actions" }}</th>


### PR DESCRIPTION
This pull request adds a "role" column and removes bolt admin icon from active users' list.

**GIFs or Screenshots:** 
![image](https://user-images.githubusercontent.com/40331304/46294324-27105600-c5b3-11e8-9794-2717e37eb7fd.png)

@timabbott Fyi
@shubhamdhama does this fixes your issue ?


