### PR TITLE
left sidebar: Eliminate duplicate border for stream sidebar icon.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1962,8 +1962,6 @@ nav a .no-style {
 #searchbox_legacy {
     width: 100%;
     height: 40px;
-    border-left: 1px solid hsl(0, 0%, 88%);
-    border-right: 1px solid hsl(0, 0%, 88%);
 
     .navbar-search {
         margin-top: 0px;


### PR DESCRIPTION
Resolves one of the issues listed in #10423.

Before:
![](https://user-images.githubusercontent.com/15116870/44622730-9f2c8300-a873-11e8-9a4f-00cd98e6c553.png)

After:
![screenshot at oct 01 10-00-17](https://user-images.githubusercontent.com/15116870/46303507-df60de80-c560-11e8-8dc1-751c39457d80.png)
