### PR TITLE
attachments ui: Initialize table sorted by Date uploaded column.

### DIFF
--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -56,6 +56,8 @@ function render_attachments_ui() {
         parent_container: $('#attachments-settings').expectOne(),
     }).init();
 
+    list.sort('numeric', 'create_time');
+
     list.add_sort_function("mentioned-in", function (a, b) {
         var a_m = a.messages[0];
         var b_m = b.messages[0];


### PR DESCRIPTION
Previously we only added the active class to the Date uploaded
column, thinking it was already sorted by upload date by default.
However, it wasn't, so now we explicitly make a call to sort it by upload
date to fix an issue with broken sorting.

Fixes #10518.

@showell FYI, since we previously discussed it on the frontend stream on czo.